### PR TITLE
Allow actions to run on external PRs when approved

### DIFF
--- a/.github/workflows/backend_formatting_check.yml
+++ b/.github/workflows/backend_formatting_check.yml
@@ -2,7 +2,7 @@ name: "Backend Formatting Check"
 run-name: "Backend Formatting Check on ${{ github.ref_name }} by @${{ github.actor }}"
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - "apps/opik-backend/**/*.java"
   push:

--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -2,7 +2,7 @@ name: "Backend Tests"
 run-name: "Backend Tests on ${{ github.ref_name }} by @${{ github.actor }}"
 
 on:
-  pull_request:
+  pull_request_target:
     paths: 
       - "apps/opik-backend/**"
   push:

--- a/.github/workflows/documentation_codeblock_tests.yml
+++ b/.github/workflows/documentation_codeblock_tests.yml
@@ -1,7 +1,7 @@
 name: Docs - Test codeblocks
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     paths:
       - 'apps/opik-documentation/documentation/fern/docs/*.md'
       - 'apps/opik-documentation/documentation/fern/docs/*.mdx'

--- a/.github/workflows/documentation_image_optimizer.yml
+++ b/.github/workflows/documentation_image_optimizer.yml
@@ -1,7 +1,7 @@
 name: Docs - Compress Images
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     # Run Image Actions when JPG, JPEG, PNG or WebP files are added or changed.
     # See https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onpushpull_requestpaths for reference.
     paths:

--- a/.github/workflows/end2end_suites.yml
+++ b/.github/workflows/end2end_suites.yml
@@ -28,7 +28,7 @@ on:
             ALLURE_USERNAME:
                 description: ALLURE_USERNAME service parameter. Leave blank.
                 
-    pull_request:
+    pull_request_target:
       paths:
         - 'sdks/code_generation/fern/openapi/openapi.yaml'
         - 'tests_end_to_end/**'

--- a/.github/workflows/frontend_linter.yml
+++ b/.github/workflows/frontend_linter.yml
@@ -1,7 +1,7 @@
 name: Frontend Linter
 run-name: "Frontend Linter ${{ github.ref_name }} by @${{ github.actor }}"
 on:
-  pull_request:
+  pull_request_target:
     paths: 
       - "apps/opik-frontend/src/**"
   push:

--- a/.github/workflows/lib-integration-tests-runner.yml
+++ b/.github/workflows/lib-integration-tests-runner.yml
@@ -23,7 +23,7 @@ on:
           - genai
   schedule:
     - cron: "0 0 */1 * *"
-  pull_request:
+  pull_request_target:
     paths:
     - 'sdks/python/**'
   push:

--- a/.github/workflows/lint_helm_chart.yaml
+++ b/.github/workflows/lint_helm_chart.yaml
@@ -3,7 +3,7 @@ run-name: "Lint Opik Helm Chart ${{ github.ref_name }} by @${{ github.actor }}"
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     paths: 
       - "deployment/helm_chart/opik/**"
   push:

--- a/.github/workflows/python_backend_tests.yml
+++ b/.github/workflows/python_backend_tests.yml
@@ -2,7 +2,7 @@ name: "Python Backend Tests"
 run-name: "Python Backend Tests on ${{ github.ref_name }} by @${{ github.actor }}"
 
 on:
-  pull_request:
+  pull_request_target:
     paths: 
       - "apps/opik-python-backend/**"
   push:

--- a/.github/workflows/python_sdk_linter.yml
+++ b/.github/workflows/python_sdk_linter.yml
@@ -2,7 +2,7 @@
 name: SDK Linter
 run-name: "SDK Linter ${{ github.ref_name }} by @${{ github.actor }}"
 on:
-  pull_request:
+  pull_request_target:
     paths:
     - 'sdks/python/**'
   push:

--- a/.github/workflows/python_sdk_unit_tests.yml
+++ b/.github/workflows/python_sdk_unit_tests.yml
@@ -1,7 +1,7 @@
 name: SDK Unit Tests
 run-name: "SDK Unit Tests ${{ github.ref_name }} by @${{ github.actor }}"
 on:
-  pull_request:
+  pull_request_target:
     paths:
     - 'sdks/python/**'
   push:

--- a/.github/workflows/sdk-e2e-library-tests.yaml
+++ b/.github/workflows/sdk-e2e-library-tests.yaml
@@ -15,7 +15,7 @@ on:
             - litellm
     schedule:
       - cron: "0 0 */2 * *"
-    pull_request:
+    pull_request_target:
         paths:
           - 'sdks/python/**'
     push:

--- a/.github/workflows/sdk-e2e-tests.yaml
+++ b/.github/workflows/sdk-e2e-tests.yaml
@@ -2,7 +2,7 @@ name: SDK E2E Tests
 run-name: "SDK E2E Tests ${{ github.ref_name }} by @${{ github.actor }}"
 on:
     workflow_dispatch:
-    pull_request:
+    pull_request_target:
         paths:
           - 'sdks/python/**'
           - 'apps/opik-backend/**'

--- a/.github/workflows/tests_end_to_end_linter.yml
+++ b/.github/workflows/tests_end_to_end_linter.yml
@@ -2,7 +2,7 @@
     name: E2E Tests Linter
     run-name: "E2E Tests Linter ${{ github.ref_name }} by @${{ github.actor }}"
     on:
-      pull_request:
+      pull_request_target:
         paths:
         - 'tests_end_to_end/**'
       push:

--- a/.github/workflows/typescript_sdk_unit_tests.yml
+++ b/.github/workflows/typescript_sdk_unit_tests.yml
@@ -1,7 +1,7 @@
 name: TypeScript SDK Unit Tests
 run-name: "TypeScript SDK Unit Tests ${{ github.ref_name }} by @${{ github.actor }}"
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - "sdks/typescript/**"
   push:

--- a/.github/workflows/update_helm_readme.yaml
+++ b/.github/workflows/update_helm_readme.yaml
@@ -1,7 +1,7 @@
 name: Generate helm docs
 run-name: Generate helm docs ${{ github.ref_name }} by @${{ github.actor }}"
 on:
-  pull_request:
+  pull_request_target:
     paths: 
       - "deployment/helm_chart/opik/**"
 


### PR DESCRIPTION
## Details

Currently we cannot run tests that require secrets stored in Opik for external PRs. In this PR, we update the actions to use the `pull_request_target` trigger as [documented here](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target).

The repository settings have also been updated to require approval before running tests from external contributors.