### PR TITLE
[NA] Fixed `pydantic-settings` dependency which was broken

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -43,7 +43,7 @@ setup(
         "levenshtein<1.0.0",
         "litellm",
         "openai<2.0.0",
-        "pydantic-settings>=2.0.0,<3.0.0",
+        "pydantic-settings>=2.0.0,<3.0.0,!=2.9.0",
         "pydantic>=2.0.0,<3.0.0",
         "pytest",
         "rich",


### PR DESCRIPTION
## Details
Latest release of `pydantic-settings` (2.9.0) is broken. It has mistakenly removed public export of `ConfigFileSourceMixin` which Opik uses.

Looking into GitHub repository it looks like the situation will be fixed in next release of `pydantic-settings` https://github.com/pydantic/pydantic-settings/commit/e973d9afc8fbfeaaddca466f10d56e7671e67abd

Right now we exclude version 2.9.0 of `pydantic-settings` to mitigate the issue.

## Issues

Resolves #

## Testing

## Documentation
