### PR TITLE
[OPIK-1159] [FR][FE]: Freeze table header during data scroll

### DIFF
--- a/apps/opik-frontend/src/components/layout/PageBodyScrollContainer/PageBodyScrollContainer.tsx
+++ b/apps/opik-frontend/src/components/layout/PageBodyScrollContainer/PageBodyScrollContainer.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from "react";
+
+import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
+import { cn } from "@/lib/utils";
+import { STICKY_ATTRIBUTE_VERTICAL } from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
+
+type PageBodyScrollContainerProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+const PageBodyScrollContainer: React.FC<PageBodyScrollContainerProps> = ({
+  children,
+  className,
+}) => {
+  const [width, setWidth] = useState<number>(0);
+
+  const { ref } = useObserveResizeNode<HTMLDivElement>((node) => {
+    setWidth(node.clientWidth);
+
+    const verticalElements = node.querySelectorAll(
+      `[${STICKY_ATTRIBUTE_VERTICAL}]`,
+    );
+    let offset = 0;
+    verticalElements.forEach((element) => {
+      element.setAttribute("style", `top: ${offset}px`);
+      offset += element.clientHeight;
+    });
+  });
+
+  const style =
+    width > 0
+      ? ({
+          "--scroll-body-client-width": `${width}px`,
+        } as React.CSSProperties)
+      : undefined;
+
+  return (
+    <div
+      ref={ref}
+      style={style}
+      className={cn(
+        "relative h-[calc(100vh-var(--header-height))] overflow-auto -mx-6",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default PageBodyScrollContainer;

--- a/apps/opik-frontend/src/components/layout/PageBodyStickyContainer/PageBodyStickyContainer.tsx
+++ b/apps/opik-frontend/src/components/layout/PageBodyStickyContainer/PageBodyStickyContainer.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+export enum STICKY_DIRECTION {
+  horizontal = "horizontal",
+  vertical = "vertical",
+  bidirectional = "bidirectional",
+}
+
+export const STICKY_ATTRIBUTE_VERTICAL = "data-sticky-vertical";
+
+type PageBodyStickyContainerProps = {
+  children: React.ReactNode;
+  className?: string;
+  direction?: "horizontal" | "vertical" | "bidirectional";
+  limitWidth?: boolean;
+};
+
+const PageBodyStickyContainer: React.FC<PageBodyStickyContainerProps> = ({
+  children,
+  className,
+  direction = STICKY_DIRECTION.vertical,
+  limitWidth = false,
+}) => {
+  return (
+    <div
+      {...((direction === STICKY_DIRECTION.vertical ||
+        direction === STICKY_DIRECTION.bidirectional) && {
+        [STICKY_ATTRIBUTE_VERTICAL]: direction,
+      })}
+      className={cn(
+        "sticky z-10 bg-soft-background px-6",
+        direction === STICKY_DIRECTION.horizontal && "left-0",
+        direction === STICKY_DIRECTION.vertical && "top-0",
+        direction === STICKY_DIRECTION.bidirectional && "left-0 top-0",
+        limitWidth &&
+          "w-[var(--scroll-body-client-width,var(--comet-content-width))]",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+export default PageBodyStickyContainer;

--- a/apps/opik-frontend/src/components/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper.tsx
+++ b/apps/opik-frontend/src/components/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+type PageBodyStickyTableWrapperProps = {
+  children: React.ReactNode;
+};
+
+const PageBodyStickyTableWrapper: React.FC<PageBodyStickyTableWrapperProps> = ({
+  children,
+}) => {
+  return <div className="comet-sticky-table border-b">{children}</div>;
+};
+export default PageBodyStickyTableWrapper;

--- a/apps/opik-frontend/src/components/pages-shared/automations/NoRulesPage.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/automations/NoRulesPage.tsx
@@ -9,6 +9,7 @@ type NoDataWrapperProps = {
   description: string;
   imageUrl: string;
   buttons: React.ReactNode;
+  className?: string;
   height?: number;
 };
 
@@ -16,12 +17,14 @@ type NoRulesPageProps = {
   openModal: () => void;
   height?: number;
   Wrapper: React.FC<NoDataWrapperProps>;
+  className?: string;
 };
 
 const NoRulesPage: React.FC<NoRulesPageProps> = ({
   openModal,
   Wrapper,
   height,
+  className,
 }) => {
   return (
     <Wrapper
@@ -29,6 +32,7 @@ const NoRulesPage: React.FC<NoRulesPageProps> = ({
       description="An automated rule is a predefined logic that scores LLM outputs in real-time based on set criteria, ensuring efficient and consistent performance assessment."
       imageUrl={noDataRulesImageUrl}
       height={height}
+      className={className}
       buttons={
         <>
           <Button variant="secondary" asChild>

--- a/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricsTab.tsx
@@ -127,7 +127,7 @@ const MetricsTab = ({ projectId }: MetricsTabProps) => {
 
   return (
     <>
-      <div>
+      <div className="px-6">
         <div className="flex items-center justify-between">
           <Button
             variant="outline"

--- a/apps/opik-frontend/src/components/pages/TracesPage/NoTracesPage.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/NoTracesPage.tsx
@@ -33,6 +33,7 @@ const NoTracesPage = () => {
       description="Logging traces helps you understand the flow of your application and identify specific points in your application that may be causing issues."
       imageUrl={imageUrl}
       height={188}
+      className="px-6"
       buttons={
         <>
           <Button variant="secondary" asChild>

--- a/apps/opik-frontend/src/components/pages/TracesPage/RulesTab/RulesTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/RulesTab/RulesTab.tsx
@@ -38,6 +38,8 @@ import AddEditRuleDialog from "@/components/pages-shared/automations/AddEditRule
 import RulesActionsPanel from "@/components/pages-shared/automations/RulesActionsPanel";
 import RuleRowActionsCell from "@/components/pages-shared/automations/RuleRowActionsCell";
 import RuleLogsCell from "@/components/pages-shared/automations/RuleLogsCell";
+import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
+import PageBodyStickyTableWrapper from "@/components/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
 
 const getRowId = (d: EvaluatorsRule) => d.id;
 
@@ -208,6 +210,7 @@ export const RulesTab: React.FC<RulesTabProps> = ({ projectId }) => {
           openModal={handleNewRuleClick}
           Wrapper={NoDataPage}
           height={188}
+          className="px-6"
         />
         <AddEditRuleDialog
           key={resetDialogKeyRef.current}
@@ -220,8 +223,12 @@ export const RulesTab: React.FC<RulesTabProps> = ({ projectId }) => {
   }
 
   return (
-    <div>
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-x-8 gap-y-2">
+    <>
+      <PageBodyStickyContainer
+        className="-mt-4 flex flex-wrap items-center justify-between gap-x-8 gap-y-2 py-4"
+        direction="bidirectional"
+        limitWidth
+      >
         <div className="flex items-center gap-2">
           <SearchInput
             searchText={search as string}
@@ -245,7 +252,7 @@ export const RulesTab: React.FC<RulesTabProps> = ({ projectId }) => {
             Create new rule
           </Button>
         </div>
-      </div>
+      </PageBodyStickyContainer>
       <DataTable
         columns={columns}
         data={rows}
@@ -257,8 +264,14 @@ export const RulesTab: React.FC<RulesTabProps> = ({ projectId }) => {
         getRowId={getRowId}
         columnPinning={DEFAULT_COLUMN_PINNING}
         noData={<DataTableNoData title={noDataText} />}
+        TableWrapper={PageBodyStickyTableWrapper}
+        stickyHeader
       />
-      <div className="py-4">
+      <PageBodyStickyContainer
+        className="py-4"
+        direction="horizontal"
+        limitWidth
+      >
         <DataTablePagination
           page={page as number}
           pageChange={setPage}
@@ -266,14 +279,14 @@ export const RulesTab: React.FC<RulesTabProps> = ({ projectId }) => {
           sizeChange={setSize}
           total={data?.total ?? 0}
         ></DataTablePagination>
-      </div>
+      </PageBodyStickyContainer>
       <AddEditRuleDialog
         key={resetDialogKeyRef.current}
         open={openDialog}
         projectId={projectId}
         setOpen={setOpenDialog}
       />
-    </div>
+    </>
   );
 };
 

--- a/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/NoThreadsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/NoThreadsPage.tsx
@@ -15,6 +15,7 @@ const NoThreadsPage = () => {
       description="Threads allow you to group traces together to help you evaluate your LLM model outputs in their specific context."
       imageUrl={noDataThreadsImageUrl}
       height={188}
+      className="px-6"
       buttons={
         <>
           <Button variant="secondary" asChild>

--- a/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsTab.tsx
@@ -40,6 +40,8 @@ import PrettyCell from "@/components/shared/DataTableCells/PrettyCell";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import ThreadDetailsPanel from "@/components/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel";
 import TraceDetailsPanel from "@/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel";
+import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
+import PageBodyStickyTableWrapper from "@/components/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
 import { formatDate } from "@/lib/date";
 import ThreadsActionsPanel from "@/components/pages/TracesPage/ThreadsTab/ThreadsActionsPanel";
 import useThreadList from "@/api/traces/useThreadsList";
@@ -318,8 +320,12 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
   }
 
   return (
-    <div>
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-x-8 gap-y-2">
+    <>
+      <PageBodyStickyContainer
+        className="-mt-4 flex flex-wrap items-center justify-between gap-x-8 gap-y-2 py-4"
+        direction="bidirectional"
+        limitWidth
+      >
         <div className="flex items-center gap-2">
           <SearchInput
             searchText={search as string}
@@ -366,7 +372,7 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
             onOrderChange={setColumnsOrder}
           ></ColumnsButton>
         </div>
-      </div>
+      </PageBodyStickyContainer>
       <DataTable
         columns={columns}
         data={rows}
@@ -380,8 +386,14 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
         rowHeight={height as ROW_HEIGHT}
         columnPinning={DEFAULT_COLUMN_PINNING}
         noData={<DataTableNoData title={noDataText} />}
+        TableWrapper={PageBodyStickyTableWrapper}
+        stickyHeader
       />
-      <div className="py-4">
+      <PageBodyStickyContainer
+        className="py-4"
+        direction="horizontal"
+        limitWidth
+      >
         <DataTablePagination
           page={page as number}
           pageChange={setPage}
@@ -389,7 +401,7 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
           sizeChange={setSize}
           total={data?.total ?? 0}
         ></DataTablePagination>
-      </div>
+      </PageBodyStickyContainer>
       <TraceDetailsPanel
         projectId={projectId}
         traceId={traceId!}
@@ -410,7 +422,7 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
         hasNextRow={hasNext}
         onRowChange={handleRowChange}
       />
-    </div>
+    </>
   );
 };
 

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesPage.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesPage.tsx
@@ -4,6 +4,8 @@ import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 import { useProjectIdFromURL } from "@/hooks/useProjectIdFromURL";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import useProjectById from "@/api/projects/useProjectById";
+import PageBodyScrollContainer from "@/components/layout/PageBodyScrollContainer/PageBodyScrollContainer";
+import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
 import TracesSpansTab from "@/components/pages/TracesPage/TracesSpansTab/TracesSpansTab";
 import ThreadsTab from "@/components/pages/TracesPage/ThreadsTab/ThreadsTab";
 import MetricsTab from "@/components/pages/TracesPage/MetricsTab/MetricsTab";
@@ -32,37 +34,43 @@ const TracesPage = () => {
   const projectName = project?.name || projectId;
 
   return (
-    <div className="pt-6">
-      <div className="mb-4 flex items-center justify-between">
+    <PageBodyScrollContainer>
+      <PageBodyStickyContainer
+        className="mb-4 mt-6 flex items-center justify-between"
+        direction="horizontal"
+      >
         <h1
           data-testid="traces-page-title"
           className="comet-title-l truncate break-words"
         >
           {projectName}
         </h1>
-      </div>
+      </PageBodyStickyContainer>
       <Tabs
         defaultValue="traces"
         value={type as string}
         onValueChange={setType}
+        className="min-w-min"
       >
-        <TabsList variant="underline">
-          <TabsTrigger variant="underline" value={TRACE_DATA_TYPE.traces}>
-            Traces
-          </TabsTrigger>
-          <TabsTrigger variant="underline" value={TRACE_DATA_TYPE.llm}>
-            LLM calls
-          </TabsTrigger>
-          <TabsTrigger variant="underline" value="threads">
-            Threads
-          </TabsTrigger>
-          <TabsTrigger variant="underline" value="metrics">
-            Metrics
-          </TabsTrigger>
-          <TabsTrigger variant="underline" value="rules">
-            Online evaluation
-          </TabsTrigger>
-        </TabsList>
+        <PageBodyStickyContainer direction="horizontal" limitWidth>
+          <TabsList variant="underline">
+            <TabsTrigger variant="underline" value={TRACE_DATA_TYPE.traces}>
+              Traces
+            </TabsTrigger>
+            <TabsTrigger variant="underline" value={TRACE_DATA_TYPE.llm}>
+              LLM calls
+            </TabsTrigger>
+            <TabsTrigger variant="underline" value="threads">
+              Threads
+            </TabsTrigger>
+            <TabsTrigger variant="underline" value="metrics">
+              Metrics
+            </TabsTrigger>
+            <TabsTrigger variant="underline" value="rules">
+              Online evaluation
+            </TabsTrigger>
+          </TabsList>
+        </PageBodyStickyContainer>
         <TabsContent value={TRACE_DATA_TYPE.traces}>
           <TracesSpansTab
             type={TRACE_DATA_TYPE.traces}
@@ -87,7 +95,7 @@ const TracesPage = () => {
           <RulesTab projectId={projectId} />
         </TabsContent>
       </Tabs>
-    </div>
+    </PageBodyScrollContainer>
   );
 };
 

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
@@ -61,6 +61,8 @@ import TraceDetailsPanel, {
   LastSectionParam,
   LastSectionValue,
 } from "@/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel";
+import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
+import PageBodyStickyTableWrapper from "@/components/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
 import TracesOrSpansPathsAutocomplete from "@/components/pages-shared/traces/TracesOrSpansPathsAutocomplete/TracesOrSpansPathsAutocomplete";
 import TracesOrSpansFeedbackScoresSelect from "@/components/pages-shared/traces/TracesOrSpansFeedbackScoresSelect/TracesOrSpansFeedbackScoresSelect";
 import { formatDate, formatDuration } from "@/lib/date";
@@ -579,8 +581,12 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
   }
 
   return (
-    <div>
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-x-8 gap-y-2">
+    <>
+      <PageBodyStickyContainer
+        className="-mt-4 flex flex-wrap items-center justify-between gap-x-8 gap-y-2 py-4"
+        direction="bidirectional"
+        limitWidth
+      >
         <div className="flex items-center gap-2">
           <SearchInput
             searchText={search as string}
@@ -635,7 +641,8 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
             sections={columnSections}
           ></ColumnsButton>
         </div>
-      </div>
+      </PageBodyStickyContainer>
+
       <DataTable
         columns={columns}
         columnsStatistic={columnsStatistic}
@@ -650,9 +657,15 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
         rowHeight={height as ROW_HEIGHT}
         columnPinning={DEFAULT_TRACES_COLUMN_PINNING}
         noData={<DataTableNoData title={noDataText} />}
+        TableWrapper={PageBodyStickyTableWrapper}
+        stickyHeader
         meta={meta}
       />
-      <div className="py-4">
+      <PageBodyStickyContainer
+        className="py-4"
+        direction="horizontal"
+        limitWidth
+      >
         <DataTablePagination
           page={page as number}
           pageChange={setPage}
@@ -660,7 +673,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
           sizeChange={setSize}
           total={data?.total ?? 0}
         ></DataTablePagination>
-      </div>
+      </PageBodyStickyContainer>
       <TraceDetailsPanel
         projectId={projectId}
         traceId={traceId!}
@@ -681,7 +694,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
         open={Boolean(threadId)}
         onClose={handleClose}
       />
-    </div>
+    </>
   );
 };
 

--- a/apps/opik-frontend/src/components/shared/DataTable/DataTable.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTable/DataTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useMemo } from "react";
+import React, { ReactNode, useMemo, useState } from "react";
 import {
   Cell,
   ColumnDef,
@@ -29,6 +29,9 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import DataTableColumnResizer from "@/components/shared/DataTable/DataTableColumnResizer";
+import DataTableWrapper, {
+  DataTableWrapperProps,
+} from "@/components/shared/DataTable/DataTableWrapper";
 import {
   CELL_VERTICAL_ALIGNMENT,
   COLUMN_TYPE,
@@ -43,6 +46,11 @@ import {
 } from "@/components/shared/DataTable/utils";
 import { TABLE_HEADER_Z_INDEX } from "@/constants/shared";
 import { cn } from "@/lib/utils";
+import {
+  STICKY_ATTRIBUTE_VERTICAL,
+  STICKY_DIRECTION,
+} from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
+import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
 
 declare module "@tanstack/react-table" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -114,6 +122,8 @@ interface DataTableProps<TData, TValue> {
   columnPinning?: ColumnPinningState;
   noData?: ReactNode;
   autoWidth?: boolean;
+  stickyHeader?: boolean;
+  TableWrapper?: React.FC<DataTableWrapperProps>;
   meta?: Omit<
     TableMeta<TData>,
     "columnsStatistic" | "rowHeight" | "rowHeightStyle"
@@ -138,6 +148,8 @@ const DataTable = <TData, TValue>({
   columnPinning,
   noData,
   autoWidth = false,
+  TableWrapper = DataTableWrapper,
+  stickyHeader = false,
   meta,
 }: DataTableProps<TData, TValue>) => {
   const isResizable = resizeConfig && resizeConfig.enabled;
@@ -210,6 +222,11 @@ const DataTable = <TData, TValue>({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [headers, columnSizing]);
 
+  const [tableHeight, setTableHeight] = useState(0);
+  const { ref: tableRef } = useObserveResizeNode<HTMLTableElement>((node) => {
+    setTableHeight(node.clientHeight);
+  });
+
   const renderRow = (row: Row<TData>) => {
     if (isFunction(renderCustomRow) && getIsCustomRow(row)) {
       return renderCustomRow(row);
@@ -271,10 +288,12 @@ const DataTable = <TData, TValue>({
   };
 
   return (
-    <div className="overflow-x-auto overflow-y-hidden rounded-md border">
+    <TableWrapper>
       <Table
+        ref={tableRef}
         style={{
           ...(!autoWidth && { minWidth: table.getTotalSize() }),
+          ...(tableHeight && { "--data-table-height": `${tableHeight}px` }),
         }}
       >
         <colgroup>
@@ -282,7 +301,12 @@ const DataTable = <TData, TValue>({
             <col key={i.id} style={{ width: `${i.size}px` }} />
           ))}
         </colgroup>
-        <TableHeader>
+        <TableHeader
+          className={cn(stickyHeader && "sticky z-10")}
+          {...(stickyHeader && {
+            ...{ [STICKY_ATTRIBUTE_VERTICAL]: STICKY_DIRECTION.vertical },
+          })}
+        >
           {table.getHeaderGroups().map((headerGroup, index, groups) => {
             const isLastRow = index === groups.length - 1;
 
@@ -340,7 +364,7 @@ const DataTable = <TData, TValue>({
           )}
         </TableBody>
       </Table>
-    </div>
+    </TableWrapper>
   );
 };
 

--- a/apps/opik-frontend/src/components/shared/DataTable/DataTableColumnResizer.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTable/DataTableColumnResizer.tsx
@@ -35,7 +35,7 @@ const DataTableColumnResizer = <TData,>({
         },
       }}
       className={cn(
-        "group absolute top-0 z-[5] flex h-[10000px] cursor-ew-resize items-stretch transition-all",
+        "group absolute top-0 h-[var(--data-table-height,56px)] z-[5] flex cursor-ew-resize items-stretch transition-all",
         header.column.getIsLastColumn()
           ? "right-0 w-1 justify-end"
           : "-right-1 w-[9px] justify-center",

--- a/apps/opik-frontend/src/components/shared/DataTable/DataTableWrapper.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTable/DataTableWrapper.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export type DataTableWrapperProps = {
+  children: React.ReactNode;
+};
+
+const DataTableWrapper: React.FC<DataTableWrapperProps> = ({ children }) => {
+  return (
+    <div className="overflow-x-auto overflow-y-hidden rounded-md border">
+      {children}
+    </div>
+  );
+};
+
+export default DataTableWrapper;

--- a/apps/opik-frontend/src/components/shared/NoDataPage/NoDataPage.tsx
+++ b/apps/opik-frontend/src/components/shared/NoDataPage/NoDataPage.tsx
@@ -1,10 +1,12 @@
 import React from "react";
+import { cn } from "@/lib/utils";
 
 type NoDataPageProps = {
   title: string;
   description: string;
   imageUrl: string;
   buttons: React.ReactNode;
+  className?: string;
   height?: number;
 };
 
@@ -13,6 +15,7 @@ const NoDataPage: React.FC<NoDataPageProps> = ({
   description,
   imageUrl,
   buttons,
+  className,
   height = 60,
 }) => {
   return (
@@ -22,7 +25,10 @@ const NoDataPage: React.FC<NoDataPageProps> = ({
           "--page-difference": `${height}px`,
         } as React.CSSProperties
       }
-      className="flex h-[calc(100vh-var(--page-difference))] min-h-[500px] w-full min-w-72 items-center justify-stretch py-6"
+      className={cn(
+        "flex h-[calc(100vh-var(--page-difference))] min-h-[500px] w-full min-w-72 items-center justify-stretch py-6",
+        className,
+      )}
     >
       <div className="flex size-full flex-col items-center rounded-md border bg-white px-6 py-14">
         <h2 className="comet-title-m">{title}</h2>

--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -186,6 +186,7 @@
   }
 
   .comet-content-inset {
+    --comet-content-width: calc(100vw - var(--sidebar-width));
     left: var(--sidebar-width);
   }
 
@@ -249,6 +250,8 @@
   }
 }
 
+// Table
+
 // workaround to force firefox work correctly with cell height - https://stackoverflow.com/questions/36575846/how-to-make-div-fill-td-height-in-firefox
 .comet-fix-cell-height {
   height: 1px;
@@ -257,6 +260,36 @@
 @-moz-document url-prefix() {
   .comet-fix-cell-height {
     height: 100%;
+  }
+}
+
+// rewrite padding for first cell for tables that takes full width with sticky behaviour
+.comet-sticky-table {
+  thead:before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: hsl(var(--border));
+    z-index: 10;
+  }
+
+  thead:after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: hsl(var(--border));
+    z-index: 10;
+  }
+
+  td:first-child [data-cell-wrapper="true"],
+  th:first-child [data-header-wrapper="true"] {
+    padding-left: 24px !important;
   }
 }
 


### PR DESCRIPTION
## Details
Added "sticky" functionality for the action buttons section and table headers in the next pages:
Projects->Traces Tab
Projects->LLM Calls Tab
Projects->Threads Tab
Projects->Online Evaluation Tab

![image](https://github.com/user-attachments/assets/f626aeee-b12f-4e64-8add-1ee8a509375b)
![image](https://github.com/user-attachments/assets/cde52606-2843-481e-9935-9a385d24088d)

## Issues

Resolves #

## Testing

## Documentation
