### PR TITLE
NA: Fix docker image versions

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/MinIOContainerUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/MinIOContainerUtils.java
@@ -20,7 +20,7 @@ public class MinIOContainerUtils {
     public static final String MINIO_BUCKET = "test-bucket";
 
     public static GenericContainer<?> newMinIOContainer() {
-        return new GenericContainer<>(DockerImageName.parse("minio/minio:latest"))
+        return new GenericContainer<>(DockerImageName.parse("minio/minio:RELEASE.2025-03-12T18-04-18Z"))
                 .withExposedPorts(9000)
                 .withEnv("MINIO_ROOT_USER", MINIO_USER)
                 .withEnv("MINIO_ROOT_PASSWORD", MINIO_PASSWORD)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/MySQLContainerUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/MySQLContainerUtils.java
@@ -12,7 +12,7 @@ public class MySQLContainerUtils {
     }
 
     public static MySQLContainer<?> newMySQLContainer(boolean reusable) {
-        return new MySQLContainer<>(DockerImageName.parse("mysql"))
+        return new MySQLContainer<>(DockerImageName.parse("mysql:8.4.2"))
                 .withUrlParam("createDatabaseIfNotExist", "true")
                 .withUrlParam("rewriteBatchedStatements", "true")
                 .withUrlParam("serverTimezone", "UTC")

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/RedisContainerUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/RedisContainerUtils.java
@@ -8,7 +8,7 @@ import org.testcontainers.utility.DockerImageName;
 public class RedisContainerUtils {
 
     public static RedisContainer newRedisContainer() {
-        return new RedisContainer(DockerImageName.parse("redis"))
+        return new RedisContainer(DockerImageName.parse("redis:7.2.4-alpine3.19"))
                 .withReuse(true);
     }
 


### PR DESCRIPTION
## Details

Since a new version of MySQL was recently published, our tests were broken because we used the latest tag instead of a specific one. To prevent this from happening again, we are defining the version tag to be the same as the ones used on the Docker compose file.