### PR TITLE
OPIK-1679: Add warm up and async release of containers

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/executor_docker.py
+++ b/apps/opik-python-backend/src/opik_backend/executor_docker.py
@@ -78,12 +78,17 @@ class DockerExecutor(CodeExecutorBase):
         logger.info(f"Created container, id '{new_container.id}'")
 
     def release_container(self, container):
+
         def async_release():
             try:
+                # First, ensure we have enough containers in the pool
+                self.create_container()
+
+                # Now stop and remove the old container
                 logger.info(f"Stopping container {container.id}. Will create a new one.")
                 container.stop(timeout=1)
                 container.remove(force=True)
-                self.create_container()
+                logger.info(f"Stopped container {container.id}")
             except Exception as e:
                 logger.error(f"Error replacing container: {e}")
 


### PR DESCRIPTION
## Details
- Add warm-up 
- Add a new container to the pool quickly so new requests can be processed
- Remove the container async in the background

Context:
- It takes an average of 1.5 to stop the container that served the request.