### PR TITLE
[OPIK-1386] guardrails ingestion

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemSearchCriteria.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemSearchCriteria.java
@@ -1,7 +1,7 @@
 package com.comet.opik.api;
 
 import com.comet.opik.api.filter.Filter;
-import com.comet.opik.domain.FeedbackScoreDAO;
+import com.comet.opik.domain.EntityType;
 import lombok.Builder;
 import lombok.NonNull;
 
@@ -13,7 +13,7 @@ import java.util.UUID;
 public record DatasetItemSearchCriteria(
         @NonNull UUID datasetId,
         @NonNull Set<UUID> experimentIds,
-        @NonNull FeedbackScoreDAO.EntityType entityType,
+        @NonNull EntityType entityType,
         List<? extends Filter> filters,
         boolean truncate) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentSearchCriteria.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentSearchCriteria.java
@@ -1,14 +1,13 @@
 package com.comet.opik.api;
 
 import com.comet.opik.api.sorting.SortingField;
+import com.comet.opik.domain.EntityType;
 import lombok.Builder;
 import lombok.NonNull;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
-
-import static com.comet.opik.domain.FeedbackScoreDAO.EntityType;
 
 @Builder(toBuilder = true)
 public record ExperimentSearchCriteria(String name, UUID datasetId, @NonNull EntityType entityType,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/GuardrailBatch.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/GuardrailBatch.java
@@ -1,0 +1,24 @@
+package com.comet.opik.api;
+
+import com.comet.opik.infrastructure.ratelimit.RateEventContainer;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record GuardrailBatch(
+        @NotNull @Size(min = 1, max = 1000) @Valid List<GuardrailBatchItem> guardrails) implements RateEventContainer {
+
+    @Override
+    public long eventCount() {
+        return guardrails.size();
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/GuardrailBatchItem.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/GuardrailBatchItem.java
@@ -1,0 +1,30 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+
+import java.util.UUID;
+
+import static com.comet.opik.utils.ValidationUtils.NULL_OR_NOT_BLANK;
+
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record GuardrailBatchItem(
+        // entity (trace or span) id
+        @NotNull UUID id,
+        @Pattern(regexp = NULL_OR_NOT_BLANK, message = "must not be blank") @Schema(description = "If null, the default project is used") String projectName,
+        @JsonIgnore UUID projectId,
+        @NotBlank String name,
+        boolean passed,
+        @NotNull JsonNode config,
+        @NotNull JsonNode details) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/GuardrailsCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/GuardrailsCheck.java
@@ -1,0 +1,25 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+import java.time.Instant;
+
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record GuardrailsCheck(
+        @NotBlank String name,
+        boolean passed,
+        JsonNode config,
+        JsonNode details,
+        @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant createdAt,
+        @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
+        @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,
+        @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -20,7 +20,7 @@ import com.comet.opik.api.sorting.SortingFactoryDatasets;
 import com.comet.opik.api.sorting.SortingField;
 import com.comet.opik.domain.DatasetItemService;
 import com.comet.opik.domain.DatasetService;
-import com.comet.opik.domain.FeedbackScoreDAO;
+import com.comet.opik.domain.EntityType;
 import com.comet.opik.domain.IdGenerator;
 import com.comet.opik.domain.Streamer;
 import com.comet.opik.infrastructure.auth.RequestContext;
@@ -381,7 +381,7 @@ public class DatasetsResource {
                 .datasetId(datasetId)
                 .experimentIds(experimentIds)
                 .filters(queryFilters)
-                .entityType(FeedbackScoreDAO.EntityType.TRACE)
+                .entityType(EntityType.TRACE)
                 .truncate(truncate)
                 .build();
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -15,6 +15,7 @@ import com.comet.opik.api.Identifier;
 import com.comet.opik.api.resources.v1.priv.validate.IdParamsValidator;
 import com.comet.opik.api.sorting.ExperimentSortingFactory;
 import com.comet.opik.api.sorting.SortingField;
+import com.comet.opik.domain.EntityType;
 import com.comet.opik.domain.ExperimentItemService;
 import com.comet.opik.domain.ExperimentService;
 import com.comet.opik.domain.FeedbackScoreService;
@@ -66,7 +67,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static com.comet.opik.domain.FeedbackScoreDAO.EntityType;
 import static com.comet.opik.utils.AsyncUtils.setRequestContext;
 
 @Path("/v1/private/experiments")

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EntityType.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EntityType.java
@@ -1,0 +1,14 @@
+package com.comet.opik.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EntityType {
+    TRACE("trace", "traces"),
+    SPAN("span", "spans");
+
+    private final String type;
+    private final String tableName;
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -569,7 +569,7 @@ class ExperimentDAO {
 
     private Publisher<? extends Result> get(String query, Connection connection, Function<Statement, Statement> bind) {
         var statement = connection.createStatement(query)
-                .bind("entity_type", FeedbackScoreDAO.EntityType.TRACE.getType());
+                .bind("entity_type", EntityType.TRACE.getType());
         return makeFluxContextAware(bindWorkspaceIdToFlux(bind.apply(statement)));
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
@@ -14,7 +14,6 @@ import io.r2dbc.spi.Row;
 import io.r2dbc.spi.Statement;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,16 +42,6 @@ import static com.comet.opik.utils.TemplateUtils.getQueryItemPlaceHolder;
 
 @ImplementedBy(FeedbackScoreDAOImpl.class)
 public interface FeedbackScoreDAO {
-
-    @Getter
-    @RequiredArgsConstructor
-    enum EntityType {
-        TRACE("trace", "traces"),
-        SPAN("span", "spans");
-
-        private final String type;
-        private final String tableName;
-    }
 
     Mono<Map<UUID, List<FeedbackScore>>> getScores(EntityType entityType, List<UUID> entityIds);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
@@ -38,7 +38,6 @@ import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToFlux;
 import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToMono;
 import static com.comet.opik.utils.AsyncUtils.makeFluxContextAware;
 import static com.comet.opik.utils.AsyncUtils.makeMonoContextAware;
-import static com.comet.opik.utils.TemplateUtils.getQueryItemPlaceHolder;
 
 @ImplementedBy(FeedbackScoreDAOImpl.class)
 public interface FeedbackScoreDAO {
@@ -307,15 +306,6 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
         return scoreBatchOf(entityType, List.of(item));
     }
 
-    private ST getBatchSql(String sql, int size) {
-        var template = new ST(sql);
-        List<TemplateUtils.QueryItem> queryItems = getQueryItemPlaceHolder(size);
-
-        template.add("items", queryItems);
-
-        return template;
-    }
-
     private String getValueOrDefault(String value) {
         return Optional.ofNullable(value)
                 .map(String::trim)
@@ -331,7 +321,7 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
 
         return asyncTemplate.nonTransaction(connection -> {
 
-            ST template = getBatchSql(BULK_INSERT_FEEDBACK_SCORE, scores.size());
+            ST template = TemplateUtils.getBatchSql(BULK_INSERT_FEEDBACK_SCORE, scores.size());
 
             var statement = connection.createStatement(template.render());
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
@@ -4,7 +4,6 @@ import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.FeedbackScoreBatchItem;
 import com.comet.opik.api.FeedbackScoreNames;
 import com.comet.opik.api.Project;
-import com.comet.opik.utils.BinaryOperatorUtils;
 import com.comet.opik.utils.WorkspaceUtils;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Singleton;
@@ -18,10 +17,7 @@ import reactor.core.publisher.Mono;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static com.comet.opik.utils.ErrorUtils.failWithNotFound;
 import static java.util.stream.Collectors.groupingBy;
@@ -106,7 +102,7 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
                 .collect(groupingBy(FeedbackScoreBatchItem::projectName));
 
         return projectService.retrieveByNamesOrCreate(scoresPerProject.keySet())
-                .map(this::groupByName)
+                .map(ProjectService::groupByName)
                 .map(projectMap -> mergeProjectsAndScores(projectMap, scoresPerProject))
                 .flatMap(projects -> processScoreBatch(entityType, projects, scores.size())) // score all scores
                 .then();
@@ -134,14 +130,6 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
                                     .toList());
                 })
                 .toList();
-    }
-
-    private Map<String, Project> groupByName(List<Project> projects) {
-        return projects.stream().collect(Collectors.toMap(
-                Project::name,
-                Function.identity(),
-                BinaryOperatorUtils.last(),
-                () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
@@ -4,7 +4,6 @@ import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.FeedbackScoreBatchItem;
 import com.comet.opik.api.FeedbackScoreNames;
 import com.comet.opik.api.Project;
-import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.utils.BinaryOperatorUtils;
 import com.comet.opik.utils.WorkspaceUtils;
 import com.google.inject.ImplementedBy;
@@ -13,13 +12,9 @@ import jakarta.inject.Inject;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
-import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
-import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -28,9 +23,6 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static com.comet.opik.domain.FeedbackScoreDAO.EntityType;
-import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
-import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
 import static com.comet.opik.utils.ErrorUtils.failWithNotFound;
 import static java.util.stream.Collectors.groupingBy;
 
@@ -61,10 +53,9 @@ public interface FeedbackScoreService {
 class FeedbackScoreServiceImpl implements FeedbackScoreService {
 
     private final @NonNull FeedbackScoreDAO dao;
-    private final @NonNull TransactionTemplate syncTemplate;
     private final @NonNull SpanDAO spanDAO;
     private final @NonNull TraceDAO traceDAO;
-    private final @NonNull IdGenerator idGenerator;
+    private final @NonNull ProjectService projectService;
 
     record ProjectDto(Project project, List<FeedbackScoreBatchItem> scores) {
     }
@@ -114,30 +105,10 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
                 })
                 .collect(groupingBy(FeedbackScoreBatchItem::projectName));
 
-        return handleProjectRetrieval(scoresPerProject)
+        return projectService.retrieveByNamesOrCreate(scoresPerProject.keySet())
                 .map(this::groupByName)
                 .map(projectMap -> mergeProjectsAndScores(projectMap, scoresPerProject))
                 .flatMap(projects -> processScoreBatch(entityType, projects, scores.size())) // score all scores
-                .then();
-    }
-
-    private Mono<List<Project>> handleProjectRetrieval(Map<String, List<FeedbackScoreBatchItem>> scoresPerProject) {
-        return Mono.deferContextual(ctx -> {
-            String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
-            String userName = ctx.get(RequestContext.USER_NAME);
-
-            return checkIfNeededToCreateProjectsWithContext(workspaceId, userName, scoresPerProject) // create projects if needed
-                    .then(Mono.fromCallable(() -> getAllProjectsByName(workspaceId, scoresPerProject))
-                            .subscribeOn(Schedulers.boundedElastic())); // get all project itemIds
-        });
-    }
-
-    private Mono<Void> checkIfNeededToCreateProjectsWithContext(String workspaceId,
-            String userName,
-            Map<String, List<FeedbackScoreBatchItem>> scoresPerProject) {
-
-        return Mono.fromRunnable(() -> checkIfNeededToCreateProjects(scoresPerProject, userName, workspaceId))
-                .publishOn(Schedulers.boundedElastic())
                 .then();
     }
 
@@ -171,54 +142,6 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
                 Function.identity(),
                 BinaryOperatorUtils.last(),
                 () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));
-    }
-
-    private List<Project> getAllProjectsByName(String workspaceId,
-            Map<String, List<FeedbackScoreBatchItem>> scoresPerProject) {
-        return syncTemplate.inTransaction(READ_ONLY, handle -> {
-
-            var projectDAO = handle.attach(ProjectDAO.class);
-
-            return projectDAO.findByNames(workspaceId, scoresPerProject.keySet());
-        });
-    }
-
-    private void checkIfNeededToCreateProjects(Map<String, List<FeedbackScoreBatchItem>> scoresPerProject,
-            String userName, String workspaceId) {
-
-        Map<String, Project> projectsPerLowerCaseName = groupByName(
-                getAllProjectsByName(workspaceId, scoresPerProject));
-
-        syncTemplate.inTransaction(WRITE, handle -> {
-
-            var projectDAO = handle.attach(ProjectDAO.class);
-
-            scoresPerProject
-                    .keySet()
-                    .stream()
-                    .filter(projectName -> !projectsPerLowerCaseName.containsKey(projectName))
-                    .forEach(projectName -> {
-                        UUID projectId = idGenerator.generateId();
-                        var newProject = Project.builder()
-                                .name(projectName)
-                                .id(projectId)
-                                .createdBy(userName)
-                                .lastUpdatedBy(userName)
-                                .build();
-
-                        try {
-                            projectDAO.save(workspaceId, newProject);
-                        } catch (UnableToExecuteStatementException e) {
-                            if (e.getCause() instanceof SQLIntegrityConstraintViolationException) {
-                                log.warn("Project {} already exists", projectName);
-                            } else {
-                                throw e;
-                            }
-                        }
-                    });
-
-            return null;
-        });
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/GuardrailsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/GuardrailsDAO.java
@@ -1,12 +1,15 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.GuardrailBatchItem;
+import com.comet.opik.api.GuardrailsCheck;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
+import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.TemplateUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
 import com.google.inject.ImplementedBy;
 import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Row;
 import io.r2dbc.spi.Statement;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -15,16 +18,22 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.stringtemplate.v4.ST;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
-import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToFlux;
+import static com.comet.opik.domain.AsyncContextUtils.bindUserNameAndWorkspaceContextToStream;
 import static com.comet.opik.utils.AsyncUtils.makeFluxContextAware;
 
 @ImplementedBy(GuardrailsDAOImpl.class)
 public interface GuardrailsDAO {
     Mono<Long> addGuardrails(EntityType entityType, List<GuardrailBatchItem> guardrails);
+
+    Flux<GuardrailsCheck> getTraceGuardrails(String workspaceId, EntityType entityType, UUID entityId);
 }
 
 @Singleton
@@ -42,7 +51,9 @@ class GuardrailsDAOImpl implements GuardrailsDAO {
                 name,
                 passed,
                 config,
-                details
+                details,
+                created_by,
+                last_updated_by
             )
             VALUES
                 <items:{item |
@@ -54,12 +65,26 @@ class GuardrailsDAOImpl implements GuardrailsDAO {
                          :name<item.index>,
                          :passed<item.index>,
                          :config<item.index>,
-                         :details<item.index>
+                         :details<item.index>,
+                         :user_name,
+                         :user_name
                      )
                      <if(item.hasNext)>
                         ,
                      <endif>
                 }>
+            ;
+            """;
+
+    private static final String SELECT_GUARDRAILS_BY_ID = """
+            SELECT
+                *
+            FROM guardrails
+            WHERE entity_id = :entity_id
+            AND entity_type = :entity_type
+            AND workspace_id = :workspace_id
+            ORDER BY entity_id DESC, last_updated_at DESC
+            LIMIT 1 BY entity_id, name
             ;
             """;
 
@@ -76,9 +101,24 @@ class GuardrailsDAOImpl implements GuardrailsDAO {
 
             bindParameters(entityType, guardrails, statement);
 
-            return makeFluxContextAware(bindWorkspaceIdToFlux(statement))
+            return makeFluxContextAware(bindUserNameAndWorkspaceContextToStream(statement))
                     .flatMap(Result::getRowsUpdated)
                     .reduce(Long::sum);
+        });
+    }
+
+    @Override
+    public Flux<GuardrailsCheck> getTraceGuardrails(String workspaceId, EntityType entityType, UUID entityId) {
+        return asyncTemplate.stream(connection -> {
+            var statement = connection.createStatement(SELECT_GUARDRAILS_BY_ID);
+
+            statement
+                    .bind("workspace_id", workspaceId)
+                    .bind("entity_id", entityId)
+                    .bind("entity_type", entityType.getType());
+
+            return Flux.from(statement.execute())
+                    .flatMap(result -> result.map((row, rowMetadata) -> mapGuardrail(row)));
         });
     }
 
@@ -99,5 +139,27 @@ class GuardrailsDAOImpl implements GuardrailsDAO {
 
     private String getOrDefault(JsonNode value) {
         return value != null ? value.toString() : "";
+    }
+
+    private GuardrailsCheck mapGuardrail(Row row) {
+        return GuardrailsCheck.builder()
+                .name(row.get("name", String.class))
+                .passed(Optional.ofNullable(row.get("passed", String.class))
+                        .filter(it -> !it.isBlank())
+                        .map(Boolean::parseBoolean)
+                        .orElse(false))
+                .config(Optional.ofNullable(row.get("config", String.class))
+                        .filter(it -> !it.isBlank())
+                        .map(JsonUtils::getJsonNodeFromString)
+                        .orElse(null))
+                .details(Optional.ofNullable(row.get("details", String.class))
+                        .filter(it -> !it.isBlank())
+                        .map(JsonUtils::getJsonNodeFromString)
+                        .orElse(null))
+                .createdAt(row.get("created_at", Instant.class))
+                .lastUpdatedAt(row.get("last_updated_at", Instant.class))
+                .createdBy(row.get("created_by", String.class))
+                .lastUpdatedBy(row.get("last_updated_by", String.class))
+                .build();
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/GuardrailsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/GuardrailsDAO.java
@@ -1,0 +1,28 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.GuardrailBatchItem;
+import com.google.inject.ImplementedBy;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.NotImplementedException;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@ImplementedBy(GuardrailsDAOImpl.class)
+public interface GuardrailsDAO {
+    Mono<Long> addGuardrails(EntityType entityType, List<GuardrailBatchItem> guardrails);
+}
+
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+@Slf4j
+class GuardrailsDAOImpl implements GuardrailsDAO {
+
+    @Override
+    public Mono<Long> addGuardrails(EntityType entityType, List<GuardrailBatchItem> guardrails) {
+        throw new NotImplementedException();
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/GuardrailsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/GuardrailsDAO.java
@@ -1,15 +1,26 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.GuardrailBatchItem;
+import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
+import com.comet.opik.utils.TemplateUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
 import com.google.inject.ImplementedBy;
+import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Statement;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.collections4.CollectionUtils;
+import org.stringtemplate.v4.ST;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+
+import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToFlux;
+import static com.comet.opik.utils.AsyncUtils.makeFluxContextAware;
 
 @ImplementedBy(GuardrailsDAOImpl.class)
 public interface GuardrailsDAO {
@@ -20,9 +31,73 @@ public interface GuardrailsDAO {
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 @Slf4j
 class GuardrailsDAOImpl implements GuardrailsDAO {
+    private final @NonNull TransactionTemplateAsync asyncTemplate;
+
+    private static final String BULK_INSERT_GUARDRAILS = """
+            INSERT INTO guardrails(
+                entity_type,
+                entity_id,
+                project_id,
+                workspace_id,
+                name,
+                passed,
+                config,
+                details
+            )
+            VALUES
+                <items:{item |
+                    (
+                         :entity_type<item.index>,
+                         :entity_id<item.index>,
+                         :project_id<item.index>,
+                         :workspace_id,
+                         :name<item.index>,
+                         :passed<item.index>,
+                         :config<item.index>,
+                         :details<item.index>
+                     )
+                     <if(item.hasNext)>
+                        ,
+                     <endif>
+                }>
+            ;
+            """;
 
     @Override
     public Mono<Long> addGuardrails(EntityType entityType, List<GuardrailBatchItem> guardrails) {
-        throw new NotImplementedException();
+        Preconditions.checkArgument(CollectionUtils.isNotEmpty(guardrails),
+                "Argument 'guardrails' must not be empty");
+
+        return asyncTemplate.nonTransaction(connection -> {
+
+            ST template = TemplateUtils.getBatchSql(BULK_INSERT_GUARDRAILS, guardrails.size());
+
+            var statement = connection.createStatement(template.render());
+
+            bindParameters(entityType, guardrails, statement);
+
+            return makeFluxContextAware(bindWorkspaceIdToFlux(statement))
+                    .flatMap(Result::getRowsUpdated)
+                    .reduce(Long::sum);
+        });
+    }
+
+    private void bindParameters(EntityType entityType, List<GuardrailBatchItem> guardrails, Statement statement) {
+        for (var i = 0; i < guardrails.size(); i++) {
+
+            var guardrailBatchItem = guardrails.get(i);
+
+            statement.bind("entity_type" + i, entityType.getType())
+                    .bind("entity_id" + i, guardrailBatchItem.id())
+                    .bind("project_id" + i, guardrailBatchItem.projectId())
+                    .bind("name" + i, guardrailBatchItem.name())
+                    .bind("passed" + i, guardrailBatchItem.passed())
+                    .bind("config" + i, getOrDefault(guardrailBatchItem.config()))
+                    .bind("details" + i, getOrDefault(guardrailBatchItem.details()));
+        }
+    }
+
+    private String getOrDefault(JsonNode value) {
+        return value != null ? value.toString() : "";
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/GuardrailsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/GuardrailsService.java
@@ -1,7 +1,6 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.GuardrailBatchItem;
-import com.comet.opik.api.GuardrailsCheck;
 import com.comet.opik.api.Project;
 import com.comet.opik.utils.WorkspaceUtils;
 import com.google.inject.ImplementedBy;
@@ -10,21 +9,18 @@ import jakarta.inject.Singleton;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.tuple.Pair;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static com.comet.opik.utils.ErrorUtils.failWithNotFound;
 import static java.util.stream.Collectors.groupingBy;
 
 @ImplementedBy(GuardrailsServiceImpl.class)
 public interface GuardrailsService {
-    Flux<GuardrailsCheck> getTraceGuardrails(UUID traceId);
     Mono<Void> addTraceGuardrails(List<GuardrailBatchItem> guardrails);
 }
 
@@ -34,11 +30,6 @@ public interface GuardrailsService {
 class GuardrailsServiceImpl implements GuardrailsService {
     private final @NonNull ProjectService projectService;
     private final @NonNull GuardrailsDAO guardrailsDAO;
-
-    @Override
-    public Flux<GuardrailsCheck> getTraceGuardrails(UUID traceId) {
-        throw new NotImplementedException();
-    }
 
     @Override
     public Mono<Void> addTraceGuardrails(List<GuardrailBatchItem> guardrails) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/GuardrailsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/GuardrailsService.java
@@ -1,0 +1,37 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.GuardrailBatchItem;
+import com.comet.opik.api.GuardrailsCheck;
+import com.google.inject.ImplementedBy;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.NotImplementedException;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.UUID;
+
+@ImplementedBy(GuardrailsServiceImpl.class)
+public interface GuardrailsService {
+    Flux<GuardrailsCheck> getTraceGuardrails(UUID traceId);
+    Mono<Void> addTraceGuardrails(List<GuardrailBatchItem> guardrails);
+}
+
+@Slf4j
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+class GuardrailsServiceImpl implements GuardrailsService {
+
+    @Override
+    public Flux<GuardrailsCheck> getTraceGuardrails(UUID traceId) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Mono<Void> addTraceGuardrails(List<GuardrailBatchItem> guardrails) {
+        throw new NotImplementedException();
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/GuardrailsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/GuardrailsService.java
@@ -2,17 +2,25 @@ package com.comet.opik.domain;
 
 import com.comet.opik.api.GuardrailBatchItem;
 import com.comet.opik.api.GuardrailsCheck;
+import com.comet.opik.api.Project;
+import com.comet.opik.utils.WorkspaceUtils;
 import com.google.inject.ImplementedBy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.tuple.Pair;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+
+import static com.comet.opik.utils.ErrorUtils.failWithNotFound;
+import static java.util.stream.Collectors.groupingBy;
 
 @ImplementedBy(GuardrailsServiceImpl.class)
 public interface GuardrailsService {
@@ -24,6 +32,8 @@ public interface GuardrailsService {
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 class GuardrailsServiceImpl implements GuardrailsService {
+    private final @NonNull ProjectService projectService;
+    private final @NonNull GuardrailsDAO guardrailsDAO;
 
     @Override
     public Flux<GuardrailsCheck> getTraceGuardrails(UUID traceId) {
@@ -32,6 +42,53 @@ class GuardrailsServiceImpl implements GuardrailsService {
 
     @Override
     public Mono<Void> addTraceGuardrails(List<GuardrailBatchItem> guardrails) {
-        throw new NotImplementedException();
+        if (guardrails.isEmpty()) {
+            return Mono.empty();
+        }
+
+        var entityType = EntityType.TRACE;
+
+        // group guardrails by project name to resolve project ids
+        Map<String, List<GuardrailBatchItem>> guardrailsPerProject = guardrails
+                .stream()
+                .map(guardrail -> {
+                    IdGenerator.validateVersion(guardrail.id(), entityType.getType()); // validate trace id
+
+                    return guardrail.toBuilder()
+                            .projectName(WorkspaceUtils.getProjectName(guardrail.projectName()))
+                            .build();
+                })
+                .collect(groupingBy(GuardrailBatchItem::projectName));
+
+        return projectService.retrieveByNamesOrCreate(guardrailsPerProject.keySet())
+                .map(ProjectService::groupByName)
+                .map(projectMap -> mergeProjectsAndGuardrails(projectMap, guardrailsPerProject))
+                .flatMap(projects -> processGuardrailsBatch(entityType, projects, guardrails.size()))
+                .then();
+    }
+
+    private List<Pair<Project, List<GuardrailBatchItem>>> mergeProjectsAndGuardrails(
+            Map<String, Project> projectMap, Map<String, List<GuardrailBatchItem>> guardrailsPerProject) {
+        return guardrailsPerProject.keySet()
+                .stream()
+                .map(projectName -> {
+                    Project project = projectMap.get(projectName);
+                    return Pair.of(
+                            project,
+                            guardrailsPerProject.get(projectName)
+                                    .stream()
+                                    .map(item -> item.toBuilder().projectId(project.id()).build()) // set projectId
+                                    .toList());
+                })
+                .toList();
+    }
+
+    private Mono<Long> processGuardrailsBatch(
+            EntityType entityType, List<Pair<Project, List<GuardrailBatchItem>>> projects, int actualBatchSize) {
+        return Flux.fromIterable(projects)
+                .flatMap(projectDto -> guardrailsDAO.addGuardrails(entityType, projectDto.getValue()))
+                .reduce(0L, Long::sum)
+                .flatMap(rowsUpdated -> rowsUpdated == actualBatchSize ? Mono.just(rowsUpdated) : Mono.empty())
+                .switchIfEmpty(Mono.error(failWithNotFound("Error while processing guardrails batch")));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -93,6 +93,14 @@ public interface ProjectService {
 
     ProjectStatsSummary getStats(int page, int size, @NonNull ProjectCriteria criteria,
             @NonNull List<SortingField> sortingFields);
+
+    static Map<String, Project> groupByName(List<Project> projects) {
+        return projects.stream().collect(Collectors.toMap(
+                Project::name,
+                Function.identity(),
+                BinaryOperatorUtils.last(),
+                () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));
+    }
 }
 
 @Slf4j
@@ -543,7 +551,7 @@ class ProjectServiceImpl implements ProjectService {
     private void checkIfNeededToCreateProjects(Set<String> projectNames,
             String userName, String workspaceId) {
 
-        Map<String, Project> projectsPerLowerCaseName = groupByName(
+        Map<String, Project> projectsPerLowerCaseName = ProjectService.groupByName(
                 getAllProjectsByName(workspaceId, projectNames));
 
         template.inTransaction(WRITE, handle -> {
@@ -575,13 +583,5 @@ class ProjectServiceImpl implements ProjectService {
 
             return null;
         });
-    }
-
-    private Map<String, Project> groupByName(List<Project> projects) {
-        return projects.stream().collect(Collectors.toMap(
-                Project::name,
-                Function.identity(),
-                BinaryOperatorUtils.last(),
-                () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -17,6 +17,7 @@ import com.comet.opik.domain.sorting.SortingQueryBuilder;
 import com.comet.opik.domain.stats.StatsMapper;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
+import com.comet.opik.utils.BinaryOperatorUtils;
 import com.comet.opik.utils.PaginationUtils;
 import com.google.inject.ImplementedBy;
 import jakarta.inject.Inject;
@@ -29,6 +30,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
 import java.sql.SQLIntegrityConstraintViolationException;
@@ -40,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -82,6 +86,8 @@ public interface ProjectService {
     Project getOrCreate(String workspaceId, String projectName, String userName);
 
     Project retrieveByName(String projectName);
+
+    Mono<List<Project>> retrieveByNamesOrCreate(Set<String> projectNames);
 
     void recordLastUpdatedTrace(String workspaceId, Collection<ProjectIdLastUpdated> lastUpdatedTraces);
 
@@ -499,9 +505,83 @@ class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
+    public Mono<List<Project>> retrieveByNamesOrCreate(Set<String> projectNames) {
+        return Mono.deferContextual(ctx -> {
+            String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
+            String userName = ctx.get(RequestContext.USER_NAME);
+
+            return checkIfNeededToCreateProjectsWithContext(workspaceId, userName, projectNames) // create projects if needed
+                    .then(Mono.fromCallable(() -> getAllProjectsByName(workspaceId, projectNames))
+                            .subscribeOn(Schedulers.boundedElastic())); // get all project itemIds
+        });
+    }
+
+    @Override
     public void recordLastUpdatedTrace(String workspaceId, Collection<ProjectIdLastUpdated> lastUpdatedTraces) {
         template.inTransaction(WRITE,
                 handle -> handle.attach(ProjectDAO.class).recordLastUpdatedTrace(workspaceId, lastUpdatedTraces));
     }
 
+    private Mono<Void> checkIfNeededToCreateProjectsWithContext(String workspaceId,
+            String userName, Set<String> projectNames) {
+
+        return Mono.fromRunnable(() -> checkIfNeededToCreateProjects(projectNames, userName, workspaceId))
+                .publishOn(Schedulers.boundedElastic())
+                .then();
+    }
+
+    private List<Project> getAllProjectsByName(String workspaceId,
+            Set<String> projectNames) {
+        return template.inTransaction(READ_ONLY, handle -> {
+
+            var projectDAO = handle.attach(ProjectDAO.class);
+
+            return projectDAO.findByNames(workspaceId, projectNames);
+        });
+    }
+
+    private void checkIfNeededToCreateProjects(Set<String> projectNames,
+            String userName, String workspaceId) {
+
+        Map<String, Project> projectsPerLowerCaseName = groupByName(
+                getAllProjectsByName(workspaceId, projectNames));
+
+        template.inTransaction(WRITE, handle -> {
+
+            var projectDAO = handle.attach(ProjectDAO.class);
+
+            projectNames
+                    .stream()
+                    .filter(projectName -> !projectsPerLowerCaseName.containsKey(projectName))
+                    .forEach(projectName -> {
+                        UUID projectId = idGenerator.generateId();
+                        var newProject = Project.builder()
+                                .name(projectName)
+                                .id(projectId)
+                                .createdBy(userName)
+                                .lastUpdatedBy(userName)
+                                .build();
+
+                        try {
+                            projectDAO.save(workspaceId, newProject);
+                        } catch (UnableToExecuteStatementException e) {
+                            if (e.getCause() instanceof SQLIntegrityConstraintViolationException) {
+                                log.warn("Project {} already exists", projectName);
+                            } else {
+                                throw e;
+                            }
+                        }
+                    });
+
+            return null;
+        });
+    }
+
+    private Map<String, Project> groupByName(List<Project> projects) {
+        return projects.stream().collect(Collectors.toMap(
+                Project::name,
+                Function.identity(),
+                BinaryOperatorUtils.last(),
+                () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));
+    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -53,7 +53,6 @@ import java.util.stream.Collectors;
 import static com.comet.opik.api.Trace.TracePage;
 import static com.comet.opik.api.TraceThread.TraceThreadPage;
 import static com.comet.opik.api.attachment.EntityType.TRACE;
-import static com.comet.opik.domain.FeedbackScoreDAO.EntityType;
 import static com.comet.opik.utils.ErrorUtils.failWithNotFound;
 
 @ImplementedBy(TraceServiceImpl.class)

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/TemplateUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/TemplateUtils.java
@@ -1,6 +1,7 @@
 package com.comet.opik.utils;
 
 import lombok.RequiredArgsConstructor;
+import org.stringtemplate.v4.ST;
 
 import java.util.List;
 import java.util.stream.IntStream;
@@ -22,5 +23,14 @@ public class TemplateUtils {
         return IntStream.range(0, size)
                 .mapToObj(i -> new QueryItem(i, i < size - 1))
                 .toList();
+    }
+
+    public static ST getBatchSql(String sql, int size) {
+        var template = new ST(sql);
+        List<TemplateUtils.QueryItem> queryItems = getQueryItemPlaceHolder(size);
+
+        template.add("items", queryItems);
+
+        return template;
     }
 }

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000016_add_guardrails.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000016_add_guardrails.sql
@@ -1,0 +1,21 @@
+--liquibase formatted sql
+--changeset idoberko2:0000016_add_guardrails
+
+
+CREATE TABLE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME}.guardrails
+(
+    entity_id       FixedString(36),
+    entity_type     ENUM('unknown' = 0 , 'span' = 1, 'trace' = 2),
+    project_id      FixedString(36),
+    workspace_id    String,
+    name            String,
+    passed          Bool,
+    config          String,
+    details         String,
+    created_at      DateTime64(9, 'UTC') DEFAULT now64(9),
+    last_updated_at DateTime64(9, 'UTC') DEFAULT now64(9)
+    ) ENGINE = ReplacingMergeTree(last_updated_at)
+    ORDER BY (workspace_id, project_id, entity_type, entity_id, name);
+
+
+--rollback DROP TABLE IF EXISTS ${ANALYTICS_DB_DATABASE_NAME}.guardrails;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000016_add_guardrails.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000016_add_guardrails.sql
@@ -13,7 +13,9 @@ CREATE TABLE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME}.guardrails
     config          String,
     details         String,
     created_at      DateTime64(9, 'UTC') DEFAULT now64(9),
-    last_updated_at DateTime64(9, 'UTC') DEFAULT now64(9)
+    last_updated_at DateTime64(9, 'UTC') DEFAULT now64(9),
+    created_by      String,
+    last_updated_by String
     ) ENGINE = ReplacingMergeTree(last_updated_at)
     ORDER BY (workspace_id, project_id, entity_type, entity_id, name);
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
@@ -5,6 +5,8 @@ import com.comet.opik.api.DeleteTraceThreads;
 import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.FeedbackScoreBatch;
 import com.comet.opik.api.FeedbackScoreBatchItem;
+import com.comet.opik.api.GuardrailBatch;
+import com.comet.opik.api.GuardrailBatchItem;
 import com.comet.opik.api.Project;
 import com.comet.opik.api.ProjectStats;
 import com.comet.opik.api.Trace;
@@ -98,6 +100,19 @@ public class TraceResourceClient extends BaseCommentResourceClient {
 
             assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
             assertThat(actualResponse.hasEntity()).isFalse();
+        }
+    }
+
+    public void guardrails(List<GuardrailBatchItem> score, String apiKey, String workspaceName) {
+
+        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("guardrails")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .put(Entity.json(new GuardrailBatch(score)))) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/GuardrailsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/GuardrailsResourceTest.java
@@ -1,0 +1,132 @@
+package com.comet.opik.api.resources.v1.priv;
+
+import com.comet.opik.api.GuardrailBatchItem;
+import com.comet.opik.api.GuardrailsCheck;
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.resources.utils.AuthTestUtils;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
+import com.comet.opik.domain.GuardrailsService;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.google.inject.Inject;
+import com.redis.testcontainers.RedisContainer;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.lifecycle.Startables;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.sql.SQLException;
+import java.util.UUID;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.api.resources.utils.MigrationUtils.CLICKHOUSE_CHANGELOG_FILE;
+import static com.comet.opik.domain.ProjectService.DEFAULT_PROJECT;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@DisplayName("Guardrails Resource Test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+public class GuardrailsResourceTest {
+    private static final String API_KEY = UUID.randomUUID().toString();
+    private static final String USER = UUID.randomUUID().toString();
+    private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+    private static final String TEST_WORKSPACE = UUID.randomUUID().toString();
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final MySQLContainer<?> MYSQL_CONTAINER = MySQLContainerUtils.newMySQLContainer();
+    private final ClickHouseContainer CLICK_HOUSE_CONTAINER = ClickHouseContainerUtils.newClickHouseContainer();
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    @RegisterApp
+    private final TestDropwizardAppExtension APP;
+
+    {
+        Startables.deepStart(REDIS, MYSQL_CONTAINER, CLICK_HOUSE_CONTAINER).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
+                CLICK_HOUSE_CONTAINER, DATABASE_NAME);
+
+        APP = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                MYSQL_CONTAINER.getJdbcUrl(), databaseAnalyticsFactory, wireMock.runtimeInfo(), REDIS.getRedisURI());
+    }
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    @Inject
+    private GuardrailsService guardrailsService;
+    private TraceResourceClient traceResourceClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport client, Jdbi jdbi) throws SQLException {
+
+        MigrationUtils.runDbMigration(jdbi, MySQLContainerUtils.migrationParameters());
+
+        try (var connection = CLICK_HOUSE_CONTAINER.createConnection("")) {
+            MigrationUtils.runClickhouseDbMigration(connection, CLICKHOUSE_CHANGELOG_FILE,
+                    ClickHouseContainerUtils.migrationParameters());
+        }
+
+        var baseURI = "http://localhost:%d".formatted(client.getPort());
+
+        ClientSupportUtils.config(client);
+
+        mockTargetWorkspace(API_KEY, TEST_WORKSPACE, WORKSPACE_ID);
+
+        this.traceResourceClient = new TraceResourceClient(client, baseURI);
+    }
+
+    private void mockTargetWorkspace(String apiKey, String workspaceName, String workspaceId) {
+        AuthTestUtils.mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, USER);
+    }
+
+    @AfterAll
+    void tearDownAll() {
+        wireMock.server().stop();
+    }
+
+    @Test
+    @DisplayName("test create guardrails")
+    void testCreateGuardrails() {
+        var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                .id(null)
+                .projectName(DEFAULT_PROJECT)
+                .usage(null)
+                .feedbackScores(null)
+                .build();
+        var traceId = traceResourceClient.createTrace(trace, API_KEY, TEST_WORKSPACE);
+
+        var guardrails = PodamFactoryUtils.manufacturePojoList(factory, GuardrailBatchItem.class).stream()
+                .map(guardrail -> guardrail.toBuilder()
+                        .id(traceId)
+                        .projectName(trace.projectName())
+                        .build())
+                .toList();
+
+        traceResourceClient.guardrails(guardrails, API_KEY, TEST_WORKSPACE);
+        var actual = guardrailsService.getTraceGuardrails(traceId).collectList().block();
+
+        assertThat(actual).hasSize(guardrails.size());
+        // TODO: this should be replaced with the actual guardrails assertion in the future
+        assertThat(actual.stream().map(GuardrailsCheck::name).toList())
+                .containsExactlyInAnyOrderElementsOf(guardrails.stream().map(GuardrailBatchItem::name).toList());
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/GuardrailsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/GuardrailsResourceTest.java
@@ -12,7 +12,8 @@ import com.comet.opik.api.resources.utils.RedisContainerUtils;
 import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
 import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
-import com.comet.opik.domain.GuardrailsService;
+import com.comet.opik.domain.EntityType;
+import com.comet.opik.domain.GuardrailsDAO;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.podam.PodamFactoryUtils;
@@ -72,7 +73,7 @@ public class GuardrailsResourceTest {
     private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
 
     @Inject
-    private GuardrailsService guardrailsService;
+    private GuardrailsDAO guardrailsDAO;
     private TraceResourceClient traceResourceClient;
 
     @BeforeAll
@@ -106,6 +107,8 @@ public class GuardrailsResourceTest {
     @Test
     @DisplayName("test create guardrails")
     void testCreateGuardrails() {
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(API_KEY, TEST_WORKSPACE, workspaceId);
         var trace = factory.manufacturePojo(Trace.class).toBuilder()
                 .id(null)
                 .projectName(DEFAULT_PROJECT)
@@ -122,7 +125,7 @@ public class GuardrailsResourceTest {
                 .toList();
 
         traceResourceClient.guardrails(guardrails, API_KEY, TEST_WORKSPACE);
-        var actual = guardrailsService.getTraceGuardrails(traceId).collectList().block();
+        var actual = guardrailsDAO.getTraceGuardrails(workspaceId, EntityType.TRACE, traceId).collectList().block();
 
         assertThat(actual).hasSize(guardrails.size());
         // TODO: this should be replaced with the actual guardrails assertion in the future


### PR DESCRIPTION
## Details
This PR adds ingestion for guardrails:
1. adds the new data model
2. adds batch ingestion resource
The logic is very similar to feedback scores and reuses many parts of its logic.

It includes some refactors:
- Extract `EntityType` out of `FeedbackScoreDAO` to a standalone class
- Extract projects related logic out of `FeedbackScoreService` to `ProjectsService` 

Note: the new test assertion is based on reading directly from the DAO. This will be changed in later versions once the FE facing logic is implemented.

## Issues
OPIK-1386

## Testing
New E2E test covering the ingestion.
