### PR TITLE
[OPIK-1381] [SDK] Fix error 'NoneType' object is not a mapping

### DIFF
--- a/sdks/python/src/opik/integrations/openai/openai_chat_completions_decorator.py
+++ b/sdks/python/src/opik/integrations/openai/openai_chat_completions_decorator.py
@@ -110,7 +110,7 @@ class OpenaiChatCompletionsTrackDecorator(base_track_decorator.BaseTrackDecorato
         output, metadata = dict_utils.split_dict_by_keys(result_dict, ["choices"])
 
         opik_usage = None
-        if "usage" in result_dict:
+        if result_dict.get("usage") is not None:
             opik_usage = llm_usage.try_build_opik_usage_or_log_error(
                 provider=LLMProvider.OPENAI,
                 usage=result_dict["usage"],

--- a/sdks/python/src/opik/integrations/openai/openai_responses_decorator.py
+++ b/sdks/python/src/opik/integrations/openai/openai_responses_decorator.py
@@ -102,7 +102,7 @@ class OpenaiResponsesTrackDecorator(base_track_decorator.BaseTrackDecorator):
         )
 
         opik_usage = None
-        if "usage" in result_dict:
+        if result_dict.get("usage") is not None:
             opik_usage = llm_usage.try_build_opik_usage_or_log_error(
                 provider="_openai_responses",
                 usage=result_dict["usage"],


### PR DESCRIPTION
## Details

This pull request addresses an issue where a `NoneType` object was erroneously treated as a mapping while building OpikUsage object
