### PR TITLE
[OPIK-487] Fix null pointer

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
@@ -300,7 +300,8 @@ public class SpanService {
 
     public Mono<ProjectStats> getStats(@NonNull SpanSearchCriteria criteria) {
         if (criteria.projectId() != null) {
-            return spanDAO.getStats(criteria);
+            return spanDAO.getStats(criteria)
+                    .switchIfEmpty(Mono.just(ProjectStats.empty()));
         }
 
         return makeMonoContextAware(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -356,7 +356,8 @@ class TraceServiceImpl implements TraceService {
     public Mono<ProjectStats> getStats(@NonNull TraceSearchCriteria criteria) {
 
         if (criteria.projectId() != null) {
-            return dao.getStats(criteria);
+            return dao.getStats(criteria)
+                    .switchIfEmpty(Mono.just(ProjectStats.empty()));
         }
 
         return getProjectByName(criteria.projectName())

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -4848,6 +4848,15 @@ class SpansResourceTest {
     class GetSpanStats {
 
         @Test
+        @DisplayName("when project id does not exist, then return empty list")
+        void getSpanStats__whenProjectIdDoesNotExist__thenReturnEmptyList() {
+
+            UUID projectId = generator.generate();
+
+            getStatsAndAssert(null, projectId, null, null, null, API_KEY, TEST_WORKSPACE, List.of());
+        }
+
+        @Test
         void findWithUsage() {
             var projectName = RandomStringUtils.randomAlphanumeric(10);
             var spans = PodamFactoryUtils.manufacturePojoList(podamFactory, Span.class).stream()

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -4948,6 +4948,15 @@ class TracesResourceTest {
     class GetTraceStats {
 
         @Test
+        @DisplayName("when project id does not exist, then return empty list")
+        void getTraceStats__whenProjectIdDoesNotExist__thenReturnEmptyList() {
+
+            UUID projectId = generator.generate();
+
+            getStatsAndAssert(null, projectId, null, API_KEY, TEST_WORKSPACE, List.of());
+        }
+
+        @Test
         @DisplayName("when project name and project id are null, then return bad request")
         void getTraceStats__whenProjectNameAndIdAreNull__thenReturnBadRequest() {
 


### PR DESCRIPTION
## Details
Fix for error:

```
Cannot invoke "com.comet.opik.api.ProjectStats.stats()" because "projectStats" is null
```

## Issues
OPIK-487