### PR TITLE
OPIK-1565: Add support for Vertex AI (Gemini) on Playground

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -312,6 +312,11 @@ llmProviderClient:
   # Description: OpenRouter API URL
   openRouterUrl: ${LLM_PROVIDER_OPENROUTER_URL:-https://openrouter.ai/api/v1}
 
+  vertexAIClient:
+    # Default: https://www.googleapis.com/auth/cloud-platform
+    # Description: Vertex AI  SCOPE API URL
+    scope: ${LLM_PROVIDER_VERTEXAI_SCOPE:-https://www.googleapis.com/auth/cloud-platform}
+
 # Configuration for cache manager
 cacheManager:
     # Default: true

--- a/apps/opik-backend/pom.xml
+++ b/apps/opik-backend/pom.xml
@@ -184,6 +184,11 @@
         </dependency>
 
         <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-vertex-ai-gemini</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-json</artifactId>
         </dependency>

--- a/apps/opik-backend/src/main/java/com/comet/opik/OpikApplication.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/OpikApplication.java
@@ -21,6 +21,7 @@ import com.comet.opik.infrastructure.llm.antropic.AnthropicModule;
 import com.comet.opik.infrastructure.llm.gemini.GeminiModule;
 import com.comet.opik.infrastructure.llm.openai.OpenAIModule;
 import com.comet.opik.infrastructure.llm.openrouter.OpenRouterModule;
+import com.comet.opik.infrastructure.llm.vertexai.VertexAIModule;
 import com.comet.opik.infrastructure.ratelimit.RateLimitModule;
 import com.comet.opik.infrastructure.redis.RedisModule;
 import com.comet.opik.infrastructure.usagelimit.UsageLimitModule;
@@ -83,7 +84,7 @@ public class OpikApplication extends Application<OpikConfiguration> {
                         new RateLimitModule(), new NameGeneratorModule(), new HttpModule(), new EventModule(),
                         new ConfigurationModule(), new CacheModule(), new AnthropicModule(),
                         new GeminiModule(), new OpenAIModule(), new OpenRouterModule(), new LlmModule(),
-                        new AwsModule(), new UsageLimitModule())
+                        new AwsModule(), new UsageLimitModule(), new VertexAIModule())
                 .installers(JobGuiceyInstaller.class)
                 .listen(new OpikGuiceyLifecycleEventListener(), new EventListenerRegistrar())
                 .enableAutoConfig()

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/LlmProvider.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/LlmProvider.java
@@ -14,6 +14,7 @@ public enum LlmProvider {
     ANTHROPIC("anthropic"),
     GEMINI("gemini"),
     OPEN_ROUTER("openrouter"),
+    VERTEX_AI("vertex-ai"),
     ;
 
     @JsonValue

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderApiKey.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderApiKey.java
@@ -31,6 +31,7 @@ public record ProviderApiKey(
                 View.Write.class}) @NotBlank @JsonDeserialize(using = ProviderApiKeyDeserializer.class) String apiKey,
         @JsonView({View.Public.class, View.Write.class}) @Size(max = 150) String name,
         @JsonView({View.Public.class, View.Write.class}) Map<String, String> headers,
+        @JsonView({View.Public.class, View.Write.class}) Map<String, String> configuration,
         @JsonView({View.Public.class,
                 View.Write.class}) @Pattern(regexp = NULL_OR_NOT_BLANK, message = "must not be blank") String baseUrl,
         @JsonView({View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant createdAt,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyDAO.java
@@ -24,9 +24,9 @@ import java.util.UUID;
 @RegisterColumnMapper(MapFlatArgumentFactory.class)
 public interface LlmProviderApiKeyDAO {
 
-    @SqlUpdate("INSERT INTO llm_provider_api_key (id, provider, workspace_id, api_key, name, created_by, last_updated_by, headers, base_url) "
+    @SqlUpdate("INSERT INTO llm_provider_api_key (id, provider, workspace_id, api_key, name, created_by, last_updated_by, headers, base_url, configuration) "
             +
-            "VALUES (:bean.id, :bean.provider, :workspaceId, :bean.apiKey, :bean.name, :bean.createdBy, :bean.lastUpdatedBy, :bean.headers, :bean.baseUrl)")
+            "VALUES (:bean.id, :bean.provider, :workspaceId, :bean.apiKey, :bean.name, :bean.createdBy, :bean.lastUpdatedBy, :bean.headers, :bean.baseUrl, :bean.configuration)")
     void save(@Bind("workspaceId") String workspaceId,
             @BindMethods("bean") ProviderApiKey providerApiKey);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/LlmProviderClientConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/LlmProviderClientConfig.java
@@ -18,6 +18,9 @@ public class LlmProviderClientConfig {
     public record AnthropicClientConfig(String url, String version) {
     }
 
+    public record VertexAIClientConfig(String scope) {
+    }
+
     @Min(1) private Integer maxAttempts;
 
     @Min(1) private int delayMillis = 500;
@@ -45,6 +48,10 @@ public class LlmProviderClientConfig {
     @Valid private LlmProviderClientConfig.OpenAiClientConfig openAiClient;
 
     @Valid private LlmProviderClientConfig.AnthropicClientConfig anthropicClient;
+
+    @Valid private LlmProviderClientConfig.OpenAiClientConfig azureOpenAiClient;
+
+    @Valid private LlmProviderClientConfig.VertexAIClientConfig vertexAIClient;
 
     private String openRouterUrl;
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderClientApiConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderClientApiConfig.java
@@ -4,7 +4,8 @@ import lombok.ToString;
 
 import java.util.Map;
 
-public record LlmProviderClientApiConfig(@ToString.Exclude String apiKey, Map<String, String> headers, String baseUrl) {
+public record LlmProviderClientApiConfig(@ToString.Exclude String apiKey, Map<String, String> headers, String baseUrl,
+        Map<String, String> configuration) {
 
     @Override
     public String toString() {
@@ -12,6 +13,7 @@ public record LlmProviderClientApiConfig(@ToString.Exclude String apiKey, Map<St
                 "apiKey='*********'" +
                 ", headers=" + headers +
                 ", baseUrl='" + baseUrl + '\'' +
+                ", configuration=" + configuration +
                 '}';
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryImpl.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryImpl.java
@@ -71,6 +71,10 @@ class LlmProviderFactoryImpl implements LlmProviderFactory {
             return LlmProvider.OPEN_ROUTER;
         }
 
+        if (isModelBelongToProvider(model, LlmProvider.class, LlmProvider::getValue)) {
+            return LlmProvider.VERTEX_AI;
+        }
+
         throw new BadRequestException(ERROR_MODEL_NOT_SUPPORTED.formatted(model));
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/LlmProviderGemini.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/LlmProviderGemini.java
@@ -35,10 +35,13 @@ public class LlmProviderGemini implements LlmProviderService {
     public void generateStream(@NonNull ChatCompletionRequest request, @NonNull String workspaceId,
             @NonNull Consumer<ChatCompletionResponse> handleMessage, @NonNull Runnable handleClose,
             @NonNull Consumer<Throwable> handleError) {
-      
-        Schedulers.boundedElastic().schedule(() -> llmProviderClientGenerator.newGeminiStreamingClient(apiKey, request)
-                .generate(request.messages().stream().map(LlmProviderGeminiMapper.INSTANCE::toChatMessage).toList(),
-                        new ChunkedResponseHandler(handleMessage, handleClose, handleError, request.model())));
+
+        Schedulers.boundedElastic()
+                .schedule(() -> llmProviderClientGenerator.newGeminiStreamingClient(config.apiKey(), request)
+                        .generate(
+                                request.messages().stream().map(LlmProviderGeminiMapper.INSTANCE::toChatMessage)
+                                        .toList(),
+                                new ChunkedResponseHandler(handleMessage, handleClose, handleError, request.model())));
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/LlmProviderGemini.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/LlmProviderGemini.java
@@ -9,10 +9,10 @@ import io.dropwizard.jersey.errors.ErrorMessage;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.scheduler.Schedulers;
 
 import java.io.UncheckedIOException;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 @Slf4j
@@ -34,7 +34,7 @@ public class LlmProviderGemini implements LlmProviderService {
     public void generateStream(@NonNull ChatCompletionRequest request, @NonNull String workspaceId,
             @NonNull Consumer<ChatCompletionResponse> handleMessage, @NonNull Runnable handleClose,
             @NonNull Consumer<Throwable> handleError) {
-        CompletableFuture.runAsync(() -> llmProviderClientGenerator.newGeminiStreamingClient(apiKey, request)
+        Schedulers.boundedElastic().schedule(() -> llmProviderClientGenerator.newGeminiStreamingClient(apiKey, request)
                 .generate(request.messages().stream().map(LlmProviderGeminiMapper.INSTANCE::toChatMessage).toList(),
                         new ChunkedResponseHandler(handleMessage, handleClose, handleError, request.model())));
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/LlmProviderVertexAI.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/LlmProviderVertexAI.java
@@ -1,13 +1,18 @@
 package com.comet.opik.infrastructure.llm.vertexai;
 
+import com.comet.opik.api.ChunkedResponseHandler;
 import com.comet.opik.domain.llm.LlmProviderService;
+import com.comet.opik.infrastructure.llm.gemini.GeminiErrorObject;
+import com.comet.opik.utils.JsonUtils;
 import dev.ai4j.openai4j.chat.ChatCompletionRequest;
 import dev.ai4j.openai4j.chat.ChatCompletionResponse;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.scheduler.Schedulers;
 
+import java.io.UncheckedIOException;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -15,14 +20,26 @@ import java.util.function.Consumer;
 @Slf4j
 public class LlmProviderVertexAI implements LlmProviderService {
 
+    private final @NonNull VertexAIClientGenerator llmProviderClientGenerator;
+    private final @NonNull String apiKey;
+
     @Override
     public ChatCompletionResponse generate(@NonNull ChatCompletionRequest request, @NonNull String workspaceId) {
-        return null;
+        var response = llmProviderClientGenerator.generate(apiKey, request)
+                .generate(request.messages().stream().map(VertexAIMapper.INSTANCE::toChatMessage).toList());
+
+        return VertexAIMapper.INSTANCE.toChatCompletionResponse(request, response);
     }
 
     @Override
-    public void generateStream(@NonNull ChatCompletionRequest request, @NonNull String workspaceId, @NonNull Consumer<ChatCompletionResponse> handleMessage, @NonNull Runnable handleClose, @NonNull Consumer<Throwable> handleError) {
+    public void generateStream(@NonNull ChatCompletionRequest request, @NonNull String workspaceId,
+            @NonNull Consumer<ChatCompletionResponse> handleMessage, @NonNull Runnable handleClose,
+            @NonNull Consumer<Throwable> handleError) {
 
+        Schedulers.boundedElastic()
+                .schedule(() -> llmProviderClientGenerator.newVertexAIStreamingClient(apiKey, request)
+                        .generate(request.messages().stream().map(VertexAIMapper.INSTANCE::toChatMessage).toList(),
+                                new ChunkedResponseHandler(handleMessage, handleClose, handleError, request.model())));
     }
 
     @Override
@@ -32,6 +49,19 @@ public class LlmProviderVertexAI implements LlmProviderService {
 
     @Override
     public Optional<ErrorMessage> getLlmProviderError(@NonNull Throwable throwable) {
+        String message = throwable.getMessage();
+        var openBraceIndex = message.indexOf('{');
+        if (openBraceIndex >= 0) {
+            String jsonPart = message.substring(openBraceIndex); // Extract JSON part
+            try {
+                var geminiError = JsonUtils.readValue(jsonPart, GeminiErrorObject.class);
+                return geminiError.toErrorMessage();
+            } catch (UncheckedIOException e) {
+                log.warn("failed to parse Gemini error message", e);
+                return Optional.empty();
+            }
+        }
+
         return Optional.empty();
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/LlmProviderVertexAI.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/LlmProviderVertexAI.java
@@ -1,0 +1,37 @@
+package com.comet.opik.infrastructure.llm.vertexai;
+
+import com.comet.opik.domain.llm.LlmProviderService;
+import dev.ai4j.openai4j.chat.ChatCompletionRequest;
+import dev.ai4j.openai4j.chat.ChatCompletionResponse;
+import io.dropwizard.jersey.errors.ErrorMessage;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+@RequiredArgsConstructor
+@Slf4j
+public class LlmProviderVertexAI implements LlmProviderService {
+
+    @Override
+    public ChatCompletionResponse generate(@NonNull ChatCompletionRequest request, @NonNull String workspaceId) {
+        return null;
+    }
+
+    @Override
+    public void generateStream(@NonNull ChatCompletionRequest request, @NonNull String workspaceId, @NonNull Consumer<ChatCompletionResponse> handleMessage, @NonNull Runnable handleClose, @NonNull Consumer<Throwable> handleError) {
+
+    }
+
+    @Override
+    public void validateRequest(@NonNull ChatCompletionRequest request) {
+
+    }
+
+    @Override
+    public Optional<ErrorMessage> getLlmProviderError(@NonNull Throwable throwable) {
+        return Optional.empty();
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/LlmProviderVertexAI.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/LlmProviderVertexAI.java
@@ -2,6 +2,7 @@ package com.comet.opik.infrastructure.llm.vertexai;
 
 import com.comet.opik.api.ChunkedResponseHandler;
 import com.comet.opik.domain.llm.LlmProviderService;
+import com.comet.opik.infrastructure.llm.LlmProviderClientApiConfig;
 import com.comet.opik.infrastructure.llm.gemini.GeminiErrorObject;
 import com.comet.opik.utils.JsonUtils;
 import dev.ai4j.openai4j.chat.ChatCompletionRequest;
@@ -21,11 +22,11 @@ import java.util.function.Consumer;
 public class LlmProviderVertexAI implements LlmProviderService {
 
     private final @NonNull VertexAIClientGenerator llmProviderClientGenerator;
-    private final @NonNull String apiKey;
+    private final @NonNull LlmProviderClientApiConfig config;
 
     @Override
     public ChatCompletionResponse generate(@NonNull ChatCompletionRequest request, @NonNull String workspaceId) {
-        var response = llmProviderClientGenerator.generate(apiKey, request)
+        var response = llmProviderClientGenerator.generate(config, request)
                 .generate(request.messages().stream().map(VertexAIMapper.INSTANCE::toChatMessage).toList());
 
         return VertexAIMapper.INSTANCE.toChatCompletionResponse(request, response);
@@ -37,7 +38,7 @@ public class LlmProviderVertexAI implements LlmProviderService {
             @NonNull Consumer<Throwable> handleError) {
 
         Schedulers.boundedElastic()
-                .schedule(() -> llmProviderClientGenerator.newVertexAIStreamingClient(apiKey, request)
+                .schedule(() -> llmProviderClientGenerator.newVertexAIStreamingClient(config, request)
                         .generate(request.messages().stream().map(VertexAIMapper.INSTANCE::toChatMessage).toList(),
                                 new ChunkedResponseHandler(handleMessage, handleClose, handleError, request.model())));
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIClientGenerator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIClientGenerator.java
@@ -20,7 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Optional;
@@ -65,7 +64,7 @@ public class VertexAIClientGenerator implements LlmProviderClientGenerator<ChatL
         return new VertexAiGeminiStreamingChatModel(generativeModel, generationConfig);
     }
 
-    private InternalServerErrorException failWithError(IOException e) {
+    private InternalServerErrorException failWithError(Exception e) {
         return new InternalServerErrorException("Failed to create GoogleCredentials", e);
     }
 
@@ -93,7 +92,7 @@ public class VertexAIClientGenerator implements LlmProviderClientGenerator<ChatL
                     .setCredentials(credentials.createScoped(clientConfig.getVertexAIClient().scope()))
                     .build();
 
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw failWithError(e);
         }
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIClientGenerator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIClientGenerator.java
@@ -40,7 +40,10 @@ public class VertexAIClientGenerator implements LlmProviderClientGenerator<ChatL
 
         GenerationConfig generationConfig = getGenerationConfig(request);
 
-        GenerativeModel generativeModel = new GenerativeModel(request.model(), vertexAI)
+        var vertexAIModelName = VertexAIModelName.byQualifiedName(request.model())
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported model: " + request.model()));
+
+        GenerativeModel generativeModel = new GenerativeModel(vertexAIModelName.toString(), vertexAI)
                 .withGenerationConfig(generationConfig);
 
         return new VertexAiGeminiChatModel(generativeModel, generationConfig);

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIGenerator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIGenerator.java
@@ -1,0 +1,84 @@
+package com.comet.opik.infrastructure.llm.vertexai;
+
+import com.comet.opik.infrastructure.LlmProviderClientConfig;
+import com.comet.opik.infrastructure.llm.LlmProviderClientGenerator;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.vertexai.VertexAI;
+import com.google.cloud.vertexai.api.GenerationConfig;
+import com.google.cloud.vertexai.generativeai.GenerativeModel;
+import com.google.common.base.Preconditions;
+import dev.ai4j.openai4j.chat.ChatCompletionRequest;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.vertexai.VertexAiGeminiChatModel;
+import lombok.NonNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.comet.opik.api.AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeModelParameters;
+
+public class VertexAIGenerator implements LlmProviderClientGenerator<ChatLanguageModel> {
+
+    private final @NonNull LlmProviderClientConfig llmProviderClientConfig;
+
+    public VertexAIGenerator(@NonNull LlmProviderClientConfig llmProviderClientConfig) {
+        this.llmProviderClientConfig = llmProviderClientConfig;
+    }
+    public ChatLanguageModel newVertexAIClient(@NonNull String apiKey, @NonNull ChatCompletionRequest request) {
+
+        try {
+            ServiceAccountCredentials credentials = ServiceAccountCredentials.fromStream(new ByteArrayInputStream(
+                apiKey.getBytes(StandardCharsets.UTF_8)
+            ));
+
+            VertexAI vertexAI = new VertexAI.Builder()
+                    .setProjectId(credentials.getProjectId())
+                    .setLocation("us-central1") // Set the location as needed
+                    .setCredentials(credentials.createScoped("https://www.googleapis.com/auth/cloud-platform"))
+                    .build();
+
+            var generationConfig = GenerationConfig.newBuilder();
+
+            Optional.ofNullable(request.temperature())
+                    .map(Double::floatValue)
+                    .ifPresent(generationConfig::setTemperature);
+
+            Optional.ofNullable(request.maxTokens())
+                    .ifPresent(generationConfig::setMaxOutputTokens);
+
+
+            GenerativeModel generativeModel = new GenerativeModel(request.model(), vertexAI)
+                    .withGenerationConfig(generationConfig.build());
+
+            return new VertexAiGeminiChatModel(generativeModel, generationConfig.build());
+
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create GoogleCredentials", e);
+        }
+    }
+
+    @Override
+    public ChatLanguageModel generate(String apiKey, Object... params) {
+        Preconditions.checkArgument(params.length >= 1, "Expected at least 1 parameter, got " + params.length);
+        ChatCompletionRequest request = (ChatCompletionRequest) Objects.requireNonNull(params[0],
+                "ChatCompletionRequest is required");
+
+        if (request.model().contains("gemini")) {
+            return newVertexAIClient(apiKey, request);
+        }
+
+        throw new IllegalArgumentException("Unsupported model: " + request.model());
+    }
+
+    @Override
+    public ChatLanguageModel generateChat(String apiKey, LlmAsJudgeModelParameters modelParameters) {
+        return newVertexAIClient(apiKey, ChatCompletionRequest.builder()
+                .model(modelParameters.name())
+                .temperature(modelParameters.temperature())
+                .build());
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIMapper.java
@@ -1,0 +1,80 @@
+package com.comet.opik.infrastructure.llm.vertexai;
+
+import dev.ai4j.openai4j.chat.AssistantMessage;
+import dev.ai4j.openai4j.chat.ChatCompletionChoice;
+import dev.ai4j.openai4j.chat.ChatCompletionRequest;
+import dev.ai4j.openai4j.chat.ChatCompletionResponse;
+import dev.ai4j.openai4j.chat.Message;
+import dev.ai4j.openai4j.chat.Role;
+import dev.ai4j.openai4j.shared.Usage;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.output.Response;
+import jakarta.ws.rs.BadRequestException;
+import lombok.NonNull;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+
+@Mapper
+interface VertexAIMapper {
+
+    String ERR_UNEXPECTED_ROLE = "unexpected role '%s'";
+    String ERR_ROLE_MSG_TYPE_MISMATCH = "role and message instance are not matching, role: '%s', instance: '%s'";
+
+    VertexAIMapper INSTANCE = Mappers.getMapper(VertexAIMapper.class);
+
+    default ChatMessage toChatMessage(@NonNull Message message) {
+        if (!List.of(Role.ASSISTANT, Role.USER, Role.SYSTEM).contains(message.role())) {
+            throw new BadRequestException(ERR_UNEXPECTED_ROLE.formatted(message.role()));
+        }
+
+        switch (message.role()) {
+            case ASSISTANT -> {
+                if (message instanceof AssistantMessage assistantMessage) {
+                    return AiMessage.from(assistantMessage.content());
+                }
+            }
+            case USER -> {
+                if (message instanceof dev.ai4j.openai4j.chat.UserMessage userMessage) {
+                    return UserMessage.from(userMessage.content().toString());
+                }
+            }
+            case SYSTEM -> {
+                if (message instanceof dev.ai4j.openai4j.chat.SystemMessage systemMessage) {
+                    return SystemMessage.from(systemMessage.content());
+                }
+            }
+        }
+
+        throw new BadRequestException(ERR_ROLE_MSG_TYPE_MISMATCH.formatted(message.role(),
+                message.getClass().getSimpleName()));
+    }
+
+    @Mapping(expression = "java(request.model())", target = "model")
+    @Mapping(source = "response", target = "choices", qualifiedByName = "mapToChoices")
+    @Mapping(source = "response", target = "usage", qualifiedByName = "mapToUsage")
+    ChatCompletionResponse toChatCompletionResponse(
+            @NonNull ChatCompletionRequest request, @NonNull Response<AiMessage> response);
+
+    @Named("mapToChoices")
+    default List<ChatCompletionChoice> mapToChoices(@NonNull Response<AiMessage> response) {
+        return List.of(ChatCompletionChoice.builder()
+                .message(AssistantMessage.builder().content(response.content().text()).build())
+                .build());
+    }
+
+    @Named("mapToUsage")
+    default Usage mapToUsage(@NonNull Response<AiMessage> response) {
+        return Usage.builder()
+                .promptTokens(response.tokenUsage().inputTokenCount())
+                .completionTokens(response.tokenUsage().outputTokenCount())
+                .totalTokens(response.tokenUsage().totalTokenCount())
+                .build();
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModelName.java
@@ -14,7 +14,8 @@ import java.util.Optional;
 @Accessors(fluent = true)
 public enum VertexAIModelName {
 
-    GEMINI_2_5_PRO_PREVIEW("vertex_ai/gemini-2.5-pro-preview-05-06", "gemini-2.5-pro-preview-05-06"),
+    GEMINI_2_5_PRO_PREVIEW_04_17("vertex_ai/gemini-2.5-flash-preview-04-17", "gemini-2.5-flash-preview-04-17"),
+    GEMINI_2_5_PRO_PREVIEW_05_06("vertex_ai/gemini-2.5-pro-preview-05-06", "gemini-2.5-pro-preview-05-06"),
     GEMINI_2_5_FLASH_PREVIEW("vertex_ai/gemini-2.5-flash-preview-05-06", "gemini-2.5-flash-preview-05-06"),
     GEMINI_2_5_PRO("vertex_ai/gemini-2.5-pro-001", "gemini-2.5-pro-001"),
     GEMINI_2_5_FLASH("vertex_ai/gemini-2.5-flash-001", "gemini-2.5-flash-001"),

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModelName.java
@@ -16,21 +16,10 @@ public enum VertexAIModelName {
 
     GEMINI_2_5_PRO_PREVIEW_04_17("vertex_ai/gemini-2.5-flash-preview-04-17", "gemini-2.5-flash-preview-04-17"),
     GEMINI_2_5_PRO_PREVIEW_05_06("vertex_ai/gemini-2.5-pro-preview-05-06", "gemini-2.5-pro-preview-05-06"),
-    GEMINI_2_5_FLASH_PREVIEW("vertex_ai/gemini-2.5-flash-preview-05-06", "gemini-2.5-flash-preview-05-06"),
-    GEMINI_2_5_PRO("vertex_ai/gemini-2.5-pro-001", "gemini-2.5-pro-001"),
-    GEMINI_2_5_FLASH("vertex_ai/gemini-2.5-flash-001", "gemini-2.5-flash-001"),
-    GEMINI_2_5_PRO_LITE("vertex_ai/gemini-2.5-pro-lite-001", "gemini-2.5-pro-lite-001"),
-    GEMINI_2_5_FLASH_LITE("vertex_ai/gemini-2.5-flash-lite-001", "gemini-2.5-flash-lite-001"),
-    GEMINI_2_0_PRO_PREVIEW("vertex_ai/gemini-2.0-pro-preview-05-06", "gemini-2.0-pro-preview-05-06"),
-    GEMINI_2_0_FLASH_PREVIEW("vertex_ai/gemini-2.0-flash-preview-05-06", "gemini-2.0-flash-preview-05-06"),
-    GEMINI_2_0_PRO("vertex_ai/gemini-2.0-pro-001", "gemini-2.0-pro-001"),
+    GEMINI_2_5_PRO_PREVIEW_03_25("vertex_ai/gemini-2.5-pro-preview-03-25", "gemini-2.5-pro-preview-03-25"),
+    GEMINI_2_5_PRO_EXP_03_25("vertex_ai/gemini-2.5-pro-exp-03-25", "gemini-2.5-pro-exp-03-25"),
     GEMINI_2_0_FLASH("vertex_ai/gemini-2.0-flash-001", "gemini-2.0-flash-001"),
-    GEMINI_2_0_PRO_LITE("vertex_ai/gemini-2.0-pro-lite-001", "gemini-2.0-pro-lite-001"),
     GEMINI_2_0_FLASH_LITE("vertex_ai/gemini-2.0-flash-lite-001", "gemini-2.0-flash-lite-001"),
-    GEMINI_1_5_PRO("vertex_ai/gemini-1.5-pro-001", "gemini-1.5-pro-001"),
-    GEMINI_1_5_FLASH("vertex_ai/gemini-1.5-flash-001", "gemini-1.5-flash-001"),
-    GEMINI_1_5_FLASH_8B("vertex_ai/gemini-1.5-flash-8b-001", "gemini-1.5-flash-8b-001"),
-    GEMINI_EMBEDDING("vertex_ai/gemini-embedding-001", "gemini-embedding-001"),
     ;
 
     private static final String WARNING_UNKNOWN_MODEL = "could not find VertexAIModelName with name '{}'";

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModelName.java
@@ -1,4 +1,55 @@
 package com.comet.opik.infrastructure.llm.vertexai;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Getter
+@Accessors(fluent = true)
 public enum VertexAIModelName {
+
+    GEMINI_2_5_PRO_PREVIEW("vertex_ai/gemini-2.5-pro-preview-05-06", "gemini-2.5-pro-preview-05-06"),
+    GEMINI_2_5_FLASH_PREVIEW("vertex_ai/gemini-2.5-flash-preview-05-06", "gemini-2.5-flash-preview-05-06"),
+    GEMINI_2_5_PRO("vertex_ai/gemini-2.5-pro-001", "gemini-2.5-pro-001"),
+    GEMINI_2_5_FLASH("vertex_ai/gemini-2.5-flash-001", "gemini-2.5-flash-001"),
+    GEMINI_2_5_PRO_LITE("vertex_ai/gemini-2.5-pro-lite-001", "gemini-2.5-pro-lite-001"),
+    GEMINI_2_5_FLASH_LITE("vertex_ai/gemini-2.5-flash-lite-001", "gemini-2.5-flash-lite-001"),
+    GEMINI_2_0_PRO_PREVIEW("vertex_ai/gemini-2.0-pro-preview-05-06", "gemini-2.0-pro-preview-05-06"),
+    GEMINI_2_0_FLASH_PREVIEW("vertex_ai/gemini-2.0-flash-preview-05-06", "gemini-2.0-flash-preview-05-06"),
+    GEMINI_2_0_PRO("vertex_ai/gemini-2.0-pro-001", "gemini-2.0-pro-001"),
+    GEMINI_2_0_FLASH("vertex_ai/gemini-2.0-flash-001", "gemini-2.0-flash-001"),
+    GEMINI_2_0_PRO_LITE("vertex_ai/gemini-2.0-pro-lite-001", "gemini-2.0-pro-lite-001"),
+    GEMINI_2_0_FLASH_LITE("vertex_ai/gemini-2.0-flash-lite-001", "gemini-2.0-flash-lite-001"),
+    GEMINI_1_5_PRO("vertex_ai/gemini-1.5-pro-001", "gemini-1.5-pro-001"),
+    GEMINI_1_5_FLASH("vertex_ai/gemini-1.5-flash-001", "gemini-1.5-flash-001"),
+    GEMINI_1_5_FLASH_8B("vertex_ai/gemini-1.5-flash-8b-001", "gemini-1.5-flash-8b-001"),
+    GEMINI_EMBEDDING("vertex_ai/gemini-embedding-001", "gemini-embedding-001"),
+    ;
+
+    private static final String WARNING_UNKNOWN_MODEL = "could not find VertexAIModelName with name '{}'";
+
+    private final String qualifiedName;
+    private final String value;
+
+    public static Optional<VertexAIModelName> byQualifiedName(String qualifiedName) {
+        var response = Arrays.stream(VertexAIModelName.values())
+                .filter(modelName -> modelName.qualifiedName.equals(qualifiedName))
+                .findFirst();
+        if (response.isEmpty()) {
+            log.warn(WARNING_UNKNOWN_MODEL, qualifiedName);
+        }
+        return response;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModelName.java
@@ -1,0 +1,4 @@
+package com.comet.opik.infrastructure.llm.vertexai;
+
+public enum VertexAIModelName {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModule.java
@@ -3,8 +3,6 @@ package com.comet.opik.infrastructure.llm.vertexai;
 import com.comet.opik.domain.llm.LlmProviderFactory;
 import com.comet.opik.infrastructure.LlmProviderClientConfig;
 import com.comet.opik.infrastructure.llm.LlmServiceProvider;
-import com.comet.opik.infrastructure.llm.gemini.GeminiClientGenerator;
-import com.comet.opik.infrastructure.llm.gemini.GeminiLlmServiceProvider;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
@@ -16,15 +14,16 @@ public class VertexAIModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public VertexAIGenerator clientGenerator(@NonNull @Config("llmProviderClient") LlmProviderClientConfig config) {
-        return new VertexAIGenerator(config);
+    public VertexAIClientGenerator clientGenerator(
+            @NonNull @Config("llmProviderClient") LlmProviderClientConfig config) {
+        return new VertexAIClientGenerator(config);
     }
 
     @Provides
     @Singleton
-    @Named("gemini")
+    @Named("vertexAi")
     public LlmServiceProvider llmServiceProvider(@NonNull LlmProviderFactory llmProviderFactory,
-            @NonNull VertexAIGenerator clientGenerator) {
+            @NonNull VertexAIClientGenerator clientGenerator) {
         return new VertextAILlmServiceProvider(clientGenerator, llmProviderFactory);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModule.java
@@ -1,0 +1,30 @@
+package com.comet.opik.infrastructure.llm.vertexai;
+
+import com.comet.opik.domain.llm.LlmProviderFactory;
+import com.comet.opik.infrastructure.LlmProviderClientConfig;
+import com.comet.opik.infrastructure.llm.LlmServiceProvider;
+import com.comet.opik.infrastructure.llm.gemini.GeminiClientGenerator;
+import com.comet.opik.infrastructure.llm.gemini.GeminiLlmServiceProvider;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import jakarta.inject.Named;
+import lombok.NonNull;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
+
+public class VertexAIModule extends AbstractModule {
+
+    @Provides
+    @Singleton
+    public VertexAIGenerator clientGenerator(@NonNull @Config("llmProviderClient") LlmProviderClientConfig config) {
+        return new VertexAIGenerator(config);
+    }
+
+    @Provides
+    @Singleton
+    @Named("gemini")
+    public LlmServiceProvider llmServiceProvider(@NonNull LlmProviderFactory llmProviderFactory,
+            @NonNull VertexAIGenerator clientGenerator) {
+        return new VertextAILlmServiceProvider(clientGenerator, llmProviderFactory);
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertextAILlmServiceProvider.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertextAILlmServiceProvider.java
@@ -1,0 +1,36 @@
+package com.comet.opik.infrastructure.llm.vertexai;
+
+import com.comet.opik.api.AutomationRuleEvaluatorLlmAsJudge;
+import com.comet.opik.api.LlmProvider;
+import com.comet.opik.domain.llm.LlmProviderFactory;
+import com.comet.opik.domain.llm.LlmProviderService;
+import com.comet.opik.infrastructure.llm.LlmServiceProvider;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import jakarta.inject.Named;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class VertextAILlmServiceProvider implements LlmServiceProvider {
+
+    private final VertexAIGenerator clientGenerator;
+
+    VertextAILlmServiceProvider(
+            @Named("vertexAiGenerator") VertexAIGenerator clientGenerator, LlmProviderFactory factory) {
+        this.clientGenerator = clientGenerator;
+        factory.register(LlmProvider.VERTEX_AI, this);
+    }
+
+    @Override
+    public LlmProviderService getService(String apiKey) {
+        return new LlmProviderVertexAI();
+    }
+
+    @Override
+    public ChatLanguageModel getLanguageModel(String apiKey,
+                                              AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeModelParameters modelParameters) {
+        return clientGenerator.generateChat(apiKey, modelParameters);
+    }
+}
+

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertextAILlmServiceProvider.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertextAILlmServiceProvider.java
@@ -12,25 +12,24 @@ import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Slf4j
-public class VertextAILlmServiceProvider implements LlmServiceProvider {
+class VertextAILlmServiceProvider implements LlmServiceProvider {
 
-    private final VertexAIGenerator clientGenerator;
+    private final VertexAIClientGenerator clientGenerator;
 
     VertextAILlmServiceProvider(
-            @Named("vertexAiGenerator") VertexAIGenerator clientGenerator, LlmProviderFactory factory) {
+            @Named("vertexAiGenerator") VertexAIClientGenerator clientGenerator, LlmProviderFactory factory) {
         this.clientGenerator = clientGenerator;
         factory.register(LlmProvider.VERTEX_AI, this);
     }
 
     @Override
     public LlmProviderService getService(String apiKey) {
-        return new LlmProviderVertexAI();
+        return new LlmProviderVertexAI(clientGenerator, apiKey);
     }
 
     @Override
     public ChatLanguageModel getLanguageModel(String apiKey,
-                                              AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeModelParameters modelParameters) {
+            AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeModelParameters modelParameters) {
         return clientGenerator.generateChat(apiKey, modelParameters);
     }
 }
-

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertextAILlmServiceProvider.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertextAILlmServiceProvider.java
@@ -4,6 +4,7 @@ import com.comet.opik.api.AutomationRuleEvaluatorLlmAsJudge;
 import com.comet.opik.api.LlmProvider;
 import com.comet.opik.domain.llm.LlmProviderFactory;
 import com.comet.opik.domain.llm.LlmProviderService;
+import com.comet.opik.infrastructure.llm.LlmProviderClientApiConfig;
 import com.comet.opik.infrastructure.llm.LlmServiceProvider;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import jakarta.inject.Named;
@@ -23,12 +24,12 @@ class VertextAILlmServiceProvider implements LlmServiceProvider {
     }
 
     @Override
-    public LlmProviderService getService(String apiKey) {
+    public LlmProviderService getService(LlmProviderClientApiConfig apiKey) {
         return new LlmProviderVertexAI(clientGenerator, apiKey);
     }
 
     @Override
-    public ChatLanguageModel getLanguageModel(String apiKey,
+    public ChatLanguageModel getLanguageModel(LlmProviderClientApiConfig apiKey,
             AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeModelParameters modelParameters) {
         return clientGenerator.generateChat(apiKey, modelParameters);
     }

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000017_add_provider_config_to_ll_provider_api_key.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000017_add_provider_config_to_ll_provider_api_key.sql
@@ -1,7 +1,8 @@
 --liquibase formatted sql
 --changeset thiagohora:000017_add_provider_config_to_ll_provider_api_key
 
-ALTER TABLE llm_provider_api_key ADD COLUMN configuration JSON DEFAULT NULL;
+ALTER TABLE llm_provider_api_key ADD COLUMN configuration JSON DEFAULT NULL,
+    MODIFY COLUMN api_key TEXT NOT NULL;
 
 --rollback ALTER TABLE llm_provider_api_key DROP COLUMN configuration;
 

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000017_add_provider_config_to_ll_provider_api_key.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000017_add_provider_config_to_ll_provider_api_key.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--changeset thiagohora:000017_add_provider_config_to_ll_provider_api_key
+
+ALTER TABLE llm_provider_api_key ADD COLUMN configuration JSON DEFAULT NULL;
+
+--rollback ALTER TABLE llm_provider_api_key DROP COLUMN configuration;
+

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResourceTest.java
@@ -60,7 +60,8 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 @ExtendWith(DropwizardAppExtensionProvider.class)
 class LlmProviderApiKeyResourceTest {
     private static final String USER = UUID.randomUUID().toString();
-    public static final String[] IGNORED_FIELDS = {"createdBy", "lastUpdatedBy", "createdAt", "lastUpdatedAt", "apiKey"};
+    public static final String[] IGNORED_FIELDS = {"createdBy", "lastUpdatedBy", "createdAt", "lastUpdatedAt",
+            "apiKey"};
 
     private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
     private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
@@ -366,7 +367,6 @@ class LlmProviderApiKeyResourceTest {
         assertThat(actual.page()).isZero();
         assertThat(actual.total()).isEqualTo(expected.size());
         assertThat(actual.size()).isEqualTo(expected.size());
-
 
         assertThat(actual.content())
                 .usingRecursiveComparison()

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/AuthServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/AuthServiceImplTest.java
@@ -22,7 +22,7 @@ class AuthServiceImplTest {
     @Mock
     private HttpHeaders headers;
 
-    private UriInfo uriInfo = Mockito.mock(UriInfo.class);;
+    private UriInfo uriInfo = Mockito.mock(UriInfo.class);
 
     private AuthServiceImpl authService = new AuthServiceImpl(() -> requestContext);
     private ContextInfoHolder infoHolder = ContextInfoHolder.builder()

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryTest.java
@@ -18,6 +18,9 @@ import com.comet.opik.infrastructure.llm.openai.OpenAIModule;
 import com.comet.opik.infrastructure.llm.openai.OpenaiModelName;
 import com.comet.opik.infrastructure.llm.openrouter.OpenRouterModelName;
 import com.comet.opik.infrastructure.llm.openrouter.OpenRouterModule;
+import com.comet.opik.infrastructure.llm.vertexai.VertexAIClientGenerator;
+import com.comet.opik.infrastructure.llm.vertexai.VertexAIModelName;
+import com.comet.opik.infrastructure.llm.vertexai.VertexAIModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ConfigurationException;
 import io.dropwizard.configuration.FileConfigurationSourceProvider;
@@ -87,6 +90,7 @@ class LlmProviderFactoryTest {
         GeminiModule geminiModule = new GeminiModule();
         OpenAIModule openAIModule = new OpenAIModule();
         OpenRouterModule openRouterModule = new OpenRouterModule();
+        VertexAIModule vertexAIModule = new VertexAIModule();
 
         AnthropicClientGenerator anthropicClientGenerator = anthropicModule.clientGenerator(llmProviderClientConfig);
         anthropicModule.llmServiceProvider(llmProviderFactory, anthropicClientGenerator);
@@ -99,6 +103,9 @@ class LlmProviderFactoryTest {
 
         OpenAIClientGenerator openRouterClientGenerator = openRouterModule.clientGenerator(llmProviderClientConfig);
         openRouterModule.llmServiceProvider(llmProviderFactory, openRouterClientGenerator);
+
+        VertexAIClientGenerator vertexAIClientGenerator = vertexAIModule.clientGenerator(llmProviderClientConfig);
+        vertexAIModule.llmServiceProvider(llmProviderFactory, vertexAIClientGenerator);
 
         LlmProviderService actual = llmProviderFactory.getService(workspaceId, model);
 
@@ -115,7 +122,10 @@ class LlmProviderFactoryTest {
                 .map(model -> arguments(model.toString(), LlmProvider.GEMINI, "LlmProviderGemini"));
         var openRouterModels = EnumUtils.getEnumList(OpenRouterModelName.class).stream()
                 .map(model -> arguments(model.toString(), LlmProvider.OPEN_ROUTER, "LlmProviderOpenAi"));
+        var vertexAiModels = EnumUtils.getEnumList(VertexAIModelName.class).stream()
+                .map(model -> arguments(model.qualifiedName(), LlmProvider.VERTEX_AI, "LlmProviderVertexAI"));
 
-        return Stream.of(openAiModels, anthropicModels, geminiModels, openRouterModels).flatMap(Function.identity());
+        return Stream.of(openAiModels, anthropicModels, geminiModels, openRouterModels, vertexAiModels)
+                .flatMap(Function.identity());
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/podam/manufacturer/ProviderApiKeyManufacturer.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/podam/manufacturer/ProviderApiKeyManufacturer.java
@@ -38,6 +38,7 @@ public class ProviderApiKeyManufacturer extends AbstractTypeManufacturer<Provide
                         RandomStringUtils.secure().nextAlphabetic(5), RandomStringUtils.secure().nextAlphabetic(5),
                         RandomStringUtils.secure().nextAlphabetic(5), RandomStringUtils.secure().nextAlphabetic(5)))
                 .createdAt(Instant.now())
+                .lastUpdatedAt(Instant.now())
                 .build();
     }
 


### PR DESCRIPTION
## Details

This PR adds support for Vertex AI from Google on the playground. As the initial scope, we will support Genimi only models, and later add more models. 

## Testing
- Setup tests 
  - Provider resolution
- E2E test will be done manually
  - Playground config via API
  - Prompt chat request 
