### PR TITLE
OPIK-1036: Upgrade opik-backend dependencies

### DIFF
--- a/apps/opik-backend/pom.xml
+++ b/apps/opik-backend/pom.xml
@@ -17,21 +17,21 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>4.0.12</dropwizard.version>
-        <swagger.version>2.2.22</swagger.version>
-        <lombok.version>1.18.32</lombok.version>
+        <swagger.version>2.2.28</swagger.version>
+        <lombok.version>1.18.36</lombok.version>
         <mysql.version>9.2.0</mysql.version>
-        <dropwizard-guicey.version>7.1.3</dropwizard-guicey.version>
+        <dropwizard-guicey.version>7.1.4</dropwizard-guicey.version>
         <stringtemplate.version>3.48.0</stringtemplate.version>
         <jakarta.annotation.version>3.0.0</jakarta.annotation.version>
         <liquibase-clickhouse.version>0.7.2</liquibase-clickhouse.version>
         <clickhouse-java.version>0.7.2</clickhouse-java.version>
-        <org.mapstruct.version>1.6.2</org.mapstruct.version>
-        <testcontainers.version>1.20.2</testcontainers.version>
+        <org.mapstruct.version>1.6.3</org.mapstruct.version>
+        <testcontainers.version>1.20.4</testcontainers.version>
         <uuid.java.generator.version>5.1.0</uuid.java.generator.version>
         <wiremock.version>3.12.0</wiremock.version>
         <redisson.version>3.44.0</redisson.version>
         <opentelmetry.version>2.13.0</opentelmetry.version>
-        <aws.java.sdk.version>2.30.2</aws.java.sdk.version>
+        <aws.java.sdk.version>2.30.21</aws.java.sdk.version>
         <json-path.version>2.9.0</json-path.version>
         <mainClass>com.comet.opik.OpikApplication</mainClass>
     </properties>
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>software.amazon.jdbc</groupId>
             <artifactId>aws-advanced-jdbc-wrapper</artifactId>
-            <version>2.5.0</version>
+            <version>2.5.4</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -316,7 +316,7 @@
         <dependency>
             <groupId>com.redis</groupId>
             <artifactId>testcontainers-redis</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -358,12 +358,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.11.1</version>
+                    <version>3.11.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Details
Review and bump and all dependencies. 

They happen to be just minor versions.

Still the ClickHouse client dependencies left behind.

## Issues

OPIK-1036

## Testing
- Passed CI build.

## Documentation
- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-core
- https://mvnrepository.com/artifact/org.projectlombok/lombok
- https://mvnrepository.com/artifact/org.mapstruct/mapstruct
- https://mvnrepository.com/artifact/org.testcontainers/testcontainers-bom
- https://mvnrepository.com/artifact/software.amazon.awssdk/bom
- https://mvnrepository.com/artifact/software.amazon.jdbc/aws-advanced-jdbc-wrapper
- https://mvnrepository.com/artifact/io.projectreactor/reactor-test
- https://mvnrepository.com/artifact/uk.co.jemos.podam/podam
- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-source-plugin
- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-javadoc-plugin
- https://mvnrepository.com/artifact/com.diffplug.spotless/spotless-maven-plugin