### PR TITLE
[NA] Remove missing doc links for vertexai.mdx

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -529,9 +529,6 @@ navigation:
           - page: Ragas
             path: docs/cookbook/ragas.mdx
             slug: ragas
-          - page: Vertex AI
-            path: docs/cookbook/vertexai.mdx
-            slug: vertexai
           - page: Smolagents
             path: docs/cookbook/smolagents.mdx
             slug: smolagents


### PR DESCRIPTION
## Details
This PR removes a navigation entry for a missing Vertex AI documentation page from the documentation configuration. The change cleans up the documentation structure by removing a broken link reference.

- Removes the Vertex AI cookbook page entry from the navigation configuration

## Issues
N/A

## Testing
- Passed CI build.

## Documentation
N/A
