### PR TITLE
[OPIK-2241] [DOCS] document bulk experiment item upload in batches

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/evaluation/log_experiments_with_rest_api.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/log_experiments_with_rest_api.mdx
@@ -276,7 +276,10 @@ Use the bulk endpoint to efficiently log multiple evaluation results at once.
   smaller batches.
 </Warning>
 
-If you wish to divide the data into smaller batches, you can do as follows:
+If you wish to divide the data into smaller batches, just add the `experiment_id` to the payload 
+so experiment items can be added to an existing experiment.
+Below is an example of splitting the `evaluation_items` into two batches which will both be added
+to the same experiment:
 ```python
 experiment_id = str(uuid6.uuid7())
 experiment_name = "Bulk experiment upload"

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/log_experiments_with_rest_api.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/log_experiments_with_rest_api.mdx
@@ -276,6 +276,37 @@ Use the bulk endpoint to efficiently log multiple evaluation results at once.
   smaller batches.
 </Warning>
 
+If you wish to divide the data into smaller batches, you can do as follows:
+```python
+experiment_id = str(uuid6.uuid7())
+experiment_name = "Bulk experiment upload"
+# Split evaluation_items into two batches
+mid = len(evaluation_items) // 2
+
+halves = [
+    evaluation_items[:mid],
+    evaluation_items[mid:]
+]
+
+for half in halves:
+    client.rest_client.experiments.experiment_items_bulk(
+        experiment_id=experiment_id,
+        experiment_name=experiment_name,
+        dataset_name="geography-questions",
+        items=[
+            {
+                "dataset_item_id": item["dataset_item_id"],
+                "evaluate_task_result": item["evaluate_task_result"],
+                "feedback_scores": [
+                    {**score, "source": "sdk"} 
+                    for score in item["feedback_scores"]
+                ]
+            } 
+            for item in half
+        ]
+    )
+```
+
 ## Complete Example
 
 Here's a complete example that puts all the steps together:


### PR DESCRIPTION
## Details
Add documentation to the functionality introduced in #2977 which allows to include the `experiment_id` to bulk experiment items upload request and by so add experiment items to an existing experiments.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues
OPIK-2241

## Testing
Tested the script added to the documentation locally to make sure it works properly.
