### PR TITLE
[OPIK-915] Display all the workspaces of the organization if the user is an admin of it

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/WorkspacePreloader.tsx
+++ b/apps/opik-frontend/src/plugins/comet/WorkspacePreloader.tsx
@@ -54,9 +54,6 @@ const WorkspacePreloader: React.FunctionComponent<WorkspacePreloaderProps> = ({
     return <Loader />;
   }
 
-  useAppStore.getState().setActiveWorkspaceName(workspaceNameFromURL);
-  return children;
-
   const workspace = workspaceNameFromURL
     ? workspaces.find(
         (workspace) => workspace.workspaceName === workspaceNameFromURL,

--- a/apps/opik-frontend/src/plugins/comet/types.ts
+++ b/apps/opik-frontend/src/plugins/comet/types.ts
@@ -52,3 +52,14 @@ export interface UserPermission {
     | "project_visibility";
   permissionValue: "true" | "false";
 }
+
+export interface Workspace {
+  createdAt: number;
+  workspaceId: string;
+  workspaceName: string;
+  workspaceOwner: string;
+  workspaceCreator: string;
+  organizationId: string;
+  collaborationFeaturesDisabled: boolean;
+  default: boolean;
+}

--- a/apps/opik-frontend/src/plugins/comet/useAllUserWorkspaces.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAllUserWorkspaces.ts
@@ -1,0 +1,53 @@
+import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
+import uniqBy from "lodash/uniqBy";
+import api, { QueryConfig } from "./api";
+import { ORGANIZATION_ROLE_TYPE, Workspace } from "./types";
+import useOrganizations from "./useOrganizations";
+
+const getAllUserWorkspaces = async (
+  { signal }: QueryFunctionContext,
+  { organizationIds }: { organizationIds?: string[] } = {},
+) => {
+  const allWorkspacesPromise = api
+    .get<Workspace[]>(`/workspaces`, {
+      signal,
+      params: { withoutExtendedData: true },
+    })
+    .then(({ data }) => data);
+
+  const workspacesPromises = organizationIds?.map((organizationId) => {
+    return api
+      .get<Workspace[]>(`/workspaces`, {
+        signal,
+        params: { organizationId, withoutExtendedData: true },
+      })
+      .then(({ data }) => data);
+  });
+
+  const workspaces = await Promise.all([
+    allWorkspacesPromise,
+    ...(workspacesPromises || []),
+  ]);
+
+  return uniqBy(workspaces.flat(), "workspaceId");
+};
+
+export default function useAllUserWorkspaces(
+  options?: QueryConfig<Workspace[]>,
+) {
+  const { data: organizations } = useOrganizations({
+    enabled: options?.enabled,
+  });
+  const organizationIds = organizations
+    ?.filter((organization) => {
+      return organization.role === ORGANIZATION_ROLE_TYPE.admin;
+    })
+    .map((organization) => organization.id);
+
+  return useQuery({
+    queryKey: ["workspaces", { organizationIds }],
+    queryFn: (context) => getAllUserWorkspaces(context, { organizationIds }),
+    ...options,
+    enabled: options?.enabled && !!organizations,
+  });
+}


### PR DESCRIPTION
## Details
- For Cloud version: Change the way of getting the workspaces of the user, instead of limiting the `/api/auth/test` -> `teams` field, now we fetch all the workspaces of the user + fetch all the workspaces of the organization where the user is an admin. As result we'll allow admin users to go to workspaces where it's not part of it without having to self-invite by itself

## Issues

Resolves #

## Testing

## Documentation
