### PR TITLE
Use the project version.txt as fallback for SDK version

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -3,6 +3,16 @@ import os
 
 project_urls = {"Source code": "https://github.com/comet-ml/opik"}
 
+HERE = os.path.abspath(os.path.dirname(__file__))
+version = os.environ.get("VERSION")
+if version is None:
+    version_file = os.path.join(HERE, "..", "..", "version.txt")
+    if os.path.exists(version_file):
+        with open(version_file) as fp:
+            version = fp.read().strip()
+    else:
+        version = "0.0.1"
+
 setup(
     author="Comet ML Inc.",
     author_email="mail@comet.com",
@@ -19,7 +29,7 @@ setup(
         "Programming Language :: Python :: 3.10",
     ],
     description="Comet tool for logging and evaluating LLM traces",
-    long_description=open("./../../README.md", encoding="utf-8").read(),
+    long_description=open(os.path.join(HERE, "..", "..", "README.md"), encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     install_requires=[
         "httpx<1.0.0",
@@ -50,7 +60,7 @@ setup(
     package_dir={"": "src"},
     url="https://www.comet.com",
     project_urls=project_urls,
-    version=os.environ.get("VERSION", "0.0.1"),
+    version=version,
     zip_safe=False,
     license="Apache 2.0 License",
 )

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -29,7 +29,9 @@ setup(
         "Programming Language :: Python :: 3.10",
     ],
     description="Comet tool for logging and evaluating LLM traces",
-    long_description=open(os.path.join(HERE, "..", "..", "README.md"), encoding="utf-8").read(),
+    long_description=open(
+        os.path.join(HERE, "..", "..", "README.md"), encoding="utf-8"
+    ).read(),
     long_description_content_type="text/markdown",
     install_requires=[
         "httpx<1.0.0",


### PR DESCRIPTION
## Details

1. Use envionment "VERSION" if it exists
2. Else, uses version.txt file contents
3. Else, uses 0.0.1

## Issues

Resolves #166 

## Testing

Tested all three scenarios

## Documentation

None
