### PR TITLE
[OPIK-1266]: use workspaces instead of getTeams;

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -54,7 +54,7 @@ const UserMenu = () => {
   const { data: organizations, isLoading } = useOrganizations({
     enabled: !!user?.loggedIn,
   });
-  const { data: userWorkspaces } = useUserInvitedWorkspaces({
+  const { data: userInvitedWorkspaces } = useUserInvitedWorkspaces({
     enabled: !!user?.loggedIn,
   });
   const { data: allUserWorkspaces } = useAllUserWorkspaces({
@@ -80,7 +80,7 @@ const UserMenu = () => {
     !organizations ||
     !userPermissions ||
     !allUserWorkspaces ||
-    !userWorkspaces
+    !userInvitedWorkspaces
   ) {
     return null;
   }
@@ -97,7 +97,7 @@ const UserMenu = () => {
     return org.id === workspace?.organizationId;
   });
 
-  const organizationUserWorkspaces = userWorkspaces.filter(
+  const organizationUserWorkspaces = userInvitedWorkspaces.filter(
     (workspace) => workspace.organizationId === organization?.id,
   );
 

--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -43,7 +43,7 @@ import useOrganizations from "./useOrganizations";
 import useUser from "./useUser";
 import useUserPermissions from "./useUserPermissions";
 import { buildUrl } from "./utils";
-import useUserWorkspaces from "@/plugins/comet/useUserInvitedWorkspaces";
+import useUserInvitedWorkspaces from "@/plugins/comet/useUserInvitedWorkspaces";
 
 const UserMenu = () => {
   const navigate = useNavigate();
@@ -54,7 +54,7 @@ const UserMenu = () => {
   const { data: organizations, isLoading } = useOrganizations({
     enabled: !!user?.loggedIn,
   });
-  const { data: userWorkspaces } = useUserWorkspaces({
+  const { data: userWorkspaces } = useUserInvitedWorkspaces({
     enabled: !!user?.loggedIn,
   });
   const { data: allUserWorkspaces } = useAllUserWorkspaces({

--- a/apps/opik-frontend/src/plugins/comet/WorkspacePreloader.tsx
+++ b/apps/opik-frontend/src/plugins/comet/WorkspacePreloader.tsx
@@ -26,7 +26,7 @@ const WorkspacePreloader: React.FunctionComponent<WorkspacePreloaderProps> = ({
   children,
 }) => {
   const { data: user, isLoading } = useUser();
-  const { data: workspaces } = useAllUserWorkspaces({
+  const { data: allWorkspaces } = useAllUserWorkspaces({
     enabled: !!user?.loggedIn,
   });
   const matchRoute = useMatchRoute();
@@ -50,12 +50,12 @@ const WorkspacePreloader: React.FunctionComponent<WorkspacePreloaderProps> = ({
     return null;
   }
 
-  if (!workspaces) {
+  if (!allWorkspaces) {
     return <Loader />;
   }
 
   const workspace = workspaceNameFromURL
-    ? workspaces.find(
+    ? allWorkspaces.find(
         (workspace) => workspace.workspaceName === workspaceNameFromURL,
       )
     : null;
@@ -63,7 +63,9 @@ const WorkspacePreloader: React.FunctionComponent<WorkspacePreloaderProps> = ({
   if (workspace) {
     useAppStore.getState().setActiveWorkspaceName(workspace.workspaceName);
   } else {
-    const defaultWorkspace = workspaces.find((workspace) => workspace.default);
+    const defaultWorkspace = allWorkspaces.find(
+      (workspace) => workspace.default,
+    );
 
     if (defaultWorkspace) {
       if (isRootPath) {

--- a/apps/opik-frontend/src/plugins/comet/types.ts
+++ b/apps/opik-frontend/src/plugins/comet/types.ts
@@ -2,7 +2,6 @@ export interface User {
   apiKeys: string[];
   defaultWorkspace: string;
   email: string;
-  getTeams: GetTeams;
   gitHub: boolean;
   loggedIn: boolean;
   orgReachedTraceLimit?: boolean;

--- a/apps/opik-frontend/src/plugins/comet/useUserInvitedWorkspaces.ts
+++ b/apps/opik-frontend/src/plugins/comet/useUserInvitedWorkspaces.ts
@@ -1,7 +1,6 @@
 import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import api, { QueryConfig } from "./api";
-import { ORGANIZATION_ROLE_TYPE, Workspace } from "./types";
-import useOrganizations from "@/plugins/comet/useOrganizations";
+import { Workspace } from "./types";
 
 const getUserInvitedWorkspaces = async ({ signal }: QueryFunctionContext) => {
   return await api
@@ -16,18 +15,9 @@ const getUserInvitedWorkspaces = async ({ signal }: QueryFunctionContext) => {
 export default function useUserInvitedWorkspaces(
   options?: QueryConfig<Workspace[]>,
 ) {
-  const { data: organizations } = useOrganizations({
-    enabled: options?.enabled,
-  });
-
-  const organizationIds = organizations
-    ?.filter((organization) => {
-      return organization.role === ORGANIZATION_ROLE_TYPE.admin;
-    })
-    .map((organization) => organization.id);
-
   return useQuery({
-    queryKey: ["user-invited-workspaces", { organizationIds }],
+    // enabled: true is needed just to overcome the eslint requirement to have parameters
+    queryKey: ["user-invited-workspaces", { enabled: true }],
     queryFn: (context) => getUserInvitedWorkspaces(context),
     ...options,
     enabled: Boolean(options?.enabled),

--- a/apps/opik-frontend/src/plugins/comet/useUserInvitedWorkspaces.ts
+++ b/apps/opik-frontend/src/plugins/comet/useUserInvitedWorkspaces.ts
@@ -1,6 +1,7 @@
 import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import api, { QueryConfig } from "./api";
-import { Workspace } from "./types";
+import { ORGANIZATION_ROLE_TYPE, Workspace } from "./types";
+import useOrganizations from "@/plugins/comet/useOrganizations";
 
 const getUserInvitedWorkspaces = async ({ signal }: QueryFunctionContext) => {
   return await api
@@ -15,8 +16,18 @@ const getUserInvitedWorkspaces = async ({ signal }: QueryFunctionContext) => {
 export default function useUserInvitedWorkspaces(
   options?: QueryConfig<Workspace[]>,
 ) {
+  const { data: organizations } = useOrganizations({
+    enabled: options?.enabled,
+  });
+
+  const organizationIds = organizations
+    ?.filter((organization) => {
+      return organization.role === ORGANIZATION_ROLE_TYPE.admin;
+    })
+    .map((organization) => organization.id);
+
   return useQuery({
-    queryKey: ["user-invited-workspaces"],
+    queryKey: ["user-invited-workspaces", { organizationIds }],
     queryFn: (context) => getUserInvitedWorkspaces(context),
     ...options,
     enabled: Boolean(options?.enabled),

--- a/apps/opik-frontend/src/plugins/comet/useUserInvitedWorkspaces.ts
+++ b/apps/opik-frontend/src/plugins/comet/useUserInvitedWorkspaces.ts
@@ -16,7 +16,7 @@ export default function useUserInvitedWorkspaces(
   options?: QueryConfig<Workspace[]>,
 ) {
   return useQuery({
-    queryKey: ["user-workspaces"],
+    queryKey: ["user-invited-workspaces"],
     queryFn: (context) => getUserInvitedWorkspaces(context),
     ...options,
     enabled: Boolean(options?.enabled),

--- a/apps/opik-frontend/src/plugins/comet/useUserInvitedWorkspaces.ts
+++ b/apps/opik-frontend/src/plugins/comet/useUserInvitedWorkspaces.ts
@@ -1,0 +1,24 @@
+import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
+import api, { QueryConfig } from "./api";
+import { Workspace } from "./types";
+
+const getUserInvitedWorkspaces = async ({ signal }: QueryFunctionContext) => {
+  return await api
+    .get<Workspace[]>(`/workspaces`, {
+      signal,
+      params: { withoutExtendedData: true },
+    })
+    .then(({ data }) => data);
+};
+
+// workspaces to which a user has been invited
+export default function useUserInvitedWorkspaces(
+  options?: QueryConfig<Workspace[]>,
+) {
+  return useQuery({
+    queryKey: ["user-workspaces"],
+    queryFn: (context) => getUserInvitedWorkspaces(context),
+    ...options,
+    enabled: Boolean(options?.enabled),
+  });
+}


### PR DESCRIPTION
## Details
The issue is that in the EM we have removed `getTeams` from the `auth` endpoint to get it more optimal. Now, we have to rely on a `/workspace` endpoint. What I did was I split the logic of loading workspaces into 2: with the change, there are workspaces a user has been invited to and all accessible to a user. We should release it before EM.


## Issues

Resolves #

## Testing

## Documentation
