### PR TITLE
[OPIK-1336]: expand button change the behavior;

### DIFF
--- a/apps/opik-frontend/src/components/layout/SideBar/SideBar.tsx
+++ b/apps/opik-frontend/src/components/layout/SideBar/SideBar.tsx
@@ -390,8 +390,7 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
         size="icon-2xs"
         onClick={() => setExpanded((s) => !s)}
         className={cn(
-          "absolute -right-3 top-2 hidden rounded-full z-50",
-          expanded ? "group-hover:flex" : "flex",
+          "absolute -right-3 top-2 hidden rounded-full z-50 group-hover:flex",
         )}
       >
         {expanded ? <ChevronLeft /> : <ChevronRight />}


### PR DESCRIPTION
## Details
Now, when a sidebar is collapsed, the button is now shown by defualt;
<img width="1498" alt="image" src="https://github.com/user-attachments/assets/dfe9bdd7-2e0e-47f1-8d6d-8f3d1ca33499" />


## Issues

Resolves #

## Testing

## Documentation
