### PR TITLE
[OPIK-400] improve image truncation

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
@@ -16,7 +16,9 @@ public class ImageUtils {
             + PREFIX_PNG + IMAGE_CHARS + "|"
             + PREFIX_GIF0 + IMAGE_CHARS + "|"
             + PREFIX_GIF1 + IMAGE_CHARS + "|"
-            + PREFIX_BMP + IMAGE_CHARS;
+            + PREFIX_BMP + IMAGE_CHARS + "|"
+            + PREFIX_TIFF0 + IMAGE_CHARS + "|"
+            + PREFIX_TIFF1 + IMAGE_CHARS;
 
     public static ST addTruncateToTemplate(ST template, boolean truncate) {
         return template.add("truncate", truncate ? ImageUtils.IMAGE_TRUNCATION_REGEX : null);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
@@ -4,6 +4,7 @@ import org.stringtemplate.v4.ST;
 
 public class ImageUtils {
     public static final String PREFIX_JPEG = "/9j/";
+    public static final String PREFIX_PNG = "iVBORw0KGgo=";
     private static final String IMAGE_TRUNCATION_REGEX = "(data:image/[^;]{3,4};base64,)[^\"]+|"
             + PREFIX_JPEG + "[^\"]+";
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
@@ -20,7 +20,8 @@ public class ImageUtils {
             + PREFIX_GIF1 + IMAGE_CHARS + "|"
             + PREFIX_BMP + IMAGE_CHARS + "|"
             + PREFIX_TIFF0 + IMAGE_CHARS + "|"
-            + PREFIX_TIFF1 + IMAGE_CHARS;
+            + PREFIX_TIFF1 + IMAGE_CHARS + "|"
+            + PREFIX_WEBP + IMAGE_CHARS;
 
     public static ST addTruncateToTemplate(ST template, boolean truncate) {
         return template.add("truncate", truncate ? ImageUtils.IMAGE_TRUNCATION_REGEX : null);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
@@ -13,7 +13,8 @@ public class ImageUtils {
             + PREFIX_JPEG + IMAGE_CHARS + "|"
             + PREFIX_PNG + IMAGE_CHARS + "|"
             + PREFIX_GIF0 + IMAGE_CHARS + "|"
-            + PREFIX_GIF1 + IMAGE_CHARS;
+            + PREFIX_GIF1 + IMAGE_CHARS + "|"
+            + PREFIX_BMP + IMAGE_CHARS;
 
     public static ST addTruncateToTemplate(ST template, boolean truncate) {
         return template.add("truncate", truncate ? ImageUtils.IMAGE_TRUNCATION_REGEX : null);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
@@ -10,6 +10,8 @@ public class ImageUtils {
     public static final String PREFIX_BMP = "Qk";
     public static final String PREFIX_TIFF0 = "SUkqAA";
     public static final String PREFIX_TIFF1 = "II*";
+    public static final String PREFIX_WEBP = "UklGR";
+
     private static final String IMAGE_CHARS = "[^\"]+";
     private static final String IMAGE_TRUNCATION_REGEX = "data:image/[^;]{3,4};base64," + IMAGE_CHARS + "|"
             + PREFIX_JPEG + IMAGE_CHARS + "|"

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
@@ -7,6 +7,7 @@ public class ImageUtils {
     public static final String PREFIX_PNG = "iVBORw0KGgo=";
     public static final String PREFIX_GIF0 = "R0lGODlh";
     public static final String PREFIX_GIF1 = "R0lGODdh";
+    public static final String PREFIX_BMP = "Qk";
     private static final String IMAGE_CHARS = "[^\"]+";
     private static final String IMAGE_TRUNCATION_REGEX = "data:image/[^;]{3,4};base64," + IMAGE_CHARS + "|"
             + PREFIX_JPEG + IMAGE_CHARS + "|"

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
@@ -5,6 +5,8 @@ import org.stringtemplate.v4.ST;
 public class ImageUtils {
     public static final String PREFIX_JPEG = "/9j/";
     public static final String PREFIX_PNG = "iVBORw0KGgo=";
+    public static final String PREFIX_GIF0 = "R0lGODlh";
+    public static final String PREFIX_GIF1 = "R0lGODdh";
     private static final String IMAGE_CHARS = "[^\"]+";
     private static final String IMAGE_TRUNCATION_REGEX = "data:image/[^;]{3,4};base64," + IMAGE_CHARS + "|"
             + PREFIX_JPEG + IMAGE_CHARS + "|"

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
@@ -5,8 +5,10 @@ import org.stringtemplate.v4.ST;
 public class ImageUtils {
     public static final String PREFIX_JPEG = "/9j/";
     public static final String PREFIX_PNG = "iVBORw0KGgo=";
-    private static final String IMAGE_TRUNCATION_REGEX = "(data:image/[^;]{3,4};base64,)[^\"]+|"
-            + PREFIX_JPEG + "[^\"]+";
+    private static final String IMAGE_CHARS = "[^\"]+";
+    private static final String IMAGE_TRUNCATION_REGEX = "data:image/[^;]{3,4};base64," + IMAGE_CHARS + "|"
+            + PREFIX_JPEG + IMAGE_CHARS + "|"
+            + PREFIX_PNG + IMAGE_CHARS;
 
     public static ST addTruncateToTemplate(ST template, boolean truncate) {
         return template.add("truncate", truncate ? ImageUtils.IMAGE_TRUNCATION_REGEX : null);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
@@ -3,7 +3,9 @@ package com.comet.opik.domain;
 import org.stringtemplate.v4.ST;
 
 public class ImageUtils {
-    private static final String IMAGE_TRUNCATION_REGEX = "(data:image/[^;]{3,4};base64,)[^\"]+|/9j/[^\"]+";
+    public static final String PREFIX_JPEG = "/9j/";
+    private static final String IMAGE_TRUNCATION_REGEX = "(data:image/[^;]{3,4};base64,)[^\"]+|"
+            + PREFIX_JPEG + "[^\"]+";
 
     public static ST addTruncateToTemplate(ST template, boolean truncate) {
         return template.add("truncate", truncate ? ImageUtils.IMAGE_TRUNCATION_REGEX : null);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
@@ -10,7 +10,9 @@ public class ImageUtils {
     private static final String IMAGE_CHARS = "[^\"]+";
     private static final String IMAGE_TRUNCATION_REGEX = "data:image/[^;]{3,4};base64," + IMAGE_CHARS + "|"
             + PREFIX_JPEG + IMAGE_CHARS + "|"
-            + PREFIX_PNG + IMAGE_CHARS;
+            + PREFIX_PNG + IMAGE_CHARS + "|"
+            + PREFIX_GIF0 + IMAGE_CHARS + "|"
+            + PREFIX_GIF1 + IMAGE_CHARS;
 
     public static ST addTruncateToTemplate(ST template, boolean truncate) {
         return template.add("truncate", truncate ? ImageUtils.IMAGE_TRUNCATION_REGEX : null);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
@@ -3,7 +3,7 @@ package com.comet.opik.domain;
 import org.stringtemplate.v4.ST;
 
 public class ImageUtils {
-    private static final String IMAGE_TRUNCATION_REGEX = "data:image/[^;]{3,4};base64,[^\"]+";
+    private static final String IMAGE_TRUNCATION_REGEX = "(data:image/[^;]{3,4};base64,)[^\"]+|/9j/[^\"]+";
 
     public static ST addTruncateToTemplate(ST template, boolean truncate) {
         return template.add("truncate", truncate ? ImageUtils.IMAGE_TRUNCATION_REGEX : null);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
@@ -8,6 +8,8 @@ public class ImageUtils {
     public static final String PREFIX_GIF0 = "R0lGODlh";
     public static final String PREFIX_GIF1 = "R0lGODdh";
     public static final String PREFIX_BMP = "Qk";
+    public static final String PREFIX_TIFF0 = "SUkqAA";
+    public static final String PREFIX_TIFF1 = "II*";
     private static final String IMAGE_CHARS = "[^\"]+";
     private static final String IMAGE_TRUNCATION_REGEX = "data:image/[^;]{3,4};base64," + IMAGE_CHARS + "|"
             + PREFIX_JPEG + IMAGE_CHARS + "|"

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ImageUtils.java
@@ -3,7 +3,7 @@ package com.comet.opik.domain;
 import org.stringtemplate.v4.ST;
 
 public class ImageUtils {
-    private static final String IMAGE_TRUNCATION_REGEX = "data:image/.+;base64,[A-Za-z0-9+/=]+";
+    private static final String IMAGE_TRUNCATION_REGEX = "data:image/[^;]{3,4};base64,[^\"]+";
 
     public static ST addTruncateToTemplate(ST template, boolean truncate) {
         return template.add("truncate", truncate ? ImageUtils.IMAGE_TRUNCATION_REGEX : null);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ImageTruncationArgProvider.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ImageTruncationArgProvider.java
@@ -1,0 +1,113 @@
+package com.comet.opik.api.resources.v1.priv;
+
+import com.comet.opik.domain.ImageUtils;
+import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class ImageTruncationArgProvider {
+    public static Stream<Arguments> provideTestArguments() {
+        final String IMAGE_TEMPLATE = """
+                        { "messages": [{
+                            "role": "user",
+                            "content": [{
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "%s",
+                                "details": "some details for this image"
+                            }
+                        }]}] }
+                """;
+        final String IMAGE_TEMPLATE_MULTIPLE = """
+                        { "messages": [{
+                            "role": "user",
+                            "content": [{
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "%s",
+                                "details": "some details for this image"
+                            }
+                        }, {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "%s",
+                                "details": "some details for this image"
+                            }
+                        }]}] }
+                """;
+        final String PREFIX_JPEG_DATA = "data:image/jpg;base64," + ImageUtils.PREFIX_JPEG +
+                RandomStringUtils.randomAlphanumeric(100);
+        final String NO_PREFIX_JPEG_DATA = ImageUtils.PREFIX_JPEG + RandomStringUtils.randomAlphanumeric(100);
+        final String PREFIX_PNG_DATA = "data:image/png;base64," + ImageUtils.PREFIX_PNG +
+                RandomStringUtils.randomAlphanumeric(100);
+        final String NO_PREFIX_PNG_DATA = ImageUtils.PREFIX_PNG + RandomStringUtils.randomAlphanumeric(100);
+        final String PREFIX_GIF_DATA0 = "data:image/gif;base64," + ImageUtils.PREFIX_GIF0 +
+                RandomStringUtils.randomAlphanumeric(100);
+        final String NO_PREFIX_GIF_DATA0 = ImageUtils.PREFIX_GIF0 + RandomStringUtils.randomAlphanumeric(100);
+        final String PREFIX_GIF_DATA1 = "data:image/gif;base64," + ImageUtils.PREFIX_GIF1 +
+                RandomStringUtils.randomAlphanumeric(100);
+        final String NO_PREFIX_GIF_DATA1 = ImageUtils.PREFIX_GIF1 + RandomStringUtils.randomAlphanumeric(100);
+        final String PREFIX_BMP_DATA = "data:image/bmp;base64," + ImageUtils.PREFIX_BMP +
+                RandomStringUtils.randomAlphanumeric(100);
+        final String NO_PREFIX_BMP_DATA = ImageUtils.PREFIX_BMP + RandomStringUtils.randomAlphanumeric(100);
+        final String PREFIX_TIFF_DATA0 = "data:image/tiff;base64," + ImageUtils.PREFIX_TIFF0 +
+                RandomStringUtils.randomAlphanumeric(100);
+        final String NO_PREFIX_TIFF_DATA0 = ImageUtils.PREFIX_TIFF0 + RandomStringUtils.randomAlphanumeric(100);
+        final String PREFIX_TIFF_DATA1 = "data:image/tiff;base64," + ImageUtils.PREFIX_TIFF1 +
+                RandomStringUtils.randomAlphanumeric(100);
+        final String NO_PREFIX_TIFF_DATA1 = ImageUtils.PREFIX_TIFF1 + RandomStringUtils.randomAlphanumeric(100);
+        final String PREFIX_WEBP_DATA = "data:image/webp;base64," + ImageUtils.PREFIX_WEBP +
+                RandomStringUtils.randomAlphanumeric(100);
+        final String NO_PREFIX_WEBP_DATA = ImageUtils.PREFIX_WEBP + RandomStringUtils.randomAlphanumeric(100);
+
+        final String TRUNCATED_TEXT = "[image]";
+        final JsonNode TRUNCATED_MULTIPLE_EXPECTED = JsonUtils.getJsonNodeFromString(
+                IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT, TRUNCATED_TEXT));
+        return Stream.of(
+                arguments(
+                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
+                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(TRUNCATED_TEXT)),
+                        true),
+                arguments(
+                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
+                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
+                        false),
+                arguments(
+                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_JPEG_DATA,
+                                PREFIX_JPEG_DATA)),
+                        TRUNCATED_MULTIPLE_EXPECTED, true),
+                arguments(
+                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_PNG_DATA,
+                                PREFIX_PNG_DATA)),
+                        TRUNCATED_MULTIPLE_EXPECTED, true),
+                arguments(
+                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA0,
+                                PREFIX_GIF_DATA0)),
+                        TRUNCATED_MULTIPLE_EXPECTED, true),
+                arguments(
+                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA1,
+                                PREFIX_GIF_DATA1)),
+                        TRUNCATED_MULTIPLE_EXPECTED, true),
+                arguments(
+                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_BMP_DATA,
+                                PREFIX_BMP_DATA)),
+                        TRUNCATED_MULTIPLE_EXPECTED, true),
+                arguments(
+                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_TIFF_DATA0,
+                                PREFIX_TIFF_DATA0)),
+                        TRUNCATED_MULTIPLE_EXPECTED, true),
+                arguments(
+                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_TIFF_DATA1,
+                                PREFIX_TIFF_DATA1)),
+                        TRUNCATED_MULTIPLE_EXPECTED, true),
+                arguments(
+                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_WEBP_DATA,
+                                PREFIX_WEBP_DATA)),
+                        TRUNCATED_MULTIPLE_EXPECTED, true));
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ImageTruncationArgProvider.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ImageTruncationArgProvider.java
@@ -11,103 +11,96 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class ImageTruncationArgProvider {
-    public static Stream<Arguments> provideTestArguments() {
-        final String IMAGE_TEMPLATE = """
-                        { "messages": [{
-                            "role": "user",
-                            "content": [{
-                            "type": "image_url",
-                            "image_url": {
-                                "url": "%s",
-                                "details": "some details for this image"
-                            }
-                        }]}] }
-                """;
-        final String IMAGE_TEMPLATE_MULTIPLE = """
-                        { "messages": [{
-                            "role": "user",
-                            "content": [{
-                            "type": "image_url",
-                            "image_url": {
-                                "url": "%s",
-                                "details": "some details for this image"
-                            }
-                        }, {
-                            "type": "image_url",
-                            "image_url": {
-                                "url": "%s",
-                                "details": "some details for this image"
-                            }
-                        }]}] }
-                """;
-        final String PREFIX_JPEG_DATA = "data:image/jpg;base64," + ImageUtils.PREFIX_JPEG +
-                RandomStringUtils.randomAlphanumeric(100);
-        final String NO_PREFIX_JPEG_DATA = ImageUtils.PREFIX_JPEG + RandomStringUtils.randomAlphanumeric(100);
-        final String PREFIX_PNG_DATA = "data:image/png;base64," + ImageUtils.PREFIX_PNG +
-                RandomStringUtils.randomAlphanumeric(100);
-        final String NO_PREFIX_PNG_DATA = ImageUtils.PREFIX_PNG + RandomStringUtils.randomAlphanumeric(100);
-        final String PREFIX_GIF_DATA0 = "data:image/gif;base64," + ImageUtils.PREFIX_GIF0 +
-                RandomStringUtils.randomAlphanumeric(100);
-        final String NO_PREFIX_GIF_DATA0 = ImageUtils.PREFIX_GIF0 + RandomStringUtils.randomAlphanumeric(100);
-        final String PREFIX_GIF_DATA1 = "data:image/gif;base64," + ImageUtils.PREFIX_GIF1 +
-                RandomStringUtils.randomAlphanumeric(100);
-        final String NO_PREFIX_GIF_DATA1 = ImageUtils.PREFIX_GIF1 + RandomStringUtils.randomAlphanumeric(100);
-        final String PREFIX_BMP_DATA = "data:image/bmp;base64," + ImageUtils.PREFIX_BMP +
-                RandomStringUtils.randomAlphanumeric(100);
-        final String NO_PREFIX_BMP_DATA = ImageUtils.PREFIX_BMP + RandomStringUtils.randomAlphanumeric(100);
-        final String PREFIX_TIFF_DATA0 = "data:image/tiff;base64," + ImageUtils.PREFIX_TIFF0 +
-                RandomStringUtils.randomAlphanumeric(100);
-        final String NO_PREFIX_TIFF_DATA0 = ImageUtils.PREFIX_TIFF0 + RandomStringUtils.randomAlphanumeric(100);
-        final String PREFIX_TIFF_DATA1 = "data:image/tiff;base64," + ImageUtils.PREFIX_TIFF1 +
-                RandomStringUtils.randomAlphanumeric(100);
-        final String NO_PREFIX_TIFF_DATA1 = ImageUtils.PREFIX_TIFF1 + RandomStringUtils.randomAlphanumeric(100);
-        final String PREFIX_WEBP_DATA = "data:image/webp;base64," + ImageUtils.PREFIX_WEBP +
-                RandomStringUtils.randomAlphanumeric(100);
-        final String NO_PREFIX_WEBP_DATA = ImageUtils.PREFIX_WEBP + RandomStringUtils.randomAlphanumeric(100);
+    // templates
+    private static final String IMAGE_TEMPLATE = """
+                    { "messages": [{
+                        "role": "user",
+                        "content": [{
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "%s",
+                            "details": "some details for this image"
+                        }
+                    }]}] }
+            """;
+    private static final String IMAGE_TEMPLATE_MULTIPLE = """
+                    { "messages": [{
+                        "role": "user",
+                        "content": [{
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "%s",
+                            "details": "some details for this image"
+                        }
+                    }, {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "%s",
+                            "details": "some details for this image"
+                        }
+                    }]}] }
+            """;
 
-        final String TRUNCATED_TEXT = "[image]";
-        final JsonNode TRUNCATED_MULTIPLE_EXPECTED = JsonUtils.getJsonNodeFromString(
-                IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT, TRUNCATED_TEXT));
+    // inputs
+    private static final String PREFIX_JPEG_DATA = "data:image/jpg;base64," + ImageUtils.PREFIX_JPEG +
+            RandomStringUtils.randomAlphanumeric(100);
+    private static final String NO_PREFIX_JPEG_DATA = ImageUtils.PREFIX_JPEG +
+            RandomStringUtils.randomAlphanumeric(100);
+    private static final String PREFIX_PNG_DATA = "data:image/png;base64," + ImageUtils.PREFIX_PNG +
+            RandomStringUtils.randomAlphanumeric(100);
+    private static final String NO_PREFIX_PNG_DATA = ImageUtils.PREFIX_PNG +
+            RandomStringUtils.randomAlphanumeric(100);
+    private static final String PREFIX_GIF_DATA0 = "data:image/gif;base64," + ImageUtils.PREFIX_GIF0 +
+            RandomStringUtils.randomAlphanumeric(100);
+    private static final String NO_PREFIX_GIF_DATA0 = ImageUtils.PREFIX_GIF0 +
+            RandomStringUtils.randomAlphanumeric(100);
+    private static final String PREFIX_GIF_DATA1 = "data:image/gif;base64," + ImageUtils.PREFIX_GIF1 +
+            RandomStringUtils.randomAlphanumeric(100);
+    private static final String NO_PREFIX_GIF_DATA1 = ImageUtils.PREFIX_GIF1 +
+            RandomStringUtils.randomAlphanumeric(100);
+    private static final String PREFIX_BMP_DATA = "data:image/bmp;base64," + ImageUtils.PREFIX_BMP +
+            RandomStringUtils.randomAlphanumeric(100);
+    private static final String NO_PREFIX_BMP_DATA = ImageUtils.PREFIX_BMP +
+            RandomStringUtils.randomAlphanumeric(100);
+    private static final String PREFIX_TIFF_DATA0 = "data:image/tiff;base64," + ImageUtils.PREFIX_TIFF0 +
+            RandomStringUtils.randomAlphanumeric(100);
+    private static final String NO_PREFIX_TIFF_DATA0 = ImageUtils.PREFIX_TIFF0 +
+            RandomStringUtils.randomAlphanumeric(100);
+    private static final String PREFIX_TIFF_DATA1 = "data:image/tiff;base64," + ImageUtils.PREFIX_TIFF1 +
+            RandomStringUtils.randomAlphanumeric(100);
+    private static final String NO_PREFIX_TIFF_DATA1 = ImageUtils.PREFIX_TIFF1 +
+            RandomStringUtils.randomAlphanumeric(100);
+    private static final String PREFIX_WEBP_DATA = "data:image/webp;base64," + ImageUtils.PREFIX_WEBP +
+            RandomStringUtils.randomAlphanumeric(100);
+    private static final String NO_PREFIX_WEBP_DATA = ImageUtils.PREFIX_WEBP +
+            RandomStringUtils.randomAlphanumeric(100);
+
+    // expected
+    private static final String TRUNCATED_TEXT = "[image]";
+    private static final JsonNode TRUNCATED_MULTIPLE_EXPECTED = JsonUtils.getJsonNodeFromString(
+            IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT, TRUNCATED_TEXT));
+
+    public static Stream<Arguments> provideTestArguments() {
         return Stream.of(
-                arguments(
-                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
-                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(TRUNCATED_TEXT)),
-                        true),
-                arguments(
-                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
-                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
-                        false),
-                arguments(
-                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_JPEG_DATA,
-                                PREFIX_JPEG_DATA)),
-                        TRUNCATED_MULTIPLE_EXPECTED, true),
-                arguments(
-                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_PNG_DATA,
-                                PREFIX_PNG_DATA)),
-                        TRUNCATED_MULTIPLE_EXPECTED, true),
-                arguments(
-                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA0,
-                                PREFIX_GIF_DATA0)),
-                        TRUNCATED_MULTIPLE_EXPECTED, true),
-                arguments(
-                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA1,
-                                PREFIX_GIF_DATA1)),
-                        TRUNCATED_MULTIPLE_EXPECTED, true),
-                arguments(
-                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_BMP_DATA,
-                                PREFIX_BMP_DATA)),
-                        TRUNCATED_MULTIPLE_EXPECTED, true),
-                arguments(
-                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_TIFF_DATA0,
-                                PREFIX_TIFF_DATA0)),
-                        TRUNCATED_MULTIPLE_EXPECTED, true),
-                arguments(
-                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_TIFF_DATA1,
-                                PREFIX_TIFF_DATA1)),
-                        TRUNCATED_MULTIPLE_EXPECTED, true),
-                arguments(
-                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_WEBP_DATA,
-                                PREFIX_WEBP_DATA)),
-                        TRUNCATED_MULTIPLE_EXPECTED, true));
+                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
+                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(TRUNCATED_TEXT)), true),
+                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
+                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)), false),
+                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_JPEG_DATA,
+                        PREFIX_JPEG_DATA)), TRUNCATED_MULTIPLE_EXPECTED, true),
+                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_PNG_DATA,
+                        PREFIX_PNG_DATA)), TRUNCATED_MULTIPLE_EXPECTED, true),
+                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA0,
+                        PREFIX_GIF_DATA0)), TRUNCATED_MULTIPLE_EXPECTED, true),
+                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA1,
+                        PREFIX_GIF_DATA1)), TRUNCATED_MULTIPLE_EXPECTED, true),
+                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_BMP_DATA,
+                        PREFIX_BMP_DATA)), TRUNCATED_MULTIPLE_EXPECTED, true),
+                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_TIFF_DATA0,
+                        PREFIX_TIFF_DATA0)), TRUNCATED_MULTIPLE_EXPECTED, true),
+                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_TIFF_DATA1,
+                        PREFIX_TIFF_DATA1)), TRUNCATED_MULTIPLE_EXPECTED, true),
+                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_WEBP_DATA,
+                        PREFIX_WEBP_DATA)), TRUNCATED_MULTIPLE_EXPECTED, true));
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ImageTruncationArgProvider.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ImageTruncationArgProvider.java
@@ -1,13 +1,14 @@
 package com.comet.opik.api.resources.v1.priv;
 
 import com.comet.opik.domain.ImageUtils;
-import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.params.provider.Arguments;
 
 import java.util.stream.Stream;
 
+import static com.comet.opik.utils.JsonUtils.getJsonNodeFromString;
+import static org.junit.jupiter.api.Named.named;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class ImageTruncationArgProvider {
@@ -77,30 +78,42 @@ public class ImageTruncationArgProvider {
 
     // expected
     private static final String TRUNCATED_TEXT = "[image]";
-    private static final JsonNode TRUNCATED_MULTIPLE_EXPECTED = JsonUtils.getJsonNodeFromString(
+    private static final JsonNode TRUNCATED_MULTIPLE_EXPECTED = getJsonNodeFromString(
             IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT, TRUNCATED_TEXT));
 
     public static Stream<Arguments> provideTestArguments() {
         return Stream.of(
-                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
-                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(TRUNCATED_TEXT)), true),
-                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
-                        JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)), false),
-                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_JPEG_DATA,
-                        PREFIX_JPEG_DATA)), TRUNCATED_MULTIPLE_EXPECTED, true),
-                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_PNG_DATA,
-                        PREFIX_PNG_DATA)), TRUNCATED_MULTIPLE_EXPECTED, true),
-                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA0,
-                        PREFIX_GIF_DATA0)), TRUNCATED_MULTIPLE_EXPECTED, true),
-                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA1,
-                        PREFIX_GIF_DATA1)), TRUNCATED_MULTIPLE_EXPECTED, true),
-                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_BMP_DATA,
-                        PREFIX_BMP_DATA)), TRUNCATED_MULTIPLE_EXPECTED, true),
-                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_TIFF_DATA0,
-                        PREFIX_TIFF_DATA0)), TRUNCATED_MULTIPLE_EXPECTED, true),
-                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_TIFF_DATA1,
-                        PREFIX_TIFF_DATA1)), TRUNCATED_MULTIPLE_EXPECTED, true),
-                arguments(JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_WEBP_DATA,
-                        PREFIX_WEBP_DATA)), TRUNCATED_MULTIPLE_EXPECTED, true));
+                arguments(named("single image with prefix", getJsonNodeFromString(
+                        IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA))),
+                        named("truncated", getJsonNodeFromString(IMAGE_TEMPLATE.formatted(TRUNCATED_TEXT))),
+                        true),
+                arguments(named("single image with prefix", getJsonNodeFromString(
+                        IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA))),
+                        named("not truncated", getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA))),
+                        false),
+                arguments(named("multiple jpeg", getJsonNodeFromString(
+                        IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_JPEG_DATA, PREFIX_JPEG_DATA))),
+                        named("truncated", TRUNCATED_MULTIPLE_EXPECTED), true),
+                arguments(named("multiple png", getJsonNodeFromString(
+                        IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_PNG_DATA, PREFIX_PNG_DATA))),
+                        named("truncated", TRUNCATED_MULTIPLE_EXPECTED), true),
+                arguments(named("multiple gif, variant 0", getJsonNodeFromString(
+                        IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA0, PREFIX_GIF_DATA0))),
+                        named("truncated", TRUNCATED_MULTIPLE_EXPECTED), true),
+                arguments(named("multiple gif, variant 1", getJsonNodeFromString(
+                        IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA1, PREFIX_GIF_DATA1))),
+                        named("truncated", TRUNCATED_MULTIPLE_EXPECTED), true),
+                arguments(named("multiple bmp", getJsonNodeFromString(
+                        IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_BMP_DATA, PREFIX_BMP_DATA))),
+                        named("truncated", TRUNCATED_MULTIPLE_EXPECTED), true),
+                arguments(named("multiple tiff, variant 0", getJsonNodeFromString(
+                        IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_TIFF_DATA0, PREFIX_TIFF_DATA0))),
+                        named("truncated", TRUNCATED_MULTIPLE_EXPECTED), true),
+                arguments(named("multiple tiff, variant 1", getJsonNodeFromString(
+                        IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_TIFF_DATA1, PREFIX_TIFF_DATA1))),
+                        named("truncated", TRUNCATED_MULTIPLE_EXPECTED), true),
+                arguments(named("multiple webp", getJsonNodeFromString(
+                        IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_WEBP_DATA, PREFIX_WEBP_DATA))),
+                        named("truncated", TRUNCATED_MULTIPLE_EXPECTED), true));
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -880,11 +880,19 @@ class SpansResourceTest {
 
                 assertThat(actualSpans).hasSize(1);
 
-                String expected = JsonUtils.getJsonNodeFromString(IMAGE_INPUT_TEMPLATE
-                        .formatted(truncate ? "[image]" : IMAGE_DATA)).toPrettyString();
-                assertThat(actualSpans.getFirst().input().toPrettyString()).isEqualTo(expected);
-                assertThat(actualSpans.getFirst().output().toPrettyString()).isEqualTo(expected);
-                assertThat(actualSpans.getFirst().metadata().toPrettyString()).isEqualTo(expected);
+                JsonNode expected = JsonUtils.getJsonNodeFromString(IMAGE_INPUT_TEMPLATE
+                        .formatted(truncate ? "[image]" : IMAGE_DATA));
+                var expectedSpans = spans.stream()
+                        .map(span -> span.toBuilder()
+                                .input(expected)
+                                .output(expected)
+                                .metadata(expected)
+                                .build())
+                        .toList();
+
+                assertThat(actualSpans)
+                        .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS)
+                        .containsExactlyElementsOf(expectedSpans);
             }
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -53,7 +53,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -830,19 +829,8 @@ class SpansResourceTest {
         }
 
         @ParameterizedTest
-        @ValueSource(booleans = {true, false})
-        void findWithImageTruncation(boolean truncate) {
-            final String IMAGE_INPUT_TEMPLATE = """
-                            { "messages": [{
-                                "role": "user",
-                                "content": [{
-                                "type": "image_url",
-                                "image_url": {
-                                    "url": "%s"
-                                }
-                            }]}] }
-                    """;
-            final String IMAGE_DATA = "data:image/jpeg;base64," + RandomStringUtils.randomAlphanumeric(100);
+        @MethodSource("com.comet.opik.api.resources.v1.priv.ImageTruncationArgProvider#provideTestArguments")
+        void findWithImageTruncation(JsonNode original, JsonNode expected, boolean truncate) {
             var projectName = RandomStringUtils.randomAlphanumeric(10);
 
             String workspaceName = UUID.randomUUID().toString();
@@ -857,9 +845,9 @@ class SpansResourceTest {
                             .parentSpanId(null)
                             .projectName(projectName)
                             .feedbackScores(null)
-                            .input(JsonUtils.getJsonNodeFromString(IMAGE_INPUT_TEMPLATE.formatted(IMAGE_DATA)))
-                            .output(JsonUtils.getJsonNodeFromString(IMAGE_INPUT_TEMPLATE.formatted(IMAGE_DATA)))
-                            .metadata(JsonUtils.getJsonNodeFromString(IMAGE_INPUT_TEMPLATE.formatted(IMAGE_DATA)))
+                            .input(original)
+                            .output(original)
+                            .metadata(original)
                             .build())
                     .toList();
             spans.forEach(expectedSpan -> SpansResourceTest.this.createAndAssert(expectedSpan, apiKey, workspaceName));
@@ -880,8 +868,6 @@ class SpansResourceTest {
 
                 assertThat(actualSpans).hasSize(1);
 
-                JsonNode expected = JsonUtils.getJsonNodeFromString(IMAGE_INPUT_TEMPLATE
-                        .formatted(truncate ? "[image]" : IMAGE_DATA));
                 var expectedSpans = spans.stream()
                         .map(span -> span.toBuilder()
                                 .input(expected)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -924,6 +924,9 @@ class TracesResourceTest {
             final String PREFIX_JPEG_DATA = "data:image/jpg;base64," + ImageUtils.PREFIX_JPEG +
                     RandomStringUtils.randomAlphanumeric(100);
             final String NO_PREFIX_JPEG_DATA = ImageUtils.PREFIX_JPEG + RandomStringUtils.randomAlphanumeric(100);
+            final String PREFIX_PNG_DATA = "data:image/png;base64," + ImageUtils.PREFIX_PNG +
+                    RandomStringUtils.randomAlphanumeric(100);
+            final String NO_PREFIX_PNG_DATA = ImageUtils.PREFIX_PNG + RandomStringUtils.randomAlphanumeric(100);
             final String TRUNCATED_TEXT = "[image]";
             return Stream.of(
                     arguments(
@@ -937,6 +940,12 @@ class TracesResourceTest {
                     arguments(
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_JPEG_DATA,
                                     PREFIX_JPEG_DATA)),
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
+                                    TRUNCATED_TEXT)),
+                            true),
+                    arguments(
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_PNG_DATA,
+                                    PREFIX_PNG_DATA)),
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
                                     TRUNCATED_TEXT)),
                             true));

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -892,27 +892,50 @@ class TracesResourceTest {
         }
 
         Stream<Arguments> findWithImageTruncation() {
-            final String IMAGE_INPUT_TEMPLATE = """
+            final String IMAGE_TEMPLATE = """
                             { "messages": [{
                                 "role": "user",
                                 "content": [{
                                 "type": "image_url",
                                 "image_url": {
-                                    "url": "%s"
+                                    "url": "%s",
+                                    "details": "some details for this image"
                                 }
                             }]}] }
                     """;
+            final String IMAGE_TEMPLATE_MULTIPLE = """
+                            { "messages": [{
+                                "role": "user",
+                                "content": [{
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": "%s",
+                                    "details": "some details for this image"
+                                }
+                            }, {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": "%s",
+                                    "details": "some details for this image"
+                                }
+                            }]}] }
+                    """;;
             final String IMAGE_DATA = "data:image/png;base64," + RandomStringUtils.randomAlphanumeric(100);
             final String TRUNCATED_TEXT = "[image]";
             return Stream.of(
                     arguments(
-                            JsonUtils.getJsonNodeFromString(IMAGE_INPUT_TEMPLATE.formatted(IMAGE_DATA)),
-                            JsonUtils.getJsonNodeFromString(IMAGE_INPUT_TEMPLATE.formatted(TRUNCATED_TEXT)),
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(IMAGE_DATA)),
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(TRUNCATED_TEXT)),
                             true),
                     arguments(
-                            JsonUtils.getJsonNodeFromString(IMAGE_INPUT_TEMPLATE.formatted(IMAGE_DATA)),
-                            JsonUtils.getJsonNodeFromString(IMAGE_INPUT_TEMPLATE.formatted(IMAGE_DATA)),
-                            false));
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(IMAGE_DATA)),
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(IMAGE_DATA)),
+                            false),
+                    arguments(
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(IMAGE_DATA, IMAGE_DATA)),
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
+                                    TRUNCATED_TEXT)),
+                            true));
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -933,6 +933,9 @@ class TracesResourceTest {
             final String PREFIX_GIF_DATA1 = "data:image/gif;base64," + ImageUtils.PREFIX_GIF1 +
                     RandomStringUtils.randomAlphanumeric(100);
             final String NO_PREFIX_GIF_DATA1 = ImageUtils.PREFIX_GIF1 + RandomStringUtils.randomAlphanumeric(100);
+            final String PREFIX_BMP_DATA = "data:image/bmp;base64," + ImageUtils.PREFIX_BMP +
+                    RandomStringUtils.randomAlphanumeric(100);
+            final String NO_PREFIX_BMP_DATA = ImageUtils.PREFIX_BMP + RandomStringUtils.randomAlphanumeric(100);
             final String TRUNCATED_TEXT = "[image]";
             return Stream.of(
                     arguments(
@@ -964,6 +967,12 @@ class TracesResourceTest {
                     arguments(
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA1,
                                     PREFIX_GIF_DATA1)),
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
+                                    TRUNCATED_TEXT)),
+                            true),
+                    arguments(
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_BMP_DATA,
+                                    PREFIX_BMP_DATA)),
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
                                     TRUNCATED_TEXT)),
                             true));

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -937,6 +937,8 @@ class TracesResourceTest {
                     RandomStringUtils.randomAlphanumeric(100);
             final String NO_PREFIX_BMP_DATA = ImageUtils.PREFIX_BMP + RandomStringUtils.randomAlphanumeric(100);
             final String TRUNCATED_TEXT = "[image]";
+            final JsonNode TRUNCATED_MULTIPLE_EXPECTED = JsonUtils.getJsonNodeFromString(
+                    IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT, TRUNCATED_TEXT));
             return Stream.of(
                     arguments(
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
@@ -949,33 +951,23 @@ class TracesResourceTest {
                     arguments(
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_JPEG_DATA,
                                     PREFIX_JPEG_DATA)),
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
-                                    TRUNCATED_TEXT)),
-                            true),
+                            TRUNCATED_MULTIPLE_EXPECTED, true),
                     arguments(
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_PNG_DATA,
                                     PREFIX_PNG_DATA)),
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
-                                    TRUNCATED_TEXT)),
-                            true),
+                            TRUNCATED_MULTIPLE_EXPECTED, true),
                     arguments(
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA0,
                                     PREFIX_GIF_DATA0)),
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
-                                    TRUNCATED_TEXT)),
-                            true),
+                            TRUNCATED_MULTIPLE_EXPECTED, true),
                     arguments(
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA1,
                                     PREFIX_GIF_DATA1)),
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
-                                    TRUNCATED_TEXT)),
-                            true),
+                            TRUNCATED_MULTIPLE_EXPECTED, true),
                     arguments(
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_BMP_DATA,
                                     PREFIX_BMP_DATA)),
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
-                                    TRUNCATED_TEXT)),
-                            true));
+                            TRUNCATED_MULTIPLE_EXPECTED, true));
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -865,6 +865,7 @@ class TracesResourceTest {
             var traces = Stream.of(factory.manufacturePojo(Trace.class))
                     .map(trace -> trace.toBuilder()
                             .projectName(projectName)
+                            .usage(null)
                             .input(JsonUtils.getJsonNodeFromString(IMAGE_INPUT_TEMPLATE.formatted(IMAGE_DATA)))
                             .output(JsonUtils.getJsonNodeFromString(IMAGE_INPUT_TEMPLATE.formatted(IMAGE_DATA)))
                             .metadata(JsonUtils.getJsonNodeFromString(IMAGE_INPUT_TEMPLATE.formatted(IMAGE_DATA)))
@@ -889,11 +890,19 @@ class TracesResourceTest {
 
             assertThat(actualTraces).hasSize(1);
 
-            String expected = JsonUtils.getJsonNodeFromString(IMAGE_INPUT_TEMPLATE
-                    .formatted(truncate ? "[image]" : IMAGE_DATA)).toPrettyString();
-            assertThat(actualTraces.getFirst().input().toPrettyString()).isEqualTo(expected);
-            assertThat(actualTraces.getFirst().output().toPrettyString()).isEqualTo(expected);
-            assertThat(actualTraces.getFirst().metadata().toPrettyString()).isEqualTo(expected);
+            JsonNode expected = JsonUtils.getJsonNodeFromString(IMAGE_INPUT_TEMPLATE
+                    .formatted(truncate ? "[image]" : IMAGE_DATA));
+
+            var expectedTraces = traces.stream()
+                    .map(trace -> trace.toBuilder()
+                            .input(expected)
+                            .output(expected)
+                            .metadata(expected)
+                            .build())
+                    .toList();
+            assertThat(actualTraces)
+                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS_TRACES)
+                    .containsExactlyElementsOf(expectedTraces);
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -28,6 +28,7 @@ import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
 import com.comet.opik.api.resources.utils.TestUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
 import com.comet.opik.domain.FeedbackScoreMapper;
+import com.comet.opik.domain.ImageUtils;
 import com.comet.opik.domain.SpanType;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.podam.PodamFactoryUtils;
@@ -919,27 +920,23 @@ class TracesResourceTest {
                                     "details": "some details for this image"
                                 }
                             }]}] }
-                    """;;
-            final String IMAGE_DATA = "data:image/png;base64," + RandomStringUtils.randomAlphanumeric(100);
-            final String NO_PREFIX_JPEG_DATA = "/9j/" + RandomStringUtils.randomAlphanumeric(100);
+                    """;
+            final String PREFIX_JPEG_DATA = "data:image/jpg;base64," + ImageUtils.PREFIX_JPEG +
+                    RandomStringUtils.randomAlphanumeric(100);
+            final String NO_PREFIX_JPEG_DATA = ImageUtils.PREFIX_JPEG + RandomStringUtils.randomAlphanumeric(100);
             final String TRUNCATED_TEXT = "[image]";
             return Stream.of(
                     arguments(
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(IMAGE_DATA)),
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(TRUNCATED_TEXT)),
                             true),
                     arguments(
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(IMAGE_DATA)),
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(IMAGE_DATA)),
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
                             false),
                     arguments(
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(IMAGE_DATA, IMAGE_DATA)),
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
-                                    TRUNCATED_TEXT)),
-                            true),
-                    arguments(
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_JPEG_DATA,
-                                    IMAGE_DATA)),
+                                    PREFIX_JPEG_DATA)),
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
                                     TRUNCATED_TEXT)),
                             true));

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -28,7 +28,6 @@ import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
 import com.comet.opik.api.resources.utils.TestUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
 import com.comet.opik.domain.FeedbackScoreMapper;
-import com.comet.opik.domain.ImageUtils;
 import com.comet.opik.domain.SpanType;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.podam.PodamFactoryUtils;
@@ -848,7 +847,7 @@ class TracesResourceTest {
         }
 
         @ParameterizedTest
-        @MethodSource
+        @MethodSource("com.comet.opik.api.resources.v1.priv.ImageTruncationArgProvider#provideTestArguments")
         void findWithImageTruncation(JsonNode original, JsonNode expected, boolean truncate) {
             var projectName = RandomStringUtils.randomAlphanumeric(10);
             var traces = Stream.of(factory.manufacturePojo(Trace.class))
@@ -890,106 +889,6 @@ class TracesResourceTest {
             assertThat(actualTraces)
                     .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS_TRACES)
                     .containsExactlyElementsOf(expectedTraces);
-        }
-
-        Stream<Arguments> findWithImageTruncation() {
-            final String IMAGE_TEMPLATE = """
-                            { "messages": [{
-                                "role": "user",
-                                "content": [{
-                                "type": "image_url",
-                                "image_url": {
-                                    "url": "%s",
-                                    "details": "some details for this image"
-                                }
-                            }]}] }
-                    """;
-            final String IMAGE_TEMPLATE_MULTIPLE = """
-                            { "messages": [{
-                                "role": "user",
-                                "content": [{
-                                "type": "image_url",
-                                "image_url": {
-                                    "url": "%s",
-                                    "details": "some details for this image"
-                                }
-                            }, {
-                                "type": "image_url",
-                                "image_url": {
-                                    "url": "%s",
-                                    "details": "some details for this image"
-                                }
-                            }]}] }
-                    """;
-            final String PREFIX_JPEG_DATA = "data:image/jpg;base64," + ImageUtils.PREFIX_JPEG +
-                    RandomStringUtils.randomAlphanumeric(100);
-            final String NO_PREFIX_JPEG_DATA = ImageUtils.PREFIX_JPEG + RandomStringUtils.randomAlphanumeric(100);
-            final String PREFIX_PNG_DATA = "data:image/png;base64," + ImageUtils.PREFIX_PNG +
-                    RandomStringUtils.randomAlphanumeric(100);
-            final String NO_PREFIX_PNG_DATA = ImageUtils.PREFIX_PNG + RandomStringUtils.randomAlphanumeric(100);
-            final String PREFIX_GIF_DATA0 = "data:image/gif;base64," + ImageUtils.PREFIX_GIF0 +
-                    RandomStringUtils.randomAlphanumeric(100);
-            final String NO_PREFIX_GIF_DATA0 = ImageUtils.PREFIX_GIF0 + RandomStringUtils.randomAlphanumeric(100);
-            final String PREFIX_GIF_DATA1 = "data:image/gif;base64," + ImageUtils.PREFIX_GIF1 +
-                    RandomStringUtils.randomAlphanumeric(100);
-            final String NO_PREFIX_GIF_DATA1 = ImageUtils.PREFIX_GIF1 + RandomStringUtils.randomAlphanumeric(100);
-            final String PREFIX_BMP_DATA = "data:image/bmp;base64," + ImageUtils.PREFIX_BMP +
-                    RandomStringUtils.randomAlphanumeric(100);
-            final String NO_PREFIX_BMP_DATA = ImageUtils.PREFIX_BMP + RandomStringUtils.randomAlphanumeric(100);
-            final String PREFIX_TIFF_DATA0 = "data:image/tiff;base64," + ImageUtils.PREFIX_TIFF0 +
-                    RandomStringUtils.randomAlphanumeric(100);
-            final String NO_PREFIX_TIFF_DATA0 = ImageUtils.PREFIX_TIFF0 + RandomStringUtils.randomAlphanumeric(100);
-            final String PREFIX_TIFF_DATA1 = "data:image/tiff;base64," + ImageUtils.PREFIX_TIFF1 +
-                    RandomStringUtils.randomAlphanumeric(100);
-            final String NO_PREFIX_TIFF_DATA1 = ImageUtils.PREFIX_TIFF1 + RandomStringUtils.randomAlphanumeric(100);
-            final String PREFIX_WEBP_DATA = "data:image/webp;base64," + ImageUtils.PREFIX_WEBP +
-                    RandomStringUtils.randomAlphanumeric(100);
-            final String NO_PREFIX_WEBP_DATA = ImageUtils.PREFIX_WEBP + RandomStringUtils.randomAlphanumeric(100);
-
-            final String TRUNCATED_TEXT = "[image]";
-            final JsonNode TRUNCATED_MULTIPLE_EXPECTED = JsonUtils.getJsonNodeFromString(
-                    IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT, TRUNCATED_TEXT));
-            return Stream.of(
-                    arguments(
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(TRUNCATED_TEXT)),
-                            true),
-                    arguments(
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE.formatted(PREFIX_JPEG_DATA)),
-                            false),
-                    arguments(
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_JPEG_DATA,
-                                    PREFIX_JPEG_DATA)),
-                            TRUNCATED_MULTIPLE_EXPECTED, true),
-                    arguments(
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_PNG_DATA,
-                                    PREFIX_PNG_DATA)),
-                            TRUNCATED_MULTIPLE_EXPECTED, true),
-                    arguments(
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA0,
-                                    PREFIX_GIF_DATA0)),
-                            TRUNCATED_MULTIPLE_EXPECTED, true),
-                    arguments(
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA1,
-                                    PREFIX_GIF_DATA1)),
-                            TRUNCATED_MULTIPLE_EXPECTED, true),
-                    arguments(
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_BMP_DATA,
-                                    PREFIX_BMP_DATA)),
-                            TRUNCATED_MULTIPLE_EXPECTED, true),
-                    arguments(
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_TIFF_DATA0,
-                                    PREFIX_TIFF_DATA0)),
-                            TRUNCATED_MULTIPLE_EXPECTED, true),
-                    arguments(
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_TIFF_DATA1,
-                                    PREFIX_TIFF_DATA1)),
-                            TRUNCATED_MULTIPLE_EXPECTED, true),
-                    arguments(
-                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_WEBP_DATA,
-                                    PREFIX_WEBP_DATA)),
-                            TRUNCATED_MULTIPLE_EXPECTED, true));
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -921,6 +921,7 @@ class TracesResourceTest {
                             }]}] }
                     """;;
             final String IMAGE_DATA = "data:image/png;base64," + RandomStringUtils.randomAlphanumeric(100);
+            final String NO_PREFIX_JPEG_DATA = "/9j/" + RandomStringUtils.randomAlphanumeric(100);
             final String TRUNCATED_TEXT = "[image]";
             return Stream.of(
                     arguments(
@@ -933,6 +934,12 @@ class TracesResourceTest {
                             false),
                     arguments(
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(IMAGE_DATA, IMAGE_DATA)),
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
+                                    TRUNCATED_TEXT)),
+                            true),
+                    arguments(
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_JPEG_DATA,
+                                    IMAGE_DATA)),
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
                                     TRUNCATED_TEXT)),
                             true));

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -936,6 +936,13 @@ class TracesResourceTest {
             final String PREFIX_BMP_DATA = "data:image/bmp;base64," + ImageUtils.PREFIX_BMP +
                     RandomStringUtils.randomAlphanumeric(100);
             final String NO_PREFIX_BMP_DATA = ImageUtils.PREFIX_BMP + RandomStringUtils.randomAlphanumeric(100);
+            final String PREFIX_TIFF_DATA0 = "data:image/tiff;base64," + ImageUtils.PREFIX_TIFF0 +
+                    RandomStringUtils.randomAlphanumeric(100);
+            final String NO_PREFIX_TIFF_DATA0 = ImageUtils.PREFIX_TIFF0 + RandomStringUtils.randomAlphanumeric(100);
+            final String PREFIX_TIFF_DATA1 = "data:image/tiff;base64," + ImageUtils.PREFIX_TIFF1 +
+                    RandomStringUtils.randomAlphanumeric(100);
+            final String NO_PREFIX_TIFF_DATA1 = ImageUtils.PREFIX_TIFF1 + RandomStringUtils.randomAlphanumeric(100);
+
             final String TRUNCATED_TEXT = "[image]";
             final JsonNode TRUNCATED_MULTIPLE_EXPECTED = JsonUtils.getJsonNodeFromString(
                     IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT, TRUNCATED_TEXT));
@@ -967,6 +974,14 @@ class TracesResourceTest {
                     arguments(
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_BMP_DATA,
                                     PREFIX_BMP_DATA)),
+                            TRUNCATED_MULTIPLE_EXPECTED, true),
+                    arguments(
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_TIFF_DATA0,
+                                    PREFIX_TIFF_DATA0)),
+                            TRUNCATED_MULTIPLE_EXPECTED, true),
+                    arguments(
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_TIFF_DATA1,
+                                    PREFIX_TIFF_DATA1)),
                             TRUNCATED_MULTIPLE_EXPECTED, true));
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -900,6 +900,7 @@ class TracesResourceTest {
                             .metadata(expected)
                             .build())
                     .toList();
+
             assertThat(actualTraces)
                     .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS_TRACES)
                     .containsExactlyElementsOf(expectedTraces);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -942,6 +942,9 @@ class TracesResourceTest {
             final String PREFIX_TIFF_DATA1 = "data:image/tiff;base64," + ImageUtils.PREFIX_TIFF1 +
                     RandomStringUtils.randomAlphanumeric(100);
             final String NO_PREFIX_TIFF_DATA1 = ImageUtils.PREFIX_TIFF1 + RandomStringUtils.randomAlphanumeric(100);
+            final String PREFIX_WEBP_DATA = "data:image/webp;base64," + ImageUtils.PREFIX_WEBP +
+                    RandomStringUtils.randomAlphanumeric(100);
+            final String NO_PREFIX_WEBP_DATA = ImageUtils.PREFIX_WEBP + RandomStringUtils.randomAlphanumeric(100);
 
             final String TRUNCATED_TEXT = "[image]";
             final JsonNode TRUNCATED_MULTIPLE_EXPECTED = JsonUtils.getJsonNodeFromString(
@@ -982,6 +985,10 @@ class TracesResourceTest {
                     arguments(
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_TIFF_DATA1,
                                     PREFIX_TIFF_DATA1)),
+                            TRUNCATED_MULTIPLE_EXPECTED, true),
+                    arguments(
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_WEBP_DATA,
+                                    PREFIX_WEBP_DATA)),
                             TRUNCATED_MULTIPLE_EXPECTED, true));
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -927,6 +927,12 @@ class TracesResourceTest {
             final String PREFIX_PNG_DATA = "data:image/png;base64," + ImageUtils.PREFIX_PNG +
                     RandomStringUtils.randomAlphanumeric(100);
             final String NO_PREFIX_PNG_DATA = ImageUtils.PREFIX_PNG + RandomStringUtils.randomAlphanumeric(100);
+            final String PREFIX_GIF_DATA0 = "data:image/gif;base64," + ImageUtils.PREFIX_GIF0 +
+                    RandomStringUtils.randomAlphanumeric(100);
+            final String NO_PREFIX_GIF_DATA0 = ImageUtils.PREFIX_GIF0 + RandomStringUtils.randomAlphanumeric(100);
+            final String PREFIX_GIF_DATA1 = "data:image/gif;base64," + ImageUtils.PREFIX_GIF1 +
+                    RandomStringUtils.randomAlphanumeric(100);
+            final String NO_PREFIX_GIF_DATA1 = ImageUtils.PREFIX_GIF1 + RandomStringUtils.randomAlphanumeric(100);
             final String TRUNCATED_TEXT = "[image]";
             return Stream.of(
                     arguments(
@@ -946,6 +952,18 @@ class TracesResourceTest {
                     arguments(
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_PNG_DATA,
                                     PREFIX_PNG_DATA)),
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
+                                    TRUNCATED_TEXT)),
+                            true),
+                    arguments(
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA0,
+                                    PREFIX_GIF_DATA0)),
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
+                                    TRUNCATED_TEXT)),
+                            true),
+                    arguments(
+                            JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(NO_PREFIX_GIF_DATA1,
+                                    PREFIX_GIF_DATA1)),
                             JsonUtils.getJsonNodeFromString(IMAGE_TEMPLATE_MULTIPLE.formatted(TRUNCATED_TEXT,
                                     TRUNCATED_TEXT)),
                             true));


### PR DESCRIPTION
## Details
Image truncation was introduced in #578. It had several issues:
1. Wasn't working well for payloads with more than one image message
2. Wasn't working at all for images lacking the `data:image/...` prefix
3. Had a couple of tests that needed to be improved, see https://github.com/comet-ml/opik/pull/578#discussion_r1832699886

## Issues
- OPIK-400
- OPIK-393

## Testing
Improved E2E tests to cover all cases
