### PR TITLE
OPIK-1555: Add bake build check to opik sh and ps1 scripts

### DIFF
--- a/opik.ps1
+++ b/opik.ps1
@@ -320,6 +320,18 @@ $env:TOGGLE_GUARDRAILS_ENABLED = "false"
 
 if ($options -contains '--build') {
     $BUILD_MODE = $true
+    docker buildx bake --help *>&1 | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        # TODO: Enable bake once the issue with Windows paths is resolved:
+        # - https://github.com/docker/for-win/issues/14761
+        # - https://github.com/docker/buildx/issues/1028
+        # - https://github.com/docker/compose/issues/12669
+        Write-Host '[INFO] Bake is not available for docker compose on Windows yet. Not using it for builds'
+        $env:COMPOSE_BAKE = "false"
+    } else {
+        Write-Host '[INFO] Bake is not available on Docker Buildx. Not using it for builds'
+        $env:COMPOSE_BAKE = "false"
+    }
     $options = $options | Where-Object { $_ -ne '--build' }
 }
 

--- a/opik.sh
+++ b/opik.sh
@@ -123,7 +123,12 @@ start_missing_containers() {
   echo "🔄 Starting missing containers..."
 
   if [[ "${BUILD_MODE}" = "true" ]]; then
-    export COMPOSE_BAKE=true
+    if docker buildx bake --help >/dev/null 2>&1; then
+      echo "ℹ️ Bake is available on Docker Buildx. Exporting COMPOSE_BAKE=true"
+      export COMPOSE_BAKE=true
+    else
+      echo "ℹ️ Bake is not available on Docker Buildx. Not using it for builds"
+    fi
   fi
 
   local cmd


### PR DESCRIPTION
## Details
Added a check in the Opik start up scripts, both sh and ps1, to check if `bake` is available or not. If available, enable it for docker compose with `COMPOSE_BAKE=true`.

There's a bug in Windows and relative paths can't be resolved. Left the code ready to be enabled and annotated with a TODO.

## Issues
OPIK-1544

## Testing
- Manually tested both paths on both scripts.

## Documentation
- https://docs.docker.com/build/bake/
- https://docs.docker.com/compose/how-tos/dependent-images/

Windows issue:
- https://github.com/docker/for-win/issues/14761
- https://github.com/docker/buildx/issues/1028
- https://github.com/docker/compose/issues/12669
