### PR TITLE
[NA] Fix rate limit error

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedisRateLimitService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedisRateLimitService.java
@@ -32,12 +32,8 @@ public class RedisRateLimitService implements RateLimitService {
     }
 
     private Mono<Boolean> setLimitIfNecessary(long limit, long limitDurationInSeconds, RRateLimiterReactive rateLimit) {
-        return rateLimit.isExists()
-                .flatMap(exists -> Boolean.TRUE.equals(exists)
-                        ? Mono.empty()
-                        : rateLimit.trySetRate(RateType.OVERALL, limit, limitDurationInSeconds,
-                                RateIntervalUnit.SECONDS))
-                .then(Mono.defer(() -> rateLimit.expireIfNotSet(Duration.ofSeconds(limitDurationInSeconds))));
+        return rateLimit.trySetRate(RateType.OVERALL, limit, Duration.ofSeconds(limitDurationInSeconds))
+                .flatMap(__ -> rateLimit.expireIfNotSet(Duration.ofSeconds(limitDurationInSeconds)));
     }
 
     @Override


### PR DESCRIPTION
## Details

```
org.redisson.client.RedisException: ERR user_script:1: RateLimiter is not initialized script: 1378f96e73a4251ef63dad, on @user_script:1.. channel: [id: 0x534ebb1e, L:/10.xx.xx.77:56910 - R:redis-cache.com./10.xx.xx.51:6379] command: (EVAL), params: [local rate = redis.call('hget', KEYS[1], 'rate');local interval = redis.call('hget', KEYS[1], 'interval');local type = redis.call('hget', KEYS[1], 'type');assert(rate ~= false and interval ~= false and type ~= false, 'RateLimiter is not initialized')local valueName = KEYS[2];local permitsName = KEYS[4];if type == '1' then valueName = KEYS[3];permitsName = KEYS[5];end;local currentValue = redis.call('get', valueName); if currentValue == false then redis.call('set', valueName, rate); return rate; else local expiredValues = redis.call('zrangebyscore', permitsName, 0, tonumber(ARGV[1]) - interval); local released = 0; for i, v in ipairs(expiredValues) do local random, permits = struct.unpack('Bc0I', v);released = released + permits;end; if released > 0 then redis.call('zremrangebyscore', permitsName, 0, tonumber(ARGV[1]) - interval); currentValue = tonumber(currentValue) + released; redis.call('set', valueName, currentValue);end;return currentValue; end;, 5, general_events:xxxxxxxxx, {general_events:xxxxxxxxx}:value, {general_events:xxxxxxxxx}:value:849298ff-9abc-4fa1-845d-17733e2e8f71, {general_events:xxxxxxxxx}:permits, {general_events:xxxxxxxxx}:permits:xxxxxxxxx, 1728934706722], promise: io.opentelemetry.javaagent.instrumentation.redisson.CompletableFutureWrapper@18d329af[Not completed, 1 dependents]
	at org.redisson.client.handler.CommandDecoder.decode(CommandDecoder.java:420)
	at org.redisson.client.handler.CommandDecoder.decodeCommand(CommandDecoder.java:218)
	at org.redisson.client.handler.CommandDecoder.decode(CommandDecoder.java:146)
	at org.redisson.client.handler.CommandDecoder.decode(CommandDecoder.java:122)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:530)
	at io.netty.handler.codec.ReplayingDecoder.callDecode(ReplayingDecoder.java:366)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1473)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1336)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1385)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:530)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:469)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1407)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
	at io.nett
```
## Issues
NA