### PR TITLE
NA: Fixing the side effects of the function and printing the correct error message

### DIFF
--- a/sdks/python/src/opik/evaluation/models/litellm_chat_model.py
+++ b/sdks/python/src/opik/evaluation/models/litellm_chat_model.py
@@ -61,7 +61,7 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
         for key in params:
             if key not in self.supported_params:
                 LOGGER.debug(
-                    "This model does not support the {key} parameter and it has been ignored."
+                    f"This model does not support the '{key}' parameter and it has been ignored."
                 )
                 valid_params.pop(key, None)
 

--- a/sdks/python/src/opik/evaluation/models/litellm_chat_model.py
+++ b/sdks/python/src/opik/evaluation/models/litellm_chat_model.py
@@ -56,14 +56,15 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
                 raise ValueError(f"Unsupported parameter: '{key}'!")
 
     def _filter_supported_params(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        valid_params = params
+        valid_params = {}
 
-        for key in params:
+        for key, value in params.items():
             if key not in self.supported_params:
                 LOGGER.debug(
                     f"This model does not support the '{key}' parameter and it has been ignored."
                 )
-                valid_params.pop(key, None)
+            else:
+                valid_params[key] = value
 
         return valid_params
 


### PR DESCRIPTION
## Details
This PR contains:
- print real key name of skipped unsupported LLM params
- handle passed param/dict to avoid changing the original param value