### PR TITLE
[OPIK-136] fix cors request header comet workspace

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/CorsFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/CorsFactory.java
@@ -13,6 +13,9 @@ import java.util.EnumSet;
 
 @Slf4j
 public class CorsFactory {
+    public static final String COMET_SDK_API_HEADER = "Comet-Sdk-Api";
+    public static final String COMET_USERNAME_HEADER = "comet-username";
+    public static final String COMET_REACT_VER_HEADER = "comet-react-ver";
     public static final String COMET_WORKSPACE_REQUEST_HEADER = "comet-workspace";
     private static final String CORS_PATH_FILTER = "/*";
 
@@ -22,9 +25,9 @@ public class CorsFactory {
             HttpHeaders.ACCEPT,
             HttpHeaders.X_REQUESTED_WITH,
             HttpHeaders.ORIGIN,
-            "Comet-Sdk-Api",
-            "comet-username",
-            "comet-react-ver",
+            COMET_SDK_API_HEADER,
+            COMET_USERNAME_HEADER,
+            COMET_REACT_VER_HEADER,
             COMET_WORKSPACE_REQUEST_HEADER,
     };
 
@@ -49,9 +52,9 @@ public class CorsFactory {
         final FilterRegistration.Dynamic cors = environment.servlets().addFilter("CORS", CrossOriginFilter.class);
 
         // CORS parameters
-        cors.setInitParameter("allowedOrigins", "*");
-        cors.setInitParameter("allowedHeaders", String.join(",", ALLOWED_HEADERS));
-        cors.setInitParameter("allowedMethods", String.join(",", ALLOWED_METHODS));
+        cors.setInitParameter(CrossOriginFilter.ALLOWED_ORIGINS_PARAM, "*");
+        cors.setInitParameter(CrossOriginFilter.ALLOWED_HEADERS_PARAM, String.join(",", ALLOWED_HEADERS));
+        cors.setInitParameter(CrossOriginFilter.ALLOWED_METHODS_PARAM, String.join(",", ALLOWED_METHODS));
         cors.setInitParameter(CrossOriginFilter.CHAIN_PREFLIGHT_PARAM, Boolean.FALSE.toString());
 
         // URL mappings

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/CorsFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/CorsFactory.java
@@ -16,7 +16,7 @@ public class CorsFactory {
     public static final String COMET_SDK_API_HEADER = "Comet-Sdk-Api";
     public static final String COMET_USERNAME_HEADER = "comet-username";
     public static final String COMET_REACT_VER_HEADER = "comet-react-ver";
-    public static final String COMET_WORKSPACE_REQUEST_HEADER = "comet-workspace";
+    public static final String COMET_WORKSPACE_REQUEST_HEADER = "Comet-Workspace";
     private static final String CORS_PATH_FILTER = "/*";
 
     private static final String[] ALLOWED_HEADERS = new String[]{

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/CorsFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/CorsFactory.java
@@ -13,6 +13,7 @@ import java.util.EnumSet;
 
 @Slf4j
 public class CorsFactory {
+    public static final String COMET_WORKSPACE_REQUEST_HEADER = "comet-workspace";
     private static final String CORS_PATH_FILTER = "/*";
 
     private static final String[] ALLOWED_HEADERS = new String[]{
@@ -24,6 +25,7 @@ public class CorsFactory {
             "Comet-Sdk-Api",
             "comet-username",
             "comet-react-ver",
+            COMET_WORKSPACE_REQUEST_HEADER,
     };
 
     private static final String[] ALLOWED_METHODS = new String[]{

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/CorsFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/CorsFactory.java
@@ -1,6 +1,7 @@
 package com.comet.opik.infrastructure.http;
 
 import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.infrastructure.auth.RequestContext;
 import com.google.common.net.HttpHeaders;
 import io.dropwizard.core.setup.Environment;
 import jakarta.servlet.DispatcherType;
@@ -16,7 +17,6 @@ public class CorsFactory {
     public static final String COMET_SDK_API_HEADER = "Comet-Sdk-Api";
     public static final String COMET_USERNAME_HEADER = "comet-username";
     public static final String COMET_REACT_VER_HEADER = "comet-react-ver";
-    public static final String COMET_WORKSPACE_REQUEST_HEADER = "Comet-Workspace";
     private static final String CORS_PATH_FILTER = "/*";
 
     private static final String[] ALLOWED_HEADERS = new String[]{
@@ -28,7 +28,7 @@ public class CorsFactory {
             COMET_SDK_API_HEADER,
             COMET_USERNAME_HEADER,
             COMET_REACT_VER_HEADER,
-            COMET_WORKSPACE_REQUEST_HEADER,
+            RequestContext.WORKSPACE_HEADER,
     };
 
     private static final String[] ALLOWED_METHODS = new String[]{

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/cors/CorsDisabledE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/cors/CorsDisabledE2ETest.java
@@ -5,6 +5,7 @@ import com.comet.opik.api.resources.utils.ClientSupportUtils;
 import com.comet.opik.api.resources.utils.MySQLContainerUtils;
 import com.comet.opik.api.resources.utils.RedisContainerUtils;
 import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.google.common.net.HttpHeaders;
 import com.redis.testcontainers.RedisContainer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -66,10 +67,10 @@ class CorsDisabledE2ETest {
     @DisplayName("Should not contain CORS headers")
     void testCorsDisabled() {
         var response = client.target("%s/is-alive/ping".formatted(baseURI))
-                .request().header("Origin", "localhost")
+                .request().header(HttpHeaders.ORIGIN, "localhost")
                 .get();
 
         assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(response.getHeaders()).doesNotContainKey("Access-Control-Allow-Origin");
+        assertThat(response.getHeaders()).doesNotContainKey(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN);
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/cors/CorsEnabledE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/cors/CorsEnabledE2ETest.java
@@ -70,11 +70,11 @@ class CorsEnabledE2ETest {
     @DisplayName("Should contain CORS headers for GET request")
     void testCorsHeadersForGet() {
         var response = client.target("%s/is-alive/ping".formatted(baseURI))
-                .request().header("Origin", "localhost")
+                .request().header(HttpHeaders.ORIGIN, "localhost")
                 .get();
 
         assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(response.getHeaders()).containsKey("Access-Control-Allow-Origin");
+        assertThat(response.getHeaders()).containsKey(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN);
     }
 
     @Test
@@ -82,12 +82,12 @@ class CorsEnabledE2ETest {
     void testCorsHeadersForRequestHeader() {
         try (var response = client.target("%s/v1/private/projects".formatted(baseURI))
                 .request()
-                .header("Origin", "localhost")
+                .header(HttpHeaders.ORIGIN, "localhost")
                 .header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, CorsFactory.COMET_WORKSPACE_REQUEST_HEADER)
                 .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.GET.toString())
                 .options()) {
             assertThat(response.getStatus()).isEqualTo(200);
-            assertThat(response.getHeaders()).containsKey("Access-Control-Allow-Origin");
+            assertThat(response.getHeaders()).containsKey(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN);
         } catch (Exception exception) {
             Assertions.fail(exception);
         }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/cors/CorsEnabledE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/cors/CorsEnabledE2ETest.java
@@ -5,7 +5,7 @@ import com.comet.opik.api.resources.utils.ClientSupportUtils;
 import com.comet.opik.api.resources.utils.MySQLContainerUtils;
 import com.comet.opik.api.resources.utils.RedisContainerUtils;
 import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
-import com.comet.opik.infrastructure.http.CorsFactory;
+import com.comet.opik.infrastructure.auth.RequestContext;
 import com.google.common.net.HttpHeaders;
 import com.redis.testcontainers.RedisContainer;
 import org.eclipse.jetty.http.HttpMethod;
@@ -83,7 +83,7 @@ class CorsEnabledE2ETest {
         try (var response = client.target("%s/v1/private/projects".formatted(baseURI))
                 .request()
                 .header(HttpHeaders.ORIGIN, "localhost")
-                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, CorsFactory.COMET_WORKSPACE_REQUEST_HEADER)
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, RequestContext.WORKSPACE_HEADER)
                 .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.GET.toString())
                 .options()) {
             assertThat(response.getStatus()).isEqualTo(200);

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/cors/CorsEnabledE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/cors/CorsEnabledE2ETest.java
@@ -5,7 +5,11 @@ import com.comet.opik.api.resources.utils.ClientSupportUtils;
 import com.comet.opik.api.resources.utils.MySQLContainerUtils;
 import com.comet.opik.api.resources.utils.RedisContainerUtils;
 import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.infrastructure.http.CorsFactory;
+import com.google.common.net.HttpHeaders;
 import com.redis.testcontainers.RedisContainer;
+import org.eclipse.jetty.http.HttpMethod;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -63,13 +67,29 @@ class CorsEnabledE2ETest {
     }
 
     @Test
-    @DisplayName("Should contain CORS headers")
-    void testCorsEnabled() {
+    @DisplayName("Should contain CORS headers for GET request")
+    void testCorsHeadersForGet() {
         var response = client.target("%s/is-alive/ping".formatted(baseURI))
                 .request().header("Origin", "localhost")
                 .get();
 
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(response.getHeaders()).containsKey("Access-Control-Allow-Origin");
+    }
+
+    @Test
+    @DisplayName("Should contain CORS headers for OPTIONS request containing the comet workspace header")
+    void testCorsHeadersForRequestHeader() {
+        try (var response = client.target("%s/v1/private/projects".formatted(baseURI))
+                .request()
+                .header("Origin", "localhost")
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, CorsFactory.COMET_WORKSPACE_REQUEST_HEADER)
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.GET.toString())
+                .options()) {
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(response.getHeaders()).containsKey("Access-Control-Allow-Origin");
+        } catch (Exception exception) {
+            Assertions.fail(exception);
+        }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/cors/CorsEnabledE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/cors/CorsEnabledE2ETest.java
@@ -9,7 +9,6 @@ import com.comet.opik.infrastructure.auth.RequestContext;
 import com.google.common.net.HttpHeaders;
 import com.redis.testcontainers.RedisContainer;
 import org.eclipse.jetty.http.HttpMethod;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -88,8 +87,6 @@ class CorsEnabledE2ETest {
                 .options()) {
             assertThat(response.getStatus()).isEqualTo(200);
             assertThat(response.getHeaders()).containsKey(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN);
-        } catch (Exception exception) {
-            Assertions.fail(exception);
         }
     }
 }


### PR DESCRIPTION
## Details
Fix CORS response headers for requests containing the `comet-workspace` request header.

## Issues
OPIK-136

## Testing
Added an E2E test that covers and tested locally.

Before this change:
```sh
❯ curl 'http://localhost:5173/api/v1/private/projects' \
  -X 'OPTIONS' \
  -H 'access-control-request-headers: comet-workspace' \
  -H 'access-control-request-method: GET' \
  -H 'origin: http://localhost:5173' \
  -i
HTTP/1.1 200 OK
Server: nginx/1.27.2
Date: Thu, 31 Oct 2024 07:20:57 GMT
Content-Length: 0
Connection: keep-alive
Vary: Origin
```

After this change:
```sh
❯ curl 'http://localhost:5173/api/v1/private/projects' \
  -X 'OPTIONS' \
  -H 'access-control-request-headers: comet-workspace' \
  -H 'access-control-request-method: GET' \
  -H 'origin: http://localhost:5173' \
  -i
HTTP/1.1 200 OK
Server: nginx/1.27.2
Date: Thu, 31 Oct 2024 07:10:04 GMT
Content-Length: 0
Connection: keep-alive
Vary: Origin
Access-Control-Allow-Origin: http://localhost:5173
Access-Control-Allow-Credentials: true
Access-Control-Max-Age: 1800
Access-Control-Allow-Methods: OPTIONS,GET,PUT,POST,DELETE,HEAD,PATCH
Access-Control-Allow-Headers: Authorization,Content-Type,Accept,X-Requested-With,Origin,Comet-Sdk-Api,comet-username,comet-react-ver,comet-workspace
```
