### PR TITLE
Optimizer: pin max dspy version

### DIFF
--- a/sdks/opik_optimizer/setup.py
+++ b/sdks/opik_optimizer/setup.py
@@ -17,7 +17,7 @@ setup(
     python_requires=">=3.9,<3.13",
     install_requires=[
         "opik>=1.7.17",
-        "dspy>=2.6.18,<3",
+        "dspy>=2.6.18,<=2.6.24",
         "litellm",
         "tqdm",
         "datasets",


### PR DESCRIPTION
## Details

dspy versions greater than 2.6.24 have a bug that crashes opik-optimizer

## Issues

See also: https://github.com/stanfordnlp/dspy/pull/8314