### PR TITLE
[OPIK-422] fix projects with no traces sorting

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProjectIdLastUpdated.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProjectIdLastUpdated.java
@@ -1,0 +1,9 @@
+package com.comet.opik.api;
+
+import lombok.NonNull;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ProjectIdLastUpdated(@NonNull UUID id, @NonNull Instant lastUpdatedAt) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
@@ -1,6 +1,7 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.Project;
+import com.comet.opik.api.ProjectIdLastUpdated;
 import com.comet.opik.infrastructure.db.UUIDArgumentFactory;
 import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
@@ -20,6 +21,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @RegisterConstructorMapper(Project.class)
+@RegisterConstructorMapper(ProjectIdLastUpdated.class)
 @RegisterArgumentFactory(UUIDArgumentFactory.class)
 interface ProjectDAO {
 
@@ -66,12 +68,12 @@ interface ProjectDAO {
             @Define("name") @Bind("name") String name,
             @Define("sort_fields") @Bind("sort_fields") String sortingFields);
 
-    @SqlQuery("SELECT id FROM projects" +
+    @SqlQuery("SELECT id, last_updated_at FROM projects" +
             " WHERE workspace_id = :workspaceId" +
             " <if(name)> AND name like concat('%', :name, '%') <endif>")
     @UseStringTemplateEngine
     @AllowUnusedBindings
-    Set<UUID> getAllProjectIds(@Bind("workspaceId") String workspaceId,
+    List<ProjectIdLastUpdated> getAllProjectIdsLastUpdated(@Bind("workspaceId") String workspaceId,
             @Define("name") @Bind("name") String name);
 
     default Optional<Project> fetch(UUID id, String workspaceId) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -318,11 +318,8 @@ class ProjectServiceImpl implements ProjectService {
             @NonNull Map<UUID, Instant> projectLastUpdatedTraceAtMap,
             @NonNull SortingField sortingField) {
         // for projects with no traces - use last_updated_at
-        for (ProjectIdLastUpdated project : allProjectIdsLastUpdated) {
-            if (!projectLastUpdatedTraceAtMap.containsKey(project.id())) {
-                projectLastUpdatedTraceAtMap.put(project.id(), project.lastUpdatedAt());
-            }
-        }
+        allProjectIdsLastUpdated.stream().filter(project -> !projectLastUpdatedTraceAtMap.containsKey(project.id()))
+                .forEach(project -> projectLastUpdatedTraceAtMap.put(project.id(), project.lastUpdatedAt()));
 
         Comparator<Map.Entry<UUID, Instant>> comparator = sortingField.direction() == Direction.DESC
                 ? reverseOrder(Map.Entry.comparingByValue())

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
@@ -289,6 +290,11 @@ class ProjectServiceImpl implements ProjectService {
 
         // sort and paginate
         List<UUID> sorted = sortByLastTrace(projectLastUpdatedTraceAtMap, sortingField);
+        List<UUID> noTraceProjects = allProjectIds.stream().filter(id -> !projectLastUpdatedTraceAtMap.containsKey(id))
+                .toList();
+        if (!noTraceProjects.isEmpty()) {
+            sorted = Stream.concat(sorted.stream(), noTraceProjects.stream()).toList();
+        }
         List<UUID> finalIds = PaginationUtils.paginate(page, size, sorted);
 
         // get all project properties for the final list of ids

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -811,7 +811,6 @@ class ProjectsResourceTest {
         @DisplayName("when fetching all project with last trace sorting, then return projects sorted by last trace")
         void getProjects__whenSortingProjectsByLastTrace__thenReturnProjectSorted(Direction expected,
                 Direction request) {
-            final int NUM_OF_PROJECTS = 5;
             String workspaceName = UUID.randomUUID().toString();
             String apiKey = UUID.randomUUID().toString();
             String workspaceId = UUID.randomUUID().toString();
@@ -838,7 +837,7 @@ class ProjectsResourceTest {
                     .build());
 
             var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
-                    .queryParam("size", NUM_OF_PROJECTS)
+                    .queryParam("size", projects.size())
                     .queryParam("sorting", URLEncoder.encode(JsonUtils.writeValueAsString(sorting),
                             StandardCharsets.UTF_8))
                     .request()
@@ -849,7 +848,7 @@ class ProjectsResourceTest {
             var actualEntity = actualResponse.readEntity(Project.ProjectPage.class);
 
             assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
-            assertThat(actualEntity.size()).isEqualTo(Math.min(NUM_OF_PROJECTS, projects.size()));
+            assertThat(actualEntity.size()).isEqualTo(projects.size());
             assertThat(actualEntity.total()).isEqualTo(projects.size());
             assertThat(actualEntity.page()).isEqualTo(1);
 


### PR DESCRIPTION
## Details
The FE uses the `last_updated_at` as a fallback to when `last_trace_updated_at` is not present. When sorting, this must be taken into account.

## Issues
OPIK-422

## Testing
Added an E2E test that covers this case.
