### PR TITLE
NO-JIRA Expose backend port for local development

### DIFF
--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -166,6 +166,11 @@ echo "### Port-forward Opik Frontend to local host"
 ps -ef | grep "svc/${OPIK_FRONTEND} ${OPIK_FRONTEND_PORT}" | grep -v grep | awk '{print $2}' | xargs kill 2>/dev/null|| true
 kubectl port-forward svc/${OPIK_FRONTEND} ${OPIK_FRONTEND_PORT} > /dev/null 2>&1 &
 
+echo "### Port-forward Opik Backend to local host"
+# remove the previous port-forward
+ps -ef | grep "svc/${OPIK_BACKEND} ${OPIK_BACKEND_PORT}" | grep -v grep | awk '{print $2}' | xargs kill 2>/dev/null|| true
+kubectl port-forward svc/${OPIK_BACKEND} ${OPIK_BACKEND_PORT} > /dev/null 2>&1 &
+
 echo "### Port-forward Open API to local host"
 # remove the previous port-forward
 ps -ef | grep "svc/${OPIK_BACKEND} ${OPIK_OPENAPI_PORT}" | grep -v grep | awk '{print $2}' | xargs kill 2>/dev/null|| true


### PR DESCRIPTION
## Details
Exposes the `opik-backend` service running on port 8080 on the same port of localhost.

This is useful to directly call the service for local development, testing and debugging purposes.

## Issues

NO-JIRA

## Testing
- Started the whole application with `build_and_run.sh` and then successfully run `curl` towards `localhost:8080` to retrieve an experiment by id.

## Documentation
N/A
