### PR TITLE
OPIK-1119: Add stream experiments by name endpoint

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentStreamRequest.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentStreamRequest.java
@@ -3,11 +3,23 @@ package com.comet.opik.api;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
+
+import java.util.UUID;
 
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record Identifier(@NotBlank String name) {
+public record ExperimentStreamRequest(
+        @NotBlank String name,
+        @Min(1) @Max(2000) Integer limit,
+        UUID lastRetrievedId) {
+
+    @Override
+    public Integer limit() {
+        return limit == null ? 500 : limit;
+    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -5,6 +5,7 @@ import com.comet.opik.api.DatasetCriteria;
 import com.comet.opik.api.DatasetLastExperimentCreated;
 import com.comet.opik.api.Experiment;
 import com.comet.opik.api.ExperimentSearchCriteria;
+import com.comet.opik.api.ExperimentStreamRequest;
 import com.comet.opik.api.FeedbackScoreAverage;
 import com.comet.opik.api.sorting.ExperimentSortingFactory;
 import com.comet.opik.domain.sorting.SortingQueryBuilder;
@@ -113,145 +114,6 @@ class ExperimentDAO {
             ;
             """;
 
-    private static final String SELECT_BY = """
-            SELECT
-                e.workspace_id as workspace_id,
-                e.dataset_id as dataset_id,
-                e.id as id,
-                e.name as name,
-                e.metadata as metadata,
-                e.created_at as created_at,
-                e.last_updated_at as last_updated_at,
-                e.created_by as created_by,
-                e.last_updated_by as last_updated_by,
-                e.prompt_version_id as prompt_version_id,
-                e.prompt_id as prompt_id,
-                e.prompt_versions as prompt_versions,
-                if(
-                    notEmpty(arrayFilter(x -> length(x) > 0, groupArray(tfs.name))),
-                    mapFromArrays(
-                        arrayDistinct(arrayFilter(x -> length(x) > 0, groupArray(tfs.name))),
-                        arrayMap(
-                            vName -> if(
-                                arrayReduce(
-                                    'SUM',
-                                    arrayMap(
-                                        vNameAndValue -> vNameAndValue.2,
-                                        arrayFilter(
-                                            pair -> pair.1 = vName,
-                                            groupArray(DISTINCT tuple(tfs.name, tfs.count_value, tfs.id))
-                                        )
-                                    )
-                                ) = 0,
-                                0,
-                                arrayReduce(
-                                    'SUM',
-                                    arrayMap(
-                                        vNameAndValue -> vNameAndValue.2,
-                                        arrayFilter(
-                                            pair -> pair.1 = vName,
-                                            groupArray(DISTINCT tuple(tfs.name, tfs.total_value, tfs.id))
-                                        )
-                                    )
-                                ) / arrayReduce(
-                                    'SUM',
-                                    arrayMap(
-                                        vNameAndValue -> vNameAndValue.2,
-                                        arrayFilter(
-                                            pair -> pair.1 = vName,
-                                            groupArray(DISTINCT tuple(tfs.name, tfs.count_value, tfs.id))
-                                        )
-                                    )
-                                )
-                            ),
-                            arrayDistinct(arrayFilter(x -> length(x) > 0, groupArray(tfs.name)))
-                        )
-                    ),
-                    map()
-                ) as feedback_scores,
-                count (DISTINCT ei.trace_id) as trace_count,
-                groupUniqArrayArray(tc.comments_array) as comments_array_agg
-            FROM (
-                SELECT
-                    *
-                FROM experiments
-                WHERE workspace_id = :workspace_id
-                <if(id)> AND id = :id <endif>
-                <if(name)> AND name = :name <endif>
-                ORDER BY id DESC, last_updated_at DESC
-                LIMIT 1 BY id
-            ) AS e
-            LEFT JOIN (
-                SELECT DISTINCT
-                    experiment_id,
-                    trace_id
-                FROM experiment_items
-                WHERE workspace_id = :workspace_id
-            ) AS ei ON e.id = ei.experiment_id
-            LEFT JOIN (
-                SELECT
-                    entity_id as id,
-                    name as name,
-                    SUM(value) as total_value,
-                    COUNT(value) as count_value
-                FROM (
-                    SELECT
-                        entity_id,
-                        name,
-                        value
-                    FROM feedback_scores
-                    WHERE entity_type = :entity_type
-                    AND workspace_id = :workspace_id
-                    AND entity_id IN (
-                        SELECT
-                            id
-                        FROM traces
-                        WHERE workspace_id = :workspace_id
-                    )
-                    ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
-                    LIMIT 1 BY entity_id, name
-                )
-                GROUP BY
-                    entity_id,
-                    name
-            ) AS tfs ON ei.trace_id = tfs.id
-            LEFT JOIN (
-                SELECT
-                    entity_id,
-                    groupArray(tuple(*)) AS comments_array
-                FROM (
-                    SELECT
-                        id,
-                        text,
-                        created_at,
-                        last_updated_at,
-                        created_by,
-                        last_updated_by,
-                        entity_id
-                    FROM comments
-                    WHERE workspace_id = :workspace_id
-                    ORDER BY (workspace_id, project_id, entity_id, id) DESC, last_updated_at DESC
-                    LIMIT 1 BY id
-                )
-                GROUP BY entity_id
-            ) AS tc ON ei.trace_id = tc.entity_id
-            GROUP BY
-                e.workspace_id,
-                e.dataset_id,
-                e.id,
-                e.name,
-                e.metadata as metadata,
-                e.created_at,
-                e.last_updated_at,
-                e.created_by,
-                e.last_updated_by,
-                e.prompt_version_id,
-                e.prompt_id,
-                e.prompt_versions
-            ORDER BY e.id DESC
-            ;
-            """;
-
     private static final String FIND = """
             SELECT
                 e.workspace_id as workspace_id,
@@ -318,6 +180,8 @@ class ExperimentDAO {
                 <if(dataset_id)> AND dataset_id = :dataset_id <endif>
                 <if(name)> AND ilike(name, CONCAT('%', :name, '%')) <endif>
                 <if(dataset_ids)> AND dataset_id IN :dataset_ids <endif>
+                <if(id)> AND id = :id <endif>
+                <if(lastRetrievedId)> AND id \\< :lastRetrievedId <endif>
                 <if(prompt_ids)>AND (prompt_id IN :prompt_ids OR hasAny(mapKeys(prompt_versions), :prompt_ids))<endif>
                 ORDER BY id DESC, last_updated_at DESC
                 LIMIT 1 BY id
@@ -390,7 +254,7 @@ class ExperimentDAO {
                 e.prompt_id,
                 e.prompt_versions
             ORDER BY <if(sort_fields)><sort_fields>,<endif> e.id DESC
-            LIMIT :limit OFFSET :offset
+            <if(limit)> LIMIT :limit <endif> <if(offset)> OFFSET :offset <endif>
             ;
             """;
 
@@ -547,24 +411,38 @@ class ExperimentDAO {
     @WithSpan
     Mono<Experiment> getById(@NonNull UUID id) {
         log.info("Getting experiment by id '{}'", id);
-        var template = new ST(SELECT_BY);
+        var limit = 1;
+        var template = new ST(FIND);
         template.add("id", id.toString());
+        template.add("limit", limit);
         return Mono.from(connectionFactory.create())
-                .flatMapMany(connection -> get(template.render(), connection, statement -> statement.bind("id", id)))
+                .flatMapMany(connection -> get(
+                        template.render(), connection,
+                        statement -> statement.bind("id", id).bind("limit", limit)))
                 .flatMap(this::mapToDto)
                 .singleOrEmpty();
     }
 
     @WithSpan
-    Mono<Experiment> getByName(@NonNull String name) {
-        log.info("Getting experiment by name '{}'", name);
-        var template = new ST(SELECT_BY);
-        template.add("name", name);
+    Flux<Experiment> get(@NonNull ExperimentStreamRequest request) {
+        log.info("Getting experiment by '{}'", request);
+        var template = new ST(FIND);
+        template.add("name", request.name());
+        if (request.lastRetrievedId() != null) {
+            template.add("lastRetrievedId", request.lastRetrievedId());
+        }
+        template.add("limit", request.limit());
         return Mono.from(connectionFactory.create())
-                .flatMapMany(
-                        connection -> get(template.render(), connection, statement -> statement.bind("name", name)))
-                .flatMap(this::mapToDto)
-                .singleOrEmpty();
+                .flatMapMany(connection -> get(
+                        template.render(), connection,
+                        statement -> {
+                            statement.bind("name", request.name());
+                            if (request.lastRetrievedId() != null) {
+                                statement = statement.bind("lastRetrievedId", request.lastRetrievedId());
+                            }
+                            return statement.bind("limit", request.limit());
+                        }))
+                .flatMap(this::mapToDto);
     }
 
     private Publisher<? extends Result> get(String query, Connection connection, Function<Statement, Statement> bind) {
@@ -659,17 +537,21 @@ class ExperimentDAO {
             int page, int size, ExperimentSearchCriteria experimentSearchCriteria, Connection connection) {
         log.info("Finding experiments by '{}', page '{}', size '{}'", experimentSearchCriteria, page, size);
 
-        String sorting = sortingQueryBuilder.toOrderBySql(experimentSearchCriteria.sortingFields());
+        var sorting = sortingQueryBuilder.toOrderBySql(experimentSearchCriteria.sortingFields());
 
         var hasDynamicKeys = sortingQueryBuilder.hasDynamicKeys(experimentSearchCriteria.sortingFields());
+
+        int offset = (page - 1) * size;
 
         var template = newFindTemplate(FIND, experimentSearchCriteria);
 
         template.add("sort_fields", sorting);
+        template.add("limit", size);
+        template.add("offset", offset);
 
         var statement = connection.createStatement(template.render())
                 .bind("limit", size)
-                .bind("offset", (page - 1) * size);
+                .bind("offset", offset);
 
         if (hasDynamicKeys) {
             statement = sortingQueryBuilder.bindDynamicKeys(statement, experimentSearchCriteria.sortingFields());

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/CommentAssertionUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/CommentAssertionUtils.java
@@ -17,7 +17,10 @@ public class CommentAssertionUtils {
                 .usingRecursiveComparison()
                 .ignoringFields(IGNORED_FIELDS_COMMENTS)
                 .isEqualTo(expected);
+        assertIgnoredFields(actual);
+    }
 
+    private static void assertIgnoredFields(Comment actual) {
         assertThat(actual.createdAt()).isNotNull();
         assertThat(actual.lastUpdatedAt()).isNotNull();
         assertThat(actual.createdBy()).isNotNull();
@@ -40,5 +43,10 @@ public class CommentAssertionUtils {
                 .usingRecursiveComparison()
                 .ignoringFields(IGNORED_FIELDS_COMMENTS)
                 .isEqualTo(expected);
+        if (actual != null) {
+            for (var actualComment : actual) {
+                assertIgnoredFields(actualComment);
+            }
+        }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -9,13 +9,13 @@ import com.comet.opik.api.ExperimentItem;
 import com.comet.opik.api.ExperimentItemStreamRequest;
 import com.comet.opik.api.ExperimentItemsBatch;
 import com.comet.opik.api.ExperimentItemsDelete;
+import com.comet.opik.api.ExperimentStreamRequest;
 import com.comet.opik.api.ExperimentsDelete;
 import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.FeedbackScoreAverage;
 import com.comet.opik.api.FeedbackScoreBatch;
 import com.comet.opik.api.FeedbackScoreBatchItem;
 import com.comet.opik.api.FeedbackScoreNames;
-import com.comet.opik.api.Identifier;
 import com.comet.opik.api.Project;
 import com.comet.opik.api.Prompt;
 import com.comet.opik.api.PromptVersion;
@@ -26,6 +26,7 @@ import com.comet.opik.api.events.ExperimentsDeleted;
 import com.comet.opik.api.resources.utils.AuthTestUtils;
 import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
 import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.CommentAssertionUtils;
 import com.comet.opik.api.resources.utils.MigrationUtils;
 import com.comet.opik.api.resources.utils.MySQLContainerUtils;
 import com.comet.opik.api.resources.utils.RedisContainerUtils;
@@ -53,16 +54,15 @@ import com.redis.testcontainers.RedisContainer;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
-import org.glassfish.jersey.client.ChunkedInput;
 import org.jdbi.v3.core.Jdbi;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
@@ -94,15 +94,14 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.SQLException;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -110,7 +109,6 @@ import java.util.stream.Stream;
 import static com.comet.opik.api.Experiment.ExperimentPage;
 import static com.comet.opik.api.Experiment.PromptVersionLink;
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
-import static com.comet.opik.api.resources.utils.CommentAssertionUtils.IGNORED_FIELDS_COMMENTS;
 import static com.comet.opik.api.resources.utils.FeedbackScoreAssertionUtils.assertFeedbackScoreNames;
 import static com.comet.opik.api.resources.utils.FeedbackScoreAssertionUtils.assertFeedbackScoresIgnoredFieldsAndSetThemToNull;
 import static com.comet.opik.api.resources.utils.MigrationUtils.CLICKHOUSE_CHANGELOG_FILE;
@@ -145,22 +143,18 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 class ExperimentsResourceTest {
     private static final String URL_TEMPLATE = "%s/v1/private/experiments";
     private static final String ITEMS_PATH = "/items";
-    private static final String URL_TEMPLATE_TRACES = "%s/v1/private/traces";
 
     private static final String API_KEY = UUID.randomUUID().toString();
 
     private static final String[] EXPERIMENT_IGNORED_FIELDS = new String[]{
             "id", "datasetId", "name", "feedbackScores", "traceCount", "createdAt", "lastUpdatedAt", "createdBy",
-            "lastUpdatedBy", "comments", "promptVersion", "promptVersions"};
+            "lastUpdatedBy", "comments"};
     public static final String[] ITEM_IGNORED_FIELDS = {"input", "output", "feedbackScores", "createdAt",
             "lastUpdatedAt", "createdBy", "lastUpdatedBy", "comments"};
 
     private static final String WORKSPACE_ID = UUID.randomUUID().toString();
-    private static final String USER = UUID.randomUUID().toString();
-    private static final String TEST_WORKSPACE = UUID.randomUUID().toString();
-
-    private static final GenericType<ChunkedInput<String>> CHUNKED_INPUT_STRING_GENERIC_TYPE = new GenericType<>() {
-    };
+    private static final String USER = "user-" + RandomStringUtils.secure().nextAlphanumeric(36);
+    private static final String TEST_WORKSPACE = "workspace" + RandomStringUtils.secure().nextAlphanumeric(36);
 
     private static final TypeReference<ExperimentItem> EXPERIMENT_ITEM_TYPE_REFERENCE = new TypeReference<>() {
     };
@@ -174,7 +168,7 @@ class ExperimentsResourceTest {
     private final AppContextConfig contextConfig;
 
     @RegisterApp
-    private final TestDropwizardAppExtension APP;
+    private final TestDropwizardAppExtension app;
 
     {
         Startables.deepStart(REDIS, MY_SQL_CONTAINER, CLICK_HOUSE_CONTAINER).join();
@@ -193,7 +187,7 @@ class ExperimentsResourceTest {
                 .mockEventBus(Mockito.mock(EventBus.class))
                 .build();
 
-        APP = newTestDropwizardAppExtension(contextConfig);
+        app = newTestDropwizardAppExtension(contextConfig);
     }
 
     private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
@@ -372,7 +366,7 @@ class ExperimentsResourceTest {
 
             mockTargetWorkspace(okApikey, workspaceName, WORKSPACE_ID);
 
-            var experiments = generateExperimentList();
+            var experiments = experimentResourceClient.generateExperimentList();
 
             experiments.forEach(experiment -> createAndAssert(experiment, okApikey, workspaceName));
 
@@ -618,7 +612,7 @@ class ExperimentsResourceTest {
 
             mockTargetWorkspace(API_KEY, workspaceName, WORKSPACE_ID);
 
-            var experiments = generateExperimentList();
+            var experiments = experimentResourceClient.generateExperimentList();
 
             experiments.forEach(experiment -> createAndAssert(experiment, API_KEY, workspaceName));
 
@@ -735,10 +729,6 @@ class ExperimentsResourceTest {
         return experimentResourceClient.createPartialExperiment().build();
     }
 
-    private List<Experiment> generateExperimentList() {
-        return experimentResourceClient.generateExperimentList();
-    }
-
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class FindExperiments {
@@ -757,18 +747,17 @@ class ExperimentsResourceTest {
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
             var datasetName = RandomStringUtils.secure().nextAlphanumeric(10);
-            var experiments = PodamFactoryUtils.manufacturePojoList(podamFactory, Experiment.class)
+            var experiments = experimentResourceClient.generateExperimentList()
                     .stream()
-                    .map(experiment -> experimentResourceClient.createPartialExperiment()
+                    .map(experiment -> experiment.toBuilder()
                             .datasetName(datasetName)
                             .build())
                     .toList();
-            experiments.forEach(expectedExperiment -> createAndAssert(expectedExperiment, apiKey, workspaceName));
+            experiments.forEach(experiment -> createAndAssert(experiment, apiKey, workspaceName));
 
-            var unexpectedExperiments = List.of(experimentResourceClient.createPartialExperiment().build());
+            var unexpectedExperiments = List.of(generateExperiment());
 
-            unexpectedExperiments
-                    .forEach(expectedExperiment -> createAndAssert(expectedExperiment, apiKey, workspaceName));
+            unexpectedExperiments.forEach(experiment -> createAndAssert(experiment, apiKey, workspaceName));
 
             var pageSize = experiments.size() - 2;
             var datasetId = getAndAssert(experiments.getFirst().id(), experiments.getFirst(), workspaceName, apiKey)
@@ -806,16 +795,16 @@ class ExperimentsResourceTest {
 
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
-            var experiments = PodamFactoryUtils.manufacturePojoList(podamFactory, Experiment.class)
+            var experiments = experimentResourceClient.generateExperimentList()
                     .stream()
-                    .map(experiment -> experimentResourceClient.createPartialExperiment()
+                    .map(experiment -> experiment.toBuilder()
                             .name(name)
                             .build())
                     .toList();
             experiments.forEach(expectedExperiment -> createAndAssert(expectedExperiment,
                     apiKey, workspaceName));
 
-            var unexpectedExperiments = List.of(experimentResourceClient.createPartialExperiment().build());
+            var unexpectedExperiments = List.of(generateExperiment());
 
             unexpectedExperiments
                     .forEach(expectedExperiment -> createAndAssert(expectedExperiment, apiKey, workspaceName));
@@ -843,9 +832,9 @@ class ExperimentsResourceTest {
             var datasetName = RandomStringUtils.secure().nextAlphanumeric(10);
             var name = RandomStringUtils.secure().nextAlphanumeric(10);
 
-            var experiments = PodamFactoryUtils.manufacturePojoList(podamFactory, Experiment.class)
+            var experiments = experimentResourceClient.generateExperimentList()
                     .stream()
-                    .map(experiment -> experimentResourceClient.createPartialExperiment()
+                    .map(experiment -> experiment.toBuilder()
                             .datasetName(datasetName)
                             .name(name)
                             .metadata(null)
@@ -854,7 +843,7 @@ class ExperimentsResourceTest {
             experiments.forEach(expectedExperiment -> createAndAssert(expectedExperiment,
                     apiKey, workspaceName));
 
-            var unexpectedExperiments = List.of(experimentResourceClient.createPartialExperiment().build());
+            var unexpectedExperiments = List.of(generateExperiment());
 
             unexpectedExperiments
                     .forEach(expectedExperiment -> createAndAssert(expectedExperiment, apiKey, workspaceName));
@@ -880,10 +869,9 @@ class ExperimentsResourceTest {
 
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
-            var experiments = generateExperimentList();
+            var experiments = experimentResourceClient.generateExperimentList();
 
-            experiments.forEach(expectedExperiment -> createAndAssert(expectedExperiment,
-                    apiKey, workspaceName));
+            experiments.forEach(expectedExperiment -> createAndAssert(expectedExperiment, apiKey, workspaceName));
 
             var page = 1;
             var pageSize = experiments.size();
@@ -916,8 +904,8 @@ class ExperimentsResourceTest {
 
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
-            var experiments = PodamFactoryUtils.manufacturePojoList(podamFactory, Experiment.class).stream()
-                    .map(experiment -> experimentResourceClient.createPartialExperiment()
+            var experiments = experimentResourceClient.generateExperimentList().stream()
+                    .map(experiment -> experiment.toBuilder()
                             .feedbackScores(null)
                             .build())
                     .toList();
@@ -933,17 +921,17 @@ class ExperimentsResourceTest {
             createAndAssert(noItemExperiment, apiKey, workspaceName);
 
             // Creating three traces with input, output and scores
-            var trace1 = makeTrace();
+            var trace1 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace2 = makeTrace();
+            var trace2 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace3 = makeTrace();
+            var trace3 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace4 = makeTrace();
+            var trace4 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace5 = makeTrace();
+            var trace5 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace6 = makeTrace();
+            var trace6 = podamFactory.manufacturePojo(Trace.class);
 
             var traces = List.of(trace1, trace2, trace3, trace4, trace5);
 
@@ -1050,10 +1038,7 @@ class ExperimentsResourceTest {
                             ? comments
                             : null;
 
-                    assertThat(expectedComments)
-                            .usingRecursiveComparison()
-                            .ignoringFields(IGNORED_FIELDS_COMMENTS)
-                            .isEqualTo(experiment.comments());
+                    CommentAssertionUtils.assertComments(expectedComments, experiment.comments());
                 }
             }
         }
@@ -1073,17 +1058,17 @@ class ExperimentsResourceTest {
             createAndAssert(expectedExperiment, apiKey, workspaceName);
 
             // Creating three traces with input, output and scores
-            var trace1 = makeTrace();
+            var trace1 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace2 = makeTrace();
+            var trace2 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace3 = makeTrace();
+            var trace3 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace4 = makeTrace();
+            var trace4 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace5 = makeTrace();
+            var trace5 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace6 = makeTrace();
+            var trace6 = podamFactory.manufacturePojo(Trace.class);
 
             var traces = List.of(trace1, trace2, trace3, trace4, trace5, trace6);
 
@@ -1183,19 +1168,16 @@ class ExperimentsResourceTest {
         @Test
         @DisplayName("when searching by dataset deleted when there is none, then return empty page")
         void find__whenSearchingByDatasetDeletedWhenThereIsNone__thenReturnEmptyPage() {
-
             var workspaceName = UUID.randomUUID().toString();
             var workspaceId = UUID.randomUUID().toString();
             var apiKey = UUID.randomUUID().toString();
-
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
-            List<Dataset> datasets = PodamFactoryUtils.manufacturePojoList(podamFactory, Dataset.class);
-
+            var datasets = PodamFactoryUtils.manufacturePojoList(podamFactory, Dataset.class);
             datasets.forEach(dataset -> {
                 datasetResourceClient.createDataset(dataset, apiKey, workspaceName);
 
-                createAndAssert(generateExperiment().toBuilder()
+                createAndAssert(experimentResourceClient.createPartialExperiment()
                         .datasetName(dataset.name())
                         .build(), apiKey, workspaceName);
             });
@@ -1203,35 +1185,25 @@ class ExperimentsResourceTest {
             findAndAssert(workspaceName, 1, 10, null, null, List.of(), 0, List.of(), apiKey, true, Map.of(), null);
         }
 
-        @ParameterizedTest
-        @MethodSource
-        @DisplayName("when searching by dataset deleted and result having {} experiments, then return page")
-        void find__whenSearchingByDatasetDeletedAndResultHavingXExperiments__thenReturnPage(
-                int experimentCount) {
-
-            var workspaceName = UUID.randomUUID().toString();
+        @Test
+        void find__whenSearchingByDatasetDeletedAndResultHavingExperiments__thenReturnPage() {
+            var workspaceName = "workspace-" + UUID.randomUUID();
             var workspaceId = UUID.randomUUID().toString();
-            var apiKey = UUID.randomUUID().toString();
-
+            var apiKey = "apiKey-" + UUID.randomUUID();
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
-
-            List<Dataset> datasets = Collections.synchronizedList(new ArrayList<>());
-            List<Experiment> experiments = Collections.synchronizedList(new ArrayList<>());
-
+            var datasets = new CopyOnWriteArrayList<Dataset>();
+            var experiments = new CopyOnWriteArrayList<Experiment>();
+            var experimentCount = 11;
             IntStream.range(0, experimentCount)
                     .parallel()
                     .forEach(i -> {
                         var dataset = podamFactory.manufacturePojo(Dataset.class);
                         datasetResourceClient.createDataset(dataset, apiKey, workspaceName);
                         datasets.add(dataset);
-
-                        UUID experimentId = createAndAssert(
-                                generateExperiment().toBuilder()
-                                        .datasetName(dataset.name())
-                                        .build(),
+                        var experimentId = createAndAssert(
+                                experimentResourceClient.createPartialExperiment().datasetName(dataset.name()).build(),
                                 apiKey,
                                 workspaceName);
-
                         experiments.add(getExperiment(experimentId, workspaceName, apiKey).toBuilder()
                                 .datasetName(null)
                                 .build());
@@ -1239,80 +1211,73 @@ class ExperimentsResourceTest {
 
             datasetResourceClient.deleteDatasets(datasets, apiKey, workspaceName);
 
-            experiments.sort(Comparator.comparing(Experiment::id));
-
-            findAndAssert(workspaceName, 1, experimentCount, null, null, experiments.reversed(), experimentCount,
-                    List.of(), apiKey, true, Map.of(), null);
+            experiments.sort(Comparator.comparing(Experiment::id).reversed());
+            findAndAssert(
+                    workspaceName,
+                    1,
+                    experimentCount,
+                    null,
+                    null,
+                    experiments,
+                    experimentCount,
+                    List.of(),
+                    apiKey,
+                    true,
+                    Map.of(),
+                    null);
         }
 
-        Stream<Arguments> find__whenSearchingByDatasetDeletedAndResultHavingXExperiments__thenReturnPage() {
-            return Stream.of(
-                    arguments(10),
-                    arguments(100),
-                    arguments(110));
-        }
-
-        @ParameterizedTest
-        @MethodSource
-        @DisplayName("when searching by dataset deleted, having feedback scores, and result having {} datasets, then return page")
-        void find__whenSearchingByDatasetDeletedHavingFeedbackScoresAndResultHavingXDatasets__thenReturnPage(
-                int experimentCount, int expectedMatchCount) {
-
-            var workspaceName = UUID.randomUUID().toString();
+        @Test
+        void find__whenSearchingByDatasetDeletedHavingFeedbackScoresAndResultHavingDatasets__thenReturnPage() {
+            var workspaceName = "workspace-" + UUID.randomUUID();
             var workspaceId = UUID.randomUUID().toString();
-            var apiKey = UUID.randomUUID().toString();
-
+            var apiKey = "apiKey-" + UUID.randomUUID();
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
-
-            int unexpectedDatasetCount = experimentCount - expectedMatchCount;
-
+            var experimentCount = 11;
+            var expectedMatchCount = 5;
+            var unexpectedDatasetCount = experimentCount - expectedMatchCount;
             IntStream.range(0, unexpectedDatasetCount)
                     .parallel()
                     .forEach(i -> {
                         var dataset = podamFactory.manufacturePojo(Dataset.class);
                         datasetResourceClient.createDataset(dataset, apiKey, workspaceName);
-
                         createAndAssert(
-                                generateExperiment().toBuilder()
-                                        .datasetName(dataset.name())
-                                        .build(),
+                                experimentResourceClient.createPartialExperiment().datasetName(dataset.name()).build(),
                                 apiKey,
                                 workspaceName);
                     });
-
-            List<Dataset> datasets = Collections.synchronizedList(new ArrayList<>());
-            List<Experiment> experiments = Collections.synchronizedList(new ArrayList<>());
-
+            var datasets = new CopyOnWriteArrayList<Dataset>();
+            var experiments = new CopyOnWriteArrayList<Experiment>();
             IntStream.range(0, expectedMatchCount)
                     .parallel()
                     .forEach(experiment -> {
                         var dataset = podamFactory.manufacturePojo(Dataset.class);
                         datasetResourceClient.createDataset(dataset, apiKey, workspaceName);
                         datasets.add(dataset);
-
-                        Experiment expectedExperiment = createExperimentWithFeedbackScores(apiKey, workspaceName,
-                                dataset.name());
+                        var expectedExperiment = createExperimentWithFeedbackScores(
+                                apiKey, workspaceName, dataset.name());
                         experiments.add(expectedExperiment);
                     });
 
             datasetResourceClient.deleteDatasets(datasets, apiKey, workspaceName);
 
-            experiments.sort(Comparator.comparing(Experiment::id));
-
-            Map<UUID, Map<String, BigDecimal>> expectedScoresPerExperiment = experiments
-                    .stream()
+            experiments.sort(Comparator.comparing(Experiment::id).reversed());
+            var expectedScoresPerExperiment = experiments.stream()
                     .collect(toMap(Experiment::id, experiment -> experiment.feedbackScores().stream()
                             .collect(toMap(FeedbackScoreAverage::name, FeedbackScoreAverage::value))));
-
-            findAndAssert(workspaceName, 1, expectedMatchCount, null, null, experiments.reversed(), expectedMatchCount,
-                    List.of(), apiKey, true, expectedScoresPerExperiment, null);
-        }
-
-        Stream<Arguments> find__whenSearchingByDatasetDeletedHavingFeedbackScoresAndResultHavingXDatasets__thenReturnPage() {
-            return Stream.of(
-                    arguments(10, 5),
-                    arguments(100, 50),
-                    arguments(110, 10));
+            findAndAssert(
+                    workspaceName,
+                    1,
+                    expectedMatchCount,
+                    null,
+                    null,
+                    experiments,
+                    expectedMatchCount,
+                    List.of(),
+                    apiKey,
+                    true,
+                    expectedScoresPerExperiment,
+                    null);
         }
 
         @ParameterizedTest
@@ -1343,7 +1308,7 @@ class ExperimentsResourceTest {
         }
 
         private Experiment createExperimentWithFeedbackScores(String apiKey, String workspaceName, String datasetName) {
-            var experiment = generateExperiment().toBuilder()
+            var experiment = experimentResourceClient.createPartialExperiment()
                     .datasetName(datasetName)
                     .build();
 
@@ -1353,7 +1318,7 @@ class ExperimentsResourceTest {
                     .datasetName(null)
                     .build();
 
-            var trace = makeTrace();
+            var trace = podamFactory.manufacturePojo(Trace.class);
 
             var traces = List.of(trace);
 
@@ -1429,9 +1394,10 @@ class ExperimentsResourceTest {
                     .parallel()
                     .mapToObj(i -> {
                         PromptVersionLink versionLink = buildVersionLink(promptVersion);
-                        var experiment = generateExperiment().toBuilder()
+                        var experiment = experimentResourceClient.createPartialExperiment()
                                 .datasetName(dataset.name())
                                 .promptVersion(versionLink)
+                                .promptVersions(List.of(versionLink))
                                 .feedbackScores(null)
                                 .build();
 
@@ -1473,8 +1439,9 @@ class ExperimentsResourceTest {
                         PromptVersionLink versionLink = buildVersionLink(promptVersion);
                         PromptVersionLink versionLink2 = buildVersionLink(promptVersion2);
 
-                        var experiment = generateExperiment().toBuilder()
+                        var experiment = experimentResourceClient.createPartialExperiment()
                                 .datasetName(dataset.name())
+                                .promptVersion(versionLink)
                                 .promptVersions(List.of(versionLink, versionLink2))
                                 .feedbackScores(null)
                                 .build();
@@ -1555,17 +1522,14 @@ class ExperimentsResourceTest {
         @ParameterizedTest
         @MethodSource("whenSortingByFieldAndDirection__thenReturnPage")
         @DisplayName("when sorting by field and direction, then return page")
-        void whenSortingByFieldAndDirection__thenReturnPage(Comparator<Experiment> comparator,
-                SortingField sortingField) {
+        void whenSortingByFieldAndDirection__thenReturnPage(
+                Comparator<Experiment> comparator, SortingField sortingField) {
             var workspaceName = UUID.randomUUID().toString();
             var workspaceId = UUID.randomUUID().toString();
             var apiKey = UUID.randomUUID().toString();
-
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
-            List<FeedbackScoreBatchItem> scoreForTrace = PodamFactoryUtils.manufacturePojoList(podamFactory,
-                    FeedbackScoreBatchItem.class);
-
+            var scoreForTrace = PodamFactoryUtils.manufacturePojoList(podamFactory, FeedbackScoreBatchItem.class);
             var experiments = IntStream.range(0, 5)
                     .mapToObj(i -> experimentResourceClient.createPartialExperiment()
                             .lastUpdatedBy(USER)
@@ -1578,14 +1542,12 @@ class ExperimentsResourceTest {
                     .stream()
                     .sorted(comparator)
                     .toList();
-
-            Map<UUID, Map<String, BigDecimal>> expectedScores = expectedExperiments
+            var expectedScores = expectedExperiments
                     .stream()
                     .map(experiment -> Map.entry(experiment.id(), experiment.feedbackScores()
                             .stream()
                             .collect(toMap(FeedbackScoreAverage::name, FeedbackScoreAverage::value))))
                     .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
-
             findAndAssert(workspaceName, 1, expectedExperiments.size(), null, null, expectedExperiments,
                     expectedExperiments.size(), List.of(), apiKey, false, expectedScores, null, List.of(sortingField));
         }
@@ -1597,12 +1559,9 @@ class ExperimentsResourceTest {
             var workspaceName = UUID.randomUUID().toString();
             var workspaceId = UUID.randomUUID().toString();
             var apiKey = UUID.randomUUID().toString();
-
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
-            List<FeedbackScoreBatchItem> scoreForTrace = PodamFactoryUtils.manufacturePojoList(podamFactory,
-                    FeedbackScoreBatchItem.class);
-
+            var scoreForTrace = PodamFactoryUtils.manufacturePojoList(podamFactory, FeedbackScoreBatchItem.class);
             var experiments = IntStream.range(0, 5)
                     .mapToObj(i -> experimentResourceClient.createPartialExperiment()
                             .lastUpdatedBy(USER)
@@ -1614,26 +1573,22 @@ class ExperimentsResourceTest {
             var sortingField = new SortingField(
                     "feedback_scores.%s".formatted(scoreForTrace.getFirst().name()),
                     direction);
-
             Comparator<Experiment> comparing = Comparator.comparing(experiment -> experiment.feedbackScores()
                     .stream()
                     .filter(score -> score.name().equals(scoreForTrace.getFirst().name()))
                     .findFirst()
                     .orElseThrow()
                     .value());
-
             var expectedExperiments = experiments
                     .stream()
                     .sorted(direction == Direction.ASC ? comparing : comparing.reversed())
                     .toList();
-
-            Map<UUID, Map<String, BigDecimal>> expectedScores = expectedExperiments
+            var expectedScores = expectedExperiments
                     .stream()
                     .map(experiment -> Map.entry(experiment.id(), experiment.feedbackScores()
                             .stream()
                             .collect(toMap(FeedbackScoreAverage::name, FeedbackScoreAverage::value))))
                     .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
-
             findAndAssert(workspaceName, 1, expectedExperiments.size(), null, null, expectedExperiments,
                     expectedExperiments.size(), List.of(), apiKey, false, expectedScores, null, List.of(sortingField));
         }
@@ -1662,68 +1617,72 @@ class ExperimentsResourceTest {
             }
         }
 
-        private Experiment generateFullExperiment(String apiKey, String workspaceName, Experiment expectedExperiment,
-                List<FeedbackScoreBatchItem> scoreForTrace) {
+    }
 
-            createAndAssert(expectedExperiment, apiKey, workspaceName);
+    private Experiment generateFullExperiment(
+            String apiKey,
+            String workspaceName,
+            Experiment expectedExperiment,
+            List<FeedbackScoreBatchItem> scoreForTrace) {
 
-            int tracesNumber = PodamUtils.getIntegerInRange(1, 10);
+        createAndAssert(expectedExperiment, apiKey, workspaceName);
 
-            List<Trace> traces = IntStream.range(0, tracesNumber)
-                    .parallel()
-                    .mapToObj(i -> makeTrace())
-                    .toList();
+        int tracesNumber = PodamUtils.getIntegerInRange(1, 10);
 
-            traceResourceClient.batchCreateTraces(traces, apiKey, workspaceName);
+        List<Trace> traces = IntStream.range(0, tracesNumber)
+                .parallel()
+                .mapToObj(i -> podamFactory.manufacturePojo(Trace.class))
+                .toList();
 
-            Map<UUID, List<FeedbackScoreBatchItem>> traceIdToScoresMap = traces.stream()
-                    .map(trace -> copyScoresFrom(scoreForTrace, trace))
-                    .flatMap(List::stream)
-                    .collect(groupingBy(FeedbackScoreBatchItem::id));
+        traceResourceClient.batchCreateTraces(traces, apiKey, workspaceName);
 
-            var feedbackScoreBatch = podamFactory.manufacturePojo(FeedbackScoreBatch.class);
-            feedbackScoreBatch = feedbackScoreBatch.toBuilder()
-                    .scores(Stream.concat(
-                            feedbackScoreBatch.scores().stream(),
-                            traceIdToScoresMap.values().stream().flatMap(List::stream))
-                            .toList())
-                    .build();
+        Map<UUID, List<FeedbackScoreBatchItem>> traceIdToScoresMap = traces.stream()
+                .map(trace -> copyScoresFrom(scoreForTrace, trace))
+                .flatMap(List::stream)
+                .collect(groupingBy(FeedbackScoreBatchItem::id));
 
-            createScoreAndAssert(feedbackScoreBatch, apiKey, workspaceName);
+        var feedbackScoreBatch = podamFactory.manufacturePojo(FeedbackScoreBatch.class);
+        feedbackScoreBatch = feedbackScoreBatch.toBuilder()
+                .scores(Stream.concat(
+                        feedbackScoreBatch.scores().stream(),
+                        traceIdToScoresMap.values().stream().flatMap(List::stream))
+                        .toList())
+                .build();
 
-            int totalNumberOfScores = traceIdToScoresMap.size();
+        createScoreAndAssert(feedbackScoreBatch, apiKey, workspaceName);
 
-            var experimentItems = IntStream.range(0, totalNumberOfScores)
-                    .mapToObj(i -> podamFactory.manufacturePojo(ExperimentItem.class).toBuilder()
-                            .experimentId(expectedExperiment.id())
-                            .traceId(traces.get(i % traces.size()).id())
-                            .feedbackScores(
-                                    traceIdToScoresMap.get(traces.get(i % traces.size()).id()).stream()
-                                            .map(FeedbackScoreMapper.INSTANCE::toFeedbackScore)
-                                            .toList())
-                            .build())
-                    .toList();
+        int totalNumberOfScores = traceIdToScoresMap.size();
 
-            var experimentItemsBatch = addRandomExperiments(experimentItems);
+        var experimentItems = IntStream.range(0, totalNumberOfScores)
+                .mapToObj(i -> podamFactory.manufacturePojo(ExperimentItem.class).toBuilder()
+                        .experimentId(expectedExperiment.id())
+                        .traceId(traces.get(i % traces.size()).id())
+                        .feedbackScores(
+                                traceIdToScoresMap.get(traces.get(i % traces.size()).id()).stream()
+                                        .map(FeedbackScoreMapper.INSTANCE::toFeedbackScore)
+                                        .toList())
+                        .build())
+                .toList();
 
-            createAndAssert(experimentItemsBatch, apiKey, workspaceName);
+        var experimentItemsBatch = addRandomExperiments(experimentItems);
 
-            Map<UUID, Map<String, BigDecimal>> expectedScoresPerExperiment = getExpectedScoresPerExperiment(
-                    List.of(expectedExperiment), experimentItems);
+        createAndAssert(experimentItemsBatch, apiKey, workspaceName);
 
-            return expectedExperiment.toBuilder()
-                    .traceCount((long) traces.size())
-                    .feedbackScores(
-                            expectedScoresPerExperiment.get(expectedExperiment.id())
-                                    .entrySet()
-                                    .stream()
-                                    .map(e -> FeedbackScoreAverage.builder()
-                                            .name(e.getKey())
-                                            .value(avgFromList(List.of(e.getValue())))
-                                            .build())
-                                    .toList())
-                    .build();
-        }
+        Map<UUID, Map<String, BigDecimal>> expectedScoresPerExperiment = getExpectedScoresPerExperiment(
+                List.of(expectedExperiment), experimentItems);
+
+        return expectedExperiment.toBuilder()
+                .traceCount((long) traces.size())
+                .feedbackScores(
+                        expectedScoresPerExperiment.get(expectedExperiment.id())
+                                .entrySet()
+                                .stream()
+                                .map(e -> FeedbackScoreAverage.builder()
+                                        .name(e.getKey())
+                                        .value(avgFromList(List.of(e.getValue())))
+                                        .build())
+                                .toList())
+                .build();
     }
 
     private static PromptVersionLink buildVersionLink(PromptVersion promptVersion) {
@@ -1741,7 +1700,7 @@ class ExperimentsResourceTest {
         IntStream.range(0, experimentCount - expectedMatchCount)
                 .parallel()
                 .forEach(i -> {
-                    var experiment = generateExperiment().toBuilder()
+                    var experiment = experimentResourceClient.createPartialExperiment()
                             .datasetName(dataset.name())
                             .build();
 
@@ -1853,44 +1812,54 @@ class ExperimentsResourceTest {
             Map<UUID, Map<String, BigDecimal>> expectedScoresPerExperiment,
             UUID promptId,
             List<SortingField> sortingFields) {
-
-        try (var actualResponse = findExperiment(workspaceName, apiKey, page, pageSize, datasetId, name, datasetDeleted,
-                promptId, sortingFields)) {
-
-            var actualPage = actualResponse.readEntity(ExperimentPage.class);
-            var actualExperiments = actualPage.content();
-
+        try (var actualResponse = findExperiment(
+                workspaceName, apiKey, page, pageSize, datasetId, name, datasetDeleted, promptId, sortingFields)) {
             assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
-
+            var actualPage = actualResponse.readEntity(ExperimentPage.class);
             assertThat(actualPage.page()).isEqualTo(page);
             assertThat(actualPage.size()).isEqualTo(expectedExperiments.size());
             assertThat(actualPage.total()).isEqualTo(expectedTotal);
-            assertThat(actualExperiments).hasSize(expectedExperiments.size());
+            assertExperiments(
+                    datasetId,
+                    expectedExperiments,
+                    unexpectedExperiments,
+                    expectedScoresPerExperiment,
+                    actualPage.content());
+        }
+    }
 
+    private void assertExperiments(
+            UUID datasetId,
+            List<Experiment> expectedExperiments,
+            List<Experiment> unexpectedExperiments,
+            Map<UUID, Map<String, BigDecimal>> expectedScoresPerExperiment,
+            List<Experiment> actualExperiments) {
+
+        assertThat(actualExperiments).hasSize(expectedExperiments.size());
+
+        assertThat(actualExperiments)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields(EXPERIMENT_IGNORED_FIELDS)
+                .containsExactlyElementsOf(expectedExperiments);
+
+        assertIgnoredFields(actualExperiments, expectedExperiments, datasetId);
+
+        if (!unexpectedExperiments.isEmpty()) {
             assertThat(actualExperiments)
                     .usingRecursiveFieldByFieldElementComparatorIgnoringFields(EXPERIMENT_IGNORED_FIELDS)
-                    .containsExactlyElementsOf(expectedExperiments);
+                    .doesNotContainAnyElementsOf(unexpectedExperiments);
+        }
 
-            assertIgnoredFields(actualExperiments, expectedExperiments, datasetId);
+        if (MapUtils.isNotEmpty(expectedScoresPerExperiment)) {
+            for (Experiment experiment : actualExperiments) {
+                var expectedScores = expectedScoresPerExperiment.get(experiment.id());
+                var actualScores = getScoresMap(experiment);
 
-            if (!unexpectedExperiments.isEmpty()) {
-                assertThat(actualExperiments)
-                        .usingRecursiveFieldByFieldElementComparatorIgnoringFields(EXPERIMENT_IGNORED_FIELDS)
-                        .doesNotContainAnyElementsOf(unexpectedExperiments);
-            }
-
-            if (expectedScoresPerExperiment != null) {
-                for (Experiment experiment : actualExperiments) {
-                    var expectedScores = expectedScoresPerExperiment.get(experiment.id());
-                    var actualScores = getScoresMap(experiment);
-
-                    assertThat(actualScores)
-                            .usingRecursiveComparison(RecursiveComparisonConfiguration.builder()
-                                    .withComparatorForType(ExperimentsResourceTest.this::customComparator,
-                                            BigDecimal.class)
-                                    .build())
-                            .isEqualTo(expectedScores);
-                }
+                assertThat(actualScores)
+                        .usingRecursiveComparison(RecursiveComparisonConfiguration.builder()
+                                .withComparatorForType(ExperimentsResourceTest.this::customComparator,
+                                        BigDecimal.class)
+                                .build())
+                        .isEqualTo(expectedScores);
             }
         }
     }
@@ -1921,8 +1890,9 @@ class ExperimentsResourceTest {
         BigDecimal v2Decimal = v2.remainder(BigDecimal.ONE).abs(); // Get the decimal part
 
         // Convert decimal parts to integers by scaling them to eliminate the decimal point
-        BigDecimal v1DecimalInt = v1Decimal.movePointRight(v1Decimal.scale());
-        BigDecimal v2DecimalInt = v2Decimal.movePointRight(v2Decimal.scale());
+        var scale = Math.min(v1Decimal.scale(), v2Decimal.scale());
+        BigDecimal v1DecimalInt = v1Decimal.movePointRight(scale);
+        BigDecimal v2DecimalInt = v2Decimal.movePointRight(scale);
 
         // Calculate the difference between the integer representations of the decimal parts
         BigDecimal decimalDifference = v1DecimalInt.subtract(v2DecimalInt).abs();
@@ -1938,6 +1908,198 @@ class ExperimentsResourceTest {
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class StreamExperiments {
+
+        @Test
+        void streamWithCursorBasedPagination() {
+            var datasetName1 = "dataset1-" + RandomStringUtils.secure().nextAlphanumeric(36);
+            var datasetName2 = "dataset2-" + RandomStringUtils.secure().nextAlphanumeric(36);
+            var nameCommon = RandomStringUtils.secure().nextAlphanumeric(12);
+            // Creating 6 experiments with the same common name in the middle
+            var experiments = IntStream.range(0, 6)
+                    .mapToObj(i -> {
+                        // First 3 experiments are created with datasetName1, the next 2 with datasetName2
+                        var datasetName = i < 3 ? datasetName1 : datasetName2;
+                        var namePrefix = RandomStringUtils.secure().nextAlphanumeric(12);
+                        var nameSuffix = RandomStringUtils.secure().nextAlphanumeric(12);
+                        var experiment = experimentResourceClient.createPartialExperiment()
+                                .datasetName(datasetName)
+                                // Using the same common name for all experiments with random prefix and suffix
+                                .name("experiment-%s-%s-%s".formatted(namePrefix, nameCommon, nameSuffix))
+                                .build();
+                        experimentResourceClient.create(experiment, API_KEY, TEST_WORKSPACE);
+                        return experiment;
+                    })
+                    .toList();
+
+            // As experiments are returned in most recent order, the last 3 go to the first dataset
+            var expectedDatasetId1 = getExperiment(experiments.getLast().id(), TEST_WORKSPACE, API_KEY).datasetId();
+            var expectedDatasetId2 = getExperiment(experiments.getFirst().id(), TEST_WORKSPACE, API_KEY).datasetId();
+
+            var expectedExperiments1 = experiments.reversed().subList(0, 3);
+            var expectedExperiments2 = experiments.reversed().subList(3, experiments.size());
+
+            // An unrelated experiment is created to ensure that the stream only returns the expected ones
+            var unexpectedExperiments = List.of(generateExperiment());
+            unexpectedExperiments.forEach(experiment -> experimentResourceClient.create(
+                    experiment, API_KEY, TEST_WORKSPACE));
+
+            // Search is case-insensitive and by partial name
+            var name = nameCommon.toLowerCase();
+
+            // Retrieving the first page of 3 experiments
+            var request1 = ExperimentStreamRequest.builder()
+                    .name(name)
+                    .limit(3)
+                    .build();
+            var actualExperiments1 = experimentResourceClient.streamExperiments(request1, API_KEY, TEST_WORKSPACE);
+            assertExperiments(
+                    expectedDatasetId1, expectedExperiments1, unexpectedExperiments, null, actualExperiments1);
+
+            // Retrieving the next page with default limit
+            var request2 = ExperimentStreamRequest.builder()
+                    .name(name)
+                    .lastRetrievedId(actualExperiments1.getLast().id())
+                    .build();
+            var actualExperiments2 = experimentResourceClient.streamExperiments(request2, API_KEY, TEST_WORKSPACE);
+            assertExperiments(
+                    expectedDatasetId2, expectedExperiments2, unexpectedExperiments, null, actualExperiments2);
+
+            // Retrieving the last page which should be empty
+            var request3 = ExperimentStreamRequest.builder()
+                    .name(name)
+                    .lastRetrievedId(actualExperiments2.getLast().id())
+                    .build();
+            var actualExperiments3 = experimentResourceClient.streamExperiments(request3, API_KEY, TEST_WORKSPACE);
+            assertThat(actualExperiments3).isEmpty();
+        }
+
+        @Test
+        void streamFullExperimentWithScoresPromptVersionsAndComments() {
+            var datasetName = "dataset-" + RandomStringUtils.secure().nextAlphanumeric(36);
+            var name = "experiment-" + RandomStringUtils.secure().nextAlphanumeric(36);
+            // Only 2 experiments is enough for this test
+            var experiments = IntStream.range(0, 2)
+                    .mapToObj(i -> {
+                        // Only 2 prompt versions per experiment is enough for this test
+                        var promptVersions = IntStream.range(0, 2)
+                                .mapToObj(j -> {
+                                    var prompt = podamFactory.manufacturePojo(Prompt.class);
+                                    var promptVersion = promptResourceClient.createPromptVersion(prompt, API_KEY,
+                                            TEST_WORKSPACE);
+                                    return buildVersionLink(promptVersion);
+                                })
+                                .toList();
+                        var experiment = podamFactory.manufacturePojo(Experiment.class).toBuilder()
+                                .datasetName(datasetName)
+                                .name(name)
+                                .promptVersion(promptVersions.getFirst())
+                                .promptVersions(promptVersions)
+                                .build();
+                        // Only 2 scores per experiment is enough for this test
+                        var scores = IntStream.range(0, 2)
+                                .mapToObj(j -> podamFactory.manufacturePojo(FeedbackScoreBatchItem.class))
+                                .toList();
+                        return generateFullExperiment(API_KEY, TEST_WORKSPACE, experiment, scores);
+                    })
+                    .toList();
+
+            // Only 1 trace per experiment is enough for this test
+            var traces = IntStream.range(0, 2).mapToObj(i -> podamFactory.manufacturePojo(Trace.class)).toList();
+            traceResourceClient.batchCreateTraces(traces, API_KEY, TEST_WORKSPACE);
+
+            // Attaching 2 comments to each trace.
+            // As experiments are later returned in most recent order, the last comments go to the first trace.
+            var commentsLast = IntStream.range(0, 2)
+                    .mapToObj(i -> traceResourceClient.generateAndCreateComment(
+                            traces.getFirst().id(), API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED))
+                    .toList();
+            var commentsFirst = IntStream.range(0, 2)
+                    .mapToObj(i -> traceResourceClient.generateAndCreateComment(
+                            traces.getLast().id(), API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED))
+                    .toList();
+
+            // Linking an experiment item to each trace and experiment
+            var experimentItemFirst = podamFactory.manufacturePojo(ExperimentItem.class).toBuilder()
+                    .experimentId(experiments.getFirst().id())
+                    .traceId(traces.getFirst().id())
+                    .build();
+            var experimentItemLast = podamFactory.manufacturePojo(ExperimentItem.class).toBuilder()
+                    .experimentId(experiments.getLast().id())
+                    .traceId(traces.getLast().id())
+                    .build();
+            experimentResourceClient.createExperimentItem(
+                    Set.of(experimentItemFirst, experimentItemLast), API_KEY, TEST_WORKSPACE);
+
+            // Determining the expected datasetId
+            var expectedDatasetId = getExperiment(experiments.getFirst().id(), TEST_WORKSPACE, API_KEY).datasetId();
+
+            var expectedExperiments = experiments.reversed();
+
+            // An unrelated experiment is created to ensure that the stream only returns the expected ones
+            var unexpectedExperiments = List.of(generateExperiment());
+            unexpectedExperiments.forEach(experiment -> experimentResourceClient.create(
+                    experiment, API_KEY, TEST_WORKSPACE));
+
+            // The expected scores are calculated for each experiment
+            var expectedScores = expectedExperiments.stream()
+                    .map(experiment -> Map.entry(experiment.id(), experiment.feedbackScores()
+                            .stream()
+                            .collect(toMap(FeedbackScoreAverage::name, FeedbackScoreAverage::value))))
+                    .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            var request = ExperimentStreamRequest.builder().name(name).build();
+            var actualExperiments = experimentResourceClient.streamExperiments(request, API_KEY, TEST_WORKSPACE);
+
+            assertExperiments(
+                    expectedDatasetId, expectedExperiments, unexpectedExperiments, expectedScores, actualExperiments);
+            CommentAssertionUtils.assertComments(commentsFirst, actualExperiments.getFirst().comments());
+            CommentAssertionUtils.assertComments(commentsLast, actualExperiments.getLast().comments());
+        }
+
+        @Test
+        void streamHandlesDatasetDeletion() {
+            var name = "experiment-" + RandomStringUtils.secure().nextAlphanumeric(36);
+            // Creating 2 experiments with the same name
+            var experiments = IntStream.range(0, 2)
+                    .mapToObj(i -> {
+                        // Each experiment is created with a different dataset name
+                        var datasetName = "dataset-" + RandomStringUtils.secure().nextAlphanumeric(36);
+                        var experiment = experimentResourceClient.createPartialExperiment()
+                                .datasetName(datasetName)
+                                .name(name)
+                                .build();
+                        experimentResourceClient.create(experiment, API_KEY, TEST_WORKSPACE);
+                        return experiment;
+                    })
+                    .toList();
+
+            // Resolving the datasetId of the first experiment, in order to delete it later
+            var datasetIdToDelete = getExperiment(experiments.getFirst().id(), TEST_WORKSPACE, API_KEY).datasetId();
+
+            // Experiments are returned in most recent order.
+            var expectedExperiments = List.of(
+                    experiments.getLast(), experiments.getFirst().toBuilder().datasetName(null).build());
+
+            // An unrelated experiment is created to ensure that the stream only returns the expected ones
+            var unexpectedExperiments = List.of(generateExperiment());
+            unexpectedExperiments.forEach(experiment -> experimentResourceClient.create(
+                    experiment, API_KEY, TEST_WORKSPACE));
+
+            // Deleting the dataset of the first experiment
+            var datasets = List.of(Dataset.builder().id(datasetIdToDelete).build());
+            datasetResourceClient.deleteDatasets(datasets, API_KEY, TEST_WORKSPACE);
+
+            var request = ExperimentStreamRequest.builder().name(name).build();
+            var actualExperiments = experimentResourceClient.streamExperiments(request, API_KEY, TEST_WORKSPACE);
+
+            assertExperiments(
+                    null, expectedExperiments, unexpectedExperiments, null, actualExperiments);
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class CreateAndGetExperiments {
 
         @Test
@@ -1949,11 +2111,11 @@ class ExperimentsResourceTest {
             createAndAssert(expectedExperiment, API_KEY, TEST_WORKSPACE);
 
             // Creating three traces with input, output and scores
-            var trace1 = makeTrace();
+            var trace1 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace2 = makeTrace();
+            var trace2 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace3 = makeTrace();
+            var trace3 = podamFactory.manufacturePojo(Trace.class);
 
             var traces = List.of(trace1, trace2, trace3);
 
@@ -2009,51 +2171,6 @@ class ExperimentsResourceTest {
         }
 
         @Test
-        void createAndGetByName() {
-            var expectedExperiment = generateExperiment();
-            createAndAssert(expectedExperiment, API_KEY, TEST_WORKSPACE);
-
-            getAndAssert(expectedExperiment.id(), expectedExperiment, TEST_WORKSPACE, API_KEY);
-
-            try (var actualResponse = client.target(getExperimentsPath())
-                    .path("retrieve")
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .post(Entity.json(new Identifier(expectedExperiment.name())))) {
-
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
-                var actualExperiment = actualResponse.readEntity(Experiment.class);
-                assertThat(actualExperiment.id()).isEqualTo(expectedExperiment.id());
-
-                assertThat(actualExperiment)
-                        .usingRecursiveComparison()
-                        .ignoringFields(EXPERIMENT_IGNORED_FIELDS)
-                        .isEqualTo(expectedExperiment);
-            }
-        }
-
-        @Test
-        void getByNameNotFound() {
-            String name = UUID.randomUUID().toString();
-            var expectedError = new ErrorMessage(HttpStatus.SC_NOT_FOUND,
-                    "Not found experiment with name '%s'".formatted(name));
-            try (var actualResponse = client.target(getExperimentsPath())
-                    .path("retrieve")
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .post(Entity.json(new Identifier(name)))) {
-
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NOT_FOUND);
-
-                var actualError = actualResponse.readEntity(ErrorMessage.class);
-
-                assertThat(actualError).isEqualTo(expectedError);
-            }
-        }
-
-        @Test
         void createAndGetFeedbackAvgAndComments() {
             var expectedExperiment = experimentResourceClient.createPartialExperiment()
                     .traceCount(3L)
@@ -2062,11 +2179,11 @@ class ExperimentsResourceTest {
             createAndAssert(expectedExperiment, API_KEY, TEST_WORKSPACE);
 
             // Creating three traces with input, output, and scores
-            var trace1 = makeTrace();
+            var trace1 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace2 = makeTrace();
+            var trace2 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace3 = makeTrace();
+            var trace3 = podamFactory.manufacturePojo(Trace.class);
 
             var traces = List.of(trace1, trace2, trace3);
 
@@ -2127,10 +2244,7 @@ class ExperimentsResourceTest {
                             .build())
                     .isEqualTo(expectedScores);
 
-            assertThat(expectedComments)
-                    .usingRecursiveComparison()
-                    .ignoringFields(IGNORED_FIELDS_COMMENTS)
-                    .isEqualTo(experiment.comments());
+            CommentAssertionUtils.assertComments(expectedComments, experiment.comments());
         }
 
         @Test
@@ -2175,7 +2289,9 @@ class ExperimentsResourceTest {
             var expectedExperiment = generateExperiment();
             createAndAssert(expectedExperiment, API_KEY, TEST_WORKSPACE);
 
-            var unexpectedExperiment = generateExperiment().toBuilder().id(expectedExperiment.id()).build();
+            var unexpectedExperiment = experimentResourceClient.createPartialExperiment()
+                    .id(expectedExperiment.id())
+                    .build();
             var actualId = experimentResourceClient.create(unexpectedExperiment, API_KEY, TEST_WORKSPACE);
 
             // The event isn't posted when the experiment already exists.
@@ -2266,17 +2382,17 @@ class ExperimentsResourceTest {
             createAndAssert(expectedExperiment, apiKey, workspaceName);
 
             // Creating three traces with input, output and scores
-            var trace1 = makeTrace();
+            var trace1 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace2 = makeTrace();
+            var trace2 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace3 = makeTrace();
+            var trace3 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace4 = makeTrace();
+            var trace4 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace5 = makeTrace();
+            var trace5 = podamFactory.manufacturePojo(Trace.class);
 
-            var trace6 = makeTrace();
+            var trace6 = podamFactory.manufacturePojo(Trace.class);
 
             var traces = List.of(trace1, trace2, trace3, trace4, trace5, trace6);
 
@@ -2449,10 +2565,6 @@ class ExperimentsResourceTest {
                 trace);
     }
 
-    private Trace makeTrace() {
-        return podamFactory.manufacturePojo(Trace.class);
-    }
-
     private synchronized UUID createAndAssert(Experiment expectedExperiment, String apiKey, String workspaceName) {
         Mockito.reset(defaultEventBus);
         try (var actualResponse = client.target(getExperimentsPath())
@@ -2494,10 +2606,11 @@ class ExperimentsResourceTest {
                 .header(WORKSPACE_HEADER, workspaceName)
                 .get()) {
 
-            if (actualResponse.getStatusInfo().getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+            if (actualResponse.getStatus() == HttpStatus.SC_NOT_FOUND) {
                 return null;
             }
 
+            assertThat(actualResponse.getStatus()).isEqualTo(HttpStatus.SC_OK);
             return actualResponse.readEntity(Experiment.class);
         }
     }
@@ -2690,7 +2803,7 @@ class ExperimentsResourceTest {
 
         @Test
         void deleteExperimentsById__whenDeletingMultipleExperiments__thenReturnNoContent() {
-            var experiments = generateExperimentList();
+            var experiments = experimentResourceClient.generateExperimentList();
 
             experiments.forEach(experiment -> createAndAssert(experiment, API_KEY, TEST_WORKSPACE));
             experiments.parallelStream()
@@ -3120,7 +3233,7 @@ class ExperimentsResourceTest {
             List<List<FeedbackScoreBatchItem>> multipleValuesFeedbackScoreList,
             List<List<FeedbackScoreBatchItem>> singleValueScores) {
 
-        UUID experimentId = experimentResourceClient.createExperiment(apiKey, workspaceName);
+        UUID experimentId = experimentResourceClient.create(apiKey, workspaceName);
 
         Stream.of(multipleValuesFeedbackScoreList, singleValueScores)
                 .flatMap(List::stream)
@@ -3199,10 +3312,7 @@ class ExperimentsResourceTest {
                     .isEqualTo(expectedExperimentItem.feedbackScores());
             assertThat(actualExperimentItem.input()).isEqualTo(expectedExperimentItem.input());
             assertThat(actualExperimentItem.output()).isEqualTo(expectedExperimentItem.output());
-            assertThat(actualExperimentItem.comments())
-                    .usingRecursiveComparison()
-                    .ignoringFields(IGNORED_FIELDS_COMMENTS)
-                    .isEqualTo(expectedExperimentItem.comments());
+            CommentAssertionUtils.assertComments(expectedExperimentItem.comments(), actualExperimentItem.comments());
         } else {
             assertThat(actualExperimentItem.input()).isNull();
             assertThat(actualExperimentItem.output()).isNull();
@@ -3244,7 +3354,8 @@ class ExperimentsResourceTest {
 
             assertThat(actualResponse.getStatus()).isEqualTo(HttpStatus.SC_OK);
 
-            var actualExperimentItems = getStreamedItems(actualResponse);
+            var actualExperimentItems = experimentResourceClient.getStreamed(
+                    actualResponse, EXPERIMENT_ITEM_TYPE_REFERENCE);
 
             assertThat(actualExperimentItems)
                     .usingRecursiveFieldByFieldElementComparatorIgnoringFields(ITEM_IGNORED_FIELDS)
@@ -3258,17 +3369,6 @@ class ExperimentsResourceTest {
                         .doesNotContainAnyElementsOf(unexpectedExperimentItems);
             }
         }
-    }
-
-    private List<ExperimentItem> getStreamedItems(Response response) {
-        var items = new ArrayList<ExperimentItem>();
-        try (var inputStream = response.readEntity(CHUNKED_INPUT_STRING_GENERIC_TYPE)) {
-            String stringItem;
-            while ((stringItem = inputStream.read()) != null) {
-                items.add(JsonUtils.readValue(stringItem, EXPERIMENT_ITEM_TYPE_REFERENCE));
-            }
-        }
-        return items;
     }
 
     private String getExperimentsPath() {


### PR DESCRIPTION
## Details
Deprecated old unused `getExperimentByName` by a proper implementation for the SDK:
- Returning multiple results.
- Name match as in find endpoint (partial and case insensitive).
- Stream based.
- Cursor based pagination.

Refactored the experiments service and DAO for reusability and tech debt reduction:
- Centralise all the logic in a single query and removed duplication.
- Centralise enrichment process in the service: dataset name and prompt resolution.

## Issues
OPIK-1119

## Testing
- Added automation test for all potential scenarios:
-- Pagination.
-- Retrieval of all fields: scores, prompt versions and comments.
- Passed CI regression for refactored parts.

## Documentation
