### PR TITLE
[OPIK-845] Fix potential NPE

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItem.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItem.java
@@ -47,6 +47,9 @@ public record DatasetItem(
             @JsonView({DatasetItem.View.Public.class}) long total,
             @JsonView({DatasetItem.View.Public.class}) Set<Column> columns) implements Page<DatasetItem>{
 
+        public static DatasetItemPage empty(int page) {
+            return new DatasetItemPage(List.of(), page, 0, 0, Set.of());
+        }
     }
 
     public static class View {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -209,7 +209,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
     @Override
     @WithSpan
     public Mono<DatasetItemPage> getItems(@NonNull UUID datasetId, int page, int size, boolean truncate) {
-        return dao.getItems(datasetId, page, size, truncate);
+        return dao.getItems(datasetId, page, size, truncate)
+                .defaultIfEmpty(DatasetItemPage.empty(page));
     }
 
     @Override


### PR DESCRIPTION
## Details
I wasn't able to reproduce this NPE. Even if we don't have any dataset items, an empty page is returned now. Also in NewRelic this issue happened only twice some time ago. Maybe some temporary DB issues.
Anyway added fallback strategy, just in case.