### PR TITLE
OPIK-1510: Reduce view to micro secs of span last updated at

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Span.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Span.java
@@ -1,6 +1,7 @@
 package com.comet.opik.api;
 
 import com.comet.opik.domain.SpanType;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonView;
@@ -50,7 +51,9 @@ public record Span(
         @JsonView({Span.View.Public.class, Span.View.Write.class}) Map<String, Integer> usage,
         @JsonView({Span.View.Public.class, Span.View.Write.class}) ErrorInfo errorInfo,
         @JsonView({Span.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant createdAt,
-        @JsonView({Span.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
+        // ISO 8601 Instant with microseconds precision
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSX", timezone = "UTC") @JsonView({
+                Span.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
         @JsonView({Span.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,
         @JsonView({Span.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy,
         @JsonView({


### PR DESCRIPTION
## Details
Client side timestamps in Python, TypeScript and also many JVMs, only support up to microseconds, whereas ClickHouse timestamps support up to nanoseconds.

In order to add support of ingestion for long running jobs, we'll use a client side `last_updated_at` for conflict resolution.

In preparation for that, reducing the precision of that field to microseconds as it will be ingested from the client and nanoseconds precision isn't possible in that case. 

A PR will follow to actually truncate the ClickHouse field.

See previous PR for traces: https://github.com/comet-ml/opik/pull/1923

## Issues

OPIK-1510

## Testing
- Covered by tests.
- Tested locally.
- Will be deployed and tested.

## Documentation
N/A
