### PR TITLE
Enable truncate base64 images in traces/spans table

### DIFF
--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab.tsx
@@ -96,7 +96,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
       page: page as number,
       size: size as number,
       search: search as string,
-      truncate: false,
+      truncate: true,
     },
     {
       placeholderData: keepPreviousData,


### PR DESCRIPTION
## Details
- Re-enable the truncation for base64 images in traces/spans table

## Issues

Resolves #

## Testing

## Documentation
