### PR TITLE
[NA] Validate fern installed

### DIFF
--- a/scripts/generate_openapi.sh
+++ b/scripts/generate_openapi.sh
@@ -3,6 +3,13 @@ set -e
 
 OPENAPI_YML_PATH="apps/opik-backend/target/openapi.yaml"
 
+# Check if fern is installed
+if ! command -v "fern" &> /dev/null; then
+    echo "fern is not installed."
+    echo "Please follow the instructions: https://github.com/comet-ml/opik/blob/main/sdks/code_generation/fern/README.md"
+    exit 1
+fi
+
 # Generate openapi.yaml
 cd apps/opik-backend
 mvn compile swagger:resolve


### PR DESCRIPTION
## Details
When executing the `generate_openapi.sh` script, if fern wasn't installed, the script finished successfully which was confusing. 
This PR adds validation that fern is installed when generating OpenAPI client code.

## Testing
Tested with and without `fern` installed. The script works as expected.
