### PR TITLE
OPIK-1765: Create trace thread tables

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000028_add_trace_threads_table.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000028_add_trace_threads_table.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME}.trace_threads ON CLUSTE
     project_id          FixedString(36),
     workspace_id        String,
     status              ENUM('unknown' = 0 , 'active' = 1, 'inactive' = 2),
-    created_at          DateTime64(6, 'UTC') DEFAULT now64(6),
+    created_at          DateTime64(9, 'UTC') DEFAULT now64(9),
     last_updated_at     DateTime64(6, 'UTC') DEFAULT now64(6),
     created_by          String,
     last_updated_by     String

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000028_add_trace_threads_table.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000028_add_trace_threads_table.sql
@@ -7,8 +7,8 @@ CREATE TABLE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME}.trace_threads ON CLUSTE
     project_id          FixedString(36),
     workspace_id        String,
     status              ENUM('unknown' = 0 , 'active' = 1, 'inactive' = 2),
-    created_at          DateTime64(9, 'UTC') DEFAULT now64(9),
-    last_updated_at     DateTime64(9, 'UTC') DEFAULT now64(9),
+    created_at          DateTime64(6, 'UTC') DEFAULT now64(6),
+    last_updated_at     DateTime64(6, 'UTC') DEFAULT now64(6),
     created_by          String,
     last_updated_by     String
 )

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000028_add_trace_threads_table.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000028_add_trace_threads_table.sql
@@ -1,0 +1,18 @@
+--liquibase formatted sql
+--changeset thiagohora:000028_add_trace_threads_table
+
+CREATE TABLE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME}.trace_threads ON CLUSTER '{cluster}' (
+    id                  FixedString(36),
+    thread_id           String,
+    project_id          FixedString(36),
+    workspace_id        String,
+    status              ENUM('unknown' = 0 , 'active' = 1, 'inactive' = 2),
+    created_at          DateTime64(9, 'UTC') DEFAULT now64(9),
+    last_updated_at     DateTime64(9, 'UTC') DEFAULT now64(9),
+    created_by          String,
+    last_updated_by     String
+)
+ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/${ANALYTICS_DB_DATABASE_NAME}/trace_threads', '{replica}', last_updated_at)
+ORDER BY (workspace_id, project_id, thread_id, id)
+
+--rollback DROP TABLE IF EXISTS ${ANALYTICS_DB_DATABASE_NAME}.trace_threads ON CLUSTER '{cluster}';

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000018_project_threads_table.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000018_project_threads_table.sql
@@ -1,0 +1,14 @@
+--liquibase formatted sql
+--changeset thiagohora:000018_project_trace_threads_table
+
+CREATE TABLE IF NOT EXISTS project_trace_threads (
+    id CHAR(36) NOT NULL,
+    project_id CHAR(36) NOT NULL,
+    thread_id VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    created_by VARCHAR(100) NOT NULL DEFAULT 'admin',
+    CONSTRAINT `project_trace_threads_pk` PRIMARY KEY (id),
+    CONSTRAINT `project_trace_threads_uk` UNIQUE (project_id, thread_id)
+);
+
+--rollback DROP TABLE IF EXISTS project_trace_threads;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000018_project_threads_table.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000018_project_threads_table.sql
@@ -4,7 +4,7 @@
 CREATE TABLE IF NOT EXISTS project_trace_threads (
     id CHAR(36) NOT NULL,
     project_id CHAR(36) NOT NULL,
-    thread_id VARCHAR(255) NOT NULL,
+    thread_id VARCHAR(150) NOT NULL,
     created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     created_by VARCHAR(100) NOT NULL DEFAULT 'admin',
     CONSTRAINT `project_trace_threads_pk` PRIMARY KEY (id),


### PR DESCRIPTION
## Details
- Create the `trace_threads` table to hold all primary data related to threads
- Create the `project_trace_threads` table, which will guarantee unique and consistent ID mapping between  `project_id`, `thread_id`, and the creation of a **trace thread ID** (Opik's internal ID for the thread)
