### PR TITLE
[OPIK-1552]: [SDK] Add provider field to the span usage in ADK integration

### DIFF
--- a/sdks/python/tests/e2e_library_integration/adk/test_opik_tracer.py
+++ b/sdks/python/tests/e2e_library_integration/adk/test_opik_tracer.py
@@ -6,6 +6,7 @@ import pytest
 import requests
 
 from opik import synchronization
+from opik.integrations.adk import adk_decorators
 from ... import testlib
 
 ADK_SERVER_PORT = 21345
@@ -100,3 +101,8 @@ def test_opik_tracer_with_sample_agent(
             "total_tokens",
         ],
     )
+
+    spans = opik_client_unique_project_name.search_spans()
+    assert len(spans) == 3
+    assert spans[0].provider == adk_decorators.get_adk_provider()
+    assert spans[2].provider == adk_decorators.get_adk_provider()


### PR DESCRIPTION
## Details
Add ADK provider determination logic and update tests.

Introduced `get_adk_provider` to determine the LLM provider based on environment variables. Updated `ADKLLMTrackDecorator` to include the provider in span parameters and extended integration tests to validate this behavior.

## Testing
Fixed integration test to check for provider field value.
