### PR TITLE
[OPIK-739]: hide unsupported by ai proxy models;

### DIFF
--- a/apps/opik-frontend/src/constants/playground.ts
+++ b/apps/opik-frontend/src/constants/playground.ts
@@ -22,10 +22,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       value: PROVIDER_MODEL_TYPE.GPT_4O_MINI_2024_07_18,
       label: "GPT 4o Mini 2024-07-18",
     },
-    {
-      value: PROVIDER_MODEL_TYPE.GPT_4O_2024_11_20,
-      label: "GPT 4o 2024-11-20",
-    },
+    // {
+    //   value: PROVIDER_MODEL_TYPE.GPT_4O_2024_11_20,
+    //   label: "GPT 4o 2024-11-20",
+    // },
     {
       value: PROVIDER_MODEL_TYPE.GPT_4O_2024_08_06,
       label: "GPT 4o 2024-08-06",
@@ -70,10 +70,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       value: PROVIDER_MODEL_TYPE.GPT_3_5_TURBO,
       label: "GPT 3.5 Turbo",
     },
-    {
-      value: PROVIDER_MODEL_TYPE.GPT_3_5_TURBO_16K,
-      label: "GPT 3.5 Turbo 16k",
-    },
+    // {
+    //   value: PROVIDER_MODEL_TYPE.GPT_3_5_TURBO_16K,
+    //   label: "GPT 3.5 Turbo 16k",
+    // },
     {
       value: PROVIDER_MODEL_TYPE.GPT_3_5_TURBO_1106,
       label: "GPT 3.5 Turbo 1106",
@@ -84,28 +84,28 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
     },
 
     // Reasoning Models
-    {
-      value: PROVIDER_MODEL_TYPE.O1_PREVIEW,
-      label: "O1 Preview",
-    },
-    {
-      value: PROVIDER_MODEL_TYPE.O1_MINI,
-      label: "O1 Mini",
-    },
-    {
-      value: PROVIDER_MODEL_TYPE.O1_MINI_2024_09_12,
-      label: "O1 Mini 2024-09-12",
-    },
-    {
-      value: PROVIDER_MODEL_TYPE.O1_PREVIEW_2024_09_12,
-      label: "O1 Preview 2024-09-12",
-    },
+    // {
+    //   value: PROVIDER_MODEL_TYPE.O1_PREVIEW,
+    //   label: "O1 Preview",
+    // },
+    // {
+    //   value: PROVIDER_MODEL_TYPE.O1_MINI,
+    //   label: "O1 Mini",
+    // },
+    // {
+    //   value: PROVIDER_MODEL_TYPE.O1_MINI_2024_09_12,
+    //   label: "O1 Mini 2024-09-12",
+    // },
+    // {
+    //   value: PROVIDER_MODEL_TYPE.O1_PREVIEW_2024_09_12,
+    //   label: "O1 Preview 2024-09-12",
+    // },
 
     // Other Models
-    {
-      value: PROVIDER_MODEL_TYPE.CHATGPT_4O_LATEST,
-      label: "ChatGPT 4o Latest",
-    },
+    // {
+    //   value: PROVIDER_MODEL_TYPE.CHATGPT_4O_LATEST,
+    //   label: "ChatGPT 4o Latest",
+    // },
   ],
 };
 

--- a/apps/opik-frontend/src/constants/playground.ts
+++ b/apps/opik-frontend/src/constants/playground.ts
@@ -22,10 +22,6 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       value: PROVIDER_MODEL_TYPE.GPT_4O_MINI_2024_07_18,
       label: "GPT 4o Mini 2024-07-18",
     },
-    // {
-    //   value: PROVIDER_MODEL_TYPE.GPT_4O_2024_11_20,
-    //   label: "GPT 4o 2024-11-20",
-    // },
     {
       value: PROVIDER_MODEL_TYPE.GPT_4O_2024_08_06,
       label: "GPT 4o 2024-08-06",
@@ -70,10 +66,6 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       value: PROVIDER_MODEL_TYPE.GPT_3_5_TURBO,
       label: "GPT 3.5 Turbo",
     },
-    // {
-    //   value: PROVIDER_MODEL_TYPE.GPT_3_5_TURBO_16K,
-    //   label: "GPT 3.5 Turbo 16k",
-    // },
     {
       value: PROVIDER_MODEL_TYPE.GPT_3_5_TURBO_1106,
       label: "GPT 3.5 Turbo 1106",
@@ -82,30 +74,6 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       value: PROVIDER_MODEL_TYPE.GPT_3_5_TURBO_0125,
       label: "GPT 3.5 Turbo 0125",
     },
-
-    // Reasoning Models
-    // {
-    //   value: PROVIDER_MODEL_TYPE.O1_PREVIEW,
-    //   label: "O1 Preview",
-    // },
-    // {
-    //   value: PROVIDER_MODEL_TYPE.O1_MINI,
-    //   label: "O1 Mini",
-    // },
-    // {
-    //   value: PROVIDER_MODEL_TYPE.O1_MINI_2024_09_12,
-    //   label: "O1 Mini 2024-09-12",
-    // },
-    // {
-    //   value: PROVIDER_MODEL_TYPE.O1_PREVIEW_2024_09_12,
-    //   label: "O1 Preview 2024-09-12",
-    // },
-
-    // Other Models
-    // {
-    //   value: PROVIDER_MODEL_TYPE.CHATGPT_4O_LATEST,
-    //   label: "ChatGPT 4o Latest",
-    // },
   ],
 };
 

--- a/apps/opik-frontend/src/types/providers.ts
+++ b/apps/opik-frontend/src/types/providers.ts
@@ -3,17 +3,10 @@ export enum PROVIDER_TYPE {
 }
 
 export enum PROVIDER_MODEL_TYPE {
-  // Reasoning Models
-  O1_PREVIEW = "o1-preview",
-  O1_MINI = "o1-mini",
-  O1_MINI_2024_09_12 = "o1-mini-2024-09-12",
-  O1_PREVIEW_2024_09_12 = "o1-preview-2024-09-12",
-
   // GPT-4.0 Models
   GPT_4O = "gpt-4o",
   GPT_4O_MINI = "gpt-4o-mini",
   GPT_4O_MINI_2024_07_18 = "gpt-4o-mini-2024-07-18",
-  GPT_4O_2024_11_20 = "gpt-4o-2024-11-20",
   GPT_4O_2024_08_06 = "gpt-4o-2024-08-06",
   GPT_4O_2024_05_13 = "gpt-4o-2024-05-13",
 
@@ -28,12 +21,8 @@ export enum PROVIDER_MODEL_TYPE {
 
   // GPT-3.5 Models
   GPT_3_5_TURBO = "gpt-3.5-turbo",
-  GPT_3_5_TURBO_16K = "gpt-3.5-turbo-16k",
   GPT_3_5_TURBO_1106 = "gpt-3.5-turbo-1106",
   GPT_3_5_TURBO_0125 = "gpt-3.5-turbo-0125",
-
-  // Other Models
-  CHATGPT_4O_LATEST = "chatgpt-4o-latest",
 }
 
 export interface ProviderKey {


### PR DESCRIPTION
## Details
The list of models has been aligned with the BE Proxy:
<img width="1474" alt="image" src="https://github.com/user-attachments/assets/dbfdc6bb-34c0-4667-bb19-0f86fa7bc262" />

## Issues

Resolves #

## Testing

## Documentation
