### PR TITLE
Enable sorting for all trace columns

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortableFields.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortableFields.java
@@ -15,6 +15,7 @@ public class SortableFields {
     public static final String DURATION = "duration";
     public static final String METADATA = "metadata";
     public static final String USAGE = "usage";
+    public static final String USAGE_DYNAMIC = "usage.*";
     public static final String TAGS = "tags";
     public static final String TRACE_ID = "trace_id";
     public static final String THREAD_ID = "thread_id";
@@ -26,6 +27,7 @@ public class SortableFields {
     public static final String ERROR_INFO = "error_info";
     public static final String CREATED_BY = "created_by";
     public static final String LAST_UPDATED_BY = "last_updated_by";
+    public static final String SPAN_COUNT = "span_count";
     public static final String TRACE_COUNT = "trace_count";
     public static final String FEEDBACK_SCORES = "feedback_scores.*";
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SpanSortingFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SpanSortingFactory.java
@@ -23,6 +23,7 @@ import static com.comet.opik.api.sorting.SortableFields.TOTAL_ESTIMATED_COST;
 import static com.comet.opik.api.sorting.SortableFields.TRACE_ID;
 import static com.comet.opik.api.sorting.SortableFields.TYPE;
 import static com.comet.opik.api.sorting.SortableFields.USAGE;
+import static com.comet.opik.api.sorting.SortableFields.USAGE_DYNAMIC;
 
 public class SpanSortingFactory extends SortingFactory {
 
@@ -41,6 +42,7 @@ public class SpanSortingFactory extends SortingFactory {
                 END_TIME,
                 DURATION,
                 USAGE,
+                USAGE_DYNAMIC,
                 METADATA,
                 TAGS,
                 CREATED_AT,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/TraceSortingFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/TraceSortingFactory.java
@@ -2,6 +2,8 @@ package com.comet.opik.api.sorting;
 
 import java.util.List;
 
+import com.comet.opik.api.sorting.SortingField;
+
 import static com.comet.opik.api.sorting.SortableFields.CREATED_BY;
 import static com.comet.opik.api.sorting.SortableFields.DURATION;
 import static com.comet.opik.api.sorting.SortableFields.END_TIME;
@@ -15,8 +17,27 @@ import static com.comet.opik.api.sorting.SortableFields.OUTPUT;
 import static com.comet.opik.api.sorting.SortableFields.START_TIME;
 import static com.comet.opik.api.sorting.SortableFields.TAGS;
 import static com.comet.opik.api.sorting.SortableFields.THREAD_ID;
+import static com.comet.opik.api.sorting.SortableFields.USAGE_DYNAMIC;
+import static com.comet.opik.api.sorting.SortableFields.TOTAL_ESTIMATED_COST;
+import static com.comet.opik.api.sorting.SortableFields.SPAN_COUNT;
 
 public class TraceSortingFactory extends SortingFactory {
+
+    @Override
+    public List<SortingField> newSorting(String queryParam) {
+        List<SortingField> sorting = super.newSorting(queryParam);
+
+        return sorting.stream()
+                .map(field -> {
+                    if (field.field().startsWith("usage_")) {
+                        return field.toBuilder()
+                                .field(field.field().replaceFirst("usage_", "usage."))
+                                .build();
+                    }
+                    return field;
+                })
+                .toList();
+    }
 
     @Override
     public List<String> getSortableFields() {
@@ -30,6 +51,9 @@ public class TraceSortingFactory extends SortingFactory {
                 DURATION,
                 METADATA,
                 THREAD_ID,
+                SPAN_COUNT,
+                USAGE_DYNAMIC,
+                TOTAL_ESTIMATED_COST,
                 TAGS,
                 ERROR_INFO,
                 CREATED_BY,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -538,6 +538,9 @@ class TraceDAOImpl implements TraceDAO {
                 <if(sort_has_feedback_scores)>
                 LEFT JOIN feedback_scores_agg fsagg ON fsagg.entity_id = t.id
                 <endif>
+                <if(sort_has_span_statistics)>
+                LEFT JOIN spans_agg s ON t.id = s.trace_id
+                <endif>
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
                 <if(last_received_trace_id)> AND id \\< :last_received_trace_id <endif>
@@ -1524,6 +1527,11 @@ class TraceDAOImpl implements TraceDAO {
 
                     if (sortFields.contains("feedback_scores")) {
                         finalTemplate.add("sort_has_feedback_scores", true);
+                    }
+
+                    if (sortFields.contains("usage") || sortFields.contains("span_count")
+                            || sortFields.contains("total_estimated_cost")) {
+                        finalTemplate.add("sort_has_span_statistics", true);
                     }
 
                     finalTemplate.add("sort_fields", sortFields);

--- a/apps/opik-frontend/src/lib/sorting.ts
+++ b/apps/opik-frontend/src/lib/sorting.ts
@@ -10,7 +10,7 @@ export const processSorting = (sorting?: ColumnSort[]) => {
 
   if (sorting && sorting.length > 0) {
     sorting.forEach((column) => {
-      const { id, desc } = mapFeedbackScoresColumn(column);
+      const { id, desc } = mapUsageColumn(mapFeedbackScoresColumn(column));
 
       sortingFields.push({
         field: id,
@@ -34,6 +34,16 @@ export const mapFeedbackScoresColumn = (column: ColumnSort): ColumnSort => {
         `${COLUMN_FEEDBACK_SCORES_ID}_`,
         `${COLUMN_FEEDBACK_SCORES_ID}.`,
       ),
+    };
+  }
+  return column;
+};
+
+export const mapUsageColumn = (column: ColumnSort): ColumnSort => {
+  if (column.id.startsWith("usage_")) {
+    return {
+      ...column,
+      id: column.id.replace("usage_", "usage."),
     };
   }
   return column;


### PR DESCRIPTION
## Summary
- support dynamic usage keys and span count in sorting constants
- expose new fields from trace and span sorting factories
- map underscore usage fields to dot notation in the frontend
- map underscore usage fields in backend sorting factory
- join span statistics when sorting by usage or cost

## Testing
- `mvn -q -pl apps/opik-backend test` *(fails: mvn not found)*
- `npm --prefix apps/opik-frontend test --silent` *(fails: vitest not found)*
- `pytest -q` *(fails: missing dependencies)*