### PR TITLE
[OPIK-495] Don't return model and provider in payload instead of empty sting if missing

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -1038,8 +1038,12 @@ class SpanDAO {
                             .filter(str -> !str.isBlank())
                             .map(JsonUtils::getJsonNodeFromString)
                             .orElse(null))
-                    .model(row.get("model", String.class))
-                    .provider(row.get("provider", String.class))
+                    .model(StringUtils.isBlank(row.get("model", String.class))
+                            ? null
+                            : row.get("model", String.class))
+                    .provider(StringUtils.isBlank(row.get("provider", String.class))
+                            ? null
+                            : row.get("provider", String.class))
                     .totalEstimatedCost(
                             row.get("total_estimated_cost", BigDecimal.class).compareTo(BigDecimal.ZERO) == 0
                                     ? null

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -3321,10 +3321,10 @@ class SpansResourceTest {
                 Arguments.of(Map.of("completion_tokens", Math.abs(podamFactory.manufacturePojo(Integer.class)),
                         "prompt_tokens", Math.abs(podamFactory.manufacturePojo(Integer.class))), "gpt-3.5-turbo-1106", metadata),
                 Arguments.of(Map.of("completion_tokens", Math.abs(podamFactory.manufacturePojo(Integer.class)),
-                        "prompt_tokens", Math.abs(podamFactory.manufacturePojo(Integer.class))), "", metadata),
+                        "prompt_tokens", Math.abs(podamFactory.manufacturePojo(Integer.class))), null, metadata),
                 Arguments.of(null, "gpt-3.5-turbo-1106", null),
                 Arguments.of(null, "unknown-model", null),
-                Arguments.of(null, "", null));
+                Arguments.of(null, null, null));
     }
 
     @Test


### PR DESCRIPTION
## Details
Don't return model and provider in payload instead of empty sting if missing

## Testing
Updated corresponding test
