### PR TITLE
[OPIK-2270] [FE] [Improve self-serve flow] Add Visible Upgrade button

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -11,6 +11,7 @@ import {
   Settings,
   Shield,
   UserPlus,
+  Zap,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -121,6 +122,8 @@ const UserMenu = () => {
   const isOrganizationAdmin =
     organization?.role === ORGANIZATION_ROLE_TYPE.admin;
 
+  const isAcademic = organization?.academic;
+
   const handleChangeOrganization = (newOrganization: Organization) => {
     const newOrganizationWorkspaces = userInvitedWorkspaces.filter(
       (workspace) => workspace.organizationId === newOrganization.id,
@@ -145,6 +148,29 @@ const UserMenu = () => {
         <AvatarFallback>{user.userName.charAt(0).toUpperCase()}</AvatarFallback>
       </Avatar>
     );
+  };
+
+  const renderUpgradeButton = () => {
+    if (isOrganizationAdmin && !isAcademic) {
+      return (
+        <a
+          href={buildUrl(
+            `organizations/${organization.id}/billing`,
+            workspaceName,
+            "&initialOpenUpgradeCard=true",
+          )}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <Button size="sm" variant="special">
+            <Zap className="mr-1.5 size-3.5 shrink-0" />
+            Upgrade
+          </Button>
+        </a>
+      );
+    }
+
+    return null;
   };
 
   const renderAppSelector = () => {
@@ -383,7 +409,8 @@ const UserMenu = () => {
   };
 
   return (
-    <div className="flex shrink-0 items-center gap-4">
+    <div className="flex shrink-0 items-center gap-3">
+      {renderUpgradeButton()}
       {renderAppSelector()}
       {renderUserMenu()}
 

--- a/apps/opik-frontend/src/plugins/comet/types.ts
+++ b/apps/opik-frontend/src/plugins/comet/types.ts
@@ -41,6 +41,7 @@ export interface Organization {
   id: string;
   name: string;
   paymentPlan: string;
+  academic: boolean;
   role: ORGANIZATION_ROLE_TYPE;
 }
 


### PR DESCRIPTION
## Details

This PR adds a visible upgrade button to the user menu as part of improving the self-serve flow. The upgrade button helps organization admins easily discover and access billing upgrade options directly from the main interface.

**Key Changes:**
- Added an upgrade button in the `UserMenu` component that appears next to the app selector and user menu
- The button is only visible to organization administrators who are not on academic plans
<img width="1736" height="917" alt="image" src="https://github.com/user-attachments/assets/c62135d7-c69d-406c-a04d-86825f3bb872" />


## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2270

## Testing
- Tested upgrade button visibility for different user roles (admin vs non-admin)
- Verified button does not appear for academic organizations
- Confirmed button links correctly to billing page with upgrade card parameter
- Tested responsive behavior and visual integration with existing header elements
- Manual testing scenarios:
  - Organization admin (non-academic): Button visible and functional
  - Organization admin (academic): Button hidden
  - Non-admin user: Button hidden
  - Button click opens billing page in new tab with correct parameters

## Documentation
