### PR TITLE
OPIK-20 [UX] Add simple keyboard shortcuts for trace sidebar

### DIFF
--- a/apps/opik-frontend/package-lock.json
+++ b/apps/opik-frontend/package-lock.json
@@ -47,6 +47,7 @@
         "react-complex-tree": "^2.4.4",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
+        "react-hotkeys-hook": "^4.5.1",
         "react-resizable-panels": "^2.0.20",
         "react18-json-view": "^0.2.8",
         "stylelint-scss": "^6.4.1",
@@ -10557,6 +10558,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hotkeys-hook": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.5.1.tgz",
+      "integrity": "sha512-scAEJOh3Irm0g95NIn6+tQVf/OICCjsQsC9NBHfQws/Vxw4sfq1tDQut5fhTEvPraXhu/sHxRd9lOtxzyYuNAg==",
+      "peerDependencies": {
+        "react": ">=16.8.1",
+        "react-dom": ">=16.8.1"
       }
     },
     "node_modules/react-is": {

--- a/apps/opik-frontend/package.json
+++ b/apps/opik-frontend/package.json
@@ -64,6 +64,7 @@
     "react-complex-tree": "^2.4.4",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
+    "react-hotkeys-hook": "^4.5.1",
     "react-resizable-panels": "^2.0.20",
     "react18-json-view": "^0.2.8",
     "stylelint-scss": "^6.4.1",

--- a/apps/opik-frontend/src/components/pages/DatasetCompareExperimentsPage/DatasetCompareExperimentsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetCompareExperimentsPage/DatasetCompareExperimentsPage.tsx
@@ -18,7 +18,7 @@ import IdCell from "@/components/shared/DataTableCells/IdCell";
 import DataTableNoData from "@/components/shared/DataTableNoData/DataTableNoData";
 import DataTableRowHeightSelector from "@/components/shared/DataTableRowHeightSelector/DataTableRowHeightSelector";
 import useCompareExperimentsList from "@/api/datasets/useCompareExperimentsList";
-import { DatasetItem, ExperimentsCompare } from "@/types/datasets";
+import { ExperimentsCompare } from "@/types/datasets";
 import Loader from "@/components/shared/Loader/Loader";
 import useAppStore from "@/store/AppStore";
 import { useDatasetIdFromURL } from "@/hooks/useDatasetIdFromURL";
@@ -37,6 +37,8 @@ import { convertColumnDataToColumn } from "@/lib/table";
 import ColumnsButton from "@/components/shared/ColumnsButton/ColumnsButton";
 import TraceDetailsPanel from "@/components/shared/TraceDetailsPanel/TraceDetailsPanel";
 import useExperimentById from "@/api/datasets/useExperimentById";
+
+const getRowId = (d: ExperimentsCompare) => d.id;
 
 const getRowHeightClass = (height: ROW_HEIGHT) => {
   switch (height) {
@@ -65,6 +67,7 @@ export const DEFAULT_COLUMNS: ColumnData<ExperimentsCompare>[] = [
     label: "Input",
     size: 400,
     type: COLUMN_TYPE.string,
+    iconType: COLUMN_TYPE.dictionary,
     accessorFn: (row) =>
       isObject(row.input)
         ? JSON.stringify(row.input, null, 2)
@@ -227,7 +230,7 @@ const DatasetCompareExperimentsPage: React.FunctionComponent = () => {
       : `Compare (${experimentsIds.length})`;
 
   const handleRowClick = useCallback(
-    (row: DatasetItem) => {
+    (row: ExperimentsCompare) => {
       setActiveRowId((state) => (row.id === state ? "" : row.id));
     },
     [setActiveRowId],
@@ -289,7 +292,9 @@ const DatasetCompareExperimentsPage: React.FunctionComponent = () => {
         columns={columns}
         data={rows}
         onRowClick={handleRowClick}
+        activeRowId={activeRowId ?? ""}
         resizeConfig={resizeConfig}
+        getRowId={getRowId}
         rowHeight={height as ROW_HEIGHT}
         getRowHeightClass={getRowHeightClass}
         noData={<DataTableNoData title={noDataText} />}
@@ -312,6 +317,7 @@ const DatasetCompareExperimentsPage: React.FunctionComponent = () => {
         openTrace={setTraceId as OnChangeFn<string>}
         onClose={handleClose}
         onRowChange={handleRowChange}
+        isTraceDetailsOpened={Boolean(traceId)}
       />
       <TraceDetailsPanel
         traceId={traceId as string}

--- a/apps/opik-frontend/src/components/pages/DatasetCompareExperimentsPage/DatasetCompareExperimentsPanel/DatasetCompareExperimentsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetCompareExperimentsPage/DatasetCompareExperimentsPanel/DatasetCompareExperimentsPanel.tsx
@@ -29,6 +29,7 @@ type DatasetCompareExperimentsPanelProps = {
   hasNextRow?: boolean;
   onClose: () => void;
   onRowChange?: (shift: number) => void;
+  isTraceDetailsOpened: boolean;
 };
 
 const DatasetCompareExperimentsPanel: React.FunctionComponent<
@@ -42,6 +43,7 @@ const DatasetCompareExperimentsPanel: React.FunctionComponent<
   hasNextRow,
   onClose,
   onRowChange,
+  isTraceDetailsOpened,
 }) => {
   const { toast } = useToast();
 
@@ -151,6 +153,7 @@ const DatasetCompareExperimentsPanel: React.FunctionComponent<
   return (
     <ResizableSidePanel
       panelId="compare-experiments"
+      entity="item"
       open={Boolean(experimentsCompareId)}
       headerContent={renderHeaderContent()}
       hasPreviousRow={hasPreviousRow}
@@ -158,6 +161,7 @@ const DatasetCompareExperimentsPanel: React.FunctionComponent<
       onClose={onClose}
       onRowChange={onRowChange}
       initialWidth={0.8}
+      ignoreHotkeys={isTraceDetailsOpened}
     >
       {renderContent()}
     </ResizableSidePanel>

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
@@ -192,6 +192,7 @@ const DatasetItemsPage = () => {
       </div>
       <ResizableSidePanel
         panelId="dataset-items"
+        entity="item"
         open={Boolean(activeRowId)}
         hasPreviousRow={hasPrevious}
         hasNextRow={hasNext}

--- a/apps/opik-frontend/src/components/shared/TooltipWrapper/TooltipWrapper.tsx
+++ b/apps/opik-frontend/src/components/shared/TooltipWrapper/TooltipWrapper.tsx
@@ -12,20 +12,27 @@ type TooltipWrapperProps = {
   content: string;
   children?: React.ReactNode;
   side?: "top" | "right" | "bottom" | "left";
+  hotkey?: React.ReactNode;
 };
 
 const TooltipWrapper: React.FunctionComponent<TooltipWrapperProps> = ({
   content,
   children,
   side,
+  hotkey = null,
 }) => {
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>{children}</TooltipTrigger>
         <TooltipPortal>
-          <TooltipContent side={side}>
+          <TooltipContent side={side} variant={hotkey ? "hotkey" : "default"}>
             {content}
+            {hotkey && (
+              <div className="flex h-5 min-w-5 items-center justify-center rounded-s border border-light-slate px-1 text-light-slate">
+                {hotkey}
+              </div>
+            )}
             <TooltipArrow />
           </TooltipContent>
         </TooltipPortal>

--- a/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.tsx
+++ b/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.tsx
@@ -37,12 +37,12 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
   );
   useEffect(() => {
     setCategoryName(feedbackScore?.category_name);
-  }, [feedbackScore?.category_name]);
+  }, [feedbackScore?.category_name, traceId, spanId]);
 
   const [value, setValue] = useState(feedbackScore?.value);
   useEffect(() => {
     setValue(feedbackScore?.value);
-  }, [feedbackScore?.value]);
+  }, [feedbackScore?.value, spanId, traceId]);
 
   const feedbackScoreDeleteMutation = useTraceFeedbackScoreDeleteMutation();
 

--- a/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceAnnotateViewer/TraceAnnotateViewer.tsx
+++ b/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceAnnotateViewer/TraceAnnotateViewer.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import sortBy from "lodash/sortBy";
 import { Plus } from "lucide-react";
+import { useHotkeys } from "react-hotkeys-hook";
 
 import {
   FEEDBACK_SCORE_TYPE,
@@ -12,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import useAppStore from "@/store/AppStore";
 import useFeedbackDefinitionsList from "@/api/feedback-definitions/useFeedbackDefinitionsList";
 import { FeedbackDefinition } from "@/types/feedback-definitions";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import AddFeedbackDefinitionDialog from "@/components/shared/AddFeedbackDefinitionDialog/AddFeedbackDefinitionDialog";
 import AnnotateRow from "./AnnotateRow";
 
@@ -19,14 +21,29 @@ type TraceAnnotateViewerProps = {
   data: Trace | Span;
   spanId?: string;
   traceId: string;
+  annotateOpen: boolean;
   setAnnotateOpen: (open: boolean) => void;
 };
 
 const TraceAnnotateViewer: React.FunctionComponent<
   TraceAnnotateViewerProps
-> = ({ data, spanId, traceId, setAnnotateOpen }) => {
+> = ({ data, spanId, traceId, annotateOpen, setAnnotateOpen }) => {
   const [feedbackDefinitionDialogOpen, setFeedbackDefinitionDialogOpen] =
     useState(false);
+
+  useHotkeys(
+    "Escape",
+    (keyboardEvent: KeyboardEvent) => {
+      if (!annotateOpen) return;
+      keyboardEvent.stopPropagation();
+      switch (keyboardEvent.code) {
+        case "Escape":
+          setAnnotateOpen(false);
+          break;
+      }
+    },
+    [annotateOpen],
+  );
 
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const { data: feedbackDefinitionsData } = useFeedbackDefinitionsList({
@@ -78,13 +95,15 @@ const TraceAnnotateViewer: React.FunctionComponent<
           <div className="flex items-center gap-2 overflow-x-hidden">
             <div className="comet-title-m truncate">Annotate</div>
           </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setAnnotateOpen(false)}
-          >
-            Close
-          </Button>
+          <TooltipWrapper content="Close annotate" hotkey="Esc">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setAnnotateOpen(false)}
+            >
+              Close
+            </Button>
+          </TooltipWrapper>
         </div>
         <div className="mt-4 flex flex-col gap-4">
           <div className="grid max-w-full grid-cols-[minmax(0,5fr)_minmax(0,10fr)_minmax(0,2fr)] border-t border-border">

--- a/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceDetailsPanel.tsx
+++ b/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceDetailsPanel.tsx
@@ -145,6 +145,7 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
                   data={dataToView}
                   spanId={spanId}
                   traceId={traceId}
+                  annotateOpen={annotateOpen as boolean}
                   setAnnotateOpen={setAnnotateOpen}
                 />
               </ResizablePanel>
@@ -195,6 +196,7 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
   return (
     <ResizableSidePanel
       panelId="traces"
+      entity="trace"
       open={Boolean(traceId)}
       headerContent={renderHeaderContent()}
       hasPreviousRow={hasPreviousRow}

--- a/apps/opik-frontend/src/components/ui/tooltip.tsx
+++ b/apps/opik-frontend/src/components/ui/tooltip.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
@@ -24,17 +25,35 @@ const TooltipArrow = React.forwardRef<
 
 TooltipArrow.displayName = TooltipPrimitive.Arrow.displayName;
 
+const tooltipVariants = cva(
+  "comet-body-s z-50 max-w-[80vw] overflow-hidden rounded-md bg-tooltip text-tooltip-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+  {
+    variants: {
+      variant: {
+        default: "px-3 py-0.5",
+        hotkey: "flex gap-2 py-1 pl-3 pr-2",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface TooltipContentProps
+  extends React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>,
+    VariantProps<typeof tooltipVariants> {
+  asChild?: boolean;
+}
+
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
+  TooltipContentProps
+>(({ className, variant, sideOffset = 4, ...props }, ref) => (
   <TooltipPrimitive.Content
     ref={ref}
     sideOffset={sideOffset}
-    className={cn(
-      "comet-body-s z-50 max-w-[80vw] overflow-hidden rounded-md bg-tooltip px-3 py-1 text-tooltip-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className,
-    )}
+    className={cn(tooltipVariants({ variant, className }))}
     {...props}
   />
 ));


### PR DESCRIPTION
## Details
Pressing esc should:
- Close the annotation sidebar if it is open
- Close the sidebar if it’s open

Pressing up_arrow or down_arrow should go to the previous and next trace

![image](https://github.com/user-attachments/assets/ee553a5a-73e1-47c8-860c-105d2a4ca8ae)

## Issues

Resolves #

## Testing

## Documentation
