### PR TITLE
[OPIK-838] Add proper support for litellm completion kwargs

### DIFF
--- a/sdks/python/src/opik/evaluation/models/base_model.py
+++ b/sdks/python/src/opik/evaluation/models/base_model.py
@@ -57,7 +57,7 @@ class OpikBaseModel(abc.ABC):
             kwargs: arguments required by the provider to generate a response.
 
         Returns:
-            Any: The response from the model provider, which can be of any type depending on the use case and LLM model.
+            Any: The response from the model provider, which can be of any type depending on the use case and LLM.
         """
         pass
 
@@ -72,6 +72,6 @@ class OpikBaseModel(abc.ABC):
             kwargs: arguments required by the provider to generate a response.
 
         Returns:
-            Any: The response from the model provider, which can be of any type depending on the use case and LLM model.
+            Any: The response from the model provider, which can be of any type depending on the use case and LLM.
         """
         pass

--- a/sdks/python/src/opik/evaluation/models/litellm/litellm_chat_model.py
+++ b/sdks/python/src/opik/evaluation/models/litellm/litellm_chat_model.py
@@ -38,9 +38,11 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
 
         Args:
             model_name: The name of the LLM model to be used.
-            must_support_arguments: A list of arguments that the provider must support.
+            must_support_arguments: A list of openai-like arguments that the given model + provider pair must support.
                 `litellm.get_supported_openai_params(model_name)` call is used to get
                 supported arguments. If any is missing, ValueError is raised.
+                You can pass the arguments from the table: https://docs.litellm.ai/docs/completion/input#translated-openai-params
+
             **completion_kwargs: key-value arguments to always pass additionally into `litellm.completion` function.
         """
 
@@ -49,8 +51,8 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
         self._check_model_name()
         self._check_must_support_arguments(must_support_arguments)
 
-        self._completion_kwargs: Dict[str, Any] = self._filter_supported_params(
-            completion_kwargs
+        self._completion_kwargs: Dict[str, Any] = (
+            self._remove_unnecessary_not_supported_params(completion_kwargs)
         )
 
         self._engine = litellm
@@ -61,10 +63,6 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
             litellm.get_supported_openai_params(model=self.model_name)
         )
         self._ensure_supported_params(supported_params)
-
-        # Add metadata and success_callback as a parameter that is always supported
-        supported_params.add("metadata")
-        supported_params.add("success_callback")
 
         return supported_params
 
@@ -101,18 +99,21 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
             if key not in self.supported_params:
                 raise ValueError(f"Unsupported parameter: '{key}'!")
 
-    def _filter_supported_params(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        valid_params = {}
+    def _remove_unnecessary_not_supported_params(
+        self, params: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        filtered_params = {**params}
 
-        for key, value in params.items():
-            if key not in self.supported_params:
-                LOGGER.debug(
-                    f"This model does not support the '{key}' parameter and it has been ignored."
-                )
-            else:
-                valid_params[key] = value
+        if (
+            "response_format" in params
+            and "response_format" not in self.supported_params
+        ):
+            filtered_params.pop("response_format")
+            LOGGER.debug(
+                "This model does not support the response_format parameter and it will be ignored."
+            )
 
-        return valid_params
+        return filtered_params
 
     def generate_string(self, input: str, **kwargs: Any) -> str:
         """
@@ -127,7 +128,7 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
             str: The generated string output.
         """
 
-        valid_litellm_params = self._filter_supported_params(kwargs)
+        valid_litellm_params = self._remove_unnecessary_not_supported_params(kwargs)
 
         request = [
             {
@@ -160,7 +161,7 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
         # we need to pop messages first, and after we will check the rest params
         messages = kwargs.pop("messages")
 
-        valid_litellm_params = self._filter_supported_params(kwargs)
+        valid_litellm_params = self._remove_unnecessary_not_supported_params(kwargs)
         all_kwargs = {**self._completion_kwargs, **valid_litellm_params}
 
         if opik_monitor.enabled_in_config():
@@ -185,7 +186,7 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
             str: The generated string output.
         """
 
-        valid_litellm_params = self._filter_supported_params(kwargs)
+        valid_litellm_params = self._remove_unnecessary_not_supported_params(kwargs)
 
         request = [
             {
@@ -215,7 +216,7 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
         # we need to pop messages first, and after we will check the rest params
         messages = kwargs.pop("messages")
 
-        valid_litellm_params = self._filter_supported_params(kwargs)
+        valid_litellm_params = self._remove_unnecessary_not_supported_params(kwargs)
         all_kwargs = {**self._completion_kwargs, **valid_litellm_params}
 
         if opik_monitor.enabled_in_config():

--- a/sdks/python/src/opik/evaluation/models/litellm/litellm_chat_model.py
+++ b/sdks/python/src/opik/evaluation/models/litellm/litellm_chat_model.py
@@ -37,7 +37,7 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
         You can find all possible completion_kwargs parameters here: https://docs.litellm.ai/docs/completion/input.
 
         Args:
-            model_name: The name of the LLM model to be used.
+            model_name: The name of the LLM to be used.
                 This parameter will be passed to `litellm.completion(model=model_name)` so you don't need to pass
                 the `model` argument separately inside **completion_kwargs.
             must_support_arguments: A list of openai-like arguments that the given model + provider pair must support.

--- a/sdks/python/src/opik/evaluation/models/litellm/litellm_chat_model.py
+++ b/sdks/python/src/opik/evaluation/models/litellm/litellm_chat_model.py
@@ -38,6 +38,8 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
 
         Args:
             model_name: The name of the LLM model to be used.
+                This parameter will be passed to `litellm.completion(model=model_name)` so you don't need to pass
+                the `model` argument separately inside **completion_kwargs.
             must_support_arguments: A list of openai-like arguments that the given model + provider pair must support.
                 `litellm.get_supported_openai_params(model_name)` call is used to get
                 supported arguments. If any is missing, ValueError is raised.

--- a/sdks/python/src/opik/evaluation/models/litellm/litellm_chat_model.py
+++ b/sdks/python/src/opik/evaluation/models/litellm/litellm_chat_model.py
@@ -157,7 +157,7 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
             kwargs: arguments required by the provider to generate a response.
 
         Returns:
-            Any: The response from the model provider, which can be of any type depending on the use case and LLM model.
+            Any: The response from the model provider, which can be of any type depending on the use case and LLM.
         """
 
         # we need to pop messages first, and after we will check the rest params
@@ -212,7 +212,7 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
             kwargs: arguments required by the provider to generate a response.
 
         Returns:
-            Any: The response from the model provider, which can be of any type depending on the use case and LLM model.
+            Any: The response from the model provider, which can be of any type depending on the use case and LLM.
         """
 
         # we need to pop messages first, and after we will check the rest params


### PR DESCRIPTION
## Details
LiteLLMChatModel no longer filters completion_kwargs passed by user if they are not presented in `litellm.get_supported_openai_params()`. It caused a bug when litellm-specific params (e.g. `api_base`) were misclassified as not supported.
With the current implementation the only user-passed argument that can be filtered - `response_format` (there will be a warnings about that in that case)

## Issues
1. https://github.com/comet-ml/opik/issues/1094
2. Probably https://github.com/comet-ml/opik/issues/1050

## Testing
Integration tests  work.
Documentation cookbooks workflows also  work.

## Documentation
Updated the docstrings to make them more verbose regarding the arguments passed.
