### PR TITLE
[OPIK-1027] Persist table pagination settings using query parameters and local storage.

### DIFF
--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -55,6 +55,7 @@ import useCompareExperimentsList from "@/api/datasets/useCompareExperimentsList"
 import useAppStore from "@/store/AppStore";
 import { Experiment, ExperimentsCompare } from "@/types/datasets";
 import { useDatasetIdFromCompareExperimentsURL } from "@/hooks/useDatasetIdFromCompareExperimentsURL";
+import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import { formatDate } from "@/lib/date";
 import {
   convertColumnDataToColumn,
@@ -94,6 +95,8 @@ const COLUMNS_ORDER_KEY = "compare-experiments-columns-order";
 const DYNAMIC_COLUMNS_KEY = "compare-experiments-dynamic-columns";
 const COLUMNS_SCORES_ORDER_KEY = "compare-experiments-scores-columns-order";
 const COLUMNS_OUTPUT_ORDER_KEY = "compare-experiments-output-columns-order";
+const PAGINATION_SIZE_KEY = "compare-experiments-pagination-size";
+const ROW_HEIGHT_KEY = "compare-experiments-row-height";
 
 export const FILTER_COLUMNS: ColumnData<ExperimentsCompare>[] = [
   {
@@ -151,17 +154,25 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
     updateType: "replaceIn",
   });
 
-  const [size = 100, setSize] = useQueryParam("size", NumberParam, {
-    updateType: "replaceIn",
+  const [size, setSize] = useQueryParamAndLocalStorageState<
+    number | null | undefined
+  >({
+    localStorageKey: PAGINATION_SIZE_KEY,
+    queryKey: "size",
+    defaultValue: 100,
+    queryParamConfig: NumberParam,
+    syncQueryWithLocalStorageOnInit: true,
   });
 
-  const [height = ROW_HEIGHT.small, setHeight] = useQueryParam(
-    "height",
-    StringParam,
-    {
-      updateType: "replaceIn",
-    },
-  );
+  const [height, setHeight] = useQueryParamAndLocalStorageState<
+    string | null | undefined
+  >({
+    localStorageKey: ROW_HEIGHT_KEY,
+    queryKey: "height",
+    defaultValue: ROW_HEIGHT.small,
+    queryParamConfig: StringParam,
+    syncQueryWithLocalStorageOnInit: true,
+  });
 
   const [filters = [], setFilters] = useQueryParam("filters", JsonParam, {
     updateType: "replaceIn",

--- a/apps/opik-frontend/src/components/pages/CompareTrialsPage/TrialsItemsTab/TrialItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareTrialsPage/TrialsItemsTab/TrialItemsTab.tsx
@@ -50,6 +50,7 @@ import {
 import { mapDynamicColumnTypesToColumnType } from "@/lib/filters";
 import useCompareExperimentsColumns from "@/api/datasets/useCompareExperimentsColumns";
 import { useDynamicColumnsCache } from "@/hooks/useDynamicColumnsCache";
+import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import FeedbackScoreHeader from "@/components/shared/DataTableHeaders/FeedbackScoreHeader";
 import ExperimentsFeedbackScoresSelect from "@/components/pages-shared/experiments/ExperimentsFeedbackScoresSelect/ExperimentsFeedbackScoresSelect";
 import { calculateHeightStyle } from "@/components/shared/DataTable/utils";
@@ -74,6 +75,8 @@ const COLUMNS_ORDER_KEY = "compare-trials-columns-order";
 const DYNAMIC_COLUMNS_KEY = "compare-trials-dynamic-columns";
 const COLUMNS_SCORES_ORDER_KEY = "compare-trials-scores-columns-order";
 const COLUMNS_OUTPUT_ORDER_KEY = "compare-trials-output-columns-order";
+const PAGINATION_SIZE_KEY = "compare-trials-pagination-size";
+const ROW_HEIGHT_KEY = "compare-trials-row-height";
 
 export const FILTER_COLUMNS: ColumnData<ExperimentsCompare>[] = [
   {
@@ -122,17 +125,25 @@ const TrialItemsTab: React.FC<TrialItemsTabProps> = ({
     updateType: "replaceIn",
   });
 
-  const [size = 100, setSize] = useQueryParam("size", NumberParam, {
-    updateType: "replaceIn",
+  const [size, setSize] = useQueryParamAndLocalStorageState<
+    number | null | undefined
+  >({
+    localStorageKey: PAGINATION_SIZE_KEY,
+    queryKey: "size",
+    defaultValue: 100,
+    queryParamConfig: NumberParam,
+    syncQueryWithLocalStorageOnInit: true,
   });
 
-  const [height = ROW_HEIGHT.small, setHeight] = useQueryParam(
-    "height",
-    StringParam,
-    {
-      updateType: "replaceIn",
-    },
-  );
+  const [height, setHeight] = useQueryParamAndLocalStorageState<
+    string | null | undefined
+  >({
+    localStorageKey: ROW_HEIGHT_KEY,
+    queryKey: "height",
+    defaultValue: ROW_HEIGHT.small,
+    queryParamConfig: StringParam,
+    syncQueryWithLocalStorageOnInit: true,
+  });
 
   const [filters = [], setFilters] = useQueryParam("filters", JsonParam, {
     updateType: "replaceIn",

--- a/apps/opik-frontend/src/components/pages/ConfigurationPage/FeedbackDefinitionsTab/FeedbackDefinitionsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/ConfigurationPage/FeedbackDefinitionsTab/FeedbackDefinitionsTab.tsx
@@ -40,6 +40,7 @@ export const getRowId = (f: FeedbackDefinition) => f.id;
 const SELECTED_COLUMNS_KEY = "feedback-definitions-selected-columns";
 const COLUMNS_WIDTH_KEY = "feedback-definitions-columns-width";
 const COLUMNS_ORDER_KEY = "feedback-definitions-columns-order";
+const PAGINATION_SIZE_KEY = "feedback-definitions-pagination-size";
 
 export const DEFAULT_COLUMNS: ColumnData<FeedbackDefinition>[] = [
   {
@@ -89,7 +90,9 @@ const FeedbackDefinitionsTab: React.FunctionComponent = () => {
 
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
-  const [size, setSize] = useState(10);
+  const [size, setSize] = useLocalStorageState<number>(PAGINATION_SIZE_KEY, {
+    defaultValue: 10,
+  });
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
@@ -10,6 +10,8 @@ import Loader from "@/components/shared/Loader/Loader";
 import DataTable from "@/components/shared/DataTable/DataTable";
 import DataTablePagination from "@/components/shared/DataTablePagination/DataTablePagination";
 import { useDatasetIdFromURL } from "@/hooks/useDatasetIdFromURL";
+import { useDynamicColumnsCache } from "@/hooks/useDynamicColumnsCache";
+import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import ColumnsButton from "@/components/shared/ColumnsButton/ColumnsButton";
 import useDatasetItemsList from "@/api/datasets/useDatasetItemsList";
 import useDatasetById from "@/api/datasets/useDatasetById";
@@ -41,7 +43,6 @@ import {
   generateActionsColumDef,
   generateSelectColumDef,
 } from "@/components/shared/DataTable/utils";
-import { useDynamicColumnsCache } from "@/hooks/useDynamicColumnsCache";
 
 const getRowId = (d: DatasetItem) => d.id;
 
@@ -56,6 +57,8 @@ const SELECTED_COLUMNS_KEY = "dataset-items-selected-columns";
 const COLUMNS_WIDTH_KEY = "dataset-items-columns-width";
 const COLUMNS_ORDER_KEY = "dataset-items-columns-order";
 const DYNAMIC_COLUMNS_KEY = "dataset-items-dynamic-columns";
+const PAGINATION_SIZE_KEY = "dataset-items-pagination-size";
+const ROW_HEIGHT_KEY = "dataset-items-row-height";
 
 const DatasetItemsPage = () => {
   const datasetId = useDatasetIdFromURL();
@@ -68,19 +71,27 @@ const DatasetItemsPage = () => {
     updateType: "replaceIn",
   });
 
-  const [size = 10, setSize] = useQueryParam("size", NumberParam, {
-    updateType: "replaceIn",
+  const [size, setSize] = useQueryParamAndLocalStorageState<
+    number | null | undefined
+  >({
+    localStorageKey: PAGINATION_SIZE_KEY,
+    queryKey: "size",
+    defaultValue: 10,
+    queryParamConfig: NumberParam,
+    syncQueryWithLocalStorageOnInit: true,
   });
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
-  const [height = ROW_HEIGHT.small, setHeight] = useQueryParam(
-    "height",
-    StringParam,
-    {
-      updateType: "replaceIn",
-    },
-  );
+  const [height, setHeight] = useQueryParamAndLocalStorageState<
+    string | null | undefined
+  >({
+    localStorageKey: ROW_HEIGHT_KEY,
+    queryKey: "height",
+    defaultValue: ROW_HEIGHT.small,
+    queryParamConfig: StringParam,
+    syncQueryWithLocalStorageOnInit: true,
+  });
 
   const resetDialogKeyRef = useRef(0);
   const [openDialog, setOpenDialog] = useState<boolean>(false);

--- a/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetsPage.tsx
@@ -39,6 +39,7 @@ export const getRowId = (d: Dataset) => d.id;
 const SELECTED_COLUMNS_KEY = "datasets-selected-columns";
 const COLUMNS_WIDTH_KEY = "datasets-columns-width";
 const COLUMNS_ORDER_KEY = "datasets-columns-order";
+const PAGINATION_SIZE_KEY = "datasets-pagination-size";
 
 export const DEFAULT_COLUMNS: ColumnData<Dataset>[] = [
   {
@@ -103,7 +104,9 @@ const DatasetsPage: React.FunctionComponent = () => {
 
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
-  const [size, setSize] = useState(10);
+  const [size, setSize] = useLocalStorageState<number>(PAGINATION_SIZE_KEY, {
+    defaultValue: 10,
+  });
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 

--- a/apps/opik-frontend/src/components/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
+++ b/apps/opik-frontend/src/components/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
@@ -21,6 +21,7 @@ import {
   generateActionsColumDef,
   generateSelectColumDef,
 } from "@/components/shared/DataTable/utils";
+import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import Loader from "@/components/shared/Loader/Loader";
 import SearchInput from "@/components/shared/SearchInput/SearchInput";
 import { Button } from "@/components/ui/button";
@@ -102,6 +103,7 @@ const DEFAULT_SELECTED_COLUMNS: string[] = [
 const SELECTED_COLUMNS_KEY = "workspace-rules-selected-columns";
 const COLUMNS_WIDTH_KEY = "workspace-rules-columns-width";
 const COLUMNS_ORDER_KEY = "workspace-rules-columns-order";
+const PAGINATION_SIZE_KEY = "workspace-rules-pagination-size";
 
 export const OnlineEvaluationPage: React.FC = () => {
   const resetDialogKeyRef = useRef(0);
@@ -115,8 +117,14 @@ export const OnlineEvaluationPage: React.FC = () => {
     updateType: "replaceIn",
   });
 
-  const [size = 10, setSize] = useQueryParam("size", NumberParam, {
-    updateType: "replaceIn",
+  const [size, setSize] = useQueryParamAndLocalStorageState<
+    number | null | undefined
+  >({
+    localStorageKey: PAGINATION_SIZE_KEY,
+    queryKey: "size",
+    defaultValue: 10,
+    queryParamConfig: NumberParam,
+    syncQueryWithLocalStorageOnInit: true,
   });
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});

--- a/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
@@ -19,6 +19,7 @@ import DurationCell from "@/components/shared/DataTableCells/DurationCell";
 import CostCell from "@/components/shared/DataTableCells/CostCell";
 import ResourceCell from "@/components/shared/DataTableCells/ResourceCell";
 import useProjectWithStatisticsList from "@/hooks/useProjectWithStatisticsList";
+import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import { ProjectWithStatistic } from "@/types/projects";
 import Loader from "@/components/shared/Loader/Loader";
 import AddEditProjectDialog from "@/components/pages/ProjectsPage/AddEditProjectDialog";
@@ -55,6 +56,7 @@ const SELECTED_COLUMNS_KEY = "projects-selected-columns";
 const COLUMNS_WIDTH_KEY = "projects-columns-width";
 const COLUMNS_ORDER_KEY = "projects-columns-order";
 const COLUMNS_SORT_KEY = "projects-columns-sort";
+const PAGINATION_SIZE_KEY = "projects-pagination-size";
 
 export const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
   left: [COLUMN_SELECT_ID, COLUMN_NAME_ID],
@@ -217,9 +219,17 @@ const ProjectsPage: React.FunctionComponent = () => {
   const [page = 1, setPage] = useQueryParam("page", NumberParam, {
     updateType: "replaceIn",
   });
-  const [size = 10, setSize] = useQueryParam("size", NumberParam, {
-    updateType: "replaceIn",
+
+  const [size, setSize] = useQueryParamAndLocalStorageState<
+    number | null | undefined
+  >({
+    localStorageKey: PAGINATION_SIZE_KEY,
+    queryKey: "size",
+    defaultValue: 10,
+    queryParamConfig: NumberParam,
+    syncQueryWithLocalStorageOnInit: true,
   });
+
   const [rowSelection = {}, setRowSelection] = useQueryParam(
     "selection",
     JsonParam,

--- a/apps/opik-frontend/src/components/pages/PromptPage/CommitsTab/CommitsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/CommitsTab/CommitsTab.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
 import { RowSelectionState } from "@tanstack/react-table";
+import useLocalStorageState from "use-local-storage-state";
 import get from "lodash/get";
 import isObject from "lodash/isObject";
 
@@ -26,6 +27,8 @@ export const getRowId = (p: PromptVersion) => p.id;
 interface CommitsTabInterface {
   prompt?: PromptWithLatestVersion;
 }
+
+const PAGINATION_SIZE_KEY = "prompt-commits-pagination-size";
 
 export const COMMITS_DEFAULT_COLUMNS = [
   generateSelectColumDef<PromptVersion>(),
@@ -84,7 +87,9 @@ export const COMMITS_DEFAULT_COLUMNS = [
 
 const CommitsTab = ({ prompt }: CommitsTabInterface) => {
   const [page, setPage] = useState(1);
-  const [size, setSize] = useState(10);
+  const [size, setSize] = useLocalStorageState<number>(PAGINATION_SIZE_KEY, {
+    defaultValue: 10,
+  });
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 

--- a/apps/opik-frontend/src/components/pages/PromptsPage/PromptsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptsPage/PromptsPage.tsx
@@ -39,6 +39,7 @@ export const getRowId = (p: Prompt) => p.id;
 const SELECTED_COLUMNS_KEY = "prompts-selected-columns";
 const COLUMNS_WIDTH_KEY = "prompts-columns-width";
 const COLUMNS_ORDER_KEY = "prompts-columns-order";
+const PAGINATION_SIZE_KEY = "prompts-pagination-size";
 
 export const DEFAULT_COLUMNS: ColumnData<Prompt>[] = [
   {
@@ -90,7 +91,9 @@ const PromptsPage: React.FunctionComponent = () => {
 
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
-  const [size, setSize] = useState(10);
+  const [size, setSize] = useLocalStorageState<number>(PAGINATION_SIZE_KEY, {
+    defaultValue: 10,
+  });
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 

--- a/apps/opik-frontend/src/components/pages/TracesPage/RulesTab/RulesTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/RulesTab/RulesTab.tsx
@@ -21,6 +21,7 @@ import {
   generateActionsColumDef,
   generateSelectColumDef,
 } from "@/components/shared/DataTable/utils";
+import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import Loader from "@/components/shared/Loader/Loader";
 import SearchInput from "@/components/shared/SearchInput/SearchInput";
 import { Button } from "@/components/ui/button";
@@ -91,6 +92,7 @@ const DEFAULT_SELECTED_COLUMNS: string[] = [
 const SELECTED_COLUMNS_KEY = "project-rules-selected-columns";
 const COLUMNS_WIDTH_KEY = "project-rules-columns-width";
 const COLUMNS_ORDER_KEY = "project-rules-columns-order";
+const PAGINATION_SIZE_KEY = "project-rules-pagination-size";
 
 type RulesTabProps = {
   projectId: string;
@@ -108,8 +110,14 @@ export const RulesTab: React.FC<RulesTabProps> = ({ projectId }) => {
     updateType: "replaceIn",
   });
 
-  const [size = 10, setSize] = useQueryParam("size", NumberParam, {
-    updateType: "replaceIn",
+  const [size, setSize] = useQueryParamAndLocalStorageState<
+    number | null | undefined
+  >({
+    localStorageKey: PAGINATION_SIZE_KEY,
+    queryKey: "size",
+    defaultValue: 10,
+    queryParamConfig: NumberParam,
+    syncQueryWithLocalStorageOnInit: true,
   });
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});

--- a/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsTab.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/types/shared";
 import { Thread } from "@/types/traces";
 import { convertColumnDataToColumn, mapColumnDataFields } from "@/lib/table";
+import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import { generateSelectColumDef } from "@/components/shared/DataTable/utils";
 import Loader from "@/components/shared/Loader/Loader";
 import NoThreadsPage from "@/components/pages/TracesPage/ThreadsTab/NoThreadsPage";
@@ -146,6 +147,8 @@ const DEFAULT_SELECTED_COLUMNS: string[] = [
 const SELECTED_COLUMNS_KEY = "threads-selected-columns";
 const COLUMNS_WIDTH_KEY = "threads-columns-width";
 const COLUMNS_ORDER_KEY = "threads-columns-order";
+const PAGINATION_SIZE_KEY = "threads-pagination-size";
+const ROW_HEIGHT_KEY = "threads-row-height";
 
 type ThreadsTabProps = {
   projectId: string;
@@ -180,17 +183,25 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
     updateType: "replaceIn",
   });
 
-  const [size = 100, setSize] = useQueryParam("threads_size", NumberParam, {
-    updateType: "replaceIn",
+  const [size, setSize] = useQueryParamAndLocalStorageState<
+    number | null | undefined
+  >({
+    localStorageKey: PAGINATION_SIZE_KEY,
+    queryKey: "size",
+    defaultValue: 100,
+    queryParamConfig: NumberParam,
+    syncQueryWithLocalStorageOnInit: true,
   });
 
-  const [height = ROW_HEIGHT.small, setHeight] = useQueryParam(
-    "threads_height",
-    StringParam,
-    {
-      updateType: "replaceIn",
-    },
-  );
+  const [height, setHeight] = useQueryParamAndLocalStorageState<
+    string | null | undefined
+  >({
+    localStorageKey: ROW_HEIGHT_KEY,
+    queryKey: "threads_height",
+    defaultValue: ROW_HEIGHT.small,
+    queryParamConfig: StringParam,
+    syncQueryWithLocalStorageOnInit: true,
+  });
 
   const [filters = [], setFilters] = useQueryParam(
     `threads_filters`,

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
@@ -202,6 +202,8 @@ const COLUMNS_ORDER_KEY = "traces-columns-order";
 const COLUMNS_SORT_KEY_SUFFIX = "-columns-sort";
 const COLUMNS_SCORES_ORDER_KEY = "traces-scores-columns-order";
 const DYNAMIC_COLUMNS_KEY = "traces-dynamic-columns";
+const PAGINATION_SIZE_KEY = "traces-pagination-size";
+const ROW_HEIGHT_KEY = "traces-row-height";
 
 type TracesSpansTabProps = {
   type: TRACE_DATA_TYPE;
@@ -234,21 +236,29 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
     updateType: "replaceIn",
   });
 
-  const [size = 100, setSize] = useQueryParam("size", NumberParam, {
-    updateType: "replaceIn",
+  const [size, setSize] = useQueryParamAndLocalStorageState<
+    number | null | undefined
+  >({
+    localStorageKey: PAGINATION_SIZE_KEY,
+    queryKey: "size",
+    defaultValue: 100,
+    queryParamConfig: NumberParam,
+    syncQueryWithLocalStorageOnInit: true,
   });
 
   const [, setLastSection] = useQueryParam("lastSection", LastSectionParam, {
     updateType: "replaceIn",
   });
 
-  const [height = ROW_HEIGHT.small, setHeight] = useQueryParam(
-    "height",
-    StringParam,
-    {
-      updateType: "replaceIn",
-    },
-  );
+  const [height, setHeight] = useQueryParamAndLocalStorageState<
+    string | null | undefined
+  >({
+    localStorageKey: ROW_HEIGHT_KEY,
+    queryKey: "height",
+    defaultValue: ROW_HEIGHT.small,
+    queryParamConfig: StringParam,
+    syncQueryWithLocalStorageOnInit: true,
+  });
 
   const [filters = [], setFilters] = useQueryParam(
     `${type}_filters`,


### PR DESCRIPTION
## Details
- height is stored for all places where it is used
- pagination is saved only for tables

## Issues
https://github.com/comet-ml/opik/issues/1279
https://github.com/comet-ml/opik/issues/549

Resolves #

## Testing

## Documentation
