### PR TITLE
[NA] Fixed `pydantic-settings` broken dependency in python-backend

### DIFF
--- a/apps/opik-python-backend/requirements.txt
+++ b/apps/opik-python-backend/requirements.txt
@@ -12,6 +12,7 @@ itsdangerous==2.2.0
 Jinja2==3.1.5
 MarkupSafe==3.0.2
 packaging==24.2
+pydantic-settings>=2.0.0,<3.0.0,!=2.9.0
 requests==2.32.3
 urllib3==2.3.0
 Werkzeug==3.1.3


### PR DESCRIPTION
## Details
`pydantic-settings` version `2.9.0` is broken (see #1886 for more information). This PR excludes the broken version from `requirements.txt`

## Testing
Ran the following command:
```
docker compose -f docker-compose.yaml -f docker-compose.override.yaml up python-backend -d --build
```
Once with a requirements file that contains:
```
pydantic-settings==2.9.0
```
And another time with a requirements file that contain:
```
pydantic-settings>=2.0.0,<3.0.0,!=2.9.0
```

Made sure the container crashes during startup for the first and not crashing for the second.
Note that in order to test properly, `no_cache` must be set to `true` in the docker compose file.