### PR TITLE
Allocate needed memory for building the FE locally in the Dockerfile

### DIFF
--- a/apps/opik-frontend/Dockerfile
+++ b/apps/opik-frontend/Dockerfile
@@ -12,6 +12,7 @@ COPY . .
 
 ARG OPIK_VERSION
 ENV VITE_APP_VERSION=${OPIK_VERSION}
+ENV NODE_OPTIONS="--max-old-space-size=8192"
 
 ARG BUILD_MODE=production
 RUN npm run build -- --mode $BUILD_MODE


### PR DESCRIPTION
## Details
- When building the docker images locally (`docker compose up --build`) it could throw out of memory on running the FE build (`npm run build`)

## Issues

Resolves #

## Testing

## Documentation
