### PR TITLE
[OPIK-2073] Fix 500 error for illegal base64 character

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentService.java
@@ -17,6 +17,7 @@ import com.google.inject.ImplementedBy;
 import com.google.inject.Singleton;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
@@ -293,6 +294,11 @@ class AttachmentServiceImpl implements AttachmentService {
     }
 
     private String decodeBaseUrl(String baseUrlEncoded) {
-        return new String(Base64.getUrlDecoder().decode(baseUrlEncoded), StandardCharsets.UTF_8);
+        try {
+            return new String(Base64.getUrlDecoder().decode(baseUrlEncoded), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            log.error("Failed to decode base URL: {}", baseUrlEncoded, e);
+            throw new BadRequestException("Invalid base URL format");
+        }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AttachmentResourceMinIOTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AttachmentResourceMinIOTest.java
@@ -179,6 +179,14 @@ class AttachmentResourceMinIOTest {
         attachmentResourceClient.downloadFile(downloadLink, API_KEY, 404);
     }
 
+    @Test
+    @DisplayName("Invalid base URL format returns error for MinIO attachment upload")
+    void invalidBaseUrlFormatReturnsError() {
+        StartMultipartUploadRequest startUploadRequest = prepareStartUploadRequest("https://www.comet.com/");
+        attachmentResourceClient
+                .startMultiPartUpload(startUploadRequest, API_KEY, TEST_WORKSPACE, 400);
+    }
+
     @ParameterizedTest
     @MethodSource
     void deleteTraceDeletesTraceAndSpanAttachments(Consumer<UUID> deleteTrace) throws IOException {
@@ -249,7 +257,7 @@ class AttachmentResourceMinIOTest {
     Pair<StartMultipartUploadRequest, byte[]> uploadFile(String projectName, EntityType type, UUID entityId)
             throws IOException {
         // Initiate upload
-        StartMultipartUploadRequest startUploadRequest = prepareStartUploadRequest();
+        StartMultipartUploadRequest startUploadRequest = prepareStartUploadRequest(baseURIEncoded);
         if (projectName != null) {
             startUploadRequest = startUploadRequest.toBuilder()
                     .projectName(projectName)
@@ -278,7 +286,7 @@ class AttachmentResourceMinIOTest {
         return Pair.of(startUploadRequest, fileData);
     }
 
-    private StartMultipartUploadRequest prepareStartUploadRequest() {
+    private StartMultipartUploadRequest prepareStartUploadRequest(String baseURIEncoded) {
         return factory.manufacturePojo(StartMultipartUploadRequest.class)
                 .toBuilder()
                 .path(baseURIEncoded)


### PR DESCRIPTION
## Details
Fix 500 error for illegal base64 character

## Change checklist
- [ ] User facing
- [x] Bug
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2073

## Testing
Integration test added
