### PR TITLE
[NA] Reraise instead of retry errors

### DIFF
--- a/sdks/python/src/opik/rest_client_configurator/retry_decorator.py
+++ b/sdks/python/src/opik/rest_client_configurator/retry_decorator.py
@@ -29,4 +29,5 @@ opik_rest_retry = tenacity.retry(
     stop=tenacity.stop_after_attempt(3),
     wait=tenacity.wait_exponential(multiplier=3, min=5, max=15),  # 5, 6, 12
     retry=tenacity.retry_if_exception(_allowed_to_retry),
+    reraise=True,
 )


### PR DESCRIPTION
## Details
Tenacity retry decorator used in our REST API calls now re-raises the original error from the last try instead of always raising RetryError, which wraps the original error.