### PR TITLE
[OPIK-405] Add missing format for GIF images

### DIFF
--- a/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceDataViewer/InputOutputTab.tsx
+++ b/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceDataViewer/InputOutputTab.tsx
@@ -46,6 +46,7 @@ const BASE64_PREFIXES_MAP = {
   "/9j/": "jpeg",
   iVBORw0KGgo: "png",
   R0lGODlh: "gif",
+  R0lGODdh: "gif",
   Qk: "bmp",
   SUkq: "tiff",
   TU0A: "tiff",


### PR DESCRIPTION
## Details
- Add missing GIF format

## Issues

Resolves #

## Testing

## Documentation
