### PR TITLE
NA: Remove containers after use

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/ClickHouseContainerUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/ClickHouseContainerUtils.java
@@ -1,13 +1,13 @@
 package com.comet.opik.api.resources.utils;
 
 import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
+import com.google.common.collect.Sets;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -16,16 +16,16 @@ public class ClickHouseContainerUtils {
     public static final String DATABASE_NAME = "opik";
     public static final String DATABASE_NAME_VARIABLE = "ANALYTICS_DB_DATABASE_NAME";
     private static final Network NETWORK = Network.newNetwork();
-    private static final Set<GenericContainer<?>> CONTAINERS = new HashSet<>();
+    private static final Set<GenericContainer<?>> CONTAINERS = Sets.newConcurrentHashSet();
 
     static {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            NETWORK.close();
             CONTAINERS.forEach(container -> {
                 if (container.isRunning()) {
                     container.stop();
                 }
             });
+            NETWORK.close();
         }));
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/ClickHouseContainerUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/ClickHouseContainerUtils.java
@@ -7,21 +7,40 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class ClickHouseContainerUtils {
 
     public static final String DATABASE_NAME = "opik";
     public static final String DATABASE_NAME_VARIABLE = "ANALYTICS_DB_DATABASE_NAME";
     private static final Network NETWORK = Network.newNetwork();
+    private static final Set<GenericContainer<?>> CONTAINERS = new HashSet<>();
+
+    static {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            NETWORK.close();
+            CONTAINERS.forEach(container -> {
+                if (container.isRunning()) {
+                    container.stop();
+                }
+            });
+        }));
+    }
 
     public static ClickHouseContainer newClickHouseContainer() {
         return newClickHouseContainer(true);
     }
 
     public static ClickHouseContainer newClickHouseContainer(boolean reusable) {
-        return new ClickHouseContainer(DockerImageName.parse("clickhouse/clickhouse-server:24.3.6.48-alpine"))
+        ClickHouseContainer container = new ClickHouseContainer(
+                DockerImageName.parse("clickhouse/clickhouse-server:24.3.6.48-alpine"))
                 .withReuse(reusable);
+
+        CONTAINERS.add(container);
+
+        return container;
     }
 
     public static GenericContainer<?> newZookeeperContainer() {
@@ -29,13 +48,17 @@ public class ClickHouseContainerUtils {
     }
 
     public static GenericContainer<?> newZookeeperContainer(boolean reusable, Network network) {
-        return new GenericContainer<>("zookeeper:3.9.3")
+        var container = new GenericContainer<>("zookeeper:3.9.3")
                 .withExposedPorts(2181)
                 .withNetworkAliases("zookeeper")
                 .withNetwork(network)
                 .withEnv("ALLOW_ANONYMOUS_LOGIN", "yes")
                 .withEnv("ZOO_MY_ID", "1")
                 .withReuse(reusable);
+
+        CONTAINERS.add(container);
+
+        return container;
     }
 
     public static ClickHouseContainer newClickHouseContainer(GenericContainer<?> zooKeeperContainer) {
@@ -52,6 +75,8 @@ public class ClickHouseContainerUtils {
             if (zooKeeperContainer != null) {
                 container.dependsOn(zooKeeperContainer);
             }
+
+            CONTAINERS.add(container);
 
             return container
                     .withReuse(reusable)

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/DailyUsageReportJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/DailyUsageReportJobTest.java
@@ -286,8 +286,8 @@ class DailyUsageReportJobTest {
             wireMock.server().stop();
             MYSQL.stop();
             CLICKHOUSE.stop();
-            NETWORK.close();
             ZOOKEEPER_CONTAINER.stop();
+            NETWORK.close();
         }
 
         private void mockTargetWorkspace(String apiKey, String workspaceName, String workspaceId) {
@@ -427,8 +427,8 @@ class DailyUsageReportJobTest {
             wireMock.server().stop();
             MYSQL.stop();
             CLICKHOUSE.stop();
-            NETWORK.close();
             ZOOKEEPER_CONTAINER.stop();
+            NETWORK.close();
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/DailyUsageReportJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/DailyUsageReportJobTest.java
@@ -287,6 +287,7 @@ class DailyUsageReportJobTest {
             MYSQL.stop();
             CLICKHOUSE.stop();
             NETWORK.close();
+            ZOOKEEPER_CONTAINER.stop();
         }
 
         private void mockTargetWorkspace(String apiKey, String workspaceName, String workspaceId) {
@@ -427,6 +428,7 @@ class DailyUsageReportJobTest {
             MYSQL.stop();
             CLICKHOUSE.stop();
             NETWORK.close();
+            ZOOKEEPER_CONTAINER.stop();
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListenerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListenerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.lifecycle.Startables;
 import ru.vyarus.dropwizard.guice.module.lifecycle.GuiceyLifecycle;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
@@ -56,9 +57,11 @@ class OpikGuiceyLifecycleEventListenerTest {
 
     private final MySQLContainer<?> MYSQL_CONTAINER = MySQLContainerUtils.newMySQLContainer(false);
     private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
-    private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final Network network = Network.newNetwork();
+    private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer(false,
+            network);
     private final ClickHouseContainer CLICK_HOUSE_CONTAINER = ClickHouseContainerUtils
-            .newClickHouseContainer(ZOOKEEPER_CONTAINER);
+            .newClickHouseContainer(false, network, ZOOKEEPER_CONTAINER);
 
     private static final Random RANDOM = new Random();
     private static final String VERSION = "%s.%s.%s".formatted(RANDOM.nextInt(10), RANDOM.nextInt(),
@@ -190,5 +193,8 @@ class OpikGuiceyLifecycleEventListenerTest {
     @AfterAll
     void tearDown() {
         MYSQL_CONTAINER.stop();
+        CLICK_HOUSE_CONTAINER.stop();
+        ZOOKEEPER_CONTAINER.stop();
+        network.close();
     }
 }


### PR DESCRIPTION
## Details

Due to the need to create a network to link zookeepers, clickhouse containers cannot be reused between different test executions. That is because the way the Network object from the test container (which uses UUID as the network name) is implemented. 

This makes it hard to reuse the network, as every run generates a new network. For this reason, we close the network after all runs.

