### PR TITLE
OPIK-1081: Remove lock from RemoteAuthService

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthCredentialsCacheService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthCredentialsCacheService.java
@@ -2,41 +2,48 @@ package com.comet.opik.infrastructure.auth;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.RListReactive;
+import org.redisson.api.RMapReactive;
 import org.redisson.api.RedissonReactiveClient;
 
 import java.time.Duration;
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
-@Slf4j
 @RequiredArgsConstructor
 class AuthCredentialsCacheService implements CacheService {
 
-    public static final String KEY_FORMAT = "auth-%s-%s";
-    private final RedissonReactiveClient redissonClient;
+    private static final String KEY_FORMAT = "authV2-%s-%s";
+    private static final String USER_NAME_KEY = "userName";
+    private static final String WORKSPACE_ID_KEY = "workspaceId";
+
+    private final @NonNull RedissonReactiveClient redissonClient;
     private final int ttlInSeconds;
 
-    public Optional<AuthCredentials> resolveApiKeyUserAndWorkspaceIdFromCache(@NonNull String apiKey,
-            @NonNull String workspaceName) {
-
-        String key = KEY_FORMAT.formatted(apiKey, workspaceName);
-
-        RListReactive<String> bucket = redissonClient.getList(key);
-
-        return bucket
-                .readAll()
+    public Optional<AuthCredentials> resolveApiKeyUserAndWorkspaceIdFromCache(
+            @NonNull String apiKey, @NonNull String workspaceName) {
+        var key = getKey(apiKey, workspaceName);
+        RMapReactive<String, String> map = redissonClient.getMap(key);
+        return map.getAll(Set.of(USER_NAME_KEY, WORKSPACE_ID_KEY))
                 .blockOptional()
-                .filter(pair -> pair.size() == 2)
-                .map(pair -> new AuthCredentials(pair.getFirst(), pair.getLast()));
+                .filter(m -> !m.isEmpty())
+                .map(m -> AuthCredentials.builder()
+                        .userName(m.get(USER_NAME_KEY))
+                        .workspaceId(m.get(WORKSPACE_ID_KEY))
+                        .build());
     }
 
-    public void cache(@NonNull String apiKey, @NonNull String workspaceName, @NonNull String userName,
+    public void cache(
+            @NonNull String apiKey,
+            @NonNull String workspaceName,
+            @NonNull String userName,
             @NonNull String workspaceId) {
-        String key = KEY_FORMAT.formatted(apiKey, workspaceName);
-        redissonClient.getList(key).addAll(List.of(userName, workspaceId)).block();
-        redissonClient.getList(key).expire(Duration.ofSeconds(ttlInSeconds)).block();
+        var key = getKey(apiKey, workspaceName);
+        redissonClient.getMap(key).putAll(Map.of(USER_NAME_KEY, userName, WORKSPACE_ID_KEY, workspaceId)).block();
+        redissonClient.getMap(key).expire(Duration.ofSeconds(ttlInSeconds)).block();
     }
 
+    private String getKey(String apiKey, String workspaceName) {
+        return KEY_FORMAT.formatted(apiKey, workspaceName);
+    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
@@ -2,7 +2,6 @@ package com.comet.opik.infrastructure.auth;
 
 import com.comet.opik.infrastructure.AuthenticationConfig;
 import com.comet.opik.infrastructure.OpikConfiguration;
-import com.comet.opik.infrastructure.lock.LockService;
 import com.google.common.base.Preconditions;
 import com.google.inject.Provides;
 import jakarta.inject.Provider;
@@ -24,8 +23,7 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
     public AuthService authService(
             @Config("authentication") AuthenticationConfig config,
             @NonNull Provider<RequestContext> requestContext,
-            @NonNull RedissonReactiveClient redissonClient,
-            @NonNull LockService lockService) {
+            @NonNull RedissonReactiveClient redissonClient) {
 
         if (!config.isEnabled()) {
             return new AuthServiceImpl(requestContext);
@@ -45,12 +43,10 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
                 ? new AuthCredentialsCacheService(redissonClient, config.getApiKeyResolutionCacheTTLInSec())
                 : new NoopCacheService();
 
-        return new RemoteAuthService(client(), config.getSdk(), config.getUi(), requestContext, cacheService,
-                lockService);
+        return new RemoteAuthService(client(), config.getSdk(), config.getUi(), requestContext, cacheService);
     }
 
     public Client client() {
         return ClientBuilder.newClient();
     }
-
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/CacheService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/CacheService.java
@@ -1,13 +1,17 @@
 package com.comet.opik.infrastructure.auth;
 
+import lombok.Builder;
+
 import java.util.Optional;
 
 interface CacheService {
 
+    @Builder(toBuilder = true)
     record AuthCredentials(String userName, String workspaceId) {
     }
 
     void cache(String apiKey, String workspaceName, String userName, String workspaceId);
+
     Optional<AuthCredentials> resolveApiKeyUserAndWorkspaceIdFromCache(String apiKey, String workspaceName);
 }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
@@ -2,7 +2,7 @@ package com.comet.opik.infrastructure.auth;
 
 import com.comet.opik.api.AuthenticationErrorResponse;
 import com.comet.opik.domain.ProjectService;
-import com.comet.opik.infrastructure.lock.LockService;
+import com.comet.opik.infrastructure.AuthenticationConfig;
 import jakarta.inject.Provider;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.InternalServerErrorException;
@@ -12,156 +12,130 @@ import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import lombok.Builder;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import java.net.URI;
 import java.util.Optional;
-
-import static com.comet.opik.api.AuthenticationErrorResponse.MISSING_API_KEY;
-import static com.comet.opik.api.AuthenticationErrorResponse.MISSING_WORKSPACE;
-import static com.comet.opik.api.AuthenticationErrorResponse.NOT_ALLOWED_TO_ACCESS_WORKSPACE;
-import static com.comet.opik.infrastructure.AuthenticationConfig.UrlConfig;
-import static com.comet.opik.infrastructure.auth.AuthCredentialsCacheService.AuthCredentials;
-import static com.comet.opik.infrastructure.lock.LockService.Lock;
 
 @RequiredArgsConstructor
 @Slf4j
 class RemoteAuthService implements AuthService {
     private static final String USER_NOT_FOUND = "User not found";
+
     private final @NonNull Client client;
-    private final @NonNull UrlConfig apiKeyAuthUrl;
-    private final @NonNull UrlConfig uiAuthUrl;
+    private final @NonNull AuthenticationConfig.UrlConfig apiKeyAuthUrl;
+    private final @NonNull AuthenticationConfig.UrlConfig uiAuthUrl;
     private final @NonNull Provider<RequestContext> requestContext;
     private final @NonNull CacheService cacheService;
-    private final @NonNull LockService lockService;
 
+    @Builder(toBuilder = true)
     record AuthRequest(String workspaceName, String path) {
     }
 
+    @Builder(toBuilder = true)
     record AuthResponse(String user, String workspaceId) {
     }
 
+    @Builder(toBuilder = true)
     record ValidatedAuthCredentials(boolean shouldCache, String userName, String workspaceId) {
     }
 
     @Override
     public void authenticate(HttpHeaders headers, Cookie sessionToken, String path) {
-
-        var currentWorkspaceName = getCurrentWorkspaceName(headers);
-
+        var currentWorkspaceName = Optional.ofNullable(headers.getHeaderString(RequestContext.WORKSPACE_HEADER))
+                .orElse("");
         if (currentWorkspaceName.isBlank()) {
             log.warn("Workspace name is missing");
-            throw new ClientErrorException(MISSING_WORKSPACE, Response.Status.FORBIDDEN);
+            throw new ClientErrorException(AuthenticationErrorResponse.MISSING_WORKSPACE, Response.Status.FORBIDDEN);
         }
-
         if (sessionToken != null) {
             authenticateUsingSessionToken(sessionToken, currentWorkspaceName, path);
             return;
         }
-
         authenticateUsingApiKey(headers, currentWorkspaceName, path);
     }
 
-    private String getCurrentWorkspaceName(HttpHeaders headers) {
-        return Optional.ofNullable(headers.getHeaderString(RequestContext.WORKSPACE_HEADER))
-                .orElse("");
-    }
-
     private void authenticateUsingSessionToken(Cookie sessionToken, String workspaceName, String path) {
-
         if (ProjectService.DEFAULT_WORKSPACE_NAME.equalsIgnoreCase(workspaceName)) {
             log.warn("Default workspace name is not allowed for UI authentication");
-            throw new ClientErrorException(NOT_ALLOWED_TO_ACCESS_WORKSPACE, Response.Status.FORBIDDEN);
+            throw new ClientErrorException(
+                    AuthenticationErrorResponse.NOT_ALLOWED_TO_ACCESS_WORKSPACE, Response.Status.FORBIDDEN);
         }
-
         try (var response = client.target(URI.create(uiAuthUrl.url()))
                 .request()
                 .accept(MediaType.APPLICATION_JSON)
                 .cookie(sessionToken)
-                .post(Entity.json(new AuthRequest(workspaceName, path)))) {
-
-            AuthResponse credentials = verifyResponse(response);
-
+                .post(Entity.json(AuthRequest.builder().workspaceName(workspaceName).path(path).build()))) {
+            var credentials = verifyResponse(response);
             setCredentialIntoContext(credentials.user(), credentials.workspaceId());
             requestContext.get().setApiKey(sessionToken.getValue());
         }
     }
 
     private void authenticateUsingApiKey(HttpHeaders headers, String workspaceName, String path) {
-
-        String apiKey = Optional.ofNullable(headers.getHeaderString(HttpHeaders.AUTHORIZATION))
-                .orElse("");
-
+        var apiKey = Optional.ofNullable(headers.getHeaderString(HttpHeaders.AUTHORIZATION)).orElse("");
         if (apiKey.isBlank()) {
             log.info("API key not found in headers");
-            throw new ClientErrorException(MISSING_API_KEY, Response.Status.UNAUTHORIZED);
+            throw new ClientErrorException(AuthenticationErrorResponse.MISSING_API_KEY, Response.Status.UNAUTHORIZED);
         }
-
-        var lock = new Lock(apiKey, workspaceName);
-
-        ValidatedAuthCredentials credentials = lockService.executeWithLock(
-                lock,
-                Mono.fromCallable(() -> validateApiKeyAndGetCredentials(workspaceName, apiKey, path))
-                        .subscribeOn(Schedulers.boundedElastic()))
-                .block();
-
+        var credentials = validateApiKeyAndGetCredentials(workspaceName, apiKey, path);
         if (credentials.shouldCache()) {
             log.debug("Caching user and workspace id for API key");
             cacheService.cache(apiKey, workspaceName, credentials.userName(), credentials.workspaceId());
         }
-
         setCredentialIntoContext(credentials.userName(), credentials.workspaceId());
         requestContext.get().setApiKey(apiKey);
     }
 
     private ValidatedAuthCredentials validateApiKeyAndGetCredentials(String workspaceName, String apiKey, String path) {
-        Optional<AuthCredentials> credentials = cacheService.resolveApiKeyUserAndWorkspaceIdFromCache(apiKey,
-                workspaceName);
-
+        var credentials = cacheService.resolveApiKeyUserAndWorkspaceIdFromCache(apiKey, workspaceName);
         if (credentials.isEmpty()) {
             log.debug("User and workspace id not found in cache for API key");
-
             try (var response = client.target(URI.create(apiKeyAuthUrl.url()))
                     .request()
                     .accept(MediaType.APPLICATION_JSON)
                     .header(HttpHeaders.AUTHORIZATION,
                             apiKey)
-                    .post(Entity.json(new AuthRequest(workspaceName, path)))) {
-
-                AuthResponse authResponse = verifyResponse(response);
-                return new ValidatedAuthCredentials(true, authResponse.user(), authResponse.workspaceId());
+                    .post(Entity.json(AuthRequest.builder().workspaceName(workspaceName).path(path).build()))) {
+                var authResponse = verifyResponse(response);
+                return ValidatedAuthCredentials.builder()
+                        .shouldCache(true)
+                        .userName(authResponse.user())
+                        .workspaceId(authResponse.workspaceId())
+                        .build();
             }
         } else {
-            return new ValidatedAuthCredentials(false, credentials.get().userName(), credentials.get().workspaceId());
+            return ValidatedAuthCredentials.builder()
+                    .shouldCache(false)
+                    .userName(credentials.get().userName())
+                    .workspaceId(credentials.get().workspaceId())
+                    .build();
         }
     }
 
     private AuthResponse verifyResponse(Response response) {
         if (response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL) {
             var authResponse = response.readEntity(AuthResponse.class);
-
             if (StringUtils.isEmpty(authResponse.user())) {
                 log.warn("User not found");
                 throw new ClientErrorException(USER_NOT_FOUND, Response.Status.UNAUTHORIZED);
             }
-
             return authResponse;
         } else if (response.getStatus() == Response.Status.UNAUTHORIZED.getStatusCode()) {
             var errorResponse = response.readEntity(AuthenticationErrorResponse.class);
             throw new ClientErrorException(errorResponse.msg(), Response.Status.UNAUTHORIZED);
         } else if (response.getStatus() == Response.Status.FORBIDDEN.getStatusCode()) {
             // EM never returns FORBIDDEN as of now
-            throw new ClientErrorException(NOT_ALLOWED_TO_ACCESS_WORKSPACE, Response.Status.FORBIDDEN);
+            throw new ClientErrorException(
+                    AuthenticationErrorResponse.NOT_ALLOWED_TO_ACCESS_WORKSPACE, Response.Status.FORBIDDEN);
         } else if (response.getStatus() == Response.Status.BAD_REQUEST.getStatusCode()) {
             var errorResponse = response.readEntity(AuthenticationErrorResponse.class);
             throw new ClientErrorException(errorResponse.msg(), Response.Status.BAD_REQUEST);
         }
-
         log.error("Unexpected error while authenticating user, received status code: {}", response.getStatus());
         throw new InternalServerErrorException();
     }
@@ -170,5 +144,4 @@ class RemoteAuthService implements AuthService {
         requestContext.get().setUserName(userName);
         requestContext.get().setWorkspaceId(workspaceId);
     }
-
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -3,7 +3,6 @@ package com.comet.opik.infrastructure.auth;
 import com.comet.opik.api.AuthenticationErrorResponse;
 import com.comet.opik.api.resources.utils.TestHttpClientUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
-import com.comet.opik.domain.DummyLockService;
 import com.comet.opik.infrastructure.AuthenticationConfig;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -27,8 +26,6 @@ import org.mockito.Mockito;
 import java.util.UUID;
 import java.util.stream.Stream;
 
-import static com.comet.opik.api.AuthenticationErrorResponse.MISSING_API_KEY;
-import static com.comet.opik.api.AuthenticationErrorResponse.MISSING_WORKSPACE;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
@@ -41,42 +38,39 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 class RemoteAuthServiceTest {
     private Client client;
 
-    private static final WireMockUtils.WireMockRuntime wireMock;
-
-    static {
-        wireMock = WireMockUtils.startWireMock();
-    }
+    private static final WireMockUtils.WireMockRuntime WIRE_MOCK = WireMockUtils.startWireMock();
 
     @BeforeAll
     void setUpAll() {
         client = TestHttpClientUtils.client();
-        wireMock.server().start();
+        WIRE_MOCK.server().start();
     }
 
     @AfterAll
     void tearDownAll() {
-        wireMock.server().stop();
+        WIRE_MOCK.server().stop();
     }
 
     @AfterEach
     void afterEach() {
-        wireMock.server().resetAll();
+        WIRE_MOCK.server().resetAll();
     }
 
     @Test
     void testAuthSuccessful() throws JsonProcessingException {
         var workspaceId = UUID.randomUUID();
-        var user = RandomStringUtils.randomAlphabetic(10);
-        var workspaceName = RandomStringUtils.randomAlphabetic(10);
-        var apiKey = RandomStringUtils.randomAlphabetic(10);
-
-        wireMock.server().stubFor(post("/auth")
+        var user = "user-" + RandomStringUtils.secure().nextAlphanumeric(20);
+        var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(20);
+        var apiKey = "apiKey" + RandomStringUtils.secure().nextAlphanumeric(20);
+        WIRE_MOCK.server().stubFor(post("/auth")
                 .willReturn(okJson(new ObjectMapper()
-                        .writeValueAsString(new RemoteAuthService.AuthResponse(user, workspaceId.toString())))));
-        RequestContext requestContext = new RequestContext();
+                        .writeValueAsString(RemoteAuthService.AuthResponse.builder()
+                                .user(user)
+                                .workspaceId(workspaceId.toString())
+                                .build()))));
 
+        var requestContext = new RequestContext();
         var service = getService(requestContext);
-
         service.authenticate(getHeadersMock(workspaceName, apiKey), null, "/priv/something");
 
         assertThat(requestContext.getWorkspaceId()).isEqualTo(workspaceId.toString());
@@ -87,11 +81,10 @@ class RemoteAuthServiceTest {
     @ParameterizedTest
     @MethodSource
     void testUnauthorized(int remoteAuthStatusCode, Class<? extends Exception> expected) {
-        var workspaceName = RandomStringUtils.randomAlphabetic(10);
-        var apiKey = RandomStringUtils.randomAlphabetic(10);
-
-        wireMock.server()
-                .stubFor(post("/auth").willReturn(aResponse().withStatus(remoteAuthStatusCode)
+        var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(20);
+        var apiKey = "apiKey" + RandomStringUtils.secure().nextAlphanumeric(20);
+        WIRE_MOCK.server().stubFor(post("/auth")
+                .willReturn(aResponse().withStatus(remoteAuthStatusCode)
                         .withHeader("Content-Type", "application/json")
                         .withJsonBody(JsonUtils.readTree(
                                 new AuthenticationErrorResponse("test error message",
@@ -111,39 +104,37 @@ class RemoteAuthServiceTest {
 
     @Test
     void testAuthNoWorkspace() {
-        var apiKey = RandomStringUtils.randomAlphabetic(10);
-        wireMock.server().stubFor(post("/auth").willReturn(ok()));
+        var apiKey = "apiKey" + RandomStringUtils.secure().nextAlphanumeric(20);
+        WIRE_MOCK.server().stubFor(post("/auth").willReturn(ok()));
 
         assertThatThrownBy(() -> getService(new RequestContext()).authenticate(
                 getHeadersMock("", apiKey), null, "/priv/something"))
                 .isInstanceOf(ClientErrorException.class)
-                .hasMessageContaining(MISSING_WORKSPACE);
+                .hasMessageContaining(AuthenticationErrorResponse.MISSING_WORKSPACE);
     }
 
     @Test
     void testAuthNoApiKey() {
-        var workspaceName = RandomStringUtils.randomAlphabetic(10);
-        wireMock.server().stubFor(post("/auth").willReturn(ok()));
+        var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(20);
+        WIRE_MOCK.server().stubFor(post("/auth").willReturn(ok()));
 
         assertThatThrownBy(() -> getService(new RequestContext()).authenticate(
                 getHeadersMock(workspaceName, ""), null, "/priv/something"))
                 .isInstanceOf(ClientErrorException.class)
-                .hasMessage(MISSING_API_KEY);
+                .hasMessage(AuthenticationErrorResponse.MISSING_API_KEY);
     }
 
     private RemoteAuthService getService(RequestContext requestContext) {
         return new RemoteAuthService(client,
-                new AuthenticationConfig.UrlConfig(wireMock.server().url("/auth")),
-                new AuthenticationConfig.UrlConfig(wireMock.server().url("/")),
-                () -> requestContext, new NoopCacheService(), new DummyLockService());
+                new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url("/auth")),
+                new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url("/")),
+                () -> requestContext, new NoopCacheService());
     }
 
     private HttpHeaders getHeadersMock(String workspaceName, String apiKey) {
         var headersMock = Mockito.mock(HttpHeaders.class);
-
         Mockito.when(headersMock.getHeaderString(RequestContext.WORKSPACE_HEADER)).thenReturn(workspaceName);
         Mockito.when(headersMock.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn(apiKey);
-
         return headersMock;
     }
 }


### PR DESCRIPTION
## Details
Removed the distributed lock from the `RemoteAuthService` when retrieving the `userName` and `workspaceId` from Redis cache for a particular `apiKey` and `workspaceName`. 

Reasons:
1. It seems to be causing high latencies, as it serialises across all instances that cache retrieval for each `apiKey` and `workspaceName` combination.
2. It was not really useful:
  2.1. Cache insertion was not within the critical section created by the distributed lock.
  2.2. The cached data can't really change.
  2.3. If cached data changed, it doesn't really matter as last wins and expires quickly (5s).

Additionally, the `AuthCredentialsCacheService` used a `List` object which doesn't handle concurrency properly if by chance multiple values are inserted. I changed it for a `Map` with clearly defined keys. The map is similar in size to the previous list object (232B to 264B).

For a safe production deployment, I had to update the key prefix from `auth-` to `authV2-` due to the change from `List` to `Map` type. I checked the amount of keys in production and it's very low. So it's ok to invalidate the auth cache and just allow old keys to expire.

Many other minor improvements along the way.

## Issues

OPIK-1081

## Testing
- Passed and manually verified all related tests in `src/test/java/com/comet/opik/infrastructure/auth`.
- Passed CI build.
- Manually tested.
- Verified local Redis instance values.
- Verified production Redis instance values.

## Documentation
N/A
