### PR TITLE
[OPIK-1813] Implement a worker pool for executor process

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/__init__.py
+++ b/apps/opik-python-backend/src/opik_backend/__init__.py
@@ -59,7 +59,7 @@ def setup_telemetry(app):
     """Configure OpenTelemetry metrics for the application."""
     # Create metric readers based on environment
     metric_readers = []
-    
+
     # Always add Prometheus reader for k8s scraping
     prometheus_reader = PrometheusMetricReader()
     metric_readers.append(prometheus_reader)
@@ -76,7 +76,7 @@ def setup_telemetry(app):
     # Create MeterProvider with all readers
     resource = Resource.create({"service.name": os.getenv("OTEL_SERVICE_NAME", "opik-python-backend")})
     provider = MeterProvider(resource=resource, metric_readers=metric_readers)
-    
+
     # Set the global MeterProvider
     metrics.set_meter_provider(provider)
     

--- a/apps/opik-python-backend/src/opik_backend/evaluator.py
+++ b/apps/opik-python-backend/src/opik_backend/evaluator.py
@@ -19,7 +19,11 @@ def init_executor(app):
         app.executor = DockerExecutor()
     elif EXECUTION_STRATEGY == "process":
         from opik_backend.executor_process import ProcessExecutor
-        app.executor = ProcessExecutor(os.environ.get('WERKZEUG_RUN_MAIN') == 'true' or not app.debug)
+        process_executor = ProcessExecutor()
+        # start services only in the following case to avoid double initialization in debug mode
+        if os.environ.get('WERKZEUG_RUN_MAIN') == 'true' or not app.debug:
+            process_executor.start_services()
+        app.executor = process_executor
     else:
         raise ValueError(f"Unknown execution strategy: {EXECUTION_STRATEGY}")
 

--- a/apps/opik-python-backend/src/opik_backend/evaluator.py
+++ b/apps/opik-python-backend/src/opik_backend/evaluator.py
@@ -19,7 +19,7 @@ def init_executor(app):
         app.executor = DockerExecutor()
     elif EXECUTION_STRATEGY == "process":
         from opik_backend.executor_process import ProcessExecutor
-        app.executor = ProcessExecutor()
+        app.executor = ProcessExecutor(os.environ.get('WERKZEUG_RUN_MAIN') == 'true' or not app.debug)
     else:
         raise ValueError(f"Unknown execution strategy: {EXECUTION_STRATEGY}")
 

--- a/apps/opik-python-backend/src/opik_backend/executor_process.py
+++ b/apps/opik-python-backend/src/opik_backend/executor_process.py
@@ -1,66 +1,373 @@
+import atexit
 import concurrent.futures
 import json
 import logging
+import os
 import subprocess
 import time
-from threading import BoundedSemaphore
+import uuid
+from queue import Queue
+from threading import Lock, Event
+from uuid6 import uuid7
 
-from opik_backend.executor import CodeExecutorBase, ExecutionResult
-from opik_backend.scoring_commands import PYTHON_SCORING_COMMAND
+import schedule
+from opentelemetry import metrics
+
+from opik_backend.executor import CodeExecutorBase
 
 logger = logging.getLogger(__name__)
+
+# Create a meter for Process executor metrics
+meter = metrics.get_meter("process_executor")
+
+# Create histogram metrics for process operations
+process_creation_histogram = meter.create_histogram(
+    name="process_creation_latency",
+    description="Latency of process creation operations in milliseconds",
+    unit="ms",
+)
+
+process_execution_histogram = meter.create_histogram(
+    name="process_execution_latency",
+    description="Latency of code execution in process in milliseconds",
+    unit="ms",
+)
+
+# Create a gauge metric to track the number of available processes in the pool
+process_pool_size_gauge = meter.create_gauge(
+    name="process_pool_size",
+    description="Number of available processes in the pool queue",
+)
+
 
 class ProcessExecutor(CodeExecutorBase):
     def __init__(self):
         super().__init__()
-        self.semaphore = BoundedSemaphore(self.max_parallel)
+        self.instance_id = str(uuid7())
+        self.process_pool = Queue()
+        self.pool_lock = Lock()
+        self.releaser_executor = concurrent.futures.ThreadPoolExecutor(max_workers=4)
+        self.stop_event = Event()
+        self.pool_check_interval = int(os.getenv("PYTHON_CODE_EXECUTOR_POOL_CHECK_INTERVAL_IN_SECONDS", "3"))
+        
+        # Pre-warm the process pool
+        self._pre_warm_process_pool()
+
+        # Start the pool monitor
+        self._start_pool_monitor()
+
+        atexit.register(self.cleanup)
+
+    def _start_pool_monitor(self):
+        """Start a background thread that periodically checks and fills the process pool."""
+        logger.info(f"Starting process pool monitor with {self.pool_check_interval} second interval")
+
+        # Schedule the pool check to run at the configured interval
+        schedule.every(self.pool_check_interval).seconds.do(self._check_pool)
+
+        # Start a background thread to run the scheduler
+        self.releaser_executor.submit(self._run_scheduler)
+
+    def _check_pool(self):
+        """Check and fill the process pool if needed."""
+        if self.stop_event.is_set():
+            logger.info("Process pool monitor stopped")
+            return schedule.CancelJob  # Cancel this job
+
+        try:
+            # Update the process pool size metric
+            self._update_process_pool_size_metric()
+
+            self.ensure_pool_filled()
+            return None  # Continue the job
+        except Exception as e:
+            logger.error(f"Error in pool monitor: {e}")
+            return None  # Continue the job despite the error
+
+    def _run_scheduler(self):
+        """Run the scheduler in a background thread."""
+        logger.info("Starting scheduler for process pool monitoring")
+        while not self.stop_event.is_set():
+            schedule.run_pending()
+            time.sleep(1)  # Sleep to avoid busy-waiting
+
+        logger.info("Scheduler finished running")
+
+    def _pre_warm_process_pool(self):
+        """
+        Pre-warm the process pool by creating all processes in parallel.
+        This ensures processes are ready when the service starts.
+        """
+        logger.info(f"Pre-warming process pool with {self.max_parallel} processes")
+        with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_parallel) as pool_init:
+            # Submit process creation tasks in parallel
+            futures = [pool_init.submit(self.create_worker_process) for _ in range(self.max_parallel)]
+            # Wait for all processes to be created
+            concurrent.futures.wait(futures)
+
+    def ensure_pool_filled(self):
+        """Ensure the process pool has enough processes."""
+        if self.stop_event.is_set():
+            logger.warning("Executor is shutting down, skipping process creation")
+            return
+
+        with self.pool_lock:
+            current_pool_size = self.process_pool.qsize()
+            to_create = self.max_parallel - current_pool_size
+            if to_create > 0:
+                logger.info(f"Not enough python runner processes; creating {to_create} more...")
+                for _ in range(to_create):
+                    self.create_worker_process()
+
+    def _update_process_pool_size_metric(self):
+        """Update the process pool size metric with the current number of processes in the pool."""
+        pool_size = self.process_pool.qsize()
+        process_pool_size_gauge.set(pool_size)
+        logger.debug(f"Current process pool size: {pool_size}")
+        return pool_size
+
+    def _calculate_latency_ms(self, start_time):
+        """Calculate elapsed time in milliseconds."""
+        return (time.time() - start_time) * 1000  # Convert to milliseconds
+
+    def create_worker_process(self):
+        """Create a new worker process that can be used for execution."""
+        # Record the start time for detailed process creation metrics
+        start_time = time.time()
+
+        try:
+            # Create a unique ID for this worker
+            worker_id = str(uuid.uuid4())[:8]
+
+            # Path to the worker script (assuming it's in the same directory as this file)
+            import os.path
+            worker_script_path = os.path.join(os.path.dirname(__file__), "process_worker.py")
+
+            # Start the worker process using the dedicated worker script file
+            process = subprocess.Popen(
+                ["python", "-u", worker_script_path],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                bufsize=1,  # Line-buffered
+                universal_newlines=True  # Text mode for easy line reading
+            )
+
+            # Wait for the "READY" signal from the worker with timeout
+            try:
+                ready_line = ""
+                # Set up a thread to read stderr in background to catch initialization errors
+                stderr_lines = []
+                def read_stderr():
+                    while True:
+                        line = process.stderr.readline()
+                        if not line:
+                            break
+                        stderr_lines.append(line.strip())
+                
+                stderr_thread = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+                stderr_future = stderr_thread.submit(read_stderr)
+                
+                # Wait for READY with timeout
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ready_pool:
+                    ready_future = ready_pool.submit(process.stdout.readline)
+                    try:
+                        ready_line = ready_future.result(timeout=5)  # 5 second timeout for startup
+                        ready_line = ready_line.strip()
+                    except concurrent.futures.TimeoutError:
+                        # If we time out waiting for READY, check if the process is still alive
+                        if process.poll() is not None:
+                            # Process has exited
+                            exit_code = process.poll()
+                            logger.error(f"Worker {worker_id} exited with code {exit_code} during initialization")
+                            # Get any stderr output
+                            if stderr_lines:
+                                logger.error(f"Worker {worker_id} stderr output: {stderr_lines}")
+                            raise Exception(f"Worker process exited with code {exit_code} during startup")
+                        else:
+                            logger.error(f"Worker {worker_id} timed out waiting for READY signal")
+                            process.kill()
+                            raise Exception("Worker process timed out during startup")
+                
+                # Check if we got the expected READY signal
+                if ready_line != "READY":
+                    # Process is alive but didn't respond with READY
+                    logger.warning(f"Worker {worker_id} sent unexpected ready signal: '{ready_line}'")
+                    if stderr_lines:
+                        logger.error(f"Worker {worker_id} stderr output: {stderr_lines}")
+                    # Still try to use the process, but log the warning
+            
+            except Exception as e:
+                # Clean up the process if anything goes wrong
+                if process.poll() is None:
+                    process.kill()
+                logger.error(f"Failed to initialize worker {worker_id}: {e}")
+                if stderr_lines:
+                    logger.error(f"Worker {worker_id} stderr output: {stderr_lines}")
+                raise
+
+            # Store the worker process info
+            worker = {
+                'id': worker_id,
+                'process': process,
+                'creation_time': time.time()
+            }
+
+            # Add the worker to the pool
+            self.process_pool.put(worker)
+
+            # Calculate and record the latency
+            latency = self._calculate_latency_ms(start_time)
+            process_creation_histogram.record(latency, attributes={"method": "create_process"})
+
+            logger.info(f"Created worker process {worker_id}, pid {process.pid} in {latency:.3f} milliseconds")
+            return worker
+        except Exception as e:
+            logger.error(f"Failed to create worker process: {e}")
+            return None
+
+    def terminate_worker(self, worker):
+        """Terminate a worker process."""
+        try:
+            process = worker.get('process')
+            if not process:
+                return
+
+            worker_id = worker.get('id', 'unknown')
+
+            # Try to gracefully exit first
+            try:
+                if process.poll() is None:  # If process is still running
+                    process.stdin.write("EXIT\n")
+                    process.stdin.flush()
+                    process.wait(timeout=1)
+            except Exception:
+                pass
+
+            # Force kill if still running
+            if process.poll() is None:
+                try:
+                    process.terminate()
+                    process.wait(timeout=1)
+                except Exception:
+                    pass
+
+            # Last resort
+            if process.poll() is None:
+                try:
+                    process.kill()
+                except Exception:
+                    pass
+
+            logger.info(f"Terminated worker {worker_id}")
+
+            # Create a replacement worker asynchronously
+            self.releaser_executor.submit(self.create_worker_process)
+        except Exception as e:
+            logger.error(f"Error terminating worker: {e}")
+            # Still try to create a replacement
+            self.releaser_executor.submit(self.create_worker_process)
+
+    def get_worker(self):
+        """Get a worker from the pool with timeout handling."""
+        if self.stop_event.is_set():
+            raise RuntimeError("Executor is shutting down, no workers available")
+
+        while not self.stop_event.is_set():
+            try:
+                worker = self.process_pool.get(timeout=self.exec_timeout)
+                process = worker.get('process')
+
+                # Verify the process is still running
+                if process.poll() is not None:  # Process has exited
+                    logger.warning(f"Worker {worker.get('id')} has exited unexpectedly, creating replacement")
+                    self.terminate_worker(worker)  # Clean up and create replacement
+                    continue  # Try another worker
+
+                return worker
+            except Exception as e:
+                if self.stop_event.is_set():
+                    raise RuntimeError("Executor is shutting down, no workers available")
+
+                logger.warning(f"Couldn't get a worker after waiting for {self.exec_timeout}s. Will retry: {e}")
 
     def run_scoring(self, code: str, data: dict) -> dict:
+        if self.stop_event.is_set():
+            return {"code": 503, "error": "Service is shutting down"}
+
+        worker = self.get_worker()
+        start_time = time.time()
+
         try:
-            # Try to acquire a slot, with timeout
-            if not self.semaphore.acquire(timeout=self.exec_timeout):
-                return {"code": 503, "error": "Server is at capacity. Please try again later."}
+            process = worker.get('process')
+            worker_id = worker.get('id', 'unknown')
 
-            try:
-                with concurrent.futures.ThreadPoolExecutor() as exec_pool:
-                    # Execute exactly like Docker - pass code and data as args
-                    process = subprocess.Popen(
-                        ["python", "-u", "-c", PYTHON_SCORING_COMMAND, code, json.dumps(data)],
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE,
-                        text=False  # Use bytes to match ExecutionResult
-                    )
+            # Prepare the command data
+            command_data = {
+                'code': code,
+                'data': data
+            }
 
+            # Send the command
+            command_json = json.dumps(command_data) + "\n"
+            process.stdin.write(command_json)
+            process.stdin.flush()
+
+            # Read the response with timeout using a thread
+            with concurrent.futures.ThreadPoolExecutor() as exec_pool:
+                future = exec_pool.submit(process.stdout.readline)
+                try:
+                    response_line = future.result(timeout=self.exec_timeout)
+                    # If we got an empty response, the worker has died
+                    if not response_line:
+                        logger.error(f"Worker {worker_id} died during execution")
+                        self.terminate_worker(worker)
+                        return {"code": 500, "error": "Worker process died during execution"}
+
+                    # Parse the response
                     try:
-                        future = exec_pool.submit(process.wait)
-                        exit_code = future.result(timeout=self.exec_timeout)
-                        stdout, stderr = process.stdout.read(), process.stderr.read()
-                        # Combine stdout/stderr like Docker does
-                        result = ExecutionResult(
-                            exit_code=exit_code,
-                            output=stdout if not stderr else stderr,  # Use stderr if present
-                        )
-                        return self.parse_execution_result(result)
-                    except concurrent.futures.TimeoutError:
-                        logger.error(f"Execution timed out in process {process.pid}")
-                        self.terminate_process(process)
-                        return {"code": 504, "error": "Server processing exceeded timeout limit."}
-                    except Exception as e:
-                        logger.error(f"An unexpected error occurred: {e}")
-                        self.terminate_process(process)
-                        return {"code": 500, "error": "An unexpected error occurred"}
-            finally:
-                self.semaphore.release()
-        except Exception as e:
-            logger.error(f"Error creating process: {e}")
-            return {"code": 500, "error": "Failed to create process"}
+                        result = json.loads(response_line)
 
-    def terminate_process(self, process):
-        """Terminate a process with SIGTERM, falling back to SIGKILL if needed."""
-        try:
-            process.terminate()
-            process.wait(timeout=1)
-        except subprocess.TimeoutExpired:
-            process.kill()
+                        # Calculate and record latency
+                        latency = self._calculate_latency_ms(start_time)
+                        process_execution_histogram.record(latency, attributes={"method": "run_scoring"})
+                        logger.debug(f"Worker {worker_id} executed code in {latency:.3f} milliseconds")
+
+                        # Return the worker to the pool for reuse
+                        self.process_pool.put(worker)
+
+                        return result
+                    except json.JSONDecodeError as e:
+                        logger.error(f"Failed to decode response from worker {worker_id}: {e}")
+                        logger.error(f"Response was: {response_line}")
+                        self.terminate_worker(worker)
+                        return {"code": 500, "error": "Failed to decode worker response"}
+                except concurrent.futures.TimeoutError:
+                    logger.error(f"Execution timed out in worker {worker_id}")
+                    self.terminate_worker(worker)
+                    return {"code": 504, "error": "Server processing exceeded timeout limit."}
         except Exception as e:
-            logger.error(f"Error terminating process {process.pid}: {e}")
+            logger.error(f"Error in run_scoring: {e}")
+            if 'worker' in locals():
+                self.terminate_worker(worker)
+            return {"code": 500, "error": f"Failed to execute code: {str(e)}"}
+
+    def cleanup(self):
+        """Clean up resources used by this executor."""
+        logger.info("Shutting down Process executor")
+        self.stop_event.set()
+
+        # Clear all scheduled jobs
+        schedule.clear()
+
+        # Clean up all worker processes
+        while not self.process_pool.empty():
+            try:
+                worker = self.process_pool.get_nowait()
+                self.terminate_worker(worker)
+            except:
+                pass
+
+        # Shutdown the executor
+        logger.info("Shutting down executor")
+        self.releaser_executor.shutdown(wait=False, cancel_futures=True)

--- a/apps/opik-python-backend/src/opik_backend/process_worker.py
+++ b/apps/opik-python-backend/src/opik_backend/process_worker.py
@@ -1,11 +1,10 @@
 import json
 import sys
 import traceback
-import time
 import inspect
 import uuid
 from types import ModuleType
-from typing import Type, Union, List, Any, Dict
+from typing import Type, Union, List
 
 from opik.evaluation.metrics import BaseMetric
 from opik.evaluation.metrics.score_result import ScoreResult
@@ -28,7 +27,7 @@ def to_scores(score_result: Union[ScoreResult, List[ScoreResult]]) -> List[Score
     return scores
 
 
-def run_scoring(code: str, data: dict) -> dict:
+def run_user_code(code: str, data: dict) -> dict:
     """
     Run the scoring logic with the provided code and data.
     """
@@ -80,7 +79,7 @@ def main():
                 input_data = data.get('data', {})
                 
                 # Execute the code
-                result = run_scoring(code, input_data)
+                result = run_user_code(code, input_data)
                 
                 # Return the result
                 sys.stdout.write(json.dumps(result) + "\n")
@@ -98,6 +97,7 @@ def main():
         sys.stderr.write(f"Worker initialization error: {str(e)}\n{traceback.format_exc()}\n")
         sys.stderr.flush()
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/apps/opik-python-backend/src/opik_backend/process_worker.py
+++ b/apps/opik-python-backend/src/opik_backend/process_worker.py
@@ -1,0 +1,103 @@
+import json
+import sys
+import traceback
+import time
+import inspect
+import uuid
+from types import ModuleType
+from typing import Type, Union, List, Any, Dict
+
+from opik.evaluation.metrics import BaseMetric
+from opik.evaluation.metrics.score_result import ScoreResult
+
+
+def get_metric_class(module: ModuleType) -> Type[BaseMetric]:
+    for _, cls in inspect.getmembers(module, inspect.isclass):
+        if issubclass(cls, BaseMetric):
+            return cls
+
+
+def to_scores(score_result: Union[ScoreResult, List[ScoreResult]]) -> List[ScoreResult]:
+    scores = []
+    if isinstance(score_result, ScoreResult):
+        scores = [score_result]
+    elif isinstance(score_result, list):
+        for item in score_result:
+            if isinstance(item, ScoreResult):
+                scores.append(item)
+    return scores
+
+
+def run_scoring(code: str, data: dict) -> dict:
+    """
+    Run the scoring logic with the provided code and data.
+    """
+    module = ModuleType(str(uuid.uuid4()))
+
+    try:
+        exec(code, module.__dict__)
+    except Exception:  
+        stacktrace = "\n".join(traceback.format_exc().splitlines()[2:])  
+        return {"error": f"Field 'code' contains invalid Python code: {stacktrace}"}
+
+    metric_class = get_metric_class(module)
+    if metric_class is None:
+        return {"error": "Field 'code' in the request doesn't contain a subclass implementation of 'opik.evaluation.metrics.BaseMetric'"}
+
+    score_result: Union[ScoreResult, List[ScoreResult]] = []
+    try:
+        metric = metric_class()
+        score_result = metric.score(**data)
+    except Exception:
+        stacktrace = "\n".join(traceback.format_exc().splitlines()[2:])
+        return {"error": f"The provided 'code' and 'data' fields can't be evaluated: {stacktrace}"}
+            
+    scores = to_scores(score_result)
+
+    return {"scores": [score.__dict__ for score in scores]}
+
+
+def main():
+    try:
+        # Make sure stdout is flushed immediately
+        sys.stdout = open(sys.stdout.fileno(), 'w', buffering=1)
+        
+        # Flush immediately to signal we're ready
+        sys.stdout.write("READY\n")
+        sys.stdout.flush()
+        
+        # Keep reading commands until told to exit
+        while True:
+            try:
+                # Read a line from stdin - this will block until we get a command
+                line = sys.stdin.readline()
+                if not line or line.strip() == "EXIT":
+                    break
+                    
+                # Parse the command (code and data)
+                data = json.loads(line)
+                code = data.get('code', '')
+                input_data = data.get('data', {})
+                
+                # Execute the code
+                result = run_scoring(code, input_data)
+                
+                # Return the result
+                sys.stdout.write(json.dumps(result) + "\n")
+                sys.stdout.flush()
+            except Exception as e:
+                # Report any errors
+                error_msg = {"code": 500, "error": f"Worker error: {str(e)}", "traceback": traceback.format_exc()}
+                sys.stdout.write(json.dumps(error_msg) + "\n")
+                sys.stdout.flush()
+        
+        # Exit cleanly
+        sys.exit(0)
+    except Exception as e:
+        # If we get an error during initialization, write it to stderr and exit
+        sys.stderr.write(f"Worker initialization error: {str(e)}\n{traceback.format_exc()}\n")
+        sys.stderr.flush()
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/apps/opik-python-backend/src/opik_backend/process_worker.py
+++ b/apps/opik-python-backend/src/opik_backend/process_worker.py
@@ -81,13 +81,13 @@ def main():
                 # Execute the code
                 result = run_user_code(code, input_data)
                 
-                # Return the result
-                sys.stdout.write(json.dumps(result) + "\n")
+                # Return the result with a prefix to distinguish it from user print statements
+                sys.stdout.write("RESULT=" + json.dumps(result) + "\n")
                 sys.stdout.flush()
             except Exception as e:
-                # Report any errors
+                # Report any errors with the same prefix
                 error_msg = {"code": 500, "error": f"Worker error: {str(e)}", "traceback": traceback.format_exc()}
-                sys.stdout.write(json.dumps(error_msg) + "\n")
+                sys.stdout.write("RESULT=" + json.dumps(error_msg) + "\n")
                 sys.stdout.flush()
         
         # Exit cleanly


### PR DESCRIPTION
## Details
When running the online scoring with `process` execution strategy, we noticed the service responds with high percentage of `504` http codes.
We suspected this is a result of a process creation overhead. The suggested solution uses a process pool to run the user code and eliminates the `504` error responses.

## Issues
OPIK-1813

## Testing
I used the following scripts to test the solution - 

`send_code_to_executor.py`:
```
import asyncio
import aiohttp
from collections import Counter

# === Config ===
python_file_path = 'for_evaluator.py'
endpoint_url = 'http://localhost:5001/v1/private/evaluators/python'
total_requests = 50
concurrency_limit = 5

# === Read file once ===
with open(python_file_path, 'r') as file:
    code_content = file.read()

# === Prepare JSON payload ===
payload = {
    "code": code_content,
    "data": {"output": "", "reference": ""}
}

# === Semaphore to limit concurrency ===
semaphore = asyncio.Semaphore(concurrency_limit)


# === Single request task ===
async def make_request(session, idx):
    async with semaphore:
        try:
            async with session.post(endpoint_url, json=payload) as resp:
                return resp.status
        except Exception as e:
            print(f"Request {idx} failed: {e}")
            return "EXCEPTION"


# === Main async runner ===
async def main():
    async with aiohttp.ClientSession() as session:
        tasks = [make_request(session, i) for i in range(total_requests)]
        results = await asyncio.gather(*tasks)

        # Count status codes
        counter = Counter(results)
        for status, count in counter.items():
            print(f"{status}: {count}")

# === Run it ===
if __name__ == "__main__":
    asyncio.run(main())
```

`for_evaluator.py`:
```
from typing import Any
from opik.evaluation.metrics import base_metric, score_result
from time import sleep
from random import random


class NetworkAccessTest(base_metric.BaseMetric):
    def __init__(self, name: str = "network_access_test"):
        super().__init__(name=name, track=False)

    def score(self, output: str, reference: str, **ignored_kwargs: Any) -> score_result.ScoreResult:
        sleep(random() * 2)
        return score_result.ScoreResult(
            name=self.name,
            value=1.0,
            reason="Network access succeeded")
```

**Before this PR's changes:**
```
504: 9
200: 41
```
`504` is constantly returned for 10%-20% of requests.

**After this PR's changes:**
```
200: 50
```
Not a single `504` in multiple attempts.

# Caveats
1. The code in `process_worker.py` duplicates many of the code in `scoring_commands.py`. I found no way around it and I didn't want to introduce changes to `executor_docker.py`
2. When running in flask `debug` mode, the application not always terminates cleanly, sometimes showing this warning: `multiprocessing/resource_tracker.py:301: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown: {'/mp-bzrnbai9'}
  warnings.warn(`. I minimized the impact of this as much as possible but eliminating it entirely involved too many changes to other parts of the application and I gave it up. Note that this only happens when running in `debug` mode due to the way flask debugger works