### PR TITLE
[OPIK-1061] [FE] Add support for `is_empty` in the feedback scores

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/experiments/ExperimentsFeedbackScoresSelect/ExperimentsFeedbackScoresSelect.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/experiments/ExperimentsFeedbackScoresSelect/ExperimentsFeedbackScoresSelect.tsx
@@ -10,6 +10,7 @@ type ExperimentsFeedbackScoresSelectProps = {
   value: string;
   onValueChange: (value: string) => void;
   placeholder?: string;
+  className?: string;
 };
 
 const ExperimentsFeedbackScoresSelect: React.FC<
@@ -19,6 +20,7 @@ const ExperimentsFeedbackScoresSelect: React.FC<
   value,
   onValueChange,
   placeholder = "Select score",
+  className,
 }) => {
   const { data } = useExperimentsFeedbackScoresNames(
     {
@@ -42,6 +44,7 @@ const ExperimentsFeedbackScoresSelect: React.FC<
       onChange={onValueChange}
       options={options}
       placeholder={placeholder}
+      className={className}
     />
   );
 };

--- a/apps/opik-frontend/src/components/pages-shared/traces/TracesOrSpansFeedbackScoresSelect/TracesOrSpansFeedbackScoresSelect.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TracesOrSpansFeedbackScoresSelect/TracesOrSpansFeedbackScoresSelect.tsx
@@ -11,6 +11,7 @@ type TracesOrSpansFeedbackScoresSelectProps = {
   onValueChange: (value: string) => void;
   type?: TRACE_DATA_TYPE;
   placeholder?: string;
+  className?: string;
 };
 
 const TracesOrSpansFeedbackScoresSelect: React.FC<
@@ -21,6 +22,7 @@ const TracesOrSpansFeedbackScoresSelect: React.FC<
   onValueChange,
   type = TRACE_DATA_TYPE.traces,
   placeholder = "Select score",
+  className,
 }) => {
   const { data } = useTracesOrSpansScoresColumns(
     {
@@ -43,6 +45,7 @@ const TracesOrSpansFeedbackScoresSelect: React.FC<
       onChange={onValueChange}
       options={options}
       placeholder={placeholder}
+      className={className}
     />
   );
 };

--- a/apps/opik-frontend/src/components/shared/FiltersButton/rows/DictionaryRow.tsx
+++ b/apps/opik-frontend/src/components/shared/FiltersButton/rows/DictionaryRow.tsx
@@ -4,6 +4,7 @@ import OperatorSelector from "@/components/shared/FiltersButton/OperatorSelector
 import DebounceInput from "@/components/shared/DebounceInput/DebounceInput";
 import { DEFAULT_OPERATORS, OPERATORS_MAP } from "@/constants/filters";
 import { COLUMN_TYPE } from "@/types/shared";
+import { cn } from "@/lib/utils";
 
 export type DictionaryRowConfig = {
   keyComponent: React.FC<unknown> & {
@@ -28,44 +29,55 @@ export const DictionaryRow: React.FunctionComponent<DictionaryRowProps> = ({
   const type: "string" | "number" =
     filter.type === COLUMN_TYPE.dictionary ? "string" : "number";
 
+  const noInput =
+    filter.operator === "is_empty" || filter.operator === "is_not_empty";
+
   const keyValueChangeHandler = (value: unknown) =>
     onChange({ ...filter, key: value as string });
 
   const KeyComponent = config?.keyComponent ?? DebounceInput;
 
+  const operatorSelector = (
+    <OperatorSelector
+      operator={filter.operator}
+      operators={OPERATORS_MAP[filter.type as COLUMN_TYPE] ?? DEFAULT_OPERATORS}
+      onSelect={(o) => onChange({ ...filter, operator: o })}
+    />
+  );
+
   return (
     <>
       <td className="flex gap-2 p-1">
         <KeyComponent
-          className="w-full min-w-32"
+          className="w-full min-w-32 max-w-[30vw]"
           placeholder="key"
           value={filter.key}
           onValueChange={keyValueChangeHandler}
           data-testid="filter-dictionary-key-input"
           {...(config?.keyComponentProps ?? {})}
         />
-        <div className="max-w-32">
-          <OperatorSelector
-            operator={filter.operator}
-            operators={
-              OPERATORS_MAP[filter.type as COLUMN_TYPE] ?? DEFAULT_OPERATORS
-            }
-            onSelect={(o) => onChange({ ...filter, operator: o })}
-          />
-        </div>
+        {!noInput && (
+          <div className={cn(noInput ? "min-w-48" : "max-w-32")}>
+            {operatorSelector}
+          </div>
+        )}
       </td>
       <td className="p-1">
-        <DebounceInput
-          className="w-full min-w-40"
-          placeholder="value"
-          value={filter.value}
-          onValueChange={(value) =>
-            onChange({ ...filter, value: value as string })
-          }
-          disabled={filter.operator === ""}
-          type={type}
-          data-testid="filter-dictionary-value-input"
-        />
+        {noInput ? (
+          operatorSelector
+        ) : (
+          <DebounceInput
+            className="w-full min-w-40"
+            placeholder="value"
+            value={filter.value}
+            onValueChange={(value) =>
+              onChange({ ...filter, value: value as string })
+            }
+            disabled={filter.operator === ""}
+            type={type}
+            data-testid="filter-dictionary-value-input"
+          />
+        )}
       </td>
     </>
   );

--- a/apps/opik-frontend/src/constants/filters.ts
+++ b/apps/opik-frontend/src/constants/filters.ts
@@ -175,5 +175,13 @@ export const OPERATORS_MAP: Record<
       label: "<=",
       value: "<=",
     },
+    {
+      label: "is empty",
+      value: "is_empty",
+    },
+    {
+      label: "is not empty",
+      value: "is_not_empty",
+    },
   ],
 };

--- a/apps/opik-frontend/src/lib/filters.ts
+++ b/apps/opik-frontend/src/lib/filters.ts
@@ -9,12 +9,18 @@ import {
 } from "@/lib/date";
 
 export const isFilterValid = (filter: Filter) => {
-  return (
-    (filter.type === COLUMN_TYPE.dictionary ||
+  const hasValue =
+    filter.value !== "" ||
+    filter.operator === "is_empty" ||
+    filter.operator === "is_not_empty";
+
+  const hasKey =
+    filter.type === COLUMN_TYPE.dictionary ||
     filter.type === COLUMN_TYPE.numberDictionary
       ? filter.key !== ""
-      : true) && filter.value !== ""
-  );
+      : true;
+
+  return hasValue && hasKey;
 };
 
 export const createEmptyFilter = () => {

--- a/apps/opik-frontend/src/types/filters.ts
+++ b/apps/opik-frontend/src/types/filters.ts
@@ -5,6 +5,8 @@ export type FilterOperator =
   | "not_contains"
   | "starts_with"
   | "ends_with"
+  | "is_empty"
+  | "is_not_empty"
   | "="
   | ">"
   | ">="


### PR DESCRIPTION
## Details
![image](https://github.com/user-attachments/assets/314fc02d-83ce-4779-94aa-ef26ce0434f2)
![image](https://github.com/user-attachments/assets/b5b0bde5-6985-4bf0-a0f6-a66b342bd8c8)

## Issues

Resolves #

## Testing

## Documentation
