### PR TITLE
[OPIK-2309] [FE] show links in the experiment config tab

### DIFF
--- a/apps/opik-frontend/package-lock.json
+++ b/apps/opik-frontend/package-lock.json
@@ -59,6 +59,8 @@
         "js-yaml": "^4.1.0",
         "json-2-csv": "^5.5.6",
         "jsonpath-plus": "^10.3.0",
+        "linkify-react": "^4.3.2",
+        "linkifyjs": "^4.3.2",
         "lodash": "^4.17.21",
         "lucide-react": "^0.461.0",
         "md5": "^2.3.0",
@@ -11539,6 +11541,22 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "node_modules/linkify-react": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkify-react/-/linkify-react-4.3.2.tgz",
+      "integrity": "sha512-mi744h1hf+WDsr+paJgSBBgYNLMWNSHyM9V9LVUo03RidNGdw1VpI7Twnt+K3pEh3nIzB4xiiAgZxpd61ItKpQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "linkifyjs": "^4.0.0",
+        "react": ">= 15.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
     },
     "node_modules/lint-staged": {
       "version": "15.2.7",

--- a/apps/opik-frontend/package.json
+++ b/apps/opik-frontend/package.json
@@ -76,6 +76,8 @@
     "js-yaml": "^4.1.0",
     "json-2-csv": "^5.5.6",
     "jsonpath-plus": "^10.3.0",
+    "linkify-react": "^4.3.2",
+    "linkifyjs": "^4.3.2",
     "lodash": "^4.17.21",
     "lucide-react": "^0.461.0",
     "md5": "^2.3.0",

--- a/apps/opik-frontend/src/components/layout/SideBar/SideBar.tsx
+++ b/apps/opik-frontend/src/components/layout/SideBar/SideBar.tsx
@@ -295,7 +295,11 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
     ]);
 
     if (SidebarInviteDevButton) {
-      bottomItems.splice(2, 0, <SidebarInviteDevButton expanded={expanded} />);
+      bottomItems.splice(
+        2,
+        0,
+        <SidebarInviteDevButton key="inviteDevButton" expanded={expanded} />,
+      );
     }
 
     return bottomItems;

--- a/apps/opik-frontend/src/components/pages-shared/experiments/CompareExperimentsConfigCell/CompareExperimentsConfigCell.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/experiments/CompareExperimentsConfigCell/CompareExperimentsConfigCell.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import isUndefined from "lodash/isUndefined";
 import { CellContext } from "@tanstack/react-table";
-
+import Linkify from "linkify-react";
 import CellWrapper from "@/components/shared/DataTableCells/CellWrapper";
 import { ROW_HEIGHT } from "@/types/shared";
 import TextDiff from "@/components/shared/CodeDiff/TextDiff";
@@ -41,7 +41,21 @@ const CompareExperimentsConfigCell: React.FC<
         {showDiffView ? (
           <TextDiff content1={toString(baseData)} content2={toString(data)} />
         ) : (
-          toString(data)
+          <Linkify
+            options={{
+              defaultProtocol: "https",
+              target: "_blank",
+              rel: "noopener noreferrer",
+              className:
+                "break-all text-blue-600 underline hover:text-blue-800",
+              ignoreTags: ["script", "style"],
+              validate: {
+                url: (value) => /^https?:\/\//.test(value),
+              },
+            }}
+          >
+            {toString(data)}
+          </Linkify>
         )}
       </div>
     );


### PR DESCRIPTION
## Details
<img width="1356" height="1039" alt="image" src="https://github.com/user-attachments/assets/83395651-e3f0-4cc9-8f1a-1d787c033edf" />

This pull request adds support for automatic link detection and rendering in the experiment comparison config cell, and introduces the necessary dependencies for this feature. The most significant changes include updating dependencies, enhancing the config cell UI, and a minor fix for a sidebar component.

**Dependencies:**

* Added `linkify-react` and `linkifyjs` as new dependencies in `package.json` and `package-lock.json` to enable link detection and rendering in React components.

**UI Enhancements:**

* Updated `CompareExperimentsConfigCell.tsx` to wrap cell content in a `Linkify` component, automatically converting URLs in the config data to clickable links with appropriate styling and security attributes. 

**Component Fixes:**

* Added a `key` prop to the `SidebarInviteDevButton` in the `SideBar` component to avoid React key warnings and improve rendering stability.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2309

## Testing

## Documentation
