### PR TITLE
[OPIK-1166] Add support for "\n" to "pretty mode" in traces and span sidebar

### DIFF
--- a/apps/opik-frontend/package-lock.json
+++ b/apps/opik-frontend/package-lock.json
@@ -74,6 +74,7 @@
         "react-textarea-autosize": "^8.5.7",
         "react18-json-view": "^0.2.8",
         "recharts": "^2.13.3",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "slugify": "^1.6.6",
         "stylelint-scss": "^6.4.1",
@@ -11874,6 +11875,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -14025,6 +14039,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/apps/opik-frontend/package.json
+++ b/apps/opik-frontend/package.json
@@ -91,6 +91,7 @@
     "react-textarea-autosize": "^8.5.7",
     "react18-json-view": "^0.2.8",
     "recharts": "^2.13.3",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "slugify": "^1.6.6",
     "stylelint-scss": "^6.4.1",

--- a/apps/opik-frontend/src/components/shared/MarkdownPreview/MarkdownPreview.tsx
+++ b/apps/opik-frontend/src/components/shared/MarkdownPreview/MarkdownPreview.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { cn } from "@/lib/utils";
+import remarkBreaks from "remark-breaks";
+import isNull from "lodash/isNull";
+
+import { cn, isStringMarkdown } from "@/lib/utils";
 
 type MarkdownPreviewProps = {
   children?: string | null;
@@ -12,14 +15,24 @@ export const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({
   children,
   className,
 }) => {
-  return (
-    <ReactMarkdown
-      className={cn("prose comet-markdown", className)}
-      remarkPlugins={[remarkGfm]}
-    >
-      {children}
-    </ReactMarkdown>
-  );
+  if (isNull(children)) return "";
+
+  if (isStringMarkdown(children)) {
+    return (
+      <ReactMarkdown
+        className={cn("prose comet-markdown", className)}
+        remarkPlugins={[remarkBreaks, remarkGfm]}
+      >
+        {children}
+      </ReactMarkdown>
+    );
+  } else {
+    return (
+      <div className={cn("comet-markdown whitespace-pre-wrap", className)}>
+        {children}
+      </div>
+    );
+  }
 };
 
 export default MarkdownPreview;

--- a/apps/opik-frontend/src/lib/utils.test.ts
+++ b/apps/opik-frontend/src/lib/utils.test.ts
@@ -103,22 +103,6 @@ describe("isStringMarkdown", () => {
     ).toBe(true);
   });
 
-  // Test URLs
-  it("should identify text with URLs as markdown", () => {
-    expect(isStringMarkdown("Visit https://example.com for more info")).toBe(
-      true,
-    );
-    expect(isStringMarkdown("Visit http://example.com for more info")).toBe(
-      true,
-    );
-  });
-
-  // Test multiple paragraphs
-  it("should identify text with multiple paragraphs as markdown", () => {
-    const paragraphs = "This is paragraph 1.\n\nThis is paragraph 2.";
-    expect(isStringMarkdown(paragraphs)).toBe(true);
-  });
-
   // Test complex markdown
   it("should identify complex markdown", () => {
     const complex = `# Markdown Example
@@ -153,6 +137,15 @@ For more info, see [this link](https://example.com).`;
     expect(
       isStringMarkdown("This contains a hash # but is not markdown."),
     ).toBe(false);
+    expect(
+      isStringMarkdown("This is paragraph 1.\n\nThis is paragraph 2."),
+    ).toBe(false);
+    expect(isStringMarkdown("Visit https://example.com for more info")).toBe(
+      false,
+    );
+    expect(isStringMarkdown("Visit http://example.com for more info")).toBe(
+      false,
+    );
     // The following test might pass (true) due to the URL detection logic in the function
     // expect(isStringMarkdown('The URL example.com is not formatted as a markdown link')).toBe(false);
   });

--- a/apps/opik-frontend/src/lib/utils.ts
+++ b/apps/opik-frontend/src/lib/utils.ts
@@ -77,18 +77,8 @@ export const isStringMarkdown = (string: unknown): boolean => {
     /^\[\^.+?]:/m, // footnote definitions
   ];
 
-  // Check if the string contains URLs - common in markdown content
-  const urlPattern = /https?:\/\/\S+/.test(string);
-
-  // Check if we have multiple paragraphs (a strong indicator of structured text)
-  const multipleParagraphs = /\n\s*\n/.test(string);
-
   // Check for markdown patterns
-  const hasMarkdownSyntax = markdownPatterns.some((pattern) =>
-    pattern.test(string),
-  );
-
-  return hasMarkdownSyntax || urlPattern || multipleParagraphs;
+  return markdownPatterns.some((pattern) => pattern.test(string));
 };
 
 export const isValidJsonObject = (string: string) => {


### PR DESCRIPTION
## Details
![image](https://github.com/user-attachments/assets/0edbbb9c-e860-485c-af51-66302bc91c76)
![image](https://github.com/user-attachments/assets/8230c701-9cc4-4566-9fa2-0bcea4b9a1ff)

## Issues

Resolves #

## Testing

## Documentation
