### PR TITLE
[OPIK-238] Fix orphan spans error ignoring them

### DIFF
--- a/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/TraceTreeViewer.tsx
+++ b/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/TraceTreeViewer.tsx
@@ -173,7 +173,7 @@ const TraceTreeViewer: React.FunctionComponent<TraceTreeViewerProps> = ({
   );
 
   const maxWidth = useMemo(() => {
-    const map: Record<string, number> = {};
+    const map: Record<string, number | undefined> = {};
     const list: ItemWidthObject[] = traceSpans.map((s) => ({
       id: s.id,
       name: s.name || "",
@@ -193,7 +193,13 @@ const TraceTreeViewer: React.FunctionComponent<TraceTreeViewerProps> = ({
 
     list.forEach((item) => {
       if (item.parentId) {
-        list[map[item.parentId]].children.push(item);
+        const listIndex = map[item.parentId];
+
+        if (listIndex !== undefined) {
+          list[listIndex].children.push(item);
+        } else {
+          console.warn(`Parent ${item.parentId} not found for ${item.id}`);
+        }
       } else {
         rootElement.children.push(item);
       }


### PR DESCRIPTION
## Details
- Fix orphan spans crash when `parent_span_id` is not present in the list of spans of the trace (orphan spans = ignored spans in the sidebar)

## Issues

Resolves #

## Testing

## Documentation
