### PR TITLE
[NA] Langchain integration: replace to_json with model_dump

### DIFF
--- a/sdks/python/src/opik/integrations/langchain/opik_encoder_extension.py
+++ b/sdks/python/src/opik/integrations/langchain/opik_encoder_extension.py
@@ -1,11 +1,11 @@
-from typing import Any
+from typing import Any, Dict
 from langchain.load import serializable
 from opik import jsonable_encoder
 
 
 def register() -> None:
-    def encoder_extension(obj: serializable.Serializable) -> Any:
-        return obj.to_json()
+    def encoder_extension(obj: serializable.Serializable) -> Dict[str, Any]:
+        return obj.model_dump()
 
     jsonable_encoder.register_encoder_extension(
         obj_type=serializable.Serializable,


### PR DESCRIPTION
## Details
`to_json` is replaced with `model_dump` inside encoder function because it adds less data that we don't want to log. 
## Issues

Resolves #

## Testing

## Documentation
