### PR TITLE
Improve batch item size estimation

### DIFF
--- a/sdks/python/src/opik/message_processing/batching/sequence_splitter.py
+++ b/sdks/python/src/opik/message_processing/batching/sequence_splitter.py
@@ -1,14 +1,59 @@
-import json
-from typing import List, Optional, TypeVar, Sequence
+import logging
+from typing import List, Optional, TypeVar, Sequence, Any
 from opik import jsonable_encoder
 
 T = TypeVar("T")
 
+LOGGER = logging.getLogger(__name__)
+
 
 def _get_expected_payload_size_MB(item: T) -> float:
     encoded_for_json = jsonable_encoder.encode(item)
-    json_str = json.dumps(encoded_for_json)
-    return len(json_str.encode("utf-8")) / (1024 * 1024)
+    size = _get_json_size(encoded_for_json)
+    return size
+
+
+def _get_json_size(obj: Any) -> Any:
+    """
+    Compute the size of the resulting JSON without actually doing the JSON
+    encoding which is CPU and memory consuming. This assumes that we only
+    receives basic Python objects, strings, boolean, numbers, list and dicts
+    and that the object do not contains any cyclic reference.
+    """
+    try:
+        if isinstance(obj, str):
+            return len(obj.encode("utf-8")) + 2  # "str_content"
+        elif isinstance(obj, (int, float)):
+            return len(str(obj))
+        elif isinstance(obj, type(None)):
+            # "null"
+            return 6
+        elif isinstance(obj, dict):
+            size = 2  # {obj}
+            allowed_keys = set(obj.keys())
+            for key, value in obj.items():
+                if key in allowed_keys:
+                    encoded_key = _get_json_size(key)
+                    encoded_value = _get_json_size(value)
+                    size += encoded_key + encoded_value + 1  # key:value
+            return size
+        elif isinstance(obj, list):
+            size = 2  # [obj]
+            for item in obj:
+                size += _get_json_size(item) + 1  # ,
+            return size - 1  # Remove the last trailing comma
+        elif isinstance(obj, bool):
+            return len(str(obj))
+        else:
+            LOGGER.debug(
+                "Unexpected object seen during JSON size estimation %r", type(obj)
+            )
+            return len(str(obj))
+
+    except Exception:
+        LOGGER.debug("Failed to compute object size.", exc_info=True)
+        # Return a value that will cause the span to be in its own batch to be on the safe side
+        return float("inf")
 
 
 def split_into_batches(

--- a/sdks/python/src/opik/message_processing/batching/sequence_splitter.py
+++ b/sdks/python/src/opik/message_processing/batching/sequence_splitter.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 def _get_expected_payload_size_MB(item: T) -> float:
     encoded_for_json = jsonable_encoder.encode(item)
     size = _get_json_size(encoded_for_json)
-    return size
+    return size / (1024 * 1024)
 
 
 def _get_json_size(obj: Any) -> Any:

--- a/sdks/python/src/opik/message_processing/batching/sequence_splitter.py
+++ b/sdks/python/src/opik/message_processing/batching/sequence_splitter.py
@@ -26,8 +26,8 @@ def _get_json_size(obj: Any) -> Any:
         elif isinstance(obj, (int, float)):
             return len(str(obj))
         elif isinstance(obj, type(None)):
-            # "null"
-            return 6
+            # null
+            return 4
         elif isinstance(obj, dict):
             size = 2  # {obj}
             allowed_keys = set(obj.keys())
@@ -35,8 +35,8 @@ def _get_json_size(obj: Any) -> Any:
                 if key in allowed_keys:
                     encoded_key = _get_json_size(key)
                     encoded_value = _get_json_size(value)
-                    size += encoded_key + encoded_value + 1  # key:value
-            return size
+                    size += encoded_key + encoded_value + 1 + 1  # key:value and ,
+            return size - 1  # Remove the last trailing comma
         elif isinstance(obj, list):
             size = 2  # [obj]
             for item in obj:


### PR DESCRIPTION
New algorithm is as fast but takes minimal memory versus the old algorithm

## Details

I tested against a 30 MB spans batch.

In term of speed, this is equivalent if not slightly faster:

main branch:
```
654 ms ± 3.67 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

this branch:
```
620 ms ± 22.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

In term of memory, I measure a spike of 20MB in the main branch and couldn't measure any memory spike in the new branch (versus reading just the data in memory).
