### PR TITLE
[NA] Fix naming mismatch between Opik backend and remote auth service

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/usagelimit/Quota.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/usagelimit/Quota.java
@@ -6,6 +6,6 @@ import lombok.Builder;
 @Builder
 public record Quota(int limit, int used, @NotNull QuotaType type) {
     public enum QuotaType {
-        SPAN_COUNT
+        OPIK_SPAN_COUNT
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/QuotaLimitTestUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/QuotaLimitTestUtils.java
@@ -16,12 +16,12 @@ public class QuotaLimitTestUtils {
                 arguments(null, false),
                 arguments(List.of(), false),
                 arguments(List.of(Quota.builder()
-                        .type(Quota.QuotaType.SPAN_COUNT)
+                        .type(Quota.QuotaType.OPIK_SPAN_COUNT)
                         .limit(25_000)
                         .used(24_999)
                         .build()), false),
                 arguments(List.of(Quota.builder()
-                        .type(Quota.QuotaType.SPAN_COUNT)
+                        .type(Quota.QuotaType.OPIK_SPAN_COUNT)
                         .limit(25_000)
                         .used(25_000)
                         .build()), true));

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/AuthCredentialsCacheServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/AuthCredentialsCacheServiceTest.java
@@ -66,7 +66,7 @@ public class AuthCredentialsCacheServiceTest {
                 arguments(named("null quotas", null)),
                 arguments(named("empty quotas", List.of())),
                 arguments(named("valid quotas", List.of(Quota.builder()
-                        .type(Quota.QuotaType.SPAN_COUNT)
+                        .type(Quota.QuotaType.OPIK_SPAN_COUNT)
                         .limit(25_000)
                         .used(24_999)
                         .build()))));


### PR DESCRIPTION
## Details
There was a mismatch between Opik's backend `SPAN_COUNT` and remote authentication service `OPIK_SPAN_COUNT`. This PR resolves this mismatch.

