### PR TITLE
[OPIK-964] home page improvements

### DIFF
--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
@@ -54,6 +54,7 @@ import { useExpandingConfig } from "@/components/pages/ExperimentsShared/useExpa
 import { generateActionsColumDef } from "@/components/shared/DataTable/utils";
 import MultiResourceCell from "@/components/shared/DataTableCells/MultiResourceCell";
 import FeedbackScoreListCell from "@/components/shared/DataTableCells/FeedbackScoreListCell";
+import { formatNumericData } from "@/lib/utils";
 
 const SELECTED_COLUMNS_KEY = "experiments-selected-columns";
 const COLUMNS_WIDTH_KEY = "experiments-columns-width";
@@ -101,7 +102,11 @@ export const DEFAULT_COLUMNS: ColumnData<GroupedExperiment>[] = [
     id: "feedback_scores",
     label: "Feedback scores",
     type: COLUMN_TYPE.numberDictionary,
-    accessorFn: (row) => get(row, "feedback_scores", []),
+    accessorFn: (row) =>
+      get(row, "feedback_scores", []).map((score) => ({
+        ...score,
+        value: formatNumericData(score.value),
+      })),
     cell: FeedbackScoreListCell as never,
   },
 ];
@@ -111,7 +116,10 @@ export const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
   right: [],
 };
 
-export const DEFAULT_SELECTED_COLUMNS: string[] = ["created_at"];
+export const DEFAULT_SELECTED_COLUMNS: string[] = [
+  "created_at",
+  "feedback_scores",
+];
 
 const ExperimentsPage: React.FunctionComponent = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);

--- a/apps/opik-frontend/src/components/pages/HomePage/EvaluationSection.tsx
+++ b/apps/opik-frontend/src/components/pages/HomePage/EvaluationSection.tsx
@@ -19,8 +19,8 @@ import { RESOURCE_TYPE } from "@/components/shared/ResourceLink/ResourceLink";
 import { Experiment } from "@/types/datasets";
 import { convertColumnDataToColumn } from "@/lib/table";
 import { formatDate } from "@/lib/date";
-import MultiResourceCell from "@/components/shared/DataTableCells/MultiResourceCell";
 import FeedbackScoreListCell from "@/components/shared/DataTableCells/FeedbackScoreListCell";
+import { formatNumericData } from "@/lib/utils";
 
 const COLUMNS_WIDTH_KEY = "home-experiments-columns-width";
 
@@ -53,30 +53,19 @@ export const COLUMNS = convertColumnDataToColumn<Experiment, Experiment>(
       },
     },
     {
-      id: "prompt",
-      label: "Prompt commit",
-      type: COLUMN_TYPE.list,
-      accessorFn: (row) => get(row, ["prompt_versions"], []),
-      cell: MultiResourceCell as never,
-      customMeta: {
-        nameKey: "commit",
-        idKey: "prompt_id",
-        resource: RESOURCE_TYPE.prompt,
-        getSearch: (data: Experiment) => ({
-          activeVersionId: get(data, "id", null),
-        }),
-      },
-    },
-    {
       id: "trace_count",
-      label: "Trace count",
+      label: "Nb of items",
       type: COLUMN_TYPE.number,
     },
     {
       id: "feedback_scores",
       label: "Feedback scores",
       type: COLUMN_TYPE.numberDictionary,
-      accessorFn: (row) => get(row, "feedback_scores", []),
+      accessorFn: (row) =>
+        get(row, "feedback_scores", []).map((score) => ({
+          ...score,
+          value: formatNumericData(score.value),
+        })),
       cell: FeedbackScoreListCell as never,
     },
     {
@@ -84,13 +73,6 @@ export const COLUMNS = convertColumnDataToColumn<Experiment, Experiment>(
       label: "Created",
       type: COLUMN_TYPE.time,
       accessorFn: (row) => formatDate(row.created_at),
-      sortable: true,
-    },
-    {
-      id: "last_updated_at",
-      label: "Last updated",
-      type: COLUMN_TYPE.time,
-      accessorFn: (row) => formatDate(row.last_updated_at),
       sortable: true,
     },
   ],

--- a/apps/opik-frontend/src/components/pages/HomePage/ObservabilitySection.tsx
+++ b/apps/opik-frontend/src/components/pages/HomePage/ObservabilitySection.tsx
@@ -21,6 +21,7 @@ import { formatDate } from "@/lib/date";
 import { convertColumnDataToColumn } from "@/lib/table";
 import FeedbackScoreListCell from "@/components/shared/DataTableCells/FeedbackScoreListCell";
 import { get } from "lodash";
+import { formatNumericData } from "@/lib/utils";
 
 const COLUMNS_WIDTH_KEY = "home-projects-columns-width";
 
@@ -42,13 +43,6 @@ export const COLUMNS = convertColumnDataToColumn<
       },
     },
     {
-      id: "created_at",
-      label: "Created",
-      type: COLUMN_TYPE.time,
-      accessorFn: (row) => formatDate(row.created_at),
-      sortable: true,
-    },
-    {
       id: "last_updated_at",
       label: "Last updated",
       type: COLUMN_TYPE.time,
@@ -60,7 +54,11 @@ export const COLUMNS = convertColumnDataToColumn<
       id: "feedback_scores",
       label: "Feedback scores",
       type: COLUMN_TYPE.numberDictionary,
-      accessorFn: (row) => get(row, "feedback_scores", []),
+      accessorFn: (row) =>
+        get(row, "feedback_scores", []).map((score) => ({
+          ...score,
+          value: formatNumericData(score.value),
+        })),
       cell: FeedbackScoreListCell as never,
     },
     {

--- a/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
@@ -116,7 +116,11 @@ export const DEFAULT_COLUMNS: ColumnData<ProjectWithStatistic>[] = [
     id: "feedback_scores",
     label: "Feedback scores",
     type: COLUMN_TYPE.numberDictionary,
-    accessorFn: (row) => get(row, "feedback_scores", []),
+    accessorFn: (row) =>
+      get(row, "feedback_scores", []).map((score) => ({
+        ...score,
+        value: formatNumericData(score.value),
+      })),
     cell: FeedbackScoreListCell as never,
   },
   {

--- a/apps/opik-frontend/src/components/shared/FeedbackScoreTag/FeedbackScoreTag.tsx
+++ b/apps/opik-frontend/src/components/shared/FeedbackScoreTag/FeedbackScoreTag.tsx
@@ -42,7 +42,7 @@ const FeedbackScoreTag: React.FunctionComponent<FeedbackScoreTagProps> = ({
     <div
       data-testid="feedback-score-tag"
       className={cn(
-        "group flex h-6 items-center gap-2 rounded-md border border-border pl-2 pr-2",
+        "group flex h-6 items-center gap-1.5 rounded-md border border-border pl-2 pr-2",
         className,
       )}
     >
@@ -52,7 +52,7 @@ const FeedbackScoreTag: React.FunctionComponent<FeedbackScoreTagProps> = ({
       />
       <div
         data-testid="feedback-score-tag-label"
-        className="comet-body-s-accented truncate leading-none text-light-slate"
+        className="comet-body-s-accented truncate leading-none text-muted-slate"
       >
         {label}
       </div>

--- a/apps/opik-frontend/src/lib/money.ts
+++ b/apps/opik-frontend/src/lib/money.ts
@@ -9,7 +9,7 @@ export const formatCost = (
   value: number | string | undefined,
   short = false,
 ) => {
-  if (isUndefined(value)) {
+  if (isUndefined(value) || value === 0 || value === "0") {
     return "-";
   }
 


### PR DESCRIPTION
## Details
- feedback scores tag UI fixes
- round feedback scores value to 3
- remove columns from home page
- show feedback scores column by default on Experiment page
- show "-" if total cost is 0
## Issues

Resolves #

## Testing

## Documentation
