### PR TITLE
[OPIK-2315] [P SDK] Move thread evaluation e2e test requiring real LLM calls to e2e-integration workflow

### DIFF
--- a/sdks/python/tests/conftest.py
+++ b/sdks/python/tests/conftest.py
@@ -12,6 +12,8 @@ import pytest
 from opik import context_storage
 from opik.api_objects import opik_client
 from opik.message_processing import streamer_constructors
+
+from .testlib import environment
 from . import testlib
 from .testlib import backend_emulator_message_processor, noop_file_upload_manager
 
@@ -193,7 +195,7 @@ def temp_file_15mb():
 @pytest.fixture(scope="session")
 def ensure_openai_configured():
     # don't use assertion here to prevent printing os.environ with all env variables
-    if not ("OPENAI_API_KEY" in os.environ and "OPENAI_ORG_ID" in os.environ):
+    if not environment.has_openai_api_key():
         raise Exception("OpenAI not configured!")
 
 

--- a/sdks/python/tests/e2e/evaluation/test_threads_evaluate.py
+++ b/sdks/python/tests/e2e/evaluation/test_threads_evaluate.py
@@ -1,6 +1,5 @@
 import time
 import uuid
-import os
 import pytest
 
 from opik import synchronization
@@ -8,6 +7,8 @@ from opik.api_objects.threads import threads_client
 from opik.evaluation import metrics
 from opik.evaluation.threads import evaluator
 from opik.types import FeedbackScoreDict
+
+from ...testlib import environment
 from .. import verifiers
 
 
@@ -83,7 +84,7 @@ def eval_project_name(temporary_project_name: str) -> str:
 
 
 @pytest.mark.skipif(
-    "OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY is not set"
+    not environment.has_openai_api_key(), reason="OPENAI_API_KEY is not set"
 )
 def test_evaluate_threads__happy_path(
     opik_client, active_thread_and_project_name, eval_project_name

--- a/sdks/python/tests/testlib/environment.py
+++ b/sdks/python/tests/testlib/environment.py
@@ -3,17 +3,17 @@ import os
 
 def has_openai_api_key():
     """
-    Checks if the OpenAI API key exists in the environment variables.
+    Checks if the OpenAI API key and organization ID exist in the environment variables.
 
-    This function verifies the presence of an API key labeled 'OPIK_API_KEY' in the
-    system's environment variables and ensures it is not empty.
+    This function verifies the presence and non-emptiness of both the 'OPENAI_API_KEY'
+    and 'OPENAI_ORG_ID' environment variables in the system's environment.
 
     Returns:
-        bool: True if the API key exists and is not empty, False otherwise.
+        bool: True if both variables exist and are not empty, False otherwise.
     """
     return (
-        "OPIK_API_KEY" in os.environ
-        and len(os.environ["OPIK_API_KEY"]) > 0
+        "OPENAI_API_KEY" in os.environ
+        and len(os.environ["OPENAI_API_KEY"]) > 0
         and "OPENAI_ORG_ID" in os.environ
         and len(os.environ["OPENAI_ORG_ID"]) > 0
     )

--- a/sdks/python/tests/testlib/environment.py
+++ b/sdks/python/tests/testlib/environment.py
@@ -1,0 +1,19 @@
+import os
+
+
+def has_openai_api_key():
+    """
+    Checks if the OpenAI API key exists in the environment variables.
+
+    This function verifies the presence of an API key labeled 'OPIK_API_KEY' in the
+    system's environment variables and ensures it is not empty.
+
+    Returns:
+        bool: True if the API key exists and is not empty, False otherwise.
+    """
+    return (
+        "OPIK_API_KEY" in os.environ
+        and len(os.environ["OPIK_API_KEY"]) > 0
+        and "OPENAI_ORG_ID" in os.environ
+        and len(os.environ["OPENAI_ORG_ID"]) > 0
+    )


### PR DESCRIPTION
## Details

Currently thread evaluation is the only test that requires LLM API key to run, which makes e2e tests jobs red for every external contribution, let’s improve it and try keep e2e tests not requiring any external API keys.

### Key changes

This PR refactors the thread evaluation test to separate concerns around external API dependencies. The changes extract OpenAI API key validation logic into a reusable utility function and update test skip conditions to use this centralized approach.

- Creates a new utility function to check for required OpenAI environment variables
- Updates thread evaluation tests to use the new validation function
- Centralizes the logic for checking external API dependencies

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-2315

## Testing
Fixed related test case

## Documentation
No documentation changes