### PR TITLE
OPIK-1510: Add client side last_updated_at resolution for Span

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Span.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Span.java
@@ -1,7 +1,6 @@
 package com.comet.opik.api;
 
 import com.comet.opik.domain.SpanType;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonView;
@@ -51,9 +50,7 @@ public record Span(
         @JsonView({Span.View.Public.class, Span.View.Write.class}) Map<String, Integer> usage,
         @JsonView({Span.View.Public.class, Span.View.Write.class}) ErrorInfo errorInfo,
         @JsonView({Span.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant createdAt,
-        // ISO 8601 Instant with microseconds precision
-        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSX", timezone = "UTC") @JsonView({
-                Span.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
+        @JsonView({Span.View.Public.class, Span.View.Write.class}) Instant lastUpdatedAt,
         @JsonView({Span.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,
         @JsonView({Span.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy,
         @JsonView({

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -91,6 +91,7 @@ class SpanDAO {
                 total_estimated_cost_version,
                 tags,
                 usage,
+                last_updated_at,
                 error_info,
                 created_by,
                 last_updated_by
@@ -115,6 +116,7 @@ class SpanDAO {
                         :total_estimated_cost_version<item.index>,
                         :tags<item.index>,
                         mapFromArrays(:usage_keys<item.index>, :usage_values<item.index>),
+                        if(:last_updated_at<item.index> IS NULL, NULL, parseDateTime64BestEffort(:last_updated_at<item.index>, 6)),
                         :error_info<item.index>,
                         :created_by<item.index>,
                         :last_updated_by<item.index>
@@ -971,6 +973,12 @@ class SpanDAO {
                 } else {
                     statement.bind("usage_keys" + i, new String[]{});
                     statement.bind("usage_values" + i, new Integer[]{});
+                }
+
+                if (span.lastUpdatedAt() != null) {
+                    statement.bind("last_updated_at" + i, span.lastUpdatedAt().toString());
+                } else {
+                    statement.bindNull("last_updated_at" + i, String.class);
                 }
 
                 bindCost(span, statement, String.valueOf(i));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -1280,79 +1280,77 @@ class SpanDAO {
 
     private Publisher<Span> mapToDto(Result result, Set<SpanField> exclude) {
 
-        return result.map((row, rowMetadata) -> {
-            return Span.builder()
-                    .id(row.get("id", UUID.class))
-                    .projectId(row.get("project_id", UUID.class))
-                    .traceId(row.get("trace_id", UUID.class))
-                    .parentSpanId(Optional.ofNullable(row.get("parent_span_id", String.class))
-                            .filter(str -> !str.isBlank())
-                            .map(UUID::fromString)
-                            .orElse(null))
-                    .name(getValue(exclude, SpanField.NAME, row, "name", String.class))
-                    .type(Optional.ofNullable(
-                            getValue(exclude, SpanField.TYPE, row, "type", String.class))
-                            .map(SpanType::fromString)
-                            .orElse(null))
-                    .startTime(getValue(exclude, SpanField.START_TIME, row, "start_time", Instant.class))
-                    .endTime(getValue(exclude, SpanField.END_TIME, row, "end_time", Instant.class))
-                    .input(Optional.ofNullable(getValue(exclude, SpanField.INPUT, row, "input", String.class))
-                            .filter(str -> !str.isBlank())
-                            .map(JsonUtils::getJsonNodeFromString)
-                            .orElse(null))
-                    .output(Optional.ofNullable(getValue(exclude, SpanField.OUTPUT, row, "output", String.class))
-                            .filter(str -> !str.isBlank())
-                            .map(JsonUtils::getJsonNodeFromString)
-                            .orElse(null))
-                    .metadata(Optional
-                            .ofNullable(getValue(exclude, SpanField.METADATA, row, "metadata", String.class))
-                            .filter(str -> !str.isBlank())
-                            .map(JsonUtils::getJsonNodeFromString)
-                            .orElse(null))
-                    .model(Optional.ofNullable(getValue(exclude, SpanField.MODEL, row, "model", String.class))
-                            .filter(str -> !str.isBlank())
-                            .orElse(null))
-                    .provider(Optional
-                            .ofNullable(getValue(exclude, SpanField.PROVIDER, row, "provider", String.class))
-                            .filter(str -> !str.isBlank())
-                            .orElse(null))
-                    .totalEstimatedCost(
-                            Optional.ofNullable(getValue(exclude, SpanField.TOTAL_ESTIMATED_COST, row,
-                                    "total_estimated_cost", BigDecimal.class))
-                                    .filter(value -> value.compareTo(BigDecimal.ZERO) > 0)
-                                    .orElse(null))
-                    .totalEstimatedCostVersion(getValue(exclude, SpanField.TOTAL_ESTIMATED_COST_VERSION, row,
-                            "total_estimated_cost_version", String.class))
-                    .feedbackScores(Optional
-                            .ofNullable(getValue(exclude, SpanField.FEEDBACK_SCORES, row, "feedback_scores_list",
-                                    List.class))
-                            .filter(not(List::isEmpty))
-                            .map(this::mapFeedbackScores)
-                            .filter(not(List::isEmpty))
-                            .orElse(null))
-                    .tags(Optional.ofNullable(getValue(exclude, SpanField.TAGS, row, "tags", String[].class))
-                            .map(tags -> Arrays.stream(tags).collect(Collectors.toSet()))
-                            .filter(set -> !set.isEmpty())
-                            .orElse(null))
-                    .usage(getValue(exclude, SpanField.USAGE, row, "usage", Map.class))
-                    .comments(Optional
-                            .ofNullable(getValue(exclude, SpanField.COMMENTS, row, "comments", List[].class))
-                            .map(CommentResultMapper::getComments)
-                            .filter(not(List::isEmpty))
-                            .orElse(null))
-                    .errorInfo(Optional
-                            .ofNullable(getValue(exclude, SpanField.ERROR_INFO, row, "error_info", String.class))
-                            .filter(str -> !str.isBlank())
-                            .map(errorInfo -> JsonUtils.readValue(errorInfo, ERROR_INFO_TYPE))
-                            .orElse(null))
-                    .createdAt(getValue(exclude, SpanField.CREATED_AT, row, "created_at", Instant.class))
-                    .lastUpdatedAt(row.get("last_updated_at", Instant.class))
-                    .createdBy(getValue(exclude, SpanField.CREATED_BY, row, "created_by", String.class))
-                    .lastUpdatedBy(
-                            getValue(exclude, SpanField.LAST_UPDATED_BY, row, "last_updated_by", String.class))
-                    .duration(getValue(exclude, SpanField.DURATION, row, "duration", Double.class))
-                    .build();
-        });
+        return result.map((row, rowMetadata) -> Span.builder()
+                .id(row.get("id", UUID.class))
+                .projectId(row.get("project_id", UUID.class))
+                .traceId(row.get("trace_id", UUID.class))
+                .parentSpanId(Optional.ofNullable(row.get("parent_span_id", String.class))
+                        .filter(str -> !str.isBlank())
+                        .map(UUID::fromString)
+                        .orElse(null))
+                .name(getValue(exclude, SpanField.NAME, row, "name", String.class))
+                .type(Optional.ofNullable(
+                        getValue(exclude, SpanField.TYPE, row, "type", String.class))
+                        .map(SpanType::fromString)
+                        .orElse(null))
+                .startTime(getValue(exclude, SpanField.START_TIME, row, "start_time", Instant.class))
+                .endTime(getValue(exclude, SpanField.END_TIME, row, "end_time", Instant.class))
+                .input(Optional.ofNullable(getValue(exclude, SpanField.INPUT, row, "input", String.class))
+                        .filter(str -> !str.isBlank())
+                        .map(JsonUtils::getJsonNodeFromString)
+                        .orElse(null))
+                .output(Optional.ofNullable(getValue(exclude, SpanField.OUTPUT, row, "output", String.class))
+                        .filter(str -> !str.isBlank())
+                        .map(JsonUtils::getJsonNodeFromString)
+                        .orElse(null))
+                .metadata(Optional
+                        .ofNullable(getValue(exclude, SpanField.METADATA, row, "metadata", String.class))
+                        .filter(str -> !str.isBlank())
+                        .map(JsonUtils::getJsonNodeFromString)
+                        .orElse(null))
+                .model(Optional.ofNullable(getValue(exclude, SpanField.MODEL, row, "model", String.class))
+                        .filter(str -> !str.isBlank())
+                        .orElse(null))
+                .provider(Optional
+                        .ofNullable(getValue(exclude, SpanField.PROVIDER, row, "provider", String.class))
+                        .filter(str -> !str.isBlank())
+                        .orElse(null))
+                .totalEstimatedCost(
+                        Optional.ofNullable(getValue(exclude, SpanField.TOTAL_ESTIMATED_COST, row,
+                                "total_estimated_cost", BigDecimal.class))
+                                .filter(value -> value.compareTo(BigDecimal.ZERO) > 0)
+                                .orElse(null))
+                .totalEstimatedCostVersion(getValue(exclude, SpanField.TOTAL_ESTIMATED_COST_VERSION, row,
+                        "total_estimated_cost_version", String.class))
+                .feedbackScores(Optional
+                        .ofNullable(getValue(exclude, SpanField.FEEDBACK_SCORES, row, "feedback_scores_list",
+                                List.class))
+                        .filter(not(List::isEmpty))
+                        .map(this::mapFeedbackScores)
+                        .filter(not(List::isEmpty))
+                        .orElse(null))
+                .tags(Optional.ofNullable(getValue(exclude, SpanField.TAGS, row, "tags", String[].class))
+                        .map(tags -> Arrays.stream(tags).collect(Collectors.toSet()))
+                        .filter(set -> !set.isEmpty())
+                        .orElse(null))
+                .usage(getValue(exclude, SpanField.USAGE, row, "usage", Map.class))
+                .comments(Optional
+                        .ofNullable(getValue(exclude, SpanField.COMMENTS, row, "comments", List[].class))
+                        .map(CommentResultMapper::getComments)
+                        .filter(not(List::isEmpty))
+                        .orElse(null))
+                .errorInfo(Optional
+                        .ofNullable(getValue(exclude, SpanField.ERROR_INFO, row, "error_info", String.class))
+                        .filter(str -> !str.isBlank())
+                        .map(errorInfo -> JsonUtils.readValue(errorInfo, ERROR_INFO_TYPE))
+                        .orElse(null))
+                .createdAt(getValue(exclude, SpanField.CREATED_AT, row, "created_at", Instant.class))
+                .lastUpdatedAt(row.get("last_updated_at", Instant.class))
+                .createdBy(getValue(exclude, SpanField.CREATED_BY, row, "created_by", String.class))
+                .lastUpdatedBy(
+                        getValue(exclude, SpanField.LAST_UPDATED_BY, row, "last_updated_by", String.class))
+                .duration(getValue(exclude, SpanField.DURATION, row, "duration", Double.class))
+                .build());
     }
 
     private List<FeedbackScore> mapFeedbackScores(List<List<Object>> feedbackScores) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/RandomTestUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/RandomTestUtils.java
@@ -1,0 +1,11 @@
+package com.comet.opik.api.resources.utils;
+
+import org.apache.commons.lang3.RandomUtils;
+
+public class RandomTestUtils {
+
+    public static <T extends Enum<T>> T randomEnumValue(Class<T> enumClass) {
+        var values = enumClass.getEnumConstants();
+        return values[RandomUtils.secure().randomInt(0, values.length)];
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/spans/SpanAssertions.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/spans/SpanAssertions.java
@@ -8,6 +8,7 @@ import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguratio
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static com.comet.opik.api.Span.SpanPage;
@@ -73,7 +74,13 @@ public class SpanAssertions {
             }
 
             if (actualSpan.lastUpdatedAt() != null) {
-                assertThat(actualSpan.lastUpdatedAt()).isAfter(expectedSpan.lastUpdatedAt());
+                if (expectedSpan.lastUpdatedAt() != null) {
+                    assertThat(actualSpan.lastUpdatedAt())
+                            // Some JVMs can resolve higher than microseconds, such as nanoseconds in the Ubuntu AMD64 JVM
+                            .isAfterOrEqualTo(expectedSpan.lastUpdatedAt().truncatedTo(ChronoUnit.MICROS));
+                } else {
+                    assertThat(actualSpan.lastUpdatedAt()).isCloseTo(Instant.now(), within(2, ChronoUnit.SECONDS));
+                }
             }
 
             assertThat(actualSpan.feedbackScores())


### PR DESCRIPTION
## Details
In preparation for trace ingestion for long-running jobs:
- Updated span batch ingestion endpoint as an `upsert` endpoint which uses `last_updated_at` field as client side resolution. 
- This field can be ingested now for this purpose. 
- When not provided, it's resolved internally with the usual behaviour.

Reverted previous view changes to reduce `last_updated_at` to microseconds, as this is already enforced on the DB.

Reduced tech debt in the code and in the tests.

See related PR for traces: https://github.com/comet-ml/opik/pull/1992 

## Issues
- OPIK-1510


## Testing
- Reviewed, updated and extended test coverage for the related endpoint.
- Tested locally.

## Documentation
N/A
