### PR TITLE
OPIK-859: Reduce find spans query cost

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -521,30 +521,44 @@ class SpanDAO {
                          (dateDiff('microsecond', start_time, end_time) / 1000.0),
                          NULL) AS duration_millis
              FROM spans
-             WHERE project_id = :project_id
-             AND workspace_id = :workspace_id
-             <if(trace_id)> AND trace_id = :trace_id <endif>
-             <if(type)> AND type = :type <endif>
-             <if(filters)> AND <filters> <endif>
-             <if(feedback_scores_filters)>
-             AND id in (
+             WHERE id IN (
                 SELECT
-                    entity_id
+                    id
                 FROM (
-                    SELECT *
-                    FROM feedback_scores
-                    WHERE entity_type = 'span'
-                    AND project_id = :project_id
-                    ORDER BY entity_id DESC, last_updated_at DESC
-                    LIMIT 1 BY entity_id, name
+                    SELECT
+                        id,
+                        if(end_time IS NOT NULL AND start_time IS NOT NULL
+                                 AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)),
+                             (dateDiff('microsecond', start_time, end_time) / 1000.0),
+                             NULL) AS duration_millis
+                    FROM spans
+                    WHERE project_id = :project_id
+                    AND workspace_id = :workspace_id
+                    <if(trace_id)> AND trace_id = :trace_id <endif>
+                    <if(type)> AND type = :type <endif>
+                    <if(filters)> AND <filters> <endif>
+                    <if(feedback_scores_filters)>
+                    AND id in (
+                        SELECT
+                            entity_id
+                        FROM (
+                            SELECT *
+                            FROM feedback_scores
+                            WHERE entity_type = 'span'
+                            AND project_id = :project_id
+                            ORDER BY entity_id DESC, last_updated_at DESC
+                            LIMIT 1 BY entity_id, name
+                        )
+                        GROUP BY entity_id
+                        HAVING <feedback_scores_filters>
+                    )
+                    <endif>
+                    ORDER BY id DESC, last_updated_at DESC
+                    LIMIT 1 BY id
+                    LIMIT :limit OFFSET :offset
                 )
-                GROUP BY entity_id
-                HAVING <feedback_scores_filters>
              )
-             <endif>
-             ORDER BY id DESC, last_updated_at DESC
-             LIMIT 1 BY id
-             LIMIT :limit OFFSET :offset
+             ORDER BY id DESC
             ;
             """;
 


### PR DESCRIPTION
## Details

Despite the slight differences in the parts and the big difference in granules. I'm confident this new query is more efficient since it postpones the retrieval of fields that are not part of the sortable key. This has sped up the process considerably.

Before:

```
Expression (Project names)
  Limit
    LimitBy
      Expression ((Before LIMIT BY + (Before ORDER BY + Projection) [lifted up part]))
        Sorting (Sorting for ORDER BY)
          Expression ((Before ORDER BY + Projection))
            Expression
              ReadFromMergeTree (opik_prod.spans)
              Indexes:
                PrimaryKey
                  Keys: 
                    workspace_id
                    project_id
                  Condition: and((workspace_id in ['48d64607-f70d-4cb1-9207-dd658a423f8e', '48d64607-f70d-4cb1-9207-dd658a423f8e']), (project_id in ['019484c0-1a3c-7987-b2d4-0e3598e8717a', '019484c0-1a3c-7987-b2d4-0e3598e8717a']))
                  Parts: 16/20
                  Granules: 828/29114
```
<img width="1398" alt="Screenshot 2025-01-23 at 14 46 11" src="https://github.com/user-attachments/assets/c58fa0c2-17f6-43fb-894f-00d79df96e70" />

After:

```
CreatingSets (Create sets before main query execution)
  Expression ((Project names + (Before ORDER BY + Projection) [lifted up part]))
    Sorting (Sorting for ORDER BY)
      Expression ((Before ORDER BY + Projection))
        Expression
          ReadFromMergeTree (opik_prod.spans)
          Indexes:
            PrimaryKey
              Keys: 
                id
              Condition: (id in 200-element set)
              Parts: 14/14
              Granules: 25196/29116
```
<img width="1415" alt="Screenshot 2025-01-23 at 14 49 01" src="https://github.com/user-attachments/assets/a4fd6a12-4bb0-4cdd-9ba7-0be106c045ff" />


## Issues
OPIK-859

