### PR TITLE
[OPIK-1266]: change the logic of a default workspace when changing an organization;

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -116,7 +116,7 @@ const UserMenu = () => {
     isOrganizationAdmin || invitePermission?.permissionValue === "true";
 
   const handleChangeOrganization = (newOrganization: Organization) => {
-    const newOrganizationWorkspaces = allWorkspaces.filter(
+    const newOrganizationWorkspaces = userInvitedWorkspaces.filter(
       (workspace) => workspace.organizationId === newOrganization.id,
     );
 


### PR DESCRIPTION
## Details
it took the default workspace from the entire list before, now it takes the default from the ones that a user has been invited to

## Issues

Resolves #

## Testing

## Documentation
