### PR TITLE
[OPIK-2205] [BE] apply multi-value feedback scores changes to all entities

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -236,14 +236,44 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
      * Counts dataset items only if there's a matching experiment item.
      */
     private static final String SELECT_DATASET_ITEMS_WITH_EXPERIMENT_ITEMS_COUNT = """
+            WITH feedback_scores_combined AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       value,
+                       last_updated_at
+                FROM feedback_scores FINAL
+                WHERE entity_type = 'trace'
+                  AND workspace_id = :workspace_id
+                UNION ALL
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       value,
+                       last_updated_at
+                 FROM authored_feedback_scores FINAL
+                 WHERE entity_type = 'trace'
+                   AND workspace_id = :workspace_id
+             ), feedback_scores_final AS (
+                SELECT
+                    workspace_id,
+                    project_id,
+                    entity_id,
+                    name,
+                    if(count() = 1, any(value), toDecimal64(avg(value), 9)) AS value,
+                    max(last_updated_at) AS last_updated_at
+                FROM feedback_scores_combined
+                GROUP BY workspace_id, project_id, entity_id, name
+            )
             <if(feedback_scores_empty_filters)>
-            WITH fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
+            , fsc AS (
+                SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
                 FROM (
                     SELECT *
-                    FROM feedback_scores
-                    WHERE entity_type = 'trace'
-                    AND workspace_id = :workspace_id
-                    ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
+                    FROM feedback_scores_final
+                    ORDER BY (workspace_id, project_id, entity_id, name) DESC, last_updated_at DESC
                     LIMIT 1 BY entity_id, name
                  )
                  GROUP BY entity_id
@@ -287,10 +317,8 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                             entity_id
                         FROM (
                             SELECT *
-                            FROM feedback_scores
-                            WHERE entity_type = 'trace'
-                            AND workspace_id = :workspace_id
-                            ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
+                            FROM feedback_scores_final
+                            ORDER BY (workspace_id, project_id, entity_id, name) DESC, last_updated_at DESC
                             LIMIT 1 BY entity_id, name
                         )
                         GROUP BY entity_id
@@ -367,24 +395,83 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                 AND experiment_id IN :experimentIds
                 ORDER BY (workspace_id, experiment_id, dataset_item_id, trace_id, id) DESC, last_updated_at DESC
             	LIMIT 1 BY id
-            ), feedback_scores_final AS (
-            	SELECT
-                	entity_id,
+            ), feedback_scores_combined AS (
+                SELECT
+                    workspace_id,
+                    project_id,
+                    entity_id,
                     name,
                     category_name,
                     value,
                     reason,
                     source,
+                    created_by,
+                    last_updated_by,
                     created_at,
                     last_updated_at,
+                    feedback_scores.last_updated_by AS author
+                FROM feedback_scores FINAL
+                WHERE entity_type = :entityType
+                  AND workspace_id = :workspace_id
+                  AND entity_id IN (SELECT trace_id FROM experiment_items_scope)
+                UNION ALL
+                SELECT
+                    workspace_id,
+                    project_id,
+                    entity_id,
+                    name,
+                    category_name,
+                    value,
+                    reason,
+                    source,
                     created_by,
-                    last_updated_by
-                FROM feedback_scores
-                WHERE workspace_id = :workspace_id
-                AND entity_type = :entityType
-                AND entity_id IN (SELECT trace_id FROM experiment_items_scope)
-                ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
-                LIMIT 1 BY entity_id, name
+                    last_updated_by,
+                    created_at,
+                    last_updated_at,
+                    author
+                FROM authored_feedback_scores FINAL
+                WHERE entity_type = :entityType
+                  AND workspace_id = :workspace_id
+                  AND entity_id IN (SELECT trace_id FROM experiment_items_scope)
+            ), feedback_scores_combined_grouped AS (
+                SELECT
+                    workspace_id,
+                    project_id,
+                    entity_id,
+                    name,
+                    groupArray(value) AS values,
+                    groupArray(reason) AS reasons,
+                    groupArray(category_name) AS categories,
+                    groupArray(author) AS authors,
+                    groupArray(source) AS sources,
+                    groupArray(created_by) AS created_bies,
+                    groupArray(last_updated_by) AS updated_bies,
+                    groupArray(created_at) AS created_ats,
+                    groupArray(last_updated_at) AS last_updated_ats
+                FROM feedback_scores_combined
+                GROUP BY workspace_id, project_id, entity_id, name
+            ), feedback_scores_final AS (
+                SELECT
+                    workspace_id,
+                    project_id,
+                    entity_id,
+                    name,
+                    arrayStringConcat(categories, ', ') AS category_name,
+                    IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
+                    arrayStringConcat(reasons, ', ') AS reason,
+                    arrayElement(sources, 1) AS source,
+                    mapFromArrays(
+                        authors,
+                        arrayMap(
+                            i -> tuple(values[i], reasons[i], categories[i], sources[i], last_updated_ats[i]),
+                            arrayEnumerate(values)
+                        )
+                    ) AS value_by_author,
+                    arrayStringConcat(created_bies, ', ') AS created_by,
+                    arrayStringConcat(updated_bies, ', ') AS last_updated_by,
+                    arrayMin(created_ats) AS created_at,
+                    arrayMax(last_updated_ats) AS last_updated_at
+                FROM feedback_scores_combined_grouped
             ), comments_final AS (
                 SELECT
                     id AS comment_id,
@@ -482,7 +569,19 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                     t.visibility_mode,
                     s.total_estimated_cost,
                     s.usage,
-                    groupUniqArray(tuple(fs.*)) AS feedback_scores_array,
+                    groupUniqArray(tuple(
+                        fs.entity_id,
+                        fs.name,
+                        fs.category_name,
+                        fs.value,
+                        fs.reason,
+                        fs.source,
+                        fs.created_at,
+                        fs.last_updated_at,
+                        fs.created_by,
+                        fs.last_updated_by,
+                        fs.value_by_author
+                    )) AS feedback_scores_array,
                     groupUniqArray(tuple(c.*)) AS comments_array_agg
                 FROM (
                     SELECT

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -442,23 +442,15 @@ class ExperimentDAO {
                 WHERE entity_type = 'trace'
                    AND workspace_id = :workspace_id
                    AND entity_id IN (SELECT trace_id FROM experiment_items_final)
-            ), feedback_scores_combined_grouped AS (
-                SELECT
-                    workspace_id,
-                    project_id,
-                    entity_id,
-                    name,
-                    groupArray(value) AS values
-                FROM feedback_scores_combined
-                GROUP BY workspace_id, project_id, entity_id, name
             ), feedback_scores_final AS (
                 SELECT
                     workspace_id,
                     project_id,
                     entity_id,
                     name,
-                    IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value
-                FROM feedback_scores_combined_grouped
+                    if(count() = 1, any(value), toDecimal64(avg(value), 9)) AS value
+                FROM feedback_scores_combined
+                GROUP BY workspace_id, project_id, entity_id, name
             ),
             feedback_scores_agg AS (
                 SELECT

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -477,8 +477,6 @@ class ExperimentDAO {
                             entity_id AS trace_id,
                             value
                         FROM feedback_scores_final
-                        WHERE workspace_id = :workspace_id
-                        AND entity_id IN (SELECT trace_id FROM experiment_items_final)
                     ) fs ON fs.trace_id = et.trace_id
                     GROUP BY et.experiment_id, fs.name
                     HAVING length(fs.name) > 0

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -199,6 +199,44 @@ class ExperimentDAO {
                     ) AS s ON ei.trace_id = s.trace_id
                 )
                 GROUP BY experiment_id
+            ), feedback_scores_combined AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       value
+                FROM feedback_scores FINAL
+                WHERE entity_type = 'trace'
+                  AND workspace_id = :workspace_id
+                  AND entity_id IN (SELECT trace_id FROM experiment_items_final)
+                UNION ALL
+                SELECT
+                    workspace_id,
+                    project_id,
+                    entity_id,
+                    name,
+                    value
+                FROM authored_feedback_scores FINAL
+                WHERE entity_type = 'trace'
+                   AND workspace_id = :workspace_id
+                   AND entity_id IN (SELECT trace_id FROM experiment_items_final)
+            ), feedback_scores_combined_grouped AS (
+                SELECT
+                    workspace_id,
+                    project_id,
+                    entity_id,
+                    name,
+                    groupArray(value) AS values
+                FROM feedback_scores_combined
+                GROUP BY workspace_id, project_id, entity_id, name
+            ), feedback_scores_final AS (
+                SELECT
+                    workspace_id,
+                    project_id,
+                    entity_id,
+                    name,
+                    IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value
+                FROM feedback_scores_combined_grouped
             ),
             feedback_scores_agg AS (
                 SELECT
@@ -224,9 +262,8 @@ class ExperimentDAO {
                             name,
                             entity_id AS trace_id,
                             value
-                        FROM feedback_scores final
+                        FROM feedback_scores_final
                         WHERE workspace_id = :workspace_id
-                        AND entity_type = 'trace'
                         AND entity_id IN (SELECT trace_id FROM experiment_items_final)
                     ) fs ON fs.trace_id = et.trace_id
                     GROUP BY et.experiment_id, fs.name
@@ -386,6 +423,44 @@ class ExperimentDAO {
                     ) AS s ON ei.trace_id = s.trace_id
                 )
                 GROUP BY experiment_id
+            ), feedback_scores_combined AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       value
+                FROM feedback_scores FINAL
+                WHERE entity_type = 'trace'
+                  AND workspace_id = :workspace_id
+                  AND entity_id IN (SELECT trace_id FROM experiment_items_final)
+                UNION ALL
+                SELECT
+                    workspace_id,
+                    project_id,
+                    entity_id,
+                    name,
+                    value
+                FROM authored_feedback_scores FINAL
+                WHERE entity_type = 'trace'
+                   AND workspace_id = :workspace_id
+                   AND entity_id IN (SELECT trace_id FROM experiment_items_final)
+            ), feedback_scores_combined_grouped AS (
+                SELECT
+                    workspace_id,
+                    project_id,
+                    entity_id,
+                    name,
+                    groupArray(value) AS values
+                FROM feedback_scores_combined
+                GROUP BY workspace_id, project_id, entity_id, name
+            ), feedback_scores_final AS (
+                SELECT
+                    workspace_id,
+                    project_id,
+                    entity_id,
+                    name,
+                    IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value
+                FROM feedback_scores_combined_grouped
             ),
             feedback_scores_agg AS (
                 SELECT
@@ -411,9 +486,8 @@ class ExperimentDAO {
                             name,
                             entity_id AS trace_id,
                             value
-                        FROM feedback_scores final
+                        FROM feedback_scores_final
                         WHERE workspace_id = :workspace_id
-                        AND entity_type = 'trace'
                         AND entity_id IN (SELECT trace_id FROM experiment_items_final)
                     ) fs ON fs.trace_id = et.trace_id
                     GROUP BY et.experiment_id, fs.name

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -263,8 +263,6 @@ class ExperimentDAO {
                             entity_id AS trace_id,
                             value
                         FROM feedback_scores_final
-                        WHERE workspace_id = :workspace_id
-                        AND entity_id IN (SELECT trace_id FROM experiment_items_final)
                     ) fs ON fs.trace_id = et.trace_id
                     GROUP BY et.experiment_id, fs.name
                     HAVING length(fs.name) > 0

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
@@ -150,6 +150,7 @@ public interface FeedbackScoreMapper {
                             .lastUpdatedAt(Instant.parse(feedbackScore.get(7).toString()))
                             .createdBy(feedbackScore.get(8).toString())
                             .lastUpdatedBy(feedbackScore.get(9).toString())
+                            .valueByAuthor(parseValueByAuthor(feedbackScore.get(10)))
                             .build())
                     .toList();
             return feedbackScores.isEmpty() ? null : feedbackScores;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
@@ -185,8 +185,6 @@ class OptimizationDAOImpl implements OptimizationDAO {
                             entity_id AS trace_id,
                             value
                         FROM feedback_scores_final
-                        WHERE workspace_id = :workspace_id
-                        AND entity_id IN (SELECT trace_id FROM experiment_items_final)
                     ) fs ON fs.trace_id = et.trace_id
                     GROUP BY et.experiment_id, fs.name
                     HAVING length(fs.name) > 0

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
@@ -129,6 +129,43 @@ class OptimizationDAOImpl implements OptimizationDAO {
                 AND experiment_id IN (SELECT id FROM experiments_final)
                 ORDER BY id DESC, last_updated_at DESC
                 LIMIT 1 BY id
+            ), feedback_scores_combined AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       value
+                FROM feedback_scores FINAL
+                WHERE entity_type = :entity_type
+                  AND workspace_id = :workspace_id
+                  AND entity_id IN (SELECT trace_id FROM experiment_items_final)
+                UNION ALL
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       value
+                FROM authored_feedback_scores FINAL
+                WHERE entity_type = :entity_type
+                  AND workspace_id = :workspace_id
+                  AND entity_id IN (SELECT trace_id FROM experiment_items_final)
+            ), feedback_scores_combined_grouped AS (
+                SELECT
+                    workspace_id,
+                    project_id,
+                    entity_id,
+                    name,
+                    groupArray(value) AS values
+                FROM feedback_scores_combined
+                GROUP BY workspace_id, project_id, entity_id, name
+            ), feedback_scores_final AS (
+                SELECT
+                    workspace_id,
+                    project_id,
+                    entity_id,
+                    name,
+                    IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value
+                FROM feedback_scores_combined_grouped
             ), feedback_scores_agg AS (
                 SELECT
                     experiment_id,
@@ -147,9 +184,8 @@ class OptimizationDAOImpl implements OptimizationDAO {
                             name,
                             entity_id AS trace_id,
                             value
-                        FROM feedback_scores final
+                        FROM feedback_scores_final
                         WHERE workspace_id = :workspace_id
-                        AND entity_type = :entity_type
                         AND entity_id IN (SELECT trace_id FROM experiment_items_final)
                     ) fs ON fs.trace_id = et.trace_id
                     GROUP BY et.experiment_id, fs.name

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/FeedbackScoreAssertionUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/FeedbackScoreAssertionUtils.java
@@ -39,6 +39,7 @@ public class FeedbackScoreAssertionUtils {
                                 .lastUpdatedBy(null)
                                 .createdAt(null)
                                 .lastUpdatedAt(null)
+                                .valueByAuthor(null)
                                 .build())
                         .toList())
                 .build();


### PR DESCRIPTION
## Details
This PR continues the effort from #2935. It adds multi-value feedback scores capabilities to all entities that weren't covered by the previous PR.

**Comment:** Changes were not applied to `WorkspaceMetricsDAO` as its related resource is currently not in use, and it is not clear whether it will be used any time soon.

## Issues
OPIK-2205

## Testing
Regression is covered by existing tests.
Tested manually for inserting entries to `authored_feedback_scores`:
- `ProjectMetricsDAO`: made sure results are aggregated in the project metrics page
- `ExperimentDAO`: made sure results are aggregated in the experiments page
- `ExperimentItemDAO`: invoked `http://localhost:8080/v1/private/experiments/items/stream` using `curl` and made sure results are aggregated
- `DatasetItemDAO`: drilled down an experiment and made sure the results are aggregated as expected and filtering works properly with the aggregated results
- `OptimizationDAO`: made sure the results for an optimization run are aggregated
