### PR TITLE
modified regex example to fix invalid escape strings warning

### DIFF
--- a/sdks/python/src/opik/evaluation/metrics/heuristics/regex_match.py
+++ b/sdks/python/src/opik/evaluation/metrics/heuristics/regex_match.py
@@ -18,7 +18,7 @@ class RegexMatch(base_metric.BaseMetric):
 
     Example:
         >>> from opik.evaluation.metrics import RegexMatch
-        >>> regex_metric = RegexMatch(r"\d{3}-\d{2}-\d{4}")
+        >>> regex_metric = RegexMatch("\\d{3}-\\d{2}-\\d{4}")
         >>> result = regex_metric.score("My SSN is 123-45-6789")
         >>> print(result.value)
         1.0


### PR DESCRIPTION
## Details

The regex example in `regex_match.py` was using `\d` in a regular string, which triggers a Python `SyntaxWarning: invalid escape sequence '\d'` when running an application using Opik. This warning occurs because Python interprets backslashes in regular strings as escape sequences, and `\d` is not a valid escape sequence.

## Issues

Resolves #1163 

## Testing

This change properly escapes the backslashes in the regular string while maintaining identical regex matching functionality. The double backslash ensures Python correctly passes a single backslash to the regex engine.

- Verified that the warning no longer appears when running the application
- Confirmed that the regex pattern continues to match the same strings as before. Doesn't really matter since it's just an example
