### PR TITLE
OPIK-1731 [PY SDK] Google ADK: adk_invocation_id from callback context is not used

### DIFF
--- a/sdks/python/src/opik/integrations/adk/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/opik_tracer.py
@@ -189,7 +189,7 @@ class OpikTracer:
             new_trace_data = trace.TraceData(
                 name=name,
                 input=user_input,
-                metadata=self.metadata,
+                metadata=trace_metadata,
                 project_name=self.project_name,
                 thread_id=thread_id,
             )

--- a/sdks/python/tests/e2e_library_integration/adk/test_opik_tracer.py
+++ b/sdks/python/tests/e2e_library_integration/adk/test_opik_tracer.py
@@ -128,6 +128,7 @@ def test_opik_tracer_with_sample_agent(
     trace = traces[0]
     assert trace.span_count == 3  # two LLM calls and one function call
     assert trace.usage is not None
+    assert "adk_invocation_id" in trace.metadata.keys()
     testlib.assert_dict_has_keys(trace.usage, EXPECTED_USAGE_KEYS_GOOGLE)
 
     spans = opik_client_unique_project_name.search_spans()
@@ -167,6 +168,7 @@ def test_opik_tracer_with_sample_agent__openai(
     trace = traces[0]
     assert trace.span_count == 3  # two LLM calls and one function call
     assert trace.usage is not None
+    assert "adk_invocation_id" in trace.metadata.keys()
     testlib.assert_dict_has_keys(trace.usage, EXPECTED_USAGE_KEYS_OPENAI)
 
     spans = opik_client_unique_project_name.search_spans()


### PR DESCRIPTION
## Details
Do not forget to put `adk_invocation_id` to trace metadata

## Issues
https://github.com/comet-ml/opik/issues/2305

## Testing
tests are updated


