### PR TITLE
OPIK-1476: Add ability to exclude fields from find spans response

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Span.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Span.java
@@ -2,6 +2,7 @@ package com.comet.opik.api;
 
 import com.comet.opik.domain.SpanType;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -12,6 +13,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -26,7 +29,6 @@ import static com.comet.opik.utils.ValidationUtils.NULL_OR_NOT_BLANK;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record Span(
-
         @JsonView( {
                 Span.View.Public.class, Span.View.Write.class}) UUID id,
         @JsonView({
@@ -69,6 +71,36 @@ public record Span(
         public static SpanPage empty(int page, List<String> sortableBy) {
             return new SpanPage(page, 0, 0, List.of(), sortableBy);
         }
+    }
+
+    @RequiredArgsConstructor
+    @Getter
+    public enum SpanField {
+
+        NAME("name"),
+        TYPE("type"),
+        START_TIME("start_time"),
+        END_TIME("end_time"),
+        INPUT("input"),
+        OUTPUT("output"),
+        METADATA("metadata"),
+        MODEL("model"),
+        PROVIDER("provider"),
+        TAGS("tags"),
+        USAGE("usage"),
+        ERROR_INFO("error_info"),
+        CREATED_AT("created_at"),
+        CREATED_BY("created_by"),
+        LAST_UPDATED_BY("last_updated_by"),
+        FEEDBACK_SCORES("feedback_scores"),
+        COMMENTS("comments"),
+        TOTAL_ESTIMATED_COST("total_estimated_cost"),
+        TOTAL_ESTIMATED_COST_VERSION("total_estimated_cost_version"),
+        DURATION("duration");
+
+        @JsonValue
+        private final String value;
+
     }
 
     public static class View {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/SpanSearchCriteria.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/SpanSearchCriteria.java
@@ -6,7 +6,10 @@ import com.comet.opik.domain.SpanType;
 import lombok.Builder;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+
+import static com.comet.opik.api.Span.SpanField;
 
 @Builder(toBuilder = true)
 public record SpanSearchCriteria(
@@ -17,5 +20,6 @@ public record SpanSearchCriteria(
         List<? extends Filter> filters,
         boolean truncate,
         UUID lastReceivedSpanId,
-        List<SortingField> sortingFields) {
+        List<SortingField> sortingFields,
+        Set<SpanField> exclude) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -15,7 +15,7 @@ import com.comet.opik.api.ExperimentItem;
 import com.comet.opik.api.PageColumns;
 import com.comet.opik.api.filter.ExperimentsComparisonFilter;
 import com.comet.opik.api.filter.FiltersFactory;
-import com.comet.opik.api.resources.v1.priv.validate.IdParamsValidator;
+import com.comet.opik.api.resources.v1.priv.validate.ParamsValidator;
 import com.comet.opik.api.sorting.SortingFactoryDatasets;
 import com.comet.opik.api.sorting.SortingField;
 import com.comet.opik.domain.DatasetItemService;
@@ -373,7 +373,7 @@ public class DatasetsResource {
             @QueryParam("filters") String filters,
             @QueryParam("truncate") @Schema(description = "Truncate image included in either input, output or metadata") boolean truncate) {
 
-        var experimentIds = IdParamsValidator.getIds(experimentIdsQueryParam);
+        var experimentIds = ParamsValidator.getIds(experimentIdsQueryParam);
 
         var queryFilters = filtersFactory.newFilters(filters, ExperimentsComparisonFilter.LIST_TYPE_REFERENCE);
 
@@ -411,7 +411,7 @@ public class DatasetsResource {
 
         var experimentIds = Optional.ofNullable(experimentIdsQueryParam)
                 .filter(Predicate.not(String::isEmpty))
-                .map(IdParamsValidator::getIds)
+                .map(ParamsValidator::getIds)
                 .orElse(null);
 
         String workspaceId = requestContext.get().getWorkspaceId();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -12,7 +12,7 @@ import com.comet.opik.api.ExperimentStreamRequest;
 import com.comet.opik.api.ExperimentsDelete;
 import com.comet.opik.api.FeedbackDefinition;
 import com.comet.opik.api.FeedbackScoreNames;
-import com.comet.opik.api.resources.v1.priv.validate.IdParamsValidator;
+import com.comet.opik.api.resources.v1.priv.validate.ParamsValidator;
 import com.comet.opik.api.sorting.ExperimentSortingFactory;
 import com.comet.opik.api.sorting.SortingField;
 import com.comet.opik.domain.EntityType;
@@ -315,7 +315,7 @@ public class ExperimentsResource {
     public Response findFeedbackScoreNames(@QueryParam("experiment_ids") String experimentIdsQueryParam) {
 
         var experimentIds = Optional.ofNullable(experimentIdsQueryParam)
-                .map(IdParamsValidator::getIds)
+                .map(ParamsValidator::getIds)
                 .orElse(Collections.emptySet());
 
         String workspaceId = requestContext.get().getWorkspaceId();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
@@ -12,7 +12,7 @@ import com.comet.opik.api.ProjectUpdate;
 import com.comet.opik.api.error.ErrorMessage;
 import com.comet.opik.api.metrics.ProjectMetricRequest;
 import com.comet.opik.api.metrics.ProjectMetricResponse;
-import com.comet.opik.api.resources.v1.priv.validate.IdParamsValidator;
+import com.comet.opik.api.resources.v1.priv.validate.ParamsValidator;
 import com.comet.opik.api.sorting.SortingFactoryProjects;
 import com.comet.opik.api.sorting.SortingField;
 import com.comet.opik.domain.FeedbackScoreService;
@@ -248,7 +248,7 @@ public class ProjectsResource {
     public Response findFeedbackScoreNames(@QueryParam("project_ids") String projectIdsQueryParam) {
 
         var projectIds = Optional.ofNullable(projectIdsQueryParam)
-                .map(IdParamsValidator::getIds)
+                .map(ParamsValidator::getIds)
                 .orElse(Collections.emptySet());
 
         String workspaceId = requestContext.get().getWorkspaceId();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
@@ -16,6 +16,7 @@ import com.comet.opik.api.SpanSearchStreamRequest;
 import com.comet.opik.api.SpanUpdate;
 import com.comet.opik.api.filter.FiltersFactory;
 import com.comet.opik.api.filter.SpanFilter;
+import com.comet.opik.api.resources.v1.priv.validate.ParamsValidator;
 import com.comet.opik.api.sorting.SpanSortingFactory;
 import com.comet.opik.domain.CommentDAO;
 import com.comet.opik.domain.CommentService;
@@ -71,7 +72,9 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static com.comet.opik.api.Span.SpanField;
 import static com.comet.opik.api.Span.SpanPage;
+import static com.comet.opik.api.Span.View;
 import static com.comet.opik.utils.AsyncUtils.setRequestContext;
 import static com.comet.opik.utils.ValidationUtils.validateProjectNameAndProjectId;
 
@@ -97,7 +100,7 @@ public class SpansResource {
     @GET
     @Operation(operationId = "getSpansByProject", summary = "Get spans by project_name or project_id and optionally by trace_id and/or type", description = "Get spans by project_name or project_id and optionally by trace_id and/or type", responses = {
             @ApiResponse(responseCode = "200", description = "Spans resource", content = @Content(schema = @Schema(implementation = SpanPage.class)))})
-    @JsonView(Span.View.Public.class)
+    @JsonView(View.Public.class)
     @RateLimited(value = "getSpans:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     public Response getSpansByProject(
             @QueryParam("page") @Min(1) @DefaultValue("1") int page,
@@ -108,7 +111,8 @@ public class SpansResource {
             @QueryParam("type") SpanType type,
             @QueryParam("filters") String filters,
             @QueryParam("truncate") @Schema(description = "Truncate image included in either input, output or metadata") boolean truncate,
-            @QueryParam("sorting") String sorting) {
+            @QueryParam("sorting") String sorting,
+            @QueryParam("exclude") String exclude) {
 
         validateProjectNameAndProjectId(projectName, projectId);
         var spanFilters = filtersFactory.newFilters(filters, SpanFilter.LIST_TYPE_REFERENCE);
@@ -130,6 +134,7 @@ public class SpansResource {
                 .filters(spanFilters)
                 .truncate(truncate)
                 .sortingFields(sortingFields)
+                .exclude(ParamsValidator.get(exclude, SpanField.class, "exclude"))
                 .build();
 
         String workspaceId = requestContext.get().getWorkspaceId();
@@ -154,7 +159,7 @@ public class SpansResource {
     @Operation(operationId = "getSpanById", summary = "Get span by id", description = "Get span by id", responses = {
             @ApiResponse(responseCode = "200", description = "Span resource", content = @Content(schema = @Schema(implementation = Span.class))),
             @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = Span.class)))})
-    @JsonView(Span.View.Public.class)
+    @JsonView(View.Public.class)
     @RateLimited(value = "getSpanById:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     public Response getById(@PathParam("id") @NotNull UUID id) {
 
@@ -178,7 +183,7 @@ public class SpansResource {
     @RateLimited
     @UsageLimited
     public Response create(
-            @RequestBody(content = @Content(schema = @Schema(implementation = Span.class))) @JsonView(Span.View.Write.class) @NotNull @Valid Span span,
+            @RequestBody(content = @Content(schema = @Schema(implementation = Span.class))) @JsonView(View.Write.class) @NotNull @Valid Span span,
             @Context UriInfo uriInfo) {
         var workspaceId = requestContext.get().getWorkspaceId();
         log.info("Creating span with id '{}', projectName '{}', traceId '{}', parentSpanId '{}', workspaceId '{}'",
@@ -199,7 +204,7 @@ public class SpansResource {
     @RateLimited
     @UsageLimited
     public Response createSpans(
-            @RequestBody(content = @Content(schema = @Schema(implementation = SpanBatch.class))) @JsonView(Span.View.Write.class) @NotNull @Valid SpanBatch spans) {
+            @RequestBody(content = @Content(schema = @Schema(implementation = SpanBatch.class))) @JsonView(View.Write.class) @NotNull @Valid SpanBatch spans) {
 
         spans.spans()
                 .stream()
@@ -383,7 +388,7 @@ public class SpansResource {
             }), maxItems = 2000))),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
     })
-    @JsonView(Span.View.Public.class)
+    @JsonView(View.Public.class)
     @RateLimited(value = "search_spans:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     public ChunkedOutput<JsonNode> searchSpans(
             @RequestBody(content = @Content(schema = @Schema(implementation = SpanSearchStreamRequest.class))) @NotNull @Valid SpanSearchStreamRequest request) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/validate/ParamsValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/validate/ParamsValidator.java
@@ -2,10 +2,13 @@ package com.comet.opik.api.resources.v1.priv.validate;
 
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import jakarta.ws.rs.BadRequestException;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -13,7 +16,7 @@ import java.util.stream.Collectors;
 
 @UtilityClass
 @Slf4j
-public class IdParamsValidator {
+public class ParamsValidator {
 
     private static final TypeReference<List<UUID>> LIST_UUID_TYPE_REFERENCE = new TypeReference<>() {
     };
@@ -24,6 +27,30 @@ public class IdParamsValidator {
             return JsonUtils.readValue(idsQueryParam, LIST_UUID_TYPE_REFERENCE)
                     .stream()
                     .collect(Collectors.toUnmodifiableSet());
+        } catch (RuntimeException exception) {
+            log.warn(message, exception);
+            throw new BadRequestException(message, exception);
+        }
+    }
+
+    public static <T> Set<T> get(String listParamValue, Class<T> clazz, String paramName) {
+        var message = "Invalid query param %s '%s'".formatted(paramName, listParamValue);
+        try {
+
+            if (StringUtils.isEmpty(listParamValue)) {
+                return Set.of();
+            }
+
+            TypeReference<Set<T>> typeReference = new TypeReference<>() {
+
+                @Override
+                public Type getType() {
+                    return TypeFactory.defaultInstance().constructCollectionType(Set.class, clazz);
+                }
+
+            };
+
+            return JsonUtils.readValue(listParamValue, typeReference);
         } catch (RuntimeException exception) {
             log.warn(message, exception);
             throw new BadRequestException(message, exception);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -22,6 +22,7 @@ import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Row;
 import io.r2dbc.spi.Statement;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -46,14 +47,16 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.comet.opik.api.ErrorInfo.ERROR_INFO_TYPE;
+import static com.comet.opik.api.Span.SpanField;
+import static com.comet.opik.api.Span.SpanPage;
 import static com.comet.opik.domain.AsyncContextUtils.bindUserNameAndWorkspaceContextToStream;
 import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToFlux;
 import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToMono;
-import static com.comet.opik.domain.CommentResultMapper.getComments;
 import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils.Segment;
 import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils.endSegment;
 import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils.startSegment;
@@ -635,7 +638,7 @@ class SpanDAO {
             <endif>
             , spans_final AS (
                 SELECT
-                      s.*,
+                      s.* <if(exclude_fields)>EXCEPT (<exclude_fields>) <endif>,
                       if(end_time IS NOT NULL AND start_time IS NOT NULL
                                AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)),
                            (dateDiff('microsecond', start_time, end_time) / 1000.0),
@@ -682,32 +685,13 @@ class SpanDAO {
                 LIMIT :limit <if(offset)>OFFSET :offset <endif>
             )
             SELECT
-                s.id as id,
-                s.workspace_id as workspace_id,
-                s.project_id as project_id,
-                s.trace_id as trace_id,
-                s.parent_span_id as parent_span_id,
-                s.name as name,
-                s.type as type,
-                s.start_time as start_time,
-                s.end_time as end_time,
-                <if(truncate)> replaceRegexpAll(s.input, '<truncate>', '"[image]"') as input <else> s.input as input<endif>,
-                <if(truncate)> replaceRegexpAll(s.output, '<truncate>', '"[image]"') as output <else> s.output as output<endif>,
-                <if(truncate)> replaceRegexpAll(s.metadata, '<truncate>', '"[image]"') as metadata <else> s.metadata as metadata<endif>,
-                s.model as model,
-                s.provider as provider,
-                s.total_estimated_cost as total_estimated_cost,
-                s.tags as tags,
-                s.usage as usage,
-                s.error_info as error_info,
-                s.created_at as created_at,
-                s.last_updated_at as last_updated_at,
-                s.created_by as created_by,
-                s.last_updated_by as last_updated_by,
-                s.duration as duration,
-                fsa.feedback_scores_list as feedback_scores_list,
-                fsa.feedback_scores as feedback_scores,
-                c.comments AS comments
+                s.* <if(exclude_fields)>EXCEPT (<exclude_fields>) <else> EXCEPT (input, output, metadata)<endif>
+                <if(!exclude_input)>, <if(truncate)> replaceRegexpAll(s.input, '<truncate>', '"[image]"') as input <else> s.input as input<endif> <endif>
+                <if(!exclude_output)>, <if(truncate)> replaceRegexpAll(s.output, '<truncate>', '"[image]"') as output <else> s.output as output<endif> <endif>
+                <if(!exclude_metadata)>, <if(truncate)> replaceRegexpAll(s.metadata, '<truncate>', '"[image]"') as metadata <else> s.metadata as metadata<endif> <endif>
+                <if(!exclude_feedback_scores)>, fsa.feedback_scores_list as feedback_scores_list <endif>
+                , fsa.feedback_scores as feedback_scores
+                <if(!exclude_comments)>, c.comments AS comments <endif>
             FROM spans_final s
             LEFT JOIN comments_final c ON s.id = c.entity_id
             LEFT JOIN feedback_scores_agg fsa ON fsa.entity_id = s.id
@@ -1355,63 +1339,90 @@ class SpanDAO {
     }
 
     private Publisher<Span> mapToDto(Result result) {
+        return mapToDto(result, Set.of());
+    }
+
+    private <T> T getValue(Set<SpanField> exclude, SpanField field, Row row, String fieldName, Class<T> clazz) {
+        return exclude.contains(field) ? null : row.get(fieldName, clazz);
+    }
+
+    private Publisher<Span> mapToDto(Result result, Set<SpanField> exclude) {
+
+        Set<SpanField> excludedFields = CollectionUtils.isEmpty(exclude) ? Set.of() : exclude;
+
         return result.map((row, rowMetadata) -> {
-            var parentSpanId = row.get("parent_span_id", String.class);
             return Span.builder()
                     .id(row.get("id", UUID.class))
                     .projectId(row.get("project_id", UUID.class))
                     .traceId(row.get("trace_id", UUID.class))
-                    .parentSpanId(Optional.ofNullable(parentSpanId)
+                    .parentSpanId(Optional.ofNullable(row.get("parent_span_id", String.class))
                             .filter(str -> !str.isBlank())
                             .map(UUID::fromString)
                             .orElse(null))
-                    .name(row.get("name", String.class))
-                    .type(SpanType.fromString(row.get("type", String.class)))
-                    .startTime(row.get("start_time", Instant.class))
-                    .endTime(row.get("end_time", Instant.class))
-                    .input(Optional.ofNullable(row.get("input", String.class))
+                    .name(getValue(excludedFields, SpanField.NAME, row, "name", String.class))
+                    .type(Optional.ofNullable(
+                            getValue(excludedFields, SpanField.TYPE, row, "type", String.class))
+                            .map(SpanType::fromString)
+                            .orElse(null))
+                    .startTime(getValue(excludedFields, SpanField.START_TIME, row, "start_time", Instant.class))
+                    .endTime(getValue(excludedFields, SpanField.END_TIME, row, "end_time", Instant.class))
+                    .input(Optional.ofNullable(getValue(excludedFields, SpanField.INPUT, row, "input", String.class))
                             .filter(str -> !str.isBlank())
                             .map(JsonUtils::getJsonNodeFromString)
                             .orElse(null))
-                    .output(Optional.ofNullable(row.get("output", String.class))
+                    .output(Optional.ofNullable(getValue(excludedFields, SpanField.OUTPUT, row, "output", String.class))
                             .filter(str -> !str.isBlank())
                             .map(JsonUtils::getJsonNodeFromString)
                             .orElse(null))
-                    .metadata(Optional.ofNullable(row.get("metadata", String.class))
+                    .metadata(Optional
+                            .ofNullable(getValue(excludedFields, SpanField.METADATA, row, "metadata", String.class))
                             .filter(str -> !str.isBlank())
                             .map(JsonUtils::getJsonNodeFromString)
                             .orElse(null))
-                    .model(StringUtils.isBlank(row.get("model", String.class))
-                            ? null
-                            : row.get("model", String.class))
-                    .provider(StringUtils.isBlank(row.get("provider", String.class))
-                            ? null
-                            : row.get("provider", String.class))
+                    .model(Optional.ofNullable(getValue(excludedFields, SpanField.MODEL, row, "model", String.class))
+                            .filter(str -> !str.isBlank())
+                            .orElse(null))
+                    .provider(Optional
+                            .ofNullable(getValue(excludedFields, SpanField.PROVIDER, row, "provider", String.class))
+                            .filter(str -> !str.isBlank())
+                            .orElse(null))
                     .totalEstimatedCost(
-                            BigDecimal.ZERO.compareTo(row.get("total_estimated_cost", BigDecimal.class)) == 0
-                                    ? null
-                                    : row.get("total_estimated_cost", BigDecimal.class))
-                    .totalEstimatedCostVersion(row.getMetadata().contains("total_estimated_cost_version")
-                            ? row.get("total_estimated_cost_version", String.class)
-                            : null)
-                    .feedbackScores(Optional.ofNullable(row.get("feedback_scores_list", List.class))
+                            Optional.ofNullable(getValue(excludedFields, SpanField.TOTAL_ESTIMATED_COST, row,
+                                    "total_estimated_cost", BigDecimal.class))
+                                    .filter(value -> value.compareTo(BigDecimal.ZERO) > 0)
+                                    .orElse(null))
+                    .totalEstimatedCostVersion(getValue(excludedFields, SpanField.TOTAL_ESTIMATED_COST_VERSION, row,
+                            "total_estimated_cost_version", String.class))
+                    .feedbackScores(Optional
+                            .ofNullable(getValue(excludedFields, SpanField.FEEDBACK_SCORES, row, "feedback_scores_list",
+                                    List.class))
+                            .filter(not(List::isEmpty))
                             .map(this::mapFeedbackScores)
                             .filter(not(List::isEmpty))
                             .orElse(null))
-                    .tags(Optional.of(Arrays.stream(row.get("tags", String[].class)).collect(Collectors.toSet()))
-                            .filter(set -> !set.isEmpty())
+                    .tags(Optional.ofNullable(getValue(excludedFields, SpanField.TAGS, row, "tags", String[].class))
+                            .map(Arrays::stream)
+                            .map(Stream::toList)
+                            .filter(not(List::isEmpty))
+                            .map(Set::copyOf)
                             .orElse(null))
-                    .usage(row.get("usage", Map.class))
-                    .comments(getComments(row.get("comments", List[].class)))
-                    .errorInfo(Optional.ofNullable(row.get("error_info", String.class))
+                    .usage(getValue(excludedFields, SpanField.USAGE, row, "usage", Map.class))
+                    .comments(Optional
+                            .ofNullable(getValue(excludedFields, SpanField.COMMENTS, row, "comments", List[].class))
+                            .map(CommentResultMapper::getComments)
+                            .filter(not(List::isEmpty))
+                            .orElse(null))
+                    .errorInfo(Optional
+                            .ofNullable(getValue(excludedFields, SpanField.ERROR_INFO, row, "error_info", String.class))
                             .filter(str -> !str.isBlank())
                             .map(errorInfo -> JsonUtils.readValue(errorInfo, ERROR_INFO_TYPE))
                             .orElse(null))
-                    .createdAt(row.get("created_at", Instant.class))
+                    .createdAt(getValue(excludedFields, SpanField.CREATED_AT, row, "created_at", Instant.class))
                     .lastUpdatedAt(row.get("last_updated_at", Instant.class))
-                    .createdBy(row.get("created_by", String.class))
-                    .lastUpdatedBy(row.get("last_updated_by", String.class))
-                    .duration(row.get("duration", Double.class))
+                    .createdBy(getValue(excludedFields, SpanField.CREATED_BY, row, "created_by", String.class))
+                    .lastUpdatedBy(
+                            getValue(excludedFields, SpanField.LAST_UPDATED_BY, row, "last_updated_by", String.class))
+                    .duration(getValue(excludedFields, SpanField.DURATION, row, "duration", Double.class))
                     .build();
         });
     }
@@ -1449,17 +1460,17 @@ class SpanDAO {
     }
 
     @WithSpan
-    public Mono<Span.SpanPage> find(int page, int size, @NonNull SpanSearchCriteria spanSearchCriteria) {
+    public Mono<SpanPage> find(int page, int size, @NonNull SpanSearchCriteria spanSearchCriteria) {
         log.info("Finding span by '{}'", spanSearchCriteria);
         return countTotal(spanSearchCriteria).flatMap(total -> find(page, size, spanSearchCriteria, total));
     }
 
-    private Mono<Span.SpanPage> find(int page, int size, SpanSearchCriteria spanSearchCriteria, Long total) {
+    private Mono<SpanPage> find(int page, int size, SpanSearchCriteria spanSearchCriteria, Long total) {
         return Mono.from(connectionFactory.create())
                 .flatMapMany(connection -> find(page, size, spanSearchCriteria, connection))
-                .flatMap(this::mapToDto)
+                .flatMap(result -> mapToDto(result, spanSearchCriteria.exclude()))
                 .collectList()
-                .map(spans -> new Span.SpanPage(page, spans.size(), total, spans, sortingFactory.getSortableFields()));
+                .map(spans -> new SpanPage(page, spans.size(), total, spans, sortingFactory.getSortableFields()));
     }
 
     @WithSpan
@@ -1515,6 +1526,22 @@ class SpanDAO {
         template = ImageUtils.addTruncateToTemplate(template, spanSearchCriteria.truncate());
 
         var finalTemplate = template;
+        Optional.ofNullable(spanSearchCriteria.exclude())
+                .filter(Predicate.not(Set::isEmpty))
+                .ifPresent(exclude -> {
+
+                    String fields = exclude.stream()
+                            .map(SpanField::getValue)
+                            .collect(Collectors.joining(", "));
+
+                    finalTemplate.add("exclude_fields", fields);
+                    finalTemplate.add("exclude_input", exclude.contains(SpanField.INPUT));
+                    finalTemplate.add("exclude_output", exclude.contains(SpanField.OUTPUT));
+                    finalTemplate.add("exclude_metadata", exclude.contains(SpanField.METADATA));
+                    finalTemplate.add("exclude_feedback_scores", exclude.contains(SpanField.FEEDBACK_SCORES));
+                    finalTemplate.add("exclude_comments", exclude.contains(SpanField.COMMENTS));
+                });
+
         Optional.ofNullable(sortingQueryBuilder.toOrderBySql(spanSearchCriteria.sortingFields()))
                 .ifPresent(sortFields -> {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -687,7 +687,7 @@ class SpanDAO {
                 LIMIT :limit <if(offset)>OFFSET :offset <endif>
             )
             SELECT
-                s.* <if(exclude_fields)>EXCEPT (<exclude_fields>) <else> EXCEPT (input, output, metadata)<endif>
+                s.* <if(exclude_fields)>EXCEPT (<exclude_fields>, input, output, metadata) <else> EXCEPT (input, output, metadata)<endif>
                 <if(!exclude_input)>, <if(truncate)> replaceRegexpAll(s.input, '<truncate>', '"[image]"') as input <else> s.input as input<endif> <endif>
                 <if(!exclude_output)>, <if(truncate)> replaceRegexpAll(s.output, '<truncate>', '"[image]"') as output <else> s.output as output<endif> <endif>
                 <if(!exclude_metadata)>, <if(truncate)> replaceRegexpAll(s.metadata, '<truncate>', '"[image]"') as metadata <else> s.metadata as metadata<endif> <endif>

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -1405,10 +1405,8 @@ class SpanDAO {
                             .filter(not(List::isEmpty))
                             .orElse(null))
                     .tags(Optional.ofNullable(getValue(excludedFields, SpanField.TAGS, row, "tags", String[].class))
-                            .map(Arrays::stream)
-                            .map(Stream::toList)
-                            .filter(not(List::isEmpty))
-                            .map(Set::copyOf)
+                            .map(tags -> Arrays.stream(tags).collect(Collectors.toSet()))
+                            .filter(set -> !set.isEmpty())
                             .orElse(null))
                     .usage(getValue(excludedFields, SpanField.USAGE, row, "usage", Map.class))
                     .comments(Optional

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/SpanResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/SpanResourceClient.java
@@ -229,7 +229,7 @@ public class SpanResourceClient extends BaseCommentResourceClient {
 
     public Span.SpanPage findSpans(String workspaceName, String apiKey, String projectName,
             UUID projectId, Integer page, Integer size, UUID traceId, SpanType type, List<? extends SpanFilter> filters,
-            List<SortingField> sortingFields) {
+            List<SortingField> sortingFields, List<Span.SpanField> exclude) {
         WebTarget webTarget = client.target(RESOURCE_PATH.formatted(baseURI));
 
         if (page != null) {
@@ -262,6 +262,10 @@ public class SpanResourceClient extends BaseCommentResourceClient {
 
         if (sortingFields != null) {
             webTarget = webTarget.queryParam("sorting", toURLEncodedQueryParam(sortingFields));
+        }
+
+        if (exclude != null && !exclude.isEmpty()) {
+            webTarget = webTarget.queryParam("exclude", toURLEncodedQueryParam(exclude));
         }
 
         try (var actualResponse = webTarget

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/spans/SpanAssertions.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/spans/SpanAssertions.java
@@ -7,6 +7,7 @@ import com.comet.opik.api.resources.utils.StatsUtils;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 
 import static com.comet.opik.api.Span.SpanPage;
@@ -53,13 +54,28 @@ public class SpanAssertions {
         for (int i = 0; i < actualSpans.size(); i++) {
             var actualSpan = actualSpans.get(i);
             var expectedSpan = expectedSpans.get(i);
+
+            if (expectedSpan.startTime() != null && expectedSpan.endTime() != null && expectedSpan.duration() != null) {
+                expectedSpan = expectedSpan.toBuilder()
+                        .duration(DurationUtils.getDurationInMillisWithSubMilliPrecision(expectedSpan.startTime(),
+                                expectedSpan.endTime()))
+                        .build();
+            }
+
             var expectedFeedbackScores = expectedSpan.feedbackScores() == null
                     ? null
                     : expectedSpan.feedbackScores().reversed();
             assertThat(actualSpan.projectId()).isNotNull();
             assertThat(actualSpan.projectName()).isNull();
-            assertThat(actualSpan.createdAt()).isAfter(expectedSpan.createdAt());
-            assertThat(actualSpan.lastUpdatedAt()).isAfter(expectedSpan.lastUpdatedAt());
+
+            if (actualSpan.createdAt() != null) {
+                assertThat(actualSpan.createdAt()).isAfter(expectedSpan.createdAt());
+            }
+
+            if (actualSpan.lastUpdatedAt() != null) {
+                assertThat(actualSpan.lastUpdatedAt()).isAfter(expectedSpan.lastUpdatedAt());
+            }
+
             assertThat(actualSpan.feedbackScores())
                     .usingRecursiveComparison(
                             RecursiveComparisonConfiguration.builder()
@@ -68,18 +84,22 @@ public class SpanAssertions {
                                     .build())
                     .ignoringCollectionOrder()
                     .isEqualTo(expectedFeedbackScores);
-            var expected = DurationUtils.getDurationInMillisWithSubMilliPrecision(
-                    expectedSpan.startTime(), expectedSpan.endTime());
-            if (actualSpan.duration() == null || expected == null) {
-                assertThat(actualSpan.duration()).isEqualTo(expected);
+
+            if (actualSpan.duration() == null || expectedSpan.duration() == null) {
+                assertThat(actualSpan.duration()).isEqualTo(expectedSpan.duration());
             } else {
-                assertThat(actualSpan.duration()).isEqualTo(expected, within(0.001));
+                assertThat(actualSpan.duration()).isEqualTo(expectedSpan.duration(), within(0.001));
             }
 
             if (actualSpan.feedbackScores() != null) {
+                Instant createdAt = expectedSpan.createdAt() == null
+                        ? expectedSpan.lastUpdatedAt()
+                        : expectedSpan.createdAt();
+                Instant lastUpdatedAt = expectedSpan.lastUpdatedAt();
+
                 actualSpan.feedbackScores().forEach(feedbackScore -> {
-                    assertThat(feedbackScore.createdAt()).isAfter(expectedSpan.createdAt());
-                    assertThat(feedbackScore.lastUpdatedAt()).isAfter(expectedSpan.lastUpdatedAt());
+                    assertThat(feedbackScore.createdAt()).isAfter(createdAt);
+                    assertThat(feedbackScore.lastUpdatedAt()).isAfter(lastUpdatedAt);
                     assertThat(feedbackScore.createdBy()).isEqualTo(userName);
                     assertThat(feedbackScore.lastUpdatedBy()).isEqualTo(userName);
                 });
@@ -89,7 +109,7 @@ public class SpanAssertions {
                 assertComments(expectedSpan.comments(), actualSpan.comments());
 
                 actualSpan.comments().forEach(comment -> {
-                    assertThat(comment.createdAt()).isAfter(actualSpan.createdAt());
+                    assertThat(comment.createdAt()).isAfter(actualSpan.lastUpdatedAt());
                     assertThat(comment.lastUpdatedAt()).isAfter(actualSpan.lastUpdatedAt());
                     assertThat(comment.createdBy()).isEqualTo(userName);
                     assertThat(comment.lastUpdatedBy()).isEqualTo(userName);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/spans/SpansTestAssertion.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/spans/SpansTestAssertion.java
@@ -45,6 +45,7 @@ public final class SpansTestAssertion implements SpanPageTestAssertion<Span, Spa
                 Optional.ofNullable(queryParams.get("trace_id")).map(UUID::fromString).orElse(null),
                 Optional.ofNullable(queryParams.get("type")).map(SpanType::valueOf).orElse(null),
                 filters,
+                List.of(),
                 List.of());
 
         SpanAssertions.assertPage(actualPage, page, expected.size(), expected.size());


### PR DESCRIPTION
## Details

- Add new `exclude` query param that accepts a list like `exclude=["input", "output"]` to remove fields from the response body.

Note: To enable sorting with the capability, when sorting by an excluded column, the column is included in the query but excluded from the returned DTO.
