### PR TITLE
OPIK-2125: Remove stop container call

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/executor_docker.py
+++ b/apps/opik-python-backend/src/opik_backend/executor_docker.py
@@ -186,8 +186,7 @@ class DockerExecutor(CodeExecutorBase):
             # Record the start time
             start_time = time.time()
 
-            # Stop and remove the container
-            container.stop(timeout=1)
+            # Remove the container
             container.remove(force=True)
 
             # Calculate and record the latency


### PR DESCRIPTION
## Details

The call to stop containers takes longer because the stop container process tries to wait for the container to stop gracefully. However, the container will be killed anyway. Hence, the more forceful approach already takes care of it, and the container is supposed to be stateless and ephemeral, so I see no danger here. This would improve the application's responsiveness. 
