### PR TITLE
[OPIK-1191] get spans counts by workspace

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/SpansCountResponse.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/SpansCountResponse.java
@@ -1,0 +1,26 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record SpansCountResponse(
+        List<WorkspaceSpansCount> workspacesSpansCount) {
+    public static SpansCountResponse empty() {
+        return new SpansCountResponse(List.of());
+    }
+
+    @Builder(toBuilder = true)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record WorkspaceSpansCount(
+            String workspace,
+            int spanCount) {
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/internal/UsageResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/internal/UsageResource.java
@@ -2,9 +2,11 @@ package com.comet.opik.api.resources.v1.internal;
 
 import com.codahale.metrics.annotation.Timed;
 import com.comet.opik.api.BiInformationResponse;
+import com.comet.opik.api.SpansCountResponse;
 import com.comet.opik.api.TraceCountResponse;
 import com.comet.opik.domain.DatasetService;
 import com.comet.opik.domain.ExperimentService;
+import com.comet.opik.domain.SpanService;
 import com.comet.opik.domain.TraceService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -30,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @Tag(name = "System usage", description = "System usage related resource")
 public class UsageResource {
     private final @NonNull TraceService traceService;
+    private final @NonNull SpanService spanService;
     private final @NonNull ExperimentService experimentService;
     private final @NonNull DatasetService datasetService;
 
@@ -40,6 +43,16 @@ public class UsageResource {
     public Response getTracesCountForWorkspaces() {
         return traceService.countTracesPerWorkspace()
                 .map(tracesCountResponse -> Response.ok(tracesCountResponse).build())
+                .block();
+    }
+
+    @GET
+    @Path("/workspace-span-counts")
+    @Operation(operationId = "getSpansCountForWorkspaces", summary = "Get spans count on previous day for all available workspaces", description = "Get spans count on previous day for all available workspaces", responses = {
+            @ApiResponse(responseCode = "200", description = "SpanCountResponse resource", content = @Content(schema = @Schema(implementation = SpansCountResponse.class)))})
+    public Response getSpansCountForWorkspaces() {
+        return spanService.countSpansPerWorkspace()
+                .map(spansCountResponse -> Response.ok(spansCountResponse).build())
                 .block();
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -4,6 +4,7 @@ import com.comet.opik.api.ProjectStats;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.SpanSearchCriteria;
 import com.comet.opik.api.SpanUpdate;
+import com.comet.opik.api.SpansCountResponse;
 import com.comet.opik.domain.cost.CostService;
 import com.comet.opik.domain.filter.FilterQueryBuilder;
 import com.comet.opik.domain.filter.FilterStrategy;
@@ -763,6 +764,16 @@ class SpanDAO {
             AND workspace_id = :workspace_id
             """;
 
+    private static final String SPAN_COUNT_BY_WORKSPACE_ID = """
+                SELECT
+                     workspace_id,
+                     COUNT(DISTINCT id) as span_count
+                 FROM spans
+                 WHERE created_at BETWEEN toStartOfDay(yesterday()) AND toStartOfDay(today())
+                 GROUP BY workspace_id
+            ;
+            """;
+
     private static final String ESTIMATED_COST_VERSION = "1.0";
 
     private final @NonNull ConnectionFactory connectionFactory;
@@ -1386,6 +1397,19 @@ class SpanDAO {
                 })
                 .flatMap(result -> result.map((row, rowMetadata) -> row.get("id", UUID.class)))
                 .collectList();
+    }
+
+    @WithSpan
+    public Flux<SpansCountResponse.WorkspaceSpansCount> countSpansPerWorkspace() {
+        return Mono.from(connectionFactory.create())
+                .flatMapMany(connection -> {
+                    var statement = connection.createStatement(SPAN_COUNT_BY_WORKSPACE_ID);
+                    return Flux.from(statement.execute());
+                })
+                .flatMap(result -> result.map((row, rowMetadata) -> SpansCountResponse.WorkspaceSpansCount.builder()
+                        .workspace(row.get("workspace_id", String.class))
+                        .spanCount(row.get("span_count", Integer.class))
+                        .build()));
     }
 
     private boolean isManualCost(Span span) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
@@ -7,6 +7,7 @@ import com.comet.opik.api.Span;
 import com.comet.opik.api.SpanBatch;
 import com.comet.opik.api.SpanSearchCriteria;
 import com.comet.opik.api.SpanUpdate;
+import com.comet.opik.api.SpansCountResponse;
 import com.comet.opik.api.error.EntityAlreadyExistsException;
 import com.comet.opik.api.error.ErrorMessage;
 import com.comet.opik.api.error.IdentifierMismatchException;
@@ -347,5 +348,16 @@ public class SpanService {
                         spanIds -> commentService.deleteByEntityIds(CommentDAO.EntityType.SPAN, new HashSet<>(spanIds)))
                 .then(Mono.defer(() -> spanDAO.deleteByTraceIds(traceIds)))
                 .then();
+    }
+
+    @WithSpan
+    public Mono<SpansCountResponse> countSpansPerWorkspace() {
+        return spanDAO.countSpansPerWorkspace()
+                .collectList()
+                .flatMap(items -> Mono.just(
+                        SpansCountResponse.builder()
+                                .workspacesSpansCount(items)
+                                .build()))
+                .switchIfEmpty(Mono.just(SpansCountResponse.empty()));
     }
 }


### PR DESCRIPTION
## Details
This PR adds a new resource: `/workspace-span-counts`.
Its logic is very similar to the existing `/workspace-trace-counts` endpoint - provides daily span count per workspace for the previous day.

## Issues
OPIK-1191

## Testing
Added an E2E test that covers the new logic.
