### PR TITLE
[OPIK-2227]: [P SDK] "Failed to upload 1 file(s). Check logs for details." but there are no details in logs

### DIFF
--- a/sdks/python/src/opik/file_upload/file_uploader.py
+++ b/sdks/python/src/opik/file_upload/file_uploader.py
@@ -3,9 +3,9 @@ from typing import Optional
 
 import httpx
 
-from opik import s3_httpx_client
 from . import upload_client, file_upload_monitor
 from . import upload_options as file_upload_options
+from .. import format_helpers, s3_httpx_client
 from .s3_multipart_upload import file_parts_strategy, s3_file_uploader
 from ..rest_api import client as rest_api_client
 from ..rest_api import types as rest_api_types
@@ -30,13 +30,14 @@ def upload_attachment(
         )
     except Exception as e:
         LOGGER.error(
-            "Failed to upload attachment: '%s' from file: '%s', reason: %s",
+            "Failed to upload attachment: '%s' from file: [%s] with size: [%s]. Error: %s",
             upload_options.file_name,
             upload_options.file_path,
+            format_helpers.format_bytes(upload_options.file_size),
             e,
             exc_info=True,
         )
-        raise
+        raise e
 
 
 def _do_upload_attachment(


### PR DESCRIPTION
## Details
We have a couple of dozens of users who had these log messages shown, however, no details are found in log traces, based on Sentry. If we can’t fix it, we should provide them with the actual details.

### Key changes:
The majority of the modifications were aimed at enhancing the logging of potential user-facing errors that may occur during attachment uploads.

- Added enhanced exception handling in `successful` method for upload failures.
- Included detailed logging for timeout and upload failure scenarios.
- Updated `UploadResult` to include `upload_options` for better context within error logs.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2227
