### PR TITLE
OPIK-663: Add Python Backend to Docker compose

### DIFF
--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -1,21 +1,21 @@
-# Run opik with docker-compose
+# Run Opik with docker-compose
 
-## Installation Prerequisites for local installation
+## Installation pre-requirements for local installation
 
-- Docker - https://docs.docker.com/engine/install/
-- Docker Compose - https://docs.docker.com/compose/install/
+- Docker: https://docs.docker.com/engine/install/
+- Docker Compose: https://docs.docker.com/compose/install/
 
 ## Run docker-compose using the images
 
-If you want to use a specific version, set opik version like
+If you want to use a specific version, set Opik version like:
+
 ```bash
 export OPIK_VERSION=0.1.10
 ```
 
- otherwise it will use the latest images
+Otherwise, it will use the latest images.
 
- Run docker-compose
- From the root of the project
+Run docker-compose from the root of the project:
 
 ```bash
 cd deployment/docker-compose
@@ -24,7 +24,7 @@ docker compose up -d
 
 ## Run docker-compose with building application from latest code
 
-From the root of the project
+From the root of the project:
 
 ```bash
 cd deployment/docker-compose
@@ -33,7 +33,8 @@ docker compose up -d --build
 
 ## Exposing Database and Backend Ports for Local Development
 
-If you're a developer and need to expose the database and backend ports to your host machine for local testing or debugging, you can use the provided Docker Compose override file.
+If you're a developer and need to expose the database and backend ports to your host machine for local testing or
+debugging, you can use the provided Docker Compose override file.
 
 ### Steps to Expose Ports
 
@@ -44,36 +45,45 @@ docker compose -f docker-compose.yaml -f docker-compose.override.yaml up -d
 ```
 
 This will expose the following services to the host machine:
+
 - Redis: Available on port 6379.
 - ClickHouse: Available on ports 8123 (HTTP) and 9000 (Native Protocol).
 - MySQL: Available on port 3306.
 - Backend: Available on ports 8080 (HTTP) and 3003 (OpenAPI specification).
+- Python backend: Available on port 8000 (HTTP).
 - Frontend: Available on port 5173.
 
 ## Run Opik backend locally and the rest of the components with docker-compose
-1. In `nginx_default_local.conf` replace
+
+1. In `nginx_default_local.conf` replace:
+
 ```bash
 http://backend:8080
 ```
-with your localhost
 
-For Mac/Windows (Docker Desktop)
+With your localhost.
+
+For Mac/Windows (Docker Desktop):
+
 ```bash
 http://host.docker.internal:8080
 ```
-For Linux
+
+For Linux:
+
 ```bash
 http://172.17.0.1:8080
 ```
 
-2. Run docker-compose including exposing ports to localhost
+2. Run docker-compose including exposing ports to localhost:
+
 ```bash
 docker compose -f docker-compose.yaml -f docker-compose.override.yaml up -d
 ```
-Stop backend container, cause you don't need it..
 
+Stop the backend container, because you don't need it.
 
-## Stop opik
+## Stop Opik
 
 ```bash
 docker compose down

--- a/deployment/docker-compose/docker-compose.override.yaml
+++ b/deployment/docker-compose/docker-compose.override.yaml
@@ -17,6 +17,10 @@ services:
       - "8080:8080" # Exposing backend HTTP port to host
       - "3003:3003" # Exposing backend OpenAPI specification port to host
 
+  python-backend:
+    ports:
+      - "8000:8000" # Exposing Python backend HTTP port to host
+
   frontend:
     ports:
       - "5173:5173" # Exposing frontend server port to host

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -90,6 +90,16 @@ services:
       clickhouse:
         condition: service_healthy
 
+  python-backend:
+    image: ghcr.io/comet-ml/opik/opik-python-backend:${OPIK_VERSION:-latest}
+    build:
+      context: ../../apps/opik-python-backend
+      dockerfile: Dockerfile
+    hostname: python-backend
+    privileged: true # Required for Docker-in-Docker, so it can launch containers
+    environment:
+      PYTHON_CODE_EXECUTOR_IMAGE_TAG: ${OPIK_VERSION:-latest}
+
   frontend:
     image: ghcr.io/comet-ml/opik/opik-frontend:${OPIK_VERSION:-latest}
     build:


### PR DESCRIPTION
## Details

Added `opik-python-backend` service to docker-compose files. Following the usual conventions:
- Version defined by variable `OPIK_VERSION`.
- Override (default behaviour) exposes port into local host.

Documented in `README.md`, plus some minor improvements in this file.

## Issues

OPIK-663

## Testing
Successfully started the service and curl the endpoint with a success reponse.
Manual tests:
- Pulled latest version AMD64 in local ARM64.
- Pulled specific version, which applies to both the service and the inner executor images. (AMD64 in local ARM64),
- Build locally as ARM64.

## Documentation
N/A
