### PR TITLE
[OPIK-2213] Add `experimentId` to experiment items bulk

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentItemBulkUpload.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentItemBulkUpload.java
@@ -14,10 +14,13 @@ import lombok.Builder;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Request object for bulk uploading experiment items.
  * The total size of the request is limited to 4MB.
+ * If experimentId is provided, items will be added to the existing experiment.
+ * If experimentId is not provided, a new experiment will be created.
  */
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -27,6 +30,8 @@ public record ExperimentItemBulkUpload(
         @JsonView( {
                 View.ExperimentItemBulkWriteView.class}) @NotBlank String experimentName,
         @JsonView({View.ExperimentItemBulkWriteView.class}) @NotBlank String datasetName,
+        @JsonView({
+                View.ExperimentItemBulkWriteView.class}) UUID experimentId,
         @JsonView({
                 View.ExperimentItemBulkWriteView.class}) @NotNull @Size(min = 1, max = 250) @Valid List<ExperimentItemBulkRecord> items)
         implements

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentItemBulkUpload.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentItemBulkUpload.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -19,8 +20,6 @@ import java.util.UUID;
 /**
  * Request object for bulk uploading experiment items.
  * The total size of the request is limited to 4MB.
- * If experimentId is provided, items will be added to the existing experiment.
- * If experimentId is not provided, a new experiment will be created.
  */
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -30,8 +29,10 @@ public record ExperimentItemBulkUpload(
         @JsonView( {
                 View.ExperimentItemBulkWriteView.class}) @NotBlank String experimentName,
         @JsonView({View.ExperimentItemBulkWriteView.class}) @NotBlank String datasetName,
-        @JsonView({
-                View.ExperimentItemBulkWriteView.class}) UUID experimentId,
+        @JsonView({View.ExperimentItemBulkWriteView.class}) @Schema(description = "Optional experiment ID. If " +
+                "provided, items will be added to the existing experiment and experimentName will be ignored. If not " +
+                "provided or experiment with that ID doesn't exist, a new experiment will be created with the given " +
+                "experimentName") UUID experimentId,
         @JsonView({
                 View.ExperimentItemBulkWriteView.class}) @NotNull @Size(min = 1, max = 250) @Valid List<ExperimentItemBulkRecord> items)
         implements

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -418,7 +418,6 @@ public class ExperimentsResource {
             "Maximum request size is 4MB.", responses = {
                     @ApiResponse(responseCode = "204", description = "No content"),
                     @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
-                    @ApiResponse(responseCode = "404", description = "Experiment not found", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
                     @ApiResponse(responseCode = "409", description = "Experiment dataset mismatch", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
                     @ApiResponse(responseCode = "422", description = "Unprocessable Content", content = @Content(schema = @Schema(implementation = com.comet.opik.api.error.ErrorMessage.class))),
             })
@@ -443,7 +442,7 @@ public class ExperimentsResource {
                 .toList();
 
         Experiment experiment = Experiment.builder()
-                .id(request.experimentId()) // May be null for new experiments
+                .id(request.experimentId())
                 .datasetName(request.datasetName())
                 .name(request.experimentName())
                 .build();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -418,6 +418,8 @@ public class ExperimentsResource {
             "Maximum request size is 4MB.", responses = {
                     @ApiResponse(responseCode = "204", description = "No content"),
                     @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
+                    @ApiResponse(responseCode = "404", description = "Experiment not found", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
+                    @ApiResponse(responseCode = "409", description = "Experiment dataset mismatch", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
                     @ApiResponse(responseCode = "422", description = "Unprocessable Content", content = @Content(schema = @Schema(implementation = com.comet.opik.api.error.ErrorMessage.class))),
             })
     @RateLimited
@@ -428,7 +430,8 @@ public class ExperimentsResource {
         String workspaceId = requestContext.get().getWorkspaceId();
         String userName = requestContext.get().getUserName();
 
-        log.info("Recording experiment items in bulk, count '{}'", request.items().size());
+        log.info("Recording experiment items in bulk, count '{}', experimentId '{}'", request.items().size(),
+                request.experimentId());
 
         List<ExperimentItemBulkRecord> items = request.items()
                 .stream()
@@ -440,6 +443,7 @@ public class ExperimentsResource {
                 .toList();
 
         Experiment experiment = Experiment.builder()
+                .id(request.experimentId()) // May be null for new experiments
                 .datasetName(request.datasetName())
                 .name(request.experimentName())
                 .build();
@@ -450,7 +454,8 @@ public class ExperimentsResource {
                 .retryWhen(AsyncUtils.handleConnectionError())
                 .block();
 
-        log.info("Recorded experiment items in bulk, count '{}'", request.items().size());
+        log.info("Recorded experiment items in bulk, count '{}', experimentId '{}'", request.items().size(),
+                request.experimentId());
 
         return Response.noContent().build();
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
@@ -123,6 +123,12 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
                                 experiment.datasetName() + "'";
                         return Mono.error(new ClientErrorException(errorMessage, Response.Status.CONFLICT));
                     }
+                    if (!experiment.name().equals(existingExperiment.name())) {
+                        String errorMessage = "Experiment '" + experiment.id() + "' has name '" +
+                                existingExperiment.name() + "', but request specifies a different name '" +
+                                experiment.name() + "'";
+                        return Mono.error(new ClientErrorException(errorMessage, Response.Status.CONFLICT));
+                    }
                     return Mono.<Void>empty();
                 });
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
@@ -115,17 +115,15 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
                 .flatMap(existingExperiment -> {
                     // Validate dataset consistency
                     if (!experiment.datasetName().equals(existingExperiment.datasetName())) {
-                        String errorMessage = "Experiment '" + experiment.id() + "' belongs to dataset '" +
-                                existingExperiment.datasetName() + "', but request specifies dataset '" +
-                                experiment.datasetName() + "'";
+                        String errorMessage = "Experiment '%s' belongs to dataset '%s', but request specifies dataset '%s'"
+                                .formatted(experiment.id(), existingExperiment.datasetName(), experiment.datasetName());
                         return Mono.error(new ClientErrorException(errorMessage, Response.Status.CONFLICT));
                     }
 
                     // Validate experiment name consistency
                     if (!experiment.name().equals(existingExperiment.name())) {
-                        String errorMessage = "Experiment '" + experiment.id() + "' has name '" +
-                                existingExperiment.name() + "', but request specifies a different name '" +
-                                experiment.name() + "'";
+                        String errorMessage = "Experiment '%s' has name '%s', but request specifies a different name '%s'"
+                                .formatted(experiment.id(), existingExperiment.name(), experiment.name());
                         return Mono.error(new ClientErrorException(errorMessage, Response.Status.CONFLICT));
                     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
@@ -37,7 +37,7 @@ public interface ExperimentItemBulkIngestionService {
     /**
      * Ingests a batch of experiment items.
      *
-     * @param experiment the experiment to add items to (may have null ID for new experiments)
+     * @param experiment the experiment to add items to
      * @param items the list of experiment items to ingest
      * @return a list of feedback score batch items
      */
@@ -59,7 +59,7 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
     /**
      * Ingests a batch of experiment items.
      *
-     * @param experiment the experiment to add items to (may have null ID for new experiments)
+     * @param experiment the experiment to add items to
      * @param items the list of experiment items to ingest
      * @return a list of feedback score batch items
      */

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
@@ -120,13 +120,6 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
                         return Mono.error(new ClientErrorException(errorMessage, Response.Status.CONFLICT));
                     }
 
-                    // Validate experiment name consistency
-                    if (!experiment.name().equals(existingExperiment.name())) {
-                        String errorMessage = "Experiment '%s' has name '%s', but request specifies a different name '%s'"
-                                .formatted(experiment.id(), existingExperiment.name(), experiment.name());
-                        return Mono.error(new ClientErrorException(errorMessage, Response.Status.CONFLICT));
-                    }
-
                     return Mono.<Void>empty();
                 })
                 .onErrorResume(NotFoundException.class, ex -> {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -5086,8 +5086,8 @@ class ExperimentsResourceTest {
 
                 var errorMessage = response.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class);
                 assertThat(errorMessage.getMessage()).contains(
-                        "Experiment '" + experimentId + "' belongs to dataset '" + dataset1.name() +
-                                "', but request specifies dataset '" + dataset2.name() + "'");
+                        "Experiment '%s' belongs to dataset '%s', but request specifies dataset '%s'"
+                                .formatted(experimentId, dataset1.name(), dataset2.name()));
             }
 
             // Verify only the first experiment items were created
@@ -5151,9 +5151,8 @@ class ExperimentsResourceTest {
 
                 var errorMessage = response.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class);
                 assertThat(errorMessage.getMessage()).contains(
-                        "Experiment '" + experimentId + "' has name '" +
-                                experimentName + "', but request specifies a different name '" +
-                                anotherExperimentName + "'");
+                        "Experiment '%s' has name '%s', but request specifies a different name '%s'"
+                                .formatted(experimentId, experimentName, anotherExperimentName));
             }
 
             // Verify only the first experiment items were created

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -5027,11 +5027,15 @@ class ExperimentsResourceTest {
             var experimentId = podamFactory.manufacturePojo(UUID.class);
             var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
 
-            // Create first bulk upload with the experiment ID
             var trace1 = createTrace();
+            var span1 = creatrSpan();
+            var feedbackScore1 = createScore();
+
             var bulkRecord1 = ExperimentItemBulkRecord.builder()
                     .datasetItemId(datasetItem1.id())
                     .trace(trace1)
+                    .spans(List.of(span1))
+                    .feedbackScores(List.of(feedbackScore1))
                     .build();
 
             var bulkUpload1 = ExperimentItemBulkUpload.builder()
@@ -5056,9 +5060,13 @@ class ExperimentsResourceTest {
 
             // Create second bulk upload with the same experiment ID but different dataset
             var trace2 = createTrace();
+            var span2 = creatrSpan();
+            var feedbackScore2 = createScore();
             var bulkRecord2 = ExperimentItemBulkRecord.builder()
                     .datasetItemId(datasetItem2.id())
                     .trace(trace2)
+                    .spans(List.of(span2))
+                    .feedbackScores(List.of(feedbackScore2))
                     .build();
 
             var bulkUpload2 = ExperimentItemBulkUpload.builder()


### PR DESCRIPTION
## Details
The purpose of this change is to support adding experiment items to existing experiments by specifying an experiment id to the experiment items bulk request payload.

To preserve consistency, experiment name and dataset are validated to be the same as the original experiment (if exists).

## Issues
OPIK-2213

## Testing
Added the following resources tests:
- Happy path: add experiment items in 2 bulks
- Dataset consistency: second bulk request with a different dataset will result in `409`
- Experiment name consistency: second bulk request with a different name will result in `409`
