### PR TITLE
[Opik 1237] [Bug] Fix getting started issue with os import for injected code

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/onboarding/EvaluationExamples/evaluation-scripts/EvaluateLLM.py
+++ b/apps/opik-frontend/src/components/pages-shared/onboarding/EvaluationExamples/evaluation-scripts/EvaluateLLM.py
@@ -1,6 +1,7 @@
 import opik
 from opik.evaluation import evaluate
 from opik.evaluation.metrics import ContextPrecision, ContextRecall
+import os
 
 # INJECT_OPIK_CONFIGURATION
 
@@ -24,7 +25,7 @@ dataset.insert([
 def evaluation_task(dataset_item):
     # Simulate RAG pipeline, replace this with your LLM application
     output = "<LLM response placeholder>"
-    
+
     return {
         "output": output
     }

--- a/apps/opik-frontend/src/components/pages-shared/onboarding/EvaluationExamples/evaluation-scripts/EvaluatePrompts.py
+++ b/apps/opik-frontend/src/components/pages-shared/onboarding/EvaluationExamples/evaluation-scripts/EvaluatePrompts.py
@@ -1,6 +1,7 @@
 import opik
 from opik.evaluation import evaluate_prompt
 from opik.evaluation.metrics import Hallucination
+import os
 
 # INJECT_OPIK_CONFIGURATION
 

--- a/apps/opik-frontend/src/components/pages-shared/onboarding/FrameworkIntegrations/integration-scripts/Anthropic.py
+++ b/apps/opik-frontend/src/components/pages-shared/onboarding/FrameworkIntegrations/integration-scripts/Anthropic.py
@@ -1,5 +1,6 @@
 import anthropic
 from opik.integrations.anthropic import track_anthropic # HIGHLIGHTED_LINE
+import os
 
 # INJECT_OPIK_CONFIGURATION
 

--- a/apps/opik-frontend/src/components/pages-shared/onboarding/FrameworkIntegrations/integration-scripts/Bedrock.py
+++ b/apps/opik-frontend/src/components/pages-shared/onboarding/FrameworkIntegrations/integration-scripts/Bedrock.py
@@ -1,5 +1,6 @@
 import boto3
 from opik.integrations.bedrock import track_bedrock # HIGHLIGHTED_LINE
+import os
 
 # INJECT_OPIK_CONFIGURATION
 

--- a/apps/opik-frontend/src/components/pages-shared/onboarding/FrameworkIntegrations/integration-scripts/DSPy.py
+++ b/apps/opik-frontend/src/components/pages-shared/onboarding/FrameworkIntegrations/integration-scripts/DSPy.py
@@ -1,5 +1,6 @@
 import dspy
 from opik.integrations.dspy.callback import OpikCallback # HIGHLIGHTED_LINE
+import os
 
 # INJECT_OPIK_CONFIGURATION
 


### PR DESCRIPTION
## Details
Added import os to all getting started code templates where it's missing.
## Issues
Resolves OPIK-1237
In getting started page some of the getting started python code is broken due to missing os import after code injection of the environment configuration code.
Can be seen in [Run evaluations] both templates, as well as [Log LLM calls] in Anthropic, Bedrock, and DSPy
## Testing
Manual
## Documentation
N/A