### PR TITLE
[NA] [BE] Add retry mechanism for python online evaluation metrics

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -401,6 +401,12 @@ pythonEvaluator:
   # Default: http://localhost:8000
   # Description: URL of the Python evaluator service, generally the opik-python-backend service
   url: ${PYTHON_EVALUATOR_URL:-http://localhost:8000}
+  # Default: 4
+  # Description: Maximum number of retry attempts for failed requests to the Python evaluator service
+  maxRetryAttempts: ${PYTHON_EVALUATOR_MAX_RETRY_ATTEMPTS:-4}
+  # Default: 500
+  # Description: Delay in milliseconds between retry attempts for failed requests to the Python evaluator service
+  retryDelay: ${PYTHON_EVALUATOR_RETRY_DELAY:-500}
 
 serviceToggles:
   # Default: true

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorService.java
@@ -3,17 +3,25 @@ package com.comet.opik.domain.evaluators.python;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.google.common.base.Preconditions;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.lang3.StringUtils;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
+import reactor.util.retry.RetryBackoffSpec;
 
+import java.net.SocketTimeoutException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -34,47 +42,140 @@ public class PythonEvaluatorService {
                 .code(code)
                 .data(data)
                 .build();
-        try (var response = client.target(URL_TEMPLATE.formatted(config.getPythonEvaluator().url()))
-                .request()
-                .post(Entity.json(request))) {
-            var result = getAndValidateResult(response);
-            return result.scores();
-        }
+
+        return executeWithRetry(() -> performHttpCall(request));
     }
 
     public List<PythonScoreResult> evaluateThread(@NonNull String code, List<ChatMessage> context) {
-        Preconditions.checkArgument(CollectionUtils.isNotEmpty(context), "Argument 'data' must not be empty");
+        Preconditions.checkArgument(CollectionUtils.isNotEmpty(context), "Argument 'context' must not be empty");
         var request = TraceThreadPythonEvaluatorRequest.builder()
                 .code(code)
                 .data(context)
                 .build();
-        try (var response = client.target(URL_TEMPLATE.formatted(config.getPythonEvaluator().url()))
+
+        return executeWithRetry(() -> performHttpCall(request));
+    }
+
+    private List<PythonScoreResult> executeWithRetry(HttpCallSupplier operation) {
+        return Mono.fromCallable(operation::execute)
+                .retryWhen(createRetrySpec())
+                .subscribeOn(Schedulers.boundedElastic())
+                .block();
+    }
+
+    private RetryBackoffSpec createRetrySpec() {
+        var retryConfig = config.getPythonEvaluator();
+
+        return Retry.backoff(retryConfig.getMaxRetryAttempts(),
+                Duration.ofMillis(retryConfig.getRetryDelay().toMilliseconds()))
+                .doBeforeRetry(retrySignal -> log.warn("Retrying Python evaluation, attempt '{}': '{}'",
+                        retrySignal.totalRetries() + 1,
+                        retrySignal.failure().getMessage()))
+                .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> {
+                    log.error("Failed to execute Python evaluation after '{}' attempts",
+                            retrySignal.totalRetries() + 1,
+                            retrySignal.failure());
+                    return retrySignal.failure();
+                })
+                .filter(this::isRetryableException);
+    }
+
+    private List<PythonScoreResult> performHttpCall(Object request) {
+        try (var response = client.target(URL_TEMPLATE.formatted(config.getPythonEvaluator().getUrl()))
                 .request()
                 .post(Entity.json(request))) {
-            var result = getAndValidateResult(response);
-            return result.scores();
+            return processResponse(response);
         }
     }
 
-    private PythonEvaluatorResponse getAndValidateResult(Response response) {
+    private List<PythonScoreResult> processResponse(Response response) {
+        var statusCode = response.getStatus();
+
         if (response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL) {
-            return response.readEntity(PythonEvaluatorResponse.class);
+            return response.readEntity(PythonEvaluatorResponse.class).scores();
         }
-        String errorMessage = null;
+
+        String errorMessage = extractErrorMessage(response);
+
+        if (statusCode == 400) {
+            throw new BadRequestException(errorMessage);
+        } else if (isRetryableStatusCode(statusCode)) {
+            // Create a custom retryable exception for 503/504 status codes
+            throw new RetryableServiceException(
+                    "Service temporarily unavailable (HTTP " + statusCode + "): " + errorMessage, statusCode);
+        } else {
+            throw new InternalServerErrorException(
+                    "Python evaluation failed (HTTP " + statusCode + "): " + errorMessage);
+        }
+    }
+
+    private String extractErrorMessage(Response response) {
+        String errorMessage = "Unknown error during Python evaluation";
+
         if (response.hasEntity() && response.bufferEntity()) {
             try {
                 errorMessage = response.readEntity(PythonEvaluatorErrorResponse.class).error();
-            } catch (RuntimeException exceptionErrorResponse) {
-                log.warn("Failed to parse error response, falling back to parsing string", exceptionErrorResponse);
+            } catch (RuntimeException parseErrorResponse) {
+                log.warn("Failed to parse error response, falling back to parsing string", parseErrorResponse);
                 try {
                     errorMessage = response.readEntity(String.class);
-                } catch (RuntimeException exceptionStringResponse) {
-                    log.warn("Failed to parse error string, falling back to default message", exceptionStringResponse);
+                } catch (RuntimeException parseStringResponse) {
+                    log.warn("Failed to parse error string response", parseStringResponse);
                 }
             }
         }
-        // Any other status code is an internal server error from the perspective of the caller
-        errorMessage = StringUtils.isNotBlank(errorMessage) ? errorMessage : "Unknown error during Python evaluation";
-        throw new InternalServerErrorException(errorMessage);
+
+        return errorMessage;
+    }
+
+    private boolean isRetryableException(Throwable exception) {
+        return switch (exception) {
+            case RetryableServiceException ignored -> true;
+            case ProcessingException processingException -> {
+                Throwable cause = processingException.getCause();
+                yield isTimeoutOrNetworkException(cause);
+            }
+            case InternalServerErrorException ignored -> false;
+            default -> false;
+        };
+    }
+
+    private boolean isRetryableStatusCode(int statusCode) {
+        return statusCode == 503 || statusCode == 504;
+    }
+
+    /**
+     * Checks if the exception is a timeout or network-related exception.
+     */
+    private boolean isTimeoutOrNetworkException(Throwable cause) {
+        if (cause == null) {
+            return false;
+        }
+
+        return cause instanceof SocketTimeoutException ||
+                cause instanceof java.net.ConnectException ||
+                cause instanceof java.net.SocketException ||
+                cause instanceof java.io.InterruptedIOException ||
+                cause instanceof java.util.concurrent.TimeoutException;
+    }
+
+    @FunctionalInterface
+    private interface HttpCallSupplier {
+        List<PythonScoreResult> execute();
+    }
+
+    /**
+     * Custom exception for retryable HTTP service errors (503, 504).
+     * This avoids Jakarta validation issues with InternalServerErrorException.
+     */
+    @Getter
+    private static class RetryableServiceException extends RuntimeException {
+
+        private final int statusCode;
+
+        public RetryableServiceException(String message, int statusCode) {
+            super(message);
+            this.statusCode = statusCode;
+        }
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/PythonEvaluatorConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/PythonEvaluatorConfig.java
@@ -1,11 +1,20 @@
 package com.comet.opik.infrastructure;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.util.Duration;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
 
-public record PythonEvaluatorConfig(@JsonProperty @NotBlank String url) {
+@Data
+public class PythonEvaluatorConfig {
 
-    public PythonEvaluatorConfig() {
-        this(null);
-    }
+    @JsonProperty
+    @NotBlank private String url;
+
+    @JsonProperty
+    @Min(1) private int maxRetryAttempts = 4;
+
+    @JsonProperty
+    private Duration retryDelay = Duration.milliseconds(500);
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
@@ -1,0 +1,416 @@
+package com.comet.opik.domain.evaluators.python;
+
+import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.infrastructure.PythonEvaluatorConfig;
+import com.comet.opik.podam.PodamFactoryUtils;
+import io.dropwizard.util.Duration;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.net.SocketTimeoutException;
+import java.util.List;
+import java.util.Map;
+
+import static com.comet.opik.domain.evaluators.python.TraceThreadPythonEvaluatorRequest.ChatMessage;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Python Evaluator Service Test")
+class PythonEvaluatorServiceTest {
+
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+
+    @Mock
+    private Client client;
+
+    @Mock
+    private OpikConfiguration config;
+
+    @Mock
+    private PythonEvaluatorConfig pythonEvaluatorConfig;
+
+    @Mock
+    private WebTarget webTarget;
+
+    @Mock
+    private Invocation.Builder builder;
+
+    @Mock
+    private Response response;
+
+    private PythonEvaluatorService pythonEvaluatorService;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(config.getPythonEvaluator()).thenReturn(pythonEvaluatorConfig);
+        lenient().when(pythonEvaluatorConfig.getUrl()).thenReturn("http://localhost:8000");
+        lenient().when(pythonEvaluatorConfig.getMaxRetryAttempts()).thenReturn(4);
+        lenient().when(pythonEvaluatorConfig.getRetryDelay()).thenReturn(Duration.milliseconds(100));
+
+        pythonEvaluatorService = new PythonEvaluatorService(client, config);
+    }
+
+    private void setupHttpCall() {
+        when(client.target(anyString())).thenReturn(webTarget);
+        when(webTarget.request()).thenReturn(builder);
+        lenient().when(builder.post(any(Entity.class))).thenReturn(response);
+    }
+
+    @Nested
+    @DisplayName("Evaluate Method Tests")
+    class EvaluateTests {
+
+        @Test
+        void evaluate__whenValidRequest__shouldReturnResults() {
+            // Given
+            var code = "def evaluate(input, output): return 1.0";
+            var data = Map.of("input", "test input", "output", "test output");
+            var expectedScores = List.of(
+                    podamFactory.manufacturePojo(PythonScoreResult.class),
+                    podamFactory.manufacturePojo(PythonScoreResult.class));
+            var pythonResponse = PythonEvaluatorResponse.builder()
+                    .scores(expectedScores)
+                    .build();
+
+            setupHttpCall();
+            when(response.getStatusInfo()).thenReturn(Response.Status.OK);
+            when(response.readEntity(PythonEvaluatorResponse.class)).thenReturn(pythonResponse);
+
+            // When
+            var actualScores = pythonEvaluatorService.evaluate(code, data);
+
+            // Then
+            assertThat(actualScores).isEqualTo(expectedScores);
+            verify(client).target("http://localhost:8000/v1/private/evaluators/python");
+        }
+
+        @Test
+        void evaluate__whenEmptyData__shouldThrowIllegalArgumentException() {
+            // Given
+            var code = "def evaluate(input, output): return 1.0";
+            var emptyData = Map.<String, String>of();
+
+            // When & Then
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, emptyData))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Argument 'data' must not be empty");
+        }
+
+        @Test
+        void evaluate__when503Error__shouldRetryAndEventuallySucceed() {
+            // Given
+            var code = "def evaluate(input, output): return 1.0";
+            var data = Map.of("input", "test input", "output", "test output");
+            var expectedScores = List.of(podamFactory.manufacturePojo(PythonScoreResult.class));
+            var pythonResponse = PythonEvaluatorResponse.builder()
+                    .scores(expectedScores)
+                    .build();
+
+            setupHttpCall();
+
+            // First 2 calls return 503, 3rd call succeeds
+            when(response.getStatusInfo())
+                    .thenReturn(Response.Status.SERVICE_UNAVAILABLE)
+                    .thenReturn(Response.Status.SERVICE_UNAVAILABLE)
+                    .thenReturn(Response.Status.OK);
+            when(response.getStatus())
+                    .thenReturn(503)
+                    .thenReturn(503)
+                    .thenReturn(200);
+            when(response.readEntity(PythonEvaluatorResponse.class)).thenReturn(pythonResponse);
+
+            // When
+            var actualScores = pythonEvaluatorService.evaluate(code, data);
+
+            // Then
+            assertThat(actualScores).isEqualTo(expectedScores);
+            verify(builder, times(3)).post(any(Entity.class));
+        }
+
+        @Test
+        void evaluate__when504Error__shouldRetryAndEventuallySucceed() {
+            // Given
+            var code = "def evaluate(input, output): return 1.0";
+            var data = Map.of("input", "test input", "output", "test output");
+            var expectedScores = List.of(podamFactory.manufacturePojo(PythonScoreResult.class));
+            var pythonResponse = PythonEvaluatorResponse.builder()
+                    .scores(expectedScores)
+                    .build();
+
+            setupHttpCall();
+
+            // First call returns 504, 2nd call succeeds
+            when(response.getStatusInfo())
+                    .thenReturn(Response.Status.GATEWAY_TIMEOUT)
+                    .thenReturn(Response.Status.OK);
+            when(response.getStatus())
+                    .thenReturn(504)
+                    .thenReturn(200);
+            when(response.readEntity(PythonEvaluatorResponse.class)).thenReturn(pythonResponse);
+
+            // When
+            var actualScores = pythonEvaluatorService.evaluate(code, data);
+
+            // Then
+            assertThat(actualScores).isEqualTo(expectedScores);
+            verify(builder, times(2)).post(any(Entity.class));
+        }
+
+        @Test
+        void evaluate__whenTimeoutException__shouldRetryAndEventuallySucceed() {
+            // Given
+            var code = "def evaluate(input, output): return 1.0";
+            var data = Map.of("input", "test input", "output", "test output");
+            var expectedScores = List.of(podamFactory.manufacturePojo(PythonScoreResult.class));
+            var pythonResponse = PythonEvaluatorResponse.builder()
+                    .scores(expectedScores)
+                    .build();
+
+            setupHttpCall();
+
+            // First call throws timeout, 2nd call succeeds
+            when(builder.post(any(Entity.class)))
+                    .thenThrow(new ProcessingException("Request timeout",
+                            new SocketTimeoutException("Connection timed out")))
+                    .thenReturn(response);
+            when(response.getStatusInfo()).thenReturn(Response.Status.OK);
+            when(response.readEntity(PythonEvaluatorResponse.class)).thenReturn(pythonResponse);
+
+            // When
+            var actualScores = pythonEvaluatorService.evaluate(code, data);
+
+            // Then
+            assertThat(actualScores).isEqualTo(expectedScores);
+            verify(builder, times(2)).post(any(Entity.class));
+        }
+
+        @Test
+        void evaluate__whenMaxRetriesExceeded__shouldThrowException() {
+            // Given
+            var code = "def evaluate(input, output): return 1.0";
+            var data = Map.of("input", "test input", "output", "test output");
+
+            setupHttpCall();
+
+            // All calls return 503
+            when(response.getStatusInfo()).thenReturn(Response.Status.SERVICE_UNAVAILABLE);
+            when(response.getStatus()).thenReturn(503);
+
+            // When & Then
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data))
+                    .isInstanceOf(RuntimeException.class);
+
+            // Should retry 4 times + initial attempt = 5 total calls
+            verify(builder, times(5)).post(any(Entity.class));
+        }
+
+        @Test
+        void evaluate__when400Error__shouldNotRetryAndThrowImmediately() {
+            // Given
+            var code = "def evaluate(input, output): return 1.0";
+            var data = Map.of("input", "test input", "output", "test output");
+            var errorResponse = PythonEvaluatorErrorResponse.builder()
+                    .error("Invalid Python code")
+                    .build();
+
+            setupHttpCall();
+            when(response.getStatusInfo()).thenReturn(Response.Status.BAD_REQUEST);
+            when(response.getStatus()).thenReturn(400);
+            when(response.hasEntity()).thenReturn(true);
+            when(response.bufferEntity()).thenReturn(true);
+            when(response.readEntity(PythonEvaluatorErrorResponse.class)).thenReturn(errorResponse);
+
+            // When & Then
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessageContaining("Invalid Python code");
+
+            // Should not retry for 400 errors
+            verify(builder, times(1)).post(any(Entity.class));
+        }
+
+        @Test
+        void evaluate__whenNonRetryableProcessingException__shouldThrowImmediately() {
+            // Given
+            var code = "def evaluate(input, output): return 1.0";
+            var data = Map.of("input", "test input", "output", "test output");
+
+            setupHttpCall();
+            when(builder.post(any(Entity.class)))
+                    .thenThrow(new ProcessingException("Connection refused"));
+
+            // When & Then
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data))
+                    .isInstanceOf(ProcessingException.class)
+                    .hasMessageContaining("Connection refused");
+
+            // Should not retry for non-timeout processing exceptions
+            verify(builder, times(1)).post(any(Entity.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("EvaluateThread Method Tests")
+    class EvaluateThreadTests {
+
+        @Test
+        void evaluateThread__whenValidRequest__shouldReturnResults() {
+            // Given
+            var code = "def evaluate(messages): return 1.0";
+            var context = List.of(
+                    podamFactory.manufacturePojo(ChatMessage.class),
+                    podamFactory.manufacturePojo(ChatMessage.class));
+            var expectedScores = List.of(
+                    podamFactory.manufacturePojo(PythonScoreResult.class));
+            var pythonResponse = PythonEvaluatorResponse.builder()
+                    .scores(expectedScores)
+                    .build();
+
+            setupHttpCall();
+            when(response.getStatusInfo()).thenReturn(Response.Status.OK);
+            when(response.readEntity(PythonEvaluatorResponse.class)).thenReturn(pythonResponse);
+
+            // When
+            var actualScores = pythonEvaluatorService.evaluateThread(code, context);
+
+            // Then
+            assertThat(actualScores).isEqualTo(expectedScores);
+            verify(client).target("http://localhost:8000/v1/private/evaluators/python");
+        }
+
+        @Test
+        void evaluateThread__whenEmptyContext__shouldThrowIllegalArgumentException() {
+            // Given
+            var code = "def evaluate(messages): return 1.0";
+            var emptyContext = List.<ChatMessage>of();
+
+            // When & Then
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluateThread(code, emptyContext))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Argument 'context' must not be empty");
+        }
+
+        @Test
+        void evaluateThread__when503Error__shouldRetryAndEventuallySucceed() {
+            // Given
+            var code = "def evaluate(messages): return 1.0";
+            var context = List.of(podamFactory.manufacturePojo(ChatMessage.class));
+            var expectedScores = List.of(podamFactory.manufacturePojo(PythonScoreResult.class));
+            var pythonResponse = PythonEvaluatorResponse.builder()
+                    .scores(expectedScores)
+                    .build();
+
+            setupHttpCall();
+
+            // First call returns 503, 2nd call succeeds
+            when(response.getStatusInfo())
+                    .thenReturn(Response.Status.SERVICE_UNAVAILABLE)
+                    .thenReturn(Response.Status.OK);
+            when(response.getStatus())
+                    .thenReturn(503)
+                    .thenReturn(200);
+            when(response.readEntity(PythonEvaluatorResponse.class)).thenReturn(pythonResponse);
+
+            // When
+            var actualScores = pythonEvaluatorService.evaluateThread(code, context);
+
+            // Then
+            assertThat(actualScores).isEqualTo(expectedScores);
+            verify(builder, times(2)).post(any(Entity.class));
+        }
+
+        @Test
+        void evaluateThread__whenMaxRetriesExceeded__shouldThrowException() {
+            // Given
+            var code = "def evaluate(messages): return 1.0";
+            var context = List.of(podamFactory.manufacturePojo(ChatMessage.class));
+
+            setupHttpCall();
+
+            // All calls return 504
+            when(response.getStatusInfo()).thenReturn(Response.Status.GATEWAY_TIMEOUT);
+            when(response.getStatus()).thenReturn(504);
+
+            // When & Then
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluateThread(code, context))
+                    .isInstanceOf(RuntimeException.class);
+
+            // Should retry 4 times + initial attempt = 5 total calls
+            verify(builder, times(5)).post(any(Entity.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("Error Response Parsing Tests")
+    class ErrorResponseParsingTests {
+
+        @Test
+        void evaluate__whenErrorResponseParsingFails__shouldFallbackToStringParsing() {
+            // Given
+            var code = "def evaluate(input, output): return 1.0";
+            var data = Map.of("input", "test input", "output", "test output");
+
+            setupHttpCall();
+            when(response.getStatusInfo()).thenReturn(Response.Status.BAD_REQUEST);
+            when(response.getStatus()).thenReturn(400);
+            when(response.hasEntity()).thenReturn(true);
+            when(response.bufferEntity()).thenReturn(true);
+
+            // First readEntity call fails, second succeeds with string
+            when(response.readEntity(PythonEvaluatorErrorResponse.class))
+                    .thenThrow(new RuntimeException("JSON parsing failed"));
+            when(response.readEntity(String.class)).thenReturn("Custom error message");
+
+            // When & Then
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessageContaining("Custom error message");
+        }
+
+        @Test
+        void evaluate__whenBothErrorResponseParsingFails__shouldUseDefaultMessage() {
+            // Given
+            var code = "def evaluate(input, output): return 1.0";
+            var data = Map.of("input", "test input", "output", "test output");
+
+            setupHttpCall();
+            when(response.getStatusInfo()).thenReturn(Response.Status.INTERNAL_SERVER_ERROR);
+            when(response.getStatus()).thenReturn(500);
+            when(response.hasEntity()).thenReturn(true);
+            when(response.bufferEntity()).thenReturn(true);
+
+            // Both readEntity calls fail
+            when(response.readEntity(PythonEvaluatorErrorResponse.class))
+                    .thenThrow(new RuntimeException("JSON parsing failed"));
+            when(response.readEntity(String.class))
+                    .thenThrow(new RuntimeException("String parsing failed"));
+
+            // When & Then
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data))
+                    .isInstanceOf(InternalServerErrorException.class)
+                    .hasMessageContaining(
+                            "Python evaluation failed (HTTP 500): Unknown error during Python evaluation");
+        }
+    }
+}


### PR DESCRIPTION
## Details
This PR adds a retry mechanism to the Python online evaluation metrics consumer, allowing it to retry HTTP calls to the 'Opik-python-backend`. The goal is to mitigate the issues caused by the 504 errors, which are a result of Docker containers' slow processing. 

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
NA

## Testing
- Added Unittest to validate retry behaviour
