### PR TITLE
fix: valid custom domain for opik docs

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -1,6 +1,6 @@
 instances:
   - url: https://opik.docs.buildwithfern.com/docs/opik
-    custom-domain: https://www.comet.com/docs/opik/
+    custom-domain: www.comet.com/docs/opik/
 metadata:
   # Core platform identity
   og:site_name: "Opik Documentation"


### PR DESCRIPTION
## Details
As per fern docs we should ommit the `https://`, current main docs are not being indexed by google. Likley fern is rejecting this custom domain which creates redirect/canonical tags.

## Issues
Google has de-indexed live comet.com domain docs pages.

Resolves #

## Testing

## Documentation
https://buildwithfern.com/learn/docs/building-and-customizing-your-docs/custom-domain#subdomain