### PR TITLE
[OPIK-2160] Traces - filter on specific input keys

### DIFF
--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
@@ -366,7 +366,9 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
             if (
               filter.key &&
               filter.value &&
-              !/^((\$\.)?input|(\$\.)?output)(\.[^.]+)*$/.test(filter.key)
+              !/^((\$\.)?input|\$?input\[\d+\]|(\$\.)?output|\$?output\[\d+\])(\.[^.]+)*$/.test(
+                filter.key,
+              )
             ) {
               return `Key is invalid, it should begin with "input", or "output" and follow this format: "input.[PATH]" For example: "input.message" `;
             }


### PR DESCRIPTION
Fix validation to handle as well input[\d] and output[\d]
<img width="1728" height="934" alt="image" src="https://github.com/user-attachments/assets/8f1734f7-10c6-4e27-8ccf-2045a4f57bb0" />

## Details

## Issues

Resolves #

## Testing

## Documentation
