### PR TITLE
NO-JIRA: Exclude TypeScript Fern classes from typecheck

### DIFF
--- a/.github/workflows/typescript_sdk_linter.yml
+++ b/.github/workflows/typescript_sdk_linter.yml
@@ -32,4 +32,4 @@ jobs:
         run: npm run lint
 
       - name: Type check
-        run: npm run typecheck -- --ignore-path ./src/opik/rest_api
+        run: npm run typecheck

--- a/sdks/typescript/tsconfig.json
+++ b/sdks/typescript/tsconfig.json
@@ -25,6 +25,7 @@
   "include": ["src", "tests"],
   "exclude": [
     "node_modules",
+    "src/opik/rest_api",
     "src/opik/integrations/opik-langchain",
     "src/opik/integrations/opik-openai"
   ]


### PR DESCRIPTION
## Details
Fern auto-generated code from the Open API spec for the TypeScript SDK is found under `sdks/typescript/src/opik/rest_api`. Excluded from `typecheck`.

## Issues
N/A

## Testing
- Will be tested in CI.
- Will be tested by https://github.com/comet-ml/opik/pull/2558

## Documentation
N/A
