### PR TITLE
Add support for searching feedback scores with spaces

### DIFF
--- a/apps/opik-documentation/documentation/docs/tracing/export_data.md
+++ b/apps/opik-documentation/documentation/docs/tracing/export_data.md
@@ -2,6 +2,7 @@
 sidebar_label: Export Traces and Spans
 description: Describes how to export traces and spans from the Opik platform.
 toc_max_heading_level: 4
+pytest_codeblocks_skip: true
 ---
 
 # Exporting Traces and Spans

--- a/apps/opik-documentation/documentation/docs/tracing/export_data.md
+++ b/apps/opik-documentation/documentation/docs/tracing/export_data.md
@@ -98,6 +98,28 @@ traces = client.search_traces(filter_string='usage.total_tokens > 1000')
 traces = client.search_traces(filter_string='metadata.model = "gpt-4o"')
 ```
 
+:::tip
+
+If your feedback scores names contain spaces, you will need to wrap them in double quotes:
+
+```python
+
+import opik
+
+client = opik.Opik(
+    project_name="Default project"
+)
+
+# Search for traces where the input contains text
+traces = client.search_traces(
+  filter_string='feedback_score."My Score" > 0'
+)
+```
+
+If the feedback score contains both spaces and double quotes, you will need to escape the double quotes as `""`:
+`traces = client.search_traces(filter_string='feedback_score."Score ""with"" Quotes" > 0')`
+:::
+
 ### Exporting spans
 
 You can export spans using the [`Opik.search_spans`](https://www.comet.com/docs/opik/python-sdk-reference/Opik.html#opik.Opik.search_spans) method. This methods allows you to search for spans based on `trace_id` or based on a filter string.

--- a/sdks/python/src/opik/api_objects/opik_query_language.py
+++ b/sdks/python/src/opik/api_objects/opik_query_language.py
@@ -70,6 +70,38 @@ class OpikQueryLanguage:
         ):
             self._cursor += 1
 
+    def _check_escaped_key(self) -> tuple[bool, str]:
+        if self.query_string[self._cursor] in ('"', "'"):
+            is_quoted_key = True
+            quote_type = self.query_string[self._cursor]
+            self._cursor += 1
+        else:
+            is_quoted_key = False
+            quote_type = ""
+
+        return is_quoted_key, quote_type
+
+    def _is_valid_escaped_key_char(self, quote_type: str, start: int) -> bool:
+        if self.query_string[self._cursor] != quote_type:
+            # Check this isn't the end of the string (means we missed the closing quote)
+            if self._cursor + 2 >= len(self.query_string):
+                raise ValueError(
+                    "Missing closing quote for: " + self.query_string[start - 1 :]
+                )
+
+            return True
+
+        # Check if it's an escaped quote (doubled quote)
+        if (
+            self._cursor + 1 < len(self.query_string)
+            and self.query_string[self._cursor + 1] == quote_type
+        ):
+            # Skip the second quote
+            self._cursor += 1
+            return True
+
+        return False
+
     def _parse_field(self) -> Dict[str, Any]:
         # Skip whitespace
         self._skip_whitespace()
@@ -84,13 +116,29 @@ class OpikQueryLanguage:
 
         # Parse the key if it exists
         if self.query_string[self._cursor] == ".":
+            # Skip the "."
             self._cursor += 1
+
+            # Check if the key is quoted
+            is_quoted_key, quote_type = self._check_escaped_key()
+
             start = self._cursor
-            while self._cursor < len(self.query_string) and self._is_valid_field_char(
-                self.query_string[self._cursor]
+            while self._cursor < len(self.query_string) and (
+                self._is_valid_field_char(self.query_string[self._cursor])
+                or (
+                    is_quoted_key and self._is_valid_escaped_key_char(quote_type, start)
+                )
             ):
                 self._cursor += 1
+
             key = self.query_string[start : self._cursor]
+
+            # If escaped key, skip the closing quote
+            if is_quoted_key:
+                key = key.replace(
+                    quote_type * 2, quote_type
+                )  # Replace doubled quotes with single quotes
+                self._cursor += 1
 
             # Keys are only supported for usage, feedback_scores and metadata
             if field not in ["usage", "feedback_scores", "metadata"]:
@@ -168,6 +216,8 @@ class OpikQueryLanguage:
         if self.query_string[self._cursor] == '"':
             self._cursor += 1
             start = self._cursor
+
+            # TODO: replace with new quote parser used in field parser
             while (
                 self._cursor < len(self.query_string)
                 and self.query_string[self._cursor] != '"'

--- a/sdks/python/src/opik/api_objects/opik_query_language.py
+++ b/sdks/python/src/opik/api_objects/opik_query_language.py
@@ -5,7 +5,7 @@ simple filters without "and" or "or" operators.
 
 import json
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 COLUMNS = {
     "name": "string",
@@ -70,7 +70,7 @@ class OpikQueryLanguage:
         ):
             self._cursor += 1
 
-    def _check_escaped_key(self) -> tuple[bool, str]:
+    def _check_escaped_key(self) -> Tuple[bool, str]:
         if self.query_string[self._cursor] in ('"', "'"):
             is_quoted_key = True
             quote_type = self.query_string[self._cursor]

--- a/sdks/python/tests/unit/api_objects/test_opik_query_language.py
+++ b/sdks/python/tests/unit/api_objects/test_opik_query_language.py
@@ -23,6 +23,25 @@ from opik.api_objects.opik_query_language import OpikQueryLanguage
             "feedback_scores >= 4.5",
             {"field": "feedback_scores", "operator": ">=", "value": "4.5"},
         ),
+        # New test cases for quoted identifiers
+        (
+            'feedback_scores."Answer Relevance" < 0.8',
+            {
+                "field": "feedback_scores",
+                "key": "Answer Relevance",
+                "operator": "<",
+                "value": "0.8",
+            },
+        ),
+        (
+            'feedback_scores."Escaped ""Quote""" < 0.8',
+            {
+                "field": "feedback_scores",
+                "key": 'Escaped "Quote"',
+                "operator": "<",
+                "value": "0.8",
+            },
+        ),
     ],
 )
 def test_valid_oql_expressions(filter_string, expected):
@@ -46,6 +65,10 @@ def test_valid_oql_expressions(filter_string, expected):
             r"When querying usage, invalid_metric is not supported.*",
         ),
         ('name = "test" extra_stuff', r"Invalid filter string, trailing characters.*"),
+        (
+            'feedback_scores."Unterminated Quote < 0.8',
+            r'Missing closing quote for: "Unterminated Quote < 0.8',
+        ),
     ],
 )
 def test_invalid_oql_expressions(filter_string, error_pattern):


### PR DESCRIPTION
## Details

Add support for searching traces and spans by feedback scores even if they contain spaces:

```
# Search for traces where the input contains text
traces = client.search_traces(
  filter_string='feedback_score."My Score" > 0'
)
```