### PR TITLE
NA: Throw original error when retry exhausted

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/AsyncUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/AsyncUtils.java
@@ -56,6 +56,7 @@ public class AsyncUtils {
     public static RetryBackoffSpec handleConnectionError() {
         return Retry.backoff(3, Duration.ofMillis(100))
                 .doBeforeRetry(retrySignal -> log.debug("Retrying due to: {}", retrySignal.failure().getMessage()))
+                .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> retrySignal.failure())
                 .filter(throwable -> {
                     log.debug("Filtering for retry: {}", throwable.getMessage());
 


### PR DESCRIPTION
## Details

Currently, after the retry is exhausted, the error throw is RetryExhaustedException and the original exception is omitted
