### PR TITLE
[FEAT] Added mermaid graphs for DSPy modules

### DIFF
--- a/sdks/python/src/opik/integrations/dspy/callback.py
+++ b/sdks/python/src/opik/integrations/dspy/callback.py
@@ -16,6 +16,14 @@ SpanOrTraceData = Union[span.SpanData, trace.TraceData]
 
 
 class OpikCallback(dspy_callback.BaseCallback):
+    """
+    Callback for DSPy Opik logging.
+
+    Args:
+        project_name: The name of the Opik project to log data.
+        module: the DSPy module to generate graph from
+    """
+
     def __init__(
         self,
         project_name: Optional[str] = None,

--- a/sdks/python/src/opik/integrations/dspy/callback.py
+++ b/sdks/python/src/opik/integrations/dspy/callback.py
@@ -24,7 +24,7 @@ class OpikCallback(dspy_callback.BaseCallback):
         self._map_call_id_to_span_data: Dict[str, span.SpanData] = {}
         self._map_call_id_to_trace_data: Dict[str, trace.TraceData] = {}
 
-        self._origins_metadata = {"created_from": "dspy"}
+        self._origins_metadata: Dict[str, Any] = {"created_from": "dspy"}
         if module is not None:
             self._try_add_module_graph_to_metadata(module)
 

--- a/sdks/python/src/opik/integrations/dspy/callback.py
+++ b/sdks/python/src/opik/integrations/dspy/callback.py
@@ -7,6 +7,8 @@ from opik import types, opik_context, context_storage
 from opik.api_objects import helpers, span, trace, opik_client
 from opik.decorator import error_info_collector
 
+from .utils import get_mermaid_graph
+
 SpanOrTraceData = Union[span.SpanData, trace.TraceData]
 
 
@@ -14,11 +16,16 @@ class OpikCallback(dspy_callback.BaseCallback):
     def __init__(
         self,
         project_name: Optional[str] = None,
+        module: Optional[dspy.Module] = None,
     ):
         self._map_call_id_to_span_data: Dict[str, span.SpanData] = {}
         self._map_call_id_to_trace_data: Dict[str, trace.TraceData] = {}
 
         self._origins_metadata = {"created_from": "dspy"}
+        try:
+            self._update_with_graph(self._origins_metadata, module)
+        except Exception:
+            pass
 
         self._context_storage = context_storage.OpikContextStorage()
 
@@ -129,7 +136,7 @@ class OpikCallback(dspy_callback.BaseCallback):
         trace_data = trace.TraceData(
             name=instance.__class__.__name__,
             input=inputs,
-            metadata={"created_from": "dspy"},
+            metadata=self._origins_metadata,
             project_name=self._project_name,
         )
         self._map_call_id_to_trace_data[call_id] = trace_data
@@ -155,6 +162,19 @@ class OpikCallback(dspy_callback.BaseCallback):
 
             if self._context_storage.get_trace_data() == trace_data:
                 self._context_storage.set_trace_data(None)
+
+    def _update_with_graph(self, metadata, instance):
+        if instance:
+            graph = get_mermaid_graph(instance)
+            if graph:
+                metadata.update(
+                    {
+                        "_opik_graph_definition": {
+                            "format": "mermaid",
+                            "data": graph,
+                        }
+                    }
+                )
 
     def _end_span(
         self,
@@ -198,9 +218,11 @@ class OpikCallback(dspy_callback.BaseCallback):
         return span.SpanData(
             trace_id=trace_id,
             parent_span_id=parent_span_id,
-            name=instance.name
-            if hasattr(instance, "name")
-            else instance.__class__.__name__,
+            name=(
+                instance.name
+                if hasattr(instance, "name")
+                else instance.__class__.__name__
+            ),
             input=inputs,
             type=span_type,
             project_name=project_name,

--- a/sdks/python/src/opik/integrations/dspy/callback.py
+++ b/sdks/python/src/opik/integrations/dspy/callback.py
@@ -163,7 +163,9 @@ class OpikCallback(dspy_callback.BaseCallback):
             if self._context_storage.get_trace_data() == trace_data:
                 self._context_storage.set_trace_data(None)
 
-    def _update_with_graph(self, metadata, instance):
+    def _update_with_graph(
+        self, metadata: Dict[str, Any], instance: dspy.Module
+    ) -> None:
         if instance:
             graph = get_mermaid_graph(instance)
             if graph:

--- a/sdks/python/src/opik/integrations/dspy/graph.py
+++ b/sdks/python/src/opik/integrations/dspy/graph.py
@@ -10,15 +10,15 @@ classDef Tools fill:##D3D3D3
 """
 
 
-def get_mermaid_graph(module: dspy.Module) -> str:
+def build_mermaid_graph_from_module(module: dspy.Module) -> str:
     modules: Dict[str, Any] = {}
-    get_dspy_module_heirarchy(module, modules)
+    _get_dspy_module_heirarchy(module, modules)
     graph = ""
     queue = [modules]
     states: Dict[str, Any] = {}
     while queue:
         current = queue.pop()
-        graph += get_mermaid_arrows(queue, current, states)
+        graph += _get_mermaid_arrows(queue, current, states)
 
     if graph:
         for key in states:
@@ -29,13 +29,13 @@ def get_mermaid_graph(module: dspy.Module) -> str:
     return ""
 
 
-def get_mermaid_arrows(
+def _get_mermaid_arrows(
     queue: List[dspy.Module], current: Dict[str, Any], states: Dict[str, Any]
 ) -> str:
-    start = get_mermaid_state(current, states)
+    start = _get_mermaid_state(current, states)
     arrows = []
     for module in current["sub_data"]:
-        end = get_mermaid_state(module, states)
+        end = _get_mermaid_state(module, states)
         arrows.append("%s --> %s\n" % (start["text"], end["text"]))
         queue.append(module)
     if "tools" in current["details"]:
@@ -47,7 +47,7 @@ def get_mermaid_arrows(
     return "".join(arrows)
 
 
-def get_mermaid_state(
+def _get_mermaid_state(
     current: Dict[str, Any], states: Dict[str, Any]
 ) -> Dict[str, Any]:
     if current["id"] not in states:
@@ -65,7 +65,7 @@ def get_mermaid_state(
     return states[current["id"]]
 
 
-def get_dspy_module_heirarchy(module: dspy.Module, data: Dict[str, Any]) -> None:
+def _get_dspy_module_heirarchy(module: dspy.Module, data: Dict[str, Any]) -> None:
     data["name"] = module.__class__.__name__
     data["id"] = id(module)
     data["details"] = {}
@@ -77,7 +77,7 @@ def get_dspy_module_heirarchy(module: dspy.Module, data: Dict[str, Any]) -> None
     for name, attribute in module.__dict__.items():
         if isinstance(attribute, dspy.Module):
             sub_data: Dict[str, Any] = {}
-            get_dspy_module_heirarchy(attribute, sub_data)
+            _get_dspy_module_heirarchy(attribute, sub_data)
             data["sub_data"].append(sub_data)
         elif name == "lm":
             lm_data: Dict[str, Any] = {}

--- a/sdks/python/src/opik/integrations/dspy/utils.py
+++ b/sdks/python/src/opik/integrations/dspy/utils.py
@@ -30,7 +30,7 @@ def get_mermaid_graph(module: dspy.Module) -> str:
 
 
 def get_mermaid_arrows(
-    queue: List[dspy.Modules], current: Dict[str, Any], states: Dict[str, Any]
+    queue: List[dspy.Module], current: Dict[str, Any], states: Dict[str, Any]
 ) -> str:
     start = get_mermaid_state(current, states)
     arrows = []

--- a/sdks/python/src/opik/integrations/dspy/utils.py
+++ b/sdks/python/src/opik/integrations/dspy/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List
 import dspy
 import string
 
@@ -9,12 +9,13 @@ classDef ChainOfThought fill:#ADD8E6
 classDef Tools fill:##D3D3D3
 """
 
+
 def get_mermaid_graph(module: dspy.Module) -> str:
-    modules = {}
+    modules: Dict[str, Any] = {}
     get_dspy_module_heirarchy(module, modules)
     graph = ""
     queue = [modules]
-    states = {}
+    states: Dict[str, Any] = {}
     while queue:
         current = queue.pop()
         graph += get_mermaid_arrows(queue, current, states)
@@ -25,8 +26,12 @@ def get_mermaid_graph(module: dspy.Module) -> str:
         graph += "class Tools Tools\n"
 
         return "graph TD\n" + graph + STYLES
+    return ""
 
-def get_mermaid_arrows(queue: List[dspy.Modules], current: Dict[str, Any], states: Dict[str, Any]):
+
+def get_mermaid_arrows(
+    queue: List[dspy.Modules], current: Dict[str, Any], states: Dict[str, Any]
+) -> str:
     start = get_mermaid_state(current, states)
     arrows = []
     for module in current["sub_data"]:
@@ -41,12 +46,17 @@ def get_mermaid_arrows(queue: List[dspy.Modules], current: Dict[str, Any], state
         arrows.append("end\n")
     return "".join(arrows)
 
-def get_mermaid_state(current: Dict[str, Any], states: Dict[str, Any]):
+
+def get_mermaid_state(
+    current: Dict[str, Any], states: Dict[str, Any]
+) -> Dict[str, Any]:
     if current["id"] not in states:
         state_name = string.ascii_uppercase[len(states)]
         state_text = "<b>%s</b>" % current["name"]
         if "instructions" in current["details"]:
-            state_text += "<br><i>%s</i>" % current["details"]["instructions"][:100].replace("`", "'")
+            state_text += "<br><i>%s</i>" % current["details"]["instructions"][
+                :100
+            ].replace("`", "'")
         states[current["id"]] = {
             "state_name": state_name,
             "text": "%s(%s)" % (state_name, state_text),
@@ -54,7 +64,8 @@ def get_mermaid_state(current: Dict[str, Any], states: Dict[str, Any]):
         }
     return states[current["id"]]
 
-def get_dspy_module_heirarchy(module: dspy.Module, data: Dict[str, Any]):
+
+def get_dspy_module_heirarchy(module: dspy.Module, data: Dict[str, Any]) -> None:
     data["name"] = module.__class__.__name__
     data["id"] = id(module)
     data["details"] = {}
@@ -65,14 +76,13 @@ def get_dspy_module_heirarchy(module: dspy.Module, data: Dict[str, Any]):
     data["sub_data"] = []
     for name, attribute in module.__dict__.items():
         if isinstance(attribute, dspy.Module):
-            sub_data = {}
+            sub_data: Dict[str, Any] = {}
             get_dspy_module_heirarchy(attribute, sub_data)
             data["sub_data"].append(sub_data)
         elif name == "lm":
-            sub_data = {}
-            sub_data["name"] = "LM"
-            sub_data["id"] = id(attribute)
-            sub_data["details"] = {}
-            sub_data["sub_data"] = []
-            data["sub_data"].append(sub_data)
-
+            lm_data: Dict[str, Any] = {}
+            lm_data["name"] = "LM"
+            lm_data["id"] = id(attribute)
+            lm_data["details"] = {}
+            lm_data["sub_data"] = []
+            data["sub_data"].append(lm_data)

--- a/sdks/python/src/opik/integrations/dspy/utils.py
+++ b/sdks/python/src/opik/integrations/dspy/utils.py
@@ -1,0 +1,78 @@
+from typing import Any, Dict, Optional, Union
+import dspy
+import string
+
+STYLES = """
+classDef ReAct fill:#90EE90
+classDef Predict fill:#F08080
+classDef ChainOfThought fill:#ADD8E6
+classDef Tools fill:##D3D3D3
+"""
+
+def get_mermaid_graph(module: dspy.Module) -> str:
+    modules = {}
+    get_dspy_module_heirarchy(module, modules)
+    graph = ""
+    queue = [modules]
+    states = {}
+    while queue:
+        current = queue.pop()
+        graph += get_mermaid_arrows(queue, current, states)
+
+    if graph:
+        for key in states:
+            graph += "class %s %s\n" % (states[key]["state_name"], states[key]["class"])
+        graph += "class Tools Tools\n"
+
+        return "graph TD\n" + graph + STYLES
+
+def get_mermaid_arrows(queue: List[dspy.Modules], current: Dict[str, Any], states: Dict[str, Any]):
+    start = get_mermaid_state(current, states)
+    arrows = []
+    for module in current["sub_data"]:
+        end = get_mermaid_state(module, states)
+        arrows.append("%s --> %s\n" % (start["text"], end["text"]))
+        queue.append(module)
+    if "tools" in current["details"]:
+        arrows.append("%s --> Tools\n" % (start["text"],))
+        arrows.append("subgraph Tools[<b>Tools</b>]\n")
+        for tool in current["details"]["tools"]:
+            arrows.append("    %s(<b>%s</b>)\n" % (tool, tool))
+        arrows.append("end\n")
+    return "".join(arrows)
+
+def get_mermaid_state(current: Dict[str, Any], states: Dict[str, Any]):
+    if current["id"] not in states:
+        state_name = string.ascii_uppercase[len(states)]
+        state_text = "<b>%s</b>" % current["name"]
+        if "instructions" in current["details"]:
+            state_text += "<br><i>%s</i>" % current["details"]["instructions"][:100].replace("`", "'")
+        states[current["id"]] = {
+            "state_name": state_name,
+            "text": "%s(%s)" % (state_name, state_text),
+            "class": current["name"],
+        }
+    return states[current["id"]]
+
+def get_dspy_module_heirarchy(module: dspy.Module, data: Dict[str, Any]):
+    data["name"] = module.__class__.__name__
+    data["id"] = id(module)
+    data["details"] = {}
+    if hasattr(module, "tools"):
+        data["details"]["tools"] = [name for name in module.tools]
+    if hasattr(module, "signature"):
+        data["details"]["instructions"] = module.signature.instructions
+    data["sub_data"] = []
+    for name, attribute in module.__dict__.items():
+        if isinstance(attribute, dspy.Module):
+            sub_data = {}
+            get_dspy_module_heirarchy(attribute, sub_data)
+            data["sub_data"].append(sub_data)
+        elif name == "lm":
+            sub_data = {}
+            sub_data["name"] = "LM"
+            sub_data["id"] = id(attribute)
+            sub_data["details"] = {}
+            sub_data["sub_data"] = []
+            data["sub_data"].append(sub_data)
+


### PR DESCRIPTION
## Details

LangGraph could add Agent Graphs. But DSPy modules did not. So I added them for DSPy

![image](https://github.com/user-attachments/assets/bd7ce989-a1a2-46d5-878e-1492e7356bf7)


## Testing

Need to add tests.

## Documentation

The logging of graph data is only activated when you also pass in a module to the DSPy callback, so there are no backward incompatibilities. 