### PR TITLE
[OPIK-2231] fix invite button width

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/InviteDevButton.tsx
+++ b/apps/opik-frontend/src/plugins/comet/InviteDevButton.tsx
@@ -14,7 +14,7 @@ const InviteDevButton: React.FC<InviteDevButtonProps> = ({ onClick }) => {
   }
 
   return (
-    <Button className="w-full" variant="outline" onClick={onClick} asChild>
+    <Button className="flex-1" variant="outline" onClick={onClick} asChild>
       <a href={inviteMembersURL} target="_blank" rel="noopener noreferrer">
         <UserPlus className="mr-2 size-4" />
         <span>Invite a developer</span>


### PR DESCRIPTION
## Details
This pull request makes a minor UI adjustment to the `InviteDevButton` component, changing its width styling for improved layout flexibility.

* Changed the `Button` component's class from `w-full` to `flex-1` to allow the button to grow and fill available space within a flex container, instead of always taking the full width.
## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2231

## Testing

## Documentation
