### PR TITLE
[OPIK-437]: add fe cost chart

### DIFF
--- a/apps/opik-frontend/src/api/projects/useProjectMetric.ts
+++ b/apps/opik-frontend/src/api/projects/useProjectMetric.ts
@@ -7,6 +7,7 @@ export enum METRIC_NAME_TYPE {
   TRACE_COUNT = "TRACE_COUNT",
   DURATION = "DURATION",
   TOKEN_USAGE = "TOKEN_USAGE",
+  COST = "COST",
 }
 
 export enum INTERVAL_TYPE {

--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/charts/ExperimentChartContainer.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/charts/ExperimentChartContainer.tsx
@@ -62,7 +62,13 @@ const ExperimentChartContainer: React.FC<ExperimentChartContainerProps> = ({
     }, []);
   }, [chartData.data]);
 
-  const { width: tickWidth } = useChartTickDefaultConfig(values);
+  const {
+    width: tickWidth,
+    ticks,
+    domain,
+    tickFormatter,
+    interval: tickInterval,
+  } = useChartTickDefaultConfig(values);
 
   const [width, setWidth] = useState<number>(0);
   const { ref } = useObserveResizeNode<HTMLDivElement>((node) =>
@@ -119,7 +125,10 @@ const ExperimentChartContainer: React.FC<ExperimentChartContainerProps> = ({
                 axisLine={false}
                 tickLine={false}
                 tick={DEFAULT_CHART_TICK}
-                interval="preserveStartEnd"
+                interval={tickInterval}
+                ticks={ticks}
+                tickFormatter={tickFormatter}
+                domain={domain}
               />
               <ChartTooltip
                 cursor={false}

--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/charts/ExperimentChartContainer.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/charts/ExperimentChartContainer.tsx
@@ -69,7 +69,8 @@ const ExperimentChartContainer: React.FC<ExperimentChartContainerProps> = ({
     tickFormatter,
     interval: tickInterval,
   } = useChartTickDefaultConfig(values, {
-    tickPrecision: 3,
+    tickPrecision: 2,
+    numberOfTicks: 3,
   });
 
   const [width, setWidth] = useState<number>(0);

--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/charts/ExperimentChartContainer.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/charts/ExperimentChartContainer.tsx
@@ -68,7 +68,9 @@ const ExperimentChartContainer: React.FC<ExperimentChartContainerProps> = ({
     domain,
     tickFormatter,
     interval: tickInterval,
-  } = useChartTickDefaultConfig(values);
+  } = useChartTickDefaultConfig(values, {
+    tickPrecision: 3,
+  });
 
   const [width, setWidth] = useState<number>(0);
   const { ref } = useObserveResizeNode<HTMLDivElement>((node) =>

--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/charts/ExperimentChartContainer.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/charts/ExperimentChartContainer.tsx
@@ -21,6 +21,7 @@ import {
 import ChartTooltipContent, {
   ChartTooltipRenderHeaderArguments,
 } from "@/components/shared/ChartTooltipContent/ChartTooltipContent";
+import useChartTickDefaultConfig from "@/hooks/charts/useChartTickDefaultConfig";
 
 const MIN_LEGEND_WIDTH = 140;
 const MAX_LEGEND_WIDTH = 300;
@@ -58,13 +59,13 @@ const ExperimentChartContainer: React.FC<ExperimentChartContainerProps> = ({
     return chartData.data.every((record) => isEmpty(record.scores));
   }, [chartData.data]);
 
-  const tickWidth = useMemo(() => {
-    const values = chartData.data.reduce<number[]>((acc, data) => {
+  const values = useMemo(() => {
+    return chartData.data.reduce<number[]>((acc, data) => {
       return [...acc, ...Object.values(data.scores)];
     }, []);
-
-    return getDefaultChartYTickWidth({ values });
   }, [chartData.data]);
+
+  const { width: tickWidth } = useChartTickDefaultConfig(values);
 
   const [width, setWidth] = useState<number>(0);
   const { ref } = useObserveResizeNode<HTMLDivElement>((node) =>

--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/charts/ExperimentChartContainer.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/charts/ExperimentChartContainer.tsx
@@ -14,10 +14,7 @@ import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { DEFAULT_CHART_TICK } from "@/constants/chart";
-import {
-  getDefaultChartYTickWidth,
-  getDefaultHashedColorsChartConfig,
-} from "@/lib/charts";
+import { getDefaultHashedColorsChartConfig } from "@/lib/charts";
 import ChartTooltipContent, {
   ChartTooltipRenderHeaderArguments,
 } from "@/components/shared/ChartTooltipContent/ChartTooltipContent";

--- a/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricChart.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricChart.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   CartesianGrid,

--- a/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricChart.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricChart.tsx
@@ -53,6 +53,7 @@ const MetricChart = ({
   intervalEnd,
   disableLoadingData,
 }: MetricChartProps) => {
+  const isCost = metricName === METRIC_NAME_TYPE.COST;
   const { data: traces, isPending } = useProjectMetric(
     {
       projectId,
@@ -99,6 +100,8 @@ const MetricChart = ({
     return getDefaultChartYTickWidth({
       values,
       tickPrecision: TICK_PRECISION,
+      includeDecimals: isCost,
+      extraSpace: 15,
     });
   }, [values]);
 
@@ -115,13 +118,13 @@ const MetricChart = ({
 
   const renderTooltipValue = useCallback(
     ({ value }: ChartTooltipRenderValueArguments) => {
-      if (metricName === METRIC_NAME_TYPE.COST) {
+      if (isCost) {
         return formatCost(value as number);
       }
 
       return value;
     },
-    [metricName],
+    [isCost],
   );
 
   const xTickFormatter = useCallback(
@@ -158,7 +161,7 @@ const MetricChart = ({
           margin={{
             top: 5,
             right: 10,
-            left: 0,
+            left: 5,
             bottom: 5,
           }}
         >

--- a/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricChart.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricChart.tsx
@@ -26,6 +26,7 @@ import ChartTooltipContent, {
   ChartTooltipRenderValueArguments,
 } from "@/components/shared/ChartTooltipContent/ChartTooltipContent";
 import { formatDate } from "@/lib/date";
+import { formatCost } from "@/lib/money";
 import floor from "lodash/floor";
 
 interface MetricChartProps {
@@ -40,6 +41,8 @@ interface MetricChartProps {
 
 type TransformedDataValueType = null | number | string;
 type TransformedData = { [key: string]: TransformedDataValueType };
+
+const TICK_PRECISION = 6;
 
 const MetricChart = ({
   name,
@@ -95,6 +98,7 @@ const MetricChart = ({
   const yTickWidth = useMemo(() => {
     return getDefaultChartYTickWidth({
       values,
+      tickPrecision: TICK_PRECISION,
     });
   }, [values]);
 
@@ -111,10 +115,8 @@ const MetricChart = ({
 
   const renderTooltipValue = useCallback(
     ({ value }: ChartTooltipRenderValueArguments) => {
-      // ALEX REUSE FORMAT COST
-
       if (metricName === METRIC_NAME_TYPE.COST) {
-        return `$${value}`;
+        return formatCost(value as number);
       }
 
       return value;
@@ -133,9 +135,8 @@ const MetricChart = ({
     [interval],
   );
 
-  const yTickFormatter = useCallback((val: string) => {
-    // ALEX
-    return floor(Number(val), 6).toString();
+  const yTickFormatter = useCallback((val: number) => {
+    return floor(val, TICK_PRECISION).toString();
   }, []);
 
   const renderContent = () => {

--- a/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricChart.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricChart.tsx
@@ -103,7 +103,7 @@ const MetricChart = ({
       includeDecimals: isCost,
       extraSpace: 15,
     });
-  }, [values]);
+  }, [values, isCost]);
 
   const renderChartTooltipHeader = useCallback(
     ({ payload }: ChartTooltipRenderHeaderArguments) => {

--- a/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricChart.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricChart.tsx
@@ -23,8 +23,10 @@ import useProjectMetric, {
 } from "@/api/projects/useProjectMetric";
 import ChartTooltipContent, {
   ChartTooltipRenderHeaderArguments,
+  ChartTooltipRenderValueArguments,
 } from "@/components/shared/ChartTooltipContent/ChartTooltipContent";
 import { formatDate } from "@/lib/date";
+import floor from "lodash/floor";
 
 interface MetricChartProps {
   name: string;
@@ -107,7 +109,20 @@ const MetricChart = ({
     [],
   );
 
-  const tickFormatter = useCallback(
+  const renderTooltipValue = useCallback(
+    ({ value }: ChartTooltipRenderValueArguments) => {
+      // ALEX REUSE FORMAT COST
+
+      if (metricName === METRIC_NAME_TYPE.COST) {
+        return `$${value}`;
+      }
+
+      return value;
+    },
+    [metricName],
+  );
+
+  const xTickFormatter = useCallback(
     (val: string) => {
       if (interval === INTERVAL_TYPE.HOURLY) {
         return dayjs(val).utc().format("MM/DD hh:mm A");
@@ -117,6 +132,11 @@ const MetricChart = ({
     },
     [interval],
   );
+
+  const yTickFormatter = useCallback((val: string) => {
+    // ALEX
+    return floor(Number(val), 6).toString();
+  }, []);
 
   const renderContent = () => {
     if (isPending) {
@@ -147,19 +167,23 @@ const MetricChart = ({
             axisLine={false}
             tickLine={false}
             tick={DEFAULT_CHART_TICK}
-            tickFormatter={tickFormatter}
+            tickFormatter={xTickFormatter}
           />
           <YAxis
             tick={DEFAULT_CHART_TICK}
             axisLine={false}
             width={yTickWidth}
             tickLine={false}
+            tickFormatter={yTickFormatter}
           />
           <ChartTooltip
             cursor={false}
             isAnimationActive={false}
             content={
-              <ChartTooltipContent renderHeader={renderChartTooltipHeader} />
+              <ChartTooltipContent
+                renderHeader={renderChartTooltipHeader}
+                renderValue={renderTooltipValue}
+              />
             }
           />
           <Tooltip />

--- a/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricChart.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricChart.tsx
@@ -95,6 +95,7 @@ const MetricChart = ({
     ticks,
     tickFormatter: yTickFormatter,
     domain,
+    interval: yTickInterval,
   } = useChartTickDefaultConfig(values);
 
   const renderChartTooltipHeader = useCallback(
@@ -169,6 +170,7 @@ const MetricChart = ({
             tickFormatter={yTickFormatter}
             ticks={ticks}
             domain={domain}
+            interval={yTickInterval}
           />
           <ChartTooltip
             cursor={false}

--- a/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricsTab.tsx
@@ -162,6 +162,18 @@ const MetricsTab = ({ projectId }: MetricsTabProps) => {
                 disableLoadingData={!isValidDays}
               />
             </div>
+
+            <div className="flex-1">
+              <MetricChart
+                name="Estimated cost"
+                metricName={METRIC_NAME_TYPE.COST}
+                interval={interval}
+                intervalStart={intervalStart}
+                intervalEnd={intervalEnd}
+                projectId={projectId}
+                disableLoadingData={!isValidDays}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/apps/opik-frontend/src/components/shared/ChartTooltipContent/ChartTooltipContent.tsx
+++ b/apps/opik-frontend/src/components/shared/ChartTooltipContent/ChartTooltipContent.tsx
@@ -18,77 +18,102 @@ export type ChartTooltipRenderHeaderArguments = {
   payload: Payload<ValueType, NameType>[];
 };
 
+export type ChartTooltipRenderValueArguments = {
+  value: ValueType;
+};
+
 type ChartTooltipContentProps = {
   renderHeader?: ({
     payload,
   }: ChartTooltipRenderHeaderArguments) => React.ReactNode;
+
+  renderValue?: ({
+    value,
+  }: ChartTooltipRenderValueArguments) => React.ReactNode;
 } & React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
   React.ComponentProps<"div">;
 
 const ChartTooltipContent = React.forwardRef<
   HTMLDivElement,
   ChartTooltipContentProps
->(({ active, payload, color, renderHeader }, ref) => {
-  const { config } = useChart();
+>(
+  (
+    { active, payload, color, renderHeader, renderValue: parentRenderValue },
+    ref,
+  ) => {
+    const { config } = useChart();
 
-  if (!active || !payload?.length) {
-    return null;
-  }
+    if (!active || !payload?.length) {
+      return null;
+    }
 
-  return (
-    <Popover open>
-      <PopoverAnchor asChild>
-        <div className="size-0.5 bg-transparent"></div>
-      </PopoverAnchor>
-      <PopoverContent className="min-w-32 max-w-72 px-1 py-1.5">
-        <div ref={ref} className="grid items-start gap-1.5 bg-background">
-          {isFunction(renderHeader) && (
-            <div className="mb-1 max-w-full overflow-hidden border-b px-2 pt-0.5">
-              {renderHeader({ payload })}
-            </div>
-          )}
+    const renderValue = (value: ValueType) => {
+      if (isFunction(parentRenderValue)) {
+        return parentRenderValue({ value });
+      }
 
-          <div className="grid gap-1.5">
-            {payload.map((item) => {
-              const key = `${item.name || item.dataKey || "value"}`;
-              const itemConfig = getPayloadConfigFromPayload(config, item, key);
-              const indicatorColor = color || item.payload.fill || item.color;
+      return value.toLocaleString();
+    };
 
-              return (
-                <div
-                  key={key}
-                  className="flex h-6 w-full flex-wrap items-center gap-1.5 px-2"
-                >
+    return (
+      <Popover open>
+        <PopoverAnchor asChild>
+          <div className="size-0.5 bg-transparent"></div>
+        </PopoverAnchor>
+        <PopoverContent className="min-w-32 max-w-72 px-1 py-1.5">
+          <div ref={ref} className="grid items-start gap-1.5 bg-background">
+            {isFunction(renderHeader) && (
+              <div className="mb-1 max-w-full overflow-hidden border-b px-2 pt-0.5">
+                {renderHeader({ payload })}
+              </div>
+            )}
+
+            <div className="grid gap-1.5">
+              {payload.map((item) => {
+                const key = `${item.name || item.dataKey || "value"}`;
+                const itemConfig = getPayloadConfigFromPayload(
+                  config,
+                  item,
+                  key,
+                );
+                const indicatorColor = color || item.payload.fill || item.color;
+
+                return (
                   <div
-                    className="size-2 shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]"
-                    style={
-                      {
-                        "--color-bg": indicatorColor,
-                        "--color-border": indicatorColor,
-                      } as React.CSSProperties
-                    }
-                  />
-                  <div className="flex flex-1 items-center justify-between gap-2 leading-none">
-                    <div className="grid gap-1.5">
-                      <span className="comet-body-xs truncate text-muted-slate">
-                        {itemConfig?.label || item.name}
-                      </span>
+                    key={key}
+                    className="flex h-6 w-full flex-wrap items-center gap-1.5 px-2"
+                  >
+                    <div
+                      className="size-2 shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]"
+                      style={
+                        {
+                          "--color-bg": indicatorColor,
+                          "--color-border": indicatorColor,
+                        } as React.CSSProperties
+                      }
+                    />
+                    <div className="flex flex-1 items-center justify-between gap-2 leading-none">
+                      <div className="grid gap-1.5">
+                        <span className="comet-body-xs truncate text-muted-slate">
+                          {itemConfig?.label || item.name}
+                        </span>
+                      </div>
+                      {!isUndefined(item.value) && (
+                        <span className="comet-body-xs-accented">
+                          {renderValue(item.value)}
+                        </span>
+                      )}
                     </div>
-                    {!isUndefined(item.value) && (
-                      <span className="comet-body-xs-accented">
-                        {item.value.toLocaleString()}
-                      </span>
-                    )}
                   </div>
-                </div>
-              );
-            })}
+                );
+              })}
+            </div>
           </div>
-        </div>
-      </PopoverContent>
-    </Popover>
-  );
-});
+        </PopoverContent>
+      </Popover>
+    );
+  },
+);
 ChartTooltipContent.displayName = "ChartTooltipContent";
 
 export default ChartTooltipContent;

--- a/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -126,7 +126,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
               <TooltipWrapper content="Estimated cost">
                 <div
                   data-testid="data-viewer-scores"
-                  className="flex items-center gap-2 px-1"
+                  className="flex items-center gap-2 px-1 break-all"
                 >
                   <Coins className="size-4 shrink-0" />
                   {formatCost(data.total_estimated_cost)}

--- a/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -126,7 +126,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
               <TooltipWrapper content="Estimated cost">
                 <div
                   data-testid="data-viewer-scores"
-                  className="flex items-center gap-2 px-1 break-all"
+                  className="flex items-center gap-2 break-all px-1"
                 >
                   <Coins className="size-4 shrink-0" />
                   {formatCost(data.total_estimated_cost)}

--- a/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/TraceTreeViewer.module.scss
+++ b/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/TraceTreeViewer.module.scss
@@ -163,7 +163,7 @@
     }
 
     .chainSpanOuterContainer {
-      min-width: 170px;
+      min-width: 150px;
       display: flex;
       flex-direction: column;
       align-items: start;

--- a/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/TraceTreeViewer.module.scss
+++ b/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/TraceTreeViewer.module.scss
@@ -163,7 +163,7 @@
     }
 
     .chainSpanOuterContainer {
-      min-width: 150px;
+      min-width: 170px;
       display: flex;
       flex-direction: column;
       align-items: start;
@@ -203,18 +203,14 @@
           position: absolute;
           top: 9px;
           border-radius: 5px;
-          -webkit-transition:
-            width 0.6s ease-in-out,
-            left 0.6s ease-in-out;
-          -moz-transition:
-            width 0.6s ease-in-out,
-            left 0.6s ease-in-out;
-          -o-transition:
-            width 0.6s ease-in-out,
-            left 0.6s ease-in-out;
-          transition:
-            width 0.6s ease-in-out,
-            left 0.6s ease-in-out;
+          -webkit-transition: width 0.6s ease-in-out,
+          left 0.6s ease-in-out;
+          -moz-transition: width 0.6s ease-in-out,
+          left 0.6s ease-in-out;
+          -o-transition: width 0.6s ease-in-out,
+          left 0.6s ease-in-out;
+          transition: width 0.6s ease-in-out,
+          left 0.6s ease-in-out;
         }
       }
 

--- a/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/TraceTreeViewer.module.scss
+++ b/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/TraceTreeViewer.module.scss
@@ -163,7 +163,7 @@
     }
 
     .chainSpanOuterContainer {
-      min-width: 170px;
+      min-width: 200px;
       display: flex;
       flex-direction: column;
       align-items: start;

--- a/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/TraceTreeViewer.module.scss
+++ b/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/TraceTreeViewer.module.scss
@@ -203,14 +203,18 @@
           position: absolute;
           top: 9px;
           border-radius: 5px;
-          -webkit-transition: width 0.6s ease-in-out,
-          left 0.6s ease-in-out;
-          -moz-transition: width 0.6s ease-in-out,
-          left 0.6s ease-in-out;
-          -o-transition: width 0.6s ease-in-out,
-          left 0.6s ease-in-out;
-          transition: width 0.6s ease-in-out,
-          left 0.6s ease-in-out;
+          -webkit-transition:
+            width 0.6s ease-in-out,
+            left 0.6s ease-in-out;
+          -moz-transition:
+            width 0.6s ease-in-out,
+            left 0.6s ease-in-out;
+          -o-transition:
+            width 0.6s ease-in-out,
+            left 0.6s ease-in-out;
+          transition:
+            width 0.6s ease-in-out,
+            left 0.6s ease-in-out;
         }
       }
 

--- a/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/TraceTreeViewer.module.scss
+++ b/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/TraceTreeViewer.module.scss
@@ -163,7 +163,7 @@
     }
 
     .chainSpanOuterContainer {
-      min-width: 150px;
+      min-width: 170px;
       display: flex;
       flex-direction: column;
       align-items: start;

--- a/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/treeRenderers.tsx
+++ b/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/treeRenderers.tsx
@@ -126,7 +126,9 @@ export const treeRenderers: TreeRenderProps = {
                   </TooltipWrapper>
                 )}
                 {!isUndefined(estimatedCost) && (
-                  <TooltipWrapper content="Estimated cost">
+                  <TooltipWrapper
+                    content={`Estimated cost ${formatCost(estimatedCost)}`}
+                  >
                     <div className={styles.chainSpanDetailsItem}>
                       <Coins /> {formatCost(estimatedCost, true)}
                     </div>

--- a/apps/opik-frontend/src/hooks/charts/useChartTickDefaultConfig.ts
+++ b/apps/opik-frontend/src/hooks/charts/useChartTickDefaultConfig.ts
@@ -1,5 +1,7 @@
 import { useCallback, useMemo } from "react";
-import { isInteger, max, min } from "lodash";
+import isInteger from "lodash/isInteger";
+import max from "lodash/max";
+import min from "lodash/min";
 import isNull from "lodash/isNull";
 import { getDefaultChartYTickWidth } from "@/lib/charts";
 import floor from "lodash/floor";

--- a/apps/opik-frontend/src/hooks/charts/useChartTickDefaultConfig.ts
+++ b/apps/opik-frontend/src/hooks/charts/useChartTickDefaultConfig.ts
@@ -1,0 +1,93 @@
+import { useCallback, useMemo } from "react";
+import { isInteger, max, min } from "lodash";
+import isNull from "lodash/isNull";
+import { getDefaultChartYTickWidth } from "@/lib/charts";
+import floor from "lodash/floor";
+import { AxisDomain } from "recharts/types/util/types";
+
+const DEFAULT_NUMBER_OF_TICKS = 5;
+const DEFAULT_TICK_PRECISION = 6;
+
+interface UseChartTickDefaultConfigProps {
+  numberOfTicks?: number;
+  tickPrecision?: number;
+}
+
+const generateEvenlySpacedValues = (
+  a: number,
+  b: number,
+  n: number,
+  isWithDecimals = true,
+) => {
+  if (n <= 2) return [a, b];
+
+  const step = (b - a) / (n - 1);
+  const values = [];
+
+  for (let i = 0; i < n; i++) {
+    const value = a + i * step;
+
+    if (isNull(value)) {
+      continue;
+    }
+
+    if (!isWithDecimals) {
+      values.push(Math.round(value));
+    } else {
+      values.push(value);
+    }
+  }
+
+  return values;
+};
+
+const DEFAULT_DOMAIN: AxisDomain = [0, "max"];
+
+const useChartTickDefaultConfig = (
+  values: (number | null)[],
+  {
+    numberOfTicks = DEFAULT_NUMBER_OF_TICKS,
+    tickPrecision = DEFAULT_TICK_PRECISION,
+  }: UseChartTickDefaultConfigProps = {},
+) => {
+  const filteredValues = useMemo(() => {
+    return values.filter((v) => !isNull(v)) as number[];
+  }, [values]);
+
+  const areValuesWithDecimals = useMemo(() => {
+    return values.some((v) => v !== null && !isInteger(v));
+  }, [values]);
+
+  const ticks = useMemo(() => {
+    return generateEvenlySpacedValues(
+      min([...filteredValues, 0]) as number,
+      max(filteredValues) as number,
+      numberOfTicks,
+      areValuesWithDecimals,
+    );
+  }, [filteredValues, areValuesWithDecimals, numberOfTicks]);
+
+  const tickWidth = useMemo(() => {
+    return getDefaultChartYTickWidth({
+      values: ticks,
+      tickPrecision,
+      includeDecimals: areValuesWithDecimals,
+    });
+  }, [values, areValuesWithDecimals]);
+
+  const tickFormatter = useCallback(
+    (value: number) => {
+      return floor(value, tickPrecision).toString();
+    },
+    [areValuesWithDecimals],
+  );
+
+  return {
+    width: tickWidth,
+    ticks,
+    tickFormatter,
+    domain: DEFAULT_DOMAIN,
+  };
+};
+
+export default useChartTickDefaultConfig;

--- a/apps/opik-frontend/src/hooks/charts/useChartTickDefaultConfig.ts
+++ b/apps/opik-frontend/src/hooks/charts/useChartTickDefaultConfig.ts
@@ -3,7 +3,7 @@ import { isInteger, max, min } from "lodash";
 import isNull from "lodash/isNull";
 import { getDefaultChartYTickWidth } from "@/lib/charts";
 import floor from "lodash/floor";
-import { AxisDomain } from "recharts/types/util/types";
+import { AxisDomain, AxisInterval } from "recharts/types/util/types";
 
 const DEFAULT_NUMBER_OF_TICKS = 5;
 const DEFAULT_TICK_PRECISION = 6;
@@ -42,6 +42,7 @@ const generateEvenlySpacedValues = (
 };
 
 const DEFAULT_DOMAIN: AxisDomain = [0, "max"];
+const DEFAULT_INTERVAL: AxisInterval = "preserveStartEnd";
 
 const useChartTickDefaultConfig = (
   values: (number | null)[],
@@ -73,13 +74,13 @@ const useChartTickDefaultConfig = (
       tickPrecision,
       includeDecimals: areValuesWithDecimals,
     });
-  }, [values, areValuesWithDecimals]);
+  }, [areValuesWithDecimals, tickPrecision, ticks]);
 
   const tickFormatter = useCallback(
     (value: number) => {
       return floor(value, tickPrecision).toString();
     },
-    [areValuesWithDecimals],
+    [tickPrecision],
   );
 
   return {
@@ -87,6 +88,7 @@ const useChartTickDefaultConfig = (
     ticks,
     tickFormatter,
     domain: DEFAULT_DOMAIN,
+    interval: DEFAULT_INTERVAL,
   };
 };
 

--- a/apps/opik-frontend/src/hooks/charts/useChartTickDefaultConfig.ts
+++ b/apps/opik-frontend/src/hooks/charts/useChartTickDefaultConfig.ts
@@ -87,7 +87,7 @@ const useChartTickDefaultConfig = (
   }, [filteredValues, areValuesWithDecimals, numberOfTicks]);
 
   const areTicksWithDecimals = useMemo(() => {
-    return ticks.some((v) => !isInteger(floor(v, tickPrecision)));
+    return ticks.some((v: number) => !isInteger(floor(v, tickPrecision)));
   }, [ticks, tickPrecision]);
 
   const tickWidth = useMemo(() => {
@@ -100,13 +100,13 @@ const useChartTickDefaultConfig = (
 
   const tickFormatter = useCallback(
     (value: number) => {
-      if (areValuesWithDecimals) {
+      if (areTicksWithDecimals) {
         return value.toFixed(maxDecimalNumbersLength);
       }
 
       return value.toString();
     },
-    [areValuesWithDecimals, maxDecimalNumbersLength],
+    [areTicksWithDecimals, maxDecimalNumbersLength],
   );
 
   return {

--- a/apps/opik-frontend/src/lib/charts.ts
+++ b/apps/opik-frontend/src/lib/charts.ts
@@ -12,6 +12,7 @@ interface GetDefaultChartYTickWidthArguments {
   maxWidth?: number;
   extraSpace?: number;
   tickPrecision?: number;
+  includeDecimals?: boolean;
 }
 
 export const getDefaultChartYTickWidth = ({
@@ -21,10 +22,17 @@ export const getDefaultChartYTickWidth = ({
   maxWidth = 80,
   extraSpace = 10,
   tickPrecision = DEFAULT_TICK_PRECISION,
+  includeDecimals = false,
 }: GetDefaultChartYTickWidthArguments) => {
   const lengths = values
     .filter((v) => v !== null)
-    .map((v) => floor(v!, tickPrecision).toString().length);
+    .map((v) => {
+      if (includeDecimals) {
+        return floor(v!, tickPrecision).toString().length;
+      }
+
+      return Math.round(v!).toString().length;
+    });
 
   return Math.min(
     Math.max(minWidth, Math.max(...lengths) * characterWidth + extraSpace),

--- a/apps/opik-frontend/src/lib/charts.ts
+++ b/apps/opik-frontend/src/lib/charts.ts
@@ -11,6 +11,7 @@ interface GetDefaultChartYTickWidthArguments {
   minWidth?: number;
   maxWidth?: number;
   extraSpace?: number;
+  tickPrecision?: number;
 }
 
 export const getDefaultChartYTickWidth = ({
@@ -19,10 +20,11 @@ export const getDefaultChartYTickWidth = ({
   minWidth = 26,
   maxWidth = 80,
   extraSpace = 10,
+  tickPrecision = DEFAULT_TICK_PRECISION,
 }: GetDefaultChartYTickWidthArguments) => {
   const lengths = values
     .filter((v) => v !== null)
-    .map((v) => floor(v!, DEFAULT_TICK_PRECISION).toString().length);
+    .map((v) => floor(v!, tickPrecision).toString().length);
 
   return Math.min(
     Math.max(minWidth, Math.max(...lengths) * characterWidth + extraSpace),

--- a/apps/opik-frontend/src/lib/charts.ts
+++ b/apps/opik-frontend/src/lib/charts.ts
@@ -1,6 +1,9 @@
 import { ChartConfig } from "@/components/ui/chart";
 import { TAG_VARIANTS_COLOR_MAP } from "@/components/ui/tag";
 import { generateTagVariant } from "@/lib/traces";
+import floor from "lodash/floor";
+
+const DEFAULT_TICK_PRECISION = 6;
 
 interface GetDefaultChartYTickWidthArguments {
   values: (number | null)[];
@@ -19,7 +22,7 @@ export const getDefaultChartYTickWidth = ({
 }: GetDefaultChartYTickWidthArguments) => {
   const lengths = values
     .filter((v) => v !== null)
-    .map((v) => Math.round(v!).toString().length);
+    .map((v) => floor(v!, DEFAULT_TICK_PRECISION).toString().length);
 
   return Math.min(
     Math.max(minWidth, Math.max(...lengths) * characterWidth + extraSpace),

--- a/apps/opik-frontend/src/lib/charts.ts
+++ b/apps/opik-frontend/src/lib/charts.ts
@@ -1,7 +1,6 @@
 import { ChartConfig } from "@/components/ui/chart";
 import { TAG_VARIANTS_COLOR_MAP } from "@/components/ui/tag";
 import { generateTagVariant } from "@/lib/traces";
-import floor from "lodash/floor";
 
 const DEFAULT_TICK_PRECISION = 6;
 
@@ -12,7 +11,7 @@ interface GetDefaultChartYTickWidthArguments {
   maxWidth?: number;
   extraSpace?: number;
   tickPrecision?: number;
-  includeDecimals?: boolean;
+  withDecimals?: boolean;
 }
 
 export const getDefaultChartYTickWidth = ({
@@ -22,13 +21,13 @@ export const getDefaultChartYTickWidth = ({
   maxWidth = 80,
   extraSpace = 10,
   tickPrecision = DEFAULT_TICK_PRECISION,
-  includeDecimals = false,
+  withDecimals = false,
 }: GetDefaultChartYTickWidthArguments) => {
   const lengths = values
     .filter((v) => v !== null)
     .map((v) => {
-      if (includeDecimals) {
-        return floor(v!, tickPrecision).toString().length;
+      if (withDecimals) {
+        return v?.toFixed(tickPrecision).toString().length || 0;
       }
 
       return Math.round(v!).toString().length;


### PR DESCRIPTION
## Details
* add a cost chart
<img width="1649" alt="image" src="https://github.com/user-attachments/assets/130e3501-ed1f-407f-af5b-ef4d1412ded5">
* worked on the tick width and formatting behavior


## Issues

Resolves #
* also fixes the issues for the cases where the cost didn't fit:
<img width="517" alt="image" src="https://github.com/user-attachments/assets/c7c9858c-dfb8-4974-a5ad-cecb8431de1c">

## Testing

## Documentation
