### PR TITLE
OPIK-1036: Updated backend dependencies part 3

### DIFF
--- a/apps/opik-backend/pom.xml
+++ b/apps/opik-backend/pom.xml
@@ -66,6 +66,23 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.118.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>5.3.3</version>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.5.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -197,11 +214,6 @@
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
             <version>5.4.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents.core5</groupId>
-            <artifactId>httpcore5</artifactId>
-            <version>5.3.3</version>
         </dependency>
         <dependency>
             <groupId>org.mvel</groupId>


### PR DESCRIPTION
## Details
Upgraded only transitive dependencies:
- `netty` with a BOM.
- `json-smart`.

Regarding `httpcore5` as it's also a transitive dependency, it was wrongly defined a `dependency` in a previous PR https://github.com/comet-ml/opik/pull/1299. It's not an actual direct dependency, so moved to `dependencyManagement` which is the correct place.

## Issues

OPIK-1036

## Testing
- Passed CI build.

## Documentation
- https://mvnrepository.com/artifact/io.netty/netty-bom
- https://mvnrepository.com/artifact/org.apache.httpcomponents.core5/httpcore5
- https://mvnrepository.com/artifact/net.minidev/json-smart
