### PR TITLE
OPIK-1628: Add new RateLimit-Reset header

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RequestContext.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RequestContext.java
@@ -23,6 +23,7 @@ public class RequestContext {
     public static final String REMAINING_LIMIT = "Opik-%s-Remaining-Limit";
     public static final String LIMIT_REMAINING_TTL = "Opik-%s-Remaining-Limit-TTL-Millis";
     public static final String VISIBILITY = "visibility";
+    public static final String RATE_LIMIT_RESET = "RateLimit-Reset";
 
     public static final String PROJECT_NAME = "projectName";
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ratelimit/RateLimitResponseFilter.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ratelimit/RateLimitResponseFilter.java
@@ -1,5 +1,6 @@
 package com.comet.opik.infrastructure.ratelimit;
 
+import com.comet.opik.infrastructure.auth.RequestContext;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;
@@ -7,9 +8,11 @@ import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.Provider;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 @Provider
 @RequiredArgsConstructor(onConstructor_ = @Inject)
@@ -20,14 +23,22 @@ public class RateLimitResponseFilter implements ContainerResponseFilter {
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
             throws IOException {
-        moveHeader(requestContext, MATCHING, responseContext.getHeaders());
+        moveRatelimitHeader(requestContext, responseContext.getHeaders());
+        moveRateLimitResetHeader(requestContext, responseContext);
     }
 
-    private void moveHeader(ContainerRequestContext requestContext, String keyPattern,
-            MultivaluedMap<String, Object> headers) {
+    private void moveRateLimitResetHeader(ContainerRequestContext requestContext,
+            ContainerResponseContext responseContext) {
+        Optional.ofNullable(requestContext.getHeaders().get(RequestContext.RATE_LIMIT_RESET))
+                .filter(CollectionUtils::isNotEmpty)
+                .ifPresent(values -> responseContext.getHeaders().put(RequestContext.RATE_LIMIT_RESET,
+                        List.copyOf(values)));
+    }
+
+    private void moveRatelimitHeader(ContainerRequestContext requestContext, MultivaluedMap<String, Object> headers) {
         requestContext.getHeaders().keySet()
                 .stream()
-                .filter(k -> k.matches(keyPattern))
+                .filter(k -> k.matches(MATCHING))
                 .forEach(key -> {
                     List<String> values = requestContext.getHeaders().get(key);
                     headers.add(key, values.getFirst());


### PR DESCRIPTION
## Details
As discussed, we will use the header `RateLimit-Reset` to flag the required wait time. Such a header will contain the amount of time in seconds (integer, non-negative value).

## Testing
- Same coverage, just added the assert to verify the new header

