### PR TITLE
NO-JIRA: Fix images path in Python backend

### DIFF
--- a/apps/opik-python-backend/Dockerfile
+++ b/apps/opik-python-backend/Dockerfile
@@ -9,7 +9,7 @@ RUN pip install -r requirements.txt --break-system-packages
 
 ENV PYTHON_CODE_EXECUTOR_ASSET_NAME="opik-sandbox-executor-python"
 # Optionally copies the file. It's built ok without it, as it'll be pulled before running anyway.
-COPY *${PYTHON_CODE_EXECUTOR_ASSET_NAME}.tar.gz /images/${PYTHON_CODE_EXECUTOR_ASSET_NAME}.tar.gz
+COPY *${PYTHON_CODE_EXECUTOR_ASSET_NAME}.tar.gz ./images/${PYTHON_CODE_EXECUTOR_ASSET_NAME}.tar.gz
 
 COPY src ./src
 


### PR DESCRIPTION
## Details
Image was copied to root folder `/images/` but `./entrypoint.sh` refers to it from `./image/`, which is actually `/opt/opik-python-backend/images/`.

I aligned it by following the general convention of copying resources within the work directory: `./image` or `/opt/opik-python-backend/images`.

## Issues

N/A

## Testing
- I will deploy to dev or stg and check for logs `Successfully loaded the Opik Sandbox Executor Python image`

## Documentation
N/A
