### PR TITLE
fix: correct 'Raad more' typo to 'Read more'

### DIFF
--- a/apps/opik-frontend/src/components/shared/CalloutAlert/CalloutAlert.tsx
+++ b/apps/opik-frontend/src/components/shared/CalloutAlert/CalloutAlert.tsx
@@ -32,7 +32,7 @@ const CalloutAlert: React.FC<CalloutAlertProps> = ({
               target="_blank"
               rel="noreferrer"
             >
-              Raad more
+              Read more
               <SquareArrowOutUpRight className="ml-0.5 size-3 shrink-0" />
             </a>
           </Button>

--- a/apps/opik-frontend/src/components/shared/ExplainerIcon/ExplainerIcon.tsx
+++ b/apps/opik-frontend/src/components/shared/ExplainerIcon/ExplainerIcon.tsx
@@ -31,7 +31,7 @@ const ExplainerIcon: React.FC<ExplainerIconProps> = ({
                 target="_blank"
                 rel="noreferrer"
               >
-                Raad more
+                Read more
                 <SquareArrowOutUpRight className="ml-0.5 size-3 shrink-0" />
               </a>
             </Button>


### PR DESCRIPTION
fix: correct typo in "Read more" link text

## Details

Fixed a typo where "Raad more" was incorrectly spelled instead of "Read more" in the link text for two components:
- CalloutAlert component
- ExplainerIcon component

## Documentation

No documentation changes required - this is a simple text correction.