### PR TITLE
[OPIK-1226] fix feedback scores `is_empty` filter

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -237,6 +237,20 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
      * Counts dataset items only if there's a matching experiment item.
      */
     private static final String SELECT_DATASET_ITEMS_WITH_EXPERIMENT_ITEMS_COUNT = """
+                <if(feedback_scores_empty_filters)>
+                WITH fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
+                    FROM (
+                        SELECT *
+                        FROM feedback_scores
+                        WHERE entity_type = 'trace'
+                        AND workspace_id = :workspace_id
+                        ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
+                        LIMIT 1 BY entity_id, name
+                     )
+                     GROUP BY entity_id
+                     HAVING <feedback_scores_empty_filters>
+                )
+                <endif>
                 SELECT
                    COUNT(DISTINCT di.id) AS count
                 FROM (
@@ -256,11 +270,14 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                         dataset_item_id,
                         trace_id
                     FROM experiment_items ei
-                    <if(experiment_item_filters || feedback_scores_filters)>
+                    <if(experiment_item_filters || feedback_scores_filters || feedback_scores_empty_filters)>
                     INNER JOIN (
                         SELECT
                             id
                         FROM traces
+                        <if(feedback_scores_empty_filters)>
+                            LEFT JOIN fsc ON fsc.entity_id = traces.id
+                        <endif>
                         WHERE workspace_id = :workspace_id
                         <if(experiment_item_filters)>
                         AND <experiment_item_filters>
@@ -280,6 +297,9 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                             GROUP BY entity_id
                             HAVING <feedback_scores_filters>
                         )
+                        <endif>
+                        <if(feedback_scores_empty_filters)>
+                        AND fsc.feedback_scores_count = 0
                         <endif>
                         ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
                         LIMIT 1 BY id
@@ -380,16 +400,27 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                 AND entity_id IN (SELECT trace_id FROM experiment_items_scope)
                 ORDER BY (workspace_id, project_id, entity_id, id) DESC, last_updated_at DESC
                 LIMIT 1 BY id
-            ),  experiment_items_final AS (
+            ),
+            <if(feedback_scores_empty_filters)>
+            fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
+                 FROM feedback_scores_final
+                 GROUP BY entity_id
+                 HAVING <feedback_scores_empty_filters>
+            ),
+            <endif>
+            experiment_items_final AS (
             	SELECT
             		ei.*
             	FROM experiment_items_scope ei
             	WHERE workspace_id = :workspace_id
-            	<if(experiment_item_filters || feedback_scores_filters)>
+            	<if(experiment_item_filters || feedback_scores_filters || feedback_scores_empty_filters)>
                 AND trace_id IN (
                     SELECT
                         id
                     FROM traces
+                    <if(feedback_scores_empty_filters)>
+                        LEFT JOIN fsc ON fsc.entity_id = traces.id
+                    <endif>
                     WHERE workspace_id = :workspace_id
                     <if(experiment_item_filters)>
                     AND <experiment_item_filters>
@@ -402,6 +433,9 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                         GROUP BY entity_id
                         HAVING <feedback_scores_filters>
                     )
+                    <endif>
+                    <if(feedback_scores_empty_filters)>
+                    AND fsc.feedback_scores_count = 0
                     <endif>
                     ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
                     LIMIT 1 BY id
@@ -783,6 +817,10 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
 
                     filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.FEEDBACK_SCORES)
                             .ifPresent(scoresFilters -> template.add("feedback_scores_filters", scoresFilters));
+
+                    filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.FEEDBACK_SCORES_IS_EMPTY)
+                            .ifPresent(feedbackScoreIsEmptyFilters -> template.add("feedback_scores_empty_filters",
+                                    feedbackScoreIsEmptyFilters));
                 });
 
         return template;
@@ -794,6 +832,7 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                     filterQueryBuilder.bind(statement, filters, FilterStrategy.DATASET_ITEM);
                     filterQueryBuilder.bind(statement, filters, FilterStrategy.EXPERIMENT_ITEM);
                     filterQueryBuilder.bind(statement, filters, FilterStrategy.FEEDBACK_SCORES);
+                    filterQueryBuilder.bind(statement, filters, FilterStrategy.FEEDBACK_SCORES_IS_EMPTY);
                 });
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -543,6 +543,21 @@ class SpanDAO {
               ORDER BY (workspace_id, project_id, entity_id, id) DESC, last_updated_at DESC
               LIMIT 1 BY id
             )
+            <if(feedback_scores_empty_filters)>
+             , fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
+                 FROM (
+                    SELECT *
+                    FROM feedback_scores
+                    WHERE entity_type = 'span'
+                    AND workspace_id = :workspace_id
+                    AND project_id = :project_id
+                    ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
+                    LIMIT 1 BY entity_id, name
+                 )
+                 GROUP BY entity_id
+                 HAVING <feedback_scores_empty_filters>
+            )
+            <endif>
             SELECT
                 s.id as id,
                 s.workspace_id as workspace_id,
@@ -576,6 +591,9 @@ class SpanDAO {
                            (dateDiff('microsecond', start_time, end_time) / 1000.0),
                            NULL) AS duration
                 FROM spans
+                <if(feedback_scores_empty_filters)>
+                    LEFT JOIN fsc ON fsc.entity_id = spans.id
+                <endif>
                 WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
                 <if(last_received_span_id)> AND id > :last_received_span_id <endif>
@@ -598,6 +616,9 @@ class SpanDAO {
                   HAVING <feedback_scores_filters>
                 )
                 <endif>
+                <if(feedback_scores_empty_filters)>
+                AND fsc.feedback_scores_count = 0
+                <endif>
                 <if(stream)>
                 ORDER BY id DESC, last_updated_at DESC
                 <else>
@@ -617,6 +638,21 @@ class SpanDAO {
             """;
 
     private static final String COUNT_BY_PROJECT_ID = """
+            <if(feedback_scores_empty_filters)>
+             WITH fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
+                 FROM (
+                    SELECT *
+                    FROM feedback_scores
+                    WHERE entity_type = 'span'
+                    AND workspace_id = :workspace_id
+                    AND project_id = :project_id
+                    ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
+                    LIMIT 1 BY entity_id, name
+                 )
+                 GROUP BY entity_id
+                 HAVING <feedback_scores_empty_filters>
+            )
+            <endif>
             SELECT
                 count(id) as count
             FROM
@@ -628,6 +664,9 @@ class SpanDAO {
                                      (dateDiff('microsecond', start_time, end_time) / 1000.0),
                                      NULL) AS duration
                 FROM spans
+                <if(feedback_scores_empty_filters)>
+                    LEFT JOIN fsc ON fsc.entity_id = spans.id
+                <endif>
                 WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
                 <if(trace_id)> AND trace_id = :trace_id <endif>
@@ -648,6 +687,9 @@ class SpanDAO {
                     GROUP BY entity_id
                     HAVING <feedback_scores_filters>
                 )
+                <endif>
+                <if(feedback_scores_empty_filters)>
+                AND fsc.feedback_scores_count = 0
                 <endif>
                 ORDER BY (workspace_id, project_id, trace_id, parent_span_id, id) DESC, last_updated_at DESC
                 LIMIT 1 BY id
@@ -700,6 +742,21 @@ class SpanDAO {
                     LIMIT 1 BY entity_id, name
                 ) GROUP BY workspace_id, project_id, entity_id
             )
+            <if(feedback_scores_empty_filters)>
+             , fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
+                 FROM (
+                    SELECT *
+                    FROM feedback_scores
+                    WHERE entity_type = 'span'
+                    AND workspace_id = :workspace_id
+                    AND project_id = :project_id
+                    ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
+                    LIMIT 1 BY entity_id, name
+                 )
+                 GROUP BY entity_id
+                 HAVING <feedback_scores_empty_filters>
+            )
+            <endif>
             SELECT
                 project_id as project_id,
                 count(DISTINCT span_id) as span_count,
@@ -741,6 +798,9 @@ class SpanDAO {
                          usage,
                          total_estimated_cost
                     FROM spans
+                    <if(feedback_scores_empty_filters)>
+                        LEFT JOIN fsc ON fsc.entity_id = spans.id
+                    <endif>
                     WHERE project_id = :project_id
                     AND workspace_id = :workspace_id
                     <if(trace_id)> AND trace_id = :trace_id <endif>
@@ -762,6 +822,9 @@ class SpanDAO {
                         GROUP BY entity_id
                         HAVING <feedback_scores_filters>
                     )
+                    <endif>
+                    <if(feedback_scores_empty_filters)>
+                    AND fsc.feedback_scores_count = 0
                     <endif>
                     ORDER BY (workspace_id, project_id, trace_id, parent_span_id, id) DESC, last_updated_at DESC
                     LIMIT 1 BY id
@@ -1357,6 +1420,9 @@ class SpanDAO {
                             .ifPresent(spanFilters -> template.add("filters", spanFilters));
                     filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.FEEDBACK_SCORES)
                             .ifPresent(scoresFilters -> template.add("feedback_scores_filters", scoresFilters));
+                    filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.FEEDBACK_SCORES_IS_EMPTY)
+                            .ifPresent(feedbackScoreIsEmptyFilters -> template.add("feedback_scores_empty_filters",
+                                    feedbackScoreIsEmptyFilters));
                 });
         Optional.ofNullable(spanSearchCriteria.lastReceivedSpanId())
                 .ifPresent(lastReceivedSpanId -> template.add("last_received_span_id", lastReceivedSpanId));
@@ -1372,6 +1438,7 @@ class SpanDAO {
                 .ifPresent(filters -> {
                     filterQueryBuilder.bind(statement, filters, FilterStrategy.SPAN);
                     filterQueryBuilder.bind(statement, filters, FilterStrategy.FEEDBACK_SCORES);
+                    filterQueryBuilder.bind(statement, filters, FilterStrategy.FEEDBACK_SCORES_IS_EMPTY);
                 });
         Optional.ofNullable(spanSearchCriteria.lastReceivedSpanId())
                 .ifPresent(lastReceivedSpanId -> statement.bind("last_received_span_id", lastReceivedSpanId));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -401,6 +401,21 @@ class TraceDAOImpl implements TraceDAO {
                 )
                 GROUP BY workspace_id, project_id, entity_id
             )
+            <if(feedback_scores_empty_filters)>
+             , fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
+                 FROM (
+                    SELECT *
+                    FROM feedback_scores
+                    WHERE entity_type = 'trace'
+                    AND workspace_id = :workspace_id
+                    AND project_id = :project_id
+                    ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
+                    LIMIT 1 BY entity_id, name
+                 )
+                 GROUP BY entity_id
+                 HAVING <feedback_scores_empty_filters>
+            )
+            <endif>
             SELECT
                   t.id as id,
                   t.workspace_id as workspace_id,
@@ -433,6 +448,9 @@ class TraceDAOImpl implements TraceDAO {
                  <if(trace_aggregation_filters)>
                  LEFT JOIN spans_agg s ON t.id = s.trace_id
                  <endif>
+                 <if(feedback_scores_empty_filters)>
+                    LEFT JOIN fsc ON fsc.entity_id = traces.id
+                 <endif>
                  WHERE workspace_id = :workspace_id
                  AND project_id = :project_id
                  <if(filters)> AND <filters> <endif>
@@ -455,6 +473,9 @@ class TraceDAOImpl implements TraceDAO {
                  <endif>
                  <if(trace_aggregation_filters)>
                  AND <trace_aggregation_filters>
+                 <endif>
+                 <if(feedback_scores_empty_filters)>
+                 AND fsc.feedback_scores_count = 0
                  <endif>
                  ORDER BY <if(sort_fields)> <sort_fields>, id DESC <else>(workspace_id, project_id, id) DESC, last_updated_at DESC <endif>
                  LIMIT 1 BY id
@@ -491,6 +512,21 @@ class TraceDAOImpl implements TraceDAO {
             """;
 
     private static final String COUNT_BY_PROJECT_ID = """
+            <if(feedback_scores_empty_filters)>
+             WITH fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
+                 FROM (
+                    SELECT *
+                    FROM feedback_scores
+                    WHERE entity_type = 'trace'
+                    AND workspace_id = :workspace_id
+                    AND project_id = :project_id
+                    ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
+                    LIMIT 1 BY entity_id, name
+                 )
+                 GROUP BY entity_id
+                 HAVING <feedback_scores_empty_filters>
+            )
+            <endif>
             SELECT
                 count(id) as count
             FROM (
@@ -508,6 +544,9 @@ class TraceDAOImpl implements TraceDAO {
                          (dateDiff('microsecond', start_time, end_time) / 1000.0),
                          NULL) AS duration
                     FROM traces
+                    <if(feedback_scores_empty_filters)>
+                    LEFT JOIN fsc ON fsc.entity_id = traces.id
+                    <endif>
                     WHERE project_id = :project_id
                     AND workspace_id = :workspace_id
                     <if(filters)> AND <filters> <endif>
@@ -527,6 +566,9 @@ class TraceDAOImpl implements TraceDAO {
                         GROUP BY entity_id
                         HAVING <feedback_scores_filters>
                     )
+                    <endif>
+                    <if(feedback_scores_empty_filters)>
+                    AND fsc.feedback_scores_count = 0
                     <endif>
                     ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
                     LIMIT 1 BY id
@@ -739,6 +781,21 @@ class TraceDAOImpl implements TraceDAO {
                 )
                 GROUP BY workspace_id, project_id, entity_id
             )
+            <if(feedback_scores_empty_filters)>
+            , fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
+                 FROM (
+                    SELECT *
+                    FROM feedback_scores
+                    WHERE entity_type = 'trace'
+                    AND workspace_id = :workspace_id
+                    AND project_id IN :project_ids
+                    ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
+                    LIMIT 1 BY entity_id, name
+                 )
+                 GROUP BY entity_id
+                 HAVING <feedback_scores_empty_filters>
+            )
+            <endif>
             SELECT
                 t.workspace_id as workspace_id,
                 t.project_id as project_id,
@@ -760,6 +817,9 @@ class TraceDAOImpl implements TraceDAO {
                         (dateDiff('microsecond', start_time, end_time) / 1000.0),
                         NULL) as duration
                 FROM traces
+                <if(feedback_scores_empty_filters)>
+                    LEFT JOIN fsc ON fsc.entity_id = traces.id
+                <endif>
                 WHERE workspace_id = :workspace_id
                 AND project_id IN :project_ids
                 <if(filters)> AND <filters> <endif>
@@ -787,6 +847,9 @@ class TraceDAOImpl implements TraceDAO {
                     FROM spans_agg
                     WHERE <trace_aggregation_filters>
                 )
+                <endif>
+                <if(feedback_scores_empty_filters)>
+                AND fsc.feedback_scores_count = 0
                 <endif>
                 ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
                 LIMIT 1 BY id
@@ -1300,6 +1363,9 @@ class TraceDAOImpl implements TraceDAO {
                             .ifPresent(scoresFilters -> template.add("feedback_scores_filters", scoresFilters));
                     filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE_THREAD)
                             .ifPresent(threadFilters -> template.add("trace_thread_filters", threadFilters));
+                    filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.FEEDBACK_SCORES_IS_EMPTY)
+                            .ifPresent(feedbackScoreIsEmptyFilters -> template.add("feedback_scores_empty_filters",
+                                    feedbackScoreIsEmptyFilters));
                 });
         return template;
     }
@@ -1311,6 +1377,7 @@ class TraceDAOImpl implements TraceDAO {
                     filterQueryBuilder.bind(statement, filters, FilterStrategy.TRACE_AGGREGATION);
                     filterQueryBuilder.bind(statement, filters, FilterStrategy.FEEDBACK_SCORES);
                     filterQueryBuilder.bind(statement, filters, FilterStrategy.TRACE_THREAD);
+                    filterQueryBuilder.bind(statement, filters, FilterStrategy.FEEDBACK_SCORES_IS_EMPTY);
                 });
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -56,6 +56,7 @@ public class FilterQueryBuilder {
     private static final String CREATED_AT_ANALYTICS_DB = "created_at";
     private static final String LAST_UPDATED_AT_ANALYTICS_DB = "last_updated_at";
     private static final String NUMBER_OF_MESSAGES_ANALYTICS_DB = "number_of_messages";
+    private static final String FEEDBACK_SCORE_COUNT_DB = "fsc.feedback_scores_count";
 
     private static final Map<Operator, Map<FieldType, String>> ANALYTICS_DB_OPERATOR_MAP = new EnumMap<>(
             ImmutableMap.<Operator, Map<FieldType, String>>builder()
@@ -113,7 +114,7 @@ public class FilterQueryBuilder {
                             "arrayExists(element -> (element.1 = lower(:filterKey%2$d) AND element.2 <= toDecimal64(:filter%2$d, 9)), groupArray(tuple(lower(name), %1$s))) = 1")))
                     .put(Operator.IS_EMPTY, new EnumMap<>(Map.of(
                             FieldType.FEEDBACK_SCORES_NUMBER,
-                            "empty(arrayFilter(element -> (element.1 = lower(:filterKey%2$d)), groupArray(tuple(lower(name), %1$s)))) = 1")))
+                            "empty(arrayFilter(element -> (element = lower(:filterKey%2$d)), groupArray(lower(name)))) = 0")))
                     .put(Operator.IS_NOT_EMPTY, new EnumMap<>(Map.of(
                             FieldType.FEEDBACK_SCORES_NUMBER,
                             "empty(arrayFilter(element -> (element.1 = lower(:filterKey%2$d)), groupArray(tuple(lower(name), %1$s)))) = 0")))
@@ -259,7 +260,7 @@ public class FilterQueryBuilder {
         stringJoiner.setEmptyValue("");
         for (var i = 0; i < filters.size(); i++) {
             var filter = filters.get(i);
-            if (FILTER_STRATEGY_MAP.getOrDefault(filterStrategy, Set.of()).contains(filter.field())
+            if (getFieldsByStrategy(filterStrategy, filter).orElse(Set.of()).contains(filter.field())
                     || filter.field().isDynamic(filterStrategy)) {
                 stringJoiner.add(toAnalyticsDbFilter(filter, i, filterStrategy));
             }
@@ -270,6 +271,17 @@ public class FilterQueryBuilder {
                 : Optional.of("(%s)".formatted(analyticsDbFilters));
     }
 
+    private Optional<Set<? extends Field>> getFieldsByStrategy(FilterStrategy filterStrategy, Filter filter) {
+        // we want to apply the is empty filter only in the case below
+        if (filter.operator() == Operator.IS_EMPTY && filterStrategy == FilterStrategy.FEEDBACK_SCORES_IS_EMPTY) {
+            return Optional.of(FILTER_STRATEGY_MAP.get(FilterStrategy.FEEDBACK_SCORES));
+        } else if (filter.operator() == Operator.IS_EMPTY) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(FILTER_STRATEGY_MAP.get(filterStrategy));
+    }
+
     private String toAnalyticsDbFilter(Filter filter, int i, FilterStrategy filterStrategy) {
         var template = toAnalyticsDbOperator(filter);
         var formattedTemplate = template.formatted(getAnalyticsDbField(filter.field(), filterStrategy, i), i);
@@ -277,6 +289,10 @@ public class FilterQueryBuilder {
     }
 
     private String getAnalyticsDbField(Field field, FilterStrategy filterStrategy, int i) {
+        // this is a special case where the DB field is determined by the filter strategy rather than the filter field
+        if (filterStrategy == FilterStrategy.FEEDBACK_SCORES_IS_EMPTY) {
+            return FEEDBACK_SCORE_COUNT_DB;
+        }
 
         return switch (field) {
             case TraceField traceField -> TRACE_FIELDS_MAP.get(traceField);
@@ -302,7 +318,7 @@ public class FilterQueryBuilder {
             @NonNull FilterStrategy filterStrategy) {
         for (var i = 0; i < filters.size(); i++) {
             var filter = filters.get(i);
-            if (FILTER_STRATEGY_MAP.getOrDefault(filterStrategy, Set.of()).contains(filter.field())
+            if (getFieldsByStrategy(filterStrategy, filter).orElse(Set.of()).contains(filter.field())
                     || filter.field().isDynamic(filterStrategy)) {
 
                 if (filter.field().isDynamic(filterStrategy)) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterStrategy.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterStrategy.java
@@ -12,6 +12,7 @@ public enum FilterStrategy {
     DATASET_ITEM,
     FEEDBACK_SCORES,
     TRACE_THREAD,
+    FEEDBACK_SCORES_IS_EMPTY,
     ;
 
     public static final String DYNAMIC_FIELD = ":dynamicField%1$d";

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -4318,11 +4318,13 @@ class DatasetsResourceTest {
             UUID experimentId = GENERATOR.generate();
 
             List<FeedbackScoreBatchItem> scores = new ArrayList<>();
-            createScores(traces, projectName, scores);
+            createScores(traces.subList(0, traces.size() - 1), projectName, scores);
             createScoreAndAssert(new FeedbackScoreBatch(scores), apiKey, workspaceName);
 
             List<ExperimentItem> experimentItems = new ArrayList<>();
-            createExperimentItems(datasetItems, traces, scores, experimentId, experimentItems);
+            createExperimentItems(datasetItems, traces, Stream.concat(scores.stream(),
+                    Stream.of((FeedbackScoreBatchItem) null)).collect(Collectors.toList()),
+                    experimentId, experimentItems);
 
             createAndAssert(
                     ExperimentItemsBatch.builder()

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -4319,6 +4319,11 @@ class DatasetsResourceTest {
 
             List<FeedbackScoreBatchItem> scores = new ArrayList<>();
             createScores(traces.subList(0, traces.size() - 1), projectName, scores);
+            scores = scores.stream()
+                    .map(score -> score.toBuilder()
+                            .name(factory.manufacturePojo(String.class))
+                            .build())
+                    .toList();
             createScoreAndAssert(new FeedbackScoreBatch(scores), apiKey, workspaceName);
 
             List<ExperimentItem> experimentItems = new ArrayList<>();
@@ -4343,10 +4348,11 @@ class DatasetsResourceTest {
                             .value("")
                             .build());
 
-            var actualPageIsEmpty = assertDatasetExperimentPage(datasetId, experimentId, isNotEmptyFilter, apiKey,
-                    workspaceName, columns, datasetItems.reversed());
+            var actualPageIsNotEmpty = assertDatasetExperimentPage(datasetId, experimentId, isNotEmptyFilter, apiKey,
+                    workspaceName, columns, List.of(datasetItems.getFirst()));
 
-            assertDatasetItemExperiments(actualPageIsEmpty, datasetItems.reversed(), experimentItems.reversed());
+            assertDatasetItemExperiments(actualPageIsNotEmpty, List.of(datasetItems.getFirst()),
+                    List.of(experimentItems.getFirst()));
 
             var isEmptyFilter = List.of(
                     ExperimentsComparisonFilter.builder()
@@ -4356,10 +4362,11 @@ class DatasetsResourceTest {
                             .value("")
                             .build());
 
-            var actualPageIsNotEmpty = assertDatasetExperimentPage(datasetId, experimentId, isEmptyFilter, apiKey,
-                    workspaceName, columns, List.of());
+            var actualPageIsEmpty = assertDatasetExperimentPage(datasetId, experimentId, isEmptyFilter, apiKey,
+                    workspaceName, columns, datasetItems.subList(1, datasetItems.size()).reversed());
 
-            assertDatasetItemExperiments(actualPageIsNotEmpty, List.of(), List.of());
+            assertDatasetItemExperiments(actualPageIsEmpty, datasetItems.subList(1, datasetItems.size()).reversed(),
+                    experimentItems.subList(1, datasetItems.size()).reversed());
         }
 
         @ParameterizedTest

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -3256,8 +3256,9 @@ class SpansResourceTest {
                     })
                     .collect(Collectors.toCollection(ArrayList::new));
 
+            spans.set(spans.size() - 1, spans.getLast().toBuilder().feedbackScores(null).build());
             spans.forEach(expectedSpan -> createAndAssert(expectedSpan, apiKey, workspaceName));
-            spans.forEach(span -> span.feedbackScores()
+            spans.subList(0, spans.size() - 1).forEach(span -> span.feedbackScores()
                     .forEach(feedbackScore -> createAndAssert(span.id(), feedbackScore, workspaceName, apiKey)));
 
             var expectedSpans = getExpectedSpans.apply(spans);
@@ -8200,8 +8201,9 @@ class SpansResourceTest {
                     })
                     .collect(Collectors.toCollection(ArrayList::new));
 
+            spans.set(spans.size() - 1, spans.getLast().toBuilder().feedbackScores(null).build());
             spans.forEach(expectedSpan -> createAndAssert(expectedSpan, apiKey, workspaceName));
-            spans.forEach(
+            spans.subList(0, spans.size() - 1).forEach(
                     span -> span.feedbackScores().forEach(
                             feedbackScore -> createAndAssert(span.id(), feedbackScore, workspaceName, apiKey)));
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -3446,8 +3446,9 @@ class TracesResourceTest {
                             .totalEstimatedCost(null)
                             .build())
                     .collect(Collectors.toCollection(ArrayList::new));
+            traces.set(traces.size() - 1, traces.getLast().toBuilder().feedbackScores(null).build());
             traces.forEach(trace1 -> create(trace1, apiKey, workspaceName));
-            traces.forEach(trace -> trace.feedbackScores()
+            traces.subList(0, traces.size() - 1).forEach(trace -> trace.feedbackScores()
                     .forEach(feedbackScore -> create(trace.id(), feedbackScore, workspaceName, apiKey)));
             var expectedTraces = getExpectedTraces.apply(traces);
             var unexpectedTraces = getUnexpectedTraces.apply(traces);


### PR DESCRIPTION
## Details
In #1409, two new filter operators were introduced: `is_empty` and `is_not_empty`. The `is_empty` filter didn't work as expected since it didn't consider entities that don't have any feedback score and therefore don't exist in the `feedback_scores` table.

After a discussion with @andriidudar and @andrescrz, we decided to introduce this workaround in `FilterQueryBuilder` which essentially uses a different `FilterStrategy` for the `is_empty` filter while reusing the existing filter query parameter.

## Issues
OPIK-1226

## Testing
Changed the existing tests so that each test will contain one entry with no feedback score at all. This reproduces the issue we noticed during integration.
Made sure the tests were failing as expected (empty feedback score is filtered out although it shouldn't) and fixed the code so the tests are green.
