### PR TITLE
[OPIK-445] LLama-index tests fix

### DIFF
--- a/.github/workflows/lib-llama-index-tests.yml
+++ b/.github/workflows/lib-llama-index-tests.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: sdks/python
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         python_version: ["3.8", "3.12"]
 

--- a/.github/workflows/lib-llama-index-tests.yml
+++ b/.github/workflows/lib-llama-index-tests.yml
@@ -19,9 +19,9 @@ jobs:
         working-directory: sdks/python
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        python_version: ["3.8", "3.12"]
+        python_version: ["3.9", "3.12"]
 
     steps:
       - name: Check out code

--- a/sdks/python/tests/library_integration/llama_index/test_llama_index.py
+++ b/sdks/python/tests/library_integration/llama_index/test_llama_index.py
@@ -69,8 +69,7 @@ def test_llama_index__happyflow(
     index = VectorStoreIndex.from_documents(documents)
 
     query_engine = index.as_query_engine()
-    response = query_engine.query("What did the author do growing up?")
-    print(response)
+    _ = query_engine.query("What did the author do growing up?")
 
     opik_callback_handler.flush()
 


### PR DESCRIPTION
## Details
Something is broken in llama-index when you try to install it for python 3.8, so you can't even import it due to some pydantic errors.
So I just bumped the minimal tested python version to 3.9 
