### PR TITLE
[OPIK-1096] [SDK] Customerf feedback Python SDK handle multiple results get_experiment_by_name

### DIFF
--- a/sdks/python/src/opik/api_objects/experiment/experiment.py
+++ b/sdks/python/src/opik/api_objects/experiment/experiment.py
@@ -37,6 +37,10 @@ class Experiment:
             dataset_name=self._dataset_name
         ).id
 
+    @property
+    def dataset_name(self) -> str:
+        return self._dataset_name
+
     @functools.cached_property
     def name(self) -> str:
         if self._name is not None:

--- a/sdks/python/src/opik/api_objects/experiment/rest_operations.py
+++ b/sdks/python/src/opik/api_objects/experiment/rest_operations.py
@@ -1,17 +1,18 @@
 from typing import List
 
+from opik import exceptions
 from opik.rest_api import OpikApi
 from opik.rest_api.types import experiment_public
-from opik import exceptions
 
 
 def get_experiment_data_by_name(
     rest_client: OpikApi, name: str
 ) -> experiment_public.ExperimentPublic:
-    page = 0
+    # TODO: this method is deprecated and should be removed after
+    #  deprecated Opik.get_experiment_by_name() will be removed.
+    #  This function should not be used anywhere else except for deprecated logic as it is confusing and misleading
 
     while True:
-        page += 1
         experiment_page_public = rest_client.experiments.find_experiments(name=name)
         if len(experiment_page_public.content) == 0:
             raise exceptions.ExperimentNotFound(

--- a/sdks/python/src/opik/api_objects/experiment/rest_operations.py
+++ b/sdks/python/src/opik/api_objects/experiment/rest_operations.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from opik.rest_api import OpikApi
 from opik.rest_api.types import experiment_public
 from opik import exceptions
@@ -19,3 +21,15 @@ def get_experiment_data_by_name(
         for experiment in experiment_page_public.content:
             if experiment.name == name:
                 return experiment
+
+
+def get_experiments_data_by_name(
+    rest_client: OpikApi, name: str
+) -> List[experiment_public.ExperimentPublic]:
+    experiment_page_public = rest_client.experiments.find_experiments(name=name)
+    if len(experiment_page_public.content) == 0:
+        raise exceptions.ExperimentNotFound(
+            f"Experiment with the name {name} not found."
+        )
+
+    return experiment_page_public.content

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -728,6 +728,9 @@ class Opik:
         Returns:
             experiment.Experiment: the API object for an existing experiment.
         """
+        LOGGER.warning(
+            "Deprecated, use `get_experiments_by_name` or `get_experiment_by_id` instead."
+        )
         experiment_public = experiment_rest_operations.get_experiment_data_by_name(
             rest_client=self._rest_client, name=name
         )
@@ -739,6 +742,32 @@ class Opik:
             rest_client=self._rest_client,
             # TODO: add prompt if exists
         )
+
+    def get_experiments_by_name(self, name: str) -> List[experiment.Experiment]:
+        """
+        Returns an existing experiments by its name.
+
+        Args:
+            name: The name of the experiment(s).
+
+        Returns:
+            List[experiment.Experiment]: List of existing experiments.
+        """
+        experiments_public = experiment_rest_operations.get_experiments_data_by_name(
+            rest_client=self._rest_client, name=name
+        )
+        result = []
+
+        for public_experiment in experiments_public:
+            experiment_ = experiment.Experiment(
+                id=public_experiment.id,
+                dataset_name=public_experiment.dataset_name,
+                name=name,
+                rest_client=self._rest_client,
+            )
+            result.append(experiment_)
+
+        return result
 
     def get_experiment_by_id(self, id: str) -> experiment.Experiment:
         """

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -138,6 +138,7 @@ def evaluate_experiment(
     scoring_threads: int = 16,
     verbose: int = 1,
     scoring_key_mapping: Optional[ScoringKeyMappingType] = None,
+    experiment_id: Optional[str] = None,
 ) -> evaluation_result.EvaluationResult:
     """Update existing experiment with new evaluation metrics.
 
@@ -163,14 +164,18 @@ def evaluate_experiment(
 
     client = opik_client.get_client_cached()
 
-    experiment_public = rest_operations.get_experiment_by_name(
-        client=client, experiment_name=experiment_name
-    )
+    if experiment_id:
+        LOGGER.info("Getting experiment by id. Experiment name is ignored.")
+        experiment = client.get_experiment_by_id(id=experiment_id)
+    else:
+        experiment = rest_operations.get_experiment_by_name(
+            client=client, experiment_name=experiment_name
+        )
 
     test_cases = rest_operations.get_experiment_test_cases(
         client=client,
-        experiment_id=experiment_public.id,
-        dataset_id=experiment_public.dataset_id,
+        experiment_id=experiment.id,
+        dataset_id=experiment.dataset_id,
         scoring_key_mapping=scoring_key_mapping,
     )
     first_trace_id = test_cases[0].trace_id
@@ -182,7 +187,7 @@ def evaluate_experiment(
         evaluation_engine = engine.EvaluationEngine(
             client=client,
             project_name=project_name,
-            experiment_=experiment_public,
+            experiment_=experiment,
             scoring_metrics=scoring_metrics,
             workers=scoring_threads,
             verbose=verbose,
@@ -196,18 +201,18 @@ def evaluate_experiment(
 
     if verbose == 1:
         report.display_experiment_results(
-            experiment_public.dataset_name, total_time, test_results
+            experiment.dataset_name, total_time, test_results
         )
 
     report.display_experiment_link(
-        dataset_id=experiment_public.dataset_id,
-        experiment_id=experiment_public.id,
+        dataset_id=experiment.dataset_id,
+        experiment_id=experiment.id,
         url_override=client.config.url_override,
     )
 
     evaluation_result_ = evaluation_result.EvaluationResult(
-        experiment_id=experiment_public.id,
-        experiment_name=experiment_public.name,
+        experiment_id=experiment.id,
+        experiment_name=experiment.name,
         test_results=test_results,
     )
 

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -168,7 +168,7 @@ def evaluate_experiment(
         LOGGER.info("Getting experiment by id. Experiment name is ignored.")
         experiment = client.get_experiment_by_id(id=experiment_id)
     else:
-        experiment = rest_operations.get_experiment_by_name(
+        experiment = rest_operations.get_experiment_with_unique_name(
             client=client, experiment_name=experiment_name
         )
 

--- a/sdks/python/src/opik/evaluation/rest_operations.py
+++ b/sdks/python/src/opik/evaluation/rest_operations.py
@@ -7,7 +7,7 @@ from .metrics import arguments_helpers
 from .types import ScoringKeyMappingType
 
 
-def get_experiment_by_name(
+def get_experiment_with_unique_name(
     client: opik_client.Opik, experiment_name: str
 ) -> experiment.Experiment:
     experiments = client.get_experiments_by_name(name=experiment_name)

--- a/sdks/python/src/opik/evaluation/rest_operations.py
+++ b/sdks/python/src/opik/evaluation/rest_operations.py
@@ -1,26 +1,26 @@
 from typing import List, Optional
 
+from opik.api_objects import experiment, opik_client
 from opik.types import FeedbackScoreDict
-from .types import ScoringKeyMappingType
-
-from ..api_objects import opik_client
-from ..rest_api.experiments.client import ExperimentPublic
 from . import test_case, test_result
 from .metrics import arguments_helpers
+from .types import ScoringKeyMappingType
 
 
 def get_experiment_by_name(
     client: opik_client.Opik, experiment_name: str
-) -> ExperimentPublic:
-    experiments = client._rest_client.experiments.find_experiments(name=experiment_name)
+) -> experiment.Experiment:
+    experiments = client.get_experiments_by_name(name=experiment_name)
 
-    if len(experiments.content) == 0:
+    if len(experiments) == 0:
         raise ValueError(f"Experiment with name {experiment_name} not found")
-    elif len(experiments.content) > 1:
-        raise ValueError(f"Found multiple experiments with name {experiment_name}")
+    elif len(experiments) > 1:
+        raise ValueError(
+            f"Found multiple experiments with name {experiment_name}. Try to use `experiment_id` instead"
+        )
 
-    experiment = experiments.content[0]
-    return experiment
+    experiment_ = experiments[0]
+    return experiment_
 
 
 def get_trace_project_name(client: opik_client.Opik, trace_id: str) -> str:


### PR DESCRIPTION
## Details
The Pull Request introduces additional methods and properties for better handling and retrieval of experiments, including the usage of experiment_id for more precise operations. It also deprecates a method and updates related code to use the new functionality.

Main Changes:
New method in `opik_client.py`: `get_experiments_by_name`, which returns a list of experiments by name.
Addition of new property: `dataset_name` in `experiment.py`.
Introduction of a new method: `get_experiments_data_by_name` in `rest_operations.py`.
Modified `get_experiment_by_name` functionality: Rewritten to handle cases where multiple experiments share the same name.
Deprecation warning: Added in `opik_client.py` for `get_experiment_by_name` with recommendations for alternative methods.
Enhanced evaluator functionality: Added `experiment_id` support to differentiate experiments more precisely.
Test improvement: Introduced a test case in `test_experiment.py` to validate behavior when multiple experiments have the same name.

## Testing
e2e test added