### PR TITLE
[OPIK-1594] Optimization: added display run link

### DIFF
--- a/sdks/python/src/opik/evaluation/report.py
+++ b/sdks/python/src/opik/evaluation/report.py
@@ -100,3 +100,18 @@ def display_experiment_link(
     console_container.print(
         f"View the results [link={experiment_url}]in your Opik dashboard[/link]."
     )
+
+
+def display_optimization_run_link(
+    optimization_id: str, dataset_id: str, url_override: str
+) -> None:
+    console_container = console.Console()
+
+    optimization_url = url_helpers.get_optimization_run_url_by_id(
+        optimization_id=optimization_id,
+        dataset_id=dataset_id,
+        url_override=url_override,
+    )
+    console_container.print(
+        f"View the optimization run [link={optimization_url}]in your Opik dashboard[/link]."
+    )

--- a/sdks/python/src/opik/url_helpers.py
+++ b/sdks/python/src/opik/url_helpers.py
@@ -39,6 +39,18 @@ def get_experiment_url_by_id(
     return urllib.parse.urljoin(ensure_ending_slash(url_override), project_path)
 
 
+def get_optimization_run_url_by_id(
+    dataset_id: str, optimization_id: str, url_override: str
+) -> str:
+    encoded_opik_url = base64.b64encode(url_override.encode("utf-8")).decode("utf-8")
+
+    run_path = urllib.parse.quote(
+        f"v1/session/redirect/optimizations/?optimization_id={optimization_id}&dataset_id={dataset_id}&path={encoded_opik_url}",
+        safe=ALLOWED_URL_CHARACTERS,
+    )
+    return urllib.parse.urljoin(ensure_ending_slash(url_override), run_path)
+
+
 def get_project_url_by_workspace(
     workspace: str, project_name: str
 ) -> str:  # don't use or update, will be removed soon

--- a/sdks/python/tests/unit/optimization/test_optimization.py
+++ b/sdks/python/tests/unit/optimization/test_optimization.py
@@ -1,0 +1,46 @@
+import pytest
+from unittest.mock import patch
+import base64
+import io
+
+import opik
+from opik.url_helpers import get_optimization_run_url_by_id
+from opik.evaluation.report import display_optimization_run_link
+
+from ...testlib import assert_equal
+
+
+def test_get_optimization_run_url_by_id():
+    URL_OVERRIDE = "https://URL/opik/api"
+    ENCODED_URL = base64.b64encode(URL_OVERRIDE.encode("utf-8")).decode("utf-8")
+    OPTIMIZATION_ID = "OPTIMIZATION-ID"
+    DATASET_ID = "DATASET-ID"
+
+    url = get_optimization_run_url_by_id(
+        dataset_id=DATASET_ID,
+        optimization_id=OPTIMIZATION_ID,
+        url_override=URL_OVERRIDE,
+    )
+
+    assert_equal(
+        url,
+        f"{URL_OVERRIDE}/v1/session/redirect/optimizations/?optimization_id={OPTIMIZATION_ID}&dataset_id={DATASET_ID}&path={ENCODED_URL}",
+    )
+
+
+@patch("sys.stdout", new_callable=io.StringIO)
+def test_display_optimization_run_link(mock_stdout):
+    URL_OVERRIDE = "https://URL/opik/api"
+    ENCODED_URL = base64.b64encode(URL_OVERRIDE.encode("utf-8")).decode("utf-8")
+    OPTIMIZATION_ID = "OPTIMIZATION-ID"
+    DATASET_ID = "DATASET-ID"
+
+    display_optimization_run_link(
+        dataset_id=DATASET_ID,
+        optimization_id=OPTIMIZATION_ID,
+        url_override=URL_OVERRIDE,
+    )
+
+    output = mock_stdout.getvalue().strip()
+
+    assert_equal(output, "View the optimization run in your Opik dashboard.")

--- a/sdks/python/tests/unit/optimization/test_optimization.py
+++ b/sdks/python/tests/unit/optimization/test_optimization.py
@@ -1,9 +1,7 @@
-import pytest
 from unittest.mock import patch
 import base64
 import io
 
-import opik
 from opik.url_helpers import get_optimization_run_url_by_id
 from opik.evaluation.report import display_optimization_run_link
 
@@ -31,7 +29,6 @@ def test_get_optimization_run_url_by_id():
 @patch("sys.stdout", new_callable=io.StringIO)
 def test_display_optimization_run_link(mock_stdout):
     URL_OVERRIDE = "https://URL/opik/api"
-    ENCODED_URL = base64.b64encode(URL_OVERRIDE.encode("utf-8")).decode("utf-8")
     OPTIMIZATION_ID = "OPTIMIZATION-ID"
     DATASET_ID = "DATASET-ID"
 


### PR DESCRIPTION
## Details

Now that the backend supports a redirect for getting an optimization-run URL, we can add the support for displaying that link in the console.

![image](https://github.com/user-attachments/assets/9b5cd08d-99d7-4700-8811-2f9b631f9e88)


## Testing

Tests were added for happy paths.

## Documentation

None needed as these are internal methods.