### PR TITLE
[OPIK-1082] [FE] Implement sorting for traces table

### DIFF
--- a/apps/opik-frontend/src/api/traces/useSpansList.ts
+++ b/apps/opik-frontend/src/api/traces/useSpansList.ts
@@ -3,12 +3,15 @@ import api, { QueryConfig, SPANS_KEY, SPANS_REST_ENDPOINT } from "@/api/api";
 import { Span, SPAN_TYPE } from "@/types/traces";
 import { Filters } from "@/types/filters";
 import { generateSearchByIDFilters, processFilters } from "@/lib/filters";
+import { Sorting } from "@/types/sorting";
+import { processSorting } from "@/lib/sorting";
 
 type UseSpansListParams = {
   projectId: string;
   traceId?: string;
   type?: SPAN_TYPE;
   filters?: Filters;
+  sorting?: Sorting;
   search?: string;
   page: number;
   size: number;
@@ -17,6 +20,7 @@ type UseSpansListParams = {
 
 export type UseSpansListResponse = {
   content: Span[];
+  sortable_by: string[];
   total: number;
 };
 
@@ -27,6 +31,7 @@ const getSpansList = async (
     traceId,
     type,
     filters,
+    sorting,
     search,
     size,
     page,
@@ -40,6 +45,7 @@ const getSpansList = async (
       ...(traceId && { trace_id: traceId }),
       ...(type && { type }),
       ...processFilters(filters, generateSearchByIDFilters(search)),
+      ...processSorting(sorting),
       size,
       page,
       truncate,

--- a/apps/opik-frontend/src/api/traces/useTracesList.ts
+++ b/apps/opik-frontend/src/api/traces/useTracesList.ts
@@ -3,10 +3,13 @@ import api, { QueryConfig, TRACES_KEY, TRACES_REST_ENDPOINT } from "@/api/api";
 import { Trace } from "@/types/traces";
 import { Filters } from "@/types/filters";
 import { generateSearchByIDFilters, processFilters } from "@/lib/filters";
+import { Sorting } from "@/types/sorting";
+import { processSorting } from "@/lib/sorting";
 
 type UseTracesListParams = {
   projectId: string;
   filters?: Filters;
+  sorting?: Sorting;
   search?: string;
   page: number;
   size: number;
@@ -15,18 +18,28 @@ type UseTracesListParams = {
 
 export type UseTracesListResponse = {
   content: Trace[];
+  sortable_by: string[];
   total: number;
 };
 
 const getTracesList = async (
   { signal }: QueryFunctionContext,
-  { projectId, filters, search, size, page, truncate }: UseTracesListParams,
+  {
+    projectId,
+    filters,
+    sorting,
+    search,
+    size,
+    page,
+    truncate,
+  }: UseTracesListParams,
 ) => {
   const { data } = await api.get<UseTracesListResponse>(TRACES_REST_ENDPOINT, {
     signal,
     params: {
       project_id: projectId,
       ...processFilters(filters, generateSearchByIDFilters(search)),
+      ...processSorting(sorting),
       size,
       page,
       truncate,

--- a/apps/opik-frontend/src/components/shared/DataTableHeaders/FeedbackScoreHeader.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableHeaders/FeedbackScoreHeader.tsx
@@ -3,6 +3,7 @@ import { HeaderContext } from "@tanstack/react-table";
 import { TAG_VARIANTS_COLOR_MAP } from "@/components/ui/tag";
 import { generateTagVariant } from "@/lib/traces";
 import HeaderWrapper from "@/components/shared/DataTableHeaders/HeaderWrapper";
+import useSortableHeader from "@/components/shared/DataTableHeaders/useSortableHeader";
 
 const FeedbackScoreHeader = <TData,>(
   context: HeaderContext<TData, unknown>,
@@ -11,16 +12,23 @@ const FeedbackScoreHeader = <TData,>(
   const { header } = column.columnDef.meta ?? {};
   const color = TAG_VARIANTS_COLOR_MAP[generateTagVariant(header!)!];
 
+  const { className, onClickHandler, renderSort } = useSortableHeader({
+    column,
+  });
+
   return (
     <HeaderWrapper
       metadata={context.column.columnDef.meta}
       tableMetadata={context.table.options.meta}
+      className={className}
+      onClick={onClickHandler}
     >
       <div
         className="mr-0.5 size-2 shrink-0 rounded-[2px] bg-[--color-bg]"
         style={{ "--color-bg": color } as React.CSSProperties}
       ></div>
       <span className="truncate">{header}</span>
+      {renderSort()}
     </HeaderWrapper>
   );
 };

--- a/apps/opik-frontend/src/components/shared/DataTableHeaders/TypeHeader.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableHeaders/TypeHeader.tsx
@@ -9,12 +9,10 @@ import {
   Clock,
   Braces,
   PenLine,
-  ArrowDown,
-  ArrowUp,
   Coins,
 } from "lucide-react";
-import { cn } from "@/lib/utils";
 import HeaderWrapper from "@/components/shared/DataTableHeaders/HeaderWrapper";
+import useSortableHeader from "@/components/shared/DataTableHeaders/useSortableHeader";
 
 const COLUMN_TYPE_MAP: Record<
   COLUMN_TYPE,
@@ -37,41 +35,21 @@ const TypeHeader = <TData,>(context: HeaderContext<TData, unknown>) => {
   const { header, type: columnType, iconType } = column.columnDef.meta ?? {};
   const type = iconType ?? columnType;
   const Icon = type ? COLUMN_TYPE_MAP[type] : "span";
-  const isSortable = column.getCanSort();
-  const direction = column.getIsSorted();
 
-  const renderSort = () => {
-    const nextDirection = column.getNextSortingOrder();
-
-    if (!direction && !nextDirection) return null;
-
-    const Icon = (direction || nextDirection) === "asc" ? ArrowUp : ArrowDown;
-    return (
-      <>
-        <Icon
-          className={cn(
-            "hidden size-3.5 group-hover:inline",
-            direction && "inline",
-          )}
-        />
-      </>
-    );
-  };
+  const { className, onClickHandler, renderSort } = useSortableHeader({
+    column,
+  });
 
   return (
     <HeaderWrapper
       metadata={context.column.columnDef.meta}
       tableMetadata={context.table.options.meta}
-      className={cn(isSortable && "cursor-pointer group")}
-      onClick={
-        isSortable
-          ? column.getToggleSortingHandler()
-          : (e) => e.stopPropagation()
-      }
+      className={className}
+      onClick={onClickHandler}
     >
       {Boolean(Icon) && <Icon className="size-3.5 shrink-0 text-slate-300" />}
       <span className="truncate">{header}</span>
-      {isSortable && renderSort()}
+      {renderSort()}
     </HeaderWrapper>
   );
 };

--- a/apps/opik-frontend/src/components/shared/DataTableHeaders/useSortableHeader.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableHeaders/useSortableHeader.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { ArrowDown, ArrowUp } from "lucide-react";
+import { Column } from "@tanstack/react-table";
+import { cn } from "@/lib/utils";
+
+type UseSortableHeaderProps<TData> = {
+  column: Column<TData>;
+};
+
+export const useSortableHeader = <TData,>({
+  column,
+}: UseSortableHeaderProps<TData>) => {
+  const isSortable = column.getCanSort();
+  const direction = column.getIsSorted();
+
+  const renderSort = () => {
+    if (!isSortable) return null;
+
+    const nextDirection = column.getNextSortingOrder();
+
+    if (!direction && !nextDirection) return null;
+
+    const Icon = (direction || nextDirection) === "asc" ? ArrowUp : ArrowDown;
+    return (
+      <>
+        <Icon
+          className={cn(
+            "shrink-0 hidden size-3.5 group-hover:inline",
+            direction && "inline",
+          )}
+        />
+      </>
+    );
+  };
+
+  return {
+    renderSort,
+    className: isSortable ? "cursor-pointer group" : undefined,
+    onClickHandler: isSortable
+      ? column.getToggleSortingHandler()
+      : (e: React.MouseEvent<unknown>) => e.stopPropagation(),
+  };
+};
+
+export default useSortableHeader;

--- a/apps/opik-frontend/src/hooks/useQueryParamAndLocalStorageState.ts
+++ b/apps/opik-frontend/src/hooks/useQueryParamAndLocalStorageState.ts
@@ -1,0 +1,59 @@
+import { useCallback, useMemo } from "react";
+import useLocalStorageState from "use-local-storage-state";
+import {
+  useQueryParam,
+  QueryParamConfig,
+  QueryParamOptions,
+} from "use-query-params";
+import { Updater } from "@/types/shared";
+import isFunction from "lodash/isFunction";
+
+const QUERY_OPTIONS: QueryParamOptions = {
+  updateType: "replaceIn",
+};
+
+type UseQueryParamAndLocalStorageStateParams<T> = {
+  localStorageKey: string;
+  queryKey: string;
+  defaultValue: T;
+  queryParamConfig: QueryParamConfig<T>;
+  queryOptions?: QueryParamOptions;
+};
+
+const useQueryParamAndLocalStorageState = <T>({
+  localStorageKey,
+  queryKey,
+  defaultValue,
+  queryParamConfig,
+  queryOptions = QUERY_OPTIONS,
+}: UseQueryParamAndLocalStorageStateParams<T>) => {
+  const [localStorageValue, setLocalStorageValue] = useLocalStorageState<T>(
+    localStorageKey,
+    {
+      defaultValue,
+    },
+  );
+  const [queryValue, setQueryValue] = useQueryParam(
+    queryKey,
+    queryParamConfig,
+    queryOptions,
+  );
+
+  const combinedValue = useMemo(
+    () => (queryValue as T) ?? localStorageValue,
+    [queryValue, localStorageValue],
+  );
+
+  const setValue = useCallback(
+    (value: Updater<T>) => {
+      const newValue = isFunction(value) ? value(combinedValue) : value;
+      setLocalStorageValue(newValue);
+      setQueryValue(newValue);
+    },
+    [setLocalStorageValue, setQueryValue, combinedValue],
+  );
+
+  return [combinedValue, setValue] as const;
+};
+
+export default useQueryParamAndLocalStorageState;

--- a/apps/opik-frontend/src/hooks/useTracesOrSpansList.ts
+++ b/apps/opik-frontend/src/hooks/useTracesOrSpansList.ts
@@ -11,6 +11,7 @@ import useTracesList from "@/api/traces/useTracesList";
 import useSpansList from "@/api/traces/useSpansList";
 import { Span, SPAN_TYPE, Trace } from "@/types/traces";
 import { Filters } from "@/types/filters";
+import { Sorting } from "@/types/sorting";
 
 export enum TRACE_DATA_TYPE {
   traces = "traces",
@@ -21,6 +22,7 @@ type UseTracesOrSpansListParams = {
   projectId: string;
   type: TRACE_DATA_TYPE;
   filters?: Filters;
+  sorting?: Sorting;
   search?: string;
   page: number;
   size: number;
@@ -30,6 +32,7 @@ type UseTracesOrSpansListParams = {
 type UseTracesOrSpansListResponse = {
   data: {
     content: Array<Trace | Span>;
+    sortable_by: string[];
     total: number;
   };
   isPending: boolean;

--- a/apps/opik-frontend/src/lib/table.ts
+++ b/apps/opik-frontend/src/lib/table.ts
@@ -24,14 +24,24 @@ export const hasAnyVisibleColumns = <TColumnData>(
   selectedColumns: string[],
 ) => columns.some(({ id }) => selectedColumns.includes(id));
 
+export const isColumnSortable = (id: string, sortableColumns: string[]) => {
+  if (sortableColumns.includes(id)) return true;
+
+  const keys = id.split(".");
+
+  return keys.length > 1 ? sortableColumns.includes(`${keys[0]}.*`) : false;
+};
+
 export const convertColumnDataToColumn = <TColumnData, TData>(
   columns: ColumnData<TColumnData>[],
   {
     columnsOrder = [],
     selectedColumns,
+    sortableColumns = [],
   }: {
     columnsOrder?: string[];
     selectedColumns?: string[];
+    sortableColumns?: string[];
   },
 ) => {
   const retVal: ColumnDef<TData>[] = [];
@@ -41,7 +51,19 @@ export const convertColumnDataToColumn = <TColumnData, TData>(
       ? selectedColumns.includes(column.id)
       : true;
     if (isSelected) {
-      retVal.push(mapColumnDataFields(column));
+      if (
+        Boolean(sortableColumns?.length) &&
+        isColumnSortable(column.id, sortableColumns)
+      ) {
+        retVal.push(
+          mapColumnDataFields({
+            ...column,
+            sortable: true,
+          }),
+        );
+      } else {
+        retVal.push(mapColumnDataFields(column));
+      }
     }
   });
 


### PR DESCRIPTION
## Details
![image](https://github.com/user-attachments/assets/b00211c6-f2ee-4b72-990e-fc4ef7074ff7)
![image](https://github.com/user-attachments/assets/1bff5dd1-91bf-4fd3-85e0-6d8456b2ea62)

We have a different set of columns for these entities now:
Traces:

`[
  "id",
  "name",
  "input",
  "output",
  "start_time",
  "end_time",
  "duration",
  "metadata",
  "thread_id",
  "tags",
  "error_info",
  "created_by",
  "feedback_scores.*"
]`
LLM Calls:
`[
  "id",
  "name",
  "type",
  "trace_id",
  "parent_span_id",
  "input",
  "output",
  "metadata",
  "start_time",
  "end_time",
  "duration",
  "usage",
  "metadata",
  "tags",
  "created_at",
  "last_updated_at",
  "model",
  "provider",
  "total_estimated_cost",
  "error_info",
  "created_by",
  "feedback_scores.*"
]`

## Issues

Resolves #

## Testing

## Documentation
