### PR TITLE
OPIK-1036: Updated backend dependencies part 2

### DIFF
--- a/apps/opik-backend/pom.xml
+++ b/apps/opik-backend/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>
             <artifactId>compiler</artifactId>
-            <version>0.9.10</version>
+            <version>0.9.14</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
@@ -246,7 +246,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>3.7.0</version>
+            <version>3.7.3</version>
             <scope>test</scope>
         </dependency>
 
@@ -381,7 +381,7 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.44.1</version>
+                <version>2.44.2</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>


### PR DESCRIPTION
## Details
Upgrading the remaining dependencies.

They're all minor versions.

## Issues

OPIK-1036

## Testing
- Passed CI build.

## Documentation
- https://mvnrepository.com/artifact/com.github.spullara.mustache.java/compiler
- https://mvnrepository.com/artifact/io.projectreactor/reactor-test
- https://mvnrepository.com/artifact/com.diffplug.spotless/spotless-maven-plugin
