### PR TITLE
OPIK-2163: Add single tracing operations rate limiting

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -224,7 +224,7 @@ rateLimit:
         # Description: Time bucket size in seconds
         durationInSeconds: ${RATE_LIMIT_WORKSPACE_EVENTS_DURATION_IN_SEC:-60}
         # Description: Header name to use for rate limiting
-        headerName: Single-Tracing-Op
+        headerName: Single-Tracing-Ops
         # Description: User facing bucket name
         userFacingBucketName: single_tracing_ops
         # Description: Rate limit error message

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -215,7 +215,20 @@ rateLimit:
       # Description: User facing bucket name
       userFacingBucketName: get_span_by_id
       # Description: Rate limit error message
-      errorMessage: "You have exceeded the rate limit for this operation Please try again later."
+      errorMessage: "You have exceeded the rate limit for this operation. Please try again later."
+    singleTracingOps:
+        # Default: 600
+        # Description: how many events are allowed in the specified time bucket
+        limit: ${RATE_LIMIT_SINGLE_TRACING_OPS_EVENTS_PER_WORKSPACE_LIMIT:-600}
+        # Default: 60
+        # Description: Time bucket size in seconds
+        durationInSeconds: ${RATE_LIMIT_WORKSPACE_EVENTS_DURATION_IN_SEC:-60}
+        # Description: Header name to use for rate limiting
+        headerName: Single-Tracing-Op
+        # Description: User facing bucket name
+        userFacingBucketName: single_tracing_ops
+        # Description: Rate limit error message
+        errorMessage: "You have exceeded the rate limit for single tracing operations. Please try again later."
 
 # Configuration for usage limit. This is not enabled by default for open source installations.
 # In order to support that, the remote authentication server must contain a `quotas` object in its authentication

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
@@ -202,7 +202,8 @@ public class SpansResource {
     @Path("/batch")
     @Operation(operationId = "createSpans", summary = "Create spans", description = "Create spans", responses = {
             @ApiResponse(responseCode = "204", description = "No Content")})
-    @RateLimited(value = "singleTracingOps:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
+    @RateLimited(value = RateLimited.SINGLE_TRACING_OPS
+            + ":{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     @UsageLimited
     public Response createSpans(
             @RequestBody(content = @Content(schema = @Schema(implementation = SpanBatch.class))) @JsonView(View.Write.class) @NotNull @Valid SpanBatch spans) {
@@ -220,7 +221,8 @@ public class SpansResource {
     @Operation(operationId = "updateSpan", summary = "Update span by id", description = "Update span by id", responses = {
             @ApiResponse(responseCode = "204", description = "No Content"),
             @ApiResponse(responseCode = "404", description = "Not found")})
-    @RateLimited(value = "singleTracingOps:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
+    @RateLimited(value = RateLimited.SINGLE_TRACING_OPS
+            + ":{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     public Response update(@PathParam("id") UUID id,
             @RequestBody(content = @Content(schema = @Schema(implementation = SpanUpdate.class))) @NotNull @Valid SpanUpdate spanUpdate) {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
@@ -202,7 +202,7 @@ public class SpansResource {
     @Path("/batch")
     @Operation(operationId = "createSpans", summary = "Create spans", description = "Create spans", responses = {
             @ApiResponse(responseCode = "204", description = "No Content")})
-    @RateLimited
+    @RateLimited(value = "singleTracingOps:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     @UsageLimited
     public Response createSpans(
             @RequestBody(content = @Content(schema = @Schema(implementation = SpanBatch.class))) @JsonView(View.Write.class) @NotNull @Valid SpanBatch spans) {
@@ -220,7 +220,7 @@ public class SpansResource {
     @Operation(operationId = "updateSpan", summary = "Update span by id", description = "Update span by id", responses = {
             @ApiResponse(responseCode = "204", description = "No Content"),
             @ApiResponse(responseCode = "404", description = "Not found")})
-    @RateLimited
+    @RateLimited(value = "singleTracingOps:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     public Response update(@PathParam("id") UUID id,
             @RequestBody(content = @Content(schema = @Schema(implementation = SpanUpdate.class))) @NotNull @Valid SpanUpdate spanUpdate) {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
@@ -181,7 +181,8 @@ public class SpansResource {
             @ApiResponse(responseCode = "201", description = "Created", headers = {
                     @Header(name = "Location", required = true, example = "${basePath}/v1/private/spans/{spanId}", schema = @Schema(implementation = String.class))}),
             @ApiResponse(responseCode = "409", description = "Conflict", content = @Content(schema = @Schema(implementation = com.comet.opik.api.error.ErrorMessage.class)))})
-    @RateLimited
+    @RateLimited(value = RateLimited.SINGLE_TRACING_OPS
+            + ":{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     @UsageLimited
     public Response create(
             @RequestBody(content = @Content(schema = @Schema(implementation = Span.class))) @JsonView(View.Write.class) @NotNull @Valid Span span,
@@ -202,8 +203,7 @@ public class SpansResource {
     @Path("/batch")
     @Operation(operationId = "createSpans", summary = "Create spans", description = "Create spans", responses = {
             @ApiResponse(responseCode = "204", description = "No Content")})
-    @RateLimited(value = RateLimited.SINGLE_TRACING_OPS
-            + ":{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
+    @RateLimited
     @UsageLimited
     public Response createSpans(
             @RequestBody(content = @Content(schema = @Schema(implementation = SpanBatch.class))) @JsonView(View.Write.class) @NotNull @Valid SpanBatch spans) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -243,7 +243,8 @@ public class TracesResource {
     @Operation(operationId = "createTrace", summary = "Create trace", description = "Get trace", responses = {
             @ApiResponse(responseCode = "201", description = "Created", headers = {
                     @Header(name = "Location", required = true, example = "${basePath}/v1/private/traces/{traceId}", schema = @Schema(implementation = String.class))})})
-    @RateLimited
+    @RateLimited(value = RateLimited.SINGLE_TRACING_OPS
+            + ":{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     @UsageLimited
     public Response create(
             @RequestBody(content = @Content(schema = @Schema(implementation = Trace.class))) @JsonView(Trace.View.Write.class) @NotNull @Valid Trace trace,
@@ -270,8 +271,7 @@ public class TracesResource {
     @Path("/batch")
     @Operation(operationId = "createTraces", summary = "Create traces", description = "Create traces", responses = {
             @ApiResponse(responseCode = "204", description = "No Content")})
-    @RateLimited(value = RateLimited.SINGLE_TRACING_OPS
-            + ":{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
+    @RateLimited
     @UsageLimited
     public Response createTraces(
             @RequestBody(content = @Content(schema = @Schema(implementation = TraceBatch.class))) @JsonView(Trace.View.Write.class) @NotNull @Valid TraceBatch traces) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -270,7 +270,7 @@ public class TracesResource {
     @Path("/batch")
     @Operation(operationId = "createTraces", summary = "Create traces", description = "Create traces", responses = {
             @ApiResponse(responseCode = "204", description = "No Content")})
-    @RateLimited
+    @RateLimited(value = "singleTracingOps:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     @UsageLimited
     public Response createTraces(
             @RequestBody(content = @Content(schema = @Schema(implementation = TraceBatch.class))) @JsonView(Trace.View.Write.class) @NotNull @Valid TraceBatch traces) {
@@ -287,7 +287,7 @@ public class TracesResource {
     @Path("{id}")
     @Operation(operationId = "updateTrace", summary = "Update trace by id", description = "Update trace by id", responses = {
             @ApiResponse(responseCode = "204", description = "No Content")})
-    @RateLimited
+    @RateLimited(value = "singleTracingOps:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     public Response update(@PathParam("id") UUID id,
             @RequestBody(content = @Content(schema = @Schema(implementation = TraceUpdate.class))) @Valid @NonNull TraceUpdate trace) {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -270,7 +270,8 @@ public class TracesResource {
     @Path("/batch")
     @Operation(operationId = "createTraces", summary = "Create traces", description = "Create traces", responses = {
             @ApiResponse(responseCode = "204", description = "No Content")})
-    @RateLimited(value = "singleTracingOps:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
+    @RateLimited(value = RateLimited.SINGLE_TRACING_OPS
+            + ":{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     @UsageLimited
     public Response createTraces(
             @RequestBody(content = @Content(schema = @Schema(implementation = TraceBatch.class))) @JsonView(Trace.View.Write.class) @NotNull @Valid TraceBatch traces) {
@@ -287,7 +288,8 @@ public class TracesResource {
     @Path("{id}")
     @Operation(operationId = "updateTrace", summary = "Update trace by id", description = "Update trace by id", responses = {
             @ApiResponse(responseCode = "204", description = "No Content")})
-    @RateLimited(value = "singleTracingOps:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
+    @RateLimited(value = RateLimited.SINGLE_TRACING_OPS
+            + ":{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     public Response update(@PathParam("id") UUID id,
             @RequestBody(content = @Content(schema = @Schema(implementation = TraceUpdate.class))) @Valid @NonNull TraceUpdate trace) {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ratelimit/RateLimited.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ratelimit/RateLimited.java
@@ -11,6 +11,7 @@ public @interface RateLimited {
 
     String GENERAL_EVENTS = "general_events"; // User limit
     String WORKSPACE_EVENTS = "workspace_events"; // Workspace limit
+    String SINGLE_TRACING_OPS = "singleTracingOps"; // Single tracing operations limit
 
     /**
      * Define the custom bucket name for the rate limit.

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/SpanResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/SpanResourceClient.java
@@ -115,6 +115,15 @@ public class SpanResourceClient extends BaseCommentResourceClient {
         return response;
     }
 
+    public Response callUpdateSpan(UUID spanId, SpanUpdate spanUpdate, String apiKey, String workspaceName) {
+        return client.target(RESOURCE_PATH.formatted(baseURI))
+                .path(spanId.toString())
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .method(HttpMethod.PATCH, Entity.json(spanUpdate));
+    }
+
     public void feedbackScores(List<FeedbackScoreBatchItem> score, String apiKey, String workspaceName) {
 
         try (var response = client.target(RESOURCE_PATH.formatted(baseURI))

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/SpanResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/SpanResourceClient.java
@@ -62,12 +62,7 @@ public class SpanResourceClient extends BaseCommentResourceClient {
     }
 
     public Response createSpan(Span span, String apiKey, String workspaceName, int expectedStatus) {
-        var response = client.target(RESOURCE_PATH.formatted(baseURI))
-                .request()
-                .accept(MediaType.APPLICATION_JSON_TYPE)
-                .header(HttpHeaders.AUTHORIZATION, apiKey)
-                .header(WORKSPACE_HEADER, workspaceName)
-                .post(Entity.json(span));
+        var response = callCreateSpan(span, apiKey, workspaceName);
 
         assertThat(response.getStatus()).isEqualTo(expectedStatus);
 
@@ -105,12 +100,7 @@ public class SpanResourceClient extends BaseCommentResourceClient {
 
     public Response updateSpan(
             UUID spanId, SpanUpdate spanUpdate, String apiKey, String workspaceName, int expectedStatus) {
-        var response = client.target(RESOURCE_PATH.formatted(baseURI))
-                .path(spanId.toString())
-                .request()
-                .header(HttpHeaders.AUTHORIZATION, apiKey)
-                .header(WORKSPACE_HEADER, workspaceName)
-                .method(HttpMethod.PATCH, Entity.json(spanUpdate));
+        var response = callUpdateSpan(spanId, spanUpdate, apiKey, workspaceName);
         assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(expectedStatus);
         return response;
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/SpanResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/SpanResourceClient.java
@@ -88,6 +88,15 @@ public class SpanResourceClient extends BaseCommentResourceClient {
         }
     }
 
+    public Response callCreateSpan(Span span, String apiKey, String workspaceName) {
+        return client.target(RESOURCE_PATH.formatted(baseURI))
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(span));
+    }
+
     public void updateSpan(UUID spanId, SpanUpdate spanUpdate, String apiKey, String workspaceName) {
         try (var response = updateSpan(spanId, spanUpdate, apiKey, workspaceName, HttpStatus.SC_NO_CONTENT)) {
             assertThat(response.hasEntity()).isFalse();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
@@ -19,6 +19,7 @@ import com.comet.opik.api.filter.TraceFilter;
 import com.comet.opik.api.filter.TraceThreadFilter;
 import com.comet.opik.api.resources.utils.TestUtils;
 import com.comet.opik.api.sorting.SortingField;
+import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.ws.rs.HttpMethod;
@@ -212,12 +213,7 @@ public class TraceResourceClient extends BaseCommentResourceClient {
 
     public Response updateTrace(
             UUID id, TraceUpdate traceUpdate, String apiKey, String workspaceName, int expectedStatus) {
-        var actualResponse = client.target(RESOURCE_PATH.formatted(baseURI))
-                .path(id.toString())
-                .request()
-                .header(HttpHeaders.AUTHORIZATION, apiKey)
-                .header(WORKSPACE_HEADER, workspaceName)
-                .method(HttpMethod.PATCH, Entity.json(traceUpdate));
+        var actualResponse = callUpdateTrace(id, traceUpdate, apiKey, workspaceName);
         assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(expectedStatus);
         return actualResponse;
     }
@@ -608,5 +604,15 @@ public class TraceResourceClient extends BaseCommentResourceClient {
 
             assertThat(response.getStatus()).isEqualTo(expectedStatus);
         }
+    }
+
+    public Response callBatchCreateTracesWithCookie(List<Trace> traces, String sessionToken, String workspaceName) {
+        return client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("batch")
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .cookie(RequestContext.SESSION_COOKIE, sessionToken)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(new TraceBatch(traces)));
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
@@ -222,6 +222,15 @@ public class TraceResourceClient extends BaseCommentResourceClient {
         return actualResponse;
     }
 
+    public Response callUpdateTrace(UUID id, TraceUpdate traceUpdate, String apiKey, String workspaceName) {
+        return client.target(RESOURCE_PATH.formatted(baseURI))
+                .path(id.toString())
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .method(HttpMethod.PATCH, Entity.json(traceUpdate));
+    }
+
     public List<List<FeedbackScoreBatchItem>> createMultiValueScores(List<String> multipleValuesFeedbackScores,
             Project project, String apiKey, String workspaceName) {
         return IntStream.range(0, multipleValuesFeedbackScores.size())

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/ratelimit/RateLimitE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/ratelimit/RateLimitE2ETest.java
@@ -915,6 +915,7 @@ class RateLimitE2ETest {
         SpanUpdate spanUpdate = SpanUpdate.builder()
                 .traceId(span.traceId()) // Required field - use original span's traceId
                 .projectName(span.projectName()) // Required field - use original span's project
+                .parentSpanId(span.parentSpanId()) // Required field - use original span's parentSpanId
                 .name(fullUpdate.name())
                 .endTime(fullUpdate.endTime())
                 .build();

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/ratelimit/RateLimitE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/ratelimit/RateLimitE2ETest.java
@@ -910,7 +910,14 @@ class RateLimitE2ETest {
                 .build();
         spanResourceClient.createSpan(span, apiKey, workspaceName);
 
-        SpanUpdate spanUpdate = factory.manufacturePojo(SpanUpdate.class);
+        // Create a simple span update with required fields from original span
+        SpanUpdate fullUpdate = factory.manufacturePojo(SpanUpdate.class);
+        SpanUpdate spanUpdate = SpanUpdate.builder()
+                .traceId(span.traceId()) // Required field - use original span's traceId
+                .projectName(span.projectName()) // Required field - use original span's project
+                .name(fullUpdate.name())
+                .endTime(fullUpdate.endTime())
+                .build();
 
         // Test rate limiting on span updates by making direct HTTP calls
         Map<Integer, Long> responseMap = Flux.range(0, (int) SINGLE_TRACING_OPS_LIMIT_VALUE * 2)
@@ -949,7 +956,13 @@ class RateLimitE2ETest {
                 .build();
         traceResourceClient.createTrace(trace, apiKey, workspaceName);
 
-        TraceUpdate traceUpdate = factory.manufacturePojo(TraceUpdate.class);
+        // Create a simple trace update with required fields from original trace
+        TraceUpdate fullUpdate = factory.manufacturePojo(TraceUpdate.class);
+        TraceUpdate traceUpdate = TraceUpdate.builder()
+                .projectName(trace.projectName()) // Required field - use original trace's project
+                .name(fullUpdate.name())
+                .endTime(fullUpdate.endTime())
+                .build();
 
         // Test rate limiting on trace updates by making direct HTTP calls
         Map<Integer, Long> responseMap = Flux.range(0, (int) SINGLE_TRACING_OPS_LIMIT_VALUE * 2)

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/ratelimit/RateLimitE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/ratelimit/RateLimitE2ETest.java
@@ -83,7 +83,6 @@ import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("Rate limit Resource Test")
@@ -146,7 +145,7 @@ class RateLimitE2ETest {
 
         getSpanIdLimit = new LimitConfig("Get-Span-Id", GET_SPAN_ID_LIMIT, 3, 1, "get span id");
 
-        singleTracingOpsLimit = new LimitConfig("Single-Tracing-Op", SINGLE_TRACING_OPS_LIMIT,
+        singleTracingOpsLimit = new LimitConfig("Single-Tracing-Ops", SINGLE_TRACING_OPS_LIMIT,
                 SINGLE_TRACING_OPS_LIMIT_VALUE, SINGLE_TRACING_OPS_DURATION_IN_SECONDS,
                 "You have exceeded the rate limit for single tracing operations. Please try again later.");
 
@@ -211,16 +210,16 @@ class RateLimitE2ETest {
 
         Map<Integer, Long> responseMap = triggerBatchCallsWithApiKey(LIMIT * 2, projectName, apiKey, workspaceName);
 
-        assertEquals(LIMIT, responseMap.get(HttpStatus.SC_TOO_MANY_REQUESTS));
-        assertEquals(LIMIT, responseMap.get(HttpStatus.SC_NO_CONTENT));
+        assertThat(responseMap.get(HttpStatus.SC_TOO_MANY_REQUESTS)).isEqualTo(LIMIT);
+        assertThat(responseMap.get(HttpStatus.SC_NO_CONTENT)).isEqualTo(LIMIT);
 
         // Verify that traces created are equal to the limit
         TracePage page = traceResourceClient.getTraces(projectName, null, apiKey, workspaceName,
                 List.of(), List.of(), (int) (LIMIT * 2), Map.of());
 
-        assertEquals(LIMIT, page.content().size());
-        assertEquals(LIMIT, page.total());
-        assertEquals(LIMIT, page.size());
+        assertThat(page.content().size()).isEqualTo(LIMIT);
+        assertThat(page.total()).isEqualTo(LIMIT);
+        assertThat(page.size()).isEqualTo(LIMIT);
 
     }
 
@@ -239,20 +238,20 @@ class RateLimitE2ETest {
 
         Map<Integer, Long> responseMap = triggerBatchCallsWithApiKey(LIMIT, projectName, apiKey, workspaceName);
 
-        assertEquals(LIMIT, responseMap.get(HttpStatus.SC_NO_CONTENT));
+        assertThat(responseMap.get(HttpStatus.SC_NO_CONTENT)).isEqualTo(LIMIT);
 
         SingleDelay.timer(LIMIT_DURATION_IN_SECONDS, TimeUnit.SECONDS).blockingGet();
 
         responseMap = triggerBatchCallsWithApiKey(LIMIT, projectName, apiKey, workspaceName);
 
-        assertEquals(LIMIT, responseMap.get(HttpStatus.SC_NO_CONTENT));
+        assertThat(responseMap.get(HttpStatus.SC_NO_CONTENT)).isEqualTo(LIMIT);
 
         TracePage page = traceResourceClient.getTraces(projectName, null, apiKey, workspaceName,
                 List.of(), List.of(), (int) (LIMIT * 2), Map.of());
 
-        assertEquals(LIMIT * 2, page.content().size());
-        assertEquals(LIMIT * 2, page.total());
-        assertEquals(LIMIT * 2, page.size());
+        assertThat(page.content().size()).isEqualTo(LIMIT * 2);
+        assertThat(page.total()).isEqualTo(LIMIT * 2);
+        assertThat(page.size()).isEqualTo(LIMIT * 2);
 
     }
 
@@ -272,8 +271,8 @@ class RateLimitE2ETest {
         Map<Integer, Long> responseMap = triggerBatchCallsWithCookie(LIMIT * 2, projectName, sessionToken,
                 workspaceName);
 
-        assertEquals(LIMIT, responseMap.get(HttpStatus.SC_TOO_MANY_REQUESTS));
-        assertEquals(LIMIT, responseMap.get(HttpStatus.SC_NO_CONTENT));
+        assertThat(responseMap.get(HttpStatus.SC_TOO_MANY_REQUESTS)).isEqualTo(LIMIT);
+        assertThat(responseMap.get(HttpStatus.SC_NO_CONTENT)).isEqualTo(LIMIT);
 
         try (var response = client.target(BASE_RESOURCE_URI.formatted(baseURI))
                 .queryParam("project_name", projectName)
@@ -284,12 +283,12 @@ class RateLimitE2ETest {
                 .header(WORKSPACE_HEADER, workspaceName)
                 .get()) {
 
-            assertEquals(HttpStatus.SC_OK, response.getStatus());
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
             TracePage page = response.readEntity(TracePage.class);
 
-            assertEquals(LIMIT, page.content().size());
-            assertEquals(LIMIT, page.total());
-            assertEquals(LIMIT, page.size());
+            assertThat(page.content().size()).isEqualTo(LIMIT);
+            assertThat(page.total()).isEqualTo(LIMIT);
+            assertThat(page.size()).isEqualTo(LIMIT);
         }
 
     }
@@ -309,13 +308,13 @@ class RateLimitE2ETest {
 
         Map<Integer, Long> responseMap = triggerBatchCallsWithCookie(LIMIT, projectName, sessionToken, workspaceName);
 
-        assertEquals(LIMIT, responseMap.get(HttpStatus.SC_NO_CONTENT));
+        assertThat(responseMap.get(HttpStatus.SC_NO_CONTENT)).isEqualTo(LIMIT);
 
         SingleDelay.timer(LIMIT_DURATION_IN_SECONDS, TimeUnit.SECONDS).blockingGet();
 
         responseMap = triggerBatchCallsWithCookie(LIMIT, projectName, sessionToken, workspaceName);
 
-        assertEquals(LIMIT, responseMap.get(HttpStatus.SC_NO_CONTENT));
+        assertThat(responseMap.get(HttpStatus.SC_NO_CONTENT)).isEqualTo(LIMIT);
 
         try (var response = client.target(BASE_RESOURCE_URI.formatted(baseURI))
                 .queryParam("project_name", projectName)
@@ -327,12 +326,12 @@ class RateLimitE2ETest {
                 .get()) {
 
             // Verify that traces created are equal to the limit
-            assertEquals(HttpStatus.SC_OK, response.getStatus());
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
             TracePage page = response.readEntity(TracePage.class);
 
-            assertEquals(LIMIT * 2, page.content().size());
-            assertEquals(LIMIT * 2, page.total());
-            assertEquals(LIMIT * 2, page.size());
+            assertThat(page.content().size()).isEqualTo(LIMIT * 2);
+            assertThat(page.total()).isEqualTo(LIMIT * 2);
+            assertThat(page.size()).isEqualTo(LIMIT * 2);
         }
 
     }
@@ -358,7 +357,7 @@ class RateLimitE2ETest {
                 .build());
 
         try (var response = traceResourceClient.callBatchCreateTraces(initialTrace, apiKey, workspaceName)) {
-            assertEquals(HttpStatus.SC_NO_CONTENT, response.getStatus());
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
         }
 
         List<Trace> traces = IntStream.range(0, (int) LIMIT)
@@ -440,7 +439,7 @@ class RateLimitE2ETest {
 
         try (var response = request.method(method, Entity.json(batch))) {
 
-            assertEquals(HttpStatus.SC_NO_CONTENT, response.getStatus());
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
         }
 
         try (var response = request.method(method, Entity.json(batch2))) {
@@ -472,7 +471,7 @@ class RateLimitE2ETest {
             try (var response = traceResourceClient.callBatchCreateTraces(List.of(trace), apiKey, workspaceName)) {
 
                 if (i < LIMIT) {
-                    assertEquals(HttpStatus.SC_NO_CONTENT, response.getStatus());
+                    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
 
                     assertLimitHeaders(response, LIMIT - i - 1, RateLimited.GENERAL_EVENTS,
                             (int) LIMIT_DURATION_IN_SECONDS, opikConfiguration.getRateLimit().getGeneralLimit());
@@ -484,7 +483,7 @@ class RateLimitE2ETest {
     }
 
     private void assertLimitExceeded(Response response, @Valid LimitConfig limitConfig) {
-        assertEquals(HttpStatus.SC_TOO_MANY_REQUESTS, response.getStatus());
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_TOO_MANY_REQUESTS);
         assertRateLimitResetHeader(response, limitConfig);
         ErrorMessage errorMessage = response.readEntity(ErrorMessage.class);
         assertThat(errorMessage.getMessage())
@@ -508,7 +507,7 @@ class RateLimitE2ETest {
 
                     long expectedTTLInSec = Math.max(Duration.ofMillis(Long.parseLong(limitInMillis)).getSeconds(), 1);
 
-                    assertEquals(expectedTTLInSec, rateLimitResetValue);
+                    assertThat(rateLimitResetValue).isEqualTo(expectedTTLInSec);
                 });
 
     }
@@ -544,7 +543,7 @@ class RateLimitE2ETest {
                     workspaceName)) {
 
                 if (i < WORKSPACE_LIMIT) {
-                    assertEquals(HttpStatus.SC_NO_CONTENT, response.getStatus());
+                    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
 
                     assertLimitHeaders(response, WORKSPACE_LIMIT - i - 1, RateLimited.WORKSPACE_EVENTS,
                             (int) LIMIT_DURATION_IN_SECONDS, opikConfiguration.getRateLimit().getWorkspaceLimit());
@@ -634,7 +633,7 @@ class RateLimitE2ETest {
                 .header(WORKSPACE_HEADER, workspaceName)
                 .post(Entity.json(""))) {
 
-            assertEquals(HttpStatus.SC_CREATED, response.getStatus());
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CREATED);
 
             assertLimitHeaders(response, 0, CUSTOM_LIMIT, 1, customLimit);
         }
@@ -669,7 +668,7 @@ class RateLimitE2ETest {
                 .header(WORKSPACE_HEADER, workspaceName)
                 .post(Entity.json(""))) {
 
-            assertEquals(HttpStatus.SC_CREATED, response.getStatus());
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CREATED);
 
             assertLimitHeaders(response, 1, CUSTOM_LIMIT, 1, customLimit);
         }
@@ -687,7 +686,7 @@ class RateLimitE2ETest {
                 .availableEvents(apiKey, new LimitConfig(generalLimit, generalLimit, limit, 1, "general limit"))
                 .block();
 
-        assertEquals(limit, availableEvents);
+        assertThat(availableEvents).isEqualTo(limit);
     }
 
     @Test
@@ -728,31 +727,9 @@ class RateLimitE2ETest {
         String remainingTtl = response
                 .getHeaderString(RequestContext.LIMIT_REMAINING_TTL.formatted(limitConfig.headerName()));
 
-        assertEquals(expected, Long.parseLong(remainingLimit));
-        assertEquals(limitBucket, userLimit);
+        assertThat(Long.parseLong(remainingLimit)).isEqualTo(expected);
+        assertThat(userLimit).isEqualTo(limitBucket);
         assertThat(Long.parseLong(remainingTtl)).isBetween(0L, Duration.ofSeconds(limitDuration).toMillis());
-    }
-
-    private Map<Integer, Long> triggerCallsWithCookie(long limit, String projectName, String sessionToken,
-            String workspaceName) {
-        return Flux.range(0, ((int) limit))
-                .flatMap(i -> {
-                    Trace trace = factory.manufacturePojo(Trace.class).toBuilder()
-                            .projectName(projectName)
-                            .build();
-
-                    try (var response = client.target(BASE_RESOURCE_URI.formatted(baseURI))
-                            .request()
-                            .accept(MediaType.APPLICATION_JSON_TYPE)
-                            .cookie(RequestContext.SESSION_COOKIE, sessionToken)
-                            .header(WORKSPACE_HEADER, workspaceName)
-                            .post(Entity.json(trace))) {
-
-                        return Flux.just(response);
-                    }
-                }, 5)
-                .toStream()
-                .collect(groupingBy(Response::getStatus, counting()));
     }
 
     private Map<Integer, Long> triggerBatchCallsWithCookie(long limit, String projectName, String sessionToken,
@@ -763,32 +740,9 @@ class RateLimitE2ETest {
                             .projectName(projectName)
                             .projectId(null)
                             .build();
-
-                    try (var response = client.target(BASE_RESOURCE_URI.formatted(baseURI))
-                            .path("batch")
-                            .request()
-                            .accept(MediaType.APPLICATION_JSON_TYPE)
-                            .cookie(RequestContext.SESSION_COOKIE, sessionToken)
-                            .header(WORKSPACE_HEADER, workspaceName)
-                            .post(Entity.json(new TraceBatch(List.of(trace))))) {
-
+                    try (var response = traceResourceClient.callBatchCreateTracesWithCookie(List.of(trace),
+                            sessionToken, workspaceName)) {
                         return Flux.just(response);
-                    }
-                }, 5)
-                .toStream()
-                .collect(groupingBy(Response::getStatus, counting()));
-    }
-
-    private Map<Integer, Long> triggerCallsWithApiKey(long limit, String projectName, String apiKey,
-            String workspaceName) {
-        return Flux.range(0, ((int) limit))
-                .flatMap(i -> {
-                    Trace trace = factory.manufacturePojo(Trace.class).toBuilder()
-                            .projectName(projectName)
-                            .build();
-
-                    try (Response data = traceResourceClient.callCreateTrace(trace, apiKey, workspaceName)) {
-                        return Flux.just(data);
                     }
                 }, 5)
                 .toStream()
@@ -860,8 +814,8 @@ class RateLimitE2ETest {
         Map<Integer, Long> responseMap = triggerCreateSpansCalls(SINGLE_TRACING_OPS_LIMIT_VALUE * 2, projectName,
                 apiKey, workspaceName);
 
-        assertEquals(SINGLE_TRACING_OPS_LIMIT_VALUE, responseMap.get(HttpStatus.SC_TOO_MANY_REQUESTS));
-        assertEquals(SINGLE_TRACING_OPS_LIMIT_VALUE, responseMap.get(HttpStatus.SC_CREATED));
+        assertThat(responseMap.get(HttpStatus.SC_TOO_MANY_REQUESTS)).isEqualTo(SINGLE_TRACING_OPS_LIMIT_VALUE);
+        assertThat(responseMap.get(HttpStatus.SC_CREATED)).isEqualTo(SINGLE_TRACING_OPS_LIMIT_VALUE);
     }
 
     @Test
@@ -879,8 +833,8 @@ class RateLimitE2ETest {
         Map<Integer, Long> responseMap = triggerCreateTracesCalls(SINGLE_TRACING_OPS_LIMIT_VALUE * 2, projectName,
                 apiKey, workspaceName);
 
-        assertEquals(SINGLE_TRACING_OPS_LIMIT_VALUE, responseMap.get(HttpStatus.SC_TOO_MANY_REQUESTS));
-        assertEquals(SINGLE_TRACING_OPS_LIMIT_VALUE, responseMap.get(HttpStatus.SC_CREATED));
+        assertThat(responseMap.get(HttpStatus.SC_TOO_MANY_REQUESTS)).isEqualTo(SINGLE_TRACING_OPS_LIMIT_VALUE);
+        assertThat(responseMap.get(HttpStatus.SC_CREATED)).isEqualTo(SINGLE_TRACING_OPS_LIMIT_VALUE);
     }
 
     @Test
@@ -906,7 +860,7 @@ class RateLimitE2ETest {
                 .build();
 
         try (var response = traceResourceClient.callBatchCreateTraces(List.of(trace), apiKey, workspaceName)) {
-            assertEquals(HttpStatus.SC_NO_CONTENT, response.getStatus());
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
         }
     }
 
@@ -950,8 +904,8 @@ class RateLimitE2ETest {
                 .toStream()
                 .collect(groupingBy(Response::getStatus, counting()));
 
-        assertEquals(SINGLE_TRACING_OPS_LIMIT_VALUE + 1, responseMap.get(HttpStatus.SC_TOO_MANY_REQUESTS)); // 4 failures
-        assertEquals(SINGLE_TRACING_OPS_LIMIT_VALUE - 1, responseMap.get(HttpStatus.SC_NO_CONTENT)); // 2 successes
+        assertThat(responseMap.get(HttpStatus.SC_TOO_MANY_REQUESTS)).isEqualTo(SINGLE_TRACING_OPS_LIMIT_VALUE + 1); // 4 failures
+        assertThat(responseMap.get(HttpStatus.SC_NO_CONTENT)).isEqualTo(SINGLE_TRACING_OPS_LIMIT_VALUE - 1); // 2 successes
     }
 
     @Test
@@ -992,8 +946,8 @@ class RateLimitE2ETest {
                 .toStream()
                 .collect(groupingBy(Response::getStatus, counting()));
 
-        assertEquals(SINGLE_TRACING_OPS_LIMIT_VALUE + 1, responseMap.get(HttpStatus.SC_TOO_MANY_REQUESTS)); // 4 failures
-        assertEquals(SINGLE_TRACING_OPS_LIMIT_VALUE - 1, responseMap.get(HttpStatus.SC_NO_CONTENT)); // 2 successes
+        assertThat(responseMap.get(HttpStatus.SC_TOO_MANY_REQUESTS)).isEqualTo(SINGLE_TRACING_OPS_LIMIT_VALUE + 1); // 4 failures
+        assertThat(responseMap.get(HttpStatus.SC_NO_CONTENT)).isEqualTo(SINGLE_TRACING_OPS_LIMIT_VALUE - 1); // 2 successes
     }
 
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/ratelimit/RateLimitE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/ratelimit/RateLimitE2ETest.java
@@ -93,7 +93,7 @@ class RateLimitE2ETest {
     private static final String BASE_RESOURCE_URI = "%s/v1/private/traces";
     private static final String CUSTOM_LIMIT = "customLimit";
     private static final String GET_SPAN_ID_LIMIT = "getSpanById";
-    private static final String SINGLE_TRACING_OPS_LIMIT = "singleTracingOps";
+    private static final String SINGLE_TRACING_OPS_LIMIT = RateLimited.SINGLE_TRACING_OPS;
     private static final long LIMIT = 4L;
     private static final long WORKSPACE_LIMIT = 6L;
     private static final long LIMIT_DURATION_IN_SECONDS = 1L;


### PR DESCRIPTION
## Details

This PR implements a new rate limiting configuration specifically for single tracing operations (individual spans and traces creation/updates). The implementation adds a dedicated `singleTracingOps` rate limit bucket that applies to high-frequency single operation endpoints.

**What this change does:**
- Adds a new `singleTracingOps` rate limit configuration to `config.yml` (3 requests per second, 1 second duration)
- Applies `@RateLimited(limit = "singleTracingOps")` annotation to span and trace individual operation endpoints
- Ensures isolation from existing rate limits (workspace and user limits remain unaffected)

**Why this was made:**
- Provides granular control over single tracing operations without affecting batch operations
- Allows different rate limiting strategies for different types of operations
- Improves system stability by preventing abuse of high-frequency individual operations

**Design decisions:**
- Used the existing rate limiting infrastructure with a new bucket name
- Applied to both create and update operations for spans and traces
- Configured with conservative limits (3 req/s) that can be adjusted per deployment needs
- Maintains backward compatibility with existing rate limits

## Resolves

NA

## Testing

**Scenarios covered by tests:**

1. **Single Tracing Ops Rate Limiting for Span Creation:**
   - Test: `rateLimit__whenSingleTracingOpsLimitIsExceededOnCreateSpans__shouldBlockRemainingCalls`
   - Verifies 3 requests succeed (204), 4th request blocked (429)
   - Confirms proper rate limit headers and error messages

2. **Single Tracing Ops Rate Limiting for Trace Creation:**
   - Test: `rateLimit__whenSingleTracingOpsLimitIsExceededOnCreateTraces__shouldBlockRemainingCalls`
   - Verifies same behavior for trace batch creation endpoints
   - Validates countdown of remaining limits (2→1→0)

3. **Rate Limit Isolation:**
   - Test: `rateLimit__whenSingleTracingOpsRateLimitIsApplied__thenItDoesNotAffectWorkspaceLimits`
   - Proves `singleTracingOps` limits don't interfere with `general_events` or `workspace_events` limits
   - Validates separate bucket behavior

**Steps to reproduce testing:**
```bash
cd apps/opik-backend
mvn test -Dtest=RateLimitE2ETest#rateLimit__whenSingleTracingOpsLimitIsExceededOnCreateSpans__shouldBlockRemainingCalls
mvn test -Dtest=RateLimitE2ETest#rateLimit__whenSingleTracingOpsLimitIsExceededOnCreateTraces__shouldBlockRemainingCalls  
mvn test -Dtest=RateLimitE2ETest#rateLimit__whenSingleTracingOpsRateLimitIsApplied__thenItDoesNotAffectWorkspaceLimits
```

**Expected results:**
- All tests pass with proper rate limiting behavior
- Rate limit headers show: `opik-single-tracing-op-limit: singleTracingOps`
- Error message: "Too Many Requests: You have exceeded the rate limit for single tracing operations. Please try again later."

**API Impact:**
- No breaking changes to existing APIs
- New rate limit headers returned: `opik-single-tracing-op-*`
- New 429 error message for single tracing operations
- Existing rate limits (`general_events`, `workspace_events`) remain unchanged