### PR TITLE
[DEV-2440] opik chart improvements

### DIFF
--- a/deployment/helm_chart/opik/Chart.lock
+++ b/deployment/helm_chart/opik/Chart.lock
@@ -11,5 +11,8 @@ dependencies:
 - name: altinity-clickhouse-operator
   repository: https://docs.altinity.com/clickhouse-operator/
   version: 0.23.7
-digest: sha256:1863002507fafe0a986af167356bbb3178a4870994225b728efac3cfd9db617e
-generated: "2024-10-13T14:38:17.89184+03:00"
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.27.0
+digest: sha256:abbf693f77864eb242acd9cce31514c3c4335c0a52f10471ac8d43a67c02e0d4
+generated: "2024-11-17T14:25:02.348737+02:00"

--- a/deployment/helm_chart/opik/Chart.yaml
+++ b/deployment/helm_chart/opik/Chart.yaml
@@ -42,4 +42,7 @@ dependencies:
 - name: altinity-clickhouse-operator
   version: "0.23.7"
   repository: https://docs.altinity.com/clickhouse-operator/
+- name: common
+  version: 2.x.x
+  repository: oci://registry-1.docker.io/bitnamicharts
 

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -94,6 +94,7 @@ Call opik api on http://localhost:5173/api
 | clickhouse.adminUser.useSecret.enabled | bool | `false` |  |
 | clickhouse.adminUser.username | string | `"opik"` |  |
 | clickhouse.backup.enabled | bool | `false` |  |
+| clickhouse.backup.successfulJobsHistoryLimit | int | `1` |  |
 | clickhouse.image | string | `"altinity/clickhouse-server:24.3.5.47.altinitystable"` |  |
 | clickhouse.logsLevel | string | `"information"` |  |
 | clickhouse.monitoring.enabled | bool | `false` |  |

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -81,6 +81,7 @@ Call opik api on http://localhost:5173/api
 | https://charts.bitnami.com/bitnami | redis | 18.19.2 |
 | https://charts.bitnami.com/bitnami | zookeeper | 12.12.1 |
 | https://docs.altinity.com/clickhouse-operator/ | altinity-clickhouse-operator | 0.23.7 |
+| oci://registry-1.docker.io/bitnamicharts | common | 2.x.x |
 
 ## Values
 

--- a/deployment/helm_chart/opik/templates/clickhouse-backup-cronjob.yaml
+++ b/deployment/helm_chart/opik/templates/clickhouse-backup-cronjob.yaml
@@ -16,7 +16,7 @@ spec:
               - "/bin/bash"
               - "-c"
             args:
-              - export backupname=backup$(date +'%Y%m%d%H%M'); echo "BACKUP ALL EXCEPT DATABASE system TO S3('https://{{ .Values.clickhouse.backup.bucketName }}.s3.{{ .Values.clickhouse.backup.region }}.amazonaws.com/$backupname/', '$ACCESS_KEY', '$SECRET_KEY');" > /tmp/backQuery.sql; clickhouse-client -h clickhouse-opik-clickhouse --send_timeout 600000 --receive_timeout 600000 --port 9000 --queries-file=/tmp/backQuery.sql;
+              - export backupname=backup$(date +'%Y%m%d%H%M'); echo "BACKUP ALL EXCEPT DATABASE system TO S3('{{ .Values.clickhouse.backup.bucketURL }}', '$ACCESS_KEY', '$SECRET_KEY');" > /tmp/backQuery.sql; clickhouse-client -h clickhouse-opik-clickhouse --send_timeout 600000 --receive_timeout 600000 --port 9000 --queries-file=/tmp/backQuery.sql;
             env:
             - name: CLICKHOUSE_USER
               value: {{ .Values.clickhouse.adminUser.username }}

--- a/deployment/helm_chart/opik/templates/clickhouse-backup-cronjob.yaml
+++ b/deployment/helm_chart/opik/templates/clickhouse-backup-cronjob.yaml
@@ -39,6 +39,15 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.clickhouse.backup.secretName}}
                   key: access_key_secret
+
+          {{- with .Values.clickhouse.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          {{- with .Values.clickhouse.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
           restartPolicy: Never
       backoffLimit:
 {{end}}

--- a/deployment/helm_chart/opik/templates/clickhouse-backup-cronjob.yaml
+++ b/deployment/helm_chart/opik/templates/clickhouse-backup-cronjob.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "opik.name" $ }}-clickhouse-backup
 spec:
   schedule: "{{ .Values.clickhouse.backup.schedule }}"
+  successfulJobsHistoryLimit: {{ .Values.clickhouse.backup.successfulJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:

--- a/deployment/helm_chart/opik/templates/clickhouse-backup-cronjob.yaml
+++ b/deployment/helm_chart/opik/templates/clickhouse-backup-cronjob.yaml
@@ -43,11 +43,11 @@ spec:
 
           {{- with .Values.clickhouse.nodeSelector }}
           nodeSelector:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.clickhouse.tolerations }}
           tolerations:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           restartPolicy: Never
       backoffLimit:

--- a/deployment/helm_chart/opik/templates/clickhouse-backup-cronjob.yaml
+++ b/deployment/helm_chart/opik/templates/clickhouse-backup-cronjob.yaml
@@ -17,7 +17,7 @@ spec:
               - "/bin/bash"
               - "-c"
             args:
-              - export backupname=backup$(date +'%Y%m%d%H%M'); echo "BACKUP ALL EXCEPT DATABASE system TO S3('{{ .Values.clickhouse.backup.bucketURL }}', '$ACCESS_KEY', '$SECRET_KEY');" > /tmp/backQuery.sql; clickhouse-client -h clickhouse-opik-clickhouse --send_timeout 600000 --receive_timeout 600000 --port 9000 --queries-file=/tmp/backQuery.sql;
+              - export backupname=backup$(date +'%Y%m%d%H%M'); echo "BACKUP ALL EXCEPT DATABASE system TO S3('{{ .Values.clickhouse.backup.bucketURL }}/$backupname/', '$ACCESS_KEY', '$SECRET_KEY');" > /tmp/backQuery.sql; clickhouse-client -h clickhouse-opik-clickhouse --send_timeout 600000 --receive_timeout 600000 --port 9000 --queries-file=/tmp/backQuery.sql;
             env:
             - name: CLICKHOUSE_USER
               value: {{ .Values.clickhouse.adminUser.username }}

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -218,8 +218,7 @@ clickhouse:
     password: opik
   backup: 
     enabled: false
-    # bucketName: ""
-    # region: ""
+    # bucketURL: ""
     # secretName: ""
     # schedule: ""
     # baseBackup: ""

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -218,6 +218,7 @@ clickhouse:
     password: opik
   backup: 
     enabled: false
+    successfulJobsHistoryLimit: 1
     # bucketURL: ""
     # secretName: ""
     # schedule: ""


### PR DESCRIPTION
## Details
- added bitnami-common as a dependency to opik chart to support simpler value configurations
- add variable for clickhouse backup bucket 
- add toleration and nodeSelector for clickhouse backup job
- set default successfulJobsHistoryLimit=1 for clickhouse backup cronjob
## Issues

Resolves #

## Testing
Tested on Dev

## Documentation
