### PR TITLE
NO-OPIK remove api explorer links from testing docs links

### DIFF
--- a/tests_end_to_end/tests/Documentation/test_links.py
+++ b/tests_end_to_end/tests/Documentation/test_links.py
@@ -12,12 +12,14 @@ def broken_links():
     with open("tests/Documentation/output.csv", "r") as file:
         reader = csv.DictReader(file)
         for row in reader:
-            if row["state"] == "BROKEN" and (
-                "comet" in row["url"].lower()
-                or "ferndocs" in row["url"].lower()
-                or "opik" in row["url"].lower()
-            ) and (
-                "~explorer" not in row["parent"].lower()
+            if (
+                row["state"] == "BROKEN"
+                and (
+                    "comet" in row["url"].lower()
+                    or "ferndocs" in row["url"].lower()
+                    or "opik" in row["url"].lower()
+                )
+                and ("~explorer" not in row["parent"].lower())
             ):
                 broken_links.append(
                     {


### PR DESCRIPTION
## Details

/~explorer API docs pages seem to be very flaky due to the way they're generated and they are out of the scope of the docs links tests