### PR TITLE
OPIK-186 [SDK] Allow users to configure the project name in LangChain integration

### DIFF
--- a/sdks/python/src/opik/integrations/langchain/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/langchain/opik_tracer.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Literal, Set
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Literal, Set, Union
 
 from langchain_core.tracers import BaseTracer
 
@@ -13,6 +14,8 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from langchain_core.tracers.schemas import Run
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _get_span_type(run: "Run") -> Literal["llm", "tool", "general"]:
@@ -29,6 +32,7 @@ class OpikTracer(BaseTracer):
         self,
         tags: Optional[List[str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        project_name: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -37,6 +41,7 @@ class OpikTracer(BaseTracer):
         Args:
             tags: List of tags to be applied to each trace logged by the tracer.
             metadata: Additional metadata for each trace logged by the tracer.
+            project_name: The name of the project to log data.
         """
         super().__init__(**kwargs)
         self._trace_default_metadata = metadata if metadata is not None else {}
@@ -52,7 +57,11 @@ class OpikTracer(BaseTracer):
 
         self._externally_created_traces_ids: Set[str] = set()
 
-        self._opik_client = opik_client.get_client_cached()
+        self._project_name = project_name
+
+        self._opik_client = opik_client.Opik(
+            _use_batching=True, project_name=project_name
+        )
 
     def _persist_run(self, run: "Run") -> None:
         run_dict: Dict[str, Any] = run.dict()
@@ -74,6 +83,9 @@ class OpikTracer(BaseTracer):
             self._track_root_run(run_dict)
         else:
             parent_span_data = self._span_data_map[run.parent_run_id]
+
+            project_name = self._get_project_name(parent_span_data)
+
             span_data = span.SpanData(
                 trace_id=parent_span_data.trace_id,
                 parent_span_id=parent_span_data.id,
@@ -81,6 +93,7 @@ class OpikTracer(BaseTracer):
                 metadata=run_dict["extra"],
                 name=run.name,
                 type=_get_span_type(run),
+                project_name=project_name,
             )
 
             self._span_data_map[run.id] = span_data
@@ -89,6 +102,24 @@ class OpikTracer(BaseTracer):
                 self._created_traces_data_map[run.id] = self._created_traces_data_map[
                     run.parent_run_id
                 ]
+
+    def _get_project_name(
+        self, parent_data: Union[trace.TraceData, span.SpanData]
+    ) -> str:
+        if parent_data.project_name != self._project_name:
+            # if the user has specified a project name -> print warning
+            if self._project_name is not None:
+                LOGGER.warning(
+                    "You are attempting to log data into a nested span under "
+                    f'the project name "{self._project_name}". '
+                    f'However, the project name "{parent_data.project_name}" '
+                    "from parent span will be used instead."
+                )
+            project_name = parent_data.project_name
+        else:
+            project_name = self._project_name
+
+        return project_name
 
     def _track_root_run(self, run_dict: Dict[str, Any]) -> None:
         run_metadata = run_dict["extra"].get("metadata", {})
@@ -123,6 +154,7 @@ class OpikTracer(BaseTracer):
             input=run_dict["inputs"],
             metadata=root_metadata,
             tags=self._trace_default_tags,
+            project_name=self._project_name,
         )
 
         self._created_traces_data_map[run_dict["id"]] = trace_data
@@ -134,6 +166,7 @@ class OpikTracer(BaseTracer):
             input=run_dict["inputs"],
             metadata=root_metadata,
             tags=self._trace_default_tags,
+            project_name=self._project_name,
         )
 
         self._span_data_map[run_dict["id"]] = span_
@@ -144,6 +177,8 @@ class OpikTracer(BaseTracer):
         current_span_data: span.SpanData,
         root_metadata: Dict[str, Any],
     ) -> None:
+        project_name = self._get_project_name(current_span_data)
+
         span_data = span.SpanData(
             trace_id=current_span_data.trace_id,
             parent_span_id=current_span_data.id,
@@ -151,6 +186,7 @@ class OpikTracer(BaseTracer):
             input=run_dict["inputs"],
             metadata=root_metadata,
             tags=self._trace_default_tags,
+            project_name=project_name,
         )
         self._span_data_map[run_dict["id"]] = span_data
         self._externally_created_traces_ids.add(span_data.trace_id)
@@ -161,6 +197,8 @@ class OpikTracer(BaseTracer):
         current_trace_data: trace.TraceData,
         root_metadata: Dict[str, Any],
     ) -> None:
+        project_name = self._get_project_name(current_trace_data)
+
         span_data = span.SpanData(
             trace_id=current_trace_data.id,
             parent_span_id=None,
@@ -168,6 +206,7 @@ class OpikTracer(BaseTracer):
             input=run_dict["inputs"],
             metadata=root_metadata,
             tags=self._trace_default_tags,
+            project_name=project_name,
         )
         self._span_data_map[run_dict["id"]] = span_data
         self._externally_created_traces_ids.add(current_trace_data.id)

--- a/sdks/python/src/opik/integrations/langchain/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/langchain/opik_tracer.py
@@ -105,7 +105,7 @@ class OpikTracer(BaseTracer):
 
     def _get_project_name(
         self, parent_data: Union[trace.TraceData, span.SpanData]
-    ) -> str:
+    ) -> Optional[str]:
         if parent_data.project_name != self._project_name:
             # if the user has specified a project name -> print warning
             if self._project_name is not None:


### PR DESCRIPTION
## Details
This PR allows user to set project name for LangChain callback.

## Testing
end-2-end tests are added
