### PR TITLE
[OPIK-352] Display dataset item count

### DIFF
--- a/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetsPage.tsx
@@ -42,12 +42,7 @@ export const DEFAULT_COLUMNS: ColumnData<Dataset>[] = [
   },
   {
     id: "dataset_items_count",
-    label: "Dataset items count",
-    type: COLUMN_TYPE.number,
-  },
-  {
-    id: "experiment_count",
-    label: "Experiment count",
+    label: "Item count",
     type: COLUMN_TYPE.number,
   },
   {
@@ -68,7 +63,6 @@ export const DEFAULT_SELECTED_COLUMNS: string[] = [
   "name",
   "description",
   "dataset_items_count",
-  "experiment_count",
   "most_recent_experiment_at",
   "created_at",
 ];

--- a/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetsPage.tsx
@@ -41,6 +41,11 @@ export const DEFAULT_COLUMNS: ColumnData<Dataset>[] = [
     type: COLUMN_TYPE.string,
   },
   {
+    id: "dataset_items_count",
+    label: "Dataset items count",
+    type: COLUMN_TYPE.number,
+  },
+  {
     id: "experiment_count",
     label: "Experiment count",
     type: COLUMN_TYPE.number,
@@ -62,6 +67,7 @@ export const DEFAULT_COLUMNS: ColumnData<Dataset>[] = [
 export const DEFAULT_SELECTED_COLUMNS: string[] = [
   "name",
   "description",
+  "dataset_items_count",
   "experiment_count",
   "most_recent_experiment_at",
   "created_at",

--- a/apps/opik-frontend/src/types/datasets.ts
+++ b/apps/opik-frontend/src/types/datasets.ts
@@ -5,6 +5,7 @@ export interface Dataset {
   id: string;
   name: string;
   description?: string;
+  dataset_items_count: number;
   experiment_count: number;
   most_recent_experiment_at: string;
   created_at: string;


### PR DESCRIPTION
## Details
- Add dataset item count column in the dataset table
- Remove experiment count column in the dataset table

![image](https://github.com/user-attachments/assets/1abd7072-f452-48a3-a80a-5df5eda5f235)

## Issues

Resolves #

## Testing

## Documentation
