### PR TITLE
[OPIK-1050] Improving OpenTelemetry -> Opik ids mapping

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResource.java
@@ -49,7 +49,7 @@ public class OpenTelemetryResource {
                     workspaceId);
 
             Long stored = openTelemetryService
-                    .parseAndStoreSpans(traceRequest, projectName, workspaceId)
+                    .parseAndStoreSpans(traceRequest, projectName)
                     .contextWrite(ctx -> AsyncUtils.setRequestContext(ctx, userName, workspaceId))
                     .block();
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResource.java
@@ -49,7 +49,7 @@ public class OpenTelemetryResource {
                     workspaceId);
 
             Long stored = openTelemetryService
-                    .parseAndStoreSpans(traceRequest, projectName)
+                    .parseAndStoreSpans(traceRequest, projectName, workspaceId)
                     .contextWrite(ctx -> AsyncUtils.setRequestContext(ctx, userName, workspaceId))
                     .block();
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryService.java
@@ -1,16 +1,27 @@
 package com.comet.opik.domain;
 
+import com.comet.opik.api.Span;
 import com.comet.opik.api.SpanBatch;
 import com.comet.opik.api.Trace;
 import com.google.inject.ImplementedBy;
+import com.google.protobuf.ByteString;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RedissonReactiveClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @ImplementedBy(OpenTelemetryServiceImpl.class)
 public interface OpenTelemetryService {
@@ -25,17 +36,68 @@ class OpenTelemetryServiceImpl implements OpenTelemetryService {
 
     private final @NonNull TraceService traceService;
     private final @NonNull SpanService spanService;
+    private final @NonNull RedissonReactiveClient redisson;
+
+    private static final Duration REDIS_TTL = Duration.ofDays(1L);
+    private static final String UNKNOWN_TRACE_ID = "";
+
+    private String base64OtelId(ByteString idBytes) {
+        return Base64.getEncoder().encodeToString(idBytes.toByteArray());
+    }
 
     @Override
     public Mono<Long> parseAndStoreSpans(@NonNull ExportTraceServiceRequest traceRequest, @NonNull String projectName) {
 
-        var opikSpans = traceRequest.getResourceSpansList().stream()
+        var otelSpans = traceRequest.getResourceSpansList().stream()
                 .flatMap(resourceSpans -> resourceSpans.getScopeSpansList().stream())
                 .flatMap(scopeSpans -> scopeSpans.getSpansList().stream())
-                .map(OpenTelemetryMapper::toOpikSpan)
-                .map(opikSpan -> opikSpan.toBuilder()
-                        .projectName(projectName)
-                        .build())
+                .toList();
+
+        // we expect a single trace per batch, but lets protect ourselves anyway
+        var traceIdMapper = otelSpans.stream()
+                .map(io.opentelemetry.proto.trace.v1.Span::getTraceId)
+                .map(this::base64OtelId)
+                .distinct()
+                .map(otelBase64TraceId -> {
+                    var opikTraceId = (String) redisson.getBucket(otelBase64TraceId).getAndExpire(REDIS_TTL).block();
+                    log.info("Redis lookup: {} -> {}", otelBase64TraceId, opikTraceId);
+
+                    return Map.entry(otelBase64TraceId, Optional.ofNullable(opikTraceId));
+                })
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        // converts otel spans into opik spans, sorting the result list by start time
+        var opikSpans = otelSpans.stream()
+                .map(otelSpan -> {
+                    var otelTraceId = otelSpan.getTraceId();
+                    var otelBase64TraceId = base64OtelId(otelTraceId);
+                    var optTraceId = traceIdMapper.get(otelBase64TraceId);
+
+                    final UUID opikTraceId;
+                    if (optTraceId.isPresent()) {
+                        // its a known otel trace id, lets just reuse it
+                        opikTraceId = UUID.fromString(optTraceId.get());
+                        log.info("Found {} in local cache: {}", otelBase64TraceId, opikTraceId);
+                    }
+                    else {
+                        // its an unknown otel trace id, lets create an opik trace id with this span timestamp
+                        var startTimeMs = Duration.ofNanos(otelSpan.getStartTimeUnixNano()).toMillis();
+                        opikTraceId = OpenTelemetryMapper.convertOtelIdToUUIDv7(otelTraceId.toByteArray(), startTimeMs);
+                        log.info("Creating mapping for otel id {} -> {}", otelBase64TraceId, opikTraceId);
+                        // set on redis: otelId -> opikId
+                        redisson.getBucket(otelBase64TraceId).set(opikTraceId, REDIS_TTL).block();
+                        // update the mapper so next span can use it
+                        traceIdMapper.put(otelBase64TraceId, Optional.of(opikTraceId.toString()));
+                    }
+
+                    return OpenTelemetryMapper.toOpikSpan(otelSpan, opikTraceId);
+                })
+                .map(opikSpan -> {
+                    return opikSpan.toBuilder()
+                            .projectName(projectName)
+                            .build();
+                })
+                .sorted(Comparator.comparing(Span::startTime))
                 .toList();
 
         // check if there spans without parentId: we will use them as a Trace too

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryService.java
@@ -1,11 +1,12 @@
 package com.comet.opik.domain;
 
-import com.comet.opik.api.Span;
 import com.comet.opik.api.SpanBatch;
 import com.comet.opik.api.Trace;
+import com.comet.opik.infrastructure.auth.RequestContext;
 import com.google.inject.ImplementedBy;
 import com.google.protobuf.ByteString;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.trace.v1.Span;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -18,15 +19,17 @@ import reactor.core.publisher.Mono;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @ImplementedBy(OpenTelemetryServiceImpl.class)
 public interface OpenTelemetryService {
 
-    Mono<Long> parseAndStoreSpans(@NonNull ExportTraceServiceRequest traceRequest, @NonNull String projectName);
+    Mono<Long> parseAndStoreSpans(@NonNull ExportTraceServiceRequest traceRequest, @NonNull String projectName,
+            @NonNull String workspaceId);
 }
 
 @Singleton
@@ -36,68 +39,58 @@ class OpenTelemetryServiceImpl implements OpenTelemetryService {
 
     private final @NonNull TraceService traceService;
     private final @NonNull SpanService spanService;
+    private final @NonNull ProjectService projectService;
     private final @NonNull RedissonReactiveClient redisson;
 
     private static final Duration REDIS_TTL = Duration.ofDays(1L);
-    private static final String UNKNOWN_TRACE_ID = "";
+
+    @Override
+    public Mono<Long> parseAndStoreSpans(@NonNull ExportTraceServiceRequest traceRequest,
+            @NonNull String projectName,
+            @NonNull String workspaceId) {
+
+        // make sure project exists before starting processing
+        return Mono.deferContextual(ctx -> {
+            String userName = ctx.get(RequestContext.USER_NAME);
+            return Mono.just(projectService.getOrCreate(workspaceId, projectName, userName).id());
+        }).flatMap(projectId -> {
+            // extracts all otel spans in the batch, sorted by start time
+            var otelSpans = traceRequest.getResourceSpansList().stream()
+                    .flatMap(resourceSpans -> resourceSpans.getScopeSpansList().stream())
+                    .flatMap(scopeSpans -> scopeSpans.getSpansList().stream())
+                    .sorted(Comparator.comparing(Span::getStartTimeUnixNano))
+                    .toList();
+
+            // get or create a mapping of otel trace id -> opik trace id
+            final Map<String, UUID> traceIdMapper = prepareOtelToOpikTraceIdMapping(otelSpans, projectId, workspaceId);
+
+            return doStoreSpans(otelSpans, traceIdMapper, projectName);
+        });
+    }
 
     private String base64OtelId(ByteString idBytes) {
         return Base64.getEncoder().encodeToString(idBytes.toByteArray());
     }
 
-    @Override
-    public Mono<Long> parseAndStoreSpans(@NonNull ExportTraceServiceRequest traceRequest, @NonNull String projectName) {
+    private String redisKey(String workspaceId, UUID projectId, String otelId) {
+        return workspaceId + ":" + projectId + ":" + otelId;
+    }
 
-        var otelSpans = traceRequest.getResourceSpansList().stream()
-                .flatMap(resourceSpans -> resourceSpans.getScopeSpansList().stream())
-                .flatMap(scopeSpans -> scopeSpans.getSpansList().stream())
-                .toList();
+    private Mono<Long> doStoreSpans(List<Span> otelSpans, Map<String, UUID> traceIdMapper, String projectName) {
 
-        // we expect a single trace per batch, but lets protect ourselves anyway
-        var traceIdMapper = otelSpans.stream()
-                .map(io.opentelemetry.proto.trace.v1.Span::getTraceId)
-                .map(this::base64OtelId)
-                .distinct()
-                .map(otelBase64TraceId -> {
-                    var opikTraceId = (String) redisson.getBucket(otelBase64TraceId).getAndExpire(REDIS_TTL).block();
-                    log.info("Redis lookup: {} -> {}", otelBase64TraceId, opikTraceId);
-
-                    return Map.entry(otelBase64TraceId, Optional.ofNullable(opikTraceId));
-                })
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-        // converts otel spans into opik spans, sorting the result list by start time
+        // converts otel spans into opik spans, using the mapped opik trace id
         var opikSpans = otelSpans.stream()
                 .map(otelSpan -> {
-                    var otelTraceId = otelSpan.getTraceId();
-                    var otelBase64TraceId = base64OtelId(otelTraceId);
-                    var optTraceId = traceIdMapper.get(otelBase64TraceId);
+                    var otelTraceIdBase64 = base64OtelId(otelSpan.getTraceId());
 
-                    final UUID opikTraceId;
-                    if (optTraceId.isPresent()) {
-                        // its a known otel trace id, lets just reuse it
-                        opikTraceId = UUID.fromString(optTraceId.get());
-                        log.info("Found {} in local cache: {}", otelBase64TraceId, opikTraceId);
-                    }
-                    else {
-                        // its an unknown otel trace id, lets create an opik trace id with this span timestamp
-                        var startTimeMs = Duration.ofNanos(otelSpan.getStartTimeUnixNano()).toMillis();
-                        opikTraceId = OpenTelemetryMapper.convertOtelIdToUUIDv7(otelTraceId.toByteArray(), startTimeMs);
-                        log.info("Creating mapping for otel id {} -> {}", otelBase64TraceId, opikTraceId);
-                        // set on redis: otelId -> opikId
-                        redisson.getBucket(otelBase64TraceId).set(opikTraceId, REDIS_TTL).block();
-                        // update the mapper so next span can use it
-                        traceIdMapper.put(otelBase64TraceId, Optional.of(opikTraceId.toString()));
-                    }
+                    var opikTraceId = traceIdMapper.get(otelTraceIdBase64);
+                    log.info("'{}' -> '{}'", otelTraceIdBase64, opikTraceId);
 
                     return OpenTelemetryMapper.toOpikSpan(otelSpan, opikTraceId);
                 })
-                .map(opikSpan -> {
-                    return opikSpan.toBuilder()
-                            .projectName(projectName)
-                            .build();
-                })
-                .sorted(Comparator.comparing(Span::startTime))
+                .map(opikSpan -> opikSpan.toBuilder()
+                        .projectName(projectName)
+                        .build())
                 .toList();
 
         // check if there spans without parentId: we will use them as a Trace too
@@ -126,5 +119,46 @@ class OpenTelemetryServiceImpl implements OpenTelemetryService {
 
                     return spanService.create(spanBatch);
                 }));
+    }
+
+    private Map<String, UUID> prepareOtelToOpikTraceIdMapping(List<Span> otelSpans, UUID projectId,
+            String workspaceId) {
+        // checks Redis for the otel traceIds in the batch; have we seen them before?
+        // maps (base64 otel id -> UUIDv7 opik id)
+        final Map<String, UUID> traceIdMapper = new HashMap<>();
+
+        otelSpans.forEach(otelSpan -> {
+            var otelTraceId = otelSpan.getTraceId();
+            var otelTraceIdBase64 = base64OtelId(otelTraceId);
+
+            // do we know this traceId? if we do, skip step
+            if (traceIdMapper.containsKey(otelTraceIdBase64)) {
+                return;
+            }
+
+            // checks if this key is mapped in redis
+            var otelTraceIdRedisKey = redisKey(workspaceId, projectId, otelTraceIdBase64);
+            var optOpikTraceId = Optional
+                    .ofNullable((String) redisson.getBucket(otelTraceIdRedisKey).getAndExpire(REDIS_TTL).block());
+
+            final UUID opikTraceId;
+            if (optOpikTraceId.isPresent()) {
+                // its a known otel trace id from a previous batch, lets just reuse it
+                opikTraceId = UUID.fromString(optOpikTraceId.get());
+            } else {
+                // its an unknown otel trace id, lets create an opik trace id with this span timestamp as we sorted otel
+                // spans by time on previous step, it will be the closest time possible for the actual trace start
+                var startTimeMs = Duration.ofNanos(otelSpan.getStartTimeUnixNano()).toMillis();
+                opikTraceId = OpenTelemetryMapper.convertOtelIdToUUIDv7(otelTraceId.toByteArray(), startTimeMs);
+
+                log.info("Creating mapping in Redis for otel trace id '{}' -> opik trace id '{}'", otelTraceIdRedisKey,
+                        opikTraceId);
+                redisson.getBucket(otelTraceIdRedisKey).set(opikTraceId.toString(), REDIS_TTL).block();
+            }
+
+            traceIdMapper.put(otelTraceIdBase64, opikTraceId);
+        });
+
+        return traceIdMapper;
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.protobuf.ByteString;
 import com.redis.testcontainers.RedisContainer;
+import io.dropwizard.jersey.errors.ErrorMessage;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.proto.trace.v1.ScopeSpans;
@@ -56,8 +57,9 @@ import uk.co.jemos.podam.api.PodamFactory;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -188,7 +190,7 @@ class OpenTelemetryResourceTest {
             var otelTraceId = UUID.randomUUID().toString().getBytes(); // otel uses 128-bit, but it doesnt matter
             var parentSpanId = UUID.randomUUID().toString().getBytes();// otel uses  64-bit, but it doesnt matter
 
-             // creates a batch with parent + 4-9 spans
+            // creates a batch with parent + 4-9 spans
             var otelSpans = new ArrayList<Span>();
             otelSpans.add(Span.newBuilder()
                     .setName("parent span")
@@ -210,12 +212,56 @@ class OpenTelemetryResourceTest {
                             .build())
                     .forEach(otelSpans::add);
 
-            // opik trace id should be created with the earliest timestamp in the batch
-            var minTimestamp = otelSpans.stream().map(Span::getStartTimeUnixNano).min(Long::compareTo).orElseThrow();
+            // split batch in 2 small batches so we can test redis trace id mapping
+            // lets shuffle th
+            var otelSpansBatch1 = otelSpans.subList(0, batchSize / 2);
+            Collections.shuffle(otelSpansBatch1);
+            var otelSpansBatch2 = otelSpans.subList(batchSize / 2, batchSize);
+            Collections.shuffle(otelSpansBatch2);
+
+            // opik trace id should be created with the earliest timestamp in the batch;
+            // we use batch as its the first server will receive
+            var minTimestamp = otelSpansBatch1.stream().map(Span::getStartTimeUnixNano).min(Long::compareTo)
+                    .orElseThrow();
             var minTimestampMs = Duration.ofNanos(minTimestamp).toMillis();
             var expectedOpikTraceId = OpenTelemetryMapper.convertOtelIdToUUIDv7(otelTraceId, minTimestampMs);
             var expectedOpikParentSpanId = OpenTelemetryMapper.convertOtelIdToUUIDv7(parentSpanId, minTimestampMs);
 
+            // send batch with the half the spans
+            sendBatch(otelSpansBatch1, projectName, workspaceName, apiKey, expected, errorMessage);
+            // send another
+            sendBatch(otelSpansBatch2, projectName, workspaceName, apiKey, expected, errorMessage);
+
+            if (expected) {
+                // the otel span batch should have created a trace with this expect traceId. Check it.
+                Trace trace = traceResourceClient.getById(expectedOpikTraceId, workspaceName, apiKey);
+                assertThat(trace.id()).isEqualTo(expectedOpikTraceId);
+
+                var projectNameOrDefault = StringUtils.isNotEmpty(projectName)
+                        ? projectName
+                        : ProjectService.DEFAULT_PROJECT;
+
+                // the otel span batch should have created spans with this expected traceId. Check it.
+                var generatedSpanPage = spanResourceClient.getByTraceIdAndProject(expectedOpikTraceId,
+                        projectNameOrDefault,
+                        workspaceName, apiKey);
+
+                assertThat(generatedSpanPage.size()).isEqualTo(otelSpansBatch1.size() + otelSpansBatch2.size());
+
+                // in the test we have root span and 1st level spans, so check if our calculated parent span appears
+                generatedSpanPage.content().forEach(span -> {
+                    if (span.parentSpanId() != null) {
+                        assertThat(span.parentSpanId()).isEqualTo(expectedOpikParentSpanId);
+                    } else {
+                        assertThat(span.id()).isEqualTo(expectedOpikParentSpanId);
+                    }
+                });
+
+            }
+        }
+
+        void sendBatch(List<Span> otelSpans, String projectName, String workspaceName, String apiKey, boolean expected,
+                ErrorMessage errorMessage) {
             byte[] requestProtobufBytes = ExportTraceServiceRequest.newBuilder()
                     .addResourceSpans(ResourceSpans.newBuilder()
                             .addScopeSpans(ScopeSpans.newBuilder().addAllSpans(otelSpans).build())
@@ -238,21 +284,6 @@ class OpenTelemetryResourceTest {
                 if (expected) {
                     assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
 
-                    // the otel span batch should have created a trace with this expect traceId. Check it.
-                    Trace trace = traceResourceClient.getById(expectedOpikTraceId, workspaceName, apiKey);
-                    assertThat(trace.id()).isEqualTo(expectedOpikTraceId);
-
-                    var projectNameOrDefault = StringUtils.isNotEmpty(projectName)
-                            ? projectName
-                            : ProjectService.DEFAULT_PROJECT;
-
-                    // the otel span batch should have created spans with this expected traceId. Check it.
-                    var spanPage = spanResourceClient.getByTraceIdAndProject(expectedOpikTraceId, projectNameOrDefault,
-                            workspaceName, apiKey);
-                    // TODO: check all parent span value has a span id
-                    // TODO: check root span id
-                    // TODO: a test checkin two batches?
-                    assertThat(spanPage.size()).isEqualTo(otelSpans.size());
                 } else {
                     assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
                     assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))


### PR DESCRIPTION
## Details
Implements a better conversion of random 64 and 128-bit integers to Opik's UUIDv7, following this [design docs](https://www.notion.so/cometml/OpenTelemetry-Integration-Design-19f7124010a3805b848bcd3ebc180eb0?pvs=4).

In summary, we deal with the unpredictability of a perfect otel -> opik id (by the first time we see an record refering to this id we dont know whats the time stamp of the span/trace, so we can't create a perfect uuidv7) by using Redis an otel -> opik cache. If its an trace id never seen before, we use the earliest possible timestamp in the batch as a proxy for the trace timestamp, a much better solution then daily time truncation. It's a good enough approximation and allows good trace sorting in the UI. With this opikTraceId calculated, we update redis with this `otelTraceId -> opikTraceId`.

As the same problem happens with spans (they relate to themselves via parent span id) we will use the timestamp from the trace as the timestamp for all its spans, this way we have a good span id and they can be sorted in the LLM calls tab.

## Issues

Resolves #

## Testing

## Documentation
