### PR TITLE
[OPIK-679] fix feedback scores tests

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMapper.java
@@ -22,6 +22,10 @@ public class StatsMapper {
     public static final String FEEDBACK_SCORE = "feedback_scores";
     public static final String TOTAL_ESTIMATED_COST = "total_estimated_cost";
     public static final String DURATION = "duration";
+    public static final String INPUT = "input";
+    public static final String OUTPUT = "output";
+    public static final String METADATA = "metadata";
+    public static final String TAGS = "tags";
 
     public static ProjectStats mapProjectStats(Row row, String entityCountLabel) {
 
@@ -35,10 +39,10 @@ public class StatsMapper {
                                 getP(durations, 1),
                                 getP(durations, 2)))
                         .orElse(null)))
-                .add(new CountValueStat("input", row.get("input", Long.class)))
-                .add(new CountValueStat("output", row.get("output", Long.class)))
-                .add(new CountValueStat("metadata", row.get("metadata", Long.class)))
-                .add(new AvgValueStat("tags", row.get("tags", Double.class)));
+                .add(new CountValueStat(INPUT, row.get("input", Long.class)))
+                .add(new CountValueStat(OUTPUT, row.get("output", Long.class)))
+                .add(new CountValueStat(METADATA, row.get("metadata", Long.class)))
+                .add(new AvgValueStat(TAGS, row.get("tags", Double.class)));
 
         BigDecimal totalEstimatedCost = row.get("total_estimated_cost_avg", BigDecimal.class);
         if (totalEstimatedCost == null) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/StatsUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/StatsUtils.java
@@ -7,6 +7,7 @@ import com.comet.opik.api.ProjectStats.SingleValueStat;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
 import com.comet.opik.domain.cost.ModelPrice;
+import com.comet.opik.domain.stats.StatsMapper;
 import com.comet.opik.utils.ValidationUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.math.Quantiles;
@@ -168,10 +169,10 @@ public class StatsUtils {
 
         stats.add(new CountValueStat(countLabel, input));
         if (!quantities.isEmpty()) {
-            stats.add(new PercentageValueStat("duration",
+            stats.add(new PercentageValueStat(StatsMapper.DURATION,
                     new PercentageValues(quantities.get(0), quantities.get(1), quantities.get(2))));
         } else {
-            stats.add(new PercentageValueStat("duration",
+            stats.add(new PercentageValueStat(StatsMapper.DURATION,
                     new PercentageValues(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO)));
         }
 
@@ -180,23 +181,23 @@ public class StatsUtils {
                 : totalEstimatedCost.divide(BigDecimal.valueOf(countEstimatedCost), ValidationUtils.SCALE,
                         RoundingMode.HALF_UP);
 
-        stats.add(new CountValueStat("input", input));
-        stats.add(new CountValueStat("output", output));
-        stats.add(new CountValueStat("metadata", metadata));
-        stats.add(new AvgValueStat("tags", (tags / expectedEntities.size())));
-        stats.add(new AvgValueStat("total_estimated_cost", totalEstimatedCostValue.doubleValue()));
+        stats.add(new CountValueStat(StatsMapper.INPUT, input));
+        stats.add(new CountValueStat(StatsMapper.OUTPUT, output));
+        stats.add(new CountValueStat(StatsMapper.METADATA, metadata));
+        stats.add(new AvgValueStat(StatsMapper.TAGS, (tags / expectedEntities.size())));
+        stats.add(new AvgValueStat(StatsMapper.TOTAL_ESTIMATED_COST, totalEstimatedCostValue.doubleValue()));
 
         usage.keySet()
                 .stream()
                 .sorted()
                 .forEach(key -> stats
-                        .add(new AvgValueStat("%s.%s".formatted("usage", key), usage.get(key))));
+                        .add(new AvgValueStat("%s.%s".formatted(StatsMapper.USAGE, key), usage.get(key))));
 
         feedback.keySet()
                 .stream()
                 .sorted()
                 .forEach(key -> stats
-                        .add(new AvgValueStat("%s.%s".formatted("feedback_score", key),
+                        .add(new AvgValueStat("%s.%s".formatted(StatsMapper.FEEDBACK_SCORE, key),
                                 feedback.get(key))));
 
         return stats;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/StatsUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/StatsUtils.java
@@ -254,6 +254,13 @@ public class StatsUtils {
 
     private static int singleValueStatCompareTo(SingleValueStat<? extends Number> v1,
             SingleValueStat<? extends Number> v2) {
+        if (!v1.getName().equals(v2.getName())) {
+            return Comparator.comparing(String::toString).compare(v1.getName(), v2.getName());
+        }
+        if (!v1.getType().equals(v2.getType())) {
+            return Comparator.comparing(String::toString).compare(v1.getType().toString(), v2.getType().toString());
+        }
+
         return switch (v1) {
             case CountValueStat count -> Comparator.comparing(CountValueStat::getValue)
                     .compare((CountValueStat) v1, (CountValueStat) v2);


### PR DESCRIPTION
## Details
Project statistics tests were not covering correct stat name and type due to a custom comparator implementation mistake. 
I fixed the tests to fail on the wrong stat name, and then fixed the tests to make it green.

## Issues
OPIK-679
