### PR TITLE
Simplify OpikBaseModel class

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/custom_model.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/custom_model.mdx
@@ -47,31 +47,11 @@ class CustomModel(OpikBaseModel):
     def __init__(self, model_name: str):
         super().__init__(model_name)
 
-    def generate_provider_response(self, **kwargs: Any) -> str:
+    def generate_provider_response(self, messages: List[Dict[str, Any]], **kwargs: Any) -> str:
         """
         Generate a provider-specific response. Can be used to interface with
         the underlying model provider (e.g., OpenAI, Anthropic) and get raw output.
         """
-        pass
-
-    def agenerate_provider_response_stream(self, **kwargs: Any) -> str:
-        """
-        Generate a provider-specific response. Can be used to interface with
-        the underlying model provider (e.g., OpenAI, Anthropic) and get raw output.
-        Async version.
-        """
-        pass
-
-    def agenerate_provider_response(self, **kwargs: Any) -> str:
-        """
-        Generate a provider-specific response. Can be used to interface with
-        the underlying model provider (e.g., OpenAI, Anthropic) and get raw output.
-        Async version.
-        """
-        pass
-
-    def agenerate_string(self, input: str, **kwargs: Any) -> str:
-        """Simplified interface to generate a string output from the model. Async version."""
         pass
 
     def generate_string(self, input: str, **kwargs: Any) -> str:

--- a/sdks/python/src/opik/evaluation/models/base_model.py
+++ b/sdks/python/src/opik/evaluation/models/base_model.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any
+from typing import Any, List, Dict
 
 
 class OpikBaseModel(abc.ABC):
@@ -34,6 +34,22 @@ class OpikBaseModel(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def generate_provider_response(
+        self, messages: List[Dict[str, Any]], **kwargs: Any
+    ) -> Any:
+        """
+        Generate a provider-specific response. Can be used to interface with
+        the underlying model provider (e.g., OpenAI, Anthropic) and get raw output.
+
+        Args:
+            messages: A list of messages to be sent to the model, should be a list of dictionaries with the keys
+            kwargs: arguments required by the provider to generate a response.
+
+        Returns:
+            Any: The response from the model provider, which can be of any type depending on the use case and LLM.
+        """
+        pass
+
     async def agenerate_string(self, input: str, **kwargs: Any) -> str:
         """
         Simplified interface to generate a string output from the model. Async version.
@@ -45,33 +61,22 @@ class OpikBaseModel(abc.ABC):
         Returns:
             str: The generated string output.
         """
-        pass
+        raise NotImplementedError("Async generation not implemented for this provider")
 
-    @abc.abstractmethod
-    def generate_provider_response(self, **kwargs: Any) -> Any:
-        """
-        Generate a provider-specific response. Can be used to interface with
-        the underlying model provider (e.g., OpenAI, Anthropic) and get raw output.
-
-        Args:
-            kwargs: arguments required by the provider to generate a response.
-
-        Returns:
-            Any: The response from the model provider, which can be of any type depending on the use case and LLM.
-        """
-        pass
-
-    @abc.abstractmethod
-    async def agenerate_provider_response(self, **kwargs: Any) -> Any:
+    async def agenerate_provider_response(
+        self, messages: List[Dict[str, Any]], **kwargs: Any
+    ) -> Any:
         """
         Generate a provider-specific response. Can be used to interface with
         the underlying model provider (e.g., OpenAI, Anthropic) and get raw output.
         Async version.
 
         Args:
+            messages: A list of messages to be sent to the model, should be a list of dictionaries with the keys
+                "content" and "role".
             kwargs: arguments required by the provider to generate a response.
 
         Returns:
             Any: The response from the model provider, which can be of any type depending on the use case and LLM.
         """
-        pass
+        raise NotImplementedError("Async generation not implemented for this provider")

--- a/sdks/python/src/opik/evaluation/models/litellm/litellm_chat_model.py
+++ b/sdks/python/src/opik/evaluation/models/litellm/litellm_chat_model.py
@@ -153,6 +153,7 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
 
     def generate_provider_response(
         self,
+        messages: List[Dict[str, Any]],
         **kwargs: Any,
     ) -> "ModelResponse":
         """
@@ -161,6 +162,8 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
         You can find all possible input parameters here: https://docs.litellm.ai/docs/completion/input
 
         Args:
+            messages: A list of messages to be sent to the model, should be a list of dictionaries with the keys
+                "content" and "role".
             kwargs: arguments required by the provider to generate a response.
 
         Returns:
@@ -168,8 +171,6 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
         """
 
         # we need to pop messages first, and after we will check the rest params
-        messages = kwargs.pop("messages")
-
         valid_litellm_params = self._remove_unnecessary_not_supported_params(kwargs)
         all_kwargs = {**self._completion_kwargs, **valid_litellm_params}
 
@@ -212,21 +213,22 @@ class LiteLLMChatModel(base_model.OpikBaseModel):
         )
         return response.choices[0].message.content
 
-    async def agenerate_provider_response(self, **kwargs: Any) -> "ModelResponse":
+    async def agenerate_provider_response(
+        self, messages: List[Dict[str, Any]], **kwargs: Any
+    ) -> "ModelResponse":
         """
         Generate a provider-specific response. Can be used to interface with
         the underlying model provider (e.g., OpenAI, Anthropic) and get raw output. Async version.
         You can find all possible input parameters here: https://docs.litellm.ai/docs/completion/input
 
         Args:
+            messages: A list of messages to be sent to the model, should be a list of dictionaries with the keys
+                "content" and "role".
             kwargs: arguments required by the provider to generate a response.
 
         Returns:
             Any: The response from the model provider, which can be of any type depending on the use case and LLM.
         """
-
-        # we need to pop messages first, and after we will check the rest params
-        messages = kwargs.pop("messages")
 
         valid_litellm_params = self._remove_unnecessary_not_supported_params(kwargs)
         all_kwargs = {**self._completion_kwargs, **valid_litellm_params}


### PR DESCRIPTION
## Details

Simplify the `OpikBaseModel` class, since we don't use the `async` methods in the code I've made these optional. I've also cleaned up the `generate_provider_response` class to explicitly require the messages object