### PR TITLE
[OPIK-1503] add missing guardrails join to the final section of the query

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -1028,6 +1028,7 @@ class TraceDAOImpl implements TraceDAO {
                             (dateDiff('microsecond', start_time, end_time) / 1000.0),
                             NULL) as duration
                     FROM traces final
+                        LEFT JOIN guardrails_agg gagg ON guardrails_agg.entity_id = traces.id
                     <if(feedback_scores_empty_filters)>
                         LEFT JOIN fsc ON fsc.entity_id = traces.id
                     <endif>

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -281,3 +281,6 @@ serviceToggles:
   # Default: false for testing. It should be enabled for test scenarios when it's relevant.
   # Description: Whether or not Python evaluator is enabled
   pythonEvaluatorEnabled: "false"
+
+# Enables query improvement using final
+enableFinal: false


### PR DESCRIPTION
## Details
This `JOIN` was added in the non-final part of the query, but was forgotten in the `FINAL` part. This PR adds it to the final part of the query.

## Issues
OPIK-1503

## Testing
Ran the tests with `enableFinal: true` and watch it fail. Adding the missing `JOIN` made the test green.
