### PR TITLE
[OPIK-298] [UX improvements] Increase default amount of items per page

### DIFF
--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -104,7 +104,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
     updateType: "replaceIn",
   });
 
-  const [size = 10, setSize] = useQueryParam("size", NumberParam, {
+  const [size = 100, setSize] = useQueryParam("size", NumberParam, {
     updateType: "replaceIn",
   });
 

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab.tsx
@@ -70,7 +70,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
     updateType: "replaceIn",
   });
 
-  const [size = 10, setSize] = useQueryParam("size", NumberParam, {
+  const [size = 100, setSize] = useQueryParam("size", NumberParam, {
     updateType: "replaceIn",
   });
 


### PR DESCRIPTION
## Details
Increase the default amount of items per page in the Traces and Experiment items pages to 100

## Issues

Resolves #

## Testing

## Documentation
