### PR TITLE
[OPIK-887] Change flattening delimiter from "|" to "." in experiment configuration

### DIFF
--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
@@ -96,7 +96,7 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
     return experiments.reduce<Record<string, Record<string, FiledValue>>>(
       (acc, experiment) => {
         acc[experiment.id] = isObject(experiment.metadata)
-          ? flattie(experiment.metadata, "|", true)
+          ? flattie(experiment.metadata, ".", true)
           : {};
 
         return acc;


### PR DESCRIPTION
## Details
![image](https://github.com/user-attachments/assets/b1f689db-24a9-4f0e-8b25-ac62dfca4862)

## Issues

Resolves #

## Testing

## Documentation
