### PR TITLE
[OPIK-2074] Filter crashes for values that contain `%`

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/filter/FiltersFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/filter/FiltersFactory.java
@@ -119,6 +119,7 @@ public class FiltersFactory {
                 filter = filter.build(URLDecoder.decode(filter.value(), StandardCharsets.UTF_8));
             } catch (IllegalArgumentException exception) {
                 log.warn("invalid filter '{}'", filter.value(), exception);
+                throw new BadRequestException("Invalid filter '%s'".formatted(filter.value()), exception);
             }
         }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/filter/FiltersFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/filter/FiltersFactory.java
@@ -111,7 +111,6 @@ public class FiltersFactory {
     }
 
     private Filter toValidAndDecoded(Filter filter) {
-        // Decode the value as first thing prior to any validation
         filter = filter.build(filter.value());
         if (filterQueryBuilder.toAnalyticsDbOperator(filter) == null) {
             throw new BadRequestException("Invalid operator '%s' for field '%s' of type '%s'"

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/filter/FiltersFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/filter/FiltersFactory.java
@@ -15,8 +15,6 @@ import org.apache.commons.lang3.math.NumberUtils;
 
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.EnumMap;
@@ -114,7 +112,7 @@ public class FiltersFactory {
 
     private Filter toValidAndDecoded(Filter filter) {
         // Decode the value as first thing prior to any validation
-        filter = filter.build(URLDecoder.decode(filter.value(), StandardCharsets.UTF_8));
+        filter = filter.build(filter.value());
         if (filterQueryBuilder.toAnalyticsDbOperator(filter) == null) {
             throw new BadRequestException("Invalid operator '%s' for field '%s' of type '%s'"
                     .formatted(filter.operator().getQueryParamOperator(), filter.field().getQueryParamField(),

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/filter/FiltersFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/filter/FiltersFactory.java
@@ -114,11 +114,11 @@ public class FiltersFactory {
 
     private Filter toValidAndDecoded(Filter filter) {
         if (filter.field().getType() != FieldType.STRING) {
-            // don't decode value for string fields as it is already decoded
+            // don't decode value for string fields as it is already decoded during JSON deserialization
             try {
                 filter = filter.build(URLDecoder.decode(filter.value(), StandardCharsets.UTF_8));
             } catch (IllegalArgumentException exception) {
-                log.warn("invalid filter '{}'", filter.value(), exception);
+                log.warn("failed to URL decode filter value '{}'", filter.value(), exception);
                 throw new BadRequestException("Invalid filter '%s'".formatted(filter.value()), exception);
             }
         }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -1247,6 +1247,7 @@ class SpansResourceTest {
                     .flatMap(filter -> filter.getValue()
                             .stream()
                             .flatMap(operator -> switch (filter.getKey().getType()) {
+                                case STRING -> Stream.empty();
                                 case DICTIONARY, FEEDBACK_SCORES_NUMBER -> Stream.of(
                                         SpanFilter.builder()
                                                 .field(filter.getKey())

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -1413,6 +1413,7 @@ class TracesResourceTest {
                     .flatMap(filter -> filter.getValue()
                             .stream()
                             .flatMap(operator -> switch (filter.getKey().getType()) {
+                                case STRING -> Stream.empty();
                                 case DICTIONARY, FEEDBACK_SCORES_NUMBER -> Stream.of(
                                         TraceFilter.builder()
                                                 .field(filter.getKey())
@@ -4669,6 +4670,7 @@ class TracesResourceTest {
                     .flatMap(filter -> filter.getValue()
                             .stream()
                             .flatMap(operator -> switch (filter.getKey().getType()) {
+                                case STRING -> Stream.empty();
                                 case DICTIONARY, FEEDBACK_SCORES_NUMBER -> Stream.of(
                                         TraceThreadFilter.builder()
                                                 .field(filter.getKey())

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -6162,6 +6162,42 @@ class TracesResourceTest {
                     List.of(), exclude);
 
         }
+
+        @Test
+        @DisplayName("should handle filter with percent characters in value correctly")
+        void shouldHandleTracesWithPercentCharactersInName() {
+            var workspaceName = RandomStringUtils.secure().nextAlphanumeric(10);
+            var workspaceId = UUID.randomUUID().toString();
+            var apiKey = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var projectName = RandomStringUtils.secure().nextAlphanumeric(10);
+            var traceName = "test%";
+
+            // Create a trace with % characters in the name
+            var traces = List.of(createTrace().toBuilder()
+                    .projectName(projectName)
+                    .name(traceName)
+                    .usage(null)
+                    .feedbackScores(null)
+                    .threadId(null)
+                    .comments(null)
+                    .totalEstimatedCost(null)
+                    .build());
+
+            traceResourceClient.batchCreateTraces(traces, apiKey, workspaceName);
+
+            // Create a filter to search for the trace by name
+            var filter = TraceFilter.builder()
+                    .field(TraceField.NAME)
+                    .operator(Operator.EQUAL)
+                    .value(traceName)
+                    .build();
+
+            getAndAssertPage(workspaceName, projectName, null, List.of(filter), traces, traces, List.of(),
+                    apiKey, null, Set.of());
+        }
     }
 
     private Integer randomNumber() {


### PR DESCRIPTION
## Details
**Steps to reproduce:**
Open the traces page, try adding a filter that contains the % character in the filter value

**Expected result:**
Traces table filters according to the filter input

**Actual result:**
Request fails with 500 error code

**Details:**
The filters string is decoded initially by invoking:

```
filters = JsonUtils.readValue(queryParam, valueTypeRef);
```

Then, the value is decoded again by invoking:
```
filter = filter.build(URLDecoder.decode(filter.value(), StandardCharsets.UTF_8));
```

The reason for the secondary decode seems to be more complex data structures, such as `LIST` and `DICTIONARY`. When trying to decode a string that contains `%`, the decode fails.

This is fixed by not having the second decode for STRING filters. In addition, a `try...catch` logic is applied to catch other cases.

## Issues
OPIK-2074

## Testing
1. Wrote a failing test that reproduces the issue
2. Reproduced the issue locally before fixing it. Made sure the issue no longer reproduces afterwards
3. Rely on existing tests for regressions