### PR TITLE
[OPIK-657]: update playground ux;

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/llm/LLMPromptMessages/LLMPromptMessages.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/llm/LLMPromptMessages/LLMPromptMessages.tsx
@@ -30,6 +30,7 @@ interface LLMPromptMessagesProps {
   possibleTypes?: DropdownOption<LLM_MESSAGE_ROLE>[];
   onChange: (messages: LLMMessage[]) => void;
   onAddMessage: () => void;
+  hint?: string;
 }
 
 const LLMPromptMessages = ({
@@ -38,6 +39,7 @@ const LLMPromptMessages = ({
   possibleTypes,
   onChange,
   onAddMessage,
+  hint = "",
 }: LLMPromptMessagesProps) => {
   const sensors = useSensors(
     useSensor(MouseSensor, {
@@ -128,6 +130,8 @@ const LLMPromptMessages = ({
             ))}
           </div>
         </SortableContext>
+
+        {hint && <p className="comet-body-s mt-2 text-light-slate">{hint}</p>}
 
         <Button
           variant="outline"

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutput.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutput.tsx
@@ -5,6 +5,7 @@ import { getAlphabetLetter } from "@/lib/utils";
 import PlaygroundOutputLoader from "@/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputLoader/PlaygroundOutputLoader";
 import {
   useOutputLoadingByPromptDatasetItemId,
+  useOutputStaleStatusByPromptDatasetItemId,
   useOutputValueByPromptDatasetItemId,
 } from "@/store/PlaygroundStore";
 
@@ -16,13 +17,18 @@ interface PlaygroundOutputProps {
 const PlaygroundOutput = ({ promptId, index }: PlaygroundOutputProps) => {
   const value = useOutputValueByPromptDatasetItemId(promptId);
   const isLoading = useOutputLoadingByPromptDatasetItemId(promptId);
+  const stale = useOutputStaleStatusByPromptDatasetItemId(promptId);
 
   const renderContent = () => {
     if (isLoading && !value) {
       return <PlaygroundOutputLoader />;
     }
 
-    return <ReactMarkdown>{value}</ReactMarkdown>;
+    return (
+      <ReactMarkdown className={stale ? "text-muted-gray" : ""}>
+        {value}
+      </ReactMarkdown>
+    );
   };
 
   return (

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/PlaygroundOutputActions.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/PlaygroundOutputActions.tsx
@@ -207,9 +207,9 @@ const PlaygroundOutputActions = ({
           options={datasetOptions}
           value={datasetId || ""}
           placeholder={
-            <div className="flex w-full items-center text-foreground">
+            <div className="flex w-full items-center text-light-slate">
               <Database className="mr-2 size-4" />
-              <span className="truncate">Dataset</span>
+              <span className="truncate font-normal">Dataset</span>
             </div>
           }
           onChange={handleChangeDatasetId}

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundOutputCell.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundOutputCell.tsx
@@ -4,6 +4,7 @@ import { CellContext } from "@tanstack/react-table";
 import CellWrapper from "@/components/shared/DataTableCells/CellWrapper";
 import {
   useOutputLoadingByPromptDatasetItemId,
+  useOutputStaleStatusByPromptDatasetItemId,
   useOutputValueByPromptDatasetItemId,
 } from "@/store/PlaygroundStore";
 import ReactMarkdown from "react-markdown";
@@ -24,22 +25,31 @@ const PlaygroundOutputCell: React.FunctionComponent<
   const { promptId } = (custom ?? {}) as CustomMeta;
   const originalRow = context.row.original;
 
-  const cellValue = useOutputValueByPromptDatasetItemId(
+  const value = useOutputValueByPromptDatasetItemId(
     promptId,
     originalRow.dataItemId,
   );
 
-  const cellIsLoading = useOutputLoadingByPromptDatasetItemId(
+  const isLoading = useOutputLoadingByPromptDatasetItemId(
+    promptId,
+    originalRow.dataItemId,
+  );
+
+  const stale = useOutputStaleStatusByPromptDatasetItemId(
     promptId,
     originalRow.dataItemId,
   );
 
   const renderContent = () => {
-    if (cellIsLoading && !cellValue) {
+    if (isLoading && !value) {
       return <PlaygroundOutputLoader />;
     }
 
-    return <ReactMarkdown>{cellValue}</ReactMarkdown>;
+    return (
+      <ReactMarkdown className={stale ? "text-muted-gray" : ""}>
+        {value}
+      </ReactMarkdown>
+    );
   };
 
   return (

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputs.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputs.tsx
@@ -1,8 +1,8 @@
-import React from "react";
+import React, { useEffect } from "react";
 import PlaygroundOutputTable from "@/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundOutputTable";
 import PlaygroundOutputActions from "@/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/PlaygroundOutputActions";
 import PlaygroundOutput from "@/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutput";
-import { usePromptIds } from "@/store/PlaygroundStore";
+import { usePromptIds, useSetDatasetVariables } from "@/store/PlaygroundStore";
 import useDatasetItemsList from "@/api/datasets/useDatasetItemsList";
 import { DatasetItem, DatasetItemColumn } from "@/types/datasets";
 
@@ -21,6 +21,7 @@ const PlaygroundOutputs = ({
   onChangeDatasetId,
 }: PlaygroundOutputsProps) => {
   const promptIds = usePromptIds();
+  const setDatasetVariables = useSetDatasetVariables();
 
   const { data: datasetItemsData, isLoading: isLoadingDatasetItems } =
     useDatasetItemsList(
@@ -65,8 +66,12 @@ const PlaygroundOutputs = ({
     );
   };
 
+  useEffect(() => {
+    setDatasetVariables(datasetColumns.map((c) => c.name));
+  }, [setDatasetVariables, datasetColumns]);
+
   return (
-    <div className="mt-auto flex min-w-full flex-col border-t">
+    <div className="flex min-w-full flex-col">
       <PlaygroundOutputActions
         datasetId={datasetId}
         datasetItems={datasetItems}

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -6,12 +6,17 @@ import PlaygroundOutputs from "@/components/pages/PlaygroundPage/PlaygroundOutpu
 import useAppStore from "@/store/AppStore";
 import useProviderKeys from "@/api/provider-keys/useProviderKeys";
 import PlaygroundPrompts from "@/components/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompts";
+import ResizableBottomDiv from "@/components/shared/ResizableBottomDiv/ResizableBottomDiv";
 
 const PLAYGROUND_SELECTED_DATASET_KEY = "playground-selected-dataset";
 const LEGACY_PLAYGROUND_PROMPTS_KEY = "playground-prompts-state";
+const PLAYGROUND_PROMPT_HEIGHT_KEY = "playground-prompts-height";
+const PLAYGROUND_PROMPT_MIN_HEIGHT = 190;
 
 const PlaygroundPage = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const defaultPromptHeight = window.innerHeight - 300;
+  const maxPromptHeight = window.innerHeight - 150;
 
   const { data: providerKeysData, isPending: isPendingProviderKeys } =
     useProviderKeys({
@@ -49,17 +54,28 @@ const PlaygroundPage = () => {
         } as React.CSSProperties
       }
     >
-      <PlaygroundPrompts
-        workspaceName={workspaceName}
-        providerKeys={providerKeys}
-        isPendingProviderKeys={isPendingProviderKeys}
-      />
+      <ResizableBottomDiv
+        minHeight={PLAYGROUND_PROMPT_MIN_HEIGHT}
+        localStorageKey={PLAYGROUND_PROMPT_HEIGHT_KEY}
+        defaultHeight={defaultPromptHeight}
+        maxHeight={maxPromptHeight}
+      >
+        <div className="size-full">
+          <PlaygroundPrompts
+            workspaceName={workspaceName}
+            providerKeys={providerKeys}
+            isPendingProviderKeys={isPendingProviderKeys}
+          />
+        </div>
+      </ResizableBottomDiv>
 
-      <PlaygroundOutputs
-        datasetId={datasetId}
-        onChangeDatasetId={setDatasetId}
-        workspaceName={workspaceName}
-      />
+      <div className="flex">
+        <PlaygroundOutputs
+          datasetId={datasetId}
+          onChangeDatasetId={setDatasetId}
+          workspaceName={workspaceName}
+        />
+      </div>
     </div>
   );
 };

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -27,6 +27,7 @@ import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import PromptModelConfigs from "@/components/pages-shared/llm/PromptModelSettings/PromptModelConfigs";
 import {
   useAddPrompt,
+  useDatasetVariables,
   useDeletePrompt,
   usePromptById,
   useUpdateOutput,
@@ -54,6 +55,8 @@ const PlaygroundPrompt = ({
   const checkedIfModelIsValidRef = useRef(false);
 
   const prompt = usePromptById(promptId);
+  const datasetVariables = useDatasetVariables();
+
   const [, setLastPickedModel] = useLastPickedModel();
 
   const { model, messages, configs, name } = prompt;
@@ -64,6 +67,12 @@ const PlaygroundPrompt = ({
   const updateOutput = useUpdateOutput();
 
   const provider = model ? getModelProvider(model) : "";
+
+  const hintMessage = datasetVariables?.length
+    ? `Reference dataset variables using mustache syntax: ${datasetVariables
+        .map((dv) => `{{${dv}}}`)
+        .join(", ")}`
+    : "";
 
   const handleAddMessage = useCallback(() => {
     const newMessage = generateDefaultLLMPromptMessage();
@@ -181,7 +190,14 @@ const PlaygroundPrompt = ({
   ]);
 
   return (
-    <div className="w-full min-w-[var(--min-prompt-width)]">
+    <div
+      className="h-[var(--prompt-height)] w-full min-w-[var(--min-prompt-width)]"
+      style={
+        {
+          "--prompt-height": "calc(100% - 64px)",
+        } as React.CSSProperties
+      }
+    >
       <div className="mb-2 flex h-8 items-center justify-between">
         <p className="comet-body-s-accented">
           {name} {getAlphabetLetter(index)}
@@ -195,6 +211,7 @@ const PlaygroundPrompt = ({
               provider={provider}
               workspaceName={workspaceName}
               onAddProvider={handleAddProvider}
+              hasError={!model}
             />
           </div>
           <PromptModelConfigs
@@ -229,6 +246,7 @@ const PlaygroundPrompt = ({
         messages={messages}
         onChange={handleUpdateMessage}
         onAddMessage={handleAddMessage}
+        hint={hintMessage}
       />
     </div>
   );

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompts.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompts.tsx
@@ -72,7 +72,7 @@ const PlaygroundPrompts = ({
         </div>
       </div>
 
-      <div className="mb-6 flex min-h-[50%] w-full gap-[var(--item-gap)]">
+      <div className="flex size-full gap-[var(--item-gap)]">
         {promptIds.map((promptId, idx) => (
           <PlaygroundPrompt
             workspaceName={workspaceName}

--- a/apps/opik-frontend/src/components/shared/ResizableBottomDiv/ResizableBottomDiv.tsx
+++ b/apps/opik-frontend/src/components/shared/ResizableBottomDiv/ResizableBottomDiv.tsx
@@ -27,7 +27,6 @@ const ResizableBottomDiv = ({
   const handlePointerDown = (e: PointerEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.currentTarget.setPointerCapture(e.pointerId);
-    
     isResizing.current = true;
     startY.current = e.clientY;
     startHeight.current = height;

--- a/apps/opik-frontend/src/components/shared/ResizableBottomDiv/ResizableBottomDiv.tsx
+++ b/apps/opik-frontend/src/components/shared/ResizableBottomDiv/ResizableBottomDiv.tsx
@@ -25,7 +25,9 @@ const ResizableBottomDiv = ({
   const startHeight = useRef(0);
 
   const handlePointerDown = (e: PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
     e.currentTarget.setPointerCapture(e.pointerId);
+    
     isResizing.current = true;
     startY.current = e.clientY;
     startHeight.current = height;
@@ -34,11 +36,14 @@ const ResizableBottomDiv = ({
   const handlePointerMove = (e: PointerEvent<HTMLDivElement>) => {
     if (!isResizing.current) return;
 
+    e.preventDefault();
+
     const deltaY = e.clientY - startY.current;
     let newHeight = startHeight.current + deltaY;
     const computedMaxHeight = maxHeight ?? window.innerHeight;
     newHeight = Math.max(minHeight, Math.min(computedMaxHeight, newHeight));
-    setHeight(newHeight);
+
+    requestAnimationFrame(() => setHeight(newHeight));
   };
 
   const handlePointerUp = (e: PointerEvent<HTMLDivElement>) => {

--- a/apps/opik-frontend/src/components/shared/ResizableBottomDiv/ResizableBottomDiv.tsx
+++ b/apps/opik-frontend/src/components/shared/ResizableBottomDiv/ResizableBottomDiv.tsx
@@ -1,0 +1,70 @@
+import React, { useRef, PointerEvent } from "react";
+import useLocalStorageState from "use-local-storage-state";
+
+interface ResizableBottomDivProps {
+  children: React.ReactNode;
+  minHeight?: number;
+  localStorageKey: string;
+  defaultHeight?: number;
+  maxHeight?: number;
+}
+
+const ResizableBottomDiv = ({
+  children,
+  localStorageKey,
+  minHeight = 200,
+  defaultHeight = 200,
+  maxHeight,
+}: ResizableBottomDivProps) => {
+  const [height, setHeight] = useLocalStorageState<number>(localStorageKey, {
+    defaultValue: defaultHeight,
+  });
+
+  const isResizing = useRef(false);
+  const startY = useRef(0);
+  const startHeight = useRef(0);
+
+  const handlePointerDown = (e: PointerEvent<HTMLDivElement>) => {
+    e.currentTarget.setPointerCapture(e.pointerId);
+    isResizing.current = true;
+    startY.current = e.clientY;
+    startHeight.current = height;
+  };
+
+  const handlePointerMove = (e: PointerEvent<HTMLDivElement>) => {
+    if (!isResizing.current) return;
+
+    const deltaY = e.clientY - startY.current;
+    let newHeight = startHeight.current + deltaY;
+    const computedMaxHeight = maxHeight ?? window.innerHeight;
+    newHeight = Math.max(minHeight, Math.min(computedMaxHeight, newHeight));
+    setHeight(newHeight);
+  };
+
+  const handlePointerUp = (e: PointerEvent<HTMLDivElement>) => {
+    isResizing.current = false;
+    e.currentTarget.releasePointerCapture(e.pointerId);
+  };
+
+  return (
+    <div
+      className="box-border flex h-[var(--container-height)] min-h-[var(--container-height)] flex-col overflow-hidden"
+      style={
+        {
+          "--container-height": `${height}px`,
+        } as React.CSSProperties
+      }
+    >
+      <div className="flex grow overflow-hidden">{children}</div>
+
+      <div
+        className="sticky bottom-0 mt-auto flex w-full cursor-row-resize border-b py-0.5"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+      />
+    </div>
+  );
+};
+
+export default ResizableBottomDiv;


### PR DESCRIPTION
## Details
* Implement resizing of sections (allow users to freely set the height of the Output section by dragging the divider). No changes in scrolling behavior.
<img width="1492" alt="image" src="https://github.com/user-attachments/assets/9e8ae013-dccd-4ce1-bc57-a073d5b987eb" />

* Improve empty state for dataset select: make it lighter in weight and color when no dataset is selected. [Figma link](https://www.figma.com/design/4DchV5t7FXiwngzBUiqcZ3/Opik-UI?node-id=3080-21806&t=EhSJPUTB59XAxasR-1).
<img width="1243" alt="image" src="https://github.com/user-attachments/assets/9f47a7c3-0f82-4b3d-9b4e-dae1422e0607" />

* Outline model select in red when empty. No need to click on Run, it should be outlined in red when no model is selected. [Figma link](https://www.figma.com/design/4DchV5t7FXiwngzBUiqcZ3/Opik-UI?node-id=3080-21806&t=EhSJPUTB59XAxasR-1).
<img width="1509" alt="image" src="https://github.com/user-attachments/assets/11a06518-7d2f-4b30-8f8f-ebc4c3aafcb7" />


* When a dataset is selected, add a hint text above the + Message button that explains how to reference variables. Please include the actual variables the user can set (column names of the selected dataset). Wrap if needed. [Figma link](https://www.figma.com/design/4DchV5t7FXiwngzBUiqcZ3/Opik-UI?node-id=3080-29314&t=EhSJPUTB59XAxasR-1).
<img width="1188" alt="image" src="https://github.com/user-attachments/assets/163ef898-b93a-407c-8ac5-283ca7f3d1ff" />

* Gray out stale data. No dataset is selected [Figma link](https://www.figma.com/design/4DchV5t7FXiwngzBUiqcZ3/Opik-UI?node-id=2132-107503&t=EhSJPUTB59XAxasR-1). Dataset is selected [Figma link](https://www.figma.com/design/4DchV5t7FXiwngzBUiqcZ3/Opik-UI?node-id=2230-254505&t=EhSJPUTB59XAxasR-1).
<img width="1254" alt="image" src="https://github.com/user-attachments/assets/98eb0b85-91d9-4a76-931d-021d70dde21b" />

## Issues

Resolves #

## Testing

## Documentation
