### PR TITLE
OPIK-918 Experiment configuration comparison is showing the wrong data in some cases

### DIFF
--- a/apps/opik-frontend/src/components/ui/table.tsx
+++ b/apps/opik-frontend/src/components/ui/table.tsx
@@ -88,7 +88,7 @@ const TableCell = React.forwardRef<
   <td
     ref={ref}
     className={cn(
-      "relative p-0 align-middle [&:has([role=checkbox])]:pr-0 [&:first-child_[data-cell-wrapper=true]]:pl-5 [&:last-child_[data-cell-wrapper=true]]:pr-5 h-px group-hover/row:bg-destructive-foreground",
+      "comet-fix-cell-height relative p-0 align-middle [&:has([role=checkbox])]:pr-0 [&:first-child_[data-cell-wrapper=true]]:pl-5 [&:last-child_[data-cell-wrapper=true]]:pr-5 group-hover/row:bg-destructive-foreground",
       className,
     )}
     {...props}

--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -247,3 +247,14 @@
     scrollbar-width: none;
   }
 }
+
+// workaround to force firefox work correctly with cell height - https://stackoverflow.com/questions/36575846/how-to-make-div-fill-td-height-in-firefox
+.comet-fix-cell-height {
+  height: 1px;
+}
+
+@-moz-document url-prefix() {
+  .comet-fix-cell-height {
+    height: 100%;
+  }
+}


### PR DESCRIPTION
## Details
![image](https://github.com/user-attachments/assets/cf3ea960-dacb-4a4c-80db-020ee9fd7fba)

## Issues

Resolves #

## Testing

## Documentation
