### PR TITLE
G-Eval without logprobs

### DIFF
--- a/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/metric.py
+++ b/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/metric.py
@@ -68,10 +68,10 @@ class GEval(base_metric.BaseMetric):
         if isinstance(model, base_model.OpikBaseModel):
             self._model = model
         else:
-            supported_arguments_kwargs = {"must_support_arguments": ["logprobs", "top_logprobs"]} if self.use_logprobs else {}
+            model_kwargs = {"must_support_arguments": ["logprobs", "top_logprobs"]} if self.use_logprobs else {}
             self._model = models_factory.get(
                 model_name=model,
-                **supported_arguments_kwargs
+                **model_kwargs
             )
 
     def score(
@@ -104,11 +104,11 @@ class GEval(base_metric.BaseMetric):
             },
         ]
 
-        supported_model_kwargs = { "logprobs" : True , "top_logprobs": 20, } if self.use_logprobs else {}
+        model_kwargs = { "logprobs" : True , "top_logprobs": 20, } if self.use_logprobs else {}
         model_output = self._model.generate_provider_response(
             messages=request,
             response_format=GEvalScoreFormat,
-            **supported_model_kwargs
+            **model_kwargs
         )
 
         return self._parse_model_output(model_output)


### PR DESCRIPTION

## Details  
Geval scoring currently relies on log probabilities (`logprobs`). However, some models do not support `logprobs`, which causes compatibility issues.  

This PR adds support for running Geval **without requiring logprobs**, making it compatible with a wider range of models.

---

## Issues  
Closes [[#1477](https://github.com/comet-ml/opik/issues/1477)]

---

## Resolves  
Provides a fix to support Geval scoring for models that do not support `logprobs`.

---

## Testing  
- Verified Geval works with both `logprobs=True` and `logprobs=False`.  
- Confirmed compatibility with previously unsupported model providers.

---

## Documentation  

---
