### PR TITLE
Moving the logic of grouping from the UI to the backend

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Experiment.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Experiment.java
@@ -81,4 +81,22 @@ public record Experiment(
         public static class Public {
         }
     }
+
+    public record GroupedExperimentResponse(
+            @JsonView(View.Public.class) Dataset dataset,
+            @JsonView(View.Public.class) List<Experiment> experiments,
+            @JsonView(View.Public.class) long total) {
+    }
+
+    @Builder(toBuilder = true)
+    public record GroupedExperimentPage(
+            @JsonView(View.Public.class) int page,
+            @JsonView(View.Public.class) int size,
+            @JsonView(View.Public.class) long total,
+            @JsonView(View.Public.class) List<GroupedExperimentResponse> content,
+            @JsonView(View.Public.class) List<String> sortableBy) {
+        public static GroupedExperimentPage empty(int page, List<String> sortableBy) {
+            return new GroupedExperimentPage(page, 0, 0, List.of(), sortableBy);
+        }
+    }
 }

--- a/apps/opik-frontend/src/components/pages-shared/experiments/ExperimentsPathsAutocomplete/ExperimentsPathsAutocomplete.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/experiments/ExperimentsPathsAutocomplete/ExperimentsPathsAutocomplete.tsx
@@ -6,7 +6,10 @@ import isArray from "lodash/isArray";
 import { Sorting } from "@/types/sorting";
 import { getJSONPaths } from "@/lib/utils";
 import Autocomplete from "@/components/shared/Autocomplete/Autocomplete";
-import useExperimentsList from "@/api/datasets/useExperimentsList";
+import useGroupedExperimentsList, { GroupedExperiment } from "@/hooks/useGroupedExperimentsList";
+import useAppStore from "@/store/AppStore";
+import { Filters } from "@/types/filters";
+import { COLUMN_TYPE } from "@/types/shared";
 
 type ExperimentsPathsAutocompleteProps = {
   hasError?: boolean;
@@ -31,10 +34,28 @@ const ExperimentsPathsAutocomplete: React.FC<
   placeholder = "Select a key from recent experiments",
   excludeRoot = false,
 }) => {
-  const { data, isPending } = useExperimentsList({
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+
+  // Convert datasetId to filters format if provided
+  const filters: Filters = useMemo(() => {
+    if (datasetId) {
+      return [{
+        id: "dataset_filter",
+        field: "dataset_id",
+        type: COLUMN_TYPE.string,
+        operator: "=",
+        value: datasetId
+      }];
+    }
+    return [];
+  }, [datasetId]);
+
+  const { data, isPending } = useGroupedExperimentsList({
+    workspaceName,
     promptId,
-    datasetId,
+    filters,
     sorting,
+    search: "", // Empty search to get all experiments
     page: 1,
     size: 100,
   });
@@ -42,18 +63,18 @@ const ExperimentsPathsAutocomplete: React.FC<
   const items = useMemo(() => {
     const key = "metadata";
 
-    return uniq(
-      (data?.content || []).reduce<string[]>((acc, d) => {
-        return acc.concat(
-          isObject(d[key]) || isArray(d[key])
-            ? getJSONPaths(d[key], key).map((path) =>
-                excludeRoot ? path.substring(path.indexOf(".") + 1) : path,
-              )
-            : [],
-        );
-      }, []),
-    )
-      .filter((p) =>
+    const allPaths = (data?.experiments || []).reduce((acc: string[], d: GroupedExperiment) => {
+      return acc.concat(
+        isObject(d[key]) || isArray(d[key])
+          ? getJSONPaths(d[key], key).map((path: string) =>
+              excludeRoot ? path.substring(path.indexOf(".") + 1) : path,
+            )
+          : [],
+      );
+    }, [] as string[]);
+
+    return (uniq(allPaths) as string[])
+      .filter((p: string) =>
         value ? p.toLowerCase().includes(value.toLowerCase()) : true,
       )
       .sort();

--- a/apps/opik-frontend/src/components/pages-shared/experiments/useExpandingConfig.ts
+++ b/apps/opik-frontend/src/components/pages-shared/experiments/useExpandingConfig.ts
@@ -15,10 +15,12 @@ export const useExpandingConfig = ({ groupIds }: UseExpandingConfigProps) => {
     const updateForExpandedState: Record<string, boolean> = {};
     groupIds.forEach((groupId) => {
       const id = `${GROUPING_COLUMN}:${groupId}`;
+      // Always set dataset groups to be expanded by default
       if (!openGroupsRef.current[id]) {
         openGroupsRef.current[id] = true;
-        updateForExpandedState[id] = true;
       }
+      // Ensure all groups are expanded in the state
+      updateForExpandedState[id] = true;
     });
 
     if (Object.keys(updateForExpandedState).length) {

--- a/apps/opik-frontend/src/hooks/useGroupedExperimentsList.ts
+++ b/apps/opik-frontend/src/hooks/useGroupedExperimentsList.ts
@@ -4,6 +4,7 @@ import {
   QueryFunctionContext,
   RefetchOptions,
   useQueries,
+  useQuery,
 } from "@tanstack/react-query";
 import isUndefined from "lodash/isUndefined";
 import { Dataset, Experiment } from "@/types/datasets";
@@ -16,11 +17,13 @@ import useExperimentsList, {
 } from "@/api/datasets/useExperimentsList";
 import useDatasetById from "@/api/datasets/useDatasetById";
 import { Sorting } from "@/types/sorting";
+import { processSorting } from "@/lib/sorting";
 import {
   DEFAULT_ITEMS_PER_GROUP,
   DELETED_DATASET_ID,
   GROUPING_COLUMN,
 } from "@/constants/grouping";
+import api from "@/api/api";
 
 export const GROUP_SORTING = [{ id: "last_created_experiment_at", desc: true }];
 
@@ -28,6 +31,12 @@ export type GroupedExperiment = {
   dataset: Dataset;
   virtual_dataset_id: string;
 } & Experiment;
+
+export type GroupedExperimentGroup = {
+  dataset: Dataset;
+  experiments: Experiment[];
+  total: number;
+};
 
 type UseGroupedExperimentsListParams = {
   workspaceName: string;
@@ -44,7 +53,7 @@ type UseGroupedExperimentsListParams = {
 
 type UseGroupedExperimentsListResponse = {
   data: {
-    content: Array<GroupedExperiment>;
+    groups: Array<GroupedExperimentGroup>;
     groupIds: string[];
     sortable_by: string[];
     total: number;
@@ -86,236 +95,64 @@ const generateMoreRow = (dataset: Dataset) => {
 export default function useGroupedExperimentsList(
   params: UseGroupedExperimentsListParams,
 ) {
-  const refetchInterval = params.polling ? 30000 : undefined;
-  const experimentsCache = useRef<Record<string, UseExperimentsListResponse>>(
-    {},
-  );
-  const isFilteredByDataset = Boolean(params.datasetId);
-
-  const {
-    data: deletedDatasetExperiments,
-    refetch: refetchDeletedDatasetExperiments,
-  } = useExperimentsList(
-    {
-      workspaceName: params.workspaceName,
-      filters: params.filters,
-      sorting: params.sorting,
-      search: params.search,
-      datasetDeleted: true,
-      promptId: params.promptId,
-      page: 1,
-      size: extractPageSize(DELETED_DATASET_ID, params?.groupLimit),
-    },
-    {
-      placeholderData: keepPreviousData,
-      refetchInterval,
-    },
-  );
-
-  const {
-    data: dataset,
-    isPending: isDatasetPending,
-    refetch: refetchDataset,
-  } = useDatasetById(
-    {
-      datasetId: params.datasetId!,
-    },
-    { enabled: isFilteredByDataset },
-  );
-
-  const hasRemovedDatasetExperiments =
-    (deletedDatasetExperiments?.total || 0) > 0;
-
-  const {
-    data: datasetsRowData,
-    isPending: isDatasetsPending,
-    refetch: refetchDatasetsRowData,
-  } = useDatasetsList(
-    {
-      workspaceName: params.workspaceName,
-      page: params.page,
-      size: params.size,
-      withExperimentsOnly: true,
-      sorting: GROUP_SORTING,
-      promptId: params.promptId,
-    },
-    {
-      placeholderData: keepPreviousData,
-      refetchInterval,
-      enabled: !isFilteredByDataset,
-    } as never,
-  );
-
-  const datasetsData = useMemo(() => {
-    return (
-      (isFilteredByDataset && dataset ? [dataset] : datasetsRowData?.content) ||
-      []
-    );
-  }, [dataset, isFilteredByDataset, datasetsRowData?.content]);
-
-  const total = useMemo(() => {
-    const totalDatasets = datasetsRowData?.total || 0;
-
-    return isFilteredByDataset
-      ? 1
-      : hasRemovedDatasetExperiments
-        ? totalDatasets + 1
-        : totalDatasets;
-  }, [
-    datasetsRowData?.total,
-    isFilteredByDataset,
-    hasRemovedDatasetExperiments,
-  ]);
-
-  const datasetsIds = useMemo(() => {
-    return datasetsData.map(({ id }) => id);
-  }, [datasetsData]);
-
-  const experimentsResponse = useQueries({
-    queries: datasetsIds.map((datasetId) => {
-      const p: UseExperimentsListParams = {
-        workspaceName: params.workspaceName,
-        filters: params.filters,
-        sorting: params.sorting,
-        search: params.search,
-        datasetId,
-        promptId: params.promptId,
-        page: 1,
-        size: extractPageSize(datasetId, params?.groupLimit),
-      };
-
-      return {
-        queryKey: ["experiments", p],
-        queryFn: (context: QueryFunctionContext) =>
-          getExperimentsList(context, p),
-        refetchInterval,
-      };
-    }),
-  });
-
-  const needToShowDeletedDataset =
-    hasRemovedDatasetExperiments &&
-    !isFilteredByDataset &&
-    Math.ceil(total / params.size) === params.page;
-
-  const deletedDatasetGroupExperiments = useMemo(() => {
-    if (!needToShowDeletedDataset) return null;
-    const hasMoreData =
-      extractPageSize(DELETED_DATASET_ID, params.groupLimit) <
-      (deletedDatasetExperiments?.total || 0);
-    const deletedDatasetExperimentsData =
-      deletedDatasetExperiments?.content || [];
-
-    const deletedDataset = {
-      id: DELETED_DATASET_ID,
-    } as Dataset;
-
-    const retVal = deletedDatasetExperimentsData.map((e) =>
-      wrapExperimentRow(e, deletedDataset),
-    );
-
-    if (hasMoreData) {
-      return [...retVal, generateMoreRow(deletedDataset)];
-    }
-
-    return retVal;
-  }, [
-    deletedDatasetExperiments?.content,
-    deletedDatasetExperiments?.total,
-    needToShowDeletedDataset,
-    params.groupLimit,
-  ]);
-
-  const data = useMemo(() => {
-    let sortableBy: string[] | undefined;
-    const content = datasetsData.reduce<GroupedExperiment[]>(
-      (acc, dataset, index) => {
-        let experimentsData = experimentsResponse[index].data;
-        if (isUndefined(experimentsData)) {
-          experimentsData = experimentsCache.current[dataset.id] ?? {
-            content: [],
-            total: 0,
-          };
-        } else {
-          experimentsCache.current[dataset.id] = experimentsData;
-        }
-
-        // we are taking sortable data from any experiments that have it defined
-        if (!sortableBy && Boolean(experimentsData.sortable_by?.length)) {
-          sortableBy = experimentsData.sortable_by;
-        }
-
-        const hasMoreData =
-          extractPageSize(dataset.id, params.groupLimit) <
-          experimentsData.total;
-
-        const retVal = experimentsData.content.map((e: Experiment) =>
-          wrapExperimentRow(e, dataset),
-        );
-
-        if (hasMoreData) {
-          return acc.concat([...retVal, generateMoreRow(dataset)]);
-        }
-
-        return acc.concat(retVal);
-      },
-      [],
-    );
-
-    const groupIds = datasetsData.map((dataset) => dataset.id);
-
-    if (deletedDatasetGroupExperiments) {
-      groupIds.push(DELETED_DATASET_ID);
-
-      deletedDatasetGroupExperiments.forEach((e) => {
-        content.push(e);
+  // Map params to backend API query params
+  const { workspaceName, filters, sorting, datasetId, promptId, page, size, search } = params;
+  const queryKey = ["grouped-experiments", { workspaceName, filters, sorting, datasetId, promptId, page, size, search }];
+  const { data, isPending, refetch } = useQuery({
+    queryKey,
+    queryFn: async () => {
+      const { data } = await api.get("/v1/private/experiments/grouped", {
+        params: {
+          page,
+          size,
+          ...(datasetId && { dataset_id: datasetId }),
+          ...(promptId && { prompt_id: promptId }),
+          ...processSorting(sorting),
+          ...(filters && { filters: JSON.stringify(filters) }),
+          ...(search && { name: search }),
+        },
       });
-    }
-
-    return {
-      content,
-      groupIds,
-      sortable_by: sortableBy ?? [],
-      total,
-    };
-  }, [
-    datasetsData,
-    deletedDatasetGroupExperiments,
-    experimentsResponse,
-    params.groupLimit,
-    total,
-  ]);
-
-  const refetch = useCallback(
-    (options: RefetchOptions) => {
-      return Promise.all([
-        refetchDeletedDatasetExperiments(options),
-        refetchDataset(options),
-        refetchDatasetsRowData(options),
-        ...experimentsResponse.map((r) => r.refetch(options)),
-      ]);
+      // Build a flat array of experiments with grouping fields for the table
+      const experiments: GroupedExperiment[] = (data.content || []).flatMap((group: any) =>
+        (group.experiments || []).map((exp: any) => ({
+          ...exp,
+          dataset_id: exp.dataset_id,
+          dataset_name: exp.dataset_name,
+          name: exp.name,
+          virtual_dataset_id: exp.dataset_id,
+          dataset: group.dataset && group.dataset.id ? group.dataset : { id: exp.dataset_id, name: exp.dataset_name },
+        }))
+      );
+      const groups = (data.content || []).map((group: any) => {
+        // Get first experiment to use as fallback for dataset info
+        const firstExp = (group.experiments || [])[0];
+        return {
+          dataset: group.dataset && group.dataset.id ? group.dataset : { id: firstExp?.dataset_id, name: firstExp?.dataset_name },
+          experiments: (group.experiments || []).map((exp: any) => ({
+            ...exp,
+            dataset_id: exp.dataset_id,
+            dataset_name: exp.dataset_name,
+            name: exp.name,
+            virtual_dataset_id: exp.dataset_id,
+            dataset: group.dataset && group.dataset.id ? group.dataset : { id: exp.dataset_id, name: exp.dataset_name },
+          })),
+          total: group.total,
+        };
+      });
+      const groupIds = groups.map((g: GroupedExperimentGroup) => g.dataset.id);
+      return {
+        experiments,
+        groups,
+        groupIds,
+        sortable_by: data.sortable_by || [],
+        total: data.total,
+      };
     },
-    [
-      experimentsResponse,
-      refetchDataset,
-      refetchDatasetsRowData,
-      refetchDeletedDatasetExperiments,
-    ],
-  );
-
-  const isPending =
-    (isFilteredByDataset ? isDatasetPending : isDatasetsPending) ||
-    (experimentsResponse.length > 0 &&
-      experimentsResponse.some((r) => r.isPending));
-
-  const [isInitialPending, setIsInitialPending] = useState(true);
-  useEffect(() => {
-    setIsInitialPending((s) => (!isPending && s ? false : s));
-  }, [isPending]);
-
+    placeholderData: undefined,
+  });
   return {
     data,
-    isPending: isInitialPending,
+    isPending,
     refetch,
-  } as UseGroupedExperimentsListResponse;
+  } as UseGroupedExperimentsListResponse & { data: any };
 }


### PR DESCRIPTION
* Moving the logic of grouping in the experiment view into the backend
* Reducing amount of api calls from experiment view
* Support pagination on the datasets level
* Supporting sorting on the backend side
