### PR TITLE
[OPIK-619]: playground fe cache

### DIFF
--- a/apps/opik-frontend/src/api/playground/useCompletionProxyStreaming.ts
+++ b/apps/opik-frontend/src/api/playground/useCompletionProxyStreaming.ts
@@ -37,7 +37,7 @@ const isOpikError = (
   );
 };
 
-const isPlatformError = (
+const isProviderError = (
   response: ChatCompletionResponse,
 ): response is ChatCompletionProviderErrorMessageType => {
   return "code" in response && isValidJsonObject(response.message);
@@ -178,7 +178,7 @@ const useCompletionProxyStreaming = ({
           // handle different message types
           if (isOpikError(parsed)) {
             handleOpikErrorMessage(parsed);
-          } else if (isPlatformError(parsed)) {
+          } else if (isProviderError(parsed)) {
             handleAIPlatformErrorMessage(parsed);
           } else {
             handleSuccessMessage(parsed);

--- a/apps/opik-frontend/src/api/playground/useCompletionProxyStreaming.ts
+++ b/apps/opik-frontend/src/api/playground/useCompletionProxyStreaming.ts
@@ -195,7 +195,6 @@ const useCompletionProxyStreaming = ({
       };
       //   abort signal also jumps into here
     } catch (error) {
-      console.log(error, "ERROR");
       const typedError = error as Error;
       const isStopped = typedError.name === "AbortError";
 

--- a/apps/opik-frontend/src/api/playground/useCompletionProxyStreaming.ts
+++ b/apps/opik-frontend/src/api/playground/useCompletionProxyStreaming.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import dayjs from "dayjs";
 import { UsageType } from "@/types/shared";
@@ -14,6 +14,7 @@ import {
 import { isValidJsonObject, safelyParseJSON, snakeCaseObj } from "@/lib/utils";
 import { BASE_API_URL } from "@/api/api";
 import { PROVIDER_MODEL_TYPE } from "@/types/providers";
+import { useLocation } from "@tanstack/react-router";
 
 const getNowUtcTimeISOString = (): string => {
   return dayjs().utc().toISOString();
@@ -212,6 +213,13 @@ const useCompletionProxyStreaming = ({
       };
     }
   }, [messages, model, onAddChunk, configs, workspaceName]);
+
+  const location = useLocation();
+
+  useEffect(() => {
+    // stop streaming whenever the location changes
+    return () => stop();
+  }, [location, stop]);
 
   return { runStreaming, stop };
 };

--- a/apps/opik-frontend/src/api/playground/useCreateOutputTraceAndSpan.ts
+++ b/apps/opik-frontend/src/api/playground/useCreateOutputTraceAndSpan.ts
@@ -42,7 +42,7 @@ const useCreateOutputTraceAndSpan = () => {
       endTime,
       result,
       usage,
-      platformError,
+      providerError,
       choices,
       model,
       providerMessages,
@@ -59,7 +59,7 @@ const useCreateOutputTraceAndSpan = () => {
           startTime,
           endTime,
           input: { messages: providerMessages },
-          output: { output: result || platformError },
+          output: { output: result || providerError },
         });
 
         await createSpanMutateAsync({

--- a/apps/opik-frontend/src/components/pages/ConfigurationPage/AIProvidersTab/AIProvidersTab.tsx
+++ b/apps/opik-frontend/src/components/pages/ConfigurationPage/AIProvidersTab/AIProvidersTab.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useRef, useState } from "react";
-import { keepPreviousData } from "@tanstack/react-query";
 import { ColumnPinningState } from "@tanstack/react-table";
 
 import { convertColumnDataToColumn } from "@/lib/table";
@@ -58,7 +57,6 @@ const AIProvidersTab = () => {
       workspaceName,
     },
     {
-      placeholderData: keepPreviousData,
       refetchInterval: 30000,
     },
   );

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputs.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputs.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { Pause, Play } from "lucide-react";
 
 import { Button } from "@/components/ui/button";

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputs.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputs.tsx
@@ -1,8 +1,8 @@
-import React, { useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Pause, Play } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { PlaygroundPromptType } from "@/types/playground";
+import { PlaygroundOutputType, PlaygroundPromptType } from "@/types/playground";
 
 import PlaygroundOutput, {
   PlaygroundOutputRef,
@@ -11,9 +11,15 @@ import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 
 interface PlaygroundOutputsProps {
   prompts: PlaygroundPromptType[];
+  onChange: (id: string, changes: Partial<PlaygroundPromptType>) => void;
+  workspaceName: string;
 }
 
-const PlaygroundOutputs = ({ prompts }: PlaygroundOutputsProps) => {
+const PlaygroundOutputs = ({
+  prompts,
+  onChange,
+  workspaceName,
+}: PlaygroundOutputsProps) => {
   const [isRunning, setIsRunning] = useState(false);
 
   const outputRefs = useRef<Map<number, PlaygroundOutputRef>>(new Map());
@@ -49,6 +55,13 @@ const PlaygroundOutputs = ({ prompts }: PlaygroundOutputsProps) => {
 
     setIsRunning(false);
   };
+
+  const handleOutputChange = useCallback(
+    (id: string, output: PlaygroundOutputType) => {
+      onChange(id, { output });
+    },
+    [onChange],
+  );
 
   const renderActionButton = () => {
     if (isRunning) {
@@ -106,10 +119,13 @@ const PlaygroundOutputs = ({ prompts }: PlaygroundOutputsProps) => {
         {prompts?.map((prompt, promptIdx) => (
           <PlaygroundOutput
             key={`output-${prompt.id}`}
+            workspaceName={workspaceName}
             model={prompt.model}
             index={promptIdx}
             messages={prompt.messages}
+            output={prompt.output}
             configs={prompt.configs}
+            onOutputChange={(o) => handleOutputChange(prompt.id, o)}
             ref={(node) => {
               const map = getOutputRefMap();
 

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -99,14 +99,17 @@ const PlaygroundPage = () => {
         });
       });
     },
-    [],
+    [setPrompts],
   );
 
-  const handlePromptRemove = useCallback((id: string) => {
-    setPrompts((ps) => {
-      return ps.filter((p) => p.id !== id);
-    });
-  }, []);
+  const handlePromptRemove = useCallback(
+    (id: string) => {
+      setPrompts((ps) => {
+        return ps.filter((p) => p.id !== id);
+      });
+    },
+    [setPrompts],
+  );
 
   const handlePromptDuplicate = useCallback(
     (prompt: PlaygroundPromptType, position: number) => {
@@ -119,7 +122,7 @@ const PlaygroundPage = () => {
         return newPrompts;
       });
     },
-    [],
+    [setPrompts],
   );
 
   const handleAddPrompt = () => {
@@ -130,7 +133,7 @@ const PlaygroundPage = () => {
   const resetPlayground = useCallback(() => {
     const newPrompt = generateDefaultPrompt({ setupProviders: providerKeys });
     setPrompts(() => [newPrompt]);
-  }, [providerKeys]);
+  }, [providerKeys, setPrompts]);
 
   useEffect(() => {
     // hasn't been initialized yet or the last prompt is removed
@@ -183,7 +186,7 @@ const PlaygroundPage = () => {
 
       checkedIfModelsAreValidRef.current = true;
     }
-  }, [prompts, providerKeys, isPendingProviderKeys]);
+  }, [prompts, providerKeys, isPendingProviderKeys, setPrompts]);
 
   if (isPendingProviderKeys) {
     return <Loader />;

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -1,12 +1,6 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { Button } from "@/components/ui/button";
-import { Loader, Plus } from "lucide-react";
+import { Loader, Plus, RotateCcw } from "lucide-react";
 import PlaygroundPrompt from "./PlaygroundPrompt/PlaygroundPrompt";
 import { PlaygroundPromptType } from "@/types/playground";
 import { generateRandomString } from "@/lib/utils";
@@ -133,12 +127,17 @@ const PlaygroundPage = () => {
     setPrompts((ps) => [...ps, newPrompt]);
   };
 
+  const resetPlayground = useCallback(() => {
+    const newPrompt = generateDefaultPrompt({ setupProviders: providerKeys });
+    setPrompts(() => [newPrompt]);
+  }, [providerKeys]);
+
   useEffect(() => {
     // hasn't been initialized yet or the last prompt is removed
     if (prompts?.length === 0 && !isPendingProviderKeys) {
-      setPrompts([generateDefaultPrompt({ setupProviders: providerKeys })]);
+      resetPlayground();
     }
-  }, [prompts, providerKeys, isPendingProviderKeys]);
+  }, [prompts, isPendingProviderKeys, resetPlayground]);
 
   useEffect(() => {
     // on init, to check if all prompts have models from valid providers: (f.e., remove a provider after setting a model)
@@ -203,15 +202,17 @@ const PlaygroundPage = () => {
       <div className="mb-4 flex items-center justify-between">
         <h1 className="comet-title-l">Playground</h1>
 
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleAddPrompt}
-          className="sticky right-0"
-        >
-          <Plus className="mr-2 size-4" />
-          Add prompt
-        </Button>
+        <div className="sticky right-0 flex gap-2 ">
+          <Button variant="outline" size="sm" onClick={resetPlayground}>
+            <RotateCcw className="mr-2 size-4" />
+            Reset playground
+          </Button>
+
+          <Button variant="outline" size="sm" onClick={handleAddPrompt}>
+            <Plus className="mr-2 size-4" />
+            Add prompt
+          </Button>
+        </div>
       </div>
 
       <div className="mb-6 flex min-h-[50%] w-full gap-[var(--item-gap)]">

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPrompt/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPrompt/PlaygroundPrompt.tsx
@@ -35,7 +35,6 @@ const getNextMessageType = (
 interface PlaygroundPromptProps extends PlaygroundPromptType {
   workspaceName: string;
   index: number;
-  hideRemoveButton: boolean;
   onChange: (id: string, changes: Partial<PlaygroundPromptType>) => void;
   onClickRemove: (id: string) => void;
   onClickDuplicate: (prompt: PlaygroundPromptType, position: number) => void;
@@ -44,7 +43,6 @@ interface PlaygroundPromptProps extends PlaygroundPromptType {
 const PlaygroundPrompt = ({
   workspaceName,
   index,
-  hideRemoveButton,
   onChange,
   onClickRemove,
   onClickDuplicate,
@@ -109,15 +107,12 @@ const PlaygroundPrompt = ({
               workspaceName={workspaceName}
             />
           </div>
-
           <PromptModelConfigs
             provider={provider}
             configs={configs}
             onChange={handleUpdateConfig}
           />
-
           <Separator orientation="vertical" className="h-6" />
-
           <TooltipWrapper content="Duplicate a prompt">
             <Button
               variant="outline"
@@ -128,17 +123,15 @@ const PlaygroundPrompt = ({
             </Button>
           </TooltipWrapper>
 
-          {!hideRemoveButton && (
-            <TooltipWrapper content="Delete a prompt">
-              <Button
-                variant="outline"
-                size="icon-sm"
-                onClick={() => onClickRemove(id)}
-              >
-                <Trash className="size-3.5" />
-              </Button>
-            </TooltipWrapper>
-          )}
+          <TooltipWrapper content="Delete a prompt">
+            <Button
+              variant="outline"
+              size="icon-sm"
+              onClick={() => onClickRemove(id)}
+            >
+              <Trash className="size-3.5" />
+            </Button>
+          </TooltipWrapper>
         </div>
       </div>
 

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPrompt/PromptModelSelect/PromptModelSelect.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPrompt/PromptModelSelect/PromptModelSelect.tsx
@@ -37,6 +37,8 @@ interface PromptModelSelectProps {
   provider: PROVIDER_TYPE | "";
 }
 
+const STALE_TIME = 1000;
+
 const PromptModelSelect = ({
   value,
   workspaceName,
@@ -50,9 +52,14 @@ const PromptModelSelect = ({
   const [filterValue, setFilterValue] = useState("");
   const [openProviderMenu, setOpenProviderMenu] = useState<string | null>(null);
 
-  const { data } = useProviderKeys({
-    workspaceName,
-  });
+  const { data } = useProviderKeys(
+    {
+      workspaceName,
+    },
+    {
+      staleTime: STALE_TIME,
+    },
+  );
 
   const configuredProviderKeys = useMemo(
     () => data?.content?.map((p) => p.provider) ?? [],

--- a/apps/opik-frontend/src/lib/provider.ts
+++ b/apps/opik-frontend/src/lib/provider.ts
@@ -1,8 +1,13 @@
 import { PROVIDER_TYPE, ProviderKey } from "@/types/providers";
 import { PROVIDERS } from "@/constants/providers";
+import first from "lodash/first";
 
 export const areAllProvidersConfigured = (
   providers: (ProviderKey | PROVIDER_TYPE)[],
 ) => {
   return providers.length === Object.keys(PROVIDERS).length;
+};
+
+export const getDefaultProviderKey = (providers: PROVIDER_TYPE[]) => {
+  return first(providers) || "";
 };

--- a/apps/opik-frontend/src/types/playground.ts
+++ b/apps/opik-frontend/src/types/playground.ts
@@ -21,12 +21,15 @@ export type PlaygroundPromptConfigsType =
   | Record<string, never>
   | PlaygroundOpenAIConfigsType;
 
+export type PlaygroundOutputType = string | null;
+
 export interface PlaygroundPromptType {
   name: string;
   id: string;
   messages: PlaygroundMessageType[];
   model: PROVIDER_MODEL_TYPE | "";
   configs: PlaygroundPromptConfigsType;
+  output: PlaygroundOutputType;
 }
 
 export interface ProviderMessageType {
@@ -45,16 +48,21 @@ export interface ChatCompletionSuccessMessageType {
   usage: UsageType;
 }
 
-export interface ChatCompletionErrorMessageType {
+export interface ChatCompletionProviderErrorMessageType {
   code: HttpStatusCode;
   message: string;
 }
 
-export interface ChatCompletionProxyErrorMessageType {
-  errors: string[];
-}
+export type ChatCompletionOpikErrorMessageType =
+  | {
+      errors: string[];
+    }
+  | {
+      message: string;
+      code: string;
+    };
 
 export type ChatCompletionResponse =
-  | ChatCompletionProxyErrorMessageType
+  | ChatCompletionOpikErrorMessageType
   | ChatCompletionSuccessMessageType
-  | ChatCompletionErrorMessageType;
+  | ChatCompletionProviderErrorMessageType;


### PR DESCRIPTION
## Details
* Now playground is cached in a local storage.
* The cases when a user has no valid model anymore are also handled;
* Outputs now are controlled by prompts;
* Add a reset button
<img width="1477" alt="image" src="https://github.com/user-attachments/assets/c8bf3501-b2f5-40d4-8ca5-6f117fca5f60" />

## Issues

Resolves #

## Testing

## Documentation
