### PR TITLE
NO-JIRA: Add product as md files owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,8 @@
 # review when someone opens a pull request.
 * @comet-ml/comet-opik-devs # This is an inline comment.
 
+*.md @comet-ml/product @comet-ml/comet-opik-devs
+
 /.github/ISSUE_TEMPLATE/ @comet-ml/product @comet-ml/comet-opik-devs
 /.github/workflows/ @comet-ml/comet-devops @comet-ml/comet-qa @comet-ml/comet-opik-devs
 


### PR DESCRIPTION
## Details
Product team should be able to review and approve all `*.md` files without Opik devs involvement.

This is case sensitive, but I checked that the extension of all existing files in the repo are currently in lower case.

## Issues

N/A

## Testing
Github reports:

> This CODEOWNERS file is valid.

## Documentation
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
