### PR TITLE
[OPIK-1010] fix `Error while processing scores batch` error in log

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
@@ -112,8 +112,13 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
         return Flux.fromIterable(projects)
                 .flatMap(projectDto -> dao.scoreBatchOf(entityType, projectDto.scores()))
                 .reduce(0L, Long::sum)
-                .flatMap(rowsUpdated -> rowsUpdated == actualBatchSize ? Mono.just(rowsUpdated) : Mono.empty())
-                .switchIfEmpty(Mono.error(failWithNotFound("Error while processing scores batch")));
+                .flatMap(rowsUpdated -> {
+                    if (rowsUpdated == actualBatchSize) {
+                        return Mono.just(rowsUpdated);
+                    }
+
+                    return Mono.error(failWithNotFound("Error while processing scores batch"));
+                });
     }
 
     private List<ProjectDto> mergeProjectsAndScores(Map<String, Project> projectMap,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
@@ -8,7 +8,6 @@ import com.comet.opik.utils.WorkspaceUtils;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Singleton;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.InternalServerErrorException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -112,16 +111,7 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
     private Mono<Long> processScoreBatch(EntityType entityType, List<ProjectDto> projects, int actualBatchSize) {
         return Flux.fromIterable(projects)
                 .flatMap(projectDto -> dao.scoreBatchOf(entityType, projectDto.scores()))
-                .reduce(0L, Long::sum)
-                .flatMap(rowsUpdated -> {
-                    if (rowsUpdated == actualBatchSize) {
-                        return Mono.just(rowsUpdated);
-                    }
-
-                    log.error("Error while processing scores batch. actualBatchSize={}, rowsUpdated={}",
-                            actualBatchSize, rowsUpdated);
-                    return Mono.error(new InternalServerErrorException("Error while processing scores batch"));
-                });
+                .reduce(0L, Long::sum);
     }
 
     private List<ProjectDto> mergeProjectsAndScores(Map<String, Project> projectMap,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
@@ -8,6 +8,7 @@ import com.comet.opik.utils.WorkspaceUtils;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Singleton;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.InternalServerErrorException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -117,7 +118,9 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
                         return Mono.just(rowsUpdated);
                     }
 
-                    return Mono.error(failWithNotFound("Error while processing scores batch"));
+                    log.error("Error while processing scores batch. actualBatchSize={}, rowsUpdated={}",
+                            actualBatchSize, rowsUpdated);
+                    return Mono.error(new InternalServerErrorException("Error while processing scores batch"));
                 });
     }
 


### PR DESCRIPTION
## Details
During the investigation I realized this error is logged per every feedback score batch that is processed, even when everything goes well.
Removing the `switchIfEmpty` fixed the issue which suggests that the error is timing-related or some reactive propagation issue.
In addition, `NotFoundException` seems strange in this case, I changed it to an `InternalServerErrorException` instead. In addition, added some logging.

## Issues
OPIK-1010

## Testing
Ran feedback scores related tests prior to the fix and after it and made sure the error disappears.
