### PR TITLE
NO-JIRA: Refine CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,12 @@
 # @comet-ml/comet-opik-devs will be requested for
 # review when someone opens a pull request.
 * @comet-ml/comet-opik-devs # This is an inline comment.
+
+/.github/ISSUE_TEMPLATE/ @comet-ml/product @comet-ml/comet-opik-devs
+/.github/workflows/ @comet-ml/comet-devops @comet-ml/comet-qa @comet-ml/comet-opik-devs
+
+/apps/opik-documentation/ @comet-ml/product @comet-ml/comet-opik-devs
+
+/deployment/ @comet-ml/comet-devops @comet-ml/deployment-team @comet-ml/comet-opik-devs
+
+/tests_end_to_end/ @comet-ml/comet-qa @comet-ml/comet-opik-devs


### PR DESCRIPTION
## Details
Extended ownership of some subfolders to other teams, so PRs are requested to them and only require their approval, so they can move faster.

## Issues

N/A

## Testing
Github reports `This CODEOWNERS file is valid.`

## Documentation
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
