### PR TITLE
[OPIK-1494]: [SDK] Migrate to stream_experiments endpoints

### DIFF
--- a/sdks/python/src/opik/api_objects/experiment/rest_operations.py
+++ b/sdks/python/src/opik/api_objects/experiment/rest_operations.py
@@ -13,16 +13,14 @@ def get_experiment_data_by_name(
     #  deprecated Opik.get_experiment_by_name() will be removed.
     #  This function should not be used anywhere else except for deprecated logic as it is confusing and misleading
 
-    while True:
-        experiment_page_public = rest_client.experiments.find_experiments(name=name)
-        if len(experiment_page_public.content) == 0:
-            raise exceptions.ExperimentNotFound(
-                f"Experiment with the name '{name}' is not found."
-            )
+    experiments = get_experiments_data_by_name(rest_client, name)
+    for experiment in experiments:
+        if experiment.name == name:
+            return experiment
 
-        for experiment in experiment_page_public.content:
-            if experiment.name == name:
-                return experiment
+    raise exceptions.ExperimentNotFound(
+        f"Experiment with the name '{name}' is not found."
+    )
 
 
 def get_experiments_data_by_name(

--- a/sdks/python/src/opik/api_objects/experiment/rest_operations.py
+++ b/sdks/python/src/opik/api_objects/experiment/rest_operations.py
@@ -1,8 +1,9 @@
 from typing import List
 
-from opik import exceptions
-from opik.rest_api import OpikApi
-from opik.rest_api.types import experiment_public
+from ... import exceptions
+from .. import rest_stream_parser
+from ...rest_api import OpikApi
+from ...rest_api.types import experiment_public
 
 
 def get_experiment_data_by_name(
@@ -16,7 +17,7 @@ def get_experiment_data_by_name(
         experiment_page_public = rest_client.experiments.find_experiments(name=name)
         if len(experiment_page_public.content) == 0:
             raise exceptions.ExperimentNotFound(
-                f"Experiment with the name {name} not found."
+                f"Experiment with the name '{name}' is not found."
             )
 
         for experiment in experiment_page_public.content:
@@ -27,10 +28,14 @@ def get_experiment_data_by_name(
 def get_experiments_data_by_name(
     rest_client: OpikApi, name: str
 ) -> List[experiment_public.ExperimentPublic]:
-    experiment_page_public = rest_client.experiments.find_experiments(name=name)
-    if len(experiment_page_public.content) == 0:
+    experiments_stream = rest_client.experiments.stream_experiments(name=name)
+    experiments = rest_stream_parser.read_and_parse_stream(
+        stream=experiments_stream, item_class=experiment_public.ExperimentPublic
+    )
+
+    if len(experiments) == 0:
         raise exceptions.ExperimentNotFound(
-            f"Experiment with the name {name} not found."
+            f"Experiment(s) with the name '{name}' is not found."
         )
 
-    return experiment_page_public.content
+    return experiments

--- a/sdks/python/src/opik/api_objects/experiment/rest_operations.py
+++ b/sdks/python/src/opik/api_objects/experiment/rest_operations.py
@@ -18,9 +18,7 @@ def get_experiment_data_by_name(
         if experiment.name == name:
             return experiment
 
-    raise exceptions.ExperimentNotFound(
-        f"Experiment with the name '{name}' is not found."
-    )
+    raise exceptions.ExperimentNotFound(f"No experiment found with the name '{name}'.")
 
 
 def get_experiments_data_by_name(
@@ -33,7 +31,7 @@ def get_experiments_data_by_name(
 
     if len(experiments) == 0:
         raise exceptions.ExperimentNotFound(
-            f"Experiment(s) with the name '{name}' is not found."
+            f"No experiment(s) found with the name '{name}'."
         )
 
     return experiments

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -798,7 +798,7 @@ class Opik:
 
     def get_experiments_by_name(self, name: str) -> List[experiment.Experiment]:
         """
-        Returns an existing experiments by its name.
+        Returns a list of existing experiments by its name.
 
         Args:
             name: The name of the experiment(s).


### PR DESCRIPTION
## Details
Refactored experiments fetching by name to use streaming API.

Updated experiment data retrieval to leverage the streaming API for improved performance and scalability. Adjusted imports and error messages for consistency and clarified return documentation in the client method.

## Testing
Added  E2E test for fetching experiments by name. This test validates the functionality of retrieving experiments using their names, ensuring accurate results for experiments with duplicate and unique names. It also verifies the persistence of experiment metadata and correctness of associated traces and scores.
