### PR TITLE
[OPIK-1026] Add `--yes` and `-y` options to `opik configure` CLI command

### DIFF
--- a/sdks/python/src/opik/cli.py
+++ b/sdks/python/src/opik/cli.py
@@ -45,7 +45,9 @@ def configure(use_local: bool, yes: bool) -> None:
     automatic_approvals = yes
 
     if use_local:
-        opik_configure.configure(use_local=True, force=True, automatic_approvals=automatic_approvals)
+        opik_configure.configure(
+            use_local=True, force=True, automatic_approvals=automatic_approvals
+        )
     else:
         deployment_type_choice = interactive_helpers.ask_user_for_deployment_type()
 

--- a/sdks/python/src/opik/cli.py
+++ b/sdks/python/src/opik/cli.py
@@ -25,17 +25,27 @@ def cli() -> None:
 @cli.command(context_settings={"ignore_unknown_options": True})
 @click.option(
     "--use_local",
+    "--use-local",
     is_flag=True,
     default=False,
     help="Flag to configure the Opik Python SDK for local Opik deployments.",
 )
-def configure(use_local: bool) -> None:
+@click.option(
+    "-y",
+    "--yes",
+    is_flag=True,
+    default=False,
+    help="Flag to automatically answer `yes` whenever a user approval might be required",
+)
+def configure(use_local: bool, yes: bool) -> None:
     """
     Create a configuration file for the Opik Python SDK, if a configuration file already exists, it will be overwritten.
     This is also available as a function in the Python SDK.
     """
+    automatic_approvals = yes
+
     if use_local:
-        opik_configure.configure(use_local=True, force=True)
+        opik_configure.configure(use_local=True, force=True, automatic_approvals=automatic_approvals)
     else:
         deployment_type_choice = interactive_helpers.ask_user_for_deployment_type()
 
@@ -45,18 +55,21 @@ def configure(use_local: bool) -> None:
                 use_local=False,
                 force=True,
                 self_hosted_comet=False,
+                automatic_approvals=automatic_approvals,
             )
         elif deployment_type_choice == interactive_helpers.DeploymentType.SELF_HOSTED:
             configurator = opik_configure.OpikConfigurator(
                 use_local=False,
                 force=True,
                 self_hosted_comet=True,
+                automatic_approvals=automatic_approvals,
             )
         elif deployment_type_choice == interactive_helpers.DeploymentType.LOCAL:
             configurator = opik_configure.OpikConfigurator(
                 use_local=True,
                 force=True,
                 self_hosted_comet=False,
+                automatic_approvals=automatic_approvals,
             )
         else:
             LOGGER.error("Unknown deployment type was selected. Exiting.")

--- a/sdks/python/src/opik/configurator/configure.py
+++ b/sdks/python/src/opik/configurator/configure.py
@@ -22,7 +22,6 @@ OPIK_BASE_URL_CLOUD: Final[str] = "https://www.comet.com/"
 OPIK_BASE_URL_LOCAL: Final[str] = "http://localhost:5173/"
 
 
-
 class OpikConfigurator:
     def __init__(
         self,
@@ -32,7 +31,7 @@ class OpikConfigurator:
         use_local: bool = False,
         force: bool = False,
         self_hosted_comet: bool = False,
-        automatic_approvals: bool = False
+        automatic_approvals: bool = False,
     ):
         self.api_key = api_key
         self.workspace = workspace
@@ -134,7 +133,7 @@ class OpikConfigurator:
 
             use_url = (
                 True
-                if self.automatic_approvals 
+                if self.automatic_approvals
                 else ask_user_for_approval(
                     f"Found local Opik instance on: {OPIK_BASE_URL_LOCAL}, do you want to use it? (Y/n)"
                 )

--- a/sdks/python/src/opik/configurator/configure.py
+++ b/sdks/python/src/opik/configurator/configure.py
@@ -22,6 +22,7 @@ OPIK_BASE_URL_CLOUD: Final[str] = "https://www.comet.com/"
 OPIK_BASE_URL_LOCAL: Final[str] = "http://localhost:5173/"
 
 
+
 class OpikConfigurator:
     def __init__(
         self,
@@ -31,6 +32,7 @@ class OpikConfigurator:
         use_local: bool = False,
         force: bool = False,
         self_hosted_comet: bool = False,
+        automatic_approvals: bool = False
     ):
         self.api_key = api_key
         self.workspace = workspace
@@ -38,6 +40,7 @@ class OpikConfigurator:
         self.force = force
         self.current_config = opik.config.OpikConfig()
         self.self_hosted_comet = self_hosted_comet
+        self.automatic_approvals = automatic_approvals
 
         # Handle URL
         #
@@ -129,9 +132,14 @@ class OpikConfigurator:
                     f"Opik URL is not specified - A local Opik instance was detected at {OPIK_BASE_URL_LOCAL}, to use it set your URL using the environment variable OPIK_URL_OVERRIDE or provide it as an argument. For more details, refer to the documentation: https://www.comet.com/docs/opik/tracing/sdk_configuration."
                 )
 
-            use_url = ask_user_for_approval(
-                f"Found local Opik instance on: {OPIK_BASE_URL_LOCAL}, do you want to use it? (Y/n)"
+            use_url = (
+                True
+                if self.automatic_approvals 
+                else ask_user_for_approval(
+                    f"Found local Opik instance on: {OPIK_BASE_URL_LOCAL}, do you want to use it? (Y/n)"
+                )
             )
+
             if use_url:
                 self.base_url = OPIK_BASE_URL_LOCAL
                 self._update_config()
@@ -272,8 +280,12 @@ class OpikConfigurator:
 
         # Case 3: No workspace provided, prompt the user
         default_workspace = self._get_default_workspace()
-        use_default_workspace = ask_user_for_approval(
-            f'Do you want to use "{default_workspace}" workspace? (Y/n)'
+        use_default_workspace = (
+            True
+            if self.automatic_approvals
+            else ask_user_for_approval(
+                f'Do you want to use "{default_workspace}" workspace? (Y/n)'
+            )
         )
 
         if use_default_workspace:
@@ -447,6 +459,7 @@ def configure(
     url: Optional[str] = None,
     use_local: bool = False,
     force: bool = False,
+    automatic_approvals: bool = False,
 ) -> None:
     """
     Create a local configuration file for the Python SDK. If a configuration file already exists,
@@ -459,6 +472,7 @@ def configure(
         use_local: Whether to use a local deployment.
         force: If true, the configuration file will be recreated and existing settings
                will be overwritten with passed parameters.
+        automatic_approvals: if True, `yes` will automatically be answered whenever a user approval is required
 
     Raises:
         ConfigurationError
@@ -469,5 +483,6 @@ def configure(
         url=url,
         use_local=use_local,
         force=force,
+        automatic_approvals=automatic_approvals,
     )
     client.configure()

--- a/sdks/python/src/opik/configurator/configure.py
+++ b/sdks/python/src/opik/configurator/configure.py
@@ -126,7 +126,7 @@ class OpikConfigurator:
                 return
 
             # Step 3: Ask user if they want to use the found local instance
-            if not is_interactive():
+            if not is_interactive() and not self.automatic_approvals:
                 raise ConfigurationError(
                     f"Opik URL is not specified - A local Opik instance was detected at {OPIK_BASE_URL_LOCAL}, to use it set your URL using the environment variable OPIK_URL_OVERRIDE or provide it as an argument. For more details, refer to the documentation: https://www.comet.com/docs/opik/tracing/sdk_configuration."
                 )

--- a/sdks/python/tests/unit/configurator/test_configure.py
+++ b/sdks/python/tests/unit/configurator/test_configure.py
@@ -747,6 +747,34 @@ class TestGetWorkspace:
         "opik.configurator.configure.OpikConfigurator._get_default_workspace",
         return_value="default_workspace",
     )
+    @patch("opik.configurator.configure.ask_user_for_approval", return_value=True)
+    def test_get_workspace_accept_default__automatic_approvals_enabled__no_approval_questions_asked(
+        self, mock_ask_user_for_approval, mock_get_default_workspace, mock_opik_config
+    ):
+        """
+        Test that the user accepts the default workspace.
+        """
+        current_config = OpikConfig(workspace=OPIK_WORKSPACE_DEFAULT_NAME)
+        mock_opik_config.return_value = current_config
+
+        configurator = OpikConfigurator(
+            workspace=None,
+            force=False,
+            api_key="valid_api_key",
+            automatic_approvals=True,
+        )
+        needs_update = configurator._set_workspace()
+
+        assert configurator.workspace == "default_workspace"
+        assert needs_update is True
+        mock_get_default_workspace.assert_called_once_with()
+        mock_ask_user_for_approval.assert_not_called()
+
+    @patch("opik.configurator.configure.opik.config.OpikConfig")
+    @patch(
+        "opik.configurator.configure.OpikConfigurator._get_default_workspace",
+        return_value="default_workspace",
+    )
     @patch("opik.configurator.configure.ask_user_for_approval", return_value=False)
     @patch("opik.configurator.configure.OpikConfigurator._ask_for_workspace")
     def test_get_workspace_choose_different(
@@ -1087,6 +1115,33 @@ class TestConfigureLocal:
         assert configurator.base_url == OPIK_BASE_URL_LOCAL
         assert configurator.workspace == OPIK_WORKSPACE_DEFAULT_NAME
 
+    @patch("opik.configurator.configure.is_interactive", return_value=True)
+    @patch("opik.configurator.configure.ask_user_for_approval")
+    @patch(
+        "opik.configurator.configure.opik_rest_helpers.is_instance_active",
+        return_value=True,
+    )
+    @patch("opik.configurator.configure.OpikConfigurator._update_config")
+    def test_configure_local_uses_local_instance__automatic_approvals_enabled__no_approval_questions_asked(
+        self,
+        mock_update_config,
+        mock_is_instance_active,
+        mock_ask_user_for_approval,
+        mock_is_interactive,
+    ):
+        """
+        Test that the function configures the local instance when found and user approves.
+        """
+        configurator = OpikConfigurator(url=None, force=False, automatic_approvals=True)
+        configurator._configure_local()
+
+        mock_ask_user_for_approval.assert_not_called()
+        mock_update_config.assert_called_once_with()
+
+        assert configurator.api_key is None
+        assert configurator.base_url == OPIK_BASE_URL_LOCAL
+        assert configurator.workspace == OPIK_WORKSPACE_DEFAULT_NAME
+
     @patch("opik.configurator.configure.is_interactive", return_value=False)
     @patch("opik.configurator.configure.ask_user_for_approval", return_value=True)
     @patch(
@@ -1110,6 +1165,33 @@ class TestConfigureLocal:
 
         mock_ask_user_for_approval.assert_not_called()
         mock_update_config.assert_not_called()
+
+    @patch("opik.configurator.configure.is_interactive", return_value=False)
+    @patch("opik.configurator.configure.ask_user_for_approval")
+    @patch(
+        "opik.configurator.configure.opik_rest_helpers.is_instance_active",
+        return_value=True,
+    )
+    @patch("opik.configurator.configure.OpikConfigurator._update_config")
+    def test_configure_local_uses_local_instance__non_interactive__automatic_approvals_enabled__no_error_raised(
+        self,
+        mock_update_config,
+        mock_is_instance_active,
+        mock_ask_user_for_approval,
+        mock_is_interactive,
+    ):
+        """
+        Test that the function configures the local instance when found and user approves.
+        """
+        configurator = OpikConfigurator(url=None, force=False, automatic_approvals=True)
+        configurator._configure_local()
+
+        mock_ask_user_for_approval.assert_not_called()
+        mock_update_config.assert_called_once_with()
+
+        assert configurator.api_key is None
+        assert configurator.base_url == OPIK_BASE_URL_LOCAL
+        assert configurator.workspace == OPIK_WORKSPACE_DEFAULT_NAME
 
     @patch("opik.configurator.configure.is_interactive", return_value=True)
     @patch("opik.configurator.configure.ask_user_for_approval", return_value=False)


### PR DESCRIPTION
## Details
If `opik configure` is called with `--yes` or `-y` then instead of asking a user for approval (with yes/no options) when it might be needed, an answer will automatically be set to True.

For example `opik configure --use-local --yes` will not lead to asking about using a currently running opik server if it was detected by configurator. The answer will assumed to be `yes` automatically.

The argument `automatic_approvals` appeared in python version of the configuration API.

Also added `--use-local` option in addition to the existing `--use_local`.

## Issues

Resolves https://github.com/comet-ml/opik/issues/1287


## Testing
New unit tests are added. Also tested manually.

## Documentation
Docstrings are updated.