### PR TITLE
chore: add copilot bot to all bounty claim PRs

### DIFF
--- a/.github/workflows/bounty-pr-copilot-reviewer.yml
+++ b/.github/workflows/bounty-pr-copilot-reviewer.yml
@@ -1,0 +1,52 @@
+name: 🤖 Auto Assign Copilot Reviewer for Bounty Claims
+
+on:
+  pull_request:
+    types: [opened, labeled]
+
+jobs:
+  assign_copilot_reviewer:
+    name: Assign GitHub Copilot as Reviewer
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, '🙋 Bounty claim')
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Check if bounty claim label exists
+        id: check_label
+        run: |
+          echo "Checking for bounty claim label on PR #${{ github.event.pull_request.number }}"
+          LABELS=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json labels --jq '.labels[].name')
+          echo "PR labels: $LABELS"
+          
+          if echo "$LABELS" | grep -q "🙋 Bounty claim"; then
+            echo "bounty_claim=true" >> "$GITHUB_OUTPUT"
+            echo "Found bounty claim label"
+          else
+            echo "bounty_claim=false" >> "$GITHUB_OUTPUT"
+            echo "No bounty claim label found"
+          fi
+
+      - name: Request GitHub Copilot review
+        if: steps.check_label.outputs.bounty_claim == 'true'
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          
+          echo "Requesting GitHub Copilot review for bounty claim PR #$PR_NUMBER"
+          
+          # Add github-copilot[bot] as a reviewer
+          gh pr edit "$PR_NUMBER" --add-reviewer "github-copilot[bot]" --repo "${{ github.repository }}" || true
+          
+          echo "Successfully requested GitHub Copilot review for PR #$PR_NUMBER"
+          
+      - name: Add comment about Copilot review
+        if: steps.check_label.outputs.bounty_claim == 'true'
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          
+          # Add a comment explaining the automatic Copilot review
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "🤖 **GitHub Copilot has been automatically assigned as a reviewer** for this bounty claim PR. Copilot will provide an initial code review to help ensure code quality and security standards."


### PR DESCRIPTION
## Details
We want to ensure first line review of all external PRs but auto-assigning copilot bot to all bounty PRs.

## Issues
n/a

## Testing
tbd, would need to reviewed/tested - unable to test on my side without merging.

## Documentation
n/a