### PR TITLE
Handle long names (without spaces) in breadcrumbs, page titles and popups

### DIFF
--- a/apps/opik-frontend/src/components/layout/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/opik-frontend/src/components/layout/Breadcrumbs/Breadcrumbs.tsx
@@ -59,7 +59,7 @@ const Breadcrumbs = () => {
       items.push(
         <BreadcrumbItem key={breadcrumb.path}>
           {isLast ? (
-            <span className="cursor-default">{breadcrumb.title}</span>
+            <span className="cursor-default truncate">{breadcrumb.title}</span>
           ) : (
             <BreadcrumbLink asChild>
               <Link to={breadcrumb.path}>{breadcrumb.title}</Link>

--- a/apps/opik-frontend/src/components/layout/TopBar/TopBar.tsx
+++ b/apps/opik-frontend/src/components/layout/TopBar/TopBar.tsx
@@ -7,7 +7,7 @@ const TopBar = () => {
 
   return (
     <nav className="comet-header-height flex w-full items-center justify-between gap-6 border-b pl-4 pr-6">
-      <div className="flex-1">
+      <div className="min-w-1 flex-1">
         <Breadcrumbs />
       </div>
 

--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsDetails.tsx
@@ -197,12 +197,16 @@ const CompareExperimentsDetails: React.FunctionComponent<
   return (
     <div className="pb-4 pt-6">
       <div className="mb-4 flex min-h-8 items-center justify-between">
-        <h1 className="comet-title-l">{title}</h1>
+        <h1 className="comet-title-l truncate break-words">{title}</h1>
         {renderCompareFeedbackScoresButton()}
       </div>
       <div className="mb-1 flex gap-4 overflow-x-auto">
         {!isCompare && (
-          <Tag size="lg" variant="gray" className="flex items-center gap-2">
+          <Tag
+            size="lg"
+            variant="gray"
+            className="flex shrink-0 items-center gap-2"
+          >
             <Clock className="size-4 shrink-0" />
             <div className="truncate">{formatDate(experiment?.created_at)}</div>
           </Tag>

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemPanelContent.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemPanelContent.tsx
@@ -46,7 +46,7 @@ const DatasetItemPanelContent: React.FunctionComponent<
       <div className="size-full overflow-y-auto p-4">
         <div className="my-4 flex flex-row gap-1">
           <div className="font-bold">Dataset:</div>
-          <div>{dataset?.name}</div>
+          <div className="truncate">{dataset?.name}</div>
         </div>
         <Accordion
           type="multiple"

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
@@ -159,7 +159,7 @@ const DatasetItemsPage = () => {
   return (
     <div className="pt-6">
       <div className="mb-4 flex items-center justify-between">
-        <h1 className="comet-title-l">{dataset?.name}</h1>
+        <h1 className="comet-title-l truncate break-words">{dataset?.name}</h1>
       </div>
       <div className="mb-4 flex items-center justify-between gap-8">
         <div className="flex items-center gap-2"></div>

--- a/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetsPage.tsx
@@ -168,7 +168,7 @@ const DatasetsPage: React.FunctionComponent = () => {
   return (
     <div className="pt-6">
       <div className="mb-4 flex items-center justify-between">
-        <h1 className="comet-title-l">Datasets</h1>
+        <h1 className="comet-title-l truncate break-words">Datasets</h1>
       </div>
       <div className="mb-4 flex items-center justify-between gap-8">
         <SearchInput

--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
@@ -199,7 +199,7 @@ const ExperimentsPage: React.FunctionComponent = () => {
   return (
     <div className="pt-6">
       <div className="mb-4 flex items-center justify-between">
-        <h1 className="comet-title-l">Experiments</h1>
+        <h1 className="comet-title-l truncate break-words">Experiments</h1>
       </div>
       <div className="mb-4 flex items-center justify-between gap-8">
         <div className="flex items-center gap-2">

--- a/apps/opik-frontend/src/components/pages/FeedbackDefinitionsPage/FeedbackDefinitionsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/FeedbackDefinitionsPage/FeedbackDefinitionsPage.tsx
@@ -151,7 +151,9 @@ const FeedbackDefinitionsPage: React.FunctionComponent = () => {
   return (
     <div className="pt-6">
       <div className="mb-4 flex items-center justify-between">
-        <h1 className="comet-title-l">Feedback definitions</h1>
+        <h1 className="comet-title-l truncate break-words">
+          Feedback definitions
+        </h1>
       </div>
       <div className="mb-4 flex items-center justify-between gap-8">
         <SearchInput

--- a/apps/opik-frontend/src/components/pages/ProjectsPage/DeleteProjectDialog.tsx
+++ b/apps/opik-frontend/src/components/pages/ProjectsPage/DeleteProjectDialog.tsx
@@ -49,7 +49,7 @@ const DeleteProjectDialog: React.FunctionComponent<
             and cannot be recovered.
           </DialogDescription>
         </DialogHeader>
-        <div className="flex flex-col gap-4">
+        <div className="flex min-w-1 max-w-full flex-col gap-4">
           <Label htmlFor="projectName">
             {`To validation, type "${project.name}"`}
           </Label>

--- a/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
@@ -157,7 +157,7 @@ const ProjectsPage: React.FunctionComponent = () => {
   return (
     <div className="pt-6">
       <div className="mb-4 flex items-center justify-between">
-        <h1 className="comet-title-l">Projects</h1>
+        <h1 className="comet-title-l truncate break-words">Projects</h1>
       </div>
       <div className="mb-4 flex items-center justify-between gap-8">
         <SearchInput

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesPage.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesPage.tsx
@@ -216,11 +216,19 @@ const TracesPage = () => {
   return (
     <div className="pt-6">
       <div className="mb-4 flex items-center justify-between">
-        <h1 data-testid="traces-page-title" className="comet-title-l">
+        <h1
+          data-testid="traces-page-title"
+          className="comet-title-l truncate break-words"
+        >
           {name}
         </h1>
         <TooltipWrapper content="Refresh traces list">
-          <Button variant="outline" size="icon-sm" onClick={() => refetch()}>
+          <Button
+            variant="outline"
+            size="icon-sm"
+            className="shrink-0"
+            onClick={() => refetch()}
+          >
             <RotateCw className="size-4" />
           </Button>
         </TooltipWrapper>

--- a/apps/opik-frontend/src/components/ui/breadcrumb.tsx
+++ b/apps/opik-frontend/src/components/ui/breadcrumb.tsx
@@ -19,7 +19,7 @@ const BreadcrumbList = React.forwardRef<
   <ol
     ref={ref}
     className={cn(
-      "comet-body-s flex flex-wrap items-center break-words text-muted-slate",
+      "comet-body-s flex items-center break-words text-muted-slate",
       className,
     )}
     {...props}
@@ -34,7 +34,7 @@ const BreadcrumbItem = React.forwardRef<
   <li
     ref={ref}
     className={cn(
-      "inline-flex items-center gap-1.5 last:text-[#475569] last:font-medium p-1.5",
+      "inline-flex items-center gap-1.5 last:text-[#475569] last:font-medium p-1.5 truncate",
       className,
     )}
     {...props}
@@ -53,7 +53,10 @@ const BreadcrumbLink = React.forwardRef<
   return (
     <Comp
       ref={ref}
-      className={cn("transition-colors hover:underline", className)}
+      className={cn(
+        "transition-colors hover:underline truncate break-words",
+        className,
+      )}
       {...props}
     />
   );

--- a/apps/opik-frontend/src/components/ui/dialog.tsx
+++ b/apps/opik-frontend/src/components/ui/dialog.tsx
@@ -57,7 +57,7 @@ const DialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-1.5 text-center pb-2 sm:text-left",
+      "flex flex-col space-y-1.5 text-center pb-2 sm:text-left max-w-full min-w-1",
       className,
     )}
     {...props}
@@ -85,7 +85,7 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn("comet-title-s pr-8", className)}
+    className={cn("comet-title-s pr-8 break-words", className)}
     {...props}
   />
 ));

--- a/apps/opik-frontend/src/components/ui/label.tsx
+++ b/apps/opik-frontend/src/components/ui/label.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const labelVariants = cva(
-  "comet-body-s-accented peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+  "comet-body-s-accented break-words peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
 );
 
 const Label = React.forwardRef<

--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -356,7 +356,7 @@ const UserMenu = () => {
   };
 
   return (
-    <div className="flex items-center gap-4">
+    <div className="flex shrink-0 items-center gap-4">
       {renderAppSelector()}
       {renderUserMenu()}
     </div>


### PR DESCRIPTION
## Details
![image](https://github.com/user-attachments/assets/8e89c1c1-08be-452a-9309-49db4cdf918d)
![image](https://github.com/user-attachments/assets/aba67662-23bf-412b-b78e-e39211645bc9)

## Issues

Resolves #

## Testing

## Documentation
