### PR TITLE
[OPIK-853] handle gemini client errors

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/LlmProviderService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/LlmProviderService.java
@@ -22,5 +22,5 @@ public interface LlmProviderService {
 
     void validateRequest(@NonNull ChatCompletionRequest request);
 
-    Optional<ErrorMessage> getLlmProviderError(@NonNull Throwable runtimeException);
+    Optional<ErrorMessage> getLlmProviderError(@NonNull Throwable throwable);
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/LlmProviderAnthropic.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/LlmProviderAnthropic.java
@@ -57,8 +57,8 @@ class LlmProviderAnthropic implements LlmProviderService {
     }
 
     @Override
-    public Optional<ErrorMessage> getLlmProviderError(@NonNull Throwable runtimeException) {
-        if (runtimeException instanceof AnthropicHttpException anthropicHttpException) {
+    public Optional<ErrorMessage> getLlmProviderError(@NonNull Throwable throwable) {
+        if (throwable instanceof AnthropicHttpException anthropicHttpException) {
             return Optional.of(new ErrorMessage(anthropicHttpException.statusCode(),
                     anthropicHttpException.getMessage()));
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiErrorObject.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiErrorObject.java
@@ -1,0 +1,18 @@
+package com.comet.opik.infrastructure.llm.gemini;
+
+import io.dropwizard.jersey.errors.ErrorMessage;
+
+import java.util.Optional;
+
+public record GeminiErrorObject(GeminiError error) {
+    public Optional<ErrorMessage> toErrorMessage() {
+        if (error != null) {
+            return Optional.of(new ErrorMessage(error.code(), error.message(), error().status()));
+        }
+
+        return Optional.empty();
+    }
+}
+
+record GeminiError(int code, String message, String status) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/LlmProviderOpenAi.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/LlmProviderOpenAi.java
@@ -43,8 +43,8 @@ class LlmProviderOpenAi implements LlmProviderService {
     }
 
     @Override
-    public Optional<ErrorMessage> getLlmProviderError(@NonNull Throwable runtimeException) {
-        if (runtimeException instanceof OpenAiHttpException openAiHttpException) {
+    public Optional<ErrorMessage> getLlmProviderError(@NonNull Throwable throwable) {
+        if (throwable instanceof OpenAiHttpException openAiHttpException) {
             return Optional.of(new ErrorMessage(openAiHttpException.code(), openAiHttpException.getMessage()));
         }
 


### PR DESCRIPTION
## Details
Gemini client errors were not handled correctly. The purpose of this PR is fix the Gemini error handling method to respond with a human readable error.
Gemini API throws `RuntimeException`s with the error details as a JSON inside the message. This PR adds parsing to the error message in order to extract the meaningful part out of it.

## Issues
OPIK-853

## Testing
Tested locally:
```
❯ curl -v -X "POST" -H "Content-Type: application/json" --data '{"model":"gemini-1.5-flash","messages":[{"role":"user","content":"why are the sky blue?"}],"stream":true,"stream_options":{"include_usage":true},"temperature":0,"max_completion_tokens":1024,"top_p":1}' http://localhost:8080/v1/private/chat/completions

* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080
> POST /v1/private/chat/completions HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 200
>
* upload completely sent off: 200 bytes
< HTTP/1.1 200 OK
< Date: Sun, 26 Jan 2025 11:23:34 GMT
< Content-Type: text/event-stream
< Transfer-Encoding: chunked
<
{"code":429,"message":"Resource has been exhausted (e.g. check quota).","details":"RESOURCE_EXHAUSTED"}
* Connection #0 to host localhost left intact
```
