### PR TITLE
Fix typo in docs

### DIFF
--- a/apps/opik-documentation/documentation/docs/cookbook/litellm.md
+++ b/apps/opik-documentation/documentation/docs/cookbook/litellm.md
@@ -1,6 +1,6 @@
 # Using Opik with LiteLLM
 
-Lite allows you to call all LLM APIs using the OpenAI format [Bedrock, Huggingface, VertexAI, TogetherAI, Azure, OpenAI, Groq etc.]. You can learn more about LiteLLM [here](https://github.com/BerriAI/litellm).
+LiteLLM allows you to call all LLM APIs using the OpenAI format [Bedrock, Huggingface, VertexAI, TogetherAI, Azure, OpenAI, Groq etc.]. You can learn more about LiteLLM [here](https://github.com/BerriAI/litellm).
 
 There are two main approaches to using LiteLLM, either using the `litellm` [python library](https://docs.litellm.ai/docs/#litellm-python-sdk) that will query the LLM API for you or by using the [LiteLLM proxy server](https://docs.litellm.ai/docs/#litellm-proxy-server-llm-gateway). In this cookbook we will focus on the first approach but you can learn more about using Opik with the LiteLLM proxy server in our [documentation](https://www.comet.com/docs/opik/tracing/integrations/litellm).
 


### PR DESCRIPTION
Fixing a small typo to the LiteLLM md

## Details
Small typo in docs

## Issues

Resolves #

## Testing

## Documentation
