### PR TITLE
[OPIK-955] [BUG] [SDK] improve VertexAI provider detection

### DIFF
--- a/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/metric.py
+++ b/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/metric.py
@@ -166,6 +166,12 @@ class GEval(base_metric.BaseMetric):
             weighted_score_sum = 0.0
 
             for token_info in top_score_logprobs:
+                # litellm in v1.60.2 (or earlier) started provide logprobes
+                # as pydantic model, not just dict
+                # we will convert model to dict to provide backward compatability
+                if not isinstance(token_info, dict):
+                    token_info = token_info.model_dump()
+
                 # if not a number
                 if not token_info["token"].isdecimal():
                     continue

--- a/sdks/python/src/opik/integrations/langchain/google_run_helpers.py
+++ b/sdks/python/src/opik/integrations/langchain/google_run_helpers.py
@@ -51,8 +51,9 @@ def is_google_run(run: "Run") -> bool:
         if run.serialized is None:
             return False
 
-        provider = run.metadata.get("ls_provider", "")
-        is_google = "google" in provider.lower()
+        invocation_params = run.extra.get("invocation_params", {})
+        provider = invocation_params.get("_type", "").lower()
+        is_google = "vertexai" in provider.lower()
 
         return is_google
 
@@ -73,8 +74,10 @@ def _get_provider_and_model(
     provider = None
     model = None
 
-    if metadata := run_dict["extra"].get("metadata"):
-        provider = metadata.get("ls_provider")
-        model = metadata.get("ls_model_name")
+    if invocation_params := run_dict["extra"].get("invocation_params"):
+        provider = invocation_params.get("_type")
+        if provider == "vertexai":
+            provider = "google_vertexai"
+        model = invocation_params.get("model_name")
 
     return provider, model

--- a/sdks/python/tests/e2e/verifiers.py
+++ b/sdks/python/tests/e2e/verifiers.py
@@ -231,7 +231,7 @@ def verify_experiment(
 
     experiment_content = rest_client.experiments.get_experiment_by_id(id)
 
-    verify_experiment_metadata(experiment_content, experiment_metadata)
+    _verify_experiment_metadata(experiment_content, experiment_metadata)
 
     assert (
         experiment_content.name == experiment_name
@@ -253,10 +253,10 @@ def verify_experiment(
         actual_trace_count == traces_amount
     ), f"{actual_trace_count} != {traces_amount}"
 
-    verify_experiment_prompts(experiment_content, prompts)
+    _verify_experiment_prompts(experiment_content, prompts)
 
 
-def verify_experiment_metadata(
+def _verify_experiment_metadata(
     experiment_content: ExperimentPublic,
     metadata: Optional[Dict[str, Any]],
 ):
@@ -269,7 +269,7 @@ def verify_experiment_metadata(
     assert experiment_metadata == metadata, f"{experiment_metadata} != {metadata}"
 
 
-def verify_experiment_prompts(
+def _verify_experiment_prompts(
     experiment_content: ExperimentPublic,
     prompts: Optional[List[Prompt]],
 ):


### PR DESCRIPTION
## Details
LLM call pricing isn’t always correctly determined for the Vertex-AI provider. The provider detection logic was fixed.
