### PR TITLE
NO-JIRA: Increased Python backend Docker daemon wait

### DIFF
--- a/apps/opik-python-backend/entrypoint.sh
+++ b/apps/opik-python-backend/entrypoint.sh
@@ -7,11 +7,11 @@ if [ "$PYTHON_CODE_EXECUTOR_STRATEGY" = "docker" ]; then
   dockerd-entrypoint.sh &
 
   SLEEP_SECONDS=1
-  MAX_ATTEMPTS=5
+  MAX_ATTEMPTS=30
   attempts=1
 
   until docker info >/dev/null 2>&1 || [ $attempts -ge $MAX_ATTEMPTS ]; do
-    echo "Waiting ${SLEEP_SECONDS}s for the Docker daemon to start, attempt: $attempts"
+    echo "Waiting ${SLEEP_SECONDS}s for the Docker daemon to start, attempt: $attempts, out of: $MAX_ATTEMPTS"
     sleep $SLEEP_SECONDS
     attempts=$((attempts+1))
   done


### PR DESCRIPTION
## Details
Wait for the Docker daemon increased to 30s, which is around our usual wait for Kubernetes probes and docker compose health checks. 

Previous value of 5 was too aggressive and cause the container to fail sometimes when setting `PYTHON_CODE_EXECUTOR_STRATEGY= docker`.

Minor logs improvements.

## Issues

N/A

## Testing
- Locally tested with:

`PYTHON_CODE_EXECUTOR_STRATEGY= docker`

and

`docker compose up -d --build `

## Documentation
N/A
