### PR TITLE
OPIK-2004: Graceful error handling for malformed Mustache templates (backend)

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/template/MustacheParser.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/template/MustacheParser.java
@@ -3,8 +3,10 @@ package com.comet.opik.domain.template;
 import com.github.mustachejava.Code;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.MustacheFactory;
 import com.github.mustachejava.codes.ValueCode;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -17,6 +19,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+@Slf4j
 public class MustacheParser implements TemplateParser {
 
     public static final MustacheFactory MF = new DefaultMustacheFactory();
@@ -25,26 +28,43 @@ public class MustacheParser implements TemplateParser {
     public Set<String> extractVariables(String template) {
         Set<String> variables = new HashSet<>();
 
-        // Initialize Mustache Factory
-        Mustache mustache = MF.compile(new StringReader(template), "template");
+        if (template == null || template.trim().isEmpty()) {
+            return variables;
+        }
 
-        // Get the root node of the template
-        Code[] codes = mustache.getCodes();
-        collectVariables(codes, variables);
+        try {
+            // Initialize Mustache Factory
+            Mustache mustache = MF.compile(new StringReader(template), "template");
 
-        return variables;
+            // Get the root node of the template
+            Code[] codes = mustache.getCodes();
+            collectVariables(codes, variables);
+
+            return variables;
+        } catch (MustacheException e) {
+            log.warn("Failed to parse Mustache template for variable extraction: {}", e.getMessage());
+            return variables; // Return empty set when parsing fails
+        }
     }
 
     @Override
     public String render(String template, Map<String, ?> context) {
+        if (template == null) {
+            return "";
+        }
 
-        Mustache mustache = MF.compile(new StringReader(template), "template");
+        try {
+            Mustache mustache = MF.compile(new StringReader(template), "template");
 
-        try (Writer writer = mustache.execute(new StringWriter(), context)) {
-            writer.flush();
-            return writer.toString();
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to render template", e);
+            try (Writer writer = mustache.execute(new StringWriter(), context)) {
+                writer.flush();
+                return writer.toString();
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to render template", e);
+            }
+        } catch (MustacheException e) {
+            log.error("Failed to parse Mustache template for rendering: {}", e.getMessage());
+            throw new RuntimeException("Failed to parse Mustache template for rendering", e);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/template/MustacheParserTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/template/MustacheParserTest.java
@@ -1,0 +1,102 @@
+package com.comet.opik.domain.template;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("MustacheParser Test")
+class MustacheParserTest {
+
+    private MustacheParser mustacheParser;
+
+    @BeforeEach
+    void setUp() {
+        mustacheParser = new MustacheParser();
+    }
+
+    @Test
+    @DisplayName("should extract variables from valid template")
+    void shouldExtractVariablesFromValidTemplate() {
+        String template = "Hello {{name}}, you are {{age}} years old and live in {{city}}.";
+
+        Set<String> variables = mustacheParser.extractVariables(template);
+
+        assertThat(variables).containsExactlyInAnyOrder("name", "age", "city");
+    }
+
+    @Test
+    @DisplayName("should return empty set for template without variables")
+    void shouldReturnEmptySetForTemplateWithoutVariables() {
+        String template = "Hello world, this is a simple text without variables.";
+
+        Set<String> variables = mustacheParser.extractVariables(template);
+
+        assertThat(variables).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should handle malformed template with unclosed tag")
+    void shouldHandleMalformedTemplateWithUnclosedTag() {
+        String malformedTemplate = "Hello {{name}}, this is a malformed template with {{unclosed";
+
+        Set<String> variables = mustacheParser.extractVariables(malformedTemplate);
+
+        // Should return empty set instead of throwing exception
+        assertThat(variables).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should handle malformed template with unclosed mustache tag")
+    void shouldHandleMalformedTemplateWithUnclosedMustacheTag() {
+        String malformedTemplate = "Hello {{name}}, this is a malformed template with {{#section}} but no closing";
+
+        Set<String> variables = mustacheParser.extractVariables(malformedTemplate);
+
+        // Should return empty set instead of throwing exception
+        assertThat(variables).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should render valid template with context")
+    void shouldRenderValidTemplateWithContext() {
+        String template = "Hello {{name}}, you are {{age}} years old.";
+        Map<String, Object> context = Map.of("name", "John", "age", 30);
+
+        String result = mustacheParser.render(template, context);
+
+        assertThat(result).isEqualTo("Hello John, you are 30 years old.");
+    }
+
+    @Test
+    @DisplayName("should throw exception when rendering malformed template")
+    void shouldThrowExceptionWhenRenderingMalformedTemplate() {
+        String malformedTemplate = "Hello {{name}}, this is a malformed template with {{unclosed";
+        Map<String, Object> context = Map.of("name", "John");
+
+        assertThatThrownBy(() -> mustacheParser.render(malformedTemplate, context))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to parse Mustache template for rendering");
+    }
+
+    @Test
+    @DisplayName("should handle null template")
+    void shouldHandleNullTemplate() {
+        Set<String> variables = mustacheParser.extractVariables(null);
+
+        assertThat(variables).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should handle empty template")
+    void shouldHandleEmptyTemplate() {
+        Set<String> variables = mustacheParser.extractVariables("");
+
+        assertThat(variables).isEmpty();
+    }
+}


### PR DESCRIPTION
## What
Gracefully handle malformed Mustache templates in the backend, preventing system crashes and aligning with frontend robustness.

## Why
- Fixes bug where malformed templates (e.g., unclosed tags) would throw MustacheException and crash DB queries or API calls.
- Ensures backend fails gracefully and logs the error, returning empty variable sets for extraction and clear errors for rendering.
- Adds robust unit tests for valid, malformed, null, and empty templates.

## How
- Catch MustacheException in MustacheParser for extractVariables and render.
- Return empty set for variable extraction errors, throw clear error for render.
- Add comprehensive unit tests.

## Impact
- Backend is now robust to malformed prompt templates.
- No more system-wide failures from user template errors.
- Matches frontend error handling pattern.
