### PR TITLE
[OPIK-1223] [FR]: Export the reason field of metrics via JSON download

### DIFF
--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
@@ -35,13 +35,14 @@ const CompareExperimentsActionsPanel: React.FC<
         const keyPrefix = first(keys) as string;
 
         if (keyPrefix === "feedback_scores") {
-          acc[`feedback_scores.${key}`] = get(
-            row.experiment_items?.[0].feedback_scores?.find(
-              (f) => f.name === key,
-            ),
-            "value",
-            "-",
+          const scoreObject = row.experiment_items?.[0].feedback_scores?.find(
+            (f) => f.name === key,
           );
+          acc[`feedback_scores.${key}`] = get(scoreObject, "value", "-");
+
+          if (scoreObject && scoreObject.reason) {
+            acc[`feedback_scores.${key}_reason`] = scoreObject.reason;
+          }
         } else if (keyPrefix === "output") {
           acc[`dataset.${key}`] = get(
             row.experiment_items?.[0] ?? {},

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesActionsPanel.tsx
@@ -52,11 +52,12 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
         const keyPrefix = first(keys) as string;
 
         if (keyPrefix === "feedback_scores") {
-          acc[key] = get(
-            row.feedback_scores?.find((f) => f.name === key),
-            "value",
-            "-",
-          );
+          const scoreObject = row.feedback_scores?.find((f) => f.name === key);
+          acc[key] = get(scoreObject, "value", "-");
+
+          if (scoreObject && scoreObject.reason) {
+            acc[`${key}_reason`] = scoreObject.reason;
+          }
         } else {
           acc[key] = get(row, keys, "");
         }


### PR DESCRIPTION
## Details
Solution: When downloading items, a new column called <feedback_score>_reason is added if one of the items to download has a reason.

## Issues

Resolves #

## Testing 
Tested manually

## Documentation
