### PR TITLE
NO-JIRA: Disable python evaluator

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -366,4 +366,4 @@ pythonEvaluator:
 serviceToggles:
   # Default: true
   # Description: Whether or not Python evaluator is enabled
-  pythonEvaluatorEnabled: ${TOGGLE_PYTHON_EVALUATOR_ENABLED:-"true"}
+  pythonEvaluatorEnabled: ${TOGGLE_PYTHON_EVALUATOR_ENABLED:-"false"}


### PR DESCRIPTION
## Details
Disabling for next open source release, while testing finalises.

## Issues
N/A

## Testing
- Tested by building and running the service locally with docker compose.
- Verified all usages, including env vars in Helm configuration.

## Documentation
N/A
