### PR TITLE
[OPIK-1553]: Add LLM Calls count column to traces

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Trace.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Trace.java
@@ -65,7 +65,7 @@ public record Trace(
         @JsonView({
                 Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) VisibilityMode visibilityMode,
         @JsonView({
-                Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) int llmCallCount){
+                Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) int llmSpanCount){
 
     @Builder(toBuilder = true)
     public record TracePage(
@@ -101,7 +101,7 @@ public record Trace(
         GUARDRAILS_VALIDATIONS("guardrails_validations"),
         TOTAL_ESTIMATED_COST("total_estimated_cost"),
         SPAN_COUNT("span_count"),
-        LLM_CALL_COUNT("llm_call_count"),
+        LLM_SPAN_COUNT("llm_span_count"),
         DURATION("duration"),
         THREAD_ID("thread_id"),
         VISIBILITY_MODE("visibility_mode"),

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -324,7 +324,7 @@ class TraceDAOImpl implements TraceDAO {
                 sumMap(s.usage) as usage,
                 sum(s.total_estimated_cost) as total_estimated_cost,
                 COUNT(s.id) AS span_count,
-                countIf(s.type = 'llm') AS llm_call_count,
+                countIf(s.type = 'llm') AS llm_span_count,
                 groupUniqArrayArray(c.comments_array) as comments,
                 any(fs.feedback_scores) as feedback_scores_list,
                 any(gr.guardrails) as guardrails_validations
@@ -493,7 +493,7 @@ class TraceDAOImpl implements TraceDAO {
                     sumMap(usage) as usage,
                     sum(total_estimated_cost) as total_estimated_cost,
                     COUNT(DISTINCT id) as span_count,
-                    countIf(type = 'llm') as llm_call_count
+                    countIf(type = 'llm') as llm_span_count
                 FROM spans final
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
@@ -605,7 +605,7 @@ class TraceDAOImpl implements TraceDAO {
                   <if(!exclude_comments)>, c.comments_array as comments <endif>
                   <if(!exclude_guardrails_validations)>, gagg.guardrails_list as guardrails_validations<endif>
                   <if(!exclude_span_count)>, s.span_count AS span_count<endif>
-                  <if(!exclude_llm_call_count)>, s.llm_call_count AS llm_call_count<endif>
+                  <if(!exclude_llm_span_count)>, s.llm_span_count AS llm_span_count<endif>
              FROM traces_final t
              LEFT JOIN feedback_scores_agg fsagg ON fsagg.entity_id = t.id
              LEFT JOIN spans_agg s ON t.id = s.trace_id
@@ -1428,8 +1428,8 @@ class TraceDAOImpl implements TraceDAO {
                 .spanCount(Optional
                         .ofNullable(getValue(exclude, Trace.TraceField.SPAN_COUNT, row, "span_count", Integer.class))
                         .orElse(0))
-                .llmCallCount(Optional
-                        .ofNullable(getValue(exclude, Trace.TraceField.LLM_CALL_COUNT, row, "llm_call_count",
+                .llmSpanCount(Optional
+                        .ofNullable(getValue(exclude, Trace.TraceField.LLM_SPAN_COUNT, row, "llm_span_count",
                                 Integer.class))
                         .orElse(0))
                 .usage(getValue(exclude, Trace.TraceField.USAGE, row, "usage", Map.class))
@@ -1621,8 +1621,8 @@ class TraceDAOImpl implements TraceDAO {
                         template.add("exclude_guardrails_validations",
                                 fields.contains(Trace.TraceField.GUARDRAILS_VALIDATIONS.getValue()));
                         template.add("exclude_span_count", fields.contains(Trace.TraceField.SPAN_COUNT.getValue()));
-                        template.add("exclude_llm_call_count",
-                                fields.contains(Trace.TraceField.LLM_CALL_COUNT.getValue()));
+                        template.add("exclude_llm_span_count",
+                                fields.contains(Trace.TraceField.LLM_SPAN_COUNT.getValue()));
                     }
                 });
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/traces/TraceAssertions.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/traces/TraceAssertions.java
@@ -19,7 +19,7 @@ public class TraceAssertions {
 
     public static final String[] IGNORED_FIELDS_TRACES = {"projectId", "projectName", "createdAt",
             "lastUpdatedAt", "feedbackScores", "createdBy", "lastUpdatedBy", "totalEstimatedCost", "spanCount",
-            "llmCallCount", "duration", "comments", "threadId", "guardrailsValidations"};
+            "llmSpanCount", "duration", "comments", "threadId", "guardrailsValidations"};
 
     private static final String[] IGNORED_FIELDS_SCORES = {"createdAt", "lastUpdatedAt", "createdBy", "lastUpdatedBy"};
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -199,7 +199,7 @@ class TracesResourceTest {
         EXCLUDE_FUNCTIONS.put(Trace.TraceField.GUARDRAILS_VALIDATIONS,
                 it -> it.toBuilder().guardrailsValidations(null).build());
         EXCLUDE_FUNCTIONS.put(Trace.TraceField.SPAN_COUNT, it -> it.toBuilder().spanCount(0).build());
-        EXCLUDE_FUNCTIONS.put(Trace.TraceField.LLM_CALL_COUNT, it -> it.toBuilder().llmCallCount(0).build());
+        EXCLUDE_FUNCTIONS.put(Trace.TraceField.LLM_SPAN_COUNT, it -> it.toBuilder().llmSpanCount(0).build());
         EXCLUDE_FUNCTIONS.put(Trace.TraceField.TOTAL_ESTIMATED_COST,
                 it -> it.toBuilder().totalEstimatedCost(null).build());
         EXCLUDE_FUNCTIONS.put(Trace.TraceField.THREAD_ID, it -> it.toBuilder().threadId(null).build());
@@ -4965,8 +4965,8 @@ class TracesResourceTest {
                             assertThat(returned.spanCount())
                                     .as("Trace with id %s should have spanCount %d", created.id(), created.spanCount())
                                     .isEqualTo(created.spanCount());
-                            assertThat(returned.llmCallCount())
-                                    .as("Trace with id %s should have llmCallCount %d", created.id(),
+                            assertThat(returned.llmSpanCount())
+                                    .as("Trace with id %s should have llmSpanCount %d", created.id(),
                                             created.spanCount())
                                     .isEqualTo(created.spanCount());
                         },
@@ -4984,13 +4984,13 @@ class TracesResourceTest {
                     .as("Total spanCount across all traces should match the expected total")
                     .isEqualTo(expectedTotalSpanCount);
 
-            int actualTotalLlmCallCount = returnedTraces.stream()
+            int actualTotalLlmSpanCount = returnedTraces.stream()
                     .filter(rt -> traces.stream().anyMatch(t -> t.id().equals(rt.id())))
-                    .mapToInt(Trace::llmCallCount)
+                    .mapToInt(Trace::llmSpanCount)
                     .sum();
 
-            assertThat(actualTotalLlmCallCount)
-                    .as("Total llmCallCount across all traces should match the expected total")
+            assertThat(actualTotalLlmSpanCount)
+                    .as("Total llmSpanCount across all traces should match the expected total")
                     .isEqualTo(expectedTotalSpanCount);
         }
         private Stream<Arguments> getTracesByProject__whenSortingByValidFields__thenReturnTracesSorted() {

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
@@ -490,11 +490,11 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
               accessorFn: (row: BaseTraceData) => get(row, "span_count", "-"),
             },
             {
-              id: "llm_call_count",
+              id: "llm_span_count",
               label: "LLM calls count",
               type: COLUMN_TYPE.number,
               accessorFn: (row: BaseTraceData) =>
-                get(row, "llm_call_count", "-"),
+                get(row, "llm_span_count", "-"),
             },
             {
               id: "thread_id",

--- a/apps/opik-frontend/src/types/traces.ts
+++ b/apps/opik-frontend/src/types/traces.ts
@@ -51,7 +51,7 @@ export interface BaseTraceData {
 
 export interface Trace extends BaseTraceData {
   span_count?: number;
-  llm_call_count?: number;
+  llm_span_count?: number;
   thread_id?: string;
   project_id: string;
   workspace_name?: string;


### PR DESCRIPTION
## Details
- Added llmCallCount to the Trace API model so each trace exposes the number of LLM calls count.
- Aggregated countIf(s.type = 'llm') in TraceDAO queries to compute the count and included it in trace mapping.
- Frontend Traces table includes the “Number of LLM Calls” column using the new field.

## Issues
Needed to add a new column called "LLM Calls count"  to each trace record.
As per issue (1553): "Add column "Number of LLM Calls" for a Trace the in Project table"
This allows to better understand the complexity of Traces without the need to click on each of them
Resolves #1553 
## Testing
Updated tests to ignore the new field when comparing traces and to verify the count of LLM calls (same as done for the similar field spanCount).

Screencast of it working:
https://github.com/user-attachments/assets/1bd96bf8-6e2b-497c-8625-b4baea70d699


