### PR TITLE
[OPIK-417] Truncate base64 images for dataset items

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemSearchCriteria.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemSearchCriteria.java
@@ -14,5 +14,6 @@ public record DatasetItemSearchCriteria(
         @NonNull UUID datasetId,
         @NonNull Set<UUID> experimentIds,
         @NonNull FeedbackScoreDAO.EntityType entityType,
-        List<? extends Filter> filters) {
+        List<? extends Filter> filters,
+        boolean truncate) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -251,12 +251,13 @@ public class DatasetsResource {
     public Response getDatasetItems(
             @PathParam("id") UUID id,
             @QueryParam("page") @Min(1) @DefaultValue("1") int page,
-            @QueryParam("size") @Min(1) @DefaultValue("10") int size) {
+            @QueryParam("size") @Min(1) @DefaultValue("10") int size,
+            @QueryParam("truncate") boolean truncate) {
 
         String workspaceId = requestContext.get().getWorkspaceId();
         log.info("Finding dataset items by id '{}', page '{}', size '{} on workspace_id '{}''", id, page, size,
                 workspaceId);
-        DatasetItem.DatasetItemPage datasetItemPage = itemService.getItems(id, page, size)
+        DatasetItem.DatasetItemPage datasetItemPage = itemService.getItems(id, page, size, truncate)
                 .contextWrite(ctx -> setRequestContext(ctx, requestContext))
                 .block();
         log.info("Found dataset items by id '{}', count '{}', page '{}', size '{} on workspace_id '{}''", id,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -351,7 +351,8 @@ public class DatasetsResource {
             @QueryParam("page") @Min(1) @DefaultValue("1") int page,
             @QueryParam("size") @Min(1) @DefaultValue("10") int size,
             @QueryParam("experiment_ids") @NotNull @NotBlank String experimentIdsQueryParam,
-            @QueryParam("filters") String filters) {
+            @QueryParam("filters") String filters,
+            @QueryParam("truncate") boolean truncate) {
 
         var experimentIds = getExperimentIds(experimentIdsQueryParam);
 
@@ -362,6 +363,7 @@ public class DatasetsResource {
                 .experimentIds(experimentIds)
                 .filters(queryFilters)
                 .entityType(FeedbackScoreDAO.EntityType.TRACE)
+                .truncate(truncate)
                 .build();
 
         String workspaceId = requestContext.get().getWorkspaceId();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -46,7 +46,7 @@ public interface DatasetItemDAO {
 
     Mono<Long> delete(List<UUID> ids);
 
-    Mono<DatasetItemPage> getItems(UUID datasetId, int page, int size);
+    Mono<DatasetItemPage> getItems(UUID datasetId, int page, int size, boolean truncate);
 
     Mono<DatasetItemPage> getItems(DatasetItemSearchCriteria datasetItemSearchCriteria, int page, int size);
 
@@ -139,7 +139,19 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
 
     private static final String SELECT_DATASET_ITEMS = """
                 SELECT
-                    *,
+                    id,
+                    dataset_id,
+                    input,
+                    <if(truncate)> mapApply((k, v) -> (k, replaceRegexpAll(v, '<truncate>', '"[image]"')), data) as data <else> data <endif>,
+                    expected_output,
+                    metadata,
+                    trace_id,
+                    span_id,
+                    source,
+                    created_at,
+                    last_updated_at,
+                    created_by,
+                    last_updated_by,
                     null AS experiment_items_array
                 FROM dataset_items
                 WHERE dataset_id = :datasetId
@@ -657,7 +669,7 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
 
     @Override
     @WithSpan
-    public Mono<DatasetItemPage> getItems(@NonNull UUID datasetId, int page, int size) {
+    public Mono<DatasetItemPage> getItems(@NonNull UUID datasetId, int page, int size, boolean truncate) {
 
         Segment segmentCount = startSegment("dataset_items", "Clickhouse", "select_dataset_items_page_count");
 
@@ -676,7 +688,9 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                     long total = result.getKey();
                     Set<Column> columns = result.getValue();
 
-                    return Flux.from(connection.createStatement(SELECT_DATASET_ITEMS)
+                    ST template = ImageUtils.addTruncateToTemplate(new ST(SELECT_DATASET_ITEMS), truncate);
+
+                    return Flux.from(connection.createStatement(template.render())
                             .bind("workspace_id", workspaceId)
                             .bind("datasetId", datasetId)
                             .bind("limit", size)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -331,7 +331,7 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                 di.id AS id,
                 di.dataset_id AS dataset_id,
                 di.input AS input,
-                di.data AS data,
+                <if(truncate)> mapApply((k, v) -> (k, replaceRegexpAll(v, '<truncate>', '"[image]"')), di.data) as data <else> di.data <endif>,
                 di.expected_output AS expected_output,
                 di.metadata AS metadata,
                 di.trace_id AS trace_id,
@@ -740,6 +740,8 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
 
                     ST selectTemplate = newFindTemplate(SELECT_DATASET_ITEMS_WITH_EXPERIMENT_ITEMS,
                             datasetItemSearchCriteria);
+                    selectTemplate = ImageUtils.addTruncateToTemplate(selectTemplate,
+                            datasetItemSearchCriteria.truncate());
 
                     var selectStatement = connection.createStatement(selectTemplate.render())
                             .bind("datasetId", datasetItemSearchCriteria.datasetId())

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -39,7 +39,7 @@ public interface DatasetItemService {
 
     Mono<Void> delete(List<UUID> ids);
 
-    Mono<DatasetItemPage> getItems(UUID datasetId, int page, int size);
+    Mono<DatasetItemPage> getItems(UUID datasetId, int page, int size, boolean truncate);
 
     Mono<DatasetItemPage> getItems(int page, int size, DatasetItemSearchCriteria datasetItemSearchCriteria);
 
@@ -198,8 +198,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
     @Override
     @WithSpan
-    public Mono<DatasetItemPage> getItems(@NonNull UUID datasetId, int page, int size) {
-        return dao.getItems(datasetId, page, size);
+    public Mono<DatasetItemPage> getItems(@NonNull UUID datasetId, int page, int size, boolean truncate) {
+        return dao.getItems(datasetId, page, size, truncate);
     }
 
     @Override

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -3756,6 +3756,10 @@ class DatasetsResourceTest {
             putAndAssert(datasetItemBatchWithImage, workspaceName, apiKey);
 
             // Creating 5 different experiment ids
+            var expectedDatasetItems = datasetItemBatchWithImage.items()
+                    .stream()
+                    .map(item -> item.toBuilder().data(ImmutableMap.of("image", expected)).build())
+                    .toList().reversed();
             var experimentIds = IntStream.range(0, 5).mapToObj(__ -> GENERATOR.generate()).toList();
             var experimentItemsBatch = factory.manufacturePojo(ExperimentItemsBatch.class);
             var experimentItemsBatchWithIds = experimentItemsBatch.toBuilder().experimentItems(
@@ -3770,13 +3774,6 @@ class DatasetsResourceTest {
             var page = 1;
             var pageSize = 5;
             var experimentIdsQueryParm = JsonUtils.writeValueAsString(experimentIds);
-
-            var expectedDatasetItems = IntStream.range(0, 5)
-                    .mapToObj(i -> datasetItemBatchWithImage.items().get(i).toBuilder()
-                            .data(ImmutableMap.of("image", expected))
-                            .experimentItems(List.of(new ArrayList<>(experimentItemsBatch.experimentItems()).get(i)))
-                            .build())
-                    .toList().reversed();
 
             try (var actualResponse = client.target(BASE_RESOURCE_URI.formatted(baseURI))
                     .path(datasetId.toString())

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -3756,10 +3756,6 @@ class DatasetsResourceTest {
             putAndAssert(datasetItemBatchWithImage, workspaceName, apiKey);
 
             // Creating 5 different experiment ids
-            var expectedDatasetItems = datasetItemBatchWithImage.items()
-                    .stream()
-                    .map(item -> item.toBuilder().data(ImmutableMap.of("image", expected)).build())
-                    .toList().reversed();
             var experimentIds = IntStream.range(0, 5).mapToObj(__ -> GENERATOR.generate()).toList();
             var experimentItemsBatch = factory.manufacturePojo(ExperimentItemsBatch.class);
             var experimentItemsBatchWithIds = experimentItemsBatch.toBuilder().experimentItems(
@@ -3774,6 +3770,13 @@ class DatasetsResourceTest {
             var page = 1;
             var pageSize = 5;
             var experimentIdsQueryParm = JsonUtils.writeValueAsString(experimentIds);
+
+            var expectedDatasetItems = IntStream.range(0, 5)
+                    .mapToObj(i -> datasetItemBatchWithImage.items().get(i).toBuilder()
+                            .data(ImmutableMap.of("image", expected))
+                            .experimentItems(List.of(new ArrayList<>(experimentItemsBatch.experimentItems()).get(i)))
+                            .build())
+                    .toList().reversed();
 
             try (var actualResponse = client.target(BASE_RESOURCE_URI.formatted(baseURI))
                     .path(datasetId.toString())

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -3787,7 +3787,7 @@ class DatasetsResourceTest {
                     .header(WORKSPACE_HEADER, workspaceName)
                     .get()) {
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
                 var actualPage = actualResponse.readEntity(DatasetItemPage.class);
 
                 assertThat(actualPage.page()).isEqualTo(page);

--- a/apps/opik-backend/src/test/java/com/comet/opik/podam/manufacturer/JsonNodeTypeManufacturer.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/podam/manufacturer/JsonNodeTypeManufacturer.java
@@ -50,20 +50,10 @@ public class JsonNodeTypeManufacturer extends AbstractTypeManufacturer<JsonNode>
     // verifies that no random string contains base64 image prefixes
     private String getValidRandomString(int count) {
         String randomString = RandomStringUtils.randomAlphanumeric(count);
-        while (!isValidString(randomString)) {
+        while (FORBIDDEN_STRINGS.stream().anyMatch(randomString::startsWith)) {
             randomString = RandomStringUtils.randomAlphanumeric(count);
         }
 
         return randomString;
-    }
-
-    private boolean isValidString(String string) {
-        for (String forbiddenString : FORBIDDEN_STRINGS) {
-            if (string.startsWith(forbiddenString)) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/podam/manufacturer/JsonNodeTypeManufacturer.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/podam/manufacturer/JsonNodeTypeManufacturer.java
@@ -9,10 +9,31 @@ import uk.co.jemos.podam.common.ManufacturingContext;
 import uk.co.jemos.podam.typeManufacturers.AbstractTypeManufacturer;
 
 import java.util.HashMap;
+import java.util.List;
+
+import static com.comet.opik.domain.ImageUtils.PREFIX_BMP;
+import static com.comet.opik.domain.ImageUtils.PREFIX_GIF0;
+import static com.comet.opik.domain.ImageUtils.PREFIX_GIF1;
+import static com.comet.opik.domain.ImageUtils.PREFIX_JPEG;
+import static com.comet.opik.domain.ImageUtils.PREFIX_PNG;
+import static com.comet.opik.domain.ImageUtils.PREFIX_TIFF0;
+import static com.comet.opik.domain.ImageUtils.PREFIX_TIFF1;
+import static com.comet.opik.domain.ImageUtils.PREFIX_WEBP;
 
 public class JsonNodeTypeManufacturer extends AbstractTypeManufacturer<JsonNode> {
 
     public static final JsonNodeTypeManufacturer INSTANCE = new JsonNodeTypeManufacturer();
+
+    private static final List<String> FORBIDDEN_STRINGS = List.of(
+            PREFIX_JPEG,
+            PREFIX_PNG,
+            PREFIX_GIF0,
+            PREFIX_GIF1,
+            PREFIX_BMP,
+            PREFIX_TIFF0,
+            PREFIX_TIFF1,
+            PREFIX_WEBP
+    );
 
     @Override
     public JsonNode getType(
@@ -21,8 +42,28 @@ public class JsonNodeTypeManufacturer extends AbstractTypeManufacturer<JsonNode>
             ManufacturingContext manufacturingContext) {
         var map = new HashMap<>();
         for (var i = 0; i < 5; i++) {
-            map.put(RandomStringUtils.randomAlphanumeric(10), RandomStringUtils.randomAlphanumeric(10));
+            map.put(getValidRandomString(10), getValidRandomString(10));
         }
         return JsonUtils.getJsonNodeFromString(JsonUtils.writeValueAsString(map));
+    }
+
+    // verifies that no random string contains base64 image prefixes
+    private String getValidRandomString(int count) {
+        String randomString = RandomStringUtils.randomAlphanumeric(count);
+        while (!isValidString(randomString)) {
+            randomString = RandomStringUtils.randomAlphanumeric(count);
+        }
+
+        return randomString;
+    }
+
+    private boolean isValidString(String string) {
+        for (String forbiddenString : FORBIDDEN_STRINGS) {
+            if (string.startsWith(forbiddenString)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
## Details
Similarly to traces and spans, we would like to truncate base64 encoded images in dataset items as well.

## Issues
OPIK-417

## Testing
Added a couple of E2E tests to cover the new flows.
