### PR TITLE
NO-JIRA: Expose MySQL for local development

### DIFF
--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -4,10 +4,12 @@ set -e
 OPIK_BACKEND="opik-backend"
 OPIK_FRONTEND="opik-frontend"
 OPIK_CLICKHOUSE="clickhouse-opik-clickhouse"
+OPIK_MYSQL="opik-mysql"
 OPIK_FRONTEND_PORT=5173
 OPIK_BACKEND_PORT=8080
 OPIK_OPENAPI_PORT=3003
 OPIK_CLICKHOUSE_PORT=8123
+OPIK_MYSQL_PORT=3306
 DOCKER_REGISTRY_LOCAL="local" 
 BUILD=true
 FE_BUILD=true
@@ -168,5 +170,10 @@ echo "### Port-forward Clickhouse to local host"
 # remove the previous port-forward
 ps -ef | grep "svc/${OPIK_CLICKHOUSE} ${OPIK_CLICKHOUSE_PORT}" | grep -v grep | awk '{print $2}' | xargs kill || true
 kubectl port-forward svc/${OPIK_CLICKHOUSE} ${OPIK_CLICKHOUSE_PORT} &
+
+echo "### Port-forward MySQL to local host"
+# remove the previous port-forward
+ps -ef | grep "svc/${OPIK_MYSQL} ${OPIK_MYSQL_PORT}" | grep -v grep | awk '{print $2}' | xargs kill || true
+kubectl port-forward svc/${OPIK_MYSQL} ${OPIK_MYSQL_PORT} &
 
 echo "Now you can open your browser and connect http://localhost:${OPIK_FRONTEND_PORT}"


### PR DESCRIPTION
## Details
Exposed MySQL port from Minikube to localhost.

This is useful for local development purposes and to make easier debugging.

## Issues

N/A

## Testing
- Connected to MySQL within Minikube running locally and able to send queries and to inspect the schema.

## Documentation
N/A
