### PR TITLE
[SDK] Control output format

### DIFF
--- a/sdks/python/src/opik/evaluation/metrics/llm_judges/hallucination/template.py
+++ b/sdks/python/src/opik/evaluation/metrics/llm_judges/hallucination/template.py
@@ -42,7 +42,7 @@ It is crucial that you provide your answer in the following JSON format:
     "score": <your score between 0.0 and 1.0>,
     "reason": ["reason 1", "reason 2"]
 }}
-Reasons amount is not restricted.
+Reasons amount is not restricted. Output must be JSON format only.
 """
 
 output_hallucination_template = """You are an expert judge tasked with evaluating the factual accuracy and reliability of an AI-generated answer. Analyze the provided INPUT, and OUTPUT to determine if the OUTPUT contains any hallucinations or unfaithful information.
@@ -73,7 +73,7 @@ It is crucial that you provide your answer in the following JSON format:
     "score": <your score between 0.0 and 1.0>,
     "reason": ["some reason 1", "some reason 2"]
 }}
-Reasons amount is not restricted.
+Reasons amount is not restricted. Output must be JSON format only.
 """
 
 


### PR DESCRIPTION
## Preproduce

```
from opik.evaluation.metrics import Hallucination

metric = Hallucination(model="ollama/qwen2.5:3b")

score = metric.score(
    input="What is the capital of France?",
    output="Paris",
    context=["France is a country in Europe."]
)
print(score)
```

## Issues
The output format of the LLM may not in JSON format.
```
opik/evaluation/metrics/llm_judges/hallucination/metric.py", line 133, in _parse_model_output
    dict_content = json.loads(content)
                   ^^^^^^^^^^^^^^^^^^^
raise exceptions.MetricComputationError(
opik.evaluation.metrics.exceptions.MetricComputationError: Failed hallucination detection
```
## Resolves 

Add "Output format must be JSON format only." into the prompt template

## Testing

Re-run the above code. The output result would be like this
```
{
    "score": 1.0,
    "reason": [
        "The CONTEXT provided only basic information about France being a country in Europe, without mentioning any capital city.",
        "The OUTPUT provides 'Paris' as the capital of France, which is not mentioned or implied in the given CONTEXT."
    ]
}
ScoreResult(name='hallucination_metric', value=1.0, reason='[\'The CONTEXT provided only basic information about France being a country in Europe, without mentioning any capital city.\', "The OUTPUT provides \'Paris\' as the capital of France, which is not mentioned or implied in the given CONTEXT."]', metadata=None, scoring_failed=False)
```

## Documentation
