### PR TITLE
Optimizer: add optimizer name in "Optimization runs"

### DIFF
--- a/sdks/opik_optimizer/src/opik_optimizer/evolutionary_optimizer/evolutionary_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/evolutionary_optimizer/evolutionary_optimizer.py
@@ -706,7 +706,9 @@ Ensure a good mix of variations, all targeting the specified output style from t
         opik_optimization_run = None
         try:
             opik_optimization_run = self._opik_client.create_optimization(
-                dataset_name=opik_dataset_obj.name, objective_name=metric_config.metric.name
+                dataset_name=opik_dataset_obj.name,
+                objective_name=metric_config.metric.name,
+                metadata={"optimizer": self.__class__.__name__},
             )
             self._current_optimization_id = opik_optimization_run.id
             logger.info(f"Created Opik Optimization run with ID: {self._current_optimization_id}")

--- a/sdks/opik_optimizer/src/opik_optimizer/few_shot_bayesian_optimizer/few_shot_bayesian_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/few_shot_bayesian_optimizer/few_shot_bayesian_optimizer.py
@@ -295,6 +295,7 @@ class FewShotBayesianOptimizer(base_optimizer.BaseOptimizer):
             optimization = self._opik_client.create_optimization(
                 dataset_name=dataset.name,
                 objective_name=metric_config.metric.name,
+                metadata={"optimizer": self.__class__.__name__},
             )
         except Exception:
             logger.warning(

--- a/sdks/opik_optimizer/src/opik_optimizer/meta_prompt_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/meta_prompt_optimizer.py
@@ -474,7 +474,9 @@ class MetaPromptOptimizer(BaseOptimizer):
         optimization = None
         try:
             optimization = self._opik_client.create_optimization(
-                dataset_name=dataset.name, objective_name=metric_config.metric.name
+                dataset_name=dataset.name,
+                objective_name=metric_config.metric.name,
+                metadata={"optimizer": self.__class__.__name__},
             )
             logger.info(f"Created optimization with ID: {optimization.id}")
         except Exception as e:

--- a/sdks/opik_optimizer/src/opik_optimizer/mipro_optimizer/mipro_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/mipro_optimizer/mipro_optimizer.py
@@ -205,6 +205,7 @@ class MiproOptimizer(BaseOptimizer):
             optimization = self._opik_client.create_optimization(
                 dataset_name=dataset.name,
                 objective_name=metric_config.metric.name,
+                metadata={"optimizer": self.__class__.__name__},
             )
         except Exception:
             logger.warning(

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -1107,6 +1107,7 @@ class Opik:
         dataset_name: str,
         objective_name: str,
         name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> optimization.Optimization:
         id = id_helpers.generate_id()
 
@@ -1116,6 +1117,7 @@ class Opik:
             dataset_name=dataset_name,
             objective_name=objective_name,
             status="running",
+            metadata=metadata,
         )
 
         optimization_client = optimization.Optimization(


### PR DESCRIPTION
## Details

This PR sends the optimizer name (`MiproOptimizer`, `MetaPromptOptimizer`, etc.) in the metadata when creating an optimization.

The goal is to have the FE display the name in Optimization rows:

![image](https://github.com/user-attachments/assets/0eb1655c-b9bd-4754-9da6-66adf9a59b7f)

## Issues

@alexkuzmik I'm not sure about making the Python Typings match. 

Once this is merged, then the frontend can get the name out of the metadata to display in the rows.