### PR TITLE
Langchain Docs Typos

### DIFF
--- a/apps/opik-documentation/documentation/docs/tracing/integrations/langchain.md
+++ b/apps/opik-documentation/documentation/docs/tracing/integrations/langchain.md
@@ -5,7 +5,7 @@ sidebar_label: LangChain
 
 # LangChain
 
-Comet provides seamless integration with LangChain, allowing you to easily log and trace your LangChain-based applications. By using the `CometTracer` callback, you can automatically capture detailed information about your LangChain runs, including inputs, outputs, and metadata for each step in your chain.
+Comet provides seamless integration with LangChain, allowing you to easily log and trace your LangChain-based applications. By using the `OpikTracer` callback, you can automatically capture detailed information about your LangChain runs, including inputs, outputs, and metadata for each step in your chain.
 
 <div style="display: flex; align-items: center; flex-wrap: wrap; margin: 20px 0;">
   <span style="margin-right: 10px;">You can check out the Colab Notebook if you'd like to jump straight to the code:</span>
@@ -16,7 +16,7 @@ Comet provides seamless integration with LangChain, allowing you to easily log a
 
 ## Getting Started
 
-To use the `CometTracer` with LangChain, you'll need to have both the `opik` and `langchain` packages installed. You can install them using pip:
+To use the `OpikTracer` with LangChain, you'll need to have both the `opik` and `langchain` packages installed. You can install them using pip:
 
 ```bash
 pip install opik langchain langchain_openai
@@ -28,9 +28,9 @@ In addition, you can configure Opik using the `opik configure` command which wil
 opik configure
 ```
 
-## Using CometTracer
+## Using OpikTracer
 
-Here's a basic example of how to use the `CometTracer` callback with a LangChain chain:
+Here's a basic example of how to use the `OpikTracer` callback with a LangChain chain:
 
 ```python
 from langchain.chains import LLMChain
@@ -55,14 +55,14 @@ llm_chain = LLMChain(llm=llm, prompt=prompt_template)
 translation = llm_chain.run("Hello, how are you?", callbacks=[opik_tracer])
 print(translation)
 
-# The CometTracer will automatically log the run and its details to Comet
+# The OpikTracer will automatically log the run and its details to Comet
 ```
 
-This example demonstrates how to create a LangChain chain with a `CometTracer` callback. When you run the chain with a prompt, the `CometTracer` will automatically log the run and its details to Comet, including the input prompt, the output, and metadata for each step in the chain.
+This example demonstrates how to create a LangChain chain with a `OpikTracer` callback. When you run the chain with a prompt, the `OpikTracer` will automatically log the run and its details to Comet, including the input prompt, the output, and metadata for each step in the chain.
 
 ## Settings tags and metadata
 
-You can also customize the `CometTracer` callback to include additional metadata or logging options. For example:
+You can also customize the `OpikTracer` callback to include additional metadata or logging options. For example:
 
 ```python
 from opik.integrations.langchain import OpikTracer
@@ -75,7 +75,7 @@ opik_tracer = OpikTracer(
 
 ## Accessing logged traces
 
-You can use the `created_traces` method to access the trace IDs collected by the `CometTracer` callback:
+You can use the `created_traces` method to access the trace IDs collected by the `OpikTracer` callback:
 
 ```python
 from opik.integrations.langchain import OpikTracer
@@ -88,11 +88,11 @@ traces = opik_tracer.created_traces()
 print([trace.id for trace in traces])
 ```
 
-This can be especially useful if you would like to update or log feedback scores for traces logged using the CometTracer.
+This can be especially useful if you would like to update or log feedback scores for traces logged using the OpikTracer.
 
 ## Advanced usage
 
-The `CometTracer` object has a `flush` method that can be used to make sure that all traces are logged to the Comet platform before you exit a script. This method will return once all traces have been logged or if the timeout is reach, whichever comes first.
+The `OpikTracer` object has a `flush` method that can be used to make sure that all traces are logged to the Comet platform before you exit a script. This method will return once all traces have been logged or if the timeout is reach, whichever comes first.
 
 ```python
 from opik.integrations.langchain import OpikTracer


### PR DESCRIPTION
## Details
fixes outdated references to `CometTracer` and replaces them with `OpikTracer`
## Issues

Resolves #

## Testing

## Documentation
updated langchain docs 