### PR TITLE
Remove most of the warnings in tests

### DIFF
--- a/sdks/python/tests/library_integration/langchain/test_langchain.py
+++ b/sdks/python/tests/library_integration/langchain/test_langchain.py
@@ -15,8 +15,8 @@ import pytest
 import opik
 from opik.api_objects import opik_client, trace, span
 from opik import context_storage
-from langchain.llms import openai as langchain_openai
-from langchain.llms import fake
+import langchain_openai as langchain_openai
+from langchain_community.llms import fake
 
 from langchain.prompts import PromptTemplate
 from opik.integrations.langchain.opik_tracer import OpikTracer

--- a/sdks/python/tests/pytest.ini
+++ b/sdks/python/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_default_fixture_loop_scope = session


### PR DESCRIPTION
## Details

Removes most of the warnings created when running tests by updating LangChain tests to avoid deprecated functions and creating a pytest config file.