### PR TITLE
fix: Clear-text logging of sensitive information

### DIFF
--- a/sdks/python/src/opik/api_key/opik_api_key.py
+++ b/sdks/python/src/opik/api_key/opik_api_key.py
@@ -91,6 +91,7 @@ def parse_api_key(raw_key: str) -> Optional[OpikApiKey]:
         return None
 
     parts = raw_key.split(DELIMITER_CHAR)
+    redacted_key = _redact_sensitive_data(raw_key)
     size = len(parts)
     if size == 1:
         LOGGER.debug("Opik API key doesn't have attributes associated")
@@ -102,11 +103,11 @@ def parse_api_key(raw_key: str) -> Optional[OpikApiKey]:
             attributes = json.loads(data)
         else:
             # edge case - delimiter found but no encoded JSON afterward
-            LOGGER.warning(PARSE_API_KEY_EMPTY_EXPECTED_ATTRIBUTES % raw_key)
+            LOGGER.warning(PARSE_API_KEY_EMPTY_EXPECTED_ATTRIBUTES % redacted_key)
             raw_key = parts[0]  # remove obsolete delimiter
             attributes = None
 
         return OpikApiKey(api_key_raw=raw_key, api_key=parts[0], attributes=attributes)
 
-    LOGGER.warning(PARSE_API_KEY_TOO_MANY_PARTS, size, _redact_sensitive_data(raw_key))
+    LOGGER.warning(PARSE_API_KEY_TOO_MANY_PARTS, size, redacted_key)
     return None

--- a/sdks/python/src/opik/api_key/opik_api_key.py
+++ b/sdks/python/src/opik/api_key/opik_api_key.py
@@ -91,7 +91,7 @@ def parse_api_key(raw_key: str) -> Optional[OpikApiKey]:
         return None
 
     parts = raw_key.split(DELIMITER_CHAR)
-    redacted_key = _redact_sensitive_data(raw_key)
+    redacted = _redact_sensitive_data(raw_key)
     size = len(parts)
     if size == 1:
         LOGGER.debug("Opik API key doesn't have attributes associated")
@@ -103,11 +103,11 @@ def parse_api_key(raw_key: str) -> Optional[OpikApiKey]:
             attributes = json.loads(data)
         else:
             # edge case - delimiter found but no encoded JSON afterward
-            LOGGER.warning(PARSE_API_KEY_EMPTY_EXPECTED_ATTRIBUTES % redacted_key)
+            LOGGER.warning(PARSE_API_KEY_EMPTY_EXPECTED_ATTRIBUTES % redacted)
             raw_key = parts[0]  # remove obsolete delimiter
             attributes = None
 
         return OpikApiKey(api_key_raw=raw_key, api_key=parts[0], attributes=attributes)
 
-    LOGGER.warning(PARSE_API_KEY_TOO_MANY_PARTS, size, redacted_key)
+    LOGGER.warning(PARSE_API_KEY_TOO_MANY_PARTS, size, redacted)
     return None

--- a/sdks/python/src/opik/api_key/opik_api_key.py
+++ b/sdks/python/src/opik/api_key/opik_api_key.py
@@ -24,6 +24,21 @@ from .base64_helper import decode_base64
 
 LOGGER = logging.getLogger(__name__)
 
+
+def _redact_sensitive_data(data: str, visible_chars: int = 4) -> str:
+    """
+    Redacts sensitive data by showing only the first few characters and replacing the rest with asterisks.
+
+    Args:
+        data (str): The sensitive data to redact.
+        visible_chars (int): The number of characters to leave visible at the start.
+
+    Returns:
+        str: The redacted version of the data.
+    """
+    if not data or len(data) <= visible_chars:
+        return "*" * len(data)
+    return data[:visible_chars] + "*" * (len(data) - visible_chars)
 DELIMITER_CHAR = "*"
 
 
@@ -93,5 +108,5 @@ def parse_api_key(raw_key: str) -> Optional[OpikApiKey]:
 
         return OpikApiKey(api_key_raw=raw_key, api_key=parts[0], attributes=attributes)
 
-    LOGGER.warning(PARSE_API_KEY_TOO_MANY_PARTS, size, raw_key)
+    LOGGER.warning(PARSE_API_KEY_TOO_MANY_PARTS, size, _redact_sensitive_data(raw_key))
     return None

--- a/sdks/python/src/opik/api_key/opik_api_key.py
+++ b/sdks/python/src/opik/api_key/opik_api_key.py
@@ -39,6 +39,8 @@ def _redact_sensitive_data(data: str, visible_chars: int = 4) -> str:
     if not data or len(data) <= visible_chars:
         return "*" * len(data)
     return data[:visible_chars] + "*" * (len(data) - visible_chars)
+
+
 DELIMITER_CHAR = "*"
 
 

--- a/sdks/python/tests/unit/api_key/test_opik_api_key.py
+++ b/sdks/python/tests/unit/api_key/test_opik_api_key.py
@@ -25,14 +25,14 @@ def test_parse_api_key__one_part():
 
 def test_parse_api_key__no_expected_attributes(capture_log):
     raw_key = "some API key"
-    comet_api_key = parse_api_key(raw_key + DELIMITER_CHAR)
+    opik_api_key = parse_api_key(raw_key + DELIMITER_CHAR)
 
-    assert comet_api_key is not None
-    assert comet_api_key.api_key == raw_key
-    assert comet_api_key.short_api_key == raw_key
+    assert opik_api_key is not None
+    assert opik_api_key.api_key == raw_key
+    assert opik_api_key.short_api_key == raw_key
 
     assert (
-        PARSE_API_KEY_EMPTY_EXPECTED_ATTRIBUTES % (raw_key + DELIMITER_CHAR)
+        PARSE_API_KEY_EMPTY_EXPECTED_ATTRIBUTES % "some*********"
         in capture_log.messages
     )
 
@@ -42,7 +42,7 @@ def test_parse_api_key__too_many_parts(capture_log):
     opik_api_key = parse_api_key(raw_key)
 
     assert opik_api_key is None
-    assert PARSE_API_KEY_TOO_MANY_PARTS % (3, "some*") in capture_log.messages
+    assert PARSE_API_KEY_TOO_MANY_PARTS % (3, "some****************") in capture_log.messages
 
 
 def test_parse_api_key__happy_path__with_padding():

--- a/sdks/python/tests/unit/api_key/test_opik_api_key.py
+++ b/sdks/python/tests/unit/api_key/test_opik_api_key.py
@@ -42,7 +42,10 @@ def test_parse_api_key__too_many_parts(capture_log):
     opik_api_key = parse_api_key(raw_key)
 
     assert opik_api_key is None
-    assert PARSE_API_KEY_TOO_MANY_PARTS % (3, "some****************") in capture_log.messages
+    assert (
+        PARSE_API_KEY_TOO_MANY_PARTS % (3, "some****************")
+        in capture_log.messages
+    )
 
 
 def test_parse_api_key__happy_path__with_padding():

--- a/sdks/python/tests/unit/api_key/test_opik_api_key.py
+++ b/sdks/python/tests/unit/api_key/test_opik_api_key.py
@@ -39,10 +39,10 @@ def test_parse_api_key__no_expected_attributes(capture_log):
 
 def test_parse_api_key__too_many_parts(capture_log):
     raw_key = "some API key" + DELIMITER_CHAR + "one" + DELIMITER_CHAR + "two"
-    comet_api_key = parse_api_key(raw_key)
+    opik_api_key = parse_api_key(raw_key)
 
-    assert comet_api_key is None
-    assert PARSE_API_KEY_TOO_MANY_PARTS % (3, raw_key) in capture_log.messages
+    assert opik_api_key is None
+    assert PARSE_API_KEY_TOO_MANY_PARTS % (3, "some*") in capture_log.messages
 
 
 def test_parse_api_key__happy_path__with_padding():

--- a/sdks/python/tests/unit/api_objects/api_key/test_opik_api_key.py
+++ b/sdks/python/tests/unit/api_objects/api_key/test_opik_api_key.py
@@ -32,7 +32,7 @@ def test_parse_api_key__no_expected_attributes(capture_log):
     assert opik_api_key.short_api_key == raw_key
 
     assert (
-        PARSE_API_KEY_EMPTY_EXPECTED_ATTRIBUTES % (raw_key + DELIMITER_CHAR)
+        PARSE_API_KEY_EMPTY_EXPECTED_ATTRIBUTES % "some*********"
         in capture_log.messages
     )
 
@@ -42,7 +42,7 @@ def test_parse_api_key__too_many_parts(capture_log):
     opik_api_key = parse_api_key(raw_key)
 
     assert opik_api_key is None
-    assert PARSE_API_KEY_TOO_MANY_PARTS % (3, "some*") in capture_log.messages
+    assert PARSE_API_KEY_TOO_MANY_PARTS % (3, "some****************") in capture_log.messages
 
 
 def test_parse_api_key__happy_path__with_padding():

--- a/sdks/python/tests/unit/api_objects/api_key/test_opik_api_key.py
+++ b/sdks/python/tests/unit/api_objects/api_key/test_opik_api_key.py
@@ -42,7 +42,7 @@ def test_parse_api_key__too_many_parts(capture_log):
     opik_api_key = parse_api_key(raw_key)
 
     assert opik_api_key is None
-    assert PARSE_API_KEY_TOO_MANY_PARTS % (3, raw_key) in capture_log.messages
+    assert PARSE_API_KEY_TOO_MANY_PARTS % (3, "some*") in capture_log.messages
 
 
 def test_parse_api_key__happy_path__with_padding():

--- a/sdks/python/tests/unit/api_objects/api_key/test_opik_api_key.py
+++ b/sdks/python/tests/unit/api_objects/api_key/test_opik_api_key.py
@@ -42,7 +42,10 @@ def test_parse_api_key__too_many_parts(capture_log):
     opik_api_key = parse_api_key(raw_key)
 
     assert opik_api_key is None
-    assert PARSE_API_KEY_TOO_MANY_PARTS % (3, "some****************") in capture_log.messages
+    assert (
+        PARSE_API_KEY_TOO_MANY_PARTS % (3, "some****************")
+        in capture_log.messages
+    )
 
 
 def test_parse_api_key__happy_path__with_padding():


### PR DESCRIPTION
Potential fix for [https://github.com/comet-ml/opik/security/code-scanning/64](https://github.com/comet-ml/opik/security/code-scanning/64)

To fix the issue, we need to ensure that sensitive data such as the API key is not logged in clear text. Instead of logging the full `raw_key`, we can log a redacted version of it (e.g., only the first few characters followed by asterisks) to provide enough context for debugging without exposing the full key. This approach balances security and debugging needs.

The changes will involve:
1. Modifying the logging statement on line 96 in `sdks/python/src/opik/api_key/opik_api_key.py` to log a redacted version of `raw_key`.
2. Adding a helper function to handle the redaction of sensitive data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
