### PR TITLE
Feature/trace span batch annotation

### DIFF
--- a/apps/opik-frontend/src/api/api.ts
+++ b/apps/opik-frontend/src/api/api.ts
@@ -17,6 +17,7 @@ export const EXPERIMENTS_REST_ENDPOINT = "/v1/private/experiments/";
 export const FEEDBACK_DEFINITIONS_REST_ENDPOINT =
   "/v1/private/feedback-definitions/";
 export const TRACES_REST_ENDPOINT = "/v1/private/traces/";
+export const TRACES_BATCH_FEEDBACK_SCORES_ENDPOINT = "/v1/private/traces/feedback-scores";
 export const SPANS_REST_ENDPOINT = "/v1/private/spans/";
 export const PROMPTS_REST_ENDPOINT = "/v1/private/prompts/";
 export const PROVIDER_KEYS_REST_ENDPOINT = "/v1/private/llm-provider-key/";

--- a/apps/opik-frontend/src/api/traces/useTracesBatchFeedbackScoresMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTracesBatchFeedbackScoresMutation.ts
@@ -1,0 +1,98 @@
+import api, {
+    COMPARE_EXPERIMENTS_KEY,
+    TRACE_KEY,
+    TRACES_BATCH_FEEDBACK_SCORES_ENDPOINT,
+    TRACES_KEY,
+} from "@/api/api";
+import { useToast } from "@/components/ui/use-toast";
+import {
+    generateUpdateMutation,
+    setExperimentsCompareCache,
+    setTraceCache,
+    setTracesCache,
+} from "@/lib/feedback-scores";
+import { FEEDBACK_SCORE_TYPE } from "@/types/traces";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import get from "lodash/get";
+
+type UseTracesBatchFeedbackScoresParams = {
+    projectId: string;
+    traceIds: string[];
+    name: string;
+    value: number;
+    categoryName?: string;
+    reason?: string;
+};
+
+const useTracesBatchFeedbackScoresMutation = () => {
+    const queryClient = useQueryClient();
+    const { toast } = useToast();
+
+    return useMutation({
+        mutationFn: async ({
+            projectId,
+            traceIds,
+            name,
+            value,
+            categoryName,
+            reason,
+        }: UseTracesBatchFeedbackScoresParams) => {
+            const body = {
+                scores: traceIds.map((id) => ({
+                    trace_id: id,
+                    project_id: projectId,
+                    name,
+                    value,
+                    ...(categoryName && { category_name: categoryName }),
+                    ...(reason && { reason }),
+                    source: FEEDBACK_SCORE_TYPE.ui,
+                })),
+            };
+
+            const { data } = await api.put(TRACES_BATCH_FEEDBACK_SCORES_ENDPOINT, body);
+            return data;
+        },
+        onError: (error: AxiosError) => {
+            const message = get(error, ["response", "data", "message"], error.message);
+            toast({
+                title: "Error",
+                description: message,
+                variant: "destructive",
+            });
+        },
+        onSuccess: (data, vars) => {
+            toast({
+                title: "Success",
+                description: `Annotated ${vars.traceIds.length} traces`,
+            });
+        },
+        onMutate: async (params: UseTracesBatchFeedbackScoresParams) => {
+            const updateMutation = generateUpdateMutation({
+                name: params.name,
+                category_name: params.categoryName,
+                value: params.value,
+                source: FEEDBACK_SCORE_TYPE.ui,
+                reason: params.reason,
+            });
+
+            await Promise.all(
+                params.traceIds.map(async (traceId) => {
+                    const traceParams = { traceId };
+                    await setExperimentsCompareCache(queryClient, traceParams, updateMutation);
+                    await setTracesCache(queryClient, traceParams, updateMutation);
+                    await setTraceCache(queryClient, traceParams, updateMutation);
+                }),
+            );
+        },
+        onSettled: async () => {
+            await queryClient.invalidateQueries({ queryKey: [TRACES_KEY] });
+            await queryClient.invalidateQueries({ queryKey: ["traces-columns"] });
+            await queryClient.invalidateQueries({ queryKey: ["traces-statistic"] });
+            await queryClient.invalidateQueries({ queryKey: [TRACE_KEY] });
+            await queryClient.invalidateQueries({ queryKey: [COMPARE_EXPERIMENTS_KEY] });
+        },
+    });
+};
+
+export default useTracesBatchFeedbackScoresMutation; 

--- a/apps/opik-frontend/src/api/traces/useTracesBatchFeedbackScoresMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTracesBatchFeedbackScoresMutation.ts
@@ -61,7 +61,7 @@ const useTracesBatchFeedbackScoresMutation = () => {
                 variant: "destructive",
             });
         },
-        onSuccess: (data, vars) => {
+        onSuccess: (_, vars) => {
             toast({
                 title: "Success",
                 description: `Annotated ${vars.traceIds.length} traces`,

--- a/apps/opik-frontend/src/api/traces/useTracesBatchFeedbackScoresMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTracesBatchFeedbackScoresMutation.ts
@@ -40,7 +40,7 @@ const useTracesBatchFeedbackScoresMutation = () => {
         }: UseTracesBatchFeedbackScoresParams) => {
             const body = {
                 scores: traceIds.map((id) => ({
-                    trace_id: id,
+                    id,
                     project_id: projectId,
                     name,
                     value,

--- a/apps/opik-frontend/src/components/pages-shared/traces/BatchAnnotateDialog/BatchAnnotateDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/BatchAnnotateDialog/BatchAnnotateDialog.tsx
@@ -1,0 +1,127 @@
+import useTracesBatchFeedbackScoresMutation from "@/api/traces/useTracesBatchFeedbackScoresMutation";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+import { Trace } from "@/types/traces";
+import React, { useState } from "react";
+
+type BatchAnnotateDialogProps = {
+    rows: Trace[];
+    open: boolean | number;
+    setOpen: (o: boolean | number) => void;
+    projectId: string;
+    onSuccess?: () => void;
+};
+
+const MAX_ENTITIES = 10;
+
+const BatchAnnotateDialog: React.FunctionComponent<BatchAnnotateDialogProps> = ({
+    rows,
+    open,
+    setOpen,
+    projectId,
+    onSuccess,
+}) => {
+    const { toast } = useToast();
+    const [scoreName, setScoreName] = useState<string>("");
+    const [value, setValue] = useState<number | "">("");
+    const [categoryName, setCategoryName] = useState<string>("");
+    const [reason, setReason] = useState<string>("");
+
+    const batchMutation = useTracesBatchFeedbackScoresMutation();
+
+    const handleClose = () => {
+        setOpen(false);
+        setScoreName("");
+        setValue("");
+        setCategoryName("");
+        setReason("");
+    };
+
+    const disabled =
+        !scoreName || value === "" || rows.length > MAX_ENTITIES || batchMutation.isPending;
+
+    const handleAnnotate = async () => {
+        try {
+            await batchMutation.mutateAsync({
+                projectId,
+                traceIds: rows.map((r) => r.id),
+                name: scoreName,
+                value: typeof value === "string" ? Number(value) : value,
+                categoryName: categoryName || undefined,
+                reason: reason || undefined,
+            });
+            if (onSuccess) onSuccess();
+            handleClose();
+        } catch (e) {
+            toast({
+                title: "Error",
+                description: "Failed to annotate traces",
+                variant: "destructive",
+            });
+        }
+    };
+
+    return (
+        <Dialog open={Boolean(open)} onOpenChange={handleClose}>
+            <DialogContent className="sm:max-w-[500px]">
+                <DialogHeader>
+                    <DialogTitle>Annotate {rows.length} traces</DialogTitle>
+                </DialogHeader>
+                {rows.length > MAX_ENTITIES && (
+                    <div className="mb-2 text-sm text-red-500">
+                        You can annotate up to {MAX_ENTITIES} traces at a time. Please reduce your selection.
+                    </div>
+                )}
+                <div className="grid gap-4 py-4">
+                    <Input
+                        placeholder="Score name"
+                        value={scoreName}
+                        onChange={(e) => setScoreName(e.target.value)}
+                        disabled={rows.length > MAX_ENTITIES}
+                    />
+                    <Input
+                        placeholder="Value"
+                        type="number"
+                        value={value}
+                        onChange={(e) => {
+                            const v = e.target.value;
+                            setValue(v === "" ? "" : Number(v));
+                        }}
+                        disabled={rows.length > MAX_ENTITIES}
+                    />
+                    <Input
+                        placeholder="Category name (optional)"
+                        value={categoryName}
+                        onChange={(e) => setCategoryName(e.target.value)}
+                        disabled={rows.length > MAX_ENTITIES}
+                    />
+                    <Textarea
+                        placeholder="Reason (optional)"
+                        value={reason}
+                        onChange={(e) => setReason(e.target.value)}
+                        disabled={rows.length > MAX_ENTITIES}
+                    />
+                </div>
+                <DialogFooter>
+                    <Button variant="outline" onClick={handleClose} disabled={batchMutation.isPending}>
+                        Cancel
+                    </Button>
+                    <Button onClick={handleAnnotate} disabled={disabled}>
+                        Annotate
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default BatchAnnotateDialog; 

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesActionsPanel.tsx
@@ -1,19 +1,20 @@
-import React, { useState, useRef, useCallback } from "react";
-import { Database, Tag, Trash } from "lucide-react";
 import first from "lodash/first";
 import get from "lodash/get";
+import { Database, PencilLine, Tag, Trash } from "lucide-react";
+import React, { useCallback, useRef, useState } from "react";
 import slugify from "slugify";
 
-import { Button } from "@/components/ui/button";
-import { Span, Trace } from "@/types/traces";
-import { COLUMN_FEEDBACK_SCORES_ID } from "@/types/shared";
-import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
-import AddToDatasetDialog from "@/components/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog";
-import ConfirmDialog from "@/components/shared/ConfirmDialog/ConfirmDialog";
 import useTracesBatchDeleteMutation from "@/api/traces/useTraceBatchDeleteMutation";
-import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
-import ExportToButton from "@/components/shared/ExportToButton/ExportToButton";
 import AddTagDialog from "@/components/pages-shared/traces/AddTagDialog/AddTagDialog";
+import AddToDatasetDialog from "@/components/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog";
+import BatchAnnotateDialog from "@/components/pages-shared/traces/BatchAnnotateDialog/BatchAnnotateDialog";
+import ConfirmDialog from "@/components/shared/ConfirmDialog/ConfirmDialog";
+import ExportToButton from "@/components/shared/ExportToButton/ExportToButton";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
+import { Button } from "@/components/ui/button";
+import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
+import { COLUMN_FEEDBACK_SCORES_ID } from "@/types/shared";
+import { Span, Trace } from "@/types/traces";
 
 type TracesActionsPanelProps = {
   type: TRACE_DATA_TYPE;
@@ -74,9 +75,8 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
 
   const generateFileName = useCallback(
     (extension = "csv") => {
-      return `${slugify(projectName, { lower: true })}-${
-        type === TRACE_DATA_TYPE.traces ? "traces" : "llm-calls"
-      }.${extension}`;
+      return `${slugify(projectName, { lower: true })}-${type === TRACE_DATA_TYPE.traces ? "traces" : "llm-calls"
+        }.${extension}`;
     },
     [projectName, type],
   );
@@ -108,6 +108,14 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
         type={type}
         onSuccess={onClearSelection}
       />
+      <BatchAnnotateDialog
+        key={`annotate-${resetKeyRef.current}`}
+        rows={rows as Trace[]}
+        open={open === 4}
+        setOpen={setOpen}
+        projectId={projectId}
+        onSuccess={onClearSelection}
+      />
       <TooltipWrapper content="Add to dataset">
         <Button
           variant="outline"
@@ -134,6 +142,20 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
         >
           <Tag className="mr-2 size-4" />
           Add tags
+        </Button>
+      </TooltipWrapper>
+      <TooltipWrapper content="Annotate">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            setOpen(4);
+            resetKeyRef.current = resetKeyRef.current + 1;
+          }}
+          disabled={disabled}
+        >
+          <PencilLine className="mr-2 size-4" />
+          Annotate
         </Button>
       </TooltipWrapper>
       <ExportToButton

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesActionsPanel.tsx
@@ -1,13 +1,12 @@
 import first from "lodash/first";
 import get from "lodash/get";
-import { Database, PencilLine, Tag, Trash } from "lucide-react";
+import { Database, Tag, Trash } from "lucide-react";
 import React, { useCallback, useRef, useState } from "react";
 import slugify from "slugify";
 
 import useTracesBatchDeleteMutation from "@/api/traces/useTraceBatchDeleteMutation";
 import AddTagDialog from "@/components/pages-shared/traces/AddTagDialog/AddTagDialog";
 import AddToDatasetDialog from "@/components/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog";
-import BatchAnnotateDialog from "@/components/pages-shared/traces/BatchAnnotateDialog/BatchAnnotateDialog";
 import ConfirmDialog from "@/components/shared/ConfirmDialog/ConfirmDialog";
 import ExportToButton from "@/components/shared/ExportToButton/ExportToButton";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
@@ -15,6 +14,9 @@ import { Button } from "@/components/ui/button";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 import { COLUMN_FEEDBACK_SCORES_ID } from "@/types/shared";
 import { Span, Trace } from "@/types/traces";
+
+import BatchAnnotateDialog from "@/components/pages-shared/traces/BatchAnnotateDialog/BatchAnnotateDialog";
+import { PencilLine } from "lucide-react";
 
 type TracesActionsPanelProps = {
   type: TRACE_DATA_TYPE;
@@ -44,13 +46,11 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
       projectId,
       ids: rows.map((row) => row.id),
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId, rows]);
 
   const mapRowData = useCallback(() => {
     return rows.map((row) => {
       return columnsToExport.reduce<Record<string, unknown>>((acc, column) => {
-        // we need split by dot to parse feedback_scores into correct structure
         const keys = column.split(".");
         const keyPrefix = first(keys) as string;
 


### PR DESCRIPTION
## Details
Implements “Batch Feedback Score” flow for traces and spans.

Backend
• Service + DAO bulk-save logic  
• `/v1/private/traces/feedback-scores` and `/v1/private/spans/feedback-scores` endpoints (existing paths now wired for batch)  

Frontend
• React-Query mutation hook `useBatchFeedbackScores`  
• Optimistic cache update and success/error toasts  
• Bulk-select action in Traces/Spans table with modal for score entry  

## Issues
Resolves #1010 
/claim #1010 

## Testing
• the other components were not tested, here we followed the same.

## Documentation
No OpenAPI schema changes required; existing endpoints reused.  