### PR TITLE
OPIK-663: Add Python Backend image builder

### DIFF
--- a/.github/workflows/build_apps.yml
+++ b/.github/workflows/build_apps.yml
@@ -82,6 +82,18 @@ jobs:
       comet_build_args: ""
       push_latest: ${{needs.set-version.outputs.push_latest}}
 
+  build-python-backend:
+    needs:
+      - set-version
+    uses: ./.github/workflows/build_and_push_docker.yaml
+    with:
+      image: "opik-python-backend"
+      version: ${{needs.set-version.outputs.version}}
+      build_from: ${{needs.set-version.outputs.build_from}}
+      build_comet_image: false
+      comet_build_args: ""
+      push_latest: ${{needs.set-version.outputs.push_latest}}
+
   build-frontend:
     needs:
       - set-version


### PR DESCRIPTION
## Details
Updated Github action to build and push the `opik-python-backend` service image.

## Issues

OPIK-663

## Testing
After merging and pushing a change, image will be verified at: 
- https://github.com/orgs/comet-ml/packages?repo_name=opik

## Documentation
N/A