### PR TITLE
Revert "NO-JIRA: Exclude TypeScript Fern classes from typecheck (#2561)"

### DIFF
--- a/sdks/typescript/tsconfig.json
+++ b/sdks/typescript/tsconfig.json
@@ -25,7 +25,6 @@
   "include": ["src", "tests"],
   "exclude": [
     "node_modules",
-    "src/opik/rest_api",
     "src/opik/integrations/opik-langchain",
     "src/opik/integrations/opik-openai"
   ]


### PR DESCRIPTION
## Details
This reverts commit 86f9251f9b4f55f7646ed3a9b6a37ab2bdfb1e1a.

And PR: https://github.com/comet-ml/opik/pull/2561

The fix didn't work. There's a follow-up conversation for this. Not a blocker in the meantime.

## Issues

N/A

## Testing
N/A

## Documentation
N/A
