### PR TITLE
[OPIK-1457]Run docker images with non root user

### DIFF
--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -42,4 +42,5 @@ jobs:
               if: always()
               with:
                 action_fail: true
+                check_name: Backend Tests Results
                 files: '**/target/surefire-reports/TEST-*.xml'

--- a/.github/workflows/python_backend_tests.yml
+++ b/.github/workflows/python_backend_tests.yml
@@ -48,4 +48,5 @@ jobs:
         if: always()
         with:
           action_fail: true
+          check_name: Python Backend Tests Results
           files: apps/opik-python-backend/test-results.xml

--- a/.github/workflows/python_sdk_unit_tests.yml
+++ b/.github/workflows/python_sdk_unit_tests.yml
@@ -66,4 +66,5 @@ jobs:
         if: failure()
         with:
           action_fail: true
+          check_name: SDK Unit Tests Results
           files: ${{ github.workspace }}/test_results.xml

--- a/.github/workflows/sdk-e2e-tests.yaml
+++ b/.github/workflows/sdk-e2e-tests.yaml
@@ -74,6 +74,7 @@ jobs:
           if: failure()
           with:
             action_fail: true
+            check_name: SDK E2E Tests Results
             files: ${{ github.workspace }}/test_results_${{matrix.python_version}}.xml
 
         - name: Keep BE log in case of failure

--- a/apps/opik-backend/Dockerfile
+++ b/apps/opik-backend/Dockerfile
@@ -43,4 +43,9 @@ EXPOSE 3003
 ARG OPIK_VERSION
 ENV OPIK_VERSION=${OPIK_VERSION}
 
+RUN chmod -R 777 /tmp && chown -R 1001:1001 /opt/opik
+
+# Switch to the non-root user
+USER 1001:1001
+
 CMD ["./entrypoint.sh"]

--- a/apps/opik-backend/Dockerfile
+++ b/apps/opik-backend/Dockerfile
@@ -44,8 +44,6 @@ ARG OPIK_VERSION
 ENV OPIK_VERSION=${OPIK_VERSION}
 
 RUN chmod -R 777 /tmp && chown -R 1001:1001 /opt/opik
-
-# Switch to the non-root user
 USER 1001:1001
 
 CMD ["./entrypoint.sh"]

--- a/apps/opik-frontend/Dockerfile
+++ b/apps/opik-frontend/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /opt/frontend
 COPY package*.json ./
 COPY patches ./patches
 RUN npm install
-
 # Copy and build the application
 COPY . .
 
@@ -17,7 +16,6 @@ ARG SENTRY_DSN
 ENV VITE_APP_VERSION=${OPIK_VERSION}
 ENV VITE_SENTRY_ENABLED=${SENTRY_ENABLED}
 ENV VITE_SENTRY_DSN=${SENTRY_DSN}
-
 ENV NODE_OPTIONS="--max-old-space-size=8192"
 
 ARG BUILD_MODE=production
@@ -34,12 +32,22 @@ RUN yum update -y && yum install -y nginx \
 ARG BUILD_MODE=production
 LABEL build.mode="${BUILD_MODE}"
 
+# implement changes required to run NGINX as an unprivileged user
+RUN rm -f /etc/nginx/nginx.conf.default && \
+    sed -i '/access_log.*main/d' /etc/nginx/nginx.conf && \
+    sed -i 's,listen       80;,listen       8080;,' /etc/nginx/nginx.conf && \
+    sed -i 's,listen       \[::\]:80;,listen       \[::\]:8080;,' /etc/nginx/nginx.conf && \
+    sed -i '/user  nginx;/d' /etc/nginx/nginx.conf
+# nginx user must own the cache and etc directory to write cache and tweak the nginx config
+RUN mkdir -p /var/cache/nginx /var/log/nginx /run && \
+    chown -R nginx:nginx /var/cache/nginx /var/log/nginx /etc/nginx /run && \
+    chmod -R g+w /var/cache/nginx /var/log/nginx /etc/nginx /run
+
 # Copy the built files from the builder stage
 COPY --from=builder /opt/frontend/dist /usr/share/nginx/html
 
-RUN sed -i '/access_log.*main/d' /etc/nginx/nginx.conf
-
 EXPOSE 5173
-
+# Switch to the non-root user
+USER nginx:nginx
 # Start Nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/apps/opik-frontend/Dockerfile
+++ b/apps/opik-frontend/Dockerfile
@@ -37,7 +37,7 @@ RUN rm -f /etc/nginx/nginx.conf.default && \
     sed -i '/access_log.*main/d' /etc/nginx/nginx.conf && \
     sed -i 's,listen       80;,listen       8080;,' /etc/nginx/nginx.conf && \
     sed -i 's,listen       \[::\]:80;,listen       \[::\]:8080;,' /etc/nginx/nginx.conf && \
-    sed -i '/user  nginx;/d' /etc/nginx/nginx.conf
+    sed -i '/user nginx/d' /etc/nginx/nginx.conf
 RUN mkdir -p /var/cache/nginx /var/log/nginx /run && \
     chown -R nginx:nginx /var/cache/nginx /var/log/nginx /etc/nginx /run && \
     chmod -R g+w /var/cache/nginx /var/log/nginx /etc/nginx /run

--- a/apps/opik-frontend/Dockerfile
+++ b/apps/opik-frontend/Dockerfile
@@ -38,7 +38,6 @@ RUN rm -f /etc/nginx/nginx.conf.default && \
     sed -i 's,listen       80;,listen       8080;,' /etc/nginx/nginx.conf && \
     sed -i 's,listen       \[::\]:80;,listen       \[::\]:8080;,' /etc/nginx/nginx.conf && \
     sed -i '/user  nginx;/d' /etc/nginx/nginx.conf
-# nginx user must own the cache and etc directory to write cache and tweak the nginx config
 RUN mkdir -p /var/cache/nginx /var/log/nginx /run && \
     chown -R nginx:nginx /var/cache/nginx /var/log/nginx /etc/nginx /run && \
     chmod -R g+w /var/cache/nginx /var/log/nginx /etc/nginx /run
@@ -47,7 +46,7 @@ RUN mkdir -p /var/cache/nginx /var/log/nginx /run && \
 COPY --from=builder /opt/frontend/dist /usr/share/nginx/html
 
 EXPOSE 5173
-# Switch to the non-root user
+
 USER nginx:nginx
 # Start Nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/apps/opik-guardrails-backend/Dockerfile
+++ b/apps/opik-guardrails-backend/Dockerfile
@@ -43,10 +43,7 @@ ENV NVIDIA_VISIBLE_DEVICES=all \
 RUN chmod u+x entrypoint.sh
 EXPOSE 5000
 
-# Change ownership of workdir before switching user
 RUN chown -R 1001:1001 /opt/opik-guardrails-backend
-
-# Switch to the non-root user
 USER 1001:1001
 
 ENTRYPOINT ["tini", "--"]

--- a/apps/opik-guardrails-backend/Dockerfile
+++ b/apps/opik-guardrails-backend/Dockerfile
@@ -43,5 +43,11 @@ ENV NVIDIA_VISIBLE_DEVICES=all \
 RUN chmod u+x entrypoint.sh
 EXPOSE 5000
 
+# Change ownership of workdir before switching user
+RUN chown -R 1001:1001 /opt/opik-guardrails-backend
+
+# Switch to the non-root user
+USER 1001:1001
+
 ENTRYPOINT ["tini", "--"]
 CMD ["./entrypoint.sh"]

--- a/apps/opik-sandbox-executor-python/Dockerfile
+++ b/apps/opik-sandbox-executor-python/Dockerfile
@@ -5,7 +5,5 @@ WORKDIR /opt/opik-sandbox-executor-python
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 
-# Set proper ownership
 RUN chown -R 1001:1001 /opt/opik-sandbox-executor-python
-
 USER 1001:1001

--- a/apps/opik-sandbox-executor-python/Dockerfile
+++ b/apps/opik-sandbox-executor-python/Dockerfile
@@ -4,3 +4,8 @@ WORKDIR /opt/opik-sandbox-executor-python
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt
+
+# Set proper ownership
+RUN chown -R 1001:1001 /opt/opik-sandbox-executor-python
+
+USER 1001:1001


### PR DESCRIPTION
## Details
update Dockefiles to run as non-root user
implement changes required to run NGINX as an unprivileged user in opik-frontend
small workflows update - update name for test results for different workflows

## Issues

Resolves #

## Testing

## Documentation
