### PR TITLE
[OPIK-2253] opik logo for cloud version

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/Logo.tsx
+++ b/apps/opik-frontend/src/plugins/comet/Logo.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { cn } from "@/lib/utils";
-import imageLogoUrl from "/images/comet-logo.png";
+import imageLogoUrl from "/images/opik-logo.png";
 
 type LogoProps = {
   expanded: boolean;
@@ -9,11 +9,11 @@ type LogoProps = {
 const Logo: React.FunctionComponent<LogoProps> = ({ expanded }) => {
   return (
     <img
-      className={cn("h-8 object-cover object-left", {
-        "w-[26px]": !expanded,
+      className={cn("h-8 object-cover object-left -ml-[3px] mr-[3px]", {
+        "w-[32px]": !expanded,
       })}
       src={imageLogoUrl}
-      alt="comet logo"
+      alt="opik logo"
     />
   );
 };


### PR DESCRIPTION
## Details
This pull request removes support for plugin-provided custom logos in the application layout. All references to a plugin-provided `Logo` component have been removed, and the default logo component is now used everywhere. This simplifies the logo rendering logic and cleans up related plugin store code.
<img width="2041" height="909" alt="image" src="https://github.com/user-attachments/assets/61f07870-a66d-476d-a770-e53404b604aa" />

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2253

## Testing

## Documentation
