### PR TITLE
Increase the client_max_body_size in nginx for better support for images in the payload

### DIFF
--- a/deployment/helm_chart/opik/templates/configmap-frontend-nginx.yaml
+++ b/deployment/helm_chart/opik/templates/configmap-frontend-nginx.yaml
@@ -15,7 +15,7 @@ data:
     gzip_http_version 1.1;
     gzip_min_length 256;
     gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon application/javascript;
-    client_max_body_size 50M;
+    client_max_body_size 500M;
     absolute_redirect off;
     real_ip_header      X-Forwarded-For;
     real_ip_recursive   on;


### PR DESCRIPTION
## Details
- Current `50M` is not enough if we batch + upload images for each item (traces/spans/datasets)

## Issues

Resolves #

## Testing

## Documentation
