### PR TITLE
fix: Aggregate empty or incomplete GenAI responses

### DIFF
--- a/sdks/python/src/opik/integrations/genai/generations_aggregators.py
+++ b/sdks/python/src/opik/integrations/genai/generations_aggregators.py
@@ -6,12 +6,27 @@ from google.genai import types as genai_types
 def aggregate_response_content_items(
     items: List[genai_types.GenerateContentResponse],
 ) -> genai_types.GenerateContentResponse:
-    full_text = "".join([item.text for item in items if item.text is not None])
+    # Handle empty items list by returning an empty response
+    if not items:
+        return genai_types.GenerateContentResponse()
+
+    full_text = "".join([item.text for item in items if item and item.text is not None])
+
+    # Get a copy of the last item to preserve metadata
     last_item_with_metadata = items[-1].model_copy(deep=True)
 
-    if last_item_with_metadata.candidates:
+    # Update the text in the first candidate's first part, if they exist
+    if (
+        last_item_with_metadata.candidates
+        and last_item_with_metadata.candidates[0]
+        and last_item_with_metadata.candidates[0].content
+        and last_item_with_metadata.candidates[0].content.parts
+        and last_item_with_metadata.candidates[0].content.parts[0]
+    ):
         first_candidate = last_item_with_metadata.candidates[0]
         first_candidate.content.parts[0].text = full_text
+        # Replace candidates list with just the modified first candidate
         last_item_with_metadata.candidates = [first_candidate]
+    # If candidates or their structure is missing, the original candidates list is kept
 
     return last_item_with_metadata


### PR DESCRIPTION
This commit addresses an issue where the aggregation of GenerateContentResponse items would fail when the input list was empty or when candidate structures were incomplete.

The changes include:

- Handling the case of an empty items list by returning an empty GenerateContentResponse.
- Ensuring that the code gracefully handles missing candidate structures, preserving the original candidates list if necessary.

## Details

## Issues

Resolves #

## Testing

## Documentation
