### PR TITLE
OPIK-75: Add client side and server side compression

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -63,3 +63,5 @@ authentication:
 
 server:
   enableVirtualThreads: ${ENABLE_VIRTUAL_THREADS:-false}
+  gzip:
+    enabled: true

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/instrumentation/InstrumentAsyncUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/instrumentation/InstrumentAsyncUtils.java
@@ -6,8 +6,6 @@ import com.newrelic.api.agent.Segment;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.scheduler.Schedulers;
 
-import java.lang.reflect.Method;
-
 @Slf4j
 public class InstrumentAsyncUtils {
 
@@ -30,8 +28,7 @@ public class InstrumentAsyncUtils {
             Schedulers.boundedElastic().schedule(() -> {
                 try {
                     // End the segment
-                    Method endMethod = segment.getClass().getMethod("end");
-                    endMethod.invoke(segment);
+                    segment.end();
                 } catch (Exception e) {
                     log.warn("Failed to end segment", e);
                 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/JsonUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/JsonUtils.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 
@@ -49,6 +51,14 @@ public class JsonUtils {
             return MAPPER.writeValueAsString(value);
         } catch (JsonProcessingException exception) {
             throw new UncheckedIOException(exception);
+        }
+    }
+
+    public void writeValueAsString(@NonNull ByteArrayOutputStream baos, @NonNull Object value) {
+        try {
+            MAPPER.writeValue(baos, value);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/ClientSupportUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/ClientSupportUtils.java
@@ -10,6 +10,8 @@ public class ClientSupportUtils {
     }
 
     public static void config(ClientSupport client) {
+        client.getClient().register(new ConditionalGZipFilter());
+
         client.getClient().getConfiguration().property(ClientProperties.READ_TIMEOUT, 35_000);
         client.getClient().getConfiguration().connectorProvider(new GrizzlyConnectorProvider()); // Required for PATCH:
         // https://github.com/dropwizard/dropwizard/discussions/6431/ Required for PATCH:

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/ConditionalGZipFilter.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/ConditionalGZipFilter.java
@@ -1,0 +1,43 @@
+package com.comet.opik.api.resources.utils;
+
+
+import com.comet.opik.utils.JsonUtils;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPOutputStream;
+
+public class ConditionalGZipFilter implements ClientRequestFilter {
+
+    private static final int GZIP_THRESHOLD_500KB = 500 * 1024;
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+
+        if (requestContext.hasEntity() && MediaType.APPLICATION_JSON_TYPE.equals(requestContext.getMediaType())) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            JsonUtils.writeValueAsString(baos, requestContext.getEntity()); // Serialize the entity to byte array
+
+            byte[] entityBytes = baos.toByteArray();
+            int entitySize = entityBytes.length;
+
+            if (entitySize > GZIP_THRESHOLD_500KB) {
+                ByteArrayOutputStream compressedBaos = new ByteArrayOutputStream();
+                try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(compressedBaos)) {
+                    gzipOutputStream.write(entityBytes);
+                }
+
+                byte[] compressedEntity = compressedBaos.toByteArray();
+                requestContext.setEntity(compressedEntity, null, MediaType.APPLICATION_JSON_TYPE);
+                requestContext.getHeaders().add(HttpHeaders.CONTENT_ENCODING, "gzip");
+            } else {
+                // Use the original entity if below the threshold
+                requestContext.setEntity(entityBytes, null, MediaType.APPLICATION_JSON_TYPE);
+            }
+        }
+    }
+}

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -63,3 +63,5 @@ authentication:
 
 server:
   enableVirtualThreads: ${ENABLE_VIRTUAL_THREADS:-false}
+  gzip:
+    enabled: true


### PR DESCRIPTION
## Details
Add compression to avoid errors like the one below:

```
[Client action]---------------------------------------------{
1 * Client response received on thread main
1 < 400
1 < content-length: 47
1 < content-type: application/json
1 < date: Thu, 12 Sep 2024 08:38:07 GMT
{"code":400,"message":"Unable to process JSON"}

}----------------------------------------------------------
```

## Issues

Resolves #

## Testing

## Documentation
