### PR TITLE
Updated max body size for docker deployments

### DIFF
--- a/deployment/docker-compose/nginx_default_local.conf
+++ b/deployment/docker-compose/nginx_default_local.conf
@@ -17,6 +17,7 @@ server {
         proxy_send_timeout 90;
 
         proxy_http_version 1.1;
+        client_max_body_size 500M;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
     }


### PR DESCRIPTION
## Details

Fix issues with `413 Request Entity Too Large` errors due to missing configuration in docker compose deployments

Should resolve #834 