### PR TITLE
OPIK-663: Pull instead of building Sandbox Python Executor image

### DIFF
--- a/apps/opik-python-backend/Dockerfile
+++ b/apps/opik-python-backend/Dockerfile
@@ -1,12 +1,6 @@
 FROM docker:27.5.0
 
-ENV DOCKER_HOST=unix:///var/run/docker.sock
-
-RUN apk update \
-    && apk add --no-cache \
-    python3 python3-dev py3-pip \
-    libffi-dev openssl-dev build-base git curl bash \
-    cargo gcc musl-dev
+RUN apk add --no-cache tini python3 py3-pip
 
 WORKDIR /opt/opik-python-backend
 
@@ -15,8 +9,18 @@ RUN pip install -r requirements.txt --break-system-packages
 
 COPY src ./src
 
+COPY entrypoint.sh .
+RUN chmod u+x entrypoint.sh
+
 EXPOSE 8000
 
-CMD dockerd-entrypoint.sh & \
-    sleep 5 \
-    && gunicorn --workers 4 --bind=0.0.0.0:8000 --chdir ./src 'opik_backend:create_app()'
+ENV DOCKER_HOST=unix:///var/run/docker.sock
+
+ENV TINI_SUBREAPER=""
+
+ENV PYTHON_CODE_EXECUTOR_IMAGE_REGISTRY=ghcr.io/comet-ml/opik
+ENV PYTHON_CODE_EXECUTOR_IMAGE_NAME=opik-sandbox-executor-python
+ENV PYTHON_CODE_EXECUTOR_IMAGE_TAG=latest
+
+ENTRYPOINT ["tini", "--"]
+CMD ./entrypoint.sh

--- a/apps/opik-python-backend/entrypoint.sh
+++ b/apps/opik-python-backend/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Using sh as bash is not available in the Alpine image
+set -e
+
+echo "Starting the Docker daemon as background process"
+dockerd-entrypoint.sh &
+
+sleep_seconds=1
+attempts=1
+max_attempts=5
+
+until docker info >/dev/null 2>&1 || [ $attempts -ge $max_attempts ]; do
+  echo "Waiting ${sleep_seconds}s for the Docker daemon to start, attempt: $attempts"
+  sleep $sleep_seconds
+  attempts=$((attempts+1))
+done
+
+if [ $attempts -ge $max_attempts ]; then
+  echo "Docker daemon did not start after $max_attempts attempts"
+  exit 1
+fi
+
+echo "Docker daemon started successfully after $attempts attempts"
+
+# Pre-pulling the to warm up the server the first time it attempts to run the image
+echo "Pulling the Opik Sandbox Executor Python image"
+docker pull "$PYTHON_CODE_EXECUTOR_IMAGE_REGISTRY"/"$PYTHON_CODE_EXECUTOR_IMAGE_NAME":"$PYTHON_CODE_EXECUTOR_IMAGE_TAG"
+echo "Successfully pulled the Opik Sandbox Executor Python image"
+
+echo "Starting the Opik Python Backend server"
+gunicorn --workers 4 --bind=0.0.0.0:8000 --chdir ./src 'opik_backend:create_app()'

--- a/apps/opik-python-backend/src/opik_backend/__init__.py
+++ b/apps/opik-python-backend/src/opik_backend/__init__.py
@@ -14,11 +14,4 @@ def create_app(test_config=None):
     from opik_backend.evaluator import evaluator
     app.register_blueprint(evaluator)
 
-    # TODO: optimize creation e.g: at service build time
-    from opik_backend.docker_runner import \
-        create_docker_image, \
-        PYTHON_CODE_EXECUTOR_DOCKERFILE, \
-        PYTHON_CODE_EXECUTOR_IMAGE_NAME_AND_TAG
-    create_docker_image(PYTHON_CODE_EXECUTOR_DOCKERFILE, PYTHON_CODE_EXECUTOR_IMAGE_NAME_AND_TAG, )
-
     return app


### PR DESCRIPTION
## Details
The Sandbox Python Executor image is now pulled instead of being built locally. 

The exact registry, name and tag is parameterised as env variables and aligned with the variable names from the Helm charts.

The image is pulled before starting the service as a warm-up. Although this isn't strictly necessary as running a docker container automatically pulls the image if not available locally.

Other improvements in Dockerfile: 
- Added `tini` to handle zombie sub-processes.
- Pulling minimum OS packages
- Better wait on the docker daemon start up.
- Etc.

## Issues

OPIK-663

## Testing
- Run all automated tests.
- Curl on Flask service locally.
- Curl on gunicorn server inside Docker.

## Documentation
- https://github.com/krallin/tini
