### PR TITLE
[OPIK-337] anthropic integration

### DIFF
--- a/.github/workflows/lib-anthropic-tests.yml
+++ b/.github/workflows/lib-anthropic-tests.yml
@@ -1,0 +1,50 @@
+# Workflow to run Anthropic tests
+#
+# Please read inputs to provide correct values.
+#
+name: SDK Lib Anthropic Tests
+run-name: "SDK Lib Anthropic Tests ${{ github.ref_name }} by @${{ github.actor }}"
+env:
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+on:
+  workflow_call:
+
+jobs:
+  tests:
+    name: Anthropic Python ${{matrix.python_version}}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/python
+
+    strategy:
+      fail-fast: true
+      matrix:
+        python_version: ["3.8", "3.12"]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{matrix.python_version}}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{matrix.python_version}}
+
+      - name: Install opik
+        run: pip install .
+
+      - name: Install test tools
+        run: |
+          cd ./tests
+          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+
+      - name: Install lib
+        run: |
+          cd ./tests
+          pip install --no-cache-dir --disable-pip-version-check -r library_integration/anthropic/requirements.txt
+
+      - name: Run tests
+        run: |
+          cd ./tests/library_integration/anthropic/
+          python -m pytest  -vv .

--- a/.github/workflows/lib-integration-tests-runner.yml
+++ b/.github/workflows/lib-integration-tests-runner.yml
@@ -14,6 +14,7 @@ on:
           - openai
           - langchain
           - llama_index
+          - anthropic
   schedule:
     - cron: "0 0 */1 * *"
   pull_request:
@@ -53,5 +54,11 @@ jobs:
     needs: [init_environment]
     if: contains(fromJSON('["llama_index", "all"]'), needs.init_environment.outputs.LIBS)
     uses: ./.github/workflows/lib-llama-index-tests.yml
+    secrets: inherit
+
+  anthropic_tests:
+    needs: [init_environment]
+    if: contains(fromJSON('["anthropic", "all"]'), needs.init_environment.outputs.LIBS)
+    uses: ./.github/workflows/lib-anthropic-tests.yml
     secrets: inherit
 

--- a/sdks/python/src/opik/integrations/anthropic/__init__.py
+++ b/sdks/python/src/opik/integrations/anthropic/__init__.py
@@ -1,0 +1,4 @@
+from .opik_tracker import track_anthropic
+
+
+__all__ = ["track_anthropic"]

--- a/sdks/python/src/opik/integrations/anthropic/messages_create_decorator.py
+++ b/sdks/python/src/opik/integrations/anthropic/messages_create_decorator.py
@@ -1,0 +1,83 @@
+import logging
+from typing import List, Any, Dict, Optional, Callable, Tuple, Union
+from opik.types import SpanType
+from opik.decorator import base_track_decorator, arguments_helpers
+from opik import dict_utils
+
+from anthropic.types import Message as AnthropicMessage
+
+
+LOGGER = logging.getLogger(__name__)
+
+KWARGS_KEYS_TO_LOG_AS_INPUTS = ["messages", "system", "tools"]
+RESPONSE_KEYS_TO_LOG_AS_OUTPUT = ["content"]
+
+
+class AnthropicMessagesCreateDecorator(base_track_decorator.BaseTrackDecorator):
+    """
+    An implementation of BaseTrackDecorator designed specifically for tracking
+    calls of `[Anthropic.AsyncAnthropic].messages.create` method.
+    """
+
+    def _start_span_inputs_preprocessor(
+        self,
+        func: Callable,
+        name: Optional[str],
+        type: SpanType,
+        tags: Optional[List[str]],
+        metadata: Optional[Dict[str, Any]],
+        capture_input: bool,
+        args: Optional[Tuple],
+        kwargs: Optional[Dict[str, Any]],
+        project_name: Optional[str],
+    ) -> arguments_helpers.StartSpanParameters:
+        assert (
+            kwargs is not None
+        ), "Expected kwargs to be not None in Antropic.messages.create(**kwargs)"
+
+        input, metadata = dict_utils.split_dict_by_keys(
+            kwargs, KWARGS_KEYS_TO_LOG_AS_INPUTS
+        )
+
+        name = name if name is not None else func.__name__
+
+        result = arguments_helpers.StartSpanParameters(
+            name=name,
+            input=input,
+            type=type,
+            tags=tags,
+            metadata=metadata,
+            project_name=project_name,
+        )
+
+        return result
+
+    def _end_span_inputs_preprocessor(
+        self, output: AnthropicMessage, capture_output: bool
+    ) -> arguments_helpers.EndSpanParameters:
+        usage = {
+            "prompt_tokens": output.usage.input_tokens,
+            "completion_tokens": output.usage.output_tokens,
+            "total_tokens": output.usage.input_tokens + output.usage.output_tokens,
+        }
+
+        output_dict = output.model_dump()
+        span_output, metadata = dict_utils.split_dict_by_keys(
+            output_dict, RESPONSE_KEYS_TO_LOG_AS_OUTPUT
+        )
+
+        result = arguments_helpers.EndSpanParameters(
+            output=span_output, usage=usage, metadata=metadata
+        )
+
+        return result
+
+    def _generators_handler(
+        self,
+        output: Any,
+        capture_output: bool,
+        generations_aggregator: Optional[Callable[[List[Any]], Any]],
+    ) -> Union[None,]:
+        NOT_A_STREAM = None
+
+        return NOT_A_STREAM

--- a/sdks/python/src/opik/integrations/anthropic/messages_create_decorator.py
+++ b/sdks/python/src/opik/integrations/anthropic/messages_create_decorator.py
@@ -38,7 +38,8 @@ class AnthropicMessagesCreateDecorator(base_track_decorator.BaseTrackDecorator):
         input, metadata = dict_utils.split_dict_by_keys(
             kwargs, KWARGS_KEYS_TO_LOG_AS_INPUTS
         )
-
+        metadata["created_from"] = "anthropic"
+        tags = ["anthropic"]
         name = name if name is not None else func.__name__
 
         result = arguments_helpers.StartSpanParameters(

--- a/sdks/python/src/opik/integrations/anthropic/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/anthropic/opik_tracker.py
@@ -14,9 +14,9 @@ def track_anthropic(
     anthropic_client: AnthropicClient,
     project_name: Optional[str] = None,
 ) -> AnthropicClient:
-    """Adds Opik tracking to an OpenAI client.
+    """Adds Opik tracking to an Anthropic client.
 
-    Tracks calls to `openai_client.chat.completions.create()`, it includes support for streaming model.
+    Tracks calls to `Anthropic`'s or `AsynsAnthropic`'s `messages.create()` method.
     Can be used within other Opik-tracked functions.
 
     Args:
@@ -24,7 +24,7 @@ def track_anthropic(
         project_name: The name of the project to log data.
 
     Returns:
-        The modified OpenAI client with Opik tracking enabled.
+        The modified Anthropic client with Opik tracking enabled.
     """
     decorator = messages_create_decorator.AnthropicMessagesCreateDecorator()
     if not hasattr(anthropic_client.messages.create, "opik_tracked"):

--- a/sdks/python/src/opik/integrations/anthropic/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/anthropic/opik_tracker.py
@@ -1,0 +1,39 @@
+from typing import Optional
+
+
+import anthropic
+from . import messages_create_decorator
+from typing import TypeVar
+
+AnthropicClient = TypeVar(
+    "AnthropicClient", anthropic.AsyncAnthropic, anthropic.Anthropic
+)
+
+
+def track_anthropic(
+    anthropic_client: AnthropicClient,
+    project_name: Optional[str] = None,
+) -> AnthropicClient:
+    """Adds Opik tracking to an OpenAI client.
+
+    Tracks calls to `openai_client.chat.completions.create()`, it includes support for streaming model.
+    Can be used within other Opik-tracked functions.
+
+    Args:
+        anthropic_client: An instance of Anthropic client.
+        project_name: The name of the project to log data.
+
+    Returns:
+        The modified OpenAI client with Opik tracking enabled.
+    """
+    decorator = messages_create_decorator.AnthropicMessagesCreateDecorator()
+    if not hasattr(anthropic_client.messages.create, "opik_tracked"):
+        wrapper = decorator.track(
+            type="llm",
+            name="anthropic_messages_create",
+            # generations_aggregator=chunks_aggregator.aggregate,
+            project_name=project_name,
+        )
+        anthropic_client.messages.create = wrapper(anthropic_client.messages.create)
+
+    return anthropic_client

--- a/sdks/python/src/opik/integrations/anthropic/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/anthropic/opik_tracker.py
@@ -31,8 +31,8 @@ def track_anthropic(
         wrapper = decorator.track(
             type="llm",
             name="anthropic_messages_create",
-            # generations_aggregator=chunks_aggregator.aggregate,
             project_name=project_name,
+            metadata={"base_url": anthropic_client.base_url}
         )
         anthropic_client.messages.create = wrapper(anthropic_client.messages.create)
 

--- a/sdks/python/src/opik/integrations/anthropic/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/anthropic/opik_tracker.py
@@ -32,7 +32,7 @@ def track_anthropic(
             type="llm",
             name="anthropic_messages_create",
             project_name=project_name,
-            metadata={"base_url": anthropic_client.base_url}
+            metadata={"base_url": anthropic_client.base_url},
         )
         anthropic_client.messages.create = wrapper(anthropic_client.messages.create)
 

--- a/sdks/python/tests/library_integration/anthropic/requirements.txt
+++ b/sdks/python/tests/library_integration/anthropic/requirements.txt
@@ -1,0 +1,1 @@
+anthropic

--- a/sdks/python/tests/library_integration/anthropic/test_anthropic.py
+++ b/sdks/python/tests/library_integration/anthropic/test_anthropic.py
@@ -1,0 +1,343 @@
+import pytest
+import mock
+import os
+import asyncio
+
+import opik
+from opik.message_processing import streamer_constructors
+from opik.integrations.anthropic import track_anthropic
+from opik.config import OPIK_PROJECT_DEFAULT_NAME
+from ...testlib import backend_emulator_message_processor
+from ...testlib import (
+    SpanModel,
+    TraceModel,
+    ANY_BUT_NONE,
+    ANY_DICT,
+    ANY_LIST,
+    assert_equal,
+)
+
+import anthropic
+
+
+@pytest.fixture(autouse=True)
+def ensure_anthropic_configured():
+    # don't use assertion here to prevent printing os.environ with all env variables
+
+    if "ANTHROPIC_API_KEY" not in os.environ:
+        raise Exception("Anthropic not configured!")
+
+
+@pytest.mark.parametrize(
+    "project_name, expected_project_name",
+    [
+        (None, OPIK_PROJECT_DEFAULT_NAME),
+        ("anthropic-integration-test", "anthropic-integration-test"),
+    ],
+)
+def test_anthropic_messages_create__happyflow(
+    fake_streamer, project_name, expected_project_name
+):
+    fake_message_processor_: (
+        backend_emulator_message_processor.BackendEmulatorMessageProcessor
+    )
+    streamer, fake_message_processor_ = fake_streamer
+
+    mock_construct_online_streamer = mock.Mock()
+    mock_construct_online_streamer.return_value = streamer
+
+    with mock.patch.object(
+        streamer_constructors,
+        "construct_online_streamer",
+        mock_construct_online_streamer,
+    ):
+        client = anthropic.Anthropic()
+        wrapped_client = track_anthropic(
+            anthropic_client=client,
+            project_name=project_name,
+        )
+        messages = [{"role": "user", "content": "Tell a short fact"}]
+
+        response = wrapped_client.messages.create(
+            model="claude-3-opus-20240229",
+            messages=messages,
+            max_tokens=10,
+            system="You are a helpful assistant",
+        )
+
+        opik.flush_tracker()
+        mock_construct_online_streamer.assert_called_once()
+
+        EXPECTED_TRACE_TREE = TraceModel(
+            id=ANY_BUT_NONE,
+            name="anthropic_messages_create",
+            input={"messages": messages, "system": "You are a helpful assistant"},
+            output={"content": response.model_dump()["content"]},
+            tags=["anthropic"],
+            metadata=ANY_DICT,
+            start_time=ANY_BUT_NONE,
+            end_time=ANY_BUT_NONE,
+            project_name=expected_project_name,
+            spans=[
+                SpanModel(
+                    id=ANY_BUT_NONE,
+                    name="anthropic_messages_create",
+                    input={
+                        "messages": messages,
+                        "system": "You are a helpful assistant",
+                    },
+                    output={"content": response.model_dump()["content"]},
+                    tags=["anthropic"],
+                    metadata=ANY_DICT,
+                    start_time=ANY_BUT_NONE,
+                    end_time=ANY_BUT_NONE,
+                    project_name=expected_project_name,
+                    type="llm",
+                    usage=ANY_DICT,
+                    spans=[],
+                )
+            ],
+        )
+
+        assert len(fake_message_processor_.trace_trees) == 1
+
+        assert_equal(EXPECTED_TRACE_TREE, fake_message_processor_.trace_trees[0])
+
+
+def test_anthropic_messages_create__create_raises_an_error__span_and_trace_finished_gracefully(
+    fake_streamer,
+):
+    fake_message_processor_: (
+        backend_emulator_message_processor.BackendEmulatorMessageProcessor
+    )
+    streamer, fake_message_processor_ = fake_streamer
+
+    mock_construct_online_streamer = mock.Mock()
+    mock_construct_online_streamer.return_value = streamer
+
+    with mock.patch.object(
+        streamer_constructors,
+        "construct_online_streamer",
+        mock_construct_online_streamer,
+    ):
+        client = anthropic.Anthropic()
+        wrapped_client = track_anthropic(client)
+
+        with pytest.raises(Exception):
+            _ = wrapped_client.messages.create(
+                messages=None,
+                model=None,
+            )
+
+        opik.flush_tracker()
+        mock_construct_online_streamer.assert_called_once()
+
+        EXPECTED_TRACE_TREE = TraceModel(
+            id=ANY_BUT_NONE,
+            name="anthropic_messages_create",
+            input={"messages": None},
+            output=None,
+            tags=["anthropic"],
+            metadata={
+                "created_from": "anthropic",
+                "model": None,
+            },
+            start_time=ANY_BUT_NONE,
+            end_time=ANY_BUT_NONE,
+            project_name=ANY_BUT_NONE,
+            spans=[
+                SpanModel(
+                    id=ANY_BUT_NONE,
+                    type="llm",
+                    name="anthropic_messages_create",
+                    input={"messages": None},
+                    output=None,
+                    tags=["anthropic"],
+                    metadata={
+                        "created_from": "anthropic",
+                        "model": None,
+                    },
+                    usage=None,
+                    start_time=ANY_BUT_NONE,
+                    end_time=ANY_BUT_NONE,
+                    project_name=ANY_BUT_NONE,
+                    spans=[],
+                )
+            ],
+        )
+
+        assert len(fake_message_processor_.trace_trees) == 1
+
+        assert_equal(EXPECTED_TRACE_TREE, fake_message_processor_.trace_trees[0])
+
+
+def test_anthropic_messages_create__create_call_made_in_another_tracked_function__anthropic_span_attached_to_existing_trace(
+    fake_streamer,
+):
+    fake_message_processor_: (
+        backend_emulator_message_processor.BackendEmulatorMessageProcessor
+    )
+    streamer, fake_message_processor_ = fake_streamer
+
+    mock_construct_online_streamer = mock.Mock()
+    mock_construct_online_streamer.return_value = streamer
+
+    with mock.patch.object(
+        streamer_constructors,
+        "construct_online_streamer",
+        mock_construct_online_streamer,
+    ):
+        messages = [
+            {"role": "user", "content": "Tell a short fact"},
+        ]
+
+        @opik.track(project_name="anthropic-integration-test")
+        def f():
+            client = anthropic.Anthropic()
+            wrapped_client = track_anthropic(
+                anthropic_client=client,
+                project_name="anthropic-integration-test",
+            )
+            messages = [
+                {
+                    "role": "user",
+                    "content": "Tell a short fact",
+                }
+            ]
+
+            _ = wrapped_client.messages.create(
+                model="claude-3-opus-20240229",
+                messages=messages,
+                max_tokens=10,
+                system="You are a helpful assistant",
+            )
+
+        f()
+
+        opik.flush_tracker()
+        mock_construct_online_streamer.assert_called_once()
+
+        EXPECTED_TRACE_TREE = TraceModel(
+            id=ANY_BUT_NONE,
+            name="f",
+            input={},
+            output=None,
+            start_time=ANY_BUT_NONE,
+            end_time=ANY_BUT_NONE,
+            project_name="anthropic-integration-test",
+            spans=[
+                SpanModel(
+                    id=ANY_BUT_NONE,
+                    name="f",
+                    input={},
+                    output=None,
+                    start_time=ANY_BUT_NONE,
+                    end_time=ANY_BUT_NONE,
+                    project_name="anthropic-integration-test",
+                    spans=[
+                        SpanModel(
+                            id=ANY_BUT_NONE,
+                            name="anthropic_messages_create",
+                            input={
+                                "messages": messages,
+                                "system": "You are a helpful assistant",
+                            },
+                            output={"content": ANY_LIST},
+                            tags=["anthropic"],
+                            metadata=ANY_DICT,
+                            start_time=ANY_BUT_NONE,
+                            end_time=ANY_BUT_NONE,
+                            project_name="anthropic-integration-test",
+                            type="llm",
+                            usage=ANY_DICT,
+                            spans=[],
+                        )
+                    ],
+                )
+            ],
+        )
+
+        assert len(fake_message_processor_.trace_trees) == 1
+
+        assert_equal(EXPECTED_TRACE_TREE, fake_message_processor_.trace_trees[0])
+
+
+def test_async_anthropic_messages_create_call_made_in_another_tracked_async_function__anthropic_span_attached_to_existing_trace(
+    fake_streamer,
+):
+    fake_message_processor_: (
+        backend_emulator_message_processor.BackendEmulatorMessageProcessor
+    )
+    streamer, fake_message_processor_ = fake_streamer
+
+    mock_construct_online_streamer = mock.Mock()
+    mock_construct_online_streamer.return_value = streamer
+
+    with mock.patch.object(
+        streamer_constructors,
+        "construct_online_streamer",
+        mock_construct_online_streamer,
+    ):
+        messages = [
+            {"role": "user", "content": "Tell a short fact"},
+        ]
+
+        @opik.track()
+        async def async_f():
+            client = anthropic.AsyncAnthropic()
+            wrapped_client = track_anthropic(client)
+            _ = await wrapped_client.messages.create(
+                model="claude-3-opus-20240229",
+                messages=messages,
+                max_tokens=10,
+                system="You are a helpful assistant",
+            )
+
+        asyncio.run(async_f())
+
+        opik.flush_tracker()
+        mock_construct_online_streamer.assert_called_once()
+
+        EXPECTED_TRACE_TREE = TraceModel(
+            id=ANY_BUT_NONE,
+            name="async_f",
+            input={},
+            output=None,
+            start_time=ANY_BUT_NONE,
+            end_time=ANY_BUT_NONE,
+            project_name=ANY_BUT_NONE,
+            spans=[
+                SpanModel(
+                    id=ANY_BUT_NONE,
+                    name="async_f",
+                    input={},
+                    output=None,
+                    start_time=ANY_BUT_NONE,
+                    end_time=ANY_BUT_NONE,
+                    project_name=ANY_BUT_NONE,
+                    spans=[
+                        SpanModel(
+                            id=ANY_BUT_NONE,
+                            name="anthropic_messages_create",
+                            input={
+                                "messages": messages,
+                                "system": "You are a helpful assistant",
+                            },
+                            output={"content": ANY_LIST},
+                            tags=["anthropic"],
+                            metadata=ANY_DICT,
+                            start_time=ANY_BUT_NONE,
+                            end_time=ANY_BUT_NONE,
+                            project_name=ANY_BUT_NONE,
+                            type="llm",
+                            usage=ANY_DICT,
+                            spans=[],
+                        )
+                    ],
+                )
+            ],
+        )
+
+        assert len(fake_message_processor_.trace_trees) == 1
+
+        assert_equal(EXPECTED_TRACE_TREE, fake_message_processor_.trace_trees[0])

--- a/sdks/python/tests/testlib/__init__.py
+++ b/sdks/python/tests/testlib/__init__.py
@@ -1,7 +1,7 @@
 from .backend_emulator_message_processor import BackendEmulatorMessageProcessor
 from .models import SpanModel, TraceModel, FeedbackScoreModel
 from .assert_helpers import assert_dicts_equal, prepare_difference_report, assert_equal
-from .any_compare_helpers import ANY_BUT_NONE, ANY_DICT, ANY
+from .any_compare_helpers import ANY_BUT_NONE, ANY_DICT, ANY_LIST, ANY
 from .patch_helpers import patch_environ
 
 __all__ = [
@@ -10,6 +10,7 @@ __all__ = [
     "FeedbackScoreModel",
     "ANY_BUT_NONE",
     "ANY_DICT",
+    "ANY_LIST",
     "ANY",
     "assert_equal",
     "assert_dicts_equal",

--- a/sdks/python/tests/testlib/any_compare_helpers.py
+++ b/sdks/python/tests/testlib/any_compare_helpers.py
@@ -33,6 +33,23 @@ class AnyDict:
         return "<ANY_DICT>"
 
 
+class AnyList:
+    "A helper object that compares equal to all lists."
+
+    def __eq__(self, other):
+        if isinstance(other, list):
+            return True
+
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return "<ANY_LIST>"
+
+
 ANY_BUT_NONE = AnyButNone()
 ANY_DICT = AnyDict()
+ANY_LIST = AnyList()
 ANY = mock.ANY


### PR DESCRIPTION
## Details
This PR adds an integration with Anthropic similar to the ones we have for OpenAI and Bedrock.
Only non-streaming mode is supported at the moment.

Synchronous API
```python
import asyncio

from anthropic import Anthropic, AsyncAnthropic
from opik.integrations.anthropic import track_anthropic

client = Anthropic()
client = track_anthropic(client)

client.messages.create(
    max_tokens=1024,
    messages=[
        {
            "role": "user",
            "content": "Tell a fact",
        }
    ],
    model="claude-3-opus-20240229",
)


async_client = AsyncAnthropic()
async_client = track_anthropic(async_client)

asyncio.run(
    async_client.messages.create(
        max_tokens=1024,
        messages=[
            {
                "role": "user",
                "content": "Tell a joke",
            }
        ],
        model="claude-3-opus-20240229",
    )
)
```


## Issues

Resolves #

## Testing

## Documentation
