### PR TITLE
NA: Ignore unknown fields on Open Route error message

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterErrorMessage.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterErrorMessage.java
@@ -1,6 +1,7 @@
 package com.comet.opik.infrastructure.llm.openrouter;
 
 import com.comet.opik.infrastructure.llm.LlmProviderError;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -10,6 +11,7 @@ import static com.comet.opik.infrastructure.llm.openrouter.OpenRouterErrorMessag
 public record OpenRouterErrorMessage(
         OpenRouterError error) implements LlmProviderError<OpenRouterError> {
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public record OpenRouterError(@NotBlank String message, @NotNull Integer code) {
     }
 


### PR DESCRIPTION
## Details
- Handling error messages like:

```
exception.stacktrace:dev.langchain4j.exception.HttpException: {"error":{"message":"This request requires more credits, or fewer max_tokens. You requested up to 16384 tokens, but can only afford 4000. To increase, visit https://openrouter.ai/settings/credits and upgrade to a paid account","code":402,"metadata":{"provider_name":null}},"user_id":"userxxxxxxxx"}
```

## Issues

Resolves #

## Testing

## Documentation
