### PR TITLE
[OPIK-1145] Fix non-helpful message for gemini invalid api key

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiErrorObject.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiErrorObject.java
@@ -1,9 +1,11 @@
 package com.comet.opik.infrastructure.llm.gemini;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.dropwizard.jersey.errors.ErrorMessage;
 
 import java.util.Optional;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record GeminiErrorObject(GeminiError error) {
     public Optional<ErrorMessage> toErrorMessage() {
         if (error != null) {
@@ -14,5 +16,6 @@ public record GeminiErrorObject(GeminiError error) {
     }
 }
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 record GeminiError(int code, String message, String status) {
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ChatCompletionsClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ChatCompletionsClient.java
@@ -108,6 +108,21 @@ public class ChatCompletionsClient {
         }
     }
 
+    public List<ErrorMessage> createAndGetStreamedError(
+            String apiKey, String workspaceName, ChatCompletionRequest request) {
+        assertThat(request.stream()).isTrue();
+
+        try (var response = clientSupport.target(getCreateUrl())
+                .request()
+                .accept(MediaType.SERVER_SENT_EVENTS)
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(RequestContext.WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(request))) {
+
+            return getStreamedError(response);
+        }
+    }
+
     private String getCreateUrl() {
         return RESOURCE_PATH.formatted(baseURI);
     }


### PR DESCRIPTION
## Details
Fixes bad error message presented to the user due to extra fields in the original payload.

## Issues
OPIK-1145

## Testing
Added an E2E test covering this flow.
