### PR TITLE
NO-OPIK fix locator for next page buttons

### DIFF
--- a/tests_end_to_end/page_objects/DatasetItemsPage.py
+++ b/tests_end_to_end/page_objects/DatasetItemsPage.py
@@ -1,12 +1,10 @@
 from playwright.sync_api import Page
-
+import re
 
 class DatasetItemsPage:
     def __init__(self, page: Page):
         self.page = page
-        self.next_page_button_locator = self.page.locator(
-            "div:has(> button:nth-of-type(4))"
-        ).locator("button:nth-of-type(3)")
+        self.next_page_button_locator = self.page.locator("div").filter(has_text=re.compile(r"^Showing (\d+)-(\d+) of (\d+)")).nth(2).locator("button:nth-of-type(3)")
 
     def remove_default_columns(self):
         self.page.get_by_role("button", name="Columns").click()

--- a/tests_end_to_end/page_objects/DatasetItemsPage.py
+++ b/tests_end_to_end/page_objects/DatasetItemsPage.py
@@ -1,10 +1,16 @@
 from playwright.sync_api import Page
 import re
 
+
 class DatasetItemsPage:
     def __init__(self, page: Page):
         self.page = page
-        self.next_page_button_locator = self.page.locator("div").filter(has_text=re.compile(r"^Showing (\d+)-(\d+) of (\d+)")).nth(2).locator("button:nth-of-type(3)")
+        self.next_page_button_locator = (
+            self.page.locator("div")
+            .filter(has_text=re.compile(r"^Showing (\d+)-(\d+) of (\d+)"))
+            .nth(2)
+            .locator("button:nth-of-type(3)")
+        )
 
     def remove_default_columns(self):
         self.page.get_by_role("button", name="Columns").click()

--- a/tests_end_to_end/page_objects/ExperimentItemsPage.py
+++ b/tests_end_to_end/page_objects/ExperimentItemsPage.py
@@ -5,9 +5,7 @@ import re
 class ExperimentItemsPage:
     def __init__(self, page: Page):
         self.page = page
-        self.next_page_button_locator = self.page.locator(
-            "div:has(> button:nth-of-type(4))"
-        ).locator("button:nth-of-type(3)")
+        self.next_page_button_locator = self.page.locator("div").filter(has_text=re.compile(r"^Showing (\d+)-(\d+) of (\d+)")).nth(2).locator("button:nth-of-type(3)")
 
     def get_pagination_button(self) -> Locator:
         return self.page.get_by_role("button", name="Showing")

--- a/tests_end_to_end/page_objects/ExperimentItemsPage.py
+++ b/tests_end_to_end/page_objects/ExperimentItemsPage.py
@@ -5,7 +5,12 @@ import re
 class ExperimentItemsPage:
     def __init__(self, page: Page):
         self.page = page
-        self.next_page_button_locator = self.page.locator("div").filter(has_text=re.compile(r"^Showing (\d+)-(\d+) of (\d+)")).nth(2).locator("button:nth-of-type(3)")
+        self.next_page_button_locator = (
+            self.page.locator("div")
+            .filter(has_text=re.compile(r"^Showing (\d+)-(\d+) of (\d+)"))
+            .nth(2)
+            .locator("button:nth-of-type(3)")
+        )
 
     def get_pagination_button(self) -> Locator:
         return self.page.get_by_role("button", name="Showing")

--- a/tests_end_to_end/page_objects/FeedbackDefinitionsPage.py
+++ b/tests_end_to_end/page_objects/FeedbackDefinitionsPage.py
@@ -25,7 +25,7 @@ class FeedbackDefinitionsPage:
             category1_name.click()
             category1_name.fill("a")
             category1_val.click()
-            category1_val.fill("1")
+            category1_val.fill("2")
 
             category2_name.click()
             category2_name.fill("b")

--- a/tests_end_to_end/page_objects/PromptPage.py
+++ b/tests_end_to_end/page_objects/PromptPage.py
@@ -5,7 +5,12 @@ import re
 class PromptPage:
     def __init__(self, page: Page):
         self.page = page
-        self.next_page_button_locator = self.page.locator("div").filter(has_text=re.compile(r"^Showing (\d+)-(\d+) of (\d+)")).nth(2).locator("button:nth-of-type(3)")
+        self.next_page_button_locator = (
+            self.page.locator("div")
+            .filter(has_text=re.compile(r"^Showing (\d+)-(\d+) of (\d+)"))
+            .nth(2)
+            .locator("button:nth-of-type(3)")
+        )
 
     def edit_prompt(self, new_prompt: str):
         self.page.get_by_role("button", name="Edit prompt").click()

--- a/tests_end_to_end/page_objects/PromptPage.py
+++ b/tests_end_to_end/page_objects/PromptPage.py
@@ -1,12 +1,11 @@
 from playwright.sync_api import Page, expect, Locator
+import re
 
 
 class PromptPage:
     def __init__(self, page: Page):
         self.page = page
-        self.next_page_button_locator = self.page.locator(
-            "div:has(> button:nth-of-type(4))"
-        ).locator("button:nth-of-type(3)")
+        self.next_page_button_locator = self.page.locator("div").filter(has_text=re.compile(r"^Showing (\d+)-(\d+) of (\d+)")).nth(2).locator("button:nth-of-type(3)")
 
     def edit_prompt(self, new_prompt: str):
         self.page.get_by_role("button", name="Edit prompt").click()

--- a/tests_end_to_end/page_objects/TracesPage.py
+++ b/tests_end_to_end/page_objects/TracesPage.py
@@ -8,7 +8,12 @@ class TracesPage:
         self.traces_table = self.page.get_by_role("table")
         self.trace_names_selector = "tr td:nth-child(3) div span"
         self.trace_id_selector = "tr:nth-child({}) > td:nth-child(2) > div".format
-        self.next_page_button_locator = self.page.locator("div").filter(has_text=re.compile(r"^Showing (\d+)-(\d+) of (\d+)")).nth(2).locator("button:nth-of-type(3)")
+        self.next_page_button_locator = (
+            self.page.locator("div")
+            .filter(has_text=re.compile(r"^Showing (\d+)-(\d+) of (\d+)"))
+            .nth(2)
+            .locator("button:nth-of-type(3)")
+        )
         self.delete_button_locator = (
             self.page.locator("div")
             .filter(has_text=re.compile(r"^Add to dataset$"))

--- a/tests_end_to_end/page_objects/TracesPage.py
+++ b/tests_end_to_end/page_objects/TracesPage.py
@@ -8,9 +8,7 @@ class TracesPage:
         self.traces_table = self.page.get_by_role("table")
         self.trace_names_selector = "tr td:nth-child(3) div span"
         self.trace_id_selector = "tr:nth-child({}) > td:nth-child(2) > div".format
-        self.next_page_button_locator = self.page.locator(
-            "div:has(> button:nth-of-type(4))"
-        ).locator("button:nth-of-type(3)")
+        self.next_page_button_locator = self.page.locator("div").filter(has_text=re.compile(r"^Showing (\d+)-(\d+) of (\d+)")).nth(2).locator("button:nth-of-type(3)")
         self.delete_button_locator = (
             self.page.locator("div")
             .filter(has_text=re.compile(r"^Add to dataset$"))


### PR DESCRIPTION
## Details

Traces tests got broken because adding a 4th tab above the tables interfered with the locator for the next page button that was being used. Changed the locator everywhere to cover this and any possible future changes.