### PR TITLE
OPIK-1332: Reduce trace last updated at to microseconds

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000019_reduce_trace_last_updated_at_to_micros.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000019_reduce_trace_last_updated_at_to_micros.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+--changeset andrescrz:000019_reduce_trace_last_updated_at_to_micros
+
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces
+    MODIFY COLUMN last_updated_at DateTime64(6, 'UTC') DEFAULT now64(6);

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000019_reduce_trace_last_updated_at_to_micros.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000019_reduce_trace_last_updated_at_to_micros.sql
@@ -3,3 +3,5 @@
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces
     MODIFY COLUMN last_updated_at DateTime64(6, 'UTC') DEFAULT now64(6);
+
+--rollback empty


### PR DESCRIPTION
## Details
Reducing the precision of `trace.last_updated_at` field to microseconds (6) in the ClickHouse DB field. 

No rollback in the migration, as nanoseconds data will be lost forever once the migration is applied.

Per my testing, the size of the DB table won't change as still uses a int64 under the hood. Less precision just leaves more run for a longer range of values (see documentation).

## Issues
OPIK-1332

## Testing
- Applied migration locally in table with about 330K traces.
- Manually tested API responses and UI.
- Manually tested thread filter.
- Passed CI tests.

## Documentation
- https://clickhouse.com/docs/sql-reference/data-types/datetime64
