### PR TITLE
OPIK-1547: Add pre-computed column on ingestion to reduce overhead on aggregations

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -819,9 +819,9 @@ class SpanDAO {
                                  AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)),
                              (dateDiff('microsecond', start_time, end_time) / 1000.0),
                              NULL) AS duration,
-                     if(has_input, 1, 0) as input_count,
-                     if(has_output, 1, 0) as output_count,
-                     if(has_metadata, 1, 0) as metadata_count,
+                     if(input_length > 0, 1, 0) as input_count,
+                     if(output_length > 0, 1, 0) as output_count,
+                     if(metadata_length > 0, 1, 0) as metadata_count,
                      length(tags) as tags_count,
                      usage,
                      total_estimated_cost

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -819,9 +819,9 @@ class SpanDAO {
                                  AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)),
                              (dateDiff('microsecond', start_time, end_time) / 1000.0),
                              NULL) AS duration,
-                     notEmpty(input) as input_count,
-                     notEmpty(output) as output_count,
-                     notEmpty(metadata) as metadata_count,
+                     if(has_input, 1, 0) as input_count,
+                     if(has_output, 1, 0) as output_count,
+                     if(has_metadata, 1, 0) as metadata_count,
                      length(tags) as tags_count,
                      usage,
                      total_estimated_cost

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -934,9 +934,9 @@ class TraceDAOImpl implements TraceDAO {
                     workspace_id,
                     project_id,
                     id,
-                    notEmpty(input) as input_count,
-                    notEmpty(output) as output_count,
-                    notEmpty(metadata) as metadata_count,
+                    if(has_input, 1, 0) as input_count,
+                    if(has_output, 1, 0) as output_count,
+                    if(has_metadata, 1, 0) as metadata_count,
                     length(tags) as tags_length,
                     if(end_time IS NOT NULL AND start_time IS NOT NULL
                             AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)),

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -934,9 +934,9 @@ class TraceDAOImpl implements TraceDAO {
                     workspace_id,
                     project_id,
                     id,
-                    if(has_input, 1, 0) as input_count,
-                    if(has_output, 1, 0) as output_count,
-                    if(has_metadata, 1, 0) as metadata_count,
+                    if(input_length > 0, 1, 0) as input_count,
+                    if(output_length > 0, 1, 0) as output_count,
+                    if(metadata_length > 0, 1, 0) as metadata_count,
                     length(tags) as tags_length,
                     if(end_time IS NOT NULL AND start_time IS NOT NULL
                             AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)),

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000024_add_output_input_pre_computed_columns_to_spans_and_traces.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000024_add_output_input_pre_computed_columns_to_spans_and_traces.sql
@@ -2,14 +2,14 @@
 --changeset thiagohora:000024_add_output_input_pre_computed_columns_to_spans_and_traces
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS has_input BOOL MATERIALIZED notEmpty(input),
-    ADD COLUMN IF NOT EXISTS has_output BOOL MATERIALIZED notEmpty(output),
-    ADD COLUMN IF NOT EXISTS has_metadata BOOL MATERIALIZED notEmpty(metadata);
+    ADD COLUMN IF NOT EXISTS input_length UInt64 MATERIALIZED length(input),
+    ADD COLUMN IF NOT EXISTS output_length UInt64 MATERIALIZED length(output),
+    ADD COLUMN IF NOT EXISTS metadata_length UInt64 MATERIALIZED length(metadata);
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans ON CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS has_input BOOL MATERIALIZED notEmpty(input),
-    ADD COLUMN IF NOT EXISTS has_output BOOL MATERIALIZED notEmpty(output),
-    ADD COLUMN IF NOT EXISTS has_metadata BOOL MATERIALIZED notEmpty(metadata);
+    ADD COLUMN IF NOT EXISTS input_length UInt64 MATERIALIZED length(input),
+    ADD COLUMN IF NOT EXISTS output_length UInt64 MATERIALIZED length(output),
+    ADD COLUMN IF NOT EXISTS metadata_length UInt64 MATERIALIZED length(metadata);
 
---rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS has_input, DROP COLUMN IF EXISTS has_output, DROP COLUMN IF EXISTS has_metadata;
---rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS has_input, DROP COLUMN IF EXISTS has_output, DROP COLUMN IF EXISTS has_metadata;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS input_length, DROP COLUMN IF EXISTS output_length, DROP COLUMN IF EXISTS metadata_length;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS input_length, DROP COLUMN IF EXISTS output_length, DROP COLUMN IF EXISTS metadata_length;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000024_add_output_input_pre_computed_columns_to_spans_and_traces.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000024_add_output_input_pre_computed_columns_to_spans_and_traces.sql
@@ -4,14 +4,12 @@
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}'
     ADD COLUMN IF NOT EXISTS has_input BOOL MATERIALIZED notEmpty(input),
     ADD COLUMN IF NOT EXISTS has_output BOOL MATERIALIZED notEmpty(output),
-    ADD COLUMN IF NOT EXISTS has_metadata BOOL MATERIALIZED notEmpty(metadata)
-    SETTINGS alter_sync=1;
+    ADD COLUMN IF NOT EXISTS has_metadata BOOL MATERIALIZED notEmpty(metadata);
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans ON CLUSTER '{cluster}'
     ADD COLUMN IF NOT EXISTS has_input BOOL MATERIALIZED notEmpty(input),
     ADD COLUMN IF NOT EXISTS has_output BOOL MATERIALIZED notEmpty(output),
-    ADD COLUMN IF NOT EXISTS has_metadata BOOL MATERIALIZED notEmpty(metadata)
-    SETTINGS alter_sync=1;
+    ADD COLUMN IF NOT EXISTS has_metadata BOOL MATERIALIZED notEmpty(metadata);
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS has_input, DROP COLUMN IF EXISTS has_output, DROP COLUMN IF EXISTS has_metadata;
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS has_input, DROP COLUMN IF EXISTS has_output, DROP COLUMN IF EXISTS has_metadata;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000024_add_output_input_pre_computed_columns_to_spans_and_traces.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000024_add_output_input_pre_computed_columns_to_spans_and_traces.sql
@@ -1,5 +1,5 @@
 --liquibase formatted sql
---changeset thiagohora:add_output_input_pre_computed_columns_to_spans_and_traces
+--changeset thiagohora:000024_add_output_input_pre_computed_columns_to_spans_and_traces
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}'
     ADD COLUMN IF NOT EXISTS has_input BOOL MATERIALIZED notEmpty(input),

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000024_add_output_input_pre_computed_columns_to_spans_and_traces.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000024_add_output_input_pre_computed_columns_to_spans_and_traces.sql
@@ -1,0 +1,17 @@
+--liquibase formatted sql
+--changeset thiagohora:add_output_input_pre_computed_columns_to_spans_and_traces
+
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS has_input BOOLEAN MATERIALIZED notEmpty(input),
+    ADD COLUMN IF NOT EXISTS has_output BOOLEAN MATERIALIZED notEmpty(output),
+    ADD COLUMN IF NOT EXISTS has_metadata BOOLEAN MATERIALIZED notEmpty(metadata)
+    SETTINGS alter_sync=1;
+
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS has_input BOOLEAN MATERIALIZED notEmpty(input),
+    ADD COLUMN IF NOT EXISTS has_output BOOLEAN MATERIALIZED notEmpty(output),
+    ADD COLUMN IF NOT EXISTS has_metadata BOOLEAN MATERIALIZED notEmpty(metadata)
+    SETTINGS alter_sync=1;
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS has_input, DROP COLUMN IF EXISTS has_output, DROP COLUMN IF EXISTS has_metadata;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS has_input, DROP COLUMN IF EXISTS has_output, DROP COLUMN IF EXISTS has_metadata;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000024_add_output_input_pre_computed_columns_to_spans_and_traces.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000024_add_output_input_pre_computed_columns_to_spans_and_traces.sql
@@ -2,15 +2,15 @@
 --changeset thiagohora:add_output_input_pre_computed_columns_to_spans_and_traces
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS has_input BOOLEAN MATERIALIZED notEmpty(input),
-    ADD COLUMN IF NOT EXISTS has_output BOOLEAN MATERIALIZED notEmpty(output),
-    ADD COLUMN IF NOT EXISTS has_metadata BOOLEAN MATERIALIZED notEmpty(metadata)
+    ADD COLUMN IF NOT EXISTS has_input BOOL MATERIALIZED notEmpty(input),
+    ADD COLUMN IF NOT EXISTS has_output BOOL MATERIALIZED notEmpty(output),
+    ADD COLUMN IF NOT EXISTS has_metadata BOOL MATERIALIZED notEmpty(metadata)
     SETTINGS alter_sync=1;
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans ON CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS has_input BOOLEAN MATERIALIZED notEmpty(input),
-    ADD COLUMN IF NOT EXISTS has_output BOOLEAN MATERIALIZED notEmpty(output),
-    ADD COLUMN IF NOT EXISTS has_metadata BOOLEAN MATERIALIZED notEmpty(metadata)
+    ADD COLUMN IF NOT EXISTS has_input BOOL MATERIALIZED notEmpty(input),
+    ADD COLUMN IF NOT EXISTS has_output BOOL MATERIALIZED notEmpty(output),
+    ADD COLUMN IF NOT EXISTS has_metadata BOOL MATERIALIZED notEmpty(metadata)
     SETTINGS alter_sync=1;
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS has_input, DROP COLUMN IF EXISTS has_output, DROP COLUMN IF EXISTS has_metadata;


### PR DESCRIPTION
## Details
 We are adding new materialized columns so that later, the stats endpoints will use them rather than calculating the values on the fly.
 
 Until the column materializes, Clickhouse will continue calculating the values on the fly. However, for new rows, the values will be calculated on ingestion or update. Later, probably out of peak hours, we can run the `MATERIALIZE COLUMN` command and backfill all history.