### PR TITLE
[NA] removed no longer supported `gemini-1.0-pro` model

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiModelName.java
@@ -12,7 +12,6 @@ public enum GeminiModelName {
     GEMINI_1_5_FLASH("gemini-1.5-flash"),
     GEMINI_1_5_FLASH_8B("gemini-1.5-flash-8b"),
     GEMINI_1_5_PRO("gemini-1.5-pro"),
-    GEMINI_1_0_PRO("gemini-1.0-pro"),
     TEXT_EMBEDDING("text-embedding-004"),
     AQA("aqa");
 


### PR DESCRIPTION
## Details
This model is no longer supported by Google and should be removed.

