### PR TITLE
OPIK-1510: Reduce span last updated at to microseconds

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000025_reduce_span_last_updated_at_to_micros.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000025_reduce_span_last_updated_at_to_micros.sql
@@ -1,7 +1,7 @@
 --liquibase formatted sql
 --changeset andrescrz:000025_reduce_span_last_updated_at_to_micros
 
-ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans
-    MODIFY COLUMN last_updated_at DateTime64(6, 'UTC') DEFAULT now64(6);
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans ON CLUSTER '{cluster}'
+    MODIFY COLUMN IF EXISTS last_updated_at DateTime64(6, 'UTC') DEFAULT now64(6);
 
 --rollback empty

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000025_reduce_span_last_updated_at_to_micros.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000025_reduce_span_last_updated_at_to_micros.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--changeset andrescrz:000025_reduce_span_last_updated_at_to_micros
+
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans
+    MODIFY COLUMN last_updated_at DateTime64(6, 'UTC') DEFAULT now64(6);
+
+--rollback empty


### PR DESCRIPTION
## Details
Reducing the precision of `span.last_updated_at` field to microseconds (6) in the ClickHouse DB field. 

No rollback in the migration, as nanoseconds data will be lost forever once the migration is applied.

See previous PRs:
- https://github.com/comet-ml/opik/pull/2130
- https://github.com/comet-ml/opik/pull/1930

## Issues
OPIK-1510

## Testing
- Covered by tests.
- Tested locally.
- Will be deployed and tested.

## Documentation
- https://clickhouse.com/docs/sql-reference/data-types/datetime64
