### PR TITLE
[NA]: Removed ref from checkout actions in Python SDK tests.

### DIFF
--- a/.github/workflows/python_sdk_unit_tests.yml
+++ b/.github/workflows/python_sdk_unit_tests.yml
@@ -35,8 +35,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Print environment variables
         run: env

--- a/.github/workflows/sdk-e2e-library-tests.yaml
+++ b/.github/workflows/sdk-e2e-library-tests.yaml
@@ -46,8 +46,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
           
       - name: Install uv and set the Python version ${{ matrix.python_version }}
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/sdk-e2e-tests.yaml
+++ b/.github/workflows/sdk-e2e-tests.yaml
@@ -33,8 +33,6 @@ jobs:
         steps:
         - name: Checkout
           uses: actions/checkout@v4.1.1
-          with:
-            ref: ${{ github.event.pull_request.base.ref }}
             
         - name: Setup Python ${{matrix.python_version}}
           uses: actions/setup-python@v5


### PR DESCRIPTION
## Details
The `ref` added to the `checkout` action in the workflow resulted in testing code of PR against parent branch - the master in most cases. This PR removes this `ref` from Python SDK workloads.

## Issues

Resolves #

## Testing

## Documentation
