### PR TITLE
OPIK-71 Resolve dataset name in experiment endpoints

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Experiment.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Experiment.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 public record Experiment(
         @JsonView( {
                 Experiment.View.Public.class, Experiment.View.Write.class}) UUID id,
-        @JsonView({Experiment.View.Write.class}) @NotBlank String datasetName,
+        @JsonView({Experiment.View.Public.class, Experiment.View.Write.class}) @NotBlank String datasetName,
         @JsonView({Experiment.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) UUID datasetId,
         @JsonView({Experiment.View.Public.class, Experiment.View.Write.class}) @NotBlank String name,
         @JsonView({
@@ -31,7 +31,7 @@ public record Experiment(
         @JsonView({
                 Experiment.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy){
 
-    @Builder
+    @Builder(toBuilder = true)
     public record ExperimentPage(
             @JsonView(Experiment.View.Public.class) int page,
             @JsonView(Experiment.View.Public.class) int size,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetDAO.java
@@ -9,6 +9,7 @@ import org.jdbi.v3.sqlobject.config.RegisterColumnMapper;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.AllowUnusedBindings;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
 import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -17,6 +18,7 @@ import org.jdbi.v3.stringtemplate4.UseStringTemplateEngine;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 @RegisterColumnMapper(InstantColumnMapper.class)
@@ -42,6 +44,9 @@ public interface DatasetDAO {
 
     @SqlQuery("SELECT * FROM datasets WHERE id = :id AND workspace_id = :workspace_id")
     Optional<Dataset> findById(@Bind("id") UUID id, @Bind("workspace_id") String workspaceId);
+
+    @SqlQuery("SELECT * FROM datasets WHERE id IN (<ids>) AND workspace_id = :workspace_id")
+    List<Dataset> findByIds(@BindList("ids") Set<UUID> ids, @Bind("workspace_id") String workspaceId);
 
     @SqlUpdate("DELETE FROM datasets WHERE id = :id AND workspace_id = :workspace_id")
     void delete(@Bind("id") UUID id, @Bind("workspace_id") String workspaceId);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -89,7 +89,7 @@ class ExperimentsResourceTest {
     private static final String API_KEY = UUID.randomUUID().toString();
 
     private static final String[] EXPERIMENT_IGNORED_FIELDS = new String[]{
-            "id", "datasetName", "datasetId", "feedbackScores", "traceCount", "createdAt", "lastUpdatedAt", "createdBy",
+            "id", "datasetId", "feedbackScores", "traceCount", "createdAt", "lastUpdatedAt", "createdBy",
             "lastUpdatedBy"};
 
     public static final String[] IGNORED_FIELDS = {"input", "output", "feedbackScores", "createdAt", "lastUpdatedAt",
@@ -1588,7 +1588,6 @@ class ExperimentsResourceTest {
     private void assertIgnoredFields(
             Experiment actualExperiment, Experiment expectedExperiment, UUID expectedDatasetId) {
         assertThat(actualExperiment.id()).isEqualTo(expectedExperiment.id());
-        assertThat(actualExperiment.datasetName()).isNull();
         if (null != expectedDatasetId) {
             assertThat(actualExperiment.datasetId()).isEqualTo(expectedDatasetId);
         } else {


### PR DESCRIPTION
## Details
Applies to the two existing endpoints:
- Get experiment by ID.
- Find experiments.

Datasets are stored in MySQL whereas experiments are in ClickHouse, so there's going to be a performance penalty no matter the implementation.

Implemented the dataset name retrieval in a single DB call in both cases, so there's a single MySQL query per each ClickHouse query.

Nevertheless, it should be fine in production for both endpoints:
- Get experiment by ID: No concern as the size of the response is very small, only one experiment and therefore one dataset is returned.
- Find experiments: it's a paginated call and meant to be used by the UI. As long as the page size has a resonable size, it should be fine. That should always be the case for a UI usage.

## Issues

OPIK-71

## Testing
- Updated and verified integration tests.

## Documentation
N/A