### PR TITLE
[OPIK-1437] Not force small images to take full size in preview

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/attachments/AttachmentPreviewDialog/AttachmentPreviewDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/attachments/AttachmentPreviewDialog/AttachmentPreviewDialog.tsx
@@ -68,7 +68,7 @@ const AttachmentPreviewDialog: React.FC<AttachmentPreviewProps> = ({
           src={url}
           loading="lazy"
           alt={name}
-          className="size-full object-contain"
+          className="m-auto max-h-full max-w-full object-contain"
         />
       </div>
     );


### PR DESCRIPTION
## Details
Fix image preview

## Issues

Resolves #

## Testing

## Documentation
