### PR TITLE
add an option to easily configure clickhouse log level

### DIFF
--- a/deployment/helm_chart/opik/templates/clickhouseinstallation.yaml
+++ b/deployment/helm_chart/opik/templates/clickhouseinstallation.yaml
@@ -43,14 +43,18 @@ spec:
     {{- end }}
 
     {{- if .Values.clickhouse.configuration }}
-    {{- with .Values.clickhouse.configuration.files }}
-    files:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
     {{- with .Values.clickhouse.configuration.additional_configuration }}
     {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- end }}
+
+    files:
+      config.d/logger.xml: "<yandex><logger><level>{{ .Values.clickhouse.logsLevel }}</level></logger></yandex>"
+      {{- if .Values.clickhouse.configuration }}
+      {{- with .Values.clickhouse.configuration.files }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
     
     {{- if .Values.zookeeper.enabled }}
     zookeeper:


### PR DESCRIPTION
## Details
Now it can be configured by setting `clickhouse.logsLevel`, the default is 'information'

## Issues

Resolves #

## Testing

## Documentation
