### PR TITLE
[OPIK-433] truncate base64 images for `datasetItem.experimentItems`

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -432,8 +432,8 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                 FROM (
                     SELECT
                         id,
-                        input,
-                        output
+                        <if(truncate)> replaceRegexpAll(input, '<truncate>', '"[image]"') as input <else> input <endif>,
+                        <if(truncate)> replaceRegexpAll(output, '<truncate>', '"[image]"') as output <else> output <endif>
                     FROM traces
                     WHERE workspace_id = :workspace_id
                     ORDER BY id DESC, last_updated_at DESC

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -3774,7 +3774,7 @@ class DatasetsResourceTest {
                             .datasetItemId(datasetItemBatchWithImage.items().get(i).id()).build()).toList();
                     PodamFactoryUtils.manufacturePojoList(factory, ExperimentItem.class);
             var experimentItemsBatch = ExperimentItemsBatch.builder()
-                    .experimentItems(new HashSet<>(experimentItems)).build();
+                    .experimentItems(Set.copyOf(experimentItems)).build();
 
             createAndAssert(experimentItemsBatch, apiKey, workspaceName);
 
@@ -3813,6 +3813,7 @@ class DatasetsResourceTest {
 
                 assertPage(expectedDatasetItems, actualPage.content());
 
+                assertThat(actualPage.content()).hasSize(expectedDatasetItems.size());
                 for (int i = 0; i < expectedExperimentItems.size(); i++) {
                     assertThat(actualPage.content().get(i).experimentItems())
                             .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS_LIST)


### PR DESCRIPTION
## Details
In #651 truncation was added for dataset items but only truncated the `data` field.

This PR covers truncation for the `experimentItems` field as well.

## Issues
OPIK-433

## Testing
Extended the existing E2E test to cover the new behavior.
