### PR TITLE
skipping docs tests in main runs

### DIFF
--- a/.github/workflows/end2end_suites.yml
+++ b/.github/workflows/end2end_suites.yml
@@ -118,7 +118,7 @@ jobs:
                 elif [ "$SUITE" == "sanity" ]; then
                     allurectl watch -- pytest -s -m sanity --browser chromium --alluredir="${ALLURE_RESULTS}"
                 elif [ "$SUITE" == "all_features" ]; then
-                    allurectl watch -- pytest -s tests --ignore tests/Admin --ignore tests/Installation --ignore tests/QuickstartGuide --browser chromium --alluredir="${ALLURE_RESULTS}"
+                    allurectl watch -- pytest -s tests --ignore tests/Admin --ignore tests/Installation --ignore tests/QuickstartGuide --ignore tests/Documentation --browser chromium --alluredir="${ALLURE_RESULTS}"
                 fi
 
             - name: Stop Opik server (Local)


### PR DESCRIPTION
## Details

Documentation links have their own workflow which installs some specific tools needed, skipping them in the main test runs
