### PR TITLE
Implement tracking for beta.chat.completions.parse method

### DIFF
--- a/apps/opik-documentation/documentation/docs/tracing/integrations/openai.md
+++ b/apps/opik-documentation/documentation/docs/tracing/integrations/openai.md
@@ -56,3 +56,12 @@ print(response.choices[0].message.content)
 The `track_openai` will automatically track and log the API call, including the input prompt, model used, and response generated. You can view these logs in your Opik project dashboard.
 
 By following these steps, you can seamlessly integrate Opik with the OpenAI Python SDK and gain valuable insights into your model's performance and usage.
+
+## Supported OpenAI methods
+
+The `track_openai` wrapper supports the following OpenAI methods:
+
+- `openai_client.chat.completions.create()`
+- `openai_client.beta.chat.completions.parse()`
+
+If you would like to track another OpenAI method, please let us know by opening an issue on [GitHub](https://github.com/comet-ml/opik/issues).

--- a/sdks/python/examples/openai_integration_example.py
+++ b/sdks/python/examples/openai_integration_example.py
@@ -10,6 +10,7 @@ client = OpenAI()
 
 client = opik_tracker.track_openai(client)
 
+
 @track()
 def f_with_structured_output_openai_call():
     class CalendarEvent(BaseModel):
@@ -21,7 +22,10 @@ def f_with_structured_output_openai_call():
         model="gpt-4o-2024-08-06",
         messages=[
             {"role": "system", "content": "Extract the event information."},
-            {"role": "user", "content": "Alice and Bob are going to a science fair on Friday."},
+            {
+                "role": "user",
+                "content": "Alice and Bob are going to a science fair on Friday.",
+            },
         ],
         response_format=CalendarEvent,
     )

--- a/sdks/python/src/opik/integrations/openai/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/openai/opik_tracker.py
@@ -33,4 +33,15 @@ def track_openai(
             openai_client.chat.completions.create
         )
 
+    if not hasattr(openai_client.beta.chat.completions.parse, "opik_tracked"):
+        completions_create_decorator = decorator_factory.track(
+            type="llm",
+            name="chat_completion_parse",
+            generations_aggregator=chat_completion_chunks_aggregator.aggregate,
+            project_name=project_name,
+        )
+        openai_client.beta.chat.completions.parse = completions_create_decorator(
+            openai_client.beta.chat.completions.parse
+        )
+
     return openai_client

--- a/sdks/python/src/opik/integrations/openai/stream_wrappers.py
+++ b/sdks/python/src/opik/integrations/openai/stream_wrappers.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Generator, Any, AsyncGenerator, List, Optional, Callable
+from typing import Iterator, AsyncIterator, Any, List, Optional, Callable
 from opik.api_objects import trace, span
 from opik.decorator import generator_wrappers
 from openai.types.chat import chat_completion_chunk
@@ -15,7 +15,7 @@ def wrap_sync_stream(
     trace_to_end: Optional[trace.TraceData],
     generations_aggregator: Callable[[List[Any]], Any],
     finally_callback: generator_wrappers.FinishGeneratorCallback,
-) -> Generator[Any, None, None]:
+) -> Iterator[chat_completion_chunk.ChatCompletionChunk]:
     items: List[chat_completion_chunk.ChatCompletionChunk] = []
 
     try:
@@ -41,7 +41,7 @@ async def wrap_async_stream(
     trace_to_end: Optional[trace.TraceData],
     generations_aggregator: Callable[[List[Any]], Any],
     finally_callback: generator_wrappers.FinishGeneratorCallback,
-) -> AsyncGenerator[Any, None]:
+) -> AsyncIterator[chat_completion_chunk.ChatCompletionChunk]:
     items: List[chat_completion_chunk.ChatCompletionChunk] = []
 
     try:

--- a/sdks/python/tests/library_integration/openai/test_openai.py
+++ b/sdks/python/tests/library_integration/openai/test_openai.py
@@ -2,6 +2,7 @@ import pytest
 import openai
 import os
 import asyncio
+from pydantic import BaseModel
 
 import opik
 from opik.integrations.openai import track_openai
@@ -485,6 +486,90 @@ def test_openai_client_chat_completions_create__async_openai_call_made_in_anothe
         "usage",
         "model",
         "max_tokens",
+        "created_from",
+        "type",
+        "id",
+        "created",
+        "object",
+    ]
+    assert_dict_has_keys(llm_span_metadata, REQUIRED_METADATA_KEYS)
+
+
+@pytest.mark.parametrize(
+    "project_name, expected_project_name",
+    [
+        (None, OPIK_PROJECT_DEFAULT_NAME),
+        ("openai-integration-test", "openai-integration-test"),
+    ],
+)
+def test_openai_client_beta_chat_completions_parse__happyflow(
+    fake_backend, project_name, expected_project_name
+):
+    client = openai.OpenAI()
+    wrapped_client = track_openai(client, project_name=project_name)
+
+    class CalendarEvent(BaseModel):
+        name: str
+        date: str
+        participants: list[str]
+
+    messages = [
+        {"role": "system", "content": "Extract the event information."},
+        {
+            "role": "user",
+            "content": "Alice and Bob are going to a science fair on Friday.",
+        },
+    ]
+
+    _ = wrapped_client.beta.chat.completions.parse(
+        model="gpt-4o",
+        messages=messages,
+        response_format=CalendarEvent,
+    )
+
+    opik.flush_tracker()
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="chat_completion_parse",
+        input={"messages": messages},
+        output={"choices": ANY_BUT_NONE},
+        tags=["openai"],
+        metadata=ANY_DICT,
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        project_name=expected_project_name,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="chat_completion_parse",
+                input={"messages": messages},
+                output={"choices": ANY_BUT_NONE},
+                tags=["openai"],
+                metadata=ANY_DICT,
+                usage={
+                    "prompt_tokens": ANY_BUT_NONE,
+                    "completion_tokens": ANY_BUT_NONE,
+                    "total_tokens": ANY_BUT_NONE,
+                },
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=expected_project_name,
+                spans=[],
+            )
+        ],
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)
+
+    llm_span_metadata = trace_tree.spans[0].metadata
+    REQUIRED_METADATA_KEYS = [
+        "usage",
+        "model",
         "created_from",
         "type",
         "id",

--- a/sdks/python/tests/library_integration/openai/test_openai.py
+++ b/sdks/python/tests/library_integration/openai/test_openai.py
@@ -3,6 +3,7 @@ import openai
 import os
 import asyncio
 from pydantic import BaseModel
+from typing import List
 
 import opik
 from opik.integrations.openai import track_openai
@@ -511,7 +512,7 @@ def test_openai_client_beta_chat_completions_parse__happyflow(
     class CalendarEvent(BaseModel):
         name: str
         date: str
-        participants: list[str]
+        participants: List[str]
 
     messages = [
         {"role": "system", "content": "Extract the event information."},


### PR DESCRIPTION
## Details

Updated the OpenAI integration to track `openai_client.beta.chat.completions.parse` calls:

```
from opik.integrations.openai import opik_tracker
from openai import OpenAI
from pydantic import BaseModel

client = opik_tracker.track_openai(OpenAI())

class CalendarEvent(BaseModel):
    name: str
    date: str
    participants: list[str]

completion = client.beta.chat.completions.parse(
    model="gpt-4o-2024-08-06",
    messages=[
        {"role": "system", "content": "Extract the event information."},
        {"role": "user", "content": "Alice and Bob are going to a science fair on Friday."},
    ],
    response_format=CalendarEvent,
)

print(completion)
```

## Issues

Resolves #706 

## Testing
Added a new end to end test and updated the `examples/openai_integration_example.py` method.

## Documentation
OpenAI integration page was updated