### PR TITLE
[OPIK-193] Fixtures to setup traces, spans, datasets, experiments via SDK for end to end automated tests

### DIFF
--- a/tests_end_to_end/application_sanity/conftest.py
+++ b/tests_end_to_end/application_sanity/conftest.py
@@ -1,0 +1,123 @@
+import pytest
+import os
+import opik
+import yaml
+from opik.configurator.configure import configure
+from opik import opik_context, track
+
+
+@pytest.fixture(scope='session', autouse=True)
+def config():
+    curr_dir = os.path.dirname(__file__)
+    config_path = os.path.join(curr_dir, 'sanity_config.yaml')
+
+    with open(config_path, 'r') as f:
+        conf = yaml.safe_load(f)
+    return conf
+
+
+@pytest.fixture(scope='session', autouse=True)
+def configure_local(config):
+    configure(use_local=True)
+    os.environ['OPIK_PROJECT_NAME'] = config['project']['name']
+
+
+@pytest.fixture(scope='session', autouse=True)
+def client(config):
+    return opik.Opik(project_name=config['project']['name'])
+
+
+@pytest.fixture(scope='function')
+def log_traces_and_spans_low_level(client, config):
+    """
+    Log 5 traces with spans and subspans using the low level Opik client
+    Each should have their own names, tags, metadata and feedback scores to test integrity of data transmitted
+    """
+
+    trace_config = {
+        'count': config['traces']['client']['count'],
+        'prefix': config['traces']['client']['prefix'],
+        'tags': config['traces']['client']['tags'],
+        'metadata': config['traces']['client']['metadata'],
+        'feedback_scores': [{'name': key, 'value': value} for key, value in config['traces']['client']['feedback-scores'].items()]
+    }
+
+    span_config = {
+        'count': config['spans']['client']['count'],
+        'prefix': config['spans']['client']['prefix'],
+        'tags': config['spans']['client']['tags'],
+        'metadata': config['spans']['client']['metadata'],
+        'feedback_scores': [{'name': key, 'value': value} for key, value in config['spans']['client']['feedback-scores'].items()]
+    }
+
+    for trace_index in range(trace_config['count']):
+        client_trace = client.trace(
+            name=trace_config['prefix'] + str(trace_index),
+            input=f'input-{trace_index}',
+            output=f'output-{trace_index}',
+            tags=trace_config['tags'],
+            metadata=trace_config['metadata'],
+            feedback_scores=trace_config['feedback_scores']
+        )
+        for span_index in range(span_config['count']):
+            client_span = client_trace.span(
+                name=span_config['prefix'] + str(span_index),
+                input=f'input-{span_index}',
+                output=f'output-{span_index}',
+                tags=span_config['tags'],
+                metadata=span_config['metadata']
+            )
+            for score in span_config['feedback_scores']:
+                client_span.log_feedback_score(name=score['name'], value=score['value'])
+
+
+@pytest.fixture(scope='function')
+def log_traces_and_spans_decorator(config):
+    """
+    Log 5 traces with spans and subspans using the low level Opik client
+    Each should have their own names, tags, metadata and feedback scores to test integrity of data transmitted
+    """
+    
+    trace_config = {
+        'count': config['traces']['decorator']['count'],
+        'prefix': config['traces']['decorator']['prefix'],
+        'tags': config['traces']['decorator']['tags'],
+        'metadata': config['traces']['decorator']['metadata'],
+        'feedback_scores': [{'name': key, 'value': value} for key, value in config['traces']['decorator']['feedback-scores'].items()]
+    }
+
+    span_config = {
+        'count': config['spans']['decorator']['count'],
+        'prefix': config['spans']['decorator']['prefix'],
+        'tags': config['spans']['decorator']['tags'],
+        'metadata': config['spans']['decorator']['metadata'],
+        'feedback_scores': [{'name': key, 'value': value} for key, value in config['spans']['decorator']['feedback-scores'].items()]
+    }
+
+    @track()
+    def make_span(x):
+        opik_context.update_current_span(
+            name=span_config['prefix'] + str(x),
+            input=f'input-{x}',
+            metadata=span_config['metadata'],
+            tags=span_config['tags'],
+            feedback_scores=span_config['feedback_scores']
+        )
+        return f'output-{x}'
+    
+    @track()
+    def make_trace(x):
+        for spans_no in range(span_config['count']):
+            make_span(spans_no)
+
+        opik_context.update_current_trace(
+            name=trace_config['prefix'] + str(x),
+            input=f'input-{x}',
+            metadata=trace_config['metadata'],
+            tags=trace_config['tags'],
+            feedback_scores=trace_config['feedback_scores']
+        )
+        return f'output-{x}'
+    
+    for x in range(trace_config['count']):
+        make_trace(x)

--- a/tests_end_to_end/application_sanity/sanity_config.yaml
+++ b/tests_end_to_end/application_sanity/sanity_config.yaml
@@ -1,0 +1,48 @@
+project:
+  name: "test-project"
+
+traces:
+  client:
+    prefix: "client-trace-"
+    count: 5
+    tags: ["c-tag1", "c-tag2"]
+    feedback-scores:
+      c-score1: 0.5
+      c-score2: 4
+    metadata:
+      c-md1: "val1"
+      c-md2: "val2"
+  
+  decorator:
+    prefix: "decorator-trace-"
+    count: 5
+    tags: ["d-tag1", "d-tag2"]
+    feedback-scores:
+      d-score1: 0.1
+      d-score2: 7
+    metadata:
+      d-md1: "val1"
+      d-md2: "val2"
+
+spans:
+  client:
+    prefix: "client-span-"
+    count: 2
+    tags: ["c-span1", "c-span2"]
+    feedback-scores:
+      s-score1: 0.2
+      s-score2: 3
+    metadata:
+      s-md1: "val1"
+      s-md2: "val2"
+
+  decorator:
+    prefix: "decorator-span-"
+    count: 2
+    tags: ["d-span1", "d-span2"]
+    feedback-scores:
+      s-score1: 0.93
+      s-score2: 2
+    metadata:
+      d-md1: "val1"
+      d-md2: "val2"

--- a/tests_end_to_end/application_sanity/sanity_config.yaml
+++ b/tests_end_to_end/application_sanity/sanity_config.yaml
@@ -46,3 +46,13 @@ spans:
     metadata:
       d-md1: "val1"
       d-md2: "val2"
+
+dataset:
+  name: &dataset-name "test-dataset"
+  filename: "sanity_dataset.jsonl"
+  item-count: 10
+
+experiments:
+  prefix: "test-experiment-"
+  metrics: ["Equals", "Contains"]
+  dataset-name: *dataset-name

--- a/tests_end_to_end/application_sanity/sanity_dataset.jsonl
+++ b/tests_end_to_end/application_sanity/sanity_dataset.jsonl
@@ -1,0 +1,10 @@
+{"input": {"user_question": "Paris"}, "expected_output": {"assistant_answer": "Hello, Paris!"}}
+{"input": {"user_question": "London"}, "expected_output": {"assistant_answer": "Hello, London!"}}
+{"input": {"user_question": "New York"}, "expected_output": {"assistant_answer": "Hello, New York!"}}
+{"input": {"user_question": "Tokyo"}, "expected_output": {"assistant_answer": "Hello, Tokyo!"}}
+{"input": {"user_question": "Berlin"}, "expected_output": {"assistant_answer": "Hello, Berlin!"}}
+{"input": {"user_question": "Sydney"}, "expected_output": {"assistant_answer": "Hello, Sydney!"}}
+{"input": {"user_question": "Cairo"}, "expected_output": {"assistant_answer": "Hello, Cairo!"}}
+{"input": {"user_question": "Toronto"}, "expected_output": {"assistant_answer": "Hello, Toronto!"}}
+{"input": {"user_question": "Stockholm"}, "expected_output": {"assistant_answer": "Hello, Stockholm!"}}
+{"input": {"user_question": "Sao Paulo"}, "expected_output": {"assistant_answer": "Hello, Sao Paulo!"}}


### PR DESCRIPTION
# Details

* Made the decision to call the basic flows defined in the [initial Notion page](https://www.notion.so/cometml/Opik-open-source-Test-Automation-Initial-Plan-9854af5df2e4414c8b224d269fb959e5) "sanity tests" as they should cover all of our basic flows and not take too long to run. As such, the setup fixtures and test suite itself is going to live inside the "application_sanity" subfolder of test_end_to_end, to maybe differentiate these flows from more specific features tests we might add in the future

* For traces and spans we are currently creating 5 traces each via the low level Opik() client and via the @track() decorator, each containing 2 spans, all objects have different names, and they all contain tags, metadata, feedback scores to check all data integrity is kept in the UI when testing. Also if anything fails on the SDK side as part of this setup, errors during fixtures are easy to collect via pytest and will stop the execution of everything, allowing us easy access to any SDK errors that might appear when testing via this suite.

* Defining all the characteristics of these objects (datasets and experiments to also be included later) in the **sanity_config.yaml** file for easy access within the tests and to facilitate any future changes. We could also take this approach with all the other suites we might later add, and break this up even more. Future specific-feature-test-suites can have fixtures/helper functions that create one object at a time as defined in their own config files, and we can have a file structure like:

```
   > tests_end_to_end
        > application_sanity
             conftest.py
             sanity_config.yaml
             test_sanity.py
        > features
             generic_config.yaml
             conftest.py
             > traces_table
                  conftest.py
                  speficic_config.yaml
                  test_pagination.py
                  test_filters.py
           etc
```

Keeping the most basic sanity tests compartmentalized like this is going to help us differentiate and make it more intuitive when to run which tests. This way we can always know what configuration of objects we're creating as part of sanity when doing just that (assuming we go for something like running sanity on every push/PR, and running the specific feature tests once in a while/when needed).

---

# Thursday Update:

Added fixtures to create a dataset and experiments as part of setup as well. Not much to test on the dataset side that is simple enough to classify as "sanity" so that ended up as just a simple dataset of 10 items. Made 2 experiments, each testing for 1 different Heuristic metric (Equals and Contains) and set it up in a way to always return the same values (0 for Equals, 1 for Contains) in order to check that scores are being send correctly as part of sanity.

