### PR TITLE
[ISSUE-1677] [FR]: Remember pretty/JSON/YAML preference for experiment item view

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/InputOutputTab.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/InputOutputTab.tsx
@@ -55,6 +55,7 @@ const InputOutputTab: React.FunctionComponent<InputOutputTabProps> = ({
           <SyntaxHighlighter
             data={data.input}
             prettifyConfig={{ fieldType: "input" }}
+            preserveKey="syntax-highlighter-trace-sidebar-input"
           />
         </AccordionContent>
       </AccordionItem>
@@ -64,6 +65,7 @@ const InputOutputTab: React.FunctionComponent<InputOutputTabProps> = ({
           <SyntaxHighlighter
             data={data.output}
             prettifyConfig={{ fieldType: "output" }}
+            preserveKey="syntax-highlighter-trace-sidebar-output"
           />
         </AccordionContent>
       </AccordionItem>

--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsPanel/CompareExperimentsViewer.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsPanel/CompareExperimentsViewer.tsx
@@ -74,6 +74,7 @@ const CompareExperimentsViewer: React.FunctionComponent<
         <SyntaxHighlighter
           data={experimentItem.output}
           prettifyConfig={{ fieldType: "output" }}
+          preserveKey={`syntax-highlighter-compare-experiment-output-${sectionIdx}`}
         />
       );
     }

--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/ExperimentDatasetItems.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/ExperimentDatasetItems.tsx
@@ -39,6 +39,7 @@ const ExperimentDatasetItems = ({
       <SyntaxHighlighter
         data={selectedData}
         prettifyConfig={{ fieldType: "input" }}
+        preserveKey="syntax-highlighter-compare-experiment-input"
       />
     ) : (
       <NoData />
@@ -83,6 +84,7 @@ const ExperimentDatasetItems = ({
             <SyntaxHighlighter
               data={selectedData || {}}
               prettifyConfig={{ fieldType: "input" }}
+              preserveKey="syntax-highlighter-compare-experiment-input"
             />
           ) : (
             <NoData />

--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/CompareExperimentsOutputCell.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/CompareExperimentsOutputCell.tsx
@@ -69,10 +69,11 @@ const CompareExperimentsOutputCell: React.FC<
           <Button
             size="icon-xs"
             variant="outline"
-            onClick={() => {
+            onClick={(event) => {
               if (isFunction(openTrace) && item?.trace_id) {
                 openTrace(item.trace_id);
               }
+              event.stopPropagation();
             }}
             className="absolute right-1 top-1 hidden group-hover:flex"
           >


### PR DESCRIPTION
## Details
We preserve selected mode  for StyleHighlighter for next places:
Trace sidebar -> input
Trace sidebar -> output
Experiments sidebar -> Dataset input
Experiments sidebar -> Experiment item output [index]

## Issues

Resolves #1677

## Testing
Manually

## Documentation
