### PR TITLE
[OPIK-1157] [SDK] [FR]: Python SDK: Provide method to delete trace feedback scores

### DIFF
--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -507,6 +507,42 @@ class Opik:
 
             self._streamer.put(add_span_feedback_scores_batch_message)
 
+    def delete_feedback_score_for_trace(self, trace_id: str, name: str) -> None:
+        """
+        Deletes a feedback score associated with a specific trace.
+
+        Args:
+            trace_id:
+                The unique identifier of the trace for which the feedback score needs to be deleted.
+            name: str
+                The name associated with the feedback score that should be deleted.
+
+        Returns:
+            None
+        """
+        self._rest_client.traces.delete_trace_feedback_score(
+            id=trace_id,
+            name=name,
+        )
+
+    def delete_feedback_score_for_span(self, span_id: str, name: str) -> None:
+        """
+        Deletes a feedback score associated with a specific span.
+
+        Args:
+            span_id:
+                The unique identifier of the trace for which the feedback score needs to be deleted.
+            name: str
+                The name associated with the feedback score that should be deleted.
+
+        Returns:
+            None
+        """
+        self._rest_client.spans.delete_span_feedback_score(
+            id=span_id,
+            name=name,
+        )
+
     def get_dataset(self, name: str) -> dataset.Dataset:
         """
         Get dataset by name

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -507,7 +507,7 @@ class Opik:
 
             self._streamer.put(add_span_feedback_scores_batch_message)
 
-    def delete_feedback_score_for_trace(self, trace_id: str, name: str) -> None:
+    def delete_trace_feedback_score(self, trace_id: str, name: str) -> None:
         """
         Deletes a feedback score associated with a specific trace.
 
@@ -525,7 +525,7 @@ class Opik:
             name=name,
         )
 
-    def delete_feedback_score_for_span(self, span_id: str, name: str) -> None:
+    def delete_span_feedback_score(self, span_id: str, name: str) -> None:
         """
         Deletes a feedback score associated with a specific span.
 

--- a/sdks/python/tests/e2e/test_feedback_scores.py
+++ b/sdks/python/tests/e2e/test_feedback_scores.py
@@ -101,9 +101,9 @@ def test_feedbacks_are_logged_via_trace_and_span__and_deleted(opik_client: opik.
 
     opik_client.flush()
 
-    opik_client.delete_feedback_score_for_trace(trace.id, "trace-metric-1")
-    opik_client.delete_feedback_score_for_span(span.id, "span-metric-1")
-    opik_client.delete_feedback_score_for_span(span.id, "span-metric-2")
+    opik_client.delete_trace_feedback_score(trace.id, "trace-metric-1")
+    opik_client.delete_span_feedback_score(span.id, "span-metric-1")
+    opik_client.delete_span_feedback_score(span.id, "span-metric-2")
 
     opik_client.flush()
 

--- a/sdks/python/tests/e2e/test_feedback_scores.py
+++ b/sdks/python/tests/e2e/test_feedback_scores.py
@@ -78,6 +78,63 @@ def test_feedbacks_are_logged_via_trace_and_span__happyflow(opik_client: opik.Op
     )
 
 
+def test_feedbacks_are_logged_via_trace_and_span__and_deleted(opik_client: opik.Opik):
+    trace = opik_client.trace(
+        name="trace-name",
+    )
+    trace.log_feedback_score(
+        "trace-metric-1", value=0.5, category_name="category-1", reason="some-reason-1"
+    )
+    trace.log_feedback_score(
+        "trace-metric-2", value=0.95, category_name="category-2", reason="some-reason-2"
+    )
+
+    span = trace.span(
+        name="span-name",
+    )
+    span.log_feedback_score(
+        "span-metric-1", value=0.75, category_name="category-3", reason="some-reason-3"
+    )
+    span.log_feedback_score(
+        "span-metric-2", value=0.25, category_name="category-4", reason="some-reason-4"
+    )
+
+    opik_client.flush()
+
+    opik_client.delete_feedback_score_for_trace(trace.id, "trace-metric-1")
+    opik_client.delete_feedback_score_for_span(span.id, "span-metric-1")
+    opik_client.delete_feedback_score_for_span(span.id, "span-metric-2")
+
+    opik_client.flush()
+
+    EXPECTED_TRACE_FEEDBACK_SCORES: List[FeedbackScoreDict] = [
+        {
+            "id": trace.id,
+            "name": "trace-metric-2",
+            "value": 0.95,
+            "category_name": "category-2",
+            "reason": "some-reason-2",
+        },
+    ]
+
+    EXPECTED_SPAN_FEEDBACK_SCORES = None
+
+    verifiers.verify_trace(
+        opik_client=opik_client,
+        trace_id=trace.id,
+        name="trace-name",
+        feedback_scores=EXPECTED_TRACE_FEEDBACK_SCORES,
+    )
+    verifiers.verify_span(
+        opik_client=opik_client,
+        span_id=span.id,
+        trace_id=span.trace_id,
+        parent_span_id=None,
+        name="span-name",
+        feedback_scores=EXPECTED_SPAN_FEEDBACK_SCORES,
+    )
+
+
 def test_feedbacks_are_logged_via_client__happyflow(opik_client: opik.Opik):
     trace = opik_client.trace(name="trace-name-1")
     span = trace.span(name="span-name-1")

--- a/sdks/python/tests/e2e/verifiers.py
+++ b/sdks/python/tests/e2e/verifiers.py
@@ -59,6 +59,12 @@ def verify_trace(
         assert trace_project.name == project_name
 
     if feedback_scores is not mock.ANY:
+        if trace.feedback_scores is None:
+            assert (
+                feedback_scores is None
+            ), f"Expected feedback scores to be None, but got {feedback_scores}"
+            return
+
         actual_feedback_scores = (
             [] if trace.feedback_scores is None else trace.feedback_scores
         )
@@ -147,6 +153,12 @@ def verify_span(
         assert span_project.name == project_name
 
     if feedback_scores is not mock.ANY:
+        if span.feedback_scores is None:
+            assert (
+                feedback_scores is None
+            ), f"Expected feedback scores to be None, but got {feedback_scores}"
+            return
+
         actual_feedback_scores = (
             [] if span.feedback_scores is None else span.feedback_scores
         )


### PR DESCRIPTION
## Details
Added two methods to delete feedback scores from trace/span

Resolves #
https://github.com/comet-ml/opik/issues/1442

## Testing
e2e test is added
