### PR TITLE
[NA] [SDK] alexkuzmik / Fix tests and integration, now error are propagated correctly

### DIFF
--- a/sdks/python/src/opik/integrations/adk/patchers/adk_otel_tracer/opik_adk_otel_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/patchers/adk_otel_tracer/opik_adk_otel_tracer.py
@@ -125,6 +125,7 @@ class OpikADKOtelTracer(opentelemetry.trace.NoOpTracer):
                 trace_to_close_in_finally_block.update(error_info=error_info)
             if span_to_close_in_finally_block is not None:
                 span_to_close_in_finally_block.update(error_info=error_info)
+            raise
         finally:
             if trace_to_close_in_finally_block is not None:
                 self._ensure_trace_is_finalized(trace_to_close_in_finally_block.id)

--- a/sdks/python/tests/library_integration/adk/test_adk_sync.py
+++ b/sdks/python/tests/library_integration/adk/test_adk_sync.py
@@ -1636,7 +1636,7 @@ def test_adk__tool_call_failed__error_info_is_logged_in_tool_span(fake_backend):
     )
 
     def get_weather(city: str) -> str:
-        1/0
+        1 / 0
         return ""
 
     root_agent = adk_agents.Agent(


### PR DESCRIPTION
## Details
Fixed the bug when OpikTracer interfered with ADK error processing.

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- NA

## Testing
Updated existing integration test and added a new one.

## Documentation
-