### PR TITLE
[OPIK-1009] Only display workspaces where the user is member of

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -94,6 +94,10 @@ const UserMenu = () => {
   const organizationWorkspaces = workspaces.filter(
     (workspace) => workspace.organizationId === organization?.id,
   );
+  const teamNames = user.getTeams.teams.map((team) => team.teamName);
+  const organizationWorkspacesAsMember = organizationWorkspaces.filter(
+    (workspace) => teamNames.includes(workspace.workspaceName),
+  );
   const isOrganizationAdmin =
     organization?.role === ORGANIZATION_ROLE_TYPE.admin;
   const workspacePermissions = userPermissions.find(
@@ -189,24 +193,25 @@ const UserMenu = () => {
               <DropdownMenuPortal>
                 <DropdownMenuSubContent className="w-60">
                   <div className="max-h-[200px] overflow-auto">
-                    {sortBy(organizationWorkspaces, "workspaceName").map(
-                      (workspace) => (
-                        <Link
-                          key={workspace.workspaceName}
-                          to={`/${workspace.workspaceName}`}
+                    {sortBy(
+                      organizationWorkspacesAsMember,
+                      "workspaceName",
+                    ).map((workspace) => (
+                      <Link
+                        key={workspace.workspaceName}
+                        to={`/${workspace.workspaceName}`}
+                      >
+                        <DropdownMenuCheckboxItem
+                          checked={workspaceName === workspace.workspaceName}
                         >
-                          <DropdownMenuCheckboxItem
-                            checked={workspaceName === workspace.workspaceName}
-                          >
-                            <TooltipWrapper content={workspace.workspaceName}>
-                              <span className="truncate">
-                                {workspace.workspaceName}
-                              </span>
-                            </TooltipWrapper>
-                          </DropdownMenuCheckboxItem>
-                        </Link>
-                      ),
-                    )}
+                          <TooltipWrapper content={workspace.workspaceName}>
+                            <span className="truncate">
+                              {workspace.workspaceName}
+                            </span>
+                          </TooltipWrapper>
+                        </DropdownMenuCheckboxItem>
+                      </Link>
+                    ))}
                   </div>
                   <DropdownMenuSeparator />
                   <a


### PR DESCRIPTION
## Details
- Only display workspaces where the user is member of (not all organization workspaces if you are an admin anymore)

Before
![Screenshot 2025-02-12 at 12 21 05 PM](https://github.com/user-attachments/assets/dcdb9e25-5365-4553-9a67-b6343ca04b1a)

After (admin not being part of `fcarril-asdas` workspace, can access, not in the dropdown anymore)
![Screenshot 2025-02-12 at 12 21 26 PM](https://github.com/user-attachments/assets/767ceb7f-6a4c-4519-99e4-eb64d7547b03)
![Screenshot 2025-02-12 at 12 22 05 PM](https://github.com/user-attachments/assets/29493bb8-2360-4f05-94be-36a48d612c1d)
