### PR TITLE
[OPIK-2291] [FE] Line gradient in feedback scores in metrics tab is black

### DIFF
--- a/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricLineChart.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricLineChart.tsx
@@ -8,13 +8,16 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { ValueType } from "recharts/types/component/DefaultTooltipContent";
+import dayjs from "dayjs";
+import snakeCase from "lodash/snakeCase";
+
 import {
   ChartConfig,
   ChartContainer,
   ChartLegend,
   ChartTooltip,
 } from "@/components/ui/chart";
-import dayjs from "dayjs";
 import { DEFAULT_CHART_TICK } from "@/constants/chart";
 import { Spinner } from "@/components/ui/spinner";
 import { INTERVAL_TYPE } from "@/api/projects/useProjectMetric";
@@ -23,7 +26,6 @@ import ChartTooltipContent, {
   ChartTooltipRenderValueArguments,
 } from "@/components/shared/ChartTooltipContent/ChartTooltipContent";
 import { formatDate } from "@/lib/date";
-import { ValueType } from "recharts/types/component/DefaultTooltipContent";
 import useChartTickDefaultConfig from "@/hooks/charts/useChartTickDefaultConfig";
 import ChartHorizontalLegendContent from "@/components/shared/ChartHorizontalLegendContent/ChartHorizontalLegendContent";
 import { ProjectMetricValue, TransformedData } from "@/types/projects";
@@ -158,7 +160,7 @@ const MetricLineChart = ({
           <>
             <defs>
               <linearGradient
-                id={`chart-area-gradient-${firstLine}`}
+                id={`chart-area-gradient-${snakeCase(firstLine)}`}
                 x1="0"
                 y1="0"
                 x2="0"
@@ -180,7 +182,7 @@ const MetricLineChart = ({
               type="monotone"
               dataKey={firstLine}
               stroke={config[firstLine].color}
-              fill={`url(#chart-area-gradient-${firstLine})`}
+              fill={`url(#chart-area-gradient-${snakeCase(firstLine)})`}
               connectNulls
               strokeWidth={1.5}
               activeDot={activeDot}


### PR DESCRIPTION
## Details
Fix the issue when the line in the chart has space, the filled area below was black

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2291

## Testing
Manual testing
## Documentation
