### PR TITLE
Add minimal litellm version to setup.py

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -40,7 +40,7 @@ setup(
         "click",
         "httpx<0.28.0",
         "levenshtein<1.0.0",
-        "litellm",
+        "litellm>=1.49.1",
         "openai<2.0.0",
         "pydantic-settings>=2.0.0,<3.0.0",
         "pydantic>=2.0.0,<3.0.0",


### PR DESCRIPTION
The minimal version is the one where OpikLogger was introduced.