### PR TITLE
sanity fixes

### DIFF
--- a/tests_end_to_end/application_sanity/conftest.py
+++ b/tests_end_to_end/application_sanity/conftest.py
@@ -6,7 +6,7 @@ import json
 from opik.configurator.configure import configure
 from opik.evaluation import evaluate
 from opik.evaluation.metrics import Contains, Equals
-from opik import opik_context, track, DatasetItem
+from opik import opik_context, track
 from playwright.sync_api import Page
 
 from page_objects.ProjectsPage import ProjectsPage
@@ -34,7 +34,7 @@ def configure_local(config):
 
 @pytest.fixture(scope='session', autouse=True)
 def client(config):
-    return opik.Opik(project_name=config['project']['name'], host='http://localhost:5173/api')
+    return opik.Opik(project_name=config['project']['name'], workspace='default', host='http://localhost:5173/api')
 
 
 @pytest.fixture(scope='function')
@@ -48,7 +48,7 @@ def projects_page(page: Page):
 def projects_page_timeout(page: Page):
     projects_page = ProjectsPage(page)
     projects_page.go_to_page()
-    projects_page.page.wait_for_timeout(7000)
+    projects_page.page.wait_for_timeout(10000)
     return projects_page
 
 
@@ -175,7 +175,7 @@ def dataset(config, client):
         'name': config['dataset']['name'],
         'filename': config['dataset']['filename']
     }
-    dataset = client.create_dataset(dataset_config['name'])
+    dataset = client.get_or_create_dataset(dataset_config['name'])
 
     curr_dir = os.path.dirname(__file__)
     dataset_filepath = os.path.join(curr_dir, dataset_config['filename'])
@@ -192,17 +192,17 @@ def create_experiments(config, dataset):
         'dataset_name': config['experiments']['dataset-name']
     }
 
-    def eval_contains(x: DatasetItem):
+    def eval_contains(x):
         return {
-            'input': x.input['user_question'],
-            'output': x.expected_output['assistant_answer'],
+            'input': x['input'],
+            'output': x['expected_output'],
             'reference': 'hello'
         }
 
-    def eval_equals(x: DatasetItem):
+    def eval_equals(x):
         return {
-            'input': x.input['user_question'],
-            'output': x.expected_output['assistant_answer'],
+            'input': x['input'],
+            'output': x['expected_output'],
             'reference': 'goodbye'
         }
 

--- a/tests_end_to_end/application_sanity/sanity_dataset.jsonl
+++ b/tests_end_to_end/application_sanity/sanity_dataset.jsonl
@@ -1,10 +1,10 @@
-{"input": {"user_question": "Paris"}, "expected_output": {"assistant_answer": "Hello, Paris!"}}
-{"input": {"user_question": "London"}, "expected_output": {"assistant_answer": "Hello, London!"}}
-{"input": {"user_question": "New York"}, "expected_output": {"assistant_answer": "Hello, New York!"}}
-{"input": {"user_question": "Tokyo"}, "expected_output": {"assistant_answer": "Hello, Tokyo!"}}
-{"input": {"user_question": "Berlin"}, "expected_output": {"assistant_answer": "Hello, Berlin!"}}
-{"input": {"user_question": "Sydney"}, "expected_output": {"assistant_answer": "Hello, Sydney!"}}
-{"input": {"user_question": "Cairo"}, "expected_output": {"assistant_answer": "Hello, Cairo!"}}
-{"input": {"user_question": "Toronto"}, "expected_output": {"assistant_answer": "Hello, Toronto!"}}
-{"input": {"user_question": "Stockholm"}, "expected_output": {"assistant_answer": "Hello, Stockholm!"}}
-{"input": {"user_question": "Sao Paulo"}, "expected_output": {"assistant_answer": "Hello, Sao Paulo!"}}
+{"input": "Paris", "expected_output": "Hello, Paris!"}
+{"input": "London", "expected_output": "Hello, London!"}
+{"input": "New York", "expected_output": "Hello, New York!"}
+{"input": "Tokyo", "expected_output": "Hello, Tokyo!"}
+{"input": "Berlin", "expected_output": "Hello, Berlin!"}
+{"input": "Sydney", "expected_output": "Hello, Sydney!"}
+{"input": "Cairo", "expected_output": "Hello, Cairo!"}
+{"input": "Toronto", "expected_output": "Hello, Toronto!"}
+{"input": "Stockholm", "expected_output": "Hello, Stockholm!"}
+{"input": "Sao Paulo", "expected_output": "Hello, Sao Paulo!"}

--- a/tests_end_to_end/application_sanity/test_sanity.py
+++ b/tests_end_to_end/application_sanity/test_sanity.py
@@ -97,6 +97,9 @@ def test_trace_and_span_details(page, traces_page, config, log_traces_and_spans_
             for md_key in config['spans'][trace_type]['metadata']:
                 expect(page.get_by_text(f'{md_key}: {config['spans'][trace_type]['metadata'][md_key]}')).to_be_visible()
 
+            # provisional patchy solution, sometimes when clicking through spans very fast some of them show up as "no data" and the test fails
+            page.wait_for_timeout(500)
+
 
 def test_dataset_name(datasets_page, config, dataset):
     '''
@@ -113,8 +116,8 @@ def test_dataset_items(page: Page, datasets_page, config, dataset_content):
 
     individual_dataset_page = IndividualDatasetPage(page)
     for item in dataset_content:
-        individual_dataset_page.check_cell_exists_by_text(json.dumps(item['input']).replace('{', '{ ').replace('}', ' }'))
-        individual_dataset_page.check_cell_exists_by_text(json.dumps(item['expected_output']).replace('{', '{ ').replace('}', ' }'))
+        individual_dataset_page.check_cell_exists_by_text(item['input'])
+        individual_dataset_page.check_cell_exists_by_text(item['expected_output'])
         
 
 def test_experiments_exist(experiments_page, config, create_experiments):

--- a/tests_end_to_end/page_objects/IndividualDatasetPage.py
+++ b/tests_end_to_end/page_objects/IndividualDatasetPage.py
@@ -6,4 +6,4 @@ class IndividualDatasetPage:
         self.traces_table = page.get_by_role('table')
 
     def check_cell_exists_by_text(self, text):
-        expect(self.traces_table.get_by_text(text)).to_be_visible()
+        expect(self.traces_table.get_by_text(text, exact=True)).to_be_visible()


### PR DESCRIPTION
## Details

Fixes for end to end sanity
- removed DatasetItem usage
- changed format of dataset experiment eval functions to reflect that
- added a small timeout when clicking through spans checking all menus to momentarily get over a rare issue where span shows "no data" when clicking through them really fast, will make up a better solution later