### PR TITLE
Removed tokenizer dependency that isn't used

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -49,7 +49,6 @@ setup(
         "rich",
         "sentry_sdk>=2.0.0",
         "tenacity",
-        "tokenizers<0.21.0 ; python_version<'3.9.0'",  # no 3.8 support starting from 0.21.0
         "tqdm",
         "uuid6",
         "jinja2",


### PR DESCRIPTION
## Details

Removed the tokenizer dependency that is causing issues building `opik` on ARM. It doesn't seem to be used anywhere in the code so should be safe to remove.