### PR TITLE
[OPIK-993] [SDK] Update langchain integration to support distributed headers

### DIFF
--- a/sdks/python/src/opik/integrations/langchain/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/langchain/opik_tracer.py
@@ -250,6 +250,9 @@ class OpikTracer(BaseTracer):
         run_dict: Dict[str, Any],
         root_metadata: Dict[str, Any],
     ) -> None:
+        if self._distributed_headers is None:
+            raise ValueError("Distributed headers are not set")
+
         span_data = span.SpanData(
             trace_id=self._distributed_headers["opik_trace_id"],
             parent_span_id=self._distributed_headers["opik_parent_span_id"],

--- a/sdks/python/src/opik/integrations/langchain/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/langchain/opik_tracer.py
@@ -5,15 +5,15 @@ from langchain_core import language_models
 from langchain_core.tracers import BaseTracer
 
 from opik import dict_utils, opik_context
-from opik.api_objects import opik_client, span, trace
-from opik.types import ErrorInfoDict, LLMUsageInfo
+from opik.api_objects import span, trace
+from opik.types import DistributedTraceHeadersDict, ErrorInfoDict, LLMUsageInfo
 from . import (
     base_llm_patcher,
     google_run_helpers,
     openai_run_helpers,
     opik_encoder_extension,
 )
-from ...api_objects import helpers
+from ...api_objects import helpers, opik_client
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -56,6 +56,7 @@ class OpikTracer(BaseTracer):
         metadata: Optional[Dict[str, Any]] = None,
         graph: Optional["Graph"] = None,
         project_name: Optional[str] = None,
+        distributed_headers: Optional[DistributedTraceHeadersDict] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -81,7 +82,9 @@ class OpikTracer(BaseTracer):
 
         self._project_name = project_name
 
-        self._opik_client = get_client_cached()
+        self._distributed_headers = distributed_headers
+
+        self._opik_client = opik_client.get_client_cached()
 
     def _persist_run(self, run: "Run") -> None:
         run_dict: Dict[str, Any] = run.dict()
@@ -138,6 +141,14 @@ class OpikTracer(BaseTracer):
     def _track_root_run(self, run_dict: Dict[str, Any]) -> None:
         run_metadata = run_dict["extra"].get("metadata", {})
         root_metadata = dict_utils.deepmerge(self._trace_default_metadata, run_metadata)
+
+        if self._distributed_headers:
+            self._attach_span_to_distributed_headers(
+                run_dict=run_dict,
+                root_metadata=root_metadata,
+            )
+            return
+
         current_span_data = opik_context.get_current_span_data()
         if current_span_data is not None:
             self._attach_span_to_existing_span(
@@ -233,6 +244,24 @@ class OpikTracer(BaseTracer):
         )
         self._span_data_map[run_dict["id"]] = span_data
         self._externally_created_traces_ids.add(current_trace_data.id)
+
+    def _attach_span_to_distributed_headers(
+        self,
+        run_dict: Dict[str, Any],
+        root_metadata: Dict[str, Any],
+    ) -> None:
+        span_data = span.SpanData(
+            trace_id=self._distributed_headers["opik_trace_id"],
+            parent_span_id=self._distributed_headers["opik_parent_span_id"],
+            name=run_dict["name"],
+            input=run_dict["inputs"],
+            metadata=root_metadata,
+            tags=self._trace_default_tags,
+            project_name=self._project_name,
+            type=_get_span_type(run_dict),
+        )
+        self._span_data_map[run_dict["id"]] = span_data
+        self._externally_created_traces_ids.add(span_data.trace_id)
 
     def _process_end_span(self, run: "Run") -> None:
         run_dict: Dict[str, Any] = run.dict()

--- a/sdks/python/src/opik/integrations/langchain/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/langchain/opik_tracer.py
@@ -81,9 +81,7 @@ class OpikTracer(BaseTracer):
 
         self._project_name = project_name
 
-        self._opik_client = opik_client.Opik(
-            _use_batching=True, project_name=project_name
-        )
+        self._opik_client = get_client_cached()
 
     def _persist_run(self, run: "Run") -> None:
         run_dict: Dict[str, Any] = run.dict()

--- a/sdks/python/tests/library_integration/langchain/test_langchain.py
+++ b/sdks/python/tests/library_integration/langchain/test_langchain.py
@@ -11,6 +11,7 @@ from opik import context_storage
 from opik.api_objects import opik_client, span, trace
 from opik.config import OPIK_PROJECT_DEFAULT_NAME
 from opik.integrations.langchain.opik_tracer import OpikTracer
+from opik.types import DistributedTraceHeadersDict
 from ...testlib import (
     ANY_BUT_NONE,
     ANY_DICT,
@@ -122,6 +123,149 @@ def test_langchain__happyflow(
 
     assert len(fake_backend.trace_trees) == 1
     assert len(callback.created_traces()) == 1
+    assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
+
+
+def test_langchain__distributed_headers__happyflow(
+    fake_backend,
+):
+    project_name = "langchain-integration-test--distributed-headers"
+    client = opik_client.get_client_cached()
+
+    # PREPARE DISTRIBUTED HEADERS
+    trace_data = trace.TraceData(
+        name="custom-distributed-headers--trace",
+        input={
+            "key1": 1,
+            "key2": "val2",
+        },
+        project_name=project_name,
+        tags=["tag_d1", "tag_d2"],
+    )
+    trace_data.init_end_time()
+    client.trace(**trace_data.__dict__)
+
+    span_data = span.SpanData(
+        trace_id=trace_data.id,
+        parent_span_id=None,
+        name="custom-distributed-headers--span",
+        input={
+            "input": "custom-distributed-headers--input",
+        },
+        project_name=project_name,
+        tags=["tag_d3", "tag_d4"],
+    )
+    span_data.init_end_time().update(
+        output={"output": "custom-distributed-headers--output"},
+    )
+    client.span(**span_data.__dict__)
+
+    distributed_headers = DistributedTraceHeadersDict(
+        opik_trace_id=span_data.trace_id,
+        opik_parent_span_id=span_data.id,
+    )
+
+    # CALL LLM
+    llm = fake.FakeListLLM(
+        responses=["I'm sorry, I don't think I'm talented enough to write a synopsis"]
+    )
+
+    template = "Given the title of play, write a synopsys for that. Title: {title}."
+
+    prompt_template = PromptTemplate(input_variables=["title"], template=template)
+
+    synopsis_chain = prompt_template | llm
+    test_prompts = {"title": "Documentary about Bigfoot in Paris"}
+
+    callback = OpikTracer(
+        project_name=project_name,
+        tags=["tag1", "tag2"],
+        metadata={"a": "b"},
+        distributed_headers=distributed_headers,
+    )
+    synopsis_chain.invoke(input=test_prompts, config={"callbacks": [callback]})
+
+    callback.flush()
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="custom-distributed-headers--trace",
+        input={"key1": 1, "key2": "val2"},
+        output=None,
+        tags=["tag_d1", "tag_d2"],
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        project_name=project_name,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                name="custom-distributed-headers--span",
+                input={"input": "custom-distributed-headers--input"},
+                output={"output": "custom-distributed-headers--output"},
+                tags=["tag_d3", "tag_d4"],
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=project_name,
+                spans=[
+                    SpanModel(
+                        id=ANY_BUT_NONE,
+                        name="RunnableSequence",
+                        input={"title": "Documentary about Bigfoot in Paris"},
+                        output=ANY_DICT,
+                        tags=["tag1", "tag2"],
+                        start_time=ANY_BUT_NONE,
+                        end_time=ANY_BUT_NONE,
+                        metadata={"a": "b"},
+                        project_name=project_name,
+                        spans=[
+                            SpanModel(
+                                id=ANY_BUT_NONE,
+                                type="tool",
+                                name="PromptTemplate",
+                                input={"title": "Documentary about Bigfoot in Paris"},
+                                output=ANY_DICT,
+                                metadata={},
+                                start_time=ANY_BUT_NONE,
+                                end_time=ANY_BUT_NONE,
+                                project_name=project_name,
+                                spans=[],
+                            ),
+                            SpanModel(
+                                id=ANY_BUT_NONE,
+                                type="llm",
+                                name="FakeListLLM",
+                                input={
+                                    "prompts": [
+                                        "Given the title of play, write a synopsys for that. Title: Documentary about Bigfoot in Paris."
+                                    ]
+                                },
+                                output=ANY_DICT,
+                                metadata={
+                                    "invocation_params": {
+                                        "responses": [
+                                            "I'm sorry, I don't think I'm talented enough to write a synopsis"
+                                        ],
+                                        "_type": "fake-list",
+                                        "stop": None,
+                                    },
+                                    "options": {"stop": None},
+                                    "batch_size": 1,
+                                    "metadata": ANY_BUT_NONE,
+                                },
+                                start_time=ANY_BUT_NONE,
+                                end_time=ANY_BUT_NONE,
+                                project_name=project_name,
+                                spans=[],
+                            ),
+                        ],
+                    )
+                ],
+            )
+        ],
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+    assert len(callback.created_traces()) == 0
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
 
 


### PR DESCRIPTION
## Details
It is possible to pass distributed headers to `langchain` callback init.
In that case root span will be attached to a parent span from those headers.

## Testing
Test added
