### PR TITLE
[OPIK-127] [UX Improvements] Show two category input rows by default on categorical feedback score definition form

### DIFF
--- a/apps/opik-frontend/src/components/shared/AddEditFeedbackDefinitionDialog/FeedbackDefinitionDetails/CategoricalFeedbackDefinitionDetails.tsx
+++ b/apps/opik-frontend/src/components/shared/AddEditFeedbackDefinitionDialog/FeedbackDefinitionDetails/CategoricalFeedbackDefinitionDetails.tsx
@@ -43,7 +43,7 @@ const CategoricalFeedbackDefinitionDetails: React.FunctionComponent<
           })),
           "name",
         )
-      : [{}],
+      : [{}, {}],
   );
 
   const categoricalDetails = useMemo(


### PR DESCRIPTION
## Details
![image](https://github.com/user-attachments/assets/6a669fae-3da2-49a4-890e-220fb702a86c)

## Issues

Resolves #

## Testing

## Documentation
