### PR TITLE
NO-JIRA: Fix Online Scoring Sampler logs

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
@@ -110,7 +110,7 @@ public class OnlineScoringSampler {
             try (MDC.MDCCloseable logScope = MDC.putCloseable(UserLog.MARKER, UserLog.AUTOMATION_RULE_EVALUATOR.name());
                     MDC.MDCCloseable scope = MDC.putCloseable("workspace_id", tracesBatch.workspaceId())) {
 
-                evaluators.parallelStream().forEach(evaluator -> {
+                evaluators.forEach(evaluator -> {
                     // samples traces for this rule
                     var samples = traces.stream().filter(trace -> shouldSampleTrace(evaluator, trace));
                     switch (evaluator.getType()) {


### PR DESCRIPTION
## Details
Fixed a bug introduced here: https://github.com/comet-ml/opik/pull/1611#discussion_r2008000736

After adding parallelism when processing the evaluators stream.

That caused the following automation rule logs to disappear and showed the following example error:

```
com.comet.opik.infrastructure.log.ClickHouseAppender: UserLog marker is not set for events: The traceId '0195fadf-e5c3-7f85-a268-a5f8df5f3a4e' was skipped for rule: 'json' and per the sampling rate '0.5'
```

The issue only reproduces when having multiple rules for a project. 


## Issues

N/A

## Testing
- Added a test that reproduces the issue before the fix and ensures it doesn't happen after the fix.
- Reproduced and fixed locally.

## Documentation
N/A