### PR TITLE
[NA] [SDK] Move pytest to test-only dependency; remove from install_requires

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -46,7 +46,6 @@ setup(
         "openai<1.100.0",  # unlock when litellm supports 1.100.0
         "pydantic-settings>=2.0.0,<3.0.0,!=2.9.0",
         "pydantic>=2.0.0,<3.0.0",
-        "pytest",
         "rich",
         "sentry_sdk>=2.0.0",
         "tenacity",


### PR DESCRIPTION
## Details
- Remove `pytest` from runtime dependencies by deleting it from `sdks/python/setup.py` `install_requires`.
- Keep `pytest` only in test requirements (`sdks/python/tests/test_requirements.txt`).
- No functional/runtime changes. Pytest plugin entry point remains and is only active when pytest is installed and running tests.
- Reduces production footprint and avoids unnecessary transitive dependencies.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves #
- OPIK- NA

## Testing
- Production install (no pytest expected):
  - `pip install -e sdks/python`
  - Verify: `python -c "import importlib.util as u; print(u.find_spec('pytest') is None)"`
    - Should print `True`.
- Run tests (pytest only for dev/CI):
  - `pip install -r sdks/python/tests/test_requirements.txt`
  - `pytest -q sdks/python/tests`
- Sanity check: importing SDK in a clean env works without pytest:
  - `python -c "import opik; print(opik.__version__)"`

## Documentation
- Not required (internal packaging change only).