### PR TITLE
Fix issue with parsing log_probs

### DIFF
--- a/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/metric.py
+++ b/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/metric.py
@@ -192,15 +192,14 @@ class GEval(base_metric.BaseMetric):
                 linear_probs_sum += linear_prob
                 weighted_score_sum += linear_prob * score
 
-            
             if linear_probs_sum != 0.0:
                 final_score: float = weighted_score_sum / linear_probs_sum / 10
             else:
                 # Handle cases where we can't find any matching tokens in the top_log_probs
                 if not log_probs_token.isdecimal():
                     raise exceptions.MetricComputationError(GEVAL_SCORE_CALC_FAILED)
-                
-                final_score : float = int(log_probs_token) / 10
+
+                final_score = int(log_probs_token) / 10
 
             if not (0.0 <= final_score <= 1.0):
                 raise ValueError


### PR DESCRIPTION
## Details

Fixes #1635 

Manually tested:

Ran the example from the docs about 10 times and got the following output in one of the runs:
```
{"token": "10", "bytes": [49, 48], "logprob": -9999.0, "top_logprobs": [{"token": "\":", "bytes": [34, 58], "logprob": 0.0}, {"token": "\":\n\n", "bytes": [34, 58, 10, 10], "logprob": -21.125}, {"token": "\"", "bytes": [34], "logprob": -22.5}, {"token": "\":\n", "bytes": [34, 58, 10], "logprob": -24.75}, {"token": "\":\r\n", "bytes": [34, 58, 13, 10], "logprob": -26.25}, {"token": "\"\n\n", "bytes": [34, 10, 10], "logprob": -27.8125}, {"token": "\"\n", "bytes": [34, 10], "logprob": -31.8125}, {"token": "\"\r\n", "bytes": [34, 13, 10], "logprob": -35.1875}, {"token": "\"\n\n\n", "bytes": [34, 10, 10, 10], "logprob": -36.5625}, {"token": "\"\r\n\r\n", "bytes": [34, 13, 10, 13, 10], "logprob": -36.71875}, {"token": "\"\n\n\n\n", "bytes": [34, 10, 10, 10, 10], "logprob": -37.21875}, {"token": "#", "bytes": [35], "logprob": -100.0}, {"token": "&", "bytes": [38], "logprob": -100.0}, {"token": "$", "bytes": [36], "logprob": -100.0}, {"token": "%", "bytes": [37], "logprob": -100.0}, {"token": "!", "bytes": [33], "logprob": -100.0}, {"token": "'", "bytes": [39], "logprob": -100.0}, {"token": "(", "bytes": [40], "logprob": -100.0}, {"token": ")", "bytes": [41], "logprob": -100.0}, {"token": "*", "bytes": [42], "logprob": -100.0}]}
```

Following my change this was parsed as:
```
ScoreResult(name='g_eval_metric', value=1.0, reason="The AI-generated OUTPUT stating 'Paris is the capital of France' precisely mirrors the information present in the CONTEXT without any deviation or introduction of new information. The CONTEXT explicitly confirms that 'its capital is Paris,' aligning well with the OUTPUT. Moreover, there are no omissions or unnecessary elaboration in the OUTPUT, making it a faithful reflection of the CONTEXT.", metadata=None, scoring_failed=False)
```