### PR TITLE
Fix traces/spans aggregations for feedback scores

### DIFF
--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab.tsx
@@ -349,7 +349,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
             cell: FeedbackScoreCell as never,
             accessorFn: (row) =>
               row.feedback_scores?.find((f) => f.name === label),
-            statisticKey: `feedback_score.${label}`,
+            statisticKey: `feedback_scores.${label}`,
           }) as ColumnData<BaseTraceData>,
       ),
     ];


### PR DESCRIPTION
## Details
- Due a recent BE API contract the feedback scores aggregations in the traces/spans table are broken, this adjusts the FE with the new BE API contract

https://github.com/comet-ml/opik/pull/894/files#diff-fecda966dc2808695e352f153a981a39f19d31c17a32f1b6315bdb239f74af19R65

## Issues

Resolves #

## Testing

## Documentation
