### PR TITLE
OPIK-58 Add trace usage

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Trace.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Trace.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -35,6 +36,7 @@ public record Trace(
         @JsonView({Trace.View.Public.class, Trace.View.Write.class}) JsonNode output,
         @JsonView({Trace.View.Public.class, Trace.View.Write.class}) JsonNode metadata,
         @JsonView({Trace.View.Public.class, Trace.View.Write.class}) Set<String> tags,
+        @JsonView({Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Map<String, Long> usage,
         @JsonView({Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant createdAt,
         @JsonView({Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
         @JsonView({Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
@@ -6,6 +6,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
+import java.util.List;
 import java.util.UUID;
 
 @Mapper
@@ -14,6 +15,8 @@ public interface FeedbackScoreMapper {
     FeedbackScoreMapper INSTANCE = Mappers.getMapper(FeedbackScoreMapper.class);
 
     FeedbackScore toFeedbackScore(FeedbackScoreBatchItem feedbackScoreBatchItem);
+
+    List<FeedbackScore> toFeedbackScores(List<FeedbackScoreBatchItem> feedbackScoreBatchItems);
 
     @Mapping(target = "id", source = "entityId")
     FeedbackScoreBatchItem toFeedbackScoreBatchItem(UUID entityId, String projectName, FeedbackScore feedbackScore);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -239,20 +239,7 @@ class TraceDAOImpl implements TraceDAO {
 
     private static final String SELECT_BY_ID = """
             SELECT
-                t.id,
-                t.workspace_id,
-                t.project_id,
-                t.name,
-                t.start_time,
-                t.end_time,
-                t.input,
-                t.output,
-                t.metadata,
-                t.tags,
-                t.created_at,
-                t.last_updated_at,
-                t.created_by,
-                t.last_updated_by,
+                t.*,
                 sumMap(s.usage) as usage
             FROM (
                 SELECT
@@ -274,40 +261,14 @@ class TraceDAOImpl implements TraceDAO {
                 LIMIT 1 BY id
             ) AS s ON t.id = s.trace_id
             GROUP BY
-                t.id,
-                t.workspace_id,
-                t.project_id,
-                t.name,
-                t.start_time,
-                t.end_time,
-                t.input,
-                t.output,
-                t.metadata,
-                t.tags,
-                t.created_at,
-                t.last_updated_at,
-                t.created_by,
-                t.last_updated_by
+                t.*
             ORDER BY t.id DESC
             ;
             """;
 
     private static final String SELECT_BY_PROJECT_ID = """
             SELECT
-                t.id,
-                t.workspace_id,
-                t.project_id,
-                t.name,
-                t.start_time,
-                t.end_time,
-                t.input,
-                t.output,
-                t.metadata,
-                t.tags,
-                t.created_at,
-                t.last_updated_at,
-                t.created_by,
-                t.last_updated_by,
+                t.*,
                 sumMap(s.usage) as usage
             FROM (
                 SELECT
@@ -348,20 +309,7 @@ class TraceDAOImpl implements TraceDAO {
                 LIMIT 1 BY id
             ) AS s ON t.id = s.trace_id
             GROUP BY
-                t.id,
-                t.workspace_id,
-                t.project_id,
-                t.name,
-                t.start_time,
-                t.end_time,
-                t.input,
-                t.output,
-                t.metadata,
-                t.tags,
-                t.created_at,
-                t.last_updated_at,
-                t.created_by,
-                t.last_updated_by
+                t.*
             ORDER BY t.id DESC
             ;
             """;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -29,6 +29,7 @@ import reactor.core.publisher.Mono;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -238,17 +239,77 @@ class TraceDAOImpl implements TraceDAO {
 
     private static final String SELECT_BY_ID = """
             SELECT
-                *
-            FROM
-                traces
-            WHERE id = :id
-            AND workspace_id = :workspace_id
-            ORDER BY last_updated_at DESC
-            LIMIT 1
+                t.id,
+                t.workspace_id,
+                t.project_id,
+                t.name,
+                t.start_time,
+                t.end_time,
+                t.input,
+                t.output,
+                t.metadata,
+                t.tags,
+                t.created_at,
+                t.last_updated_at,
+                t.created_by,
+                t.last_updated_by,
+                sumMap(s.usage) as usage
+            FROM (
+                SELECT
+                    *
+                FROM traces
+                WHERE workspace_id = :workspace_id
+                AND id = :id
+                ORDER BY id DESC, last_updated_at DESC
+                LIMIT 1 BY id
+            ) AS t
+            LEFT JOIN (
+                SELECT
+                    trace_id,
+                    usage
+                FROM spans
+                WHERE workspace_id = :workspace_id
+                AND trace_id = :id
+                ORDER BY id DESC, last_updated_at DESC
+                LIMIT 1 BY id
+            ) AS s ON t.id = s.trace_id
+            GROUP BY
+                t.id,
+                t.workspace_id,
+                t.project_id,
+                t.name,
+                t.start_time,
+                t.end_time,
+                t.input,
+                t.output,
+                t.metadata,
+                t.tags,
+                t.created_at,
+                t.last_updated_at,
+                t.created_by,
+                t.last_updated_by
+            ORDER BY t.id DESC
             ;
             """;
 
     private static final String SELECT_BY_PROJECT_ID = """
+            SELECT
+                t.id,
+                t.workspace_id,
+                t.project_id,
+                t.name,
+                t.start_time,
+                t.end_time,
+                t.input,
+                t.output,
+                t.metadata,
+                t.tags,
+                t.created_at,
+                t.last_updated_at,
+                t.created_by,
+                t.last_updated_by,
+                sumMap(s.usage) as usage
+            FROM (
                 SELECT
                      *
                  FROM traces
@@ -263,6 +324,7 @@ class TraceDAOImpl implements TraceDAO {
                         SELECT *
                         FROM feedback_scores
                         WHERE entity_type = 'trace'
+                        AND workspace_id = :workspace_id
                         AND project_id = :project_id
                         ORDER BY entity_id DESC, last_updated_at DESC
                         LIMIT 1 BY entity_id, name
@@ -274,6 +336,33 @@ class TraceDAOImpl implements TraceDAO {
                  ORDER BY id DESC, last_updated_at DESC
                  LIMIT 1 BY id
                  LIMIT :limit OFFSET :offset
+            ) AS t
+            LEFT JOIN (
+                SELECT
+                    trace_id,
+                    usage
+                FROM spans
+                WHERE workspace_id = :workspace_id
+                AND project_id = :project_id
+                ORDER BY id DESC, last_updated_at DESC
+                LIMIT 1 BY id
+            ) AS s ON t.id = s.trace_id
+            GROUP BY
+                t.id,
+                t.workspace_id,
+                t.project_id,
+                t.name,
+                t.start_time,
+                t.end_time,
+                t.input,
+                t.output,
+                t.metadata,
+                t.tags,
+                t.created_at,
+                t.last_updated_at,
+                t.created_by,
+                t.last_updated_by
+            ORDER BY t.id DESC
             ;
             """;
 
@@ -306,6 +395,7 @@ class TraceDAOImpl implements TraceDAO {
                         SELECT *
                         FROM feedback_scores
                         WHERE entity_type = 'trace'
+                        AND workspace_id = :workspace_id
                         AND project_id = :project_id
                         ORDER BY entity_id DESC, last_updated_at DESC
                         LIMIT 1 BY entity_id, name
@@ -314,7 +404,7 @@ class TraceDAOImpl implements TraceDAO {
                     HAVING <feedback_scores_filters>
                  )
                  <endif>
-                ORDER BY last_updated_at DESC
+                ORDER BY id DESC, last_updated_at DESC
                 LIMIT 1 BY id
             ) AS latest_rows
             ;
@@ -627,6 +717,7 @@ class TraceDAOImpl implements TraceDAO {
                         .collect(Collectors.toSet()))
                         .filter(it -> !it.isEmpty())
                         .orElse(null))
+                .usage(row.get("usage", Map.class))
                 .createdAt(row.get("created_at", Instant.class))
                 .lastUpdatedAt(row.get("last_updated_at", Instant.class))
                 .createdBy(row.get("created_by", String.class))


### PR DESCRIPTION
## Details
Added new `usage` field on `Trace`, which is calculated by summing the values of all the spans under the particular trace, per each usage key.

Due to summing, using `Long` type and `summap` function in ClickHouse instead of `Integer` and `summapwithoverflow`.

Some minor fixes in a few queries and also improved many Trace tests along the way.

## Issues

OPIK-58

## Testing
- Added and updated integration tests:
  - Summing usual token values.
  - Mixed with other random keys.
  - Mixed with missing keys.
  - Mixed with null keys.
  - Spans with null values case.
- Tests for all Trace retrieval endpoints: get by ID and find endpoints.
- Existing tests already check the case of no spans under the trace, resulting in a null trace usage.

## Documentation
- https://clickhouse.com/docs/en/sql-reference/aggregate-functions/reference/summap
- https://clickhouse.com/docs/en/sql-reference/aggregate-functions/reference/summapwithoverflow
- https://clickhouse.com/blog/aggregate-functions-combinators-in-clickhouse-for-arrays-maps-and-states