### PR TITLE
NO-JIRA: Handle backend flaky tests

### DIFF
--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -35,7 +35,7 @@ jobs:
             - name: Run Tests for backend
               env:
                 TESTCONTAINERS_REUSE_ENABLE: true
-              run: mvn clean test -Dmaven.test.failure.ignore=true
+              run: mvn clean test -Dmaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=3
 
             - name: Publish Test Report
               uses: EnricoMi/publish-unit-test-result-action/linux@v2


### PR DESCRIPTION
## Details
Re-running failed test up to 3 times, as we have some flakiness due to infrastructure or programmatic failures.

This will improve the CI experience, by preventing the need to run the whole test action again when experiencing flakiness.

The test report should show this information, which will allow us to debug flaky tests and actually fix them.

## Issues

N/A

## Testing
- https://github.com/comet-ml/opik/actions/runs/14490158332

## Documentation
- https://maven.apache.org/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html
