### PR TITLE
[OPIK-1542] Fix formating for markdown with extra spaces

### DIFF
--- a/apps/opik-frontend/src/components/shared/MarkdownPreview/MarkdownPreview.tsx
+++ b/apps/opik-frontend/src/components/shared/MarkdownPreview/MarkdownPreview.tsx
@@ -27,7 +27,11 @@ export const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({
       </ReactMarkdown>
     );
   } else {
-    return <div className={cn("comet-markdown", className)}>{children}</div>;
+    return (
+      <div className={cn("comet-markdown whitespace-pre-wrap", className)}>
+        {children}
+      </div>
+    );
   }
 };
 

--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -320,13 +320,12 @@
   font-weight: 400;
   letter-spacing: 0.02em;
   max-width: 100%;
-  white-space: pre-wrap;
   overflow-wrap: break-word;
   word-break: break-word;
 
   pre code {
     font-size: 0.875rem !important;
-    white-space: pre-wrap;
+    white-space: preserve-breaks;
     overflow-wrap: break-word;
     word-break: break-word;
   }


### PR DESCRIPTION
## Details
![image](https://github.com/user-attachments/assets/c5f8e3da-326c-410b-9508-d71083690643)
![image](https://github.com/user-attachments/assets/0f3f3ca0-47db-41f9-9cac-4948daea718b)


## Issues

Resolves #

## Testing

## Documentation
