### PR TITLE
[OPIK-2237] Fix unable to parse JSON path exception

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/ExperimentsTestUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/ExperimentsTestUtils.java
@@ -19,8 +19,8 @@ import com.comet.opik.domain.ExperimentResponseBuilder;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.ValidationUtils;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.PathNotFoundException;
 import lombok.experimental.UtilityClass;
 
 import java.math.BigDecimal;
@@ -430,7 +430,7 @@ public class ExperimentsTestUtils {
         try {
             Object value = JsonPath.read(jsonText, key);
             return String.valueOf(value);
-        } catch (PathNotFoundException e) {
+        } catch (InvalidPathException e) {
             return "";
         }
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -2468,6 +2468,9 @@ class ExperimentsResourceTest {
                     Arguments.of(List.of(GroupBy.builder().field(DATASET_ID).type(FieldType.STRING).build())),
                     Arguments.of(List
                             .of(GroupBy.builder().field(METADATA).key("provider").type(FieldType.DICTIONARY).build())),
+                    Arguments.of(List
+                            .of(GroupBy.builder().field(METADATA).key("invalid key").type(FieldType.DICTIONARY)
+                                    .build())),
                     Arguments.of(List.of(GroupBy.builder().field(DATASET_ID).type(FieldType.STRING).build(),
                             GroupBy.builder().field(METADATA).key("something").type(FieldType.DICTIONARY).build())));
         }


### PR DESCRIPTION
## Details
Fix unable to parse JSON path exception

## Change checklist
- [x] User facing
- [ ] Documentation update

- Resolves #
- OPIK-2237

## Testing
Covered by integration test
