### PR TITLE
NO-JIRA: Add pip cache to all docker images

### DIFF
--- a/apps/opik-python-backend/Dockerfile
+++ b/apps/opik-python-backend/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache tini python3 py3-pip rust cargo
 WORKDIR /opt/opik-python-backend
 
 COPY requirements.txt .
-RUN pip install -r requirements.txt --break-system-packages
+RUN pip install --no-cache-dir -r requirements.txt --break-system-packages
 
 ENV PYTHON_CODE_EXECUTOR_ASSET_NAME="opik-sandbox-executor-python"
 # Optionally copies the file. It's built ok without it, as it'll be pulled before running anyway.

--- a/apps/opik-sandbox-executor-python/Dockerfile
+++ b/apps/opik-sandbox-executor-python/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.12.9-slim
 WORKDIR /opt/opik-sandbox-executor-python
 
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 RUN chown -R 1001:1001 /opt/opik-sandbox-executor-python
 USER 1001:1001


### PR DESCRIPTION
## Details
Added `--no-cache-dir` flag to pip install in Dockerfile when missing, in order to optimised image size.

## Issues

N/A

## Testing
- Built both images locally, with 5% to 12% image size reduction.
- Passed CI build.

## Documentation
- https://pip.pypa.io/en/stable/topics/caching/#disabling-caching
