### PR TITLE
OPIK-962: Make experiment creation idempotent

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -131,18 +131,16 @@ public class ExperimentsResource {
     public Response create(
             @RequestBody(content = @Content(schema = @Schema(implementation = Experiment.class))) @JsonView(Experiment.View.Write.class) @NotNull @Valid Experiment experiment,
             @Context UriInfo uriInfo) {
-
-        log.info("Creating experiment with id '{}', datasetName '{}' workspaceId '{}' ", experiment.id(),
-                experiment.datasetName(),
-                requestContext.get().getWorkspaceId());
-
-        var newExperiment = experimentService
-                .create(experiment)
+        var workspaceId = requestContext.get().getWorkspaceId();
+        log.info("Creating experiment with id '{}', name '{}', datasetName '{}', workspaceId '{}'",
+                experiment.id(), experiment.name(), experiment.datasetName(), workspaceId);
+        var newExperiment = experimentService.create(experiment)
                 .contextWrite(ctx -> setRequestContext(ctx, requestContext))
                 .block();
         var uri = uriInfo.getAbsolutePathBuilder().path("/%s".formatted(newExperiment.id())).build();
-        log.info("Created experiment with id '{}', datasetId '{}', datasetName '{}'",
-                newExperiment.id(), newExperiment.datasetId(), newExperiment.datasetName());
+        log.info("Created experiment with id '{}', name '{}', datasetId '{}', datasetName '{}', workspaceId '{}'",
+                newExperiment.id(), newExperiment.name(), newExperiment.datasetId(), newExperiment.datasetName(),
+                workspaceId);
         return Response.created(uri).build();
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -160,7 +160,7 @@ class ExperimentsResourceTest {
     private static final ClickHouseContainer CLICK_HOUSE_CONTAINER = ClickHouseContainerUtils.newClickHouseContainer();
 
     @RegisterExtension
-    private static final TestDropwizardAppExtension app;
+    private static final TestDropwizardAppExtension APP;
 
     private static final WireMockUtils.WireMockRuntime wireMock;
 
@@ -183,7 +183,7 @@ class ExperimentsResourceTest {
                 .mockEventBus(Mockito.mock(EventBus.class))
                 .build();
 
-        app = newTestDropwizardAppExtension(contextConfig);
+        APP = newTestDropwizardAppExtension(contextConfig);
     }
 
     private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
@@ -260,7 +260,7 @@ class ExperimentsResourceTest {
                             .willReturn(WireMock.unauthorized().withHeader("Content-Type", "application/json")
                                     .withJsonBody(JsonUtils.readTree(
                                             new ReactServiceErrorResponse(FAKE_API_KEY_MESSAGE,
-                                                    401)))));
+                                                    HttpStatus.SC_UNAUTHORIZED)))));
         }
 
         @ParameterizedTest
@@ -283,11 +283,11 @@ class ExperimentsResourceTest {
                     .get()) {
 
                 if (success) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
                     var actualEntity = actualResponse.readEntity(Experiment.class);
                     assertThat(actualEntity.id()).isEqualTo(expectedExperiment.id());
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
                     assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(errorMessage);
                 }
             }
@@ -310,9 +310,9 @@ class ExperimentsResourceTest {
                     .post(Entity.json(expectedExperiment))) {
 
                 if (success) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(201);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_CREATED);
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
                     assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(errorMessage);
                 }
             }
@@ -344,11 +344,11 @@ class ExperimentsResourceTest {
                     .get()) {
 
                 if (success) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
                     var actualEntity = actualResponse.readEntity(ExperimentPage.class);
                     assertThat(actualEntity.content()).hasSize(1);
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
                     assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(errorMessage);
                 }
             }
@@ -378,10 +378,10 @@ class ExperimentsResourceTest {
                     .post(Entity.json(deleteRequest))) {
 
                 if (success) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
                     assertThat(actualResponse.hasEntity()).isFalse();
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
                     assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(errorMessage);
                 }
             }
@@ -412,10 +412,10 @@ class ExperimentsResourceTest {
                     .post(Entity.json(deleteRequest))) {
 
                 if (success) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
                     assertThat(actualResponse.hasEntity()).isFalse();
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
                     assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(errorMessage);
                 }
             }
@@ -439,10 +439,10 @@ class ExperimentsResourceTest {
                     .post(Entity.json(request))) {
 
                 if (success) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
                     assertThat(actualResponse.hasEntity()).isFalse();
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
                     assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(errorMessage);
                 }
             }
@@ -470,12 +470,12 @@ class ExperimentsResourceTest {
                     .get()) {
 
                 if (success) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
 
                     var actualEntity = actualResponse.readEntity(ExperimentItem.class);
                     assertThat(actualEntity.id()).isEqualTo(id);
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
                     assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(errorMessage);
                 }
             }
@@ -511,7 +511,7 @@ class ExperimentsResourceTest {
                             .willReturn(WireMock.unauthorized().withHeader("Content-Type", "application/json")
                                     .withJsonBody(JsonUtils.readTree(
                                             new ReactServiceErrorResponse(FAKE_API_KEY_MESSAGE,
-                                                    401)))));
+                                                    HttpStatus.SC_UNAUTHORIZED)))));
         }
 
         @ParameterizedTest
@@ -531,9 +531,9 @@ class ExperimentsResourceTest {
                     .get()) {
 
                 if (success) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
                     assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(UNAUTHORIZED_RESPONSE);
                 }
             }
@@ -554,9 +554,9 @@ class ExperimentsResourceTest {
                     .post(Entity.json(expectedExperiment))) {
 
                 if (success) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(201);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_CREATED);
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
                     assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(UNAUTHORIZED_RESPONSE);
                 }
             }
@@ -591,11 +591,11 @@ class ExperimentsResourceTest {
                     .get()) {
 
                 if (success) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
                     var actualEntity = actualResponse.readEntity(ExperimentPage.class);
                     assertThat(actualEntity.content()).hasSize(1);
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
                     assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(UNAUTHORIZED_RESPONSE);
                 }
             }
@@ -624,10 +624,10 @@ class ExperimentsResourceTest {
                     .post(Entity.json(deleteRequest))) {
 
                 if (success) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
                     assertThat(actualResponse.hasEntity()).isFalse();
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
                     assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(UNAUTHORIZED_RESPONSE);
                 }
             }
@@ -655,10 +655,10 @@ class ExperimentsResourceTest {
                     .post(Entity.json(deleteRequest))) {
 
                 if (success) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
                     assertThat(actualResponse.hasEntity()).isFalse();
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
                     assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(UNAUTHORIZED_RESPONSE);
                 }
             }
@@ -678,10 +678,10 @@ class ExperimentsResourceTest {
                     .post(Entity.json(request))) {
 
                 if (success) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
                     assertThat(actualResponse.hasEntity()).isFalse();
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
                     assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(UNAUTHORIZED_RESPONSE);
                 }
             }
@@ -710,11 +710,11 @@ class ExperimentsResourceTest {
                     .get()) {
 
                 if (success) {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
                     var actualEntity = actualResponse.readEntity(ExperimentItem.class);
                     assertThat(actualEntity.id()).isEqualTo(expectedExperiment.id());
                 } else {
-                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(401);
+                    assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
                     assertThat(actualResponse.readEntity(ErrorMessage.class)).isEqualTo(UNAUTHORIZED_RESPONSE);
                 }
             }
@@ -746,7 +746,7 @@ class ExperimentsResourceTest {
 
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
-            var datasetName = RandomStringUtils.randomAlphanumeric(10);
+            var datasetName = RandomStringUtils.secure().nextAlphanumeric(10);
             var experiments = PodamFactoryUtils.manufacturePojoList(podamFactory, Experiment.class)
                     .stream()
                     .map(experiment -> experimentResourceClient.createPartialExperiment()
@@ -775,10 +775,10 @@ class ExperimentsResourceTest {
         }
 
         Stream<Arguments> findByName() {
-            var exactName = RandomStringUtils.randomAlphanumeric(10);
-            var exactNameIgnoreCase = RandomStringUtils.randomAlphanumeric(10);
-            var partialName = RandomStringUtils.randomAlphanumeric(10);
-            var partialNameIgnoreCase = RandomStringUtils.randomAlphanumeric(10);
+            var exactName = RandomStringUtils.secure().nextAlphanumeric(10);
+            var exactNameIgnoreCase = RandomStringUtils.secure().nextAlphanumeric(10);
+            var partialName = RandomStringUtils.secure().nextAlphanumeric(10);
+            var partialNameIgnoreCase = RandomStringUtils.secure().nextAlphanumeric(10);
             return Stream.of(
                     arguments(exactName, exactName),
                     arguments(exactNameIgnoreCase, exactNameIgnoreCase.toLowerCase()),
@@ -830,8 +830,8 @@ class ExperimentsResourceTest {
 
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
-            var datasetName = RandomStringUtils.randomAlphanumeric(10);
-            var name = RandomStringUtils.randomAlphanumeric(10);
+            var datasetName = RandomStringUtils.secure().nextAlphanumeric(10);
+            var name = RandomStringUtils.secure().nextAlphanumeric(10);
 
             var experiments = PodamFactoryUtils.manufacturePojoList(podamFactory, Experiment.class)
                     .stream()
@@ -888,7 +888,7 @@ class ExperimentsResourceTest {
                 var actualPage = actualResponse.readEntity(ExperimentPage.class);
                 var actualExperiments = actualPage.content();
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
 
                 assertThat(actualPage.page()).isEqualTo(page);
                 assertThat(actualPage.size()).isEqualTo(pageSize);
@@ -965,7 +965,7 @@ class ExperimentsResourceTest {
 
             createScoreAndAssert(feedbackScoreBatch, apiKey, workspaceName);
 
-            int totalNumberOfScores = traceIdToScoresMap.values().size();
+            int totalNumberOfScores = traceIdToScoresMap.size();
             int totalNumberOfScoresPerTrace = totalNumberOfScores / traces.size(); // This will be 3 if traces.size() == 5
 
             var experimentItems = IntStream.range(0, totalNumberOfScores)
@@ -996,8 +996,8 @@ class ExperimentsResourceTest {
 
             // Add comments to trace
             List<Comment> comments = IntStream.range(0, 5)
-                    .mapToObj(
-                            i -> traceResourceClient.generateAndCreateComment(trace1.id(), apiKey, workspaceName, 201))
+                    .mapToObj(i -> traceResourceClient.generateAndCreateComment(
+                            trace1.id(), apiKey, workspaceName, HttpStatus.SC_CREATED))
                     .toList();
 
             Set<UUID> expectedExperimentIdsWithComments = getExpectedExperimentIdsWithComments(experiments,
@@ -1014,7 +1014,7 @@ class ExperimentsResourceTest {
                     .header(WORKSPACE_HEADER, workspaceName)
                     .get()) {
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
                 var actualPage = actualResponse.readEntity(ExperimentPage.class);
                 var actualExperiments = actualPage.content();
 
@@ -1105,7 +1105,7 @@ class ExperimentsResourceTest {
 
             createScoreAndAssert(feedbackScoreBatch, apiKey, workspaceName);
 
-            int totalNumberOfScores = traceIdToScoresMap.values().size();
+            int totalNumberOfScores = traceIdToScoresMap.size();
 
             var experimentItems = IntStream.range(0, totalNumberOfScores)
                     .mapToObj(i -> podamFactory.manufacturePojo(ExperimentItem.class).toBuilder()
@@ -1143,7 +1143,7 @@ class ExperimentsResourceTest {
                     .header(WORKSPACE_HEADER, workspaceName)
                     .get()) {
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
                 var actualPage = actualResponse.readEntity(ExperimentPage.class);
                 var actualExperiments = actualPage.content();
 
@@ -1361,14 +1361,14 @@ class ExperimentsResourceTest {
 
             createScoreAndAssert(feedbackScoreBatch, apiKey, workspaceName);
 
-            int totalNumberOfScores = traceIdToScoresMap.values().size();
+            int totalNumberOfScores = traceIdToScoresMap.size();
 
             var experimentItems = IntStream.range(0, totalNumberOfScores)
                     .mapToObj(i -> podamFactory.manufacturePojo(ExperimentItem.class).toBuilder()
                             .experimentId(expectedExperiment.id())
-                            .traceId(traces.get(0).id())
+                            .traceId(traces.getFirst().id())
                             .feedbackScores(
-                                    traceIdToScoresMap.get(traces.get(0).id()).stream()
+                                    traceIdToScoresMap.get(traces.getFirst().id()).stream()
                                             .map(FeedbackScoreMapper.INSTANCE::toFeedbackScore)
                                             .toList())
                             .build())
@@ -1515,7 +1515,7 @@ class ExperimentsResourceTest {
                 .header(HttpHeaders.AUTHORIZATION, apiKey)
                 .header(WORKSPACE_HEADER, workspaceName)
                 .delete()) {
-            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
+            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
         }
     }
 
@@ -1588,7 +1588,7 @@ class ExperimentsResourceTest {
             var actualPage = actualResponse.readEntity(ExperimentPage.class);
             var actualExperiments = actualPage.content();
 
-            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
 
             assertThat(actualPage.page()).isEqualTo(page);
             assertThat(actualPage.size()).isEqualTo(expectedExperiments.size());
@@ -1635,7 +1635,7 @@ class ExperimentsResourceTest {
                 .header(WORKSPACE_HEADER, workspaceName)
                 .put(Entity.json(feedbackScoreBatch))) {
 
-            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
+            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
             assertThat(actualResponse.hasEntity()).isFalse();
         }
     }
@@ -1757,7 +1757,7 @@ class ExperimentsResourceTest {
                     .header(WORKSPACE_HEADER, TEST_WORKSPACE)
                     .post(Entity.json(new Identifier(expectedExperiment.name())))) {
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
                 var actualExperiment = actualResponse.readEntity(Experiment.class);
                 assertThat(actualExperiment.id()).isEqualTo(expectedExperiment.id());
 
@@ -1771,7 +1771,8 @@ class ExperimentsResourceTest {
         @Test
         void getByNameNotFound() {
             String name = UUID.randomUUID().toString();
-            var expectedError = new ErrorMessage(404, "Not found experiment with name '%s'".formatted(name));
+            var expectedError = new ErrorMessage(HttpStatus.SC_NOT_FOUND,
+                    "Not found experiment with name '%s'".formatted(name));
             try (var actualResponse = client.target(getExperimentsPath())
                     .path("retrieve")
                     .request()
@@ -1779,7 +1780,7 @@ class ExperimentsResourceTest {
                     .header(WORKSPACE_HEADER, TEST_WORKSPACE)
                     .post(Entity.json(new Identifier(name)))) {
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(404);
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NOT_FOUND);
 
                 var actualError = actualResponse.readEntity(ErrorMessage.class);
 
@@ -1830,7 +1831,7 @@ class ExperimentsResourceTest {
             // Add comments to trace
             List<Comment> expectedComments = IntStream.range(0, 5)
                     .mapToObj(i -> traceResourceClient.generateAndCreateComment(trace1.id(), API_KEY, TEST_WORKSPACE,
-                            201))
+                            HttpStatus.SC_CREATED))
                     .toList();
 
             int totalNumberOfScores = 15;
@@ -1868,7 +1869,7 @@ class ExperimentsResourceTest {
         @Test
         void createExperimentWithPromptVersionLink() {
 
-            String promptName = RandomStringUtils.randomAlphanumeric(10);
+            String promptName = RandomStringUtils.secure().nextAlphanumeric(10);
             Prompt prompt = Prompt.builder()
                     .name(promptName)
                     .build();
@@ -1903,25 +1904,21 @@ class ExperimentsResourceTest {
         }
 
         @Test
-        void createConflict() {
-            var experiment = generateExperiment();
+        void createWithSameIdIsIdempotent() {
+            var expectedExperiment = generateExperiment();
+            createAndAssert(expectedExperiment, API_KEY, TEST_WORKSPACE);
 
-            var expectedError = new ErrorMessage(
-                    409, "Already exists experiment with id '%s'".formatted(experiment.id()));
-            createAndAssert(experiment, API_KEY, TEST_WORKSPACE);
+            var unexpectedExperiment = generateExperiment().toBuilder().id(expectedExperiment.id()).build();
+            var actualId = experimentResourceClient.create(unexpectedExperiment, API_KEY, TEST_WORKSPACE);
 
-            try (var actualResponse = client.target(getExperimentsPath())
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .post(Entity.json(experiment))) {
-
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(409);
-
-                var actualError = actualResponse.readEntity(ErrorMessage.class);
-
-                assertThat(actualError).isEqualTo(expectedError);
-            }
+            // The event isn't posted when the experiment already exists.
+            Mockito.verifyNoMoreInteractions(defaultEventBus);
+            assertThat(actualId).isEqualTo(expectedExperiment.id());
+            var actualExperiment = getAndAssert(expectedExperiment.id(), expectedExperiment, TEST_WORKSPACE, API_KEY);
+            assertThat(actualExperiment)
+                    .usingRecursiveComparison()
+                    .ignoringFields(EXPERIMENT_IGNORED_FIELDS)
+                    .isNotEqualTo(unexpectedExperiment);
         }
 
         @Test
@@ -1959,7 +1956,7 @@ class ExperimentsResourceTest {
                     .header(WORKSPACE_HEADER, TEST_WORKSPACE)
                     .post(Entity.json(experiment))) {
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(400);
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
 
                 var actualError = actualResponse.readEntity(com.comet.opik.api.error.ErrorMessage.class);
 
@@ -1970,7 +1967,8 @@ class ExperimentsResourceTest {
         @Test
         void getNotFound() {
             UUID id = GENERATOR.generate();
-            var expectedError = new ErrorMessage(404, "Not found experiment with id '%s'".formatted(id));
+            var expectedError = new ErrorMessage(HttpStatus.SC_NOT_FOUND,
+                    "Not found experiment with id '%s'".formatted(id));
             try (var actualResponse = client.target(getExperimentsPath())
                     .path(id.toString())
                     .request()
@@ -1978,7 +1976,7 @@ class ExperimentsResourceTest {
                     .header(WORKSPACE_HEADER, TEST_WORKSPACE)
                     .get()) {
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(404);
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NOT_FOUND);
 
                 var actualError = actualResponse.readEntity(ErrorMessage.class);
 
@@ -2045,7 +2043,7 @@ class ExperimentsResourceTest {
 
             createScoreAndAssert(feedbackScoreBatch, apiKey, workspaceName);
 
-            int totalNumberOfScores = traceIdToScoresMap.values().size();
+            int totalNumberOfScores = traceIdToScoresMap.size();
 
             var experimentItems = IntStream.range(0, totalNumberOfScores)
                     .mapToObj(i -> podamFactory.manufacturePojo(ExperimentItem.class).toBuilder()
@@ -2205,7 +2203,7 @@ class ExperimentsResourceTest {
                 .header(WORKSPACE_HEADER, workspaceName)
                 .post(Entity.json(trace))) {
 
-            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(201);
+            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_CREATED);
             assertThat(actualResponse.hasEntity()).isFalse();
 
             var actualHeaderString = actualResponse.getHeaderString("Location");
@@ -2215,14 +2213,13 @@ class ExperimentsResourceTest {
 
     private synchronized UUID createAndAssert(Experiment expectedExperiment, String apiKey, String workspaceName) {
         Mockito.reset(defaultEventBus);
-
         try (var actualResponse = client.target(getExperimentsPath())
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, apiKey)
                 .header(WORKSPACE_HEADER, workspaceName)
                 .post(Entity.json(expectedExperiment))) {
 
-            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(201);
+            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_CREATED);
 
             var actualId = TestUtils.getIdFromLocation(actualResponse.getLocation());
 
@@ -2255,7 +2252,7 @@ class ExperimentsResourceTest {
                 .header(WORKSPACE_HEADER, workspaceName)
                 .get()) {
 
-            if (actualResponse.getStatusInfo().getStatusCode() == 404) {
+            if (actualResponse.getStatusInfo().getStatusCode() == HttpStatus.SC_NOT_FOUND) {
                 return null;
             }
 
@@ -2273,7 +2270,7 @@ class ExperimentsResourceTest {
 
             var actualExperiment = actualResponse.readEntity(Experiment.class);
 
-            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
 
             assertThat(actualExperiment)
                     .usingRecursiveComparison()
@@ -2360,7 +2357,7 @@ class ExperimentsResourceTest {
                     .header(WORKSPACE_HEADER, TEST_WORKSPACE)
                     .post(Entity.json(deleteRequest))) {
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
                 assertThat(actualResponse.hasEntity()).isFalse();
             }
 
@@ -2390,7 +2387,7 @@ class ExperimentsResourceTest {
                     .header(WORKSPACE_HEADER, workspaceName)
                     .post(Entity.json(new ExperimentsDelete(ids)))) {
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
 
                 if (datasetIds.isEmpty()) {
 
@@ -2413,7 +2410,7 @@ class ExperimentsResourceTest {
                     .header(WORKSPACE_HEADER, workspaceName)
                     .get()) {
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(404);
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NOT_FOUND);
             }
         }
 
@@ -2470,7 +2467,7 @@ class ExperimentsResourceTest {
         @Test
         void streamByExperimentName() {
             var apiKey = UUID.randomUUID().toString();
-            var workspaceName = RandomStringUtils.randomAlphanumeric(10);
+            var workspaceName = RandomStringUtils.secure().nextAlphanumeric(10);
             var workspaceId = UUID.randomUUID().toString();
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
@@ -2494,7 +2491,7 @@ class ExperimentsResourceTest {
             // Add comments to trace
             List<Comment> expectedComments = IntStream.range(0, 5)
                     .mapToObj(i -> traceResourceClient.generateAndCreateComment(traceWithScores2.getKey().id(), apiKey,
-                            workspaceName, 201))
+                            workspaceName, HttpStatus.SC_CREATED))
                     .toList();
 
             var experiment1 = generateExperiment();
@@ -2579,7 +2576,7 @@ class ExperimentsResourceTest {
         @Test
         void streamByExperimentNameWithNoItems() {
             var apiKey = UUID.randomUUID().toString();
-            var workspaceName = RandomStringUtils.randomAlphanumeric(10);
+            var workspaceName = RandomStringUtils.secure().nextAlphanumeric(10);
             var workspaceId = UUID.randomUUID().toString();
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
@@ -2596,12 +2593,12 @@ class ExperimentsResourceTest {
         @Test
         void streamByExperimentNameWithoutExperiments() {
             var apiKey = UUID.randomUUID().toString();
-            var workspaceName = RandomStringUtils.randomAlphanumeric(10);
+            var workspaceName = RandomStringUtils.secure().nextAlphanumeric(10);
             var workspaceId = UUID.randomUUID().toString();
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
             var streamRequest = ExperimentItemStreamRequest.builder()
-                    .experimentName(RandomStringUtils.randomAlphanumeric(10))
+                    .experimentName(RandomStringUtils.secure().nextAlphanumeric(10))
                     .build();
             var expectedExperimentItems = List.<ExperimentItem>of();
             var unexpectedExperimentItems1 = List.<ExperimentItem>of();
@@ -2662,7 +2659,7 @@ class ExperimentsResourceTest {
                     .header(WORKSPACE_HEADER, workspaceName)
                     .post(Entity.json(request))) {
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(409);
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_CONFLICT);
                 assertThat(actualResponse.hasEntity()).isTrue();
                 assertThat(actualResponse.readEntity(ErrorMessage.class).getMessage())
                         .isEqualTo("Upserting experiment item with 'dataset_item_id' not belonging to the workspace");
@@ -2695,7 +2692,7 @@ class ExperimentsResourceTest {
                     .header(WORKSPACE_HEADER, workspaceName)
                     .post(Entity.json(request))) {
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(409);
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_CONFLICT);
                 assertThat(actualResponse.hasEntity()).isTrue();
                 assertThat(actualResponse.readEntity(ErrorMessage.class).getMessage())
                         .isEqualTo("Upserting experiment item with 'experiment_id' not belonging to the workspace");
@@ -2717,7 +2714,7 @@ class ExperimentsResourceTest {
                     .header(WORKSPACE_HEADER, workspaceName)
                     .put(Entity.json(batch))) {
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
             }
 
             return item.id();
@@ -2761,7 +2758,7 @@ class ExperimentsResourceTest {
                     .header(WORKSPACE_HEADER, TEST_WORKSPACE)
                     .post(Entity.json(request))) {
 
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(400);
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
 
                 var actualError = actualResponse.readEntity(com.comet.opik.api.error.ErrorMessage.class);
 
@@ -2898,7 +2895,7 @@ class ExperimentsResourceTest {
                 .header(WORKSPACE_HEADER, workspaceName)
                 .get()) {
 
-            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
 
             var actualExperimentItem = actualResponse.readEntity(ExperimentItem.class);
 
@@ -2957,7 +2954,8 @@ class ExperimentsResourceTest {
     }
 
     private void getAndAssertNotFound(UUID id, String apiKey, String workspaceName) {
-        var expectedError = new ErrorMessage(404, "Not found experiment item with id '%s'".formatted(id));
+        var expectedError = new ErrorMessage(HttpStatus.SC_NOT_FOUND,
+                "Not found experiment item with id '%s'".formatted(id));
         try (var actualResponse = client.target(getExperimentItemsPath())
                 .path(id.toString())
                 .request()
@@ -2965,7 +2963,7 @@ class ExperimentsResourceTest {
                 .header(WORKSPACE_HEADER, workspaceName)
                 .get()) {
 
-            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(404);
+            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NOT_FOUND);
 
             var actualError = actualResponse.readEntity(ErrorMessage.class);
 
@@ -2987,7 +2985,7 @@ class ExperimentsResourceTest {
                 .header(WORKSPACE_HEADER, workspaceName)
                 .post(Entity.json(request))) {
 
-            assertThat(actualResponse.getStatus()).isEqualTo(200);
+            assertThat(actualResponse.getStatus()).isEqualTo(HttpStatus.SC_OK);
 
             var actualExperimentItems = getStreamedItems(actualResponse);
 


### PR DESCRIPTION
## Details
When creating an experiment with the same ID, a `409 Conflict` is no longer returned. Instead, the existing experiment by that ID is returned without creating a new one.

When not created and returned, the experiment created event isn't posted: 
1. No event was really created.
2. No experiment should be recorded for the related dataset ID, including updating the `last_created_experiment_at`.

Additionally, improved logs, code and test health along the way.

## Issues

Resolves OPIK-962

## Testing
- Updated related test: when experiment already exists.
- Passed related tests: including normal experiment creation.
- Manually tested the cases above and also a 500 exception.

## Documentation
N/A
