### PR TITLE
Fix forwarded-port identification on macOS

### DIFF
--- a/deployment/installer/opik_installer/ansible/roles/comet-opik/tasks/main.yml
+++ b/deployment/installer/opik_installer/ansible/roles/comet-opik/tasks/main.yml
@@ -130,8 +130,8 @@
 
 - name: Read Forwarded Port from File
   ansible.builtin.shell: |
-    cat /Users/{{ ansible_connection_user }}/Library/LaunchAgents/com.comet.opik.port_forward.plist | grep -oE '<string>[0-9]{2,5}:5173<string>' | perl -pe 's/.+<string>([0-9]{2,5}):5173<\/string>/$1/'
-  register: local_forward_port
+    cat /Users/{{ ansible_connection_user }}/Library/LaunchAgents/com.comet.opik.port_forward.plist | grep -oE '<string>[0-9]{2,5}:5173</string>' | perl -pe 's/<string>([0-9]{2,5}):5173<\/string>/$1/'
+  register: local_forward_port_darwin
   when: ansible_os_family == "Darwin"
 
 - name: Start Port Forward Service (Darwin)
@@ -166,11 +166,13 @@
 - name: Read Forwarded Port from File
   ansible.builtin.shell: |
     cat /etc/systemd/system/opik-frontend-port-forward.service | grep -oP 'ExecStart=.+[0-9]{2,5}:5173$' | perl -pe 's/.+?([0-9]{2,5}):5173/$1/'
-  register: local_forward_port
+  register: local_forward_port_linux
   when: ansible_os_family == "Debian"
 
 - debug:
-    var: local_forward_port.stdout
+    var: local_forward_port_linux.stdout
+- debug:
+    var: local_forward_port_darwin.stdout
 
 - name: Start Port Forward Service (Linux)
   ansible.builtin.systemd:
@@ -181,6 +183,6 @@
 
 - name: Wait for the port forward service to be ready
   ansible.builtin.wait_for:
-    port: "{{ local_forward_port.stdout | int }}"
+    port: "{{ ((ansible_os_family == 'Debian') | ternary(local_forward_port_linux, local_forward_port_darwin)).stdout | int }}"
     state: started
   become_user: "{{ ansible_connection_user }}"


### PR DESCRIPTION
## Details
- Ansible had some trouble identifying the forwarded port on macOS, this has now been addressed.
