### PR TITLE
[OPIK-1531] Bump default Guardrails timeout to 30s and make it configurable

### DIFF
--- a/sdks/python/src/opik/config.py
+++ b/sdks/python/src/opik/config.py
@@ -196,6 +196,11 @@ class OpikConfig(pydantic_settings.BaseSettings):
     If set to True - Opik will compress the JSON request body.
     """
 
+    guardrail_timeout: int = 30
+    """
+    Timeout for guardrail.validate calls in seconds. If response takes more than this, it will be considered failed and raises an Exception.
+    """
+
     @property
     def config_file_fullpath(self) -> pathlib.Path:
         config_file_path = os.getenv("OPIK_CONFIG_PATH", CONFIG_FILE_PATH_DEFAULT)

--- a/sdks/python/src/opik/guardrails/guardrail.py
+++ b/sdks/python/src/opik/guardrails/guardrail.py
@@ -1,10 +1,11 @@
 from typing import (
     List,
+    Optional,
 )
 
 import httpx
 
-from opik import exceptions
+from opik import exceptions, config
 from opik.api_objects import opik_client
 from opik.message_processing.messages import (
     GuardrailBatchItemMessage,
@@ -28,6 +29,7 @@ class Guardrail:
     def __init__(
         self,
         guards: List[guards.Guard],
+        guardrail_timeout: Optional[int] = None,
     ) -> None:
         """
         Initialize a Guardrail client.
@@ -65,13 +67,17 @@ class Guardrail:
         self.guards = guards
         self._client = opik_client.get_client_cached()
 
+        self.config_ = config.get_from_user_inputs(
+            guardrail_timeout=guardrail_timeout,
+        )
+
         self._initialize_api_client(
             host_url=self._client.config.guardrails_backend_host,
         )
 
     def _initialize_api_client(self, host_url: str) -> None:
         self._api_client = rest_api_client.GuardrailsApiClient(
-            httpx_client=httpx.Client(),
+            httpx_client=httpx.Client(timeout=self.config_.guardrail_timeout),
             host_url=host_url,
         )
 


### PR DESCRIPTION
## Details

The Topic classification takes up to 23s on my CPU throttled at 1Ghz, the new default timeout at 30s seems reasonable.

## Issues

Resolves #

## Testing

## Documentation
