### PR TITLE
[NA] fix backed service depends on redis

### DIFF
--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -168,6 +168,8 @@ services:
         condition: service_healthy
       minio:
         condition: service_healthy
+      redis:
+        condition: service_healthy
 
   python-backend:
     image: ghcr.io/comet-ml/opik/opik-python-backend:${OPIK_VERSION:-latest}


### PR DESCRIPTION
## Details
When starting the backend service like so:
```
docker compose -f docker-compose.yaml -f docker-compose.override.yaml up backend -d
```
it could not become healthy since its health rely on redis. This PR fixes it.

## Testing
Ran the following command before and after this change:
```
docker compose -f docker-compose.yaml -f docker-compose.override.yaml up backend -d
```

**Before:**
```
docker ps -a

CONTAINER ID   IMAGE                                           COMMAND                   CREATED          STATUS                      PORTS                                                      NAMES
84e34e0a002d   ghcr.io/comet-ml/opik/opik-backend:latest       "bash -c './run_db_m…"    48 seconds ago   Up 41 seconds (unhealthy)   0.0.0.0:3003->3003/tcp, 0.0.0.0:8080->8080/tcp             opik-backend-1
```

**After:**
```
docker ps -a

CONTAINER ID   IMAGE                                           COMMAND                  CREATED              STATUS                        PORTS                                                      NAMES
fd0ce5c46311   ghcr.io/comet-ml/opik/opik-backend:latest       "bash -c './run_db_m…"   About a minute ago   Up 55 seconds (healthy)       0.0.0.0:3003->3003/tcp, 0.0.0.0:8080->8080/tcp             opik-backend-1
```

(note the `healthy` vs. `unhealthy`)