### PR TITLE
OPIK-1332: Reduce view to micro secs of trace last updated at

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Project.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Project.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -13,6 +14,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import static com.comet.opik.utils.JsonUtils.ISO_INSTANT_MICROS_PATTERN;
 
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -30,7 +33,7 @@ public record Project(
         @JsonView({Project.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,
         @JsonView({Project.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
         @JsonView({Project.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy,
-        @JsonView({
+        @JsonFormat(pattern = ISO_INSTANT_MICROS_PATTERN, timezone = "UTC") @JsonView({
                 Project.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) @Nullable Instant lastUpdatedTraceAt,
         @JsonView({
                 Project.View.Detailed.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) @Nullable List<FeedbackScoreAverage> feedbackScores,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Trace.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Trace.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -18,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.comet.opik.utils.JsonUtils.ISO_INSTANT_MICROS_PATTERN;
 import static com.comet.opik.utils.ValidationUtils.NULL_OR_NOT_BLANK;
 
 @Builder(toBuilder = true)
@@ -40,7 +42,8 @@ public record Trace(
         @JsonView({Trace.View.Public.class, Trace.View.Write.class}) ErrorInfo errorInfo,
         @JsonView({Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Map<String, Long> usage,
         @JsonView({Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant createdAt,
-        @JsonView({Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
+        @JsonFormat(pattern = ISO_INSTANT_MICROS_PATTERN, timezone = "UTC") @JsonView({
+                Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
         @JsonView({Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,
         @JsonView({Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy,
         @JsonView({

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -54,7 +54,9 @@ public class FilterQueryBuilder {
     private static final String FIRST_MESSAGE_ANALYTICS_DB = "first_message";
     private static final String LAST_MESSAGE_ANALYTICS_DB = "last_message";
     private static final String CREATED_AT_ANALYTICS_DB = "created_at";
-    private static final String LAST_UPDATED_AT_ANALYTICS_DB = "last_updated_at";
+    // TODO - OPIK-1332: Temporary conversion to microseconds until the field is updated in ClickHouse.
+    //  It only affects trace, in particular for filtering trace threads.
+    private static final String LAST_UPDATED_AT_MICROS_ANALYTICS_DB = "toStartOfMicrosecond(last_updated_at)";
     private static final String NUMBER_OF_MESSAGES_ANALYTICS_DB = "number_of_messages";
     private static final String FEEDBACK_SCORE_COUNT_DB = "fsc.feedback_scores_count";
     private static final String GUARDRAILS_RESULT_DB = "gagg.guardrails_result";
@@ -149,7 +151,7 @@ public class FilterQueryBuilder {
                     .put(TraceThreadField.LAST_MESSAGE, LAST_MESSAGE_ANALYTICS_DB)
                     .put(TraceThreadField.DURATION, DURATION_ANALYTICS_DB)
                     .put(TraceThreadField.CREATED_AT, CREATED_AT_ANALYTICS_DB)
-                    .put(TraceThreadField.LAST_UPDATED_AT, LAST_UPDATED_AT_ANALYTICS_DB)
+                    .put(TraceThreadField.LAST_UPDATED_AT, LAST_UPDATED_AT_MICROS_ANALYTICS_DB)
                     .build());
 
     private static final Map<SpanField, String> SPAN_FIELDS_MAP = new EnumMap<>(

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/JsonUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/JsonUtils.java
@@ -26,6 +26,8 @@ import java.util.Collection;
 @Slf4j
 public class JsonUtils {
 
+    public static final String ISO_INSTANT_MICROS_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSX";
+
     public static final ObjectMapper MAPPER = new ObjectMapper()
             .setPropertyNamingStrategy(PropertyNamingStrategies.SnakeCaseStrategy.INSTANCE)
             .setSerializationInclusion(JsonInclude.Include.NON_NULL)

--- a/apps/opik-backend/src/test/java/com/comet/opik/TestComparators.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/TestComparators.java
@@ -6,7 +6,7 @@ public class TestComparators {
     public static int compareMicroNanoTime(Instant i1, Instant i2) {
         // Calculate the difference in nanoseconds
         long nanoDifference = Math.abs(i1.getNano() - i2.getNano());
-        if (nanoDifference < 1_000) {
+        if (nanoDifference <= 1_000) {
             return 0; // Consider equal if within a microsecond
         }
         return i1.compareTo(i2);


### PR DESCRIPTION
## Details
Client side timestamps in Python, TypeScript and also server side in Java, only support up to microseconds. Whereas ClickHouse timestamps support up to nanoseconds.

In order to add support of ingestion for long running jobs, we'll use a client side `last_updated_at` for conflict resolution. See in progress work in branch:
- https://github.com/comet-ml/opik/tree/andrescrz/OPIK-1332-trace-support-ingestion-long-running-jobs

In preparation for that, reducing the precision of that field to microseconds as it will be ingested from the client and nanoseconds precision isn't possible in that case. 

A PR will follow to actually truncate the ClickHouse field, which in turn should also optimise disk usage and performance.

## Issues

OPIK-1332

## Testing
- Covered by tests.
- Tested locally.
- Will be deployed and tested in dev.

## Documentation
N/A
