### PR TITLE
[DEV-2650] set configurable proxy timeouts for opik backend

### DIFF
--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -171,6 +171,7 @@ Call opik api on http://localhost:5173/api
 | component.frontend.service.type | string | `"ClusterIP"` |  |
 | component.frontend.serviceAccount.create | bool | `true` |  |
 | component.frontend.throttling | object | `{}` |  |
+| component.frontend.upstreamConfig | object | `{}` |  |
 | component.frontend.volumeMounts[0].mountPath | string | `"/etc/nginx/conf.d/"` |  |
 | component.frontend.volumeMounts[0].name | string | `"opik-frontend-nginx"` |  |
 | component.frontend.volumes[0].configMap.items[0].key | string | `"default.conf"` |  |

--- a/deployment/helm_chart/opik/templates/configmap-frontend-nginx.yaml
+++ b/deployment/helm_chart/opik/templates/configmap-frontend-nginx.yaml
@@ -79,10 +79,9 @@ data:
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-
-            proxy_read_timeout 90;
-            proxy_connect_timeout 90;
-            proxy_send_timeout 90;
+        {{- range $k, $v := .Values.component.frontend.upstreamConfig }}
+            {{ $k }} {{ $v }};
+        {{- end }}
 
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -182,6 +182,12 @@ component:
         "time_local": "$time_local",
         "x_forwarded_for": "$http_x_forwarded_for"
         }'
+    upstreamConfig: {}
+      # proxy_read_timeout: 60
+      # proxy_connect_timeout: 60
+      # proxy_send_timeout: 60
+      # proxy_buffering: 'on'
+      # proxy_request_buffering: 'on'
 
 mysql:
   enabled: true 


### PR DESCRIPTION
[DEV-2650](https://comet-ml.atlassian.net/browse/DEV-2650])

[DEV-2650]: https://comet-ml.atlassian.net/browse/DEV-2650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ