### PR TITLE
[OPIK-137] Integrate new last_updated_trace_at in the Projects table

### DIFF
--- a/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
@@ -45,7 +45,8 @@ export const DEFAULT_COLUMNS: ColumnData<Project>[] = [
     id: "last_updated_at",
     label: "Last updated",
     type: COLUMN_TYPE.time,
-    accessorFn: (row) => formatDate(row.last_updated_at),
+    accessorFn: (row) =>
+      formatDate(row.last_updated_trace_at ?? row.created_at),
   },
 ];
 

--- a/apps/opik-frontend/src/types/projects.ts
+++ b/apps/opik-frontend/src/types/projects.ts
@@ -6,4 +6,5 @@ export interface Project {
   created_by: string;
   last_updated_at: string;
   last_updated_by: string;
+  last_updated_trace_at?: string;
 }


### PR DESCRIPTION
## Details
- Integrate new `last_updated_trace_at` field in the Projects table

## Issues

Resolves #

## Testing

## Documentation
