### PR TITLE
[NA] Use ApplicationShutdown for shutting down jobs

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListener.java
@@ -41,9 +41,7 @@ public class OpikGuiceyLifecycleEventListener implements GuiceyLifecycleListener
                 setTraceThreadsClosingJob();
             }
 
-            case GuiceyLifecycle.ApplicationStopped -> {
-                shutdownJobManager();
-            }
+            case GuiceyLifecycle.ApplicationShutdown -> shutdownJobManager();
         }
     }
 


### PR DESCRIPTION
## Details
## Pull Request Overview

This PR updates the lifecycle event handling for job manager shutdown by changing from `ApplicationStopped` to `ApplicationShutdown` event. This ensures the job manager is shut down earlier in the application lifecycle, which is typically more appropriate for resource cleanup.

- Changes the Guicey lifecycle event from `ApplicationStopped` to `ApplicationShutdown`

## Issues
N/A

## Testing
- Tested locally.

## Documentation
- https://xvik.github.io/dropwizard-guicey/7.0.2/guide/events/#events
