### PR TITLE
[OPIK-217] Fix FE docker image to do not use the local node_modules folder

### DIFF
--- a/apps/opik-frontend/.dockerignore
+++ b/apps/opik-frontend/.dockerignore
@@ -1,3 +1,2 @@
-.git
-target
+dist
 node_modules


### PR DESCRIPTION
## Details
- The `.dockerignore` was in the wrong folder and the local `node_modules` was overriding the one in the Docker image
- Other ignores in that previous `.dockerignore` weren't needed since the BE doesn't copy the `target` folder

## Issues

Resolves #

## Testing

## Documentation
