### PR TITLE
[OPIK-428] Detect images in the trace/span input by URL extension

### DIFF
--- a/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceDataViewer/InputOutputTab.tsx
+++ b/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceDataViewer/InputOutputTab.tsx
@@ -53,8 +53,45 @@ const BASE64_PREFIXES_MAP = {
   UklGR: "webp",
 } as const;
 
+const IMAGE_URL_EXTENSIONS = [
+  "apng",
+  "avif",
+  "bmp",
+  "cr2",
+  "djv",
+  "djvu",
+  "eps",
+  "gif",
+  "hdp",
+  "heic",
+  "heif",
+  "ico",
+  "j2k",
+  "jp2",
+  "jpeg",
+  "jpf",
+  "jpg",
+  "jpm",
+  "jxr",
+  "mj2",
+  "nef",
+  "orf",
+  "png",
+  "psd",
+  "raw",
+  "sr2",
+  "svg",
+  "tif",
+  "tiff",
+  "wdp",
+  "webp",
+] as const;
+
 const IMAGE_CHARS_REGEX = "[A-Za-z0-9+/]+={0,2}";
 const DATA_IMAGE_PREFIX = `"data:image/[^;]{3,4};base64,${IMAGE_CHARS_REGEX}"`;
+const IMAGE_URL_REGEX = `"https?:\\/\\/[^\\s"']+\\.(${IMAGE_URL_EXTENSIONS.join(
+  "|",
+)})(\\?[^"']*)?(#[^"']*)?"`;
 
 function extractInputImages(input?: object) {
   if (!input) return [];
@@ -82,6 +119,13 @@ function extractInputImages(input?: object) {
   const dataImageMatches = stringifiedInput.match(dataImageRegex);
   if (dataImageMatches) {
     images.push(...dataImageMatches.map((match) => match.replace(/"/g, "")));
+  }
+
+  // Extract image URLs
+  const imageUrlRegex = new RegExp(IMAGE_URL_REGEX, "gi");
+  const imageUrlMatches = stringifiedInput.match(imageUrlRegex);
+  if (imageUrlMatches) {
+    images.push(...imageUrlMatches.map((match) => match.replace(/"/g, "")));
   }
 
   return images;


### PR DESCRIPTION
## Details
- Extract also the images in the trace/span by URL (not only base64 images)
<img width="1114" alt="Screenshot 2024-11-15 at 3 36 16 PM" src="https://github.com/user-attachments/assets/40876842-6247-4180-b655-3f3cad280daa">

## Issues

Resolves #

## Testing

## Documentation
