### PR TITLE
[OPIK-203] Filter our spans.usage with null values

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -568,8 +569,10 @@ class SpanDAO {
                     Stream.Builder<Integer> values = Stream.builder();
 
                     span.usage().forEach((key, value) -> {
-                        keys.add(key);
-                        values.add(value);
+                        if (Objects.nonNull(value)) {
+                            keys.add(key);
+                            values.add(value);
+                        }
                     });
 
                     statement.bind("usage_keys" + i, keys.build().toArray(String[]::new));
@@ -634,8 +637,10 @@ class SpanDAO {
             Stream.Builder<Integer> values = Stream.builder();
 
             span.usage().forEach((key, value) -> {
-                keys.add(key);
-                values.add(value);
+                if (Objects.nonNull(value)) {
+                    keys.add(key);
+                    values.add(value);
+                }
             });
 
             statement.bind("usage_keys", keys.build().toArray(String[]::new));

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000007_change_spans_usage_value_to_nullable.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000007_change_spans_usage_value_to_nullable.sql
@@ -1,7 +1,0 @@
---liquibase formatted sql
---changeset thiagohora:change_decimal_precision
-
-ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans
-    MODIFY COLUMN usage Map(String, Nullable(Int32));
-
---rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans MODIFY COLUMN usage Map(String, Int32);

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000007_change_spans_usage_value_to_nullable.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000007_change_spans_usage_value_to_nullable.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--changeset thiagohora:change_decimal_precision
+
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans
+    MODIFY COLUMN usage Map(String, Nullable(Int32));
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans MODIFY COLUMN usage Map(String, Int32);


### PR DESCRIPTION
## Details
Null value in payload leads to 500 error

Resolves #https://comet-ml.atlassian.net/browse/OPIK-203

## Testing
Tested with running Opik locally. Reproduced without the fix, and then checked that fix resolves this issue.
Added integration test.
