### PR TITLE
OPIK-1332: Remove duplicate ID validation batch create trace and span

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -4943,26 +4943,6 @@ class SpansResourceTest {
         }
 
         @Test
-        void batch__whenSendingMultipleSpansWithSameId__thenReturn422() {
-            var id = generator.generate();
-            var spans = PodamFactoryUtils.manufacturePojoList(podamFactory, Span.class).stream()
-                    .map(span -> span.toBuilder()
-                            .id(id)
-                            .build())
-                    .toList();
-            try (var actualResponse = spanResourceClient.callBatchCreateSpans(spans, API_KEY, TEST_WORKSPACE)) {
-
-                assertThat(actualResponse.getStatusInfo().getStatusCode())
-                        .isEqualTo(HttpStatus.SC_UNPROCESSABLE_ENTITY);
-                assertThat(actualResponse.hasEntity()).isTrue();
-                var actualErrorMessage = actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class);
-                var expectedErrorMessage = new io.dropwizard.jersey.errors.ErrorMessage(
-                        HttpStatus.SC_UNPROCESSABLE_ENTITY, "Duplicate span id '%s'".formatted(id));
-                assertThat(actualErrorMessage).isEqualTo(expectedErrorMessage);
-            }
-        }
-
-        @Test
         void batch__whenMissingFields__thenReturnNoContent() {
             var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
             var expectedSpans = IntStream.range(0, 5)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -5874,26 +5874,6 @@ class TracesResourceTest {
         }
 
         @Test
-        void batch__whenSendingMultipleTracesWithSameId__thenReturn422() {
-            var id = generator.generate();
-            var traces = PodamFactoryUtils.manufacturePojoList(factory, Trace.class).stream()
-                    .map(trace -> trace.toBuilder()
-                            .id(id)
-                            .build())
-                    .toList();
-            try (var actualResponse = traceResourceClient.callBatchCreateTraces(traces, API_KEY, TEST_WORKSPACE)) {
-
-                assertThat(actualResponse.getStatusInfo().getStatusCode())
-                        .isEqualTo(HttpStatus.SC_UNPROCESSABLE_ENTITY);
-                assertThat(actualResponse.hasEntity()).isTrue();
-                var actualErrorMessage = actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class);
-                var expectedErrorMessage = new io.dropwizard.jersey.errors.ErrorMessage(
-                        HttpStatus.SC_UNPROCESSABLE_ENTITY, "Duplicate trace id '%s'".formatted(id));
-                assertThat(actualErrorMessage).isEqualTo(expectedErrorMessage);
-            }
-        }
-
-        @Test
         void batch__whenMissingFields__thenReturnNoContent() {
             var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
             var expectedTraces = IntStream.range(0, 5)


### PR DESCRIPTION
## Details
No longer needed validation removed.

As batch creation endpoints for spans and traces work as an upsert endpoint, if items with the same ID are sent, the one with the highest `last_updated_at` wins.

For the original use case where `last_updated_at` is not sent from the client side, as the items in the request are defined in a `list`, the last one in the list wins.

## Issues
- OPIK-1332
- #1610 

## Testing
- Passed CI tests.

## Documentation
N/A
