### PR TITLE
Migrate span data and trace data to pydantic

### DIFF
--- a/sdks/python/src/opik/__init__.py
+++ b/sdks/python/src/opik/__init__.py
@@ -1,4 +1,5 @@
-from . import _logging, environment, error_tracking, package_version
+from . import _logging, environment, package_version
+from . import error_tracking
 from .api_objects.dataset import Dataset
 from .api_objects.experiment.experiment_item import (
     ExperimentItemContent,

--- a/sdks/python/src/opik/api_objects/observation_data.py
+++ b/sdks/python/src/opik/api_objects/observation_data.py
@@ -10,10 +10,13 @@ from opik.types import ErrorInfoDict, FeedbackScoreDict
 
 LOGGER = logging.getLogger(__name__)
 
+
 class ObservationData(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra="allow", validate_default=False)
 
-    id: pydantic.SkipValidation[str] = pydantic.Field(default_factory=id_helpers.generate_id)
+    id: pydantic.SkipValidation[str] = pydantic.Field(
+        default_factory=id_helpers.generate_id
+    )
     name: Optional[str] = None
     start_time: Optional[datetime.datetime] = pydantic.Field(
         default_factory=datetime_helpers.local_timestamp

--- a/sdks/python/src/opik/api_objects/observation_data.py
+++ b/sdks/python/src/opik/api_objects/observation_data.py
@@ -1,0 +1,76 @@
+import datetime
+import logging
+from typing import Any, Dict, Optional, List
+
+import pydantic
+
+from opik import datetime_helpers, id_helpers, dict_utils
+from opik.types import ErrorInfoDict, FeedbackScoreDict
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ObservationData(pydantic.BaseModel):
+    id: str = pydantic.Field(default_factory=id_helpers.generate_id)
+    name: Optional[str] = None
+    start_time: Optional[datetime.datetime] = pydantic.Field(
+        default_factory=datetime_helpers.local_timestamp
+    )
+    end_time: Optional[datetime.datetime] = None
+    metadata: Optional[Dict[str, Any]] = None
+    input: Optional[Dict[str, Any]] = None
+    output: Optional[Dict[str, Any]] = None
+    tags: Optional[List[str]] = None
+    feedback_scores: Optional[List[FeedbackScoreDict]] = None
+    project_name: Optional[str] = None
+    error_info: Optional[ErrorInfoDict] = None
+
+    def update(self, **new_data: Any) -> "ObservationData":
+        for key, value in new_data.items():
+            if value is None:
+                continue
+
+            if key not in self.__dict__:
+                LOGGER.debug(
+                    "An attempt to update span with parameter name it doesn't have: %s",
+                    key,
+                )
+                continue
+
+            if key == "metadata":
+                self._update_metadata(value)
+                continue
+            elif key == "output":
+                self._update_output(value)
+                continue
+            elif key == "input":
+                self._update_input(value)
+                continue
+
+            self.__dict__[key] = value
+
+        return self
+
+    def _update_metadata(self, new_metadata: Dict[str, Any]) -> None:
+        if self.metadata is None:
+            self.metadata = new_metadata
+        else:
+            self.metadata = dict_utils.deepmerge(self.metadata, new_metadata)
+
+    def _update_output(self, new_output: Dict[str, Any]) -> None:
+        if self.output is None:
+            self.output = new_output
+        else:
+            self.output = dict_utils.deepmerge(self.output, new_output)
+
+    def _update_input(self, new_input: Dict[str, Any]) -> None:
+        if self.input is None:
+            self.input = new_input
+        else:
+            self.input = dict_utils.deepmerge(self.input, new_input)
+
+    def init_end_time(self) -> "ObservationData":
+        self.end_time = datetime_helpers.local_timestamp()
+
+        return self

--- a/sdks/python/src/opik/api_objects/observation_data.py
+++ b/sdks/python/src/opik/api_objects/observation_data.py
@@ -10,9 +10,10 @@ from opik.types import ErrorInfoDict, FeedbackScoreDict
 
 LOGGER = logging.getLogger(__name__)
 
-
 class ObservationData(pydantic.BaseModel):
-    id: str = pydantic.Field(default_factory=id_helpers.generate_id)
+    model_config = pydantic.ConfigDict(extra="allow", validate_default=False)
+
+    id: pydantic.SkipValidation[str] = pydantic.Field(default_factory=id_helpers.generate_id)
     name: Optional[str] = None
     start_time: Optional[datetime.datetime] = pydantic.Field(
         default_factory=datetime_helpers.local_timestamp

--- a/sdks/python/src/opik/api_objects/span/span_client.py
+++ b/sdks/python/src/opik/api_objects/span/span_client.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+
 from typing import Any, Dict, List, Optional, Union
 
 from opik import datetime_helpers, id_helpers, llm_usage

--- a/sdks/python/src/opik/api_objects/span/span_data.py
+++ b/sdks/python/src/opik/api_objects/span/span_data.py
@@ -1,100 +1,32 @@
-import dataclasses
-import datetime
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional, Union
 
-from opik import datetime_helpers, dict_utils, llm_usage
+from opik import llm_usage
 from opik.types import (
-    ErrorInfoDict,
-    FeedbackScoreDict,
     LLMProvider,
     SpanType,
 )
 
-from .. import helpers
+from .. import observation_data
 
 LOGGER = logging.getLogger(__name__)
 
 
-# Engineer note:
-#
-# After moving to minimal python version 3.10, a lot of common content
-# from SpanData and TraceData can be moved to ObservationData parent dataclass.
-# Before that it's impossible because of the dataclasses limitation to have optional arguments
-# strictly after positional ones (including the attributes from the parent class).
-# In python 3.10 @dataclass(kw_only=True) should help.
-@dataclasses.dataclass
-class SpanData:
+class SpanData(observation_data.ObservationData):
     """
     The SpanData object is returned when calling :func:`opik.opik_context.get_current_span_data` from a tracked function.
     """
 
     trace_id: str
-    id: str = dataclasses.field(default_factory=helpers.generate_id)
     parent_span_id: Optional[str] = None
-    name: Optional[str] = None
     type: SpanType = "general"
-    start_time: Optional[datetime.datetime] = dataclasses.field(
-        default_factory=datetime_helpers.local_timestamp
-    )
-    end_time: Optional[datetime.datetime] = None
-    metadata: Optional[Dict[str, Any]] = None
-    input: Optional[Dict[str, Any]] = None
-    output: Optional[Dict[str, Any]] = None
-    tags: Optional[List[str]] = None
     usage: Optional[Union[Dict[str, Any], llm_usage.OpikUsage]] = None
-    feedback_scores: Optional[List[FeedbackScoreDict]] = None
-    project_name: Optional[str] = None
     model: Optional[str] = None
     provider: Optional[Union[str, LLMProvider]] = None
-    error_info: Optional[ErrorInfoDict] = None
     total_cost: Optional[float] = None
 
     def update(self, **new_data: Any) -> "SpanData":
-        for key, value in new_data.items():
-            if value is None:
-                continue
-
-            if key not in self.__dict__:
-                LOGGER.debug(
-                    "An attempt to update span with parameter name it doesn't have: %s",
-                    key,
-                )
-                continue
-
-            if key == "metadata":
-                self._update_metadata(value)
-                continue
-            elif key == "output":
-                self._update_output(value)
-                continue
-            elif key == "input":
-                self._update_input(value)
-                continue
-
-            self.__dict__[key] = value
-
-        return self
-
-    def _update_metadata(self, new_metadata: Dict[str, Any]) -> None:
-        if self.metadata is None:
-            self.metadata = new_metadata
-        else:
-            self.metadata = dict_utils.deepmerge(self.metadata, new_metadata)
-
-    def _update_output(self, new_output: Dict[str, Any]) -> None:
-        if self.output is None:
-            self.output = new_output
-        else:
-            self.output = dict_utils.deepmerge(self.output, new_output)
-
-    def _update_input(self, new_input: Dict[str, Any]) -> None:
-        if self.input is None:
-            self.input = new_input
-        else:
-            self.input = dict_utils.deepmerge(self.input, new_input)
+        return super().update(**new_data)
 
     def init_end_time(self) -> "SpanData":
-        self.end_time = datetime_helpers.local_timestamp()
-
-        return self
+        return super().init_end_time()

--- a/sdks/python/src/opik/api_objects/trace/trace_data.py
+++ b/sdks/python/src/opik/api_objects/trace/trace_data.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Any, Optional
 
+from opik.types import CreatedByType
+
 from .. import observation_data
 
 LOGGER = logging.getLogger(__name__)
@@ -12,6 +14,7 @@ class TraceData(observation_data.ObservationData):
     """
 
     thread_id: Optional[str] = None
+    created_by: Optional[CreatedByType] = None
 
     def update(self, **new_data: Any) -> "TraceData":
         return super().update(**new_data)

--- a/sdks/python/src/opik/api_objects/trace/trace_data.py
+++ b/sdks/python/src/opik/api_objects/trace/trace_data.py
@@ -1,93 +1,20 @@
-import dataclasses
-import datetime
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
-from opik import dict_utils
-
-from ... import datetime_helpers, id_helpers
-from ...types import (
-    CreatedByType,
-    ErrorInfoDict,
-    FeedbackScoreDict,
-)
+from .. import observation_data
 
 LOGGER = logging.getLogger(__name__)
 
 
-# Engineer note:
-#
-# After moving to minimal python version 3.10, a lot of common content
-# from SpanData and TraceData can be moved to ObservationData parent dataclass.
-# Before that it's impossible because of the dataclasses limitation to have optional arguments
-# strictly after positional ones (including the attributes from the parent class).
-# In python 3.10 @dataclass(kw_only=True) should help.
-@dataclasses.dataclass
-class TraceData:
+class TraceData(observation_data.ObservationData):
     """
     The TraceData object is returned when calling :func:`opik.opik_context.get_current_trace_data` from a tracked function.
     """
 
-    id: str = dataclasses.field(default_factory=id_helpers.generate_id)
-    name: Optional[str] = None
-    start_time: Optional[datetime.datetime] = dataclasses.field(
-        default_factory=datetime_helpers.local_timestamp
-    )
-    end_time: Optional[datetime.datetime] = None
-    metadata: Optional[Dict[str, Any]] = None
-    input: Optional[Dict[str, Any]] = None
-    output: Optional[Dict[str, Any]] = None
-    tags: Optional[List[str]] = None
-    feedback_scores: Optional[List[FeedbackScoreDict]] = None
-    project_name: Optional[str] = None
-    created_by: Optional[CreatedByType] = None
-    error_info: Optional[ErrorInfoDict] = None
     thread_id: Optional[str] = None
 
     def update(self, **new_data: Any) -> "TraceData":
-        for key, value in new_data.items():
-            if value is None:
-                continue
-
-            if key not in self.__dict__:
-                LOGGER.debug(
-                    "An attempt to update span with parameter name it doesn't have: %s",
-                    key,
-                )
-                continue
-
-            if key == "metadata":
-                self._update_metadata(value)
-                continue
-            elif key == "output":
-                self._update_output(value)
-                continue
-            elif key == "input":
-                self._update_input(value)
-                continue
-
-            self.__dict__[key] = value
-
-        return self
-
-    def _update_metadata(self, new_metadata: Dict[str, Any]) -> None:
-        if self.metadata is None:
-            self.metadata = new_metadata
-        else:
-            self.metadata = dict_utils.deepmerge(self.metadata, new_metadata)
-
-    def _update_output(self, new_output: Dict[str, Any]) -> None:
-        if self.output is None:
-            self.output = new_output
-        else:
-            self.output = dict_utils.deepmerge(self.output, new_output)
-
-    def _update_input(self, new_input: Dict[str, Any]) -> None:
-        if self.input is None:
-            self.input = new_input
-        else:
-            self.input = dict_utils.deepmerge(self.input, new_input)
+        return super().update(**new_data)
 
     def init_end_time(self) -> "TraceData":
-        self.end_time = datetime_helpers.local_timestamp()
-        return self
+        return super().init_end_time()


### PR DESCRIPTION
## Details
Internal improvement of SpanData and TraceData, pydantic models are used, common fields and logic are moved to the superclass.

No behavior changes expected, extra fields are enabled, fields validation is disabled.
It is possible now to not specify the id, and it will be generated automatically.
