### PR TITLE
Add Gemini 2.5 models

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiModelName.java
@@ -16,6 +16,9 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public enum GeminiModelName implements StructuredOutputSupported {
     GEMINI_2_0_FLASH("gemini-2.0-flash-exp", true),
+    GEMINI_2_5_PRO("gemini-2.5-pro", true),
+    GEMINI_2_5_FLASH("gemini-2.5-flash", true),
+    GEMINI_2_5_FLASH_LITE("gemini-2.5-flash-lite-preview-06-17", true),
     GEMINI_1_5_PRO_LATEST("gemini-1.5-pro-latest", true),
     GEMINI_1_5_FLASH("gemini-1.5-flash", false),
     GEMINI_1_5_FLASH_LATEST("gemini-1.5-flash-latest", true),

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModelName.java
@@ -21,6 +21,9 @@ public enum VertexAIModelName implements StructuredOutputSupported {
     GEMINI_2_5_PRO_EXP_03_25("vertex_ai/gemini-2.5-pro-exp-03-25", "gemini-2.5-pro-exp-03-25", true),
     GEMINI_2_0_FLASH("vertex_ai/gemini-2.0-flash-001", "gemini-2.0-flash-001", true),
     GEMINI_2_0_FLASH_LITE("vertex_ai/gemini-2.0-flash-lite-001", "gemini-2.0-flash-lite-001", false),
+    GEMINI_2_5_PRO("vertex_ai/gemini-2.5-pro", "gemini-2.5-pro", true),
+    GEMINI_2_5_FLASH("vertex_ai/gemini-2.5-flash", "gemini-2.5-flash", true),
+    GEMINI_2_5_FLASH_LITE("vertex_ai/gemini-2.5-flash-lite-preview-06-17", "gemini-2.5-flash-lite-preview-06-17", true),
     ;
 
     private static final String WARNING_UNKNOWN_MODEL = "could not find VertexAIModelName with name '{}'";

--- a/apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts
+++ b/apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts
@@ -1495,6 +1495,18 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       structuredOutput: true,
     },
     {
+      value: PROVIDER_MODEL_TYPE.GEMINI_2_5_PRO,
+      label: "Gemini 2.5 Pro",
+    },
+    {
+      value: PROVIDER_MODEL_TYPE.GEMINI_2_5_FLASH,
+      label: "Gemini 2.5 Flash",
+    },
+    {
+      value: PROVIDER_MODEL_TYPE.GEMINI_2_5_FLASH_LITE,
+      label: "Gemini 2.5 Flash Lite",
+    },
+    {
       value: PROVIDER_MODEL_TYPE.GEMINI_1_5_FLASH,
       label: "Gemini 1.5 Flash",
       structuredOutput: true,
@@ -1540,6 +1552,21 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
     {
       value: PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_2_0_FLASH_LITE,
       label: "Gemini 2.0 Flash Lite",
+      structuredOutput: true,
+    },
+    {
+      value: PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_2_5_PRO,
+      label: "Gemini 2.5 Pro",
+      structuredOutput: true,
+    },
+    {
+      value: PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_2_5_FLASH,
+      label: "Gemini 2.5 Flash",
+      structuredOutput: true,
+    },
+    {
+      value: PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_2_5_FLASH_LITE,
+      label: "Gemini 2.5 Flash Lite",
       structuredOutput: true,
     },
   ],

--- a/apps/opik-frontend/src/types/providers.ts
+++ b/apps/opik-frontend/src/types/providers.ts
@@ -365,6 +365,9 @@ export enum PROVIDER_MODEL_TYPE {
   GEMINI_1_5_FLASH = "gemini-1.5-flash",
   GEMINI_1_5_FLASH_8B = "gemini-1.5-flash-8b",
   GEMINI_1_5_PRO = "gemini-1.5-pro",
+  GEMINI_2_5_PRO = "gemini-2.5-pro",
+  GEMINI_2_5_FLASH = "gemini-2.5-flash",
+  GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite-preview-06-17",
 
   //   <------ vertex ai
   VERTEX_AI_GEMINI_2_5_PRO_PREVIEW_04_17 = "vertex_ai/gemini-2.5-flash-preview-04-17",
@@ -373,6 +376,9 @@ export enum PROVIDER_MODEL_TYPE {
   GEMINI_2_5_PRO_EXP_03_25 = "vertex_ai/gemini-2.5-pro-exp-03-25",
   VERTEX_AI_GEMINI_2_0_FLASH = "vertex_ai/gemini-2.0-flash-001",
   VERTEX_AI_GEMINI_2_0_FLASH_LITE = "vertex_ai/gemini-2.0-flash-lite-001",
+  VERTEX_AI_GEMINI_2_5_PRO = "vertex_ai/gemini-2.5-pro",
+  VERTEX_AI_GEMINI_2_5_FLASH = "vertex_ai/gemini-2.5-flash",
+  VERTEX_AI_GEMINI_2_5_FLASH_LITE = "vertex_ai/gemini-2.5-flash-lite-preview-06-17",
 }
 
 export type PROVIDER_MODELS_TYPE = {


### PR DESCRIPTION
## Summary
- support Gemini 2.5 Pro/Flash/Flash-Lite models
- expose new Gemini models in the frontend
- register new Gemini models in backend enums
- remove structuredOutput flag per review comment

## Testing
- `mvn -q spotless:apply` *(fails: command not found)*
- `npm test` *(fails: could not read package.json)*
- `pip install -e .` *(fails: project not found)*

------
https://chatgpt.com/codex/tasks/task_b_686522d4e5ac833299045c7e8d3f4a40