### PR TITLE
[OPIK-1625] [P SDK] Distributed headers don't create the correct trace context

### DIFF
--- a/sdks/python/src/opik/decorator/base_track_decorator.py
+++ b/sdks/python/src/opik/decorator/base_track_decorator.py
@@ -524,7 +524,7 @@ def pop_end_candidates() -> Tuple[span.SpanData, Optional[trace.TraceData]]:
     from the current context, returns popped objects.
 
     Decorator can't attach any child objects to the popped ones because
-    they are no longer in context stack.
+    they are no longer in the context stack.
     """
     span_data_to_end = context_storage.pop_span_data()
     assert (

--- a/sdks/python/src/opik/decorator/span_creation_handler.py
+++ b/sdks/python/src/opik/decorator/span_creation_handler.py
@@ -17,9 +17,6 @@ def create_span_for_current_context(
     """
     Handles different span creation flows.
     """
-    span_data: span.SpanData
-    trace_data: trace.TraceData
-
     if distributed_trace_headers:
         span_data = arguments_helpers.create_span_data(
             start_span_arguments=start_span_arguments,
@@ -33,14 +30,20 @@ def create_span_for_current_context(
     current_trace_data = context_storage.get_trace_data()
 
     if current_span_data is not None:
-        # There is already at least one span in current context.
-        # Simply attach a new span to it.
-        assert current_trace_data is not None
+        # There is already at least one span in the current context - attach a new span to it.
+        #
+        # NOTE: We can have a situation when span data is in context, but there is no trace data
+        # because we are in a distributed environment and trace data was created in another thread.
+        # See:
+        if current_trace_data is None:
+            show_warning = False
+        else:
+            show_warning = current_trace_data.created_by != "evaluation"
 
         project_name = helpers.resolve_child_span_project_name(
             parent_project_name=current_span_data.project_name,
             child_project_name=start_span_arguments.project_name,
-            show_warning=current_trace_data.created_by != "evaluation",
+            show_warning=show_warning,
         )
 
         start_span_arguments.project_name = project_name
@@ -57,7 +60,7 @@ def create_span_for_current_context(
         # By default, we expect trace to be created with a span.
         # But there can be cases when trace was created and added
         # to context manually (not via decorator).
-        # In that case decorator should just create a span for the existing trace.
+        # In that case the decorator should just create a span for the existing trace.
 
         project_name = helpers.resolve_child_span_project_name(
             parent_project_name=current_trace_data.project_name,
@@ -77,8 +80,8 @@ def create_span_for_current_context(
 
     if current_span_data is None and current_trace_data is None:
         # Create a trace and root span because it is
-        # the first decorated function run in current context.
-        trace_data = trace.TraceData(
+        # the first decorated function run in the current context.
+        current_trace_data = trace.TraceData(
             id=helpers.generate_id(),
             start_time=datetime_helpers.local_timestamp(),
             name=start_span_arguments.name,
@@ -88,10 +91,10 @@ def create_span_for_current_context(
             project_name=start_span_arguments.project_name,
         )
 
-        span_data = arguments_helpers.create_span_data(
+        current_span_data = arguments_helpers.create_span_data(
             start_span_arguments=start_span_arguments,
             parent_span_id=None,
-            trace_id=trace_data.id,
+            trace_id=current_trace_data.id,
         )
 
-        return trace_data, span_data
+    return current_trace_data, current_span_data

--- a/sdks/python/src/opik/opik_context.py
+++ b/sdks/python/src/opik/opik_context.py
@@ -10,7 +10,7 @@ from . import context_storage, exceptions
 
 def get_current_span_data() -> Optional[span.SpanData]:
     """
-    Returns current span created by track() decorator or None if no span was found.
+    Returns the current span created by track() decorator or None if no span was found.
     """
     span_data = context_storage.top_span_data()
     if span_data is None:
@@ -21,7 +21,7 @@ def get_current_span_data() -> Optional[span.SpanData]:
 
 def get_current_trace_data() -> Optional[trace.TraceData]:
     """
-    Returns current trace created by track() decorator or None if no trace was found.
+    Returns the current trace created by track() decorator or None if no trace was found.
     """
     trace_data = context_storage.get_trace_data()
     if trace_data is None:

--- a/sdks/python/src/opik/opik_context.py
+++ b/sdks/python/src/opik/opik_context.py
@@ -32,7 +32,7 @@ def get_current_trace_data() -> Optional[trace.TraceData]:
 
 def get_distributed_trace_headers() -> DistributedTraceHeadersDict:
     """
-    Returns headers dictionary to be passed into tracked function on remote node.
+    Returns headers' dictionary to be passed into tracked function on remote node.
     Requires an existing span in the context, otherwise raises an error.
     """
     current_span_data = context_storage.top_span_data()

--- a/sdks/python/tests/unit/decorator/test_tracker.py
+++ b/sdks/python/tests/unit/decorator/test_tracker.py
@@ -1,5 +1,7 @@
+import threading
 from unittest import mock
 
+from opik import opik_context
 from opik.api_objects import opik_client
 from opik.decorator import tracker
 
@@ -17,3 +19,34 @@ def test_track__get_client_cached_raised_error__error_is_caught__user_function_i
         assert f() == 42
 
         mock_get_client_cached.assert_called_once()
+
+
+def test_track__using_distributed_headers__headers_are_set_correctly(fake_backend):
+    @tracker.track
+    def inner_thread(x):
+        print("Inner thread")
+        return "inner-thread-output"
+
+    @tracker.track
+    def top_thread(x):
+        print("TOP THREAD")
+        inner_thread(x)
+        return "top-thread-output"
+
+    @tracker.track
+    def do_distributed_trace():
+        headers = opik_context.get_distributed_trace_headers()
+
+        t = threading.Thread(
+            target=top_thread,
+            kwargs={
+                "x": "inner-thread-input",
+                "opik_distributed_trace_headers": headers,
+            },
+        )
+        t.start()
+        t.join()
+
+        return "distributed-trace-output"
+
+    do_distributed_trace()


### PR DESCRIPTION
## Details
Fixed distributed tracing support for threaded spans.

Fixed `span_creation_handler.create_span_for_current_context` method to avoid assertion error if there is no `current_trace_data` but only `current_span_data` which can happen in multithreaded environment.

## Issues
When passing distributed headers to a @track decorated function, the trace context don’t seems to be correctly created. This lead to issue when calling other tracked function within the function that received the distributed headers.

```Python
import opik
import threading


@opik.track
def inner_thread():
    print("Inner thread")


@opik.track
def top_thread():
    print("TOP THREAD")
    inner_thread()


@opik.track
def main():
    headers = opik.opik_context.get_distributed_trace_headers()

    t = threading.Thread(
        target=top_thread, kwargs={"opik_distributed_trace_headers": headers}
    )
    t.start()
    t.join()


if __name__ == "__main__":
    main()
```
## Testing
Added related test cases,
