### PR TITLE
OPIK-1708: Add error stats to trace and spans stats endpoints

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ErrorCountWithDeviation.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ErrorCountWithDeviation.java
@@ -1,0 +1,18 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+/**
+ * Represents an error count with its deviation compared to the previous period.
+ */
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ErrorCountWithDeviation(
+        long count,
+        long deviation,
+        Long deviationPercentage) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Project.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Project.java
@@ -45,7 +45,9 @@ public record Project(
         @JsonView({
                 Project.View.Detailed.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) @Nullable Long traceCount,
         @JsonView({
-                Project.View.Detailed.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) @Nullable Long guardrailsFailedCount){
+                Project.View.Detailed.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) @Nullable Long guardrailsFailedCount,
+        @JsonView({
+                Project.View.Detailed.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) @Nullable ErrorCountWithDeviation errorCount){
 
     public static class View {
         public static class Write {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProjectStatsSummary.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProjectStatsSummary.java
@@ -25,7 +25,8 @@ public record ProjectStatsSummary(List<ProjectStatsSummaryItem> content) {
             Double totalEstimatedCostSum,
             Map<String, Double> usage,
             Long traceCount,
-            Long guardrailsFailedCount) {
+            Long guardrailsFailedCount,
+            ErrorCountWithDeviation errorCount) {
     }
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -267,6 +267,7 @@ class ProjectServiceImpl implements ProjectService {
                 .usage(StatsMapper.getStatsUsage(projectStats))
                 .traceCount(StatsMapper.getStatsTraceCount(projectStats))
                 .guardrailsFailedCount(StatsMapper.getStatsGuardrailsFailedCount(projectStats))
+                .errorCount(StatsMapper.getStatsErrorCount(projectStats))
                 .build();
     }
 
@@ -530,6 +531,7 @@ class ProjectServiceImpl implements ProjectService {
                                 .traceCount(StatsMapper.getStatsTraceCount(projectStats.get(project.id())))
                                 .guardrailsFailedCount(
                                         StatsMapper.getStatsGuardrailsFailedCount(projectStats.get(project.id())))
+                                .errorCount(StatsMapper.getStatsErrorCount(projectStats.get(project.id())))
                                 .build();
                     })
                     .orElseThrow(this::createNotFoundError);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -826,7 +826,8 @@ class SpanDAO {
                      if(metadata_length > 0, 1, 0) as metadata_count,
                      length(tags) as tags_count,
                      usage,
-                     total_estimated_cost
+                     total_estimated_cost,
+                     error_info
                 FROM spans final
                 <if(feedback_scores_empty_filters)>
                     LEFT JOIN fsc ON fsc.entity_id = spans.id
@@ -870,7 +871,8 @@ class SpanDAO {
                 avgIf(total_estimated_cost, total_estimated_cost > 0) AS total_estimated_cost_,
                 toDecimal128(if(isNaN(total_estimated_cost_), 0, total_estimated_cost_), 12) AS total_estimated_cost_avg,
                 sumIf(total_estimated_cost, total_estimated_cost > 0) AS total_estimated_cost_sum_,
-                toDecimal128(total_estimated_cost_sum_, 12) AS total_estimated_cost_sum
+                toDecimal128(total_estimated_cost_sum_, 12) AS total_estimated_cost_sum,
+                countIf(error_info, error_info != '') AS error_count
             FROM spans_final s
             LEFT JOIN feedback_scores_agg AS f ON s.id = f.entity_id
             GROUP BY project_id

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -934,6 +934,30 @@ class TraceDAOImpl implements TraceDAO {
                 )
                 GROUP BY workspace_id, project_id, entity_type, entity_id
             )
+            <if(project_stats)>
+            ,    error_count_current AS (
+                    SELECT
+                        project_id,
+                        count(error_info) AS recent_error_count
+                    FROM traces final
+                    WHERE workspace_id = :workspace_id
+                    AND project_id IN :project_ids
+                    AND error_info != ''
+                    AND start_time BETWEEN toStartOfDay(subtractDays(now(), 7)) AND now64(9)
+                    GROUP BY workspace_id, project_id
+                ),
+                error_count_past_period AS (
+                    SELECT
+                        project_id,
+                        count(error_info) AS past_period_error_count
+                    FROM traces final
+                    WHERE workspace_id = :workspace_id
+                    AND project_id IN :project_ids
+                    AND error_info != ''
+                    AND start_time \\< toStartOfDay(subtractDays(now(), 7))
+                    GROUP BY workspace_id, project_id
+                )
+            <endif>
             <if(feedback_scores_empty_filters)>
             , fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
                  FROM (
@@ -961,7 +985,8 @@ class TraceDAOImpl implements TraceDAO {
                     if(end_time IS NOT NULL AND start_time IS NOT NULL
                             AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)),
                         (dateDiff('microsecond', start_time, end_time) / 1000.0),
-                        NULL) as duration
+                        NULL) as duration,
+                    error_info
                 FROM traces final
                 LEFT JOIN guardrails_agg gagg ON gagg.entity_id = traces.id
                 <if(feedback_scores_empty_filters)>
@@ -1014,11 +1039,21 @@ class TraceDAOImpl implements TraceDAO {
                 toDecimal128(if(isNaN(total_estimated_cost_), 0, total_estimated_cost_), 12) AS total_estimated_cost_avg,
                 sumIf(s.total_estimated_cost, s.total_estimated_cost > 0) AS total_estimated_cost_sum_,
                 toDecimal128(total_estimated_cost_sum_, 12) AS total_estimated_cost_sum,
-                sum(g.failed_count) AS guardrails_failed_count
+                sum(g.failed_count) AS guardrails_failed_count,
+                <if(project_stats)>
+                any(ec.recent_error_count) AS recent_error_count,
+                any(ecl.past_period_error_count) AS past_period_error_count
+                <else>
+                countIf(t.error_info, t.error_info != '') AS error_count
+                <endif>
             FROM trace_final t
             LEFT JOIN spans_agg AS s ON t.id = s.trace_id
             LEFT JOIN feedback_scores_agg as f ON t.id = f.entity_id
             LEFT JOIN guardrails_agg as g ON t.id = g.entity_id
+            <if(project_stats)>
+            LEFT JOIN error_count_current ec ON t.project_id = ec.project_id
+            LEFT JOIN error_count_past_period ecl ON t.project_id = ecl.project_id
+            <endif>
             GROUP BY t.workspace_id, t.project_id
             ;
             """;
@@ -1881,6 +1916,8 @@ class TraceDAOImpl implements TraceDAO {
         return asyncTemplate
                 .nonTransaction(connection -> {
                     ST template = new ST(SELECT_TRACES_STATS);
+
+                    template.add("project_stats", true);
 
                     Statement statement = connection.createStatement(template.render())
                             .bind("project_ids", projectIds)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMapper.java
@@ -1,5 +1,6 @@
 package com.comet.opik.domain.stats;
 
+import com.comet.opik.api.ErrorCountWithDeviation;
 import com.comet.opik.api.FeedbackScoreAverage;
 import com.comet.opik.api.PercentageValues;
 import com.comet.opik.api.ProjectStats;
@@ -30,6 +31,9 @@ public class StatsMapper {
     public static final String TAGS = "tags";
     public static final String TRACE_COUNT = "trace_count";
     public static final String GUARDRAILS_FAILED_COUNT = "guardrails_failed_count";
+    public static final String RECENT_ERROR_COUNT = "recent_error_count";
+    public static final String PAST_PERIOD_ERROR_COUNT = "past_period_error_count";
+    public static final String ERROR_COUNT = "error_count";
 
     public static ProjectStats mapProjectStats(Row row, String entityCountLabel) {
 
@@ -86,6 +90,39 @@ public class StatsMapper {
             Optional.ofNullable(row.get("guardrails_failed_count", Long.class)).ifPresent(
                     guardrailsFailedCount -> stats
                             .add(new CountValueStat(GUARDRAILS_FAILED_COUNT, guardrailsFailedCount)));
+        }
+
+        Long recentErrorCount = Optional.ofNullable(row)
+                .filter(r -> r.getMetadata().contains(RECENT_ERROR_COUNT))
+                .map(r -> r.get(RECENT_ERROR_COUNT, Long.class))
+                .orElse(null);
+
+        Long pastPeriodErrorCount = Optional.ofNullable(row)
+                .filter(r -> r.getMetadata().contains(PAST_PERIOD_ERROR_COUNT))
+                .map(r -> r.get(PAST_PERIOD_ERROR_COUNT, Long.class))
+                .orElse(null);
+
+        Long errorCount = null;
+
+        // If mapping project stats, the error has to be calculated from recent and past period error counts
+        if (recentErrorCount != null) {
+            stats.add(new CountValueStat(RECENT_ERROR_COUNT, recentErrorCount));
+            errorCount = recentErrorCount;
+        }
+
+        if (pastPeriodErrorCount != null) {
+            stats.add(new CountValueStat(PAST_PERIOD_ERROR_COUNT, pastPeriodErrorCount));
+
+            errorCount = errorCount == null ? pastPeriodErrorCount : errorCount + pastPeriodErrorCount;
+        }
+
+        // Otherwise, if the error count is not calculated from recent and past period error counts
+        if (errorCount == null && row.getMetadata().contains(ERROR_COUNT)) {
+            errorCount = row.get(ERROR_COUNT, Long.class);
+        }
+
+        if (errorCount != null) {
+            stats.add(new CountValueStat(ERROR_COUNT, errorCount));
         }
 
         return new ProjectStats(stats.build().toList());
@@ -148,5 +185,28 @@ public class StatsMapper {
         return Optional.ofNullable(projectStats)
                 .map(map -> (Long) map.get(GUARDRAILS_FAILED_COUNT))
                 .orElse(null);
+    }
+
+    public static ErrorCountWithDeviation getStatsErrorCount(Map<String, Object> projectStats) {
+        if (projectStats == null) {
+            return null;
+        }
+
+        Long recentErrorCount = (Long) projectStats.get(RECENT_ERROR_COUNT);
+        Long partPeriodErrorCount = (Long) projectStats.get(PAST_PERIOD_ERROR_COUNT);
+
+        double recentErrorTotal = recentErrorCount + partPeriodErrorCount;
+
+        Long deviationPercentage = null;
+        if (partPeriodErrorCount > 0) {
+            // Calculate the percentage change between recent errors and historical errors
+            deviationPercentage = Math.round(((recentErrorTotal - partPeriodErrorCount) / partPeriodErrorCount) * 100);
+        }
+
+        return ErrorCountWithDeviation.builder()
+                .count((long) recentErrorTotal)
+                .deviation(recentErrorCount)
+                .deviationPercentage(deviationPercentage)
+                .build();
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/StatsUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/StatsUtils.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api.resources.utils;
 
+import com.comet.opik.api.ErrorInfo;
 import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.FeedbackScoreBatchItem;
 import com.comet.opik.api.GuardrailsValidation;
@@ -75,6 +76,7 @@ public class StatsUtils {
                 Trace::endTime,
                 Trace::totalEstimatedCost,
                 Trace::guardrailsValidations,
+                Trace::errorInfo,
                 "trace_count");
     }
 
@@ -116,6 +118,7 @@ public class StatsUtils {
                     return BigDecimal.ZERO;
                 },
                 null,
+                Span::errorInfo,
                 "span_count");
     }
 
@@ -131,6 +134,7 @@ public class StatsUtils {
             Function<T, Instant> endProvider,
             Function<T, BigDecimal> totalEstimatedCostProvider,
             Function<T, List<GuardrailsValidation>> guardrailsProvider,
+            Function<T, ErrorInfo> errorProvider,
             String countLabel) {
 
         if (expectedEntities.isEmpty()) {
@@ -145,12 +149,14 @@ public class StatsUtils {
         double tags = 0;
         BigDecimal totalEstimatedCost = BigDecimal.ZERO;
         int countEstimatedCost = 0;
+        long errorCount = 0;
 
         for (T entity : expectedEntities) {
             input += inputProvider.apply(entity) != null ? 1 : 0;
             output += outputProvider.apply(entity) != null ? 1 : 0;
             metadata += metadataProvider.apply(entity) != null ? 1 : 0;
             tags += tagsProvider.apply(entity) != null ? tagsProvider.apply(entity).size() : 0;
+            errorCount += errorProvider.apply(entity) != null ? 1 : 0;
 
             BigDecimal cost = totalEstimatedCostProvider.apply(entity) != null
                     ? totalEstimatedCostProvider.apply(entity)
@@ -221,6 +227,8 @@ public class StatsUtils {
 
         Optional.ofNullable(failedGuardrails).ifPresent(failedGuardrailCount -> stats
                 .add(new CountValueStat(StatsMapper.GUARDRAILS_FAILED_COUNT, failedGuardrailCount)));
+
+        stats.add(new CountValueStat(StatsMapper.ERROR_COUNT, errorCount));
 
         return stats;
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ProjectResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ProjectResourceClient.java
@@ -2,18 +2,23 @@ package com.comet.opik.api.resources.utils.resources;
 
 import com.comet.opik.api.FeedbackScoreNames;
 import com.comet.opik.api.Project;
+import com.comet.opik.api.ProjectStatsSummary;
 import com.comet.opik.api.resources.utils.TestUtils;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.http.HttpStatus;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import uk.co.jemos.podam.api.PodamFactory;
 
 import java.util.UUID;
 
+import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RequiredArgsConstructor
@@ -98,5 +103,25 @@ public class ProjectResourceClient {
 
             return actualResponse.readEntity(FeedbackScoreNames.class);
         }
+    }
+
+    public ProjectStatsSummary getProjectStatsSummary(String projectName, @NonNull String apiKey,
+            @NonNull String workspaceName) {
+        WebTarget webTarget = client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("/stats");
+
+        if (StringUtils.isEmpty(projectName)) {
+            webTarget = webTarget.queryParam("name", projectName);
+        }
+
+        Response actualResponse = webTarget
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .get();
+
+        assertThat(actualResponse.getStatus()).isEqualTo(org.apache.http.HttpStatus.SC_OK);
+
+        return actualResponse.readEntity(ProjectStatsSummary.class);
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -2183,7 +2183,7 @@ class TracesResourceTest {
                             .build())
                     .collect(Collectors.toCollection(ArrayList::new));
             traces.set(0, traces.getFirst().toBuilder()
-                    .startTime(Instant.now().plusSeconds(60 * 5))
+                    .startTime(Instant.now())
                     .build());
 
             traceResourceClient.batchCreateTraces(traces, apiKey, workspaceName);


### PR DESCRIPTION
## Details
This PR introduces the following error stats:
- Error Count and last week's deviation at the project level
- Error count at the trace stats level
- Error count at the span stats level

## Issues

Resolves #

## Testing
- Added Test for Project stats
- For traces and spans, only add extra stats assertion since they were already tested
