### PR TITLE
OPIK-1569: Vertex AI integration fix to avoid 500 due to missing user or ai message

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/LlmProviderVertexAI.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/LlmProviderVertexAI.java
@@ -6,12 +6,17 @@ import com.comet.opik.infrastructure.llm.LlmProviderClientApiConfig;
 import com.comet.opik.infrastructure.llm.LlmProviderLangChainMapper;
 import dev.ai4j.openai4j.chat.ChatCompletionRequest;
 import dev.ai4j.openai4j.chat.ChatCompletionResponse;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageType;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.scheduler.Schedulers;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -24,9 +29,8 @@ public class LlmProviderVertexAI implements LlmProviderService {
 
     @Override
     public ChatCompletionResponse generate(@NonNull ChatCompletionRequest request, @NonNull String workspaceId) {
-        var mapper = LlmProviderLangChainMapper.INSTANCE;
-        var response = llmProviderClientGenerator.generate(config, request).generate(mapper.mapMessages(request));
-        return mapper.toChatCompletionResponse(request, response);
+        var response = llmProviderClientGenerator.generate(config, request).generate(getChatMessages(request));
+        return LlmProviderLangChainMapper.INSTANCE.toChatCompletionResponse(request, response);
     }
 
     @Override
@@ -42,7 +46,7 @@ public class LlmProviderVertexAI implements LlmProviderService {
 
                         streamingChatLanguageModel
                                 .generate(
-                                        LlmProviderLangChainMapper.INSTANCE.mapMessages(request),
+                                        getChatMessages(request),
                                         new ChunkedResponseHandler(handleMessage, handleClose, handleError,
                                                 request.model()));
                     } catch (Exception e) {
@@ -50,6 +54,21 @@ public class LlmProviderVertexAI implements LlmProviderService {
                         handleClose.run();
                     }
                 });
+    }
+
+    private List<ChatMessage> getChatMessages(ChatCompletionRequest request) {
+        List<ChatMessage> chatMessages = LlmProviderLangChainMapper.INSTANCE.mapMessages(request);
+
+        // This is a workaround for the Vertex AI API, which requires at least one user or AI message in the request.
+        if (chatMessages.stream().noneMatch(chatMessage -> chatMessage.type() == ChatMessageType.AI
+                || chatMessage.type() == ChatMessageType.USER)) {
+            var newMessages = new ArrayList<ChatMessage>();
+            newMessages.add(AiMessage.from("User message:")); // Add an empty user message to the list as has to have at least one user or ai message
+            newMessages.addAll(chatMessages);
+            chatMessages = newMessages;
+        }
+
+        return chatMessages;
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIClientGenerator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIClientGenerator.java
@@ -76,8 +76,26 @@ public class VertexAIClientGenerator implements LlmProviderClientGenerator<ChatL
                 .map(Double::floatValue)
                 .ifPresent(generationConfig::setTemperature);
 
+        Optional.ofNullable(request.topP())
+                .map(Double::floatValue)
+                .ifPresent(generationConfig::setTopP);
+
+        Optional.ofNullable(request.stop())
+                .ifPresent(values -> values.forEach(generationConfig::addStopSequences));
+
+        Optional.ofNullable(request.presencePenalty())
+                .map(Double::floatValue)
+                .ifPresent(generationConfig::setPresencePenalty);
+
+        Optional.ofNullable(request.frequencyPenalty())
+                .map(Double::floatValue)
+                .ifPresent(generationConfig::setFrequencyPenalty);
+
         Optional.ofNullable(request.maxTokens())
                 .ifPresent(generationConfig::setMaxOutputTokens);
+
+        Optional.ofNullable(request.seed())
+                .ifPresent(generationConfig::setSeed);
 
         return generationConfig.build();
     }


### PR DESCRIPTION
## Details
- Mapping missing fields from request
- Avoid error "contents can't be null or empty." on `com.google.cloud.vertexai.generativeai.GenerativeModel.buildGenerateContentRequest line 597`

## Issues

Resolves #

## Testing

## Documentation
