### PR TITLE
[OPIK-1266]: fix the bug with the workspaces where a user is not an admin;

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -38,11 +38,12 @@ import { buildDocsUrl, cn, maskAPIKey } from "@/lib/utils";
 import useAppStore from "@/store/AppStore";
 import api from "./api";
 import { Organization, ORGANIZATION_ROLE_TYPE } from "./types";
-import useAllUserWorkspaces from "./useAllUserWorkspaces";
 import useOrganizations from "./useOrganizations";
 import useUser from "./useUser";
 import useUserPermissions from "./useUserPermissions";
 import { buildUrl } from "./utils";
+
+import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
 import useUserInvitedWorkspaces from "@/plugins/comet/useUserInvitedWorkspaces";
 
 const UserMenu = () => {
@@ -54,14 +55,16 @@ const UserMenu = () => {
   const { data: organizations, isLoading } = useOrganizations({
     enabled: !!user?.loggedIn,
   });
+
   const { data: userInvitedWorkspaces } = useUserInvitedWorkspaces({
     enabled: !!user?.loggedIn,
   });
-  const { data: allUserWorkspaces } = useAllUserWorkspaces({
+
+  const { data: allWorkspaces } = useAllWorkspaces({
     enabled: !!user?.loggedIn,
   });
 
-  const workspace = allUserWorkspaces?.find(
+  const workspace = allWorkspaces?.find(
     (workspace) => workspace.workspaceName === workspaceName,
   );
 
@@ -79,7 +82,7 @@ const UserMenu = () => {
     isLoading ||
     !organizations ||
     !userPermissions ||
-    !allUserWorkspaces ||
+    !allWorkspaces ||
     !userInvitedWorkspaces
   ) {
     return null;
@@ -97,8 +100,12 @@ const UserMenu = () => {
     return org.id === workspace?.organizationId;
   });
 
-  const organizationUserWorkspaces = userInvitedWorkspaces.filter(
-    (workspace) => workspace.organizationId === organization?.id,
+  const organizationUserWorkspaces = allWorkspaces.filter(
+    (workspace) =>
+      workspace.organizationId === organization?.id &&
+      !!userInvitedWorkspaces.find(
+        (w) => w.workspaceId === workspace?.workspaceId,
+      ),
   );
 
   const isOrganizationAdmin =
@@ -113,7 +120,7 @@ const UserMenu = () => {
     isOrganizationAdmin || invitePermission?.permissionValue === "true";
 
   const handleChangeOrganization = (newOrganization: Organization) => {
-    const newOrganizationWorkspaces = allUserWorkspaces.filter(
+    const newOrganizationWorkspaces = allWorkspaces.filter(
       (workspace) => workspace.organizationId === newOrganization.id,
     );
 

--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -100,12 +100,8 @@ const UserMenu = () => {
     return org.id === workspace?.organizationId;
   });
 
-  const organizationUserWorkspaces = allWorkspaces.filter(
-    (workspace) =>
-      workspace.organizationId === organization?.id &&
-      !!userInvitedWorkspaces.find(
-        (w) => w.workspaceId === workspace?.workspaceId,
-      ),
+  const organizationUserWorkspaces = userInvitedWorkspaces.filter(
+    (workspace) => workspace.organizationId === organization?.id,
   );
 
   const isOrganizationAdmin =

--- a/apps/opik-frontend/src/plugins/comet/WorkspacePreloader.tsx
+++ b/apps/opik-frontend/src/plugins/comet/WorkspacePreloader.tsx
@@ -14,9 +14,9 @@ import { DEFAULT_WORKSPACE_NAME } from "@/constants/user";
 import useAppStore from "@/store/AppStore";
 import useSegment from "./analytics/useSegment";
 import Logo from "./Logo";
-import useAllUserWorkspaces from "./useAllUserWorkspaces";
 import useUser from "./useUser";
 import { buildUrl } from "./utils";
+import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
 
 type WorkspacePreloaderProps = {
   children: React.ReactNode;
@@ -26,9 +26,11 @@ const WorkspacePreloader: React.FunctionComponent<WorkspacePreloaderProps> = ({
   children,
 }) => {
   const { data: user, isLoading } = useUser();
-  const { data: allWorkspaces } = useAllUserWorkspaces({
+
+  const { data: allWorkspaces } = useAllWorkspaces({
     enabled: !!user?.loggedIn,
   });
+
   const matchRoute = useMatchRoute();
   const workspaceNameFromURL = useParams({
     strict: false,

--- a/apps/opik-frontend/src/plugins/comet/useAdminOrganizationWorkspaces.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAdminOrganizationWorkspaces.ts
@@ -35,7 +35,7 @@ export default function useAdminOrganizationWorkspaces(
     .map((organization) => organization.id);
 
   return useQuery({
-    queryKey: ["all-user-workspaces", { organizationIds }],
+    queryKey: ["user-admin-organization-workspaces", { organizationIds }],
     queryFn: (context) =>
       getAllUserWorkspaces(context, {
         organizationIds,

--- a/apps/opik-frontend/src/plugins/comet/useAdminOrganizationWorkspaces.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAdminOrganizationWorkspaces.ts
@@ -19,7 +19,8 @@ const getAllUserWorkspaces = async (
   return (await Promise.all(workspacesPromises || [])).flat();
 };
 
-// the workspaces of all organizations that a user has access to
+// the workspaces of all organizations where a user is admin
+// we can't take all organizations because it throws 403 error
 export default function useAdminOrganizationWorkspaces(
   options?: QueryConfig<Workspace[]>,
 ) {

--- a/apps/opik-frontend/src/plugins/comet/useAdminOrganizationWorkspaces.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAdminOrganizationWorkspaces.ts
@@ -20,12 +20,13 @@ const getAllUserWorkspaces = async (
 };
 
 // the workspaces of all organizations that a user has access to
-export default function useAllUserWorkspaces(
+export default function useAdminOrganizationWorkspaces(
   options?: QueryConfig<Workspace[]>,
 ) {
   const { data: organizations } = useOrganizations({
     enabled: options?.enabled,
   });
+
   const organizationIds = organizations
     ?.filter((organization) => {
       return organization.role === ORGANIZATION_ROLE_TYPE.admin;
@@ -34,7 +35,10 @@ export default function useAllUserWorkspaces(
 
   return useQuery({
     queryKey: ["all-user-workspaces", { organizationIds }],
-    queryFn: (context) => getAllUserWorkspaces(context, { organizationIds }),
+    queryFn: (context) =>
+      getAllUserWorkspaces(context, {
+        organizationIds,
+      }),
     ...options,
     enabled: options?.enabled && !!organizations,
   });

--- a/apps/opik-frontend/src/plugins/comet/useAllWorkspaces.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAllWorkspaces.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import { QueryConfig } from "./api";
+import { Workspace } from "./types";
+import { uniqBy } from "lodash";
+import useUserInvitedWorkspaces from "@/plugins/comet/useUserInvitedWorkspaces";
+import useAdminOrganizationWorkspaces from "@/plugins/comet/useAdminOrganizationWorkspaces";
+
+// all workspaces of organizations
+export default function useAllWorkspaces(options?: QueryConfig<Workspace[]>) {
+  const { data: userInvitedWorkspaces } = useUserInvitedWorkspaces(options);
+  const { data: allUserWorkspaces } = useAdminOrganizationWorkspaces(options);
+
+  return useQuery({
+    queryKey: ["user-workspaces", { enabled: true }],
+    queryFn: async () => {
+      return !allUserWorkspaces || !userInvitedWorkspaces
+        ? undefined
+        : uniqBy(
+            [...allUserWorkspaces, ...userInvitedWorkspaces],
+            "workspaceId",
+          );
+    },
+    enabled: !!allUserWorkspaces && !!userInvitedWorkspaces,
+  });
+}

--- a/apps/opik-frontend/src/plugins/comet/useAllWorkspaces.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAllWorkspaces.ts
@@ -11,7 +11,7 @@ export default function useAllWorkspaces(options?: QueryConfig<Workspace[]>) {
   const { data: allUserWorkspaces } = useAdminOrganizationWorkspaces(options);
 
   return useQuery({
-    queryKey: ["user-workspaces", { enabled: true }],
+    queryKey: ["all-user-workspaces", { enabled: true }],
     queryFn: async () => {
       return !allUserWorkspaces || !userInvitedWorkspaces
         ? undefined

--- a/apps/opik-frontend/src/plugins/comet/useUserInvitedWorkspaces.ts
+++ b/apps/opik-frontend/src/plugins/comet/useUserInvitedWorkspaces.ts
@@ -3,12 +3,12 @@ import api, { QueryConfig } from "./api";
 import { Workspace } from "./types";
 
 const getUserInvitedWorkspaces = async ({ signal }: QueryFunctionContext) => {
-  const workspaces = await api.get<Workspace[]>(`/workspaces`, {
+  const response = await api.get<Workspace[]>(`/workspaces`, {
     signal,
     params: { withoutExtendedData: true },
   });
 
-  return workspaces.data;
+  return response.data;
 };
 
 // workspaces to which a user has been invited

--- a/apps/opik-frontend/src/plugins/comet/useUserInvitedWorkspaces.ts
+++ b/apps/opik-frontend/src/plugins/comet/useUserInvitedWorkspaces.ts
@@ -3,12 +3,12 @@ import api, { QueryConfig } from "./api";
 import { Workspace } from "./types";
 
 const getUserInvitedWorkspaces = async ({ signal }: QueryFunctionContext) => {
-  return await api
-    .get<Workspace[]>(`/workspaces`, {
-      signal,
-      params: { withoutExtendedData: true },
-    })
-    .then(({ data }) => data);
+  const workspaces = await api.get<Workspace[]>(`/workspaces`, {
+    signal,
+    params: { withoutExtendedData: true },
+  });
+
+  return workspaces.data;
 };
 
 // workspaces to which a user has been invited


### PR DESCRIPTION


## Details
the probem is that we can't get access to all potential workspaces of a user. if they are not an admin of an org, it is not possible to get the list of all org workspaces, so we need to show all workapces as the combination of `all to which a user has been invited` + `all workspaces where a user is an admin`

## Issues

Resolves #

## Testing

## Documentation
