### PR TITLE
Implements ROUGE score with unit tests and documentation

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/heuristic_metrics.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/heuristic_metrics.mdx
@@ -15,6 +15,7 @@ You can use the following heuristic metrics:
 | Levenshtein  | Calculates the Levenshtein distance between the output and an expected string                     |
 | SentenceBLEU | Calculates a single-sentence BLEU score for a candidate vs. one or more references                |
 | CorpusBLEU   | Calculates a corpus-level BLEU score for multiple candidates vs. their references                 |
+| ROUGE        | Calculates the ROUGE score for a candidate vs. one or more references                             |
 
 ## Score an LLM response
 
@@ -172,3 +173,80 @@ print(score.value, score.reason)
 ```
 
 **Note:** If any candidate or reference is empty, SentenceBLEU or CorpusBLEU will raise a MetricComputationError. Handle or validate inputs accordingly.
+
+### ROUGE
+
+The [ROUGE (Recall-Oriented Understudy for Gisting Evaluation)](<https://en.wikipedia.org/wiki/ROUGE_(metric)>) metrics estimate how close the LLM outputs are to one or more reference summaries, commonly used for evaluating summarization and text generation tasks. It measures the overlap between an output string and a reference string, with support for multiple ROUGE types. This metrics is a wrapper around the Google Research reimplementation of ROUGE, which is based on the `rouge-score` library. You will need rouge-score library:
+
+```bash
+pip install rouge-score
+```
+
+It can be used in a following way:
+
+```python
+from opik.evaluation.metrics import ROUGE
+
+metric = ROUGE()
+
+# Single reference
+score = metric.score(
+    output="Hello world!",
+    reference="Hello world"
+)
+print(score.value, score.reason)
+
+# Multiple references
+score = metric.score(
+    output="Hello world!",
+    reference=["Hello planet", "Hello world"]
+)
+print(score.value, score.reason)
+```
+
+You can customize the ROUGE metric using the following parameters:
+
+- **`rouge_type` (str)**: Type of ROUGE score to compute. Must be one of:
+
+  - `rouge1`: Unigram-based scoring
+  - `rouge2`: Bigram-based scoring
+  - `rougeL`: Longest common subsequence-based scoring
+  - `rougeLsum`: ROUGE-L score based on sentence splitting
+
+  _Default_: `rouge1`
+
+- **`use_stemmer` (bool)**: Whether to use stemming in ROUGE computation.  
+  _Default_: `False`
+
+- **`split_summaries` (bool)**: Whether to split summaries into sentences.  
+  _Default_: `False`
+
+- **`tokenizer` (Any | None)**: Custom tokenizer for sentence splitting.  
+  _Default_: `None`
+
+```python
+from opik.evaluation.metrics import ROUGE
+
+metric = ROUGE(
+    rouge_type="rouge2",
+    use_stemmer=True
+)
+
+score = metric.score(
+    output="The cats sat on the mats",
+    reference=["The cat is on the mat", "A cat sat here on the mat"]
+)
+print(score.value, score.reason)
+```
+
+#### References
+
+- [Understanding ROUGE Metrics](https://www.linkedin.com/pulse/mastering-rouge-matrix-your-guide-large-language-model-mamdouh/)
+- [Google Research ROUGE Implementation](https://github.com/google-research/google-research/tree/master/rouge)
+- [Hugging Face ROUGE Metric](https://huggingface.co/spaces/evaluate-metric/rouge)
+
+#### Notes
+
+- The metric is case-insensitive.
+- ROUGE scores are useful for comparing text summarization models or evaluating text similarity.
+- Consider using stemming for improved evaluation in certain cases.

--- a/sdks/python/src/opik/evaluation/metrics/__init__.py
+++ b/sdks/python/src/opik/evaluation/metrics/__init__.py
@@ -4,6 +4,7 @@ from .heuristics.is_json import IsJson
 from .heuristics.levenshtein_ratio import LevenshteinRatio
 from .heuristics.regex_match import RegexMatch
 from .heuristics.bleu import SentenceBLEU, CorpusBLEU
+from .heuristics.rouge import ROUGE
 from .llm_judges.answer_relevance.metric import AnswerRelevance
 from .llm_judges.context_precision.metric import ContextPrecision
 from .llm_judges.context_recall.metric import ContextRecall
@@ -34,4 +35,5 @@ __all__ = [
     "BaseMetric",
     "SentenceBLEU",
     "CorpusBLEU",
+    "ROUGE",
 ]

--- a/sdks/python/src/opik/evaluation/metrics/heuristics/rouge.py
+++ b/sdks/python/src/opik/evaluation/metrics/heuristics/rouge.py
@@ -16,7 +16,7 @@ class ROUGE(base_metric.BaseMetric):
 
     References:
         - https://github.com/google-research/google-research/tree/master/rouge
-        - https://huggingface.co/spaces/evaluate-metric/rouge 
+        - https://huggingface.co/spaces/evaluate-metric/rouge
 
     Args:
         name: The name of the metric. Defaults to "rouge_metric".
@@ -48,7 +48,7 @@ class ROUGE(base_metric.BaseMetric):
         rouge_type: str = "rouge1",
         use_stemmer: bool = False,
         split_summaries: bool = False,
-        tokenizer: Any | None = None
+        tokenizer: Any | None = None,
     ):
         super().__init__(name=name, track=track)
 
@@ -58,17 +58,18 @@ class ROUGE(base_metric.BaseMetric):
                 "Install via `pip install rouge-score`."
             )
 
-        valid_rouge_types = {'rouge1', 'rouge2', 'rougeL', 'rougeLsum'}
+        valid_rouge_types = {"rouge1", "rouge2", "rougeL", "rougeLsum"}
         if rouge_type not in valid_rouge_types:
             raise MetricComputationError(
-                f"Invalid rouge_type '{rouge_type}'. Must be one of {valid_rouge_types}.")
+                f"Invalid rouge_type '{rouge_type}'. Must be one of {valid_rouge_types}."
+            )
 
         self._rouge_type = rouge_type
         self._rouge = rouge_scorer.RougeScorer(
             [rouge_type],
             use_stemmer=use_stemmer,
             split_summaries=split_summaries,
-            tokenizer=tokenizer
+            tokenizer=tokenizer,
         )
 
     def score(
@@ -86,7 +87,10 @@ class ROUGE(base_metric.BaseMetric):
             **ignored_kwargs: Additional keyword arguments that are ignored.
 
         Returns:
-            score_result.ScoreResult: A ScoreResult object with the ROUGE score.
+            score_result.ScoreResult with:
+              - `value`: The ROUGE score (float).
+              - `name`: The metric name.
+              - `reason`: A short explanation (e.g. "rouge1 score: 0.91").
 
         Raises:
             MetricComputationError:
@@ -101,14 +105,11 @@ class ROUGE(base_metric.BaseMetric):
                 raise MetricComputationError("Reference is empty.")
         else:
             if len(reference) != 1:
-                raise MetricComputationError(
-                    "Reference strings are in multiple lists."
-                )
+                raise MetricComputationError("Reference strings are in multiple lists.")
 
             for ref_str in reference:
                 if not ref_str.strip():
-                    raise MetricComputationError(
-                        "Encountered empty reference.")
+                    raise MetricComputationError("Encountered empty reference.")
 
         rouge_score_type = self._rouge_type
         results = self._rouge.score(reference, output)

--- a/sdks/python/src/opik/evaluation/metrics/heuristics/rouge.py
+++ b/sdks/python/src/opik/evaluation/metrics/heuristics/rouge.py
@@ -116,8 +116,7 @@ class ROUGE(base_metric.BaseMetric):
 
             for ref_str in reference:
                 if not ref_str.strip():
-                    raise MetricComputationError(
-                        "Encountered empty reference.")
+                    raise MetricComputationError("Encountered empty reference.")
 
         rouge_score_type = self._rouge_type
         results = self._rouge.score_multi(reference, output)

--- a/sdks/python/src/opik/evaluation/metrics/heuristics/rouge.py
+++ b/sdks/python/src/opik/evaluation/metrics/heuristics/rouge.py
@@ -1,11 +1,11 @@
-from typing import Any, List, Union
+from typing import Any, List, Union, Optional
 from opik.exceptions import MetricComputationError
 from opik.evaluation.metrics import base_metric, score_result
 
 try:
-    from rouge_score import rouge_scorer
+    import rouge_score as rouge_score
 except ImportError:
-    rouge_scorer = None
+    rouge_score = None
 
 
 class ROUGE(base_metric.BaseMetric):
@@ -48,11 +48,11 @@ class ROUGE(base_metric.BaseMetric):
         rouge_type: str = "rouge1",
         use_stemmer: bool = False,
         split_summaries: bool = False,
-        tokenizer: Any | None = None,
+        tokenizer: Optional[Any] = None,
     ):
         super().__init__(name=name, track=track)
 
-        if rouge_scorer is None:
+        if rouge_score.rouge_scorer is None:
             raise ImportError(
                 "`rouge-score` libraries are required for ROUGE score calculation. "
                 "Install via `pip install rouge-score`."
@@ -65,7 +65,7 @@ class ROUGE(base_metric.BaseMetric):
             )
 
         self._rouge_type = rouge_type
-        self._rouge = rouge_scorer.RougeScorer(
+        self._rouge = rouge_score.rouge_scorer.RougeScorer(
             [rouge_type],
             use_stemmer=use_stemmer,
             split_summaries=split_summaries,

--- a/sdks/python/src/opik/evaluation/metrics/heuristics/rouge.py
+++ b/sdks/python/src/opik/evaluation/metrics/heuristics/rouge.py
@@ -95,7 +95,7 @@ class ROUGE(base_metric.BaseMetric):
         Raises:
             MetricComputationError:
                 - If the candidate or any reference is empty.
-                - If the reference strings are in multiple lists.
+                - If the reference is not a string or a list of strings.
         """
         if not output.strip():
             raise MetricComputationError("Candidate is empty.")
@@ -103,16 +103,24 @@ class ROUGE(base_metric.BaseMetric):
         if isinstance(reference, str):
             if not reference.strip():
                 raise MetricComputationError("Reference is empty.")
-        else:
-            if len(reference) != 1:
-                raise MetricComputationError("Reference strings are in multiple lists.")
+
+            reference = [reference]
+        elif isinstance(reference, list):
+            if len(reference) == 0:
+                raise MetricComputationError("Reference is empty.")
+
+            if not all(isinstance(item, str) for item in reference):
+                raise MetricComputationError(
+                    "Reference must be a string or a list of strings."
+                )
 
             for ref_str in reference:
                 if not ref_str.strip():
-                    raise MetricComputationError("Encountered empty reference.")
+                    raise MetricComputationError(
+                        "Encountered empty reference.")
 
         rouge_score_type = self._rouge_type
-        results = self._rouge.score(reference, output)
+        results = self._rouge.score_multi(reference, output)
         rouge_f1_value = results[rouge_score_type].fmeasure
 
         return score_result.ScoreResult(

--- a/sdks/python/src/opik/evaluation/metrics/heuristics/rouge.py
+++ b/sdks/python/src/opik/evaluation/metrics/heuristics/rouge.py
@@ -1,0 +1,106 @@
+from typing import Any, List, Union
+from opik.exceptions import MetricComputationError
+from opik.evaluation.metrics import base_metric, score_result
+
+try:
+    import evaluate
+    import rouge_score
+except ImportError:
+    evaluate = None
+    rouge_score = None
+
+
+class ROUGE(base_metric.BaseMetric):
+    """
+    A metric that computes the ROUGE score between an output and reference string.
+
+    This metric uses the `evaluate` and `rouge-score` libraries to compute the ROUGE score.
+
+    Args:
+        name: The name of the metric. Defaults to "rouge_1_metric".
+        track: Whether to track the metric. Defaults to True.
+
+    Example:
+        >>> from opik.evaluation.metrics import ROUGE
+        >>> rouge_metric = ROUGE()
+        >>> result = rouge_metric.score(
+        ...     output="The quick brown fox jumps over the lazy dog.",
+        ...     reference="The quick brown fox jumps over the lazy dog."
+        ...     rouge_type="rouge1"
+        ... )
+        >>> print(result.value)
+        1.0
+    """
+
+    def __init__(self, name: str = "rouge_metric", track: bool = True):
+        super().__init__(name=name, track=track)
+
+        if evaluate is None or rouge_score is None:
+            raise ImportError(
+                "`evaluate and rouge-score` libraries are required for ROUGE score calculation. "
+                "Install via `pip install evaluate rouge-score`."
+            )
+
+        self._rouge = evaluate.load('rouge')
+
+    def score(
+        self,
+        output: str,
+        reference: Union[str, List[str]],
+        rouge_type: str,
+        **ignored_kwargs: Any,
+    ) -> score_result.ScoreResult:
+        """
+        Compute the ROUGE score between the output and reference strings.
+
+        Args:
+            output: The output string to score.
+            reference: The reference string or list of reference strings.
+            rouge_type: Type of ROUGE score to compute. Must be one of the following:
+                    - "rouge1": unigram (1-gram) based scoring
+                    - "rouge2": bigram (2-gram) based scoring
+                    - "rougeL": Longest common subsequence based scoring
+                    - "rougeLSum": splits text using "\n"
+            **ignored_kwargs: Additional keyword arguments that are ignored.
+
+        Returns:
+            score_result.ScoreResult: A ScoreResult object with the ROUGE score.
+
+        Raises:
+            MetricComputationError:
+                - If the candidate or any reference is empty.
+                - If the reference strings are in multiple lists.
+                - If the rouge_type is invalid.
+        """
+        valid_rouge_types = {'rouge1', 'rouge2', 'rougeL', 'rougeLsum'}
+
+        if rouge_type not in valid_rouge_types:
+            raise MetricComputationError(
+                f"Invalid rouge_type '{rouge_type}'. Must be one of {valid_rouge_types}.")
+
+        if not output.strip():
+            raise MetricComputationError("Candidate is empty.")
+
+        if isinstance(reference, str):
+            if not reference.strip():
+                raise MetricComputationError("Reference is empty.")
+        else:
+            if len(reference) != 1:
+                raise MetricComputationError(
+                    "Reference strings are in multiple lists."
+                )
+
+            for ref_str in reference:
+                if not ref_str.strip():
+                    raise MetricComputationError(
+                        "Encountered empty reference.")
+
+        results = self._rouge.compute(
+            predictions=[output], references=[reference], rouge_type=[rouge_type])
+        rouge_f1_value = results[rouge_type].item()
+
+        return score_result.ScoreResult(
+            value=rouge_f1_value,
+            name=self.name,
+            reason=f"ROUGE score of {rouge_type}: {rouge_f1_value:.4f}",
+        )

--- a/sdks/python/src/opik/evaluation/metrics/heuristics/rouge.py
+++ b/sdks/python/src/opik/evaluation/metrics/heuristics/rouge.py
@@ -12,12 +12,12 @@ except ImportError:
 
 class ROUGE(base_metric.BaseMetric):
     """
-    A metric that computes the ROUGE score between an output and reference string.
-
-    This metric uses the `evaluate` and `rouge-score` libraries to compute the ROUGE score.
+    A metric that computes the ROUGE, or Recall-Oriented Understudy for Gisting Evaluation score between an output and reference string mainly used for evaluating text summarization.
+    ROUGE is case insensitive, meaning that upper case letters are treated the same way as lower case letters.
+    This metrics is a wrapper around the Google Research reimplementation of ROUGE, which is based on the `evaluate` and `rouge-score` libraries.
 
     Args:
-        name: The name of the metric. Defaults to "rouge_1_metric".
+        name: The name of the metric. Defaults to "rouge_metric".
         track: Whether to track the metric. Defaults to True.
 
     Example:

--- a/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
+++ b/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
@@ -352,3 +352,40 @@ def test_rougeLsum_score(candidate, reference, expected_min, expected_max):
         f"For candidate='{candidate}' vs reference='{reference}', "
         f"expected rougeLsum score in [{expected_min}, {expected_max}], got {result.value:.4f}"
     )
+
+# For multiple references
+
+
+@pytest.mark.parametrize(
+    "candidate,reference,expected_min,expected_max",
+    [
+        # Calculates rouge scores between targets and prediction.
+        # The target with the maximum f-measure is used for the final score
+        # Candidate = "The brown fox jumps quickly"
+        # Reference = ["The fox moves", "The quick brown fox jumps over the lazy dog"]
+        # Matches for reference 1 => "The" "fox"
+        # # Precision = 2/5 = 0.4
+        # # Recall = 2/3 = 0.6667
+        # # F1 = 2 * (0.4 * 0.6667) / (0.4 + 0.6667) = 0.5
+        # Matches for reference 2 => "The" "brown" "fox" "jumps"
+        # # Precision = 4/4 = 1.0
+        # # Recall = 4/8 = 0.5
+        # # F1 = 2 * (1.0 * 0.5) / (1.0 + 0.5) = 0.6667
+        # Hence, the final score = 0.6667
+        (
+            "The brown fox jumps quickly",
+            ["The fox moves quickly", "The quick brown fox jumps over the lazy dog"],
+            0.65,
+            0.67,
+        ),
+    ],
+)
+def test_rouge1_score_for_multiple_references(candidate, reference, expected_min, expected_max):
+    metric = rouge.ROUGE(rouge_type="rouge1")
+    result = metric.score(output=candidate, reference=reference)
+    assert isinstance(result, ScoreResult)
+
+    assert expected_min <= result.value <= expected_max, (
+        f"For candidate='{candidate}' vs reference='{reference}', "
+        f"expected rouge1 score for multiple references in [{expected_min}, {expected_max}], got {result.value:.4f}"
+    )

--- a/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
+++ b/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
@@ -1,7 +1,12 @@
 import pytest
 
 from opik.exceptions import MetricComputationError
-from opik.evaluation.metrics.heuristics import equals, levenshtein_ratio, regex_match
+from opik.evaluation.metrics.heuristics import (
+    equals,
+    levenshtein_ratio,
+    regex_match,
+    rouge,
+)
 from opik.evaluation.metrics.score_result import ScoreResult
 from opik.evaluation.metrics.heuristics.bleu import SentenceBLEU, CorpusBLEU
 
@@ -77,6 +82,29 @@ def test_sentence_bleu_score(candidate, reference, expected_min, expected_max):
     assert expected_min <= result.value <= expected_max, (
         f"For candidate='{candidate}' vs reference='{reference}', "
         f"expected sentence BLEU in [{expected_min}, {expected_max}], got {result.value:.4f}"
+    )
+
+
+@pytest.mark.parametrize(
+    "candidate,reference,expected_min,expected_max",
+    [
+        # Perfect match => ROUGE~1.0
+        (
+            "The quick brown fox jumps over the lazy dog",
+            "The quick brown fox jumps over the lazy dog",
+            0.99,
+            1.01,
+        ),
+    ],
+)
+def test_rouge1_score(candidate, reference, expected_min, expected_max):
+    metric = rouge.ROUGE(rouge_type="rouge1")
+    result = metric.score(output=candidate, reference=reference)
+    assert isinstance(result, ScoreResult)
+
+    assert expected_min <= result.value <= expected_max, (
+        f"For candidate='{candidate}' vs reference='{reference}', "
+        f"expected rouge1 score in [{expected_min}, {expected_max}], got {result.value:.4f}"
     )
 
 

--- a/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
+++ b/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
@@ -195,6 +195,7 @@ def test_corpus_bleu_score_empty_inputs(outputs, references):
         metric.score(output=outputs, reference=references)
     assert "empty" in str(exc_info.value).lower()
 
+
 # ROUGE score tests
 
 
@@ -208,8 +209,10 @@ def test_rouge_score_for_invalid_reference_type():
     metric = rouge.ROUGE()
     with pytest.raises(MetricComputationError) as exc_info:
         metric.score("candidate", [1, False, -3, 4])
-    assert str(exc_info.value).lower(
-    ) == "reference must be a string or a list of strings."
+    assert (
+        str(exc_info.value).lower()
+        == "reference must be a string or a list of strings."
+    )
 
 
 @pytest.mark.parametrize(
@@ -417,7 +420,9 @@ def test_rougeLsum_score(candidate, reference, expected_min, expected_max):
         ),
     ],
 )
-def test_rouge_score_for_multiple_references(candidate, reference, expected_min, expected_max):
+def test_rouge_score_for_multiple_references(
+    candidate, reference, expected_min, expected_max
+):
     metric = rouge.ROUGE()
     result = metric.score(output=candidate, reference=reference)
     assert isinstance(result, ScoreResult)
@@ -481,7 +486,9 @@ def test_rouge_score_using_stemmer(candidate, reference, expected_min, expected_
         ),
     ],
 )
-def test_rouge_score_using_custom_tokenizer(candidate, reference, expected_min, expected_max, tokenizer):
+def test_rouge_score_using_custom_tokenizer(
+    candidate, reference, expected_min, expected_max, tokenizer
+):
     metric = rouge.ROUGE(tokenizer=tokenizer)
     result = metric.score(output=candidate, reference=reference)
     assert isinstance(result, ScoreResult)

--- a/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
+++ b/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
@@ -86,29 +86,6 @@ def test_sentence_bleu_score(candidate, reference, expected_min, expected_max):
 
 
 @pytest.mark.parametrize(
-    "candidate,reference,expected_min,expected_max",
-    [
-        # Perfect match => ROUGE~1.0
-        (
-            "The quick brown fox jumps over the lazy dog",
-            "The quick brown fox jumps over the lazy dog",
-            0.99,
-            1.01,
-        ),
-    ],
-)
-def test_rouge1_score(candidate, reference, expected_min, expected_max):
-    metric = rouge.ROUGE(rouge_type="rouge1")
-    result = metric.score(output=candidate, reference=reference)
-    assert isinstance(result, ScoreResult)
-
-    assert expected_min <= result.value <= expected_max, (
-        f"For candidate='{candidate}' vs reference='{reference}', "
-        f"expected rouge1 score in [{expected_min}, {expected_max}], got {result.value:.4f}"
-    )
-
-
-@pytest.mark.parametrize(
     "candidate,reference",
     [
         ("", "The quick brown fox"),
@@ -209,3 +186,169 @@ def test_corpus_bleu_score_empty_inputs(outputs, references):
     with pytest.raises(MetricComputationError) as exc_info:
         metric.score(output=outputs, reference=references)
     assert "empty" in str(exc_info.value).lower()
+
+
+@pytest.mark.parametrize(
+    "candidate,reference,expected_min,expected_max",
+    [
+        # Perfect match => ~1.0
+        (
+            "The quick brown fox jumps over the lazy dog",
+            "The quick brown fox jumps over the lazy dog",
+            0.99,
+            1.01,
+        ),
+        # Partial overlap => hence greater than 0.5 less than 0.75
+        # Matches => "The" "brown" "fox"
+        # Precision = 3/3 = 1.0
+        # Recall = 3/6 = 0.5
+        # F1 = 2 * (1.0 * 0.5) / (1.0 + 0.5) = 0.6667
+        (
+            "The brown fox",
+            "The quick brown fox moves quickly",
+            0.65,
+            0.67,
+        ),
+        # No overlap => ~0.0
+        (
+            "A green dog",
+            "The quick brown fox moves quickly",
+            0.0,
+            0.01,
+        ),
+    ],
+)
+def test_rouge1_score(candidate, reference, expected_min, expected_max):
+    metric = rouge.ROUGE(rouge_type="rouge1")
+    result = metric.score(output=candidate, reference=reference)
+    assert isinstance(result, ScoreResult)
+
+    assert expected_min <= result.value <= expected_max, (
+        f"For candidate='{candidate}' vs reference='{reference}', "
+        f"expected rouge1 score in [{expected_min}, {expected_max}], got {result.value:.4f}"
+    )
+
+
+@pytest.mark.parametrize(
+    "candidate,reference,expected_min,expected_max",
+    [
+        # Perfect match => ~1.0
+        (
+            "The quick brown fox jumps over the lazy dog",
+            "The quick brown fox jumps over the lazy dog",
+            0.99,
+            1.01,
+        ),
+        # No overlap => ~0.0
+        (
+            "A green dog",
+            "The quick brown fox moves quickly",
+            0.0,
+            0.01,
+        ),
+        # Rouge 2 uses bigrams
+        # Candidate = "the brown", "brown fox"
+        # Reference = "the quick, quick brown", "brown fox, fox moves, moves quickly"
+        # Match => "brown fox"
+        # Precision = 1/2 = 0.5
+        # Recall = 1/5 = 0.2
+        # F1 = 2 * (0.5 * 0.2) / (0.5 + 0.2) = 0.2857
+        (
+            "The brown fox",
+            "The quick brown fox moves quickly",
+            0.27,
+            0.29,
+        ),
+    ],
+)
+def test_rouge2_score(candidate, reference, expected_min, expected_max):
+    metric = rouge.ROUGE(rouge_type="rouge2")
+    result = metric.score(output=candidate, reference=reference)
+    assert isinstance(result, ScoreResult)
+
+    assert expected_min <= result.value <= expected_max, (
+        f"For candidate='{candidate}' vs reference='{reference}', "
+        f"expected rouge2 score in [{expected_min}, {expected_max}], got {result.value:.4f}"
+    )
+
+
+@pytest.mark.parametrize(
+    "candidate,reference,expected_min,expected_max",
+    [
+        # Perfect match => ~1.0
+        (
+            "The quick brown fox jumps over the lazy dog",
+            "The quick brown fox jumps over the lazy dog",
+            0.99,
+            1.01,
+        ),
+        # No overlap => ~0.0
+        (
+            "A green dog",
+            "The quick brown fox moves quickly",
+            0.0,
+            0.01,
+        ),
+        # Rouge L uses longest common subsequence i.e. the longest sequence of words (not necessarily consecutive, but still in order)
+        # Candidate = "the brown fox"
+        # Reference = "the quick brown fox moves quickly"
+        # LCS => "the brown fox"
+        # ROUGE-L precision is the ratio of the length of the LCS, over the number of unigrams in candidate.
+        # Precision = 3/3 = 1.0
+        # ROUGE-L recall is the ratio of the length of the LCS, over the number of unigrams in reference.
+        # Recall = 3/6 = 0.5
+        # F1 = 2 * (1.0 * 0.5) / (1.0 + 0.5) = 0.6667
+        (
+            "The brown fox",
+            "The quick brown fox moves quickly",
+            0.65,
+            0.67,
+        ),
+    ],
+)
+def test_rougeL_score(candidate, reference, expected_min, expected_max):
+    metric = rouge.ROUGE(rouge_type="rougeL")
+    result = metric.score(output=candidate, reference=reference)
+    assert isinstance(result, ScoreResult)
+    assert expected_min <= result.value <= expected_max, (
+        f"For candidate='{candidate}' vs reference='{reference}', "
+        f"expected rougeL score in [{expected_min}, {expected_max}], got {result.value:.4f}"
+    )
+
+
+@pytest.mark.parametrize(
+    "candidate,reference,expected_min,expected_max",
+    [
+        # ROUGE-Lsum splits the text into sentences based on newlines and
+        # computes the LCS for each pair of sentences and
+        # take the average score for all sentences.
+        # Candidate = "John is an accomplished artist.\\n He is part of a music band"
+        # Reference = "John is a talented musician.\\n He has a band called as 'The Band'"
+        # Split based on newlines:
+        # Candidate = ["John is an accomplished artist.", " He is part of a music band"]
+        # Reference = ["John is a talented musician.", " He has a band called as 'The Band'"]
+        # LCS for first pair = "John is"
+        # Precision = 2/5 = 0.4
+        # Recall = 2/5 = 0.4
+        # F1 = 2 * (0.4 * 0.4) / (0.4 + 0.4) = 0.4
+        # LCS for second pair = "He a band"
+        # Precision = 3/7 = 0.4286
+        # Recall = 3/8 = 0.375
+        # F1 = 2 * (0.4286 * 0.375) / (0.4286 + 0.375) = 0.4
+        # Average of both = (0.4 + 0.4) / 2 = 0.4
+        (
+            "John is an accomplished artist.\n He is part of a music band",
+            "John is a talented musician.\n He has a band called as 'The Band'",
+            0.40,
+            0.45,
+        ),
+    ],
+)
+def test_rougeLsum_score(candidate, reference, expected_min, expected_max):
+    metric = rouge.ROUGE(rouge_type="rougeLsum")
+    result = metric.score(output=candidate, reference=reference)
+    assert isinstance(result, ScoreResult)
+    assert expected_min <= result.value <= expected_max, (
+        f"For candidate='{candidate}' vs reference='{reference}', "
+        f"expected rougeLsum score in [{expected_min}, {expected_max}], got {result.value:.4f}"
+    )

--- a/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
+++ b/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
@@ -389,3 +389,35 @@ def test_rouge1_score_for_multiple_references(candidate, reference, expected_min
         f"For candidate='{candidate}' vs reference='{reference}', "
         f"expected rouge1 score for multiple references in [{expected_min}, {expected_max}], got {result.value:.4f}"
     )
+
+
+@pytest.mark.parametrize(
+    "candidate,reference,expected_min,expected_max",
+    [
+        # Porter stemmer - removes plurals and word suffixes such as (ing, ion, ment)
+        # Candidate = "The brown dogs jumps on the log quickly"
+        # Reference = "The quick brown fox jumps over the lazy dog"
+        # Stemmed Candidate = "the brown dog jump on the log quick"
+        # Stemmed Reference = "the quick brown fox jump over the lazy dog"
+        # Matches => "the" "brown" "dog" "jump" "quick"
+        # Precision = 5/8 = 0.625
+        # Recall = 5/9 = 0.5556
+        # F1 = 2 * (0.625 * 0.5556) / (0.625 + 0.5556) = 0.5882
+        # Hence, the final score = 0.5882
+        (
+            "The brown dogs jumps on the log quickly",
+            "The quick brown fox jumps over the lazy dog",
+            0.57,
+            0.59,
+        ),
+    ],
+)
+def test_rouge1_score_using_stemmer(candidate, reference, expected_min, expected_max):
+    metric = rouge.ROUGE(rouge_type="rouge1", use_stemmer=True)
+    result = metric.score(output=candidate, reference=reference)
+    assert isinstance(result, ScoreResult)
+
+    assert expected_min <= result.value <= expected_max, (
+        f"For candidate='{candidate}' vs reference='{reference}', "
+        f"expected rouge1 score in [{expected_min}, {expected_max}], got {result.value:.4f}"
+    )

--- a/sdks/python/tests/unit/test_requirements.txt
+++ b/sdks/python/tests/unit/test_requirements.txt
@@ -1,2 +1,3 @@
 pandas
 nltk
+rouge-score


### PR DESCRIPTION
## Details

Introduces a new class ROUGE to implement ROUGE heuristic metric using the `rouge-score` [library](https://pypi.org/project/rouge-score/)

## Issues

Resolves https://github.com/comet-ml/opik/issues/979

## Testing

- Includes unit tests covering various argument types and error scenarios.
- Ensures compliance with linting and code quality standards.

## Documentation

Adds documentation for ROUGE in `fern/docs/evaluation/metrics/heuristic_metrics.mdx` including an introduction, dependencies, usage examples, and references.

## Considerations

I am still gaining familiarity with pytest and the ROUGE metric. Feedback and suggestions are welcome! I referred to @kadamrahul18's PR https://github.com/comet-ml/opik/pull/1006 as a reference