### PR TITLE
fix docs: correct 'host' to 'apiUrl' in TypeScript quickstart example

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/quickstart.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/quickstart.mdx
@@ -54,7 +54,7 @@ import { Opik } from "opik";
 // Create a new Opik client with your configuration
 const client = new Opik({
   apiKey: "<your-api-key>",
-  host: "https://www.comet.com/opik/api", // Replace with http://localhost:5173/api if you are self-hosting
+  apiUrl: "https://www.comet.com/opik/api", // Replace with http://localhost:5173/api if you are self-hosting
   projectName: "default",
   workspaceName: "<your-workspace-name>", // Typically the same as your username
 });


### PR DESCRIPTION
Fix typo reported by Chase Fortier

Typescript docs typo:
https://www.comet.com/docs/opik/quickstart
const client = new Opik({
  apiKey: "<your-api-key>",
  host: "https://www.comet.com/opik/api",
  projectName: "<your-project-name>",
  workspaceName: "<your-workspace-name>",
});
Should actually be apiUrl instead of host