### PR TITLE
NO-JIRA: Remove amd64 architecture from docker compose

### DIFF
--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -61,7 +61,6 @@ services:
       dockerfile: Dockerfile
       args:
         OPIK_VERSION: ${OPIK_VERSION:-latest}
-    platform: linux/amd64
     hostname: backend
     command: [ "bash", "-c", "./run_db_migrations.sh && ./entrypoint.sh" ]
     environment:
@@ -104,7 +103,6 @@ services:
     build:
       context: ../../apps/opik-frontend
       dockerfile: Dockerfile
-    platform: linux/amd64
     hostname: frontend
     ports:
       - "5173:5173"


### PR DESCRIPTION
## Details
The Opik backend and frontend containers were hardcoded to be built on `linux/amd64`.

Removed that, so it builds in the native architecture of the user, such as arm64 etc.

## Issues

N/A

## Testing
I run `docker compose -f docker-compose.yaml -f docker-compose.override.yaml up -d --build` prior and after the change in my local Mac with arm64 architecture.

Prior to the change, the containers where built as amd64 and run in emulated mode.

After the change, they were built as arm64 and run natively. 

## Documentation
- https://docs.docker.com/reference/compose-file/build/#platforms
