### PR TITLE
added typing for BedrockRuntimeClient

### DIFF
--- a/apps/opik-sandbox-executor-python/requirements.txt
+++ b/apps/opik-sandbox-executor-python/requirements.txt
@@ -4,6 +4,7 @@ aiosignal==1.3.2
 annotated-types==0.7.0
 anyio==4.8.0
 attrs==24.3.0
+boto3-stubs[bedrock-runtime]==1.34.110
 certifi==2024.12.14
 charset-normalizer==3.4.1
 click==8.1.8

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -37,6 +37,7 @@ setup(
     ).read(),
     long_description_content_type="text/markdown",
     install_requires=[
+        "boto3-stubs[bedrock-runtime]>=1.34.110",
         "click",
         "httpx",  # some older version of openai/litellm are broken with httpx>=0.28.0
         "levenshtein<1.0.0",

--- a/sdks/python/src/opik/integrations/bedrock/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/bedrock/opik_tracker.py
@@ -3,13 +3,13 @@ from typing import Optional, TYPE_CHECKING
 from . import chunks_aggregator, converse_decorator, invoke_agent_decorator
 
 if TYPE_CHECKING:
-    import botocore.client
+    from mypy_boto3_bedrock_runtime.client import BedrockRuntimeClient
 
 
 def track_bedrock(
-    client: "botocore.client.BaseClient",
+    client: "BedrockRuntimeClient",
     project_name: Optional[str] = None,
-) -> "botocore.client.BaseClient":
+) -> "BedrockRuntimeClient":
     """Adds Opik tracking to an AWS Bedrock client.
 
     Tracks calls to `converse()` and `converse_stream()` methods


### PR DESCRIPTION
## Details

Improves typing of Bedrock client from BaseClient to BedrockRuntimeClient.

## Issues

Resolves #1250

## Testing

Worked when I modified my imported version of Opik. A CometML dev will want to pull down and make sure the updates to setup.py and requirements.txt work as expected, as my setup is using pyproject.toml + Poetry.