### PR TITLE
[OPIK-1407] [SDK] Update Provider-to-OpikUsageBuilder logic

### DIFF
--- a/sdks/python/src/opik/api_objects/experiment/experiment.py
+++ b/sdks/python/src/opik/api_objects/experiment/experiment.py
@@ -99,8 +99,8 @@ class Experiment:
         from the backend. If truncation is enabled, the backend may return truncated details for each item.
 
         Args:
-            max_results: Maximum number of experiment items to retrieve. Defaults to None (unlimited).
-            truncate: Whether to truncate the items returned by the backend. Defaults to True.
+            max_results: Maximum number of experiment items to retrieve.
+            truncate: Whether to truncate the items returned by the backend.
 
         """
         result: List[experiment_item.ExperimentItemContent] = []

--- a/sdks/python/src/opik/integrations/openai/agents/span_data_parsers.py
+++ b/sdks/python/src/opik/integrations/openai/agents/span_data_parsers.py
@@ -121,7 +121,7 @@ def _parse_response_span_content(span_data: tracing.ResponseSpanData) -> ParsedS
 
     if response.usage is not None:
         opik_usage = llm_usage.try_build_opik_usage_or_log_error(
-            provider="_openai_responses",
+            provider=LLMProvider.OPENAI,
             usage=response.usage.model_dump(),
             logger=LOGGER,
             error_message="Failed to log usage in openai agent run",

--- a/sdks/python/src/opik/integrations/openai/openai_responses_decorator.py
+++ b/sdks/python/src/opik/integrations/openai/openai_responses_decorator.py
@@ -12,7 +12,7 @@ from typing_extensions import override
 
 import openai
 
-from opik import dict_utils, llm_usage
+from opik import LLMProvider, dict_utils, llm_usage
 from opik.api_objects import span
 from opik.decorator import arguments_helpers, base_track_decorator
 from openai.types import responses as openai_responses
@@ -104,7 +104,7 @@ class OpenaiResponsesTrackDecorator(base_track_decorator.BaseTrackDecorator):
         opik_usage = None
         if result_dict.get("usage") is not None:
             opik_usage = llm_usage.try_build_opik_usage_or_log_error(
-                provider="_openai_responses",
+                provider=LLMProvider.OPENAI,
                 usage=result_dict["usage"],
                 logger=LOGGER,
                 error_message="Failed to log token usage from openai responses call",

--- a/sdks/python/src/opik/llm_usage/opik_usage_factory.py
+++ b/sdks/python/src/opik/llm_usage/opik_usage_factory.py
@@ -1,24 +1,22 @@
 import logging
-from . import opik_usage
-from typing import Dict, Any, Callable, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
+
 from opik.types import LLMProvider
+from . import opik_usage
 
 
-# TODO: it was discovered that one provider may have more than one token usage formats, and
-# sometimes we support one usage format but not the cost tracking for its provider.
-# So, this dictionary and corresponding logic should be updated.
-# We need to have one dict - USAGE_FORMAT: OPIK_USAGE_BUILDER, and probably
-# another dict - PROVIDER: USAGE_FORMATS.
-# See the ticket: OPIK-1407
 _PROVIDER_TO_OPIK_USAGE_BUILDER: Dict[
-    Union[str, LLMProvider], Callable[[Dict[str, Any]], opik_usage.OpikUsage]
+    Union[str, LLMProvider],
+    List[Callable[[Dict[str, Any]], opik_usage.OpikUsage]],
 ] = {
-    LLMProvider.OPENAI: opik_usage.OpikUsage.from_openai_completions_dict,
-    LLMProvider.GOOGLE_VERTEXAI: opik_usage.OpikUsage.from_google_dict,
-    LLMProvider.GOOGLE_AI: opik_usage.OpikUsage.from_google_dict,
-    LLMProvider.ANTHROPIC: opik_usage.OpikUsage.from_anthropic_dict,
-    "_bedrock": opik_usage.OpikUsage.from_bedrock_dict,
-    "_openai_responses": opik_usage.OpikUsage.from_openai_responses_dict,
+    LLMProvider.OPENAI: [
+        opik_usage.OpikUsage.from_openai_completions_dict,
+        opik_usage.OpikUsage.from_openai_responses_dict,
+    ],
+    LLMProvider.GOOGLE_VERTEXAI: [opik_usage.OpikUsage.from_google_dict],
+    LLMProvider.GOOGLE_AI: [opik_usage.OpikUsage.from_google_dict],
+    LLMProvider.ANTHROPIC: [opik_usage.OpikUsage.from_anthropic_dict],
+    "_bedrock": [opik_usage.OpikUsage.from_bedrock_dict],
 }
 
 
@@ -26,22 +24,30 @@ def build_opik_usage(
     provider: Union[str, LLMProvider],
     usage: Dict[str, Any],
 ) -> opik_usage.OpikUsage:
-    build_function = _PROVIDER_TO_OPIK_USAGE_BUILDER[provider]
+    build_functions = _PROVIDER_TO_OPIK_USAGE_BUILDER[provider]
 
-    result = build_function(usage)
+    for build_function in build_functions:
+        try:
+            result = build_function(usage)
+            return result
+        except Exception:
+            pass
 
-    return result
+    raise ValueError(
+        f"Failed to build OpikUsage for provider {provider} and usage {usage}"
+    )
 
 
 def build_opik_usage_from_unknown_provider(
     usage: Dict[str, Any],
 ) -> opik_usage.OpikUsage:
-    for build_function in _PROVIDER_TO_OPIK_USAGE_BUILDER.values():
-        try:
-            opik_usage_ = build_function(usage)
-            return opik_usage_
-        except Exception:
-            pass
+    for build_functions in _PROVIDER_TO_OPIK_USAGE_BUILDER.values():
+        for build_function in build_functions:
+            try:
+                opik_usage_ = build_function(usage)
+                return opik_usage_
+            except Exception:
+                pass
 
     return opik_usage.OpikUsage.from_unknown_usage_dict(usage)
 

--- a/sdks/python/src/opik/llm_usage/opik_usage_factory.py
+++ b/sdks/python/src/opik/llm_usage/opik_usage_factory.py
@@ -5,7 +5,10 @@ from opik.types import LLMProvider
 from . import opik_usage
 
 
-_PROVIDER_TO_OPIK_USAGE_BUILDER: Dict[
+# One provider can have multiple formats of usage dicts, so it could be many build functions
+# if provider's name specified as string and not as LLMProvider enum value -
+# it means that we do not support cost tracking for this provider (but support usage info)
+_PROVIDER_TO_OPIK_USAGE_BUILDERS: Dict[
     Union[str, LLMProvider],
     List[Callable[[Dict[str, Any]], opik_usage.OpikUsage]],
 ] = {
@@ -24,7 +27,7 @@ def build_opik_usage(
     provider: Union[str, LLMProvider],
     usage: Dict[str, Any],
 ) -> opik_usage.OpikUsage:
-    build_functions = _PROVIDER_TO_OPIK_USAGE_BUILDER[provider]
+    build_functions = _PROVIDER_TO_OPIK_USAGE_BUILDERS[provider]
 
     for build_function in build_functions:
         try:
@@ -41,7 +44,7 @@ def build_opik_usage(
 def build_opik_usage_from_unknown_provider(
     usage: Dict[str, Any],
 ) -> opik_usage.OpikUsage:
-    for build_functions in _PROVIDER_TO_OPIK_USAGE_BUILDER.values():
+    for build_functions in _PROVIDER_TO_OPIK_USAGE_BUILDERS.values():
         for build_function in build_functions:
             try:
                 opik_usage_ = build_function(usage)


### PR DESCRIPTION
## Details
Refactoring Usage Logic for LLM Providers:
- Updated _PROVIDER_TO_OPIK_USAGE_BUILDER in opik_usage_factory.py to support multiple build functions per provider.
- Improved error handling by iterating through all potential build functions before raising exceptions.
- Removed outdated comments

## Testing
Tests are already existing for the refactored code.
