### PR TITLE
[OPIK-974] Make table rows clickable while allowing for text selection

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/automations/RuleLogsCell.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/automations/RuleLogsCell.tsx
@@ -19,6 +19,7 @@ const RuleLogsCell = (context: CellContext<EvaluatorsRule, string>) => {
       className="items-center justify-end p-0"
     >
       <Link
+        onClick={(event) => event.stopPropagation()}
         to="/$workspaceName/automation-logs"
         params={{ workspaceName }}
         search={{

--- a/apps/opik-frontend/src/components/pages-shared/automations/RuleRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/automations/RuleRowActionsCell.tsx
@@ -58,7 +58,11 @@ const RuleRowActionsCell: React.FC<CellContext<EvaluatorsRule, unknown>> = (
             <MoreHorizontal className="size-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuContent
+          align="end"
+          className="w-52"
+          onClick={(event) => event.stopPropagation()}
+        >
           <DropdownMenuItem
             onClick={() => {
               setOpen(2);

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreValueCell.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreValueCell.tsx
@@ -19,7 +19,7 @@ const FeedbackScoreValueCell = (
       tableMetadata={context.table.options.meta}
       className="gap-1.5"
     >
-      <TooltipWrapper content={computedValue}>
+      <TooltipWrapper content={computedValue} stopClickPropagation>
         <span className="truncate direction-alternate">{computedValue}</span>
       </TooltipWrapper>
     </CellWrapper>

--- a/apps/opik-frontend/src/components/pages-shared/traces/UserComment/UserCommentHoverList.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/UserComment/UserCommentHoverList.tsx
@@ -48,6 +48,7 @@ const UserCommentHoverList: React.FC<UserCommentHoverListProps> = ({
       <HoverCardContent
         className="w-[320px] bg-popover-gray p-0"
         collisionPadding={24}
+        onClick={(event) => event.stopPropagation()}
       >
         <div
           className="relative size-full max-h-[40vh] max-w-[320px] overflow-auto p-1 pb-0"

--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -664,6 +664,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
       <DataTable
         columns={columns}
         data={rows}
+        onRowClick={handleRowClick}
         activeRowId={activeRowId ?? ""}
         resizeConfig={resizeConfig}
         selectionConfig={{

--- a/apps/opik-frontend/src/components/pages/ConfigurationPage/FeedbackDefinitionsTab/FeedbackDefinitionsRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/ConfigurationPage/FeedbackDefinitionsTab/FeedbackDefinitionsRowActionsCell.tsx
@@ -60,7 +60,11 @@ const FeedbackDefinitionsRowActionsCell: React.FunctionComponent<
             <MoreHorizontal className="size-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuContent
+          align="end"
+          className="w-52"
+          onClick={(event) => event.stopPropagation()}
+        >
           <DropdownMenuItem
             onClick={() => {
               setOpen(2);

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemRowActionsCell.tsx
@@ -58,7 +58,11 @@ export const DatasetItemRowActionsCell: React.FunctionComponent<
             <MoreHorizontal className="size-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuContent
+          align="end"
+          className="w-52"
+          onClick={(event) => event.stopPropagation()}
+        >
           <DropdownMenuItem
             onClick={() => {
               setOpen(1);

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
@@ -279,6 +279,7 @@ const DatasetItemsPage = () => {
       <DataTable
         columns={columns}
         data={rows}
+        onRowClick={handleRowClick}
         activeRowId={activeRowId ?? ""}
         resizeConfig={resizeConfig}
         selectionConfig={{

--- a/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetRowActionsCell.tsx
@@ -57,7 +57,11 @@ export const DatasetRowActionsCell: React.FunctionComponent<
             <MoreHorizontal className="size-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuContent
+          align="end"
+          className="w-52"
+          onClick={(event) => event.stopPropagation()}
+        >
           <DropdownMenuItem
             onClick={() => {
               setOpen(2);

--- a/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetsPage.tsx
@@ -180,14 +180,14 @@ const DatasetsPage: React.FunctionComponent = () => {
     resetDialogKeyRef.current = resetDialogKeyRef.current + 1;
   }, []);
 
-  const onDatasetCreated = useCallback(
-    (dataset: Dataset) => {
-      if (!dataset.id) return;
+  const handleRowClick = useCallback(
+    (row: Dataset) => {
+      if (!row.id) return;
 
       navigate({
         to: "/$workspaceName/datasets/$datasetId",
         params: {
-          datasetId: dataset.id,
+          datasetId: row.id,
           workspaceName,
         },
       });
@@ -230,6 +230,7 @@ const DatasetsPage: React.FunctionComponent = () => {
       <DataTable
         columns={columns}
         data={datasets}
+        onRowClick={handleRowClick}
         resizeConfig={resizeConfig}
         selectionConfig={{
           rowSelection,
@@ -260,7 +261,7 @@ const DatasetsPage: React.FunctionComponent = () => {
         key={resetDialogKeyRef.current}
         open={openDialog}
         setOpen={setOpenDialog}
-        onDatasetCreated={onDatasetCreated}
+        onDatasetCreated={handleRowClick}
       />
     </div>
   );

--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentRowActionsCell.tsx
@@ -51,7 +51,11 @@ const ExperimentRowActionsCell: React.FunctionComponent<
             <MoreHorizontal className="size-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuContent
+          align="end"
+          className="w-52"
+          onClick={(event) => event.stopPropagation()}
+        >
           <DropdownMenuItem
             onClick={() => {
               setOpen(true);

--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
@@ -6,6 +6,7 @@ import {
   Row,
   RowSelectionState,
 } from "@tanstack/react-table";
+import { useNavigate } from "@tanstack/react-router";
 import {
   JsonParam,
   NumberParam,
@@ -140,6 +141,7 @@ export const DEFAULT_SELECTED_COLUMNS: string[] = [
 
 const ExperimentsPage: React.FunctionComponent = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const navigate = useNavigate();
   const resetDialogKeyRef = useRef(0);
   const [openDialog, setOpenDialog] = useState<boolean>(false);
 
@@ -253,6 +255,22 @@ const ExperimentsPage: React.FunctionComponent = () => {
     [columnsWidth, setColumnsWidth],
   );
 
+  const handleRowClick = useCallback(
+    (row: GroupedExperiment) => {
+      navigate({
+        to: "/$workspaceName/experiments/$datasetId/compare",
+        params: {
+          datasetId: row.dataset_id,
+          workspaceName,
+        },
+        search: {
+          experiments: [row.id],
+        },
+      });
+    },
+    [navigate, workspaceName],
+  );
+
   const expandingConfig = useExpandingConfig({
     groupIds,
   });
@@ -326,6 +344,7 @@ const ExperimentsPage: React.FunctionComponent = () => {
       <DataTable
         columns={columns}
         data={experiments}
+        onRowClick={handleRowClick}
         renderCustomRow={renderCustomRowCallback}
         getIsCustomRow={getIsCustomRow}
         resizeConfig={resizeConfig}

--- a/apps/opik-frontend/src/components/pages/HomePage/EvaluationSection.tsx
+++ b/apps/opik-frontend/src/components/pages/HomePage/EvaluationSection.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useRef, useState } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
 import useLocalStorageState from "use-local-storage-state";
 import { ColumnPinningState } from "@tanstack/react-table";
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
 import get from "lodash/get";
 
@@ -89,6 +89,7 @@ export const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
 };
 
 const EvaluationSection: React.FunctionComponent = () => {
+  const navigate = useNavigate();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
 
   const resetDialogKeyRef = useRef(0);
@@ -113,6 +114,22 @@ const EvaluationSection: React.FunctionComponent = () => {
   >(COLUMNS_WIDTH_KEY, {
     defaultValue: {},
   });
+
+  const handleRowClick = useCallback(
+    (row: Experiment) => {
+      navigate({
+        to: "/$workspaceName/experiments/$datasetId/compare",
+        params: {
+          datasetId: row.dataset_id,
+          workspaceName,
+        },
+        search: {
+          experiments: [row.id],
+        },
+      });
+    },
+    [navigate, workspaceName],
+  );
 
   const resizeConfig = useMemo(
     () => ({
@@ -140,6 +157,7 @@ const EvaluationSection: React.FunctionComponent = () => {
       <DataTable
         columns={COLUMNS}
         data={experiments}
+        onRowClick={handleRowClick}
         resizeConfig={resizeConfig}
         columnPinning={DEFAULT_COLUMN_PINNING}
         noData={

--- a/apps/opik-frontend/src/components/pages/HomePage/ObservabilitySection.tsx
+++ b/apps/opik-frontend/src/components/pages/HomePage/ObservabilitySection.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useRef, useState } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
 import useLocalStorageState from "use-local-storage-state";
 import { ColumnPinningState } from "@tanstack/react-table";
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
 
 import DataTable from "@/components/shared/DataTable/DataTable";
@@ -79,6 +79,7 @@ export const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
 };
 
 const ObservabilitySection: React.FunctionComponent = () => {
+  const navigate = useNavigate();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
 
   const resetDialogKeyRef = useRef(0);
@@ -119,6 +120,19 @@ const ObservabilitySection: React.FunctionComponent = () => {
     [columnsWidth, setColumnsWidth],
   );
 
+  const handleRowClick = useCallback(
+    (row: ProjectWithStatistic) => {
+      navigate({
+        to: "/$workspaceName/projects/$projectId/traces",
+        params: {
+          projectId: row.id,
+          workspaceName,
+        },
+      });
+    },
+    [navigate, workspaceName],
+  );
+
   const handleNewProjectClick = useCallback(() => {
     setOpenDialog(true);
     resetDialogKeyRef.current = resetDialogKeyRef.current + 1;
@@ -136,6 +150,7 @@ const ObservabilitySection: React.FunctionComponent = () => {
       <DataTable
         columns={COLUMNS}
         data={projects}
+        onRowClick={handleRowClick}
         resizeConfig={resizeConfig}
         columnPinning={DEFAULT_COLUMN_PINNING}
         noData={

--- a/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectRowActionsCell.tsx
@@ -57,7 +57,11 @@ export const ProjectRowActionsCell: React.FC<CellContext<Project, unknown>> = (
             <MoreHorizontal className="size-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuContent
+          align="end"
+          className="w-52"
+          onClick={(event) => event.stopPropagation()}
+        >
           <DropdownMenuItem
             onClick={() => {
               setOpen(2);

--- a/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import {
   JsonParam,
   NumberParam,
@@ -182,6 +183,7 @@ export const DEFAULT_SORTING_COLUMNS: ColumnSort[] = [
 ];
 
 const ProjectsPage: React.FunctionComponent = () => {
+  const navigate = useNavigate();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
 
   const resetDialogKeyRef = useRef(0);
@@ -297,6 +299,19 @@ const ProjectsPage: React.FunctionComponent = () => {
     [columnsWidth, setColumnsWidth],
   );
 
+  const handleRowClick = useCallback(
+    (row: ProjectWithStatistic) => {
+      navigate({
+        to: "/$workspaceName/projects/$projectId/traces",
+        params: {
+          projectId: row.id,
+          workspaceName,
+        },
+      });
+    },
+    [navigate, workspaceName],
+  );
+
   const handleNewProjectClick = useCallback(() => {
     setOpenDialog(true);
     resetDialogKeyRef.current = resetDialogKeyRef.current + 1;
@@ -337,6 +352,7 @@ const ProjectsPage: React.FunctionComponent = () => {
       <DataTable
         columns={columns}
         data={projects}
+        onRowClick={handleRowClick}
         sortConfig={{
           enabled: true,
           sorting: sortedColumns,

--- a/apps/opik-frontend/src/components/pages/PromptsPage/PromptRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptsPage/PromptRowActionsCell.tsx
@@ -62,7 +62,11 @@ export const PromptRowActionsCell: React.FunctionComponent<
             <MoreHorizontal className="size-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuContent
+          align="end"
+          className="w-52"
+          onClick={(event) => event.stopPropagation()}
+        >
           <DropdownMenuItem
             onClick={() => {
               setOpen(EDIT_KEY);

--- a/apps/opik-frontend/src/components/pages/PromptsPage/PromptsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptsPage/PromptsPage.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+
 import DataTable from "@/components/shared/DataTable/DataTable";
 import DataTablePagination from "@/components/shared/DataTablePagination/DataTablePagination";
 import DataTableNoData from "@/components/shared/DataTableNoData/DataTableNoData";
@@ -80,6 +82,7 @@ export const DEFAULT_SELECTED_COLUMNS: string[] = [
 ];
 
 const PromptsPage: React.FunctionComponent = () => {
+  const navigate = useNavigate();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
 
   const resetDialogKeyRef = useRef(0);
@@ -166,6 +169,19 @@ const PromptsPage: React.FunctionComponent = () => {
     [columnsWidth, setColumnsWidth],
   );
 
+  const handleRowClick = useCallback(
+    (row: Prompt) => {
+      navigate({
+        to: "/$workspaceName/prompts/$promptId",
+        params: {
+          promptId: row.id,
+          workspaceName,
+        },
+      });
+    },
+    [navigate, workspaceName],
+  );
+
   const handleNewPromptClick = useCallback(() => {
     setOpenDialog(true);
     resetDialogKeyRef.current = resetDialogKeyRef.current + 1;
@@ -206,6 +222,7 @@ const PromptsPage: React.FunctionComponent = () => {
       <DataTable
         columns={columns}
         data={prompts}
+        onRowClick={handleRowClick}
         resizeConfig={resizeConfig}
         selectionConfig={{
           rowSelection,

--- a/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsTab.tsx
@@ -376,6 +376,7 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
       <DataTable
         columns={columns}
         data={rows}
+        onRowClick={handleRowClick}
         activeRowId={activeRowId ?? ""}
         resizeConfig={resizeConfig}
         selectionConfig={{

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
@@ -647,6 +647,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
         columns={columns}
         columnsStatistic={columnsStatistic}
         data={rows}
+        onRowClick={handleRowClick}
         activeRowId={activeRowId ?? ""}
         resizeConfig={resizeConfig}
         selectionConfig={{

--- a/apps/opik-frontend/src/components/shared/ColoredTag/ColoredTag.tsx
+++ b/apps/opik-frontend/src/components/shared/ColoredTag/ColoredTag.tsx
@@ -26,7 +26,7 @@ const ColoredTag: React.FunctionComponent<ColoredTagProps> = ({
       data-testid={testId}
       className={className}
     >
-      <TooltipWrapper content={label}>
+      <TooltipWrapper content={label} stopClickPropagation>
         <span>{label}</span>
       </TooltipWrapper>
     </Tag>

--- a/apps/opik-frontend/src/components/shared/ColoredTag/ColoredTagNew.tsx
+++ b/apps/opik-frontend/src/components/shared/ColoredTag/ColoredTagNew.tsx
@@ -44,7 +44,7 @@ const ColoredTagNew: React.FunctionComponent<ColoredTagNewProps> = ({
         className="grow-0 rounded-[2px] bg-[var(--bg-color)] p-1"
         style={{ "--bg-color": color } as React.CSSProperties}
       />
-      <TooltipWrapper content={label}>
+      <TooltipWrapper content={label} stopClickPropagation>
         <div className={cn(labelVariants({ size }))}>{label}</div>
       </TooltipWrapper>
     </div>

--- a/apps/opik-frontend/src/components/shared/DataTable/DataTable.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTable/DataTable.tsx
@@ -51,6 +51,7 @@ import {
   STICKY_DIRECTION,
 } from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
 import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
+import useCustomRowClick from "@/components/shared/DataTable/useCustomRowClick";
 
 declare module "@tanstack/react-table" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -108,6 +109,7 @@ interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   columnsStatistic?: ColumnsStatistic;
   data: TData[];
+  onRowClick?: (row: TData) => void;
   renderCustomRow?: (
     row: Row<TData>,
     stickyWorkaround?: boolean,
@@ -137,6 +139,7 @@ const DataTable = <TData, TValue>({
   columns,
   columnsStatistic,
   data,
+  onRowClick,
   renderCustomRow,
   getIsCustomRow = () => false,
   activeRowId,
@@ -156,6 +159,7 @@ const DataTable = <TData, TValue>({
   meta,
 }: DataTableProps<TData, TValue>) => {
   const isResizable = resizeConfig && resizeConfig.enabled;
+  const isRowClickable = isFunction(onRowClick);
 
   const table = useReactTable({
     data,
@@ -206,6 +210,9 @@ const DataTable = <TData, TValue>({
     },
   });
 
+  const { onClick } = useCustomRowClick<TData>({
+    onRowClick: onRowClick,
+  });
   const columnSizing = table.getState().columnSizing;
   const headers = table.getFlatHeaders();
 
@@ -250,6 +257,15 @@ const DataTable = <TData, TValue>({
         key={row.id}
         data-state={row.getIsSelected() && "selected"}
         data-row-active={row.id === activeRowId}
+        data-row-id={row.id}
+        className={cn({
+          "cursor-pointer": isRowClickable,
+        })}
+        {...(isRowClickable && !row.getIsGrouped()
+          ? {
+              onClick: (e) => onClick?.(e, row.original),
+            }
+          : {})}
       >
         {row.getVisibleCells().map((cell) => renderCell(row, cell))}
       </TableRow>

--- a/apps/opik-frontend/src/components/shared/DataTable/useCustomRowClick.ts
+++ b/apps/opik-frontend/src/components/shared/DataTable/useCustomRowClick.ts
@@ -1,0 +1,47 @@
+import React, { useCallback, useRef } from "react";
+import isFunction from "lodash/isFunction";
+
+const CLICK_RESET_TIMEOUT = 200;
+
+type UseCustomRowClickParams<TData> = {
+  onRowClick?: (row: TData) => void;
+};
+
+type UseCustomRowClickResponse<TData> = {
+  onClick?: (event: React.MouseEvent<HTMLElement>, data: TData) => void;
+};
+
+const useCustomRowClick = <TData>({
+  onRowClick,
+}: UseCustomRowClickParams<TData>): UseCustomRowClickResponse<TData> => {
+  const callbackTimeout = useRef<NodeJS.Timeout>();
+
+  const onClickHandler = useCallback(
+    (event: React.MouseEvent<HTMLElement>, data: TData) => {
+      if (callbackTimeout.current) {
+        clearTimeout(callbackTimeout.current);
+      }
+
+      const selection = window.getSelection();
+      const hasSelection =
+        selection &&
+        selection.toString().length > 0 &&
+        selection.containsNode(event.target as Node, true);
+
+      if (isFunction(onRowClick) && data && !hasSelection) {
+        callbackTimeout.current = setTimeout(() => {
+          onRowClick(data);
+        }, CLICK_RESET_TIMEOUT);
+      }
+    },
+    [onRowClick],
+  );
+
+  return isFunction(onRowClick)
+    ? {
+        onClick: onClickHandler,
+      }
+    : {};
+};
+
+export default useCustomRowClick;

--- a/apps/opik-frontend/src/components/shared/DataTableCells/CellTooltipWrapper.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableCells/CellTooltipWrapper.tsx
@@ -15,7 +15,9 @@ const CellTooltipWrapper: React.FC<CellTooltipWrapperProps> = ({
   const showTooltip =
     content && content !== "-" && content.length > MIN_CHARACTERS_FOR_TOOLTIP;
   return showTooltip ? (
-    <TooltipWrapper content={content}>{children}</TooltipWrapper>
+    <TooltipWrapper content={content} stopClickPropagation>
+      {children}
+    </TooltipWrapper>
   ) : (
     children
   );

--- a/apps/opik-frontend/src/components/shared/DataTableCells/CodeCell.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableCells/CodeCell.tsx
@@ -26,7 +26,10 @@ const CodeCell = (context: CellContext<unknown, unknown>) => {
     );
   } else {
     content = (
-      <div className="size-full overflow-y-auto overflow-x-hidden whitespace-normal">
+      <div
+        className="size-full overflow-y-auto overflow-x-hidden whitespace-normal"
+        onClick={(event) => event.stopPropagation()}
+      >
         <JsonView
           src={safelyParseJSON(value)}
           theme="github"

--- a/apps/opik-frontend/src/components/shared/DataTableCells/ErrorCell.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableCells/ErrorCell.tsx
@@ -29,6 +29,7 @@ const ErrorCell = <TData,>(
             ? `Message: ${value.message}`
             : "Error message is not specified"
         }
+        stopClickPropagation
       >
         {isSmall ? (
           <span className="truncate">{value.exception_type}</span>

--- a/apps/opik-frontend/src/components/shared/DataTableCells/IdCell.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableCells/IdCell.tsx
@@ -29,7 +29,7 @@ const IdCell = (context: CellContext<unknown, string>) => {
       tableMetadata={context.table.options.meta}
       className="group"
     >
-      <TooltipWrapper content={value}>
+      <TooltipWrapper content={value} stopClickPropagation>
         <div className="flex max-w-full items-center">
           <div className="truncate">{value}</div>
           <Button

--- a/apps/opik-frontend/src/components/shared/DataTableCells/LinkCell.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableCells/LinkCell.tsx
@@ -38,13 +38,16 @@ const LinkCell = <TData,>(context: CellContext<TData, unknown>) => {
       className="group py-1"
     >
       {value ? (
-        <TooltipWrapper content={value}>
+        <TooltipWrapper content={value} stopClickPropagation>
           <div className="flex max-w-full items-center">
             <Button
               variant="tableLink"
               size="sm"
               className="block truncate px-0 leading-8"
-              onClick={() => callback(context.row.original)}
+              onClick={(event) => {
+                event.stopPropagation();
+                callback(context.row.original);
+              }}
             >
               {value}
             </Button>

--- a/apps/opik-frontend/src/components/shared/FeedbackScoreTag/FeedbackScoreHoverCard.tsx
+++ b/apps/opik-frontend/src/components/shared/FeedbackScoreTag/FeedbackScoreHoverCard.tsx
@@ -33,6 +33,7 @@ const FeedbackScoreHoverCard: React.FC<FeedbackScoreHoverCardProps> = ({
         align="start"
         className="w-[320px] border border-border px-1 py-1.5"
         collisionPadding={24}
+        onClick={(event) => event.stopPropagation()}
       >
         <div className="relative size-full max-h-[40vh] max-w-[320px] overflow-auto p-1 pb-0">
           <div className="flex flex-col gap-1.5 border-b border-border px-2 pb-2">

--- a/apps/opik-frontend/src/components/shared/FeedbackScoreTag/FeedbackScoreReasonTooltip.tsx
+++ b/apps/opik-frontend/src/components/shared/FeedbackScoreTag/FeedbackScoreReasonTooltip.tsx
@@ -32,6 +32,7 @@ const FeedbackScoreReasonTooltip: React.FC<FeedbackScoreReasonTooltipProps> = ({
         </div>
       }
       delayDuration={100}
+      stopClickPropagation
     >
       {children}
     </TooltipWrapper>

--- a/apps/opik-frontend/src/components/shared/ResourceLink/ResourceLink.tsx
+++ b/apps/opik-frontend/src/components/shared/ResourceLink/ResourceLink.tsx
@@ -84,7 +84,7 @@ const ResourceLink: React.FunctionComponent<ResourceLinkProps> = ({
       disabled={deleted}
     >
       {asTag ? (
-        <TooltipWrapper content={text}>
+        <TooltipWrapper content={text} stopClickPropagation>
           <Tag
             size="lg"
             variant="gray"

--- a/apps/opik-frontend/src/components/shared/TooltipWrapper/TooltipWrapper.tsx
+++ b/apps/opik-frontend/src/components/shared/TooltipWrapper/TooltipWrapper.tsx
@@ -17,6 +17,7 @@ export type TooltipWrapperProps = {
   hotkeys?: React.ReactNode[];
   delayDuration?: number;
   defaultOpen?: TooltipProps["defaultOpen"];
+  stopClickPropagation?: boolean;
 };
 
 const TooltipWrapper: React.FunctionComponent<TooltipWrapperProps> = ({
@@ -26,6 +27,7 @@ const TooltipWrapper: React.FunctionComponent<TooltipWrapperProps> = ({
   hotkeys = null,
   delayDuration = 500,
   defaultOpen,
+  stopClickPropagation,
 }) => {
   return (
     <TooltipProvider delayDuration={delayDuration}>
@@ -37,6 +39,9 @@ const TooltipWrapper: React.FunctionComponent<TooltipWrapperProps> = ({
             variant={hotkeys?.length ? "hotkey" : "default"}
             className="max-h-[calc(var(--radix-popper-available-height))] overflow-y-auto"
             collisionPadding={16}
+            {...(stopClickPropagation && {
+              onClick: (event) => event.stopPropagation(),
+            })}
           >
             {content}
 


### PR DESCRIPTION
## Details
Added the ability to click on the table row to run its "main function". 

Next tables affected:

- Home -> observability
- Home -> Evaluation
- Projects
- Projects -> Traces
- Projects -> LLM Calls
- Projects -> Threads
- Datasets
- Datasets -> Items
- Experiments
- Experiments -> Details/Compare
- Prompt Library
- Please check it and provide your feedback.

The functionality behind.

- The click event will be handled with a delay of 200 milliseconds to allow the user to double-click to select text with this
- If a row is clicked and the text in the cell that was clicked is selected, the click handler will not run.


## Issues

Resolves #

## Testing

## Documentation
