### PR TITLE
OPIK-1660: Show proper messages on playground

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderError.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderError.java
@@ -1,0 +1,9 @@
+package com.comet.opik.infrastructure.llm;
+
+import io.dropwizard.jersey.errors.ErrorMessage;
+
+public interface LlmProviderError<T> {
+    T error();
+
+    ErrorMessage toErrorMessage();
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiErrorObject.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiErrorObject.java
@@ -1,18 +1,13 @@
 package com.comet.opik.infrastructure.llm.gemini;
 
+import com.comet.opik.infrastructure.llm.LlmProviderError;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.dropwizard.jersey.errors.ErrorMessage;
 
-import java.util.Optional;
-
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record GeminiErrorObject(GeminiError error) {
-    public Optional<ErrorMessage> toErrorMessage() {
-        if (error != null) {
-            return Optional.of(new ErrorMessage(error.code(), error.message(), error().status()));
-        }
-
-        return Optional.empty();
+public record GeminiErrorObject(GeminiError error) implements LlmProviderError<GeminiError> {
+    public ErrorMessage toErrorMessage() {
+        return new ErrorMessage(error.code(), error.message(), error().status());
     }
 }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/OpenAiErrorMessage.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/OpenAiErrorMessage.java
@@ -2,24 +2,35 @@ package com.comet.opik.infrastructure.llm.openai;
 
 import com.comet.opik.infrastructure.llm.LlmProviderError;
 import io.dropwizard.jersey.errors.ErrorMessage;
-import org.apache.commons.lang3.StringUtils;
 
 import static com.comet.opik.infrastructure.llm.openai.OpenAiErrorMessage.OpenAiError;
 
 public record OpenAiErrorMessage(OpenAiError error) implements LlmProviderError<OpenAiError> {
 
-    public record OpenAiError(String message, String code) {
+    public record OpenAiError(String message, String code, String type) {
     }
 
     public ErrorMessage toErrorMessage() {
+        String message = error.message();
+
+        if (message == null) {
+            return null;
+        }
+
+        Integer code = getCode(error);
+
+        if (code != null) {
+            return new ErrorMessage(code, message);
+        }
+
+        return new ErrorMessage(500, error.message(), error.code);
+    }
+
+    private Integer getCode(OpenAiError error) {
         return switch (error.code) {
-            case "internal_error" -> new ErrorMessage(500, error.message(), error.code());
-            default -> {
-                if (StringUtils.isNotEmpty(error.code) && StringUtils.isNumeric(error.code)) {
-                    yield new ErrorMessage(Integer.parseInt(error.code), error.message());
-                }
-                yield new ErrorMessage(500, error.message(), error.code());
-            }
+            case "invalid_api_key" -> 401;
+            case "internal_error" -> 500;
+            default -> null;
         };
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/OpenAiErrorMessage.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/OpenAiErrorMessage.java
@@ -1,13 +1,16 @@
 package com.comet.opik.infrastructure.llm.openai;
 
 import com.comet.opik.infrastructure.llm.LlmProviderError;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.dropwizard.jersey.errors.ErrorMessage;
+import jakarta.validation.constraints.NotBlank;
 
 import static com.comet.opik.infrastructure.llm.openai.OpenAiErrorMessage.OpenAiError;
 
 public record OpenAiErrorMessage(OpenAiError error) implements LlmProviderError<OpenAiError> {
 
-    public record OpenAiError(String message, String code, String type) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OpenAiError(@NotBlank String message, @NotBlank String code, @NotBlank String type) {
     }
 
     public ErrorMessage toErrorMessage() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/OpenAiErrorMessage.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/OpenAiErrorMessage.java
@@ -1,0 +1,25 @@
+package com.comet.opik.infrastructure.llm.openai;
+
+import com.comet.opik.infrastructure.llm.LlmProviderError;
+import io.dropwizard.jersey.errors.ErrorMessage;
+import org.apache.commons.lang3.StringUtils;
+
+import static com.comet.opik.infrastructure.llm.openai.OpenAiErrorMessage.OpenAiError;
+
+public record OpenAiErrorMessage(OpenAiError error) implements LlmProviderError<OpenAiError> {
+
+    public record OpenAiError(String message, String code) {
+    }
+
+    public ErrorMessage toErrorMessage() {
+        return switch (error.code) {
+            case "internal_error" -> new ErrorMessage(500, error.message(), error.code());
+            default -> {
+                if (StringUtils.isNotEmpty(error.code) && StringUtils.isNumeric(error.code)) {
+                    yield new ErrorMessage(Integer.parseInt(error.code), error.message());
+                }
+                yield new ErrorMessage(500, error.message(), error.code());
+            }
+        };
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterErrorMessage.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterErrorMessage.java
@@ -3,8 +3,10 @@ package com.comet.opik.infrastructure.llm.openrouter;
 import com.comet.opik.infrastructure.llm.LlmProviderError;
 import io.dropwizard.jersey.errors.ErrorMessage;
 
+import static com.comet.opik.infrastructure.llm.openrouter.OpenRouterErrorMessage.OpenRouterError;
+
 public record OpenRouterErrorMessage(
-        OpenRouterError error) implements LlmProviderError<OpenRouterErrorMessage.OpenRouterError> {
+        OpenRouterError error) implements LlmProviderError<OpenRouterError> {
 
     public record OpenRouterError(String message, Integer code) {
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterErrorMessage.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterErrorMessage.java
@@ -2,13 +2,15 @@ package com.comet.opik.infrastructure.llm.openrouter;
 
 import com.comet.opik.infrastructure.llm.LlmProviderError;
 import io.dropwizard.jersey.errors.ErrorMessage;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import static com.comet.opik.infrastructure.llm.openrouter.OpenRouterErrorMessage.OpenRouterError;
 
 public record OpenRouterErrorMessage(
         OpenRouterError error) implements LlmProviderError<OpenRouterError> {
 
-    public record OpenRouterError(String message, Integer code) {
+    public record OpenRouterError(@NotBlank String message, @NotNull Integer code) {
     }
 
     public ErrorMessage toErrorMessage() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterErrorMessage.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterErrorMessage.java
@@ -1,8 +1,16 @@
 package com.comet.opik.infrastructure.llm.openrouter;
 
-public record OpenRouterErrorMessage(OpenRouterError error) {
+import com.comet.opik.infrastructure.llm.LlmProviderError;
+import io.dropwizard.jersey.errors.ErrorMessage;
+
+public record OpenRouterErrorMessage(
+        OpenRouterError error) implements LlmProviderError<OpenRouterErrorMessage.OpenRouterError> {
 
     public record OpenRouterError(String message, Integer code) {
+    }
+
+    public ErrorMessage toErrorMessage() {
+        return new ErrorMessage(error.code(), error.message());
     }
 
 }


### PR DESCRIPTION
## Details

Add error handling to the following scenarios:

- Error before making the request
![Screenshot 2025-05-22 at 18 15 04](https://github.com/user-attachments/assets/417a5a95-3b97-4ad1-a5ff-06a8680d6f5a)

- Error coming from Vertex AI API
![Screenshot 2025-05-22 at 16 59 32](https://github.com/user-attachments/assets/14fb8b0e-dece-48d5-9c6e-43d70c852a23)

- Error coming from OpenAiClient HTTP Call

```json
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: dev.langchain4j.exception.InternalServerException: {
"error": {
"message": "Internal server error",
"type": "auth_subrequest_error",
"param": null,
"code": "internal_error"
}
}

at dev.langchain4j.internal.ExceptionMapper$DefaultExceptionMapper.mapHttpStatusCode(ExceptionMapper.java:56)
at dev.langchain4j.internal.ExceptionMapper$DefaultExceptionMapper.mapException(ExceptionMapper.java:44)
at dev.langchain4j.internal.ExceptionMapper.withExceptionMapper(ExceptionMapper.java:31)
at dev.langchain4j.interna
```

## Testing
- Tested manually
