### PR TITLE
[OPIK-515] implement opik client auth_check method

### DIFF
--- a/.github/workflows/documentation_cookbook_tests.yml
+++ b/.github/workflows/documentation_cookbook_tests.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -U ipython nbconvert
+      - name: Install opik
+        run: pip install sdks/python
       - name: Prepare env variables
         run: |
           directory=$(dirname -- "${NOTEBOOK_TO_TEST}")

--- a/.github/workflows/documentation_cookbook_tests.yml
+++ b/.github/workflows/documentation_cookbook_tests.yml
@@ -43,8 +43,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -U ipython nbconvert
-      - name: Install opik
-        run: pip install sdks/python
+      # - name: Install opik # Uncomment if you want to run cookbooks with local version of opik
+      #   run: pip install sdks/python
       - name: Prepare env variables
         run: |
           directory=$(dirname -- "${NOTEBOOK_TO_TEST}")

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -118,6 +118,9 @@ class Opik:
 
         LOGGER.info(f'Created a "{dataset_name}" dataset at {dataset_url}.')
 
+    def auth_check(self) -> None:
+        self._rest_client.check.access(request={})  # empty body for future backward compatibility
+
     def trace(
         self,
         id: Optional[str] = None,

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -37,6 +37,7 @@ from .. import (
 LOGGER = logging.getLogger(__name__)
 OPIK_API_REQUESTS_TIMEOUT_SECONDS = 5.0
 
+
 class Opik:
     def __init__(
         self,
@@ -90,7 +91,7 @@ class Opik:
             base_url=base_url,
             httpx_client=httpx_client_,
         )
-        self._rest_client._client_wrapper._timeout = OPIK_API_REQUESTS_TIMEOUT_SECONDS # See https://github.com/fern-api/fern/issues/5321
+        self._rest_client._client_wrapper._timeout = OPIK_API_REQUESTS_TIMEOUT_SECONDS  # See https://github.com/fern-api/fern/issues/5321
         rest_client_configurator.configure(self._rest_client)
         self._streamer = streamer_constructors.construct_online_streamer(
             n_consumers=workers,

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -35,7 +35,7 @@ from .. import (
 )
 
 LOGGER = logging.getLogger(__name__)
-
+OPIK_API_REQUESTS_TIMEOUT_SECONDS = 5.0
 
 class Opik:
     def __init__(
@@ -90,6 +90,7 @@ class Opik:
             base_url=base_url,
             httpx_client=httpx_client_,
         )
+        self._rest_client._client_wrapper._timeout = OPIK_API_REQUESTS_TIMEOUT_SECONDS # See https://github.com/fern-api/fern/issues/5321
         rest_client_configurator.configure(self._rest_client)
         self._streamer = streamer_constructors.construct_online_streamer(
             n_consumers=workers,

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -122,7 +122,9 @@ class Opik:
         """
         Checks if current API key user has an access to the configured workspace and its content.
         """
-        self._rest_client.check.access(request={})  # empty body for future backward compatibility
+        self._rest_client.check.access(
+            request={}
+        )  # empty body for future backward compatibility
 
     def trace(
         self,

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -119,6 +119,9 @@ class Opik:
         LOGGER.info(f'Created a "{dataset_name}" dataset at {dataset_url}.')
 
     def auth_check(self) -> None:
+        """
+        Checks if current API key user has an access to the configured workspace and its content.
+        """
         self._rest_client.check.access(request={})  # empty body for future backward compatibility
 
     def trace(

--- a/sdks/python/src/opik/rest_client_configurator/retry_decorators.py
+++ b/sdks/python/src/opik/rest_client_configurator/retry_decorators.py
@@ -8,7 +8,7 @@ connection_retry = tenacity.retry(
         (
             httpx.RemoteProtocolError,  # handle retries for expired connections
             httpx.ConnectError,
-            httpx.ConnectTimeout,
+            httpx.TimeoutException,
         )
     ),
 )

--- a/sdks/python/tests/e2e/test_backend_check.py
+++ b/sdks/python/tests/e2e/test_backend_check.py
@@ -1,0 +1,17 @@
+import opik
+import pytest
+from opik.rest_api.core import api_error
+
+
+def test_auth_check__happyflow(opik_client: opik.Opik):
+    # Assuming opik client is correctly configured for tests, no
+    # exceptions must be raised.
+    assert opik_client.auth_check() is None
+
+
+def test_auth_check__not_existing_workspace__api_error_raised():
+    opik_client = opik.Opik(
+        workspace="workspace-that-does-not-exist-in-any-installation"
+    )
+    with pytest.raises(api_error.ApiError):
+        opik_client.auth_check()


### PR DESCRIPTION
## Details
Adds `auth_check()` method to Opik. The method returns None if everything if the configured workspace is accessible for the configured API key, and raises an `ApiError` with the error message and status code from the backend if there is a problem with access.

Added e2e tests.
Also added a workaround for Fern bug with ignored httpx timeouts.