### PR TITLE
Saves deepcopy of input and outputs for logging

### DIFF
--- a/sdks/python/src/opik/message_processing/messages.py
+++ b/sdks/python/src/opik/message_processing/messages.py
@@ -1,3 +1,4 @@
+import copy
 import dataclasses
 import datetime
 from typing import Optional, Any, Dict, List, Union
@@ -25,6 +26,13 @@ class CreateTraceMessage(BaseMessage):
     tags: Optional[List[str]]
     error_info: Optional[ErrorInfoDict]
     thread_id: Optional[str]
+
+    def __post_init__(self) -> None:
+        # Make deep copies of mutable objects to prevent mutation
+        if self.input is not None:
+            self.input = copy.deepcopy(self.input)
+        if self.output is not None:
+            self.output = copy.deepcopy(self.output)
 
     def as_payload_dict(self) -> Dict[str, Any]:
         data = super().as_payload_dict()
@@ -73,6 +81,13 @@ class CreateSpanMessage(BaseMessage):
     provider: Optional[Union[LLMProvider, str]]
     error_info: Optional[ErrorInfoDict]
     total_cost: Optional[float]
+
+    def __post_init__(self) -> None:
+        # Make deep copies of mutable objects to prevent mutation
+        if self.input is not None:
+            self.input = copy.deepcopy(self.input)
+        if self.output is not None:
+            self.output = copy.deepcopy(self.output)
 
     def as_payload_dict(self) -> Dict[str, Any]:
         data = super().as_payload_dict()


### PR DESCRIPTION
## Details

This is meant to "snapshot" the input and outputs as they might contains mutable objects that can be altered after spans have been created.

A common examples is with the OpenAI integration where the messages list is often modified when multiple LLM calls are made one after another with the same history.

## Issues

Here is a reproducing script:

```python
from opik import track
from openai import OpenAI

from opik.integrations.openai import track_openai

client = OpenAI()
client = track_openai(client)
messages = [
    {"role": "system", "content": "You are a helpful assistant."},
    {"role": "user", "content": "Hello"},
]

response = client.chat.completions.create(
    model="gpt-4o",
    messages=messages,
)

messages.append(
    {
        "unrelated": "unrelated",
    }
)
```

Without this branch, the span (and trace) input will have the incorrect value:

```json
{
  "messages": [
    {
      "role": "system",
      "content": "You are a helpful assistant."
    },
    {
      "role": "user",
      "content": "Hello"
    },
    {
      "unrelated": "unrelated"
    }
  ]
}
```

![Screenshot 2025-03-27 at 18-31-09 Comet Opik](https://github.com/user-attachments/assets/7df789e9-1df6-478b-be0d-598278533ac9)

With this branch, it will have the correct value:

```json
{
  "messages": [
    {
      "role": "system",
      "content": "You are a helpful assistant."
    },
    {
      "role": "user",
      "content": "Hello"
    }
  ]
}
```

![Screenshot 2025-03-27 at 18-31-09 Comet Opik](https://github.com/user-attachments/assets/ba56eb98-98aa-4fca-8573-f712a11a8674)


Resolves #

## Testing

## Documentation
