### PR TITLE
[OPIK-395] Project Metrics - all but `usage`

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DataPoint.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DataPoint.java
@@ -5,4 +5,4 @@ import lombok.Builder;
 import java.time.Instant;
 
 @Builder(toBuilder = true)
-public record DataPoint(Instant time, Number value) {}
+public record DataPoint<T extends Number>(Instant time, T value) {}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DataPoint.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DataPoint.java
@@ -1,8 +1,13 @@
 package com.comet.opik.api;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.time.Instant;
 
 @Builder(toBuilder = true)
-public record DataPoint<T extends Number>(Instant time, T value) {}
+public record DataPoint<T extends Number>(
+        @NotNull Instant time,
+        @Nullable @JsonInclude(JsonInclude.Include.ALWAYS) T value) {}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DataPoint.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DataPoint.java
@@ -5,5 +5,4 @@ import lombok.Builder;
 import java.time.Instant;
 
 @Builder(toBuilder = true)
-public record DataPoint(Instant time, Number value) {
-}
+public record DataPoint(Instant time, Number value) {}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/metrics/ProjectMetricRequest.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/metrics/ProjectMetricRequest.java
@@ -15,6 +15,6 @@ import java.time.Instant;
 public record ProjectMetricRequest(
         @NonNull MetricType metricType,
         @NonNull TimeInterval interval,
-        Instant intervalStart,
-        Instant intervalEnd) {
+        @NonNull Instant intervalStart,
+        @NonNull Instant intervalEnd) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/metrics/ProjectMetricResponse.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/metrics/ProjectMetricResponse.java
@@ -13,11 +13,11 @@ import java.util.UUID;
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record ProjectMetricResponse(
+public record ProjectMetricResponse<T extends Number>(
         UUID projectId,
         MetricType metricType,
         TimeInterval interval,
-        List<Results> results) {
+        List<Results<T>> results) {
 
     public static final ProjectMetricResponse EMPTY = ProjectMetricResponse.builder()
             .results(List.of())
@@ -26,6 +26,6 @@ public record ProjectMetricResponse(
     @Builder(toBuilder = true)
     @JsonIgnoreProperties(ignoreUnknown = true)
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public record Results(String name, List<DataPoint> data) {
+    public record Results<T extends Number>(String name, List<DataPoint<T>> data) {
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
@@ -50,7 +50,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
 
     private static final String GET_TRACE_COUNT = """
             SELECT toStartOfInterval(start_time, <convert_interval>) AS bucket,
-                   count(DISTINCT id) as count
+                   nullIf(count(DISTINCT id), 0) as count
             FROM traces
             WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
@@ -83,7 +83,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             )
             SELECT toStartOfInterval(created_at, <convert_interval>) AS bucket,
                     name,
-                    avg(value) AS value
+                    nullIf(avg(value), 0) AS value
             FROM feedback_scores_deduplication
             WHERE created_at >= parseDateTime64BestEffort(:start_time, 9)
                 AND created_at \\<= parseDateTime64BestEffort(:end_time, 9)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
@@ -4,7 +4,6 @@ import com.comet.opik.api.TimeInterval;
 import com.comet.opik.api.metrics.ProjectMetricRequest;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.ImplementedBy;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.Result;
@@ -22,7 +21,6 @@ import reactor.core.publisher.Mono;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -35,8 +33,6 @@ import static com.comet.opik.utils.AsyncUtils.makeMonoContextAware;
 public interface ProjectMetricsDAO {
     @Builder
     record Entry(String name, Instant time, Number value) {}
-    @Builder
-    record DataPointMultiValue(Instant time, Map<String, Number> values) {}
 
     Mono<List<Entry>> getTraceCount(UUID projectId, ProjectMetricRequest request);
     Mono<List<Entry>> getFeedbackScores(UUID projectId, ProjectMetricRequest request);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
@@ -43,7 +43,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
 
     private static final String GET_TRACE_COUNT = """
             SELECT toStartOfInterval(start_time, <convert_interval>) AS bucket,
-                   count() as count
+                   count(DISTINCT id) as count
             FROM traces
             WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
@@ -89,7 +89,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
 
     private String intervalToSql(TimeInterval interval) {
         if (interval == TimeInterval.WEEKLY) {
-               return "toIntervalDay(7)";
+               return "toIntervalWeek(1)";
         }
         if (interval == TimeInterval.DAILY) {
             return "toIntervalDay(1)";

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
@@ -18,6 +18,7 @@ import org.reactivestreams.Publisher;
 import org.stringtemplate.v4.ST;
 import reactor.core.publisher.Mono;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -31,9 +32,12 @@ import static com.comet.opik.utils.AsyncUtils.makeMonoContextAware;
 @ImplementedBy(ProjectMetricsDAOImpl.class)
 public interface ProjectMetricsDAO {
     @Builder
+    record Entry(String name, Instant time, Number value) {}
+    @Builder
     record DataPointMultiValue(Instant time, Map<String, Number> values) {}
 
-    Mono<List<DataPointMultiValue>> getTraceCount(UUID projectId, ProjectMetricRequest request);
+    Mono<List<Entry>> getTraceCount(UUID projectId, ProjectMetricRequest request);
+    Mono<List<Entry>> getFeedbackScores(UUID projectId, ProjectMetricRequest request);
 }
 
 @Slf4j
@@ -51,7 +55,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
                 AND start_time >= parseDateTime64BestEffort(:start_time, 9)
-                AND end_time \\<= parseDateTime64BestEffort(:end_time, 9)
+                AND start_time \\<= parseDateTime64BestEffort(:end_time, 9)
             GROUP BY bucket
             ORDER BY bucket
             WITH FILL
@@ -60,11 +64,34 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                 STEP <convert_interval>;
             """;
 
+    private static final String GET_FEEDBACK_SCORES = """
+            SELECT toStartOfInterval(created_at, <convert_interval>) AS bucket,
+                    name,
+                    avg(value) AS value
+            FROM feedback_scores
+            WHERE project_id = :project_id
+                AND workspace_id = :workspace_id
+                AND created_at >= parseDateTime64BestEffort(:start_time, 9)
+                AND created_at \\<= parseDateTime64BestEffort(:end_time, 9)
+            GROUP BY name, bucket
+            ORDER BY name, bucket
+            WITH FILL
+                FROM parseDateTimeBestEffort(:start_time)
+                TO parseDateTimeBestEffort(:end_time)
+                STEP <convert_interval>;
+            """;
+
     @Override
-    public Mono<List<DataPointMultiValue>> getTraceCount(
-            UUID projectId, ProjectMetricRequest request) {
+    public Mono<List<Entry>> getTraceCount(UUID projectId, ProjectMetricRequest request) {
         return template.nonTransaction(connection -> getTracesCountForProject(projectId, request, connection)
                 .flatMapMany(this::mapToIntDataPoint)
+                .collectList());
+    }
+
+    @Override
+    public Mono<List<Entry>> getFeedbackScores(UUID projectId, ProjectMetricRequest request) {
+        return template.nonTransaction(connection -> getFeedbackScoresForProject(projectId, request, connection)
+                .flatMapMany(this::mapToBigDecimalDataPoint)
                 .collectList());
     }
 
@@ -83,10 +110,38 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                 .doFinally(signalType -> endSegment(segment));
     }
 
-    private Publisher<DataPointMultiValue> mapToIntDataPoint(Result result) {
-        return result.map(((row, rowMetadata) -> DataPointMultiValue.builder()
+    private Mono<? extends Result> getFeedbackScoresForProject(
+            UUID projectId, ProjectMetricRequest request, Connection connection) {
+        var template = new ST(GET_FEEDBACK_SCORES)
+                .add("convert_interval", intervalToSql(request.interval()));
+        var statement = connection.createStatement(template.render())
+                .bind("project_id", projectId)
+                .bind("start_time", request.intervalStart().toString())
+                .bind("end_time", request.intervalEnd().toString());
+
+        InstrumentAsyncUtils.Segment segment = startSegment("feedbackScores", "Clickhouse", "get");
+
+        return makeMonoContextAware(bindWorkspaceIdToMono(statement))
+                .doFinally(signalType -> endSegment(segment));
+    }
+
+    private Publisher<Entry> mapToIntDataPoint(Result result) {
+//        return result.map(((row, rowMetadata) -> DataPointMultiValue.builder()
+//                .time(row.get("bucket", Instant.class))
+//                .values(ImmutableMap.of(NAME_TRACES, row.get("count", Integer.class)))
+//                .build()));
+        return result.map(((row, rowMetadata) -> Entry.builder()
+                .name(NAME_TRACES)
                 .time(row.get("bucket", Instant.class))
-                .values(ImmutableMap.of(NAME_TRACES, row.get("count", Integer.class)))
+                .value(row.get("count", Integer.class))
+                .build()));
+    }
+
+    private Publisher<Entry> mapToBigDecimalDataPoint(Result result) {
+        return result.map(((row, rowMetadata) -> Entry.builder()
+                .name(row.get("name", String.class))
+                .time(row.get("bucket", Instant.class))
+                .value(row.get("value", BigDecimal.class))
                 .build()));
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
@@ -3,6 +3,7 @@ package com.comet.opik.domain;
 import com.comet.opik.api.DataPoint;
 import com.comet.opik.api.metrics.ProjectMetricRequest;
 import com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.ImplementedBy;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.Result;
@@ -32,6 +33,8 @@ public interface ProjectMetricsDAO {
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
+    public static final String NAME_TRACES = "traces";
+
     private static final String GET_TRACE_COUNT = """
             SELECT toStartOfInterval(start_time, toIntervalHour(1)) AS bucket,
                    count() as count
@@ -73,7 +76,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
     private Publisher<DataPoint> mapToIntDataPoint(Result result) {
         return result.map(((row, rowMetadata) -> DataPoint.builder()
                 .time(row.get("bucket", Instant.class))
-                .value(row.get("count", Integer.class))
+                .values(ImmutableMap.of(NAME_TRACES, row.get("count", Integer.class)))
                 .build()));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsService.java
@@ -23,7 +23,7 @@ public interface ProjectMetricsService {
     String ERR_START_BEFORE_END = "'start_time' must be before 'end_time'";
     String ERR_PROJECT_METRIC_NOT_SUPPORTED = "metric '%s' is not supported";
 
-    Mono<ProjectMetricResponse> getProjectMetrics(UUID projectId, ProjectMetricRequest request);
+    Mono<ProjectMetricResponse<Number>> getProjectMetrics(UUID projectId, ProjectMetricRequest request);
 }
 
 @Slf4j
@@ -33,7 +33,7 @@ class ProjectMetricsServiceImpl implements ProjectMetricsService {
     private final @NonNull ProjectMetricsDAO projectMetricsDAO;
 
     @Override
-    public Mono<ProjectMetricResponse> getProjectMetrics(UUID projectId, ProjectMetricRequest request) {
+    public Mono<ProjectMetricResponse<Number>> getProjectMetrics(UUID projectId, ProjectMetricRequest request) {
         validate(request);
 
         return handlerFactory(request).apply(projectId, request)
@@ -51,7 +51,7 @@ class ProjectMetricsServiceImpl implements ProjectMetricsService {
         }
     }
 
-    private List<ProjectMetricResponse.Results> entriesToResults(List<ProjectMetricsDAO.Entry> entries) {
+    private List<ProjectMetricResponse.Results<Number>> entriesToResults(List<ProjectMetricsDAO.Entry> entries) {
         if (entries.isEmpty()) {
             return List.of();
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsService.java
@@ -57,6 +57,7 @@ class ProjectMetricsServiceImpl implements ProjectMetricsService {
         }
 
         return entries.stream()
+                // transform into map: name -> data points list
                 .collect(Collectors.groupingBy(
                         ProjectMetricsDAO.Entry::name,
                         Collectors.mapping(
@@ -67,6 +68,7 @@ class ProjectMetricsServiceImpl implements ProjectMetricsService {
                                 Collectors.toList()
                         )
                 ))
+                // transform into a list of results
                 .entrySet().stream().map(entry -> ProjectMetricResponse.Results.builder()
                         .name(entry.getKey())
                         .data(entry.getValue())

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsService.java
@@ -4,20 +4,18 @@ import com.comet.opik.api.DataPoint;
 import com.comet.opik.api.metrics.MetricType;
 import com.comet.opik.api.metrics.ProjectMetricRequest;
 import com.comet.opik.api.metrics.ProjectMetricResponse;
-import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.google.inject.ImplementedBy;
-import io.r2dbc.spi.Connection;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.BadRequestException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.function.TriFunction;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.function.BiFunction;
 
 @ImplementedBy(ProjectMetricsServiceImpl.class)
 public interface ProjectMetricsService {
@@ -31,24 +29,19 @@ public interface ProjectMetricsService {
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 class ProjectMetricsServiceImpl implements ProjectMetricsService {
-    private final @NonNull TransactionTemplateAsync template;
     private final @NonNull ProjectMetricsDAO projectMetricsDAO;
-
-    public static final String NAME_TRACES = "traces";
 
     @Override
     public Mono<ProjectMetricResponse> getProjectMetrics(UUID projectId, ProjectMetricRequest request) {
         validate(request);
 
-        var handler = handlerFactory(request);
-
-        return template.nonTransaction(connection -> handler.apply(projectId, request, connection)
+        return handlerFactory(request).apply(projectId, request)
                 .map(dataPoints -> ProjectMetricResponse.builder()
                         .projectId(projectId)
                         .metricType(request.metricType())
                         .interval(request.interval())
                         .results(dataPointsToResults(dataPoints))
-                        .build()));
+                        .build());
     }
 
     private void validate(ProjectMetricRequest request) {
@@ -74,8 +67,8 @@ class ProjectMetricsServiceImpl implements ProjectMetricsService {
                         .build()).toList();
     }
 
-    private TriFunction<UUID, ProjectMetricRequest, Connection, Mono<List<ProjectMetricsDAO.DataPointMultiValue>>>
-    handlerFactory(ProjectMetricRequest request) {
+    private BiFunction<UUID, ProjectMetricRequest, Mono<List<ProjectMetricsDAO.DataPointMultiValue>>> handlerFactory(
+            ProjectMetricRequest request) {
         if (request.metricType() == MetricType.TRACE_COUNT) {
             return projectMetricsDAO::getTraceCount;
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsService.java
@@ -1,5 +1,6 @@
 package com.comet.opik.domain;
 
+import com.comet.opik.api.DataPoint;
 import com.comet.opik.api.metrics.ProjectMetricRequest;
 import com.comet.opik.api.metrics.ProjectMetricResponse;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
@@ -14,6 +15,8 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.UUID;
+
+import static com.comet.opik.domain.ProjectMetricsDAOImpl.NAME_TRACES;
 
 @ImplementedBy(ProjectMetricsServiceImpl.class)
 public interface ProjectMetricsService {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
@@ -528,7 +528,7 @@ class ProjectMetricsResourceTest {
                                         .build())
                                 .toList();
 
-                        traceResourceClient.feedbackScore(scores, API_KEY, WORKSPACE_NAME);
+                        traceResourceClient.feedbackScores(scores, API_KEY, WORKSPACE_NAME);
                         setCreatedAt(trace.id(), marker.plus(i, ChronoUnit.SECONDS));
 
                         return scores;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
@@ -31,6 +31,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -345,10 +346,9 @@ class ProjectMetricsResourceTest {
                             .intervalEnd(now)
                             .build()), ProjectMetricsService.ERR_START_BEFORE_END),
                     arguments(named("not supported metric", validReq.toBuilder()
-                            .metricType(MetricType.NUMBER_OF_TRACES)
-                            .aggregation(AggregationType.PERCENTILE)
+                            .metricType(MetricType.TOKEN_USAGE)
                             .build()), ProjectMetricsService.ERR_PROJECT_METRIC_NOT_SUPPORTED.formatted(
-                                    MetricType.NUMBER_OF_TRACES, AggregationType.PERCENTILE)));
+                                    MetricType.TOKEN_USAGE)));
         }
 
         private void createTraces(String projectName, Instant marker, int count) {
@@ -364,6 +364,7 @@ class ProjectMetricsResourceTest {
     @Nested
     @DisplayName("Feedback scores")
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @Disabled
     class FeedbackScoresTest {
         @Test
         void happyPath() {
@@ -378,9 +379,8 @@ class ProjectMetricsResourceTest {
             var response = getProjectMetrics(projectId, ProjectMetricRequest.builder()
                     .metricType(MetricType.FEEDBACK_SCORES)
                     .interval(TimeInterval.HOURLY)
-                    .startTimestamp(marker.minus(4, ChronoUnit.HOURS))
-                    .endTimestamp(Instant.now())
-                    .aggregation(AggregationType.SUM)
+                    .intervalStart(marker.minus(4, ChronoUnit.HOURS))
+                    .intervalEnd(Instant.now())
                     .build());
 
             // assertions

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
@@ -377,7 +377,6 @@ class ProjectMetricsResourceTest {
     @Nested
     @DisplayName("Feedback scores")
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    @Disabled
     class FeedbackScoresTest {
         @ParameterizedTest
         @EnumSource(TimeInterval.class)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
@@ -60,6 +60,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -313,7 +314,7 @@ class ProjectMetricsResourceTest {
             assertThat(response.results()).hasSize(1);
 
             assertThat(response.results().getFirst().data()).hasSize(5);
-            var expectedTraceCounts = List.of(0, 3, 0, 2, 1);
+            var expectedTraceCounts = Arrays.asList(null, 3, null, 2, 1);
             assertThat(response.results().getLast().data()).isEqualTo(IntStream.range(0, 5)
                     .mapToObj(i -> DataPoint.builder()
                             .time(subtract(marker, 4 - i, interval))
@@ -430,10 +431,10 @@ class ProjectMetricsResourceTest {
                 Map<String, BigDecimal> scoresMinus1, Map<String, BigDecimal> scores) {
             return names.stream()
                     .map(name -> {
-                        var expectedFeedbackScores = List.of(
-                                BigDecimal.ZERO,
+                        var expectedFeedbackScores = Arrays.asList(
+                                null,
                                 scoresMinus3.get(name),
-                                BigDecimal.ZERO,
+                                null,
                                 scoresMinus1.get(name),
                                 scores.get(name));
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
@@ -366,7 +366,15 @@ class ProjectMetricsResourceTest {
                     arguments(named("not supported metric", validReq.toBuilder()
                             .metricType(MetricType.TOKEN_USAGE)
                             .build()), ProjectMetricsService.ERR_PROJECT_METRIC_NOT_SUPPORTED.formatted(
-                                    MetricType.TOKEN_USAGE)));
+                                    MetricType.TOKEN_USAGE)),
+                    arguments(named("all time hourly", validReq.toBuilder()
+                            .intervalStart(null)
+                            .interval(TimeInterval.HOURLY)
+                            .build()), ProjectMetricsService.ERR_NULL_START_NOT_WEEKLY),
+                    arguments(named("all time daily", validReq.toBuilder()
+                            .intervalStart(null)
+                            .interval(TimeInterval.DAILY)
+                            .build()), ProjectMetricsService.ERR_NULL_START_NOT_WEEKLY));
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
@@ -6,6 +6,7 @@ import com.comet.opik.api.Trace;
 import com.comet.opik.api.metrics.MetricType;
 import com.comet.opik.api.metrics.ProjectMetricRequest;
 import com.comet.opik.api.metrics.ProjectMetricResponse;
+import com.comet.opik.api.Trace;
 import com.comet.opik.api.resources.utils.AuthTestUtils;
 import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
 import com.comet.opik.api.resources.utils.ClientSupportUtils;
@@ -342,7 +343,12 @@ class ProjectMetricsResourceTest {
                     arguments(named("start equal to end", validReq.toBuilder()
                             .intervalStart(now)
                             .intervalEnd(now)
-                            .build()), ProjectMetricsService.ERR_START_BEFORE_END));
+                            .build()), ProjectMetricsService.ERR_START_BEFORE_END),
+                    arguments(named("not supported metric", validReq.toBuilder()
+                            .metricType(MetricType.NUMBER_OF_TRACES)
+                            .aggregation(AggregationType.PERCENTILE)
+                            .build()), ProjectMetricsService.ERR_PROJECT_METRIC_NOT_SUPPORTED.formatted(
+                                    MetricType.NUMBER_OF_TRACES, AggregationType.PERCENTILE)));
         }
 
         private void createTraces(String projectName, Instant marker, int count) {
@@ -350,8 +356,7 @@ class ProjectMetricsResourceTest {
                     .mapToObj(i -> factory.manufacturePojo(Trace.class).toBuilder()
                             .projectName(projectName)
                             .startTime(marker.plus(i, ChronoUnit.SECONDS))
-                            .build())
-                    .toList();
+                            .build()).toList();
             traceResourceClient.batchCreateTraces(traces, API_KEY, WORKSPACE_NAME);
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
@@ -55,7 +55,10 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.SQLException;
+import java.time.DayOfWeek;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
@@ -558,7 +561,19 @@ class ProjectMetricsResourceTest {
     }
 
     private static Instant getIntervalStart(TimeInterval interval) {
+        if (interval == TimeInterval.WEEKLY) {
+            return findLastMonday(LocalDate.now()).atStartOfDay(ZoneId.of("UTC")).toInstant();
+        }
+
         return Instant.now().truncatedTo(interval == TimeInterval.HOURLY ? ChronoUnit.HOURS :
                 ChronoUnit.DAYS);
+    }
+
+    private static LocalDate findLastMonday(LocalDate today) {
+        if (today.getDayOfWeek() == DayOfWeek.MONDAY) {
+            return today;
+        }
+
+        return today.minusDays(today.getDayOfWeek().getValue() - DayOfWeek.MONDAY.getValue());
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
@@ -6,7 +6,6 @@ import com.comet.opik.api.Trace;
 import com.comet.opik.api.metrics.MetricType;
 import com.comet.opik.api.metrics.ProjectMetricRequest;
 import com.comet.opik.api.metrics.ProjectMetricResponse;
-import com.comet.opik.api.Trace;
 import com.comet.opik.api.resources.utils.AuthTestUtils;
 import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
 import com.comet.opik.api.resources.utils.ClientSupportUtils;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
@@ -308,14 +308,15 @@ class ProjectMetricsResourceTest {
                     .intervalEnd(Instant.now())
                     .build(), Integer.class);
 
+            var expectedTraceCounts = Arrays.asList(null, 3, null, 2, 1);
+
             // assertions
             assertThat(response.projectId()).isEqualTo(projectId);
             assertThat(response.metricType()).isEqualTo(MetricType.TRACE_COUNT);
             assertThat(response.interval()).isEqualTo(interval);
             assertThat(response.results()).hasSize(1);
 
-            assertThat(response.results().getFirst().data()).hasSize(5);
-            var expectedTraceCounts = Arrays.asList(null, 3, null, 2, 1);
+            assertThat(response.results().getFirst().data()).hasSize(expectedTraceCounts.size());
             assertThat(response.results().getLast().data()).isEqualTo(IntStream.range(0, expectedTraceCounts.size())
                     .mapToObj(i -> DataPoint.builder()
                             .time(subtract(marker, expectedTraceCounts.size() - i - 1, interval))
@@ -388,14 +389,15 @@ class ProjectMetricsResourceTest {
                     .interval(TimeInterval.WEEKLY)
                     .build(), Integer.class);
 
+            var expectedTraceCounts = Arrays.asList(null, null, null, null, null, null, null, null, 3, null, 2, 1);
+
             // assertions
             assertThat(response.projectId()).isEqualTo(projectId);
             assertThat(response.metricType()).isEqualTo(MetricType.TRACE_COUNT);
             assertThat(response.interval()).isEqualTo(TimeInterval.WEEKLY);
             assertThat(response.results()).hasSize(1);
 
-            assertThat(response.results().getFirst().data()).hasSize(5);
-            var expectedTraceCounts = Arrays.asList(null, null, null, null, null, null, null, null, 3, null, 2, 1);
+            assertThat(response.results().getFirst().data()).hasSize(expectedTraceCounts.size());
             assertThat(response.results().getLast().data()).isEqualTo(IntStream.range(0, expectedTraceCounts.size())
                     .mapToObj(i -> DataPoint.builder()
                             .time(subtract(marker, expectedTraceCounts.size() - i - 1, TimeInterval.WEEKLY))

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
@@ -458,7 +458,8 @@ class ProjectMetricsResourceTest {
                     .satisfies(a -> assertThat(actual.subtract(expected).abs()).isLessThanOrEqualTo(delta));
         }
 
-        private Map<String, BigDecimal> createFeedbackScores(String projectName, Instant marker, List<String> scoreNames) {
+        private Map<String, BigDecimal> createFeedbackScores(
+                String projectName, Instant marker, List<String> scoreNames) {
             return IntStream.range(0, 5)
                     .mapToObj(i -> {
                         // create a trace
@@ -512,7 +513,8 @@ class ProjectMetricsResourceTest {
         }
     }
 
-    private <T extends Number> ProjectMetricResponse<T> getProjectMetrics(UUID projectId, ProjectMetricRequest request, Class<T> aClass) {
+    private <T extends Number> ProjectMetricResponse<T> getProjectMetrics(
+            UUID projectId, ProjectMetricRequest request, Class<T> aClass) {
         try (var response = client.target(URL_TEMPLATE.formatted(baseURI, projectId))
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, API_KEY)


### PR DESCRIPTION
## Details
This PR extends the MVP implemented in #678 to have the additional following functionality:
1. Support all interval types
2. ~Support null range, i.e. "all time"~ - product requirements changed, these changes are reverted
3. `null` back-fill instead of `0`
4. Feedback scores metric implementation

This PR doesn't include the `usage` metric which will be introduced in a later PR

## Issues
Partially resolves OPIK-395

## Testing
Added several E2E tests to cover the newly added scenarios.
