### PR TITLE
[OPIK-1252] [FE] No bottom border on pinned columns

### DIFF
--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
@@ -263,8 +263,8 @@ const ExperimentsPage: React.FunctionComponent = () => {
   }, []);
 
   const renderCustomRowCallback = useCallback(
-    (row: Row<GroupedExperiment>) => {
-      return renderCustomRow(row, setGroupLimit);
+    (row: Row<GroupedExperiment>, applyStickyWorkaround?: boolean) => {
+      return renderCustomRow(row, setGroupLimit, applyStickyWorkaround);
     },
     [setGroupLimit],
   );

--- a/apps/opik-frontend/src/components/pages/ExperimentsShared/table.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsShared/table.tsx
@@ -177,6 +177,7 @@ export const generateGroupedCellDef = <TData, TValue>(
 export const renderCustomRow = (
   row: Row<GroupedExperiment>,
   setGroupLimit: OnChangeFn<Record<string, number>>,
+  applyStickyWorkaround?: boolean,
 ) => {
   if (row.getIsGrouped()) {
     const cells = row.getVisibleCells();
@@ -191,7 +192,11 @@ export const renderCustomRow = (
           key={cell.id}
           data-cell-id={cell.id}
           style={{
-            ...getCommonPinningStyles(cell.column),
+            ...getCommonPinningStyles(
+              cell.column,
+              false,
+              applyStickyWorkaround,
+            ),
             left: "0",
             boxShadow: undefined,
           }}

--- a/apps/opik-frontend/src/components/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
@@ -260,8 +260,8 @@ const ExperimentsTab: React.FC<ExperimentsTabProps> = ({ promptId }) => {
   });
 
   const renderCustomRowCallback = useCallback(
-    (row: Row<GroupedExperiment>) => {
-      return renderCustomRow(row, setGroupLimit);
+    (row: Row<GroupedExperiment>, applyStickyWorkaround?: boolean) => {
+      return renderCustomRow(row, setGroupLimit, applyStickyWorkaround);
     },
     [setGroupLimit],
   );

--- a/apps/opik-frontend/src/components/shared/DataTable/utils.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTable/utils.tsx
@@ -28,6 +28,7 @@ export const calculateHeightStyle = (rowHeight: ROW_HEIGHT) => {
 export const getCommonPinningStyles = <TData,>(
   column: Column<TData>,
   isHeader: boolean = false,
+  applyStickyWorkaround = false,
 ): CSSProperties => {
   const isPinned = column.getIsPinned();
   const isLastLeftPinnedColumn =
@@ -44,7 +45,7 @@ export const getCommonPinningStyles = <TData,>(
     left: isPinned === "left" ? `${column.getStart("left")}px` : undefined,
     right: isPinned === "right" ? `${column.getAfter("right")}px` : undefined,
     ...(isPinned && {
-      position: "sticky",
+      position: applyStickyWorkaround ? "unset" : "sticky",
       zIndex: isHeader ? TABLE_HEADER_Z_INDEX + 1 : TABLE_ROW_Z_INDEX + 1,
     }),
   };


### PR DESCRIPTION
## Details
 In the version of Chrome Version 134.0.6998.89 (Official Build) (arm64)
 was introduced an issue that the border (from row) for sticky cells is not presented on some displays
 this workaround checks if the table can be scrolled and only then allows the library to set the  position sticky for cells
 
## Issues

Resolves #

## Testing

## Documentation
