### PR TITLE
Updated trace url link

### DIFF
--- a/sdks/python/src/opik/message_processing/streamer.py
+++ b/sdks/python/src/opik/message_processing/streamer.py
@@ -7,8 +7,6 @@ from . import messages, queue_consumer
 from .. import synchronization
 from .batching import batch_manager
 
-from .. import url_helpers
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -31,9 +29,6 @@ class Streamer:
         if self._batch_manager is not None:
             self._batch_manager.start()
 
-        # Used to know when to display the project URL
-        self._project_name_most_recent_trace: Optional[str] = None
-
     def put(self, message: messages.BaseMessage) -> None:
         with self._lock:
             if self._drain:
@@ -46,19 +41,6 @@ class Streamer:
                 self._batch_manager.process_message(message)
             else:
                 self._message_queue.put(message)
-
-        # Display message in console
-        if isinstance(message, messages.CreateTraceMessage):
-            projects_url = url_helpers.get_projects_url()
-            project_name = message.project_name
-            if (
-                self._project_name_most_recent_trace is None
-                or self._project_name_most_recent_trace != project_name
-            ):
-                LOGGER.info(
-                    f'Started logging traces to the "{project_name}" project at {projects_url}.'
-                )
-                self._project_name_most_recent_trace = project_name
 
     def close(self, timeout: Optional[int]) -> bool:
         """

--- a/sdks/python/src/opik/url_helpers.py
+++ b/sdks/python/src/opik/url_helpers.py
@@ -1,5 +1,4 @@
 import opik.config
-import opik.api_objects.opik_client
 
 
 def get_ui_url() -> str:
@@ -24,8 +23,6 @@ def get_experiment_url(dataset_name: str, experiment_id: str) -> str:
     return f"{ui_url}/{config.workspace}/experiments/{dataset_id}/compare?experiments=%5B%22{experiment_id}%22%5D"
 
 
-def get_projects_url() -> str:
-    config = opik.config.OpikConfig()
+def get_projects_url(workspace: str) -> str:
     ui_url = get_ui_url()
-
-    return f"{ui_url}/{config.workspace}/projects"
+    return f"{ui_url}/{workspace}/projects"


### PR DESCRIPTION
## Details

Updated the message that is displayed when logging a trace to support the following:
```
import opik

client = opik.Opik(project_name="test", workspace="jacques-comet")
trace = client.trace(name="test")
```
will display:

```OPIK: Started logging traces to the "Default Project" project at https://www.comet.com/opik/jacques-comet/projects.```