### PR TITLE
NA: Reduce cost prompt queries

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
@@ -70,17 +70,21 @@ interface PromptDAO {
 
     @SqlQuery("""
             SELECT
-              p.*,
-              (
-                SELECT COUNT(pv.id)
-                  FROM prompt_versions pv
-                 WHERE pv.workspace_id = p.workspace_id
-                 AND pv.prompt_id = p.id
-              ) AS version_count
-            FROM prompts AS p
-            WHERE workspace_id = :workspace_id
-            <if(filters)> AND <filters> <endif>
-            <if(name)> AND name like concat('%', :name, '%') <endif>
+                *
+            FROM (
+                SELECT
+                  p.*,
+                  (
+                    SELECT COUNT(pv.id)
+                      FROM prompt_versions pv
+                     WHERE pv.workspace_id = p.workspace_id
+                     AND pv.prompt_id = p.id
+                  ) AS version_count
+                FROM prompts AS p
+                WHERE workspace_id = :workspace_id
+                <if(name)> AND name like concat('%', :name, '%') <endif>
+            ) AS prompt_full
+            <if(filters)> WHERE <filters> <endif>
             ORDER BY <if(sort_fields)> <sort_fields>, <endif> id DESC
             LIMIT :limit OFFSET :offset
             """)
@@ -93,20 +97,22 @@ interface PromptDAO {
             @BindMap Map<String, Object> filterMapping);
 
     @SqlQuery("""
-                WITH prompt_full AS (
-                    SELECT
-                    p.*,
-                    count(pv.id) as version_count
-                    FROM prompts p
-                    LEFT JOIN prompt_versions pv ON pv.prompt_id = p.id
-                    WHERE p.workspace_id = :workspace_id
-                    GROUP BY p.id
-                )
-                SELECT COUNT(id)
-                FROM prompt_full
-                WHERE 1 = 1
-                <if(filters)> AND <filters> <endif>
+             SELECT
+                count(id)
+             FROM (
+                SELECT
+                  p.*,
+                  (
+                    SELECT COUNT(pv.id)
+                      FROM prompt_versions pv
+                     WHERE pv.workspace_id = p.workspace_id
+                     AND pv.prompt_id = p.id
+                  ) AS version_count
+                FROM prompts AS p
+                WHERE workspace_id = :workspace_id
                 <if(name)> AND name like concat('%', :name, '%') <endif>
+            ) AS prompt_full
+            <if(filters)> WHERE <filters> <endif>
             """)
     @UseStringTemplateEngine
     @AllowUnusedBindings


### PR DESCRIPTION
## Details

<img width="1720" height="274" alt="Screenshot 2025-07-18 at 22 56 25" src="https://github.com/user-attachments/assets/07da6f36-4999-4424-a897-c296a0d6249e" />


Before
<img width="1112" height="83" alt="Screenshot 2025-07-18 at 22 31 10" src="https://github.com/user-attachments/assets/7e04afcd-cf2e-48b5-9e16-24dd9a83997a" />

```json
{
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "203051.72"
    },
    "table": {
      "table_name": "prompt_full",
      "access_type": "ALL",
      "rows_examined_per_scan": 1804882,
      "rows_produced_per_join": 1804882,
      "filtered": "100.00",
      "cost_info": {
        "read_cost": "22563.53",
        "eval_cost": "180488.20",
        "prefix_cost": "203051.73",
        "data_read_per_join": "6G"
      },
      "used_columns": [
        "id",
        "name",
        "description",
        "created_at",
        "created_by",
        "last_updated_at",
        "last_updated_by",
        "workspace_id",
        "tags",
        "version_count"
      ],
      "materialized_from_subquery": {
        "using_temporary_table": true,
        "dependent": false,
        "cacheable": true,
        "query_block": {
          "select_id": 2,
          "cost_info": {
            "query_cost": "632942.08"
          },
          "grouping_operation": {
            "using_temporary_table": true,
            "using_filesort": false,
            "nested_loop": [
              {
                "table": {
                  "table_name": "p",
                  "access_type": "ref",
                  "possible_keys": [
                    "PRIMARY",
                    "prompts_workspace_id_name_uk"
                  ],
                  "key": "prompts_workspace_id_name_uk",
                  "used_key_parts": [
                    "workspace_id"
                  ],
                  "key_length": "602",
                  "ref": [
                    "const"
                  ],
                  "rows_examined_per_scan": 1,
                  "rows_produced_per_join": 1,
                  "filtered": "100.00",
                  "cost_info": {
                    "read_cost": "0.40",
                    "eval_cost": "0.10",
                    "prefix_cost": "0.50",
                    "data_read_per_join": "3K"
                  },
                  "used_columns": [
                    "id",
                    "name",
                    "description",
                    "created_at",
                    "created_by",
                    "last_updated_at",
                    "last_updated_by",
                    "workspace_id",
                    "tags"
                  ]
                }
              },
              {
                "table": {
                  "table_name": "pv",
                  "access_type": "index",
                  "key": "prompt_versions_prompt_id_version_uk",
                  "used_key_parts": [
                    "workspace_id",
                    "prompt_id",
                    "commit"
                  ],
                  "key_length": "781",
                  "rows_examined_per_scan": 1804882,
                  "rows_produced_per_join": 1804882,
                  "filtered": "100.00",
                  "using_index": true,
                  "using_join_buffer": "hash join",
                  "cost_info": {
                    "read_cost": "452453.38",
                    "eval_cost": "180488.20",
                    "prefix_cost": "632942.08",
                    "data_read_per_join": "2G"
                  },
                  "used_columns": [
                    "id",
                    "prompt_id"
                  ],
                  "attached_condition": "<if>(is_not_null_compl(pv), (`opik_prod`.`pv`.`prompt_id` = `opik_prod`.`p`.`id`), true)"
                }
              }
            ]
          }
        }
      }
    }
  }
}
```

After:
<img width="1115" height="44" alt="Screenshot 2025-07-18 at 22 31 56" src="https://github.com/user-attachments/assets/b9771b17-f5d4-41cb-8710-8423d9cabbf7" />

```json
{
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "0.50"
    },
    "table": {
      "table_name": "p",
      "access_type": "ref",
      "possible_keys": [
        "prompts_workspace_id_name_uk"
      ],
      "key": "prompts_workspace_id_name_uk",
      "used_key_parts": [
        "workspace_id"
      ],
      "key_length": "602",
      "ref": [
        "const"
      ],
      "rows_examined_per_scan": 1,
      "rows_produced_per_join": 1,
      "filtered": "100.00",
      "cost_info": {
        "read_cost": "0.40",
        "eval_cost": "0.10",
        "prefix_cost": "0.50",
        "data_read_per_join": "3K"
      },
      "used_columns": [
        "id",
        "name",
        "description",
        "created_at",
        "created_by",
        "last_updated_at",
        "last_updated_by",
        "workspace_id",
        "tags"
      ]
    },
    "select_list_subqueries": [
      {
        "dependent": true,
        "cacheable": false,
        "query_block": {
          "select_id": 2,
          "cost_info": {
            "query_cost": "7.09"
          },
          "table": {
            "table_name": "pv",
            "access_type": "ref",
            "possible_keys": [
              "prompt_versions_prompt_id_version_uk"
            ],
            "key": "prompt_versions_prompt_id_version_uk",
            "used_key_parts": [
              "workspace_id",
              "prompt_id"
            ],
            "key_length": "746",
            "ref": [
              "opik_prod.p.workspace_id",
              "opik_prod.p.id"
            ],
            "rows_examined_per_scan": 53,
            "rows_produced_per_join": 53,
            "filtered": "100.00",
            "using_index": true,
            "cost_info": {
              "read_cost": "1.71",
              "eval_cost": "5.37",
              "prefix_cost": "7.09",
              "data_read_per_join": "93K"
            },
            "used_columns": [
              "prompt_id",
              "workspace_id"
            ]
          }
        }
      }
    ]
  }
}
```

## Issues

Resolves #

## Testing

## Documentation
