### PR TITLE
OPIK-1439: Migrate Opik backend to Amazon Linux 2023

### DIFF
--- a/apps/opik-frontend/Dockerfile
+++ b/apps/opik-frontend/Dockerfile
@@ -24,7 +24,11 @@ ARG BUILD_MODE=production
 RUN npm run build -- --mode $BUILD_MODE
 
 # Production stage
-FROM nginx:1.27.4-alpine3.21
+FROM amazonlinux:2023
+
+# Install packages
+RUN yum update -y && yum install -y nginx \
+    && yum clean all
 
 # Add label for later inspection
 ARG BUILD_MODE=production


### PR DESCRIPTION
## Details
Migrate Opik Frontend to Amazon Linux 2023, whose Linux packages are patched often for vulnerabilities.

## Issues

OPIK-1439

## Testing
- Tested locally by successfully running building and running with `docker compose up -d --build`.
- I will deploy and test.

## Documentation
- https://hub.docker.com/_/amazonlinux
- https://nginx.org/en/linux_packages.html#Amazon-Linux
