### PR TITLE
Add ARM64 support for Docker images

### DIFF
--- a/.github/workflows/build_and_push_docker.yaml
+++ b/.github/workflows/build_and_push_docker.yaml
@@ -54,14 +54,14 @@ jobs:
           run: |
             DOCKER_IMAGE_NAME=${{env.DOCKER_REGISTRY}}/${{ inputs.image }}:${{inputs.version}}
             echo "DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME}" | tee -a $GITHUB_ENV
-            DOCKER_BUILDKIT=1 docker build --build-arg OPIK_VERSION=${{inputs.version}} -t ${DOCKER_IMAGE_NAME} .
+            DOCKER_BUILDKIT=1 docker build --platform linux/amd64,linux/arm64 --build-arg OPIK_VERSION=${{inputs.version}} -t ${DOCKER_IMAGE_NAME} .
 
         - name: Build Docker Image for Comet integration
           if: inputs.build_comet_image 
           run: |
             DOCKER_IMAGE_NAME_COMET=${{env.DOCKER_REGISTRY}}/${{inputs.image}}-comet:${{inputs.version}}
             echo "DOCKER_IMAGE_NAME_COMET=${DOCKER_IMAGE_NAME_COMET}" | tee -a $GITHUB_ENV
-            DOCKER_BUILDKIT=1 docker build --build-arg ${{inputs.comet_build_args}} --build-arg OPIK_VERSION=${{inputs.version}} -t ${DOCKER_IMAGE_NAME_COMET} .
+            DOCKER_BUILDKIT=1 docker build --platform linux/amd64,linux/arm64 --build-arg ${{inputs.comet_build_args}} --build-arg OPIK_VERSION=${{inputs.version}} -t ${DOCKER_IMAGE_NAME_COMET} .
 
         - name: Login to GHCR
           uses: docker/login-action@v3
@@ -72,7 +72,8 @@ jobs:
   
         - name: Push Docker Image
           run: |
-            docker push ${{env.DOCKER_IMAGE_NAME}}
+            docker buildx create --use
+            docker buildx build --platform linux/amd64,linux/arm64 --push -t ${{env.DOCKER_IMAGE_NAME}} .
             echo "Docker image pushed: ${{env.DOCKER_IMAGE_NAME}}" >> $GITHUB_STEP_SUMMARY
 
         - name: Push Docker Image with latest tag
@@ -80,13 +81,14 @@ jobs:
           run: |
             DOCKER_IMAGE_NAME_LATEST=${{env.DOCKER_REGISTRY}}/${{ inputs.image }}:latest
             docker tag ${{env.DOCKER_IMAGE_NAME}} ${DOCKER_IMAGE_NAME_LATEST}
-            docker push ${DOCKER_IMAGE_NAME_LATEST}
+            docker buildx build --platform linux/amd64,linux/arm64 --push -t ${DOCKER_IMAGE_NAME_LATEST} .
             echo "Docker image pushed: ${DOCKER_IMAGE_NAME_LATEST}" >> $GITHUB_STEP_SUMMARY
 
         - name: Push Docker Image for Comet integration
           if: inputs.build_comet_image 
           run: |
-            docker push ${{env.DOCKER_IMAGE_NAME_COMET}}
+            docker buildx create --use
+            docker buildx build --platform linux/amd64,linux/arm64 --push -t ${{env.DOCKER_IMAGE_NAME_COMET}} .
             echo "Docker image pushed: ${{env.DOCKER_IMAGE_NAME_COMET}}" >> $GITHUB_STEP_SUMMARY
 
         - name: Push Docker Image for Comet integration with latest tag
@@ -94,7 +96,7 @@ jobs:
           run: |
             DOCKER_IMAGE_NAME_COMET_LATEST=${{env.DOCKER_REGISTRY}}/${{ inputs.image }}-comet:latest
             docker tag ${{env.DOCKER_IMAGE_NAME_COMET}} ${DOCKER_IMAGE_NAME_COMET_LATEST}
-            docker push ${DOCKER_IMAGE_NAME_COMET_LATEST}
+            docker buildx build --platform linux/amd64,linux/arm64 --push -t ${DOCKER_IMAGE_NAME_COMET_LATEST} .
             echo "Docker image pushed: ${DOCKER_IMAGE_NAME_COMET_LATEST}" >> $GITHUB_STEP_SUMMARY
 
         

--- a/apps/opik-backend/Dockerfile
+++ b/apps/opik-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.9-amazoncorretto-21-al2023 AS build
+FROM --platform=linux/amd64,linux/arm64 maven:3.9.9-amazoncorretto-21-al2023 AS build
 
 WORKDIR /opt/opik-backend
 
@@ -12,7 +12,7 @@ RUN mvn versions:set -DnewVersion=${OPIK_VERSION} && \
     mvn clean package -DskipTests
 
 ###############################
-FROM amazoncorretto:21-al2023
+FROM --platform=linux/amd64,linux/arm64 amazoncorretto:21-al2023
 
 RUN yum update -y && yum install -y shadow ca-certificates openssl perl \
     && yum clean all

--- a/apps/opik-frontend/Dockerfile
+++ b/apps/opik-frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20.15.0-alpine3.20 as builder
+FROM --platform=linux/amd64,linux/arm64 node:20.15.0-alpine3.20 as builder
 
 WORKDIR /opt/frontend
 
@@ -17,7 +17,7 @@ ARG BUILD_MODE=production
 RUN npm run build -- --mode $BUILD_MODE
 
 # Production stage
-FROM nginx:1.27.3-alpine3.20
+FROM --platform=linux/amd64,linux/arm64 nginx:1.27.3-alpine3.20
 
 # Copy the built files from the builder stage
 COPY --from=builder /opt/frontend/dist /usr/share/nginx/html

--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -50,7 +50,14 @@ This will expose the following services to the host machine
 - MySQL: Available on port 3306
 - Backend: Available on ports 8080 and 3003
 
+## Multi-Architecture Builds
 
+To build the Opik frontend and backend images for both `linux/amd64` and `linux/arm64` architectures, you can use the following command:
+
+```bash
+docker buildx create --use
+docker buildx build --platform linux/amd64,linux/arm64 -t <your-image-name> .
+```
 
 ## Stop opik
 

--- a/deployment/docker-compose/docker-compose.override.yaml
+++ b/deployment/docker-compose/docker-compose.override.yaml
@@ -16,7 +16,9 @@ services:
     ports:
       - "8080:8080" # Exposing backend HTTP port to host
       - "3003:3003" # Exposing additional backend port to host
+    platform: linux/amd64,linux/arm64
 
   frontend:
     ports:
       - "5173:5173" # Exposing frontend dev server port to host
+    platform: linux/amd64,linux/arm64

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -97,6 +97,7 @@ services:
         condition: service_healthy
       clickhouse:
         condition: service_healthy
+    platform: linux/amd64,linux/arm64
 
   frontend:
     image: ghcr.io/comet-ml/opik/opik-frontend:${OPIK_VERSION:-latest}
@@ -113,6 +114,7 @@ services:
     depends_on:
       backend:
         condition: service_started
+    platform: linux/amd64,linux/arm64
 
 networks:
   default:


### PR DESCRIPTION
Related to #696

Add support for multi-architecture builds for Opik frontend and backend images.

* Update `apps/opik-backend/Dockerfile` and `apps/opik-frontend/Dockerfile` to include `--platform` flag for multi-architecture builds.
* Modify `.github/workflows/build_and_push_docker.yaml` to include `--platform` flag in the `docker build` and `docker push` commands.
* Update `deployment/docker-compose/docker-compose.yaml` and `deployment/docker-compose/docker-compose.override.yaml` to specify `platform: linux/amd64,linux/arm64` for `backend` and `frontend` services.
* Update `deployment/docker-compose/README.md` to include instructions for multi-architecture builds.

Pending task build_apps.yaml
Docker push & build 
Linux support arm AMD 
