### PR TITLE
NO-JIRA: Add generate Open API script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,9 @@
+# Scripts
+
+## General guidelines
+
+Scripts in this folder are meant to be run from the repository base folder. Example:
+
+```bash
+./scripts/generate_openapi.sh
+```

--- a/scripts/generate_openapi.sh
+++ b/scripts/generate_openapi.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+OPENAPI_YML_PATH="apps/opik-backend/target/openapi.yaml"
+
+# Generate openapi.yaml
+cd apps/opik-backend
+mvn compile swagger:resolve
+cd -
+
+# Copy openapi.yaml for Fern generation
+cp $OPENAPI_YML_PATH sdks/python/code_generation/fern/openapi/
+
+# Generate Python SDK with Fern from copied openapi.yaml
+cd sdks/python/code_generation
+fern generate
+cd -
+
+# Format Python code
+cd sdks/python
+pre-commit run --all-files
+cd -

--- a/sdks/python/code_generation/fern/generators.yml
+++ b/sdks/python/code_generation/fern/generators.yml
@@ -6,4 +6,4 @@ groups:
         version: 2.14.1
         output:
           location: local-file-system
-          path: ../sdks/python/code_generation
+          path: ../../src/opik/rest_api


### PR DESCRIPTION
## Details
New script which automates:
1. Generation of the latest `openapi.yaml` from the current backend.
2. Updates the `openapi.yaml` used for the Python SDK Fern generation.
3. Generates the Python Fern code.
4. Updates the latest Python Fern code.
5. Formats the Python code.

This way, the previous manual process can all be done just by running:

```bash
/scripts/generate_openapi.sh
```

## Issues

N/A

## Testing
- Run with the current Python SDK `openapi.yaml` and generates no changes.
- I'll send a follow-up PR with the latest `openapi.yaml` from the backend, as there are changes in the endpoints.

## Documentation
- https://buildwithfern.com/learn/sdks/introduction/overview
