### PR TITLE
NO-JIRA Missing now64 precision of 9

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -1,7 +1,6 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.DatasetItem;
-import com.comet.opik.api.DatasetItemBatch;
 import com.comet.opik.api.DatasetItemSearchCriteria;
 import com.comet.opik.api.DatasetItemSource;
 import com.comet.opik.api.ExperimentItem;
@@ -348,10 +347,12 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
             return Mono.empty();
         }
 
-        return asyncTemplate.nonTransaction(connection -> mapAndInsert(datasetId, items, connection, INSERT_DATASET_ITEM));
+        return asyncTemplate.nonTransaction(connection -> mapAndInsert(
+                datasetId, items, connection, INSERT_DATASET_ITEM));
     }
 
-    private Mono<Long> mapAndInsert(UUID datasetId, List<DatasetItem> items, Connection connection, String sqlTemplate) {
+    private Mono<Long> mapAndInsert(
+            UUID datasetId, List<DatasetItem> items, Connection connection, String sqlTemplate) {
 
         List<QueryItem> queryItems = getQueryItemPlaceHolder(items.size());
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
@@ -137,7 +137,7 @@ class ExperimentItemDAO {
         }
 
         return Mono.from(connectionFactory.create())
-                        .flatMap(connection -> insert(experimentItems, connection));
+                .flatMap(connection -> insert(experimentItems, connection));
     }
 
     private Mono<Long> insert(Collection<ExperimentItem> experimentItems, Connection connection) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemService.java
@@ -1,6 +1,5 @@
 package com.comet.opik.domain;
 
-import com.clickhouse.client.ClickHouseException;
 import com.comet.opik.api.ExperimentItem;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.google.common.base.Preconditions;
@@ -100,7 +99,8 @@ public class ExperimentItemService {
         }
 
         return datasetItemDAO.getDatasetItemWorkspace(datasetItemIds)
-                .map(datasetItemWorkspace -> datasetItemWorkspace.stream().allMatch(datasetItem -> workspaceId.equals(datasetItem.workspaceId())));
+                .map(datasetItemWorkspace -> datasetItemWorkspace.stream()
+                        .allMatch(datasetItem -> workspaceId.equals(datasetItem.workspaceId())));
     }
 
     public Mono<ExperimentItem> get(@NonNull UUID id) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -19,7 +19,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.reactivestreams.Publisher;
 import org.stringtemplate.v4.ST;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.Instant;
@@ -155,7 +154,7 @@ class SpanDAO {
                     :metadata as metadata,
                     :tags as tags,
                     mapFromArrays(:usage_keys, :usage_values) as usage,
-                    now64() as created_at,
+                    now64(9) as created_at,
                     :user_name as created_by,
                     :user_name as last_updated_by
             ) as new_span
@@ -326,7 +325,7 @@ class SpanDAO {
                     <if(metadata)> :metadata <else> '' <endif> as metadata,
                     <if(tags)> :tags <else> [] <endif> as tags,
                     <if(usage)> CAST((:usageKeys, :usageValues), 'Map(String, Int64)') <else>  mapFromArrays([], []) <endif> as usage,
-                    now64() as created_at,
+                    now64(9) as created_at,
                     :user_name as created_by,
                     :user_name as last_updated_by
             ) as new_span

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -675,8 +675,9 @@ class TraceDAOImpl implements TraceDAO {
 
     @Override
     @com.newrelic.api.agent.Trace(dispatcher = true)
-    public Mono<List<WorkspaceAndResourceId>> getTraceWorkspace(@NonNull Set<UUID> traceIds, @NonNull Connection connection) {
-      
+    public Mono<List<WorkspaceAndResourceId>> getTraceWorkspace(
+            @NonNull Set<UUID> traceIds, @NonNull Connection connection) {
+
         if (traceIds.isEmpty()) {
             return Mono.just(List.of());
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -249,7 +249,8 @@ class TraceServiceImpl implements TraceService {
         }
 
         return template.nonTransaction(connection -> dao.getTraceWorkspace(traceIds, connection)
-                .map(traceWorkspace -> traceWorkspace.stream().allMatch(trace -> workspaceId.equals(trace.workspaceId()))));
+                .map(traceWorkspace -> traceWorkspace.stream()
+                        .allMatch(trace -> workspaceId.equals(trace.workspaceId()))));
     }
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/DatabaseAnalyticsModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/DatabaseAnalyticsModule.java
@@ -7,7 +7,6 @@ import io.r2dbc.spi.ConnectionFactory;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import ru.vyarus.dropwizard.guice.module.support.DropwizardAwareModule;
-import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
 public class DatabaseAnalyticsModule extends DropwizardAwareModule<OpikConfiguration> {
 


### PR DESCRIPTION
## Details
Minor bug discovered during the query plan analysis task.

The Span creation endpoint was not setting the proper precision for `created_at` field.

Fixed by adding precision 9 to the `now64` call.

Additionally, run spotless to fix formatting issues.

## Issues

N/A

## Testing
- Passed CI build.

## Documentation
N/A
