### PR TITLE
[OPIK-1277]: price retention banner init;

### DIFF
--- a/apps/opik-frontend/src/components/layout/PageBodyScrollContainer/PageBodyScrollContainer.tsx
+++ b/apps/opik-frontend/src/components/layout/PageBodyScrollContainer/PageBodyScrollContainer.tsx
@@ -54,7 +54,7 @@ const PageBodyScrollContainer: React.FC<PageBodyScrollContainerProps> = ({
         ref={ref}
         style={style}
         className={cn(
-          "relative h-[calc(100vh-var(--header-height))] overflow-auto -mx-6",
+          "relative h-[calc(100vh-var(--header-height)-var(--banner-height))] overflow-auto -mx-6",
           className,
         )}
       >

--- a/apps/opik-frontend/src/components/layout/PageLayout/PageLayout.tsx
+++ b/apps/opik-frontend/src/components/layout/PageLayout/PageLayout.tsx
@@ -1,13 +1,17 @@
-import React from "react";
+import React, { useState } from "react";
 import { Outlet } from "@tanstack/react-router";
 import SideBar from "@/components/layout/SideBar/SideBar";
 import TopBar from "@/components/layout/TopBar/TopBar";
 import { cn } from "@/lib/utils";
 import useLocalStorageState from "use-local-storage-state";
+import usePluginsStore from "@/store/PluginsStore";
 
 const PageLayout = () => {
   const [expanded = true, setExpanded] =
     useLocalStorageState<boolean>("sidebar-expanded");
+  const [bannerHeight, setBannerHeight] = useState(0);
+
+  const RetentionBanner = usePluginsStore((state) => state.RetentionBanner);
 
   return (
     <section
@@ -17,9 +21,18 @@ const PageLayout = () => {
           "comet-expanded": expanded,
         },
       )}
+      style={
+        {
+          "--banner-height": `${bannerHeight}px`,
+        } as React.CSSProperties
+      }
     >
+      {RetentionBanner ? (
+        <RetentionBanner onChangeHeight={setBannerHeight} />
+      ) : null}
+
       <SideBar expanded={expanded} setExpanded={setExpanded} />
-      <main className="comet-content-inset absolute inset-y-0 right-0 flex transition-all">
+      <main className="comet-content-inset absolute bottom-0 right-0 top-[var(--banner-height)] flex transition-all">
         <TopBar />
         <section className="comet-header-inset absolute inset-x-0 bottom-0 overflow-auto bg-soft-background px-6">
           <Outlet />

--- a/apps/opik-frontend/src/components/layout/SideBar/SideBar.tsx
+++ b/apps/opik-frontend/src/components/layout/SideBar/SideBar.tsx
@@ -400,7 +400,7 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
 
   return (
     <>
-      <aside className="comet-sidebar-width group h-full border-r transition-all">
+      <aside className="comet-sidebar-width group h-[calc(100vh-var(--banner-height))] border-r transition-all">
         <div className="comet-header-height relative flex w-full items-center justify-between gap-6 border-b">
           <Link
             to={HOME_PATH}

--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsPanel/CompareExperimentsViewer.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsPanel/CompareExperimentsViewer.tsx
@@ -110,7 +110,7 @@ const CompareExperimentsViewer: React.FunctionComponent<
 
       {isTraceExist && (
         <div className="sticky bottom-0 right-0 mt-auto flex max-h-[40vh] shrink-0 flex-col bg-white contain-content">
-          <div className="box-border min-h-[58px] shrink grow overflow-auto border-y  px-1 py-4">
+          <div className="box-border min-h-[58px] shrink grow overflow-auto border-y px-1 py-4">
             <FeedbackScoresEditor
               feedbackScores={feedbackScores}
               traceId={experimentItem.trace_id as string}

--- a/apps/opik-frontend/src/components/shared/NoDataPage/NoDataPage.tsx
+++ b/apps/opik-frontend/src/components/shared/NoDataPage/NoDataPage.tsx
@@ -26,7 +26,7 @@ const NoDataPage: React.FC<NoDataPageProps> = ({
         } as React.CSSProperties
       }
       className={cn(
-        "flex h-[calc(100vh-var(--page-difference))] min-h-[500px] w-full min-w-72 items-center justify-stretch py-6",
+        "flex h-[calc(100vh-var(--page-difference)-var(--banner-height))] min-h-[500px] w-full min-w-72 items-center justify-stretch py-6",
         className,
       )}
     >

--- a/apps/opik-frontend/src/hooks/useProjectWithStatisticsList.ts
+++ b/apps/opik-frontend/src/hooks/useProjectWithStatisticsList.ts
@@ -55,14 +55,15 @@ export default function useProjectWithStatisticsList(
 
       return {
         ...projectsData,
-        content: projectsData.content?.map((project) => {
-          return statisticMap
-            ? {
-                ...project,
-                ...statisticMap[project.id],
-              }
-            : project;
-        }),
+        content:
+          projectsData.content?.map((project) => {
+            return statisticMap
+              ? {
+                  ...project,
+                  ...statisticMap[project.id],
+                }
+              : project;
+          }) || [],
       };
     }
 

--- a/apps/opik-frontend/src/hooks/useProjectWithStatisticsList.ts
+++ b/apps/opik-frontend/src/hooks/useProjectWithStatisticsList.ts
@@ -55,7 +55,7 @@ export default function useProjectWithStatisticsList(
 
       return {
         ...projectsData,
-        content: projectsData.content.map((project) => {
+        content: projectsData.content?.map((project) => {
           return statisticMap
             ? {
                 ...project,

--- a/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
+++ b/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { X } from "lucide-react";
 
 import { useActiveWorkspaceName } from "@/store/AppStore";
@@ -32,12 +32,17 @@ const RetentionBanner = ({ onChangeHeight }: RetentionBannerProps) => {
 
   const isUsedLess80 = (spanQuota?.used || 0) / (spanQuota?.limit || 1) < 0.8;
 
+  useEffect(() => {
+    if (closed) {
+      onChangeHeight(0);
+    }
+  }, [closed]);
+
   if (!spanQuota || isUsedLess80 || closed || !user) {
     return null;
   }
 
   const closeBanner = () => {
-    onChangeHeight(0);
     setClosed(true);
   };
 

--- a/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
+++ b/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from "react";
+import { X } from "lucide-react";
+
+import { useActiveWorkspaceName } from "@/store/AppStore";
+import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
+import { QUOTA_TYPE } from "@/plugins/comet/types/quotas";
+import useWorkspaceQuotas from "@/plugins/comet/api/useWorkspaceQuotas";
+import useUser from "@/plugins/comet/useUser";
+
+import { Button } from "@/components/ui/button";
+
+interface RetentionBannerProps {
+  onChangeHeight: (height: number) => void;
+}
+
+const RetentionBanner = ({ onChangeHeight }: RetentionBannerProps) => {
+  const { data: user } = useUser();
+
+  const [closed, setClosed] = useState(false);
+  const activeWorkspaceName = useActiveWorkspaceName();
+
+  const { data: quotas } = useWorkspaceQuotas(
+    { workspaceName: activeWorkspaceName },
+    { enabled: !!activeWorkspaceName && !!user },
+  );
+
+  const { ref } = useObserveResizeNode<HTMLDivElement>((node) => {
+    onChangeHeight(node.clientHeight);
+  });
+
+  const spanQuota = quotas?.find((q) => q.type === QUOTA_TYPE.OPIK_SPAN_COUNT);
+
+  const isUsedLess80 = spanQuota?.used / spanQuota?.limit < 0.8;
+
+  if (!spanQuota || isUsedLess80 || closed || !user) {
+    return null;
+  }
+
+  const closeBanner = () => {
+    onChangeHeight(0);
+    setClosed(true);
+  };
+
+  const isExceededLimit = spanQuota?.used >= spanQuota?.limit;
+
+  const label = isExceededLimit
+    ? "You have exceeded your plan limits. Upgrade to ensure " +
+      "uninterrupted monitoring"
+    : "You're at 80% of your 100,000 free spans. Upgrade to ensure " +
+      "uninterrupted monitoring";
+  const closable = !isExceededLimit;
+
+  return (
+    <div
+      className="z-10 box-border flex min-h-12 items-center justify-center bg-primary p-1.5 text-white transition-all"
+      ref={ref}
+    >
+      <div className="flex flex-1 items-center justify-center gap-x-1">
+        <span>{label}</span>
+        <span className="hidden md:inline">-</span>
+        <a
+          href="https://www.comet.com/site/about-us/contact-us/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="whitespace-nowrap underline"
+        >
+          Contact sales
+        </a>
+      </div>
+      {closable && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="justify-self-end hover:text-white"
+          onClick={closeBanner}
+        >
+          <X />
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default RetentionBanner;

--- a/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
+++ b/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
@@ -38,7 +38,7 @@ const RetentionBanner = ({ onChangeHeight }: RetentionBannerProps) => {
 
   useEffect(() => {
     onChangeHeight(!hideBanner ? heightRef.current : 0);
-  }, [hideBanner]);
+  }, [hideBanner, onChangeHeight]);
 
   if (hideBanner) {
     return null;

--- a/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
+++ b/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
@@ -13,6 +13,8 @@ interface RetentionBannerProps {
   onChangeHeight: (height: number) => void;
 }
 
+const SHOW_BANNER_MIN_THRESHOLD = 0.8;
+
 const RetentionBanner = ({ onChangeHeight }: RetentionBannerProps) => {
   const { data: user } = useUser();
   const heightRef = useRef(0);
@@ -32,7 +34,9 @@ const RetentionBanner = ({ onChangeHeight }: RetentionBannerProps) => {
 
   const spanQuota = quotas?.find((q) => q.type === QUOTA_TYPE.OPIK_SPAN_COUNT);
 
-  const isUsedLess80 = (spanQuota?.used || 0) / (spanQuota?.limit || 1) < 0.8;
+  const isUsedLess80 =
+    (spanQuota?.used || 0) / (spanQuota?.limit || 1) <
+    SHOW_BANNER_MIN_THRESHOLD;
 
   const hideBanner = !spanQuota || isUsedLess80 || closed || !user;
 

--- a/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
+++ b/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
@@ -30,7 +30,7 @@ const RetentionBanner = ({ onChangeHeight }: RetentionBannerProps) => {
 
   const spanQuota = quotas?.find((q) => q.type === QUOTA_TYPE.OPIK_SPAN_COUNT);
 
-  const isUsedLess80 = spanQuota?.used / spanQuota?.limit < 0.8;
+  const isUsedLess80 = (spanQuota?.used || 0) / (spanQuota?.limit || 1) < 0.8;
 
   if (!spanQuota || isUsedLess80 || closed || !user) {
     return null;

--- a/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
+++ b/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { X } from "lucide-react";
 
 import { useActiveWorkspaceName } from "@/store/AppStore";
@@ -15,6 +15,7 @@ interface RetentionBannerProps {
 
 const RetentionBanner = ({ onChangeHeight }: RetentionBannerProps) => {
   const { data: user } = useUser();
+  const heightRef = useRef(0);
 
   const [closed, setClosed] = useState(false);
   const activeWorkspaceName = useActiveWorkspaceName();
@@ -25,6 +26,7 @@ const RetentionBanner = ({ onChangeHeight }: RetentionBannerProps) => {
   );
 
   const { ref } = useObserveResizeNode<HTMLDivElement>((node) => {
+    heightRef.current = node.clientHeight;
     onChangeHeight(node.clientHeight);
   });
 
@@ -32,13 +34,13 @@ const RetentionBanner = ({ onChangeHeight }: RetentionBannerProps) => {
 
   const isUsedLess80 = (spanQuota?.used || 0) / (spanQuota?.limit || 1) < 0.8;
 
-  useEffect(() => {
-    if (closed) {
-      onChangeHeight(0);
-    }
-  }, [closed]);
+  const hideBanner = !spanQuota || isUsedLess80 || closed || !user;
 
-  if (!spanQuota || isUsedLess80 || closed || !user) {
+  useEffect(() => {
+    onChangeHeight(!hideBanner ? heightRef.current : 0);
+  }, [hideBanner]);
+
+  if (hideBanner) {
     return null;
   }
 

--- a/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
+++ b/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
@@ -53,8 +53,9 @@ const RetentionBanner = ({ onChangeHeight }: RetentionBannerProps) => {
   const label = isExceededLimit
     ? "You have exceeded your plan limits. Upgrade to ensure " +
       "uninterrupted monitoring"
-    : "You're at 80% of your 100,000 free spans. Upgrade to ensure " +
+    : `You're at 80% of your ${spanQuota?.limit} free spans. Upgrade to ensure ` +
       "uninterrupted monitoring";
+
   const closable = !isExceededLimit;
 
   return (

--- a/apps/opik-frontend/src/plugins/comet/api/useWorkspaceQuotas.ts
+++ b/apps/opik-frontend/src/plugins/comet/api/useWorkspaceQuotas.ts
@@ -1,5 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
-import api from "../api";
+import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
+import api, { QueryConfig } from "../api";
 import { QUOTA_TYPE } from "@/plugins/comet/types/quotas";
 
 interface WorkspaceQuota {
@@ -16,18 +16,25 @@ interface UseWorkspaceQuotas {
   workspaceName: string;
 }
 
-const getWorkspaceQuotas = async (context, workspaceName: string) => {
+const getWorkspaceQuotas = async (
+  context: QueryFunctionContext,
+  workspaceName: string,
+) => {
   const response = await api.get<WorkspaceQuotasResponse>(
     "/organizations/quotas",
     {
       params: { workspaceName },
+      signal: context.signal,
     },
   );
 
   return response?.data?.quotas;
 };
 
-const useWorkspaceQuotas = ({ workspaceName }: UseWorkspaceQuotas, options) => {
+const useWorkspaceQuotas = (
+  { workspaceName }: UseWorkspaceQuotas,
+  options: QueryConfig<WorkspaceQuota[]>,
+) => {
   return useQuery({
     queryKey: ["workspace-quotas", { workspaceName }],
     queryFn: (context) => getWorkspaceQuotas(context, workspaceName),

--- a/apps/opik-frontend/src/plugins/comet/api/useWorkspaceQuotas.ts
+++ b/apps/opik-frontend/src/plugins/comet/api/useWorkspaceQuotas.ts
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import api from "../api";
+import { QUOTA_TYPE } from "@/plugins/comet/types/quotas";
+
+interface WorkspaceQuota {
+  limit: number;
+  type: QUOTA_TYPE;
+  used: number;
+}
+
+interface WorkspaceQuotasResponse {
+  quotas: WorkspaceQuota[];
+}
+
+interface UseWorkspaceQuotas {
+  workspaceName: string;
+}
+
+const getWorkspaceQuotas = async (context, workspaceName: string) => {
+  const response = await api.get<WorkspaceQuotasResponse>(
+    "/organizations/quotas",
+    {
+      params: { workspaceName },
+    },
+  );
+
+  return response?.data?.quotas;
+};
+
+const useWorkspaceQuotas = ({ workspaceName }: UseWorkspaceQuotas, options) => {
+  return useQuery({
+    queryKey: ["workspace-quotas", { workspaceName }],
+    queryFn: (context) => getWorkspaceQuotas(context, workspaceName),
+    ...options,
+  });
+};
+
+export default useWorkspaceQuotas;

--- a/apps/opik-frontend/src/plugins/comet/types/quotas.ts
+++ b/apps/opik-frontend/src/plugins/comet/types/quotas.ts
@@ -1,0 +1,3 @@
+export enum QUOTA_TYPE {
+  OPIK_SPAN_COUNT = "OPIK_SPAN_COUNT",
+}

--- a/apps/opik-frontend/src/store/AppStore.ts
+++ b/apps/opik-frontend/src/store/AppStore.ts
@@ -17,4 +17,7 @@ const useAppStore = create<AppStore>((set) => ({
   },
 }));
 
+export const useActiveWorkspaceName = () =>
+  useAppStore((state) => state.activeWorkspaceName);
+
 export default useAppStore;

--- a/apps/opik-frontend/src/store/PluginsStore.ts
+++ b/apps/opik-frontend/src/store/PluginsStore.ts
@@ -20,7 +20,9 @@ type PluginStore = {
   EvaluationExamples: React.ComponentType | null;
   CommentsViewer: React.ComponentType<CommentsViewerCoreProps> | null;
   ExperimentCommentsViewer: React.ComponentType<ExperimentCommentsViewerCoreProps> | null;
-  RetentionBanner: React.ComponentType | null;
+  RetentionBanner: React.ComponentType<{
+    onChangeHeight: (height: number) => void;
+  }> | null;
   init: unknown;
   setupPlugins: (folderName: string) => Promise<void>;
 };

--- a/apps/opik-frontend/src/store/PluginsStore.ts
+++ b/apps/opik-frontend/src/store/PluginsStore.ts
@@ -20,6 +20,7 @@ type PluginStore = {
   EvaluationExamples: React.ComponentType | null;
   CommentsViewer: React.ComponentType<CommentsViewerCoreProps> | null;
   ExperimentCommentsViewer: React.ComponentType<ExperimentCommentsViewerCoreProps> | null;
+  RetentionBanner: React.ComponentType | null;
   init: unknown;
   setupPlugins: (folderName: string) => Promise<void>;
 };
@@ -37,6 +38,7 @@ const PLUGIN_NAMES = [
   "WorkspacePreloader",
   "EvaluationExamples",
   "ExperimentCommentsViewer",
+  "RetentionBanner",
   "init",
 ];
 
@@ -52,6 +54,7 @@ const usePluginsStore = create<PluginStore>((set) => ({
   CommentsViewer: null,
   EvaluationExamples: null,
   ExperimentCommentsViewer: null,
+  RetentionBanner: null,
   init: null,
   setupPlugins: async (folderName: string) => {
     if (!VALID_PLUGIN_FOLDER_NAMES.includes(folderName)) {


### PR DESCRIPTION
## Details
Added the retention banner based on a workspace
<img width="1259" alt="image" src="https://github.com/user-attachments/assets/cc89a12b-eda4-46a1-a15f-7b5ba1bbdd24" />


## Issues

Resolves #

## Testing
The way I tested it was that I overrode the endpoint:
```
api/organizations/quotas?workspaceName=check-quotas
```
with 
```
{
"quotas" :[
  {
            "limit": 25000,
            "used": 25000,
            "type": "OPIK_SPAN_COUNT"
  }   
]}
or
{
"quotas" :[
  {
            "limit": 25000,
            "used": 22500,
            "type": "OPIK_SPAN_COUNT"
  }   
]}
```

## Documentation
