### PR TITLE
[NA] Update setup.py dependencies

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -38,8 +38,8 @@ setup(
     install_requires=[
         "click",
         "httpx<1.0.0",
-        "levenshtein~=0.25.1",
-        "litellm",
+        "levenshtein<1.0.0",
+        "litellm>=1.52.15",
         "openai<2.0.0",
         "pydantic-settings>=2.0.0,<3.0.0",
         "pydantic>=2.0.0,<3.0.0",


### PR DESCRIPTION
## Details
LiteLLM minimal version is bumped because they fixed a few bugs that were impacting our metrics.
Levenshtein version relaxed to "less than next major version".
