### PR TITLE
[NA] Replace levenshtein dependency with rapidfuzz

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -40,7 +40,7 @@ setup(
         "boto3-stubs[bedrock-runtime]>=1.34.110",
         "click",
         "httpx",  # some older version of openai/litellm are broken with httpx>=0.28.0
-        "levenshtein<1.0.0",
+        "rapidfuzz>=3.0.0,<4.0.0",
         "litellm",
         "openai<2.0.0",
         "pydantic-settings>=2.0.0,<3.0.0,!=2.9.0",

--- a/sdks/python/src/opik/evaluation/metrics/heuristics/levenshtein_ratio.py
+++ b/sdks/python/src/opik/evaluation/metrics/heuristics/levenshtein_ratio.py
@@ -1,7 +1,6 @@
 from typing import Any, Optional
 
-import Levenshtein
-
+import rapidfuzz.distance.Indel
 from .. import base_metric, score_result
 
 
@@ -64,6 +63,5 @@ class LevenshteinRatio(base_metric.BaseMetric):
         value = output if self._case_sensitive else output.lower()
         reference = reference if self._case_sensitive else reference.lower()
 
-        score = Levenshtein.ratio(value, reference)
-
+        score = rapidfuzz.distance.Indel.normalized_similarity(value, reference)
         return score_result.ScoreResult(value=score, name=self.name)


### PR DESCRIPTION
## Details
Replaced Levenshtein dependency with rapidfuzz, which is used under the hood of levenshtein but has a better license.

## Testing
No new tests were added, unit tests for LevenshteinRatio still pass after replacing one library call with another.