### PR TITLE
[OPIK-1433] Optimize Python OnlineEval parallelism

### DIFF
--- a/apps/opik-python-backend/entrypoint.sh
+++ b/apps/opik-python-backend/entrypoint.sh
@@ -35,8 +35,13 @@ else
 fi
 
 echo "Starting the Opik Python Backend server"
+# Use same number of threads as container pool size
+NUM_THREADS=${PYTHON_CODE_EXECUTOR_PARALLEL_NUM:-5}
+
 opentelemetry-instrument gunicorn --access-logfile '-' \
          --access-logformat '{"body_bytes_sent": %(B)s, "http_referer": "%(f)s", "http_user_agent": "%(a)s", "remote_addr": "%(h)s", "remote_user": "%(u)s", "request_length": 0, "request_time": %(L)s, "request": "%(r)s", "source": "gunicorn", "status": %(s)s, "time_local": "%(t)s", "time": %(T)s, "x_forwarded_for": "%(h)s"}' \
-         --workers 4 \
+         --workers 1 \
+         --threads "$NUM_THREADS" \
+         --worker-class gthread \
          --bind=0.0.0.0:8000 \
          --chdir ./src 'opik_backend:create_app()'


### PR DESCRIPTION
## Details
I noticed py backends metrics were messy on Grafana, like as there we multiple instances being hit on /metrics at random, which is explained by the multiple workers (individual processes) in gunicorn. So for now is much easier to us to reduce to a single worker, but with multithread support.

![Screenshot 2025-04-15 at 18 27 04](https://github.com/user-attachments/assets/b0bfe252-4d4a-41a2-95f4-b8d429b5db09)

Also, this much easier to control actual parallelism, as we were actually supporting 4 * PYTHON_CODE_EXECUTOR_PARALLEL_NUM, which was wrong and limiting us to only mutiples of 4.

Finally, I noticed with 4 workers, we were limiting our parallelism to... 4, even with 4 * 10 = 40 containers pre-allocated. So now we will support as many threads as the request parallelism.

## Issues
Resolves OPIK-1433.

## Testing

## Documentation
