### PR TITLE
Fixed broken link

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/overview.mdx
@@ -83,7 +83,7 @@ print(opt_result.prompt)
 ```
 
 You can learn more about running your first optimization in the
-[Quickstart guide](agent_optimization/opik_optimizer/quickstart).
+[Quickstart guide](/agent_optimization/opik_optimizer/quickstart).
 
 ## Optimization Algorithms
 


### PR DESCRIPTION
## Details

Link in documentation is missing a leading forward slash.
