### PR TITLE
[OPIK-1782] Thread Count Project Metric

### DIFF
--- a/apps/opik-backend/.cursor/rules/code_quality.mdc
+++ b/apps/opik-backend/.cursor/rules/code_quality.mdc
@@ -13,3 +13,4 @@ alwaysApply: true
 - Use consistent naming conventions for classes, methods, and variables
 - Avoid hardcoding values; use constants or configuration files
 - changes must pass spotless checks
+- prefer using Map.of(), List.of(), Set.of() for creating immutable collections

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/metrics/MetricType.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/metrics/MetricType.java
@@ -7,4 +7,5 @@ public enum MetricType {
     DURATION,
     COST,
     GUARDRAILS_FAILED_COUNT,
+    THREAD_COUNT,
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsService.java
@@ -35,6 +35,7 @@ class ProjectMetricsServiceImpl implements ProjectMetricsService {
             @NonNull ProjectService projectService) {
         projectMetricHandler = Map.of(
                 MetricType.TRACE_COUNT, projectMetricsDAO::getTraceCount,
+                MetricType.THREAD_COUNT, projectMetricsDAO::getThreadCount,
                 MetricType.FEEDBACK_SCORES, projectMetricsDAO::getFeedbackScores,
                 MetricType.TOKEN_USAGE, projectMetricsDAO::getTokenUsage,
                 MetricType.COST, projectMetricsDAO::getCost,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
@@ -992,6 +992,11 @@ class ProjectMetricsResourceTest {
                     .mapToObj(i -> RandomStringUtils.randomAlphabetic(10))
                     .toList();
 
+            // Open threads first
+            threadIds.forEach(threadId -> {
+                traceResourceClient.openTraceThread(threadId, null, projectName, API_KEY, WORKSPACE_NAME);
+            });
+
             // Create multiple traces per thread to test that threads are counted, not traces
             threadIds.forEach(threadId -> {
                 List<Trace> traces = IntStream.range(0, 2) // 2 traces per thread
@@ -1002,6 +1007,11 @@ class ProjectMetricsResourceTest {
                                 .build())
                         .toList();
                 traceResourceClient.batchCreateTraces(traces, API_KEY, WORKSPACE_NAME);
+            });
+
+            // Close threads to ensure they are written to the trace_threads table
+            threadIds.forEach(threadId -> {
+                traceResourceClient.closeTraceThread(threadId, null, projectName, API_KEY, WORKSPACE_NAME);
             });
 
             return (long) threadIds.size();


### PR DESCRIPTION
## Details
Added a new project metric called `THREAD_COUNT`. This metric returns the number of threads over time.

## Issues
OPIK-1782

## Testing
- Added tests to cover the new use case
- Test the new endpoint locally 
