### PR TITLE
NA: Fix fat jar manifest definition to allow the use of virtual threads

### DIFF
--- a/apps/opik-backend/pom.xml
+++ b/apps/opik-backend/pom.xml
@@ -458,6 +458,9 @@
                         <transformer
                                 implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <mainClass>${mainClass}</mainClass>
+                            <manifestEntries>
+                                <Multi-Release>true</Multi-Release>
+                            </manifestEntries>
                         </transformer>
                     </transformers>
                     <!-- exclude signed Manifests -->


### PR DESCRIPTION
## Details
By fixing this, we could enable the configuration of virtual threads. This configuration will allow Reactor to work with virtual threads. 

The backend supports it via the `ENABLE_VIRTUAL_THREADS` environment variable, which affects the Reactor scheduler and Dropwizard Jetty’s thread pool.  
  
This configuration is disabled by default.

https://issues.apache.org/jira/browse/MSHADE-385?focusedCommentId=17567674&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17567674