### PR TITLE
[OPIK-285] allow users to specify function parameters to not log when using the track decorator

### DIFF
--- a/sdks/python/src/opik/decorator/arguments_helpers.py
+++ b/sdks/python/src/opik/decorator/arguments_helpers.py
@@ -50,6 +50,7 @@ class TrackOptions(BaseArguments):
     """
     A storage for all arguments passed to the `track` decorator.
     """
+
     name: Optional[str]
     type: SpanType
     tags: Optional[List[str]]

--- a/sdks/python/src/opik/decorator/arguments_helpers.py
+++ b/sdks/python/src/opik/decorator/arguments_helpers.py
@@ -56,7 +56,7 @@ class TrackOptions(BaseArguments):
     tags: Optional[List[str]]
     metadata: Optional[Dict[str, Any]]
     capture_input: bool
-    ignore: Optional[List[str]]
+    ignore_arguments: Optional[List[str]]
     capture_output: bool
     generations_aggregator: Optional[Callable[[List[Any]], Any]]
     flush: bool

--- a/sdks/python/src/opik/decorator/arguments_helpers.py
+++ b/sdks/python/src/opik/decorator/arguments_helpers.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, Dict, List
+from typing import Optional, Any, Dict, List, Callable
 from ..types import SpanType
 
 import dataclasses
@@ -43,3 +43,20 @@ class StartSpanParameters(BaseArguments):
     metadata: Optional[Dict[str, Any]] = None
     input: Optional[Dict[str, Any]] = None
     project_name: Optional[str] = None
+
+
+@dataclasses.dataclass
+class TrackOptions(BaseArguments):
+    """
+    A storage for all arguments passed to the `track` decorator.
+    """
+    name: Optional[str]
+    type: SpanType
+    tags: Optional[List[str]]
+    metadata: Optional[Dict[str, Any]]
+    capture_input: bool
+    ignore: Optional[List[str]]
+    capture_output: bool
+    generations_aggregator: Optional[Callable[[List[Any]], Any]]
+    flush: bool
+    project_name: Optional[str]

--- a/sdks/python/src/opik/decorator/base_track_decorator.py
+++ b/sdks/python/src/opik/decorator/base_track_decorator.py
@@ -99,7 +99,6 @@ class BaseTrackDecorator(abc.ABC):
             # Decorator was used without '()'. It means that decorated function
             # automatically passed as the first argument of 'track' function - name
             func = name
-            track_options.name = None
             return self._decorate(
                 func=func,
                 track_options=track_options,

--- a/sdks/python/src/opik/decorator/base_track_decorator.py
+++ b/sdks/python/src/opik/decorator/base_track_decorator.py
@@ -47,7 +47,7 @@ class BaseTrackDecorator(abc.ABC):
         tags: Optional[List[str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         capture_input: bool = True,
-        ignore: Optional[List[str]] = None,
+        ignore_arguments: Optional[List[str]] = None,
         capture_output: bool = True,
         generations_aggregator: Optional[Callable[[List[Any]], Any]] = None,
         flush: bool = False,
@@ -64,7 +64,7 @@ class BaseTrackDecorator(abc.ABC):
             tags: Tags to associate with the span.
             metadata: Metadata to associate with the span.
             capture_input: Whether to capture the input arguments.
-            ignore: The list of the arguments NOT to include into span/trace inputs.
+            ignore_arguments: The list of the arguments NOT to include into span/trace inputs.
             capture_output: Whether to capture the output result.
             generations_aggregator: Function to aggregate generation results.
             flush: Whether to flush the client after logging.
@@ -88,7 +88,7 @@ class BaseTrackDecorator(abc.ABC):
             tags=tags,
             metadata=metadata,
             capture_input=capture_input,
-            ignore=ignore,
+            ignore_arguments=ignore_arguments,
             capture_output=capture_output,
             generations_aggregator=generations_aggregator,
             flush=flush,

--- a/sdks/python/src/opik/decorator/tracker.py
+++ b/sdks/python/src/opik/decorator/tracker.py
@@ -28,7 +28,7 @@ class OpikTrackDecorator(base_track_decorator.BaseTrackDecorator):
             else None
         )
 
-        if track_options.ignore is not None:
+        if input is not None and track_options.ignore is not None:
             for argument in track_options.ignore:
                 input.pop(argument, None)
 

--- a/sdks/python/src/opik/decorator/tracker.py
+++ b/sdks/python/src/opik/decorator/tracker.py
@@ -28,6 +28,10 @@ class OpikTrackDecorator(base_track_decorator.BaseTrackDecorator):
             else None
         )
 
+        if track_options.ignore is not None:
+            for argument in track_options.ignore:
+                input.pop(argument, None)
+
         name = track_options.name if track_options.name is not None else func.__name__
 
         result = arguments_helpers.StartSpanParameters(

--- a/sdks/python/src/opik/decorator/tracker.py
+++ b/sdks/python/src/opik/decorator/tracker.py
@@ -28,8 +28,8 @@ class OpikTrackDecorator(base_track_decorator.BaseTrackDecorator):
             else None
         )
 
-        if input is not None and track_options.ignore is not None:
-            for argument in track_options.ignore:
+        if input is not None and track_options.ignore_arguments is not None:
+            for argument in track_options.ignore_arguments:
                 input.pop(argument, None)
 
         name = track_options.name if track_options.name is not None else func.__name__

--- a/sdks/python/src/opik/decorator/tracker.py
+++ b/sdks/python/src/opik/decorator/tracker.py
@@ -2,7 +2,6 @@ import logging
 
 from typing import List, Any, Dict, Optional, Callable, Tuple, Union
 
-from ..types import SpanType
 
 from . import inspect_helpers, arguments_helpers
 from ..api_objects import opik_client
@@ -19,30 +18,25 @@ class OpikTrackDecorator(base_track_decorator.BaseTrackDecorator):
     def _start_span_inputs_preprocessor(
         self,
         func: Callable,
-        name: Optional[str],
-        type: SpanType,
-        tags: Optional[List[str]],
-        metadata: Optional[Dict[str, Any]],
-        capture_input: bool,
+        track_options: arguments_helpers.TrackOptions,
         args: Tuple,
         kwargs: Dict[str, Any],
-        project_name: Optional[str],
     ) -> arguments_helpers.StartSpanParameters:
         input = (
             inspect_helpers.extract_inputs(func, args, kwargs)
-            if capture_input
+            if track_options.capture_input
             else None
         )
 
-        name = name if name is not None else func.__name__
+        name = track_options.name if track_options.name is not None else func.__name__
 
         result = arguments_helpers.StartSpanParameters(
             name=name,
             input=input,
-            type=type,
-            tags=tags,
-            metadata=metadata,
-            project_name=project_name,
+            type=track_options.type,
+            tags=track_options.tags,
+            metadata=track_options.metadata,
+            project_name=track_options.project_name,
         )
 
         return result

--- a/sdks/python/src/opik/integrations/anthropic/messages_create_decorator.py
+++ b/sdks/python/src/opik/integrations/anthropic/messages_create_decorator.py
@@ -1,6 +1,5 @@
 import logging
 from typing import List, Any, Dict, Optional, Callable, Tuple, Union
-from opik.types import SpanType
 from opik.decorator import base_track_decorator, arguments_helpers
 from opik import dict_utils
 
@@ -24,19 +23,15 @@ class AnthropicMessagesCreateDecorator(base_track_decorator.BaseTrackDecorator):
     def _start_span_inputs_preprocessor(
         self,
         func: Callable,
-        name: Optional[str],
-        type: SpanType,
-        tags: Optional[List[str]],
-        metadata: Optional[Dict[str, Any]],
-        capture_input: bool,
+        track_options: arguments_helpers.TrackOptions,
         args: Optional[Tuple],
         kwargs: Optional[Dict[str, Any]],
-        project_name: Optional[str],
     ) -> arguments_helpers.StartSpanParameters:
         assert (
             kwargs is not None
         ), "Expected kwargs to be not None in Antropic.messages.create(**kwargs)"
-        metadata = metadata if metadata is not None else {}
+        metadata = track_options.metadata if track_options.metadata is not None else {}
+        name = track_options.name if track_options.name is not None else func.__name__
 
         input, metadata_from_kwargs = dict_utils.split_dict_by_keys(
             kwargs, KWARGS_KEYS_TO_LOG_AS_INPUTS
@@ -44,15 +39,14 @@ class AnthropicMessagesCreateDecorator(base_track_decorator.BaseTrackDecorator):
         metadata.update(metadata_from_kwargs)
         metadata["created_from"] = "anthropic"
         tags = ["anthropic"]
-        name = name if name is not None else func.__name__
 
         result = arguments_helpers.StartSpanParameters(
             name=name,
             input=input,
-            type=type,
+            type=track_options.type,
             tags=tags,
             metadata=metadata,
-            project_name=project_name,
+            project_name=track_options.project_name,
         )
 
         return result

--- a/sdks/python/src/opik/integrations/bedrock/converse_decorator.py
+++ b/sdks/python/src/opik/integrations/bedrock/converse_decorator.py
@@ -1,7 +1,6 @@
 import logging
 from typing import List, Any, Dict, Optional, Callable, Tuple, Union, TypedDict, cast
 from opik import dict_utils
-from opik.types import SpanType
 from opik.decorator import base_track_decorator, arguments_helpers
 
 from . import stream_wrappers
@@ -33,20 +32,15 @@ class BedrockConverseDecorator(base_track_decorator.BaseTrackDecorator):
     def _start_span_inputs_preprocessor(
         self,
         func: Callable,
-        name: Optional[str],
-        type: SpanType,
-        tags: Optional[List[str]],
-        metadata: Optional[Dict[str, Any]],
-        capture_input: bool,
+        track_options: arguments_helpers.TrackOptions,
         args: Optional[Tuple],
         kwargs: Optional[Dict[str, Any]],
-        project_name: Optional[str],
     ) -> arguments_helpers.StartSpanParameters:
         assert (
             kwargs is not None
         ), "Expected kwargs to be not None in BedrockRuntime.Client.converse(**kwargs)"
 
-        name = name if name is not None else func.__name__
+        name = track_options.name if track_options.name is not None else func.__name__
         input, metadata = dict_utils.split_dict_by_keys(
             kwargs, KWARGS_KEYS_TO_LOG_AS_INPUTS
         )
@@ -56,10 +50,10 @@ class BedrockConverseDecorator(base_track_decorator.BaseTrackDecorator):
         result = arguments_helpers.StartSpanParameters(
             name=name,
             input=input,
-            type=type,
+            type=track_options.type,
             tags=tags,
             metadata=metadata,
-            project_name=project_name,
+            project_name=track_options.project_name,
         )
 
         return result

--- a/sdks/python/src/opik/integrations/openai/openai_decorator.py
+++ b/sdks/python/src/opik/integrations/openai/openai_decorator.py
@@ -2,7 +2,6 @@ import logging
 from typing import List, Any, Dict, Optional, Callable, Tuple, Union
 
 from opik import dict_utils
-from opik.types import SpanType
 from opik.decorator import base_track_decorator, arguments_helpers
 from . import stream_wrappers
 
@@ -30,20 +29,15 @@ class OpenaiTrackDecorator(base_track_decorator.BaseTrackDecorator):
     def _start_span_inputs_preprocessor(
         self,
         func: Callable,
-        name: Optional[str],
-        type: SpanType,
-        tags: Optional[List[str]],
-        metadata: Optional[Dict[str, Any]],
-        capture_input: bool,
+        track_options: arguments_helpers.TrackOptions,
         args: Optional[Tuple],
         kwargs: Optional[Dict[str, Any]],
-        project_name: Optional[str],
     ) -> arguments_helpers.StartSpanParameters:
         assert (
             kwargs is not None
         ), "Expected kwargs to be not None in OpenAI().chat.completion.create(**kwargs)"
-        name = name if name is not None else func.__name__
-        metadata = metadata if metadata is not None else {}
+        name = track_options.name if track_options.name is not None else func.__name__
+        metadata = track_options.metadata if track_options.metadata is not None else {}
 
         input, new_metadata = dict_utils.split_dict_by_keys(
             kwargs, keys=KWARGS_KEYS_TO_LOG_AS_INPUTS
@@ -61,10 +55,10 @@ class OpenaiTrackDecorator(base_track_decorator.BaseTrackDecorator):
         result = arguments_helpers.StartSpanParameters(
             name=name,
             input=input,
-            type=type,
+            type=track_options.type,
             tags=tags,
             metadata=metadata,
-            project_name=project_name,
+            project_name=track_options.project_name,
         )
 
         return result

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -990,7 +990,7 @@ def test_track__span_and_trace_updated_via_opik_context_with_feedback_scores__fe
 
 
 def test_tracker__ignore_list_was_passed__ignored_inputs_are_not_logged(fake_backend):
-    @tracker.track(ignore=["a", "c", "e"])
+    @tracker.track(ignore=["a", "c", "e", "unknown_argument"])
     def f(a, b, c=3, d=4, e=5):
         return {"some-key": "the-output-value"}
 
@@ -1009,6 +1009,38 @@ def test_tracker__ignore_list_was_passed__ignored_inputs_are_not_logged(fake_bac
                 id=ANY_BUT_NONE,
                 name="f",
                 input={"b": 2, "d": 4},
+                output={"some-key": "the-output-value"},
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                spans=[],
+            )
+        ],
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+    assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
+
+
+def test_tracker__ignore_list_was_passed__function_does_not_have_any_arguments__input_dicts_are_empty(fake_backend):
+    @tracker.track(ignore=["a", "c", "e", "unknown_argument"])
+    def f():
+        return {"some-key": "the-output-value"}
+
+    f()
+    tracker.flush_tracker()
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="f",
+        input={},
+        output={"some-key": "the-output-value"},
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                name="f",
+                input={},
                 output={"some-key": "the-output-value"},
                 start_time=ANY_BUT_NONE,
                 end_time=ANY_BUT_NONE,

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -1021,7 +1021,9 @@ def test_tracker__ignore_list_was_passed__ignored_inputs_are_not_logged(fake_bac
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
 
 
-def test_tracker__ignore_list_was_passed__function_does_not_have_any_arguments__input_dicts_are_empty(fake_backend):
+def test_tracker__ignore_list_was_passed__function_does_not_have_any_arguments__input_dicts_are_empty(
+    fake_backend,
+):
     @tracker.track(ignore=["a", "c", "e", "unknown_argument"])
     def f():
         return {"some-key": "the-output-value"}

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -987,3 +987,35 @@ def test_track__span_and_trace_updated_via_opik_context_with_feedback_scores__fe
     assert len(fake_backend.trace_trees) == 1
 
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
+
+
+def test_tracker__ignore_list_was_passed__ignored_inputs_are_not_logged(fake_backend):
+    @tracker.track(ignore=["a", "c", "e"])
+    def f(a, b, c=3, d=4, e=5):
+        return {"some-key": "the-output-value"}
+
+    f(1, 2)
+    tracker.flush_tracker()
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="f",
+        input={"b": 2, "d": 4},
+        output={"some-key": "the-output-value"},
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                name="f",
+                input={"b": 2, "d": 4},
+                output={"some-key": "the-output-value"},
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                spans=[],
+            )
+        ],
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+    assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -1279,3 +1279,35 @@ def test_track__span_and_trace_updated_via_opik_context_with_feedback_scores__fe
         assert len(fake_message_processor_.trace_trees) == 1
 
         assert_equal(EXPECTED_TRACE_TREE, fake_message_processor_.trace_trees[0])
+
+
+def test_tracker__ignore_list_was_passed__ignored_inputs_are_not_logged(fake_backend):
+    @tracker.track(ignore=["a", "c", "e"])
+    def f(a, b, c=3, d=4, e=5):
+        return {"some-key": "the-output-value"}
+
+    f(1, 2)
+    tracker.flush_tracker()
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="f",
+        input={"b": 2, "d": 4},
+        output={"some-key": "the-output-value"},
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                name="f",
+                input={"b": 2, "d": 4},
+                output={"some-key": "the-output-value"},
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                spans=[],
+            )
+        ],
+    )
+    
+    assert len(fake_backend.trace_trees) == 1
+    assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -1308,6 +1308,6 @@ def test_tracker__ignore_list_was_passed__ignored_inputs_are_not_logged(fake_bac
             )
         ],
     )
-    
+
     assert len(fake_backend.trace_trees) == 1
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -1279,35 +1279,3 @@ def test_track__span_and_trace_updated_via_opik_context_with_feedback_scores__fe
         assert len(fake_message_processor_.trace_trees) == 1
 
         assert_equal(EXPECTED_TRACE_TREE, fake_message_processor_.trace_trees[0])
-
-
-def test_tracker__ignore_list_was_passed__ignored_inputs_are_not_logged(fake_backend):
-    @tracker.track(ignore=["a", "c", "e"])
-    def f(a, b, c=3, d=4, e=5):
-        return {"some-key": "the-output-value"}
-
-    f(1, 2)
-    tracker.flush_tracker()
-
-    EXPECTED_TRACE_TREE = TraceModel(
-        id=ANY_BUT_NONE,
-        name="f",
-        input={"b": 2, "d": 4},
-        output={"some-key": "the-output-value"},
-        start_time=ANY_BUT_NONE,
-        end_time=ANY_BUT_NONE,
-        spans=[
-            SpanModel(
-                id=ANY_BUT_NONE,
-                name="f",
-                input={"b": 2, "d": 4},
-                output={"some-key": "the-output-value"},
-                start_time=ANY_BUT_NONE,
-                end_time=ANY_BUT_NONE,
-                spans=[],
-            )
-        ],
-    )
-
-    assert len(fake_backend.trace_trees) == 1
-    assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -990,7 +990,7 @@ def test_track__span_and_trace_updated_via_opik_context_with_feedback_scores__fe
 
 
 def test_tracker__ignore_list_was_passed__ignored_inputs_are_not_logged(fake_backend):
-    @tracker.track(ignore=["a", "c", "e", "unknown_argument"])
+    @tracker.track(ignore_arguments=["a", "c", "e", "unknown_argument"])
     def f(a, b, c=3, d=4, e=5):
         return {"some-key": "the-output-value"}
 
@@ -1024,7 +1024,7 @@ def test_tracker__ignore_list_was_passed__ignored_inputs_are_not_logged(fake_bac
 def test_tracker__ignore_list_was_passed__function_does_not_have_any_arguments__input_dicts_are_empty(
     fake_backend,
 ):
-    @tracker.track(ignore=["a", "c", "e", "unknown_argument"])
+    @tracker.track(ignore_arguments=["a", "c", "e", "unknown_argument"])
     def f():
         return {"some-key": "the-output-value"}
 


### PR DESCRIPTION
## Details
This PR allows to pass `ignore` parameter to the decorator so that corresponding decorated function arguments were not logged as span/trace inputs.
```python
 @track(ignore=["a", "c", "e"])
    def f(a, b, c=3, d=4, e=5):
        return {"some-key": "the-output-value"}

# will lead to the span input dict {"b": 2, "d": 4}
```
Base track decorator code was refactored, now it's easier to extend.
## Issues
https://github.com/comet-ml/opik/issues/468

## Testing
Unit tests are added.

## Documentation
Docstrings are added to track decorator
