### PR TITLE
[OPIK-402]: handle project name and score definitions for evaluate();

### DIFF
--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -76,7 +76,7 @@ def evaluate(
     if verbose == 1:
         report.display_experiment_results(dataset.name, total_time, test_results)
 
-    scores_logger.log_scores(client=client, test_results=test_results)
+    scores_logger.log_scores(client=client, test_results=test_results, project_name=project_name)
 
     experiment = client.create_experiment(
         name=experiment_name,

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -76,7 +76,9 @@ def evaluate(
     if verbose == 1:
         report.display_experiment_results(dataset.name, total_time, test_results)
 
-    scores_logger.log_scores(client=client, test_results=test_results, project_name=project_name)
+    scores_logger.log_scores(
+        client=client, test_results=test_results, project_name=project_name
+    )
 
     experiment = client.create_experiment(
         name=experiment_name,

--- a/sdks/python/src/opik/evaluation/scores_logger.py
+++ b/sdks/python/src/opik/evaluation/scores_logger.py
@@ -8,7 +8,7 @@ from . import test_result
 def log_scores(
     client: opik_client.Opik,
     test_results: List[test_result.TestResult],
-    project_name: Optional[str]
+    project_name: Optional[str],
 ) -> None:
     all_trace_scores: List[FeedbackScoreDict] = []
 

--- a/sdks/python/src/opik/evaluation/scores_logger.py
+++ b/sdks/python/src/opik/evaluation/scores_logger.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from opik.types import FeedbackScoreDict
 
 from opik.api_objects import opik_client
@@ -6,7 +6,7 @@ from . import test_result
 
 
 def log_scores(
-    client: opik_client.Opik, test_results: List[test_result.TestResult]
+    client: opik_client.Opik, test_results: List[test_result.TestResult], project_name: Optional[str] = None
 ) -> None:
     all_trace_scores: List[FeedbackScoreDict] = []
 
@@ -23,4 +23,4 @@ def log_scores(
             )
             all_trace_scores.append(trace_score)
 
-    client.log_traces_feedback_scores(scores=all_trace_scores)
+    client.log_traces_feedback_scores(scores=all_trace_scores, project_name=project_name)

--- a/sdks/python/src/opik/evaluation/scores_logger.py
+++ b/sdks/python/src/opik/evaluation/scores_logger.py
@@ -8,7 +8,7 @@ from . import test_result
 def log_scores(
     client: opik_client.Opik,
     test_results: List[test_result.TestResult],
-    project_name: Optional[str] = None,
+    project_name: Optional[str]
 ) -> None:
     all_trace_scores: List[FeedbackScoreDict] = []
 

--- a/sdks/python/src/opik/evaluation/scores_logger.py
+++ b/sdks/python/src/opik/evaluation/scores_logger.py
@@ -6,7 +6,9 @@ from . import test_result
 
 
 def log_scores(
-    client: opik_client.Opik, test_results: List[test_result.TestResult], project_name: Optional[str] = None
+    client: opik_client.Opik,
+    test_results: List[test_result.TestResult],
+    project_name: Optional[str] = None,
 ) -> None:
     all_trace_scores: List[FeedbackScoreDict] = []
 
@@ -23,4 +25,6 @@ def log_scores(
             )
             all_trace_scores.append(trace_score)
 
-    client.log_traces_feedback_scores(scores=all_trace_scores, project_name=project_name)
+    client.log_traces_feedback_scores(
+        scores=all_trace_scores, project_name=project_name
+    )


### PR DESCRIPTION
## Details
* Now, the scores during `evaluate` work properly. They handle the project_name correctly
* I wanted to write some tests but for the time being, there is no way to get the project info by a name. So, it's best to do it after the BE is ready

## Issues

Resolves #553

## Testing

## Documentation
