### PR TITLE
issues-1413: follow-up improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,8 +110,11 @@ In order to develop features in the Python SDK, you will need to have Opik runni
 ```bash
 cd deployment/docker-compose
 
+# Optionally, you can force a pull of the latest images
+docker compose pull
+
 # Starting the Opik platform
-docker compose up --detach
+docker compose up -d
 
 # Configure the Python SDK to point to the local Opik deployment
 opik configure --use_local
@@ -184,6 +187,9 @@ If you want to run the front-end locally and see your changes instantly on savin
 - Run the following command to start the necessary services and expose the required ports:
 
   ```bash
+  # Optionally, you can force a pull of the latest images
+  docker compose pull
+  
   docker compose -f docker-compose.yaml -f docker-compose.override.yaml up -d
   ```
 
@@ -250,6 +256,9 @@ In order to run the external services (Clickhouse, MySQL, Redis), you can use `d
 
 ```bash
 cd deployment/docker-compose
+
+# Optionally, you can force a pull of the latest images
+docker compose pull
 
 docker compose up clickhouse redis mysql -d
 ```

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ git clone https://github.com/comet-ml/opik.git
 # Navigate to the opik/deployment/docker-compose directory
 cd opik/deployment/docker-compose
 
+# Optionally, you can force a pull of the latest images
+docker compose pull
+
 # Start the Opik platform
 docker compose up --detach
 

--- a/apps/opik-backend/entrypoint.sh
+++ b/apps/opik-backend/entrypoint.sh
@@ -1,22 +1,31 @@
 #!/bin/bash
+set -e
 
-echo $(pwd)
-
+echo "Starting redoc server..."
 jwebserver -d /opt/opik/redoc -b 0.0.0.0 -p 3003 &
+echo "Redoc service successfully started as background process"
+
+echo "Current directory is: $(pwd)"
 
 echo "OPIK_VERSION=$OPIK_VERSION"
 echo "OPIK_OTEL_SDK_ENABLED=$OPIK_OTEL_SDK_ENABLED"
 echo "OTEL_VERSION=$OTEL_VERSION"
 
 if [[ "${OPIK_OTEL_SDK_ENABLED}" == "true" && "${OTEL_VERSION}" != "" && "${OTEL_EXPORTER_OTLP_ENDPOINT}" != "" ]];then
+    echo "Downloading Open Telemetry Java Agent"
     export OTEL_RESOURCE_ATTRIBUTES="service.name=opik-backend,service.version=${OPIK_VERSION}"
     curl -L -o /tmp/opentelemetry-javaagent.jar https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_VERSION}/opentelemetry-javaagent.jar
     JAVA_OPTS="$JAVA_OPTS -javaagent:/tmp/opentelemetry-javaagent.jar"
+    echo "Successfully downloaded Open Telemetry Java Agent"
+else
+    echo "Skipping download of the Open Telemetry Java Agent"
 fi
 
 # Check if ENABLE_VIRTUAL_THREADS is set to true
 if [ "$ENABLE_VIRTUAL_THREADS" = "true" ]; then
+    echo "Enabling virtual threads"
     JAVA_OPTS="$JAVA_OPTS -Dreactor.schedulers.defaultBoundedElasticOnVirtualThreads=true"
 fi
 
+echo "Starting opik-backend service..."
 java $JAVA_OPTS -jar opik-backend-$OPIK_VERSION.jar server config.yml

--- a/apps/opik-backend/run_db_migrations.sh
+++ b/apps/opik-backend/run_db_migrations.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
+set -e
 
-echo $(pwd)
+echo "Running database migrations..."
+echo "Current directory is: $(pwd)"
 echo "OPIK_VERSION=$OPIK_VERSION"
 
-java -jar opik-backend-$OPIK_VERSION.jar db migrate config.yml \
-  && java -jar opik-backend-$OPIK_VERSION.jar dbAnalytics migrate config.yml
+java -jar opik-backend-"$OPIK_VERSION".jar db migrate config.yml \
+  && java -jar opik-backend-"$OPIK_VERSION".jar dbAnalytics migrate config.yml
+
+echo "Database migrations completed successfully"

--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -19,6 +19,10 @@ Run docker-compose from the root of the project:
 
 ```bash
 cd deployment/docker-compose
+
+# Optionally, you can force a pull of the latest images
+docker compose pull
+
 docker compose -f docker-compose.yaml up -d
 ```
 
@@ -27,7 +31,15 @@ docker compose -f docker-compose.yaml up -d
 From the root of the project:
 ```bash
 cd deployment/docker-compose
+
+# Optionally, you can force a pull of the latest images
+docker compose pull
+
+# Build the images
 docker compose -f docker-compose.yaml up -d --build
+
+# Alternatively, you can force a pull of the latest images and build the images
+docker compose -f docker-compose.yaml up -d --build --pull always
 ```
 
 ## Exposing Database and Backend Ports for Local Development
@@ -40,6 +52,9 @@ debugging, you can use the provided Docker Compose override file.
 Run the following command to start the services and expose the ports:
 
 ```bash
+# Optionally, you can force a pull of the latest images
+docker compose pull
+
 docker compose -f docker-compose.yaml -f docker-compose.override.yaml up -d
 ```
 
@@ -87,6 +102,9 @@ http://172.17.0.1:8080
 2. Run docker-compose including exposing ports to localhost:
 
 ```bash
+# Optionally, you can force a pull of the latest images
+docker compose pull
+
 docker compose -f docker-compose.yaml -f docker-compose.override.yaml up -d
 ```
 

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -3,6 +3,7 @@ name: opik
 services:
   mysql:
     image: mysql:8.4.2
+    pull_policy: always
     hostname: mysql
     environment:
       MYSQL_ROOT_PASSWORD: opik
@@ -19,6 +20,7 @@ services:
 
   redis:
     image: redis:7.2.4-alpine3.19
+    pull_policy: always
     hostname: redis
     command: redis-server --requirepass opik
     healthcheck:
@@ -30,6 +32,7 @@ services:
 
   clickhouse:
     image: clickhouse/clickhouse-server:24.3.6.48-alpine
+    pull_policy: always
     hostname: clickhouse
     environment:
       CLICKHOUSE_DB: opik
@@ -49,6 +52,7 @@ services:
 
   backend:
     image: ghcr.io/comet-ml/opik/opik-backend:${OPIK_VERSION:-latest}
+    pull_policy: always
     build:
       context: ../../apps/opik-backend
       dockerfile: Dockerfile
@@ -93,6 +97,7 @@ services:
 
   python-backend:
     image: ghcr.io/comet-ml/opik/opik-python-backend:${OPIK_VERSION:-latest}
+    pull_policy: always
     build:
       context: ../../apps/opik-python-backend
       dockerfile: Dockerfile
@@ -104,6 +109,7 @@ services:
 
   frontend:
     image: ghcr.io/comet-ml/opik/opik-frontend:${OPIK_VERSION:-latest}
+    pull_policy: always
     build:
       context: ../../apps/opik-frontend
       dockerfile: Dockerfile

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -57,6 +57,7 @@ services:
     hostname: backend
     command: [ "bash", "-c", "./run_db_migrations.sh && ./entrypoint.sh" ]
     environment:
+      # WARNING: Do not set OPIK_VERSION as env var here. It's a multi-stage build, so build and runtime values can differ.
       DOCKER_BUILDKIT: 1
       STATE_DB_PROTOCOL: "jdbc:mysql://"
       STATE_DB_URL: "mysql:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true"


### PR DESCRIPTION
## Details
Follow up from: https://github.com/comet-ml/opik/pull/1464

There's no way to prevent inconsistency between build and runtime by playing with `ARG` and `ENV` in `apps/opik-backend/Dockerfile`, so added a comment warning about this problem.

Improved backend start-up and migration scripts, for better debugging info.

Reviewed all `*.MD` files for `docker compose`, no changes as result.

## Issues

#1413 

## Testing
- Run service and verified both migration and start-up scripts.

## Documentation
N/A
