### PR TITLE
NO-JIRA: Not fail empty commit SDKs spec action

### DIFF
--- a/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
+++ b/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
@@ -51,7 +51,7 @@ jobs:
           git add sdks/typescript/src/opik/rest_api/
           git add sdks/code_generation/fern/openapi/openapi.yaml
           git add apps/opik-documentation/documentation/fern/openapi/opik.yaml
-          git commit -m "Update OpenAPI spec and Fern code"
+          git commit --allow-empty -m "Update OpenAPI spec and Fern code"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
## Details
The action fails if no files to commit. This has no other consequences, but it's confusing. 
Added `--allow-empty` flag to handle this and to delegate this case to the push PR action.

## Issues

N/A

## Testing
- https://github.com/comet-ml/opik/actions/runs/14597563840

## Documentation
N/A
