### PR TITLE
OPIK-258 [SDK] show warning message when user runs configure()

### DIFF
--- a/sdks/python/src/opik/configurator/configure.py
+++ b/sdks/python/src/opik/configurator/configure.py
@@ -58,7 +58,7 @@ class OpikConfigurator:
         # if there is already cached Opik client instance
         if get_client_cached.cache_info().currsize > 0:
             LOGGER.info(
-                'Existing Opik clients will not be use with the updated values for "url", "api_key", "workspace".'
+                'Existing Opik clients will not use updated values for "url", "api_key", "workspace".'
             )
 
         # OPIK CLOUD

--- a/sdks/python/src/opik/configurator/configure.py
+++ b/sdks/python/src/opik/configurator/configure.py
@@ -4,6 +4,7 @@ from typing import Final, List, Optional
 
 import httpx
 import opik.config
+from opik.api_objects.opik_client import get_client_cached
 from opik.config import (
     OPIK_BASE_URL_CLOUD,
     OPIK_BASE_URL_LOCAL,
@@ -53,6 +54,12 @@ class OpikConfigurator:
             ConfigurationError
             ConnectionError
         """
+
+        # if there is already cached Opik client instance
+        if get_client_cached.cache_info().currsize > 0:
+            LOGGER.info(
+                'Existing Opik clients will not be use with the updated values for "url", "api_key", "workspace".'
+            )
 
         # OPIK CLOUD
         if self.use_local is False:

--- a/sdks/python/tests/unit/configurator/test_configure.py
+++ b/sdks/python/tests/unit/configurator/test_configure.py
@@ -1361,7 +1361,7 @@ class TestOpikConfigurator:
 
         # Assert logger info was called
         mock_logger_info.assert_called_once_with(
-            'Existing Opik clients will not be use with the updated values for "url", "api_key", "workspace".'
+            'Existing Opik clients will not use updated values for "url", "api_key", "workspace".'
         )
 
     @patch("opik.configurator.configure.LOGGER.info")


### PR DESCRIPTION
## Details
We will print a warning message if user runs `configure()` and there is already cached Opik client instance.
