### PR TITLE
[OPIK-673] implement OPIK_TRACK_DISABLE configuration

### DIFF
--- a/sdks/python/src/opik/config.py
+++ b/sdks/python/src/opik/config.py
@@ -158,6 +158,14 @@ class OpikConfig(pydantic_settings.BaseSettings):
     If enabled, TLS verification is enabled for all HTTP requests.
     """
 
+    track_disable: bool = False
+    """
+    If set to True, then `@track` decorator and `track_LIBRARY(...)` integrations do not log any data.
+    Any other API will continue working.
+    We do not recommend disable tracking unless you only use tracking functionalities in your project because
+    it might lead to unexpected results for the features that rely on spans/traces created.
+    """
+
     @property
     def config_file_fullpath(self) -> pathlib.Path:
         config_file_path = os.getenv("OPIK_CONFIG_PATH", CONFIG_FILE_PATH_DEFAULT)

--- a/sdks/python/tests/unit/decorator/test_track_disabled.py
+++ b/sdks/python/tests/unit/decorator/test_track_disabled.py
@@ -47,16 +47,17 @@ def test_track_get_current_span_and_trace_called__spans_and_trace_exist__but_not
     assert len(fake_backend.span_trees) == 0
 
 
-def test_track_update_current_span_and_trace_called__but_nothing_logged(fake_backend):
+def test_track_update_current_span_and_trace_called__no_errors_raised__nothing_logged(fake_backend):
     tracker_instance = tracker.OpikTrackDecorator()
 
     with patch_environ({"OPIK_TRACK_DISABLE": "true"}):
 
         @tracker_instance.track
         def f():
-            assert opik_context.update_current_span(name="some-name")
-            assert opik_context.update_current_trace(name="some-name")
+            opik_context.update_current_span(name="some-name")
+            opik_context.update_current_trace(name="some-name")
 
+        f()
         tracker.flush_tracker()
 
     assert len(fake_backend.trace_trees) == 0

--- a/sdks/python/tests/unit/decorator/test_track_disabled.py
+++ b/sdks/python/tests/unit/decorator/test_track_disabled.py
@@ -47,7 +47,9 @@ def test_track_get_current_span_and_trace_called__spans_and_trace_exist__but_not
     assert len(fake_backend.span_trees) == 0
 
 
-def test_track_update_current_span_and_trace_called__no_errors_raised__nothing_logged(fake_backend):
+def test_track_update_current_span_and_trace_called__no_errors_raised__nothing_logged(
+    fake_backend,
+):
     tracker_instance = tracker.OpikTrackDecorator()
 
     with patch_environ({"OPIK_TRACK_DISABLE": "true"}):

--- a/sdks/python/tests/unit/decorator/test_track_disabled.py
+++ b/sdks/python/tests/unit/decorator/test_track_disabled.py
@@ -1,0 +1,63 @@
+from opik import opik_context
+from opik.decorator import tracker
+
+from ...testlib import patch_environ
+
+
+def test_track__disabled_mode__nothing_logged__happyflow(fake_backend):
+    tracker_instance = tracker.OpikTrackDecorator()
+
+    with patch_environ({"OPIK_TRACK_DISABLE": "true"}):
+
+        @tracker_instance.track
+        def f_inner():
+            return 42
+
+        @tracker_instance.track
+        def f_outer():
+            f_inner()
+
+        f_outer()
+        tracker.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 0
+    assert len(fake_backend.span_trees) == 0
+
+
+def test_track_get_current_span_and_trace_called__spans_and_trace_exist__but_nothing_logged(
+    fake_backend,
+):
+    """
+    SpanData and TraceData are still returned intentionally to make sure that scripts
+    which called them continue working and don't fail because they started return `None`
+    in disabled mode.
+    """
+    tracker_instance = tracker.OpikTrackDecorator()
+
+    with patch_environ({"OPIK_TRACK_DISABLE": "true"}):
+
+        @tracker_instance.track
+        def f():
+            assert opik_context.get_current_span_data() is not None
+            assert opik_context.get_current_trace_data() is not None
+
+        tracker.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 0
+    assert len(fake_backend.span_trees) == 0
+
+
+def test_track_update_current_span_and_trace_called__but_nothing_logged(fake_backend):
+    tracker_instance = tracker.OpikTrackDecorator()
+
+    with patch_environ({"OPIK_TRACK_DISABLE": "true"}):
+
+        @tracker_instance.track
+        def f():
+            assert opik_context.update_current_span(name="some-name")
+            assert opik_context.update_current_trace(name="some-name")
+
+        tracker.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 0
+    assert len(fake_backend.span_trees) == 0

--- a/sdks/python/tests/unit/decorator/test_track_disabled_mode.py
+++ b/sdks/python/tests/unit/decorator/test_track_disabled_mode.py
@@ -4,7 +4,7 @@ from opik.decorator import tracker
 from ...testlib import patch_environ
 
 
-def test_track__disabled_mode__nothing_logged__happyflow(fake_backend):
+def test_track_disabled_mode__nothing_logged__happyflow(fake_backend):
     tracker_instance = tracker.OpikTrackDecorator()
 
     with patch_environ({"OPIK_TRACK_DISABLE": "true"}):
@@ -24,7 +24,7 @@ def test_track__disabled_mode__nothing_logged__happyflow(fake_backend):
     assert len(fake_backend.span_trees) == 0
 
 
-def test_track_get_current_span_and_trace_called__spans_and_trace_exist__but_nothing_logged(
+def test_track_disabled_mode__get_current_span_and_trace_called__spans_and_trace_exist__but_nothing_logged(
     fake_backend,
 ):
     """
@@ -41,13 +41,14 @@ def test_track_get_current_span_and_trace_called__spans_and_trace_exist__but_not
             assert opik_context.get_current_span_data() is not None
             assert opik_context.get_current_trace_data() is not None
 
+        f()
         tracker.flush_tracker()
 
     assert len(fake_backend.trace_trees) == 0
     assert len(fake_backend.span_trees) == 0
 
 
-def test_track_update_current_span_and_trace_called__no_errors_raised__nothing_logged(
+def test_track_disabled_mode__update_current_span_and_trace_called__no_errors_raised__nothing_logged(
     fake_backend,
 ):
     tracker_instance = tracker.OpikTrackDecorator()


### PR DESCRIPTION
## Details
If you set `OPIK_TRACK_DISABLE` configuration to `True` (via the environment variable or config file) - `@track` decorator will stop logging data.
It will also disable data logging for any other `track_LIBRARY_NAME` integration: openai, anthropic, bedrock, aisuite, guardrails.
**Important!!!:** the rest of the API works as usually and is not related to a new configuration.

In order to minimize the impact on the existing user scripts that just need to stop logging data, spans and traces objects are still created under the hood, so `get_current_[span, trace]_data` and `update_current_[span, trace]` continue working as they worked before, nothing will start suddenly returning None or raising exceptions in places where it was working before the tracking was disabled. But no data will be sent to the backend.

Resolves: #963 

## Testing
Unit tests were added for vanilla `@track` decorator. Manual tests were performed for the integrations.

## Note
As the config docstring says - it's not recommended to disable tracking unless you only use tracking functionalities in your code. There is no guarantee that some current or future feature dependent on spans or traces logged with `@track` decorator will not produce an unexpected result.
