### PR TITLE
Installer UX improvements

### DIFF
--- a/deployment/installer/README.md
+++ b/deployment/installer/README.md
@@ -1,9 +1,65 @@
-# Opik Installer
+# Opik Server Installer & Manager
 
-This python package provides a wrapper around an Ansible Playbook that sets up
-Docker + Minikube and installs the Open Source Opik Server using Helm.
+The Opik server installer is a Python package that installs and manages the
+Opik server on a local machine.
+It aims to make this process as simple as possible, by reducing the number of
+steps required to install the Opik server.
 
-## Building the Package
+## Usage
+
+To install the tool, run the following command:
+
+```bash
+pip install opik-server
+```
+
+### Installing Opik Server
+
+To install the Opik server, run the following command:
+
+```bash
+opik-server install
+```
+
+You can also run the installer in debug mode to see the details of the
+installation process:
+
+```bash
+opik-server --debug install
+```
+
+By default, the installer will install the same version of the Opik as its
+own version (`opik-server -v`). If you want to install a specific version, you
+can specify the version using the `--opik-version` flag:
+
+```bash
+opik-server install --opik-version 0.1.0
+```
+
+By default, the installer will setup a local port forward to the Opik server
+using the port `5173`. If you want to use a different port, you can specify
+the port using the `--local-port` flag:
+
+```bash
+opik-server install --local-port 5174
+```
+
+### Upgrading Opik Server
+
+To upgrade the Opik server, run the following command:
+
+```bash
+pip install --upgrade opik-server
+opik-server upgrade
+```
+
+Or upgrade to a specific version:
+
+```bash
+opik-server upgrade --opik-version 0.1.1
+```
+
+## Building the Python Package
 
 To build the package:
 
@@ -26,18 +82,6 @@ This will create a `dist` directory containing the built package.
 ```bash
 twine upload dist/*
 ```
-
-### Versioning
-
-The version of the package is set dynamically by the `setup.py` file using the
-[`git-semver-compute` script](https://github.com/comet-ml/git-semver-compute/blob/main/calculate-version.sh).
-This script dynamically calculates the version of the package based on the
-latest git tag (that is a valid SemVer) and the number of commits since that
-tag. This ensures versions are always correctly incremented.
-
-Because of this, it is important to ensure that when building a release, the
-latest tag is a valid SemVer tag, and that no changes are made to the repo's
-tacked files as a side effect of the package build.
 
 ## QA Testing
 
@@ -69,11 +113,7 @@ Review the warning message to see the path to the executable.
 ```bash
 # When the package is publically released none of these flags will be needed.
 # and you will be able to simply run `opik-server install`
-opik-server install \
-    --helm-repo-url https://comet-ml.github.io/opik \
-    --container-registry ghcr.io \
-    --container-repo-prefix comet-ml/opik \
-    --opik-version 0.1.0
+opik-server install --opik-version 0.1.0
 ```
 
 This will install the Opik server on your machine.

--- a/deployment/installer/opik_installer/__init__.py
+++ b/deployment/installer/opik_installer/__init__.py
@@ -8,48 +8,15 @@ import threading
 import time
 import traceback
 
-from typing import Callable, Tuple, Final
+from typing import Callable, Tuple, cast
 from importlib import metadata
 
 import click
 
 from ansible_playbill import AnsibleRunner, PlaybookConfig
 
-ANSI_GREEN: Final[str] = "\033[32m"
-ANSI_YELLOW: Final[str] = "\033[33m"
-ANSI_RESET: Final[str] = "\033[0m"
-UNICODE_BALLOT_BOX_WITH_CHECK: Final[str] = "\u2611"
-UNICODE_WARNING_SIGN: Final[str] = "\u26A0"
-UNICODE_EMOJI_CLOCK_FACES: Final[str] = "".join([
-    "\U0001F55B",  # Clock Face Twelve O'Clock
-    "\U0001F567",  # Clock Face Twelve-Thirty
-    "\U0001F550",  # Clock Face One O'Clock
-    "\U0001F55C",  # Clock Face One-Thirty
-    "\U0001F551",  # Clock Face Two O'Clock
-    "\U0001F55D",  # Clock Face Two-Thirty
-    "\U0001F552",  # Clock Face Three O'Clock
-    "\U0001F55E",  # Clock Face Three-Thirty
-    "\U0001F553",  # Clock Face Four O'Clock
-    "\U0001F55F",  # Clock Face Four-Thirty
-    "\U0001F554",  # Clock Face Five O'Clock
-    "\U0001F560",  # Clock Face Five-Thirty
-    "\U0001F555",  # Clock Face Six O'Clock
-    "\U0001F561",  # Clock Face Six-Thirty
-    "\U0001F556",  # Clock Face Seven O'Clock
-    "\U0001F562",  # Clock Face Seven-Thirty
-    "\U0001F557",  # Clock Face Eight O'Clock
-    "\U0001F563",  # Clock Face Eight-Thirty
-    "\U0001F558",  # Clock Face Nine O'Clock
-    "\U0001F564",  # Clock Face Nine-Thirty
-    "\U0001F559",  # Clock Face Ten O'Clock
-    "\U0001F565",  # Clock Face Ten-Thirty
-    "\U0001F55A",  # Clock Face Eleven O'Clock
-    "\U0001F566",  # Clock Face Eleven-Thirty
-])
-
-__version__: str = "0.0.0+dev"
-if __package__:
-    __version__ = metadata.version(__package__)
+import opik_installer.opik_constants as c
+from .version import __version__
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
@@ -76,7 +43,8 @@ def run_external_subroutine(
 ) -> None:
     """run_external_subroutine.
 
-    Shows a pretty ascii animation while doing some processing.
+    Shows a pretty text animation while doing some processing.
+    Or just runs the function without the spinner if debug is True.
 
     Args:
         msg (str): The message to show before the spinner.
@@ -87,9 +55,9 @@ def run_external_subroutine(
         debug (bool): Whether to run the function without the spinner.
     """
     if sys.stdout.encoding.startswith('utf'):
-        spinner = UNICODE_EMOJI_CLOCK_FACES
-        success_check = UNICODE_BALLOT_BOX_WITH_CHECK
-        failure_warning = UNICODE_WARNING_SIGN
+        spinner = c.UNICODE_EMOJI_CLOCK_FACES
+        success_check = c.UNICODE_BALLOT_BOX_WITH_CHECK
+        failure_warning = c.UNICODE_WARNING_SIGN
     else:
         spinner = "|/-\\"
         success_check = "[OK]"
@@ -103,9 +71,9 @@ def run_external_subroutine(
     while True:
         for char in spinner:
             if not spinnered_thread.is_alive():
-                char = ANSI_GREEN + success_check + ANSI_RESET
+                char = c.ANSI_GREEN + success_check + c.ANSI_RESET
                 if failure_sentinel.is_set():
-                    char = ANSI_YELLOW + failure_warning + ANSI_RESET
+                    char = c.ANSI_YELLOW + failure_warning + c.ANSI_RESET
             print(f"\r{msg}... {char}", end="", flush=True)
             if not spinnered_thread.is_alive():
                 print()
@@ -145,83 +113,62 @@ def opik_server(ctx: click.Context, debug: bool) -> None:  # noqa: D301
 
 @opik_server.command()
 @click.option(
-    "--helm-repo-name",
-    required=False,
-    default="opik",
-    show_default=True,
-    help="Helm Repository Name",
+    *c.REUSABLE_OPT_ARGS["helm-repo-name"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["helm-repo-name"]["kwargs"]),
 )
 @click.option(
-    "--helm-repo-url",
-    required=False,
-    default="https://opik.github.io/helm-charts",
-    show_default=True,
-    help="Helm Repository URL",
+    *c.REUSABLE_OPT_ARGS["helm-repo-url"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["helm-repo-url"]["kwargs"]),
 )
 @click.option(
-    "--helm-repo-username",
-    required=False,
-    default="",
-    help="Helm Repository Username",
+    *c.REUSABLE_OPT_ARGS["helm-repo-username"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["helm-repo-username"]["kwargs"]),
 )
 @click.option(
-    "--helm-repo-password",
-    required=False,
-    default="",
-    help="Helm Repository Password",
+    *c.REUSABLE_OPT_ARGS["helm-repo-password"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["helm-repo-password"]["kwargs"]),
 )
 @click.option(
-    "--helm-chart-name",
-    required=False,
-    default="opik",
-    show_default=True,
-    help="Helm Chart Name",
+    *c.REUSABLE_OPT_ARGS["helm-chart-name"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["helm-chart-name"]["kwargs"]),
 )
 @click.option(
-    "--helm-chart-version",
-    required=False,
-    default="",
-    show_default=True,
-    help="Helm Chart Version",
+    *c.REUSABLE_OPT_ARGS["helm-chart-version"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["helm-chart-version"]["kwargs"]),
 )
 @click.option(
-    "--container-registry",
-    required=False,
-    default="ghcr.io",
-    show_default=True,
-    help="Container Registry",
+    *c.REUSABLE_OPT_ARGS["container-registry"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["container-registry"]["kwargs"]),
 )
 @click.option(
-    "--container-registry-username",
-    required=False,
-    default="",
-    help="Container Registry Username",
+    *c.REUSABLE_OPT_ARGS["container-registry-username"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["container-registry-username"]["kwargs"]),
 )
 @click.option(
-    "--container-registry-password",
-    required=False,
-    default="",
-    help="Container Registry Password",
+    *c.REUSABLE_OPT_ARGS["container-registry-password"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["container-registry-password"]["kwargs"]),
 )
 @click.option(
-    "--container-repo-prefix",
-    required=False,
-    default="opik/opik",
-    show_default=True,
-    help="Container Repository Prefix",
+    *c.REUSABLE_OPT_ARGS["container-repo-prefix"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["container-repo-prefix"]["kwargs"]),
 )
 @click.option(
-    "--opik-version",
-    required=False,
-    default=__version__,
-    show_default=True,
-    help="Version of Opik to install",
+    *c.REUSABLE_OPT_ARGS["opik-version"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["opik-version"]["kwargs"]),
 )
 @click.option(
-    "--ansible-path",
+    *c.REUSABLE_OPT_ARGS["ansible-path"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["ansible-path"]["kwargs"]),
+)
+@click.option(
+    *c.REUSABLE_OPT_ARGS["local-port"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["local-port"]["kwargs"]),
+)
+@click.option(
+    "--no-deps",
     required=False,
-    default="",
-    help="Path to the ansible-playbook binary",
+    is_flag=True,
+    help="Skip installation of dependencies",
 )
 def install(  # noqa: C901
     helm_repo_name: str,
@@ -236,20 +183,44 @@ def install(  # noqa: C901
     container_repo_prefix: str,
     opik_version: str,
     ansible_path: str,
+    local_port: int,
+    no_deps: bool,
+    upgrade_called: bool = False,
 ) -> None:  # noqa: D301
     """Install Self-Hosted Opik Server.
     \f
+    Args:
+        helm_repo_name (str): Helm Repository Name
+        helm_repo_url (str): Helm Repository URL
+        helm_repo_username (str): Helm Repository Username
+        helm_repo_password (str): Helm Repository Password
+        helm_chart_name (str): Helm Chart Name
+        helm_chart_version (str): Helm Chart Version
+        container_registry (str): Container Registry
+        container_registry_username (str): Container Registry Username
+        container_registry_password (str): Container Registry Password
+        container_repo_prefix (str): Container Repository Prefix
+        opik_version (str): Version of Opik to install
+        ansible_path (str): Path to the ansible-playbook executable
+        local_port (int): Local port to run the Opik server on
+        no_deps (bool): Skip installation of dependencies
+
     Returns:
         None:
     """
-    click.echo("Installing Local Opik Server...")
     debug: bool = debug_set()
     if debug:
         click.echo("Debug mode is enabled.")
 
     # Determine the need for privilege escalation.
     become_pass: str = ""
-    if os.geteuid() != 0:
+    if os.geteuid() == 0:
+        click.echo(
+            "Opik should be installed as a non-root user with sudo privileges",
+            err=True,
+        )
+        sys.exit(1)
+    else:
         # If we're not root, check if we can become root without a password.
         try:
             subprocess.run(
@@ -323,9 +294,14 @@ def install(  # noqa: C901
         "container_registry_password": container_registry_password,
         "container_repo_prefix": container_repo_prefix,
         "comet_opik_version": opik_version,
+        "opik_local_port": local_port,
     }
     if become_pass:
         global_vars.update({"ansible_become_password": become_pass})
+
+    playbook_name: str = "opik-deps"
+    if no_deps:
+        playbook_name = "opik"
 
     failure_sentinel = threading.Event()
 
@@ -340,7 +316,7 @@ def install(  # noqa: C901
                 global_vars=global_vars,
                 playbooks=[
                     PlaybookConfig(
-                        "play.opik.yml",
+                        f"play.{playbook_name}.yml",
                     ),
                 ],
                 debug=debug,
@@ -351,7 +327,7 @@ def install(  # noqa: C901
 
     click.echo()
     run_external_subroutine(
-        "Installing Opik Server",
+        "Installing Latest Opik Server",
         run_all,
         (),
         failure_sentinel,
@@ -361,10 +337,116 @@ def install(  # noqa: C901
         click.echo("Installation failed.", err=True)
         sys.exit(1)
 
-    click.echo("Installation complete!")
+    click.echo("Latest Opik Installation complete!")
     click.echo()
-    click.echo(
-        "You can access Opik at: http://localhost:5173 in your browser."
+    if not upgrade_called:
+        click.echo(
+            "You can access Opik at: "
+            f"http://localhost:{local_port} in your browser."
+        )
+
+
+@opik_server.command()
+@click.option(
+    *c.REUSABLE_OPT_ARGS["helm-repo-name"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["helm-repo-name"]["kwargs"]),
+)
+@click.option(
+    *c.REUSABLE_OPT_ARGS["helm-repo-url"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["helm-repo-url"]["kwargs"]),
+)
+@click.option(
+    *c.REUSABLE_OPT_ARGS["helm-repo-username"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["helm-repo-username"]["kwargs"]),
+)
+@click.option(
+    *c.REUSABLE_OPT_ARGS["helm-repo-password"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["helm-repo-password"]["kwargs"]),
+)
+@click.option(
+    *c.REUSABLE_OPT_ARGS["helm-chart-name"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["helm-chart-name"]["kwargs"]),
+)
+@click.option(
+    *c.REUSABLE_OPT_ARGS["helm-chart-version"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["helm-chart-version"]["kwargs"]),
+)
+@click.option(
+    *c.REUSABLE_OPT_ARGS["container-registry"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["container-registry"]["kwargs"]),
+)
+@click.option(
+    *c.REUSABLE_OPT_ARGS["container-registry-username"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["container-registry-username"]["kwargs"]),
+)
+@click.option(
+    *c.REUSABLE_OPT_ARGS["container-registry-password"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["container-registry-password"]["kwargs"]),
+)
+@click.option(
+    *c.REUSABLE_OPT_ARGS["container-repo-prefix"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["container-repo-prefix"]["kwargs"]),
+)
+@click.option(
+    *c.REUSABLE_OPT_ARGS["opik-version"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["opik-version"]["kwargs"]),
+)
+@click.option(
+    *c.REUSABLE_OPT_ARGS["ansible-path"]["args"],
+    **cast(dict, c.REUSABLE_OPT_ARGS["ansible-path"]["kwargs"]),
+)
+@click.pass_context
+def upgrade(
+    ctx: click.Context,
+    helm_repo_name: str,
+    helm_repo_url: str,
+    helm_repo_username: str,
+    helm_repo_password: str,
+    helm_chart_name: str,
+    helm_chart_version: str,
+    container_registry: str,
+    container_registry_username: str,
+    container_registry_password: str,
+    container_repo_prefix: str,
+    opik_version: str,
+    ansible_path: str,
+) -> None:  # noqa: D301
+    """Upgrade Self-Hosted Opik Server.
+    \f
+    Args:
+        ctx (click.Context): ctx
+        helm_repo_name (str): Helm Repository Name
+        helm_repo_url (str): Helm Repository URL
+        helm_repo_username (str): Helm Repository Username
+        helm_repo_password (str): Helm Repository Password
+        helm_chart_name (str): Helm Chart Name
+        helm_chart_version (str): Helm Chart Version
+        container_registry (str): Container Registry
+        container_registry_username (str): Container Registry Username
+        container_registry_password (str): Container Registry Password
+        container_repo_prefix (str): Container Repository Prefix
+        opik_version (str): Version of Opik to install
+        ansible_path (str): Path to the ansible-playbook executable
+
+    Returns:
+        None:
+    """
+    ctx.invoke(
+        install,
+        helm_repo_name=helm_repo_name,
+        helm_repo_url=helm_repo_url,
+        helm_repo_username=helm_repo_username,
+        helm_repo_password=helm_repo_password,
+        helm_chart_name=helm_chart_name,
+        helm_chart_version=helm_chart_version,
+        container_registry=container_registry,
+        container_registry_username=container_registry_username,
+        container_registry_password=container_registry_password,
+        container_repo_prefix=container_repo_prefix,
+        opik_version=opik_version,
+        ansible_path=ansible_path,
+        no_deps=True,
+        upgrade_called=True,
     )
 
 

--- a/deployment/installer/opik_installer/ansible/play.opik-deps.yml
+++ b/deployment/installer/opik_installer/ansible/play.opik-deps.yml
@@ -4,4 +4,5 @@
   connection: local
   become: true
   roles:
+    - role: comet-minikube
     - role: comet-opik

--- a/deployment/installer/opik_installer/ansible/roles/comet-opik/defaults/main.yml
+++ b/deployment/installer/opik_installer/ansible/roles/comet-opik/defaults/main.yml
@@ -8,3 +8,4 @@ container_registry: ghcr.io
 container_repo_prefix: comet-ml/opik
 container_registry_username: ""
 container_registry_password: ""
+opik_local_port: 5173

--- a/deployment/installer/opik_installer/ansible/roles/comet-opik/tasks/main.yml
+++ b/deployment/installer/opik_installer/ansible/roles/comet-opik/tasks/main.yml
@@ -84,6 +84,10 @@
 - name: Wait Opik to be ready
   ansible.builtin.command: >
     kubectl wait --for=condition=Ready pod -l app.kubernetes.io/instance=opik --timeout=300s -n opik
+  retries: 15
+  delay: 2
+  register: wait_cmd_result
+  until: wait_cmd_result.rc == 0
   become_user: "{{ ansible_connection_user }}"
 
 - name: Create Port Forward Service (Darwin)
@@ -105,7 +109,7 @@
               <string>-n</string>
               <string>opik</string>
               <string>svc/opik-frontend</string>
-              <string>5173</string>
+              <string>{{ opik_local_port }}:5173</string>
             </array>
 
           <key>UserName</key>
@@ -121,6 +125,13 @@
         </dict>
       </plist>
     dest: /Users/{{ ansible_connection_user }}/Library/LaunchAgents/com.comet.opik.port_forward.plist
+    force: false
+  when: ansible_os_family == "Darwin"
+
+- name: Read Forwarded Port from File
+  ansible.builtin.shell: |
+    cat /Users/{{ ansible_connection_user }}/Library/LaunchAgents/com.comet.opik.port_forward.plist | grep -oE '<string>[0-9]{2,5}:5173<string>' | perl -pe 's/.+<string>([0-9]{2,5}):5173<\/string>/$1/'
+  register: local_forward_port
   when: ansible_os_family == "Darwin"
 
 - name: Start Port Forward Service (Darwin)
@@ -139,7 +150,7 @@
 
       [Service]
       Type=simple
-      ExecStart=/usr/bin/kubectl --context minikube port-forward -n opik svc/opik-frontend 5173
+      ExecStart=/usr/bin/kubectl --context minikube port-forward -n opik svc/opik-frontend {{ opik_local_port }}:5173
       Restart=always
       RestartSec=3
       WorkingDirectory=/home/{{ ansible_connection_user }}
@@ -149,7 +160,17 @@
       [Install]
       WantedBy=multi-user.target
     dest: /etc/systemd/system/opik-frontend-port-forward.service
+    force: false
   when: ansible_os_family == "Debian"
+
+- name: Read Forwarded Port from File
+  ansible.builtin.shell: |
+    cat /etc/systemd/system/opik-frontend-port-forward.service | grep -oP 'ExecStart=.+[0-9]{2,5}:5173$' | perl -pe 's/.+?([0-9]{2,5}):5173/$1/'
+  register: local_forward_port
+  when: ansible_os_family == "Debian"
+
+- debug:
+    var: local_forward_port.stdout
 
 - name: Start Port Forward Service (Linux)
   ansible.builtin.systemd:
@@ -160,6 +181,6 @@
 
 - name: Wait for the port forward service to be ready
   ansible.builtin.wait_for:
-    port: 5173
+    port: "{{ local_forward_port.stdout | int }}"
     state: started
   become_user: "{{ ansible_connection_user }}"

--- a/deployment/installer/opik_installer/opik_constants.py
+++ b/deployment/installer/opik_installer/opik_constants.py
@@ -1,0 +1,178 @@
+"""Constants for Opik Server."""
+
+from typing import Final, Dict, Any, Union, List
+
+from .version import __version__
+
+ANSI_GREEN: Final[str] = "\033[32m"
+ANSI_YELLOW: Final[str] = "\033[33m"
+ANSI_RESET: Final[str] = "\033[0m"
+UNICODE_BALLOT_BOX_WITH_CHECK: Final[str] = "\u2611"
+UNICODE_WARNING_SIGN: Final[str] = "\u26A0"
+UNICODE_EMOJI_CLOCK_FACES: Final[str] = "".join([
+    "\U0001F55B",  # Clock Face Twelve O'Clock
+    "\U0001F567",  # Clock Face Twelve-Thirty
+    "\U0001F550",  # Clock Face One O'Clock
+    "\U0001F55C",  # Clock Face One-Thirty
+    "\U0001F551",  # Clock Face Two O'Clock
+    "\U0001F55D",  # Clock Face Two-Thirty
+    "\U0001F552",  # Clock Face Three O'Clock
+    "\U0001F55E",  # Clock Face Three-Thirty
+    "\U0001F553",  # Clock Face Four O'Clock
+    "\U0001F55F",  # Clock Face Four-Thirty
+    "\U0001F554",  # Clock Face Five O'Clock
+    "\U0001F560",  # Clock Face Five-Thirty
+    "\U0001F555",  # Clock Face Six O'Clock
+    "\U0001F561",  # Clock Face Six-Thirty
+    "\U0001F556",  # Clock Face Seven O'Clock
+    "\U0001F562",  # Clock Face Seven-Thirty
+    "\U0001F557",  # Clock Face Eight O'Clock
+    "\U0001F563",  # Clock Face Eight-Thirty
+    "\U0001F558",  # Clock Face Nine O'Clock
+    "\U0001F564",  # Clock Face Nine-Thirty
+    "\U0001F559",  # Clock Face Ten O'Clock
+    "\U0001F565",  # Clock Face Ten-Thirty
+    "\U0001F55A",  # Clock Face Eleven O'Clock
+    "\U0001F566",  # Clock Face Eleven-Thirty
+])
+
+DEFAULT_HELM_REPO_NAME: Final[str] = "opik"
+DEFAULT_HELM_REPO_URL: Final[str] = "https://comet-ml.github.io/opik"
+DEFAULT_HELM_REPO_USERNAME: Final[str] = ""
+DEFAULT_HELM_REPO_PASSWORD: Final[str] = ""
+DEFAULT_HELM_CHART_NAME: Final[str] = "opik"
+DEFAULT_HELM_CHART_VERSION: Final[str] = ""
+DEFAULT_CONTAINER_REGISTRY: Final[str] = "ghcr.io"
+DEFAULT_CONTAINER_REPO_PREFIX: Final[str] = "comet-ml/opik/opik"
+DEFAULT_CONTAINER_REGISTRY_USERNAME: Final[str] = ""
+DEFAULT_CONTAINER_REGISTRY_PASSWORD: Final[str] = ""
+DEFAULT_OPIK_VERSION: Final[str] = __version__
+DEFAULT_ANSIBLE_PATH: Final[str] = ""
+
+
+REUSABLE_OPT_ARGS: Final[
+    Dict[
+        str,
+        Dict[
+            str,
+            Union[
+                List[Any],
+                Dict[str, Any]
+            ]
+        ]
+    ]
+] = {
+    "helm-repo-name": {
+        "args": ["--helm-repo-name"],
+        "kwargs": {
+            "required": False,
+            "default": DEFAULT_HELM_REPO_NAME,
+            "show_default": True,
+            "help": "Helm Repository Name",
+        },
+    },
+    "helm-repo-url": {
+        "args": ["--helm-repo-url"],
+        "kwargs": {
+            "required": False,
+            "default": DEFAULT_HELM_REPO_URL,
+            "show_default": True,
+            "help": "Helm Repository URL",
+        },
+    },
+    "helm-repo-username": {
+        "args": ["--helm-repo-username"],
+        "kwargs": {
+            "required": False,
+            "default": DEFAULT_HELM_REPO_USERNAME,
+            "help": "Helm Repository Username",
+        },
+    },
+    "helm-repo-password": {
+        "args": ["--helm-repo-password"],
+        "kwargs": {
+            "required": False,
+            "default": DEFAULT_HELM_REPO_PASSWORD,
+            "help": "Helm Repository Password",
+        },
+    },
+    "helm-chart-name": {
+        "args": ["--helm-chart-name"],
+        "kwargs": {
+            "required": False,
+            "default": DEFAULT_HELM_CHART_NAME,
+            "show_default": True,
+            "help": "Helm Chart Name",
+        },
+    },
+    "helm-chart-version": {
+        "args": ["--helm-chart-version"],
+        "kwargs": {
+            "required": False,
+            "default": DEFAULT_HELM_CHART_VERSION,
+            "show_default": True,
+            "help": "Helm Chart Version",
+        },
+    },
+    "container-registry": {
+        "args": ["--container-registry"],
+        "kwargs": {
+            "required": False,
+            "default": DEFAULT_CONTAINER_REGISTRY,
+            "show_default": True,
+            "help": "Container Registry",
+        },
+    },
+    "container-registry-username": {
+        "args": ["--container-registry-username"],
+        "kwargs": {
+            "required": False,
+            "default": DEFAULT_CONTAINER_REGISTRY_USERNAME,
+            "help": "Container Registry Username",
+        },
+    },
+    "container-registry-password": {
+        "args": ["--container-registry-password"],
+        "kwargs": {
+            "required": False,
+            "default": DEFAULT_CONTAINER_REGISTRY_PASSWORD,
+            "help": "Container Registry Password",
+        },
+    },
+    "container-repo-prefix": {
+        "args": ["--container-repo-prefix"],
+        "kwargs": {
+            "required": False,
+            "default": DEFAULT_CONTAINER_REPO_PREFIX,
+            "show_default": True,
+            "help": "Container Repository Prefix",
+        },
+    },
+    "opik-version": {
+        "args": ["--opik-version"],
+        "kwargs": {
+            "required": False,
+            "default": DEFAULT_OPIK_VERSION,
+            "show_default": True,
+            "help": "Version of Opik to install",
+        },
+    },
+    "local-port": {
+        "args": ["--local-port"],
+        "kwargs": {
+            "required": False,
+            "default": 5173,
+            "type": int,
+            "show_default": True,
+            "help": "Local port to expose Opik on",
+        },
+    },
+    "ansible-path": {
+        "args": ["--ansible-path"],
+        "kwargs": {
+            "required": False,
+            "default": DEFAULT_ANSIBLE_PATH,
+            "help": "Path to the ansible-playbook binary",
+        },
+    },
+}

--- a/deployment/installer/opik_installer/version.py
+++ b/deployment/installer/opik_installer/version.py
@@ -1,0 +1,7 @@
+"""Version information for the package."""
+
+from importlib import metadata
+
+__version__: str = "0.0.0+dev"
+if __package__:
+    __version__ = metadata.version(__package__)


### PR DESCRIPTION
## Details
- Add installer `upgrade` sub-command
- Add `--local-port` option to the `install` sub-command to support specifying the locally forwarded port for opik server.
- Reject invoking command as root (this could cause some strange behavior)
- Update defaults to point to the correct values for the public repos/registries for the install artifacts (to reduce required options)