### PR TITLE
[OPIK-419] add last updated trace at to projects

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/events/TracesCreated.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/events/TracesCreated.java
@@ -1,0 +1,20 @@
+package com.comet.opik.api.events;
+
+import com.comet.opik.infrastructure.events.BaseEvent;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import java.util.Set;
+import java.util.UUID;
+
+@Getter
+@Accessors(fluent = true)
+public class TracesCreated extends BaseEvent {
+    private final @NonNull Set<UUID> projectIds;
+
+    public TracesCreated(@NonNull Set<UUID> projectIds, @NonNull String workspaceId, @NonNull String userName) {
+        super(workspaceId, userName);
+        this.projectIds = projectIds;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/events/TracesUpdated.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/events/TracesUpdated.java
@@ -1,0 +1,20 @@
+package com.comet.opik.api.events;
+
+import com.comet.opik.infrastructure.events.BaseEvent;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import java.util.Set;
+import java.util.UUID;
+
+@Getter
+@Accessors(fluent = true)
+public class TracesUpdated extends BaseEvent {
+    private final @NonNull Set<UUID> projectIds;
+
+    public TracesUpdated(@NonNull Set<UUID> projectIds, @NonNull String workspaceId, @NonNull String userName) {
+        super(workspaceId, userName);
+        this.projectIds = projectIds;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ProjectEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ProjectEventListener.java
@@ -1,0 +1,41 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.ProjectIdLastUpdated;
+import com.comet.opik.api.events.TracesCreated;
+import com.comet.opik.domain.ProjectService;
+import com.comet.opik.domain.TraceService;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
+
+@EagerSingleton
+@Slf4j
+public class ProjectEventListener {
+    private final ProjectService projectService;
+    private final TraceService traceService;
+
+    @Inject
+    public ProjectEventListener(EventBus eventBus, ProjectService projectService, TraceService traceService) {
+        this.projectService = projectService;
+        this.traceService = traceService;
+        eventBus.register(this);
+    }
+
+    @Subscribe
+    public void onTracesCreated(TracesCreated event) {
+        log.info("Recording last traces for projects '{}'", event.projectIds());
+
+        traceService.getLastUpdatedTraceAt(event.projectIds(), event.workspaceId())
+                .flatMap(lastTraceByProjectId -> Mono.fromRunnable(() -> projectService.recordLastUpdatedTrace(
+                        event.workspaceId(),
+                        lastTraceByProjectId.entrySet().stream()
+                                .map(entry -> new ProjectIdLastUpdated(entry.getKey(), entry.getValue())).toList())))
+                .block();
+
+        log.info("Recorded last traces for projects '{}'", event.projectIds());
+    }
+
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ProjectEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ProjectEventListener.java
@@ -2,6 +2,7 @@ package com.comet.opik.api.resources.v1.events;
 
 import com.comet.opik.api.ProjectIdLastUpdated;
 import com.comet.opik.api.events.TracesCreated;
+import com.comet.opik.api.events.TracesUpdated;
 import com.comet.opik.domain.ProjectService;
 import com.comet.opik.domain.TraceService;
 import com.google.common.eventbus.EventBus;
@@ -10,6 +11,9 @@ import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
+
+import java.util.Set;
+import java.util.UUID;
 
 @EagerSingleton
 @Slf4j
@@ -26,16 +30,24 @@ public class ProjectEventListener {
 
     @Subscribe
     public void onTracesCreated(TracesCreated event) {
-        log.info("Recording last traces for projects '{}'", event.projectIds());
+        updateProjectsLastUpdatedTraceAt(event.workspaceId(), event.projectIds());
+    }
 
-        traceService.getLastUpdatedTraceAt(event.projectIds(), event.workspaceId())
+    @Subscribe
+    public void onTracesUpdated(TracesUpdated event) {
+        updateProjectsLastUpdatedTraceAt(event.workspaceId(), event.projectIds());
+    }
+
+    private void updateProjectsLastUpdatedTraceAt(String workspaceId, Set<UUID> projectIds) {
+        log.info("Recording last traces for projects '{}'", projectIds);
+
+        traceService.getLastUpdatedTraceAt(projectIds, workspaceId)
                 .flatMap(lastTraceByProjectId -> Mono.fromRunnable(() -> projectService.recordLastUpdatedTrace(
-                        event.workspaceId(),
+                        workspaceId,
                         lastTraceByProjectId.entrySet().stream()
                                 .map(entry -> new ProjectIdLastUpdated(entry.getKey(), entry.getValue())).toList())))
                 .block();
 
-        log.info("Recorded last traces for projects '{}'", event.projectIds());
+        log.info("Recorded last traces for projects '{}'", projectIds);
     }
-
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 @RegisterConstructorMapper(Project.class)
 @RegisterConstructorMapper(ProjectIdLastUpdated.class)
 @RegisterArgumentFactory(UUIDArgumentFactory.class)
-interface ProjectDAO {
+public interface ProjectDAO {
 
     @SqlUpdate("INSERT INTO projects (id, name, description, workspace_id, created_by, last_updated_by) VALUES (:bean.id, :bean.name, :bean.description, :workspaceId, :bean.createdBy, :bean.lastUpdatedBy)")
     void save(@Bind("workspaceId") String workspaceId, @BindMethods("bean") Project project);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 @RegisterConstructorMapper(Project.class)
 @RegisterConstructorMapper(ProjectIdLastUpdated.class)
 @RegisterArgumentFactory(UUIDArgumentFactory.class)
-public interface ProjectDAO {
+interface ProjectDAO {
 
     @SqlUpdate("INSERT INTO projects (id, name, description, workspace_id, created_by, last_updated_by) VALUES (:bean.id, :bean.name, :bean.description, :workspaceId, :bean.createdBy, :bean.lastUpdatedBy)")
     void save(@Bind("workspaceId") String workspaceId, @BindMethods("bean") Project project);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
@@ -10,6 +10,7 @@ import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
 import org.jdbi.v3.sqlobject.customizer.Define;
+import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.stringtemplate4.UseStringTemplateEngine;
@@ -85,4 +86,11 @@ interface ProjectDAO {
 
     @SqlQuery("SELECT * FROM projects WHERE workspace_id = :workspaceId AND name IN (<names>)")
     List<Project> findByNames(@Bind("workspaceId") String workspaceId, @BindList("names") Collection<String> names);
+
+    @SqlBatch("UPDATE projects SET last_updated_trace_at = :lastUpdatedAt " +
+            "WHERE workspace_id = :workspace_id" +
+            " AND id = :id" +
+            " AND last_updated_trace_at < :lastUpdatedAt")
+    int[] recordLastUpdatedTrace(@Bind("workspace_id") String workspaceId,
+            @BindMethods Collection<ProjectIdLastUpdated> lastUpdatedTraces);
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
@@ -90,7 +90,7 @@ interface ProjectDAO {
     @SqlBatch("UPDATE projects SET last_updated_trace_at = :lastUpdatedAt " +
             "WHERE workspace_id = :workspace_id" +
             " AND id = :id" +
-            " AND last_updated_trace_at < :lastUpdatedAt")
+            " AND (last_updated_trace_at IS NULL OR last_updated_trace_at < :lastUpdatedAt)")
     int[] recordLastUpdatedTrace(@Bind("workspace_id") String workspaceId,
             @BindMethods Collection<ProjectIdLastUpdated> lastUpdatedTraces);
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -69,6 +69,8 @@ public interface ProjectService {
 
     Page<Project> find(int page, int size, ProjectCriteria criteria, List<SortingField> sortingFields);
 
+    List<Project> findByIds(String workspaceId, Set<UUID> ids);
+
     List<Project> findByNames(String workspaceId, List<String> names);
 
     Project getOrCreate(String workspaceId, String projectName, String userName);
@@ -278,6 +280,16 @@ class ProjectServiceImpl implements ProjectService {
 
         return new ProjectPage(page, projects.size(), projectRecordSet.total(), projects,
                 sortingFactory.getSortableFields());
+    }
+
+    @Override
+    public List<Project> findByIds(String workspaceId, Set<UUID> ids) {
+        if (ids.isEmpty()) {
+            log.info("ids list is empty, returning");
+            return List.of();
+        }
+
+        return template.inTransaction(READ_ONLY, handle -> handle.attach(ProjectDAO.class).findByIds(ids, workspaceId));
     }
 
     private Page<Project> findWithLastTraceSorting(int page, int size, @NonNull ProjectCriteria criteria,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -30,6 +30,7 @@ import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -73,6 +74,8 @@ public interface ProjectService {
     Project getOrCreate(String workspaceId, String projectName, String userName);
 
     Project retrieveByName(String projectName);
+
+    void recordLastUpdatedTrace(String workspaceId, Collection<ProjectIdLastUpdated> lastUpdatedTraces);
 }
 
 @Slf4j
@@ -390,6 +393,12 @@ class ProjectServiceImpl implements ProjectService {
                     .findFirst()
                     .orElseThrow(this::createNotFoundError);
         });
+    }
+
+    @Override
+    public void recordLastUpdatedTrace(String workspaceId, Collection<ProjectIdLastUpdated> lastUpdatedTraces) {
+        template.inTransaction(WRITE,
+                handle -> handle.attach(ProjectDAO.class).recordLastUpdatedTrace(workspaceId, lastUpdatedTraces));
     }
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -147,8 +147,7 @@ class TraceDAOImpl implements TraceDAO {
                 tags,
                 created_at,
                 created_by,
-                last_updated_by,
-                last_updated_at
+                last_updated_by
             )
             SELECT
                 new_trace.id as id,
@@ -198,8 +197,7 @@ class TraceDAOImpl implements TraceDAO {
                     LENGTH(old_trace.created_by) > 0, old_trace.created_by,
                     new_trace.created_by
                 ) as created_by,
-                new_trace.last_updated_by as last_updated_by,
-                new_trace.last_updated_at as last_updated_at
+                new_trace.last_updated_by as last_updated_by
             FROM (
                 SELECT
                     :id as id,
@@ -214,8 +212,7 @@ class TraceDAOImpl implements TraceDAO {
                     :tags as tags,
                     now64(9) as created_at,
                     :user_name as created_by,
-                    :user_name as last_updated_by,
-                    <if(last_updated_at)> parseDateTime64BestEffort(:last_updated_at, 9) as last_updated_at <endif>
+                    :user_name as last_updated_by
             ) as new_trace
             LEFT JOIN (
                 SELECT
@@ -738,10 +735,6 @@ class TraceDAOImpl implements TraceDAO {
             statement.bind("end_time", trace.endTime().toString());
         }
 
-        if (trace.lastUpdatedAt() != null) {
-            statement.bind("last_updated_at", trace.lastUpdatedAt().toString());
-        }
-
         if (trace.metadata() != null) {
             statement.bind("metadata", trace.metadata().toString());
         } else {
@@ -762,9 +755,6 @@ class TraceDAOImpl implements TraceDAO {
 
         Optional.ofNullable(trace.endTime())
                 .ifPresent(endTime -> template.add("end_time", endTime));
-
-        Optional.ofNullable(trace.lastUpdatedAt())
-                .ifPresent(lastUpdatedAt -> template.add("last_updated_at", lastUpdatedAt));
 
         return template;
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -147,7 +147,8 @@ class TraceDAOImpl implements TraceDAO {
                 tags,
                 created_at,
                 created_by,
-                last_updated_by
+                last_updated_by,
+                last_updated_at
             )
             SELECT
                 new_trace.id as id,
@@ -197,7 +198,8 @@ class TraceDAOImpl implements TraceDAO {
                     LENGTH(old_trace.created_by) > 0, old_trace.created_by,
                     new_trace.created_by
                 ) as created_by,
-                new_trace.last_updated_by as last_updated_by
+                new_trace.last_updated_by as last_updated_by,
+                new_trace.last_updated_at as last_updated_at
             FROM (
                 SELECT
                     :id as id,
@@ -212,7 +214,8 @@ class TraceDAOImpl implements TraceDAO {
                     :tags as tags,
                     now64(9) as created_at,
                     :user_name as created_by,
-                    :user_name as last_updated_by
+                    :user_name as last_updated_by,
+                    <if(last_updated_at)> parseDateTime64BestEffort(:last_updated_at, 9) as last_updated_at <endif>
             ) as new_trace
             LEFT JOIN (
                 SELECT
@@ -735,6 +738,10 @@ class TraceDAOImpl implements TraceDAO {
             statement.bind("end_time", trace.endTime().toString());
         }
 
+        if (trace.lastUpdatedAt() != null) {
+            statement.bind("last_updated_at", trace.lastUpdatedAt().toString());
+        }
+
         if (trace.metadata() != null) {
             statement.bind("metadata", trace.metadata().toString());
         } else {
@@ -755,6 +762,9 @@ class TraceDAOImpl implements TraceDAO {
 
         Optional.ofNullable(trace.endTime())
                 .ifPresent(endTime -> template.add("end_time", endTime));
+
+        Optional.ofNullable(trace.lastUpdatedAt())
+                .ifPresent(lastUpdatedAt -> template.add("last_updated_at", lastUpdatedAt));
 
         return template;
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -3,6 +3,7 @@ package com.comet.opik.domain;
 import com.clickhouse.client.ClickHouseException;
 import com.comet.opik.api.BiInformationResponse;
 import com.comet.opik.api.Project;
+import com.comet.opik.api.ProjectIdLastUpdated;
 import com.comet.opik.api.ProjectStats;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.TraceBatch;
@@ -33,6 +34,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -92,35 +94,57 @@ class TraceServiceImpl implements TraceService {
 
         String projectName = WorkspaceUtils.getProjectName(trace.projectName());
         UUID id = trace.id() == null ? idGenerator.generateId() : trace.id();
+        var finalTrace = trace.toBuilder().lastUpdatedAt(Instant.now()).build();
 
-        return IdGenerator
+        return AsyncUtils.makeMonoContextAware((userName, workspaceId) -> IdGenerator
                 .validateVersionAsync(id, TRACE_KEY)
                 .then(Mono.defer(() -> getOrCreateProject(projectName)))
                 .flatMap(project -> lockService.executeWithLock(
                         new LockService.Lock(id, TRACE_KEY),
-                        Mono.defer(() -> insertTrace(trace, project, id))));
+                        insertTrace(finalTrace, project, id)
+                                .then(Mono.fromRunnable(() -> projectService.recordLastUpdatedTrace(
+                                        workspaceId, List.of(new ProjectIdLastUpdated(
+                                                project.id(), finalTrace.lastUpdatedAt())))))
+                                .thenReturn(id))));
     }
 
     @WithSpan
     public Mono<Long> create(TraceBatch batch) {
-
         Preconditions.checkArgument(!batch.traces().isEmpty(), "Batch traces cannot be empty");
 
-        List<String> projectNames = batch.traces()
-                .stream()
-                .map(Trace::projectName)
-                .map(WorkspaceUtils::getProjectName)
-                .distinct()
+        return AsyncUtils.makeMonoContextAware(((userName, workspaceId) -> {
+            List<String> projectNames = batch.traces()
+                    .stream()
+                    .map(Trace::projectName)
+                    .map(WorkspaceUtils::getProjectName)
+                    .distinct()
+                    .toList();
+
+            Mono<List<Trace>> resolveProjects = Flux.fromIterable(projectNames)
+                    .flatMap(this::getOrCreateProject)
+                    .collectList()
+                    .map(projects -> bindTraceToProjectAndId(batch, projects))
+                    .subscribeOn(Schedulers.boundedElastic());
+
+            return resolveProjects
+                    .flatMap(traces -> template.nonTransaction(connection -> dao.batchInsert(traces, connection)
+                            .flatMap(count -> Mono.fromRunnable(() -> projectService.recordLastUpdatedTrace(workspaceId,
+                                    getLastUpdatedProjects(traces)))
+                                    .thenReturn(count))));
+        }));
+    }
+
+    private List<ProjectIdLastUpdated> getLastUpdatedProjects(List<Trace> traces) {
+        return traces.stream().collect(Collectors.groupingBy(Trace::projectId)).entrySet().stream()
+                .map(entry -> new ProjectIdLastUpdated(entry.getKey(), findLatestUpdatedAt(entry.getValue())))
                 .toList();
+    }
 
-        Mono<List<Trace>> resolveProjects = Flux.fromIterable(projectNames)
-                .flatMap(this::getOrCreateProject)
-                .collectList()
-                .map(projects -> bindTraceToProjectAndId(batch, projects))
-                .subscribeOn(Schedulers.boundedElastic());
-
-        return resolveProjects
-                .flatMap(traces -> template.nonTransaction(connection -> dao.batchInsert(traces, connection)));
+    private Instant findLatestUpdatedAt(List<Trace> traces) {
+        return traces.stream()
+                .map(Trace::lastUpdatedAt)
+                .sorted(Comparator.reverseOrder())
+                .toList().getFirst();
     }
 
     private List<Trace> bindTraceToProjectAndId(TraceBatch batch, List<Project> projects) {

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000006_add_projects_last_updated_trace_at.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000006_add_projects_last_updated_trace_at.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+--changeset idoberko2:add_projects_last_updated_trace_at
+
+ALTER TABLE projects ADD COLUMN last_updated_trace_at TIMESTAMP(6) NOT NULL DEFAULT '1970-01-01 00:00:01';
+
+--rollback ALTER TABLE projects DROP COLUMN last_updated_trace_at;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000006_add_projects_last_updated_trace_at.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000006_add_projects_last_updated_trace_at.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 --changeset idoberko2:add_projects_last_updated_trace_at
 
-ALTER TABLE projects ADD COLUMN last_updated_trace_at TIMESTAMP(6);
+ALTER TABLE projects ADD COLUMN last_updated_trace_at TIMESTAMP(6) DEFAULT NULL;
 
 --rollback ALTER TABLE projects DROP COLUMN last_updated_trace_at;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000006_add_projects_last_updated_trace_at.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000006_add_projects_last_updated_trace_at.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 --changeset idoberko2:add_projects_last_updated_trace_at
 
-ALTER TABLE projects ADD COLUMN last_updated_trace_at TIMESTAMP(6) NOT NULL DEFAULT '1970-01-01 00:00:01';
+ALTER TABLE projects ADD COLUMN last_updated_trace_at TIMESTAMP(6);
 
 --rollback ALTER TABLE projects DROP COLUMN last_updated_trace_at;

--- a/apps/opik-backend/src/test/java/com/comet/opik/TestComparators.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/TestComparators.java
@@ -1,0 +1,14 @@
+package com.comet.opik;
+
+import java.time.Instant;
+
+public class TestComparators {
+    public static int compareMicroNanoTime(Instant i1, Instant i2) {
+        // Calculate the difference in nanoseconds
+        long nanoDifference = Math.abs(i1.getNano() - i2.getNano());
+        if (nanoDifference < 1_000) {
+            return 0; // Consider equal if within a microsecond
+        }
+        return i1.compareTo(i2);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
@@ -6,7 +6,9 @@ import com.comet.opik.api.FeedbackScoreBatch;
 import com.comet.opik.api.FeedbackScoreBatchItem;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.TraceBatch;
+import com.comet.opik.api.TraceUpdate;
 import com.comet.opik.api.resources.utils.TestUtils;
+import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
@@ -126,4 +128,16 @@ public class TraceResourceClient {
         }
     }
 
+    public void updateTrace(UUID id, TraceUpdate traceUpdate, String apiKey, String workspaceName) {
+        try (var actualResponse = client.target(RESOURCE_PATH.formatted(baseURI))
+                .path(id.toString())
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .method(HttpMethod.PATCH, Entity.json(traceUpdate))) {
+
+            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
+            assertThat(actualResponse.hasEntity()).isFalse();
+        }
+    }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -1205,10 +1205,6 @@ class ProjectsResourceTest {
                         .isEqualTo(project.lastUpdatedTraceAt());
             }
         }
-
-        // todo: similarly cover trace batch
-
-        // todo: similarly cover trace update
     }
 
     @Nested

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -82,7 +82,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-//@TestGuiceyApp(OpikApplication.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("Project Resource Test")
 class ProjectsResourceTest {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -1102,6 +1102,11 @@ class ProjectsResourceTest {
                     .isEqualTo(expectedProject3.lastUpdatedTraceAt());
         }
 
+        // todo: similarly cover trace batch
+
+        // todo: similarly cover trace update
+
+        // timestamps in mysql are microsecond while in clickhouse they are stored as nano
         private int compareInstants(Instant i1, Instant i2) {
             // Calculate the difference in nanoseconds
             long nanoDifference = Math.abs(i1.getNano() - i2.getNano());

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api.resources.v1.priv;
 
+import com.comet.opik.TestComparators;
 import com.comet.opik.api.BatchDelete;
 import com.comet.opik.api.Project;
 import com.comet.opik.api.ProjectRetrieve;
@@ -1090,31 +1091,21 @@ class ProjectsResourceTest {
 
             assertThat(dbProjects.stream().filter(dbProject -> dbProject.id().equals(expectedProject.id()))
                     .findFirst().orElseThrow().lastUpdatedTraceAt())
-                    .usingComparator(this::compareInstants)
+                    .usingComparator(TestComparators::compareMicroNanoTime)
                     .isEqualTo(expectedProject.lastUpdatedTraceAt());
             assertThat(dbProjects.stream().filter(dbProject -> dbProject.id().equals(expectedProject2.id()))
                     .findFirst().orElseThrow().lastUpdatedTraceAt())
-                    .usingComparator(this::compareInstants)
+                    .usingComparator(TestComparators::compareMicroNanoTime)
                     .isEqualTo(expectedProject2.lastUpdatedTraceAt());
             assertThat(dbProjects.stream().filter(dbProject -> dbProject.id().equals(expectedProject3.id()))
                     .findFirst().orElseThrow().lastUpdatedTraceAt())
-                    .usingComparator(this::compareInstants)
+                    .usingComparator(TestComparators::compareMicroNanoTime)
                     .isEqualTo(expectedProject3.lastUpdatedTraceAt());
         }
 
         // todo: similarly cover trace batch
 
         // todo: similarly cover trace update
-
-        // timestamps in mysql are microsecond while in clickhouse they are stored as nano
-        private int compareInstants(Instant i1, Instant i2) {
-            // Calculate the difference in nanoseconds
-            long nanoDifference = Math.abs(i1.getNano() - i2.getNano());
-            if (nanoDifference < 1_000) {
-                return 0; // Consider equal if within a microsecond
-            }
-            return i1.compareTo(i2);
-        }
     }
 
     @Nested

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import uk.co.jemos.podam.api.PodamFactory;
@@ -1164,7 +1165,7 @@ class ProjectsResourceTest {
         }
 
         @Test
-        @DisplayName("when projects with traces, then return project with last updated trace at")
+        @DisplayName("when updating a trace, then return project with last updated trace at")
         void getProjects__whenTraceIsUpdated__thenUpdateProjectsLastUpdatedTraceAt() {
             String workspaceName = UUID.randomUUID().toString();
             String apiKey = UUID.randomUUID().toString();
@@ -1197,10 +1198,12 @@ class ProjectsResourceTest {
                     .map(Project::id).collect(Collectors.toUnmodifiableSet()));
 
             for (Project project : expectedProjects) {
-                assertThat(dbProjects.stream().filter(dbProject -> dbProject.id().equals(project.id()))
-                        .findFirst().orElseThrow().lastUpdatedTraceAt())
-                        .usingComparator(TestComparators::compareMicroNanoTime)
-                        .isEqualTo(project.lastUpdatedTraceAt());
+                Awaitility.await().untilAsserted(() -> {
+                    assertThat(dbProjects.stream().filter(dbProject -> dbProject.id().equals(project.id()))
+                            .findFirst().orElseThrow().lastUpdatedTraceAt())
+                            .usingComparator(TestComparators::compareMicroNanoTime)
+                            .isEqualTo(project.lastUpdatedTraceAt());
+                });
             }
         }
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
@@ -10,6 +10,7 @@ import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.infrastructure.lock.LockService;
 import com.fasterxml.uuid.Generators;
+import com.google.common.eventbus.EventBus;
 import io.r2dbc.spi.Connection;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,6 +59,9 @@ class TraceServiceImplTest {
     @Mock
     private ProjectService projectService;
 
+    @Mock
+    private EventBus eventBus;
+
     private final PodamFactory factory = new PodamFactoryImpl();
 
     @BeforeEach
@@ -69,7 +73,8 @@ class TraceServiceImplTest {
                 template,
                 projectService,
                 () -> Generators.timeBasedEpochGenerator().generate(),
-                DUMMY_LOCK_SERVICE);
+                DUMMY_LOCK_SERVICE,
+                eventBus);
     }
 
     @Nested

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import uk.co.jemos.podam.api.PodamFactory;
@@ -38,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -104,7 +104,7 @@ class TraceServiceImplTest {
             when(projectService.findByNames(workspaceId, List.of(projectName)))
                     .thenReturn(List.of(Project.builder().id(projectId).name(projectName).build())); // simulate project was already created
 
-            Mockito.doNothing().when(eventBus).post(eventCaptor.capture());
+            doNothing().when(eventBus).post(eventCaptor.capture());
 
             when(template.nonTransaction(any()))
                     .thenAnswer(invocation -> {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
@@ -6,6 +6,7 @@ import com.comet.opik.api.TraceSearchCriteria;
 import com.comet.opik.api.error.EntityAlreadyExistsException;
 import com.comet.opik.api.error.ErrorMessage;
 import com.comet.opik.api.error.InvalidUUIDVersionException;
+import com.comet.opik.api.events.TracesCreated;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.infrastructure.lock.LockService;
@@ -18,7 +19,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import uk.co.jemos.podam.api.PodamFactory;
@@ -26,6 +29,7 @@ import uk.co.jemos.podam.api.PodamFactoryImpl;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static com.comet.opik.domain.ProjectService.DEFAULT_USER;
@@ -87,16 +91,20 @@ class TraceServiceImplTest {
 
             // given
             var projectName = "projectName";
+            var projectId = UUID.randomUUID();
             var traceId = Generators.timeBasedEpochGenerator().generate();
             var connection = mock(Connection.class);
             String workspaceId = UUID.randomUUID().toString();
+            ArgumentCaptor<TracesCreated> eventCaptor = ArgumentCaptor.forClass(TracesCreated.class);
 
             // when
             when(projectService.getOrCreate(workspaceId, projectName, DEFAULT_USER))
                     .thenThrow(new EntityAlreadyExistsException(new ErrorMessage(List.of("Project already exists"))));
 
             when(projectService.findByNames(workspaceId, List.of(projectName)))
-                    .thenReturn(List.of(Project.builder().id(UUID.randomUUID()).name(projectName).build())); // simulate project was already created
+                    .thenReturn(List.of(Project.builder().id(projectId).name(projectName).build())); // simulate project was already created
+
+            Mockito.doNothing().when(eventBus).post(eventCaptor.capture());
 
             when(template.nonTransaction(any()))
                     .thenAnswer(invocation -> {
@@ -121,7 +129,8 @@ class TraceServiceImplTest {
                     .block();
 
             // then
-            Assertions.assertEquals(traceId, actualResult);
+            assertThat(actualResult).isEqualTo(traceId);
+            assertThat(eventCaptor.getValue().projectIds()).isEqualTo(Set.of(projectId));
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
@@ -96,7 +96,7 @@ class TraceServiceImplTest {
                     .thenThrow(new EntityAlreadyExistsException(new ErrorMessage(List.of("Project already exists"))));
 
             when(projectService.findByNames(workspaceId, List.of(projectName)))
-                    .thenReturn(List.of(Project.builder().name(projectName).build())); // simulate project was already created
+                    .thenReturn(List.of(Project.builder().id(UUID.randomUUID()).name(projectName).build())); // simulate project was already created
 
             when(template.nonTransaction(any()))
                     .thenAnswer(invocation -> {


### PR DESCRIPTION
## Details
In order to avoid in-memory sorting, we wanted this column to be added to `projects` table and updated whenever a trace is created or updated.

## Issues
OPIK-419

## Testing
Added tests that cover the flows.
