### PR TITLE
[ISSUE-1744] [Bug]: No data state when navigating between traces from the experiment page

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
@@ -114,7 +114,8 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
 
   const dataToView = useMemo(() => {
     return spanId
-      ? find(spansData?.content || [], (span: Span) => span.id === spanId)
+      ? find(spansData?.content || [], (span: Span) => span.id === spanId) ??
+          trace
       : trace;
   }, [spanId, spansData?.content, trace]);
 

--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -713,6 +713,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         open={Boolean(traceId)}
         onClose={() => {
           setTraceId("");
+          setSpanId("");
         }}
       />
     </>


### PR DESCRIPTION
## Details
- added falback in case in state selected span that doesn't exist in trace
- added cleaning of selected stan when closing trace sidebar on Experiments page
## Issues

Resolves #1744

## Testing

## Documentation
