### PR TITLE
[NA] fix gemini streaming

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/llmproviders/LlmProviderGemini.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/llmproviders/LlmProviderGemini.java
@@ -7,6 +7,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 @RequiredArgsConstructor
@@ -27,9 +28,9 @@ public class LlmProviderGemini implements LlmProviderService {
     public void generateStream(@NonNull ChatCompletionRequest request, @NonNull String workspaceId,
             @NonNull Consumer<ChatCompletionResponse> handleMessage, @NonNull Runnable handleClose,
             @NonNull Consumer<Throwable> handleError) {
-        llmProviderClientGenerator.newGeminiStreamingClient(apiKey, request)
+        CompletableFuture.runAsync(() -> llmProviderClientGenerator.newGeminiStreamingClient(apiKey, request)
                 .generate(request.messages().stream().map(LlmProviderGeminiMapper.INSTANCE::toChatMessage).toList(),
-                        new ChunkedResponseHandler(handleMessage, handleClose, handleError, request.model()));
+                        new ChunkedResponseHandler(handleMessage, handleClose, handleError, request.model())));
     }
 
     @Override

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ChatCompletionsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ChatCompletionsResourceTest.java
@@ -54,7 +54,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 /// relevant test will be skipped for that provider.
 /// - **Openai**: runs against a demo server and doesn't require an API key
 /// - **Anthropic**: set `ANTHROPIC_API_KEY` to your anthropic api key
-/// - **Gemini**: set `GEMINI_AI_KEY` to your gemini api key
+/// - **Gemini**: set `GEMINI_API_KEY` to your gemini api key
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 // Disabled because the tests require an API key to run and this seems to be failing in the CI pipeline
 class ChatCompletionsResourceTest {
@@ -188,6 +188,7 @@ class ChatCompletionsResourceTest {
 
         @ParameterizedTest
         @MethodSource("testModelsProvider")
+        @Disabled
         void createAndStreamResponse(String expectedModel, LlmProvider llmProvider, String llmProviderApiKey) {
             assumeThat(llmProviderApiKey).isNotEmpty();
 
@@ -227,7 +228,7 @@ class ChatCompletionsResourceTest {
                     arguments(AnthropicModelName.CLAUDE_3_5_SONNET_20240620.toString(), LlmProvider.ANTHROPIC,
                             System.getenv("ANTHROPIC_API_KEY")),
                     arguments(GeminiModelName.GEMINI_1_0_PRO.toString(), LlmProvider.GEMINI,
-                            System.getenv("GEMINI_AI_KEY")));
+                            System.getenv("GEMINI_API_KEY")));
         }
 
         @ParameterizedTest

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ChatCompletionsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ChatCompletionsResourceTest.java
@@ -54,6 +54,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 /// relevant test will be skipped for that provider.
 /// - **Openai**: runs against a demo server and doesn't require an API key
 /// - **Anthropic**: set `ANTHROPIC_API_KEY` to your anthropic api key
+/// - **Gemini**: set `GEMINI_AI_KEY` to your gemini api key
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 // Disabled because the tests require an API key to run and this seems to be failing in the CI pipeline
 class ChatCompletionsResourceTest {
@@ -187,7 +188,6 @@ class ChatCompletionsResourceTest {
 
         @ParameterizedTest
         @MethodSource("testModelsProvider")
-        @Disabled
         void createAndStreamResponse(String expectedModel, LlmProvider llmProvider, String llmProviderApiKey) {
             assumeThat(llmProviderApiKey).isNotEmpty();
 


### PR DESCRIPTION
## Details
FE reported that Gemini streaming isn't working properly:
> It just waits for the full response and then returns 200 status

I was able to reproduce locally and noticed that `GoogleAiGeminiStreamingChatModel::generate()` is blocking and therefore the chat completions endpoint only responds when the above is finished.
This PR fixes the issue as you can see in this video:
![Jan-22-2025 10-32-40](https://github.com/user-attachments/assets/70e5e447-aad4-4a0e-b97f-acf5a7d74bd7)

## Testing
Tested locally by running the application and calling the relevant endpoint.
