### PR TITLE
Alexkuzmik/opik 2206 sdk python configuration error opik url is not specified please set your opik instance url using the environment variable opik url override

### DIFF
--- a/sdks/python/src/opik/configurator/configure.py
+++ b/sdks/python/src/opik/configurator/configure.py
@@ -48,7 +48,9 @@ class OpikConfigurator:
         # It's possible that the URL will be extracted from the smart api key on the later stage.
         # In that case `self.base_url` field will be updated.
         if url is None:
-            self.base_url = OPIK_BASE_URL_LOCAL if self.use_local else OPIK_BASE_URL_CLOUD
+            self.base_url = (
+                OPIK_BASE_URL_LOCAL if self.use_local else OPIK_BASE_URL_CLOUD
+            )
         else:
             self.base_url = url_helpers.get_base_url(url)
 

--- a/sdks/python/src/opik/configurator/configure.py
+++ b/sdks/python/src/opik/configurator/configure.py
@@ -47,9 +47,10 @@ class OpikConfigurator:
         # This URL set here might not be the final one.
         # It's possible that the URL will be extracted from the smart api key on the later stage.
         # In that case `self.base_url` field will be updated.
-        self.base_url = (
-            OPIK_BASE_URL_CLOUD if url is None else url_helpers.get_base_url(url)
-        )
+        if url is None:
+            self.base_url = OPIK_BASE_URL_LOCAL if self.use_local else OPIK_BASE_URL_CLOUD
+        else:
+            self.base_url = url_helpers.get_base_url(url)
 
     def configure(self) -> None:
         """

--- a/sdks/python/tests/unit/configurator/test_configure.py
+++ b/sdks/python/tests/unit/configurator/test_configure.py
@@ -1097,7 +1097,6 @@ class TestConfigureLocal:
         assert configurator.api_key is None
         assert configurator.base_url == "http://custom-local-instance.com/"
         assert configurator.workspace == OPIK_WORKSPACE_DEFAULT_NAME
-    
 
     @patch("opik.configurator.configure.OpikConfigurator._update_config")
     def test_configure_local__use_local_is_True__url_not_provided__use_default_localhost_url(
@@ -1106,9 +1105,7 @@ class TestConfigureLocal:
         """
         Test that the function configures the default localhost URL if use_local is True and url is not provided.
         """
-        configurator = OpikConfigurator(
-            use_local=True, force=False
-        )
+        configurator = OpikConfigurator(use_local=True, force=False)
         configurator._configure_local()
 
         mock_update_config.assert_called_once()

--- a/sdks/python/tests/unit/configurator/test_configure.py
+++ b/sdks/python/tests/unit/configurator/test_configure.py
@@ -1097,6 +1097,25 @@ class TestConfigureLocal:
         assert configurator.api_key is None
         assert configurator.base_url == "http://custom-local-instance.com/"
         assert configurator.workspace == OPIK_WORKSPACE_DEFAULT_NAME
+    
+
+    @patch("opik.configurator.configure.OpikConfigurator._update_config")
+    def test_configure_local__use_local_is_True__url_not_provided__use_default_localhost_url(
+        self, mock_update_config
+    ):
+        """
+        Test that the function configures the default localhost URL if use_local is True and url is not provided.
+        """
+        configurator = OpikConfigurator(
+            use_local=True, force=False
+        )
+        configurator._configure_local()
+
+        mock_update_config.assert_called_once()
+
+        assert configurator.api_key is None
+        assert configurator.base_url == OPIK_BASE_URL_LOCAL
+        assert configurator.workspace == OPIK_WORKSPACE_DEFAULT_NAME
 
     @patch("opik.configurator.configure.OpikConfigurator._ask_for_url")
     @patch(


### PR DESCRIPTION
## Details

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues
- OPIK-2206

## Testing
Added new unit test, tested manually.

## Documentation
No documentation update is needed.