### PR TITLE
NO-JIRA failing tests fixes

### DIFF
--- a/.github/workflows/end2end_suites.yml
+++ b/.github/workflows/end2end_suites.yml
@@ -18,12 +18,13 @@ on:
     pull_request:
       paths:
         - 'sdks/code_generation/fern/openapi/openapi.yaml'
+        - 'tests_end_to_end/**'
 
-run-name: Appplication E2E tests - ${{ github.event.inputs.suite || github.event.inputs.suite.default }}
+run-name: Appplication E2E tests - ${{ github.event.inputs.suite || 'all_features' }}
 
 jobs:
     run_suite:
-        name: "Run suite: ${{ github.event.inputs.suite || github.event.inputs.suite.default }}"
+        name: "Run suite: ${{ github.event.inputs.suite || 'all_features' }}"
         runs-on: ubuntu-20.04
 
         steps:

--- a/tests_end_to_end/page_objects/ProjectsPage.py
+++ b/tests_end_to_end/page_objects/ProjectsPage.py
@@ -5,7 +5,7 @@ import time
 class ProjectsPage:
     def __init__(self, page: Page):
         self.page = page
-        self.url = "/projects"
+        self.url = "default/projects"
         self.projects_table = self.page.get_by_role("table")
 
     def go_to_page(self):


### PR DESCRIPTION
## Details

After addition of new homepage, URL for projects paged changed slightly to include the workspace name, causing projects and traces tests to fail. Added fix.

Also, modified the workflow file slightly to automatically run all the tests on every PR that modifies the tests (optional non-blocking check)