### PR TITLE
OPIK-795: Create rule logs table

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000010_create_automation_rule_evaluator_logs_table.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000010_create_automation_rule_evaluator_logs_table.sql
@@ -1,13 +1,13 @@
 --liquibase formatted sql
---changeset thiagohora:000010_create_automation_rule_log_table
+--changeset thiagohora:create_automation_rule_evaluator_logs_table
 
 CREATE TABLE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME}.automation_rule_evaluator_logs (
     timestamp DateTime64(9, 'UTC') DEFAULT now64(9),
     workspace_id String,
     rule_id  FixedString(36),
-    level Enum8('INFO'=0, 'ERROR'=1, 'WARN'=2, 'DEBUG'=3, 'TRACE'=4),
+    level Enum8('TRACE'=0, 'DEBUG'=1, 'INFO'=2, 'WARM'=3, 'ERROR'=4),
     message String,
-    extra Map(String, String),
+    markers Map(String, String),
     INDEX idx_workspace_rule_id (workspace_id, rule_id) TYPE bloom_filter(0.01)
 )
 ENGINE = MergeTree()

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000010_create_automation_rule_evaluator_logs_table.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000010_create_automation_rule_evaluator_logs_table.sql
@@ -7,11 +7,10 @@ CREATE TABLE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME}.automation_rule_evaluat
     rule_id  FixedString(36),
     level Enum8('TRACE'=0, 'DEBUG'=1, 'INFO'=2, 'WARM'=3, 'ERROR'=4),
     message String,
-    markers Map(String, String),
-    INDEX idx_workspace_rule_id (workspace_id, rule_id) TYPE bloom_filter(0.01)
+    markers Map(String, String)
 )
 ENGINE = MergeTree()
-ORDER BY (timestamp, workspace_id, rule_id, level)
+ORDER BY (workspace_id, rule_id, timestamp)
 TTL toDateTime(timestamp + INTERVAL 6 MONTH);
 
 --rollback DROP TABLE IF EXISTS ${ANALYTICS_DB_DATABASE_NAME}.automation_rule_evaluator_logs;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000010_create_evaluation_rule_log_table.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000010_create_evaluation_rule_log_table.sql
@@ -1,0 +1,17 @@
+--liquibase formatted sql
+--changeset thiagohora:000010_create_automation_rule_log_table
+
+CREATE TABLE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME}.automation_rule_evaluator_logs (
+    timestamp DateTime64(9, 'UTC') DEFAULT now64(9),
+    workspace_id String,
+    rule_id  FixedString(36),
+    level Enum8('INFO'=0, 'ERROR'=1, 'WARN'=2, 'DEBUG'=3, 'TRACE'=4),
+    message String,
+    extra Map(String, String),
+    INDEX idx_workspace_rule_id (workspace_id, rule_id) TYPE bloom_filter(0.01)
+)
+ENGINE = MergeTree()
+ORDER BY (timestamp, workspace_id, rule_id, level)
+TTL toDateTime(timestamp + INTERVAL 6 MONTH);
+
+--rollback DROP TABLE IF EXISTS ${ANALYTICS_DB_DATABASE_NAME}.automation_rule_evaluator_logs;


### PR DESCRIPTION
## Details
This table will store all rule logs, shown per rule. That will allow the user to see what happens during the online evaluation process.

## Issues
OPIK-795
