### PR TITLE
[OPIK-294] Add last created experiment at to dataset table

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000003_add_last_created_experiment_at_to_datasets_table.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000003_add_last_created_experiment_at_to_datasets_table.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+--changeset thiagohora:add_last_created_experiment_at_to_datasets_table
+
+ALTER TABLE datasets ADD COLUMN last_created_experiment_at TIMESTAMP(6) DEFAULT NULL;
+
+--rollback ALTER TABLE datasets DROP COLUMN last_created_experiment_at;


### PR DESCRIPTION
## Details

Migration to add field last created experiment at which will allow us to filter by datasets with experiments and sort by it.

## Issues
OPIK-294

## Documentation
