### PR TITLE
[NA] - bump opik-backend base image version

### DIFF
--- a/apps/opik-backend/Dockerfile
+++ b/apps/opik-backend/Dockerfile
@@ -12,7 +12,7 @@ RUN mvn versions:set -DnewVersion=${OPIK_VERSION} && \
     mvn clean package -DskipTests
 
 ###############################
-FROM amazoncorretto:21.0.6-al2023
+FROM amazoncorretto:21.0.7-al2023
 
 RUN yum update -y && yum install -y shadow ca-certificates openssl perl \
     && yum clean all


### PR DESCRIPTION
moving from `21.0.6-al2023` to  `21.0.7-al2023`

## Details
to resolve 
`CVE-2025-21893`
## Issues

Resolves #

## Testing

## Documentation
