### PR TITLE
[OPIK-647] Return 409 instead of throwing exception for workspaceId or project mismatch

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -48,6 +48,8 @@ import static com.comet.opik.domain.FeedbackScoreDAO.EntityType;
 @ImplementedBy(TraceServiceImpl.class)
 public interface TraceService {
 
+    String PROJECT_NAME_AND_WORKSPACE_NAME_MISMATCH = "Project name and workspace name do not match the existing trace";
+
     Mono<UUID> create(Trace trace);
 
     Mono<Long> create(TraceBatch batch);
@@ -80,7 +82,6 @@ public interface TraceService {
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 class TraceServiceImpl implements TraceService {
 
-    public static final String PROJECT_NAME_AND_WORKSPACE_NAME_MISMATCH = "Project name and workspace name do not match the existing trace";
     public static final String TRACE_KEY = "Trace";
 
     private final @NonNull TraceDAO dao;
@@ -168,8 +169,8 @@ class TraceServiceImpl implements TraceService {
     private <T> Mono<T> handleDBError(Throwable ex) {
         if (ex instanceof ClickHouseException
                 && ex.getMessage().contains("TOO_LARGE_STRING_SIZE")
-                && (ex.getMessage().contains("_CAST(project_id, FixedString(36))")
-                        && ex.getMessage().contains(", CAST(leftPad(workspace_id, 40, '*'), 'FixedString(19)') ::"))) {
+                && ex.getMessage().contains("String too long for type FixedString")
+                && (ex.getMessage().contains("project_id") || ex.getMessage().contains("workspace_id"))) {
 
             return failWithConflict(PROJECT_NAME_AND_WORKSPACE_NAME_MISMATCH);
         }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/SpanResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/SpanResourceClient.java
@@ -10,6 +10,7 @@ import com.comet.opik.domain.cost.ModelPrice;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import lombok.RequiredArgsConstructor;
 import org.apache.http.HttpStatus;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
@@ -31,14 +32,7 @@ public class SpanResourceClient {
     private final String baseURI;
 
     public UUID createSpan(Span span, String apiKey, String workspaceName) {
-        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
-                .request()
-                .accept(MediaType.APPLICATION_JSON_TYPE)
-                .header(HttpHeaders.AUTHORIZATION, apiKey)
-                .header(WORKSPACE_HEADER, workspaceName)
-                .post(Entity.json(span))) {
-
-            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CREATED);
+        try (var response = createSpan(span, apiKey, workspaceName, HttpStatus.SC_CREATED)) {
 
             var actualId = TestUtils.getIdFromLocation(response.getLocation());
 
@@ -48,6 +42,19 @@ public class SpanResourceClient {
 
             return actualId;
         }
+    }
+
+    public Response createSpan(Span span, String apiKey, String workspaceName, int expectedStatus) {
+        var response = client.target(RESOURCE_PATH.formatted(baseURI))
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(span));
+
+        assertThat(response.getStatus()).isEqualTo(expectedStatus);
+
+        return response;
     }
 
     public void feedbackScores(List<FeedbackScoreBatchItem> score, String apiKey, String workspaceName) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -102,6 +102,7 @@ import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABA
 import static com.comet.opik.api.resources.utils.MigrationUtils.CLICKHOUSE_CHANGELOG_FILE;
 import static com.comet.opik.api.resources.utils.StatsUtils.getProjectSpanStatItems;
 import static com.comet.opik.domain.ProjectService.DEFAULT_PROJECT;
+import static com.comet.opik.domain.SpanService.PROJECT_AND_WORKSPACE_NAME_MISMATCH;
 import static com.comet.opik.infrastructure.auth.RequestContext.SESSION_COOKIE;
 import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER;
 import static com.comet.opik.infrastructure.auth.TestHttpClientUtils.UNAUTHORIZED_RESPONSE;
@@ -3424,6 +3425,12 @@ class SpansResourceTest {
         }
     }
 
+    private void createAndAssertErrorMessage(Span span, String apiKey, String workspaceName, int status, String errorMessage) {
+        try (var response = spanResourceClient.createSpan(span, apiKey, workspaceName, status)) {
+            assertThat(response.readEntity(ErrorMessage.class).errors().getFirst()).isEqualTo(errorMessage);
+        }
+    }
+
     @Test
     void createAndGetById() {
         var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
@@ -3540,6 +3547,31 @@ class SpansResourceTest {
 
         getAndAssert(expectedSpan1, API_KEY, TEST_WORKSPACE);
         getAndAssert(expectedSpan2, API_KEY, TEST_WORKSPACE);
+    }
+
+    @Test
+    void createSpansWithSameIdForDifferentWorkspacesReturnsConflict() {
+
+        var span1 = podamFactory.manufacturePojo(Span.class).toBuilder()
+                .projectId(null)
+                .parentSpanId(null)
+                .build();
+
+        createAndAssert(span1, API_KEY, TEST_WORKSPACE);
+
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+
+        var span2 = podamFactory.manufacturePojo(Span.class).toBuilder()
+                .id(span1.id())
+                .projectId(null)
+                .parentSpanId(null)
+                .projectName(UUID.randomUUID().toString())
+                .build();
+
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+        createAndAssertErrorMessage(span2, apiKey, workspaceName, HttpStatus.SC_CONFLICT, PROJECT_AND_WORKSPACE_NAME_MISMATCH);
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -100,6 +100,7 @@ import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABA
 import static com.comet.opik.api.resources.utils.MigrationUtils.CLICKHOUSE_CHANGELOG_FILE;
 import static com.comet.opik.api.resources.utils.StatsUtils.getProjectTraceStatItems;
 import static com.comet.opik.domain.ProjectService.DEFAULT_PROJECT;
+import static com.comet.opik.domain.TraceService.PROJECT_NAME_AND_WORKSPACE_NAME_MISMATCH;
 import static com.comet.opik.infrastructure.auth.RequestContext.SESSION_COOKIE;
 import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER;
 import static com.comet.opik.infrastructure.auth.TestHttpClientUtils.UNAUTHORIZED_RESPONSE;
@@ -3567,6 +3568,12 @@ class TracesResourceTest {
         return traceResourceClient.createTrace(trace, apiKey, workspaceName);
     }
 
+    private void createAndAssertErrorMessage(Trace trace, String apiKey, String workspaceName, int status, String errorMessage) {
+        try (var response = traceResourceClient.createTrace(trace, apiKey, workspaceName, status)) {
+            assertThat(response.readEntity(ErrorMessage.class).errors().getFirst()).isEqualTo(errorMessage);
+        }
+    }
+
     private void create(UUID entityId, FeedbackScore score, String workspaceName, String apiKey) {
         traceResourceClient.feedbackScore(entityId, score, workspaceName, apiKey);
     }
@@ -3621,8 +3628,8 @@ class TracesResourceTest {
         }
 
         @Test
-        @DisplayName("when creating traces with different workspaces names, then return created traces")
-        void create__whenCreatingTracesWithDifferentWorkspacesNames__thenReturnCreatedTraces() {
+        @DisplayName("when creating traces with different project names, then return created traces")
+        void create__whenCreatingTracesWithDifferentProjectNames__thenReturnCreatedTraces() {
             var projectName = RandomStringUtils.randomAlphanumeric(10);
 
             var trace1 = factory.manufacturePojo(Trace.class)
@@ -3645,6 +3652,34 @@ class TracesResourceTest {
 
             getAndAssert(trace1, projectId1, API_KEY, TEST_WORKSPACE);
             getAndAssert(trace2, projectId2, API_KEY, TEST_WORKSPACE);
+        }
+
+        @Test
+        @DisplayName("when creating traces with same Id for different workspaces, then return conflict")
+        void create__whenCreatingTracesWithSameIdForDifferentWorkspaces__thenReturnConflict() {
+
+            var trace1 = factory.manufacturePojo(Trace.class)
+                    .toBuilder()
+                    .projectName(DEFAULT_PROJECT)
+                    .usage(null)
+                    .feedbackScores(null)
+                    .build();
+            create(trace1, API_KEY, TEST_WORKSPACE);
+
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var trace2 = factory.manufacturePojo(Trace.class)
+                    .toBuilder()
+                    .id(trace1.id())
+                    .projectName(DEFAULT_PROJECT)
+                    .usage(null)
+                    .feedbackScores(null)
+                    .build();
+            createAndAssertErrorMessage(trace2, apiKey, workspaceName, HttpStatus.SC_CONFLICT, PROJECT_NAME_AND_WORKSPACE_NAME_MISMATCH);
         }
 
         @Test


### PR DESCRIPTION
## Details
Return 409 instead of throwing exception for workspaceId or project mismatch

## Testing
Added integration tests
