### PR TITLE
[OPIK-2292] [FE] fix username regex Invite member

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/InviteUsersForm.tsx
+++ b/apps/opik-frontend/src/plugins/comet/InviteUsersForm.tsx
@@ -21,7 +21,7 @@ import { useInviteUsersMutation } from "@/plugins/comet/api/useInviteMembersMuta
 const USERNAME_MIN_LENGTH = 3;
 const USERNAME_MAX_LENGTH = 64;
 const usernameRegex = new RegExp(
-  `^[a-zA-Z0-9_]{${USERNAME_MIN_LENGTH},${USERNAME_MAX_LENGTH}}$`,
+  `^[a-zA-Z0-9_.+-]{${USERNAME_MIN_LENGTH},${USERNAME_MAX_LENGTH}}$`,
 );
 
 const isEmail = (val: string) => z.string().email().safeParse(val).success;


### PR DESCRIPTION
## Details
This pull request updates the username validation logic in the `InviteUsersForm` component to allow a wider range of characters, improving flexibility.

Validation improvements:

* Expanded the allowed characters in usernames by updating the `usernameRegex` to permit `.`, `+`, and `-` in addition to letters, numbers, and underscores in 

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2292

## Testing

## Documentation
