### PR TITLE
Fix incorrect project name for score when logged with span

### DIFF
--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -257,7 +257,9 @@ class Opik:
             message_streamer=self._streamer,
         )
 
-    def log_spans_feedback_scores(self, scores: List[FeedbackScoreDict], project_name: Optional[str] = None) -> None:
+    def log_spans_feedback_scores(
+        self, scores: List[FeedbackScoreDict], project_name: Optional[str] = None
+    ) -> None:
         """
         Log feedback scores for spans.
 
@@ -297,7 +299,9 @@ class Opik:
 
             self._streamer.put(add_span_feedback_scores_batch_message)
 
-    def log_traces_feedback_scores(self, scores: List[FeedbackScoreDict], project_name: Optional[str] = None) -> None:
+    def log_traces_feedback_scores(
+        self, scores: List[FeedbackScoreDict], project_name: Optional[str] = None
+    ) -> None:
         """
         Log feedback scores for traces.
 

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -118,7 +118,8 @@ class Opik:
             metadata: Additional metadata for the trace. This can be any valid JSON serializable object.
             tags: Tags associated with the trace.
             feedback_scores: The list of feedback score dicts associated with the trace. Dicts don't require to have an `id` value.
-            project_name: The name of the project.
+            project_name: The name of the project. If not set, the project name which was configured when Opik instance
+                was created will be used.
 
         Returns:
             trace.Trace: The created trace object.
@@ -147,7 +148,7 @@ class Opik:
             for feedback_score in feedback_scores:
                 feedback_score["id"] = id
 
-            self.log_traces_feedback_scores(feedback_scores)
+            self.log_traces_feedback_scores(feedback_scores, project_name)
 
         return trace.Trace(
             id=id,
@@ -189,7 +190,8 @@ class Opik:
             tags: Tags associated with the span.
             usage: Usage data for the span.
             feedback_scores: The list of feedback score dicts associated with the span. Dicts don't require to have an `id` value.
-            project_name: The name of the project.
+            project_name: The name of the project. If not set, the project name which was configured when Opik instance
+                was created will be used.
 
         Returns:
             span.Span: The created span object.
@@ -245,7 +247,7 @@ class Opik:
             for feedback_score in feedback_scores:
                 feedback_score["id"] = id
 
-            self.log_spans_feedback_scores(feedback_scores)
+            self.log_spans_feedback_scores(feedback_scores, project_name)
 
         return span.Span(
             id=id,
@@ -255,13 +257,15 @@ class Opik:
             message_streamer=self._streamer,
         )
 
-    def log_spans_feedback_scores(self, scores: List[FeedbackScoreDict]) -> None:
+    def log_spans_feedback_scores(self, scores: List[FeedbackScoreDict], project_name: Optional[str] = None) -> None:
         """
         Log feedback scores for spans.
 
         Args:
             scores (List[FeedbackScoreDict]): A list of feedback score dictionaries.
                 Specifying a span id via `id` key for each score is mandatory.
+            project_name: The name of the project in which the spans are logged. If not set, the project name
+                which was configured when Opik instance was created will be used.
 
         Returns:
             None
@@ -278,7 +282,7 @@ class Opik:
         score_messages = [
             messages.FeedbackScoreMessage(
                 source=constants.FEEDBACK_SCORE_SOURCE_SDK,
-                project_name=self._project_name,
+                project_name=project_name or self._project_name,
                 **score_dict,
             )
             for score_dict in valid_scores
@@ -293,13 +297,15 @@ class Opik:
 
             self._streamer.put(add_span_feedback_scores_batch_message)
 
-    def log_traces_feedback_scores(self, scores: List[FeedbackScoreDict]) -> None:
+    def log_traces_feedback_scores(self, scores: List[FeedbackScoreDict], project_name: Optional[str] = None) -> None:
         """
         Log feedback scores for traces.
 
         Args:
             scores (List[FeedbackScoreDict]): A list of feedback score dictionaries.
                 Specifying a trace id via `id` key for each score is mandatory.
+            project_name: The name of the project in which the traces are logged. If not set, the project name
+                which was configured when Opik instance was created will be used.
 
         Returns:
             None
@@ -316,7 +322,7 @@ class Opik:
         score_messages = [
             messages.FeedbackScoreMessage(
                 source=constants.FEEDBACK_SCORE_SOURCE_SDK,
-                project_name=self._project_name,
+                project_name=project_name or self._project_name,
                 **score_dict,
             )
             for score_dict in valid_scores

--- a/sdks/python/src/opik/integrations/langchain/opik_encoder_extension.py
+++ b/sdks/python/src/opik/integrations/langchain/opik_encoder_extension.py
@@ -1,11 +1,11 @@
-from typing import Any
+from typing import Any, Dict
 from langchain.load import serializable
 from opik import jsonable_encoder
 
 
 def register() -> None:
-    def encoder_extension(obj: serializable.Serializable) -> Any:
-        return obj.to_json()
+    def encoder_extension(obj: serializable.Serializable) -> Dict[str, Any]:
+        return obj.model_dump()
 
     jsonable_encoder.register_encoder_extension(
         obj_type=serializable.Serializable,


### PR DESCRIPTION
## Details
This PR addresses the issue when SDK didn't pass project specified for span/trace to their feedback scores, added via `update_current_span` or `update_current_trace`.

## Issues
https://github.com/comet-ml/opik/issues/424

## Testing

## Documentation
