### PR TITLE
[OPIK-295] Get experiments linked to deleted datasets

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentSearchCriteria.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentSearchCriteria.java
@@ -3,10 +3,12 @@ package com.comet.opik.api;
 import lombok.Builder;
 import lombok.NonNull;
 
+import java.util.Collection;
 import java.util.UUID;
 
 import static com.comet.opik.domain.FeedbackScoreDAO.EntityType;
 
 @Builder(toBuilder = true)
-public record ExperimentSearchCriteria(String name, UUID datasetId, @NonNull EntityType entityType) {
+public record ExperimentSearchCriteria(String name, UUID datasetId, @NonNull EntityType entityType,
+        boolean datasetDeleted, Collection<UUID> datasetIds) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -78,12 +78,14 @@ public class ExperimentsResource {
             @QueryParam("page") @Min(1) @DefaultValue("1") int page,
             @QueryParam("size") @Min(1) @DefaultValue("10") int size,
             @QueryParam("datasetId") UUID datasetId,
-            @QueryParam("name") String name) {
+            @QueryParam("name") String name,
+            @QueryParam("dataset_deleted") boolean datasetDeleted) {
 
         var experimentSearchCriteria = ExperimentSearchCriteria.builder()
                 .datasetId(datasetId)
                 .name(name)
                 .entityType(EntityType.TRACE)
+                .datasetDeleted(datasetDeleted)
                 .build();
         log.info("Finding experiments by '{}', page '{}', size '{}'", experimentSearchCriteria, page, size);
         var experiments = experimentService.find(page, size, experimentSearchCriteria)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetDAO.java
@@ -141,4 +141,9 @@ public interface DatasetDAO {
     @SqlUpdate("DROP TEMPORARY TABLE IF EXISTS experiment_dataset_ids_<table_name>")
     void dropTempTable(@Define("table_name") String tableName);
 
+    @SqlQuery("SELECT id FROM datasets WHERE id IN (<ids>) and workspace_id = :workspace_id")
+    Set<UUID> exists(@BindList("ids") Set<UUID> datasetIds, @Bind("workspace_id") String workspaceId);
+
+    @SqlQuery("SELECT id FROM datasets WHERE id IN (SELECT id FROM experiment_dataset_ids_<table_name>) and workspace_id = :workspace_id")
+    Set<UUID> existsByTempTable(@Bind("workspace_id") String workspaceId, @Define("table_name") String tableName);
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -279,6 +279,7 @@ class ExperimentDAO {
                 WHERE workspace_id = :workspace_id
                 <if(dataset_id)> AND dataset_id = :dataset_id <endif>
                 <if(name)> AND ilike(name, CONCAT('%', :name, '%')) <endif>
+                <if(dataset_ids)> AND dataset_id IN :dataset_ids <endif>
                 ORDER BY id DESC, last_updated_at DESC
                 LIMIT 1 BY id
             ) AS e
@@ -345,6 +346,7 @@ class ExperimentDAO {
                 WHERE workspace_id = :workspace_id
                 <if(dataset_id)> AND dataset_id = :dataset_id <endif>
                 <if(name)> AND ilike(name, CONCAT('%', :name, '%')) <endif>
+                <if(dataset_ids)> AND dataset_id IN :dataset_ids <endif>
                 ORDER BY id DESC, last_updated_at DESC
                 LIMIT 1 BY id
             ) as latest_rows
@@ -566,6 +568,8 @@ class ExperimentDAO {
                 .ifPresent(datasetId -> template.add("dataset_id", datasetId));
         Optional.ofNullable(criteria.name())
                 .ifPresent(name -> template.add("name", name));
+        Optional.ofNullable(criteria.datasetIds())
+                .ifPresent(datasetIds -> template.add("dataset_ids", datasetIds));
         return template;
     }
 
@@ -574,6 +578,8 @@ class ExperimentDAO {
                 .ifPresent(datasetId -> statement.bind("dataset_id", datasetId));
         Optional.ofNullable(criteria.name())
                 .ifPresent(name -> statement.bind("name", name));
+        Optional.ofNullable(criteria.datasetIds())
+                .ifPresent(datasetIds -> statement.bind("dataset_ids", datasetIds.toArray(UUID[]::new)));
         if (!isCount) {
             statement.bind("entity_type", criteria.entityType().getType());
         }


### PR DESCRIPTION
## Details
Add a flag `dataset_deleted` to allow filtering by experiments linked to deleted datasets.


## Issues
OPIK-295
