### PR TITLE
[NA] [BE] Optimize ClickHouse async insert parameters to reduce wait times and avoid flakiness

### DIFF
--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -68,7 +68,7 @@ databaseAnalytics:
   #   - failover=3
   #   - custom_http_params=max_query_size=100000000
   #  Description: query parameters that will be added to the connection string
-  queryParameters: health_check_interval=2000&compress=1&auto_discovery=true&failover=3&custom_http_params=max_query_size=100000000,async_insert_busy_timeout_max_ms=250,async_insert_busy_timeout_min_ms=100,async_insert=1,wait_for_async_insert=1,async_insert_use_adaptive_busy_timeout=1,async_insert_deduplicate=1
+  queryParameters: health_check_interval=2000&compress=1&auto_discovery=true&failover=3&custom_http_params=max_query_size=100000000,async_insert_busy_timeout_max_ms=60,async_insert_busy_timeout_min_ms=50,async_insert=1,wait_for_async_insert=1,async_insert_use_adaptive_busy_timeout=1,async_insert_deduplicate=1
 
 # Configuration for ClickHouse async insert functionality
 asyncInsert:


### PR DESCRIPTION
## Details

Optimized ClickHouse async insert parameters in test configuration to reduce wait times for inserts and avoid test flakiness. 

Updated queryParameters to include:
- `async_insert_busy_timeout_max_ms=60`
- `async_insert_busy_timeout_min_ms=50`
- `async_insert=1`
- `wait_for_async_insert=1`
- `async_insert_use_adaptive_busy_timeout=1`
- `async_insert_deduplicate=1`

## Change checklist
- [ ] User-facing
- [ ] Documentation update

## Issues
- NA (Performance optimization)

## Testing
This change modifies the test configuration to enhance insert performance and minimize test flakiness in ClickHouse operations.

## Documentation
NA