### PR TITLE
Fix OpenAI parsing logic

### DIFF
--- a/apps/opik-frontend/src/lib/traces.ts
+++ b/apps/opik-frontend/src/lib/traces.ts
@@ -45,7 +45,7 @@ const prettifyOpenAIMessageLogic = (
     isArray(message.messages)
   ) {
     const lastMessage = last(message.messages);
-    if (lastMessage && "content" in lastMessage) {
+    if (lastMessage && isObject(lastMessage) && "content" in lastMessage) {
       if (isString(lastMessage.content) && lastMessage.content.length > 0) {
         return lastMessage.content;
       } else if (isArray(lastMessage.content)) {


### PR DESCRIPTION
## Details

The new OpenAI parsing logic was trying to `in` on a string rather than object which is not supported causing a full page crash.

## Issues

Resolves #2238 
