### PR TITLE
[OPIK-2252] [BE] Consistent anonymous ID across install and backend events

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -245,6 +245,9 @@ usageReport:
   # Default: https://stats.comet.com/notify/event/
   # Description: URL to send the anonymous usage reports to
   url: ${OPIK_USAGE_REPORT_URL:-https://stats.comet.com/notify/event/}
+  # Description: Configuration for anonymous ID used to identify the installation
+  # Default: empty
+  anonymousId: ${OPIK_ANONYMOUS_ID:-}
 
 # Configuration for application metadata
 metadata:

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/UsageReportConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/UsageReportConfig.java
@@ -6,10 +6,14 @@ import lombok.Data;
 
 @Data
 public class UsageReportConfig {
+
     @Valid @JsonProperty
     private boolean enabled;
 
     @Valid @JsonProperty
     private String url;
+
+    @Valid @JsonProperty
+    private String anonymousId;
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/InstallationReportService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/InstallationReportService.java
@@ -90,7 +90,6 @@ class InstallationReportServiceImpl implements InstallationReportService {
         var anonymousId = config.getUsageReport().getAnonymousId();
 
         if (StringUtils.isNotBlank(anonymousId)) {
-            log.info("Using anonymous ID from config: {}", anonymousId);
             usageReport.saveAnonymousId(anonymousId);
             return anonymousId;
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/InstallationReportService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/InstallationReportService.java
@@ -15,7 +15,6 @@ import ru.vyarus.dropwizard.guice.module.lifecycle.GuiceyLifecycle;
 
 import java.time.Duration;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 
 @ImplementedBy(InstallationReportServiceImpl.class)
@@ -82,20 +81,25 @@ class InstallationReportServiceImpl implements InstallationReportService {
     }
 
     private String getAnonymousId() {
-        var anonymousId = usageReport.getAnonymousId();
 
-        if (anonymousId.isEmpty()) {
-            log.info("Anonymous ID not found, generating a new one");
-            var newId = UUID.randomUUID().toString();
-            log.info("Generated new ID: {}", newId);
-
-            // Save the new ID
-            usageReport.saveAnonymousId(newId);
-
-            anonymousId = Optional.of(newId);
+        var storedId = usageReport.getAnonymousId();
+        if (storedId.isPresent()) {
+            return storedId.get();
         }
 
-        return anonymousId.get();
+        var anonymousId = config.getUsageReport().getAnonymousId();
+
+        if (StringUtils.isNotBlank(anonymousId)) {
+            log.info("Using anonymous ID from config: {}", anonymousId);
+            usageReport.saveAnonymousId(anonymousId);
+            return anonymousId;
+        }
+
+        log.info("Anonymous ID not found, generating a new one");
+        var newId = UUID.randomUUID().toString();
+        log.info("Generated new ID: {}", newId);
+        usageReport.saveAnonymousId(newId);
+        return newId;
     }
 
 }

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -123,6 +123,8 @@ services:
     environment:
       # WARNING: Do not set OPIK_VERSION as env var here. It's a multi-stage build, so build and runtime values can differ.
       DOCKER_BUILDKIT: 1
+      # Persistent anonymous installation ID passed from launcher script
+      OPIK_ANONYMOUS_ID: ${OPIK_ANONYMOUS_ID:-}
       STATE_DB_PROTOCOL: "jdbc:mysql://"
       STATE_DB_URL: "mysql:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true"
       STATE_DB_DATABASE_NAME: opik

--- a/opik.ps1
+++ b/opik.ps1
@@ -136,6 +136,7 @@ function Send-InstallReport {
             event_properties = @{
                 start_time  = $StartTime
                 end_time    = $EndTime
+                event_ver = "1"
                 script_type = "ps1"
             }
         }
@@ -147,6 +148,7 @@ function Send-InstallReport {
             event_type   = $EventType
             event_properties = @{
                 start_time = $StartTime
+                event_ver  = "1"
                 script_type = "ps1"
             }
         }
@@ -173,7 +175,10 @@ function Send-InstallReport {
 function Start-MissingContainers {
     Test-DockerStatus
 
+    # Generate a run-scoped anonymous ID for this installation session
     $Uuid = [guid]::NewGuid().ToString()
+    # Export persistent install UUID so docker-compose and services can consume it
+    $env:OPIK_ANONYMOUS_ID = $Uuid
     $startTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 
     Send-InstallReport -Uuid $uuid -EventCompleted "false" -StartTime $startTime

--- a/opik.sh
+++ b/opik.sh
@@ -130,8 +130,11 @@ check_containers_status() {
 start_missing_containers() {
   check_docker_status
 
+  # Generate a run-scoped anonymous ID for this installation session
   uuid=$(generate_uuid)
   start_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  # Export persistent install UUID so docker-compose and services can consume it
+  export OPIK_ANONYMOUS_ID="$uuid"
   send_install_report "$uuid" "false" "$start_time"
 
   debugLog "🔍 Checking required containers..."
@@ -291,6 +294,7 @@ send_install_report() {
   "event_properties": {
     "start_time": "$start_time",
     "end_time": "$end_time",
+    "event_ver": "1",
     "script_type": "sh"
   }
 }
@@ -304,6 +308,7 @@ EOF
   "event_type": "$event_type",
   "event_properties": {
     "start_time": "$start_time",
+    "event_ver": "1",
     "script_type": "sh"
   }
 }


### PR DESCRIPTION
## Details
Implements a persistent anonymous ID across installation and backend events to enable consistent analytics:
- Export OPIK_ANONYMOUS_ID from installers and pass it via Docker Compose
- Backend reads OPIK_ANONYMOUS_ID (via usageReport.anonymousId), persists it in MySQL metadata, and uses it for opik_os_startup_be
- opik_os_install_started and opik_os_install_completed now include event_ver: "1"
- Add test to ensure startup event uses and persists the configured anonymous ID

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves #
- OPIK-2252

## Testing
  - OpikGuiceyLifecycleEventListenerTest generates a UUID, configures usageReport.anonymousId, verifies WireMock receives the same anonymous_id, and that UsageReportService persisted it
