### PR TITLE
[OPIK-418] Add endpoint to return all feedback score names

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackScoreNames.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackScoreNames.java
@@ -1,0 +1,17 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record FeedbackScoreNames(List<ScoreName> scores) {
+
+    public record ScoreName(String name) {
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/FeedbackScoreResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/FeedbackScoreResource.java
@@ -1,0 +1,71 @@
+package com.comet.opik.api.resources.v1.priv;
+
+import com.codahale.metrics.annotation.Timed;
+import com.comet.opik.api.FeedbackDefinition;
+import com.comet.opik.api.FeedbackScoreNames;
+import com.comet.opik.domain.FeedbackScoreService;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import com.fasterxml.jackson.annotation.JsonView;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.UUID;
+
+import static com.comet.opik.api.FeedbackScoreNames.ScoreName;
+import static com.comet.opik.utils.AsyncUtils.setRequestContext;
+
+@Path("/v1/private/feedback-scores")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Timed
+@Slf4j
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+@Tag(name = "Feedback-scores", description = "Feedback scores related resources")
+public class FeedbackScoreResource {
+
+    private final @NonNull FeedbackScoreService feedbackScoreService;
+    private final @NonNull Provider<RequestContext> requestContext;
+
+    @GET
+    @Path("/names")
+    @Operation(operationId = "findFeedbackScoreNames", summary = "Find Feedback Score names", description = "Find Feedback Score names", responses = {
+            @ApiResponse(responseCode = "200", description = "Feedback Scores resource", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class))))
+    })
+    @JsonView({FeedbackDefinition.View.Public.class})
+    public Response findFeedbackScoreNames(
+            @QueryParam("project_id") UUID projectId,
+            @QueryParam("with_experiments_only") boolean withExperimentsOnly) {
+
+        String workspaceId = requestContext.get().getWorkspaceId();
+
+        log.info("Find feedback score names by  project_id '{}' and with_experiments_only '{}', on workspaceId '{}'",
+                projectId, withExperimentsOnly, workspaceId);
+        FeedbackScoreNames feedbackScoreNames = feedbackScoreService
+                .getFeedbackScoreNames(projectId, withExperimentsOnly)
+                .map(names -> names.stream().map(ScoreName::new).toList())
+                .map(FeedbackScoreNames::new)
+                .contextWrite(ctx -> setRequestContext(ctx, requestContext))
+                .block();
+        log.info("Found feedback score names by project_id '{}' and with_experiments_only '{}', on workspaceId '{}'",
+                projectId, withExperimentsOnly, workspaceId);
+
+        return Response.ok(feedbackScoreNames).build();
+    }
+
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
@@ -392,9 +392,7 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
             template.add("project_id", projectId);
         }
 
-        if (withExperimentsOnly) {
-            template.add("with_experiments_only", withExperimentsOnly);
-        }
+        template.add("with_experiments_only", withExperimentsOnly);
     }
 
     private Mono<? extends Result> cascadeSpanDelete(Set<UUID> traceIds, Connection connection) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
@@ -66,6 +66,8 @@ public interface FeedbackScoreDAO {
     Mono<Void> deleteByEntityIds(EntityType entityType, Set<UUID> entityIds);
 
     Mono<Long> scoreBatchOf(EntityType entityType, List<FeedbackScoreBatchItem> scores);
+
+    Mono<List<String>> getFeedbackScoreNames(UUID projectId, boolean withExperimentsOnly);
 }
 
 @Singleton
@@ -150,6 +152,47 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
             WHERE entity_id IN :entity_ids
             AND entity_type = :entity_type
             AND workspace_id = :workspace_id
+            ;
+            """;
+
+    private static final String SELECT_FEEDBACK_SCORE_NAMES = """
+            SELECT
+                distinct name
+            FROM (
+                SELECT
+                    name
+                FROM feedback_scores
+                WHERE workspace_id = :workspace_id
+                <if(project_id)>
+                AND project_id = :project_id
+                <endif>
+                <if(with_experiments_only)>
+                AND entity_id IN (
+                    SELECT
+                        trace_id
+                    FROM (
+                        SELECT
+                            id
+                        FROM experiments
+                        WHERE workspace_id = :workspace_id
+                        ORDER BY id DESC, last_updated_at DESC
+                        LIMIT 1 BY id
+                    ) AS e
+                    INNER JOIN (
+                        SELECT
+                            experiment_id,
+                            trace_id
+                        FROM experiment_items
+                        WHERE workspace_id = :workspace_id
+                        ORDER BY id DESC, last_updated_at DESC
+                        LIMIT 1 BY id
+                    ) ei ON e.id = ei.experiment_id
+                )
+                <endif>
+                AND entity_type = 'trace'
+                ORDER BY entity_id DESC, last_updated_at DESC
+                LIMIT 1 BY entity_id, name
+            ) AS names
             ;
             """;
 
@@ -316,6 +359,42 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
                 asyncTemplate.nonTransaction(connection -> deleteScoresByEntityIds(entityType, entityIds, connection))
                         .then();
         };
+    }
+
+    @Override
+    @WithSpan
+    public Mono<List<String>> getFeedbackScoreNames(UUID projectId, boolean withExperimentsOnly) {
+        return asyncTemplate.nonTransaction(connection -> {
+
+            ST template = new ST(SELECT_FEEDBACK_SCORE_NAMES);
+
+            bindTemplateParam(projectId, withExperimentsOnly, template);
+
+            var statement = connection.createStatement(template.render());
+
+            bindStatementParam(projectId, statement);
+
+            return makeMonoContextAware(bindWorkspaceIdToMono(statement))
+                    .flatMapMany(result -> result.map((row, rowMetadata) -> row.get("name", String.class)))
+                    .distinct()
+                    .collect(Collectors.toList());
+        });
+    }
+
+    private void bindStatementParam(UUID projectId, Statement statement) {
+        if (projectId != null) {
+            statement.bind("project_id", projectId);
+        }
+    }
+
+    private void bindTemplateParam(UUID projectId, boolean withExperimentsOnly, ST template) {
+        if (projectId != null) {
+            template.add("project_id", projectId);
+        }
+
+        if (withExperimentsOnly) {
+            template.add("with_experiments_only", withExperimentsOnly);
+        }
     }
 
     private Mono<? extends Result> cascadeSpanDelete(Set<UUID> traceIds, Connection connection) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
@@ -44,6 +44,8 @@ public interface FeedbackScoreService {
 
     Mono<Void> deleteSpanScore(UUID id, String tag);
     Mono<Void> deleteTraceScore(UUID id, String tag);
+
+    Mono<List<String>> getFeedbackScoreNames(UUID projectId, boolean withExperimentsOnly);
 }
 
 @Slf4j
@@ -226,6 +228,11 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
     @Override
     public Mono<Void> deleteTraceScore(UUID id, String name) {
         return dao.deleteScoreFrom(EntityType.TRACE, id, name);
+    }
+
+    @Override
+    public Mono<List<String>> getFeedbackScoreNames(UUID projectId, boolean withExperimentsOnly) {
+        return dao.getFeedbackScoreNames(projectId, withExperimentsOnly);
     }
 
     private Mono<Long> failWithNotFound(String errorMessage) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ExperimentResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ExperimentResourceClient.java
@@ -1,0 +1,56 @@
+package com.comet.opik.api.resources.utils.resources;
+
+import com.comet.opik.api.Experiment;
+import com.comet.opik.api.ExperimentItem;
+import com.comet.opik.api.ExperimentItemsBatch;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import jakarta.ws.rs.client.Entity;
+import lombok.RequiredArgsConstructor;
+import org.apache.http.HttpStatus;
+import org.testcontainers.shaded.com.google.common.net.HttpHeaders;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RequiredArgsConstructor
+public class ExperimentResourceClient {
+
+    private static final String RESOURCE_PATH = "%s/v1/private/experiments";
+
+    private final ClientSupport client;
+    private final String baseURI;
+    private final PodamFactory podamFactory;
+
+    public UUID createExperiment(String apiKey, String workspaceName) {
+        var experiment = podamFactory.manufacturePojo(Experiment.class).toBuilder()
+                .promptVersion(null)
+                .build();
+
+        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(RequestContext.WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(experiment))) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CREATED);
+            return TestUtils.getIdFromLocation(response.getLocation());
+        }
+    }
+
+    public void createExperimentItem(Set<ExperimentItem> experimentItems, String apiKey, String workspaceName) {
+        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("items")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(RequestContext.WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(new ExperimentItemsBatch(experimentItems)))) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+        }
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ProjectResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ProjectResourceClient.java
@@ -1,0 +1,58 @@
+package com.comet.opik.api.resources.utils.resources;
+
+import com.comet.opik.api.Project;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.HttpHeaders;
+import lombok.RequiredArgsConstructor;
+import org.apache.hc.core5.http.HttpStatus;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RequiredArgsConstructor
+public class ProjectResourceClient {
+
+    private static final String RESOURCE_PATH = "%s/v1/private/projects";
+
+    private final ClientSupport client;
+    private final String baseURI;
+    private final PodamFactory podamFactory;
+
+    public UUID createProject(String projectName, String apiKey, String workspaceName) {
+
+        var project = podamFactory.manufacturePojo(Project.class).toBuilder()
+                .name(projectName)
+                .build();
+
+        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(RequestContext.WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(project))) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CREATED);
+
+            return TestUtils.getIdFromLocation(response.getLocation());
+        }
+    }
+
+    public Project getProject(UUID projectId, String apiKey, String workspaceName) {
+
+        try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/" + projectId)
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(RequestContext.WORKSPACE_HEADER, workspaceName)
+                .get()) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+
+            return response.readEntity(Project.class);
+        }
+    }
+
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
@@ -1,0 +1,49 @@
+package com.comet.opik.api.resources.utils.resources;
+
+import com.comet.opik.api.FeedbackScoreBatch;
+import com.comet.opik.api.FeedbackScoreBatchItem;
+import com.comet.opik.api.Trace;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.HttpHeaders;
+import lombok.RequiredArgsConstructor;
+import org.apache.http.HttpStatus;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+
+import java.util.List;
+
+import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RequiredArgsConstructor
+public class TraceResourceClient {
+
+    private static final String RESOURCE_PATH = "%s/v1/private/traces";
+
+    private final ClientSupport client;
+    private final String baseURI;
+
+    public void createTrace(Trace trace, String apiKey, String workspaceName) {
+        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(trace))) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CREATED);
+        }
+    }
+
+    public void feedbackScore(List<FeedbackScoreBatchItem> score, String apiKey, String workspaceName) {
+
+        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("feedback-scores")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .put(Entity.json(new FeedbackScoreBatch(score)))) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+        }
+    }
+
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/internal/UsageResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/internal/UsageResourceTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.lifecycle.Startables;
 import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
@@ -52,7 +52,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
-@Testcontainers(parallel = true)
 @DisplayName("Usage Resource Test")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Slf4j
@@ -77,9 +76,7 @@ public class UsageResourceTest {
     private static final WireMockUtils.WireMockRuntime wireMock;
 
     static {
-        MYSQL_CONTAINER.start();
-        CLICK_HOUSE_CONTAINER.start();
-        REDIS.start();
+        Startables.deepStart(REDIS, MYSQL_CONTAINER, CLICK_HOUSE_CONTAINER).join();
 
         wireMock = WireMockUtils.startWireMock();
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FeedbackDefinitionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FeedbackDefinitionResourceTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.lifecycle.Startables;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import uk.co.jemos.podam.api.PodamFactory;
@@ -63,7 +63,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-@Testcontainers(parallel = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("Feedback Resource Test")
 class FeedbackDefinitionResourceTest {
@@ -88,8 +87,7 @@ class FeedbackDefinitionResourceTest {
     private static final WireMockUtils.WireMockRuntime wireMock;
 
     static {
-        MYSQL.start();
-        REDIS.start();
+        Startables.deepStart(REDIS, MYSQL).join();
 
         wireMock = WireMockUtils.startWireMock();
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FeedbackScoreResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FeedbackScoreResourceTest.java
@@ -1,0 +1,258 @@
+package com.comet.opik.api.resources.v1.priv;
+
+import com.comet.opik.api.ExperimentItem;
+import com.comet.opik.api.FeedbackScoreBatchItem;
+import com.comet.opik.api.FeedbackScoreNames;
+import com.comet.opik.api.Project;
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.resources.utils.AuthTestUtils;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.ExperimentResourceClient;
+import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
+import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.redis.testcontainers.RedisContainer;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.HttpHeaders;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.lifecycle.Startables;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.api.resources.utils.MigrationUtils.CLICKHOUSE_CHANGELOG_FILE;
+import static com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension;
+import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Feedback Scores Resource")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FeedbackScoreResourceTest {
+
+    private static final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private static final MySQLContainer<?> MY_SQL_CONTAINER = MySQLContainerUtils.newMySQLContainer();
+    private static final ClickHouseContainer CLICK_HOUSE_CONTAINER = ClickHouseContainerUtils.newClickHouseContainer();
+
+    @RegisterExtension
+    private static final TestDropwizardAppExtension app;
+
+    private static final WireMockUtils.WireMockRuntime wireMock;
+
+    private static final TestDropwizardAppExtensionUtils.AppContextConfig contextConfig;
+    private static final String RESOURCE_PATH = "%s/v1/private/feedback-scores";
+
+    static {
+        Startables.deepStart(REDIS, MY_SQL_CONTAINER, CLICK_HOUSE_CONTAINER).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
+                CLICK_HOUSE_CONTAINER, DATABASE_NAME);
+
+        contextConfig = TestDropwizardAppExtensionUtils.AppContextConfig.builder()
+                .jdbcUrl(MY_SQL_CONTAINER.getJdbcUrl())
+                .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                .runtimeInfo(wireMock.runtimeInfo())
+                .redisUrl(REDIS.getRedisURI())
+                .cacheTtlInSeconds(null)
+                .build();
+
+        app = newTestDropwizardAppExtension(contextConfig);
+    }
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+
+    private String baseURI;
+    private ClientSupport client;
+    private ProjectResourceClient projectResourceClient;
+    private ExperimentResourceClient experimentResourceClient;
+    private TraceResourceClient traceResourceClient;
+
+    @BeforeAll
+    void beforeAll(ClientSupport client, Jdbi jdbi) throws SQLException {
+        MigrationUtils.runDbMigration(jdbi, MySQLContainerUtils.migrationParameters());
+
+        try (var connection = CLICK_HOUSE_CONTAINER.createConnection("")) {
+            MigrationUtils.runDbMigration(connection, CLICKHOUSE_CHANGELOG_FILE,
+                    ClickHouseContainerUtils.migrationParameters());
+        }
+
+        baseURI = "http://localhost:%d".formatted(client.getPort());
+        this.client = client;
+
+        ClientSupportUtils.config(client);
+        this.projectResourceClient = new ProjectResourceClient(client, baseURI, podamFactory);
+        this.experimentResourceClient = new ExperimentResourceClient(client, baseURI, podamFactory);
+        this.traceResourceClient = new TraceResourceClient(client, baseURI);
+    }
+
+    private static void mockTargetWorkspace(String apiKey, String workspaceName, String workspaceId) {
+        AuthTestUtils.mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, workspaceId);
+    }
+
+    @Nested
+    @DisplayName("Get Feedback Score names")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class GetFeedbackScoreNames {
+
+        @ParameterizedTest
+        @MethodSource
+        @DisplayName("when get feedback score names, then return feedback score names")
+        void getFeedbackScoreNames__whenGetFeedbackScoreNames__thenReturnFeedbackScoreNames(
+                boolean userProjectId,
+                boolean withExperimentsOnly,
+                List<String> names,
+                List<String> otherNames) {
+            // given
+            var apiKey = UUID.randomUUID().toString();
+            var workspaceId = UUID.randomUUID().toString();
+            var workspaceName = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            // when
+            String projectName = UUID.randomUUID().toString();
+
+            UUID projectId = projectResourceClient.createProject(projectName, apiKey, workspaceName);
+            Project project = projectResourceClient.getProject(projectId, apiKey, workspaceName);
+
+            // Create multiple values feedback scores
+            List<String> multipleValuesFeedbackScores = names.subList(0, names.size() - 1);
+
+            List<List<FeedbackScoreBatchItem>> multipleValuesFeedbackScoreList = createMultiValueScores(
+                    multipleValuesFeedbackScores, project, apiKey, workspaceName);
+
+            List<List<FeedbackScoreBatchItem>> singleValueScores = createMultiValueScores(List.of(names.getLast()),
+                    project, apiKey, workspaceName);
+
+            createExperimentsItems(apiKey, workspaceName, multipleValuesFeedbackScoreList, singleValueScores);
+
+            // Create unexpected feedback scores
+            var unexpectedProject = podamFactory.manufacturePojo(Project.class);
+
+            List<List<FeedbackScoreBatchItem>> unexpectedScores = createMultiValueScores(otherNames, unexpectedProject,
+                    apiKey, workspaceName);
+
+            if (!withExperimentsOnly) {
+                createExperimentsItems(apiKey, workspaceName, unexpectedScores, List.of());
+            }
+
+            WebTarget webTarget = client.target(RESOURCE_PATH.formatted(baseURI)).path("/names");
+
+            if (userProjectId) {
+                webTarget = webTarget.queryParam("project_id", projectId);
+            }
+
+            if (withExperimentsOnly) {
+                webTarget = webTarget.queryParam("with_experiments_only", withExperimentsOnly);
+            }
+
+            List<String> expectedNames = (withExperimentsOnly || userProjectId)
+                    ? names
+                    : Stream.of(names, otherNames).flatMap(List::stream).toList();
+
+            try (var actualResponse = webTarget
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, apiKey)
+                    .header(WORKSPACE_HEADER, workspaceName)
+                    .get()) {
+
+                // then
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+                var actualEntity = actualResponse.readEntity(FeedbackScoreNames.class);
+
+                assertThat(actualEntity.scores()).hasSize(expectedNames.size());
+                assertThat(actualEntity
+                        .scores()
+                        .stream()
+                        .map(FeedbackScoreNames.ScoreName::name)
+                        .toList()).containsExactlyInAnyOrderElementsOf(expectedNames);
+            }
+        }
+
+        Stream<Arguments> getFeedbackScoreNames__whenGetFeedbackScoreNames__thenReturnFeedbackScoreNames() {
+            return Stream.of(
+                    Arguments.of(true, false,
+                            PodamFactoryUtils.manufacturePojoList(podamFactory, String.class),
+                            PodamFactoryUtils.manufacturePojoList(podamFactory, String.class)),
+                    Arguments.of(false, true,
+                            PodamFactoryUtils.manufacturePojoList(podamFactory, String.class),
+                            PodamFactoryUtils.manufacturePojoList(podamFactory, String.class)),
+                    Arguments.of(true, true,
+                            PodamFactoryUtils.manufacturePojoList(podamFactory, String.class),
+                            PodamFactoryUtils.manufacturePojoList(podamFactory, String.class)),
+                    Arguments.of(false, false,
+                            PodamFactoryUtils.manufacturePojoList(podamFactory, String.class),
+                            PodamFactoryUtils.manufacturePojoList(podamFactory, String.class)));
+        }
+    }
+
+    private List<List<FeedbackScoreBatchItem>> createMultiValueScores(List<String> multipleValuesFeedbackScores,
+            Project project, String apiKey, String workspaceName) {
+        return IntStream.range(0, multipleValuesFeedbackScores.size())
+                .mapToObj(i -> {
+
+                    Trace trace = podamFactory.manufacturePojo(Trace.class).toBuilder()
+                            .name(project.name())
+                            .build();
+
+                    traceResourceClient.createTrace(trace, apiKey, workspaceName);
+
+                    List<FeedbackScoreBatchItem> scores = multipleValuesFeedbackScores.stream()
+                            .map(name -> podamFactory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
+                                    .name(name)
+                                    .projectName(project.name())
+                                    .id(trace.id())
+                                    .build())
+                            .toList();
+
+                    traceResourceClient.feedbackScore(scores, apiKey, workspaceName);
+
+                    return scores;
+                }).toList();
+    }
+
+    private void createExperimentsItems(String apiKey, String workspaceName,
+            List<List<FeedbackScoreBatchItem>> multipleValuesFeedbackScoreList,
+            List<List<FeedbackScoreBatchItem>> singleValueScores) {
+
+        UUID experimentId = experimentResourceClient.createExperiment(apiKey, workspaceName);
+
+        Stream.of(multipleValuesFeedbackScoreList, singleValueScores)
+                .flatMap(List::stream)
+                .flatMap(List::stream)
+                .map(FeedbackScoreBatchItem::id)
+                .distinct()
+                .forEach(traceId -> {
+                    var experimentItem = podamFactory.manufacturePojo(ExperimentItem.class).toBuilder()
+                            .traceId(traceId)
+                            .experimentId(experimentId)
+                            .build();
+
+                    experimentResourceClient.createExperimentItem(Set.of(experimentItem), apiKey, workspaceName);
+                });
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -57,7 +57,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.lifecycle.Startables;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
@@ -97,7 +97,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-@Testcontainers(parallel = true)
 @DisplayName("Traces Resource Test")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TracesResourceTest {
@@ -128,9 +127,7 @@ class TracesResourceTest {
     private static final WireMockUtils.WireMockRuntime wireMock;
 
     static {
-        MYSQL_CONTAINER.start();
-        CLICK_HOUSE_CONTAINER.start();
-        REDIS.start();
+        Startables.deepStart(REDIS, MYSQL_CONTAINER, CLICK_HOUSE_CONTAINER).join();
 
         wireMock = WireMockUtils.startWireMock();
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/HealthCheckIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/HealthCheckIntegrationTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.lifecycle.Startables;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 
@@ -22,7 +22,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Testcontainers(parallel = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class HealthCheckIntegrationTest {
 
@@ -42,9 +41,7 @@ class HealthCheckIntegrationTest {
     }
 
     static {
-        MYSQL.start();
-        CLICKHOUSE.start();
-        REDIS.start();
+        Startables.deepStart(MYSQL, CLICKHOUSE, REDIS).join();
 
         var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(CLICKHOUSE,
                 ClickHouseContainerUtils.DATABASE_NAME);

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/AuthModuleCache2E2Test.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/AuthModuleCache2E2Test.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.lifecycle.Startables;
 import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
@@ -33,7 +33,6 @@ import java.util.UUID;
 import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Testcontainers(parallel = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AuthModuleCache2E2Test {
 
@@ -60,9 +59,7 @@ class AuthModuleCache2E2Test {
     private static final String TEST_WORKSPACE = UUID.randomUUID().toString();
 
     static {
-        MYSQL.start();
-        CLICKHOUSE.start();
-        REDIS.start();
+        Startables.deepStart(REDIS, MYSQL, CLICKHOUSE).join();
 
         wireMock = WireMockUtils.startWireMock();
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/AuthModuleNoAuthIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/AuthModuleNoAuthIntegrationTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.lifecycle.Startables;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 
@@ -28,7 +28,6 @@ import static com.comet.opik.domain.ProjectService.DEFAULT_WORKSPACE_NAME;
 import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Testcontainers(parallel = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AuthModuleNoAuthIntegrationTest {
 
@@ -44,9 +43,7 @@ class AuthModuleNoAuthIntegrationTest {
     private static final TestDropwizardAppExtension app;
 
     static {
-        MYSQL.start();
-        CLICKHOUSE.start();
-        REDIS.start();
+        Startables.deepStart(MYSQL, CLICKHOUSE, REDIS).join();
 
         var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(CLICKHOUSE,
                 ClickHouseContainerUtils.DATABASE_NAME);

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/aws/rds/MysqlRdsIamE2eTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/aws/rds/MysqlRdsIamE2eTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.clickhouse.ClickHouseContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.lifecycle.Startables;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 
@@ -29,7 +29,6 @@ import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Disabled
-@Testcontainers(parallel = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class MysqlRdsIamE2eTest {
 
@@ -55,8 +54,7 @@ public class MysqlRdsIamE2eTest {
     private static final String TEST_WORKSPACE = "default";
 
     static {
-        CLICKHOUSE.start();
-        REDIS.start();
+        Startables.deepStart(CLICKHOUSE, REDIS).join();
 
         var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(CLICKHOUSE,
                 ClickHouseContainerUtils.DATABASE_NAME);

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListenerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListenerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.lifecycle.Startables;
 import ru.vyarus.dropwizard.guice.module.lifecycle.GuiceyLifecycle;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 
@@ -71,9 +72,7 @@ class OpikGuiceyLifecycleEventListenerTest {
         private static final WireMockUtils.WireMockRuntime wireMock;
 
         static {
-            MYSQL_CONTAINER.start();
-            CLICK_HOUSE_CONTAINER.start();
-            REDIS.start();
+            Startables.deepStart(MYSQL_CONTAINER, CLICK_HOUSE_CONTAINER, REDIS).join();
 
             wireMock = WireMockUtils.startWireMock();
 
@@ -134,9 +133,7 @@ class OpikGuiceyLifecycleEventListenerTest {
         private static final WireMockUtils.WireMockRuntime wireMock;
 
         static {
-            MYSQL_CONTAINER.start();
-            CLICK_HOUSE_CONTAINER.start();
-            REDIS.start();
+            Startables.deepStart(MYSQL_CONTAINER, CLICK_HOUSE_CONTAINER, REDIS).join();
 
             wireMock = WireMockUtils.startWireMock();
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/health/IsAliveE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/health/IsAliveE2ETest.java
@@ -14,13 +14,12 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.lifecycle.Startables;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
 
-@Testcontainers(parallel = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("Is Alive Resource Test")
 class IsAliveE2ETest {
@@ -37,9 +36,7 @@ class IsAliveE2ETest {
     private static final TestDropwizardAppExtension app;
 
     static {
-        MYSQL.start();
-        CLICKHOUSE.start();
-        REDIS.start();
+        Startables.deepStart(MYSQL, CLICKHOUSE, REDIS).join();
 
         var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
                 CLICKHOUSE, DATABASE_NAME);

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/cors/CorsDisabledE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/cors/CorsDisabledE2ETest.java
@@ -14,14 +14,13 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.lifecycle.Startables;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Testcontainers(parallel = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("CORS headers logic test when CORS config is disabled")
 class CorsDisabledE2ETest {
@@ -35,9 +34,7 @@ class CorsDisabledE2ETest {
     private static final TestDropwizardAppExtension app;
 
     static {
-        MYSQL.start();
-        CLICKHOUSE.start();
-        REDIS.start();
+        Startables.deepStart(MYSQL, CLICKHOUSE, REDIS).join();
 
         var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
                 CLICKHOUSE, DATABASE_NAME);

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/cors/CorsEnabledE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/cors/CorsEnabledE2ETest.java
@@ -16,14 +16,13 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.lifecycle.Startables;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Testcontainers(parallel = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("CORS headers logic test when CORS config is enabled")
 class CorsEnabledE2ETest {
@@ -37,9 +36,7 @@ class CorsEnabledE2ETest {
     private static final TestDropwizardAppExtension app;
 
     static {
-        MYSQL.start();
-        CLICKHOUSE.start();
-        REDIS.start();
+        Startables.deepStart(MYSQL, CLICKHOUSE, REDIS).join();
 
         var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
                 CLICKHOUSE, DATABASE_NAME);

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/ratelimit/RateLimitE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/ratelimit/RateLimitE2ETest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.lifecycle.Startables;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
@@ -76,7 +76,6 @@ import static java.util.stream.Collectors.groupingBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Testcontainers(parallel = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("Rate limit Resource Test")
 class RateLimitE2ETest {
@@ -113,9 +112,7 @@ class RateLimitE2ETest {
     }
 
     static {
-        MYSQL.start();
-        CLICKHOUSE.start();
-        REDIS.start();
+        Startables.deepStart(MYSQL, CLICKHOUSE, REDIS).join();
 
         wireMock = WireMockUtils.startWireMock();
 


### PR DESCRIPTION
## Details
- Add endpoint to retrieve all feedback score names
- Fix parallel container starting

## Issues
OPIK-418

## Testing
- Filter by `project_id`
- Filter by `with_experiments_only`
- Both filters
- No filters
