### PR TITLE
OPIK-1130: Exclude Otel resource from Open API spec

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResource.java
@@ -6,6 +6,7 @@ import com.comet.opik.domain.ProjectService;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.utils.AsyncUtils;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
@@ -24,6 +25,8 @@ import java.util.List;
 @Timed
 @Slf4j
 @RequiredArgsConstructor(onConstructor_ = @Inject)
+// TODO: Hiding The Open API definition for this resource as it's breaking Fern auto-generated classes.
+@Hidden
 @Tag(name = "OpenTelemetry Ingestion", description = "Resource to ingest Traces and Spans via OpenTelemetry")
 public class OpenTelemetryResource {
 

--- a/sdks/code_generation/fern/fern.config.json
+++ b/sdks/code_generation/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "Opik",
-  "version": "0.51.17"
+  "version": "0.56.34"
 }

--- a/sdks/code_generation/fern/generators.yml
+++ b/sdks/code_generation/fern/generators.yml
@@ -6,12 +6,12 @@ groups:
   local:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 4.3.8
+        version: 4.3.21
         output:
           location: local-file-system
           path: ../../python/src/opik/rest_api
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.48.7
+        version: 0.49.3
         output:
           location: local-file-system
           path: ../../typescript/src/opik/rest_api

--- a/sdks/code_generation/fern/openapi/overrides-global-headers.yaml
+++ b/sdks/code_generation/fern/openapi/overrides-global-headers.yaml
@@ -5,16 +5,3 @@ x-fern-global-headers:
   - header: Comet-Workspace
     name: workspaceName
     optional: true
-
-components:
-  schemas:
-    AutomationRuleEvaluator:
-      x-fern-ignore: true
-    AutomationRuleEvaluatorUpdate:
-      x-fern-ignore: true
-    AutomationRuleEvaluator_Write:
-      x-fern-ignore: true
-    AutomationRuleEvaluator_Public:
-      x-fern-ignore: true
-    AutomationRuleEvaluatorObject_Public:
-      x-fern-ignore: true


### PR DESCRIPTION
## Details
Excluded the `OpenTelemetryResource` from the Open API spec. The existing definition was wrong and not containing the latest changes from: https://github.com/comet-ml/opik/pull/1394, so there's no risk of breaking users anyway.

The issue is that request object `ExportTraceServiceRequest` creates an explosion of generated classes.

This PR fixes the issue. Another PR will follow updating the Fern classes and the Open API specs.

Additionally:
- Updated Fern and SDK generation versions to latest.
- Removed fern ignore clauses, which were not really working.

## Issues

OPIK-1130

## Testing
- Verified locally by generating classes.
- I'll verify that tests pass in the CI.

## Documentation
- https://github.com/fern-api/fern
