### PR TITLE
[NA] Add support for threadId in TS SDK

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/langchainjs.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/langchainjs.mdx
@@ -83,3 +83,29 @@ Or alternatively, you can use the environment variable:
 ```bash
 export OPIK_PROJECT_NAME="my-project"
 ```
+
+## Setting thread_id for conversation tracking
+
+You can set a `threadId` to group related traces together, which is useful for tracking conversations or multi-turn interactions:
+
+```js {pytest_codeblocks_skip=true}
+const opikHandler = new OpikCallbackHandler({
+  threadId: "conversation-123",
+  tags: ["langchain"],
+  metadata: { "use-case": "conversation-tracking" },
+});
+```
+
+You can also provide the `thread_id` dynamically via chain metadata, which will be used if no `threadId` was set in the constructor:
+
+```js {pytest_codeblocks_skip=true}
+const result = await chain.invoke(
+  { product: "colorful socks" },
+  {
+    callbacks: [opikHandler],
+    metadata: { thread_id: "conversation-456" },
+  },
+);
+```
+
+Note: If both constructor `threadId` and metadata `thread_id` are provided, the constructor value takes precedence.

--- a/sdks/typescript/examples/langchain-with-thread-id.ts
+++ b/sdks/typescript/examples/langchain-with-thread-id.ts
@@ -1,0 +1,72 @@
+import { OpenAI } from "@langchain/openai";
+import { PromptTemplate } from "@langchain/core/prompts";
+import { OpikCallbackHandler } from "opik-langchain";
+
+// Example demonstrating thread_id support in OpikCallbackHandler
+
+async function main() {
+  // Initialize the model
+  const model = new OpenAI({
+    temperature: 0.9,
+  });
+
+  const prompt = PromptTemplate.fromTemplate(
+    "What is a good name for a company that makes {product}?"
+  );
+
+  const chain = prompt.pipe(model);
+
+  // Flow 1: Log a thread with 2 traces (same thread_id)
+  console.log("\n=== Flow 1: Thread with 2 traces ===");
+  
+  const threadOpikHandler = new OpikCallbackHandler({
+    threadId: "conversation-thread-123",
+    tags: ["langchain", "thread-demo"],
+    metadata: { "use-case": "multi-trace-thread" },
+  });
+
+  console.log("Running first trace in thread...");
+  const result1 = await chain.invoke(
+    { product: "colorful socks" },
+    { callbacks: [threadOpikHandler] }
+  );
+  console.log("First trace result:", result1);
+
+  // Wait a moment between traces
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  console.log("Running second trace in same thread...");
+  const result2 = await chain.invoke(
+    { product: "eco-friendly water bottles" },
+    { callbacks: [threadOpikHandler] }
+  );
+  console.log("Second trace result:", result2);
+
+  // Flow 2: Log a trace without thread attribute
+  console.log("\n=== Flow 2: Trace without thread ===");
+  
+  const noThreadOpikHandler = new OpikCallbackHandler({
+    tags: ["langchain", "no-thread"],
+    metadata: { "use-case": "standalone-trace" },
+    // No threadId specified
+  });
+
+  console.log("Running trace without thread_id...");
+  const result3 = await chain.invoke(
+    { product: "smart home devices" },
+    { callbacks: [noThreadOpikHandler] }
+  );
+  console.log("Standalone trace result:", result3);
+
+  // Flush to ensure all data is sent
+  console.log("\n=== Flushing data ===");
+  await threadOpikHandler.flushAsync();
+  await noThreadOpikHandler.flushAsync();
+  
+  console.log("✅ All traces logged successfully!");
+  console.log("Check your Opik dashboard to see:");
+  console.log("- Two traces with threadId 'conversation-thread-123'");
+  console.log("- One standalone trace without a threadId");
+}
+
+main().catch(console.error);

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -27,6 +27,8 @@
       "devDependencies": {
         "@ai-sdk/openai": "^1.1.9",
         "@eslint/js": "^9.20.0",
+        "@langchain/core": "^0.3.72",
+        "@langchain/openai": "^0.6.9",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.56.0",
         "@opentelemetry/sdk-node": "^0.201.1",
@@ -165,6 +167,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.0",
@@ -959,6 +968,88 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@langchain/core": {
+      "version": "0.3.72",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.72.tgz",
+      "integrity": "sha512-WsGWVZYnlKffj2eEfDocPNiaTRoxyYiLSQdQ7oxZvxGZBqo/90vpjbC33UGK1uPNBM4kT+pkdaol/MnvKUh8TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": "^0.3.46",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "uuid": "^10.0.0",
+        "zod": "^3.25.32",
+        "zod-to-json-schema": "^3.22.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/openai": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.6.9.tgz",
+      "integrity": "sha512-Dl+YVBTFia7WE4/jFemQEVchPbsahy/dD97jo6A9gLnYfTkWa/jh8Q78UjHQ3lobif84j2ebjHPcDHG1L0NUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tiktoken": "^1.0.12",
+        "openai": "5.12.2",
+        "zod": "^3.25.32"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.3.68 <0.4.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4248,6 +4339,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/shimmer": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
@@ -5334,6 +5432,16 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/console-table-printer": {
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.14.6.tgz",
+      "integrity": "sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "simple-wcswidth": "^1.0.1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5440,6 +5548,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -5938,6 +6056,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -6754,6 +6879,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -6911,6 +7046,73 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/langsmith": {
+      "version": "0.3.65",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.65.tgz",
+      "integrity": "sha512-p9CWvc0R1fAARgPyaGt2JTz1FXq0Zlrq57uiOKZOoTHzAauhwU3PFtANK0EYSoHAJqJNIaO6GIaVj4q0a7IiLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "^10.0.0",
+        "chalk": "^4.1.2",
+        "console-table-printer": "^2.12.1",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "semver": "^7.6.3",
+        "uuid": "^10.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/langsmith/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/langsmith/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/levn": {
@@ -7152,6 +7354,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -7273,6 +7485,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
+      "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7337,6 +7571,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7367,6 +7611,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -7890,6 +8178,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -8111,6 +8409,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/simple-wcswidth": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
+      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -59,6 +59,8 @@
   "devDependencies": {
     "@ai-sdk/openai": "^1.1.9",
     "@eslint/js": "^9.20.0",
+    "@langchain/core": "^0.3.72",
+    "@langchain/openai": "^0.6.9",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.56.0",
     "@opentelemetry/sdk-node": "^0.201.1",

--- a/sdks/typescript/src/opik/client/Client.ts
+++ b/sdks/typescript/src/opik/client/Client.ts
@@ -22,6 +22,7 @@ import { parseNdjsonStreamToArray } from "@/utils/stream";
 
 interface TraceData extends Omit<ITrace, "startTime"> {
   startTime?: Date;
+  threadId?: string;
 }
 
 export const clients: OpikClient[] = [];


### PR DESCRIPTION
## Details

Added support for `threadId` in the LangChain JS integration. Users can now:

```tsx
import { OpenAI } from "@langchain/openai";
import { PromptTemplate } from "@langchain/core/prompts";
import { OpikCallbackHandler } from "opik-langchain";

const model = new OpenAI({ temperature: 0.9 });
const prompt = PromptTemplate.fromTemplate(
  "What is a good name for a company that makes {product}?"
);
const chain = prompt.pipe(model);

// Thread tracking via constructor
const opikHandler = new OpikCallbackHandler({
  threadId: "conversation-123",
  tags: ["langchain"],
});

const result = await chain.invoke(
  { product: "colorful socks" },
  { callbacks: [opikHandler] }
);

// Or via metadata (constructor takes precedence)
const result2 = await chain.invoke(
  { product: "eco bottles" },
  {
    callbacks: [opikHandler],
    metadata: { thread_id: "conversation-456" }
  }
);
```

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-2306

## Testing

Tested locally with:

```bash
cd sdks/typescript
npm run build && npm link
cd src/opik/integrations/opik-langchain
npm link opik && npm run build && npm link
cd ../../../../
npm link opik-langchain
npx tsx examples/langchain-with-thread-id.ts
```

## Documentation

Documentation was updated with new pattern