### PR TITLE
[P SDK] UserFrustration conversation metric

### DIFF
--- a/sdks/python/src/opik/evaluation/metrics/conversation/conversation_turns_factory.py
+++ b/sdks/python/src/opik/evaluation/metrics/conversation/conversation_turns_factory.py
@@ -32,4 +32,8 @@ def build_conversation_turns(
             turns.append(current_turn)
             user_input = None
 
+    # append the last user input if it exists
+    if user_input is not None:
+        turns.append(types.ConversationTurn(input=user_input, output=None))
+
     return turns

--- a/sdks/python/src/opik/evaluation/metrics/conversation/helpers.py
+++ b/sdks/python/src/opik/evaluation/metrics/conversation/helpers.py
@@ -1,6 +1,6 @@
 from typing import Any, Generator, List
 
-from . import types
+from . import types, conversation_turns_factory
 
 
 def get_turns_in_sliding_window(
@@ -47,3 +47,39 @@ def merge_turns(turns: List[types.ConversationTurn]) -> types.Conversation:
     for turn in turns:
         output.extend(turn.as_list())
     return output
+
+
+def extract_turns_windows_from_conversation(
+    conversation: types.Conversation, window_size: int
+) -> List[types.Conversation]:
+    """
+    Extracts a list of conversation windows based on turns using a sliding window
+    approach. This function divides a conversation into consecutive overlapping
+    windows, where each window contains a specified number of turns.
+
+    Args:
+        conversation: The input conversation from which turns will be processed.
+        window_size: The number of turns to include in each sliding window.
+
+    Returns:
+        A list of conversations, each representing a window of turns specified
+        by the given window size.
+
+    Raises:
+        ValueError: If the conversation is empty or if it has no turns.
+    """
+    if len(conversation) == 0:
+        raise ValueError("Conversation is empty")
+
+    turns = conversation_turns_factory.build_conversation_turns(
+        conversation=conversation
+    )
+    if len(turns) == 0:
+        raise ValueError("Conversation has no turns")
+
+    turns_windows: List[types.Conversation] = [
+        merge_turns(turns_window)
+        for turns_window in get_turns_in_sliding_window(turns, window_size)
+    ]
+
+    return turns_windows

--- a/sdks/python/src/opik/evaluation/metrics/conversation/types.py
+++ b/sdks/python/src/opik/evaluation/metrics/conversation/types.py
@@ -1,4 +1,4 @@
-from typing import Dict, Literal, List
+from typing import Dict, Literal, List, Optional
 
 import pydantic
 
@@ -26,7 +26,10 @@ class ConversationTurn(pydantic.BaseModel):
     """
 
     input: ConversationDict
-    output: ConversationDict
+    output: Optional[ConversationDict]
 
     def as_list(self) -> List[ConversationDict]:
+        if self.output is None:
+            return [self.input]
+
         return [self.input, self.output]

--- a/sdks/python/src/opik/evaluation/metrics/conversation/user_frustration/metric.py
+++ b/sdks/python/src/opik/evaluation/metrics/conversation/user_frustration/metric.py
@@ -1,0 +1,156 @@
+import logging
+from typing import Optional, Union, Any, List, Dict
+
+import pydantic
+
+from opik import exceptions
+from opik.evaluation.metrics import score_result
+from opik.evaluation.models import base_model, models_factory
+from . import schema, templates
+from .. import (
+    types as conversation_types,
+    conversation_thread_metric,
+    helpers,
+)
+from ...llm_judges import parsing_helpers
+
+LOGGER = logging.getLogger(__name__)
+
+
+class UserFrustrationMetric(conversation_thread_metric.ConversationThreadMetric):
+    def __init__(
+        self,
+        model: Optional[Union[str, base_model.OpikBaseModel]] = None,
+        name: str = "user_frustration_score",
+        include_reason: bool = True,
+        track: bool = True,
+        project_name: Optional[str] = None,
+        window_size: int = 10,
+    ):
+        super().__init__(
+            name=name,
+            track=track,
+            project_name=project_name,
+        )
+        self._init_model(model)
+        self._include_reason = include_reason
+        self._window_size = window_size
+
+    def _init_model(
+        self, model: Optional[Union[str, base_model.OpikBaseModel]]
+    ) -> None:
+        if isinstance(model, base_model.OpikBaseModel):
+            self._model = model
+        else:
+            self._model = models_factory.get(model_name=model)
+
+    def score(
+        self,
+        conversation: conversation_types.Conversation,
+        **ignored_kwargs: Any,
+    ) -> score_result.ScoreResult:
+        return self._calculate_score(conversation=conversation)
+
+    def _calculate_score(
+        self,
+        conversation: conversation_types.Conversation,
+    ) -> score_result.ScoreResult:
+        try:
+            turns_windows = helpers.extract_turns_windows_from_conversation(
+                conversation=conversation, window_size=self._window_size
+            )
+
+            verdicts = [
+                self._evaluate_conversation(conversation_sliding_window=window)
+                for window in turns_windows
+            ]
+
+            score = _score_from_verdicts(verdicts=verdicts)
+            reason = (
+                self._reason_from_verdicts(score=score, verdicts=verdicts)
+                if self._include_reason
+                else None
+            )
+            return score_result.ScoreResult(
+                name=self.name,
+                value=score,
+                reason=reason,
+            )
+        except Exception as e:
+            LOGGER.error(f"Failed to calculate user frustration score: {e}")
+            raise exceptions.MetricComputationError(
+                f"Failed to calculate user frustration score: {e}"
+            ) from e
+
+    def _evaluate_conversation(
+        self,
+        conversation_sliding_window: conversation_types.Conversation,
+    ) -> schema.EvaluateUserFrustrationResponse:
+        llm_query = templates.evaluate_conversation(
+            sliding_window=conversation_sliding_window
+        )
+        model_output = self._model.generate_string(
+            input=llm_query,
+            response_format=schema.EvaluateUserFrustrationResponse,
+        )
+        return _evaluate_conversation_from_model_output(model_output=model_output)
+
+    def _reason_from_verdicts(
+        self, score: float, verdicts: List[schema.EvaluateUserFrustrationResponse]
+    ) -> str:
+        frustrations: List[Dict[str, str]] = _extract_frustrations_from_verdicts(
+            verdicts
+        )
+
+        llm_query = templates.generate_reason(score=score, frustrations=frustrations)
+
+        model_output = self._model.generate_string(
+            input=llm_query, response_format=schema.ScoreReasonResponse
+        )
+        return _generate_reason_from_model_output(model_output=model_output)
+
+
+def _evaluate_conversation_from_model_output(
+    model_output: str,
+) -> schema.EvaluateUserFrustrationResponse:
+    try:
+        dict_content = parsing_helpers.extract_json_content_or_raise(model_output)
+        return schema.EvaluateUserFrustrationResponse.model_validate(dict_content)
+    except pydantic.ValidationError as e:
+        LOGGER.warning(
+            f"Failed to parse user's frustration evaluation results from the LLM output: {model_output}, reason: {e}",
+            exc_info=True,
+        )
+        raise e
+
+
+def _score_from_verdicts(
+    verdicts: List[schema.EvaluateUserFrustrationResponse],
+) -> float:
+    if len(verdicts) == 0:
+        return 0.0
+
+    relevant_count = sum(v.verdict.strip().lower() != "yes" for v in verdicts)
+    return relevant_count / len(verdicts)
+
+
+def _extract_frustrations_from_verdicts(
+    verdicts: List[schema.EvaluateUserFrustrationResponse],
+) -> List[Dict[str, str]]:
+    return [
+        {"message_number": f"{index + 1}", "reason": verdict.reason}
+        for index, verdict in enumerate(verdicts)
+        if verdict.verdict.strip().lower() == "yes" and verdict.reason is not None
+    ]
+
+
+def _generate_reason_from_model_output(model_output: str) -> str:
+    try:
+        dict_content = parsing_helpers.extract_json_content_or_raise(model_output)
+        return schema.ScoreReasonResponse.model_validate(dict_content).reason
+    except pydantic.ValidationError as e:
+        LOGGER.warning(
+            f"Failed to parse frustration score reason from the LLM output: {model_output}, reason: {e}",
+            exc_info=True,
+        )
+        raise e

--- a/sdks/python/src/opik/evaluation/metrics/conversation/user_frustration/schema.py
+++ b/sdks/python/src/opik/evaluation/metrics/conversation/user_frustration/schema.py
@@ -1,0 +1,16 @@
+from typing import Optional
+
+import pydantic
+
+
+class EvaluateUserFrustrationResponse(pydantic.BaseModel):
+    verdict: str
+    reason: Optional[str] = pydantic.Field(default=None)
+
+    __hash__ = object.__hash__
+
+
+class ScoreReasonResponse(pydantic.BaseModel):
+    reason: str
+
+    __hash__ = object.__hash__

--- a/sdks/python/src/opik/evaluation/metrics/conversation/user_frustration/templates.py
+++ b/sdks/python/src/opik/evaluation/metrics/conversation/user_frustration/templates.py
@@ -1,0 +1,134 @@
+from typing import List, Dict
+
+from .. import types as conversation_types
+
+
+def evaluate_conversation(sliding_window: conversation_types.Conversation) -> str:
+    return f"""Based on the given list of message exchanges between a user and an LLM, generate a JSON object to indicate whether the LAST `user` message is showing that the user experiences confusion, annoyance, or disengagement during the conversation session given in the context of the last messages.
+
+** Guidelines: **
+- Make sure to only return in JSON format.
+- The JSON must have only 2 fields: 'verdict' and 'reason'.
+- The 'verdict' key should STRICTLY be either 'yes' or 'no', which states whether the last `user` message is showing that the user experienced confusion, annoyance, or disengagement during the conversation session given in the context of the last messages.
+- Provide a 'reason' ONLY if the answer is 'yes'.
+- You DON'T have to provide a reason if the answer is 'no'.
+- You MUST USE the previous messages (if any) provided in the list of messages to make an informed judgement on user frustration.
+- You MUST ONLY provide a verdict for the LAST message on the list but MUST USE context from the previous messages.
+- ONLY provide a 'yes' answer if the LLM response caused the user to express COMPLETE frustration or confusion in his/her input messages.
+- Vague LLM responses to vague inputs, such as greetings DOES NOT count as causes of frustration!
+- You should mention LLM response instead of `assistant`, and User instead of `user`.
+
+===== Start OF EXAMPLE ======
+** Example Turns: **
+[
+    {{
+        "role": "user",
+        "content": "Hello!"
+    }},
+    {{
+        "role": "assistant",
+        "content": "Hi there!"
+    }},
+    {{
+        "role": "user",
+        "content": "Can you help me write a function to parse dates in Python?"
+    }},
+    {{
+        "role": "assistant",
+        "content": "Of course! Here's a basic example using `datetime.strptime`:\n\n```python\nfrom datetime import datetime\n\ndef parse_date(date_string):\n    return datetime.strptime(date_string, '%Y-%m-%d')\n```"
+    }},
+    {{
+        "role": "user",
+        "content": "That's not what I meant. I need it to handle multiple formats."
+    }},
+    {{
+        "role": "assistant",
+        "content": "Ah, got it. Here's an updated version that tries multiple formats:\n\n```python\nfrom datetime import datetime\n\ndef parse_date(date_string):\n    for fmt in ('%Y-%m-%d', '%d/%m/%Y', '%m-%d-%Y'):\n        try:\n            return datetime.strptime(date_string, fmt)\n        except ValueError:\n            continue\n    raise ValueError('No valid date format found')\n```"
+    }},
+    {{
+        "role": "user",
+        "content": "Why didn’t you just give me this the first time? This is basic."
+    }},
+    {{
+        "role": "assistant",
+        "content": "content": "Apologies for the oversight. I always aim to provide the most helpful answer based on the initial question."
+    }},
+    {{
+        "role": "user",
+        "content": "Well, it's kind of frustrating to keep asking for obvious things. Can you at least include error handling too next time?"
+    }},
+    {{
+        "role": "assistant",
+        "content": "You're right, I’ll be more thorough. Let me know if you'd like to expand the function with logging or timezone support as well."
+
+    }},
+    {{
+        "role": "user",
+        "content": "Now you're overcomplicating it. I just wanted a simple, robust function."
+    }},
+    {{
+        "role": "assistant",
+        "content": "Understood. Here's a simpler version with basic error handling included:\n\n```python\nfrom datetime import datetime\n\ndef parse_date(date_string):\n    formats = ('%Y-%m-%d', '%d/%m/%Y', '%m-%d-%Y')\n    for fmt in formats:\n        try:\n            return datetime.strptime(date_string, fmt)\n        except ValueError:\n            continue\n    return None  # Or raise an error if preferred\n```"
+    }},
+    {{
+        "role": "user", "content": "You could’ve just started with this. Why is it so hard to get a straight answer?"
+    }}
+]
+
+** Example output JSON **
+{{
+    "verdict": "yes",
+    "reason": "The User repeatedly clarifies their intent and expresses dissatisfaction with the LLM’s initial responses, indicating a mismatch between the User’s expectations and the LLM’s output. Despite asking a clear question, the LLM provides an overly simplistic solution at first, requiring the User to iterate and request obvious improvements (e.g., support for multiple formats, error handling). The User’s tone becomes increasingly critical, with statements like “Why didn’t you just give me this the first time?” and “Why is it so hard to get a straight answer?”, signaling rising frustration due to perceived inefficiency and lack of responsiveness from the assistant."
+}}
+===== END OF EXAMPLE ======
+
+** Turns: **
+{sliding_window}
+
+** JSON: **
+"""
+
+
+def generate_reason(score: float, frustrations: List[Dict[str, str]]) -> str:
+    return f"""Below is a list of user frustrations drawn from some messages in a conversation, which you have minimal knowledge of. It is a list of strings explaining why the 'assistant' messages caused the 'user' to be frustrated.
+Given the frustration score, which is a 0-1 score indicating how frustrating the OVERALL AI 'assistant' messages are in a conversation (higher the more frustrating).
+
+** Guidelines: **
+- Make sure to only return in JSON format, with the 'reason' key providing the reason.
+- Always quote WHICH MESSAGE and the INFORMATION in the reason in your final reason.
+- Be confident in your reasoning, as if you’re aware of the `assistant` messages from the messages in a conversation that led to the frustrations.
+- You should CONCISELY summarize the user frustrations to justify the score.
+- You should NOT mention concrete frustration in your reason, and make the reason sound convincing.
+- You should mention LLM response instead of `assistant`, and User instead of `user`.
+
+===== Start OF EXAMPLE ======
+** Example frustrations: **
+[
+    {{
+        "message_number": "1",
+        "reason": "The User repeatedly clarifies their intent and expresses dissatisfaction with the LLM’s initial responses, indicating a mismatch between the User’s expectations and the LLM’s output."
+    }},
+    {{
+        "message_number": "2",
+        "reason": "Despite asking a clear question, the LLM provides an overly simplistic solution at first, requiring the User to iterate and request obvious improvements (e.g., support for multiple formats, error handling)."
+    }},
+    {{
+        "message_number": "3",
+        "reason": "The User’s tone becomes increasingly critical, with statements like “Why didn’t you just give me this the first time?” and “Why is it so hard to get a straight answer?”, signaling rising frustration due to perceived inefficiency and lack of responsiveness from the assistant."
+    }}
+]
+
+** Example output JSON **
+{{
+    "reason": "The score is <frustration_score> because <your_reason>."
+}}
+===== END OF EXAMPLE ======
+
+** Frustration Score: **
+{score}
+
+** Frustrations: **
+{frustrations}
+
+** JSON: **
+"""

--- a/sdks/python/tests/unit/evaluation/metrics/conversation/test_conversation_turns_factory.py
+++ b/sdks/python/tests/unit/evaluation/metrics/conversation/test_conversation_turns_factory.py
@@ -14,3 +14,21 @@ def test_build_conversation_turns__happy_path():
     assert turns[0].output == conversation[1]
     assert turns[1].input == conversation[2]
     assert turns[1].output == conversation[3]
+
+
+def test_build_conversation_turns__last_user_message_included():
+    conversation = [
+        {"role": "user", "content": "Hi!"},
+        {"role": "assistant", "content": "Hello! How can I help you today?"},
+        {"role": "user", "content": "How are you?"},
+        {"role": "assistant", "content": "I'm doing well!"},
+        {"role": "user", "content": "I'm doing well too!"},
+    ]
+    turns = conversation_turns_factory.build_conversation_turns(conversation)
+    assert len(turns) == 3
+    assert turns[0].input == conversation[0]
+    assert turns[0].output == conversation[1]
+    assert turns[1].input == conversation[2]
+    assert turns[1].output == conversation[3]
+    assert turns[2].input == conversation[4]
+    assert turns[2].output is None

--- a/sdks/python/tests/unit/evaluation/metrics/conversation/test_helpers.py
+++ b/sdks/python/tests/unit/evaluation/metrics/conversation/test_helpers.py
@@ -1,3 +1,5 @@
+import pytest
+
 from opik.evaluation.metrics.conversation import conversation_turns_factory, helpers
 
 
@@ -19,3 +21,47 @@ def test_get_turns_in_sliding_window():
     for window in window_generator:
         assert len(window) == expected_size
         expected_size += 1
+
+
+def test_extract_turns_windows_from_conversation__happy_path():
+    conversation = [
+        {"role": "user", "content": "Hello!"},
+        {"role": "assistant", "content": "Hi there!"},
+        {"role": "user", "content": "How are you?"},
+        {"role": "assistant", "content": "I'm doing well!"},
+    ]
+
+    turns_windows = helpers.extract_turns_windows_from_conversation(
+        conversation=conversation, window_size=2
+    )
+
+    assert len(turns_windows) == 2
+
+    # Check that the first window has a list of dictionaries for the first turn
+    # and the second window has full conversation
+    assert len(turns_windows[0]) == 2
+    assert turns_windows[0] == conversation[:2]
+
+    assert len(turns_windows[1]) == 4
+    assert turns_windows[1] == conversation
+
+
+def test_extract_turns_windows_from_conversation__empty_conversation__raises_error():
+    conversation = []
+
+    with pytest.raises(ValueError):
+        helpers.extract_turns_windows_from_conversation(
+            conversation=conversation, window_size=2
+        )
+
+
+def test_extract_turns_windows_from_conversation__no_turns__raises_error():
+    conversation = [
+        {"role": "unknown", "content": "Hello!"},
+        {"role": "someone", "content": "Hi there!"},
+    ]
+
+    with pytest.raises(ValueError):
+        helpers.extract_turns_windows_from_conversation(
+            conversation=conversation, window_size=2
+        )


### PR DESCRIPTION
## Details
User Frustration Index: A heuristic score estimating the likelihood that the user experienced confusion, annoyance, or disengagement during the session — due to repetition, lack of adaptation, ignored intent signals, or failure to smoothly conclude.

How the frustration score is calculated as following:

```math
frustrationScore=\frac{frustrationVerdicts}{totalVerdicts}
```

The lager values indicate increased user's frustration.

The UserFrustrationMetric first constructs a sliding windows of turns for each turn, before using an LLM to determine whether the last turn in each sliding window has an "assistant" content that is frustrating to the previous conversational context found in the sliding window

### What was done:

- Added `UserFrustrationMetric` to evaluate user frustration in conversations based on sliding window analysis.
- Introduced templates and schema for constructing LLM queries and parsing frustration-related responses.
- Implemented scoring and reasoning generation, leveraging context and per-message analysis.

## Testing

Implemented unit and integration tests.

## Documentation

Added related documentation to the classes and methods.