### PR TITLE
[OPIK-943]: fix the ordered and unordered lists in playground;

### DIFF
--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutput.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutput.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
 
-import { getAlphabetLetter } from "@/lib/utils";
+import { cn, getAlphabetLetter } from "@/lib/utils";
 import PlaygroundOutputLoader from "@/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputLoader/PlaygroundOutputLoader";
 import {
   useOutputLoadingByPromptDatasetItemId,
@@ -25,7 +25,11 @@ const PlaygroundOutput = ({ promptId, index }: PlaygroundOutputProps) => {
     }
 
     return (
-      <ReactMarkdown className={stale ? "text-muted-gray" : ""}>
+      <ReactMarkdown
+        className={cn("comet-markdown", {
+          "text-muted-gray": stale,
+        })}
+      >
         {value}
       </ReactMarkdown>
     );

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundOutputCell.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundOutputCell.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/store/PlaygroundStore";
 import ReactMarkdown from "react-markdown";
 import PlaygroundOutputLoader from "@/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputLoader/PlaygroundOutputLoader";
+import { cn } from "@/lib/utils";
 
 interface PlaygroundOutputCellData {
   dataItemId: string;
@@ -46,7 +47,11 @@ const PlaygroundOutputCell: React.FunctionComponent<
     }
 
     return (
-      <ReactMarkdown className={stale ? "text-muted-gray" : ""}>
+      <ReactMarkdown
+        className={cn("comet-markdown", {
+          "text-muted-gray": stale,
+        })}
+      >
         {value}
       </ReactMarkdown>
     );

--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -160,16 +160,15 @@
 
   .comet-code {
     @apply font-normal text-sm tracking-[0.02em];
-    font-family:
-      Ubuntu Mono,
-      ui-monospace,
-      SFMono-Regular,
-      Menlo,
-      Monaco,
-      Consolas,
-      "Liberation Mono",
-      "Courier New",
-      monospace;
+    font-family: Ubuntu Mono,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    "Courier New",
+    monospace;
   }
 
   .comet-header-height {
@@ -196,16 +195,15 @@
   kbd,
   samp,
   pre {
-    font-family:
-      Ubuntu Mono,
-      ui-monospace,
-      SFMono-Regular,
-      Menlo,
-      Monaco,
-      Consolas,
-      "Liberation Mono",
-      "Courier New",
-      monospace;
+    font-family: Ubuntu Mono,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    "Courier New",
+    monospace;
   }
 
   .comet-custom-scrollbar {
@@ -273,4 +271,12 @@
     z-index: -5;
     background: hsl(var(--secondary));
   }
+}
+
+.comet-markdown ul {
+  @apply list-disc pl-6;
+}
+
+.comet-markdown ol {
+  @apply list-decimal pl-6;
 }

--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -160,15 +160,16 @@
 
   .comet-code {
     @apply font-normal text-sm tracking-[0.02em];
-    font-family: Ubuntu Mono,
-    ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    "Liberation Mono",
-    "Courier New",
-    monospace;
+    font-family:
+      Ubuntu Mono,
+      ui-monospace,
+      SFMono-Regular,
+      Menlo,
+      Monaco,
+      Consolas,
+      "Liberation Mono",
+      "Courier New",
+      monospace;
   }
 
   .comet-header-height {
@@ -195,15 +196,16 @@
   kbd,
   samp,
   pre {
-    font-family: Ubuntu Mono,
-    ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    "Liberation Mono",
-    "Courier New",
-    monospace;
+    font-family:
+      Ubuntu Mono,
+      ui-monospace,
+      SFMono-Regular,
+      Menlo,
+      Monaco,
+      Consolas,
+      "Liberation Mono",
+      "Courier New",
+      monospace;
   }
 
   .comet-custom-scrollbar {


### PR DESCRIPTION
## Details
The problem was that tailwind setup removes `list-style` for `ul, ol, li` by making it `none`.

<img width="1337" alt="image" src="https://github.com/user-attachments/assets/554e97e0-6a81-4431-a24c-a121e72179ce" />

## Issues

Resolves #

## Testing

## Documentation
