### PR TITLE
OPIK-876 [SDK] Opik may take a lot of time to import because of litellm

### DIFF
--- a/sdks/python/src/opik/evaluation/engine/exception_analyzer.py
+++ b/sdks/python/src/opik/evaluation/engine/exception_analyzer.py
@@ -1,8 +1,9 @@
 import openai
-import litellm.exceptions
 
 
 def is_llm_provider_rate_limit_error(exception: Exception) -> bool:
+    import litellm.exceptions
+
     rate_limit_error_known_types = (
         openai.RateLimitError,
         litellm.exceptions.RateLimitError,

--- a/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/metric.py
+++ b/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/metric.py
@@ -1,10 +1,11 @@
 import math
 from functools import cached_property
-from typing import Any, Optional, Union
+from typing import Any, Optional, TYPE_CHECKING, Union
 import pydantic
 import json
 
-from litellm.types.utils import ModelResponse
+if TYPE_CHECKING:
+    from litellm.types.utils import ModelResponse
 
 from opik.evaluation.metrics import base_metric, score_result
 from opik.evaluation.models import base_model, models_factory
@@ -145,7 +146,7 @@ class GEval(base_metric.BaseMetric):
 
         return self._parse_model_output(model_output)
 
-    def _parse_model_output(self, content: ModelResponse) -> score_result.ScoreResult:
+    def _parse_model_output(self, content: "ModelResponse") -> score_result.ScoreResult:
         """
         This method computes the final score based on the model's response. The model's response is a dictionary
         with a `score` key and a `reason` key. The prompt template also specifies that the score should be an integer

--- a/sdks/python/src/opik/evaluation/models/litellm/warning_filters.py
+++ b/sdks/python/src/opik/evaluation/models/litellm/warning_filters.py
@@ -2,8 +2,6 @@ import logging
 import warnings
 from typing import Any
 
-import litellm
-
 
 def add_warning_filters() -> None:
     # TODO: This should be removed when we have fixed the error messages in the LiteLLM library
@@ -23,5 +21,7 @@ def add_warning_filters() -> None:
     # Add filter to multiple possible loggers
     filter = NoEventLoopFilterLiteLLM()
     logging.getLogger("LiteLLM").addFilter(filter)
+
+    import litellm
 
     litellm.suppress_debug_info = True  # to disable colorized prints with links to litellm whenever an LLM provider raises an error

--- a/sdks/python/src/opik/integrations/crewai/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/crewai/opik_tracker.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 import crewai
-import litellm
 
 from . import crewai_decorator
 
@@ -33,6 +32,8 @@ def track_crewai(
     crewai_wrapper = decorator_factory.track(
         project_name=project_name,
     )
+
+    import litellm
 
     crewai.Crew.kickoff = crewai_wrapper(crewai.Crew.kickoff)
     crewai.Crew.kickoff_for_each = crewai_wrapper(crewai.Crew.kickoff_for_each)


### PR DESCRIPTION
## Details
This PR introduces lazy import of `litellm` library.
It will be loaded on the first initialization of `LiteLLMChatModel`.

## Resolves
https://github.com/comet-ml/opik/issues/1475

## Testing
Manually tested