### PR TITLE
[OPIK-1877] - Remove Levenshtein dependency from opik-sandbox-executor-python

### DIFF
--- a/apps/opik-sandbox-executor-python/requirements.txt
+++ b/apps/opik-sandbox-executor-python/requirements.txt
@@ -26,7 +26,6 @@ Jinja2==3.1.6
 jiter==0.10.0
 jsonschema==4.24.0
 jsonschema-specifications==2025.4.1
-Levenshtein==0.27.1
 litellm==1.71.1
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2


### PR DESCRIPTION
## Details

As part of effort to use non-copyleft license (MIT, Apache 2.0)
Removing Levenshtein dependency. (moved to [RapidFuzz](https://github.com/rapidfuzz/RapidFuzz) )
## Issues

Resolves #

## Testing

Need to do an E2E test with python code evals as part or tesy cycles. 

## Documentation
