### PR TITLE
OPIK-184 [SDK] Allow users to configure the project name in OpenAI integration

### DIFF
--- a/.github/workflows/sdk-e2e-tests.yaml
+++ b/.github/workflows/sdk-e2e-tests.yaml
@@ -38,7 +38,7 @@ jobs:
             cd deployment/docker-compose
             docker compose up -d --build
         
-        - name: Check Opik server avialability
+        - name: Check Opik server availability
           shell: bash
           run: |
             chmod +x ${{ github.workspace }}/tests_end_to_end/installer/*.sh

--- a/sdks/python/src/opik/integrations/openai/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/openai/opik_tracker.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 
 import openai
 
@@ -7,6 +7,7 @@ from . import openai_decorator, chunks_aggregator
 
 def track_openai(
     openai_client: Union[openai.OpenAI, openai.AsyncOpenAI],
+    project_name: Optional[str] = None,
 ) -> Union[openai.OpenAI, openai.AsyncOpenAI]:
     """Adds Opik tracking to an OpenAI client.
 
@@ -15,6 +16,7 @@ def track_openai(
 
     Args:
         openai_client: An instance of OpenAI or AsyncOpenAI client.
+        project_name: The name of the project to log data.
 
     Returns:
         The modified OpenAI client with Opik tracking enabled.
@@ -24,6 +26,7 @@ def track_openai(
         type="llm",
         name="chat_completion_create",
         generations_aggregator=chunks_aggregator.aggregate,
+        project_name=project_name,
     )
     openai_client.chat.completions.create = wrapper(
         openai_client.chat.completions.create

--- a/sdks/python/tests/library_integration/openai/test_openai.py
+++ b/sdks/python/tests/library_integration/openai/test_openai.py
@@ -7,7 +7,7 @@ import asyncio
 import opik
 from opik.message_processing import streamer_constructors
 from opik.integrations.openai import track_openai
-from ...e2e.conftest import OPIK_E2E_TESTS_PROJECT_NAME
+from opik.config import OPIK_PROJECT_DEFAULT_NAME
 from ...testlib import backend_emulator_message_processor
 from ...testlib import (
     SpanModel,
@@ -69,8 +69,7 @@ def test_openai_client_chat_completions_create__happyflow(fake_streamer, project
         # if "project name" was passed to tracker as None, default project name must be used,
         # and it will be expected in results
         if project_name is None:
-            # this is the default project name for e2e/integration tests
-            project_name = OPIK_E2E_TESTS_PROJECT_NAME
+            project_name = OPIK_PROJECT_DEFAULT_NAME
 
         EXPECTED_TRACE_TREE = TraceModel(
             id=ANY_BUT_NONE,

--- a/sdks/python/tests/library_integration/openai/test_openai.py
+++ b/sdks/python/tests/library_integration/openai/test_openai.py
@@ -30,10 +30,15 @@ def ensure_openai_configured():
 
 
 @pytest.mark.parametrize(
-    "project_name",
-    [None, "openai-integration-test"],
+    "project_name, expected_project_name",
+    [
+        (None, OPIK_PROJECT_DEFAULT_NAME),
+        ("openai-integration-test", "openai-integration-test"),
+    ],
 )
-def test_openai_client_chat_completions_create__happyflow(fake_streamer, project_name):
+def test_openai_client_chat_completions_create__happyflow(
+    fake_streamer, project_name, expected_project_name
+):
     fake_message_processor_: (
         backend_emulator_message_processor.BackendEmulatorMessageProcessor
     )
@@ -66,11 +71,6 @@ def test_openai_client_chat_completions_create__happyflow(fake_streamer, project
         opik.flush_tracker()
         mock_construct_online_streamer.assert_called_once()
 
-        # if "project name" was passed to tracker as None, default project name must be used,
-        # and it will be expected in results
-        if project_name is None:
-            project_name = OPIK_PROJECT_DEFAULT_NAME
-
         EXPECTED_TRACE_TREE = TraceModel(
             id=ANY_BUT_NONE,
             name="chat_completion_create",
@@ -85,7 +85,7 @@ def test_openai_client_chat_completions_create__happyflow(fake_streamer, project
             },
             start_time=ANY_BUT_NONE,
             end_time=ANY_BUT_NONE,
-            project_name=project_name,
+            project_name=expected_project_name,
             spans=[
                 SpanModel(
                     id=ANY_BUT_NONE,
@@ -104,7 +104,7 @@ def test_openai_client_chat_completions_create__happyflow(fake_streamer, project
                     usage=ANY_BUT_NONE,
                     start_time=ANY_BUT_NONE,
                     end_time=ANY_BUT_NONE,
-                    project_name=project_name,
+                    project_name=expected_project_name,
                     spans=[],
                 )
             ],

--- a/sdks/python/tests/testlib/backend_emulator_message_processor.py
+++ b/sdks/python/tests/testlib/backend_emulator_message_processor.py
@@ -87,6 +87,7 @@ class BackendEmulatorMessageProcessor(message_processors.BaseMessageProcessor):
                 metadata=message.metadata,
                 start_time=message.start_time,
                 end_time=message.end_time,
+                project_name=message.project_name,
             )
 
             self._trace_trees.append(trace)
@@ -104,6 +105,7 @@ class BackendEmulatorMessageProcessor(message_processors.BaseMessageProcessor):
                 start_time=message.start_time,
                 end_time=message.end_time,
                 usage=message.usage,
+                project_name=message.project_name,
             )
 
             self._span_to_parent_span[span.id] = message.parent_span_id

--- a/sdks/python/tests/testlib/models.py
+++ b/sdks/python/tests/testlib/models.py
@@ -3,6 +3,8 @@ from typing import List, Any, Optional, Dict
 import dataclasses
 import datetime
 
+from tests.e2e.conftest import OPIK_E2E_TESTS_PROJECT_NAME
+
 
 @dataclasses.dataclass
 class SpanModel:
@@ -16,6 +18,7 @@ class SpanModel:
     type: str = "general"
     usage: Optional[Dict[str, Any]] = None
     end_time: Optional[datetime.datetime] = None
+    project_name: str = OPIK_E2E_TESTS_PROJECT_NAME
     spans: List["SpanModel"] = dataclasses.field(default_factory=list)
     feedback_scores: List["FeedbackScoreModel"] = dataclasses.field(
         default_factory=list
@@ -27,11 +30,13 @@ class TraceModel:
     id: str
     start_time: datetime.datetime
     name: Optional[str]
+    project_name: str
     input: Any = None
     output: Any = None
     tags: Optional[List[str]] = None
     metadata: Optional[Dict[str, Any]] = None
     end_time: Optional[datetime.datetime] = None
+    project_name: str = OPIK_E2E_TESTS_PROJECT_NAME
     spans: List["SpanModel"] = dataclasses.field(default_factory=list)
     feedback_scores: List["FeedbackScoreModel"] = dataclasses.field(
         default_factory=list

--- a/sdks/python/tests/testlib/models.py
+++ b/sdks/python/tests/testlib/models.py
@@ -3,7 +3,7 @@ from typing import List, Any, Optional, Dict
 import dataclasses
 import datetime
 
-from tests.e2e.conftest import OPIK_E2E_TESTS_PROJECT_NAME
+from opik.config import OPIK_PROJECT_DEFAULT_NAME
 
 
 @dataclasses.dataclass
@@ -18,7 +18,7 @@ class SpanModel:
     type: str = "general"
     usage: Optional[Dict[str, Any]] = None
     end_time: Optional[datetime.datetime] = None
-    project_name: str = OPIK_E2E_TESTS_PROJECT_NAME
+    project_name: str = OPIK_PROJECT_DEFAULT_NAME
     spans: List["SpanModel"] = dataclasses.field(default_factory=list)
     feedback_scores: List["FeedbackScoreModel"] = dataclasses.field(
         default_factory=list
@@ -36,7 +36,7 @@ class TraceModel:
     tags: Optional[List[str]] = None
     metadata: Optional[Dict[str, Any]] = None
     end_time: Optional[datetime.datetime] = None
-    project_name: str = OPIK_E2E_TESTS_PROJECT_NAME
+    project_name: str = OPIK_PROJECT_DEFAULT_NAME
     spans: List["SpanModel"] = dataclasses.field(default_factory=list)
     feedback_scores: List["FeedbackScoreModel"] = dataclasses.field(
         default_factory=list


### PR DESCRIPTION
## Details
This PR allows user to set project name for OpenAI client.

```python
client = OpenAI()
client = opik_tracker.track_openai(
    openai_client=client,
    project_name="opik184",
)

```
## Issues

Resolves #

## Testing
integration tests are added

## Documentation
