### PR TITLE
OPIK-1510: Minimal Span field ingestion

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Span.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Span.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMin;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
@@ -37,7 +36,7 @@ public record Span(
         @JsonView({Span.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) UUID projectId,
         @JsonView({Span.View.Public.class, Span.View.Write.class}) @NotNull UUID traceId,
         @JsonView({Span.View.Public.class, Span.View.Write.class}) UUID parentSpanId,
-        @JsonView({Span.View.Public.class, Span.View.Write.class}) @NotBlank String name,
+        @JsonView({Span.View.Public.class, Span.View.Write.class}) String name,
         @JsonView({Span.View.Public.class, Span.View.Write.class}) @NotNull SpanType type,
         @JsonView({Span.View.Public.class, Span.View.Write.class}) @NotNull Instant startTime,
         @JsonView({Span.View.Public.class, Span.View.Write.class}) Instant endTime,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/SpanUpdate.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/SpanUpdate.java
@@ -26,6 +26,7 @@ public record SpanUpdate(
         @Schema(description = "If null and project_name not specified, Default Project is assumed") UUID projectId,
         @NotNull UUID traceId,
         UUID parentSpanId,
+        String name,
         Instant endTime,
         @Schema(implementation = JsonListString.class) JsonNode input,
         @Schema(implementation = JsonListString.class) JsonNode output,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
@@ -22,7 +22,6 @@ import jakarta.inject.Singleton;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -64,16 +63,6 @@ public class SpanService {
         searchCriteria = findProjectAndVerifyVisibility(searchCriteria);
 
         return spanDAO.find(page, size, searchCriteria);
-    }
-
-    private Mono<List<Project>> findProject(SpanSearchCriteria searchCriteria) {
-        return Mono.deferContextual(ctx -> {
-            String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
-
-            return Mono
-                    .fromCallable(() -> projectService.findByNames(workspaceId, List.of(searchCriteria.projectName())))
-                    .subscribeOn(Schedulers.boundedElastic());
-        });
     }
 
     private SpanSearchCriteria findProjectAndVerifyVisibility(SpanSearchCriteria searchCriteria) {
@@ -118,8 +107,7 @@ public class SpanService {
     private Mono<UUID> insertSpan(Span span, Project project, UUID id, Span partialExistingSpan) {
         return Mono.defer(() -> {
             // Check if a partial span exists caused by a patch request, if so, proceed to insert.
-            if (StringUtils.isBlank(partialExistingSpan.name())
-                    && Instant.EPOCH.equals(partialExistingSpan.startTime())
+            if (Instant.EPOCH.equals(partialExistingSpan.startTime())
                     && partialExistingSpan.type() == null) {
                 return create(span, project, id);
             }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -3,6 +3,7 @@ package com.comet.opik.api.resources.v1.priv;
 import com.comet.opik.api.BatchDelete;
 import com.comet.opik.api.Comment;
 import com.comet.opik.api.DeleteFeedbackScore;
+import com.comet.opik.api.ErrorInfo;
 import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.FeedbackScoreBatch;
 import com.comet.opik.api.FeedbackScoreBatchItem;
@@ -42,6 +43,7 @@ import com.comet.opik.api.resources.utils.spans.StatsTestAssertion;
 import com.comet.opik.api.sorting.Direction;
 import com.comet.opik.api.sorting.SortableFields;
 import com.comet.opik.api.sorting.SortingField;
+import com.comet.opik.domain.FeedbackScoreMapper;
 import com.comet.opik.domain.SpanMapper;
 import com.comet.opik.domain.SpanType;
 import com.comet.opik.domain.cost.CostService;
@@ -146,7 +148,6 @@ import static com.comet.opik.api.resources.utils.TestHttpClientUtils.PROJECT_NOT
 import static com.comet.opik.api.resources.utils.TestHttpClientUtils.UNAUTHORIZED_RESPONSE;
 import static com.comet.opik.api.resources.utils.TestUtils.toURLEncodedQueryParam;
 import static com.comet.opik.api.resources.utils.spans.SpanAssertions.IGNORED_FIELDS;
-import static com.comet.opik.api.resources.utils.spans.SpanAssertions.IGNORED_FIELDS_SCORES;
 import static com.comet.opik.api.resources.utils.spans.SpanAssertions.assertSpan;
 import static com.comet.opik.domain.ProjectService.DEFAULT_PROJECT;
 import static com.comet.opik.domain.SpanService.PARENT_SPAN_IS_MISMATCH;
@@ -167,7 +168,6 @@ import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -274,32 +274,6 @@ class SpansResourceTest {
         AuthTestUtils.mockGetWorkspaceIdByName(wireMock.server(), workspaceName, workspaceId);
     }
 
-    private UUID getProjectId(String projectName, String workspaceName, String apiKey) {
-        return client.target("%s/v1/private/projects".formatted(baseURI))
-                .queryParam("name", projectName)
-                .request()
-                .header(HttpHeaders.AUTHORIZATION, apiKey)
-                .header(WORKSPACE_HEADER, workspaceName)
-                .get()
-                .readEntity(Project.ProjectPage.class)
-                .content()
-                .stream()
-                .findFirst()
-                .orElseThrow()
-                .id();
-    }
-
-    private void createProject(String projectName, String workspaceName, String apiKey) {
-        try (Response response = client.target("%s/v1/private/projects".formatted(baseURI))
-                .request()
-                .header(HttpHeaders.AUTHORIZATION, apiKey)
-                .header(WORKSPACE_HEADER, workspaceName)
-                .post(Entity.json(Project.builder().name(projectName).build()))) {
-
-            assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(201);
-        }
-    }
-
     @Nested
     @DisplayName("Api Key Authentication:")
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -368,7 +342,7 @@ class SpansResourceTest {
 
             var span = podamFactory.manufacturePojo(Span.class);
 
-            var spanId = createAndAssert(span, okApikey, workspaceName);
+            var spanId = spanResourceClient.createSpan(span, okApikey, workspaceName);
 
             var update = podamFactory.manufacturePojo(SpanUpdate.class).toBuilder()
                     .parentSpanId(span.parentSpanId())
@@ -397,7 +371,7 @@ class SpansResourceTest {
 
             var span = podamFactory.manufacturePojo(Span.class);
 
-            var spanId = createAndAssert(span, okApikey, workspaceName);
+            var spanId = spanResourceClient.createSpan(span, okApikey, workspaceName);
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
                     .path(spanId.toString())
@@ -421,7 +395,7 @@ class SpansResourceTest {
 
             var span = podamFactory.manufacturePojo(Span.class);
 
-            var spanId = createAndAssert(span, okApikey, workspaceName);
+            var spanId = spanResourceClient.createSpan(span, okApikey, workspaceName);
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
                     .path(spanId.toString())
@@ -458,7 +432,7 @@ class SpansResourceTest {
 
             var span = podamFactory.manufacturePojo(Span.class).toBuilder().projectName(project.name()).build();
 
-            createAndAssert(span, okApikey, workspaceName);
+            spanResourceClient.createSpan(span, okApikey, workspaceName);
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
                     .queryParam("project_name", span.projectName())
@@ -492,7 +466,7 @@ class SpansResourceTest {
             mockGetWorkspaceIdByName(workspaceName, workspaceId);
 
             var span = podamFactory.manufacturePojo(Span.class).toBuilder().projectName(project.name()).build();
-            createAndAssert(span, okApikey, workspaceName);
+            spanResourceClient.createSpan(span, okApikey, workspaceName);
 
             spanResourceClient.getSpansStats(project.name(), null, List.of(), apiKey, workspaceName, Map.of(),
                     expectedCode);
@@ -512,7 +486,7 @@ class SpansResourceTest {
             mockGetWorkspaceIdByName(workspaceName, workspaceId);
 
             var span = podamFactory.manufacturePojo(Span.class).toBuilder().projectName(project.name()).build();
-            createAndAssert(span, okApikey, workspaceName);
+            spanResourceClient.createSpan(span, okApikey, workspaceName);
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI) + "/feedback-scores/names")
                     .queryParam("project_id", projectId)
@@ -539,7 +513,7 @@ class SpansResourceTest {
 
             var span = podamFactory.manufacturePojo(Span.class);
 
-            var spanId = createAndAssert(span, okApikey, workspaceName);
+            var spanId = spanResourceClient.createSpan(span, okApikey, workspaceName);
 
             var feedbackScore = podamFactory.manufacturePojo(FeedbackScore.class);
 
@@ -565,7 +539,7 @@ class SpansResourceTest {
 
             var span = podamFactory.manufacturePojo(Span.class);
 
-            var spanId = createAndAssert(span, okApikey, workspaceName);
+            var spanId = spanResourceClient.createSpan(span, okApikey, workspaceName);
 
             var feedbackScore = podamFactory.manufacturePojo(FeedbackScore.class);
 
@@ -594,7 +568,7 @@ class SpansResourceTest {
 
             var span = podamFactory.manufacturePojo(Span.class);
 
-            var spanId = createAndAssert(span, okApikey, workspaceName);
+            var spanId = spanResourceClient.createSpan(span, okApikey, workspaceName);
 
             var items = PodamFactoryUtils.manufacturePojoList(podamFactory, FeedbackScoreBatchItem.class)
                     .stream()
@@ -634,7 +608,7 @@ class SpansResourceTest {
             var span = podamFactory.manufacturePojo(Span.class).toBuilder().projectId(null).projectName(project.name())
                     .build();
 
-            createAndAssert(span, okApikey, workspaceName);
+            spanResourceClient.createSpan(span, okApikey, workspaceName);
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
                     .path("/search")
@@ -735,7 +709,7 @@ class SpansResourceTest {
 
             mockTargetWorkspace(API_KEY, workspaceName, WORKSPACE_ID);
 
-            var spanId = createAndAssert(span, API_KEY, workspaceName);
+            var spanId = spanResourceClient.createSpan(span, API_KEY, workspaceName);
 
             var update = podamFactory.manufacturePojo(SpanUpdate.class).toBuilder()
                     .parentSpanId(span.parentSpanId())
@@ -764,7 +738,7 @@ class SpansResourceTest {
 
             var span = podamFactory.manufacturePojo(Span.class);
 
-            var spanId = createAndAssert(span, API_KEY, workspaceName);
+            var spanId = spanResourceClient.createSpan(span, API_KEY, workspaceName);
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
                     .path(spanId.toString())
@@ -787,7 +761,7 @@ class SpansResourceTest {
 
             var span = podamFactory.manufacturePojo(Span.class);
 
-            var spanId = createAndAssert(span, API_KEY, workspaceName);
+            var spanId = spanResourceClient.createSpan(span, API_KEY, workspaceName);
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
                     .path(spanId.toString())
@@ -825,7 +799,7 @@ class SpansResourceTest {
             projectResourceClient.createProject(project, apiKey, workspaceName);
 
             var span = podamFactory.manufacturePojo(Span.class).toBuilder().projectName(project.name()).build();
-            createAndAssert(span, apiKey, workspaceName);
+            spanResourceClient.createSpan(span, apiKey, workspaceName);
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
                     .queryParam("project_name", span.projectName())
@@ -861,7 +835,7 @@ class SpansResourceTest {
             projectResourceClient.createProject(project, apiKey, workspaceName);
 
             var span = podamFactory.manufacturePojo(Span.class).toBuilder().projectName(project.name()).build();
-            createAndAssert(span, apiKey, workspaceName);
+            spanResourceClient.createSpan(span, apiKey, workspaceName);
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI) + "/stats")
                     .queryParam("project_name", span.projectName())
@@ -894,7 +868,7 @@ class SpansResourceTest {
             var projectId = projectResourceClient.createProject(project, apiKey, workspaceName);
 
             var span = podamFactory.manufacturePojo(Span.class).toBuilder().projectName(project.name()).build();
-            createAndAssert(span, apiKey, workspaceName);
+            spanResourceClient.createSpan(span, apiKey, workspaceName);
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI) + "/feedback-scores/names")
                     .queryParam("project_id", projectId)
@@ -920,7 +894,7 @@ class SpansResourceTest {
 
             mockTargetWorkspace(API_KEY, workspaceName, WORKSPACE_ID);
 
-            var spanId = createAndAssert(span, API_KEY, workspaceName);
+            var spanId = spanResourceClient.createSpan(span, API_KEY, workspaceName);
 
             var feedbackScore = podamFactory.manufacturePojo(FeedbackScore.class);
 
@@ -946,7 +920,7 @@ class SpansResourceTest {
 
             mockTargetWorkspace(API_KEY, workspaceName, WORKSPACE_ID);
 
-            var spanId = createAndAssert(span, API_KEY, workspaceName);
+            var spanId = spanResourceClient.createSpan(span, API_KEY, workspaceName);
 
             var feedbackScore = podamFactory.manufacturePojo(FeedbackScore.class);
 
@@ -975,7 +949,7 @@ class SpansResourceTest {
 
             mockTargetWorkspace(API_KEY, workspaceName, WORKSPACE_ID);
 
-            var spanId = createAndAssert(span, API_KEY, workspaceName);
+            var spanId = spanResourceClient.createSpan(span, API_KEY, workspaceName);
 
             var items = PodamFactoryUtils.manufacturePojoList(podamFactory, FeedbackScoreBatchItem.class)
                     .stream()
@@ -1017,7 +991,7 @@ class SpansResourceTest {
             projectResourceClient.createProject(project, apiKey, workspaceName);
 
             var span = podamFactory.manufacturePojo(Span.class).toBuilder().projectName(project.name()).build();
-            createAndAssert(span, apiKey, workspaceName);
+            spanResourceClient.createSpan(span, apiKey, workspaceName);
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
                     .path("/search")
@@ -1390,7 +1364,7 @@ class SpansResourceTest {
                     .parentSpanId(null)
                     .build());
             unexpectedSpans.forEach(
-                    expectedSpan -> SpansResourceTest.this.createAndAssert(expectedSpan, apiKey, workspaceName));
+                    expectedSpan -> spanResourceClient.createSpan(expectedSpan, apiKey, workspaceName));
 
             getAndAssertPage(
                     workspaceName,
@@ -1454,7 +1428,7 @@ class SpansResourceTest {
                     .parentSpanId(null)
                     .build());
             unexpectedSpans.forEach(
-                    expectedSpan -> SpansResourceTest.this.createAndAssert(expectedSpan, apiKey, workspaceName));
+                    expectedSpan -> spanResourceClient.createSpan(expectedSpan, apiKey, workspaceName));
 
             getAndAssertPage(
                     workspaceName,
@@ -1521,7 +1495,7 @@ class SpansResourceTest {
                     .parentSpanId(null)
                     .build());
             unexpectedSpans.forEach(
-                    expectedSpan -> SpansResourceTest.this.createAndAssert(expectedSpan, apiKey, workspaceName));
+                    expectedSpan -> spanResourceClient.createSpan(expectedSpan, apiKey, workspaceName));
 
             getAndAssertPage(
                     workspaceName,
@@ -1593,7 +1567,7 @@ class SpansResourceTest {
                     .type(findOtherSpanType(expectedType))
                     .build());
             unexpectedSpans.forEach(
-                    expectedSpan -> SpansResourceTest.this.createAndAssert(expectedSpan, apiKey, workspaceName));
+                    expectedSpan -> spanResourceClient.createSpan(expectedSpan, apiKey, workspaceName));
 
             getAndAssertPage(
                     workspaceName,
@@ -4627,10 +4601,6 @@ class SpansResourceTest {
         SpanAssertions.assertSpan(actualPage.content(), expectedSpans, unexpectedSpans, USER);
     }
 
-    private UUID createAndAssert(Span expectedSpan, String apiKey, String workspaceName) {
-        return spanResourceClient.createSpan(expectedSpan, apiKey, workspaceName);
-    }
-
     private void createAndAssert(UUID entityId, FeedbackScore score, String workspaceName, String apiKey) {
         spanResourceClient.feedbackScore(entityId, score, workspaceName, apiKey);
     }
@@ -4649,7 +4619,9 @@ class SpansResourceTest {
 
         @Test
         void createAndGetById() {
-            var expectedSpan = podamFactory.manufacturePojo(Span.class);
+            var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .feedbackScores(null)
+                    .build();
             spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
@@ -4668,10 +4640,11 @@ class SpansResourceTest {
             var spanStr = customObjectMapper.writeValueAsString(span);
             spanResourceClient.createSpan(spanStr, API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
 
-            getAndAssert(
-                    expectedSpan.toBuilder().input(JsonUtils.getJsonNodeFromString("{\"value\": \"Infinity\"}"))
-                            .build(),
-                    API_KEY, TEST_WORKSPACE);
+            expectedSpan = expectedSpan.toBuilder()
+                    .input(JsonUtils.getJsonNodeFromString("{\"value\": \"Infinity\"}"))
+                    .feedbackScores(null)
+                    .build();
+            getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
         }
 
         @ParameterizedTest
@@ -4684,6 +4657,7 @@ class SpansResourceTest {
                     .metadata(metadata)
                     .usage(usage)
                     .totalEstimatedCost(manualCost)
+                    .feedbackScores(null)
                     .build();
             spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
@@ -4814,6 +4788,7 @@ class SpansResourceTest {
             var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
                     .input(JsonUtils.readTree(jsonMap))
                     .output(JsonUtils.readTree(jsonMap))
+                    .feedbackScores(null)
                     .build();
             spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
@@ -4822,28 +4797,23 @@ class SpansResourceTest {
 
         @Test
         void createOnlyRequiredFieldsAndGetById() {
-            var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
-                    .projectName(null)
-                    .id(null)
-                    .parentSpanId(null)
-                    .endTime(null)
-                    .input(null)
-                    .output(null)
-                    .metadata(null)
-                    .tags(null)
-                    .usage(null)
+            var expectedSpan = Span.builder()
+                    .traceId(generator.generate())
+                    .type(RandomTestUtils.randomEnumValue(SpanType.class))
+                    .startTime(Instant.now())
+                    .createdAt(Instant.now())
                     .build();
             var expectedSpanId = spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
-            getAndAssert(expectedSpan.toBuilder()
-                    .id(expectedSpanId)
-                    .projectName(DEFAULT_PROJECT)
-                    .build(), API_KEY, TEST_WORKSPACE);
+            expectedSpan = expectedSpan.toBuilder().id(expectedSpanId).projectName(DEFAULT_PROJECT).build();
+            getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
         }
 
         @Test
         void createSpansWithSameIdIdempotent() {
-            var span1 = podamFactory.manufacturePojo(Span.class);
+            var span1 = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .feedbackScores(null)
+                    .build();
             spanResourceClient.createSpan(span1, API_KEY, TEST_WORKSPACE);
 
             var span2 = podamFactory.manufacturePojo(Span.class).toBuilder()
@@ -4886,7 +4856,7 @@ class SpansResourceTest {
 
             spanResourceClient.createSpan(span, API_KEY, TEST_WORKSPACE);
 
-            var expectedSpanBuilder = span.toBuilder();
+            var expectedSpanBuilder = span.toBuilder().feedbackScores(null);
             SpanMapper.INSTANCE.updateSpanBuilder(expectedSpanBuilder, spanUpdate);
             getAndAssert(expectedSpanBuilder.build(), API_KEY, TEST_WORKSPACE);
         }
@@ -4938,19 +4908,17 @@ class SpansResourceTest {
         @MethodSource("com.comet.opik.api.resources.utils.QuotaLimitTestUtils#quotaLimitsTestProvider")
         void testQuotasLimit_whenLimitIsEmptyOrNotReached_thenAcceptCreation(
                 List<Quota> quotas, boolean isLimitReached) {
-            var workspaceName = RandomStringUtils.secure().nextAlphanumeric(10);
+            var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
             var workspaceId = UUID.randomUUID().toString();
-
             AuthTestUtils.mockTargetWorkspace(wireMock.server(), API_KEY, workspaceName, workspaceId, USER, quotas);
 
             var span = podamFactory.manufacturePojo(Span.class);
-
             var expectedStatus = isLimitReached ? HttpStatus.SC_PAYMENT_REQUIRED : HttpStatus.SC_CREATED;
 
             try (var actualResponse = spanResourceClient.createSpan(span, API_KEY, workspaceName, expectedStatus)) {
                 if (isLimitReached) {
-                    var expectedError = new io.dropwizard.jersey.errors.ErrorMessage(HttpStatus.SC_PAYMENT_REQUIRED,
-                            ERR_USAGE_LIMIT_EXCEEDED);
+                    var expectedError = new io.dropwizard.jersey.errors.ErrorMessage(
+                            HttpStatus.SC_PAYMENT_REQUIRED, ERR_USAGE_LIMIT_EXCEEDED);
                     var actualError = actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class);
                     assertThat(actualError).isEqualTo(expectedError);
                 }
@@ -4969,137 +4937,74 @@ class SpansResourceTest {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class BatchInsert {
 
+        Stream<Arguments> batch__whenCreateSpans__thenReturnNoContent() {
+            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            return Stream.of(
+                    arguments(projectName, projectName),
+                    arguments(null, DEFAULT_PROJECT));
+        }
+
         @ParameterizedTest
         @MethodSource
-        void batch__whenCreateSpans__thenReturnNoContent(Function<String, String> projectNameModifier) {
+        void batch__whenCreateSpans__thenReturnNoContent(String projectName, String expectedProjectName) {
+            // Use dedicated workspace to avoid collisions with other tests in the default project
+            var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(API_KEY, workspaceName, workspaceId);
 
-            String projectName = UUID.randomUUID().toString();
-            createProject(projectName, TEST_WORKSPACE, API_KEY);
-
-            var expectedSpans = IntStream.range(0, 1000)
-                    .mapToObj(i -> podamFactory.manufacturePojo(Span.class).toBuilder()
-                            .projectId(null)
-                            .projectName(projectNameModifier.apply(projectName))
+            var expectedSpans = PodamFactoryUtils.manufacturePojoList(podamFactory, Span.class).stream()
+                    .map(i -> podamFactory.manufacturePojo(Span.class).toBuilder()
+                            .projectName(projectName)
                             .parentSpanId(null)
                             .feedbackScores(null)
                             .build())
                     .toList();
+            spanResourceClient.batchCreateSpans(expectedSpans, API_KEY, workspaceName);
 
-            batchCreateAndAssert(expectedSpans, API_KEY, TEST_WORKSPACE);
-
-            getAndAssertPage(TEST_WORKSPACE, projectName, List.of(), List.of(), expectedSpans.reversed(), List.of(),
-                    API_KEY, List.of(), List.of());
-        }
-
-        Stream<Arguments> batch__whenCreateSpans__thenReturnNoContent() {
-            return getProjectNameModifierArg();
-        }
-
-        @Test
-        void batch__whenSpansProjectNameIsNull__thenUserDefaultProjectAndReturnNoContent() {
-
-            String apiKey = UUID.randomUUID().toString();
-            String workspaceName = UUID.randomUUID().toString();
-            String workspaceId = UUID.randomUUID().toString();
-
-            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
-
-            var expectedSpans = PodamFactoryUtils.manufacturePojoList(podamFactory, Span.class).stream()
-                    .map(span -> span.toBuilder()
-                            .projectName(null)
-                            .endTime(null)
-                            .usage(null)
-                            .feedbackScores(null)
-                            .duration(null)
-                            .build())
-                    .toList();
-
-            batchCreateAndAssert(expectedSpans, apiKey, workspaceName);
-
-            getAndAssertPage(workspaceName, DEFAULT_PROJECT, List.of(), List.of(), expectedSpans.reversed(), List.of(),
-                    apiKey, List.of(), List.of());
+            getAndAssertPage(
+                    workspaceName,
+                    expectedProjectName.toUpperCase(),
+                    List.of(),
+                    List.of(),
+                    expectedSpans.reversed(),
+                    List.of(),
+                    API_KEY,
+                    List.of(),
+                    List.of());
         }
 
         @Test
         void batch__whenSendingMultipleSpansWithSameId__thenReturn422() {
-            var expectedSpans = List.of(podamFactory.manufacturePojo(Span.class).toBuilder()
-                    .projectId(null)
-                    .parentSpanId(null)
-                    .feedbackScores(null)
-                    .build());
+            var id = generator.generate();
+            var spans = PodamFactoryUtils.manufacturePojoList(podamFactory, Span.class).stream()
+                    .map(span -> span.toBuilder()
+                            .id(id)
+                            .build())
+                    .toList();
+            try (var actualResponse = spanResourceClient.callBatchCreateSpans(spans, API_KEY, TEST_WORKSPACE)) {
 
-            var expectedSpan = expectedSpans.getFirst().toBuilder()
-                    .tags(Set.of())
-                    .endTime(Instant.now())
-                    .output(JsonUtils.getJsonNodeFromString("{ \"output\": \"data\"}"))
-                    .build();
-
-            List<Span> expectedSpans1 = List.of(expectedSpans.getFirst(), expectedSpan);
-
-            try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
-                    .path("batch")
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .post(Entity.json(SpanBatch.builder().spans(expectedSpans1).build()))) {
-
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(422);
+                assertThat(actualResponse.getStatusInfo().getStatusCode())
+                        .isEqualTo(HttpStatus.SC_UNPROCESSABLE_ENTITY);
                 assertThat(actualResponse.hasEntity()).isTrue();
-
-                var errorMessage = actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class);
-                assertThat(errorMessage.getMessage()).isEqualTo("Duplicate span id '%s'".formatted(expectedSpan.id()));
+                var actualErrorMessage = actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class);
+                var expectedErrorMessage = new io.dropwizard.jersey.errors.ErrorMessage(
+                        HttpStatus.SC_UNPROCESSABLE_ENTITY, "Duplicate span id '%s'".formatted(id));
+                assertThat(actualErrorMessage).isEqualTo(expectedErrorMessage);
             }
-        }
-
-        @ParameterizedTest
-        @MethodSource
-        void batch__whenBatchIsInvalid__thenReturn422(List<Span> spans, String errorMessage) {
-
-            try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
-                    .path("batch")
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .post(Entity.json(new SpanBatch(spans)))) {
-
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(422);
-                assertThat(actualResponse.hasEntity()).isTrue();
-
-                var responseBody = actualResponse.readEntity(ErrorMessage.class);
-                assertThat(responseBody.errors()).contains(errorMessage);
-            }
-        }
-
-        Stream<Arguments> batch__whenBatchIsInvalid__thenReturn422() {
-            return Stream.of(
-                    Arguments.of(List.of(), "spans size must be between 1 and 1000"),
-                    Arguments.of(IntStream.range(0, 1001)
-                            .mapToObj(i -> podamFactory.manufacturePojo(Span.class).toBuilder()
-                                    .projectId(null)
-                                    .parentSpanId(null)
-                                    .feedbackScores(null)
-                                    .build())
-                            .toList(), "spans size must be between 1 and 1000"));
         }
 
         @Test
-        void batch__whenSendingMultipleSpansWithNoId__thenReturnNoContent() {
-            var newSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
-                    .projectId(null)
-                    .id(null)
-                    .parentSpanId(null)
-                    .feedbackScores(null)
-                    .build();
-
-            var expectedSpan = newSpan.toBuilder()
-                    .tags(Set.of())
-                    .endTime(Instant.now())
-                    .output(JsonUtils.getJsonNodeFromString("{ \"output\": \"data\"}"))
-                    .build();
-
-            List<Span> expectedSpans = List.of(newSpan, expectedSpan);
-
-            batchCreateAndAssert(expectedSpans, API_KEY, TEST_WORKSPACE);
+        void batch__whenMissingFields__thenReturnNoContent() {
+            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var expectedSpans = IntStream.range(0, 5)
+                    .mapToObj(i -> Span.builder()
+                            .projectName(projectName)
+                            .traceId(generator.generate())
+                            .type(RandomTestUtils.randomEnumValue(SpanType.class))
+                            .startTime(Instant.now())
+                            .build())
+                    .toList();
+            spanResourceClient.batchCreateSpans(expectedSpans, API_KEY, TEST_WORKSPACE);
         }
 
         @Test
@@ -5158,7 +5063,6 @@ class SpansResourceTest {
                             .projectName(projectName)
                             .id(generator.generate())
                             .traceId(generator.generate())
-                            .name("name-00-" + RandomStringUtils.secure().nextAlphanumeric(32))
                             .type(RandomTestUtils.randomEnumValue(SpanType.class))
                             .startTime(Instant.now())
                             .createdAt(Instant.now())
@@ -5262,14 +5166,13 @@ class SpansResourceTest {
         @MethodSource("com.comet.opik.api.resources.utils.QuotaLimitTestUtils#quotaLimitsTestProvider")
         void testQuotasLimit_whenLimitIsEmptyOrNotReached_thenAcceptCreation(
                 List<Quota> quotas, boolean isLimitReached) {
-            var workspaceName = RandomStringUtils.secure().nextAlphanumeric(10);
+            var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
             var workspaceId = UUID.randomUUID().toString();
-
             AuthTestUtils.mockTargetWorkspace(wireMock.server(), API_KEY, workspaceName, workspaceId, USER, quotas);
 
             var span = podamFactory.manufacturePojo(Span.class);
-
             try (var actualResponse = spanResourceClient.callBatchCreateSpans(List.of(span), API_KEY, workspaceName)) {
+
                 if (isLimitReached) {
                     assertThat(actualResponse.getStatus()).isEqualTo(HttpStatus.SC_PAYMENT_REQUIRED);
                     var expectedError = new io.dropwizard.jersey.errors.ErrorMessage(HttpStatus.SC_PAYMENT_REQUIRED,
@@ -5283,32 +5186,18 @@ class SpansResourceTest {
         }
     }
 
-    private void batchCreateAndAssert(List<Span> expectedSpans, String apiKey, String workspaceName) {
-        spanResourceClient.batchCreateSpans(expectedSpans, apiKey, workspaceName);
+    private Span getAndAssert(Span expectedSpan, String apiKey, String workspaceName) {
+        return getAndAssert(expectedSpan, null, apiKey, workspaceName);
     }
 
-    private Span getAndAssert(Span expectedSpan, String apiKey, String workspaceName) {
+    private Span getAndAssert(Span expectedSpan, UUID expectedProjectId, String apiKey, String workspaceName) {
         var actualSpan = spanResourceClient.getById(expectedSpan.id(), workspaceName, apiKey);
-        assertThat(actualSpan)
-                .usingRecursiveComparison()
-                .ignoringFields(IGNORED_FIELDS)
-                .ignoringCollectionOrderInFields("tags")
-                .isEqualTo(expectedSpan);
-        assertThat(actualSpan.projectId()).isNotNull();
-        assertThat(actualSpan.projectName()).isEqualTo(expectedSpan.projectName());
-        assertThat(actualSpan.createdAt()).isAfter(expectedSpan.createdAt());
-        assertThat(actualSpan.lastUpdatedAt())
-                // Some JVMs can resolve higher than microseconds, such as nanoseconds in the Ubuntu AMD64 JVM
-                .isAfterOrEqualTo(expectedSpan.lastUpdatedAt().truncatedTo(ChronoUnit.MICROS));
-        assertThat(actualSpan.createdBy()).isEqualTo(USER);
-        assertThat(actualSpan.lastUpdatedBy()).isEqualTo(USER);
-        var expected = DurationUtils.getDurationInMillisWithSubMilliPrecision(
-                expectedSpan.startTime(), expectedSpan.endTime());
-        if (actualSpan.duration() == null || expected == null) {
-            assertThat(actualSpan.duration()).isEqualTo(expected);
+        if (expectedProjectId == null) {
+            assertThat(actualSpan.projectId()).isNotNull();
         } else {
-            assertThat(actualSpan.duration()).isEqualTo(expected, within(0.001));
+            assertThat(actualSpan.projectId()).isEqualTo(expectedProjectId);
         }
+        SpanAssertions.assertSpan(List.of(actualSpan), List.of(expectedSpan), USER);
         return actualSpan;
     }
 
@@ -5370,9 +5259,9 @@ class SpansResourceTest {
                     .projectName(null)
                     .parentSpanId(null)
                     .build();
-            var expectedSpanUpdate = podamFactory.manufacturePojo(SpanUpdate.class);
-            createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
+            var expectedSpanUpdate = podamFactory.manufacturePojo(SpanUpdate.class);
             var spanUpdate = expectedSpanUpdate.toBuilder()
                     .projectId(null)
                     .projectName(expectedSpan.projectName())
@@ -5382,42 +5271,41 @@ class SpansResourceTest {
             spanResourceClient.updateSpan(expectedSpan.id(), spanUpdate, API_KEY, TEST_WORKSPACE);
 
             var expectedSpanBuilder = expectedSpan.toBuilder()
-                    .projectName(DEFAULT_PROJECT);
+                    .projectName(DEFAULT_PROJECT)
+                    .feedbackScores(null);
             SpanMapper.INSTANCE.updateSpanBuilder(expectedSpanBuilder, spanUpdate);
             getAndAssert(expectedSpanBuilder.build(), API_KEY, TEST_WORKSPACE);
         }
 
-        static Stream<SpanUpdate> update__whenFieldIsNotNull__thenAcceptUpdate() {
+        Stream<SpanUpdate> update__whenFieldIsNotNull__thenAcceptUpdate() {
             return Stream.of(
+                    SpanUpdate.builder().name("name-" + RandomStringUtils.secure().nextAlphanumeric(32)).build(),
                     SpanUpdate.builder().endTime(Instant.now()).build(),
-                    SpanUpdate.builder().input(JsonUtils.getJsonNodeFromString("{ \"input\": \"data\"}")).build(),
-                    SpanUpdate.builder().output(JsonUtils.getJsonNodeFromString("{ \"output\": \"data\"}")).build(),
-                    SpanUpdate.builder().metadata(JsonUtils.getJsonNodeFromString("{ \"metadata\": \"data\"}")).build(),
-                    SpanUpdate.builder().tags(Set.of(
-                            RandomStringUtils.secure().nextAlphanumeric(10),
-                            RandomStringUtils.secure().nextAlphanumeric(10),
-                            RandomStringUtils.secure().nextAlphanumeric(10),
-                            RandomStringUtils.secure().nextAlphanumeric(10),
-                            RandomStringUtils.secure().nextAlphanumeric(10))).build(),
-                    SpanUpdate.builder().usage(Map.of(
-                            RandomStringUtils.secure().nextAlphanumeric(10), randomNumber(),
-                            RandomStringUtils.secure().nextAlphanumeric(10), randomNumber(),
-                            RandomStringUtils.secure().nextAlphanumeric(10), randomNumber(),
-                            RandomStringUtils.secure().nextAlphanumeric(10), randomNumber(),
-                            RandomStringUtils.secure().nextAlphanumeric(10), randomNumber())).build());
+                    SpanUpdate.builder().input(podamFactory.manufacturePojo(JsonNode.class)).build(),
+                    SpanUpdate.builder().output(podamFactory.manufacturePojo(JsonNode.class)).build(),
+                    SpanUpdate.builder().metadata(podamFactory.manufacturePojo(JsonNode.class)).build(),
+                    SpanUpdate.builder().model("model-" + RandomStringUtils.secure().nextAlphanumeric(32)).build(),
+                    SpanUpdate.builder().provider("provider-" + RandomStringUtils.secure().nextAlphanumeric(32))
+                            .build(),
+                    SpanUpdate.builder().tags(PodamFactoryUtils.manufacturePojoSet(podamFactory, String.class)).build(),
+                    SpanUpdate.builder()
+                            .usage(PodamFactoryUtils.manufacturePojoMap(podamFactory, String.class, Integer.class))
+                            .build(),
+                    SpanUpdate.builder().totalEstimatedCost(podamFactory.manufacturePojo(BigDecimal.class)).build(),
+                    SpanUpdate.builder().errorInfo(podamFactory.manufacturePojo(ErrorInfo.class)).build());
         }
 
         @ParameterizedTest
         @MethodSource
         @DisplayName("when only some field is not null, then accept update")
         void update__whenFieldIsNotNull__thenAcceptUpdate(SpanUpdate expectedSpanUpdate) {
-
             var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
                     .projectName(null)
                     .parentSpanId(null)
+                    .feedbackScores(null)
                     .build();
 
-            createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             SpanUpdate spanUpdate = expectedSpanUpdate.toBuilder()
                     .parentSpanId(expectedSpan.parentSpanId())
@@ -5437,7 +5325,6 @@ class SpansResourceTest {
         @MethodSource
         @DisplayName("update cost related items")
         void update__whenCostIsChanged__thenAcceptUpdate(SpanUpdate expectedSpanUpdate, BigDecimal initialManualCost) {
-
             var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
                     .projectName(null)
                     .parentSpanId(null)
@@ -5446,9 +5333,10 @@ class SpansResourceTest {
                     .usage(Map.of("completion_tokens", Math.abs(podamFactory.manufacturePojo(Integer.class)),
                             "prompt_tokens", Math.abs(podamFactory.manufacturePojo(Integer.class))))
                     .totalEstimatedCost(initialManualCost)
+                    .feedbackScores(null)
                     .build();
 
-            createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             SpanUpdate spanUpdate = expectedSpanUpdate.toBuilder()
                     .parentSpanId(expectedSpan.parentSpanId())
@@ -5561,132 +5449,107 @@ class SpansResourceTest {
         @Test
         void updateWhenSpanDoesNotExist__thenAcceptUpdate() {
             var id = generator.generate();
+            var expectedSpanBuilder = Span.builder().id(id).startTime(Instant.EPOCH).createdAt(Instant.now());
             var expectedSpanUpdate = podamFactory.manufacturePojo(SpanUpdate.class).toBuilder()
                     .projectId(null)
                     .build();
             spanResourceClient.updateSpan(id, expectedSpanUpdate, API_KEY, TEST_WORKSPACE);
+
+            SpanMapper.INSTANCE.updateSpanBuilder(expectedSpanBuilder, expectedSpanUpdate);
+            getAndAssert(expectedSpanBuilder.build(), API_KEY, TEST_WORKSPACE);
         }
 
         @Test
         @DisplayName("when span does not exist, then return create it")
         void when__spanDoesNotExist__thenReturnCreateIt() {
             var id = generator.generate();
-
             var spanUpdate = podamFactory.manufacturePojo(SpanUpdate.class).toBuilder()
                     .projectId(null)
+                    .name(null)
                     .build();
-
+            var expectedSpan = Span.builder()
+                    .id(id)
+                    .projectName(spanUpdate.projectName())
+                    .traceId(spanUpdate.traceId())
+                    .parentSpanId(spanUpdate.parentSpanId())
+                    .name(null)
+                    .type(null)
+                    .startTime(Instant.EPOCH)
+                    .endTime(spanUpdate.endTime())
+                    .input(spanUpdate.input())
+                    .output(spanUpdate.output())
+                    .metadata(spanUpdate.metadata())
+                    .model(spanUpdate.model())
+                    .provider(spanUpdate.provider())
+                    .tags(spanUpdate.tags())
+                    .usage(spanUpdate.usage())
+                    .errorInfo(spanUpdate.errorInfo())
+                    .createdAt(Instant.now())
+                    .build();
             spanResourceClient.updateSpan(id, spanUpdate, API_KEY, TEST_WORKSPACE);
 
-            var actualResponse = getById(id, TEST_WORKSPACE, API_KEY);
-
-            var projectId = getProjectId(spanUpdate.projectName(), TEST_WORKSPACE, API_KEY);
-
-            var actualEntity = actualResponse.readEntity(Span.class);
-            assertThat(actualEntity.id()).isEqualTo(id);
-
-            assertThat(actualEntity.projectId()).isEqualTo(projectId);
-            assertThat(actualEntity.traceId()).isEqualTo(spanUpdate.traceId());
-            assertThat(actualEntity.parentSpanId()).isEqualTo(spanUpdate.parentSpanId());
-
-            assertThat(actualEntity.input()).isEqualTo(spanUpdate.input());
-            assertThat(actualEntity.output()).isEqualTo(spanUpdate.output());
-            assertThat(actualEntity.endTime()).isEqualTo(spanUpdate.endTime());
-            assertThat(actualEntity.metadata()).isEqualTo(spanUpdate.metadata());
-            assertThat(actualEntity.tags()).isEqualTo(spanUpdate.tags());
-
-            assertThat(actualEntity.name()).isEmpty();
-            assertThat(actualEntity.startTime()).isEqualTo(Instant.EPOCH);
-            assertThat(actualEntity.type()).isNull();
+            var projectId = projectResourceClient.getByName(spanUpdate.projectName(), API_KEY, TEST_WORKSPACE).id();
+            getAndAssert(expectedSpan, projectId, API_KEY, TEST_WORKSPACE);
         }
 
         @Test
         @DisplayName("when span update and insert are processed out of other, then return span")
         void when__spanUpdateAndInsertAreProcessedOutOfOther__thenReturnSpan() {
             var id = generator.generate();
-
+            var createdAt = Instant.now();
             var spanUpdate = podamFactory.manufacturePojo(SpanUpdate.class).toBuilder()
                     .projectId(null)
                     .build();
-
-            var startCreation = Instant.now();
             spanResourceClient.updateSpan(id, spanUpdate, API_KEY, TEST_WORKSPACE);
-            var created = Instant.now();
 
             var newSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
                     .projectName(spanUpdate.projectName())
                     .traceId(spanUpdate.traceId())
                     .parentSpanId(spanUpdate.parentSpanId())
                     .id(id)
+                    .createdAt(createdAt)
+                    .feedbackScores(null)
                     .build();
+            spanResourceClient.createSpan(newSpan, API_KEY, TEST_WORKSPACE);
 
-            createAndAssert(newSpan, API_KEY, TEST_WORKSPACE);
-
-            var actualResponse = getById(id, TEST_WORKSPACE, API_KEY);
-
-            var projectId = getProjectId(spanUpdate.projectName(), TEST_WORKSPACE, API_KEY);
-
-            var actualEntity = actualResponse.readEntity(Span.class);
-            assertThat(actualEntity.id()).isEqualTo(id);
-
-            assertThat(actualEntity.projectId()).isEqualTo(projectId);
-            assertThat(actualEntity.traceId()).isEqualTo(spanUpdate.traceId());
-            assertThat(actualEntity.parentSpanId()).isEqualTo(spanUpdate.parentSpanId());
-
-            assertThat(actualEntity.input()).isEqualTo(spanUpdate.input());
-            assertThat(actualEntity.output()).isEqualTo(spanUpdate.output());
-            assertThat(actualEntity.endTime()).isEqualTo(spanUpdate.endTime());
-            assertThat(actualEntity.metadata()).isEqualTo(spanUpdate.metadata());
-            assertThat(actualEntity.tags()).isEqualTo(spanUpdate.tags());
-
-            assertThat(actualEntity.name()).isEqualTo(newSpan.name());
-            assertThat(actualEntity.startTime()).isEqualTo(newSpan.startTime());
-            assertThat(actualEntity.type()).isEqualTo(newSpan.type());
-
-            assertThat(actualEntity.createdAt()).isBetween(startCreation, created);
-            assertThat(actualEntity.lastUpdatedAt()).isBetween(created, Instant.now());
-            assertThat(actualEntity.createdBy()).isEqualTo(USER);
-            assertThat(actualEntity.lastUpdatedBy()).isEqualTo(USER);
+            var expectedSpan = newSpan.toBuilder()
+                    .name(spanUpdate.name())
+                    .endTime(spanUpdate.endTime())
+                    .input(spanUpdate.input())
+                    .output(spanUpdate.output())
+                    .metadata(spanUpdate.metadata())
+                    .model(spanUpdate.model())
+                    .provider(spanUpdate.provider())
+                    .tags(spanUpdate.tags())
+                    .usage(spanUpdate.usage())
+                    .errorInfo(spanUpdate.errorInfo())
+                    .duration(DurationUtils.getDurationInMillisWithSubMilliPrecision(
+                            newSpan.startTime(), spanUpdate.endTime()))
+                    .build();
+            getAndAssert(expectedSpan, null, API_KEY, TEST_WORKSPACE);
         }
 
         @ParameterizedTest
         @MethodSource
         @DisplayName("when span update and insert conflict, then return 409")
-        void when__spanUpdateAndInsertConflict__thenReturn409(BiFunction<SpanUpdate, UUID, Span> mapper,
-                String errorMessage) {
+        void when__spanUpdateAndInsertConflict__thenReturn409(
+                BiFunction<SpanUpdate, UUID, Span> mapper, String errorMessage) {
             var id = generator.generate();
-
             var spanUpdate = podamFactory.manufacturePojo(SpanUpdate.class).toBuilder()
                     .projectId(null)
                     .build();
-
             spanResourceClient.updateSpan(id, spanUpdate, API_KEY, TEST_WORKSPACE);
 
             var newSpan = mapper.apply(spanUpdate, id);
-
-            try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .post(Entity.json(newSpan))) {
-
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(409);
+            try (var actualResponse = spanResourceClient.createSpan(
+                    newSpan, API_KEY, TEST_WORKSPACE, HttpStatus.SC_CONFLICT)) {
                 assertThat(actualResponse.hasEntity()).isTrue();
-                assertThat(actualResponse.readEntity(ErrorMessage.class).errors())
-                        .contains(errorMessage);
+                assertThat(actualResponse.readEntity(ErrorMessage.class).errors()).contains(errorMessage);
             }
         }
 
         Stream<Arguments> when__spanUpdateAndInsertConflict__thenReturn409() {
             return Stream.of(
-                    arguments(
-                            (BiFunction<SpanUpdate, UUID, Span>) (spanUpdate, id) -> podamFactory
-                                    .manufacturePojo(Span.class).toBuilder()
-                                    .traceId(spanUpdate.traceId())
-                                    .parentSpanId(spanUpdate.parentSpanId())
-                                    .id(id)
-                                    .build(),
-                            "Project name and workspace name do not match the existing span"),
                     arguments(
                             (BiFunction<SpanUpdate, UUID, Span>) (spanUpdate, id) -> podamFactory
                                     .manufacturePojo(Span.class).toBuilder()
@@ -5716,36 +5579,24 @@ class SpansResourceTest {
         @ParameterizedTest
         @MethodSource
         @DisplayName("when multiple span update conflict, then return 409")
-        void when__multipleSpanUpdateConflict__thenReturn409(BiFunction<SpanUpdate, UUID, SpanUpdate> mapper,
-                String errorMessage) {
+        void when__multipleSpanUpdateConflict__thenReturn409(
+                BiFunction<SpanUpdate, UUID, SpanUpdate> mapper, String errorMessage) {
             var id = generator.generate();
-
             var spanUpdate = podamFactory.manufacturePojo(SpanUpdate.class).toBuilder()
                     .projectId(null)
                     .build();
-
             spanResourceClient.updateSpan(id, spanUpdate, API_KEY, TEST_WORKSPACE);
 
-            SpanUpdate newSpan = mapper.apply(spanUpdate, id);
-
+            var newSpan = mapper.apply(spanUpdate, id);
             try (var actualResponse = spanResourceClient.updateSpan(
                     id, newSpan, API_KEY, TEST_WORKSPACE, HttpStatus.SC_CONFLICT)) {
                 assertThat(actualResponse.hasEntity()).isTrue();
-                assertThat(actualResponse.readEntity(ErrorMessage.class).errors())
-                        .contains(errorMessage);
+                assertThat(actualResponse.readEntity(ErrorMessage.class).errors()).contains(errorMessage);
             }
         }
 
         Stream<Arguments> when__multipleSpanUpdateConflict__thenReturn409() {
             return Stream.of(
-                    arguments(
-                            (BiFunction<SpanUpdate, UUID, SpanUpdate>) (spanUpdate, id) -> podamFactory
-                                    .manufacturePojo(SpanUpdate.class).toBuilder()
-                                    .traceId(spanUpdate.traceId())
-                                    .parentSpanId(spanUpdate.parentSpanId())
-                                    .projectId(spanUpdate.projectId())
-                                    .build(),
-                            "Project name and workspace name do not match the existing span"),
                     arguments(
                             (BiFunction<SpanUpdate, UUID, SpanUpdate>) (spanUpdate, id) -> podamFactory
                                     .manufacturePojo(SpanUpdate.class).toBuilder()
@@ -5776,121 +5627,163 @@ class SpansResourceTest {
         @DisplayName("when multiple span update and insert are processed out of other and concurrent, then return span")
         void when__multipleSpanUpdateAndInsertAreProcessedOutOfOtherAndConcurrent__thenReturnSpan() {
             var id = generator.generate();
-
             var projectName = UUID.randomUUID().toString();
-
             var spanUpdate1 = SpanUpdate.builder()
-                    .metadata(JsonUtils.getJsonNodeFromString("{ \"metadata\": \"data\" }"))
+                    .metadata(podamFactory.manufacturePojo(JsonNode.class))
                     .projectName(projectName)
                     .traceId(generator.generate())
                     .parentSpanId(null)
                     .build();
-
-            var startCreation = Instant.now();
-
             var spanUpdate2 = SpanUpdate.builder()
-                    .input(JsonUtils.getJsonNodeFromString("{ \"input\": \"data2\"}"))
-                    .tags(Set.of("tag1", "tag2"))
+                    .input(podamFactory.manufacturePojo(JsonNode.class))
+                    .tags(PodamFactoryUtils.manufacturePojoSet(podamFactory, String.class))
                     .projectName(projectName)
                     .traceId(spanUpdate1.traceId())
                     .parentSpanId(spanUpdate1.parentSpanId())
                     .build();
-
             var spanUpdate3 = SpanUpdate.builder()
-                    .output(JsonUtils.getJsonNodeFromString("{ \"output\": \"data\"}"))
+                    .output(podamFactory.manufacturePojo(JsonNode.class))
                     .endTime(Instant.now())
                     .projectName(projectName)
                     .traceId(spanUpdate1.traceId())
                     .parentSpanId(spanUpdate1.parentSpanId())
                     .build();
-
             var newSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
                     .projectName(spanUpdate1.projectName())
                     .traceId(spanUpdate1.traceId())
                     .parentSpanId(spanUpdate1.parentSpanId())
                     .endTime(null)
                     .id(id)
+                    .feedbackScores(null)
                     .build();
-
             var update1 = Mono
                     .fromRunnable(() -> spanResourceClient.updateSpan(id, spanUpdate3, API_KEY, TEST_WORKSPACE));
-            var create = Mono.fromRunnable(() -> createAndAssert(newSpan, API_KEY, TEST_WORKSPACE));
+            var create = Mono.fromRunnable(() -> spanResourceClient.createSpan(newSpan, API_KEY, TEST_WORKSPACE));
             var update2 = Mono
                     .fromRunnable(() -> spanResourceClient.updateSpan(id, spanUpdate2, API_KEY, TEST_WORKSPACE));
             var update3 = Mono
                     .fromRunnable(() -> spanResourceClient.updateSpan(id, spanUpdate1, API_KEY, TEST_WORKSPACE));
-
             Flux.merge(update1, update2, update3, create).blockLast();
 
-            var created = Instant.now();
-
-            var actualResponse = getById(id, TEST_WORKSPACE, API_KEY);
-
-            var actualEntity = actualResponse.readEntity(Span.class);
-            assertThat(actualEntity.id()).isEqualTo(id);
-
-            var projectId = getProjectId(projectName, TEST_WORKSPACE, API_KEY);
-
-            assertThat(actualEntity.projectId()).isEqualTo(projectId);
-            assertThat(actualEntity.traceId()).isEqualTo(spanUpdate1.traceId());
-            assertThat(actualEntity.parentSpanId()).isEqualTo(spanUpdate1.parentSpanId());
-
-            assertThat(actualEntity.endTime()).isEqualTo(spanUpdate3.endTime());
-            assertThat(actualEntity.input()).isEqualTo(spanUpdate2.input());
-            assertThat(actualEntity.output()).isEqualTo(spanUpdate3.output());
-            assertThat(actualEntity.metadata()).isEqualTo(spanUpdate1.metadata());
-            assertThat(actualEntity.tags()).isEqualTo(spanUpdate2.tags());
-
-            assertThat(actualEntity.name()).isEqualTo(newSpan.name());
-            assertThat(actualEntity.startTime()).isEqualTo(newSpan.startTime());
-            assertThat(actualEntity.createdAt()).isBetween(startCreation, created);
-            assertThat(actualEntity.lastUpdatedAt()).isBetween(startCreation, created);
-            assertThat(actualEntity.createdBy()).isEqualTo(USER);
-            assertThat(actualEntity.lastUpdatedBy()).isEqualTo(USER);
+            var expectedSpan = newSpan.toBuilder()
+                    .endTime(spanUpdate3.endTime())
+                    .input(spanUpdate2.input())
+                    .output(spanUpdate3.output())
+                    .metadata(spanUpdate1.metadata())
+                    .tags(spanUpdate2.tags())
+                    .duration(DurationUtils.getDurationInMillisWithSubMilliPrecision(
+                            newSpan.startTime(), spanUpdate3.endTime()))
+                    .build();
+            getAndAssert(expectedSpan, null, API_KEY, TEST_WORKSPACE);
         }
 
-        @Test
-        @DisplayName("when tags is empty, then accept update")
-        void update__whenTagsIsEmpty__thenAcceptUpdate() {
+        Stream<Arguments> updateOnlyName() {
+            var name = RandomStringUtils.secure().nextAlphanumeric(32);
+            return Stream.of(
+                    arguments(name, name),
+                    arguments(null, null),
+                    arguments("", null),
+                    arguments("   ", null));
+        }
 
+        @ParameterizedTest
+        @MethodSource
+        void updateOnlyName(String name, String expectedName) {
             var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
-                    .parentSpanId(null)
+                    .name(null)
+                    .feedbackScores(null)
                     .build();
-
-            createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             var spanUpdate = SpanUpdate.builder()
                     .traceId(expectedSpan.traceId())
                     .parentSpanId(expectedSpan.parentSpanId())
                     .projectName(expectedSpan.projectName())
-                    .tags(Set.of())
+                    .name(name)
                     .build();
-
             spanResourceClient.updateSpan(expectedSpan.id(), spanUpdate, API_KEY, TEST_WORKSPACE);
 
-            UUID projectId = getProjectId(spanUpdate.projectName(), TEST_WORKSPACE, API_KEY);
-
-            Span updatedSpan = expectedSpan.toBuilder()
-                    .tags(spanUpdate.tags())
-                    .projectId(projectId)
-                    .build();
-
-            Span actualSpan = getAndAssert(updatedSpan.toBuilder().tags(null).build(), API_KEY, TEST_WORKSPACE);
-
-            assertThat(actualSpan.tags()).isNull();
+            var actualSpan = getAndAssert(
+                    expectedSpan.toBuilder().name(expectedName).build(), null, API_KEY, TEST_WORKSPACE);
+            assertThat(actualSpan.name()).isEqualTo(expectedName);
         }
 
-        @Test
-        @DisplayName("when metadata is empty, then accept update")
-        void update__whenMetadataIsEmpty__thenAcceptUpdate() {
+        Stream<Instant> updateOnlyEndTime() {
+            return Stream.of(Instant.now(), null);
+        }
 
-            JsonNode metadata = JsonUtils.getJsonNodeFromString("{}");
-
+        @ParameterizedTest
+        @MethodSource
+        void updateOnlyEndTime(Instant endTime) {
             var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
-                    .parentSpanId(null)
+                    .endTime(null)
+                    .feedbackScores(null)
                     .build();
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
-            createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            var spanUpdate = SpanUpdate.builder()
+                    .traceId(expectedSpan.traceId())
+                    .parentSpanId(expectedSpan.parentSpanId())
+                    .projectName(expectedSpan.projectName())
+                    .endTime(endTime)
+                    .build();
+            spanResourceClient.updateSpan(expectedSpan.id(), spanUpdate, API_KEY, TEST_WORKSPACE);
+
+            var updatedSpan = expectedSpan.toBuilder()
+                    .endTime(endTime)
+                    .duration(DurationUtils.getDurationInMillisWithSubMilliPrecision(expectedSpan.startTime(), endTime))
+                    .build();
+            var actualSpan = getAndAssert(updatedSpan, null, API_KEY, TEST_WORKSPACE);
+            assertThat(actualSpan.endTime()).isEqualTo(spanUpdate.endTime());
+        }
+
+        Stream<Arguments> updateOnlyTags() {
+            var tags = PodamFactoryUtils.manufacturePojoSet(podamFactory, String.class);
+            return Stream.of(
+                    arguments(tags, tags),
+                    arguments(Set.of(), null),
+                    arguments(null, null));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void updateOnlyTags(Set<String> tags, Set<String> expectedTags) {
+            var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .tags(null)
+                    .feedbackScores(null)
+                    .build();
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
+
+            var spanUpdate = SpanUpdate.builder()
+                    .traceId(expectedSpan.traceId())
+                    .parentSpanId(expectedSpan.parentSpanId())
+                    .projectName(expectedSpan.projectName())
+                    .tags(tags)
+                    .build();
+            spanResourceClient.updateSpan(expectedSpan.id(), spanUpdate, API_KEY, TEST_WORKSPACE);
+
+            var updatedSpan = expectedSpan.toBuilder()
+                    .tags(expectedTags)
+                    .build();
+            var actualSpan = getAndAssert(updatedSpan, API_KEY, TEST_WORKSPACE);
+            assertThat(actualSpan.tags()).isEqualTo(expectedTags);
+        }
+
+        Stream<JsonNode> updateOnlyMetadata() {
+            return Stream.of(
+                    podamFactory.manufacturePojo(JsonNode.class),
+                    JsonUtils.getJsonNodeFromString("{}"),
+                    null);
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void updateOnlyMetadata(JsonNode metadata) {
+            var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .metadata(null)
+                    .feedbackScores(null)
+                    .build();
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             var spanUpdate = SpanUpdate.builder()
                     .traceId(expectedSpan.traceId())
@@ -5898,32 +5791,89 @@ class SpansResourceTest {
                     .projectName(expectedSpan.projectName())
                     .metadata(metadata)
                     .build();
-
             spanResourceClient.updateSpan(expectedSpan.id(), spanUpdate, API_KEY, TEST_WORKSPACE);
-
-            UUID projectId = getProjectId(spanUpdate.projectName(), TEST_WORKSPACE, API_KEY);
-
-            Span updatedSpan = expectedSpan.toBuilder()
-                    .metadata(metadata)
-                    .projectId(projectId)
-                    .build();
-
-            Span actualSpan = getAndAssert(updatedSpan, API_KEY, TEST_WORKSPACE);
-
+            var updatedSpan = expectedSpan.toBuilder().metadata(metadata).build();
+            var actualSpan = getAndAssert(updatedSpan, API_KEY, TEST_WORKSPACE);
             assertThat(actualSpan.metadata()).isEqualTo(metadata);
         }
 
-        @Test
-        @DisplayName("when input is empty, then accept update")
-        void update__whenInputIsEmpty__thenAcceptUpdate() {
+        Stream<Arguments> updateOnlyModel() {
+            var model = RandomStringUtils.secure().nextAlphanumeric(32);
+            return Stream.of(
+                    arguments(model, model),
+                    arguments(null, null),
+                    arguments("", null),
+                    arguments("   ", null));
+        }
 
-            JsonNode input = JsonUtils.getJsonNodeFromString("{}");
-
+        @ParameterizedTest
+        @MethodSource
+        void updateOnlyModel(String model, String expectedModel) {
             var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
-                    .parentSpanId(null)
+                    .model(null)
+                    .feedbackScores(null)
                     .build();
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
-            createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            var spanUpdate = SpanUpdate.builder()
+                    .traceId(expectedSpan.traceId())
+                    .parentSpanId(expectedSpan.parentSpanId())
+                    .projectName(expectedSpan.projectName())
+                    .model(model)
+                    .build();
+            spanResourceClient.updateSpan(expectedSpan.id(), spanUpdate, API_KEY, TEST_WORKSPACE);
+
+            var actualSpan = getAndAssert(
+                    expectedSpan.toBuilder().model(expectedModel).build(), null, API_KEY, TEST_WORKSPACE);
+            assertThat(actualSpan.model()).isEqualTo(expectedModel);
+        }
+
+        Stream<Arguments> updateOnlyProvider() {
+            var provider = RandomStringUtils.secure().nextAlphanumeric(32);
+            return Stream.of(
+                    arguments(provider, provider),
+                    arguments(null, null),
+                    arguments("", null),
+                    arguments("   ", null));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void updateOnlyProvider(String provider, String expectedProvider) {
+            var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .provider(null)
+                    .feedbackScores(null)
+                    .build();
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
+
+            var spanUpdate = SpanUpdate.builder()
+                    .traceId(expectedSpan.traceId())
+                    .parentSpanId(expectedSpan.parentSpanId())
+                    .projectName(expectedSpan.projectName())
+                    .provider(provider)
+                    .build();
+            spanResourceClient.updateSpan(expectedSpan.id(), spanUpdate, API_KEY, TEST_WORKSPACE);
+
+            var actualSpan = getAndAssert(
+                    expectedSpan.toBuilder().provider(expectedProvider).build(), null, API_KEY, TEST_WORKSPACE);
+            assertThat(actualSpan.provider()).isEqualTo(expectedProvider);
+        }
+
+        Stream<JsonNode> updateOnlyInput() {
+            return Stream.of(
+                    podamFactory.manufacturePojo(JsonNode.class),
+                    JsonUtils.getJsonNodeFromString("{}"),
+                    null);
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void updateOnlyInput(JsonNode input) {
+            var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .input(null)
+                    .feedbackScores(null)
+                    .build();
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             var spanUpdate = SpanUpdate.builder()
                     .traceId(expectedSpan.traceId())
@@ -5931,31 +5881,28 @@ class SpansResourceTest {
                     .projectName(expectedSpan.projectName())
                     .input(input)
                     .build();
-
             spanResourceClient.updateSpan(expectedSpan.id(), spanUpdate, API_KEY, TEST_WORKSPACE);
 
-            UUID projectId = getProjectId(spanUpdate.projectName(), TEST_WORKSPACE, API_KEY);
-
-            Span updatedSpan = expectedSpan.toBuilder()
-                    .input(input)
-                    .projectId(projectId)
-                    .build();
-
-            Span actualSpan = getAndAssert(updatedSpan, API_KEY, TEST_WORKSPACE);
-
+            var updatedSpan = expectedSpan.toBuilder().input(input).build();
+            var actualSpan = getAndAssert(updatedSpan, API_KEY, TEST_WORKSPACE);
             assertThat(actualSpan.input()).isEqualTo(input);
         }
 
-        @Test
-        @DisplayName("when output is empty, then accept update")
-        void update__whenOutputIsEmpty__thenAcceptUpdate() {
-            JsonNode output = JsonUtils.getJsonNodeFromString("{}");
+        Stream<JsonNode> updateOnlyOutput() {
+            return Stream.of(
+                    podamFactory.manufacturePojo(JsonNode.class),
+                    JsonUtils.getJsonNodeFromString("{}"),
+                    null);
+        }
 
+        @ParameterizedTest
+        @MethodSource
+        void updateOnlyOutput(JsonNode output) {
             var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
-                    .parentSpanId(null)
+                    .output(null)
+                    .feedbackScores(null)
                     .build();
-
-            createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             var spanUpdate = SpanUpdate.builder()
                     .traceId(expectedSpan.traceId())
@@ -5963,43 +5910,124 @@ class SpansResourceTest {
                     .projectName(expectedSpan.projectName())
                     .output(output)
                     .build();
+            spanResourceClient.updateSpan(expectedSpan.id(), spanUpdate, API_KEY, TEST_WORKSPACE);
+            var updatedSpan = expectedSpan.toBuilder().output(output).build();
+            var actualSpan = getAndAssert(updatedSpan, API_KEY, TEST_WORKSPACE);
+            assertThat(actualSpan.output()).isEqualTo(output);
+        }
 
+        Stream<Arguments> updateOnlyUsage() {
+            var usage = PodamFactoryUtils.manufacturePojoMap(podamFactory, String.class, Integer.class);
+            return Stream.of(
+                    arguments(usage, usage),
+                    arguments(Map.of(), null),
+                    arguments(null, null));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void updateOnlyUsage(Map<String, Integer> usage, Map<String, Integer> expectedUsage) {
+            var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .usage(null)
+                    .feedbackScores(null)
+                    .build();
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
+
+            var spanUpdate = SpanUpdate.builder()
+                    .traceId(expectedSpan.traceId())
+                    .parentSpanId(expectedSpan.parentSpanId())
+                    .projectName(expectedSpan.projectName())
+                    .usage(usage)
+                    .build();
             spanResourceClient.updateSpan(expectedSpan.id(), spanUpdate, API_KEY, TEST_WORKSPACE);
 
-            UUID projectId = getProjectId(spanUpdate.projectName(), TEST_WORKSPACE, API_KEY);
-
-            Span updatedSpan = expectedSpan.toBuilder()
-                    .output(output)
-                    .projectId(projectId)
+            var updatedSpan = expectedSpan.toBuilder()
+                    .usage(expectedUsage)
                     .build();
+            var actualSpan = getAndAssert(updatedSpan, API_KEY, TEST_WORKSPACE);
+            assertThat(actualSpan.usage()).isEqualTo(expectedUsage);
+        }
 
-            Span actualSpan = getAndAssert(updatedSpan, API_KEY, TEST_WORKSPACE);
+        Stream<Arguments> updateOnlyTotalEstimatedCost() {
+            var totalEstimatedCost = BigDecimal.valueOf(PodamUtils.getDoubleInRange(0, 1_000_000));
+            return Stream.of(
+                    arguments(totalEstimatedCost, totalEstimatedCost),
+                    arguments(BigDecimal.ZERO, null),
+                    arguments(null, null));
+        }
 
-            assertThat(actualSpan.output()).isEqualTo(output);
+        @ParameterizedTest
+        @MethodSource
+        void updateOnlyTotalEstimatedCost(BigDecimal totalEstimatedCost, BigDecimal expectedTotalEstimatedCost) {
+            var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .totalEstimatedCost(null)
+                    .feedbackScores(null)
+                    .build();
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
+
+            var spanUpdate = SpanUpdate.builder()
+                    .traceId(expectedSpan.traceId())
+                    .parentSpanId(expectedSpan.parentSpanId())
+                    .projectName(expectedSpan.projectName())
+                    .totalEstimatedCost(totalEstimatedCost)
+                    .build();
+            spanResourceClient.updateSpan(expectedSpan.id(), spanUpdate, API_KEY, TEST_WORKSPACE);
+
+            var updatedSpan = expectedSpan.toBuilder()
+                    .totalEstimatedCost(expectedTotalEstimatedCost)
+                    .build();
+            var actualSpan = getAndAssert(updatedSpan, API_KEY, TEST_WORKSPACE);
+            if (expectedTotalEstimatedCost != null) {
+                assertThat(actualSpan.totalEstimatedCost()).isEqualByComparingTo(expectedTotalEstimatedCost);
+            } else {
+                assertThat(actualSpan.totalEstimatedCost()).isNull();
+            }
+        }
+
+        Stream<ErrorInfo> updateOnlyErrorInfo() {
+            return Stream.of(podamFactory.manufacturePojo(ErrorInfo.class), null);
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void updateOnlyErrorInfo(ErrorInfo errorInfo) {
+            var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .errorInfo(null)
+                    .feedbackScores(null)
+                    .build();
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
+
+            var spanUpdate = SpanUpdate.builder()
+                    .traceId(expectedSpan.traceId())
+                    .parentSpanId(expectedSpan.parentSpanId())
+                    .projectName(expectedSpan.projectName())
+                    .errorInfo(errorInfo)
+                    .build();
+            spanResourceClient.updateSpan(expectedSpan.id(), spanUpdate, API_KEY, TEST_WORKSPACE);
+
+            var actualSpan = getAndAssert(
+                    expectedSpan.toBuilder().errorInfo(errorInfo).build(), null, API_KEY, TEST_WORKSPACE);
+            assertThat(actualSpan.errorInfo()).isEqualTo(spanUpdate.errorInfo());
         }
 
         @Test
         @DisplayName("when updating using projectId, then accept update")
         void update__whenUpdatingUsingProjectId__thenAcceptUpdate() {
-
             var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
-                    .parentSpanId(null)
+                    .feedbackScores(null)
                     .build();
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
-            createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
-
-            var projectId = getProjectId(expectedSpan.projectName(), TEST_WORKSPACE, API_KEY);
-
+            var projectId = projectResourceClient.getByName(expectedSpan.projectName(), API_KEY, TEST_WORKSPACE).id();
             var spanUpdate = podamFactory.manufacturePojo(SpanUpdate.class).toBuilder()
                     .traceId(expectedSpan.traceId())
                     .parentSpanId(expectedSpan.parentSpanId())
                     .projectId(projectId)
                     .build();
-
             spanResourceClient.updateSpan(expectedSpan.id(), spanUpdate, API_KEY, TEST_WORKSPACE);
 
-            Span updatedSpan = expectedSpan.toBuilder()
-                    .projectId(projectId)
+            var updatedSpan = expectedSpan.toBuilder()
+                    .name(spanUpdate.name())
                     .metadata(spanUpdate.metadata())
                     .model(spanUpdate.model())
                     .provider(spanUpdate.provider())
@@ -6010,18 +6038,8 @@ class SpansResourceTest {
                     .usage(spanUpdate.usage())
                     .errorInfo(spanUpdate.errorInfo())
                     .build();
-
             getAndAssert(updatedSpan, API_KEY, TEST_WORKSPACE);
         }
-    }
-
-    private Response getById(UUID id, String workspaceName, String apiKey) {
-        return client.target(URL_TEMPLATE.formatted(baseURI))
-                .path(id.toString())
-                .request()
-                .header(HttpHeaders.AUTHORIZATION, apiKey)
-                .header(WORKSPACE_HEADER, workspaceName)
-                .get();
     }
 
     @Nested
@@ -6056,7 +6074,7 @@ class SpansResourceTest {
                 String errorMessage) {
 
             var expectedSpan = podamFactory.manufacturePojo(Span.class);
-            var id = createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            var id = spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI)).path(id.toString())
                     .path("feedback-scores")
@@ -6074,9 +6092,8 @@ class SpansResourceTest {
         @Test
         @DisplayName("when feedback without category name or reason, then return no content")
         void feedback__whenFeedbackWithoutCategoryNameOrReason__thenReturnNoContent() {
-
             var expectedSpan = podamFactory.manufacturePojo(Span.class);
-            var id = createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            var id = spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             var score = podamFactory.manufacturePojo(FeedbackScore.class).toBuilder()
                     .categoryName(null)
@@ -6086,31 +6103,15 @@ class SpansResourceTest {
 
             createAndAssert(id, score, TEST_WORKSPACE, API_KEY);
 
-            var actual = getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
-            var actualScore = actual.feedbackScores().getFirst();
-
-            assertThat(actualScore)
-                    .usingRecursiveComparison(
-                            RecursiveComparisonConfiguration.builder()
-                                    .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
-                                    .withIgnoredFields(IGNORED_FIELDS_SCORES)
-                                    .build())
-                    .isEqualTo(score);
-
-            assertThat(actualScore.createdAt()).isAfter(expectedSpan.createdAt());
-            assertThat(actualScore.lastUpdatedAt()).isAfter(expectedSpan.lastUpdatedAt());
-            assertThat(actualScore.createdBy()).isEqualTo(USER);
-            assertThat(actualScore.lastUpdatedBy()).isEqualTo(USER);
-
+            expectedSpan = expectedSpan.toBuilder().feedbackScores(List.of(score)).build();
+            getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
         }
 
         @Test
         @DisplayName("when feedback with category name or reason, then return no content")
         void feedback__whenFeedbackWithCategoryNameOrReason__thenReturnNoContent() {
-
-            var instant = Instant.now();
             var expectedSpan = podamFactory.manufacturePojo(Span.class);
-            var id = createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            var id = spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             var score = podamFactory.manufacturePojo(FeedbackScore.class).toBuilder()
                     .value(podamFactory.manufacturePojo(BigDecimal.class))
@@ -6118,30 +6119,15 @@ class SpansResourceTest {
 
             createAndAssert(id, score, TEST_WORKSPACE, API_KEY);
 
-            var actual = getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
-            var actualScore = actual.feedbackScores().getFirst();
-
-            assertThat(actualScore)
-                    .usingRecursiveComparison(
-                            RecursiveComparisonConfiguration.builder()
-                                    .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
-                                    .withIgnoredFields(IGNORED_FIELDS_SCORES)
-                                    .build())
-                    .isEqualTo(score);
-
-            assertThat(actualScore.createdAt()).isAfter(instant);
-            assertThat(actualScore.lastUpdatedAt()).isAfter(instant);
-            assertThat(actualScore.createdBy()).isEqualTo(USER);
-            assertThat(actualScore.lastUpdatedBy()).isEqualTo(USER);
+            expectedSpan = expectedSpan.toBuilder().feedbackScores(List.of(score)).build();
+            getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
         }
 
         @Test
         @DisplayName("when overriding feedback value, then return no content")
         void feedback__whenOverridingFeedbackValue__thenReturnNoContent() {
-
-            Instant now = Instant.now();
             var expectedSpan = podamFactory.manufacturePojo(Span.class);
-            var id = createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            var id = spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             var score = podamFactory.manufacturePojo(FeedbackScore.class);
 
@@ -6150,21 +6136,8 @@ class SpansResourceTest {
             var newScore = score.toBuilder().value(BigDecimal.valueOf(2)).build();
             createAndAssert(id, newScore, TEST_WORKSPACE, API_KEY);
 
-            var actual = getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
-            var actualScore = actual.feedbackScores().getFirst();
-
-            assertThat(actualScore)
-                    .usingRecursiveComparison(
-                            RecursiveComparisonConfiguration.builder()
-                                    .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
-                                    .withIgnoredFields(IGNORED_FIELDS_SCORES)
-                                    .build())
-                    .isEqualTo(newScore);
-
-            assertThat(actualScore.createdAt()).isAfter(now);
-            assertThat(actualScore.lastUpdatedAt()).isAfter(now);
-            assertThat(actualScore.createdBy()).isEqualTo(USER);
-            assertThat(actualScore.lastUpdatedBy()).isEqualTo(USER);
+            expectedSpan = expectedSpan.toBuilder().feedbackScores(List.of(newScore)).build();
+            getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
         }
     }
 
@@ -6197,9 +6170,8 @@ class SpansResourceTest {
         @Test
         @DisplayName("Success")
         void deleteFeedback() {
-
             Span expectedSpan = podamFactory.manufacturePojo(Span.class);
-            var id = createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            var id = spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             var score = FeedbackScore.builder()
                     .name("name")
@@ -6221,14 +6193,10 @@ class SpansResourceTest {
                 assertThat(actualResponse.hasEntity()).isFalse();
             }
 
-            var actualResponse = getById(id, TEST_WORKSPACE, API_KEY);
-
-            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
-
-            var actualEntity = actualResponse.readEntity(Span.class);
+            expectedSpan = expectedSpan.toBuilder().feedbackScores(null).build();
+            var actualEntity = getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
             assertThat(actualEntity.feedbackScores()).isNull();
         }
-
     }
 
     @Nested
@@ -6296,13 +6264,13 @@ class SpansResourceTest {
             var expectedSpan1 = podamFactory.manufacturePojo(Span.class).toBuilder()
                     .projectName(DEFAULT_PROJECT)
                     .build();
-            var id = createAndAssert(expectedSpan1, API_KEY, TEST_WORKSPACE);
+            var id = spanResourceClient.createSpan(expectedSpan1, API_KEY, TEST_WORKSPACE);
 
             Span expectedSpan2 = podamFactory.manufacturePojo(Span.class).toBuilder()
                     .projectName(UUID.randomUUID().toString())
                     .build();
 
-            var id2 = createAndAssert(expectedSpan2, API_KEY, TEST_WORKSPACE);
+            var id2 = spanResourceClient.createSpan(expectedSpan2, API_KEY, TEST_WORKSPACE);
 
             var score = podamFactory.manufacturePojo(FeedbackScoreBatchItem.class)
                     .toBuilder()
@@ -6336,14 +6304,15 @@ class SpansResourceTest {
                 assertThat(actualResponse.hasEntity()).isFalse();
             }
 
-            var actualSpan1 = getAndAssert(expectedSpan1, API_KEY, TEST_WORKSPACE);
-            var actualSpan2 = getAndAssert(expectedSpan2, API_KEY, TEST_WORKSPACE);
+            expectedSpan1 = expectedSpan1.toBuilder()
+                    .feedbackScores(FeedbackScoreMapper.INSTANCE.toFeedbackScores(List.of(score, score3)))
+                    .build();
+            expectedSpan2 = expectedSpan2.toBuilder()
+                    .feedbackScores(FeedbackScoreMapper.INSTANCE.toFeedbackScores(List.of(score2)))
+                    .build();
 
-            assertThat(actualSpan2.feedbackScores()).hasSize(1);
-            assertThat(actualSpan1.feedbackScores()).hasSize(2);
-
-            assertEqualsForScores(actualSpan1, List.of(score, score3));
-            assertEqualsForScores(actualSpan2, List.of(score2));
+            getAndAssert(expectedSpan1, API_KEY, TEST_WORKSPACE);
+            getAndAssert(expectedSpan2, API_KEY, TEST_WORKSPACE);
         }
 
         @Test
@@ -6360,13 +6329,13 @@ class SpansResourceTest {
             Span expectedSpan1 = podamFactory.manufacturePojo(Span.class).toBuilder()
                     .projectName(DEFAULT_PROJECT)
                     .build();
-            var id = createAndAssert(expectedSpan1, apiKey, workspaceName);
+            var id = spanResourceClient.createSpan(expectedSpan1, apiKey, workspaceName);
 
             Span expectedSpan2 = podamFactory.manufacturePojo(Span.class).toBuilder()
                     .projectName(projectName)
                     .build();
 
-            var id2 = createAndAssert(expectedSpan2, apiKey, workspaceName);
+            var id2 = spanResourceClient.createSpan(expectedSpan2, apiKey, workspaceName);
 
             var score = podamFactory.manufacturePojo(FeedbackScoreBatchItem.class)
                     .toBuilder()
@@ -6400,14 +6369,15 @@ class SpansResourceTest {
                 assertThat(actualResponse.hasEntity()).isFalse();
             }
 
-            var actualSpan1 = getAndAssert(expectedSpan1, apiKey, workspaceName);
-            var actualSpan2 = getAndAssert(expectedSpan2, apiKey, workspaceName);
+            expectedSpan1 = expectedSpan1.toBuilder()
+                    .feedbackScores(FeedbackScoreMapper.INSTANCE.toFeedbackScores(List.of(score, score3)))
+                    .build();
+            expectedSpan2 = expectedSpan2.toBuilder()
+                    .feedbackScores(FeedbackScoreMapper.INSTANCE.toFeedbackScores(List.of(score2)))
+                    .build();
 
-            assertThat(actualSpan2.feedbackScores()).hasSize(1);
-            assertThat(actualSpan1.feedbackScores()).hasSize(2);
-
-            assertEqualsForScores(actualSpan1, List.of(score, score3));
-            assertEqualsForScores(actualSpan2, List.of(score2));
+            getAndAssert(expectedSpan1, apiKey, workspaceName);
+            getAndAssert(expectedSpan2, apiKey, workspaceName);
         }
 
         @ParameterizedTest
@@ -6436,7 +6406,7 @@ class SpansResourceTest {
                     .projectName(DEFAULT_PROJECT)
                     .build();
 
-            var id = createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            var id = spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             var score = podamFactory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
                     .id(id)
@@ -6457,12 +6427,10 @@ class SpansResourceTest {
                 assertThat(actualResponse.hasEntity()).isFalse();
             }
 
-            var actual = getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
-
-            assertThat(actual.feedbackScores()).hasSize(1);
-            FeedbackScore actualScore = actual.feedbackScores().getFirst();
-
-            assertEqualsForScores(actualScore, score);
+            expectedSpan = expectedSpan.toBuilder()
+                    .feedbackScores(FeedbackScoreMapper.INSTANCE.toFeedbackScores(List.of(score)))
+                    .build();
+            getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
         }
 
         @Test
@@ -6474,7 +6442,7 @@ class SpansResourceTest {
                     .parentSpanId(null)
                     .build();
 
-            var id = createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            var id = spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             var score = podamFactory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
                     .id(id)
@@ -6493,11 +6461,10 @@ class SpansResourceTest {
                 assertThat(actualResponse.hasEntity()).isFalse();
             }
 
-            var actual = getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
-            FeedbackScore actualScore = actual.feedbackScores().getFirst();
-
-            assertEqualsForScores(actualScore, score);
-
+            expectedSpan = expectedSpan.toBuilder()
+                    .feedbackScores(FeedbackScoreMapper.INSTANCE.toFeedbackScores(List.of(score)))
+                    .build();
+            getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
         }
 
         @Test
@@ -6509,7 +6476,7 @@ class SpansResourceTest {
                     .parentSpanId(null)
                     .build();
 
-            var id = createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            var id = spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             var score = podamFactory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
                     .id(id)
@@ -6540,9 +6507,10 @@ class SpansResourceTest {
                 assertThat(actualResponse.hasEntity()).isFalse();
             }
 
-            var actual = getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
-
-            assertEqualsForScores(actual.feedbackScores().getFirst(), newScore);
+            expectedSpan = expectedSpan.toBuilder()
+                    .feedbackScores(FeedbackScoreMapper.INSTANCE.toFeedbackScores(List.of(newScore)))
+                    .build();
+            getAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
         }
 
         @Test
@@ -6599,7 +6567,7 @@ class SpansResourceTest {
                     .projectName(DEFAULT_PROJECT)
                     .build();
 
-            var id = createAndAssert(expectedSpan, API_KEY, TEST_WORKSPACE);
+            var id = spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
             var scores = IntStream.range(0, 1000)
                     .mapToObj(__ -> podamFactory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
@@ -6617,7 +6585,7 @@ class SpansResourceTest {
 
             String projectName = UUID.randomUUID().toString();
 
-            createProject(projectName.toUpperCase(), TEST_WORKSPACE, API_KEY);
+            projectResourceClient.createProject(projectName.toUpperCase(), API_KEY, TEST_WORKSPACE);
 
             var spans = IntStream.range(0, 10)
                     .mapToObj(i -> podamFactory.manufacturePojo(Span.class).toBuilder()
@@ -6628,7 +6596,7 @@ class SpansResourceTest {
                             .build())
                     .toList();
 
-            batchCreateAndAssert(spans, API_KEY, TEST_WORKSPACE);
+            spanResourceClient.batchCreateSpans(spans, API_KEY, TEST_WORKSPACE);
 
             var scores = spans.stream()
                     .map(span -> podamFactory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
@@ -6910,31 +6878,4 @@ class SpansResourceTest {
 
         return currentSpanType;
     }
-
-    private void assertEqualsForScores(FeedbackScore actualScore, FeedbackScoreBatchItem score) {
-        assertThat(actualScore)
-                .usingRecursiveComparison(
-                        RecursiveComparisonConfiguration.builder()
-                                .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
-                                .withIgnoredFields(IGNORED_FIELDS_SCORES)
-                                .build())
-                .isEqualTo(score);
-
-        assertThat(actualScore.createdAt()).isNotNull();
-        assertThat(actualScore.lastUpdatedAt()).isNotNull();
-        assertThat(actualScore.createdBy()).isEqualTo(USER);
-        assertThat(actualScore.lastUpdatedBy()).isEqualTo(USER);
-    }
-
-    private void assertEqualsForScores(Span actualSpan1, List<FeedbackScoreBatchItem> score) {
-        assertThat(actualSpan1.feedbackScores())
-                .usingRecursiveComparison(
-                        RecursiveComparisonConfiguration.builder()
-                                .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
-                                .withIgnoredFields(IGNORED_FIELDS_SCORES)
-                                .build())
-                .ignoringCollectionOrder()
-                .isEqualTo(score);
-    }
-
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -5654,7 +5654,7 @@ class TracesResourceTest {
         @Test
         void createWithMissingFields() {
             var trace = Trace.builder()
-                    .projectName("project" + RandomStringUtils.secure().nextAlphanumeric(32))
+                    .projectName("project-" + RandomStringUtils.secure().nextAlphanumeric(32))
                     .startTime(Instant.now())
                     .createdAt(Instant.now())
                     .build();
@@ -5771,7 +5771,7 @@ class TracesResourceTest {
 
         @Test
         void batch__whenMissingFields__thenReturnNoContent() {
-            var projectName = "project" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
             var expectedTraces = IntStream.range(0, 5)
                     .mapToObj(i -> Trace.builder()
                             .projectName(projectName)

--- a/apps/opik-backend/src/test/java/com/comet/opik/podam/PodamFactoryUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/podam/PodamFactoryUtils.java
@@ -36,6 +36,7 @@ import uk.co.jemos.podam.api.RandomDataProviderStrategy;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -81,5 +82,10 @@ public class PodamFactoryUtils {
 
     public static <T> Set<T> manufacturePojoSet(PodamFactory podamFactory, Class<T> pojoClass) {
         return podamFactory.manufacturePojo(Set.class, pojoClass);
+    }
+
+    public static <K, V> Map<K, V> manufacturePojoMap(
+            PodamFactory podamFactory, Class<K> keyClass, Class<V> valueClass) {
+        return podamFactory.manufacturePojo(Map.class, keyClass, valueClass);
     }
 }


### PR DESCRIPTION
## Details
In preparation for trace ingestion for long-running jobs, reduced the required fields for ingestion to the minimum by making `name` optional.

For consistency, I made `name` an updatable field now through `update` trace endpoint.

Reduced tech debt by a lot in the DAO code and specially in the tests.

## Issues

- OPIK-1510
- OPIK-1509

## Testing
- Reviewed, updated and extended test coverage for all related endpoints.

## Documentation
N/A
