### PR TITLE
OPIK-1734: Add evaluate task result column and validation

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentItemBulkRecord.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentItemBulkRecord.java
@@ -25,9 +25,11 @@ public record ExperimentItemBulkRecord(
         @JsonView( {
                 View.ExperimentItemBulkWriteView.class}) @NotNull UUID datasetItemId,
         @JsonView({
-                View.ExperimentItemBulkWriteView.class}) @Schema(implementation = JsonListString.class, description = "Please either evaluate_task_result or trace but not both") JsonNode evaluateTaskResult,
+                View.ExperimentItemBulkWriteView.class}) @Schema(implementation = JsonListString.class, description = DESCRIPTION) JsonNode evaluateTaskResult,
         @JsonView({
-                View.ExperimentItemBulkWriteView.class}) @Schema(description = "Please either evaluate_task_result or trace but not both") @Valid Trace trace,
+                View.ExperimentItemBulkWriteView.class}) @Schema(description = DESCRIPTION) @Valid Trace trace,
         @JsonView({View.ExperimentItemBulkWriteView.class}) @Size(max = 100) List<@Valid Span> spans,
         @Size(max = 100) List<@Valid FeedbackScore> feedbackScores){
+
+    private static final String DESCRIPTION = "Please provide either none, only one of evaluate_task_result or trace, but never both";
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentItemBulkRecord.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentItemBulkRecord.java
@@ -1,9 +1,12 @@
 package com.comet.opik.api;
 
+import com.comet.opik.api.validate.ExperimentItemBulkRecordValidation;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -17,10 +20,14 @@ import static com.comet.opik.api.ExperimentItemBulkUpload.View;
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@ExperimentItemBulkRecordValidation
 public record ExperimentItemBulkRecord(
         @JsonView( {
                 View.ExperimentItemBulkWriteView.class}) @NotNull UUID datasetItemId,
-        @JsonView({View.ExperimentItemBulkWriteView.class}) @Valid Trace trace,
+        @JsonView({
+                View.ExperimentItemBulkWriteView.class}) @Schema(implementation = JsonListString.class, description = "Please either evaluate_task_result or trace but not both") JsonNode evaluateTaskResult,
+        @JsonView({
+                View.ExperimentItemBulkWriteView.class}) @Schema(description = "Please either evaluate_task_result or trace but not both") @Valid Trace trace,
         @JsonView({View.ExperimentItemBulkWriteView.class}) @Size(max = 100) List<@Valid Span> spans,
         @Size(max = 100) List<@Valid FeedbackScore> feedbackScores){
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validate/ExperimentItemBulkRecordValidation.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validate/ExperimentItemBulkRecordValidation.java
@@ -1,0 +1,24 @@
+package com.comet.opik.api.validate;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {ExperimentItemBulkRecordValidator.class})
+@Documented
+public @interface ExperimentItemBulkRecordValidation {
+
+    String message() default "must provide either evaluate_task_result or trace but not both";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validate/ExperimentItemBulkRecordValidation.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validate/ExperimentItemBulkRecordValidation.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
 @Documented
 public @interface ExperimentItemBulkRecordValidation {
 
-    String message() default "must provide either evaluate_task_result or trace but not both";
+    String message() default "cannot provide both evaluate_task_result and trace together";
 
     Class<?>[] groups() default {};
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validate/ExperimentItemBulkRecordValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validate/ExperimentItemBulkRecordValidator.java
@@ -1,0 +1,38 @@
+package com.comet.opik.api.validate;
+
+import com.comet.opik.api.ExperimentItemBulkRecord;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ExperimentItemBulkRecordValidator
+        implements
+            ConstraintValidator<ExperimentItemBulkRecordValidation, ExperimentItemBulkRecord> {
+
+    private volatile ExperimentItemBulkRecordValidation constraintAnnotation;
+
+    @Override
+    public void initialize(ExperimentItemBulkRecordValidation constraintAnnotation) {
+        this.constraintAnnotation = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(ExperimentItemBulkRecord record, ConstraintValidatorContext context) {
+        boolean hasEvaluateTaskResult = record.evaluateTaskResult() != null;
+        boolean hasTrace = record.trace() != null;
+
+        boolean isInvalid = hasEvaluateTaskResult && hasTrace;
+
+        if (isInvalid) {
+            // Disable the default error message
+            context.disableDefaultConstraintViolation();
+
+            // Add a custom error message with the exact format we want
+            context.buildConstraintViolationWithTemplate(constraintAnnotation.message())
+                    .addPropertyNode("<list element>")
+                    .addConstraintViolation();
+        }
+
+        // Return true if the record is valid (i.e., it does not have both evaluateTaskResult and trace)
+        return !isInvalid;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
@@ -144,6 +144,7 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
                 trace = Trace.builder()
                         .id(idGenerator.generateId())
                         .projectName(ProjectService.DEFAULT_PROJECT)
+                        .output(item.evaluateTaskResult())
                         .startTime(now)
                         .endTime(now)
                         .visibilityMode(VisibilityMode.HIDDEN)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -4116,7 +4116,7 @@ class ExperimentsResourceTest {
                 var errorMessage = response.readEntity(com.comet.opik.api.error.ErrorMessage.class);
 
                 assertThat(errorMessage.errors()).contains(
-                        "items[0].<list element> must provide either evaluate_task_result or trace but not both");
+                        "items[0].<list element> cannot provide both evaluate_task_result and trace together");
             }
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -59,6 +59,7 @@ import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.ValidationUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.uuid.Generators;
 import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -3790,7 +3791,7 @@ class ExperimentsResourceTest {
 
             var feedbackScore = createScore();
 
-            List<ExperimentItem> expectedItems = getExpectedItem(datasetItem, trace, feedbackScore);
+            List<ExperimentItem> expectedItems = getExpectedItem(datasetItem, trace, feedbackScore, null);
 
             var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
             var bulkRecord = ExperimentItemBulkRecord.builder()
@@ -3820,7 +3821,7 @@ class ExperimentsResourceTest {
         }
 
         private List<ExperimentItem> getExpectedItem(DatasetItem datasetItem, Trace trace,
-                FeedbackScore feedbackScore) {
+                FeedbackScore feedbackScore, JsonNode evaluateTaskResult) {
             return List.of(
                     ExperimentItem.builder()
                             .datasetItemId(datasetItem.id())
@@ -3830,7 +3831,7 @@ class ExperimentsResourceTest {
                                             t.endTime()))
                                     .orElse(0.0))
                             .input(Optional.ofNullable(trace).map(Trace::input).orElse(null))
-                            .output(Optional.ofNullable(trace).map(Trace::output).orElse(null))
+                            .output(Optional.ofNullable(trace).map(Trace::output).orElse(evaluateTaskResult))
                             .feedbackScores(List.of(feedbackScore))
                             .createdAt(Optional.ofNullable(trace).map(Trace::createdAt).orElse(null))
                             .lastUpdatedAt(Optional.ofNullable(trace).map(Trace::lastUpdatedAt).orElse(null))
@@ -3888,7 +3889,7 @@ class ExperimentsResourceTest {
 
             var feedbackScore = createScore();
 
-            List<ExperimentItem> expectedItems = getExpectedItem(datasetItem, null, feedbackScore);
+            List<ExperimentItem> expectedItems = getExpectedItem(datasetItem, null, feedbackScore, null);
 
             var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
             var bulkItemRecord = ExperimentItemBulkRecord.builder()
@@ -4075,6 +4076,104 @@ class ExperimentsResourceTest {
 
         private String generateLargeString(int size) {
             return "a".repeat(Math.max(0, size));
+        }
+
+        @Test
+        void experimentItemsBulk__whenBothEvaluateTaskResultAndTraceProvided__thenReturnBadRequest() {
+            // given
+            var dataset = podamFactory.manufacturePojo(Dataset.class);
+            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
+            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
+                    .datasetId(datasetId)
+                    .build();
+
+            datasetResourceClient.createDatasetItems(
+                    new DatasetItemBatch(dataset.name(), null, List.of(datasetItem)),
+                    TEST_WORKSPACE,
+                    API_KEY);
+
+            // Create a bulk upload request with both evaluateTaskResult and trace
+            var trace = createTrace();
+            var evaluateTaskResult = podamFactory.manufacturePojo(JsonNode.class);
+
+            var bulkItemRecord = ExperimentItemBulkRecord.builder()
+                    .datasetItemId(datasetItem.id())
+                    .trace(trace)
+                    .evaluateTaskResult(evaluateTaskResult)
+                    .build();
+
+            var bulkUploadRequest = ExperimentItemBulkUpload.builder()
+                    .experimentName("Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20))
+                    .datasetName(dataset.name())
+                    .items(List.of(bulkItemRecord))
+                    .build();
+
+            // when
+            try (var response = experimentResourceClient.callExperimentItemBulkUpload(bulkUploadRequest, API_KEY,
+                    TEST_WORKSPACE)) {
+                // then
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+                var errorMessage = response.readEntity(com.comet.opik.api.error.ErrorMessage.class);
+
+                assertThat(errorMessage.errors()).contains(
+                        "items[0].<list element> must provide either evaluate_task_result or trace but not both");
+            }
+        }
+
+        @Test
+        void experimentItemsBulk__whenOnlyEvaluateTaskResultProvided__thenSucceed() {
+            // given
+            var dataset = podamFactory.manufacturePojo(Dataset.class);
+            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
+            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
+                    .datasetId(datasetId)
+                    .build();
+
+            datasetResourceClient.createDatasetItems(
+                    new DatasetItemBatch(dataset.name(), null, List.of(datasetItem)),
+                    TEST_WORKSPACE,
+                    API_KEY);
+
+            // Create a bulk upload request with only evaluateTaskResult
+            var evaluateTaskResult = podamFactory.manufacturePojo(JsonNode.class);
+            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+
+            var feedbackScore = createScore();
+
+            var bulkItemRecord = ExperimentItemBulkRecord.builder()
+                    .datasetItemId(datasetItem.id())
+                    .evaluateTaskResult(evaluateTaskResult)
+                    .feedbackScores(List.of(feedbackScore))
+                    .build();
+
+            var bulkUploadRequest = ExperimentItemBulkUpload.builder()
+                    .experimentName(experimentName)
+                    .datasetName(dataset.name())
+                    .items(List.of(bulkItemRecord))
+                    .build();
+
+            List<ExperimentItem> expectedItems = getExpectedItem(datasetItem, null, feedbackScore, evaluateTaskResult);
+
+            // when
+            experimentResourceClient.bulkUploadExperimentItem(bulkUploadRequest, API_KEY, TEST_WORKSPACE);
+
+            // then
+            List<ExperimentItem> actualExperimentItems = experimentResourceClient.getExperimentItems(experimentName,
+                    API_KEY, TEST_WORKSPACE);
+
+            String[] ignoringFields = Stream
+                    .concat(Arrays.stream(ExperimentTestAssertions.EXPERIMENT_ITEMS_IGNORED_FIELDS),
+                            Stream.of("traceId", "id", "experimentId"))
+                    .toArray(String[]::new);
+
+            ExperimentTestAssertions.assertExperimentResultsIgnoringFields(actualExperimentItems, expectedItems,
+                    ignoringFields);
+
+            Trace trace = traceResourceClient.getById(actualExperimentItems.getFirst().traceId(), TEST_WORKSPACE,
+                    API_KEY);
+
+            assertThat(trace).isNotNull();
+            assertThat(trace.visibilityMode()).isEqualTo(VisibilityMode.HIDDEN);
         }
     }
 }


### PR DESCRIPTION
## Details
- Add a new column called evaluation task result 
- Add validation to allow either none, only one, or never both columns to be filled

## Testing
- Test to cover all scenarios 
