### PR TITLE
[OPIK-863] Allow to quickly select multiple rows with Shift+Click

### DIFF
--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
@@ -54,6 +54,7 @@ import {
   generateGroupedCellDef,
   getIsCustomRow,
   getRowId,
+  getSharedShiftCheckboxClickHandler,
   GROUPING_CONFIG,
   renderCustomRow,
 } from "@/components/pages/ExperimentsShared/table";
@@ -142,6 +143,11 @@ const ExperimentsPage: React.FunctionComponent = () => {
   );
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const { checkboxClickHandler } = useMemo(() => {
+    return {
+      checkboxClickHandler: getSharedShiftCheckboxClickHandler(),
+    };
+  }, []);
 
   const { data, isPending, refetch } = useGroupedExperimentsList({
     workspaceName,
@@ -242,18 +248,21 @@ const ExperimentsPage: React.FunctionComponent = () => {
 
   const columns = useMemo(() => {
     return [
-      generateExperimentNameColumDef<GroupedExperiment>(),
-      generateGroupedCellDef<GroupedExperiment, unknown>({
-        id: GROUPING_COLUMN,
-        label: "Dataset",
-        type: COLUMN_TYPE.string,
-        cell: ResourceCell as never,
-        customMeta: {
-          nameKey: "dataset_name",
-          idKey: "dataset_id",
-          resource: RESOURCE_TYPE.dataset,
+      generateExperimentNameColumDef<GroupedExperiment>(checkboxClickHandler),
+      generateGroupedCellDef<GroupedExperiment, unknown>(
+        {
+          id: GROUPING_COLUMN,
+          label: "Dataset",
+          type: COLUMN_TYPE.string,
+          cell: ResourceCell as never,
+          customMeta: {
+            nameKey: "dataset_name",
+            idKey: "dataset_id",
+            resource: RESOURCE_TYPE.dataset,
+          },
         },
-      }),
+        checkboxClickHandler,
+      ),
       ...convertColumnDataToColumn<GroupedExperiment, GroupedExperiment>(
         DEFAULT_COLUMNS,
         {
@@ -272,7 +281,13 @@ const ExperimentsPage: React.FunctionComponent = () => {
         cell: ExperimentRowActionsCell,
       }),
     ];
-  }, [selectedColumns, columnsOrder, scoresColumnsOrder, scoresColumnsData]);
+  }, [
+    selectedColumns,
+    columnsOrder,
+    checkboxClickHandler,
+    scoresColumnsOrder,
+    scoresColumnsData,
+  ]);
 
   const resizeConfig = useMemo(
     () => ({

--- a/apps/opik-frontend/src/components/pages/ExperimentsShared/table.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsShared/table.tsx
@@ -38,6 +38,9 @@ export const getRowId = (e: GroupedExperiment) => e.id;
 export const getIsMoreRow = (row: Row<GroupedExperiment>) =>
   checkIsMoreRowId(row?.original?.id || "");
 
+// The goal to use shared handler between two different helpers to draw cells in Experiments table,
+// to share in closure the previousSelectedRowID between two helpers
+// generateExperimentNameColumDef and generateGroupedCellDef
 export const getSharedShiftCheckboxClickHandler = () => {
   let previousSelectedRowID = "";
 

--- a/apps/opik-frontend/src/components/pages/ExperimentsShared/table.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsShared/table.tsx
@@ -26,6 +26,7 @@ import { TableCell, TableRow } from "@/components/ui/table";
 import {
   getCommonPinningClasses,
   getCommonPinningStyles,
+  shiftCheckboxClickHandler,
 } from "@/components/shared/DataTable/utils";
 
 export const GROUPING_CONFIG = {
@@ -37,7 +38,25 @@ export const getRowId = (e: GroupedExperiment) => e.id;
 export const getIsMoreRow = (row: Row<GroupedExperiment>) =>
   checkIsMoreRowId(row?.original?.id || "");
 
-export const generateExperimentNameColumDef = <TData,>() => {
+export const getSharedShiftCheckboxClickHandler = () => {
+  let previousSelectedRowID = "";
+
+  return <TData,>(
+    event: React.MouseEvent<HTMLButtonElement>,
+    context: CellContext<TData, unknown>,
+  ) => {
+    event.stopPropagation();
+    shiftCheckboxClickHandler(event, context, previousSelectedRowID);
+    previousSelectedRowID = context.row.id;
+  };
+};
+
+export const generateExperimentNameColumDef = <TData,>(
+  checkboxClickHandler: (
+    event: React.MouseEvent<HTMLButtonElement>,
+    context: CellContext<TData, unknown>,
+  ) => void,
+) => {
   return {
     accessorKey: COLUMN_NAME_ID,
     header: (context) => (
@@ -70,10 +89,10 @@ export const generateExperimentNameColumDef = <TData,>() => {
             style={{
               marginLeft: `${context.row.depth * 28}px`,
             }}
-            onClick={(event) => event.stopPropagation()}
             checked={context.row.getIsSelected()}
             disabled={!context.row.getCanSelect()}
             onCheckedChange={(value) => context.row.toggleSelected(!!value)}
+            onClick={(event) => checkboxClickHandler(event, context)}
             aria-label="Select row"
           />
           <div className="ml-3 min-w-1 max-w-full">
@@ -98,6 +117,10 @@ export const generateExperimentNameColumDef = <TData,>() => {
 
 export const generateGroupedCellDef = <TData, TValue>(
   columnData: ColumnData<TData>,
+  checkboxClickHandler: (
+    event: React.MouseEvent<HTMLButtonElement>,
+    context: CellContext<TData, unknown>,
+  ) => void,
 ) => {
   return {
     ...mapColumnDataFields(columnData),
@@ -108,13 +131,13 @@ export const generateGroupedCellDef = <TData, TValue>(
         <div className="flex size-full h-11 items-center">
           <div className="flex shrink-0 items-center pl-5">
             <Checkbox
-              onClick={(event) => event.stopPropagation()}
               checked={
                 row.getIsAllSubRowsSelected() ||
                 (row.getIsSomeSelected() && "indeterminate")
               }
               disabled={!row.getCanSelect()}
               onCheckedChange={(value) => row.toggleSelected(!!value)}
+              onClick={(event) => checkboxClickHandler(event, context)}
               aria-label="Select row"
             />
             <Button

--- a/apps/opik-frontend/src/components/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
@@ -31,6 +31,7 @@ import {
   generateGroupedCellDef,
   getIsCustomRow,
   getRowId,
+  getSharedShiftCheckboxClickHandler,
   GROUPING_CONFIG,
   renderCustomRow,
 } from "@/components/pages/ExperimentsShared/table";
@@ -100,8 +101,13 @@ const ExperimentsTab: React.FC<ExperimentsTabProps> = ({ promptId }) => {
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
   const [datasetId, setDatasetId] = useState("");
-  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [groupLimit, setGroupLimit] = useState<Record<string, number>>({});
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const { checkboxClickHandler } = useMemo(() => {
+    return {
+      checkboxClickHandler: getSharedShiftCheckboxClickHandler(),
+    };
+  }, []);
 
   const { data, isPending } = useGroupedExperimentsList({
     workspaceName,
@@ -202,18 +208,21 @@ const ExperimentsTab: React.FC<ExperimentsTabProps> = ({ promptId }) => {
 
   const columns = useMemo(() => {
     return [
-      generateExperimentNameColumDef<GroupedExperiment>(),
-      generateGroupedCellDef<GroupedExperiment, unknown>({
-        id: GROUPING_COLUMN,
-        label: "Dataset",
-        type: COLUMN_TYPE.string,
-        cell: ResourceCell as never,
-        customMeta: {
-          nameKey: "dataset_name",
-          idKey: "dataset_id",
-          resource: RESOURCE_TYPE.dataset,
+      generateExperimentNameColumDef<GroupedExperiment>(checkboxClickHandler),
+      generateGroupedCellDef<GroupedExperiment, unknown>(
+        {
+          id: GROUPING_COLUMN,
+          label: "Dataset",
+          type: COLUMN_TYPE.string,
+          cell: ResourceCell as never,
+          customMeta: {
+            nameKey: "dataset_name",
+            idKey: "dataset_id",
+            resource: RESOURCE_TYPE.dataset,
+          },
         },
-      }),
+        checkboxClickHandler,
+      ),
       ...convertColumnDataToColumn<GroupedExperiment, GroupedExperiment>(
         DEFAULT_COLUMNS,
         {
@@ -229,7 +238,13 @@ const ExperimentsTab: React.FC<ExperimentsTabProps> = ({ promptId }) => {
         },
       ),
     ];
-  }, [selectedColumns, columnsOrder, scoresColumnsOrder, scoresColumnsData]);
+  }, [
+    selectedColumns,
+    columnsOrder,
+    checkboxClickHandler,
+    scoresColumnsOrder,
+    scoresColumnsData,
+  ]);
 
   const resizeConfig = useMemo(
     () => ({


### PR DESCRIPTION
## Details
![image](https://github.com/user-attachments/assets/66c15658-5262-4b69-af96-28e20be16289)


## Issues

Resolves #

## Testing
- Manually tested on the Projects page (with sorting applied)
- Manually tested on the Experiments page with groups and subgroup rows

## Documentation
