### PR TITLE
NO-JIRA: Fix redis URL configuration

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -114,9 +114,9 @@ distributedLock:
 
 # Redis configuration
 redis:
-  # Default:
+  # Default: redis://:opik@localhost:6379/0
   # Description: single node redis's URL
-  singleNodeUrl: ${REDIS_URL:-}
+  singleNodeUrl: ${REDIS_URL:-redis://:opik@localhost:6379/0}
 
 # Authentication configuration. This is not enabled by default for open source installations.
 authentication:

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResource.java
@@ -2,7 +2,6 @@ package com.comet.opik.api.resources.v1.priv;
 
 import com.codahale.metrics.annotation.Timed;
 import com.comet.opik.api.BatchDelete;
-import com.comet.opik.api.Page;
 import com.comet.opik.api.Project;
 import com.comet.opik.api.ProviderApiKey;
 import com.comet.opik.api.ProviderApiKeyUpdate;
@@ -67,16 +66,14 @@ public class LlmProviderApiKeyResource {
         log.info("Found LLM Provider's ApiKeys for workspaceId '{}'", workspaceId);
 
         return Response.ok().entity(
-                        providerApiKeyPage.toBuilder()
-                                .content(
-                                        providerApiKeyPage.content().stream()
-                                                .map(providerApiKey -> providerApiKey.toBuilder()
-                                                        .apiKey(maskApiKey(decrypt(providerApiKey.apiKey())))
-                                                        .build())
-                                                .toList()
-                                )
-                                .build()
-                )
+                providerApiKeyPage.toBuilder()
+                        .content(
+                                providerApiKeyPage.content().stream()
+                                        .map(providerApiKey -> providerApiKey.toBuilder()
+                                                .apiKey(maskApiKey(decrypt(providerApiKey.apiKey())))
+                                                .build())
+                                        .toList())
+                        .build())
                 .build();
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyDAO.java
@@ -20,7 +20,8 @@ import java.util.UUID;
 @RegisterArgumentFactory(UUIDArgumentFactory.class)
 public interface LlmProviderApiKeyDAO {
 
-    @SqlUpdate("INSERT INTO llm_provider_api_key (id, provider, workspace_id, api_key, name, created_by, last_updated_by) " +
+    @SqlUpdate("INSERT INTO llm_provider_api_key (id, provider, workspace_id, api_key, name, created_by, last_updated_by) "
+            +
             "VALUES (:bean.id, :bean.provider, :workspaceId, :bean.apiKey, :bean.name, :bean.createdBy, :bean.lastUpdatedBy)")
     void save(@Bind("workspaceId") String workspaceId,
             @BindMethods("bean") ProviderApiKey providerApiKey);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
@@ -1,6 +1,5 @@
 package com.comet.opik.domain;
 
-import com.comet.opik.api.Page;
 import com.comet.opik.api.ProviderApiKey;
 import com.comet.opik.api.ProviderApiKeyUpdate;
 import com.comet.opik.api.error.EntityAlreadyExistsException;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionDAO.java
@@ -19,7 +19,8 @@ import java.util.UUID;
 @RegisterConstructorMapper(PromptVersionId.class)
 interface PromptVersionDAO {
 
-    @SqlUpdate("INSERT INTO prompt_versions (id, prompt_id, commit, template, metadata, change_description, created_by, workspace_id) " +
+    @SqlUpdate("INSERT INTO prompt_versions (id, prompt_id, commit, template, metadata, change_description, created_by, workspace_id) "
+            +
             "VALUES (:bean.id, :bean.promptId, :bean.commit, :bean.template, :bean.metadata, :bean.changeDescription, :bean.createdBy, :workspace_id)")
     void save(@Bind("workspace_id") String workspaceId, @BindMethods("bean") PromptVersion prompt);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/ModelPrice.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/ModelPrice.java
@@ -72,17 +72,21 @@ public enum ModelPrice {
             SpanCostCalculator::textGenerationCost),
 
     // Update for 2024-12-18
-    gpt_4o_mini_audio_preview_2024_12_17("gpt-4o-mini-audio-preview-2024-12-17", new BigDecimal("0.00000015"), new BigDecimal("0.0000006"),
+    gpt_4o_mini_audio_preview_2024_12_17("gpt-4o-mini-audio-preview-2024-12-17", new BigDecimal("0.00000015"),
+            new BigDecimal("0.0000006"),
             SpanCostCalculator::textGenerationCost),
     o1("o1", new BigDecimal("0.000015"), new BigDecimal("0.00006"),
             SpanCostCalculator::textGenerationCost),
     o1_2024_12_17("o1-2024-12-17", new BigDecimal("0.000015"), new BigDecimal("0.000060"),
             SpanCostCalculator::textGenerationCost),
-    gpt_4o_realtime_preview_2024_12_17("gpt-4o-realtime-preview-2024-12-17", new BigDecimal("0.000005"), new BigDecimal("0.00002"),
+    gpt_4o_realtime_preview_2024_12_17("gpt-4o-realtime-preview-2024-12-17", new BigDecimal("0.000005"),
+            new BigDecimal("0.00002"),
             SpanCostCalculator::textGenerationCost),
-    gpt_4o_mini_realtime_preview("gpt-4o-mini-realtime-preview", new BigDecimal("0.0000006"), new BigDecimal("0.0000024"),
+    gpt_4o_mini_realtime_preview("gpt-4o-mini-realtime-preview", new BigDecimal("0.0000006"),
+            new BigDecimal("0.0000024"),
             SpanCostCalculator::textGenerationCost),
-    gpt_4o_mini_realtime_preview_2024_12_17("gpt-4o-mini-realtime-preview-2024-12-17", new BigDecimal("0.0000006"), new BigDecimal("0.0000024"),
+    gpt_4o_mini_realtime_preview_2024_12_17("gpt-4o-mini-realtime-preview-2024-12-17", new BigDecimal("0.0000006"),
+            new BigDecimal("0.0000024"),
             SpanCostCalculator::textGenerationCost),
 
     DEFAULT("", new BigDecimal("0"), new BigDecimal("0"), SpanCostCalculator::defaultCost);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ChatCompletionsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ChatCompletionsResourceTest.java
@@ -191,26 +191,27 @@ public class ChatCompletionsResourceTest {
             assertThat(choices).anySatisfy(choice -> assertThat(choice.delta().role())
                     .isEqualTo(Role.ASSISTANT));
         }
-    }
 
-    @Test
-    void createAndStreamResponseReturnsBadRequestWhenNoModel() {
-        var workspaceName = RandomStringUtils.randomAlphanumeric(20);
-        var workspaceId = UUID.randomUUID().toString();
-        mockTargetWorkspace(workspaceName, workspaceId);
-        createLlmProviderApiKey(workspaceName);
+        @Test
+        void createAndStreamResponseReturnsBadRequestWhenNoModel() {
+            var workspaceName = RandomStringUtils.randomAlphanumeric(20);
+            var workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(workspaceName, workspaceId);
+            createLlmProviderApiKey(workspaceName);
 
-        var request = podamFactory.manufacturePojo(ChatCompletionRequest.Builder.class)
-                .stream(true)
-                .addUserMessage("Say 'Hello World'")
-                .build();
+            var request = podamFactory.manufacturePojo(ChatCompletionRequest.Builder.class)
+                    .stream(true)
+                    .addUserMessage("Say 'Hello World'")
+                    .build();
 
-        var errorMessages = chatCompletionsClient.createAndStreamError(API_KEY, workspaceName, request);
+            var errorMessages = chatCompletionsClient.createAndStreamError(API_KEY, workspaceName, request);
 
-        assertThat(errorMessages).hasSize(1);
-        assertThat(errorMessages.getFirst().getCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
-        assertThat(errorMessages.getFirst().getMessage())
-                .containsIgnoringCase("Only %s model is available".formatted(ChatCompletionModel.GPT_4O_MINI));
+            assertThat(errorMessages).hasSize(1);
+            assertThat(errorMessages.getFirst().getCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+            assertThat(errorMessages.getFirst().getMessage())
+                    .containsIgnoringCase("Only %s model is available".formatted(ChatCompletionModel.GPT_4O_MINI));
+        }
+
     }
 
     private void createLlmProviderApiKey(String workspaceName) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/podam/manufacturer/ProviderApiKeyManufacturer.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/podam/manufacturer/ProviderApiKeyManufacturer.java
@@ -17,7 +17,7 @@ public class ProviderApiKeyManufacturer extends AbstractTypeManufacturer<Provide
 
     @Override
     public ProviderApiKey getType(DataProviderStrategy strategy, AttributeMetadata metadata,
-                                 ManufacturingContext context) {
+            ManufacturingContext context) {
 
         UUID id = strategy.getTypeValue(metadata, context, UUID.class);
 

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -109,9 +109,9 @@ distributedLock:
 
 # Redis configuration
 redis:
-  # Default:
+  # Default: redis://:opik@localhost:6379/0
   # Description: single node redis's URL
-  singleNodeUrl:
+  singleNodeUrl: redis://:opik@localhost:6379/0
 
 # Authentication configuration. This is not enabled by default for open source installations.
 authentication:


### PR DESCRIPTION
## Details
In Opik Backend, there was no default redis url for local development. As this is validated to not to be null on service start up, the service failed to start locally. Fixed in config.yml

This is overwritten by the value coming from the test container in tests. However, added a value in test-config.yml in order to follow the existing convention.

Moved test in ChatCompletionsResourceTest under Create, which is the right place.

Applied Spotless formatting, which fixed multiple files.

## Issues

NO-JIRA

## Testing
- Started the service locally before and after the fix.
- Passed CI build.

## Documentation
- https://redisson.org/docs/configuration/
