### PR TITLE
NO-JIRA: Redis docker-compose no restart

### DIFF
--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -32,7 +32,6 @@ services:
       timeout: 4s
       retries: 20
       start_period: 30s
-    restart: always
 
   clickhouse:
     image: clickhouse/clickhouse-server:24.3.6.48-alpine


### PR DESCRIPTION
## Details
When running docker-compose locally, all containers have the default restart policy (no restart) whereas Redis is set to always. 

This is inconsistent and also annoying, as Redis automatically starts on laptop start-up for local development.

Aligned with the rest of containers and verified that no other occurrences happen in the repository.

## Issues
N/A

## Testing
Run docker-compose locally and re-started docker in my local laptop:
- Prior to the fix, Redis start ups automatically.
- After the fix, Redis doesn't start up automatically. 

## Documentation
- https://docs.docker.com/engine/containers/start-containers-automatically/
