### PR TITLE
Optimizer: allow string prompts for few-shot

### DIFF
--- a/sdks/opik_optimizer/src/opik_optimizer/few_shot_bayesian_optimizer/few_shot_bayesian_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/few_shot_bayesian_optimizer/few_shot_bayesian_optimizer.py
@@ -259,7 +259,7 @@ class FewShotBayesianOptimizer(base_optimizer.BaseOptimizer):
 
         if isinstance(prompt, str):
             if task_config is None:
-                raise Exception(
+                raise ValueError(
                     "To use a string prompt, please pass in task_config to evaluate_prompt()"
                 )
 


### PR DESCRIPTION
## Details

This PR allows the FewShotBayesianOptimizer.evaluate_prompt() to take a string. The one downside is that it then requires task_config.