### PR TITLE
NO-OPIK increase timeout of quickstart snippet test

### DIFF
--- a/tests_end_to_end/tests/QuickstartGuide/test_quickstart_guide.py
+++ b/tests_end_to_end/tests/QuickstartGuide/test_quickstart_guide.py
@@ -73,7 +73,7 @@ def test_quickstart_snippet(page, env_config, integration):
         try:
             # Set a timeout for the subprocess to prevent hanging
             result = subprocess.run(
-                ["python", str(file_path)], capture_output=True, text=True, timeout=30
+                ["python", str(file_path)], capture_output=True, text=True, timeout=60
             )
 
             logger.info("\n=== Output ===")


### PR DESCRIPTION
## Details

increasing the time of execution of quickstart snippets to 60 seconds to account for random stuff like Ragas taking longer than expected to run
