### PR TITLE
[NA] Fix font size for code blocks

### DIFF
--- a/apps/opik-frontend/src/hooks/useCodemirrorTheme.tsx
+++ b/apps/opik-frontend/src/hooks/useCodemirrorTheme.tsx
@@ -8,6 +8,7 @@ export const useCodemirrorTheme = () => {
       githubLightInit({
         settings: {
           fontFamily: `Ubuntu Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace`,
+          fontSize: "0.875rem",
           foreground: "#030712",
           background: "#F8FAFC",
           gutterBackground: "#F8FAFC",


### PR DESCRIPTION
## Details
Apply "0.875rem" (14px) font size for all CodeMirror components

## Issues

Resolves #

## Testing

## Documentation
