### PR TITLE
Implement multi-scoring for traces and threads

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackScore.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackScore.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.UUID;
 
 import static com.comet.opik.utils.ValidationUtils.MAX_FEEDBACK_SCORE_VALUE;
 import static com.comet.opik.utils.ValidationUtils.MIN_FEEDBACK_SCORE_VALUE;
@@ -28,5 +29,6 @@ public record FeedbackScore(
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant createdAt,
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,
-        @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy) {
+        @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy,
+        @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Unique identifier for this score instance (for multi-scoring support)") UUID scoreId) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackScoreGroup.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackScoreGroup.java
@@ -1,0 +1,25 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record FeedbackScoreGroup(
+        @NotBlank String name,
+        String categoryName,
+        @Schema(description = "Average value of all scores in this group") BigDecimal averageValue,
+        @Schema(description = "Minimum value among all scores in this group") BigDecimal minValue,
+        @Schema(description = "Maximum value among all scores in this group") BigDecimal maxValue,
+        @Schema(description = "Number of scores in this group") int scoreCount,
+        @Schema(description = "All individual scores in this group") @NotNull List<FeedbackScore> scores) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackScoreItem.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackScoreItem.java
@@ -50,6 +50,9 @@ public abstract sealed class FeedbackScoreItem {
 
     @NotNull private final ScoreSource source;
 
+    @Schema(description = "Unique identifier for this score instance (auto-generated if not provided)")
+    private final UUID scoreId;
+
     public abstract UUID id();
 
     public abstract String threadId();
@@ -73,10 +76,10 @@ public abstract sealed class FeedbackScoreItem {
         // entity (trace or span) id
         @NotNull private UUID id;
 
-        @ConstructorProperties({"id", "projectName", "projectId", "name", "categoryName", "value", "reason", "source"})
+        @ConstructorProperties({"id", "projectName", "projectId", "name", "categoryName", "value", "reason", "source", "scoreId"})
         public FeedbackScoreBatchItem(String projectName, UUID projectId, String name, String categoryName,
-                BigDecimal value, String reason, ScoreSource source, UUID id) {
-            super(projectName, projectId, name, value, categoryName, reason, source);
+                BigDecimal value, String reason, ScoreSource source, UUID scoreId, UUID id) {
+            super(projectName, projectId, name, value, categoryName, reason, source, scoreId);
             this.id = id;
         }
 
@@ -102,10 +105,10 @@ public abstract sealed class FeedbackScoreItem {
         private UUID id;
 
         @ConstructorProperties({"threadId", "projectName", "projectId", "name", "categoryName", "value", "reason",
-                "source"})
+                "source", "scoreId"})
         public FeedbackScoreBatchItemThread(String projectName, UUID projectId, String name, String categoryName,
-                BigDecimal value, String reason, ScoreSource source, String threadId) {
-            super(projectName, projectId, name, value, categoryName, reason, source);
+                BigDecimal value, String reason, ScoreSource source, UUID scoreId, String threadId) {
+            super(projectName, projectId, name, value, categoryName, reason, source, scoreId);
             this.threadId = threadId;
         }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
@@ -1,6 +1,7 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.FeedbackScore;
+import com.comet.opik.api.FeedbackScoreGroup;
 import com.comet.opik.api.FeedbackScoreItem;
 import com.comet.opik.api.ScoreSource;
 import org.apache.commons.collections4.CollectionUtils;
@@ -10,11 +11,14 @@ import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
 import static com.comet.opik.utils.ValidationUtils.CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE;
@@ -29,16 +33,67 @@ public interface FeedbackScoreMapper {
     @Mapping(target = "value", expression = "java(item.value())")
     @Mapping(target = "reason", expression = "java(item.reason())")
     @Mapping(target = "source", expression = "java(item.source())")
+    @Mapping(target = "scoreId", expression = "java(item.scoreId() != null ? item.scoreId() : java.util.UUID.randomUUID())")
     FeedbackScore toFeedbackScore(FeedbackScoreItem item);
 
     List<FeedbackScore> toFeedbackScores(List<? extends FeedbackScoreItem> feedbackScoreBatchItems);
 
     @Mapping(target = "id", source = "entityId")
+    @Mapping(target = "scoreId", expression = "java(score.scoreId() != null ? score.scoreId() : java.util.UUID.randomUUID())")
     FeedbackScoreBatchItem toFeedbackScoreBatchItem(UUID entityId, String projectName,
             FeedbackScore feedbackScore);
 
     @Mapping(target = "id", source = "entityId")
+    @Mapping(target = "scoreId", expression = "java(score.scoreId() != null ? score.scoreId() : java.util.UUID.randomUUID())")
     FeedbackScoreBatchItem toFeedbackScore(UUID entityId, UUID projectId, FeedbackScore score);
+
+    /**
+     * Groups feedback scores by name and creates FeedbackScoreGroup objects with aggregated statistics
+     */
+    default List<FeedbackScoreGroup> toFeedbackScoreGroups(List<FeedbackScore> scores) {
+        if (CollectionUtils.isEmpty(scores)) {
+            return List.of();
+        }
+
+        Map<String, List<FeedbackScore>> scoresByName = scores.stream()
+                .collect(Collectors.groupingBy(FeedbackScore::name));
+
+        return scoresByName.entrySet().stream()
+                .map(entry -> {
+                    String name = entry.getKey();
+                    List<FeedbackScore> scoreList = entry.getValue();
+                    
+                    // Calculate statistics
+                    BigDecimal sum = scoreList.stream()
+                            .map(FeedbackScore::value)
+                            .reduce(BigDecimal.ZERO, BigDecimal::add);
+                    BigDecimal average = sum.divide(BigDecimal.valueOf(scoreList.size()), 4, RoundingMode.HALF_UP);
+                    
+                    BigDecimal minValue = scoreList.stream()
+                            .map(FeedbackScore::value)
+                            .min(BigDecimal::compareTo)
+                            .orElse(BigDecimal.ZERO);
+                    
+                    BigDecimal maxValue = scoreList.stream()
+                            .map(FeedbackScore::value)
+                            .max(BigDecimal::compareTo)
+                            .orElse(BigDecimal.ZERO);
+
+                    // Use category name from the first score (they should be the same for the same name)
+                    String categoryName = scoreList.getFirst().categoryName();
+
+                    return FeedbackScoreGroup.builder()
+                            .name(name)
+                            .categoryName(categoryName)
+                            .averageValue(average)
+                            .minValue(minValue)
+                            .maxValue(maxValue)
+                            .scoreCount(scoreList.size())
+                            .scores(scoreList)
+                            .build();
+                })
+                .toList();
+    }
 
     static List<FeedbackScore> getFeedbackScores(Object feedbackScoresRaw) {
         if (feedbackScoresRaw instanceof List[] feedbackScoresArray) {
@@ -57,6 +112,11 @@ public interface FeedbackScoreMapper {
                             .lastUpdatedAt(Instant.parse(feedbackScore.get(7).toString()))
                             .createdBy(feedbackScore.get(8).toString())
                             .lastUpdatedBy(feedbackScore.get(9).toString())
+                            .scoreId(Optional.ofNullable(feedbackScore.get(10))
+                                    .map(Object::toString)
+                                    .filter(id -> !CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE.equals(id))
+                                    .map(UUID::fromString)
+                                    .orElse(null))
                             .build())
                     .toList();
             return feedbackScores.isEmpty() ? null : feedbackScores;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000035_add_multi_scoring_support.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000035_add_multi_scoring_support.sql
@@ -1,0 +1,18 @@
+--liquibase formatted sql
+--changeset opik:000035_add_multi_scoring_support
+
+-- Add score_id column to uniquely identify each score instance
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.feedback_scores ON CLUSTER '{cluster}'
+    ADD COLUMN score_id FixedString(36) DEFAULT generateUUIDv4();
+
+-- Update the ORDER BY clause to include score_id for proper deduplication
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.feedback_scores ON CLUSTER '{cluster}'
+    MODIFY ORDER BY (workspace_id, project_id, entity_type, entity_id, name, score_id);
+
+-- Add index for efficient querying by score_id
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.feedback_scores ON CLUSTER '{cluster}'
+    ADD INDEX idx_score_id score_id TYPE minmax GRANULARITY 1;
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.feedback_scores ON CLUSTER '{cluster}' DROP INDEX idx_score_id;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.feedback_scores ON CLUSTER '{cluster}' MODIFY ORDER BY (workspace_id, project_id, entity_type, entity_id, name);
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.feedback_scores ON CLUSTER '{cluster}' DROP COLUMN score_id;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiScoringResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiScoringResourceTest.java
@@ -1,0 +1,221 @@
+package com.comet.opik.api.resources.v1.priv;
+
+import com.comet.opik.api.FeedbackScore;
+import com.comet.opik.api.FeedbackScoreGroup;
+import com.comet.opik.api.FeedbackScoreItem;
+import com.comet.opik.api.ScoreSource;
+import com.comet.opik.api.Span;
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.resources.utils.resources.SpanResourceClient;
+import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
+import com.comet.opik.domain.SpanType;
+import com.comet.opik.testutils.PodamFactoryUtils;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.dropwizard.testing.junit5.ResourceExtension;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import ru.vyarus.dropwizard.guice.test.jupiter.TestGuiceyApp;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static com.comet.opik.api.resources.utils.ResourcesTestUtils.API_KEY;
+import static com.comet.opik.api.resources.utils.ResourcesTestUtils.TEST_WORKSPACE;
+import static com.comet.opik.testutils.PodamFactoryUtils.podamFactory;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+@TestGuiceyApp(value = TestApplication.class, config = "config/test-config.yml")
+class MultiScoringResourceTest {
+
+    private static final ResourceExtension resources = ResourceExtension.builder()
+            .addResource(new SpansResource(
+                    null, null, null, null, null, null, null, null, null))
+            .addResource(new TracesResource(
+                    null, null, null, null, null, null, null, null, null, null, null, null))
+            .build();
+
+    private SpanResourceClient spanResourceClient;
+    private TraceResourceClient traceResourceClient;
+
+    @BeforeEach
+    void setUp() {
+        spanResourceClient = new SpanResourceClient(resources.client(), resources.baseUri());
+        traceResourceClient = new TraceResourceClient(resources.client(), resources.baseUri());
+    }
+
+    @Test
+    void testMultiScoringForSpans() {
+        // Create a span first
+        Span span = podamFactory.manufacturePojo(Span.class);
+        span = span.toBuilder().type(SpanType.LLM).build();
+        
+        Response createResponse = spanResourceClient.create(span, API_KEY, TEST_WORKSPACE);
+        assertThat(createResponse.getStatus()).isEqualTo(201);
+        
+        UUID spanId = span.id();
+
+        // Add multiple scores for the same metric
+        FeedbackScore score1 = FeedbackScore.builder()
+                .name("quality")
+                .value(new BigDecimal("8.5"))
+                .source(ScoreSource.UI)
+                .reason("Good response")
+                .build();
+
+        FeedbackScore score2 = FeedbackScore.builder()
+                .name("quality")
+                .value(new BigDecimal("7.0"))
+                .source(ScoreSource.SDK)
+                .reason("Automated evaluation")
+                .build();
+
+        FeedbackScore score3 = FeedbackScore.builder()
+                .name("quality")
+                .value(new BigDecimal("9.0"))
+                .source(ScoreSource.UI)
+                .reason("Excellent response")
+                .build();
+
+        // Add scores one by one
+        spanResourceClient.feedbackScore(spanId, score1, TEST_WORKSPACE, API_KEY);
+        spanResourceClient.feedbackScore(spanId, score2, TEST_WORKSPACE, API_KEY);
+        spanResourceClient.feedbackScore(spanId, score3, TEST_WORKSPACE, API_KEY);
+
+        // Get the score groups
+        Response groupsResponse = spanResourceClient.getFeedbackScoreGroups(spanId, API_KEY, TEST_WORKSPACE);
+        assertThat(groupsResponse.getStatus()).isEqualTo(200);
+
+        List<FeedbackScoreGroup> groups = groupsResponse.readEntity(List.class);
+        assertThat(groups).hasSize(1);
+        
+        // Verify the group has the correct statistics
+        Map<String, Object> group = (Map<String, Object>) groups.get(0);
+        assertThat(group.get("name")).isEqualTo("quality");
+        assertThat(group.get("scoreCount")).isEqualTo(3);
+        
+        // Verify average calculation (8.5 + 7.0 + 9.0) / 3 = 8.17
+        BigDecimal averageValue = new BigDecimal(group.get("averageValue").toString());
+        assertThat(averageValue).isCloseTo(new BigDecimal("8.17"), new BigDecimal("0.01"));
+    }
+
+    @Test
+    void testMultiScoringForTraces() {
+        // Create a trace first
+        Trace trace = podamFactory.manufacturePojo(Trace.class);
+        
+        Response createResponse = traceResourceClient.create(trace, API_KEY, TEST_WORKSPACE);
+        assertThat(createResponse.getStatus()).isEqualTo(201);
+        
+        UUID traceId = trace.id();
+
+        // Add multiple scores for different metrics
+        FeedbackScore score1 = FeedbackScore.builder()
+                .name("accuracy")
+                .value(new BigDecimal("9.5"))
+                .source(ScoreSource.UI)
+                .reason("Very accurate")
+                .build();
+
+        FeedbackScore score2 = FeedbackScore.builder()
+                .name("accuracy")
+                .value(new BigDecimal("8.8"))
+                .source(ScoreSource.SDK)
+                .reason("Automated check")
+                .build();
+
+        FeedbackScore score3 = FeedbackScore.builder()
+                .name("relevance")
+                .value(new BigDecimal("7.5"))
+                .source(ScoreSource.UI)
+                .reason("Somewhat relevant")
+                .build();
+
+        // Add scores
+        traceResourceClient.feedbackScore(traceId, score1, TEST_WORKSPACE, API_KEY);
+        traceResourceClient.feedbackScore(traceId, score2, TEST_WORKSPACE, API_KEY);
+        traceResourceClient.feedbackScore(traceId, score3, TEST_WORKSPACE, API_KEY);
+
+        // Get the score groups
+        Response groupsResponse = traceResourceClient.getFeedbackScoreGroups(traceId, API_KEY, TEST_WORKSPACE);
+        assertThat(groupsResponse.getStatus()).isEqualTo(200);
+
+        List<FeedbackScoreGroup> groups = groupsResponse.readEntity(List.class);
+        assertThat(groups).hasSize(2); // accuracy and relevance
+        
+        // Find the accuracy group
+        Map<String, Object> accuracyGroup = groups.stream()
+                .map(g -> (Map<String, Object>) g)
+                .filter(g -> "accuracy".equals(g.get("name")))
+                .findFirst()
+                .orElseThrow();
+        
+        assertThat(accuracyGroup.get("scoreCount")).isEqualTo(2);
+        
+        // Verify average calculation (9.5 + 8.8) / 2 = 9.15
+        BigDecimal averageValue = new BigDecimal(accuracyGroup.get("averageValue").toString());
+        assertThat(averageValue).isCloseTo(new BigDecimal("9.15"), new BigDecimal("0.01"));
+    }
+
+    @Test
+    void testDeleteSpecificScore() {
+        // Create a span
+        Span span = podamFactory.manufacturePojo(Span.class);
+        span = span.toBuilder().type(SpanType.LLM).build();
+        
+        Response createResponse = spanResourceClient.create(span, API_KEY, TEST_WORKSPACE);
+        assertThat(createResponse.getStatus()).isEqualTo(201);
+        
+        UUID spanId = span.id();
+
+        // Add two scores
+        FeedbackScore score1 = FeedbackScore.builder()
+                .name("quality")
+                .value(new BigDecimal("8.0"))
+                .source(ScoreSource.UI)
+                .build();
+
+        FeedbackScore score2 = FeedbackScore.builder()
+                .name("quality")
+                .value(new BigDecimal("9.0"))
+                .source(ScoreSource.UI)
+                .build();
+
+        spanResourceClient.feedbackScore(spanId, score1, TEST_WORKSPACE, API_KEY);
+        spanResourceClient.feedbackScore(spanId, score2, TEST_WORKSPACE, API_KEY);
+
+        // Get score groups to find the score IDs
+        Response groupsResponse = spanResourceClient.getFeedbackScoreGroups(spanId, API_KEY, TEST_WORKSPACE);
+        assertThat(groupsResponse.getStatus()).isEqualTo(200);
+
+        List<FeedbackScoreGroup> groups = groupsResponse.readEntity(List.class);
+        assertThat(groups).hasSize(1);
+        
+        Map<String, Object> group = (Map<String, Object>) groups.get(0);
+        List<Map<String, Object>> scores = (List<Map<String, Object>>) group.get("scores");
+        assertThat(scores).hasSize(2);
+
+        // Delete one specific score
+        UUID scoreId = UUID.fromString(scores.get(0).get("scoreId").toString());
+        Response deleteResponse = spanResourceClient.deleteFeedbackScoreById(spanId, scoreId, API_KEY, TEST_WORKSPACE);
+        assertThat(deleteResponse.getStatus()).isEqualTo(204);
+
+        // Verify only one score remains
+        Response remainingGroupsResponse = spanResourceClient.getFeedbackScoreGroups(spanId, API_KEY, TEST_WORKSPACE);
+        assertThat(remainingGroupsResponse.getStatus()).isEqualTo(200);
+
+        List<FeedbackScoreGroup> remainingGroups = remainingGroupsResponse.readEntity(List.class);
+        assertThat(remainingGroups).hasSize(1);
+        
+        Map<String, Object> remainingGroup = (Map<String, Object>) remainingGroups.get(0);
+        assertThat(remainingGroup.get("scoreCount")).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Details

This PR introduces a multi-scoring system, allowing multiple feedback scores for the same entity (span, trace, thread) and metric.

Key changes include:
- **Database Schema**: Added a `score_id` column to the `feedback_scores` table to uniquely identify each score instance, enabling multiple entries per entity/name.
- **New API Model**: Introduced `FeedbackScoreGroup` to represent a collection of scores for a given metric, including aggregated statistics (average, min, max, count).
- **Data Access Layer**: Updated `FeedbackScoreDAO` and `FeedbackScoreMapper` to handle `score_id` and support grouping scores.
- **Service Layer**: `FeedbackScoreService` now includes methods to retrieve score groups and delete individual scores by `score_id`.
- **API Endpoints**: New `GET /{id}/feedback-scores` and `DELETE /{id}/feedback-scores/{scoreId}` endpoints added to `SpansResource` and `TracesResource` for multi-scoring management.
- **Backward Compatibility**: Existing single-scoring endpoints are preserved.
- **Statistics**: Existing ClickHouse `avgMap` function automatically handles averaging multiple scores, requiring no changes to current statistics queries.

## Issues

Resolves #N/A

## Testing

- New `MultiScoringResourceTest` added to verify:
    - Adding multiple scores for the same metric on spans and traces.
    - Correct calculation of average values for score groups.
    - Deletion of specific scores by their unique `scoreId`.

## Documentation

- API documentation (Swagger/OpenAPI) is updated with the new multi-scoring endpoints.
- Frontend updates will be required to display multiple scores and their aggregated statistics.

---
<a href="https://cursor.com/background-agent?bcId=bc-40336448-860a-431c-b586-5dd9e84fc475">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40336448-860a-431c-b586-5dd9e84fc475">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

