### PR TITLE
[OPIK-654] New build flow - faster main builds

### DIFF
--- a/.github/workflows/build_and_push_docker.yaml
+++ b/.github/workflows/build_and_push_docker.yaml
@@ -26,11 +26,11 @@ on:
             required: false
             default: ""
             description: Arguments for cloud docker build
-        push_latest:
-            type: string
+        is_release:
+            type: boolean
             required: true
-            description: If to push docker image with latest tag
-            default: "false"
+            description: If this is a release build (will build multi-arch and push latest tag)
+            default: false
 
 env:
   DOCKER_REGISTRY: "ghcr.io/comet-ml/opik" 
@@ -39,9 +39,6 @@ jobs:
 
   build-n-push-image:
     runs-on: ubuntu-latest
-    defaults:
-        run:
-          working-directory: apps/${{ inputs.image }}/
     steps:
         - name: Checkout
           uses: actions/checkout@v4.1.1
@@ -61,41 +58,56 @@ jobs:
             username: "github-actions"
             password: ${{ secrets.GITHUB_TOKEN }}
 
-        - name: Build and Push Docker Image
-          run: |
-            # Create a new builder instance with docker-container driver
-            docker buildx create --name multiarch-builder --driver docker-container --use
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v2
 
-            DOCKER_IMAGE_NAME=${{env.DOCKER_REGISTRY}}/${{ inputs.image }}:${{inputs.version}}
-            echo "DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME}" | tee -a $GITHUB_ENV
-            if [[ "${{inputs.push_latest}}" == "true" ]]; then
-              DOCKER_IMAGE_NAME_LATEST=${{env.DOCKER_REGISTRY}}/${{ inputs.image }}:latest
-              LATEST_TAG=" -t ${DOCKER_IMAGE_NAME_LATEST}"
-            else
-              LATEST_TAG=""
-            fi
-            echo "LATEST_TAG=${LATEST_TAG}"
-            docker buildx build --platform linux/amd64,linux/arm64 --push \
-            --build-arg OPIK_VERSION=${{inputs.version}} \
-            -t ${DOCKER_IMAGE_NAME} ${LATEST_TAG} .
-            echo "Docker image pushed: ${DOCKER_IMAGE_NAME}" >> $GITHUB_STEP_SUMMARY
+        - name: Build and Push Docker Image
+          uses: docker/build-push-action@v4
+          with:
+            context: apps/${{ inputs.image }}/
+            platforms: ${{ inputs.is_release && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+            push: true
+            tags: |
+              ${{env.DOCKER_REGISTRY}}/${{ inputs.image }}:${{inputs.version}}
+              ${{ inputs.is_release && format('{0}/{1}:latest', env.DOCKER_REGISTRY, inputs.image) || '' }}
+            build-args: |
+              OPIK_VERSION=${{inputs.version}}
 
         - name: Build and Push Docker Image for Comet integration
-          if: inputs.build_comet_image 
+          if: inputs.build_comet_image
+          uses: docker/build-push-action@v4
+          with:
+            context: apps/${{ inputs.image }}/
+            platforms: ${{ inputs.is_release && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+            push: true
+            tags: |
+              ${{env.DOCKER_REGISTRY}}/${{ inputs.image }}-comet:${{inputs.version}}
+              ${{ inputs.is_release && format('{0}/{1}-comet:latest', env.DOCKER_REGISTRY, inputs.image) || '' }}
+            build-args: |
+              ${{inputs.comet_build_args}}
+              OPIK_VERSION=${{inputs.version}}
+              SENTRY_ENABLED=true
+              SENTRY_DSN=${{secrets.OPIK_FE_SENTRY_DSN}}
+
+        - name: Write Build Summary
           run: |
-            DOCKER_IMAGE_NAME_COMET=${{env.DOCKER_REGISTRY}}/${{inputs.image}}-comet:${{inputs.version}}
-            echo "DOCKER_IMAGE_NAME_COMET=${DOCKER_IMAGE_NAME_COMET}" | tee -a $GITHUB_ENV
-            if [[ "${{inputs.push_latest}}" == "true" ]]; then
-              DOCKER_IMAGE_NAME_COMET_LATEST=${{env.DOCKER_REGISTRY}}/${{ inputs.image }}-comet:latest
-              LATEST_TAG=" -t ${DOCKER_IMAGE_NAME_COMET_LATEST}"
+            echo "### Docker images pushed:" >> $GITHUB_STEP_SUMMARY
+            echo "${{env.DOCKER_REGISTRY}}/${{ inputs.image }}:${{inputs.version}}" >> $GITHUB_STEP_SUMMARY
+            if [[ "${{ inputs.is_release }}" == "true" ]]; then
+              echo "${{env.DOCKER_REGISTRY}}/${{ inputs.image }}:latest" >> $GITHUB_STEP_SUMMARY
+              echo "Built for platforms: linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
             else
-              LATEST_TAG=""
+              echo "Built for platforms: linux/amd64" >> $GITHUB_STEP_SUMMARY
             fi
-            docker buildx build --platform linux/amd64,linux/arm64 --push \
-            --build-arg ${{inputs.comet_build_args}}  \
-            --build-arg OPIK_VERSION=${{inputs.version}} \
-            --build-arg SENTRY_ENABLED=true \
-            --build-arg SENTRY_DSN="${{secrets.OPIK_FE_SENTRY_DSN}}" \
-            -t ${DOCKER_IMAGE_NAME_COMET} ${LATEST_TAG} .
-            echo "Docker image pushed: ${DOCKER_IMAGE_NAME_COMET}" >> $GITHUB_STEP_SUMMARY
+            
+            if [[ "${{ inputs.build_comet_image }}" == "true" ]]; then
+              echo "### Comet Integration Image" >> $GITHUB_STEP_SUMMARY
+              echo "${{env.DOCKER_REGISTRY}}/${{ inputs.image }}-comet:${{inputs.version}}" >> $GITHUB_STEP_SUMMARY
+              if [[ "${{ inputs.is_release }}" == "true" ]]; then
+                echo "${{env.DOCKER_REGISTRY}}/${{ inputs.image }}-comet:latest" >> $GITHUB_STEP_SUMMARY
+                echo "Built for platforms: linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "Built for platforms: linux/amd64" >> $GITHUB_STEP_SUMMARY
+              fi
+            fi
         

--- a/.github/workflows/build_apps.yml
+++ b/.github/workflows/build_apps.yml
@@ -16,9 +16,9 @@ on:
         required: false
         description: Version (optional)
         default: ""
-      push_latest:
+      is_release:
         type: boolean
-        description: Push latest tag (optional)
+        description: Is release build
         default: false
   workflow_call:
     inputs:
@@ -27,10 +27,10 @@ on:
         required: true
         description: Version
         default: ""
-      push_latest:
+      is_release:
         type: boolean
-        description: Push latest tag 
-        default: true
+        description: Is release build
+        default: false
 
 jobs:
 
@@ -39,7 +39,6 @@ jobs:
     outputs:
         version: ${{ steps.version.outputs.version }}
         build_from: ${{ steps.version.outputs.build_from }}
-        push_latest: ${{ steps.version.outputs.push_latest }}
     steps:
         - name: Checkout
           uses: actions/checkout@v4.1.1
@@ -77,12 +76,6 @@ jobs:
             else
               echo "build_from=${{inputs.version}}" | tee -a $GITHUB_OUTPUT
             fi
-            if [[ ("${{inputs.version}}" != "" && "${{inputs.push_latest}}" == "true") || "${{ github.ref_name }}" == "main" ]]; then
-              echo "push_latest=true" | tee -a $GITHUB_OUTPUT
-            else
-              echo "push_latest=false" | tee -a $GITHUB_OUTPUT
-            fi
-
             
   build-backend:
     needs:
@@ -94,7 +87,7 @@ jobs:
       build_from: ${{needs.set-version.outputs.build_from}}
       build_comet_image: false
       comet_build_args: ""
-      push_latest: ${{needs.set-version.outputs.push_latest}}
+      is_release: ${{inputs.is_release}}
 
   build-sandbox-executor-python:
     needs:
@@ -106,7 +99,7 @@ jobs:
       build_from: ${{needs.set-version.outputs.build_from}}
       build_comet_image: false
       comet_build_args: ""
-      push_latest: ${{needs.set-version.outputs.push_latest}}
+      is_release: ${{inputs.is_release}}
 
   build-python-backend:
     needs:
@@ -119,7 +112,7 @@ jobs:
       build_from: ${{needs.set-version.outputs.build_from}}
       build_comet_image: false
       comet_build_args: ""
-      push_latest: ${{needs.set-version.outputs.push_latest}}
+      is_release: ${{inputs.is_release}}
 
   build-frontend:
     needs:
@@ -131,15 +124,18 @@ jobs:
       build_from: ${{needs.set-version.outputs.build_from}}
       build_comet_image: true
       comet_build_args: "BUILD_MODE=comet"
-      push_latest: ${{needs.set-version.outputs.push_latest}}
+      is_release: ${{inputs.is_release}}
       
   create-git-tag:
+    if: ${{ !inputs.is_release }}
     needs:
       - set-version
       - build-backend
       - build-frontend
       - build-python-backend
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{needs.set-version.outputs.version}}
+      is_release: true
 
   release-sdk:
     needs:


### PR DESCRIPTION
## Details
Since building multi-arch Docker images for Opik takes about 30 minutes, I’ve been looking for ways to make it faster.
There are a few options, but most of them are either ugly workarounds or leave the registry with extra images (one for `amd64`, one for `arm64`) on top of the final multi-arch image, which isn’t great.
Therefore, I want to suggest a different approach:
I don't see a reason why do we need multi-arch images for non-release builds. so we could just build regular linux/amd64 images for every build on main or other branches, and only create multi-arch images for official releases. Same for the `latest` tag - it would only be created on release builds (something I wanted to change a while ago).

The new flow is also using the standard action for building and pushing docker images.

## Issues

Resolves #

## Testing

## Documentation
