### PR TITLE
adding documentation for retrieving trace content and updating traces

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/production/production_monitoring.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/production/production_monitoring.mdx
@@ -84,3 +84,43 @@ for trace in traces:
 ```
 
 You will now be able to see the feedback scores in the Opik dashboard and track the changes over time.
+
+### Updating trace content
+
+#### Get trace content
+
+You can view the content of your traces using [`Opik.get_trace_content(id: str)`](https://www.comet.com/docs/opik/python-sdk-reference/Opik.html#opik.Opik.get_trace_content), to look up your trace by id. Trace ids can be found using the [`Opik.search_traces()']('https://www.comet.com/docs/opik/python-sdk-reference/Opik.html#opik.Opik.search_traces') method or by looking at the ID column within the Projects > 'My-project' view.
+
+```python {pytest_codeblocks_skip=true}
+from opik import Opik
+
+TRACE_ID = 'EXAMPLE-ID' # UUIDv7 Identifier 
+
+opik_client = Opik()
+trace_content = opik_client.get_trace_content(id = TRACE_ID)
+```
+
+This will return a ['TracePublic'](https://www.comet.com/docs/opik/python-sdk-reference/Objects/TracePublic.html#opik.rest_api.types.trace_public.TracePublic) object, a pydantic model object with all the data associated with the trace found.
+
+#### Update trace by ID
+
+You can update a given trace by first re-instantiating the trace using [`opik.Opik.trace()`](https://www.comet.com/docs/opik/python-sdk-reference/Opik.html#opik.Opik.trace) and then updating any one of the trace attributes using ['Trace.update()](https://www.comet.com/docs/opik/python-sdk-reference/Objects/Trace.html#opik.api_objects.trace.Trace.update). See above section for guidance on how to retrieve trace ids.
+
+```python {pytest_codeblocks_skip=true}
+from opik import Opik
+
+TRACE_ID = 'EXAMPLE-ID' # UUIDv7 Identifier 
+
+opik_client = Opik()
+trace = opik_client.trace(id = TRACE_ID)
+trace.update(output = updated_output)
+```
+
+The trace attributes that can be used as parameters are as follows:
+- end_time: The end time of the trace.
+- metadata: Additional metadata to be associated with the trace.
+- input: The input data for the trace.
+- output: The output data for the trace.
+- tags: A list of tags to be associated with the trace.
+- error_info: The dictionary with error information (typically used when the trace function has failed).
+- thread_id: Used to group multiple traces into a thread. The identifier is user-defined and has to be unique per project.


### PR DESCRIPTION
## Documentation
Adding documentation for retrieving trace content and updating traces.

Some documentation for get_trace_content() already exists in the langchain integration section but uses the Opik tracer and was confusing if this was a method specific to Langchain.