### PR TITLE
[OPIK-160] Fix trace and span error during insertion due to input/output size

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -28,7 +28,7 @@ databaseAnalytics:
   username: ${ANALYTICS_DB_USERNAME:-opik}
   password: ${ANALYTICS_DB_PASS:-opik}
   databaseName: ${ANALYTICS_DB_DATABASE_NAME:-opik}
-  queryParameters: ${ANALYTICS_DB_QUERY_PARAMETERS:-health_check_interval=2000&compress=1&auto_discovery=true&failover=3}
+  queryParameters: ${ANALYTICS_DB_QUERY_PARAMETERS:-health_check_interval=2000&compress=1&auto_discovery=true&failover=3&custom_http_params=max_query_size=100000000}
 
 health:
   healthCheckUrlPaths: [ "/health-check" ]

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -2319,7 +2319,7 @@ class SpansResourceTest {
                                             .map(feedbackScore -> feedbackScore.toBuilder()
                                                     .value(podamFactory.manufacturePojo(BigDecimal.class))
                                                     .build())
-                                            .toList())
+                                            .collect(Collectors.toList()))
                             .build())
                     .collect(Collectors.toCollection(ArrayList::new));
 
@@ -2380,7 +2380,7 @@ class SpansResourceTest {
                                             .map(feedbackScore -> feedbackScore.toBuilder()
                                                     .value(podamFactory.manufacturePojo(BigDecimal.class))
                                                     .build())
-                                            .toList(),
+                                            .collect(Collectors.toList()),
                                     2, 1234.5678))
                             .build())
                     .collect(Collectors.toCollection(ArrayList::new));
@@ -2435,7 +2435,7 @@ class SpansResourceTest {
                                     .map(feedbackScore -> feedbackScore.toBuilder()
                                             .value(podamFactory.manufacturePojo(BigDecimal.class))
                                             .build())
-                                    .toList(), 2, 1234.5678))
+                                    .collect(Collectors.toList()), 2, 1234.5678))
                             .build())
                     .collect(Collectors.toCollection(ArrayList::new));
             spans.set(0, spans.getFirst().toBuilder()
@@ -2485,7 +2485,7 @@ class SpansResourceTest {
                                     .map(feedbackScore -> feedbackScore.toBuilder()
                                             .value(podamFactory.manufacturePojo(BigDecimal.class))
                                             .build())
-                                    .toList(), 2, 2345.6789))
+                                    .collect(Collectors.toList()), 2, 2345.6789))
                             .build())
                     .collect(Collectors.toCollection(ArrayList::new));
             spans.set(0, spans.getFirst().toBuilder()
@@ -2535,7 +2535,7 @@ class SpansResourceTest {
                                     .map(feedbackScore -> feedbackScore.toBuilder()
                                             .value(podamFactory.manufacturePojo(BigDecimal.class))
                                             .build())
-                                    .toList(), 2, 2345.6789))
+                                    .collect(Collectors.toList()), 2, 2345.6789))
                             .build())
                     .collect(Collectors.toCollection(ArrayList::new));
             spans.set(0, spans.getFirst().toBuilder()

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -2319,7 +2319,7 @@ class SpansResourceTest {
                                             .map(feedbackScore -> feedbackScore.toBuilder()
                                                     .value(podamFactory.manufacturePojo(BigDecimal.class))
                                                     .build())
-                                            .collect(Collectors.toList()))
+                                            .toList())
                             .build())
                     .collect(Collectors.toCollection(ArrayList::new));
 
@@ -2380,7 +2380,7 @@ class SpansResourceTest {
                                             .map(feedbackScore -> feedbackScore.toBuilder()
                                                     .value(podamFactory.manufacturePojo(BigDecimal.class))
                                                     .build())
-                                            .collect(Collectors.toList()),
+                                            .toList(),
                                     2, 1234.5678))
                             .build())
                     .collect(Collectors.toCollection(ArrayList::new));
@@ -2435,7 +2435,7 @@ class SpansResourceTest {
                                     .map(feedbackScore -> feedbackScore.toBuilder()
                                             .value(podamFactory.manufacturePojo(BigDecimal.class))
                                             .build())
-                                    .collect(Collectors.toList()), 2, 1234.5678))
+                                    .toList(), 2, 1234.5678))
                             .build())
                     .collect(Collectors.toCollection(ArrayList::new));
             spans.set(0, spans.getFirst().toBuilder()
@@ -2485,7 +2485,7 @@ class SpansResourceTest {
                                     .map(feedbackScore -> feedbackScore.toBuilder()
                                             .value(podamFactory.manufacturePojo(BigDecimal.class))
                                             .build())
-                                    .collect(Collectors.toList()), 2, 2345.6789))
+                                    .toList(), 2, 2345.6789))
                             .build())
                     .collect(Collectors.toCollection(ArrayList::new));
             spans.set(0, spans.getFirst().toBuilder()
@@ -2535,7 +2535,7 @@ class SpansResourceTest {
                                     .map(feedbackScore -> feedbackScore.toBuilder()
                                             .value(podamFactory.manufacturePojo(BigDecimal.class))
                                             .build())
-                                    .collect(Collectors.toList()), 2, 2345.6789))
+                                    .toList(), 2, 2345.6789))
                             .build())
                     .collect(Collectors.toCollection(ArrayList::new));
             spans.set(0, spans.getFirst().toBuilder()
@@ -3144,6 +3144,27 @@ class SpansResourceTest {
     }
 
     @Test
+    void createAndGet__whenSpanInputIsBig__thenReturnSpan() {
+
+        int size = 1000;
+
+        Map<String, String> jsonMap = IntStream.range(0, size)
+                .mapToObj(i -> Map.entry(RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAscii(size)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
+                .projectId(null)
+                .parentSpanId(null)
+                .input(JsonUtils.readTree(jsonMap))
+                .output(JsonUtils.readTree(jsonMap))
+                .build();
+
+        createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+
+        getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+    }
+
+    @Test
     void createOnlyRequiredFieldsAndGetById() {
         var expectedSpan = podamFactory.manufacturePojo(Span.class)
                 .toBuilder()
@@ -3568,7 +3589,7 @@ class SpansResourceTest {
             assertThat(actualEntity.metadata()).isEqualTo(spanUpdate.metadata());
             assertThat(actualEntity.tags()).isEqualTo(spanUpdate.tags());
 
-            assertThat(actualEntity.name()).isEqualTo("");
+            assertThat(actualEntity.name()).isEmpty();
             assertThat(actualEntity.startTime()).isEqualTo(Instant.EPOCH);
             assertThat(actualEntity.type()).isNull();
         }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -3422,6 +3422,27 @@ class TracesResourceTest {
             assertThat(actualEntity.projectId()).isEqualTo(projectId);
         }
 
+        @Test
+        @DisplayName("when trace input is big, then accept and create trace")
+        void createAndGet__whenTraceInputIsBig__thenReturnSpan() {
+
+            int size = 1000;
+
+            Map<String, String> jsonMap = IntStream.range(0, size)
+                    .mapToObj(i -> Map.entry(RandomStringUtils.randomAlphabetic(10), RandomStringUtils.randomAscii(size)))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            var expectedTrace = factory.manufacturePojo(Trace.class).toBuilder()
+                    .projectId(null)
+                    .input(JsonUtils.readTree(jsonMap))
+                    .output(JsonUtils.readTree(jsonMap))
+                    .build();
+
+            create(expectedTrace, API_KEY, TEST_WORKSPACE);
+
+            getAndAssert(expectedTrace, getProjectId(expectedTrace.projectName(), TEST_WORKSPACE, API_KEY), API_KEY, TEST_WORKSPACE);
+        }
+
     }
 
     @Nested

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -3436,11 +3436,14 @@ class TracesResourceTest {
                     .projectId(null)
                     .input(JsonUtils.readTree(jsonMap))
                     .output(JsonUtils.readTree(jsonMap))
+                    .feedbackScores(null)
+                    .usage(null)
                     .build();
 
             create(expectedTrace, API_KEY, TEST_WORKSPACE);
 
-            getAndAssert(expectedTrace, getProjectId(expectedTrace.projectName(), TEST_WORKSPACE, API_KEY), API_KEY, TEST_WORKSPACE);
+            UUID projectId = getProjectId(expectedTrace.projectName(), TEST_WORKSPACE, API_KEY);
+            getAndAssert(expectedTrace, projectId, API_KEY, TEST_WORKSPACE);
         }
 
     }

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -26,7 +26,7 @@ databaseAnalytics:
   username: opik
   password: opik
   databaseName: opik
-  queryParameters: health_check_interval=2000&compress=1&auto_discovery=true&failover=3
+  queryParameters: health_check_interval=2000&compress=1&auto_discovery=true&failover=3&custom_http_params=max_query_size=100000000
 
 health:
   healthCheckUrlPaths: [ "/health-check" ]


### PR DESCRIPTION
## Details

Testing locally, we managed to reproduce the error, which was apparently due to some truncation of the statement. A temporary fix is to increase the query size limit. However, we will address this soon with the ClickHouse consultancy

## Issues
#OPIK-160

## Testing
Add tests to simulate error

## Documentation
