### PR TITLE
update_current_span now supports updating the output

### DIFF
--- a/sdks/python/src/opik/api_objects/span.py
+++ b/sdks/python/src/opik/api_objects/span.py
@@ -271,6 +271,12 @@ class SpanData:
             if key == "metadata":
                 self._update_metadata(value)
                 continue
+            elif key == "output":
+                self._update_output(value)
+                continue
+            elif key == "input":
+                self._update_input(value)
+                continue
 
             self.__dict__[key] = value
 
@@ -281,6 +287,18 @@ class SpanData:
             self.metadata = new_metadata
         else:
             self.metadata = dict_utils.deepmerge(self.metadata, new_metadata)
+
+    def _update_output(self, new_output: Dict[str, Any]) -> None:
+        if self.output is None:
+            self.output = new_output
+        else:
+            self.output = dict_utils.deepmerge(self.output, new_output)
+
+    def _update_input(self, new_input: Dict[str, Any]) -> None:
+        if self.input is None:
+            self.input = new_input
+        else:
+            self.input = dict_utils.deepmerge(self.input, new_input)
 
     def init_end_time(self) -> "SpanData":
         self.end_time = datetime_helpers.local_timestamp()

--- a/sdks/python/src/opik/api_objects/trace.py
+++ b/sdks/python/src/opik/api_objects/trace.py
@@ -242,6 +242,12 @@ class TraceData:
             if key == "metadata":
                 self._update_metadata(value)
                 continue
+            elif key == "output":
+                self._update_output(value)
+                continue
+            elif key == "input":
+                self._update_input(value)
+                continue
 
             self.__dict__[key] = value
 
@@ -252,6 +258,18 @@ class TraceData:
             self.metadata = new_metadata
         else:
             self.metadata = dict_utils.deepmerge(self.metadata, new_metadata)
+
+    def _update_output(self, new_output: Dict[str, Any]) -> None:
+        if self.output is None:
+            self.output = new_output
+        else:
+            self.output = dict_utils.deepmerge(self.output, new_output)
+
+    def _update_input(self, new_input: Dict[str, Any]) -> None:
+        if self.input is None:
+            self.input = new_input
+        else:
+            self.input = dict_utils.deepmerge(self.input, new_input)
 
     def init_end_time(self) -> "TraceData":
         self.end_time = datetime_helpers.local_timestamp()

--- a/sdks/python/src/opik/decorator/base_track_decorator.py
+++ b/sdks/python/src/opik/decorator/base_track_decorator.py
@@ -399,7 +399,7 @@ class BaseTrackDecorator(abc.ABC):
                 )
 
             client = opik_client.get_client_cached()
-            print("span_data_to_end", span_data_to_end)
+
             span_data_to_end.init_end_time().update(
                 **end_arguments.to_kwargs(),
             )

--- a/sdks/python/src/opik/decorator/base_track_decorator.py
+++ b/sdks/python/src/opik/decorator/base_track_decorator.py
@@ -399,7 +399,7 @@ class BaseTrackDecorator(abc.ABC):
                 )
 
             client = opik_client.get_client_cached()
-
+            print("span_data_to_end", span_data_to_end)
             span_data_to_end.init_end_time().update(
                 **end_arguments.to_kwargs(),
             )

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -936,6 +936,44 @@ def test_track__span_and_trace_updated_via_opik_context(fake_backend):
 
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
 
+def test_track__span_and_trace_output_updated_via_opik_context(fake_backend):
+    @tracker.track
+    def f(x):
+        opik_context.update_current_span(
+            output={"span-output-key": "span-output-value"},
+        )
+        opik_context.update_current_trace(
+            output={"trace-output-key": "trace-output-value"},
+        )
+
+        return "f-output"
+
+    f("f-input")
+    tracker.flush_tracker()
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="f",
+        input={"x": "f-input"},
+        output={"output": "f-output", "trace-output-key": "trace-output-value"},
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                name="f",
+                input={"x": "f-input"},
+                output={"output": "f-output", "span-output-key": "span-output-value"},
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                spans=[],
+            )
+        ],
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+
+    assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
 
 def test_track__span_and_trace_updated_via_opik_context_with_feedback_scores__feedback_scores_are_also_logged(
     fake_backend,
@@ -987,6 +1025,7 @@ def test_track__span_and_trace_updated_via_opik_context_with_feedback_scores__fe
     assert len(fake_backend.trace_trees) == 1
 
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
+
 
 
 def test_tracker__ignore_list_was_passed__ignored_inputs_are_not_logged(fake_backend):

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -936,6 +936,7 @@ def test_track__span_and_trace_updated_via_opik_context(fake_backend):
 
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
 
+
 def test_track__span_and_trace_output_updated_via_opik_context(fake_backend):
     @tracker.track
     def f(x):
@@ -974,6 +975,7 @@ def test_track__span_and_trace_output_updated_via_opik_context(fake_backend):
     assert len(fake_backend.trace_trees) == 1
 
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
+
 
 def test_track__span_and_trace_updated_via_opik_context_with_feedback_scores__feedback_scores_are_also_logged(
     fake_backend,
@@ -1025,7 +1027,6 @@ def test_track__span_and_trace_updated_via_opik_context_with_feedback_scores__fe
     assert len(fake_backend.trace_trees) == 1
 
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
-
 
 
 def test_tracker__ignore_list_was_passed__ignored_inputs_are_not_logged(fake_backend):

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -937,13 +937,15 @@ def test_track__span_and_trace_updated_via_opik_context(fake_backend):
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
 
 
-def test_track__span_and_trace_output_updated_via_opik_context(fake_backend):
+def test_track__span_and_trace_input_output_updated_via_opik_context(fake_backend):
     @tracker.track
     def f(x):
         opik_context.update_current_span(
+            input={"span-input-key": "span-input-value"},
             output={"span-output-key": "span-output-value"},
         )
         opik_context.update_current_trace(
+            input={"trace-input-key": "trace-input-value"},
             output={"trace-output-key": "trace-output-value"},
         )
 
@@ -955,7 +957,7 @@ def test_track__span_and_trace_output_updated_via_opik_context(fake_backend):
     EXPECTED_TRACE_TREE = TraceModel(
         id=ANY_BUT_NONE,
         name="f",
-        input={"x": "f-input"},
+        input={"x": "f-input", "trace-input-key": "trace-input-value"},
         output={"output": "f-output", "trace-output-key": "trace-output-value"},
         start_time=ANY_BUT_NONE,
         end_time=ANY_BUT_NONE,
@@ -963,7 +965,7 @@ def test_track__span_and_trace_output_updated_via_opik_context(fake_backend):
             SpanModel(
                 id=ANY_BUT_NONE,
                 name="f",
-                input={"x": "f-input"},
+                input={"x": "f-input", "span-input-key": "span-input-value"},
                 output={"output": "f-output", "span-output-key": "span-output-value"},
                 start_time=ANY_BUT_NONE,
                 end_time=ANY_BUT_NONE,


### PR DESCRIPTION
## Details

Updated the `update_current_span` and `update_current_trace` methods to not override `input` and `output` values but instead merge them with existing values.

## Issues

Resolves #708 

## Testing
Added unit test

## Documentation
No docs updated
