### PR TITLE
[OPIK-461] Text columns should wrap content in dataset table

### DIFF
--- a/apps/opik-frontend/src/components/shared/DataTableCells/TextCell.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableCells/TextCell.tsx
@@ -1,15 +1,27 @@
 import { CellContext } from "@tanstack/react-table";
 import CellWrapper from "@/components/shared/DataTableCells/CellWrapper";
+import { ROW_HEIGHT } from "@/types/shared";
 
 const TextCell = <TData,>(context: CellContext<TData, string>) => {
   const value = context.getValue();
+
+  const rowHeight =
+    context.column.columnDef.meta?.overrideRowHeight ??
+    context.table.options.meta?.rowHeight ??
+    ROW_HEIGHT.small;
+
+  const isSmall = rowHeight === ROW_HEIGHT.small;
 
   return (
     <CellWrapper
       metadata={context.column.columnDef.meta}
       tableMetadata={context.table.options.meta}
     >
-      <span className="truncate">{value}</span>
+      {isSmall ? (
+        <span className="truncate">{value}</span>
+      ) : (
+        <div className="size-full overflow-y-auto">{value}</div>
+      )}
     </CellWrapper>
   );
 };


### PR DESCRIPTION
## Details
![image](https://github.com/user-attachments/assets/5cf59be1-782d-438a-b701-477048973533)
![image](https://github.com/user-attachments/assets/2177513f-44dc-442c-a15a-37e8a25388fd)

## Issues

Resolves #526

## Testing

## Documentation
