### PR TITLE
[OPIK-735] Online Scoring: null projectId error when creating a rule

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluator.java
@@ -34,7 +34,7 @@ public abstract sealed class AutomationRuleEvaluator<T>
     @Schema(accessMode = Schema.AccessMode.READ_ONLY)
     UUID id;
 
-    @JsonView({View.Public.class, View.Write.class})
+    @JsonView({View.Public.class})
     UUID projectId;
 
     @JsonView({View.Public.class, View.Write.class})

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluator.java
@@ -35,6 +35,7 @@ public abstract sealed class AutomationRuleEvaluator<T>
     UUID id;
 
     @JsonView({View.Public.class})
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY)
     UUID projectId;
 
     @JsonView({View.Public.class, View.Write.class})

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluator.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonView;
 import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -36,7 +35,7 @@ public abstract sealed class AutomationRuleEvaluator<T>
     UUID id;
 
     @JsonView({View.Public.class, View.Write.class})
-    @NotNull UUID projectId;
+    UUID projectId;
 
     @JsonView({View.Public.class, View.Write.class})
     @Schema(accessMode = Schema.AccessMode.READ_WRITE)

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResource.java
@@ -100,6 +100,7 @@ public class AutomationRuleEvaluatorsResource {
     })
     @RateLimited
     public Response createEvaluator(
+            @PathParam("projectId") UUID projectId,
             @RequestBody(content = @Content(schema = @Schema(implementation = AutomationRuleEvaluator.class))) @JsonView(AutomationRuleEvaluator.View.Write.class) @NotNull @Valid AutomationRuleEvaluator<?> evaluator,
             @Context UriInfo uriInfo) {
 
@@ -108,7 +109,7 @@ public class AutomationRuleEvaluatorsResource {
 
         log.info("Creating {} evaluator for project_id '{}' on workspace_id '{}'", evaluator.type(),
                 evaluator.getProjectId(), workspaceId);
-        AutomationRuleEvaluator<?> savedEvaluator = service.save(evaluator, workspaceId, userName);
+        AutomationRuleEvaluator<?> savedEvaluator = service.save(evaluator, projectId, workspaceId, userName);
         log.info("Created {} evaluator '{}' for project_id '{}' on workspace_id '{}'", evaluator.type(),
                 savedEvaluator.getId(), evaluator.getProjectId(), workspaceId);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AutomationRuleEvaluatorService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AutomationRuleEvaluatorService.java
@@ -31,8 +31,8 @@ import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
 @ImplementedBy(AutomationRuleEvaluatorServiceImpl.class)
 public interface AutomationRuleEvaluatorService {
 
-    <E, T extends AutomationRuleEvaluator<E>> T save(T automationRuleEvaluator, @NonNull String workspaceId,
-            @NonNull String userName);
+    <E, T extends AutomationRuleEvaluator<E>> T save(T automationRuleEvaluator, @NonNull UUID projectId,
+            @NonNull String workspaceId, @NonNull String userName);
 
     void update(@NonNull UUID id, @NonNull UUID projectId, @NonNull String workspaceId, @NonNull String userName,
             AutomationRuleEvaluatorUpdate automationRuleEvaluator);
@@ -58,10 +58,10 @@ class AutomationRuleEvaluatorServiceImpl implements AutomationRuleEvaluatorServi
 
     private final @NonNull IdGenerator idGenerator;
     private final @NonNull TransactionTemplate template;
-    private final int DEFAULT_PAGE_LIMIT = 10;
 
     @Override
     public <E, T extends AutomationRuleEvaluator<E>> T save(T inputRuleEvaluator,
+            @NonNull UUID projectId,
             @NonNull String workspaceId,
             @NonNull String userName) {
 
@@ -75,6 +75,7 @@ class AutomationRuleEvaluatorServiceImpl implements AutomationRuleEvaluatorServi
                 case AutomationRuleEvaluatorLlmAsJudge llmAsJudge -> {
                     var definition = llmAsJudge.toBuilder()
                             .id(id)
+                            .projectId(projectId)
                             .createdBy(userName)
                             .lastUpdatedBy(userName)
                             .build();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AutomationRuleEvaluatorResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AutomationRuleEvaluatorResourceClient.java
@@ -26,17 +26,19 @@ public class AutomationRuleEvaluatorResourceClient {
     private final ClientSupport client;
     private final String baseURI;
 
-    public UUID createEvaluator(AutomationRuleEvaluator<?> evaluator, String workspaceName, String apiKey) {
-        try (var actualResponse = createEvaluator(evaluator, workspaceName, apiKey, HttpStatus.SC_CREATED)) {
+    public UUID createEvaluator(AutomationRuleEvaluator<?> evaluator, UUID projectId, String workspaceName,
+            String apiKey) {
+        try (var actualResponse = createEvaluator(evaluator, projectId, workspaceName, apiKey, HttpStatus.SC_CREATED)) {
             assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(201);
 
             return TestUtils.getIdFromLocation(actualResponse.getLocation());
         }
     }
 
-    public Response createEvaluator(AutomationRuleEvaluator<?> evaluator, String workspaceName, String apiKey,
+    public Response createEvaluator(AutomationRuleEvaluator<?> evaluator, UUID projectId, String workspaceName,
+            String apiKey,
             int expectedStatus) {
-        var actualResponse = client.target(RESOURCE_PATH.formatted(baseURI, evaluator.getProjectId()))
+        var actualResponse = client.target(RESOURCE_PATH.formatted(baseURI, projectId))
                 .request()
                 .accept(MediaType.APPLICATION_JSON_TYPE)
                 .header(HttpHeaders.AUTHORIZATION, apiKey)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEventListenerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEventListenerTest.java
@@ -45,7 +45,7 @@ public class OnlineScoringEventListenerTest {
     private static final String API_KEY = UUID.randomUUID().toString();
     private static final String USER = UUID.randomUUID().toString();
     private static final String WORKSPACE_ID = UUID.randomUUID().toString();
-    private static final String TEST_WORKSPACE = UUID.randomUUID().toString();
+    private static final String WORKSPACE_NAME = "workspace-" + UUID.randomUUID();
 
     private static final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
 
@@ -93,7 +93,7 @@ public class OnlineScoringEventListenerTest {
 
         ClientSupportUtils.config(client);
 
-        mockTargetWorkspace(API_KEY, TEST_WORKSPACE, WORKSPACE_ID);
+        mockTargetWorkspace(API_KEY, WORKSPACE_NAME, WORKSPACE_ID);
 
         this.traceResourceClient = new TraceResourceClient(this.client, baseURI);
         this.evaluatorResourceClient = new AutomationRuleEvaluatorResourceClient(this.client, baseURI);
@@ -117,20 +117,20 @@ public class OnlineScoringEventListenerTest {
         @DisplayName("when a new trace is created, OnlineScoring should see it within a event")
         void when__newTracesIsCreated__onlineScoringShouldKnow() {
             var projectName = factory.manufacturePojo(String.class);
-            var projectId = projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
+            var projectId = projectResourceClient.createProject(projectName, API_KEY, WORKSPACE_NAME);
 
             var evaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class)
-                    .toBuilder().projectId(projectId).build();
+                    .toBuilder().projectId(null).build();
 
-            evaluatorResourceClient.createEvaluator(evaluator, TEST_WORKSPACE, API_KEY);
+            evaluatorResourceClient.createEvaluator(evaluator, projectId, WORKSPACE_NAME, API_KEY);
 
             var trace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectName(projectName)
                     .build();
 
-            UUID traceId = traceResourceClient.createTrace(trace, API_KEY, TEST_WORKSPACE);
+            UUID traceId = traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
 
-            Trace returnTrace = traceResourceClient.getById(traceId, TEST_WORKSPACE, API_KEY);
+            Trace returnTrace = traceResourceClient.getById(traceId, WORKSPACE_NAME, API_KEY);
 
             // TODO: run the actual test checking for if we have a FeedbackScore by the end. Prob mocking AI Proxy.
         }


### PR DESCRIPTION
## Details
Using the endpoint, if the projectId is null in the payload, but ok in the path parameter, the rule creationg is aborted due to a 'projectId cant be null'.

During the triage I can see the service was using the projectId from the payload (which is optional and service should not use), while the correct would be use from the path param.

## Issues

Resolves #

## Testing

## Documentation
