### PR TITLE
[OPIK-51]: make scoring_metrics optional

### DIFF
--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -59,6 +59,9 @@ def evaluate(
         prompt: Prompt object to link with experiment.
     """
     client = opik_client.get_client_cached()
+    if scoring_metrics is None: 
+        scoring_metrics = []
+    
     start_time = time.time()
 
     test_results = tasks_scorer.run(

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -59,9 +59,9 @@ def evaluate(
         prompt: Prompt object to link with experiment.
     """
     client = opik_client.get_client_cached()
-    if scoring_metrics is None: 
+    if scoring_metrics is None:
         scoring_metrics = []
-    
+
     start_time = time.time()
 
     test_results = tasks_scorer.run(

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -14,7 +14,7 @@ from . import tasks_scorer, scores_logger, report, evaluation_result
 def evaluate(
     dataset: dataset.Dataset,
     task: LLMTask,
-    scoring_metrics: List[base_metric.BaseMetric],
+    scoring_metrics: Optional[List[base_metric.BaseMetric]] = None,
     experiment_name: Optional[str] = None,
     project_name: Optional[str] = None,
     experiment_config: Optional[Dict[str, Any]] = None,
@@ -44,13 +44,14 @@ def evaluate(
             are taken from the `task` output, check the signature
             of the `score` method in metrics that you need to find out which keys
             are mandatory in `task`-returned dictionary.
+            If no value provided, the experiment won't have any scoring metrics.
 
         verbose: an integer value that controls evaluation output logs such as summary and tqdm progress bar.
             0 - no outputs, 1 - outputs are enabled (default).
 
         nb_samples: number of samples to evaluate. If no value is provided, all samples in the dataset will be evaluated.
 
-        task_threads: amount of thread workers to run tasks. If set to 1, no additional
+        task_threads: number of thread workers to run tasks. If set to 1, no additional
             threads are created, all tasks executed in the current thread sequentially.
             are executed sequentially in the current thread.
             Use more than 1 worker if your task object is compatible with sharing across threads.

--- a/sdks/python/src/opik/evaluation/tasks_scorer.py
+++ b/sdks/python/src/opik/evaluation/tasks_scorer.py
@@ -15,37 +15,40 @@ LOGGER = logging.getLogger(__name__)
 
 
 def _score_test_case(
-    test_case_: test_case.TestCase, scoring_metrics: List[base_metric.BaseMetric]
+    test_case_: test_case.TestCase,
+    scoring_metrics: Optional[List[base_metric.BaseMetric]],
 ) -> test_result.TestResult:
     score_results = []
-    for metric in scoring_metrics:
-        try:
-            score_kwargs = test_case_.task_output
-            arguments_helpers.raise_if_score_arguments_are_missing(
-                score_function=metric.score,
-                score_name=metric.name,
-                kwargs=score_kwargs,
-            )
-            result = metric.score(**score_kwargs)
-            if isinstance(result, list):
-                score_results += result
-            else:
-                score_results.append(result)
-        except exceptions.ScoreMethodMissingArguments:
-            raise
-        except Exception as e:
-            # This can be problematic if the metric returns a list of strings as we will not know the name of the metrics that have failed
-            LOGGER.error(
-                "Failed to compute metric %s. Score result will be marked as failed.",
-                metric.name,
-                exc_info=True,
-            )
 
-            score_results.append(
-                score_result.ScoreResult(
-                    name=metric.name, value=0.0, reason=str(e), scoring_failed=True
+    if scoring_metrics:
+        for metric in scoring_metrics:
+            try:
+                score_kwargs = test_case_.task_output
+                arguments_helpers.raise_if_score_arguments_are_missing(
+                    score_function=metric.score,
+                    score_name=metric.name,
+                    kwargs=score_kwargs,
                 )
-            )
+                result = metric.score(**score_kwargs)
+                if isinstance(result, list):
+                    score_results += result
+                else:
+                    score_results.append(result)
+            except exceptions.ScoreMethodMissingArguments:
+                raise
+            except Exception as e:
+                # This can be problematic if the metric returns a list of strings as we will not know the name of the metrics that have failed
+                LOGGER.error(
+                    "Failed to compute metric %s. Score result will be marked as failed.",
+                    metric.name,
+                    exc_info=True,
+                )
+
+                score_results.append(
+                    score_result.ScoreResult(
+                        name=metric.name, value=0.0, reason=str(e), scoring_failed=True
+                    )
+                )
 
     test_result_ = test_result.TestResult(
         test_case=test_case_, score_results=score_results
@@ -58,7 +61,7 @@ def _process_item(
     client: opik_client.Opik,
     item: dataset_item.DatasetItem,
     task: LLMTask,
-    scoring_metrics: List[base_metric.BaseMetric],
+    scoring_metrics: Optional[List[base_metric.BaseMetric]],
     project_name: Optional[str],
 ) -> test_result.TestResult:
     try:
@@ -95,7 +98,7 @@ def run(
     client: opik_client.Opik,
     dataset_: dataset.Dataset,
     task: LLMTask,
-    scoring_metrics: List[base_metric.BaseMetric],
+    scoring_metrics: Optional[List[base_metric.BaseMetric]],
     workers: int,
     nb_samples: Optional[int],
     verbose: int,


### PR DESCRIPTION
## Details
this code snippet:
```

evaluation = evaluate(
    experiment_name="First eval",
    dataset=dataset,
    task=evaluation_task,
    experiment_config={
        "model": MODEL
    },
    project_name="SOME_NEW_PROJECT"
)
```

the experiment simply has no feedback scores
<img width="1257" alt="image" src="https://github.com/user-attachments/assets/83092a74-fe92-4054-93a1-d557b2201a7e">

## Issues

Resolves #

## Testing

## Documentation
