### PR TITLE
NA: Hardcode tiktoken version

### DIFF
--- a/apps/opik-python-backend/requirements.txt
+++ b/apps/opik-python-backend/requirements.txt
@@ -23,3 +23,4 @@ opentelemetry-exporter-prometheus==0.52b1
 opentelemetry-instrumentation-flask==0.52b1
 prometheus-client==0.21.1
 schedule==1.2.1
+tiktoken==0.9.0


### PR DESCRIPTION
## Details

For some reason, when running a build from scratch, a dependency conflict occurs with the tiktoken package. To avoid that, I'm hardcoding the same dependency version we have for the Python sandbox image.
 
```
14.71 Building wheels for collected packages: tiktoken
14.71   Building wheel for tiktoken (pyproject.toml): started
14.99   Building wheel for tiktoken (pyproject.toml): finished with status 'error'
14.99   error: subprocess-exited-with-error
14.99   
14.99   × Building wheel for tiktoken (pyproject.toml) did not run successfully.
14.99   │ exit code: 1
14.99   ╰─> [50 lines of output]
14.99       /tmp/pip-build-env-t33_8uce/overlay/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
14.99       !!
14.99       
14.99               ********************************************************************************
14.99               Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
14.99       
14.99               By 2026-Feb-18, you need to update your project and remove deprecated calls
14.99               or your builds will no longer be supported.
14.99       
14.99               See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
14.99               ********************************************************************************
14.99       
14.99       !!
14.99         corresp(dist, value, root_dir)
14.99       running bdist_wheel
14.99       running build
14.99       running build_py
14.99       creating build/lib.linux-aarch64-cpython-312/tiktoken
14.99       copying tiktoken/model.py -> build/lib.linux-aarch64-cpython-312/tiktoken
14.99       copying tiktoken/core.py -> build/lib.linux-aarch64-cpython-312/tiktoken
14.99       copying tiktoken/__init__.py -> build/lib.linux-aarch64-cpython-312/tiktoken
14.99       copying tiktoken/load.py -> build/lib.linux-aarch64-cpython-312/tiktoken
14.99       copying tiktoken/registry.py -> build/lib.linux-aarch64-cpython-312/tiktoken
14.99       copying tiktoken/_educational.py -> build/lib.linux-aarch64-cpython-312/tiktoken
14.99       creating build/lib.linux-aarch64-cpython-312/tiktoken_ext
14.99       copying tiktoken_ext/openai_public.py -> build/lib.linux-aarch64-cpython-312/tiktoken_ext
14.99       running egg_info
14.99       writing tiktoken.egg-info/PKG-INFO
14.99       writing dependency_links to tiktoken.egg-info/dependency_links.txt
14.99       writing requirements to tiktoken.egg-info/requires.txt
14.99       writing top-level names to tiktoken.egg-info/top_level.txt
14.99       reading manifest file 'tiktoken.egg-info/SOURCES.txt'
14.99       reading manifest template 'MANIFEST.in'
14.99       warning: no files found matching 'Makefile'
14.99       adding license file 'LICENSE'
14.99       writing manifest file 'tiktoken.egg-info/SOURCES.txt'
14.99       copying tiktoken/py.typed -> build/lib.linux-aarch64-cpython-312/tiktoken
14.99       running build_ext
14.99       running build_rust
14.99       error: failed to parse manifest at `/tmp/pip-install-dr6f242q/tiktoken_fcc31a9b525645f598d8f207a86a75df/Cargo.toml`
14.99       
14.99       Caused by:
14.99         feature `edition2024` is required
14.99       
14.99         The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.83.0 (5ffbef321 2024-10-29)).
14.99         Consider trying a newer version of Cargo (this may require the nightly release).
14.99         See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
14.99       error: `cargo metadata --manifest-path Cargo.toml --format-version 1` failed with code 101
14.99       -- Output captured from stdout:
14.99       
14.99       [end of output]
14.99   
14.99   note: This error originates from a subprocess, and is likely not a problem with pip.
14.99   ERROR: Failed building wheel for tiktoken
14.99 Failed to build tiktoken
15.12 ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (tiktoken)
------
Dockerfile:8

--------------------

   6 |     

   7 |     COPY requirements.txt .

   8 | >>> RUN pip install --no-cache-dir -r requirements.txt --break-system-packages

   9 |     

  10 |     ENV PYTHON_CODE_EXECUTOR_ASSET_NAME="opik-sandbox-executor-python"

--------------------

target python-backend: failed to solve: process "/bin/sh -c pip install --no-cache-dir -r requirements.txt --break-system-packages" did not complete successfully: exit code: 1
```

After:
<img width="915" height="482" alt="Screenshot 2025-08-11 at 12 01 00" src="https://github.com/user-attachments/assets/e49bbcd4-aa42-4af5-9e9b-a2e89f7fb2d7" />

