### PR TITLE
Use more explicit type hints about currently supported types

### DIFF
--- a/src/comet_llm/api.py
+++ b/src/comet_llm/api.py
@@ -103,7 +103,7 @@ def log_prompt(
     call_data = convert.call_data_to_dict(
         id=0,
         prompt=prompt,
-        outputs=outputs,
+        outputs=output,
         metadata=metadata,
         prompt_template=prompt_template,
         prompt_template_variables=prompt_template_variables,
@@ -122,7 +122,7 @@ def log_prompt(
             "prompt_template": prompt_template,
             "prompt_template_variables": prompt_template_variables,
         },
-        "chain_outputs": {"output": outputs},
+        "chain_outputs": {"output": output},
         "metadata": {},
         "start_timestamp": start_timestamp,
         "end_timestamp": end_timestamp,

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -91,7 +91,7 @@ def test_log_prompt__happyflow():
 
         api.log_prompt(
             prompt="the-prompt",
-            outputs="the-outputs",
+            output="the-outputs",
             workspace="passed-workspace",
             project="passed-project-name",
             api_key="passed-api-key",


### PR DESCRIPTION
We currently only support search and visualizing string prompts, prompt templates and outputs. Also we don't support yet nested metadata and variables.

Updating type hints to reflect that.