### PR TITLE
[OPIK-1234] OpenTelemetry integration shouldn't drop attributes by default

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -113,7 +113,11 @@ public class OpenTelemetryMapper {
 
                         extractToJsonColumn(node, key, value);
                 }
-            }, () -> log.debug("No rule found for key: {} (value: {}). Ignoring it.", key, attribute.getValue()));
+            }, () -> {
+                // if it's not explicitly request to drop, we keep it in input
+                log.debug("No rule found for kv {} -> {}. Using for Input.", key, attribute.getValue());
+                extractToJsonColumn(input, key, value);
+            });
         });
 
         if (!metadata.isEmpty()) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
@@ -325,6 +325,10 @@ class OpenTelemetryResourceTest {
 
         @Test
         void testRuleMapping() {
+            String randomKeyArray = UUID.randomUUID().toString();
+            String randomKeyJson = UUID.randomUUID().toString();
+            String randomKeyInt = UUID.randomUUID().toString();
+
             var attributes = List.of(
                     KeyValue.newBuilder().setKey("model_name").setValue(AnyValue.newBuilder().setStringValue("gpt-4o"))
                             .build(),
@@ -343,9 +347,14 @@ class OpenTelemetryResourceTest {
                     KeyValue.newBuilder().setKey("smolagents.node")
                             .setValue(AnyValue.newBuilder().setStringValue("{\"key\": \"value\"}")).build(),
                     KeyValue.newBuilder().setKey("smolagents.array")
-                            .setValue(AnyValue.newBuilder().setStringValue("[\"key\", \"value\"]")).build()
+                            .setValue(AnyValue.newBuilder().setStringValue("[\"key\", \"value\"]")).build(),
 
-            );
+                    KeyValue.newBuilder().setKey(randomKeyArray)
+                            .setValue(AnyValue.newBuilder().setStringValue("[\"key\", \"value\"]")).build(),
+                    KeyValue.newBuilder().setKey(randomKeyJson)
+                            .setValue(AnyValue.newBuilder().setStringValue("{\"key\": \"value\"}")).build(),
+                    KeyValue.newBuilder().setKey(randomKeyInt)
+                            .setValue(AnyValue.newBuilder().setIntValue(3)).build());
 
             var spanBuilder = com.comet.opik.api.Span.builder()
                     .id(UUID.randomUUID())
@@ -357,13 +366,19 @@ class OpenTelemetryResourceTest {
 
             var span = spanBuilder.build();
 
+            // checks key-values we know there are not rule associated with
+            assertThat(span.input().get(randomKeyArray)).size().isEqualTo(2);
+            assertThat(span.input().get(randomKeyJson).get("key").asText()).isEqualTo("value");
+            assertThat(span.input().get(randomKeyInt).asInt()).isEqualTo(3);
+
+            // checks key-values with rules
             assertThat(span.model()).isEqualTo("gpt-4o");
             assertThat(span.type()).isEqualTo(SpanType.llm);
 
             assertThat(span.metadata().get("code.line").asInt()).isEqualTo(11);
             assertThat(span.metadata().get("smolagents.single").asText()).isEqualTo("value");
             assertThat(span.metadata().get("smolagents.node").get("key").asText()).isEqualTo("value");
-            assertThat(span.metadata().get("smolagents.array").isArray()).isEqualTo(Boolean.TRUE);
+            assertThat(span.metadata().get("smolagents.array").isArray()).isTrue();
 
             assertThat(span.input().get("input").get("key").asText()).isEqualTo("value");
             assertThat(span.input().get("tools").isArray()).isEqualTo(Boolean.TRUE);


### PR DESCRIPTION
## Details
Currently the default behaviour of otel integration was to keep only mapped attributes, but now we will only drop values we've mapped to drop; if there's no matching rule, keep the value as part of `input` section.

## Issues
OPIK-1234
OPIK-1344

## Testing

## Documentation
