### PR TITLE
OPIK-917: Fix DatasetItemPage error:  java.lang.IllegalArgumentException: duplicate element: NUMBER

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
@@ -80,7 +80,7 @@ class DatasetItemResultMapper {
                 .entrySet()
                 .stream()
                 .map(columnArray -> Column.builder().name(columnArray.getKey())
-                        .types(Set.of(mapColumnType(columnArray.getValue())))
+                        .types(Arrays.stream(mapColumnType(columnArray.getValue())).collect(Collectors.toSet()))
                         .filterFieldPrefix(filterField)
                         .build())
                 .collect(Collectors.toSet());


### PR DESCRIPTION
## Details

I couldn't reproduce it yet

```
exception.message:duplicate element: NUMBER
exception.stacktrace:java.lang.IllegalArgumentException: duplicate element: NUMBER
	at java.base/java.util.ImmutableCollections$Set12.<init>(ImmutableCollections.java:798)
	at java.base/java.util.Set.of(Set.java:704)
	at com.comet.opik.domain.DatasetItemResultMapper.lambda$mapColumnsField$2(DatasetItemResultMapper.java:83)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java
```

## Issues
OPIK-917
