### PR TITLE
OPIK-2164: Enable async insert to All remaining insert statements

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CommentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CommentDAO.java
@@ -1,7 +1,9 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.Comment;
+import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
+import com.comet.opik.utils.ClickhouseUtils;
 import com.google.inject.ImplementedBy;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Statement;
@@ -65,7 +67,7 @@ class CommentDAOImpl implements CommentDAO {
                 text,
                 created_by,
                 last_updated_by
-            )
+            ) <settings_clause>
             VALUES
             (
                  :id,
@@ -95,7 +97,8 @@ class CommentDAOImpl implements CommentDAO {
     private static final String UPDATE = """
             INSERT INTO comments (
             	id, entity_id, entity_type, project_id, workspace_id, text, created_at, created_by, last_updated_by
-            ) SELECT
+            ) <settings_clause>
+            SELECT
             	id,
             	entity_id,
             	entity_type,
@@ -129,6 +132,7 @@ class CommentDAOImpl implements CommentDAO {
             """;
 
     private final @NonNull TransactionTemplateAsync asyncTemplate;
+    private final @NonNull OpikConfiguration opikConfiguration;
 
     @Override
     public Mono<Long> addComment(@NonNull UUID commentId, @NonNull UUID entityId, @NonNull EntityType entityType,
@@ -136,7 +140,11 @@ class CommentDAOImpl implements CommentDAO {
             @NonNull Comment comment) {
         return asyncTemplate.nonTransaction(connection -> {
 
-            var statement = connection.createStatement(INSERT_COMMENT);
+            ST template = new ST(INSERT_COMMENT);
+
+            ClickhouseUtils.checkAsyncConfig(template, opikConfiguration.getAsyncInsert());
+
+            var statement = connection.createStatement(template.render());
 
             bindParameters(commentId, entityId, entityType, projectId, comment, statement);
 
@@ -171,7 +179,11 @@ class CommentDAOImpl implements CommentDAO {
     public Mono<Void> updateComment(@NonNull UUID commentId, @NonNull Comment comment) {
         return asyncTemplate.nonTransaction(connection -> {
 
-            var statement = connection.createStatement(UPDATE)
+            ST update = new ST(UPDATE);
+
+            ClickhouseUtils.checkAsyncConfig(update, opikConfiguration.getAsyncInsert());
+
+            var statement = connection.createStatement(update.render())
                     .bind("text", comment.text())
                     .bind("id", commentId);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -5,7 +5,9 @@ import com.comet.opik.api.Column;
 import com.comet.opik.api.DatasetItem;
 import com.comet.opik.domain.filter.FilterQueryBuilder;
 import com.comet.opik.domain.filter.FilterStrategy;
+import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
+import com.comet.opik.utils.ClickhouseUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.ImplementedBy;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -67,257 +69,257 @@ public interface DatasetItemDAO {
 class DatasetItemDAOImpl implements DatasetItemDAO {
 
     private static final String INSERT_DATASET_ITEM = """
-                INSERT INTO dataset_items (
-                    id,
-                    dataset_id,
-                    source,
-                    trace_id,
-                    span_id,
-                    data,
-                    created_at,
-                    workspace_id,
-                    created_by,
-                    last_updated_by
-                )
-                VALUES
-                    <items:{item |
-                        (
-                             :id<item.index>,
-                             :datasetId<item.index>,
-                             :source<item.index>,
-                             :traceId<item.index>,
-                             :spanId<item.index>,
-                             :data<item.index>,
-                             now64(9),
-                             :workspace_id,
-                             :createdBy<item.index>,
-                             :lastUpdatedBy<item.index>
-                         )
-                         <if(item.hasNext)>
-                            ,
-                         <endif>
-                    }>
-                ;
+            INSERT INTO dataset_items (
+                id,
+                dataset_id,
+                source,
+                trace_id,
+                span_id,
+                data,
+                created_at,
+                workspace_id,
+                created_by,
+                last_updated_by
+            ) <settings_clause>
+            VALUES
+                <items:{item |
+                    (
+                         :id<item.index>,
+                         :datasetId<item.index>,
+                         :source<item.index>,
+                         :traceId<item.index>,
+                         :spanId<item.index>,
+                         :data<item.index>,
+                         now64(9),
+                         :workspace_id,
+                         :createdBy<item.index>,
+                         :lastUpdatedBy<item.index>
+                     )
+                     <if(item.hasNext)>
+                        ,
+                     <endif>
+                }>
+            ;
             """;
 
     private static final String SELECT_DATASET_ITEM = """
-                SELECT
-                    *,
-                    null AS experiment_items_array
-                FROM dataset_items
-                WHERE id = :id
-                AND workspace_id = :workspace_id
-                ORDER BY last_updated_at DESC
-                LIMIT 1 BY id
-                ;
+            SELECT
+                *,
+                null AS experiment_items_array
+            FROM dataset_items
+            WHERE id = :id
+            AND workspace_id = :workspace_id
+            ORDER BY last_updated_at DESC
+            LIMIT 1 BY id
+            ;
             """;
 
     private static final String SELECT_DATASET_ITEMS_STREAM = """
-                SELECT
-                    *,
-                    null AS experiment_items_array
-                FROM dataset_items
-                WHERE dataset_id = :datasetId
-                AND workspace_id = :workspace_id
-                <if(lastRetrievedId)>AND id \\< :lastRetrievedId <endif>
-                ORDER BY id DESC, last_updated_at DESC
-                LIMIT 1 BY id
-                LIMIT :limit
-                ;
+            SELECT
+                *,
+                null AS experiment_items_array
+            FROM dataset_items
+            WHERE dataset_id = :datasetId
+            AND workspace_id = :workspace_id
+            <if(lastRetrievedId)>AND id \\< :lastRetrievedId <endif>
+            ORDER BY id DESC, last_updated_at DESC
+            LIMIT 1 BY id
+            LIMIT :limit
+            ;
             """;
 
     private static final String DELETE_DATASET_ITEM = """
-                DELETE FROM dataset_items
-                WHERE id IN :ids
-                AND workspace_id = :workspace_id
-                ;
+            DELETE FROM dataset_items
+            WHERE id IN :ids
+            AND workspace_id = :workspace_id
+            ;
             """;
 
     private static final String SELECT_DATASET_ITEMS = """
-                SELECT
-                    id,
-                    dataset_id,
-                    <if(truncate)> mapApply((k, v) -> (k, replaceRegexpAll(v, '<truncate>', '"[image]"')), data) as data <else> data <endif>,
-                    trace_id,
-                    span_id,
-                    source,
-                    created_at,
-                    last_updated_at,
-                    created_by,
-                    last_updated_by,
-                    null AS experiment_items_array
-                FROM dataset_items
-                WHERE dataset_id = :datasetId
-                AND workspace_id = :workspace_id
-                ORDER BY id DESC, last_updated_at DESC
-                LIMIT 1 BY id
-                LIMIT :limit OFFSET :offset
-                ;
+            SELECT
+                id,
+                dataset_id,
+                <if(truncate)> mapApply((k, v) -> (k, replaceRegexpAll(v, '<truncate>', '"[image]"')), data) as data <else> data <endif>,
+                trace_id,
+                span_id,
+                source,
+                created_at,
+                last_updated_at,
+                created_by,
+                last_updated_by,
+                null AS experiment_items_array
+            FROM dataset_items
+            WHERE dataset_id = :datasetId
+            AND workspace_id = :workspace_id
+            ORDER BY id DESC, last_updated_at DESC
+            LIMIT 1 BY id
+            LIMIT :limit OFFSET :offset
+            ;
             """;
 
     private static final String SELECT_DATASET_ITEMS_COUNT = """
-                SELECT
-                    count(id) AS count,
-                    arrayFold(
-                        (acc, x) -> mapFromArrays(
-                            arrayMap(key -> key, arrayDistinct(arrayConcat(mapKeys(acc), mapKeys(x)))),
-                            arrayMap(key -> arrayDistinct(arrayConcat(acc[key], x[key])), arrayDistinct(arrayConcat(mapKeys(acc), mapKeys(x))))
-                        ),
-                        arrayDistinct(
-                            arrayFlatten(
-                                groupArray(
-                                    arrayMap(key -> map(key, [toString(JSONType(data[key]))]), mapKeys(data))
-                                )
+            SELECT
+                count(id) AS count,
+                arrayFold(
+                    (acc, x) -> mapFromArrays(
+                        arrayMap(key -> key, arrayDistinct(arrayConcat(mapKeys(acc), mapKeys(x)))),
+                        arrayMap(key -> arrayDistinct(arrayConcat(acc[key], x[key])), arrayDistinct(arrayConcat(mapKeys(acc), mapKeys(x))))
+                    ),
+                    arrayDistinct(
+                        arrayFlatten(
+                            groupArray(
+                                arrayMap(key -> map(key, [toString(JSONType(data[key]))]), mapKeys(data))
                             )
-                        ),
-                        CAST(map(), 'Map(String, Array(String))')
-                    ) AS columns
-                FROM (
-                    SELECT
-                        id,
-                        data
-                    FROM dataset_items
-                    WHERE dataset_id = :datasetId
-                    AND workspace_id = :workspace_id
-                    ORDER BY (workspace_id, dataset_id, source, trace_id, span_id, id) DESC, last_updated_at DESC
-                    LIMIT 1 BY id
-                ) AS lastRows
-                ;
+                        )
+                    ),
+                    CAST(map(), 'Map(String, Array(String))')
+                ) AS columns
+            FROM (
+                SELECT
+                    id,
+                    data
+                FROM dataset_items
+                WHERE dataset_id = :datasetId
+                AND workspace_id = :workspace_id
+                ORDER BY (workspace_id, dataset_id, source, trace_id, span_id, id) DESC, last_updated_at DESC
+                LIMIT 1 BY id
+            ) AS lastRows
+            ;
             """;
 
     private static final String SELECT_DATASET_ITEMS_COLUMNS_BY_DATASET_ID = """
-                SELECT
-                    arrayFold(
-                        (acc, x) -> mapFromArrays(
-                            arrayMap(key -> key, arrayDistinct(arrayConcat(mapKeys(acc), mapKeys(x)))),
-                            arrayMap(key -> arrayDistinct(arrayConcat(acc[key], x[key])), arrayDistinct(arrayConcat(mapKeys(acc), mapKeys(x))))
-                        ),
-                        arrayDistinct(
-                            arrayFlatten(
-                                groupArray(
-                                    arrayMap(key -> map(key, [toString(JSONType(data[key]))]), mapKeys(data))
-                                )
+            SELECT
+                arrayFold(
+                    (acc, x) -> mapFromArrays(
+                        arrayMap(key -> key, arrayDistinct(arrayConcat(mapKeys(acc), mapKeys(x)))),
+                        arrayMap(key -> arrayDistinct(arrayConcat(acc[key], x[key])), arrayDistinct(arrayConcat(mapKeys(acc), mapKeys(x))))
+                    ),
+                    arrayDistinct(
+                        arrayFlatten(
+                            groupArray(
+                                arrayMap(key -> map(key, [toString(JSONType(data[key]))]), mapKeys(data))
                             )
-                        ),
-                        CAST(map(), 'Map(String, Array(String))')
-                    ) AS columns
-                FROM (
-                    SELECT
-                        id,
-                        data
-                    FROM dataset_items
-                    WHERE dataset_id = :datasetId
-                    AND workspace_id = :workspace_id
-                    ORDER BY (workspace_id, dataset_id, source, trace_id, span_id, id) DESC, last_updated_at DESC
-                    LIMIT 1 BY id
-                )
-                ;
+                        )
+                    ),
+                    CAST(map(), 'Map(String, Array(String))')
+                ) AS columns
+            FROM (
+                SELECT
+                    id,
+                    data
+                FROM dataset_items
+                WHERE dataset_id = :datasetId
+                AND workspace_id = :workspace_id
+                ORDER BY (workspace_id, dataset_id, source, trace_id, span_id, id) DESC, last_updated_at DESC
+                LIMIT 1 BY id
+            )
+            ;
             """;
 
     private static final String FIND_DATASET_ITEMS_SUMMARY_BY_DATASET_IDS = """
-                        SELECT
-                            dataset_id,
-                            count(id) AS count
-                        FROM (
-                                 SELECT
-                                     id,
-                                     dataset_id
-                                 FROM dataset_items
-                                 WHERE dataset_id IN :dataset_ids
-                                   AND workspace_id = :workspace_id
-                                 ORDER BY (workspace_id, dataset_id, source, trace_id, span_id, id) DESC, last_updated_at DESC
-                                 LIMIT 1 BY id
-                                 ) AS lastRows
-                        GROUP BY dataset_id
-                        ;
+            SELECT
+                dataset_id,
+                count(id) AS count
+            FROM (
+                     SELECT
+                         id,
+                         dataset_id
+                     FROM dataset_items
+                     WHERE dataset_id IN :dataset_ids
+                       AND workspace_id = :workspace_id
+                     ORDER BY (workspace_id, dataset_id, source, trace_id, span_id, id) DESC, last_updated_at DESC
+                     LIMIT 1 BY id
+                     ) AS lastRows
+            GROUP BY dataset_id
+            ;
             """;
 
     /**
      * Counts dataset items only if there's a matching experiment item.
      */
     private static final String SELECT_DATASET_ITEMS_WITH_EXPERIMENT_ITEMS_COUNT = """
-                <if(feedback_scores_empty_filters)>
-                WITH fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
-                    FROM (
-                        SELECT *
-                        FROM feedback_scores
-                        WHERE entity_type = 'trace'
-                        AND workspace_id = :workspace_id
-                        ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
-                        LIMIT 1 BY entity_id, name
-                     )
-                     GROUP BY entity_id
-                     HAVING <feedback_scores_empty_filters>
-                )
-                <endif>
-                SELECT
-                   COUNT(DISTINCT di.id) AS count
+            <if(feedback_scores_empty_filters)>
+            WITH fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
                 FROM (
-                    SELECT
-                        id
-                    FROM dataset_items
-                    WHERE dataset_id = :datasetId
+                    SELECT *
+                    FROM feedback_scores
+                    WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
-                    <if(dataset_item_filters)>
-                    AND <dataset_item_filters>
-                    <endif>
-                    ORDER BY (workspace_id, dataset_id, source, trace_id, span_id, id) DESC, last_updated_at DESC
-                    LIMIT 1 BY id
-                ) AS di
+                    ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
+                    LIMIT 1 BY entity_id, name
+                 )
+                 GROUP BY entity_id
+                 HAVING <feedback_scores_empty_filters>
+            )
+            <endif>
+            SELECT
+               COUNT(DISTINCT di.id) AS count
+            FROM (
+                SELECT
+                    id
+                FROM dataset_items
+                WHERE dataset_id = :datasetId
+                AND workspace_id = :workspace_id
+                <if(dataset_item_filters)>
+                AND <dataset_item_filters>
+                <endif>
+                ORDER BY (workspace_id, dataset_id, source, trace_id, span_id, id) DESC, last_updated_at DESC
+                LIMIT 1 BY id
+            ) AS di
+            INNER JOIN (
+                SELECT
+                    dataset_item_id,
+                    trace_id
+                FROM experiment_items ei
+                <if(experiment_item_filters || feedback_scores_filters || feedback_scores_empty_filters)>
                 INNER JOIN (
                     SELECT
-                        dataset_item_id,
-                        trace_id
-                    FROM experiment_items ei
-                    <if(experiment_item_filters || feedback_scores_filters || feedback_scores_empty_filters)>
-                    INNER JOIN (
-                        SELECT
-                            id
-                        FROM traces
-                        <if(feedback_scores_empty_filters)>
-                            LEFT JOIN fsc ON fsc.entity_id = traces.id
-                        <endif>
-                        WHERE workspace_id = :workspace_id
-                        <if(experiment_item_filters)>
-                        AND <experiment_item_filters>
-                        <endif>
-                        <if(feedback_scores_filters)>
-                        AND id in (
-                            SELECT
-                                entity_id
-                            FROM (
-                                SELECT *
-                                FROM feedback_scores
-                                WHERE entity_type = 'trace'
-                                AND workspace_id = :workspace_id
-                                ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
-                                LIMIT 1 BY entity_id, name
-                            )
-                            GROUP BY entity_id
-                            HAVING <feedback_scores_filters>
-                        )
-                        <endif>
-                        <if(feedback_scores_empty_filters)>
-                        AND fsc.feedback_scores_count = 0
-                        <endif>
-                        ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
-                        LIMIT 1 BY id
-                    ) AS tfs ON ei.trace_id = tfs.id
+                        id
+                    FROM traces
+                    <if(feedback_scores_empty_filters)>
+                        LEFT JOIN fsc ON fsc.entity_id = traces.id
                     <endif>
-                    WHERE experiment_id in :experimentIds
-                    AND workspace_id = :workspace_id
-                    ORDER BY (workspace_id, experiment_id, dataset_item_id, trace_id, id) DESC, last_updated_at DESC
+                    WHERE workspace_id = :workspace_id
+                    <if(experiment_item_filters)>
+                    AND <experiment_item_filters>
+                    <endif>
+                    <if(feedback_scores_filters)>
+                    AND id in (
+                        SELECT
+                            entity_id
+                        FROM (
+                            SELECT *
+                            FROM feedback_scores
+                            WHERE entity_type = 'trace'
+                            AND workspace_id = :workspace_id
+                            ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
+                            LIMIT 1 BY entity_id, name
+                        )
+                        GROUP BY entity_id
+                        HAVING <feedback_scores_filters>
+                    )
+                    <endif>
+                    <if(feedback_scores_empty_filters)>
+                    AND fsc.feedback_scores_count = 0
+                    <endif>
+                    ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
                     LIMIT 1 BY id
-                ) AS ei ON di.id = ei.dataset_item_id
-                ;
+                ) AS tfs ON ei.trace_id = tfs.id
+                <endif>
+                WHERE experiment_id in :experimentIds
+                AND workspace_id = :workspace_id
+                ORDER BY (workspace_id, experiment_id, dataset_item_id, trace_id, id) DESC, last_updated_at DESC
+                LIMIT 1 BY id
+            ) AS ei ON di.id = ei.dataset_item_id
+            ;
             """;
 
     private static final String SELECT_DATASET_WORKSPACE_ITEMS = """
-                SELECT
-                    DISTINCT id, workspace_id
-                FROM dataset_items
-                WHERE id IN :datasetItemIds
-                ;
+            SELECT
+                DISTINCT id, workspace_id
+            FROM dataset_items
+            WHERE id IN :datasetItemIds
+            ;
             """;
 
     /**
@@ -536,65 +538,67 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
             LIMIT :limit OFFSET :offset
             ;
             """;
+
     public static final String DATASET_ITEMS = "dataset_items";
     public static final String CLICKHOUSE = "Clickhouse";
 
     private static final String SELECT_DATASET_EXPERIMENT_ITEMS_COLUMNS_BY_DATASET_ID = """
-                WITH dataset_item_final AS (
-                    SELECT
-                        id
-                    FROM dataset_items
-                    WHERE workspace_id = :workspace_id
-                    AND dataset_id = :dataset_id
-                    ORDER BY (workspace_id, dataset_id, source, trace_id, span_id, id) DESC, last_updated_at DESC
-                    LIMIT 1 BY id
-                ), experiment_items_final AS (
-                    SELECT DISTINCT
-                        ei.trace_id,
-                        ei.dataset_item_id
-                    FROM experiment_items ei
-                    WHERE workspace_id = :workspace_id
-                    AND ei.dataset_item_id IN (SELECT id FROM dataset_item_final)
-                    <if(experiment_ids)> AND ei.experiment_id IN :experiment_ids <endif>
-                    ORDER BY (workspace_id, experiment_id, dataset_item_id, trace_id, id) DESC, last_updated_at DESC
-                    LIMIT 1 BY id
-                )
+            WITH dataset_item_final AS (
                 SELECT
-                    arrayFold(
-                        (acc, x) -> mapFromArrays(
-                            arrayMap(key -> key, arrayDistinct(arrayConcat(mapKeys(acc), mapKeys(x)))),
-                            arrayMap(
-                                key -> arrayDistinct(arrayConcat(acc[key], x[key])),
-                                arrayDistinct(arrayConcat(mapKeys(acc), mapKeys(x)))
-                            )
-                        ),
-                        arrayDistinct(
-                            arrayFlatten(
-                                groupArray(
-                                    arrayMap(
-                                        key -> map(key, [toString(JSONType(JSONExtractRaw(output, key)))]),
-                                        JSONExtractKeys(output)
-                                    )
+                    id
+                FROM dataset_items
+                WHERE workspace_id = :workspace_id
+                AND dataset_id = :dataset_id
+                ORDER BY (workspace_id, dataset_id, source, trace_id, span_id, id) DESC, last_updated_at DESC
+                LIMIT 1 BY id
+            ), experiment_items_final AS (
+                SELECT DISTINCT
+                    ei.trace_id,
+                    ei.dataset_item_id
+                FROM experiment_items ei
+                WHERE workspace_id = :workspace_id
+                AND ei.dataset_item_id IN (SELECT id FROM dataset_item_final)
+                <if(experiment_ids)> AND ei.experiment_id IN :experiment_ids <endif>
+                ORDER BY (workspace_id, experiment_id, dataset_item_id, trace_id, id) DESC, last_updated_at DESC
+                LIMIT 1 BY id
+            )
+            SELECT
+                arrayFold(
+                    (acc, x) -> mapFromArrays(
+                        arrayMap(key -> key, arrayDistinct(arrayConcat(mapKeys(acc), mapKeys(x)))),
+                        arrayMap(
+                            key -> arrayDistinct(arrayConcat(acc[key], x[key])),
+                            arrayDistinct(arrayConcat(mapKeys(acc), mapKeys(x)))
+                        )
+                    ),
+                    arrayDistinct(
+                        arrayFlatten(
+                            groupArray(
+                                arrayMap(
+                                    key -> map(key, [toString(JSONType(JSONExtractRaw(output, key)))]),
+                                    JSONExtractKeys(output)
                                 )
                             )
-                        ),
-                        CAST(map(), 'Map(String, Array(String))')
-                    ) AS columns
-                FROM dataset_item_final as di
-                INNER JOIN experiment_items_final as ei ON ei.dataset_item_id = di.id
-                INNER JOIN (
-                    SELECT
-                        id,
-                        output
-                    FROM traces final
-                    WHERE workspace_id = :workspace_id
-                    AND id IN (SELECT trace_id FROM experiment_items_final)
-                ) as t ON t.id = ei.trace_id
-                ;
+                        )
+                    ),
+                    CAST(map(), 'Map(String, Array(String))')
+                ) AS columns
+            FROM dataset_item_final as di
+            INNER JOIN experiment_items_final as ei ON ei.dataset_item_id = di.id
+            INNER JOIN (
+                SELECT
+                    id,
+                    output
+                FROM traces final
+                WHERE workspace_id = :workspace_id
+                AND id IN (SELECT trace_id FROM experiment_items_final)
+            ) as t ON t.id = ei.trace_id
+            ;
             """;
 
     private final @NonNull TransactionTemplateAsync asyncTemplate;
     private final @NonNull FilterQueryBuilder filterQueryBuilder;
+    private final @NonNull OpikConfiguration opikConfiguration;
 
     @Override
     @WithSpan
@@ -615,6 +619,8 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
 
         var template = new ST(sqlTemplate)
                 .add("items", queryItems);
+
+        ClickhouseUtils.checkAsyncConfig(template, opikConfiguration.getAsyncInsert());
 
         String sql = template.render();
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -14,6 +14,8 @@ import com.comet.opik.api.sorting.ExperimentSortingFactory;
 import com.comet.opik.domain.filter.FilterQueryBuilder;
 import com.comet.opik.domain.filter.FilterStrategy;
 import com.comet.opik.domain.sorting.SortingQueryBuilder;
+import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.utils.ClickhouseUtils;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -83,7 +85,7 @@ class ExperimentDAO {
                 prompt_versions,
                 type,
                 optimization_id
-            )
+            ) <settings_clause>
             SELECT
                 if(
                     LENGTH(CAST(old.id AS Nullable(String))) > 0,
@@ -414,6 +416,7 @@ class ExperimentDAO {
     private final @NonNull ExperimentSortingFactory sortingFactory;
     private final @NonNull FilterQueryBuilder filterQueryBuilder;
     private final @NonNull GroupingQueryBuilder groupingQueryBuilder;
+    private final @NonNull OpikConfiguration opikConfiguration;
 
     @WithSpan
     Mono<Void> insert(@NonNull Experiment experiment) {
@@ -423,7 +426,11 @@ class ExperimentDAO {
     }
 
     private Publisher<? extends Result> insert(Experiment experiment, Connection connection) {
-        var statement = connection.createStatement(INSERT)
+        ST template = new ST(INSERT);
+
+        ClickhouseUtils.checkAsyncConfig(template, opikConfiguration.getAsyncInsert());
+
+        var statement = connection.createStatement(template.render())
                 .bind("id", experiment.id())
                 .bind("dataset_id", experiment.datasetId())
                 .bind("name", experiment.name())

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
@@ -1,6 +1,8 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.ExperimentItem;
+import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.utils.ClickhouseUtils;
 import com.google.common.base.Preconditions;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.r2dbc.spi.Connection;
@@ -56,7 +58,7 @@ class ExperimentItemDAO {
                 workspace_id,
                 created_by,
                 last_updated_by
-            )
+            ) <settings_clause>
             VALUES
                   <items:{item |
                      (
@@ -228,6 +230,7 @@ class ExperimentItemDAO {
             """;
 
     private final @NonNull ConnectionFactory connectionFactory;
+    private final @NonNull OpikConfiguration opikConfiguration;
 
     @WithSpan
     public Flux<ExperimentSummary> findExperimentSummaryByDatasetIds(Set<UUID> datasetIds) {
@@ -271,6 +274,8 @@ class ExperimentItemDAO {
 
         var template = new ST(INSERT)
                 .add("items", queryItems);
+
+        ClickhouseUtils.checkAsyncConfig(template, opikConfiguration.getAsyncInsert());
 
         String sql = template.render();
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
@@ -341,9 +341,7 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
 
             ST template = TemplateUtils.getBatchSql(BULK_INSERT_FEEDBACK_SCORE, scores.size());
 
-            if (opikConfiguration.getAsyncInsert().enabled()) {
-                template.add("settings_clause", ClickhouseUtils.ASYNC_INSERT);
-            }
+            ClickhouseUtils.checkAsyncConfig(template, opikConfiguration.getAsyncInsert());
 
             var statement = connection.createStatement(template.render());
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -97,7 +97,7 @@ class SpanDAO {
                 error_info,
                 created_by,
                 last_updated_by
-            ) VALUES
+            ) <settings_clause> VALUES
                 <items:{item |
                     (
                         :id<item.index>,
@@ -967,6 +967,8 @@ class SpanDAO {
             var template = new ST(BULK_INSERT)
                     .add("items", queryItems);
 
+            ClickhouseUtils.checkAsyncConfig(template, opikConfiguration.getAsyncInsert());
+
             Statement statement = connection.createStatement(template.render());
 
             int i = 0;
@@ -1100,9 +1102,7 @@ class SpanDAO {
         Optional.ofNullable(span.endTime())
                 .ifPresent(endTime -> template.add("end_time", endTime));
 
-        if (opikConfiguration.getAsyncInsert().enabled()) {
-            template.add("settings_clause", ClickhouseUtils.ASYNC_INSERT);
-        }
+        ClickhouseUtils.checkAsyncConfig(template, opikConfiguration.getAsyncInsert());
 
         return template;
     }
@@ -1220,9 +1220,7 @@ class SpanDAO {
     private ST newUpdateTemplate(SpanUpdate spanUpdate, String sql, boolean isManualCostExist) {
         var template = new ST(sql);
 
-        if (opikConfiguration.getAsyncInsert().enabled()) {
-            template.add("settings_clause", ClickhouseUtils.ASYNC_INSERT);
-        }
+        ClickhouseUtils.checkAsyncConfig(template, opikConfiguration.getAsyncInsert());
 
         if (StringUtils.isNotBlank(spanUpdate.name())) {
             template.add("name", spanUpdate.name());

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceConfigurationDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceConfigurationDAO.java
@@ -1,13 +1,16 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.WorkspaceConfiguration;
+import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
+import com.comet.opik.utils.ClickhouseUtils;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Singleton;
 import jakarta.inject.Inject;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.stringtemplate.v4.ST;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
@@ -40,7 +43,7 @@ class WorkspaceConfigurationDAOImpl implements WorkspaceConfigurationDAO {
                 last_updated_at,
                 created_by,
                 last_updated_by
-            )
+            ) <settings_clause>
             SELECT
                 new_config.workspace_id,
                 new_config.timeout_mark_thread_as_inactive,
@@ -72,13 +75,18 @@ class WorkspaceConfigurationDAOImpl implements WorkspaceConfigurationDAO {
             """;
 
     private final @NonNull TransactionTemplateAsync asyncTemplate;
+    private final @NonNull OpikConfiguration opikConfiguration;
 
     @Override
     public Mono<Long> upsertConfiguration(@NonNull String workspaceId,
             @NonNull WorkspaceConfiguration configuration) {
 
+        ST template = new ST(UPSERT_CONFIGURATION_SQL);
+
+        ClickhouseUtils.checkAsyncConfig(template, opikConfiguration.getAsyncInsert());
+
         return asyncTemplate.nonTransaction(connection -> {
-            var statement = connection.createStatement(UPSERT_CONFIGURATION_SQL)
+            var statement = connection.createStatement(template.render())
                     .bind("workspace_id", workspaceId);
 
             if (configuration.timeoutToMarkThreadAsInactive() != null) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentDAO.java
@@ -6,7 +6,9 @@ import com.comet.opik.api.attachment.AttachmentInfoHolder;
 import com.comet.opik.api.attachment.AttachmentSearchCriteria;
 import com.comet.opik.api.attachment.DeleteAttachmentsRequest;
 import com.comet.opik.api.attachment.EntityType;
+import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
+import com.comet.opik.utils.ClickhouseUtils;
 import com.google.inject.ImplementedBy;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.Result;
@@ -18,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.reactivestreams.Publisher;
+import org.stringtemplate.v4.ST;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -59,7 +62,7 @@ class AttachmentDAOImpl implements AttachmentDAO {
                 created_by,
                 last_updated_by,
                 last_updated_at
-            )
+            ) <settings_clause>
             VALUES
             (
                  :entity_id,
@@ -137,13 +140,18 @@ class AttachmentDAOImpl implements AttachmentDAO {
             """;
 
     private final @NonNull TransactionTemplateAsync asyncTemplate;
+    private final @NonNull OpikConfiguration opikConfiguration;
 
     @Override
     public Mono<Long> addAttachment(@NonNull AttachmentInfoHolder attachmentInfo,
             @NonNull String mimeType, long fileSize) {
         return asyncTemplate.nonTransaction(connection -> {
 
-            var statement = connection.createStatement(INSERT_ATTACHMENT);
+            ST template = new ST(INSERT_ATTACHMENT);
+
+            ClickhouseUtils.checkAsyncConfig(template, opikConfiguration.getAsyncInsert());
+
+            var statement = connection.createStatement(template.render());
 
             statement.bind("entity_id", attachmentInfo.entityId())
                     .bind("entity_type", attachmentInfo.entityType().getValue())

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/AutomationRuleEvaluatorLogsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/AutomationRuleEvaluatorLogsDAO.java
@@ -139,9 +139,7 @@ class AutomationRuleEvaluatorLogsDAOImpl implements AutomationRuleEvaluatorLogsD
                 .flatMapMany(connection -> {
                     var template = new ST(INSERT_STATEMENT);
 
-                    if (asyncInsertConfig.enabled()) {
-                        template.add("settings_clause", ClickhouseUtils.ASYNC_INSERT);
-                    }
+                    ClickhouseUtils.checkAsyncConfig(template, asyncInsertConfig);
 
                     List<QueryItem> queryItems = getQueryItemPlaceHolder(events.size());
                     template.add("items", queryItems);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadDAO.java
@@ -4,8 +4,10 @@ import com.comet.opik.api.TraceThreadSampling;
 import com.comet.opik.api.TraceThreadStatus;
 import com.comet.opik.api.TraceThreadUpdate;
 import com.comet.opik.api.events.ProjectWithPendingClosureTraceThreads;
+import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils;
+import com.comet.opik.utils.ClickhouseUtils;
 import com.comet.opik.utils.TemplateUtils;
 import com.google.inject.ImplementedBy;
 import io.r2dbc.spi.Connection;
@@ -72,6 +74,7 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
 
     private static final String INSERT_THREADS_SQL = """
             INSERT INTO trace_threads(workspace_id, project_id, thread_id, id, status, created_by, last_updated_by, created_at, last_updated_at, tags, sampling_per_rule, scored_at)
+            <settings_clause>
             VALUES
                 <items:{item |
                     (
@@ -98,7 +101,8 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
     private static final String UPDATE_THREAD_SQL = """
             INSERT INTO trace_threads (
             	workspace_id, project_id, thread_id, id, status, tags, created_by, last_updated_by, created_at, sampling_per_rule, scored_at
-            ) SELECT
+            ) <settings_clause>
+            SELECT
                 workspace_id,
                 project_id,
                 thread_id,
@@ -145,6 +149,7 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
 
     private static final String OPEN_CLOSURE_THREADS_SQL = """
             INSERT INTO trace_threads(workspace_id, project_id, thread_id, id, status, created_by, last_updated_by, created_at, last_updated_at, tags, sampling_per_rule, scored_at)
+            <settings_clause>
             SELECT
                 workspace_id, project_id, thread_id, id, :status AS new_status, created_by, :user_name, created_at, now64(6), tags, sampling_per_rule, NULL
             FROM trace_threads tt final
@@ -166,6 +171,7 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
 
     private static final String UPDATE_THREAD_SAMPLING_PER_RULE = """
             INSERT INTO trace_threads(workspace_id, project_id, thread_id, id, status, created_by, last_updated_by, created_at, last_updated_at, tags, sampling_per_rule, scored_at)
+            <settings_clause>
             SELECT
                 new_tt.workspace_id,
                 new_tt.project_id,
@@ -225,6 +231,7 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
 
     private static final String UPDATE_THREAD_SCORED_AT = """
             INSERT INTO trace_threads(workspace_id, project_id, thread_id, id, status, created_by, last_updated_by, created_at, last_updated_at, tags, sampling_per_rule, scored_at)
+            <settings_clause>
             SELECT
                 workspace_id,
                 project_id,
@@ -256,6 +263,7 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
             """;
 
     private final @NonNull TransactionTemplateAsync asyncTemplate;
+    private final @NonNull OpikConfiguration opikConfiguration;
 
     @Override
     public Mono<Long> save(@NonNull List<TraceThreadModel> traceThreads) {
@@ -268,7 +276,10 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
     private Mono<Long> mapAndInsert(List<TraceThreadModel> items, Connection connection, String sqlTemplate) {
 
         List<TemplateUtils.QueryItem> queryItems = getQueryItemPlaceHolder(items.size());
+
         var template = new ST(sqlTemplate).add("items", queryItems);
+
+        ClickhouseUtils.checkAsyncConfig(template, opikConfiguration.getAsyncInsert());
 
         String sql = template.render();
         var statement = connection.createStatement(sql);
@@ -368,6 +379,8 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
             ST openThreadsSql = new ST(OPEN_CLOSURE_THREADS_SQL);
             List<String> threadIds = List.of(threadId);
 
+            ClickhouseUtils.checkAsyncConfig(openThreadsSql, opikConfiguration.getAsyncInsert());
+
             openThreadsSql.add("thread_ids", threadIds);
 
             var statement = connection.createStatement(openThreadsSql.render())
@@ -389,6 +402,8 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
         return asyncTemplate.nonTransaction(connection -> {
             ST closureThreadsSql = new ST(OPEN_CLOSURE_THREADS_SQL);
             closureThreadsSql.add("thread_ids", threadIds);
+
+            ClickhouseUtils.checkAsyncConfig(closureThreadsSql, opikConfiguration.getAsyncInsert());
 
             var statement = connection.createStatement(closureThreadsSql.render())
                     .bind("project_id", projectId)
@@ -448,6 +463,8 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
 
             updateSamplingSql.add("items", queryItems);
 
+            ClickhouseUtils.checkAsyncConfig(updateSamplingSql, opikConfiguration.getAsyncInsert());
+
             var statement = connection.createStatement(updateSamplingSql.render())
                     .bind("project_id", projectId)
                     .bind("ids", threadSamplingPerRules.stream().map(TraceThreadSampling::threadModelId).toList());
@@ -496,6 +513,8 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
 
             var template = new ST(UPDATE_THREAD_SQL);
 
+            ClickhouseUtils.checkAsyncConfig(template, opikConfiguration.getAsyncInsert());
+
             Optional.ofNullable(threadUpdate.tags())
                     .ifPresent(tags -> template.add("tags", tags.toString()));
 
@@ -517,8 +536,12 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
             return Mono.just(0L);
         }
 
+        ST template = new ST(UPDATE_THREAD_SCORED_AT);
+
+        ClickhouseUtils.checkAsyncConfig(template, opikConfiguration.getAsyncInsert());
+
         return asyncTemplate.nonTransaction(connection -> {
-            var statement = connection.createStatement(UPDATE_THREAD_SCORED_AT)
+            var statement = connection.createStatement(template.render())
                     .bind("project_id", projectId)
                     .bind("thread_ids", threadIds)
                     .bind("scored_at", scoredAt.toString());

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/ClickhouseUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/ClickhouseUtils.java
@@ -1,6 +1,15 @@
 package com.comet.opik.utils;
 
+import com.comet.opik.infrastructure.AsyncInsertConfig;
+import org.stringtemplate.v4.ST;
+
 public class ClickhouseUtils {
 
     public static String ASYNC_INSERT = "SETTINGS async_insert=1, wait_for_async_insert=1, async_insert_use_adaptive_busy_timeout=1,async_insert_deduplicate=1";
+
+    public static void checkAsyncConfig(ST template, AsyncInsertConfig asyncInsert) {
+        if (asyncInsert.enabled()) {
+            template.add("settings_clause", ClickhouseUtils.ASYNC_INSERT);
+        }
+    }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -5069,6 +5069,9 @@ class TracesResourceTest {
 
             var projectId = getProjectId(projectName, workspaceName, apiKey);
 
+            // Wait for thread to be created
+            Mono.delay(Duration.ofMillis(250)).block();
+
             var createdThread = traceResourceClient.getTraceThread(threadId, projectId, apiKey, workspaceName);
 
             // Add tags to the thread


### PR DESCRIPTION
## Details

- We believe that to ensure the scalability of the platform, we believe that by default, all insert statements should leverage the async insert setup so that all inserts are buffered for an acceptable time window, which should reduce the number of parts created and reduce IO overhead.
