### PR TITLE
[OPIK-2064] [Dataset upload CSV] CSV with `\r\n` is not parsing correctly

### DIFF
--- a/apps/opik-frontend/src/lib/file.ts
+++ b/apps/opik-frontend/src/lib/file.ts
@@ -22,7 +22,10 @@ export async function validateCsvFile(
 
   try {
     const text = await file.text();
-    const parsed = await csv2json(text, {
+
+    const normalizedText = text.replace(/\r\n|\r/g, "\n");
+
+    const parsed = await csv2json(normalizedText, {
       excelBOM: true,
       trimHeaderFields: true,
       trimFieldValues: true,


### PR DESCRIPTION
## Details

## Issues

Resolves #

## Testing

## Documentation
