### PR TITLE
NO-JIRA: Remove docker-compose.yaml port binding

### DIFF
--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -43,14 +43,13 @@ Run the following command to start the services and expose the ports:
 docker compose -f docker-compose.yaml -f docker-compose.override.yaml up -d
 ```
 
-This will expose the following services to the host machine
+This will expose the following services to the host machine:
 
-- Redis: Available on port 6379
-- ClickHouse: Available on ports 8123 (HTTP) and 9000 (Native Protocol)
-- MySQL: Available on port 3306
-- Backend: Available on ports 8080 and 3003
-
-
+- Redis: Available on port 6379.
+- ClickHouse: Available on ports 8123 (HTTP) and 9000 (Native Protocol).
+- MySQL: Available on port 3306.
+- Backend: Available on ports 8080 (HTTP) and 3003 (OpenAPI specification).
+- Frontend: Available on port 5173.
 
 ## Stop opik
 

--- a/deployment/docker-compose/docker-compose.override.yaml
+++ b/deployment/docker-compose/docker-compose.override.yaml
@@ -15,8 +15,8 @@ services:
   backend:
     ports:
       - "8080:8080" # Exposing backend HTTP port to host
-      - "3003:3003" # Exposing additional backend port to host
+      - "3003:3003" # Exposing backend OpenAPI specification port to host
 
   frontend:
     ports:
-      - "5173:5173" # Exposing frontend dev server port to host
+      - "5173:5173" # Exposing frontend server port to host

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -14,8 +14,6 @@ services:
       timeout: 1s
       interval: 1s
       retries: 300
-    ports:
-      - "3306"
     volumes:
       - mysql:/var/lib/mysql/:type=volume,source=~/opik/mysql
 
@@ -23,8 +21,6 @@ services:
     image: redis:7.2.4-alpine3.19
     hostname: redis
     command: redis-server --requirepass opik
-    ports:
-      - '6379'
     healthcheck:
       test: [ "CMD", "nc", "-z", "localhost", "6379" ]
       interval: 2s
@@ -42,9 +38,6 @@ services:
       # Enables SQL-driven Access Control and Account Management:
       # https://clickhouse.com/docs/en/operations/access-rights#enabling-access-control
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
-    ports:
-      - "8123" # HTTP default port
-      - "9000" # Native Protocol port
     volumes:
       - clickhouse:/var/lib/clickhouse/:type=volume,source=~/opik/clickhouse/data
       - clickhouse-server:/var/log/clickhouse-server/:type=volume,source=~/opik/clickhouse/logs
@@ -90,8 +83,7 @@ services:
       OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: delta
       OPIK_USAGE_REPORT_ENABLED: ${OPIK_USAGE_REPORT_ENABLED:-true}
     ports:
-      - "8080"
-      - "3003"
+      - "3003" # OpenAPI specification port
     depends_on:
       mysql:
         condition: service_healthy
@@ -105,7 +97,7 @@ services:
       dockerfile: Dockerfile
     hostname: frontend
     ports:
-      - "5173:5173"
+      - "5173:5173" # Frontend server port
     extra_hosts:
       - "apihost:host-gateway"
     volumes:


### PR DESCRIPTION
## Details
Remove port binding for all services in `deployment/docker-compose/docker-compose.yaml` except:
- Frontend from 5173 container at 5173 in host: needed to access Opik from the browser.
- Backed OpenAPI specification from container 3003 to random host port: this is our public documentation for the API spec.

Opik works normally with this set up.

For development, `deployment/docker-compose/docker-compose.override.yaml` can be used which binds everything to known ports in the host (same as the container port).

The purpose is to reduce the risk of exposing the ports.

Updated documentation as well.

## Issues
N/A

## Testing
Run and successfully tested:
- `docker compose -f docker-compose.yaml up -d`
- `docker compose -f docker-compose.yaml -f docker-compose.override.yaml up -d`

## Documentation
N/A
