### PR TITLE
Add message with link to trace project

### DIFF
--- a/sdks/python/src/opik/message_processing/streamer.py
+++ b/sdks/python/src/opik/message_processing/streamer.py
@@ -32,7 +32,7 @@ class Streamer:
             self._batch_manager.start()
 
         # Used to know when to display the project URL
-        self._project_name_most_recent_trace = None
+        self._project_name_most_recent_trace: Optional[str] = None
 
     def put(self, message: messages.BaseMessage) -> None:
         with self._lock:

--- a/sdks/python/src/opik/message_processing/streamer.py
+++ b/sdks/python/src/opik/message_processing/streamer.py
@@ -1,10 +1,15 @@
 import queue
 import threading
+import logging
 from typing import Any, List, Optional
 
 from . import messages, queue_consumer
 from .. import synchronization
 from .batching import batch_manager
+
+from .. import url_helpers
+
+LOGGER = logging.getLogger(__name__)
 
 
 class Streamer:
@@ -26,6 +31,9 @@ class Streamer:
         if self._batch_manager is not None:
             self._batch_manager.start()
 
+        # Used to know when to display the project URL
+        self._project_name_most_recent_trace = None
+
     def put(self, message: messages.BaseMessage) -> None:
         with self._lock:
             if self._drain:
@@ -38,6 +46,19 @@ class Streamer:
                 self._batch_manager.process_message(message)
             else:
                 self._message_queue.put(message)
+
+        # Display message in console
+        if isinstance(message, messages.CreateTraceMessage):
+            projects_url = url_helpers.get_projects_url()
+            project_name = message.project_name
+            if (
+                self._project_name_most_recent_trace is None
+                or self._project_name_most_recent_trace != project_name
+            ):
+                LOGGER.info(
+                    f'Started logging traces to the "{project_name}" project at {projects_url}.'
+                )
+                self._project_name_most_recent_trace = project_name
 
     def close(self, timeout: Optional[int]) -> bool:
         """

--- a/sdks/python/src/opik/url_helpers.py
+++ b/sdks/python/src/opik/url_helpers.py
@@ -6,3 +6,10 @@ def get_ui_url() -> str:
     opik_url_override = config.url_override
 
     return opik_url_override.rstrip("/api")
+
+
+def get_projects_url() -> str:
+    config = opik.config.OpikConfig()
+    ui_url = get_ui_url()
+
+    return f"{ui_url}/{config.workspace}/projects"


### PR DESCRIPTION
## Details

When logging a trace to a project, the message:
```
OPIK: Started logging traces to the "Default Project" project at https://www.comet.com/opik/jacques-comet/projects.
```
will be displayed.

This message is only displayed once, but if you start logging to a different project you will see this message again.