### PR TITLE
[OPIK-144] Fix condition when limit expires and application tries to retrieve to check available permits

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ratelimit/RateLimitService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ratelimit/RateLimitService.java
@@ -2,12 +2,13 @@ package com.comet.opik.infrastructure.ratelimit;
 
 import reactor.core.publisher.Mono;
 
+import static com.comet.opik.infrastructure.RateLimitConfig.LimitConfig;
+
 public interface RateLimitService {
 
-    Mono<Boolean> isLimitExceeded(String apiKey, long events, String bucketName, long limit,
-            long limitDurationInSeconds);
+    Mono<Boolean> isLimitExceeded(String apiKey, long events, String bucketName, LimitConfig limitConfig);
 
-    Mono<Long> availableEvents(String apiKey, String bucketName);
+    Mono<Long> availableEvents(String apiKey, String bucketName, LimitConfig limitConfig);
 
-    Mono<Long> getRemainingTTL(String apiKey, String bucket);
+    Mono<Long> getRemainingTTL(String apiKey, String bucket, LimitConfig limitConfig);
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/ratelimit/RateLimitE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/ratelimit/RateLimitE2ETest.java
@@ -581,6 +581,18 @@ class RateLimitE2ETest {
 
     }
 
+    @Test
+    @DisplayName("Rate limit: When rate limit is not set, Then set and and return limit")
+    void rateLimit__whenCustomRatedBeanMethodIsCalled__thenRateLimitIsApplied(RateLimitService rateLimitService) {
+        String apiKey = UUID.randomUUID().toString();
+        int limit = 100;
+
+        Long availableEvents = rateLimitService.availableEvents(apiKey, "generalLimit", new LimitConfig(limit, 1))
+                .block();
+
+        assertEquals(limit, availableEvents);
+    }
+
     private static void assertLimitHeaders(Response response, long expected, String limitBucket, int limitDuration) {
         String remainingLimit = response.getHeaderString(RequestContext.USER_REMAINING_LIMIT);
         String userLimit = response.getHeaderString(RequestContext.USER_LIMIT);


### PR DESCRIPTION
## Details

During tests, we found a scenario where the limit expired, and the application tried to retrieve it, generating the following error:

```
ERR user_script:1: RateLimiter is not initialized script: 1378f96e73a4251ef63dadab589a062f8276a044, on @user_script:1.. channel: [id: 0x0e387790, L:/10.4.68.55:58598
```

## Issues
OPIK-144

## Testing
- We managed to reproduce the error by recreating it as explained above. 
- To replicate this scenario, a test was created by calling the method directly without previous limit initialization.

## Documentation
https://www.javadoc.io/doc/org.redisson/redisson/latest/org/redisson/api/RRateLimiterAsync.html
