### PR TITLE
Resolve Typing Issues on Wrapping OpenAI Client

### DIFF
--- a/sdks/python/src/opik/integrations/openai/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/openai/opik_tracker.py
@@ -4,13 +4,13 @@ import openai
 
 from . import chat_completion_chunks_aggregator, openai_decorator
 
-T = TypeVar("OpenAI Client", openai.OpenAI, openai.AsyncOpenAI)
+OpenAIClient = TypeVar("OpenAIClient", openai.OpenAI, openai.AsyncOpenAI)
 
 
 def track_openai(
-    openai_client: T,
+    openai_client: OpenAIClient,
     project_name: Optional[str] = None,
-) -> T:
+) -> OpenAIClient:
     """Adds Opik tracking to an OpenAI client.
 
     Tracks calls to:

--- a/sdks/python/src/opik/integrations/openai/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/openai/opik_tracker.py
@@ -1,14 +1,16 @@
-from typing import Optional, Union
+from typing import Optional, TypeVar
 
 import openai
 
 from . import chat_completion_chunks_aggregator, openai_decorator
 
+T = TypeVar("OpenAI Client", openai.OpenAI, openai.AsyncOpenAI)
+
 
 def track_openai(
-    openai_client: Union[openai.OpenAI, openai.AsyncOpenAI],
+    openai_client: T,
     project_name: Optional[str] = None,
-) -> Union[openai.OpenAI, openai.AsyncOpenAI]:
+) -> T:
     """Adds Opik tracking to an OpenAI client.
 
     Tracks calls to:


### PR DESCRIPTION
## Details

When wrapping the OpenAI client with the tracker, it set the type as a Union of both the regular and async client. This caused downstream type check errors when using OpenAI classes. TypeVar can resolve this by allowing the output type to match the input type. The IDE will now understand that the type of the client remains the same.

This is the same pattern that currently exists in the Anthropic wrapper.

## Issues

Resolves #1152 

## Testing

Tested locally, fixed the problem. This is my first time contributing, so would love advice/help on what the order of operations is for contributing.

## Documentation

No updates to documentation required. 
