### PR TITLE
[OPIK-396] dynamically sort by last_updated_trace_at

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
@@ -178,7 +178,8 @@ public class ProjectsResource {
         String workspaceId = requestContext.get().getWorkspaceId();
         log.info("Retrieve project by name '{}', on workspace_id '{}'", retrieve.name(), workspaceId);
         Project project = projectService.retrieveByName(retrieve.name());
-        log.info("Retrieved project id '{}' by name '{}', on workspace_id '{}'", project.id(), retrieve.name(), workspaceId);
+        log.info("Retrieved project id '{}' by name '{}', on workspace_id '{}'", project.id(), retrieve.name(),
+                workspaceId);
         return Response.ok().entity(project).build();
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortableFields.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortableFields.java
@@ -3,5 +3,7 @@ package com.comet.opik.api.sorting;
 public class SortableFields {
     public static final String ID = "id";
     public static final String NAME = "name";
+    public static final String CREATED_AT = "created_at";
     public static final String LAST_UPDATED_AT = "last_updated_at";
+    public static final String LAST_UPDATED_TRACE_AT = "last_updated_trace_at";
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactory.java
@@ -12,6 +12,8 @@ import java.util.List;
 public abstract class SortingFactory {
     public static final String ERR_INVALID_SORTING_PARAM_TEMPLATE = "Invalid sorting query parameter '%s'";
     public static final String ERR_ILLEGAL_SORTING_FIELDS_TEMPLATE = "Invalid sorting fields '%s'";
+    public static final String ERR_MULTIPLE_SORTING = "Sorting by multiple fields is currently not supported";
+
     public List<SortingField> newSorting(String queryParam) {
         List<SortingField> sorting = new ArrayList<>();
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactory.java
@@ -38,6 +38,9 @@ public abstract class SortingFactory {
         if (sorting.isEmpty()) {
             return;
         }
+        if (sorting.size() > 1) {
+            throw new BadRequestException(ERR_MULTIPLE_SORTING);
+        }
 
         List<String> illegalFields = sorting.stream()
                 .map(SortingField::field)

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactoryProjects.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactoryProjects.java
@@ -2,14 +2,21 @@ package com.comet.opik.api.sorting;
 
 import java.util.List;
 
+import static com.comet.opik.api.sorting.SortableFields.CREATED_AT;
 import static com.comet.opik.api.sorting.SortableFields.ID;
 import static com.comet.opik.api.sorting.SortableFields.LAST_UPDATED_AT;
+import static com.comet.opik.api.sorting.SortableFields.LAST_UPDATED_TRACE_AT;
 import static com.comet.opik.api.sorting.SortableFields.NAME;
 import static java.util.Arrays.asList;
 
 public class SortingFactoryProjects extends SortingFactory {
     @Override
     public List<String> getSortableFields() {
-        return asList(ID, NAME, LAST_UPDATED_AT);
+        return asList(
+                ID,
+                NAME,
+                LAST_UPDATED_AT,
+                CREATED_AT,
+                LAST_UPDATED_TRACE_AT);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
@@ -16,6 +16,7 @@ import org.jdbi.v3.stringtemplate4.UseStringTemplateEngine;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 @RegisterConstructorMapper(Project.class)
@@ -42,6 +43,9 @@ interface ProjectDAO {
     @SqlQuery("SELECT * FROM projects WHERE id = :id AND workspace_id = :workspaceId")
     Project findById(@Bind("id") UUID id, @Bind("workspaceId") String workspaceId);
 
+    @SqlQuery("SELECT * FROM projects WHERE id IN (<ids>) AND workspace_id = :workspaceId")
+    List<Project> findByIds(@BindList("ids") Set<UUID> ids, @Bind("workspaceId") String workspaceId);
+
     @SqlQuery("SELECT COUNT(*) FROM projects " +
             " WHERE workspace_id = :workspaceId " +
             " <if(name)> AND name like concat('%', :name, '%') <endif> ")
@@ -61,6 +65,14 @@ interface ProjectDAO {
             @Bind("workspaceId") String workspaceId,
             @Define("name") @Bind("name") String name,
             @Define("sort_fields") @Bind("sort_fields") String sortingFields);
+
+    @SqlQuery("SELECT id FROM projects" +
+            " WHERE workspace_id = :workspaceId" +
+            " <if(name)> AND name like concat('%', :name, '%') <endif>")
+    @UseStringTemplateEngine
+    @AllowUnusedBindings
+    Set<UUID> getAllProjectIds(@Bind("workspaceId") String workspaceId,
+            @Define("name") @Bind("name") String name);
 
     default Optional<Project> fetch(UUID id, String workspaceId) {
         return Optional.ofNullable(findById(id, workspaceId));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -228,8 +228,8 @@ class ProjectServiceImpl implements ProjectService {
 
         String workspaceId = requestContext.get().getWorkspaceId();
 
-        if (!sortingFields.isEmpty() && sortingFields.get(0).field().equals(SortableFields.LAST_UPDATED_TRACE_AT)) {
-            return findWithLastTraceSorting(page, size, criteria, sortingFields.get(0));
+        if (!sortingFields.isEmpty() && sortingFields.getFirst().field().equals(SortableFields.LAST_UPDATED_TRACE_AT)) {
+            return findWithLastTraceSorting(page, size, criteria, sortingFields.getFirst());
         }
 
         ProjectRecordSet projectRecordSet = template.inTransaction(READ_ONLY, handle -> {
@@ -312,12 +312,12 @@ class ProjectServiceImpl implements ProjectService {
             @NonNull SortingField sortingField) {
         if (sortingField.direction() == Direction.DESC) {
             return projectLastUpdatedTraceAtMap.entrySet().stream().sorted(reverseOrder(Map.Entry.comparingByValue()))
-                    .map((Map.Entry::getKey))
+                    .map(Map.Entry::getKey)
                     .toList();
         }
 
         return projectLastUpdatedTraceAtMap.entrySet().stream().sorted(Map.Entry.comparingByValue())
-                .map((Map.Entry::getKey))
+                .map(Map.Entry::getKey)
                 .toList();
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/PaginationUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/PaginationUtils.java
@@ -1,0 +1,16 @@
+package com.comet.opik.utils;
+
+import lombok.NonNull;
+
+import java.util.List;
+
+public class PaginationUtils {
+    public static <T> List<T> paginate(int page, int size, @NonNull List<T> elements) {
+        if (size > elements.size()) {
+            return elements;
+        }
+
+        int offset = (page - 1) * size;
+        return elements.subList(offset, Math.min(offset + size, elements.size()));
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/PaginationUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/PaginationUtils.java
@@ -5,6 +5,9 @@ import lombok.NonNull;
 import java.util.List;
 
 public class PaginationUtils {
+    public static String ERR_PAGE_INVALID = "invalid value for page '%d'";
+    public static String ERR_SIZE_INVALID = "invalid value for size '%d'";
+
     public static <T> List<T> paginate(int page, int size, @NonNull List<T> elements) {
         int offset = (page - 1) * size;
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/PaginationUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/PaginationUtils.java
@@ -1,5 +1,6 @@
 package com.comet.opik.utils;
 
+import com.google.common.base.Preconditions;
 import lombok.NonNull;
 
 import java.util.List;
@@ -9,12 +10,8 @@ public class PaginationUtils {
     public static String ERR_SIZE_INVALID = "invalid value for size '%d'";
 
     public static <T> List<T> paginate(int page, int size, @NonNull List<T> elements) {
-        if (page < 1) {
-            throw new IllegalArgumentException(ERR_PAGE_INVALID.formatted(page));
-        }
-        if (size < 1) {
-            throw new IllegalArgumentException(ERR_SIZE_INVALID.formatted(size));
-        }
+        Preconditions.checkArgument(page >= 1, ERR_PAGE_INVALID.formatted(page));
+        Preconditions.checkArgument(size >= 1, ERR_SIZE_INVALID.formatted(size));
 
         int offset = (page - 1) * size;
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/PaginationUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/PaginationUtils.java
@@ -8,7 +8,7 @@ public class PaginationUtils {
     public static <T> List<T> paginate(int page, int size, @NonNull List<T> elements) {
         int offset = (page - 1) * size;
 
-        if (offset > elements.size()) {
+        if (offset >= elements.size()) {
             return List.of();
         }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/PaginationUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/PaginationUtils.java
@@ -12,10 +12,6 @@ public class PaginationUtils {
             return List.of();
         }
 
-        if (size > elements.size()) {
-            return elements;
-        }
-
         return elements.subList(offset, Math.min(offset + size, elements.size()));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/PaginationUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/PaginationUtils.java
@@ -6,11 +6,16 @@ import java.util.List;
 
 public class PaginationUtils {
     public static <T> List<T> paginate(int page, int size, @NonNull List<T> elements) {
+        int offset = (page - 1) * size;
+
+        if (offset > elements.size()) {
+            return List.of();
+        }
+
         if (size > elements.size()) {
             return elements;
         }
 
-        int offset = (page - 1) * size;
         return elements.subList(offset, Math.min(offset + size, elements.size()));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/PaginationUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/PaginationUtils.java
@@ -9,6 +9,13 @@ public class PaginationUtils {
     public static String ERR_SIZE_INVALID = "invalid value for size '%d'";
 
     public static <T> List<T> paginate(int page, int size, @NonNull List<T> elements) {
+        if (page < 1) {
+            throw new IllegalArgumentException(ERR_PAGE_INVALID.formatted(page));
+        }
+        if (size < 1) {
+            throw new IllegalArgumentException(ERR_SIZE_INVALID.formatted(size));
+        }
+
         int offset = (page - 1) * size;
 
         if (offset >= elements.size()) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -849,7 +849,9 @@ class ProjectsResourceTest {
             var actualEntity = actualResponse.readEntity(Project.ProjectPage.class);
 
             assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
-            assertThat(actualEntity.size()).isEqualTo(projects.size());
+            assertThat(actualEntity.size()).isEqualTo(Math.min(NUM_OF_PROJECTS, projects.size()));
+            assertThat(actualEntity.total()).isEqualTo(projects.size());
+            assertThat(actualEntity.page()).isEqualTo(1);
 
             var actualProjects = actualEntity.content();
             if (expected == Direction.DESC) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -853,14 +853,9 @@ class ProjectsResourceTest {
             assertThat(actualEntity.total()).isEqualTo(projects.size());
             assertThat(actualEntity.page()).isEqualTo(1);
 
-            var actualProjects = actualEntity.content();
-            if (expected == Direction.DESC) {
-                assertThat(actualProjects).usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS)
-                        .containsExactlyElementsOf(projects.reversed());
-            } else {
-                assertThat(actualProjects).usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS)
-                        .containsExactlyElementsOf(projects);
-            }
+            var expectedProjects = expected == Direction.DESC ? projects.reversed() : projects;
+            assertThat(actualEntity.content()).usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS)
+                    .containsExactlyElementsOf(expectedProjects);
         }
 
         public static Stream<Arguments> sortDirectionProvider() {

--- a/apps/opik-backend/src/test/java/com/comet/opik/utils/PaginationUtilsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/utils/PaginationUtilsTest.java
@@ -1,0 +1,33 @@
+package com.comet.opik.utils;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class PaginationUtilsTest {
+    private static final List<Integer> LIST = IntStream.range(0, 50).boxed().toList();
+    @ParameterizedTest
+    @MethodSource
+    void testPagination(int page, int size, List<Integer> expected) {
+        List<Integer> actual = PaginationUtils.paginate(page, size, LIST);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> testPagination() {
+        return Stream.of(
+                arguments(1, 10, IntStream.range(0, 10).boxed().toList()),
+                arguments(2, 15, IntStream.range(15, 30).boxed().toList()),
+                arguments(4, 15, IntStream.range(45, 50).boxed().toList()),
+                arguments(5, 15, List.of()),
+                arguments(1, 60, named("full list", LIST)));
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/utils/PaginationUtilsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/utils/PaginationUtilsTest.java
@@ -28,6 +28,7 @@ public class PaginationUtilsTest {
                 arguments(2, 15, IntStream.range(15, 30).boxed().toList()),
                 arguments(4, 15, IntStream.range(45, 50).boxed().toList()),
                 arguments(5, 15, List.of()),
+                arguments(8, 7, IntStream.range(49, 50).boxed().toList()),
                 arguments(1, 60, named("full list", LIST)));
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/utils/PaginationUtilsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/utils/PaginationUtilsTest.java
@@ -9,6 +9,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Named.named;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -31,5 +32,20 @@ public class PaginationUtilsTest {
                 arguments(8, 7, IntStream.range(49, 50).boxed().toList()),
                 arguments(6, 10, List.of()),
                 arguments(1, 60, named("full list", LIST)));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testPaginationNegative(int page, int size, String expectedMessage) {
+        assertThatThrownBy(() -> PaginationUtils.paginate(page, size, LIST))
+                .isInstanceOf(IllegalArgumentException.class).hasMessage(expectedMessage);
+    }
+
+    private static Stream<Arguments> testPaginationNegative() {
+        return Stream.of(
+                arguments(-1, 10, PaginationUtils.ERR_PAGE_INVALID.formatted(-1)),
+                arguments(0, 10, PaginationUtils.ERR_PAGE_INVALID.formatted(0)),
+                arguments(1, 0, PaginationUtils.ERR_SIZE_INVALID.formatted(0)),
+                arguments(1, -1, PaginationUtils.ERR_SIZE_INVALID.formatted(-1)));
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/utils/PaginationUtilsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/utils/PaginationUtilsTest.java
@@ -29,6 +29,7 @@ public class PaginationUtilsTest {
                 arguments(4, 15, IntStream.range(45, 50).boxed().toList()),
                 arguments(5, 15, List.of()),
                 arguments(8, 7, IntStream.range(49, 50).boxed().toList()),
+                arguments(6, 10, List.of()),
                 arguments(1, 60, named("full list", LIST)));
     }
 }


### PR DESCRIPTION
## Details
We want to achieve sorting by `last_updated_trace_at`. This field has a dynamically computed value and is not stored in MySQL. For that purpose we need to manually sort and paginate.

**Note:** For the time being we decided to not support sorting by multiple fields as that would introduce some messy logic.

## Issues
OPIK-396

## Testing
Added an E2E test that covers the new sorting logic. Pagination logic is covered with unit tests.
