### PR TITLE
OPIK-1260: Fix health check

### DIFF
--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -144,7 +144,7 @@ services:
       OPIK_VERSION: ${OPIK_VERSION:-latest}
       OPIK_REVERSE_PROXY_URL: ${OPIK_REVERSE_PROXY_URL:-http://frontend:5173/api}
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:8000/healthcheck"]
+      test: ["CMD", "sh", "-c", "if [ -f /opt/opik-python-backend/healthcheck.py ]; then wget --spider --quiet http://127.0.0.1:8000/healthcheck || exit 1; else exit 0; fi"]
       interval: 1s
       timeout: 30s
       retries: 30

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -144,7 +144,7 @@ services:
       OPIK_VERSION: ${OPIK_VERSION:-latest}
       OPIK_REVERSE_PROXY_URL: ${OPIK_REVERSE_PROXY_URL:-http://frontend:5173/api}
     healthcheck:
-      test: ["CMD", "sh", "-c", "if [ -f /opt/opik-python-backend/healthcheck.py ]; then wget --spider --quiet http://127.0.0.1:8000/healthcheck || exit 1; else exit 0; fi"]
+      test: ["CMD", "sh", "-c", "if [ -f /opt/opik-python-backend/src/opik_backend/healthcheck.py ]; then wget --spider --quiet http://127.0.0.1:8000/healthcheck || exit 1; else exit 0; fi"]
       interval: 1s
       timeout: 30s
       retries: 30

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -144,7 +144,7 @@ services:
       OPIK_VERSION: ${OPIK_VERSION:-latest}
       OPIK_REVERSE_PROXY_URL: ${OPIK_REVERSE_PROXY_URL:-http://frontend:5173/api}
     healthcheck:
-      test: ["CMD", "sh", "-c", "if [ -f /opt/opik-python-backend/src/opik_backend/healthcheck.py ]; then wget --spider --quiet http://127.0.0.1:8000/healthcheck || exit 1; else exit 0; fi"]
+      test: ["CMD", "sh", "-c", "if [ -f /opt/opik-python-backend/src/opik_backend/healthcheck.py ]; then wget --spider --quiet http://127.0.0.1:8000/healthcheck; else exit 0; fi"]
       interval: 1s
       timeout: 30s
       retries: 30

--- a/opik.sh
+++ b/opik.sh
@@ -2,7 +2,7 @@
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-REQUIRED_CONTAINERS=("opik-clickhouse-1" "opik-mysql-1" "opik-python-backend-1" "opik-redis-1" "opik-frontend-1" "opik-backend-1")
+REQUIRED_CONTAINERS=("opik-clickhouse-1" "opik-mysql-1" "opik-python-backend-1" "opik-redis-1" "opik-frontend-1" "opik-backend-1" "opik-minio-1")
 
 print_usage() {
   echo "Usage: opik.sh [OPTION]"
@@ -19,7 +19,7 @@ print_usage() {
 
 check_docker_status() {
   # Ensure Docker is running
-  if ! timeout 3 docker info >/dev/null 2>&1; then
+  if ! docker info >/dev/null 2>&1; then
     echo "❌ Docker is not running or not accessible. Please start Docker first."
     exit 1
   fi
@@ -73,7 +73,8 @@ start_missing_containers() {
   fi
 
   echo "🔄 Starting missing containers..."
-  docker compose -f "$script_dir/deployment/docker-compose/docker-compose.yaml" up -d
+  cd "$script_dir/deployment/docker-compose"
+  docker compose up -d
 
   echo "⏳ Waiting for all containers to be running and healthy..."
   max_retries=60
@@ -116,7 +117,8 @@ start_missing_containers() {
 stop_containers() {
   check_docker_status
   echo "🛑 Stopping all required containers..."
-  docker compose -f $script_dir/deployment/docker-compose/docker-compose.yaml stop
+  cd "$script_dir/deployment/docker-compose"
+  docker compose stop
   echo "✅ All containers stopped and cleaned up!"
 }
 


### PR DESCRIPTION
## Details
- Make health check backward compatible
- Remove timeout since to void dependencies
- Use `docker compose up -d` do to ensure compatibility
