### PR TITLE
OPIK-1332: Support trace ingestion for long-running jobs

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Project.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Project.java
@@ -1,6 +1,5 @@
 package com.comet.opik.api;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -14,8 +13,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
-import static com.comet.opik.utils.JsonUtils.ISO_INSTANT_MICROS_PATTERN;
 
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -33,7 +30,7 @@ public record Project(
         @JsonView({Project.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,
         @JsonView({Project.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
         @JsonView({Project.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy,
-        @JsonFormat(pattern = ISO_INSTANT_MICROS_PATTERN, timezone = "UTC") @JsonView({
+        @JsonView({
                 Project.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) @Nullable Instant lastUpdatedTraceAt,
         @JsonView({
                 Project.View.Detailed.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) @Nullable List<FeedbackScoreAverage> feedbackScores,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Trace.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Trace.java
@@ -1,6 +1,5 @@
 package com.comet.opik.api;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonView;
@@ -8,7 +7,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
@@ -22,7 +20,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.comet.opik.utils.JsonUtils.ISO_INSTANT_MICROS_PATTERN;
 import static com.comet.opik.utils.ValidationUtils.NULL_OR_NOT_BLANK;
 
 @Builder(toBuilder = true)
@@ -30,12 +27,11 @@ import static com.comet.opik.utils.ValidationUtils.NULL_OR_NOT_BLANK;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record Trace(
         @JsonView( {
-                Trace.View.Public.class,
-                Trace.View.Write.class}) UUID id,
+                Trace.View.Public.class, Trace.View.Write.class}) UUID id,
         @JsonView({
                 Trace.View.Write.class}) @Pattern(regexp = NULL_OR_NOT_BLANK, message = "must not be blank") @Schema(description = "If null, the default project is used") String projectName,
         @JsonView({Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) UUID projectId,
-        @JsonView({Trace.View.Public.class, Trace.View.Write.class}) @NotBlank String name,
+        @JsonView({Trace.View.Public.class, Trace.View.Write.class}) String name,
         @JsonView({Trace.View.Public.class, Trace.View.Write.class}) @NotNull Instant startTime,
         @JsonView({Trace.View.Public.class, Trace.View.Write.class}) Instant endTime,
         @JsonView({Trace.View.Public.class, Trace.View.Write.class}) JsonNode input,
@@ -45,8 +41,7 @@ public record Trace(
         @JsonView({Trace.View.Public.class, Trace.View.Write.class}) ErrorInfo errorInfo,
         @JsonView({Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Map<String, Long> usage,
         @JsonView({Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant createdAt,
-        @JsonFormat(pattern = ISO_INSTANT_MICROS_PATTERN, timezone = "UTC") @JsonView({
-                Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
+        @JsonView({Trace.View.Public.class, Trace.View.Write.class}) Instant lastUpdatedAt,
         @JsonView({Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,
         @JsonView({Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy,
         @JsonView({

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/TraceUpdate.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/TraceUpdate.java
@@ -20,6 +20,7 @@ import static com.comet.opik.utils.ValidationUtils.NULL_OR_NOT_BLANK;
 public record TraceUpdate(
         @Pattern(regexp = NULL_OR_NOT_BLANK, message = "must not be blank") @Schema(description = "If null and project_id not specified, Default Project is assumed") String projectName,
         @Schema(description = "If null and project_name not specified, Default Project is assumed") UUID projectId,
+        String name,
         Instant endTime,
         JsonNode input,
         JsonNode output,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -17,7 +17,6 @@ import com.comet.opik.api.error.ErrorMessage;
 import com.comet.opik.api.error.IdentifierMismatchException;
 import com.comet.opik.api.events.TracesCreated;
 import com.comet.opik.api.events.TracesUpdated;
-import com.comet.opik.api.sorting.TraceSortingFactory;
 import com.comet.opik.domain.attachment.AttachmentService;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
@@ -116,7 +115,6 @@ class TraceServiceImpl implements TraceService {
     private final @NonNull IdGenerator idGenerator;
     private final @NonNull LockService lockService;
     private final @NonNull EventBus eventBus;
-    private final @NonNull TraceSortingFactory sortingFactory;
 
     @Override
     @WithSpan
@@ -230,8 +228,7 @@ class TraceServiceImpl implements TraceService {
     private Mono<UUID> insertTrace(Trace newTrace, Project project, UUID id, Trace existingTrace) {
         return Mono.defer(() -> {
             // check if a partial trace exists caused by a patch request
-            if (existingTrace.name().isBlank()
-                    && existingTrace.startTime().equals(Instant.EPOCH)
+            if (existingTrace.startTime().equals(Instant.EPOCH)
                     && existingTrace.projectId().equals(project.id())) {
 
                 return create(newTrace, project, id);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -54,9 +54,7 @@ public class FilterQueryBuilder {
     private static final String FIRST_MESSAGE_ANALYTICS_DB = "first_message";
     private static final String LAST_MESSAGE_ANALYTICS_DB = "last_message";
     private static final String CREATED_AT_ANALYTICS_DB = "created_at";
-    // TODO - OPIK-1332: Temporary conversion to microseconds until the field is updated in ClickHouse.
-    //  It only affects trace, in particular for filtering trace threads.
-    private static final String LAST_UPDATED_AT_MICROS_ANALYTICS_DB = "toStartOfMicrosecond(last_updated_at)";
+    private static final String LAST_UPDATED_AT_ANALYTICS_DB = "last_updated_at";
     private static final String NUMBER_OF_MESSAGES_ANALYTICS_DB = "number_of_messages";
     private static final String FEEDBACK_SCORE_COUNT_DB = "fsc.feedback_scores_count";
     private static final String GUARDRAILS_RESULT_DB = "gagg.guardrails_result";
@@ -151,7 +149,7 @@ public class FilterQueryBuilder {
                     .put(TraceThreadField.LAST_MESSAGE, LAST_MESSAGE_ANALYTICS_DB)
                     .put(TraceThreadField.DURATION, DURATION_ANALYTICS_DB)
                     .put(TraceThreadField.CREATED_AT, CREATED_AT_ANALYTICS_DB)
-                    .put(TraceThreadField.LAST_UPDATED_AT, LAST_UPDATED_AT_MICROS_ANALYTICS_DB)
+                    .put(TraceThreadField.LAST_UPDATED_AT, LAST_UPDATED_AT_ANALYTICS_DB)
                     .build());
 
     private static final Map<SpanField, String> SPAN_FIELDS_MAP = new EnumMap<>(

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/JsonUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/JsonUtils.java
@@ -27,8 +27,6 @@ import java.util.Optional;
 @Slf4j
 public class JsonUtils {
 
-    public static final String ISO_INSTANT_MICROS_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSX";
-
     public static final ObjectMapper MAPPER = new ObjectMapper()
             .setPropertyNamingStrategy(PropertyNamingStrategies.SnakeCaseStrategy.INSTANCE)
             .setSerializationInclusion(JsonInclude.Include.NON_NULL)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/DurationUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/DurationUtils.java
@@ -12,7 +12,7 @@ public class DurationUtils {
     public static final Double TIME_UNIT = 1_000.0;
 
     public static Double getDurationInMillisWithSubMilliPrecision(@NonNull Instant startTime, Instant endTime) {
-        if (endTime == null) {
+        if (Instant.EPOCH.equals(startTime) || endTime == null) {
             return null;
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
@@ -157,16 +157,21 @@ public class TraceResourceClient extends BaseCommentResourceClient {
     }
 
     public void updateTrace(UUID id, TraceUpdate traceUpdate, String apiKey, String workspaceName) {
-        try (var actualResponse = client.target(RESOURCE_PATH.formatted(baseURI))
+        try (var actualResponse = updateTrace(id, traceUpdate, apiKey, workspaceName, HttpStatus.SC_NO_CONTENT)) {
+            assertThat(actualResponse.hasEntity()).isFalse();
+        }
+    }
+
+    public Response updateTrace(
+            UUID id, TraceUpdate traceUpdate, String apiKey, String workspaceName, int expectedStatus) {
+        var actualResponse = client.target(RESOURCE_PATH.formatted(baseURI))
                 .path(id.toString())
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, apiKey)
                 .header(WORKSPACE_HEADER, workspaceName)
-                .method(HttpMethod.PATCH, Entity.json(traceUpdate))) {
-
-            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
-            assertThat(actualResponse.hasEntity()).isFalse();
-        }
+                .method(HttpMethod.PATCH, Entity.json(traceUpdate));
+        assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(expectedStatus);
+        return actualResponse;
     }
 
     public List<List<FeedbackScoreBatchItem>> createMultiValueScores(List<String> multipleValuesFeedbackScores,

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
@@ -91,8 +91,7 @@ class TraceServiceImplTest {
                 projectService,
                 () -> Generators.timeBasedEpochGenerator().generate(),
                 DUMMY_LOCK_SERVICE,
-                eventBus,
-                traceSortingFactory);
+                eventBus);
     }
 
     @Nested
@@ -183,15 +182,13 @@ class TraceServiceImplTest {
             when(projectService.resolveProjectIdAndVerifyVisibility(null, projectName))
                     .thenThrow(ErrorUtils.failWithNotFoundName("Project", projectName));
 
-            Exception exception = assertThrows(NotFoundException.class, () -> {
-                traceService
-                        .find(page, size, TraceSearchCriteria.builder()
-                                .projectName(projectName)
-                                .build())
-                        .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, DEFAULT_USER)
-                                .put(RequestContext.WORKSPACE_ID, workspaceId))
-                        .block();
-            });
+            Exception exception = assertThrows(NotFoundException.class, () -> traceService
+                    .find(page, size, TraceSearchCriteria.builder()
+                            .projectName(projectName)
+                            .build())
+                    .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, DEFAULT_USER)
+                            .put(RequestContext.WORKSPACE_ID, workspaceId))
+                    .block());
 
             assertThat(exception.getMessage()).isEqualTo("Project name: %s not found".formatted(projectName));
         }

--- a/apps/opik-backend/src/test/java/com/comet/opik/podam/PodamFactoryUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/podam/PodamFactoryUtils.java
@@ -36,6 +36,7 @@ import uk.co.jemos.podam.api.RandomDataProviderStrategy;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static com.comet.opik.api.FeedbackDefinition.CategoricalFeedbackDefinition;
@@ -76,5 +77,9 @@ public class PodamFactoryUtils {
 
     public static <T> List<T> manufacturePojoList(PodamFactory podamFactory, Class<T> pojoClass) {
         return podamFactory.manufacturePojo(ArrayList.class, pojoClass);
+    }
+
+    public static <T> Set<T> manufacturePojoSet(PodamFactory podamFactory, Class<T> pojoClass) {
+        return podamFactory.manufacturePojo(Set.class, pojoClass);
     }
 }


### PR DESCRIPTION
## Details
In preparation for trace ingestion for long-running jobs, made the following changes.

Reduced the required fields for ingestion to the minimum by making `name` optional. That leaves only as required:
- `start_time`: non-nullable, non updatable and desirable to have from the very beginning.

Any other field doesn't require ingestion, as either is optional or is resolved/generated by the service internally.

For consistency, I made `name` an updatable field now through `update` trace endpoint.

Updated trace batch ingestion endpoint as an `upsert` endpoint which uses `last_updated_at` field as client side resolution. This field can be ingested now for this purpose. When not provided, it's resolved internally with the usual behaviour.

Reviewed and updated all the affected trace endpoints:
- batch create: affected by both  `name` being optional and by `last_updated_at` client side resolution.
- create and update: only affected by `name` being optional. These are not required for long running jobs, so client side `last_updated_at` is ignored and the pre-existing conflict resolution mechanism doesn't change.

Reverted previous view changes to reduce `last_updated_at` to microseconds, as this is already enforced on the DB.

Reduced tech debt by a lot in the DAO code and specially in the tests.

## Issues

- OPIK-1332
- OPIK-1509

## Testing
- Reviewed, updated and extended test coverage for all related endpoints.
- Tested locally.

## Documentation
N/A
