### PR TITLE
[UI] Fix button styles to match others

### DIFF
--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
@@ -565,12 +565,7 @@ const ExperimentsPage: React.FC = () => {
             onOrderChange={setColumnsOrder}
             sections={columnSections}
           ></ColumnsButton>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleNewExperimentClick}
-          >
-            <Info className="mr-2 size-3.5" />
+          <Button variant="default" size="sm" onClick={handleNewExperimentClick}>
             Create new experiment
           </Button>
         </div>

--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
@@ -565,7 +565,11 @@ const ExperimentsPage: React.FC = () => {
             onOrderChange={setColumnsOrder}
             sections={columnSections}
           ></ColumnsButton>
-          <Button variant="default" size="sm" onClick={handleNewExperimentClick}>
+          <Button
+            variant="default"
+            size="sm"
+            onClick={handleNewExperimentClick}
+          >
             Create new experiment
           </Button>
         </div>

--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { ChartLine, Info, RotateCw } from "lucide-react";
+import { ChartLine, RotateCw } from "lucide-react";
 import { ColumnSort, Row, RowSelectionState } from "@tanstack/react-table";
 import { useNavigate } from "@tanstack/react-router";
 import useLocalStorageState from "use-local-storage-state";

--- a/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -469,7 +469,11 @@ const OptimizationsPage: React.FunctionComponent = () => {
             order={columnsOrder}
             onOrderChange={setColumnsOrder}
           ></ColumnsButton>
-          <Button variant="default" size="sm" onClick={handleNewOptimizationClick}>
+          <Button
+            variant="default"
+            size="sm"
+            onClick={handleNewOptimizationClick}
+          >
             Create new optimization
           </Button>
         </div>

--- a/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Info, RotateCw } from "lucide-react";
+import { RotateCw } from "lucide-react";
 import useLocalStorageState from "use-local-storage-state";
 import {
   ColumnPinningState,

--- a/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -469,12 +469,7 @@ const OptimizationsPage: React.FunctionComponent = () => {
             order={columnsOrder}
             onOrderChange={setColumnsOrder}
           ></ColumnsButton>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleNewOptimizationClick}
-          >
-            <Info className="mr-2 size-3.5" />
+          <Button variant="default" size="sm" onClick={handleNewOptimizationClick}>
             Create new optimization
           </Button>
         </div>


### PR DESCRIPTION
## Details

This PR fixes two button styles that were different.

The buttons for "Create new experiment" and "Create new optimization" didn't match the other buttons. Before: 

<img width="1605" height="426" alt="Screenshot from 2025-08-25 09-44-59" src="https://github.com/user-attachments/assets/2d1ffa7e-582f-45c6-a3cd-d43757cb91e0" />
<img width="1605" height="426" alt="Screenshot from 2025-08-25 09-44-51" src="https://github.com/user-attachments/assets/3b239540-0e42-4cba-9916-88a8dbcd2cc0" />


After, now they match:

<img width="1605" height="426" alt="Screenshot from 2025-08-25 09-40-36" src="https://github.com/user-attachments/assets/1ed44669-287a-4aa0-950c-aaf4dbbe1cc2" />
<img width="1605" height="426" alt="Screenshot from 2025-08-25 09-40-28" src="https://github.com/user-attachments/assets/6b4eec5c-e5d9-44b6-b994-7b4192446d3f" />
<img width="1605" height="426" alt="Screenshot from 2025-08-25 09-40-18" src="https://github.com/user-attachments/assets/aec84cc8-e4b1-445d-a02c-7cae31d2b65d" />
<img width="1605" height="426" alt="Screenshot from 2025-08-25 09-40-12" src="https://github.com/user-attachments/assets/76126272-74d2-4ec8-a51d-96123f1279c9" />
<img width="1605" height="426" alt="Screenshot from 2025-08-25 09-40-07" src="https://github.com/user-attachments/assets/082db9bf-84c6-4308-acd3-eaf6b0d49f23" />
<img width="1605" height="426" alt="Screenshot from 2025-08-25 09-40-01" src="https://github.com/user-attachments/assets/de32ff20-b835-48a6-936d-3240db636f2e" />


## Change checklist
- [x] User facing
