### PR TITLE
Update README.md

### DIFF
--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -19,7 +19,7 @@ Run docker-compose from the root of the project:
 
 ```bash
 cd deployment/docker-compose
-docker compose up -d
+docker compose -f docker-compose.yaml up -d
 ```
 
 ## Run docker-compose with building application from latest code
@@ -28,7 +28,7 @@ From the root of the project:
 
 ```bash
 cd deployment/docker-compose
-docker compose up -d --build
+docker compose -f docker-compose.yaml up -d --build
 ```
 
 ## Exposing Database and Backend Ports for Local Development
@@ -52,6 +52,16 @@ This will expose the following services to the host machine:
 - Backend: Available on ports 8080 (HTTP) and 3003 (OpenAPI specification).
 - Python backend: Available on port 8000 (HTTP).
 - Frontend: Available on port 5173.
+
+## Binding Ports in Docker Compose
+By default, Docker Compose binds exposed container ports to 0.0.0.0, making them accessible from any network interface on the host. To restrict access, specify a specific IP in the ports section, such as 127.0.0.1:8080:80, to limit exposure to the local machine.
+This can be done in `docker-compose.yaml` file
+```
+frontend:
+    ports:
+      - "127.0.0.1:5173:5173" # Frontend server port
+
+```
 
 ## Run Opik backend locally and the rest of the components with docker-compose
 


### PR DESCRIPTION
## Details

Improve docker-compose readme for enhanced security with port exposure 

## Issues

Resolves #1203 

## Testing

Tested locally and made sure desired output in `docker-ps`

* before: (see `PORTS` section)
```
docker ps
CONTAINER ID   IMAGE                                              COMMAND                  CREATED          STATUS                    PORTS                                                      NAMES
c2659ddcdb5a   ghcr.io/comet-ml/opik/opik-frontend:latest         "/docker-entrypoint.…"   16 seconds ago   Up 5 seconds              80/tcp, 0.0.0.0:5173->5173/tcp                             opik-frontend-1
0c4e59a157a0   ghcr.io/comet-ml/opik/opik-backend:latest          "bash -c './run_db_m…"   16 seconds ago   Up 6 seconds              0.0.0.0:8080->8080/tcp, 0.0.0.0:61685->3003/tcp            opik-backend-1
25fea4925c1f   mysql:8.4.2                                        "docker-entrypoint.s…"   16 seconds ago   Up 14 seconds (healthy)   0.0.0.0:3306->3306/tcp, 33060/tcp                          opik-mysql-1
e4f1eadb863c   ghcr.io/comet-ml/opik/opik-python-backend:latest   "tini -- /bin/sh -c …"   16 seconds ago   Up 14 seconds             2375-2376/tcp, 0.0.0.0:8000->8000/tcp                      opik-python-backend-1
7a931f1cac34   clickhouse/clickhouse-server:24.3.6.48-alpine      "/entrypoint.sh"         16 seconds ago   Up 14 seconds (healthy)   0.0.0.0:8123->8123/tcp, 0.0.0.0:9000->9000/tcp, 9009/tcp   opik-clickhouse-1
bef2a0cac52f   redis:7.2.4-alpine3.19                             "docker-entrypoint.s…"   16 seconds ago   Up 14 seconds (healthy)   0.0.0.0:6379->6379/tcp                                     opik-redis-1
```
* after:  (see `PORTS` section)
```
docker ps
CONTAINER ID   IMAGE                                              COMMAND                  CREATED         STATUS                   PORTS                               NAMES
8c3776cfa2a5   ghcr.io/comet-ml/opik/opik-frontend:latest         "/docker-entrypoint.…"   5 seconds ago   Up 2 seconds             80/tcp, 0.0.0.0:5173->5173/tcp      opik-frontend-1
d366bcca248d   ghcr.io/comet-ml/opik/opik-backend:latest          "bash -c './run_db_m…"   5 seconds ago   Up 2 seconds             8080/tcp, 0.0.0.0:61748->3003/tcp   opik-backend-1
b6d816cfe3f1   redis:7.2.4-alpine3.19                             "docker-entrypoint.s…"   5 seconds ago   Up 5 seconds (healthy)   6379/tcp                            opik-redis-1
24e1759e4683   ghcr.io/comet-ml/opik/opik-python-backend:latest   "tini -- /bin/sh -c …"   5 seconds ago   Up 5 seconds             2375-2376/tcp, 8000/tcp             opik-python-backend-1
c9614c5d005e   clickhouse/clickhouse-server:24.3.6.48-alpine      "/entrypoint.sh"         5 seconds ago   Up 5 seconds (healthy)   8123/tcp, 9000/tcp, 9009/tcp        opik-clickhouse-1
83edd7499d7e   mysql:8.4.2                                        "docker-entrypoint.s…"   5 seconds ago   Up 5 seconds (healthy)   3306/tcp, 33060/tcp                 opik-mysql-1
```
## Documentation

see docker compose docs