### PR TITLE
NA: Create trace thread if it doesn't exist upon closure

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -721,7 +721,9 @@ public class TracesResource {
     @PUT
     @Path("/threads/close")
     @Operation(operationId = "closeTraceThread", summary = "Close trace thread", description = "Close trace thread", responses = {
-            @ApiResponse(responseCode = "204", description = "No Content")})
+            @ApiResponse(responseCode = "204", description = "No Content"),
+            @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))
+    })
     public Response closeTraceThread(
             @RequestBody(content = @Content(schema = @Schema(implementation = TraceThreadIdentifier.class))) @NotNull @Valid TraceThreadIdentifier identifier) {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
@@ -1,13 +1,16 @@
 package com.comet.opik.domain.threads;
 
+import com.comet.opik.api.TraceThread;
 import com.comet.opik.api.TraceThreadStatus;
 import com.comet.opik.api.events.ProjectWithPendingClosureTraceThreads;
 import com.comet.opik.api.resources.v1.events.TraceThreadBufferConfig;
+import com.comet.opik.domain.TraceService;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.lock.LockService;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Singleton;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.NotFoundException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -57,6 +60,7 @@ class TraceThreadServiceImpl implements TraceThreadService {
 
     private final @NonNull TraceThreadDAO traceThreadDAO;
     private final @NonNull TraceThreadIdService traceThreadIdService;
+    private final @NonNull TraceService traceService;
     private final @NonNull LockService lockService;
 
     public Mono<Void> processTraceThreads(@NonNull Map<String, Instant> threadIdAndLastUpdateAts,
@@ -185,9 +189,45 @@ class TraceThreadServiceImpl implements TraceThreadService {
 
     @Override
     public Mono<Void> closeThread(@NonNull UUID projectId, @NonNull String threadId) {
-        return lockService.executeWithLockCustomExpire(
-                new LockService.Lock(projectId, TraceThreadService.THREADS_LOCK),
-                Mono.defer(() -> traceThreadDAO.closeThread(projectId, threadId)).then(),
-                LOCK_DURATION);
+        return verifyAndCreateThreadIfNeed(projectId, threadId)
+                // Once we have all, we can close the thread
+                .then(Mono.defer(() -> lockService.executeWithLockCustomExpire(
+                        new LockService.Lock(projectId, TraceThreadService.THREADS_LOCK),
+                        Mono.defer(() -> traceThreadDAO.closeThread(projectId, threadId))
+                                .doOnSuccess(
+                                        count -> log.info("Closed count '{}' for threadId '{}' and  projectId: '{}'",
+                                                count, threadId, projectId))
+                                .then(),
+                        LOCK_DURATION)));
+    }
+
+    private Mono<UUID> verifyAndCreateThreadIfNeed(UUID projectId, String threadId) {
+        return traceService.getThreadById(projectId, threadId)
+                .switchIfEmpty(Mono.error(new NotFoundException("Thread '%s' not found:".formatted(threadId))))
+                // If the trace thread exists on the trace table, let's check if it has a trace thread model id
+                .flatMap(traceThread -> getOrCreateThreadId(projectId, threadId)
+                        .map(threadModelId -> traceThread.toBuilder().threadModelId(threadModelId).build()))
+                // If it has a trace thread model id, check if the trace thread entity exists in the database
+                .flatMap(traceThread -> traceThreadDAO.findByThreadModelId(traceThread.threadModelId(), projectId)
+                        .map(TraceThreadModel::id)
+                        //If it does not exist, create a new one
+                        .switchIfEmpty(Mono.deferContextual(ctx -> {
+                            String userName = ctx.get(RequestContext.USER_NAME);
+                            return createTraceThread(projectId, threadId, traceThread, userName);
+                        })));
+    }
+
+    private Mono<UUID> createTraceThread(UUID projectId, String threadId, TraceThread traceThread, String userName) {
+        log.warn("Creating a new thread with id '{}' for threadId '{}' and projectId: '{}'",
+                traceThread.threadModelId(), threadId, projectId);
+
+        return traceThreadDAO
+                .save(List.of(
+                        new TraceThreadModel(projectId, threadId, traceThread.threadModelId(), TraceThreadStatus.ACTIVE,
+                                traceThread.createdBy(), userName, traceThread.createdAt(), Instant.now())))
+                .thenReturn(traceThread.threadModelId())
+                .doOnSuccess(
+                        id -> log.info("Created new trace thread with id '{}' for threadId '{}' and projectId: '{}'",
+                                id, threadId, projectId));
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/traces/TraceDBUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/traces/TraceDBUtils.java
@@ -1,0 +1,93 @@
+package com.comet.opik.api.resources.utils.traces;
+
+import com.comet.opik.api.Trace;
+import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
+import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Statement;
+import reactor.core.publisher.Mono;
+
+public class TraceDBUtils {
+
+    public static void createTraceViaDB(Trace trace, String workspaceId, TransactionTemplateAsync templateAsync) {
+
+        String sql = """
+                INSERT INTO traces (
+                    id,
+                    project_id,
+                    workspace_id,
+                    name,
+                    start_time,
+                    end_time,
+                    input,
+                    output,
+                    metadata,
+                    tags,
+                    created_at,
+                    last_updated_at,
+                    created_by,
+                    last_updated_by,
+                    thread_id
+                )
+                SELECT
+                    :id,
+                    :project_id,
+                    :workspace_id,
+                    :name,
+                    parseDateTime64BestEffort(:start_time, 9),
+                    parseDateTime64BestEffort(:end_time, 9),
+                    :input,
+                    :output,
+                    :metadata,
+                    :tags,
+                    if(:created_at IS NULL, now(), parseDateTime64BestEffort(:created_at, 9)),
+                    if(:last_updated_at IS NULL, NULL, parseDateTime64BestEffort(:last_updated_at, 6)),
+                    if(:created_by IS NULL, toString(generateUUIDv4()), :created_by),
+                    if(:last_updated_by IS NULL, toString(generateUUIDv4()), :last_updated_by),
+                    :thread_id
+                ;
+                """;
+        templateAsync.nonTransaction(connection -> {
+            Statement statement = connection.createStatement(sql);
+
+            statement.bind("id", trace.id())
+                    .bind("project_id", trace.projectId())
+                    .bind("name", trace.name())
+                    .bind("start_time", trace.startTime().toString())
+                    .bind("end_time", trace.endTime().toString())
+                    .bind("input", trace.input().toString())
+                    .bind("output", trace.output().toString())
+                    .bind("metadata", trace.metadata().toString())
+                    .bind("tags", trace.tags().toArray())
+                    .bind("thread_id", trace.threadId());
+
+            if (trace.createdAt() != null) {
+                statement.bind("created_at", trace.createdAt().toString());
+            } else {
+                statement.bindNull("created_at", String.class);
+            }
+
+            if (trace.lastUpdatedAt() != null) {
+                statement.bind("last_updated_at", trace.lastUpdatedAt().toString());
+            } else {
+                statement.bindNull("last_updated_at", String.class);
+            }
+
+            if (trace.createdBy() != null) {
+                statement.bind("created_by", trace.createdBy());
+            } else {
+                statement.bindNull("created_by", String.class);
+            }
+
+            if (trace.lastUpdatedBy() != null) {
+                statement.bind("last_updated_by", trace.lastUpdatedBy());
+            } else {
+                statement.bindNull("last_updated_by", String.class);
+            }
+
+            Mono<? extends Result> from = Mono.from(statement
+                    .bind("workspace_id", workspaceId)
+                    .execute());
+            return from;
+        }).block();
+    }
+}


### PR DESCRIPTION
## Details

During final tests, we found that the user was unable to close a thread that was created before the entity was introduced. For this reason, we are adding this. So that the user can close the thread manually, and if it doesn't exist, it gets created.

Next, we can think better about what to do in those cases.

