### PR TITLE
[NO-JIRA] Span/trace creations in the end of functions execution

### DIFF
--- a/.github/workflows/lib-integration-tests-runner.yml
+++ b/.github/workflows/lib-integration-tests-runner.yml
@@ -16,6 +16,9 @@ on:
           - llama_index
   schedule:
     - cron: "0 0 */1 * *"
+  pull_request:
+    paths:
+    - 'sdks/python/**'
 
 env:
   SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/.github/workflows/lib-integration-tests-runner.yml
+++ b/.github/workflows/lib-integration-tests-runner.yml
@@ -13,6 +13,7 @@ on:
           - all
           - openai
           - langchain
+          - llama_index
   schedule:
     - cron: "0 0 */1 * *"
 
@@ -44,3 +45,10 @@ jobs:
     if: contains(fromJSON('["langchain", "all"]'), needs.init_environment.outputs.LIBS)
     uses: ./.github/workflows/lib-langchain-tests.yml
     secrets: inherit
+  
+  llama_index_tests:
+    needs: [init_environment]
+    if: contains(fromJSON('["llama_index", "all"]'), needs.init_environment.outputs.LIBS)
+    uses: ./.github/workflows/lib-llama-index-tests.yml
+    secrets: inherit
+

--- a/.github/workflows/lib-llama-index-tests.yml
+++ b/.github/workflows/lib-llama-index-tests.yml
@@ -1,0 +1,51 @@
+# Workflow to run Langchain tests
+#
+# Please read inputs to provide correct values.
+#
+name: SDK Lib LLama Index Tests
+run-name: "SDK Lib LLama Index Tests ${{ github.ref_name }} by @${{ github.actor }}"
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  OPENAI_ORG_ID:  ${{ secrets.OPENAI_ORG_ID }}
+on:
+  workflow_call:
+
+jobs:
+  tests:
+    name: LLamaIndex Python ${{matrix.python_version}}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/python
+
+    strategy:
+      fail-fast: true
+      matrix:
+        python_version: ["3.8", "3.12"]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Setup Python ${{matrix.python_version}}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{matrix.python_version}}
+
+      - name: Install opik
+        run: pip install .
+
+      - name: Install test tools
+        run: |
+          cd ./tests
+          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+
+      - name: Install lib
+        run: |
+          cd ./tests
+          pip install --no-cache-dir --disable-pip-version-check -r library_integration/llama_index/requirements.txt
+
+      - name: Run tests
+        run: |
+          cd ./tests/library_integration/llama_index/
+          python -m pytest  -vv .

--- a/sdks/python/examples/decorators.py
+++ b/sdks/python/examples/decorators.py
@@ -1,7 +1,4 @@
-import os
-os.environ["OPIK_URL_OVERRIDE"] = "http://localhost:5173/api"
 from opik import track, flush_tracker
-from opik import opik_context
 
 
 @track()

--- a/sdks/python/examples/decorators.py
+++ b/sdks/python/examples/decorators.py
@@ -1,6 +1,7 @@
 from opik import track, flush_tracker
 from opik import opik_context
 
+
 @track()
 def f3(x):
     # creates span3 attached to trace1 with parent span2

--- a/sdks/python/examples/decorators.py
+++ b/sdks/python/examples/decorators.py
@@ -1,3 +1,5 @@
+import os
+os.environ["OPIK_URL_OVERRIDE"] = "http://localhost:5173/api"
 from opik import track, flush_tracker
 from opik import opik_context
 
@@ -5,8 +7,8 @@ from opik import opik_context
 @track()
 def f3(x):
     # creates span3 attached to trace1 with parent span2
-    span = opik_context.get_current_span()
-    span.update(tags=["f3-tag"])
+    # span = opik_context.get_current_span()
+    # span.update(tags=["f3-tag"])
     print("Done f3")
     return "f3 output"
 

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -93,6 +93,7 @@ class Opik:
             output: The output data for the trace. This can be any valid JSON serializable object.
             metadata: Additional metadata for the trace. This can be any valid JSON serializable object.
             tags: Tags associated with the trace.
+            feedback_scores: The list of feedback score dicts assosiated with the trace. Dicts don't required to have an `id` value.
 
         Returns:
             trace.Trace: The created trace object.
@@ -158,6 +159,7 @@ class Opik:
             output: The output data for the span. This can be any valid JSON serializable object.
             tags: Tags associated with the span.
             usage: Usage data for the span.
+            feedback_scores: The list of feedback score dicts assosiated with the span. Dicts don't required to have an `id` value.
 
         Returns:
             span.Span: The created span object.

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -117,7 +117,7 @@ class Opik:
         if feedback_scores is not None:
             for feedback_score in feedback_scores:
                 feedback_score["id"] = id
-            
+
             self.log_spans_feedback_scores(feedback_scores)
 
         return trace.Trace(
@@ -206,9 +206,8 @@ class Opik:
         if feedback_scores is not None:
             for feedback_score in feedback_scores:
                 feedback_score["id"] = id
-            
-            self.log_spans_feedback_scores(feedback_scores)
 
+            self.log_spans_feedback_scores(feedback_scores)
 
         return span.Span(
             id=id,

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -119,7 +119,7 @@ class Opik:
             for feedback_score in feedback_scores:
                 feedback_score["id"] = id
 
-            self.log_spans_feedback_scores(feedback_scores)
+            self.log_traces_feedback_scores(feedback_scores)
 
         return trace.Trace(
             id=id,

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -79,6 +79,7 @@ class Opik:
         output: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         tags: Optional[List[str]] = None,
+        feedback_scores: Optional[List[FeedbackScoreDict]] = None,
     ) -> trace.Trace:
         """
         Create and log a new trace.
@@ -113,6 +114,12 @@ class Opik:
         )
         self._streamer.put(create_trace_message)
 
+        if feedback_scores is not None:
+            for feedback_score in feedback_scores:
+                feedback_score["id"] = id
+            
+            self.log_spans_feedback_scores(feedback_scores)
+
         return trace.Trace(
             id=id,
             message_streamer=self._streamer,
@@ -133,6 +140,7 @@ class Opik:
         output: Optional[Dict[str, Any]] = None,
         tags: Optional[List[str]] = None,
         usage: Optional[UsageDict] = None,
+        feedback_scores: Optional[List[FeedbackScoreDict]] = None,
     ) -> span.Span:
         """
         Create and log a new span.
@@ -195,6 +203,13 @@ class Opik:
         )
         self._streamer.put(create_span_message)
 
+        if feedback_scores is not None:
+            for feedback_score in feedback_scores:
+                feedback_score["id"] = id
+            
+            self.log_spans_feedback_scores(feedback_scores)
+
+
         return span.Span(
             id=id,
             parent_span_id=parent_span_id,
@@ -209,6 +224,7 @@ class Opik:
 
         Args:
             scores (List[FeedbackScoreDict]): A list of feedback score dictionaries.
+                Specifying a span id via `id` key for each score is mandatory.
 
         Returns:
             None
@@ -249,6 +265,7 @@ class Opik:
 
         Args:
             scores (List[FeedbackScoreDict]): A list of feedback score dictionaries.
+                Specifying a trace id via `id` key for each score is mandatory.
 
         Returns:
             None

--- a/sdks/python/src/opik/api_objects/span.py
+++ b/sdks/python/src/opik/api_objects/span.py
@@ -3,7 +3,7 @@ import dataclasses
 import logging
 
 from typing import Optional, Any, List, Dict
-from ..types import SpanType, UsageDict, DistributedTraceHeadersDict
+from ..types import SpanType, UsageDict, DistributedTraceHeadersDict, FeedbackScoreDict
 
 from ..message_processing import streamer, messages
 from .. import datetime_helpers
@@ -229,6 +229,7 @@ class SpanData:
     output: Optional[Dict[str, Any]] = None
     tags: Optional[List[str]] = None
     usage: Optional[UsageDict] = None
+    feedback_scores: Optional[List[FeedbackScoreDict]] = None
 
     def update(self, **new_data: Any) -> "SpanData":
         for key, value in new_data.items():

--- a/sdks/python/src/opik/api_objects/span.py
+++ b/sdks/python/src/opik/api_objects/span.py
@@ -226,10 +226,16 @@ class SpanData:
     tags: Optional[List[str]] = None
     usage: Optional[UsageDict] = None
 
-    def update(self, new_data: Dict[str, Any]) -> "SpanData":
+    def update(self, **new_data: Any) -> "SpanData":
         for key, value in new_data.items():
-            if value is not None and key in self.__dict__:
-                self.__dict__[key] = value
+            if value is not None:
+                if key in self.__dict__:
+                    self.__dict__[key] = value
+                else:
+                    LOGGER.debug(
+                        "An attempt to update span with parameter name it doesn't have: %s",
+                        key,
+                    )
 
         return self
 

--- a/sdks/python/src/opik/api_objects/span.py
+++ b/sdks/python/src/opik/api_objects/span.py
@@ -212,11 +212,13 @@ class Span:
 @dataclasses.dataclass
 class SpanData:
     trace_id: str
-    id: str
+    id: str = dataclasses.field(default_factory=helpers.generate_id)
     parent_span_id: Optional[str] = None
     name: Optional[str] = None
-    type: Optional[SpanType] = None
-    start_time: Optional[datetime.datetime] = None
+    type: SpanType = "general"
+    start_time: Optional[datetime.datetime] = dataclasses.field(
+        default_factory=datetime_helpers.local_timestamp
+    )
     end_time: Optional[datetime.datetime] = None
     metadata: Optional[Dict[str, Any]] = None
     input: Optional[Dict[str, Any]] = None
@@ -228,5 +230,10 @@ class SpanData:
         for key, value in new_data.items():
             if value is not None and key in self.__dict__:
                 self.__dict__[key] = value
+
+        return self
+
+    def init_end_time(self) -> "SpanData":
+        self.end_time = datetime_helpers.local_timestamp()
 
         return self

--- a/sdks/python/src/opik/api_objects/span.py
+++ b/sdks/python/src/opik/api_objects/span.py
@@ -1,5 +1,7 @@
 import datetime
+import dataclasses
 import logging
+
 from typing import Optional, Any, List, Dict
 from ..types import SpanType, UsageDict, DistributedTraceHeadersDict
 
@@ -205,3 +207,26 @@ class Span:
 
     def get_distributed_trace_headers(self) -> DistributedTraceHeadersDict:
         return {"opik_parent_span_id": self.id, "opik_trace_id": self.trace_id}
+
+
+@dataclasses.dataclass
+class SpanData:
+    trace_id: str
+    id: str
+    parent_span_id: Optional[str] = None
+    name: Optional[str] = None
+    type: Optional[SpanType] = None
+    start_time: Optional[datetime.datetime] = None
+    end_time: Optional[datetime.datetime] = None
+    metadata: Optional[Dict[str, Any]] = None
+    input: Optional[Dict[str, Any]] = None
+    output: Optional[Dict[str, Any]] = None
+    tags: Optional[List[str]] = None
+    usage: Optional[UsageDict] = None
+
+    def update(self, new_data: Dict[str, Any]) -> "SpanData":
+        for key, value in new_data.items():
+            if value is not None and key in self.__dict__:
+                self.__dict__[key] = value
+
+        return self

--- a/sdks/python/src/opik/api_objects/trace.py
+++ b/sdks/python/src/opik/api_objects/trace.py
@@ -3,7 +3,7 @@ import logging
 import dataclasses
 
 from typing import Optional, Any, List, Dict
-from ..types import SpanType, UsageDict
+from ..types import SpanType, UsageDict, FeedbackScoreDict
 from ..message_processing import streamer, messages
 from .. import datetime_helpers
 from . import span, helpers, validation_helpers, constants
@@ -207,6 +207,7 @@ class TraceData:
     input: Optional[Dict[str, Any]] = None
     output: Optional[Dict[str, Any]] = None
     tags: Optional[List[str]] = None
+    feedback_scores: Optional[List[FeedbackScoreDict]] = None
 
     def update(self, **new_data: Any) -> "TraceData":
         for key, value in new_data.items():

--- a/sdks/python/src/opik/api_objects/trace.py
+++ b/sdks/python/src/opik/api_objects/trace.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import dataclasses
 
 from typing import Optional, Any, List, Dict
 from ..types import SpanType, UsageDict
@@ -25,8 +26,6 @@ class Trace:
         self.id = id
         self._streamer = message_streamer
         self._project_name = project_name
-
-        self.created_by: Optional[str] = None
 
     def end(
         self,
@@ -194,3 +193,22 @@ class Trace:
         )
 
         self._streamer.put(add_trace_feedback_batch_message)
+
+
+@dataclasses.dataclass
+class TraceData:
+    id: str
+    name: Optional[str] = None
+    start_time: Optional[datetime.datetime] = None
+    end_time: Optional[datetime.datetime] = None
+    metadata: Optional[Dict[str, Any]] = None
+    input: Optional[Dict[str, Any]] = None
+    output: Optional[Dict[str, Any]] = None
+    tags: Optional[List[str]] = None
+
+    def update(self, new_data: Dict[str, Any]) -> "TraceData":
+        for key, value in new_data.items():
+            if value is not None and key in self.__dict__:
+                self.__dict__[key] = value
+
+        return self

--- a/sdks/python/src/opik/api_objects/trace.py
+++ b/sdks/python/src/opik/api_objects/trace.py
@@ -197,9 +197,11 @@ class Trace:
 
 @dataclasses.dataclass
 class TraceData:
-    id: str
+    id: str = dataclasses.field(default_factory=helpers.generate_id)
     name: Optional[str] = None
-    start_time: Optional[datetime.datetime] = None
+    start_time: Optional[datetime.datetime] = dataclasses.field(
+        default_factory=datetime_helpers.local_timestamp
+    )
     end_time: Optional[datetime.datetime] = None
     metadata: Optional[Dict[str, Any]] = None
     input: Optional[Dict[str, Any]] = None
@@ -211,4 +213,8 @@ class TraceData:
             if value is not None and key in self.__dict__:
                 self.__dict__[key] = value
 
+        return self
+
+    def init_end_time(self) -> "TraceData":
+        self.end_time = datetime_helpers.local_timestamp()
         return self

--- a/sdks/python/src/opik/api_objects/trace.py
+++ b/sdks/python/src/opik/api_objects/trace.py
@@ -208,10 +208,16 @@ class TraceData:
     output: Optional[Dict[str, Any]] = None
     tags: Optional[List[str]] = None
 
-    def update(self, new_data: Dict[str, Any]) -> "TraceData":
+    def update(self, **new_data: Any) -> "TraceData":
         for key, value in new_data.items():
-            if value is not None and key in self.__dict__:
-                self.__dict__[key] = value
+            if value is not None:
+                if key in self.__dict__:
+                    self.__dict__[key] = value
+                else:
+                    LOGGER.debug(
+                        "An attempt to update trace with parameter name it doesn't have: %s",
+                        key,
+                    )
 
         return self
 

--- a/sdks/python/src/opik/context_storage.py
+++ b/sdks/python/src/opik/context_storage.py
@@ -1,22 +1,13 @@
 import contextvars
 
 from typing import List, Optional, Union, Dict, Any
-from .api_objects import trace, span
+from opik.types import SpanData, TraceData
 
-
-_spans_stack_context: contextvars.ContextVar[List[Union[span.Span]]] = (
-    contextvars.ContextVar("spans_stack", default=[])
-)
-
-_current_trace_context: contextvars.ContextVar[Optional[trace.Trace]] = (
-    contextvars.ContextVar("current_trace", default=None)
-)
-
-_current_trace_data_context: contextvars.ContextVar[Optional[Dict[str, Any]]] = (
+_current_trace_data_context: contextvars.ContextVar[Optional[TraceData]] = (
     contextvars.ContextVar("current_trace_data", default=None)
 )
 
-_spans_data_stack_context: contextvars.ContextVar[List[Dict[str, Any]]] = (
+_spans_data_stack_context: contextvars.ContextVar[List[SpanData]] = (
     contextvars.ContextVar("spans_data_stack", default=[])
 )
 
@@ -30,65 +21,16 @@ _spans_data_stack_context: contextvars.ContextVar[List[Dict[str, Any]]] = (
 # of ContextVar.
 #
 # You should append to it like that:
-# spans_stack = spans_stack_context.get().copy()
-# spans_stack_context.set(spans_stack + [new_element])
+# span_data_stack = span_data_stack_context.get().copy()
+# span_data_stack_context.set(span_data_stack + [new_element])
 #
 # And pop like that:
-# spans_stack = spans_stack_context.get().copy()
-# spans_stack_context.set(spans_stack[:-1])
+# span_data_stack = spans_stack_context.get().copy()
+# span_data_stack_context.set(span_data_stack[:-1])
 #
 # The following functions provide an API to work with ContextVars this way
 
-
-# def top_span() -> Optional[span.Span]:
-#     if span_stack_empty():
-#         return None
-
-#     stack = _get_stack()
-#     return stack[-1]
-
-
-# def pop_span() -> Optional[span.Span]:
-#     stack = _get_stack()
-#     _spans_stack_context.set(stack[:-1])
-#     return stack[-1]
-
-
-# def add_span(span: span.Span) -> None:
-#     stack = _get_stack()
-#     _spans_stack_context.set(stack + [span])
-
-
-# def span_stack_empty() -> bool:
-#     return len(_get_stack()) == 0
-
-
-# def _get_stack() -> List[span.Span]:
-#     return _spans_stack_context.get().copy()
-
-
-# def get_trace() -> Optional[trace.Trace]:
-#     trace = _current_trace_context.get()
-#     return trace
-
-
-# def pop_trace() -> Optional[trace.Trace]:
-#     trace = _current_trace_context.get()
-#     set_trace(None)
-#     return trace
-
-
-# def set_trace(trace: Optional[trace.Trace]) -> None:
-#     _current_trace_context.set(trace)
-
-
-# def clear_all() -> None:
-#     _current_trace_context.set(None)
-#     _spans_stack_context.set([])
-
-####################
-
-def top_span_data() -> Optional[Dict]:
+def top_span_data() -> Optional[SpanData]:
     if span_data_stack_empty():
         return None
 
@@ -96,13 +38,13 @@ def top_span_data() -> Optional[Dict]:
     return stack[-1]
 
 
-def pop_span_data() -> Optional[Dict]:
+def pop_span_data() -> Optional[SpanData]:
     stack = _get_data_stack()
     _spans_data_stack_context.set(stack[:-1])
     return stack[-1]
 
 
-def add_span_data(span: Dict) -> None:
+def add_span_data(span: SpanData) -> None:
     stack = _get_data_stack()
     _spans_data_stack_context.set(stack + [span])
 
@@ -111,22 +53,22 @@ def span_data_stack_empty() -> bool:
     return len(_get_data_stack()) == 0
 
 
-def _get_data_stack() -> List[Dict]:
+def _get_data_stack() -> List[SpanData]:
     return _spans_data_stack_context.get().copy()
 
 
-def get_trace_data() -> Optional[Dict]:
+def get_trace_data() -> Optional[TraceData]:
     trace = _current_trace_data_context.get()
     return trace
 
 
-def pop_trace_data() -> Optional[Dict]:
+def pop_trace_data() -> Optional[TraceData]:
     trace = _current_trace_data_context.get()
     set_trace_data(None)
     return trace
 
 
-def set_trace_data(trace: Optional[Dict]) -> None:
+def set_trace_data(trace: Optional[TraceData]) -> None:
     _current_trace_data_context.set(trace)
 
 

--- a/sdks/python/src/opik/context_storage.py
+++ b/sdks/python/src/opik/context_storage.py
@@ -1,6 +1,6 @@
 import contextvars
 
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict, Any
 from .api_objects import trace, span
 
 
@@ -10,6 +10,14 @@ _spans_stack_context: contextvars.ContextVar[List[Union[span.Span]]] = (
 
 _current_trace_context: contextvars.ContextVar[Optional[trace.Trace]] = (
     contextvars.ContextVar("current_trace", default=None)
+)
+
+_current_trace_data_context: contextvars.ContextVar[Optional[Dict[str, Any]]] = (
+    contextvars.ContextVar("current_trace_data", default=None)
+)
+
+_spans_data_stack_context: contextvars.ContextVar[List[Dict[str, Any]]] = (
+    contextvars.ContextVar("spans_data_stack", default=[])
 )
 
 # Read if you are going to change this module.
@@ -32,48 +40,96 @@ _current_trace_context: contextvars.ContextVar[Optional[trace.Trace]] = (
 # The following functions provide an API to work with ContextVars this way
 
 
-def top_span() -> Optional[span.Span]:
-    if span_stack_empty():
+# def top_span() -> Optional[span.Span]:
+#     if span_stack_empty():
+#         return None
+
+#     stack = _get_stack()
+#     return stack[-1]
+
+
+# def pop_span() -> Optional[span.Span]:
+#     stack = _get_stack()
+#     _spans_stack_context.set(stack[:-1])
+#     return stack[-1]
+
+
+# def add_span(span: span.Span) -> None:
+#     stack = _get_stack()
+#     _spans_stack_context.set(stack + [span])
+
+
+# def span_stack_empty() -> bool:
+#     return len(_get_stack()) == 0
+
+
+# def _get_stack() -> List[span.Span]:
+#     return _spans_stack_context.get().copy()
+
+
+# def get_trace() -> Optional[trace.Trace]:
+#     trace = _current_trace_context.get()
+#     return trace
+
+
+# def pop_trace() -> Optional[trace.Trace]:
+#     trace = _current_trace_context.get()
+#     set_trace(None)
+#     return trace
+
+
+# def set_trace(trace: Optional[trace.Trace]) -> None:
+#     _current_trace_context.set(trace)
+
+
+# def clear_all() -> None:
+#     _current_trace_context.set(None)
+#     _spans_stack_context.set([])
+
+####################
+
+def top_span_data() -> Optional[Dict]:
+    if span_data_stack_empty():
         return None
 
-    stack = _get_stack()
+    stack = _get_data_stack()
     return stack[-1]
 
 
-def pop_span() -> Optional[span.Span]:
-    stack = _get_stack()
-    _spans_stack_context.set(stack[:-1])
+def pop_span_data() -> Optional[Dict]:
+    stack = _get_data_stack()
+    _spans_data_stack_context.set(stack[:-1])
     return stack[-1]
 
 
-def add_span(span: span.Span) -> None:
-    stack = _get_stack()
-    _spans_stack_context.set(stack + [span])
+def add_span_data(span: Dict) -> None:
+    stack = _get_data_stack()
+    _spans_data_stack_context.set(stack + [span])
 
 
-def span_stack_empty() -> bool:
-    return len(_get_stack()) == 0
+def span_data_stack_empty() -> bool:
+    return len(_get_data_stack()) == 0
 
 
-def _get_stack() -> List[span.Span]:
-    return _spans_stack_context.get().copy()
+def _get_data_stack() -> List[Dict]:
+    return _spans_data_stack_context.get().copy()
 
 
-def get_trace() -> Optional[trace.Trace]:
-    trace = _current_trace_context.get()
+def get_trace_data() -> Optional[Dict]:
+    trace = _current_trace_data_context.get()
     return trace
 
 
-def pop_trace() -> Optional[trace.Trace]:
-    trace = _current_trace_context.get()
-    set_trace(None)
+def pop_trace_data() -> Optional[Dict]:
+    trace = _current_trace_data_context.get()
+    set_trace_data(None)
     return trace
 
 
-def set_trace(trace: Optional[trace.Trace]) -> None:
-    _current_trace_context.set(trace)
+def set_trace_data(trace: Optional[Dict]) -> None:
+    _current_trace_data_context.set(trace)
 
 
 def clear_all() -> None:
-    _current_trace_context.set(None)
-    _spans_stack_context.set([])
+    _current_trace_data_context.set(None)
+    _spans_data_stack_context.set([])

--- a/sdks/python/src/opik/context_storage.py
+++ b/sdks/python/src/opik/context_storage.py
@@ -1,13 +1,13 @@
 import contextvars
 
-from typing import List, Optional, Union, Dict, Any
-from opik.types import SpanData, TraceData
+from typing import List, Optional
+from opik.api_objects import span, trace
 
-_current_trace_data_context: contextvars.ContextVar[Optional[TraceData]] = (
+_current_trace_data_context: contextvars.ContextVar[Optional[trace.TraceData]] = (
     contextvars.ContextVar("current_trace_data", default=None)
 )
 
-_spans_data_stack_context: contextvars.ContextVar[List[SpanData]] = (
+_spans_data_stack_context: contextvars.ContextVar[List[span.SpanData]] = (
     contextvars.ContextVar("spans_data_stack", default=[])
 )
 
@@ -30,7 +30,8 @@ _spans_data_stack_context: contextvars.ContextVar[List[SpanData]] = (
 #
 # The following functions provide an API to work with ContextVars this way
 
-def top_span_data() -> Optional[SpanData]:
+
+def top_span_data() -> Optional[span.SpanData]:
     if span_data_stack_empty():
         return None
 
@@ -38,13 +39,13 @@ def top_span_data() -> Optional[SpanData]:
     return stack[-1]
 
 
-def pop_span_data() -> Optional[SpanData]:
+def pop_span_data() -> Optional[span.SpanData]:
     stack = _get_data_stack()
     _spans_data_stack_context.set(stack[:-1])
     return stack[-1]
 
 
-def add_span_data(span: SpanData) -> None:
+def add_span_data(span: span.SpanData) -> None:
     stack = _get_data_stack()
     _spans_data_stack_context.set(stack + [span])
 
@@ -53,22 +54,22 @@ def span_data_stack_empty() -> bool:
     return len(_get_data_stack()) == 0
 
 
-def _get_data_stack() -> List[SpanData]:
+def _get_data_stack() -> List[span.SpanData]:
     return _spans_data_stack_context.get().copy()
 
 
-def get_trace_data() -> Optional[TraceData]:
+def get_trace_data() -> Optional[trace.TraceData]:
     trace = _current_trace_data_context.get()
     return trace
 
 
-def pop_trace_data() -> Optional[TraceData]:
+def pop_trace_data() -> Optional[trace.TraceData]:
     trace = _current_trace_data_context.get()
     set_trace_data(None)
     return trace
 
 
-def set_trace_data(trace: Optional[TraceData]) -> None:
+def set_trace_data(trace: Optional[trace.TraceData]) -> None:
     _current_trace_data_context.set(trace)
 
 

--- a/sdks/python/src/opik/decorator/arguments_helpers.py
+++ b/sdks/python/src/opik/decorator/arguments_helpers.py
@@ -17,7 +17,11 @@ class BaseArguments:
 
 
 @dataclasses.dataclass
-class EndSpanArguments(BaseArguments):
+class EndSpanParameters(BaseArguments):
+    """
+    Span data parameters that we set (or might set) when the
+    tracked function is ended.
+    """
     metadata: Optional[Any] = None
     input: Optional[Dict[str, Any]] = None
     output: Optional[Dict[str, Any]] = None
@@ -26,7 +30,11 @@ class EndSpanArguments(BaseArguments):
 
 
 @dataclasses.dataclass
-class StartSpanArguments(BaseArguments):
+class StartSpanParameters(BaseArguments):
+    """
+    Span data parameters that we set (or might set) when the
+    tracked function is started.
+    """
     type: SpanType
     name: str
     tags: Optional[List[str]] = None

--- a/sdks/python/src/opik/decorator/arguments_helpers.py
+++ b/sdks/python/src/opik/decorator/arguments_helpers.py
@@ -6,11 +6,11 @@ import dataclasses
 
 @dataclasses.dataclass
 class BaseArguments:
-    def to_kwargs(self) -> Dict[str, Any]:
+    def to_kwargs(self, ignore_keys: Optional[List[str]] = None) -> Dict[str, Any]:
         result: Dict[str, Any] = {}
-
+        ignore_keys = [] if ignore_keys is None else ignore_keys
         for key, value in self.__dict__.items():
-            if value is not None:
+            if (value is not None) and (key not in ignore_keys):
                 result[key] = value
 
         return result
@@ -28,7 +28,7 @@ class EndSpanArguments(BaseArguments):
 @dataclasses.dataclass
 class StartSpanArguments(BaseArguments):
     type: SpanType
-    name: Optional[str] = None
+    name: str
     tags: Optional[List[str]] = None
     metadata: Optional[Dict[str, Any]] = None
     input: Optional[Dict[str, Any]] = None

--- a/sdks/python/src/opik/decorator/arguments_helpers.py
+++ b/sdks/python/src/opik/decorator/arguments_helpers.py
@@ -22,6 +22,7 @@ class EndSpanParameters(BaseArguments):
     Span data parameters that we set (or might set) when the
     tracked function is ended.
     """
+
     metadata: Optional[Any] = None
     input: Optional[Dict[str, Any]] = None
     output: Optional[Dict[str, Any]] = None
@@ -35,6 +36,7 @@ class StartSpanParameters(BaseArguments):
     Span data parameters that we set (or might set) when the
     tracked function is started.
     """
+
     type: SpanType
     name: str
     tags: Optional[List[str]] = None

--- a/sdks/python/src/opik/decorator/base_track_decorator.py
+++ b/sdks/python/src/opik/decorator/base_track_decorator.py
@@ -282,7 +282,7 @@ class BaseTrackDecorator(abc.ABC):
             )
 
     def _create_span(
-        self, start_span_arguments: arguments_helpers.StartSpanArguments
+        self, start_span_arguments: arguments_helpers.StartSpanParameters
     ) -> None:
         """
         Handles different span creation flows.
@@ -361,7 +361,7 @@ class BaseTrackDecorator(abc.ABC):
 
     def _create_distributed_node_root_span(
         self,
-        start_span_arguments: arguments_helpers.StartSpanArguments,
+        start_span_arguments: arguments_helpers.StartSpanParameters,
         distributed_trace_headers: DistributedTraceHeadersDict,
     ) -> None:
         span_data = span.SpanData(
@@ -390,7 +390,7 @@ class BaseTrackDecorator(abc.ABC):
                     capture_output=capture_output,
                 )
             else:
-                end_arguments = arguments_helpers.EndSpanArguments()
+                end_arguments = arguments_helpers.EndSpanParameters()
 
             if generators_span_to_end is None:
                 span_data_to_end, trace_data_to_end = pop_end_candidates()
@@ -466,14 +466,14 @@ class BaseTrackDecorator(abc.ABC):
         capture_input: bool,
         args: Tuple,
         kwargs: Dict[str, Any],
-    ) -> arguments_helpers.StartSpanArguments: ...
+    ) -> arguments_helpers.StartSpanParameters: ...
 
     @abc.abstractmethod
     def _end_span_inputs_preprocessor(
         self,
         output: Optional[Any],
         capture_output: bool,
-    ) -> arguments_helpers.EndSpanArguments: ...
+    ) -> arguments_helpers.EndSpanParameters: ...
 
 
 def pop_end_candidates() -> Tuple[span.SpanData, Optional[trace.TraceData]]:

--- a/sdks/python/src/opik/decorator/base_track_decorator.py
+++ b/sdks/python/src/opik/decorator/base_track_decorator.py
@@ -399,22 +399,16 @@ class BaseTrackDecorator(abc.ABC):
                     generators_span_to_end,
                     generators_trace_to_end,
                 )
-            span_data_to_end.update(
-                {
-                    "end_time": datetime_helpers.local_timestamp(),
-                    **end_arguments.to_kwargs(),
-                }
+            span_data_to_end.init_end_time().update(
+                **end_arguments.to_kwargs(),
             )
 
             client = opik_client.get_client_cached()
             client.span(**span_data_to_end.__dict__)
 
             if trace_data_to_end is not None:
-                trace_data_to_end.update(
-                    {
-                        "end_time": datetime_helpers.local_timestamp(),
-                        **end_arguments.to_kwargs(ignore_keys=["usage"]),
-                    }
+                trace_data_to_end.init_end_time().update(
+                    **end_arguments.to_kwargs(ignore_keys=["usage"]),
                 )
 
                 client.trace(**trace_data_to_end.__dict__)

--- a/sdks/python/src/opik/decorator/generator_wrappers.py
+++ b/sdks/python/src/opik/decorator/generator_wrappers.py
@@ -1,6 +1,5 @@
 from typing import Generator, Protocol, Any, AsyncGenerator, Optional, Callable, List
 from opik.api_objects import span, trace
-
 import logging
 from opik import logging_messages
 
@@ -12,16 +11,16 @@ class FinishGeneratorCallback(Protocol):
         self,
         output: Any,
         capture_output: bool,
-        generators_span_to_end: Optional[span.Span] = None,
-        generators_trace_to_end: Optional[trace.Trace] = None,
+        generators_span_to_end: Optional[span.SpanData] = None,
+        generators_trace_to_end: Optional[trace.TraceData] = None,
     ) -> None: ...
 
 
 def wrap_sync_generator(
     generator: Generator,
     capture_output: bool,
-    span_to_end: span.Span,
-    trace_to_end: Optional[trace.Trace],
+    span_to_end: span.SpanData,
+    trace_to_end: Optional[trace.TraceData],
     generations_aggregator: Optional[Callable[[List[Any]], str]],
     finally_callback: FinishGeneratorCallback,
 ) -> Generator[Any, None, None]:
@@ -47,8 +46,8 @@ def wrap_sync_generator(
 async def wrap_async_generator(
     generator: AsyncGenerator,
     capture_output: bool,
-    span_to_end: span.Span,
-    trace_to_end: Optional[trace.Trace],
+    span_to_end: span.SpanData,
+    trace_to_end: Optional[trace.TraceData],
     generations_aggregator: Optional[Callable[[List[Any]], str]],
     finally_callback: FinishGeneratorCallback,
 ) -> AsyncGenerator[Any, None]:

--- a/sdks/python/src/opik/decorator/tracker.py
+++ b/sdks/python/src/opik/decorator/tracker.py
@@ -26,7 +26,7 @@ class OpikTrackDecorator(base_track_decorator.BaseTrackDecorator):
         capture_input: bool,
         args: Tuple,
         kwargs: Dict[str, Any],
-    ) -> arguments_helpers.StartSpanArguments:
+    ) -> arguments_helpers.StartSpanParameters:
         input = (
             inspect_helpers.extract_inputs(func, args, kwargs)
             if capture_input
@@ -35,7 +35,7 @@ class OpikTrackDecorator(base_track_decorator.BaseTrackDecorator):
 
         name = name if name is not None else func.__name__
 
-        result = arguments_helpers.StartSpanArguments(
+        result = arguments_helpers.StartSpanParameters(
             name=name, input=input, type=type, tags=tags, metadata=metadata
         )
 
@@ -43,13 +43,13 @@ class OpikTrackDecorator(base_track_decorator.BaseTrackDecorator):
 
     def _end_span_inputs_preprocessor(
         self, output: Any, capture_output: bool
-    ) -> arguments_helpers.EndSpanArguments:
+    ) -> arguments_helpers.EndSpanParameters:
         output = output if capture_output else None
 
         if output is not None and not isinstance(output, dict):
             output = {"output": output}
 
-        result = arguments_helpers.EndSpanArguments(output=output)
+        result = arguments_helpers.EndSpanParameters(output=output)
 
         return result
 

--- a/sdks/python/src/opik/dict_utils.py
+++ b/sdks/python/src/opik/dict_utils.py
@@ -33,7 +33,7 @@ def deepmerge(
     return merged
 
 
-def remove_none_from_dict(original: Mapping[str, Optional[Any]]) -> Dict[str, Any]:
+def remove_none_from_dict(original: Mapping[str, Optional[Any]]) -> Mapping[str, Any]:
     new: Dict[str, Any] = {}
 
     for key, value in original.items():

--- a/sdks/python/src/opik/evaluation/tasks_scorer.py
+++ b/sdks/python/src/opik/evaluation/tasks_scorer.py
@@ -49,7 +49,7 @@ def _process_item(
 
     try:
         trace = client.trace(input=item.input, name="evaluation_task")
-        context_storage.set_trace(trace)
+        context_storage.set_trace_data(trace)
         task_output_ = task(item)
         trace.end(output=task_output_)
 

--- a/sdks/python/src/opik/evaluation/tasks_scorer.py
+++ b/sdks/python/src/opik/evaluation/tasks_scorer.py
@@ -4,8 +4,8 @@ from concurrent import futures
 from typing import List
 from .types import LLMTask
 from opik.api_objects.dataset import dataset, dataset_item
-from opik.api_objects import opik_client
-from opik import context_storage
+from opik.api_objects import opik_client, trace
+from opik import context_storage, opik_context
 
 from . import task_output, test_case, test_result
 from .metrics import score_result, base_metric
@@ -48,13 +48,16 @@ def _process_item(
     assert item.id is not None
 
     try:
-        trace = client.trace(input=item.input, name="evaluation_task")
-        context_storage.set_trace_data(trace)
+        trace_data = trace.TraceData(
+            input=item.input,
+            name="evaluation_task",
+        )
+        context_storage.set_trace_data(trace_data)
         task_output_ = task(item)
-        trace.end(output=task_output_)
+        opik_context.update_current_trace(output=task_output_)
 
         test_case_ = test_case.TestCase(
-            trace_id=trace.id,
+            trace_id=trace_data.id,
             dataset_item_id=item.id,
             task_output=task_output.TaskOutput(**task_output_),
         )
@@ -66,7 +69,10 @@ def _process_item(
         return test_result_
 
     finally:
-        context_storage.pop_trace()
+        trace_data = context_storage.pop_trace_data()  # type: ignore
+        assert trace_data is not None
+        trace_data.init_end_time()
+        client.trace(**trace_data.__dict__)
 
 
 def run(

--- a/sdks/python/src/opik/integrations/langchain/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/langchain/opik_tracer.py
@@ -58,12 +58,12 @@ class OpikTracer(BaseTracer):
         run_dict: Dict[str, Any] = run.dict()
 
         span_data = self._span_data_map[run.id]
-        span_data.init_end_time().update({"output": run_dict["outputs"]})
+        span_data.init_end_time().update(output=run_dict["outputs"])
         self._opik_client.span(**span_data.__dict__)
 
         if span_data.trace_id not in self._externally_created_traces_ids:
             trace_data = self._created_traces_data_map[run.id]
-            trace_data.init_end_time().update({"output": run_dict["outputs"]})
+            trace_data.init_end_time().update(output=run_dict["outputs"])
             trace_ = self._opik_client.trace(**trace_data.__dict__)
             self._created_traces.append(trace_)
 
@@ -185,7 +185,8 @@ class OpikTracer(BaseTracer):
                 usage = None
 
             span_data.init_end_time().update(
-                {"output": run_dict["outputs"], "usage": usage}
+                output=run_dict["outputs"],
+                usage=usage,
             )
             self._opik_client.span(**span_data.__dict__)
 

--- a/sdks/python/src/opik/integrations/llama_index/callback.py
+++ b/sdks/python/src/opik/integrations/llama_index/callback.py
@@ -68,7 +68,7 @@ class LlamaIndexCallbackHandler(base_handler.BaseCallbackHandler):
 
         # And then end the trace with the optional output
         if self._opik_trace_data:
-            self._opik_trace_data.init_end_time().update({"output": last_event_output})
+            self._opik_trace_data.init_end_time().update(output=last_event_output)
             self._opik_client.trace(**self._opik_trace_data.__dict__)
             self._opik_trace_data = None
 
@@ -112,7 +112,7 @@ class LlamaIndexCallbackHandler(base_handler.BaseCallbackHandler):
 
         # If the parent_id is a BASE_TRACE_EVENT, update the trace with the span input
         if parent_id == llama_index_schema.BASE_TRACE_EVENT and span_input:
-            self._opik_trace_data.update(dict(input=span_input))
+            self._opik_trace_data.update(input=span_input)
 
         return event_id
 
@@ -134,5 +134,5 @@ class LlamaIndexCallbackHandler(base_handler.BaseCallbackHandler):
             # Log the output to the span with the matching id
             if event_id in self._map_event_id_to_span_data:
                 span_data = self._map_event_id_to_span_data[event_id]
-                span_data.update({"output": span_output}).init_end_time()
+                span_data.update(output=span_output).init_end_time()
                 self._opik_client.span(**span_data.__dict__)

--- a/sdks/python/src/opik/integrations/llama_index/callback.py
+++ b/sdks/python/src/opik/integrations/llama_index/callback.py
@@ -32,7 +32,9 @@ class LlamaIndexCallbackHandler(base_handler.BaseCallbackHandler):
         self._map_event_id_to_output: Dict[str, Any] = {}
 
     def _create_trace_data(self, trace_name: Optional[str]) -> trace.TraceData:
-        trace_data = trace.TraceData(name=trace_name, metadata={"created_from": "llama_index"})
+        trace_data = trace.TraceData(
+            name=trace_name, metadata={"created_from": "llama_index"}
+        )
         return trace_data
 
     def start_trace(self, trace_id: Optional[str] = None) -> None:
@@ -102,9 +104,7 @@ class LlamaIndexCallbackHandler(base_handler.BaseCallbackHandler):
             name=event_type.value,
             parent_span_id=opik_parent_id,
             type=(
-                "llm"
-                if event_type == llama_index_schema.CBEventType.LLM
-                else "general"
+                "llm" if event_type == llama_index_schema.CBEventType.LLM else "general"
             ),
             input=span_input,
         )

--- a/sdks/python/src/opik/integrations/llama_index/callback.py
+++ b/sdks/python/src/opik/integrations/llama_index/callback.py
@@ -134,4 +134,5 @@ class LlamaIndexCallbackHandler(base_handler.BaseCallbackHandler):
             # Log the output to the span with the matching id
             if event_id in self._map_event_id_to_span_data:
                 span_data = self._map_event_id_to_span_data[event_id]
+                span_data.update({"output": span_output}).init_end_time()
                 self._opik_client.span(**span_data.__dict__)

--- a/sdks/python/src/opik/integrations/llama_index/callback.py
+++ b/sdks/python/src/opik/integrations/llama_index/callback.py
@@ -136,3 +136,7 @@ class LlamaIndexCallbackHandler(base_handler.BaseCallbackHandler):
                 span_data = self._map_event_id_to_span_data[event_id]
                 span_data.update(output=span_output).init_end_time()
                 self._opik_client.span(**span_data.__dict__)
+
+    def flush(self):
+        """Sends pending Opik data to the backend"""
+        self._opik_client.flush()

--- a/sdks/python/src/opik/integrations/llama_index/callback.py
+++ b/sdks/python/src/opik/integrations/llama_index/callback.py
@@ -137,6 +137,6 @@ class LlamaIndexCallbackHandler(base_handler.BaseCallbackHandler):
                 span_data.update(output=span_output).init_end_time()
                 self._opik_client.span(**span_data.__dict__)
 
-    def flush(self):
+    def flush(self) -> None:
         """Sends pending Opik data to the backend"""
         self._opik_client.flush()

--- a/sdks/python/src/opik/integrations/llama_index/callback.py
+++ b/sdks/python/src/opik/integrations/llama_index/callback.py
@@ -26,24 +26,22 @@ class LlamaIndexCallbackHandler(base_handler.BaseCallbackHandler):
         )
 
         self._opik_client = opik_client.get_client_cached()
-        self._opik_trace: Optional[trace.Trace] = None
+        self._opik_trace_data: Optional[trace.TraceData] = None
 
-        self._map_event_id_to_span: Dict[str, span.Span] = {}
+        self._map_event_id_to_span_data: Dict[str, span.SpanData] = {}
         self._map_event_id_to_output: Dict[str, Any] = {}
 
-    def _create_trace(self, trace_name: Optional[str]) -> trace.Trace:
-        trace = self._opik_client.trace(
-            name=trace_name, metadata={"created_from": "llama_index"}
-        )
-        return trace
+    def _create_trace_data(self, trace_name: Optional[str]) -> trace.TraceData:
+        trace_data = trace.TraceData(name=trace_name, metadata={"created_from": "llama_index"})
+        return trace_data
 
     def start_trace(self, trace_id: Optional[str] = None) -> None:
         # When a new LLama Index trace is started, create a new trace in Opik
-        existing_trace = opik_context.get_current_trace()
-        if existing_trace:
-            self._opik_trace = existing_trace
+        existing_trace_data = opik_context.get_current_trace_data()
+        if existing_trace_data:
+            self._opik_trace_data = existing_trace_data
         else:
-            self._opik_trace = self._create_trace(trace_name=trace_id)
+            self._opik_trace_data = self._create_trace_data(trace_name=trace_id)
 
     def _get_last_event(self, trace_map: Dict[str, List[str]]) -> str:
         def dfs(key: str) -> str:
@@ -67,9 +65,10 @@ class LlamaIndexCallbackHandler(base_handler.BaseCallbackHandler):
         last_event_output = self._map_event_id_to_output.get(last_event, None)
 
         # And then end the trace with the optional output
-        if self._opik_trace:
-            self._opik_trace.end(output=last_event_output)
-            self._opik_trace = None
+        if self._opik_trace_data:
+            self._opik_trace_data.init_end_time().update({"output": last_event_output})
+            self._opik_client.trace(**self._opik_trace_data.__dict__)
+            self._opik_trace_data = None
 
     def on_event_start(
         self,
@@ -85,12 +84,12 @@ class LlamaIndexCallbackHandler(base_handler.BaseCallbackHandler):
         # Under some scenarios, it is possible for `start_trace` to not be called (for example if
         # the callback raises an exception in a previous call).
         # Unclear what the best behavior is here, so for now we'll just create a new trace when
-        if self._opik_trace is None:
-            self._opik_trace = self._create_trace(trace_name=parent_id)
+        if self._opik_trace_data is None:
+            self._opik_trace_data = self._create_trace_data(trace_name=parent_id)
 
         # Get parent span Id if it exists
-        if parent_id and parent_id in self._map_event_id_to_span:
-            opik_parent_id = self._map_event_id_to_span[parent_id].id
+        if parent_id and parent_id in self._map_event_id_to_span_data:
+            opik_parent_id = self._map_event_id_to_span_data[parent_id].id
         else:
             opik_parent_id = None
 
@@ -98,20 +97,22 @@ class LlamaIndexCallbackHandler(base_handler.BaseCallbackHandler):
         span_input = event_parsing_utils.get_span_input_from_events(event_type, payload)
 
         # Create a new span for this event
-        span = self._opik_client.span(
-            trace_id=self._opik_trace.id,
+        span_data = span.SpanData(
+            trace_id=self._opik_trace_data.id,
             name=event_type.value,
             parent_span_id=opik_parent_id,
-            type="llm"
-            if event_type == llama_index_schema.CBEventType.LLM
-            else "general",
+            type=(
+                "llm"
+                if event_type == llama_index_schema.CBEventType.LLM
+                else "general"
+            ),
             input=span_input,
         )
-        self._map_event_id_to_span[event_id] = span
+        self._map_event_id_to_span_data[event_id] = span_data
 
         # If the parent_id is a BASE_TRACE_EVENT, update the trace with the span input
         if parent_id == llama_index_schema.BASE_TRACE_EVENT and span_input:
-            self._opik_trace.update(input=span_input)
+            self._opik_trace_data.update(dict(input=span_input))
 
         return event_id
 
@@ -131,6 +132,6 @@ class LlamaIndexCallbackHandler(base_handler.BaseCallbackHandler):
             self._map_event_id_to_output[event_id] = span_output
 
             # Log the output to the span with the matching id
-            if event_id in self._map_event_id_to_span:
-                span = self._map_event_id_to_span[event_id]
-                span.end(output=span_output)
+            if event_id in self._map_event_id_to_span_data:
+                span_data = self._map_event_id_to_span_data[event_id]
+                self._opik_client.span(**span_data.__dict__)

--- a/sdks/python/src/opik/integrations/openai/openai_decorator.py
+++ b/sdks/python/src/opik/integrations/openai/openai_decorator.py
@@ -33,7 +33,7 @@ class OpenaiTrackDecorator(base_track_decorator.BaseTrackDecorator):
         capture_input: bool,
         args: Optional[Tuple],
         kwargs: Optional[Dict[str, Any]],
-    ) -> arguments_helpers.StartSpanArguments:
+    ) -> arguments_helpers.StartSpanParameters:
         assert (
             kwargs is not None
         ), "Expected kwargs to be not None in OpenAI().chat.completion.create(**kwargs)"
@@ -54,7 +54,7 @@ class OpenaiTrackDecorator(base_track_decorator.BaseTrackDecorator):
 
         tags = ["openai"]
 
-        result = arguments_helpers.StartSpanArguments(
+        result = arguments_helpers.StartSpanParameters(
             name=name, input=input, type=type, tags=tags, metadata=metadata
         )
 
@@ -62,7 +62,7 @@ class OpenaiTrackDecorator(base_track_decorator.BaseTrackDecorator):
 
     def _end_span_inputs_preprocessor(
         self, output: Any, capture_output: bool
-    ) -> arguments_helpers.EndSpanArguments:
+    ) -> arguments_helpers.EndSpanParameters:
         assert isinstance(
             output,
             (chat_completion.ChatCompletion, chunks_aggregator.ExtractedStreamContent),
@@ -80,7 +80,7 @@ class OpenaiTrackDecorator(base_track_decorator.BaseTrackDecorator):
             usage = output.usage
             output = {"choices": output.choices}
 
-        result = arguments_helpers.EndSpanArguments(output=output, usage=usage)
+        result = arguments_helpers.EndSpanParameters(output=output, usage=usage)
 
         return result
 

--- a/sdks/python/src/opik/integrations/openai/stream_wrappers.py
+++ b/sdks/python/src/opik/integrations/openai/stream_wrappers.py
@@ -11,8 +11,8 @@ LOGGER = logging.getLogger(__name__)
 def wrap_sync_stream(
     generator: openai.Stream,
     capture_output: bool,
-    span_to_end: span.Span,
-    trace_to_end: Optional[trace.Trace],
+    span_to_end: span.SpanData,
+    trace_to_end: Optional[trace.TraceData],
     generations_aggregator: Callable[[List[Any]], Any],
     finally_callback: generator_wrappers.FinishGeneratorCallback,
 ) -> Generator[Any, None, None]:
@@ -37,8 +37,8 @@ def wrap_sync_stream(
 async def wrap_async_stream(
     generator: openai.AsyncStream,
     capture_output: bool,
-    span_to_end: span.Span,
-    trace_to_end: Optional[trace.Trace],
+    span_to_end: span.SpanData,
+    trace_to_end: Optional[trace.TraceData],
     generations_aggregator: Callable[[List[Any]], Any],
     finally_callback: generator_wrappers.FinishGeneratorCallback,
 ) -> AsyncGenerator[Any, None]:

--- a/sdks/python/src/opik/opik_context.py
+++ b/sdks/python/src/opik/opik_context.py
@@ -30,6 +30,11 @@ def get_current_trace_data() -> Optional[trace.TraceData]:
 
 
 def get_distributed_trace_headers() -> DistributedTraceHeadersDict:
+    """
+    Returns headers dictionary to be passed into tracked
+    function on remote node.
+    Requires an existing span in the context, otherwise raises an error.
+    """
     current_span_data = context_storage.top_span_data()
 
     if current_span_data is None:

--- a/sdks/python/src/opik/opik_context.py
+++ b/sdks/python/src/opik/opik_context.py
@@ -1,31 +1,78 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Dict, Any, List
+from opik.types import UsageDict
 
-from . import context_storage
+from . import context_storage, dict_utils
 
 if TYPE_CHECKING:
     from .api_objects import trace, span
 
 
-def get_current_span() -> Optional["span.Span"]:
+def get_current_span_data() -> Optional[Dict[str, Any]]:
     """
     Returns current span created by track() decorator or None if no span was found.
     Context-wise.
     """
-    if context_storage.span_stack_empty():
+    if context_storage.span_data_stack_empty():
         return None
 
-    return context_storage.top_span()
+    return dict(context_storage.top_span_data())
 
 
-def get_current_trace() -> Optional["trace.Trace"]:
+def get_current_trace_data() -> Optional[Dict[str, Any]]:
     """
     Returns current trace created by track() decorator or None if no trace was found.
     Context-wise.
     """
-    return context_storage.get_trace()
+    return dict(context_storage.get_trace_data())
+
+
+def update_current_span(
+    input: Optional[Dict[str, Any]] = None,
+    output: Optional[Dict[str, Any]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    tags: Optional[List[str]] = None,
+    usage: Optional[UsageDict] = None,
+):
+    new_params = dict_utils.remove_none_from_dict(
+        {
+            "input": input,
+            "output": output,
+            "metadata": metadata,
+            "tags": tags,
+            "usage": usage
+        }
+    )
+    current_span_data = context_storage.top_span_data()
+    if current_span_data is None:
+        raise Exception("There is no span in the context.")  # TODO: add proper exception
+
+    current_span_data.update(new_params)
+        
+
+def update_current_trace(
+    input: Optional[Dict[str, Any]] = None,
+    output: Optional[Dict[str, Any]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    tags: Optional[List[str]] = None,
+):
+    new_params = dict_utils.remove_none_from_dict(
+        {
+            "input": input,
+            "output": output,
+            "metadata": metadata,
+            "tags": tags,
+        }
+    )
+    current_trace_data = context_storage.get_trace_data()
+    if current_trace_data is None:
+        raise Exception("There is no trace in the context.")  # TODO: add proper exception
+    
+    current_trace_data.update(new_params)
 
 
 __all__ = [
-    "get_current_span",
-    "get_current_trace",
+    "get_current_span_data",
+    "get_current_trace_data",
+    "update_current_span",
+    "update_current_trace",
 ]

--- a/sdks/python/src/opik/opik_context.py
+++ b/sdks/python/src/opik/opik_context.py
@@ -1,5 +1,5 @@
 from typing import Optional, Dict, Any, List
-from opik.types import UsageDict, DistributedTraceHeadersDict
+from opik.types import UsageDict, DistributedTraceHeadersDict, FeedbackScoreDict
 from opik.api_objects import span, trace
 
 from . import context_storage, exceptions
@@ -53,6 +53,7 @@ def update_current_span(
     metadata: Optional[Dict[str, Any]] = None,
     tags: Optional[List[str]] = None,
     usage: Optional[UsageDict] = None,
+    feedback_scores: Optional[List[FeedbackScoreDict]] = None,
 ) -> None:
     new_params = {
         "name": name,
@@ -61,6 +62,7 @@ def update_current_span(
         "metadata": metadata,
         "tags": tags,
         "usage": usage,
+        "feedback_scores": feedback_scores,
     }
     current_span_data = context_storage.top_span_data()
     if current_span_data is None:
@@ -75,6 +77,7 @@ def update_current_trace(
     output: Optional[Dict[str, Any]] = None,
     metadata: Optional[Dict[str, Any]] = None,
     tags: Optional[List[str]] = None,
+    feedback_scores: Optional[List[FeedbackScoreDict]] = None,
 ) -> None:
     new_params = {
         "name": name,
@@ -82,6 +85,7 @@ def update_current_trace(
         "output": output,
         "metadata": metadata,
         "tags": tags,
+        "feedback_scores": feedback_scores,
     }
     current_trace_data = context_storage.get_trace_data()
     if current_trace_data is None:

--- a/sdks/python/src/opik/opik_context.py
+++ b/sdks/python/src/opik/opik_context.py
@@ -1,5 +1,5 @@
 from typing import Optional, Dict, Any, List
-from opik.types import UsageDict, DistributedTraceHeadersDict
+from opik.types import UsageDict, DistributedTraceHeadersDict, SpanData, TraceData
 
 from . import context_storage, dict_utils, exceptions
 

--- a/sdks/python/src/opik/opik_context.py
+++ b/sdks/python/src/opik/opik_context.py
@@ -1,29 +1,32 @@
 from typing import Optional, Dict, Any, List
-from opik.types import UsageDict, DistributedTraceHeadersDict, SpanData, TraceData
+from opik.types import UsageDict, DistributedTraceHeadersDict
+from opik.api_objects import span, trace
 
-from . import context_storage, dict_utils, exceptions
+from . import context_storage, exceptions
 
 
-def get_current_span_data() -> Optional[Dict[str, Any]]:
+def get_current_span_data() -> Optional[span.SpanData]:
     """
     Returns current span created by track() decorator or None if no span was found.
     Context-wise.
     """
-    if context_storage.span_data_stack_empty():
+    span_data = context_storage.top_span_data()
+    if span_data is None:
         return None
 
-    return dict(context_storage.top_span_data())
+    return span.SpanData(**span_data.__dict__)
 
 
-def get_current_trace_data() -> Optional[Dict[str, Any]]:
+def get_current_trace_data() -> Optional[trace.TraceData]:
     """
     Returns current trace created by track() decorator or None if no trace was found.
     Context-wise.
     """
-    if context_storage.get_trace_data() is None:
+    trace_data = context_storage.get_trace_data()
+    if trace_data is None:
         return None
-    
-    return dict(context_storage.get_trace_data())
+
+    return trace.TraceData(**trace_data.__dict__)
 
 
 def get_distributed_trace_headers() -> DistributedTraceHeadersDict:
@@ -31,11 +34,12 @@ def get_distributed_trace_headers() -> DistributedTraceHeadersDict:
 
     if current_span_data is None:
         raise Exception("There is no span in the context.")
-    
+
     return DistributedTraceHeadersDict(
-        opik_trace_id=current_span_data["trace_id"],
-        opik_parent_span_id=current_span_data["id"]
+        opik_trace_id=current_span_data.trace_id,
+        opik_parent_span_id=current_span_data.id,
     )
+
 
 def update_current_span(
     input: Optional[Dict[str, Any]] = None,
@@ -43,41 +47,37 @@ def update_current_span(
     metadata: Optional[Dict[str, Any]] = None,
     tags: Optional[List[str]] = None,
     usage: Optional[UsageDict] = None,
-):
-    new_params = dict_utils.remove_none_from_dict(
-        {
-            "input": input,
-            "output": output,
-            "metadata": metadata,
-            "tags": tags,
-            "usage": usage
-        }
-    )
+) -> None:
+    new_params = {
+        "input": input,
+        "output": output,
+        "metadata": metadata,
+        "tags": tags,
+        "usage": usage,
+    }
     current_span_data = context_storage.top_span_data()
     if current_span_data is None:
-        raise exceptions.OpikException("There is no span in the context.")  # TODO: add proper exception
+        raise exceptions.OpikException("There is no span in the context.")
 
     current_span_data.update(new_params)
-        
+
 
 def update_current_trace(
     input: Optional[Dict[str, Any]] = None,
     output: Optional[Dict[str, Any]] = None,
     metadata: Optional[Dict[str, Any]] = None,
     tags: Optional[List[str]] = None,
-):
-    new_params = dict_utils.remove_none_from_dict(
-        {
-            "input": input,
-            "output": output,
-            "metadata": metadata,
-            "tags": tags,
-        }
-    )
+) -> None:
+    new_params = {
+        "input": input,
+        "output": output,
+        "metadata": metadata,
+        "tags": tags,
+    }
     current_trace_data = context_storage.get_trace_data()
     if current_trace_data is None:
-        raise exceptions.OpikException("There is no trace in the context.")  # TODO: add proper exception
-    
+        raise exceptions.OpikException("There is no trace in the context.")
+
     current_trace_data.update(new_params)
 
 

--- a/sdks/python/src/opik/opik_context.py
+++ b/sdks/python/src/opik/opik_context.py
@@ -42,6 +42,7 @@ def get_distributed_trace_headers() -> DistributedTraceHeadersDict:
 
 
 def update_current_span(
+    name: Optional[str] = None,
     input: Optional[Dict[str, Any]] = None,
     output: Optional[Dict[str, Any]] = None,
     metadata: Optional[Dict[str, Any]] = None,
@@ -49,6 +50,7 @@ def update_current_span(
     usage: Optional[UsageDict] = None,
 ) -> None:
     new_params = {
+        "name": name,
         "input": input,
         "output": output,
         "metadata": metadata,
@@ -59,16 +61,18 @@ def update_current_span(
     if current_span_data is None:
         raise exceptions.OpikException("There is no span in the context.")
 
-    current_span_data.update(new_params)
+    current_span_data.update(**new_params)
 
 
 def update_current_trace(
+    name: Optional[str] = None,
     input: Optional[Dict[str, Any]] = None,
     output: Optional[Dict[str, Any]] = None,
     metadata: Optional[Dict[str, Any]] = None,
     tags: Optional[List[str]] = None,
 ) -> None:
     new_params = {
+        "name": name,
         "input": input,
         "output": output,
         "metadata": metadata,
@@ -78,7 +82,7 @@ def update_current_trace(
     if current_trace_data is None:
         raise exceptions.OpikException("There is no trace in the context.")
 
-    current_trace_data.update(new_params)
+    current_trace_data.update(**new_params)
 
 
 __all__ = [

--- a/sdks/python/src/opik/plugins/pytest/decorator.py
+++ b/sdks/python/src/opik/plugins/pytest/decorator.py
@@ -44,10 +44,10 @@ def llm_unit(
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             try:
-                test_trace = opik_context.get_current_trace()
-                test_span = opik_context.get_current_span()
+                test_trace_data = opik_context.get_current_trace_data()
+                test_span_data = opik_context.get_current_span_data()
                 assert (
-                    test_trace is not None and test_span is not None
+                    test_trace_data is not None and test_span_data is not None
                 ), "Must not be None here by design assumption"
 
                 node_id: str = _get_test_nodeid()
@@ -62,12 +62,16 @@ def llm_unit(
 
                 trace_input = {**test_run_content_.input}
                 trace_input.pop("test_name")  # we don't need it in traces
-                test_trace.update(
-                    input=trace_input, metadata=test_run_content_.metadata
+                opik_context.update_current_trace(
+                    input=trace_input,
+                    metadata=test_run_content_.metadata,
                 )
-                test_span.update(input=trace_input, metadata=test_run_content_.metadata)
+                opik_context.update_current_span(
+                    input=trace_input,
+                    metadata=test_run_content_.metadata,
+                )
 
-                test_runs_storage.TEST_RUNS_TRACES[node_id] = test_trace
+                test_runs_storage.TEST_RUNS_TO_TRACE_DATA[node_id] = test_trace_data
                 test_runs_storage.TEST_RUNS_CONTENTS[node_id] = test_run_content_
             except Exception:
                 LOGGER.error(

--- a/sdks/python/src/opik/plugins/pytest/experiment_runner.py
+++ b/sdks/python/src/opik/plugins/pytest/experiment_runner.py
@@ -52,7 +52,9 @@ def run(client: opik_client.Opik, test_items: List[Item]) -> None:
 
     for test_item in test_items:
         test_run_content = test_runs_storage.TEST_RUNS_CONTENTS[test_item.nodeid]
-        test_run_trace_id = test_runs_storage.TEST_RUNS_TRACES[test_item.nodeid].id
+        test_run_trace_id = test_runs_storage.TEST_RUNS_TO_TRACE_DATA[
+            test_item.nodeid
+        ].id
 
         dataset_item_id = dataset_item_id_finder(test_run_content)
 

--- a/sdks/python/src/opik/plugins/pytest/hooks.py
+++ b/sdks/python/src/opik/plugins/pytest/hooks.py
@@ -52,9 +52,9 @@ def pytest_sessionfinish(session: "pytest.Session", exitstatus: Any) -> None:
 
         for item in llm_test_items:
             report: "pytest.TestReport" = item.report
-            trace = test_runs_storage.TEST_RUNS_TRACES[item.nodeid]
+            trace_id = test_runs_storage.TEST_RUNS_TO_TRACE_DATA[item.nodeid].id
             traces_feedback_scores.append(
-                {"id": trace.id, "name": "Passed", "value": report.passed}
+                {"id": trace_id, "name": "Passed", "value": report.passed}
             )
 
         client = opik_client.get_client_cached()

--- a/sdks/python/src/opik/plugins/pytest/test_runs_storage.py
+++ b/sdks/python/src/opik/plugins/pytest/test_runs_storage.py
@@ -6,11 +6,11 @@ from . import test_run_content
 
 LLM_UNIT_TEST_RUNS: Set[str] = set()
 
-TEST_RUNS_TRACES: Dict[str, trace.Trace] = {}
+TEST_RUNS_TO_TRACE_DATA: Dict[str, trace.TraceData] = {}
 
 TEST_RUNS_CONTENTS: Dict[str, "test_run_content.TestRunContent"] = {}
 
 
 def clear() -> None:
     TEST_RUNS_CONTENTS.clear()
-    TEST_RUNS_TRACES.clear()
+    TEST_RUNS_TO_TRACE_DATA.clear()

--- a/sdks/python/src/opik/types.py
+++ b/sdks/python/src/opik/types.py
@@ -1,6 +1,7 @@
 import sys
 
-from typing import Literal, Optional
+import datetime
+from typing import Literal, Optional, Dict, Any, List
 from typing_extensions import TypedDict
 
 if sys.version_info < (3, 11):
@@ -58,3 +59,27 @@ class FeedbackScoreDict(TypedDict):
 
     reason: NotRequired[Optional[str]]
     """An optional explanation or justification for the given score."""
+
+
+class SpanData(TypedDict):
+    id: Optional[str]
+    name: Optional[str]
+    type: SpanType
+    start_time: Optional[datetime.datetime]
+    end_time: Optional[datetime.datetime]
+    metadata: Optional[Dict[str, Any]]
+    input: Optional[Dict[str, Any]]
+    output: Optional[Dict[str, Any]]
+    tags: Optional[List[str]]
+    usage: Optional[UsageDict]
+
+
+class TraceData(TypedDict):
+    id: Optional[str]
+    name: Optional[str]
+    start_time: Optional[datetime.datetime]
+    end_time: Optional[datetime.datetime]
+    metadata: Optional[Dict[str, Any]]
+    input: Optional[Dict[str, Any]]
+    output: Optional[Dict[str, Any]]
+    tags: Optional[List[str]]

--- a/sdks/python/src/opik/types.py
+++ b/sdks/python/src/opik/types.py
@@ -1,7 +1,6 @@
 import sys
 
-import datetime
-from typing import Literal, Optional, Dict, Any, List
+from typing import Literal, Optional
 from typing_extensions import TypedDict
 
 if sys.version_info < (3, 11):
@@ -59,27 +58,3 @@ class FeedbackScoreDict(TypedDict):
 
     reason: NotRequired[Optional[str]]
     """An optional explanation or justification for the given score."""
-
-
-class SpanData(TypedDict):
-    id: Optional[str]
-    name: Optional[str]
-    type: SpanType
-    start_time: Optional[datetime.datetime]
-    end_time: Optional[datetime.datetime]
-    metadata: Optional[Dict[str, Any]]
-    input: Optional[Dict[str, Any]]
-    output: Optional[Dict[str, Any]]
-    tags: Optional[List[str]]
-    usage: Optional[UsageDict]
-
-
-class TraceData(TypedDict):
-    id: Optional[str]
-    name: Optional[str]
-    start_time: Optional[datetime.datetime]
-    end_time: Optional[datetime.datetime]
-    metadata: Optional[Dict[str, Any]]
-    input: Optional[Dict[str, Any]]
-    output: Optional[Dict[str, Any]]
-    tags: Optional[List[str]]

--- a/sdks/python/src/opik/types.py
+++ b/sdks/python/src/opik/types.py
@@ -46,7 +46,7 @@ class FeedbackScoreDict(TypedDict):
 
     id: NotRequired[str]
     """
-    A unique identifier for the object this score should be assigned to. 
+    A unique identifier for the object this score should be assigned to.
     Refers to either the trace_id or span_id depending on how the score is logged.
     """
 

--- a/sdks/python/src/opik/types.py
+++ b/sdks/python/src/opik/types.py
@@ -44,8 +44,11 @@ class FeedbackScoreDict(TypedDict):
     an optional reason for the score.
     """
 
-    id: Required[str]
-    """A unique identifier for the object this score should be assigned to. Refers to either the trace_id or span_id depending on how the score is logged."""
+    id: NotRequired[str]
+    """
+    A unique identifier for the object this score should be assigned to. 
+    Refers to either the trace_id or span_id depending on how the score is logged.
+    """
 
     name: Required[str]
     """The name of the feedback metric or criterion."""

--- a/sdks/python/tests/e2e/test_tracing.py
+++ b/sdks/python/tests/e2e/test_tracing.py
@@ -14,8 +14,8 @@ def test_tracked_function__happyflow(opik_client):
         metadata={"outer-metadata-key": "outer-metadata-value"},
     )
     def f_outer(x):
-        ID_STORAGE["f_outer-trace-id"] = opik_context.get_current_trace().id
-        ID_STORAGE["f_outer-span-id"] = opik_context.get_current_span().id
+        ID_STORAGE["f_outer-trace-id"] = opik_context.get_current_trace_data().id
+        ID_STORAGE["f_outer-span-id"] = opik_context.get_current_span_data().id
 
         f_inner("inner-input")
         return "outer-output"
@@ -25,7 +25,7 @@ def test_tracked_function__happyflow(opik_client):
         metadata={"inner-metadata-key": "inner-metadata-value"},
     )
     def f_inner(y):
-        ID_STORAGE["f_inner-span-id"] = opik_context.get_current_span().id
+        ID_STORAGE["f_inner-span-id"] = opik_context.get_current_span_data().id
         return "inner-output"
 
     # Call

--- a/sdks/python/tests/library_integration/langchain/test_langchain.py
+++ b/sdks/python/tests/library_integration/langchain/test_langchain.py
@@ -432,7 +432,7 @@ def test_langchain_callback__used_when_there_was_already_existing_trace_without_
             name="manually-created-trace",
             input={"input": "input-of-manually-created-trace"},
         )
-        context_storage.set_trace(trace)
+        context_storage.set_trace_data(trace)
 
         f()
 
@@ -661,6 +661,6 @@ def test_langchain_callback__used_when_there_was_already_existing_span_without_t
             ],
         )
 
-        assert len(fake_message_processor_.span_trees) == 1
+        assert len(fake_message_processor_._span_trees) == 1
         assert len(callback.created_traces()) == 0
-        assert_equal(EXPECTED_SPANS_TREE, fake_message_processor_.span_trees[0])
+        assert_equal(EXPECTED_SPANS_TREE, fake_message_processor_._span_trees[0])

--- a/sdks/python/tests/library_integration/langchain/test_langchain.py
+++ b/sdks/python/tests/library_integration/langchain/test_langchain.py
@@ -440,7 +440,9 @@ def test_langchain_callback__used_when_there_was_already_existing_trace_without_
 
         # Send trace data
         trace_data = context_storage.pop_trace_data()
-        trace_data.init_end_time().update({"output": {"output": "output-of-manually-created-trace"}})
+        trace_data.init_end_time().update(
+            {"output": {"output": "output-of-manually-created-trace"}}
+        )
         client.trace(**trace_data.__dict__)
 
         opik.flush_tracker()
@@ -571,7 +573,7 @@ def test_langchain_callback__used_when_there_was_already_existing_span_without_t
             synopsis_chain.invoke(input=test_prompts, config={"callbacks": [callback]})
 
         client = opik_client.get_client_cached()
-        span_data =span.SpanData(
+        span_data = span.SpanData(
             trace_id="some-trace-id",
             name="manually-created-span",
             input={"input": "input-of-manually-created-span"},
@@ -582,7 +584,7 @@ def test_langchain_callback__used_when_there_was_already_existing_span_without_t
 
         span_data = context_storage.pop_span_data()
         span_data.init_end_time().update(
-            {"output":{"output": "output-of-manually-created-span"}}
+            {"output": {"output": "output-of-manually-created-span"}}
         )
         client.span(**span_data.__dict__)
         opik.flush_tracker()

--- a/sdks/python/tests/library_integration/langchain/test_langchain.py
+++ b/sdks/python/tests/library_integration/langchain/test_langchain.py
@@ -441,7 +441,7 @@ def test_langchain_callback__used_when_there_was_already_existing_trace_without_
         # Send trace data
         trace_data = context_storage.pop_trace_data()
         trace_data.init_end_time().update(
-            {"output": {"output": "output-of-manually-created-trace"}}
+            output={"output": "output-of-manually-created-trace"}
         )
         client.trace(**trace_data.__dict__)
 
@@ -584,7 +584,7 @@ def test_langchain_callback__used_when_there_was_already_existing_span_without_t
 
         span_data = context_storage.pop_span_data()
         span_data.init_end_time().update(
-            {"output": {"output": "output-of-manually-created-span"}}
+            output={"output": "output-of-manually-created-span"}
         )
         client.span(**span_data.__dict__)
         opik.flush_tracker()

--- a/sdks/python/tests/library_integration/langchain/test_langchain.py
+++ b/sdks/python/tests/library_integration/langchain/test_langchain.py
@@ -22,7 +22,7 @@ from opik.integrations.langchain.opik_tracer import OpikTracer
 @pytest.fixture()
 def ensure_openai_configured():
     # don't use assertion here to prevent printing os.environ with all env variables
-    print(os.environ)
+
     if not ("OPENAI_API_KEY" in os.environ and "OPENAI_ORG_ID" in os.environ):
         raise Exception("OpenAI not configured!")
 

--- a/sdks/python/tests/library_integration/llama_index/requirements.txt
+++ b/sdks/python/tests/library_integration/llama_index/requirements.txt
@@ -1,0 +1,3 @@
+lama-index
+llama-index-agent-openai
+llama-index-llms-openai

--- a/sdks/python/tests/library_integration/llama_index/requirements.txt
+++ b/sdks/python/tests/library_integration/llama_index/requirements.txt
@@ -1,3 +1,3 @@
-lama-index
+llama-index
 llama-index-agent-openai
 llama-index-llms-openai

--- a/sdks/python/tests/library_integration/llama_index/test_llama_index.py
+++ b/sdks/python/tests/library_integration/llama_index/test_llama_index.py
@@ -9,7 +9,6 @@ from ...testlib import (
     assert_equal,
 )
 import pytest
-import requests
 
 from llama_index.core import Settings
 from llama_index.core.callbacks import CallbackManager

--- a/sdks/python/tests/library_integration/llama_index/test_llama_index.py
+++ b/sdks/python/tests/library_integration/llama_index/test_llama_index.py
@@ -28,12 +28,11 @@ def ensure_openai_configured():
 def index_documents_directory():
     directory_name = "./data/paul_graham/"
 
+    TEXT = "Before college the two main things I worked on, outside of school, were writing and programming."
     os.makedirs(directory_name, exist_ok=True)
     try:
-        url = "https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt"
-        response = requests.get(url)
-        with open("./data/paul_graham/paul_graham_essay.txt", "wb") as f:
-            f.write(response.content)
+        with open("./data/paul_graham/paul_graham_essay.txt", "wt") as f:
+            f.write(TEXT)
 
         yield directory_name
     finally:

--- a/sdks/python/tests/library_integration/llama_index/test_llama_index.py
+++ b/sdks/python/tests/library_integration/llama_index/test_llama_index.py
@@ -1,0 +1,100 @@
+import mock
+import os
+import shutil
+from opik.message_processing import streamer_constructors
+from ...testlib import backend_emulator_message_processor
+from ...testlib import (
+    TraceModel,
+    ANY_BUT_NONE,
+    assert_equal,
+)
+import pytest
+import requests
+
+from llama_index.core import Settings
+from llama_index.core.callbacks import CallbackManager
+from opik.integrations.llama_index import LlamaIndexCallbackHandler
+
+@pytest.fixture()
+def ensure_openai_configured():
+    # don't use assertion here to prevent printing os.environ with all env variables
+
+    if not ("OPENAI_API_KEY" in os.environ and "OPENAI_ORG_ID" in os.environ):
+        raise Exception("OpenAI not configured!")
+
+@pytest.fixture
+def index_documents_directory():
+    directory_name = './data/paul_graham/'
+
+    os.makedirs(directory_name, exist_ok=True)
+    try:
+        url = 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt'
+        response = requests.get(url)
+        with open('./data/paul_graham/paul_graham_essay.txt', 'wb') as f:
+            f.write(response.content)
+        
+        yield directory_name
+    finally:
+        shutil.rmtree(directory_name, ignore_errors=True)
+    
+
+
+def test_llama_index__happyflow(
+    ensure_openai_configured,
+    fake_streamer,
+    index_documents_directory,
+):
+    fake_message_processor_: (
+        backend_emulator_message_processor.BackendEmulatorMessageProcessor
+    )
+    streamer, fake_message_processor_ = fake_streamer
+
+    mock_construct_online_streamer = mock.Mock()
+    mock_construct_online_streamer.return_value = streamer
+
+    with mock.patch.object(
+        streamer_constructors,
+        "construct_online_streamer",
+        mock_construct_online_streamer,
+    ):
+        opik_callback_handler = LlamaIndexCallbackHandler()
+        Settings.callback_manager = CallbackManager([opik_callback_handler])
+
+        from llama_index.core import VectorStoreIndex, SimpleDirectoryReader
+
+        documents = SimpleDirectoryReader(index_documents_directory).load_data()
+        index = VectorStoreIndex.from_documents(documents)
+        query_engine = index.as_query_engine()
+
+        response = query_engine.query("What did the author do growing up?")
+        print(response)
+
+
+        opik_callback_handler.flush()
+        mock_construct_online_streamer.assert_called_once()
+
+        EXPECTED_TRACE_TREES = [
+            TraceModel(
+                id=ANY_BUT_NONE,
+                name="index_construction",
+                input={"documents": ANY_BUT_NONE},
+                output=ANY_BUT_NONE,
+                metadata={"created_from": "llama_index"},
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                spans=ANY_BUT_NONE,  # too complex spans tree, no check
+            ),
+            TraceModel(
+                id=ANY_BUT_NONE,
+                name="query",
+                input={"query_str": "What did the author do growing up?"},
+                output=ANY_BUT_NONE,
+                metadata={"created_from": "llama_indexx"},
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                spans=ANY_BUT_NONE  # too complex spans tree, no check
+            )
+        ]
+
+        assert len(fake_message_processor_.trace_trees) == 2
+        assert_equal(EXPECTED_TRACE_TREES, fake_message_processor_.trace_trees)

--- a/sdks/python/tests/library_integration/llama_index/test_llama_index.py
+++ b/sdks/python/tests/library_integration/llama_index/test_llama_index.py
@@ -15,6 +15,7 @@ from llama_index.core import Settings
 from llama_index.core.callbacks import CallbackManager
 from opik.integrations.llama_index import LlamaIndexCallbackHandler
 
+
 @pytest.fixture()
 def ensure_openai_configured():
     # don't use assertion here to prevent printing os.environ with all env variables
@@ -22,21 +23,21 @@ def ensure_openai_configured():
     if not ("OPENAI_API_KEY" in os.environ and "OPENAI_ORG_ID" in os.environ):
         raise Exception("OpenAI not configured!")
 
+
 @pytest.fixture
 def index_documents_directory():
-    directory_name = './data/paul_graham/'
+    directory_name = "./data/paul_graham/"
 
     os.makedirs(directory_name, exist_ok=True)
     try:
-        url = 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt'
+        url = "https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt"
         response = requests.get(url)
-        with open('./data/paul_graham/paul_graham_essay.txt', 'wb') as f:
+        with open("./data/paul_graham/paul_graham_essay.txt", "wb") as f:
             f.write(response.content)
-        
+
         yield directory_name
     finally:
         shutil.rmtree(directory_name, ignore_errors=True)
-    
 
 
 def test_llama_index__happyflow(
@@ -69,7 +70,6 @@ def test_llama_index__happyflow(
         response = query_engine.query("What did the author do growing up?")
         print(response)
 
-
         opik_callback_handler.flush()
         mock_construct_online_streamer.assert_called_once()
 
@@ -92,8 +92,8 @@ def test_llama_index__happyflow(
                 metadata={"created_from": "llama_indexx"},
                 start_time=ANY_BUT_NONE,
                 end_time=ANY_BUT_NONE,
-                spans=ANY_BUT_NONE  # too complex spans tree, no check
-            )
+                spans=ANY_BUT_NONE,  # too complex spans tree, no check
+            ),
         ]
 
         assert len(fake_message_processor_.trace_trees) == 2

--- a/sdks/python/tests/library_integration/llama_index/test_llama_index.py
+++ b/sdks/python/tests/library_integration/llama_index/test_llama_index.py
@@ -89,7 +89,7 @@ def test_llama_index__happyflow(
                 name="query",
                 input={"query_str": "What did the author do growing up?"},
                 output=ANY_BUT_NONE,
-                metadata={"created_from": "llama_indexx"},
+                metadata={"created_from": "llama_index"},
                 start_time=ANY_BUT_NONE,
                 end_time=ANY_BUT_NONE,
                 spans=ANY_BUT_NONE,  # too complex spans tree, no check

--- a/sdks/python/tests/library_integration/openai/test_openai.py
+++ b/sdks/python/tests/library_integration/openai/test_openai.py
@@ -96,7 +96,7 @@ def test_openai_client_chat_completions_create__happyflow(fake_streamer):
 
         assert len(fake_message_processor_.trace_trees) == 1
 
-        assert_equal(EXPECTED_TRACE_TREE.__dict__, fake_message_processor_.trace_trees[0].__dict__)
+        assert_equal(EXPECTED_TRACE_TREE, fake_message_processor_.trace_trees[0])
 
 
 def test_openai_client_chat_completions_create__create_raises_an_error__span_and_trace_finished_gracefully(

--- a/sdks/python/tests/library_integration/openai/test_openai.py
+++ b/sdks/python/tests/library_integration/openai/test_openai.py
@@ -96,7 +96,7 @@ def test_openai_client_chat_completions_create__happyflow(fake_streamer):
 
         assert len(fake_message_processor_.trace_trees) == 1
 
-        assert_equal(EXPECTED_TRACE_TREE, fake_message_processor_.trace_trees[0])
+        assert_equal(EXPECTED_TRACE_TREE.__dict__, fake_message_processor_.trace_trees[0].__dict__)
 
 
 def test_openai_client_chat_completions_create__create_raises_an_error__span_and_trace_finished_gracefully(

--- a/sdks/python/tests/test_requirements.txt
+++ b/sdks/python/tests/test_requirements.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-cov
+pytest-env
 mock
 deepdiff

--- a/sdks/python/tests/testlib/__init__.py
+++ b/sdks/python/tests/testlib/__init__.py
@@ -1,11 +1,12 @@
 from .backend_emulator_message_processor import BackendEmulatorMessageProcessor
-from .models import SpanModel, TraceModel
+from .models import SpanModel, TraceModel, FeedbackScoreModel
 from .assert_helpers import assert_dicts_equal, prepare_difference_report, assert_equal
 from .any_but_none import ANY_BUT_NONE
 
 __all__ = [
     "SpanModel",
     "TraceModel",
+    "FeedbackScoreModel",
     "ANY_BUT_NONE",
     "assert_equal",
     "assert_dicts_equal",

--- a/sdks/python/tests/testlib/assert_helpers.py
+++ b/sdks/python/tests/testlib/assert_helpers.py
@@ -4,7 +4,6 @@ import logging
 import mock
 import deepdiff
 
-from . import any_but_none
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sdks/python/tests/testlib/assert_helpers.py
+++ b/sdks/python/tests/testlib/assert_helpers.py
@@ -21,7 +21,7 @@ def prepare_difference_report(expected: Any, actual: Any) -> str:
 
 
 def assert_equal(expected, actual):
-    assert actual == expected, prepare_difference_report(actual, expected)
+    assert actual == expected, f"Details: {prepare_difference_report(actual, expected)}"
 
 
 def assert_dicts_equal(

--- a/sdks/python/tests/testlib/assert_helpers.py
+++ b/sdks/python/tests/testlib/assert_helpers.py
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger(__name__)
 def prepare_difference_report(expected: Any, actual: Any) -> str:
     try:
         diff_report = deepdiff.DeepDiff(
-            expected, actual, exclude_types=[any_but_none.AnyButNone, mock.mock._ANY]
+            expected, actual, exclude_types=[mock.mock._ANY]
         ).pretty()
         return diff_report
     except Exception:

--- a/sdks/python/tests/testlib/backend_emulator_message_processor.py
+++ b/sdks/python/tests/testlib/backend_emulator_message_processor.py
@@ -90,6 +90,7 @@ class BackendEmulatorMessageProcessor(message_processors.BaseMessageProcessor):
                 type=message.type,
                 start_time=message.start_time,
                 end_time=message.end_time,
+                usage=message.usage,
             )
 
             self._span_to_parent_span[span.id] = message.parent_span_id

--- a/sdks/python/tests/testlib/backend_emulator_message_processor.py
+++ b/sdks/python/tests/testlib/backend_emulator_message_processor.py
@@ -110,7 +110,11 @@ class BackendEmulatorMessageProcessor(message_processors.BaseMessageProcessor):
             current_trace.end_time = message.end_time
         elif isinstance(message, messages.AddSpanFeedbackScoresBatchMessage):
             for feedback_score_message in message.batch:
-                span: SpanModel = self._observations[feedback_score_message.id]
+                span_or_trace = self._observations[feedback_score_message.id]
+                if not isinstance(span_or_trace, SpanModel):
+                    continue
+
+                span: SpanModel = span_or_trace
                 feedback_model = FeedbackScoreModel(
                     id=feedback_score_message.id,
                     name=feedback_score_message.name,
@@ -121,7 +125,12 @@ class BackendEmulatorMessageProcessor(message_processors.BaseMessageProcessor):
                 span.feedback_scores.append(feedback_model)
         elif isinstance(message, messages.AddTraceFeedbackScoresBatchMessage):
             for feedback_score_message in message.batch:
-                trace: TraceModel = self._observations[feedback_score_message.id]
+                span_or_trace = self._observations[feedback_score_message.id]
+                if not isinstance(span_or_trace, TraceModel):
+                    continue
+
+                trace: TraceModel = span_or_trace
+
                 feedback_model = FeedbackScoreModel(
                     id=feedback_score_message.id,
                     name=feedback_score_message.name,

--- a/sdks/python/tests/testlib/backend_emulator_message_processor.py
+++ b/sdks/python/tests/testlib/backend_emulator_message_processor.py
@@ -5,12 +5,15 @@ from .models import TraceModel, SpanModel, FeedbackScoreModel
 
 import collections
 
+
 class BackendEmulatorMessageProcessor(message_processors.BaseMessageProcessor):
     def __init__(self) -> None:
         self.processed_messages: List[messages.BaseMessage] = []
         self._trace_trees: List[TraceModel] = []
 
-        self._traces_to_spans_mapping: Dict[str, List[str]] = collections.defaultdict(list)
+        self._traces_to_spans_mapping: Dict[str, List[str]] = collections.defaultdict(
+            list
+        )
         self._span_trees: List[
             SpanModel
         ] = []  # the same as _trace_trees but without a trace. Useful for distributed tracing.
@@ -25,20 +28,21 @@ class BackendEmulatorMessageProcessor(message_processors.BaseMessageProcessor):
         Builds list of trace trees based on the data from processed messages.
         Before processing traces, builds span_trees
         """
-        self.span_trees # call to connect all spans
+        self.span_trees  # call to connect all spans
 
         for span_id, trace_id in self._span_to_trace.items():
             if trace_id is None:
                 continue
-            
+
             trace = self._observations[trace_id]
-            if self._span_to_parent_span[span_id] is None and not _observation_already_stored(span_id, trace.spans):
+            if self._span_to_parent_span[
+                span_id
+            ] is None and not _observation_already_stored(span_id, trace.spans):
                 trace.spans.append(self._observations[span_id])
                 trace.spans.sort(key=lambda x: x.start_time)
-        
+
         self._trace_trees.sort(key=lambda x: x.start_time)
         return self._trace_trees
-    
 
     @property
     def span_trees(self):
@@ -54,11 +58,9 @@ class BackendEmulatorMessageProcessor(message_processors.BaseMessageProcessor):
             if not _observation_already_stored(span_id, parent_span.spans):
                 parent_span.spans.append(self._observations[span_id])
                 parent_span.spans.sort(key=lambda x: x.start_time)
-        
+
         self._span_trees.sort(key=lambda x: x.start_time)
         return self._span_trees
-
-
 
     def process(self, message: messages.BaseMessage) -> None:
         print(message)
@@ -143,5 +145,5 @@ def _observation_already_stored(id, observations) -> bool:
     for observation in observations:
         if observation.id == id:
             return True
-        
+
     return False

--- a/sdks/python/tests/testlib/backend_emulator_message_processor.py
+++ b/sdks/python/tests/testlib/backend_emulator_message_processor.py
@@ -63,7 +63,6 @@ class BackendEmulatorMessageProcessor(message_processors.BaseMessageProcessor):
         return self._span_trees
 
     def process(self, message: messages.BaseMessage) -> None:
-        print(message)
         if isinstance(message, messages.CreateTraceMessage):
             trace = TraceModel(
                 id=message.trace_id,

--- a/sdks/python/tests/testlib/backend_emulator_message_processor.py
+++ b/sdks/python/tests/testlib/backend_emulator_message_processor.py
@@ -1,17 +1,52 @@
 from opik.message_processing import message_processors, messages
-from typing import List, Tuple, Type, Dict, Union
+from typing import List, Tuple, Type, Dict, Union, Optional
 
 from .models import TraceModel, SpanModel, FeedbackScoreModel
 
+import collections
 
 class BackendEmulatorMessageProcessor(message_processors.BaseMessageProcessor):
     def __init__(self) -> None:
         self.processed_messages: List[messages.BaseMessage] = []
-        self.trace_trees: List[TraceModel] = []
-        self.span_trees: List[
+        self._trace_trees: List[TraceModel] = []
+
+        self._traces_to_spans_mapping: Dict[str, List[str]] = collections.defaultdict(list)
+        self._span_trees: List[
             SpanModel
-        ] = []  # the same as trace_trees but without a trace. Useful for distributed tracing.
+        ] = []  # the same as _trace_trees but without a trace. Useful for distributed tracing.
         self._observations: Dict[str, Union[TraceModel, SpanModel]] = {}
+
+        self._span_to_parent_span: Dict[str, Optional[str]] = {}
+        self._span_to_trace: Dict[str, Optional[str]] = {}
+
+    @property
+    def trace_trees(self):
+        self.span_trees # call to connect all spans
+
+        for span_id, trace_id in self._span_to_trace.items():
+            if trace_id is None:
+                continue
+            
+            trace = self._observations[trace_id]
+            if self._span_to_parent_span[span_id] is None and not _observation_already_stored(span_id, trace.spans):
+                trace.spans.append(self._observations[span_id])
+        
+        return self._trace_trees
+    
+
+    @property
+    def span_trees(self):
+        for span_id, parent_span_id in self._span_to_parent_span.items():
+            if parent_span_id is None:
+                continue
+
+            parent_span = self._observations[parent_span_id]
+            if not _observation_already_stored(span_id, parent_span.spans):
+                parent_span.spans.append(self._observations[span_id])
+        
+        return self._trace_trees
+
+
 
     def process(self, message: messages.BaseMessage) -> None:
         print(message)
@@ -20,18 +55,22 @@ class BackendEmulatorMessageProcessor(message_processors.BaseMessageProcessor):
                 id=message.trace_id,
                 name=message.name,
                 input=message.input,
+                output=message.output,
                 tags=message.tags,
                 metadata=message.metadata,
                 start_time=message.start_time,
                 end_time=message.end_time,
             )
-            self.trace_trees.append(trace)
+
+            self._trace_trees.append(trace)
             self._observations[message.trace_id] = trace
+
         elif isinstance(message, messages.CreateSpanMessage):
             span = SpanModel(
                 id=message.span_id,
                 name=message.name,
                 input=message.input,
+                output=message.output,
                 tags=message.tags,
                 metadata=message.metadata,
                 type=message.type,
@@ -39,13 +78,11 @@ class BackendEmulatorMessageProcessor(message_processors.BaseMessageProcessor):
                 end_time=message.end_time,
             )
 
+            self._span_to_parent_span[span.id] = message.parent_span_id
             if message.parent_span_id is None:
-                current_trace: TraceModel = self._observations[message.trace_id]
-                current_trace.spans.append(span)
-                self.span_trees.append(span)
-            else:
-                parent_span: SpanModel = self._observations[message.parent_span_id]
-                parent_span.spans.append(span)
+                self._span_trees.append(span)
+
+            self._span_to_trace[span.id] = message.trace_id
 
             self._observations[message.span_id] = span
         elif isinstance(message, messages.UpdateSpanMessage):
@@ -88,3 +125,11 @@ class BackendEmulatorMessageProcessor(message_processors.BaseMessageProcessor):
             for message in self.processed_messages
             if isinstance(message, allowed_types)
         ]
+
+
+def _observation_already_stored(id, observations) -> bool:
+    for observation in observations:
+        if observation.id == id:
+            return True
+        
+    return False

--- a/sdks/python/tests/unit/decorator/test_tracker.py
+++ b/sdks/python/tests/unit/decorator/test_tracker.py
@@ -4,52 +4,6 @@ from opik.api_objects import opik_client
 from opik.decorator import tracker
 
 
-def test_track__one_level_of_nesting__trace_and_span_created():
-    """
-    This test is the only of its kind in this module. The tests
-    checking that tracker generates correct messages which lead to correct
-    trace trees are located in test_tracker_outputs.py
-    """
-    mock_get_client_cached = mock.Mock()
-    mock_comet = mock.Mock()
-    mock_trace = mock.Mock()
-    mock_span = mock.Mock()
-
-    mock_trace.span.return_value = mock_span
-    mock_comet.trace.return_value = mock_trace
-    mock_get_client_cached.return_value = mock_comet
-
-    with mock.patch.object(opik_client, "get_client_cached", mock_get_client_cached):
-
-        @tracker.track(capture_output=True)
-        def f(x):
-            return f"result-from-{x}"
-
-        f("some-input")
-
-        mock_get_client_cached.assert_called_once()
-
-        mock_comet.trace.assert_called_once_with(
-            name="f",
-            input={"x": "some-input"},
-            metadata=None,
-            tags=None,
-        )
-        mock_trace.span.assert_called_once_with(
-            name="f",
-            type="general",
-            input={"x": "some-input"},
-            metadata=None,
-            tags=None,
-        )
-        mock_span.end.assert_called_once_with(
-            output={"output": "result-from-some-input"},
-        )
-        mock_trace.end.assert_called_once_with(
-            output={"output": "result-from-some-input"},
-        )
-
-
 def test_track__get_client_cached_raised_error__error_is_caught__user_function_is_not_affected():
     mock_get_client_cached = mock.Mock()
     mock_get_client_cached.side_effect = Exception
@@ -63,46 +17,3 @@ def test_track__get_client_cached_raised_error__error_is_caught__user_function_i
         assert f() == 42
 
         mock_get_client_cached.assert_called_once()
-
-
-def test_track_without_parentheses():
-    mock_get_client_cached = mock.Mock()
-    mock_comet = mock.Mock()
-    mock_trace = mock.Mock()
-    mock_span = mock.Mock()
-
-    mock_trace.span.return_value = mock_span
-    mock_comet.trace.return_value = mock_trace
-    mock_get_client_cached.return_value = mock_comet
-
-    with mock.patch.object(opik_client, "get_client_cached", mock_get_client_cached):
-
-        @tracker.track
-        def f(x):
-            return f"result-from-{x}"
-
-        result = f("some-input")
-
-        assert result == "result-from-some-input"
-
-        mock_get_client_cached.assert_called_once()
-
-        mock_comet.trace.assert_called_once_with(
-            name="f",
-            input={"x": "some-input"},
-            metadata=None,
-            tags=None,
-        )
-        mock_trace.span.assert_called_once_with(
-            name="f",
-            type="general",
-            input={"x": "some-input"},
-            metadata=None,
-            tags=None,
-        )
-        mock_span.end.assert_called_once_with(
-            output={"output": "result-from-some-input"},
-        )
-        mock_trace.end.assert_called_once_with(
-            output={"output": "result-from-some-input"},
-        )

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -1214,7 +1214,9 @@ def test_track__span_and_trace_updated_via_opik_context(fake_streamer):
         assert_equal(EXPECTED_TRACE_TREE, fake_message_processor_.trace_trees[0])
 
 
-def test_track__span_and_trace_updated_via_opik_context_with_feedback_scores__feedback_scores_are_also_logged(fake_streamer):
+def test_track__span_and_trace_updated_via_opik_context_with_feedback_scores__feedback_scores_are_also_logged(
+    fake_streamer,
+):
     fake_message_processor_: (
         backend_emulator_message_processor.BackendEmulatorMessageProcessor
     )
@@ -1233,11 +1235,11 @@ def test_track__span_and_trace_updated_via_opik_context_with_feedback_scores__fe
         def f(x):
             opik_context.update_current_span(
                 name="span-name",
-                feedback_scores=[{"name": "span-score-name", "value": 0.5}]
+                feedback_scores=[{"name": "span-score-name", "value": 0.5}],
             )
             opik_context.update_current_trace(
                 name="trace-name",
-                feedback_scores=[{"name": "trace-score-name", "value": 0.75}]
+                feedback_scores=[{"name": "trace-score-name", "value": 0.75}],
             )
 
             return "f-output"
@@ -1266,7 +1268,9 @@ def test_track__span_and_trace_updated_via_opik_context_with_feedback_scores__fe
                     end_time=ANY_BUT_NONE,
                     spans=[],
                     feedback_scores=[
-                        FeedbackScoreModel(id=ANY_BUT_NONE, name="span-score-name", value=0.5)
+                        FeedbackScoreModel(
+                            id=ANY_BUT_NONE, name="span-score-name", value=0.5
+                        )
                     ],
                 )
             ],

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -12,6 +12,7 @@ from ...testlib import backend_emulator_message_processor
 from ...testlib import (
     SpanModel,
     TraceModel,
+    FeedbackScoreModel,
     ANY_BUT_NONE,
     assert_equal,
 )
@@ -1204,6 +1205,69 @@ def test_track__span_and_trace_updated_via_opik_context(fake_streamer):
                     start_time=ANY_BUT_NONE,
                     end_time=ANY_BUT_NONE,
                     spans=[],
+                )
+            ],
+        )
+
+        assert len(fake_message_processor_.trace_trees) == 1
+
+        assert_equal(EXPECTED_TRACE_TREE, fake_message_processor_.trace_trees[0])
+
+
+def test_track__span_and_trace_updated_via_opik_context_with_feedback_scores__feedback_scores_are_also_logged(fake_streamer):
+    fake_message_processor_: (
+        backend_emulator_message_processor.BackendEmulatorMessageProcessor
+    )
+    streamer, fake_message_processor_ = fake_streamer
+
+    mock_construct_online_streamer = mock.Mock()
+    mock_construct_online_streamer.return_value = streamer
+
+    with mock.patch.object(
+        streamer_constructors,
+        "construct_online_streamer",
+        mock_construct_online_streamer,
+    ):
+
+        @tracker.track
+        def f(x):
+            opik_context.update_current_span(
+                name="span-name",
+                feedback_scores=[{"name": "span-score-name", "value": 0.5}]
+            )
+            opik_context.update_current_trace(
+                name="trace-name",
+                feedback_scores=[{"name": "trace-score-name", "value": 0.75}]
+            )
+
+            return "f-output"
+
+        f("f-input")
+        tracker.flush_tracker()
+        mock_construct_online_streamer.assert_called_once()
+
+        EXPECTED_TRACE_TREE = TraceModel(
+            id=ANY_BUT_NONE,
+            name="trace-name",
+            input={"x": "f-input"},
+            output={"output": "f-output"},
+            start_time=ANY_BUT_NONE,
+            end_time=ANY_BUT_NONE,
+            feedback_scores=[
+                FeedbackScoreModel(id=ANY_BUT_NONE, name="trace-score-name", value=0.75)
+            ],
+            spans=[
+                SpanModel(
+                    id=ANY_BUT_NONE,
+                    name="span-name",
+                    input={"x": "f-input"},
+                    output={"output": "f-output"},
+                    start_time=ANY_BUT_NONE,
+                    end_time=ANY_BUT_NONE,
+                    spans=[],
+                    feedback_scores=[
+                        FeedbackScoreModel(id=ANY_BUT_NONE, name="span-score-name", value=0.5)
+                    ],
                 )
             ],
         )

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -4,8 +4,9 @@ import asyncio
 import pytest
 from opik.message_processing import streamer_constructors
 from opik.decorator import tracker
-from opik import context_storage, opik_context, datetime_helpers
+from opik import context_storage, opik_context
 from opik.api_objects import opik_client
+from opik.api_objects import trace
 
 from ...testlib import backend_emulator_message_processor
 from ...testlib import (
@@ -13,7 +14,6 @@ from ...testlib import (
     TraceModel,
     ANY_BUT_NONE,
     assert_equal,
-    
 )
 
 
@@ -1108,7 +1108,7 @@ def test_track__trace_already_created_not_by_decorator__decorator_just_attaches_
             return "f-output"
 
         client = opik_client.get_client_cached()
-        trace_data = dict(
+        trace_data = trace.TraceData(
             id="manually-created-trace-id",
             name="manually-created-trace",
             input={"input": "input-of-manually-created-trace"},
@@ -1124,7 +1124,7 @@ def test_track__trace_already_created_not_by_decorator__decorator_just_attaches_
             id="manually-created-trace-id",
             name="manually-created-trace",
             input={"input": "input-of-manually-created-trace"},
-            output={"output":"output-of-manually-created-trace"},
+            output={"output": "output-of-manually-created-trace"},
         )
 
         tracker.flush_tracker()
@@ -1136,7 +1136,7 @@ def test_track__trace_already_created_not_by_decorator__decorator_just_attaches_
             name="manually-created-trace",
             input={"input": "input-of-manually-created-trace"},
             output={"output": "output-of-manually-created-trace"},
-            start_time=mock.ANY, # not ANY_BUT_NONE because we created span manually in the test
+            start_time=mock.ANY,  # not ANY_BUT_NONE because we created span manually in the test
             end_time=mock.ANY,
             spans=[
                 SpanModel(

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -1112,7 +1112,7 @@ def test_track__trace_already_created_not_by_decorator__decorator_just_attaches_
             name="manually-created-trace",
             input={"input": "input-of-manually-created-trace"},
         )
-        context_storage.set_trace(trace)
+        context_storage.set_trace_data(trace)
 
         f("f-input")
 

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -1173,12 +1173,11 @@ def test_track__span_and_trace_updated_via_opik_context(fake_streamer):
         @tracker.track
         def f(x):
             opik_context.update_current_span(
-                name="span-name",
-                metadata={"span-metadata-key": "span-metadata-value"}
+                name="span-name", metadata={"span-metadata-key": "span-metadata-value"}
             )
             opik_context.update_current_trace(
                 name="trace-name",
-                metadata={"trace-metadata-key": "trace-metadata-value"}
+                metadata={"trace-metadata-key": "trace-metadata-value"},
             )
 
             return "f-output"


### PR DESCRIPTION
## Details
This PR changes the way `track` functionality works. Now CreateSpan or CreateTrace messages are generated and scheduled to be sent to the backend when the tracked function finishes working (before that CreateMessage was generated when the function began, UpdateMessage when it was ending).

Now UpdateSpan/UpdateTrace requests are sent to the backend only if you are using low-level api (which is still working as before).

## The changes in the API and UX:
1. `get_current_span()` and `get_current_trace()` functions were removed. You can now use `get_current_span_data()`, `get_current_trace_data()` to get information accumulated for sending in the end of the current function. If you want to update it, you can use `update_current_span()`, `update_current_trace()`. All these functions are stored in `opik.opik_context` namespace.
2. Since CreateRequests are sent at the end of function executions, the trace will not be created on the backend side until all trace tree is executed. Which also means it won't be visible on the frontend side.

## Implementation changes (high-level).
1. context_storage now operates not with `span.Span`, `trace.Trace` api objects, but with `span.SpanData`, `trace.TraceData`. Those objects have no methods that trigger any requests, they are simply dataclasses instances that store information about trace and span to be created. So, any part of the SDK that uses context_storage (or `opik_context`) has been adjusted accordingly.

## Integrations:
I've updated the langchain integration, llama_index integration already. Other ones should be checked in case they are affected and updated accordingly.
