### PR TITLE
OPIK-664: Add Python evaluator CRUD endpoints support

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluatorLlmAsJudge.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluatorLlmAsJudge.java
@@ -8,9 +8,8 @@ import dev.langchain4j.data.message.ChatMessageType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 import java.beans.ConstructorProperties;
@@ -21,16 +20,12 @@ import java.util.UUID;
 
 import static com.comet.opik.api.AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeCode;
 
-@Getter
-@ToString(callSuper = true)
 @SuperBuilder(toBuilder = true)
+@Data
 @EqualsAndHashCode(callSuper = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public final class AutomationRuleEvaluatorLlmAsJudge extends AutomationRuleEvaluator<LlmAsJudgeCode> {
-
-    @NotNull @JsonView({View.Public.class, View.Write.class})
-    private final LlmAsJudgeCode code;
 
     @Builder(toBuilder = true)
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -76,8 +71,7 @@ public final class AutomationRuleEvaluatorLlmAsJudge extends AutomationRuleEvalu
     public AutomationRuleEvaluatorLlmAsJudge(UUID id, UUID projectId, @NotBlank String name, Float samplingRate,
             @NotNull LlmAsJudgeCode code, Instant createdAt, String createdBy, Instant lastUpdatedAt,
             String lastUpdatedBy) {
-        super(id, projectId, name, samplingRate, createdAt, createdBy, lastUpdatedAt, lastUpdatedBy);
-        this.code = code;
+        super(id, projectId, name, samplingRate, code, createdAt, createdBy, lastUpdatedAt, lastUpdatedBy);
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluatorType.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluatorType.java
@@ -12,7 +12,9 @@ import java.util.Arrays;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum AutomationRuleEvaluatorType {
 
-    LLM_AS_JUDGE(Constants.LLM_AS_JUDGE);
+    LLM_AS_JUDGE(Constants.LLM_AS_JUDGE),
+    USER_DEFINED_METRIC_PYTHON(Constants.USER_DEFINED_METRIC_PYTHON),
+    ;
 
     @JsonValue
     private final String type;
@@ -26,5 +28,6 @@ public enum AutomationRuleEvaluatorType {
     @UtilityClass
     public static class Constants {
         public static final String LLM_AS_JUDGE = "llm_as_judge";
+        public static final String USER_DEFINED_METRIC_PYTHON = "user_defined_metric_python";
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluatorUpdate.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluatorUpdate.java
@@ -1,22 +1,52 @@
 package com.comet.opik.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
 
 import java.util.UUID;
 
-import static com.comet.opik.api.AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeCode;
-
-@Builder(toBuilder = true)
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+@Data
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = AutomationRuleEvaluatorUpdateLlmAsJudge.class, name = AutomationRuleEvaluatorType.Constants.LLM_AS_JUDGE),
+        @JsonSubTypes.Type(value = AutomationRuleEvaluatorUpdateUserDefinedMetricPython.class, name = AutomationRuleEvaluatorType.Constants.USER_DEFINED_METRIC_PYTHON)
+})
+@Schema(name = "AutomationRuleEvaluatorUpdate", discriminatorProperty = "type", discriminatorMapping = {
+        @DiscriminatorMapping(value = AutomationRuleEvaluatorType.Constants.LLM_AS_JUDGE, schema = AutomationRuleEvaluatorUpdateLlmAsJudge.class),
+        @DiscriminatorMapping(value = AutomationRuleEvaluatorType.Constants.USER_DEFINED_METRIC_PYTHON, schema = AutomationRuleEvaluatorUpdateUserDefinedMetricPython.class)
+})
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record AutomationRuleEvaluatorUpdate(
-        @NotNull String name,
-        @NotNull LlmAsJudgeCode code,
-        @NotNull Float samplingRate,
-        // TODO: add @NotNull after deprecated endpoint is removed
-        UUID projectId) {
+public abstract sealed class AutomationRuleEvaluatorUpdate<T> implements AutomationRuleUpdate
+        permits AutomationRuleEvaluatorUpdateLlmAsJudge, AutomationRuleEvaluatorUpdateUserDefinedMetricPython {
+
+    @NotBlank private final String name;
+
+    private final float samplingRate;
+
+    @NotNull private final T code;
+
+    // TODO: add @NotNull after deprecated endpoint is removed
+    private final UUID projectId;
+
+    public abstract AutomationRuleEvaluatorType getType();
+
+    public abstract <C extends AutomationRuleEvaluatorUpdate<T>, B extends AutomationRuleEvaluatorUpdate.AutomationRuleEvaluatorUpdateBuilder<T, C, B>> AutomationRuleEvaluatorUpdate.AutomationRuleEvaluatorUpdateBuilder<T, C, B> toBuilder();
+
+    @Override
+    public AutomationRule.AutomationRuleAction getAction() {
+        return AutomationRule.AutomationRuleAction.EVALUATOR;
+    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluatorUpdateLlmAsJudge.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluatorUpdateLlmAsJudge.java
@@ -1,0 +1,35 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+import java.beans.ConstructorProperties;
+import java.util.UUID;
+
+import static com.comet.opik.api.AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeCode;
+
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class AutomationRuleEvaluatorUpdateLlmAsJudge extends AutomationRuleEvaluatorUpdate<LlmAsJudgeCode> {
+
+    @ConstructorProperties({"name", "samplingRate", "code", "projectId"})
+    public AutomationRuleEvaluatorUpdateLlmAsJudge(
+            // TODO: add @NotNull to projectId after deprecated endpoint is removed
+            @NotBlank String name, float samplingRate, @NotNull LlmAsJudgeCode code, UUID projectId) {
+        super(name, samplingRate, code, projectId);
+    }
+
+    @Override
+    public AutomationRuleEvaluatorType getType() {
+        return AutomationRuleEvaluatorType.LLM_AS_JUDGE;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluatorUpdateUserDefinedMetricPython.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluatorUpdateUserDefinedMetricPython.java
@@ -1,0 +1,37 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+import java.beans.ConstructorProperties;
+import java.util.UUID;
+
+import static com.comet.opik.api.AutomationRuleEvaluatorUserDefinedMetricPython.UserDefinedMetricPythonCode;
+
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class AutomationRuleEvaluatorUpdateUserDefinedMetricPython
+        extends
+            AutomationRuleEvaluatorUpdate<UserDefinedMetricPythonCode> {
+
+    @ConstructorProperties({"name", "samplingRate", "code", "projectId"})
+    public AutomationRuleEvaluatorUpdateUserDefinedMetricPython(
+            // TODO: add @NotNull to projectId after deprecated endpoint is removed
+            @NotBlank String name, float samplingRate, @NotNull UserDefinedMetricPythonCode code, UUID projectId) {
+        super(name, samplingRate, code, projectId);
+    }
+
+    @Override
+    public AutomationRuleEvaluatorType getType() {
+        return AutomationRuleEvaluatorType.USER_DEFINED_METRIC_PYTHON;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluatorUserDefinedMetricPython.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleEvaluatorUserDefinedMetricPython.java
@@ -1,0 +1,68 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+import java.beans.ConstructorProperties;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.comet.opik.api.AutomationRuleEvaluatorUserDefinedMetricPython.UserDefinedMetricPythonCode;
+
+@SuperBuilder(toBuilder = true)
+@Data
+@EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class AutomationRuleEvaluatorUserDefinedMetricPython
+        extends
+            AutomationRuleEvaluator<UserDefinedMetricPythonCode> {
+
+    @Builder(toBuilder = true)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record UserDefinedMetricPythonCode(
+            @JsonView( {
+                    View.Public.class, View.Write.class}) @NotNull String metric,
+            @JsonView({View.Public.class, View.Write.class}) @NotEmpty Map<String, String> arguments){
+    }
+
+    @ConstructorProperties({
+            "id",
+            "projectId",
+            "name",
+            "samplingRate",
+            "code",
+            "createdAt",
+            "createdBy",
+            "lastUpdatedAt",
+            "lastUpdatedBy"
+    })
+    public AutomationRuleEvaluatorUserDefinedMetricPython(
+            UUID id,
+            UUID projectId,
+            @NotBlank String name,
+            Float samplingRate,
+            @NotNull UserDefinedMetricPythonCode code,
+            Instant createdAt,
+            String createdBy,
+            Instant lastUpdatedAt,
+            String lastUpdatedBy) {
+        super(id, projectId, name, samplingRate, code, createdAt, createdBy, lastUpdatedAt, lastUpdatedBy);
+    }
+
+    @Override
+    public AutomationRuleEvaluatorType getType() {
+        return AutomationRuleEvaluatorType.USER_DEFINED_METRIC_PYTHON;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleUpdate.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AutomationRuleUpdate.java
@@ -1,0 +1,26 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "action", visible = true)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = AutomationRuleEvaluatorUpdate.class, name = "evaluator")
+})
+@Schema(name = "AutomationRuleUpdate", discriminatorProperty = "action", discriminatorMapping = {
+        @DiscriminatorMapping(value = "evaluator", schema = AutomationRuleEvaluatorUpdate.class)
+})
+public sealed interface AutomationRuleUpdate permits AutomationRuleEvaluatorUpdate {
+
+    String getName();
+
+    AutomationRule.AutomationRuleAction getAction();
+
+    float getSamplingRate();
+
+    UUID getProjectId();
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
@@ -99,7 +99,8 @@ public class OnlineScoringSampler {
             log.debug("Fetching evaluators for {} traces, project '{}' on workspace '{}'",
                     traces.size(), projectId, tracesBatch.workspaceId());
 
-            var evaluators = ruleEvaluatorService.findAll(projectId, tracesBatch.workspaceId(), LLM_AS_JUDGE);
+            List<AutomationRuleEvaluatorLlmAsJudge> evaluators = ruleEvaluatorService.findAll(
+                    projectId, tracesBatch.workspaceId(), LLM_AS_JUDGE);
 
             // Important to set the workspaceId for logging purposes
             try (MDC.MDCCloseable logScope = MDC.putCloseable(UserLog.MARKER, UserLog.AUTOMATION_RULE_EVALUATOR.name());

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResource.java
@@ -127,17 +127,17 @@ public class AutomationRuleEvaluatorsResource {
 
     @PATCH
     @Path("/{id}")
-    @Operation(operationId = "updateAutomationRuleEvaluator", summary = "update Automation Rule Evaluator by id", description = "update Automation Rule Evaluator by id", responses = {
+    @Operation(operationId = "updateAutomationRuleEvaluator", summary = "Update Automation Rule Evaluator by id", description = "Update Automation Rule Evaluator by id", responses = {
             @ApiResponse(responseCode = "204", description = "No content"),
     })
     @RateLimited
     public Response updateEvaluator(@PathParam("id") UUID id,
-            @RequestBody(content = @Content(schema = @Schema(implementation = AutomationRuleEvaluatorUpdate.class))) @NotNull @Valid AutomationRuleEvaluatorUpdate evaluatorUpdate) {
+            @RequestBody(content = @Content(schema = @Schema(implementation = AutomationRuleEvaluatorUpdate.class))) @NotNull @Valid AutomationRuleEvaluatorUpdate<?> evaluatorUpdate) {
 
-        String workspaceId = requestContext.get().getWorkspaceId();
-        String userName = requestContext.get().getUserName();
+        var workspaceId = requestContext.get().getWorkspaceId();
+        var userName = requestContext.get().getUserName();
 
-        UUID projectId = evaluatorUpdate.projectId();
+        var projectId = evaluatorUpdate.getProjectId();
         log.info("Updating automation rule evaluator by id '{}' and project_id '{}' on workspace_id '{}'", id,
                 projectId, workspaceId);
         service.update(id, projectId, workspaceId, userName, evaluatorUpdate);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AutomationModelEvaluatorMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AutomationModelEvaluatorMapper.java
@@ -1,6 +1,7 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.AutomationRuleEvaluatorLlmAsJudge;
+import com.comet.opik.api.AutomationRuleEvaluatorUserDefinedMetricPython;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -15,9 +16,20 @@ interface AutomationModelEvaluatorMapper {
     @Mapping(target = "code", expression = "java(map(model.code()))")
     AutomationRuleEvaluatorLlmAsJudge map(LlmAsJudgeAutomationRuleEvaluatorModel model);
 
+    @Mapping(target = "code", expression = "java(map(model.code()))")
+    AutomationRuleEvaluatorUserDefinedMetricPython map(UserDefinedMetricPythonAutomationRuleEvaluatorModel model);
+
     LlmAsJudgeAutomationRuleEvaluatorModel map(AutomationRuleEvaluatorLlmAsJudge dto);
+
+    UserDefinedMetricPythonAutomationRuleEvaluatorModel map(AutomationRuleEvaluatorUserDefinedMetricPython dto);
 
     AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeCode map(LlmAsJudgeAutomationRuleEvaluatorModel.LlmAsJudgeCode detail);
 
+    AutomationRuleEvaluatorUserDefinedMetricPython.UserDefinedMetricPythonCode map(
+            UserDefinedMetricPythonAutomationRuleEvaluatorModel.UserDefinedMetricPythonCode code);
+
     LlmAsJudgeAutomationRuleEvaluatorModel.LlmAsJudgeCode map(AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeCode code);
+
+    UserDefinedMetricPythonAutomationRuleEvaluatorModel.UserDefinedMetricPythonCode map(
+            AutomationRuleEvaluatorUserDefinedMetricPython.UserDefinedMetricPythonCode code);
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AutomationRuleDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AutomationRuleDAO.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 @RegisterArgumentFactory(UUIDArgumentFactory.class)
 @RegisterRowMapper(AutomationRuleRowMapper.class)
 @RegisterConstructorMapper(LlmAsJudgeAutomationRuleEvaluatorModel.class)
+@RegisterConstructorMapper(UserDefinedMetricPythonAutomationRuleEvaluatorModel.class)
 @RegisterRowMapper(AutomationRuleEvaluatorRowMapper.class)
 interface AutomationRuleDAO {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AutomationRuleEvaluatorModel.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AutomationRuleEvaluatorModel.java
@@ -5,7 +5,7 @@ import com.comet.opik.api.AutomationRuleEvaluatorType;
 import org.jdbi.v3.json.Json;
 
 public sealed interface AutomationRuleEvaluatorModel<T> extends AutomationRuleModel
-        permits LlmAsJudgeAutomationRuleEvaluatorModel {
+        permits LlmAsJudgeAutomationRuleEvaluatorModel, UserDefinedMetricPythonAutomationRuleEvaluatorModel {
 
     @Json
     T code();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AutomationRuleEvaluatorRowMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AutomationRuleEvaluatorRowMapper.java
@@ -12,11 +12,13 @@ public class AutomationRuleEvaluatorRowMapper implements RowMapper<AutomationRul
     @Override
     public AutomationRuleEvaluatorModel<?> map(ResultSet rs, StatementContext ctx) throws SQLException {
         var type = AutomationRuleEvaluatorType.fromString(rs.getString("type"));
-        return switch (type) {
-            case LLM_AS_JUDGE -> ctx.findMapperFor(LlmAsJudgeAutomationRuleEvaluatorModel.class)
-                    .orElseThrow(() -> new IllegalStateException(
-                            "No mapper found for Automation Rule Evaluator type: %s".formatted(type)))
-                    .map(rs, ctx);
+        var mapperClass = switch (type) {
+            case LLM_AS_JUDGE -> LlmAsJudgeAutomationRuleEvaluatorModel.class;
+            case USER_DEFINED_METRIC_PYTHON -> UserDefinedMetricPythonAutomationRuleEvaluatorModel.class;
         };
+        return ctx.findMapperFor(mapperClass)
+                .orElseThrow(() -> new IllegalStateException(
+                        "No mapper found for Automation Rule Evaluator type: %s".formatted(type)))
+                .map(rs, ctx);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/UserDefinedMetricPythonAutomationRuleEvaluatorModel.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/UserDefinedMetricPythonAutomationRuleEvaluatorModel.java
@@ -1,0 +1,34 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.AutomationRuleEvaluatorType;
+import lombok.Builder;
+import org.jdbi.v3.json.Json;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.comet.opik.domain.UserDefinedMetricPythonAutomationRuleEvaluatorModel.UserDefinedMetricPythonCode;
+
+@Builder(toBuilder = true)
+public record UserDefinedMetricPythonAutomationRuleEvaluatorModel(
+        UUID id,
+        UUID projectId,
+        String name,
+        Float samplingRate,
+        @Json UserDefinedMetricPythonCode code,
+        Instant createdAt,
+        String createdBy,
+        Instant lastUpdatedAt,
+        String lastUpdatedBy)
+        implements
+            AutomationRuleEvaluatorModel<UserDefinedMetricPythonCode> {
+
+    @Override
+    public AutomationRuleEvaluatorType type() {
+        return AutomationRuleEvaluatorType.USER_DEFINED_METRIC_PYTHON;
+    }
+
+    record UserDefinedMetricPythonCode(String metric, Map<String, String> arguments) {
+    }
+}

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000011_add_automation_rule_evaluators_type_user_defined_metric_python.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000011_add_automation_rule_evaluators_type_user_defined_metric_python.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+--changeset andrescrz:000011_add_automation_rule_evaluators_type_user_defined_metric_python
+
+ALTER TABLE automation_rule_evaluators MODIFY COLUMN `type` ENUM('llm_as_judge', 'user_defined_metric_python') NOT NULL;
+
+--rollback ALTER TABLE automation_rule_evaluators MODIFY COLUMN `type` ENUM('llm_as_judge') NOT NULL;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000011_add_automation_rule_evaluators_type_user_defined_metric_python.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000011_add_automation_rule_evaluators_type_user_defined_metric_python.sql
@@ -2,5 +2,3 @@
 --changeset andrescrz:000011_add_automation_rule_evaluators_type_user_defined_metric_python
 
 ALTER TABLE automation_rule_evaluators MODIFY COLUMN `type` ENUM('llm_as_judge', 'user_defined_metric_python') NOT NULL;
-
---rollback ALTER TABLE automation_rule_evaluators MODIFY COLUMN `type` ENUM('llm_as_judge') NOT NULL;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResourceDeprecatedTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResourceDeprecatedTest.java
@@ -3,7 +3,7 @@ package com.comet.opik.api.resources.v1.priv;
 import com.comet.opik.api.AuthenticationErrorResponse;
 import com.comet.opik.api.AutomationRuleEvaluator;
 import com.comet.opik.api.AutomationRuleEvaluatorLlmAsJudge;
-import com.comet.opik.api.AutomationRuleEvaluatorUpdate;
+import com.comet.opik.api.AutomationRuleEvaluatorUpdateLlmAsJudge;
 import com.comet.opik.api.BatchDelete;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.resources.utils.AuthTestUtils;
@@ -414,7 +414,7 @@ class AutomationRuleEvaluatorsResourceDeprecatedTest {
 
             UUID id = evaluatorsResourceClient.createEvaluator(evaluator, projectId, workspaceName, okApikey);
 
-            var updatedEvaluator = factory.manufacturePojo(AutomationRuleEvaluatorUpdate.class);
+            var updatedEvaluator = factory.manufacturePojo(AutomationRuleEvaluatorUpdateLlmAsJudge.class);
 
             evaluatorsResourceClient.updateEvaluator(id, projectId, workspaceName, updatedEvaluator,
                     apiKey, isAuthorized, errorMessage);
@@ -790,7 +790,7 @@ class AutomationRuleEvaluatorsResourceDeprecatedTest {
             UUID projectId = UUID.randomUUID();
             UUID id = evaluatorsResourceClient.createEvaluator(evaluator, projectId, WORKSPACE_NAME, API_KEY);
 
-            var updatedEvaluator = factory.manufacturePojo(AutomationRuleEvaluatorUpdate.class);
+            var updatedEvaluator = factory.manufacturePojo(AutomationRuleEvaluatorUpdateLlmAsJudge.class);
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI, projectId))
                     .path(id.toString())

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResourceTest.java
@@ -4,6 +4,9 @@ import com.comet.opik.api.AuthenticationErrorResponse;
 import com.comet.opik.api.AutomationRuleEvaluator;
 import com.comet.opik.api.AutomationRuleEvaluatorLlmAsJudge;
 import com.comet.opik.api.AutomationRuleEvaluatorUpdate;
+import com.comet.opik.api.AutomationRuleEvaluatorUpdateLlmAsJudge;
+import com.comet.opik.api.AutomationRuleEvaluatorUpdateUserDefinedMetricPython;
+import com.comet.opik.api.AutomationRuleEvaluatorUserDefinedMetricPython;
 import com.comet.opik.api.BatchDelete;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.resources.utils.AuthTestUtils;
@@ -24,11 +27,14 @@ import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.inject.AbstractModule;
 import com.redis.testcontainers.RedisContainer;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import io.dropwizard.jersey.errors.ErrorMessage;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -41,16 +47,17 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
@@ -62,6 +69,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -91,6 +99,8 @@ class AutomationRuleEvaluatorsResourceTest {
 
     private static final String URL_TEMPLATE = "%s/v1/private/automations/evaluators/";
 
+    private static final String[] AUTOMATION_RULE_EVALUATOR_IGNORED_FIELDS = {"createdAt", "lastUpdatedAt"};
+
     private static final String messageToTest = "Summary: {{summary}}\\nInstruction: {{instruction}}\\n\\n";
     private static final String testEvaluator = """
             {
@@ -112,7 +122,8 @@ class AutomationRuleEvaluatorsResourceTest {
               ]
             }
             """
-            .formatted(messageToTest).trim();
+            .formatted(messageToTest)
+            .trim();
 
     private static final String summaryStr = "What was the approach to experimenting with different data mixtures?";
     private static final String outputStr = "The study employed a systematic approach to experiment with varying data mixtures by manipulating the proportions and sources of datasets used for model training.";
@@ -125,12 +136,15 @@ class AutomationRuleEvaluatorsResourceTest {
                 "pdf_url": "https://arxiv.org/pdf/2406.04744",
                 "title": "CRAG -- Comprehensive RAG Benchmark"
             }
-            """.formatted(summaryStr).trim();
+            """.formatted(summaryStr)
+            .trim();
+
     private static final String output = """
             {
                 "output": "%s"
             }
-            """.formatted(outputStr).trim();
+            """.formatted(outputStr)
+            .trim();
 
     private static final String validAiMsgTxt = "{\"Relevance\":{\"score\":5,\"reason\":\"The summary directly addresses the approach taken in the study by mentioning the systematic experimentation with varying data mixtures and the manipulation of proportions and sources.\"},"
             +
@@ -138,19 +152,19 @@ class AutomationRuleEvaluatorsResourceTest {
             +
             "\"Technical Accuracy\":{\"score\":0,\"reason\":\"The summary accurately describes the experimental approach involving data mixtures, proportions, and sources, reflecting the technical details of the study.\"}}";
 
-    private static final String USER = UUID.randomUUID().toString();
+    private static final String USER = "user-" + RandomStringUtils.randomAlphanumeric(20);
     private static final String API_KEY = UUID.randomUUID().toString();
     private static final String WORKSPACE_ID = UUID.randomUUID().toString();
-    private static final String WORKSPACE_NAME = "workspace-" + UUID.randomUUID();
+    private static final String WORKSPACE_NAME = "workspace-" + RandomStringUtils.randomAlphanumeric(20);
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
-
     private static final MySQLContainer<?> MYSQL = MySQLContainerUtils.newMySQLContainer();
-
     private static final ClickHouseContainer CLICKHOUSE = ClickHouseContainerUtils.newClickHouseContainer();
 
     @RegisterExtension
-    private static TestDropwizardAppExtension APP;
+    private static final TestDropwizardAppExtension APP;
 
     private static final WireMockUtils.WireMockRuntime wireMock;
 
@@ -169,18 +183,17 @@ class AutomationRuleEvaluatorsResourceTest {
                         .runtimeInfo(wireMock.runtimeInfo())
                         .disableModules(List.of(LlmModule.class))
                         .modules(List.of(new AbstractModule() {
-
                             @Override
                             public void configure() {
                                 bind(LlmProviderFactory.class)
                                         .toInstance(Mockito.mock(LlmProviderFactory.class, Mockito.RETURNS_DEEP_STUBS));
                             }
-
                         }))
                         .build());
     }
 
     private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+    private final TimeBasedEpochGenerator generator = Generators.timeBasedEpochGenerator();
 
     private String baseURI;
     private ClientSupport client;
@@ -198,15 +211,11 @@ class AutomationRuleEvaluatorsResourceTest {
 
         ClientSupportUtils.config(client);
 
-        mockTargetWorkspace(API_KEY, WORKSPACE_NAME, WORKSPACE_ID);
+        AuthTestUtils.mockTargetWorkspace(wireMock.server(), API_KEY, WORKSPACE_NAME, WORKSPACE_ID, USER);
 
         this.evaluatorsResourceClient = new AutomationRuleEvaluatorResourceClient(this.client, baseURI);
         this.traceResourceClient = new TraceResourceClient(this.client, baseURI);
         this.projectResourceClient = new ProjectResourceClient(this.client, baseURI, factory);
-    }
-
-    private static void mockTargetWorkspace(String apiKey, String workspaceName, String workspaceId) {
-        AuthTestUtils.mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, USER);
     }
 
     @AfterAll
@@ -219,92 +228,177 @@ class AutomationRuleEvaluatorsResourceTest {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ApiKey {
 
-        private final String fakeApikey = UUID.randomUUID().toString();
-        private final String okApikey = UUID.randomUUID().toString();
+        private static final String FAKE_API_KEY = UUID.randomUUID().toString();
 
         Stream<Arguments> credentials() {
             return Stream.of(
-                    arguments(okApikey, true, null),
-                    arguments(fakeApikey, false, UNAUTHORIZED_RESPONSE),
-                    arguments("", false, NO_API_KEY_RESPONSE));
+                    arguments(FAKE_API_KEY, UNAUTHORIZED_RESPONSE),
+                    arguments("", NO_API_KEY_RESPONSE));
         }
 
         @BeforeEach
         void setUp() {
-
             wireMock.server().stubFor(
                     post(urlPathEqualTo("/opik/auth"))
-                            .withHeader(HttpHeaders.AUTHORIZATION, equalTo(fakeApikey))
+                            .withHeader(HttpHeaders.AUTHORIZATION, equalTo(FAKE_API_KEY))
                             .withRequestBody(matchingJsonPath("$.workspaceName", matching(".+")))
                             .willReturn(WireMock.unauthorized().withHeader("Content-Type", "application/json")
                                     .withJsonBody(JsonUtils.readTree(
                                             new AuthenticationErrorResponse(FAKE_API_KEY_MESSAGE,
-                                                    401)))));
+                                                    HttpStatus.SC_UNAUTHORIZED)))));
+        }
+
+        @ParameterizedTest
+        @MethodSource("credentials")
+        void createWhenNotValidApiKey(String apiKey, ErrorMessage errorMessage) {
+            var ruleEvaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class);
+            try (var actualResponse = evaluatorsResourceClient.createEvaluator(
+                    ruleEvaluator, WORKSPACE_NAME, apiKey, HttpStatus.SC_UNAUTHORIZED)) {
+                assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(errorMessage);
+            }
+        }
+
+        @ParameterizedTest
+        @MethodSource("credentials")
+        void getWhenNotValidApiKey(String apiKey, ErrorMessage errorMessage) {
+            var projectId = generator.generate();
+            try (var actualResponse = evaluatorsResourceClient.findEvaluator(
+                    projectId, null, null, null, WORKSPACE_NAME, apiKey, HttpStatus.SC_UNAUTHORIZED)) {
+                assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(errorMessage);
+            }
+        }
+
+        @ParameterizedTest
+        @MethodSource("credentials")
+        void updateWhenNotValidApiKey(String apiKey, ErrorMessage errorMessage) {
+            var id = generator.generate();
+            var updatedEvaluator = factory.manufacturePojo(AutomationRuleEvaluatorUpdateLlmAsJudge.class);
+            try (var actualResponse = evaluatorsResourceClient.updateEvaluator(
+                    id, WORKSPACE_NAME, updatedEvaluator, apiKey, HttpStatus.SC_UNAUTHORIZED)) {
+                assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(errorMessage);
+            }
+        }
+
+        @ParameterizedTest
+        @MethodSource("credentials")
+        void deleteWhenNotValidApiKey(String apiKey, ErrorMessage errorMessage) {
+            var projectId = generator.generate();
+            var batchDelete = factory.manufacturePojo(BatchDelete.class);
+            try (var actualResponse = evaluatorsResourceClient.delete(
+                    projectId, WORKSPACE_NAME, apiKey, batchDelete, HttpStatus.SC_UNAUTHORIZED)) {
+                assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(errorMessage);
+            }
+        }
+
+        @ParameterizedTest
+        @MethodSource("credentials")
+        void getLogsWhenNotValidApiKey(String apikey, ErrorMessage errorMessage) {
+            var id = generator.generate();
+            try (var actualResponse = evaluatorsResourceClient.getLogs(
+                    id, WORKSPACE_NAME, apikey, HttpStatus.SC_UNAUTHORIZED)) {
+                assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(errorMessage);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Session Token Authentication:")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class SessionTokenCookie {
+
+        private static final String SESSION_TOKEN = UUID.randomUUID().toString();
+        private static final String FAKE_SESSION_TOKEN = UUID.randomUUID().toString();
+
+        Stream<Arguments> credentials() {
+            return Stream.of(
+                    arguments(SESSION_TOKEN, true, "OK_" + UUID.randomUUID()),
+                    arguments(FAKE_SESSION_TOKEN, false, UUID.randomUUID().toString()));
+        }
+
+        @BeforeEach
+        void setUp() {
+            wireMock.server().stubFor(
+                    post(urlPathEqualTo("/opik/auth-session"))
+                            .withCookie(SESSION_COOKIE, equalTo(SESSION_TOKEN))
+                            .withRequestBody(matchingJsonPath("$.workspaceName", matching("OK_.+")))
+                            .willReturn(okJson(AuthTestUtils.newWorkspaceAuthResponse(USER, WORKSPACE_ID))));
+
+            wireMock.server().stubFor(
+                    post(urlPathEqualTo("/opik/auth-session"))
+                            .withCookie(SESSION_COOKIE, equalTo(FAKE_SESSION_TOKEN))
+                            .withRequestBody(matchingJsonPath("$.workspaceName", matching(".+")))
+                            .willReturn(WireMock.unauthorized().withHeader("Content-Type", "application/json")
+                                    .withJsonBody(JsonUtils.readTree(
+                                            new AuthenticationErrorResponse(FAKE_API_KEY_MESSAGE,
+                                                    HttpStatus.SC_UNAUTHORIZED)))));
         }
 
         @ParameterizedTest
         @MethodSource("credentials")
         @DisplayName("create evaluator definition: when api key is present, then return proper response")
-        void createAutomationRuleEvaluator__whenApiKeyIsPresent__thenReturnProperResponse(String apiKey,
-                boolean isAuthorized, io.dropwizard.jersey.errors.ErrorMessage errorMessage) {
+        void createAutomationRuleEvaluator__whenSessionTokenIsPresent__thenReturnProperResponse(
+                String sessionToken, boolean isAuthorized, String workspaceName) {
 
-            var ruleEvaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder().id(null)
+            var projectId = UUID.randomUUID();
+            var ruleEvaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder()
+                    .id(null)
+                    .projectId(projectId)
                     .build();
-
-            mockTargetWorkspace(okApikey, WORKSPACE_NAME, WORKSPACE_ID);
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
                     .request()
-                    .header(HttpHeaders.AUTHORIZATION, apiKey)
+                    .cookie(SESSION_COOKIE, sessionToken)
                     .accept(MediaType.APPLICATION_JSON_TYPE)
-                    .header(WORKSPACE_HEADER, WORKSPACE_NAME)
+                    .header(WORKSPACE_HEADER, workspaceName)
                     .post(Entity.json(ruleEvaluator))) {
 
                 if (isAuthorized) {
                     assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(201);
                     assertThat(actualResponse.hasEntity()).isFalse();
-
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
-                    assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
-                            .isEqualTo(errorMessage);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
+                    assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(UNAUTHORIZED_RESPONSE);
                 }
             }
-
         }
 
         @ParameterizedTest
         @MethodSource("credentials")
         @DisplayName("get evaluators by project id: when api key is present, then return proper response")
-        void getProjectAutomationRuleEvaluators__whenApiKeyIsPresent__thenReturnProperResponse(String apiKey,
-                boolean isAuthorized, io.dropwizard.jersey.errors.ErrorMessage errorMessage) {
+        void getProjectAutomationRuleEvaluators__whenSessionTokenIsPresent__thenReturnProperResponse(
+                String sessionToken,
+                boolean isAuthorized,
+                String workspaceName) {
 
-            final String workspaceName = "workspace-" + UUID.randomUUID();
-            final String workspaceId = UUID.randomUUID().toString();
-            final UUID projectId = UUID.randomUUID();
-
-            mockTargetWorkspace(okApikey, workspaceName, workspaceId);
+            var projectId = generator.generate();
 
             int samplesToCreate = 15;
+            var newWorkspaceName = "workspace-" + UUID.randomUUID();
+            var newWorkspaceId = UUID.randomUUID().toString();
+
+            wireMock.server().stubFor(
+                    post(urlPathEqualTo("/opik/auth-session"))
+                            .withCookie(SESSION_COOKIE, equalTo(sessionToken))
+                            .withRequestBody(matchingJsonPath("$.workspaceName", equalTo(newWorkspaceName)))
+                            .willReturn(okJson(AuthTestUtils.newWorkspaceAuthResponse(USER, newWorkspaceId))));
 
             IntStream.range(0, samplesToCreate).forEach(i -> {
                 var evaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class)
                         .toBuilder().id(null).projectId(projectId).build();
-
-                evaluatorsResourceClient.createEvaluator(evaluator, workspaceName, okApikey);
+                evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
             });
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
                     .queryParam("size", samplesToCreate)
                     .queryParam("project_id", projectId)
                     .request()
-                    .header(HttpHeaders.AUTHORIZATION, apiKey)
+                    .cookie(SESSION_COOKIE, sessionToken)
                     .accept(MediaType.APPLICATION_JSON_TYPE)
                     .header(WORKSPACE_HEADER, workspaceName)
                     .get()) {
 
                 if (isAuthorized) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
                     assertThat(actualResponse.hasEntity()).isTrue();
 
                     var actualEntity = actualResponse
@@ -313,143 +407,108 @@ class AutomationRuleEvaluatorsResourceTest {
                     assertThat(actualEntity.total()).isEqualTo(samplesToCreate);
 
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
-                    assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
-                            .isEqualTo(errorMessage);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
+                    assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(UNAUTHORIZED_RESPONSE);
                 }
             }
         }
 
         @ParameterizedTest
-        @ValueSource(booleans = {true, false})
-        @DisplayName("search project evaluators: when searching by name, then return evaluators")
-        void find__whenSearchingByName__thenReturnEvaluators(boolean withProjectId) {
+        @MethodSource("credentials")
+        @DisplayName("get evaluator by id: when api key is present, then return proper response")
+        void getAutomationRuleEvaluatorById__whenSessionTokenIsPresent__thenReturnProperResponse(
+                String sessionToken,
+                boolean isAuthorized,
+                String workspaceName) {
 
-            var workspaceName = "workspace-" + UUID.randomUUID();
-            var workspaceId = UUID.randomUUID().toString();
-            var apiKey = UUID.randomUUID().toString();
-
-            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
-            var name = "Evaluator Name: " + UUID.randomUUID();
-
-            var evaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class)
-                    .toBuilder().id(null)
-                    .name(name)
+            var evaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder()
+                    .id(null)
                     .build();
 
-            evaluatorsResourceClient.createEvaluator(evaluator, workspaceName, apiKey);
-
-            var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
-                    .queryParam("name", "aluator")
-                    .queryParam("project_id", withProjectId ? evaluator.getProjectId() : null)
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, apiKey)
-                    .header(WORKSPACE_HEADER, workspaceName)
-                    .get();
-
-            var actualEntity = actualResponse.readEntity(AutomationRuleEvaluator.AutomationRuleEvaluatorPage.class);
-
-            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
-            assertThat(actualEntity.page()).isEqualTo(1);
-            assertThat(actualEntity.size()).isEqualTo(1);
-            assertThat(actualEntity.total()).isEqualTo(1);
-
-            List<AutomationRuleEvaluator<?>> content = actualEntity.content();
-            assertThat(content.stream().map(AutomationRuleEvaluator::getName).toList()).contains(name);
-        }
-
-        @ParameterizedTest
-        @ValueSource(booleans = {true, false})
-        @DisplayName("get evaluator by id: when api key is present, then return proper response")
-        void getAutomationRuleEvaluatorById__whenApiKeyIsPresent__thenReturnProperResponse(boolean withProjectId) {
-
-            String workspaceName = "workspace-" + UUID.randomUUID();
-            String workspaceId = UUID.randomUUID().toString();
-
-            var evaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class)
-                    .toBuilder().id(null).build();
-
-            mockTargetWorkspace(okApikey, workspaceName, workspaceId);
-
-            UUID id = evaluatorsResourceClient.createEvaluator(evaluator, workspaceName, okApikey);
+            var id = evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
                     .path(id.toString())
-                    .queryParam("project_id", withProjectId ? evaluator.getProjectId() : null)
+                    .queryParam("project_id", evaluator.getProjectId())
                     .request()
-                    .header(HttpHeaders.AUTHORIZATION, okApikey)
+                    .cookie(SESSION_COOKIE, sessionToken)
                     .accept(MediaType.APPLICATION_JSON_TYPE)
                     .header(WORKSPACE_HEADER, workspaceName)
                     .get()) {
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
-                assertThat(actualResponse.hasEntity()).isTrue();
+                if (isAuthorized) {
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
+                    assertThat(actualResponse.hasEntity()).isTrue();
 
-                var ruleEvaluator = actualResponse.readEntity(AutomationRuleEvaluator.class);
-                assertThat(ruleEvaluator.getId()).isEqualTo(id);
-                assertThat(ruleEvaluator.getProjectId()).isEqualTo(evaluator.getProjectId());
+                    var ruleEvaluator = actualResponse.readEntity(AutomationRuleEvaluator.class);
+                    assertThat(ruleEvaluator.getId()).isEqualTo(id);
+                } else {
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
+                    assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(UNAUTHORIZED_RESPONSE);
+                }
             }
         }
 
         @ParameterizedTest
         @MethodSource("credentials")
         @DisplayName("update evaluator: when api key is present, then return proper response")
-        void updateAutomationRuleEvaluator__whenApiKeyIsPresent__thenReturnProperResponse(String apiKey,
-                boolean isAuthorized, io.dropwizard.jersey.errors.ErrorMessage errorMessage) {
-
-            String workspaceName = "workspace-" + UUID.randomUUID();
-            String workspaceId = UUID.randomUUID().toString();
+        void updateAutomationRuleEvaluator__whenSessionTokenIsPresent__thenReturnProperResponse(
+                String sessionToken, boolean isAuthorized, String workspaceName) {
 
             var evaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder().id(null)
                     .build();
 
-            mockTargetWorkspace(okApikey, workspaceName, workspaceId);
+            var id = evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
 
-            UUID id = evaluatorsResourceClient.createEvaluator(evaluator, workspaceName, okApikey);
+            var updatedEvaluator = factory.manufacturePojo(AutomationRuleEvaluatorUpdateLlmAsJudge.class).toBuilder()
+                    .projectId(evaluator.getProjectId()).build();
 
-            var updatedEvaluator = factory.manufacturePojo(AutomationRuleEvaluatorUpdate.class)
-                    .toBuilder()
-                    .projectId(evaluator.getProjectId())
-                    .build();
+            try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
+                    .path(id.toString())
+                    .request()
+                    .cookie(SESSION_COOKIE, sessionToken)
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .header(WORKSPACE_HEADER, workspaceName)
+                    .method(HttpMethod.PATCH, Entity.json(updatedEvaluator))) {
 
-            evaluatorsResourceClient.updateEvaluator(id, workspaceName, updatedEvaluator,
-                    apiKey, isAuthorized, errorMessage);
+                if (isAuthorized) {
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+                    assertThat(actualResponse.hasEntity()).isFalse();
+                } else {
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
+                    assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(UNAUTHORIZED_RESPONSE);
+                }
+            }
         }
 
         @ParameterizedTest
         @MethodSource("credentials")
         @DisplayName("delete evaluator by id: when api key is present, then return proper response")
-        void deleteAutomationRuleEvaluator__whenApiKeyIsPresent__thenReturnProperResponse(String apiKey,
-                boolean isAuthorized, io.dropwizard.jersey.errors.ErrorMessage errorMessage) {
+        void deleteAutomationRuleEvaluator__whenSessionTokenIsPresent__thenReturnProperResponse(String sessionToken,
+                boolean isAuthorized,
+                String workspaceName) {
 
             var evaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder().id(null)
                     .build();
 
-            String workspaceName = "workspace-" + UUID.randomUUID();
-            String workspaceId = UUID.randomUUID().toString();
-
-            mockTargetWorkspace(okApikey, workspaceName, workspaceId);
-
-            UUID id = evaluatorsResourceClient.createEvaluator(evaluator, workspaceName, okApikey);
-
+            var id = evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
             var deleteMethod = BatchDelete.builder().ids(Collections.singleton(id)).build();
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
                     .path("delete")
                     .queryParam("project_id", evaluator.getProjectId())
                     .request()
-                    .header(HttpHeaders.AUTHORIZATION, apiKey)
+                    .cookie(SESSION_COOKIE, sessionToken)
                     .accept(MediaType.APPLICATION_JSON_TYPE)
                     .header(WORKSPACE_HEADER, workspaceName)
                     .post(Entity.json(deleteMethod))) {
 
                 if (isAuthorized) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
                     assertThat(actualResponse.hasEntity()).isFalse();
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
-                    assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
-                            .isEqualTo(errorMessage);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
+                    assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(UNAUTHORIZED_RESPONSE);
                 }
             }
         }
@@ -457,25 +516,24 @@ class AutomationRuleEvaluatorsResourceTest {
         @ParameterizedTest
         @MethodSource("credentials")
         @DisplayName("batch delete evaluators by id: when api key is present, then return proper response")
-        void deleteProjectAutomationRuleEvaluators__whenApiKeyIsPresent__thenReturnProperResponse(String apiKey,
-                boolean isAuthorized, io.dropwizard.jersey.errors.ErrorMessage errorMessage) {
-            var projectId = UUID.randomUUID();
-            var workspaceName = "workspace-" + UUID.randomUUID();
-            var workspaceId = UUID.randomUUID().toString();
+        void deleteProjectAutomationRuleEvaluators__whenSessionTokenIsPresent__thenReturnProperResponse(
+                String sessionToken,
+                boolean isAuthorized,
+                String workspaceName) {
 
-            mockTargetWorkspace(okApikey, workspaceName, workspaceId);
+            var projectId = generator.generate();
 
-            var evaluator1 = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class)
-                    .toBuilder().id(null).projectId(projectId).build();
-            var evalId1 = evaluatorsResourceClient.createEvaluator(evaluator1, workspaceName, okApikey);
+            var evaluator1 = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder()
+                    .projectId(projectId).build();
+            var evalId1 = evaluatorsResourceClient.createEvaluator(evaluator1, WORKSPACE_NAME, API_KEY);
 
-            var evaluator2 = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class)
-                    .toBuilder().id(null).projectId(projectId).build();
-            var evalId2 = evaluatorsResourceClient.createEvaluator(evaluator2, workspaceName, okApikey);
+            var evaluator2 = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder()
+                    .projectId(projectId).build();
+            var evalId2 = evaluatorsResourceClient.createEvaluator(evaluator2, WORKSPACE_NAME, API_KEY);
 
-            var evaluator3 = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class)
-                    .toBuilder().id(null).projectId(projectId).build();
-            evaluatorsResourceClient.createEvaluator(evaluator3, workspaceName, okApikey);
+            var evaluator3 = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder()
+                    .projectId(projectId).build();
+            evaluatorsResourceClient.createEvaluator(evaluator3, WORKSPACE_NAME, API_KEY);
 
             var evalIds1and2 = Set.of(evalId1, evalId2);
             var deleteMethod = BatchDelete.builder().ids(evalIds1and2).build();
@@ -484,18 +542,17 @@ class AutomationRuleEvaluatorsResourceTest {
                     .path("delete")
                     .queryParam("project_id", projectId)
                     .request()
-                    .header(HttpHeaders.AUTHORIZATION, apiKey)
+                    .cookie(SESSION_COOKIE, sessionToken)
                     .accept(MediaType.APPLICATION_JSON_TYPE)
                     .header(WORKSPACE_HEADER, workspaceName)
                     .post(Entity.json(deleteMethod))) {
 
                 if (isAuthorized) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
                     assertThat(actualResponse.hasEntity()).isFalse();
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
-                    assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
-                            .isEqualTo(errorMessage);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
+                    assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(UNAUTHORIZED_RESPONSE);
                 }
             }
 
@@ -503,13 +560,13 @@ class AutomationRuleEvaluatorsResourceTest {
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
                     .queryParam("project_id", projectId)
                     .request()
-                    .header(HttpHeaders.AUTHORIZATION, apiKey)
+                    .cookie(SESSION_COOKIE, sessionToken)
                     .accept(MediaType.APPLICATION_JSON_TYPE)
                     .header(WORKSPACE_HEADER, workspaceName)
                     .get()) {
 
                 if (isAuthorized) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
                     assertThat(actualResponse.hasEntity()).isTrue();
 
                     var actualEntity = actualResponse
@@ -518,9 +575,8 @@ class AutomationRuleEvaluatorsResourceTest {
                     assertThat(actualEntity.total()).isEqualTo(1);
 
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
-                    assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
-                            .isEqualTo(errorMessage);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
+                    assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(UNAUTHORIZED_RESPONSE);
                 }
             }
         }
@@ -529,9 +585,9 @@ class AutomationRuleEvaluatorsResourceTest {
         @MethodSource("credentials")
         @DisplayName("get logs per rule evaluators: when api key is present, then return proper response")
         void getLogsPerRuleEvaluators__whenSessionTokenIsPresent__thenReturnProperResponse(
-                String apikey,
+                String sessionToken,
                 boolean isAuthorized,
-                io.dropwizard.jersey.errors.ErrorMessage errorMessage,
+                String workspaceName,
                 LlmProviderFactory llmProviderFactory) throws JsonProcessingException {
 
             ChatResponse chatResponse = ChatResponse.builder()
@@ -544,32 +600,26 @@ class AutomationRuleEvaluatorsResourceTest {
 
             String projectName = UUID.randomUUID().toString();
 
-            String workspaceName = "workspace-" + UUID.randomUUID();
-            String workspaceId = UUID.randomUUID().toString();
-
-            mockTargetWorkspace(okApikey, workspaceName, workspaceId);
-
-            ObjectMapper mapper = new ObjectMapper();
-
-            var projectId = projectResourceClient.createProject(projectName, okApikey, workspaceName);
+            var projectId = projectResourceClient.createProject(projectName, API_KEY, WORKSPACE_NAME);
 
             var evaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder()
                     .id(null)
-                    .code(mapper.readValue(testEvaluator, AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeCode.class))
+                    .code(OBJECT_MAPPER.readValue(testEvaluator,
+                            AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeCode.class))
                     .samplingRate(1f)
                     .projectId(projectId)
                     .build();
 
             var trace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectName(projectName)
-                    .input(mapper.readTree(input))
-                    .output(mapper.readTree(output))
+                    .input(OBJECT_MAPPER.readTree(input))
+                    .output(OBJECT_MAPPER.readTree(output))
                     .build();
 
-            var id = evaluatorsResourceClient.createEvaluator(evaluator, workspaceName, okApikey);
+            var id = evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
 
             Instant startTime = Instant.now();
-            traceResourceClient.createTrace(trace, okApikey, workspaceName);
+            traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
 
             Awaitility.await().untilAsserted(() -> {
 
@@ -577,8 +627,8 @@ class AutomationRuleEvaluatorsResourceTest {
                         .path(id.toString())
                         .path("logs")
                         .request()
+                        .cookie(SESSION_COOKIE, sessionToken)
                         .accept(MediaType.APPLICATION_JSON_TYPE)
-                        .header(HttpHeaders.AUTHORIZATION, apikey)
                         .header(WORKSPACE_HEADER, workspaceName)
                         .get()) {
 
@@ -587,15 +637,359 @@ class AutomationRuleEvaluatorsResourceTest {
                     } else {
                         assertThat(actualResponse.getStatusInfo().getStatusCode())
                                 .isEqualTo(HttpStatus.SC_UNAUTHORIZED);
-                        assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
-                                .isEqualTo(errorMessage);
+                        assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(UNAUTHORIZED_RESPONSE);
                     }
                 }
             });
         }
     }
 
-    private static void assertLogResponse(Response actualResponse, Instant startTime, UUID id, Trace trace) {
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class CreateAndGetEvaluator {
+
+        Stream<Arguments> createAndGet() {
+            return Stream.of(
+                    arguments(factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class), true),
+                    arguments(factory.manufacturePojo(AutomationRuleEvaluatorUserDefinedMetricPython.class), false));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void createAndGet(AutomationRuleEvaluator<?> automationRuleEvaluator, boolean withProjectId) {
+            var id = evaluatorsResourceClient.createEvaluator(automationRuleEvaluator, WORKSPACE_NAME, API_KEY);
+            var expectedAutomationRuleEvaluator = automationRuleEvaluator.toBuilder()
+                    .id(id)
+                    .createdBy(USER)
+                    .lastUpdatedBy(USER)
+                    .build();
+
+            try (var actualResponse = evaluatorsResourceClient.getEvaluator(
+                    id,
+                    withProjectId ? expectedAutomationRuleEvaluator.getProjectId() : null,
+                    WORKSPACE_NAME,
+                    API_KEY,
+                    HttpStatus.SC_OK)) {
+
+                var actualAutomationRuleEvaluator = actualResponse.readEntity(AutomationRuleEvaluator.class);
+                assertThat(actualAutomationRuleEvaluator)
+                        .usingRecursiveComparison()
+                        .ignoringFields(AUTOMATION_RULE_EVALUATOR_IGNORED_FIELDS)
+                        .isEqualTo(expectedAutomationRuleEvaluator);
+                assertIgnoredFields(actualAutomationRuleEvaluator, expectedAutomationRuleEvaluator);
+            }
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class FindEvaluator {
+
+        Stream<Class<? extends AutomationRuleEvaluator<?>>> find() {
+            return Stream.of(
+                    AutomationRuleEvaluatorLlmAsJudge.class,
+                    AutomationRuleEvaluatorUserDefinedMetricPython.class);
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void find(Class<? extends AutomationRuleEvaluator<?>> evaluatorClass) {
+            var projectId = generator.generate();
+            var unexpectedProjectId = generator.generate();
+
+            var evaluators = PodamFactoryUtils.manufacturePojoList(factory, evaluatorClass)
+                    .stream()
+                    .map(evaluator -> evaluator.toBuilder()
+                            .projectId(projectId)
+                            .build())
+                    .map(evaluator -> {
+                        var id = evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
+                        return evaluator.toBuilder()
+                                .id(id)
+                                .createdBy(USER)
+                                .lastUpdatedBy(USER)
+                                .build();
+                    }).toList();
+
+            var unexpectedEvaluators = PodamFactoryUtils.manufacturePojoList(factory, evaluatorClass)
+                    .stream()
+                    .map(evaluator -> evaluator.toBuilder()
+                            .projectId(unexpectedProjectId)
+                            .build())
+                    .map(evaluator -> {
+                        var id = evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
+                        return evaluator.toBuilder()
+                                .id(id)
+                                .createdBy(USER)
+                                .lastUpdatedBy(USER)
+                                .build();
+                    }).toList();
+
+            var pageSize = evaluators.size() / 2 + 1;
+            var expectedEvaluators1 = evaluators.reversed().subList(0, pageSize);
+            var expectedEvaluators2 = evaluators.reversed().subList(pageSize, evaluators.size());
+
+            findAndAssertPage(
+                    projectId,
+                    null,
+                    1,
+                    pageSize,
+                    evaluators.size(),
+                    expectedEvaluators1,
+                    unexpectedEvaluators);
+            findAndAssertPage(
+                    projectId,
+                    null,
+                    2,
+                    pageSize,
+                    evaluators.size(),
+                    expectedEvaluators2,
+                    unexpectedEvaluators);
+        }
+
+        Stream<Arguments> findByName() {
+            return Stream.of(
+                    arguments(AutomationRuleEvaluatorLlmAsJudge.class, true),
+                    arguments(AutomationRuleEvaluatorUserDefinedMetricPython.class, false));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void findByName(Class<? extends AutomationRuleEvaluator<?>> evaluatorClass, boolean withProjectId) {
+            var projectId = generator.generate();
+
+            var evaluators = PodamFactoryUtils.manufacturePojoList(factory, evaluatorClass)
+                    .stream()
+                    .map(evaluator -> evaluator.toBuilder()
+                            .projectId(projectId)
+                            .build())
+                    .map(evaluator -> {
+                        var id = evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
+                        return evaluator.toBuilder()
+                                .id(id)
+                                .createdBy(USER)
+                                .lastUpdatedBy(USER)
+                                .build();
+                    }).toList();
+
+            var expectedEvaluators = List.of(evaluators.getFirst());
+            var unexpectedEvaluators = evaluators.subList(1, evaluators.size());
+
+            findAndAssertPage(
+                    withProjectId ? projectId : null,
+                    evaluators.getFirst().getName().substring(2, evaluators.getFirst().getName().length() - 3)
+                            .toUpperCase(),
+                    1,
+                    evaluators.size(),
+                    1,
+                    expectedEvaluators,
+                    unexpectedEvaluators);
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class UpdateEvaluator {
+
+        Stream<Arguments> update() {
+            return Stream.of(
+                    arguments(
+                            factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class),
+                            factory.manufacturePojo(AutomationRuleEvaluatorUpdateLlmAsJudge.class)),
+                    arguments(
+                            factory.manufacturePojo(AutomationRuleEvaluatorUserDefinedMetricPython.class),
+                            factory.manufacturePojo(AutomationRuleEvaluatorUpdateUserDefinedMetricPython.class)));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void update(
+                AutomationRuleEvaluator<Object> automationRuleEvaluator,
+                AutomationRuleEvaluatorUpdate<Object> automationRuleEvaluatorUpdate) {
+            var id = evaluatorsResourceClient.createEvaluator(automationRuleEvaluator, WORKSPACE_NAME, API_KEY);
+
+            var updatedEvaluator = automationRuleEvaluatorUpdate.toBuilder()
+                    .projectId(automationRuleEvaluator.getProjectId())
+                    .build();
+            try (var actualResponse = evaluatorsResourceClient.updateEvaluator(
+                    id, WORKSPACE_NAME, updatedEvaluator, API_KEY, HttpStatus.SC_NO_CONTENT)) {
+                assertThat(actualResponse.hasEntity()).isFalse();
+            }
+
+            var expectedAutomationRuleEvaluator = automationRuleEvaluator.toBuilder()
+                    .id(id)
+                    .createdBy(USER)
+                    .lastUpdatedBy(USER)
+                    .name(updatedEvaluator.getName())
+                    .samplingRate(updatedEvaluator.getSamplingRate())
+                    .code(updatedEvaluator.getCode())
+                    .build();
+            try (var actualResponse = evaluatorsResourceClient.getEvaluator(
+                    id, null, WORKSPACE_NAME, API_KEY, HttpStatus.SC_OK)) {
+                var actualAutomationRuleEvaluator = actualResponse.readEntity(AutomationRuleEvaluator.class);
+                assertThat(actualAutomationRuleEvaluator)
+                        .usingRecursiveComparison()
+                        .ignoringFields(AUTOMATION_RULE_EVALUATOR_IGNORED_FIELDS)
+                        .isEqualTo(expectedAutomationRuleEvaluator);
+                assertIgnoredFields(actualAutomationRuleEvaluator, expectedAutomationRuleEvaluator);
+            }
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class DeleteEvaluator {
+
+        @Test
+        void delete() {
+            var projectId = generator.generate();
+            var id1 = createGetAndAssertId(AutomationRuleEvaluatorLlmAsJudge.class, projectId);
+            var id2 = createGetAndAssertId(AutomationRuleEvaluatorUserDefinedMetricPython.class, projectId);
+            var id3 = createGetAndAssertId(AutomationRuleEvaluatorLlmAsJudge.class, projectId);
+            var id4 = createGetAndAssertId(AutomationRuleEvaluatorUserDefinedMetricPython.class, projectId);
+
+            var batchDelete = BatchDelete.builder().ids(Set.of(id1, id2)).build();
+            try (var actualResponse = evaluatorsResourceClient.delete(
+                    projectId, WORKSPACE_NAME, API_KEY, batchDelete, HttpStatus.SC_NO_CONTENT)) {
+                assertThat(actualResponse.hasEntity()).isFalse();
+            }
+
+            try (var actualResponse = evaluatorsResourceClient.getEvaluator(
+                    id1, null, WORKSPACE_NAME, API_KEY, HttpStatus.SC_NOT_FOUND)) {
+                var errorMessage = actualResponse.readEntity(com.comet.opik.api.error.ErrorMessage.class);
+                assertThat(errorMessage)
+                        .isEqualTo((new com.comet.opik.api.error.ErrorMessage(
+                                List.of("AutomationRuleEvaluator not found"))));
+            }
+
+            try (var actualResponse = evaluatorsResourceClient.findEvaluator(
+                    projectId, null, 1, 10, WORKSPACE_NAME, API_KEY, HttpStatus.SC_OK)) {
+                assertThat(actualResponse.hasEntity()).isTrue();
+
+                var actualEntity = actualResponse.readEntity(AutomationRuleEvaluator.AutomationRuleEvaluatorPage.class);
+                assertThat(actualEntity.page()).isEqualTo(1);
+                assertThat(actualEntity.size()).isEqualTo(2);
+                assertThat(actualEntity.total()).isEqualTo(2);
+
+                var actualAutomationRuleEvaluators = actualEntity.content();
+                assertThat(actualAutomationRuleEvaluators).hasSize(2);
+                var actualIds = actualAutomationRuleEvaluators.stream()
+                        .map(AutomationRuleEvaluator::getId)
+                        .collect(Collectors.toSet());
+                assertThat(actualIds).containsExactlyInAnyOrder(id3, id4);
+            }
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class GetLogs {
+
+        @Test
+        void getLogs(LlmProviderFactory llmProviderFactory) throws JsonProcessingException {
+            var chatResponse = ChatResponse.builder()
+                    .aiMessage(AiMessage.from(validAiMsgTxt))
+                    .build();
+
+            when(llmProviderFactory.getLanguageModel(anyString(), any())
+                    .chat(any()))
+                    .thenAnswer(invocationOnMock -> chatResponse);
+
+            var projectName = "project-" + RandomStringUtils.randomAlphanumeric(36);
+            var projectId = projectResourceClient.createProject(projectName, API_KEY, WORKSPACE_NAME);
+
+            var evaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder()
+                    .id(null)
+                    .code(OBJECT_MAPPER.readValue(testEvaluator,
+                            AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeCode.class))
+                    .samplingRate(1f)
+                    .projectId(projectId)
+                    .build();
+
+            var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                    .projectName(projectName)
+                    .input(OBJECT_MAPPER.readTree(input))
+                    .output(OBJECT_MAPPER.readTree(output))
+                    .build();
+
+            var id = evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
+
+            var startTime = Instant.now();
+            traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
+
+            Awaitility.await().untilAsserted(() -> {
+
+                try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
+                        .path(id.toString())
+                        .path("logs")
+                        .request()
+                        .accept(MediaType.APPLICATION_JSON_TYPE)
+                        .header(HttpHeaders.AUTHORIZATION, API_KEY)
+                        .header(WORKSPACE_HEADER, WORKSPACE_NAME)
+                        .get()) {
+
+                    assertLogResponse(actualResponse, startTime, id, trace);
+                }
+            });
+        }
+    }
+
+    private UUID createGetAndAssertId(Class<? extends AutomationRuleEvaluator<?>> evaluatorClass, UUID projectId) {
+        var automationRuleEvaluator = factory.manufacturePojo(evaluatorClass).toBuilder().projectId(projectId).build();
+        var id = evaluatorsResourceClient.createEvaluator(automationRuleEvaluator, WORKSPACE_NAME, API_KEY);
+        try (var actualResponse = evaluatorsResourceClient.getEvaluator(
+                id, null, WORKSPACE_NAME, API_KEY, HttpStatus.SC_OK)) {
+            var actualAutomationRuleEvaluator = actualResponse.readEntity(AutomationRuleEvaluator.class);
+            assertThat(actualAutomationRuleEvaluator.getId()).isEqualTo(id);
+            return id;
+        }
+    }
+
+    private void findAndAssertPage(
+            UUID projectId,
+            String evaluatorName,
+            int page,
+            int size,
+            int expectedTotal,
+            List<? extends AutomationRuleEvaluator<?>> expectedAutomationRuleEvaluators,
+            List<? extends AutomationRuleEvaluator<?>> unexpectedAutomationRuleEvaluators) {
+
+        try (var actualResponse = evaluatorsResourceClient.findEvaluator(
+                projectId, evaluatorName, page, size, WORKSPACE_NAME, API_KEY, HttpStatus.SC_OK)) {
+            assertThat(actualResponse.hasEntity()).isTrue();
+
+            var actualEntity = actualResponse.readEntity(AutomationRuleEvaluator.AutomationRuleEvaluatorPage.class);
+            assertThat(actualEntity.page()).isEqualTo(page);
+            assertThat(actualEntity.size()).isEqualTo(expectedAutomationRuleEvaluators.size());
+            assertThat(actualEntity.total()).isEqualTo(expectedTotal);
+
+            var actualAutomationRuleEvaluators = actualEntity.content();
+            assertThat(actualAutomationRuleEvaluators).hasSize(expectedAutomationRuleEvaluators.size());
+            assertThat(actualAutomationRuleEvaluators)
+                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields(
+                            AUTOMATION_RULE_EVALUATOR_IGNORED_FIELDS)
+                    .containsExactlyElementsOf(expectedAutomationRuleEvaluators);
+
+            for (int i = 0; i < actualAutomationRuleEvaluators.size(); i++) {
+                var actualAutomationRuleEvaluator = actualAutomationRuleEvaluators.get(i);
+                var expectedAutomationRuleEvaluator = expectedAutomationRuleEvaluators.get(i);
+                assertIgnoredFields(actualAutomationRuleEvaluator, expectedAutomationRuleEvaluator);
+            }
+
+            assertThat(actualAutomationRuleEvaluators)
+                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields(
+                            AUTOMATION_RULE_EVALUATOR_IGNORED_FIELDS)
+                    .doesNotContainAnyElementsOf(unexpectedAutomationRuleEvaluators);
+        }
+    }
+
+    private void assertIgnoredFields(AutomationRuleEvaluator<?> actualRuleEvaluator,
+            AutomationRuleEvaluator<?> expectedRuleEvaluator) {
+        assertThat(actualRuleEvaluator.getCreatedAt()).isAfter(expectedRuleEvaluator.getCreatedAt());
+        assertThat(actualRuleEvaluator.getLastUpdatedAt()).isAfter(expectedRuleEvaluator.getLastUpdatedAt());
+    }
+
+    private void assertLogResponse(Response actualResponse, Instant startTime, UUID id, Trace trace) {
         assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
         assertThat(actualResponse.hasEntity()).isTrue();
 
@@ -627,356 +1021,5 @@ class AutomationRuleEvaluatorsResourceTest {
 
         assertThat(actualEntity.content())
                 .anyMatch(log -> log.message().matches("Evaluating traceId '.*' sampled by rule '.*'"));
-    }
-
-    @Nested
-    @DisplayName("Session Token Authentication:")
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class SessionTokenCookie {
-
-        private final String sessionToken = UUID.randomUUID().toString();
-        private final String fakeSessionToken = UUID.randomUUID().toString();
-
-        Stream<Arguments> credentials() {
-            return Stream.of(
-                    arguments(sessionToken, true, "OK_" + UUID.randomUUID()),
-                    arguments(fakeSessionToken, false, UUID.randomUUID().toString()));
-        }
-
-        @BeforeEach
-        void setUp() {
-            wireMock.server().stubFor(
-                    post(urlPathEqualTo("/opik/auth-session"))
-                            .withCookie(SESSION_COOKIE, equalTo(sessionToken))
-                            .withRequestBody(matchingJsonPath("$.workspaceName", matching("OK_.+")))
-                            .willReturn(okJson(AuthTestUtils.newWorkspaceAuthResponse(USER, WORKSPACE_ID))));
-
-            wireMock.server().stubFor(
-                    post(urlPathEqualTo("/opik/auth-session"))
-                            .withCookie(SESSION_COOKIE, equalTo(fakeSessionToken))
-                            .withRequestBody(matchingJsonPath("$.workspaceName", matching(".+")))
-                            .willReturn(WireMock.unauthorized().withHeader("Content-Type", "application/json")
-                                    .withJsonBody(JsonUtils.readTree(
-                                            new AuthenticationErrorResponse(FAKE_API_KEY_MESSAGE,
-                                                    401)))));
-        }
-
-        @ParameterizedTest
-        @MethodSource("credentials")
-        @DisplayName("create evaluator definition: when api key is present, then return proper response")
-        void createAutomationRuleEvaluator__whenSessionTokenIsPresent__thenReturnProperResponse(String sessionToken,
-                boolean isAuthorized,
-                String workspaceName) {
-
-            var projectId = UUID.randomUUID();
-            var ruleEvaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder().id(null)
-                    .projectId(projectId)
-                    .build();
-
-            try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
-                    .request()
-                    .cookie(SESSION_COOKIE, sessionToken)
-                    .accept(MediaType.APPLICATION_JSON_TYPE)
-                    .header(WORKSPACE_HEADER, workspaceName)
-                    .post(Entity.json(ruleEvaluator))) {
-
-                if (isAuthorized) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(201);
-                    assertThat(actualResponse.hasEntity()).isFalse();
-                } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
-                    assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
-                            .isEqualTo(UNAUTHORIZED_RESPONSE);
-                }
-            }
-        }
-
-        @ParameterizedTest
-        @MethodSource("credentials")
-        @DisplayName("get evaluators by project id: when api key is present, then return proper response")
-        void getProjectAutomationRuleEvaluators__whenSessionTokenIsPresent__thenReturnProperResponse(
-                String sessionToken,
-                boolean isAuthorized,
-                String workspaceName) {
-
-            var projectId = UUID.randomUUID();
-
-            int samplesToCreate = 15;
-            var newWorkspaceName = "workspace-" + UUID.randomUUID();
-            var newWorkspaceId = UUID.randomUUID().toString();
-
-            wireMock.server().stubFor(
-                    post(urlPathEqualTo("/opik/auth-session"))
-                            .withCookie(SESSION_COOKIE, equalTo(sessionToken))
-                            .withRequestBody(matchingJsonPath("$.workspaceName", equalTo(newWorkspaceName)))
-                            .willReturn(okJson(AuthTestUtils.newWorkspaceAuthResponse(USER, newWorkspaceId))));
-
-            IntStream.range(0, samplesToCreate).forEach(i -> {
-                var evaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class)
-                        .toBuilder().id(null).projectId(projectId).build();
-                evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
-            });
-
-            try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
-                    .queryParam("size", samplesToCreate)
-                    .queryParam("project_id", projectId)
-                    .request()
-                    .cookie(SESSION_COOKIE, sessionToken)
-                    .accept(MediaType.APPLICATION_JSON_TYPE)
-                    .header(WORKSPACE_HEADER, workspaceName)
-                    .get()) {
-
-                if (isAuthorized) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
-                    assertThat(actualResponse.hasEntity()).isTrue();
-
-                    var actualEntity = actualResponse
-                            .readEntity(AutomationRuleEvaluator.AutomationRuleEvaluatorPage.class);
-                    assertThat(actualEntity.content()).hasSize(samplesToCreate);
-                    assertThat(actualEntity.total()).isEqualTo(samplesToCreate);
-
-                } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
-                    assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
-                            .isEqualTo(UNAUTHORIZED_RESPONSE);
-                }
-            }
-        }
-
-        @ParameterizedTest
-        @MethodSource("credentials")
-        @DisplayName("get evaluator by id: when api key is present, then return proper response")
-        void getAutomationRuleEvaluatorById__whenSessionTokenIsPresent__thenReturnProperResponse(String sessionToken,
-                boolean isAuthorized,
-                String workspaceName) {
-
-            var evaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder().id(null)
-                    .build();
-
-            UUID id = evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
-
-            try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
-                    .path(id.toString())
-                    .queryParam("project_id", evaluator.getProjectId())
-                    .request()
-                    .cookie(SESSION_COOKIE, sessionToken)
-                    .accept(MediaType.APPLICATION_JSON_TYPE)
-                    .header(WORKSPACE_HEADER, workspaceName)
-                    .get()) {
-
-                if (isAuthorized) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
-                    assertThat(actualResponse.hasEntity()).isTrue();
-
-                    var ruleEvaluator = actualResponse.readEntity(AutomationRuleEvaluator.class);
-                    assertThat(ruleEvaluator.getId()).isEqualTo(id);
-                } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
-                    assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
-                            .isEqualTo(UNAUTHORIZED_RESPONSE);
-                }
-            }
-        }
-
-        @ParameterizedTest
-        @MethodSource("credentials")
-        @DisplayName("update evaluator: when api key is present, then return proper response")
-        void updateAutomationRuleEvaluator__whenSessionTokenIsPresent__thenReturnProperResponse(String sessionToken,
-                boolean isAuthorized,
-                String workspaceName) {
-
-            var evaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder().id(null)
-                    .build();
-
-            UUID id = evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
-
-            var updatedEvaluator = factory.manufacturePojo(AutomationRuleEvaluatorUpdate.class).toBuilder()
-                    .projectId(evaluator.getProjectId()).build();
-
-            try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
-                    .path(id.toString())
-                    .request()
-                    .cookie(SESSION_COOKIE, sessionToken)
-                    .accept(MediaType.APPLICATION_JSON_TYPE)
-                    .header(WORKSPACE_HEADER, workspaceName)
-                    .method(HttpMethod.PATCH, Entity.json(updatedEvaluator))) {
-
-                if (isAuthorized) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
-                    assertThat(actualResponse.hasEntity()).isFalse();
-                } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
-                    assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
-                            .isEqualTo(UNAUTHORIZED_RESPONSE);
-                }
-            }
-        }
-
-        @ParameterizedTest
-        @MethodSource("credentials")
-        @DisplayName("delete evaluator by id: when api key is present, then return proper response")
-        void deleteAutomationRuleEvaluator__whenSessionTokenIsPresent__thenReturnProperResponse(String sessionToken,
-                boolean isAuthorized,
-                String workspaceName) {
-
-            var evaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder().id(null)
-                    .build();
-
-            var id = evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
-            var deleteMethod = BatchDelete.builder().ids(Collections.singleton(id)).build();
-
-            try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
-                    .path("delete")
-                    .queryParam("project_id", evaluator.getProjectId())
-                    .request()
-                    .cookie(SESSION_COOKIE, sessionToken)
-                    .accept(MediaType.APPLICATION_JSON_TYPE)
-                    .header(WORKSPACE_HEADER, workspaceName)
-                    .post(Entity.json(deleteMethod))) {
-
-                if (isAuthorized) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
-                    assertThat(actualResponse.hasEntity()).isFalse();
-                } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
-                    assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
-                            .isEqualTo(UNAUTHORIZED_RESPONSE);
-                }
-            }
-        }
-
-        @ParameterizedTest
-        @MethodSource("credentials")
-        @DisplayName("batch delete evaluators by id: when api key is present, then return proper response")
-        void deleteProjectAutomationRuleEvaluators__whenSessionTokenIsPresent__thenReturnProperResponse(
-                String sessionToken,
-                boolean isAuthorized,
-                String workspaceName) {
-
-            var projectId = UUID.randomUUID();
-
-            var evaluator1 = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder()
-                    .projectId(projectId).build();
-            var evalId1 = evaluatorsResourceClient.createEvaluator(evaluator1, WORKSPACE_NAME, API_KEY);
-
-            var evaluator2 = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder()
-                    .projectId(projectId).build();
-            var evalId2 = evaluatorsResourceClient.createEvaluator(evaluator2, WORKSPACE_NAME, API_KEY);
-
-            var evaluator3 = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder()
-                    .projectId(projectId).build();
-            evaluatorsResourceClient.createEvaluator(evaluator3, WORKSPACE_NAME, API_KEY);
-
-            var evalIds1and2 = Set.of(evalId1, evalId2);
-            var deleteMethod = BatchDelete.builder().ids(evalIds1and2).build();
-
-            try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
-                    .path("delete")
-                    .queryParam("project_id", projectId)
-                    .request()
-                    .cookie(SESSION_COOKIE, sessionToken)
-                    .accept(MediaType.APPLICATION_JSON_TYPE)
-                    .header(WORKSPACE_HEADER, workspaceName)
-                    .post(Entity.json(deleteMethod))) {
-
-                if (isAuthorized) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
-                    assertThat(actualResponse.hasEntity()).isFalse();
-                } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
-                    assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
-                            .isEqualTo(UNAUTHORIZED_RESPONSE);
-                }
-            }
-
-            // we shall see a single evaluators for the project now
-            try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
-                    .queryParam("project_id", projectId)
-                    .request()
-                    .cookie(SESSION_COOKIE, sessionToken)
-                    .accept(MediaType.APPLICATION_JSON_TYPE)
-                    .header(WORKSPACE_HEADER, workspaceName)
-                    .get()) {
-
-                if (isAuthorized) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
-                    assertThat(actualResponse.hasEntity()).isTrue();
-
-                    var actualEntity = actualResponse
-                            .readEntity(AutomationRuleEvaluator.AutomationRuleEvaluatorPage.class);
-                    assertThat(actualEntity.content()).hasSize(1);
-                    assertThat(actualEntity.total()).isEqualTo(1);
-
-                } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
-                    assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
-                            .isEqualTo(UNAUTHORIZED_RESPONSE);
-                }
-            }
-        }
-
-        @ParameterizedTest
-        @MethodSource("credentials")
-        @DisplayName("get logs per rule evaluators: when api key is present, then return proper response")
-        void getLogsPerRuleEvaluators__whenSessionTokenIsPresent__thenReturnProperResponse(
-                String sessionToken,
-                boolean isAuthorized,
-                String workspaceName,
-                LlmProviderFactory llmProviderFactory) throws JsonProcessingException {
-
-            ChatResponse chatResponse = ChatResponse.builder()
-                    .aiMessage(AiMessage.from(validAiMsgTxt))
-                    .build();
-
-            when(llmProviderFactory.getLanguageModel(anyString(), any())
-                    .chat(any()))
-                    .thenAnswer(invocationOnMock -> chatResponse);
-
-            String projectName = UUID.randomUUID().toString();
-
-            ObjectMapper mapper = new ObjectMapper();
-
-            var projectId = projectResourceClient.createProject(projectName, API_KEY, WORKSPACE_NAME);
-
-            var evaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder()
-                    .id(null)
-                    .code(mapper.readValue(testEvaluator, AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeCode.class))
-                    .samplingRate(1f)
-                    .projectId(projectId)
-                    .build();
-
-            var trace = factory.manufacturePojo(Trace.class).toBuilder()
-                    .projectName(projectName)
-                    .input(mapper.readTree(input))
-                    .output(mapper.readTree(output))
-                    .build();
-
-            var id = evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
-
-            Instant startTime = Instant.now();
-            traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
-
-            Awaitility.await().untilAsserted(() -> {
-
-                try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
-                        .path(id.toString())
-                        .path("logs")
-                        .request()
-                        .cookie(SESSION_COOKIE, sessionToken)
-                        .accept(MediaType.APPLICATION_JSON_TYPE)
-                        .header(WORKSPACE_HEADER, workspaceName)
-                        .get()) {
-
-                    if (isAuthorized) {
-                        assertLogResponse(actualResponse, startTime, id, trace);
-                    } else {
-                        assertThat(actualResponse.getStatusInfo().getStatusCode())
-                                .isEqualTo(HttpStatus.SC_UNAUTHORIZED);
-                        assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
-                                .isEqualTo(UNAUTHORIZED_RESPONSE);
-                    }
-                }
-            });
-        }
     }
 }


### PR DESCRIPTION
## Details
Extending the online evaluator CRUD endpoints to add support for the Python code evaluator.

The update objects required a bigger refactor, as they weren't polymorphic.

The service returned types weren't polymorphic either, I upgraded them.

Fixed some bugs along the way:
- DAO count.
- DAO order.

Major refactors in the tests in order to make them more maintainable and faster, by avoiding duplications.

More PRs will follow to extend the support to the online evaluator.

## Issues

OPIK-664

## Testing
Extended test coverage for the new python evaluator types: model, evaluator object and evaluator update.
- Added and updated endpoints tests.
- Updated cache tests.
- Updated deprecated tests.

## Documentation
N/A
