### PR TITLE
OPIK-1393: Reduce result before join

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -467,7 +467,10 @@ class TraceDAOImpl implements TraceDAO {
                 GROUP BY workspace_id, project_id, entity_id
             )
             <if(feedback_scores_empty_filters)>
-             , fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
+             , fsc AS (
+                 SELECT
+                    entity_id,
+                    COUNT(entity_id) AS feedback_scores_count
                  FROM (
                     SELECT *
                     FROM feedback_scores
@@ -481,6 +484,57 @@ class TraceDAOImpl implements TraceDAO {
                  HAVING <feedback_scores_empty_filters>
             )
             <endif>
+            , traces_final AS (
+                SELECT
+                    t.*,
+                    if(end_time IS NOT NULL AND start_time IS NOT NULL
+                             AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)),
+                         (dateDiff('microsecond', start_time, end_time) / 1000.0),
+                         NULL) AS duration
+                FROM traces t
+                <if(sort_has_feedback_scores)>
+                LEFT JOIN feedback_scores_agg fsagg ON fsagg.entity_id = t.id
+                <endif>
+                WHERE workspace_id = :workspace_id
+                AND project_id = :project_id
+                <if(last_received_trace_id)> AND id \\< :last_received_trace_id <endif>
+                <if(filters)> AND <filters> <endif>
+                <if(feedback_scores_filters)>
+                 AND id IN (
+                    SELECT
+                        entity_id
+                    FROM (
+                        SELECT *
+                        FROM feedback_scores
+                        WHERE entity_type = 'trace'
+                        AND workspace_id = :workspace_id
+                        AND project_id = :project_id
+                        ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
+                        LIMIT 1 BY entity_id, name
+                    )
+                    GROUP BY entity_id
+                    HAVING <feedback_scores_filters>
+                 )
+                 <endif>
+                 <if(trace_aggregation_filters)>
+                 AND id IN (
+                    SELECT
+                        trace_id
+                    FROM spans_agg
+                    WHERE <trace_aggregation_filters>
+                 )
+                 <endif>
+                 <if(feedback_scores_empty_filters)>
+                 AND (
+                    id IN (SELECT entity_id FROM fsc WHERE fsc.feedback_scores_count = 0)
+                        OR
+                    id NOT IN (SELECT entity_id FROM fsc)
+                 )
+                 <endif>
+                 ORDER BY <if(sort_fields)> <sort_fields>, id DESC <else>(workspace_id, project_id, id) DESC, last_updated_at DESC <endif>
+                 LIMIT 1 BY id
+                 LIMIT :limit <if(offset)>OFFSET :offset <endif>
+            )
             SELECT
                   t.id as id,
                   t.workspace_id as workspace_id,
@@ -499,66 +553,17 @@ class TraceDAOImpl implements TraceDAO {
                   t.last_updated_by as last_updated_by,
                   t.duration as duration,
                   t.thread_id as thread_id,
-                  t.feedback_scores_list as feedback_scores_list,
-                  t.feedback_scores as feedback_scores,
-                  sumMap(s.usage) as usage,
-                  sum(s.total_estimated_cost) as total_estimated_cost,
-                  groupUniqArrayArray(c.comments_array) as comments,
-                  max(s.span_count) AS span_count
-             FROM (
-                 SELECT
-                     t.*,
-                     if(end_time IS NOT NULL AND start_time IS NOT NULL
-                             AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)),
-                         (dateDiff('microsecond', start_time, end_time) / 1000.0),
-                         NULL) AS duration,
-                      fsagg.feedback_scores_list as feedback_scores_list,
-                      fsagg.feedback_scores as feedback_scores
-                 FROM traces t
-                 LEFT JOIN feedback_scores_agg fsagg ON fsagg.entity_id = t.id
-                 <if(trace_aggregation_filters)>
-                 LEFT JOIN spans_agg s ON t.id = s.trace_id
-                 <endif>
-                 <if(feedback_scores_empty_filters)>
-                    LEFT JOIN fsc ON fsc.entity_id = traces.id
-                 <endif>
-                 WHERE workspace_id = :workspace_id
-                 AND project_id = :project_id
-                 <if(last_received_trace_id)> AND id \\< :last_received_trace_id <endif>
-                 <if(filters)> AND <filters> <endif>
-                 <if(feedback_scores_filters)>
-                 AND id IN (
-                    SELECT
-                        entity_id
-                    FROM (
-                        SELECT *
-                        FROM feedback_scores
-                        WHERE entity_type = 'trace'
-                        AND workspace_id = :workspace_id
-                        AND project_id = :project_id
-                        ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
-                        LIMIT 1 BY entity_id, name
-                    )
-                    GROUP BY entity_id
-                    HAVING <feedback_scores_filters>
-                 )
-                 <endif>
-                 <if(trace_aggregation_filters)>
-                 AND <trace_aggregation_filters>
-                 <endif>
-                 <if(feedback_scores_empty_filters)>
-                 AND fsc.feedback_scores_count = 0
-                 <endif>
-                 ORDER BY <if(sort_fields)> <sort_fields>, id DESC <else>(workspace_id, project_id, id) DESC, last_updated_at DESC <endif>
-                 LIMIT 1 BY id
-                 LIMIT :limit <if(offset)>OFFSET :offset <endif>
-             ) AS t
-             LEFT JOIN spans_agg AS s ON t.id = s.trace_id
-             LEFT JOIN comments_agg AS c ON t.id = c.entity_id
-             GROUP BY
-                t.*
+                  fsagg.feedback_scores_list as feedback_scores_list,
+                  fsagg.feedback_scores as feedback_scores,
+                  s.usage as usage,
+                  s.total_estimated_cost as total_estimated_cost,
+                  c.comments_array as comments,
+                  s.span_count AS span_count
+             FROM traces_final t
+             LEFT JOIN feedback_scores_agg fsagg ON fsagg.entity_id = t.id
+             LEFT JOIN spans_agg s ON t.id = s.trace_id
+             LEFT JOIN comments_agg c ON t.id = c.entity_id
              ORDER BY <if(sort_fields)> <sort_fields>, id DESC <else>(workspace_id, project_id, id) DESC, last_updated_at DESC <endif>
-             SETTINGS join_algorithm = 'full_sorting_merge'
             ;
             """;
 
@@ -1423,7 +1428,14 @@ class TraceDAOImpl implements TraceDAO {
 
         var finalTemplate = template;
         Optional.ofNullable(sortingQueryBuilder.toOrderBySql(traceSearchCriteria.sortingFields()))
-                .ifPresent(sortFields -> finalTemplate.add("sort_fields", sortFields));
+                .ifPresent(sortFields -> {
+
+                    if (sortFields.contains("feedback_scores")) {
+                        finalTemplate.add("sort_has_feedback_scores", true);
+                    }
+
+                    finalTemplate.add("sort_fields", sortFields);
+                });
 
         var hasDynamicKeys = sortingQueryBuilder.hasDynamicKeys(traceSearchCriteria.sortingFields());
 


### PR DESCRIPTION
## Details
- The idea of this optimization is to reduce the resultset before the joins

Before:
![image](https://github.com/user-attachments/assets/bb6a5476-a9b0-4b7d-8fae-2422d3e2b4d4)

After:
<img width="1343" alt="Screenshot 2025-04-10 at 12 10 00" src="https://github.com/user-attachments/assets/64252160-8112-4b98-b707-ba782473b9cb" />

![Screenshot 2025-04-10 at 12 16 09](https://github.com/user-attachments/assets/7eac5396-f488-4c0d-9e64-bd3919dfb339)

![Screenshot 2025-04-10 at 12 16 56](https://github.com/user-attachments/assets/4d116dd7-f2a2-4095-a5ca-5457c732e6d6)
