### PR TITLE
[OPIK-288]: make sidebars close after clicking outside;

### DIFF
--- a/apps/opik-frontend/src/components/shared/ResizableSidePanel/ResizableSidePanel.tsx
+++ b/apps/opik-frontend/src/components/shared/ResizableSidePanel/ResizableSidePanel.tsx
@@ -149,7 +149,7 @@ const ResizableSidePanel: React.FunctionComponent<ResizableSidePanelProps> = ({
   return createPortal(
     <div className="relative z-10">
       {open && closeOnClickOutside && (
-        <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+        <div className="fixed inset-0 bg-black/10" onClick={onClose} />
       )}
       {open && (
         <div

--- a/apps/opik-frontend/src/components/shared/ResizableSidePanel/ResizableSidePanel.tsx
+++ b/apps/opik-frontend/src/components/shared/ResizableSidePanel/ResizableSidePanel.tsx
@@ -24,7 +24,10 @@ type ResizableSidePanelProps = {
   onRowChange?: (shift: number) => void;
   initialWidth?: number;
   ignoreHotkeys?: boolean;
+  closeOnClickOutside?: boolean;
 };
+
+// ALEX
 
 const ResizableSidePanel: React.FunctionComponent<ResizableSidePanelProps> = ({
   panelId,
@@ -38,6 +41,7 @@ const ResizableSidePanel: React.FunctionComponent<ResizableSidePanelProps> = ({
   onRowChange,
   initialWidth = INITIAL_WIDTH,
   ignoreHotkeys = false,
+  closeOnClickOutside = true,
 }) => {
   const localStorageKey = `${panelId}-side-panel-width`;
 
@@ -146,6 +150,9 @@ const ResizableSidePanel: React.FunctionComponent<ResizableSidePanelProps> = ({
 
   return createPortal(
     <div className="relative z-10">
+      {open && closeOnClickOutside && (
+        <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+      )}
       {open && (
         <div
           className="fixed inset-0 translate-x-0 bg-background shadow-xl"

--- a/apps/opik-frontend/src/components/shared/ResizableSidePanel/ResizableSidePanel.tsx
+++ b/apps/opik-frontend/src/components/shared/ResizableSidePanel/ResizableSidePanel.tsx
@@ -27,8 +27,6 @@ type ResizableSidePanelProps = {
   closeOnClickOutside?: boolean;
 };
 
-// ALEX
-
 const ResizableSidePanel: React.FunctionComponent<ResizableSidePanelProps> = ({
   panelId,
   children,


### PR DESCRIPTION
## Details
Added a prop to ResizableSidePanel to be able to be closed on clicking outside;
<img width="1209" alt="image" src="https://github.com/user-attachments/assets/b76172c8-a2ab-4186-a12d-09fcca89aecb">

## Issues

Resolves #

## Testing

## Documentation
