### PR TITLE
[OPIK-1698]: [P SDK] Update dynamic rate limiting to use new response headers sent by the backend

### DIFF
--- a/sdks/python/src/opik/rate_limit/rate_limit.py
+++ b/sdks/python/src/opik/rate_limit/rate_limit.py
@@ -1,43 +1,25 @@
 import dataclasses
-import re
 from typing import Any, Dict, Optional
 
 
 @dataclasses.dataclass
 class CloudRateLimit:
-    bucket_name: str
-    rate_limit_name: str
     remaining_limit: int
-    remaining_limit_reset_time_ms: int
+    remaining_limit_reset_time: int
 
     def retry_after(self) -> float:
-        return self.remaining_limit_reset_time_ms / 1000.0
+        return self.remaining_limit_reset_time
 
 
 def parse_rate_limit(rate_limit_response: Dict[str, Any]) -> Optional[CloudRateLimit]:
-    pattern = re.compile(r"opik-(.\w*)-limit")
+    rate_limit_reset_time = int(rate_limit_response.get("RateLimit-Reset", 0))
+    if rate_limit_reset_time == 0:
+        rate_limit_reset_time = int(rate_limit_response.get("ratelimit-reset", 0))
 
-    for key in rate_limit_response.keys():
-        match = pattern.match(key)
-        if match:
-            rate_limit_name = match.group(1)
-            rate_limit = CloudRateLimit(
-                bucket_name=rate_limit_response.get(
-                    f"opik-{rate_limit_name}-limit", ""
-                ),
-                rate_limit_name=rate_limit_name,
-                remaining_limit=int(
-                    rate_limit_response.get(
-                        f"opik-{rate_limit_name}-remaining-limit", 0
-                    )
-                ),
-                remaining_limit_reset_time_ms=int(
-                    rate_limit_response.get(
-                        f"opik-{rate_limit_name}-remaining-limit-ttl-millis", 0
-                    )
-                ),
-            )
-            if rate_limit.remaining_limit == 0:
-                return rate_limit
+    if rate_limit_reset_time > 0:
+        return CloudRateLimit(
+            remaining_limit=0,
+            remaining_limit_reset_time=rate_limit_reset_time,
+        )
 
     return None

--- a/sdks/python/tests/unit/rate_limit/test_rate_limit.py
+++ b/sdks/python/tests/unit/rate_limit/test_rate_limit.py
@@ -7,43 +7,26 @@ from opik.rate_limit import rate_limit
     [
         (
             {
-                "opik-customlimit-limit": "bucket",
-                "opik-customlimit-remaining-limit": "0",
-                "opik-customlimit-remaining-limit-ttl-millis": "997",
+                "RateLimit-Reset": "10",
             },
             rate_limit.CloudRateLimit(
-                bucket_name="bucket",
-                rate_limit_name="customlimit",
                 remaining_limit=0,
-                remaining_limit_reset_time_ms=997,
+                remaining_limit_reset_time=10,
             ),
         ),
         (
             {
-                "opik-available-limit": "bucket",
-                "opik-available-remaining-limit": "10",
-                "opik-available-remaining-limit-ttl-millis": "997",
+                "ratelimit-reset": "10",
             },
-            None,
+            rate_limit.CloudRateLimit(
+                remaining_limit=0,
+                remaining_limit_reset_time=10,
+            ),
         ),
         ({"foo": "bar"}, None),
-        (
-            {
-                "opik-user-limit": "general_events",
-                "opik-user-remaining-limit": "5000",
-                "opik-user-remaining-limit-ttl-millis": "56709",
-                "opik-workspace-limit": "workspace_events",
-                "opik-workspace-remaining-limit": "0",
-                "opik-workspace-remaining-limit-ttl-millis": "56700",
-            },
-            rate_limit.CloudRateLimit(
-                bucket_name="workspace_events",
-                rate_limit_name="workspace",
-                remaining_limit=0,
-                remaining_limit_reset_time_ms=56700,
-            ),
-        ),
+        ({"RateLimit-Reset": "-10"}, None),
     ],
+    ids=["standard_name", "lower_case_name", "no_rate_limit", "negative_rate_limit"],
 )
 def test_parse_rate_limit(rate_limit_dict, expected):
     parsed = rate_limit.parse_rate_limit(rate_limit_dict)


### PR DESCRIPTION
## Details
Refactor rate limit parsing for simplified implementation using standard `RateLimit-Reset` header.

Simplified the `CloudRateLimit` data structure by removing unused fields and updated the parsing logic to detect a new rate limit header. Added handling for standard and lowercase header variations to ensure compatibility.

## Testing
Fixed related tests
