### PR TITLE
[NA]: Removed the `ref` parameter from all instances of the `checkout` action in the workflows.

### DIFF
--- a/.github/workflows/documentation_codeblock_tests.yml
+++ b/.github/workflows/documentation_codeblock_tests.yml
@@ -17,8 +17,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Fetch all history for git diff
-          ref: ${{ github.event.pull_request.base.ref }}
-
 
       - id: paths
         working-directory: apps/opik-documentation/documentation

--- a/.github/workflows/documentation_image_optimizer.yml
+++ b/.github/workflows/documentation_image_optimizer.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4.2.2
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
           
       - name: Compress Images
         uses: calibreapp/image-actions@1.1.0

--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -12,8 +12,6 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
-              with:
-                ref: ${{ github.event.pull_request.base.ref }}
                 
             - name: Install Fern
               run: npm install -g fern-api

--- a/.github/workflows/end2end_suites.yml
+++ b/.github/workflows/end2end_suites.yml
@@ -43,8 +43,6 @@ jobs:
         steps:
             - name: Checkout repo
               uses: actions/checkout@v4
-              with:
-                ref: ${{ github.event.pull_request.base.ref }}
             
             - name: Setup Python
               uses: actions/setup-python@v5


### PR DESCRIPTION
## Details
Removed the `ref` parameter from all instances of the `checkout` action in the workflows to avoid performing workflow actions against parent branch (i.e., `master`) instead of current branch.

## Issues

Resolves #

## Testing

## Documentation
