### PR TITLE
[OPIK-513] allow to create and configure an opik client entierly in memory

### DIFF
--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -53,7 +53,7 @@ class Opik:
             project_name: The name of the project. If not provided, traces and spans will be logged to the `Default Project`.
             workspace: The name of the workspace. If not provided, `default` will be used.
             host: The host URL for the Opik server. If not provided, it will default to `https://www.comet.com/opik/api`.
-            api_key: The API key for Opik.
+            api_key: The API key for Opik. This parameter is ignored for local installations.
             _use_batching: intended for internal usage in specific conditions only.
                 Enabling it is unsafe and can lead to data loss.
         Returns:


### PR DESCRIPTION
## Details
This PR makes it possible to pass Opik API key to `Opik.__init__()`. In that case it will override any value coming from the environment or configuration file.
If the provided API key is a smart API key (contains encoded backend URL), this encoded value will be used only if there are no other sources of the backend URL.

## Testing
Tested manually.