### PR TITLE
OPIK-1797: Reduce span table index scan

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -184,6 +184,7 @@ class ExperimentDAO {
                             sum(total_estimated_cost) as total_estimated_cost
                         FROM spans final
                         WHERE workspace_id = :workspace_id
+                        AND trace_id IN (SELECT trace_id FROM experiment_items_final)
                         GROUP BY workspace_id, project_id, trace_id
                     ) AS s ON ei.trace_id = s.trace_id
                 )


### PR DESCRIPTION
## Details
- Although a lack of available memory caused the error, checking the explain plan, we could spot an excessive scan of the spans table data.

```
2025.06.04 06:37:42.397010 [ 9717 ] {1160b2e4-94f6-4a34-9c63-32ea464a29de} <Error> executeQuery: Code: 241. DB::Exception: Memory limit (total) exceeded: would use 57.05 GiB (attempt to allocate chunk of 4971071 bytes), maximum: 54.00 GiB. OvercommitTracker decision: Waiting timeout for memory to be freed is reached.: While executing ReplacingSorted. (MEMORY_LIMIT_EXCEEDED) (version 24.3.5.47.altinitystable (altinity build)) 
```

Before:
<img width="504" alt="Screenshot 2025-06-04 at 10 28 49" src="https://github.com/user-attachments/assets/f4d78072-4774-48d4-b3b1-75838415e360" />

<img width="1354" alt="Screenshot 2025-06-04 at 10 29 20" src="https://github.com/user-attachments/assets/debcaa96-c294-4d27-a257-27dd0f0aed45" />


---------------------------------------------------------------------------------------------------
After:
<img width="481" alt="Screenshot 2025-06-04 at 10 30 04" src="https://github.com/user-attachments/assets/51d4904b-ae2f-4bee-ba4e-f5f83521f530" />

<img width="1341" alt="Screenshot 2025-06-04 at 10 30 31" src="https://github.com/user-attachments/assets/9d530e84-ac3f-4f30-b1e0-3216097856fb" />
