### PR TITLE
NO-JIRA: Remove trace delete lock

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -329,12 +329,10 @@ class TraceServiceImpl implements TraceService {
     @WithSpan
     public Mono<Void> delete(@NonNull UUID id) {
         log.info("Deleting trace by id '{}'", id);
-        return lockService.executeWithLock(
-                new LockService.Lock(id, TRACE_KEY),
-                Mono.defer(() -> feedbackScoreDAO.deleteByEntityId(EntityType.TRACE, id))
-                        .then(Mono.defer(() -> commentDAO.deleteByEntityId(CommentDAO.EntityType.TRACE, id)))
-                        .then(Mono.defer(() -> spanService.deleteByTraceIds(Set.of(id))))
-                        .then(Mono.defer(() -> template.nonTransaction(connection -> dao.delete(id, connection)))));
+        return feedbackScoreDAO.deleteByEntityId(EntityType.TRACE, id)
+                .then(Mono.defer(() -> commentDAO.deleteByEntityId(CommentDAO.EntityType.TRACE, id)))
+                .then(Mono.defer(() -> spanService.deleteByTraceIds(Set.of(id))))
+                .then(Mono.defer(() -> template.nonTransaction(connection -> dao.delete(id, connection))));
     }
 
     @Override


### PR DESCRIPTION
## Details
It's not required to have a critical section for deleting all these elements: comments and spans.

It isn't required to delete the trace either, as it's a soft delete and it wins or it's ignored if concurrent insert or update.

## Issues
N/A

## Testing
- Passed endpoint tests.

## Documentation
N/A