### PR TITLE
[OPIK-717] Fix click into a span in the tree-viewer in Safari

### DIFF
--- a/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/treeRenderers.tsx
+++ b/apps/opik-frontend/src/components/shared/TraceDetailsPanel/TraceTreeViewer/treeRenderers.tsx
@@ -79,6 +79,11 @@ export const treeRenderers: TreeRenderProps = {
             props.context.isFocused && styles.focused,
           )}
           {...(props.context.itemContainerWithoutChildrenProps as object)}
+          onClick={() => {
+            if (props.context.interactiveElementProps.onFocus) {
+              props.context.focusItem();
+            }
+          }}
           onFocus={props.context.interactiveElementProps.onFocus}
         >
           <div className={cn(styles.chainItemContainer)}>


### PR DESCRIPTION
## Details
- The custom `renderItem` in the `react-syntax-tree` was lacking of the `onClick` handler that apparently it's needed to focus the item in Safari (without click no focus event is triggered in that browser)

## Issues

Resolves #990

## Testing

## Documentation
