### PR TITLE
[NA] [FE] [BE] Model parameters slider fix and Claude 3 Sonnet removal

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/AnthropicModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/AnthropicModelName.java
@@ -16,7 +16,6 @@ public enum AnthropicModelName implements StructuredOutputSupported {
     CLAUDE_HAIKU_3("claude-3-haiku-20240307"),
     CLAUDE_3_5_SONNET_20241022("claude-3-5-sonnet-20241022"),
     CLAUDE_3_OPUS_20240229("claude-3-opus-20240229"),
-    CLAUDE_3_SONNET_20240229("claude-3-sonnet-20240229"),
     ;
 
     private final String value;

--- a/apps/opik-frontend/src/components/shared/SliderInputControl/SliderInputControl.tsx
+++ b/apps/opik-frontend/src/components/shared/SliderInputControl/SliderInputControl.tsx
@@ -120,7 +120,7 @@ const SliderInputControl = ({
       </div>
       <Slider
         id={sliderId}
-        value={[value ?? defaultValue]}
+        value={[toNumber(localValue)]}
         onValueChange={(values) => {
           setLocalValue(values[0].toString());
         }}

--- a/apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts
+++ b/apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts
@@ -145,10 +145,6 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       value: PROVIDER_MODEL_TYPE.CLAUDE_3_OPUS_20240229,
       label: "Claude 3 Opus 2024-02-29",
     },
-    {
-      value: PROVIDER_MODEL_TYPE.CLAUDE_3_SONNET_20240229,
-      label: "Claude 3 Sonnet 2024-02-29",
-    },
   ],
 
   [PROVIDER_TYPE.OPEN_ROUTER]: [

--- a/apps/opik-frontend/src/types/providers.ts
+++ b/apps/opik-frontend/src/types/providers.ts
@@ -39,7 +39,6 @@ export enum PROVIDER_MODEL_TYPE {
   CLAUDE_HAIKU_3 = "claude-3-haiku-20240307",
   CLAUDE_3_5_SONNET_20241022 = "claude-3-5-sonnet-20241022",
   CLAUDE_3_OPUS_20240229 = "claude-3-opus-20240229",
-  CLAUDE_3_SONNET_20240229 = "claude-3-sonnet-20240229",
 
   //  <---- OpenRouter
   AGENTICA_ORG_DEEPCODER_14B_PREVIEW = "agentica-org/deepcoder-14b-preview",


### PR DESCRIPTION
## Details
Fixed the Model Parameters slider issue introduced in https://github.com/comet-ml/opik/pull/3021
Removed Claude 3 Sonnet from Anthropic support as it is fully retired and no longer available: https://docs.anthropic.com/en/docs/about-claude/model-deprecations

## Change checklist
- [x] User facing
- [ ] Documentation update

## Testing
Local build
