### PR TITLE
[OPIK-2253] expand opik logo

### DIFF
--- a/apps/opik-frontend/src/components/layout/PartialPageLayout/PartialPageLayout.tsx
+++ b/apps/opik-frontend/src/components/layout/PartialPageLayout/PartialPageLayout.tsx
@@ -14,7 +14,7 @@ export const PartialPageLayout = ({
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
 
   const logo = LogoComponent ? (
-    <LogoComponent expanded={false} />
+    <LogoComponent expanded={true} />
   ) : (
     <Logo expanded={false} />
   );


### PR DESCRIPTION
This pull request makes a minor adjustment to the `PartialPageLayout` component, changing the `expanded` prop from `false` to `true` when rendering a custom `LogoComponent`. This will cause the logo to be displayed in its expanded form when a custom logo is provided.## Details
<img width="2049" height="1040" alt="image" src="https://github.com/user-attachments/assets/437a59ae-ca3a-4be9-805c-1b9681717c06" />

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2253

## Testing

## Documentation
