### PR TITLE
[NA] Update uuid7 generation package

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -48,7 +48,7 @@ setup(
         "tenacity",
         "tokenizers<0.21.0 ; python_version<'3.9.0'",  # no 3.8 support starting from 0.21.0
         "tqdm",
-        "uuid7<1.0.0",
+        "uuid6",
     ],
     entry_points={
         "pytest11": [

--- a/sdks/python/src/opik/api_objects/helpers.py
+++ b/sdks/python/src/opik/api_objects/helpers.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 from typing import Optional
 
-import uuid_extensions
+import uuid6
 
 from .. import config, datetime_helpers, logging_messages
 
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def generate_id() -> str:
-    return str(uuid_extensions.uuid7())
+    return str(uuid6.uuid7())
 
 
 def datetime_to_iso8601_if_not_None(


### PR DESCRIPTION
## Details
Moved from `uuid7.uuid7()` to `uuid6.uuid7()` which follows `RFC9562`