### PR TITLE
Fix(api): remove unnecessary slash in endpoint URL

### DIFF
--- a/apps/opik-frontend/src/api/datasets/useDatasetItemByName.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetItemByName.ts
@@ -11,7 +11,7 @@ const getDatasetByName = async (
   { datasetName }: UseDatasetByNameParams,
 ) => {
   const response = await api.post<Dataset>(
-    `${DATASETS_REST_ENDPOINT}/retrieve`,
+    `${DATASETS_REST_ENDPOINT}retrieve`,
     {
       dataset_name: datasetName,
     },

--- a/apps/opik-frontend/src/api/datasets/useExperimentsFeedbackScoresNames.ts
+++ b/apps/opik-frontend/src/api/datasets/useExperimentsFeedbackScoresNames.ts
@@ -15,7 +15,7 @@ const getFeedbackScoresNames = async (
   { experimentsIds }: UseExperimentsFeedbackScoresNamesParams,
 ) => {
   const { data } = await api.get<FeedbackScoresNamesResponse>(
-    `${EXPERIMENTS_REST_ENDPOINT}/feedback-scores/names`,
+    `${EXPERIMENTS_REST_ENDPOINT}feedback-scores/names`,
     {
       signal,
       params: {

--- a/apps/opik-frontend/src/api/traces/useSpanCommentsBatchDeleteMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useSpanCommentsBatchDeleteMutation.ts
@@ -14,12 +14,9 @@ const useSpanCommentsBatchDeleteMutation = () => {
 
   return useMutation({
     mutationFn: async ({ ids }: UseSpanCommentsBatchDeleteMutationParams) => {
-      const { data } = await api.post(
-        `${SPANS_REST_ENDPOINT}/comments/delete`,
-        {
-          ids: ids,
-        },
-      );
+      const { data } = await api.post(`${SPANS_REST_ENDPOINT}comments/delete`, {
+        ids: ids,
+      });
       return data;
     },
     onError: (error) => {

--- a/apps/opik-frontend/src/api/traces/useSpansFeedbackScoresNames.ts
+++ b/apps/opik-frontend/src/api/traces/useSpansFeedbackScoresNames.ts
@@ -17,7 +17,7 @@ const getFeedbackScoresNames = async (
   { projectId, type }: UseSpansFeedbackScoresNamesParams,
 ) => {
   const { data } = await api.get<FeedbackScoresNamesResponse>(
-    `${SPANS_REST_ENDPOINT}/feedback-scores/names`,
+    `${SPANS_REST_ENDPOINT}feedback-scores/names`,
     {
       signal,
       params: {

--- a/apps/opik-frontend/src/api/traces/useTraceCommentsBatchDeleteMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTraceCommentsBatchDeleteMutation.ts
@@ -20,7 +20,7 @@ const useTraceCommentsBatchDeleteMutation = () => {
   return useMutation({
     mutationFn: async ({ ids }: UseTraceBatchDeleteMutationParams) => {
       const { data } = await api.post(
-        `${TRACES_REST_ENDPOINT}/comments/delete`,
+        `${TRACES_REST_ENDPOINT}comments/delete`,
         {
           ids: ids,
         },


### PR DESCRIPTION
## Details
The endpoint URL ${SPANS_REST_ENDPOINT}/feedback-scores/names had an issue where two consecutive slashes (//) were formed because the SPANS_REST_ENDPOINT already ends with a slash (/). This was causing an incorrect URL format.

## Issues
The endpoint URL was incorrectly formed due to double slashes (//) in the URL.

Resolves #2184  

## Testing
Verified that the correct endpoint URL is now formed without consecutive slashes.

Checked the functionality to ensure the API call works as expected after fixing the URL.

## Documentation
No changes to external documentation required.