### PR TITLE
[OPIK-329] fix backend version endpoint

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/AppMetadataService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/AppMetadataService.java
@@ -3,7 +3,6 @@ package com.comet.opik.infrastructure;
 import com.google.inject.ImplementedBy;
 import jakarta.inject.Inject;
 import lombok.RequiredArgsConstructor;
-import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
 @ImplementedBy(AppMetadataServiceImpl.class)
 public interface AppMetadataService {
@@ -12,11 +11,10 @@ public interface AppMetadataService {
 
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 class AppMetadataServiceImpl implements AppMetadataService {
-    @Config
-    private final MetadataConfig config;
+    private final OpikConfiguration config;
 
     @Override
     public String getVersion() {
-        return config.getVersion();
+        return config.getMetadata().getVersion();
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/AppMetadataService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/AppMetadataService.java
@@ -2,6 +2,7 @@ package com.comet.opik.infrastructure;
 
 import com.google.inject.ImplementedBy;
 import jakarta.inject.Inject;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 @ImplementedBy(AppMetadataServiceImpl.class)
@@ -11,7 +12,7 @@ public interface AppMetadataService {
 
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 class AppMetadataServiceImpl implements AppMetadataService {
-    private final OpikConfiguration config;
+    @NonNull private final OpikConfiguration config;
 
     @Override
     public String getVersion() {


### PR DESCRIPTION
## Details
In #500, the get backend version endpoint was introduced. However, the configuration were not injected properly resulting in a constantly empty response.

## Issues
OPIK-329

## Testing
Tested locally.
Before this change:
```sh
❯ curl http://localhost:5173/api/is-alive/ver
{}
```

After this change:
```sh
❯ curl http://localhost:5173/api/is-alive/ver
{"version":"my_test_version"}
```
