### PR TITLE
[NA] Ignore tags order in e2e tests

### DIFF
--- a/sdks/python/tests/e2e/verifiers.py
+++ b/sdks/python/tests/e2e/verifiers.py
@@ -18,7 +18,7 @@ def _try_get__dict__(instance: Any) -> Optional[Dict[str, Any]]:
     return instance.__dict__
 
 
-def _try_build_set(iterable: Optional[Iterable[Any]]) -> Optional[Set[str]]:
+def _try_build_set(iterable: Optional[Iterable[Any]]) -> Optional[Set[Any]]:
     if iterable is None:
         return iterable
 

--- a/sdks/python/tests/e2e/verifiers.py
+++ b/sdks/python/tests/e2e/verifiers.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Iterable, Set, Union
 import opik
 import json
 
@@ -17,6 +17,11 @@ def _try_get__dict__(instance: Any) -> Optional[Dict[str, Any]]:
 
     return instance.__dict__
 
+def _try_build_set(iterable: Optional[Iterable[Any]]) -> Optional[Set[str]]:
+    if iterable is None:
+        return iterable
+    
+    return set(iterable)
 
 def verify_trace(
     opik_client: opik.Opik,
@@ -25,7 +30,7 @@ def verify_trace(
     metadata: Dict[str, Any] = mock.ANY,  # type: ignore
     input: Dict[str, Any] = mock.ANY,  # type: ignore
     output: Dict[str, Any] = mock.ANY,  # type: ignore
-    tags: List[str] = mock.ANY,  # type: ignore
+    tags: Union[List[str], Set[str]] = mock.ANY,  # type: ignore
     feedback_scores: List[FeedbackScoreDict] = mock.ANY,  # type: ignore
     project_name: Optional[str] = mock.ANY,  # type: ignore
     error_info: Optional[ErrorInfoDict] = mock.ANY,  # type: ignore
@@ -47,10 +52,14 @@ def verify_trace(
     assert trace.metadata == metadata, testlib.prepare_difference_report(
         trace.metadata, metadata
     )
-    assert trace.tags == tags, testlib.prepare_difference_report(trace.tags, tags)
-    assert (
-        _try_get__dict__(trace.error_info) == error_info
-    ), testlib.prepare_difference_report(trace.error_info, error_info)
+
+    if tags is not mock.ANY:
+        assert _try_build_set(trace.tags) == _try_build_set(tags), testlib.prepare_difference_report(trace.tags, tags)
+    
+    if error_info is not mock.ANY:
+        assert (
+            _try_get__dict__(trace.error_info) == error_info
+        ), testlib.prepare_difference_report(trace.error_info, error_info)
 
     assert thread_id == trace.thread_id, f"{trace.thread_id} != {thread_id}"
 
@@ -104,7 +113,7 @@ def verify_span(
     metadata: Dict[str, Any] = mock.ANY,  # type: ignore
     input: Dict[str, Any] = mock.ANY,  # type: ignore
     output: Dict[str, Any] = mock.ANY,  # type: ignore
-    tags: List[str] = mock.ANY,  # type: ignore
+    tags: Union[List[str], Set[str]] = mock.ANY,  # type: ignore
     type: str = mock.ANY,  # type: ignore
     feedback_scores: List[FeedbackScoreDict] = mock.ANY,  # type: ignore
     project_name: Optional[str] = mock.ANY,
@@ -138,10 +147,15 @@ def verify_span(
     assert span.metadata == metadata, testlib.prepare_difference_report(
         span.metadata, metadata
     )
-    assert span.tags == tags, testlib.prepare_difference_report(span.tags, tags)
-    assert (
-        _try_get__dict__(span.error_info) == error_info
-    ), testlib.prepare_difference_report(span.error_info, error_info)
+
+    if tags is not mock.ANY:
+        assert _try_build_set(span.tags) == _try_build_set(tags), testlib.prepare_difference_report(span.tags, tags)
+    
+    if error_info is not mock.ANY:
+        assert (
+            _try_get__dict__(span.error_info) == error_info
+        ), testlib.prepare_difference_report(span.error_info, error_info)
+    
     assert span.model == model, f"{span.model} != {model}"
     assert span.provider == provider, f"{span.provider} != {provider}"
     assert (

--- a/sdks/python/tests/e2e/verifiers.py
+++ b/sdks/python/tests/e2e/verifiers.py
@@ -17,11 +17,13 @@ def _try_get__dict__(instance: Any) -> Optional[Dict[str, Any]]:
 
     return instance.__dict__
 
+
 def _try_build_set(iterable: Optional[Iterable[Any]]) -> Optional[Set[str]]:
     if iterable is None:
         return iterable
-    
+
     return set(iterable)
+
 
 def verify_trace(
     opik_client: opik.Opik,
@@ -54,8 +56,10 @@ def verify_trace(
     )
 
     if tags is not mock.ANY:
-        assert _try_build_set(trace.tags) == _try_build_set(tags), testlib.prepare_difference_report(trace.tags, tags)
-    
+        assert _try_build_set(trace.tags) == _try_build_set(
+            tags
+        ), testlib.prepare_difference_report(trace.tags, tags)
+
     if error_info is not mock.ANY:
         assert (
             _try_get__dict__(trace.error_info) == error_info
@@ -149,13 +153,15 @@ def verify_span(
     )
 
     if tags is not mock.ANY:
-        assert _try_build_set(span.tags) == _try_build_set(tags), testlib.prepare_difference_report(span.tags, tags)
-    
+        assert _try_build_set(span.tags) == _try_build_set(
+            tags
+        ), testlib.prepare_difference_report(span.tags, tags)
+
     if error_info is not mock.ANY:
         assert (
             _try_get__dict__(span.error_info) == error_info
         ), testlib.prepare_difference_report(span.error_info, error_info)
-    
+
     assert span.model == model, f"{span.model} != {model}"
     assert span.provider == provider, f"{span.provider} != {provider}"
     assert (

--- a/sdks/python/tests/testlib/assert_helpers.py
+++ b/sdks/python/tests/testlib/assert_helpers.py
@@ -36,7 +36,7 @@ def prepare_difference_report(expected: Any, actual: Any) -> str:
         return diff_report_clean
     except Exception:
         LOGGER.debug("Failed to prepare difference report", exc_info=True)
-        return ""
+        return "Failed to prepare difference report"
 
 
 def assert_equal(expected, actual):


### PR DESCRIPTION
## Details
Now tags are compared as sets, not lists.

The issue with ordering was detected [here](https://github.com/comet-ml/opik/actions/runs/14661217494/job/41145927115)