### PR TITLE
NO-OPIK automation fixes

### DIFF
--- a/tests_end_to_end/tests/Projects/test_projects_crud_operations.py
+++ b/tests_end_to_end/tests/Projects/test_projects_crud_operations.py
@@ -49,6 +49,7 @@ class TestProjectsCrud:
         try:
             projects_page.go_to_page()
             projects_page.create_new_project(project_name=project_name)
+            projects_page.go_to_page()
             projects_page.check_project_exists_on_current_page(
                 project_name=project_name
             )

--- a/tests_end_to_end/tests/sdk_helpers.py
+++ b/tests_end_to_end/tests/sdk_helpers.py
@@ -176,6 +176,7 @@ def client_get_prompt_retries(
 ):
     start_time = time.time()
     delay = initial_delay
+    time.sleep(initial_delay)
 
     while time.time() - start_time < timeout:
         prompt = client.get_prompt(name=prompt_name)


### PR DESCRIPTION
## Details

Fixed a test that was broken by automatically redirecting to created project's traces page after creation.
Trying to debug a JSONDecodeError on retrieve prompt version method that only seems to happen on GHA