### PR TITLE
Revert truncate base64 images in the traces/spans table

### DIFF
--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab.tsx
@@ -96,7 +96,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
       page: page as number,
       size: size as number,
       search: search as string,
-      truncate: true,
+      truncate: false,
     },
     {
       placeholderData: keepPreviousData,


### PR DESCRIPTION
## Details
- Revert truncate the base64 images in the traces/spans table until the BE has a fix for the LLM tab table (it returns less elements than requested)

## Issues

Resolves #

## Testing

## Documentation
