### PR TITLE
[NA] [BE] Fix HTTP 500 error for ValidationErrorMessage serialisation in streaming endpoints

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/json/ValidationErrorMessageBodyWriter.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/json/ValidationErrorMessageBodyWriter.java
@@ -1,0 +1,39 @@
+package com.comet.opik.infrastructure.json;
+
+import com.comet.opik.utils.JsonUtils;
+import io.dropwizard.jersey.validation.ValidationErrorMessage;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Provider;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+@Provider
+@Produces(MediaType.APPLICATION_OCTET_STREAM)
+public class ValidationErrorMessageBodyWriter implements MessageBodyWriter<ValidationErrorMessage> {
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return ValidationErrorMessage.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public void writeTo(ValidationErrorMessage validationErrorMessage, Class<?> type, Type genericType,
+            Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders,
+            OutputStream entityStream) throws IOException, WebApplicationException {
+        entityStream.write(JsonUtils.writeValueAsString(validationErrorMessage).getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public long getSize(ValidationErrorMessage validationErrorMessage, Class<?> type, Type genericType,
+            Annotation[] annotations, MediaType mediaType) {
+        return JsonUtils.writeValueAsString(validationErrorMessage).getBytes(StandardCharsets.UTF_8).length;
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/json/ValidationErrorMessageBodyWriterUnitTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/json/ValidationErrorMessageBodyWriterUnitTest.java
@@ -1,0 +1,64 @@
+package com.comet.opik.infrastructure.json;
+
+import io.dropwizard.jersey.validation.ValidationErrorMessage;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ValidationErrorMessageBodyWriter Unit Test")
+class ValidationErrorMessageBodyWriterUnitTest {
+
+    @Test
+    @DisplayName("Should correctly identify writable ValidationErrorMessage types")
+    void testIsWriteable() {
+        var writer = new ValidationErrorMessageBodyWriter();
+
+        // Should be writable for ValidationErrorMessage class
+        assertThat(writer.isWriteable(ValidationErrorMessage.class, ValidationErrorMessage.class, null,
+                MediaType.APPLICATION_OCTET_STREAM_TYPE))
+                .isTrue();
+
+        // Should not be writable for other classes
+        assertThat(writer.isWriteable(String.class, String.class, null, MediaType.APPLICATION_OCTET_STREAM_TYPE))
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("Should successfully serialize ValidationErrorMessage to JSON bytes")
+    void testWriteTo() throws Exception {
+        var writer = new ValidationErrorMessageBodyWriter();
+        var errorMessage = new ValidationErrorMessage(List.of("Validation error 1", "Validation error 2"));
+        var outputStream = new ByteArrayOutputStream();
+
+        // Write the ValidationErrorMessage to the output stream
+        writer.writeTo(errorMessage, ValidationErrorMessage.class, ValidationErrorMessage.class, null,
+                MediaType.APPLICATION_OCTET_STREAM_TYPE, null, outputStream);
+
+        // Verify the output contains the expected JSON content
+        var result = outputStream.toString();
+        assertThat(result).isNotEmpty();
+        assertThat(result).contains("Validation error 1");
+        assertThat(result).contains("Validation error 2");
+        assertThat(result).contains("errors");
+    }
+
+    @Test
+    @DisplayName("Should calculate correct size for ValidationErrorMessage JSON")
+    void testGetSize() {
+        var writer = new ValidationErrorMessageBodyWriter();
+        var errorMessage = new ValidationErrorMessage(List.of("Validation error"));
+
+        // Get the calculated size
+        long size = writer.getSize(errorMessage, ValidationErrorMessage.class, ValidationErrorMessage.class,
+                null, MediaType.APPLICATION_OCTET_STREAM_TYPE);
+
+        // Verify size is positive and reasonable
+        assertThat(size).isGreaterThan(0);
+        assertThat(size).isLessThan(1000); // Reasonable upper bound for a simple error message
+    }
+}


### PR DESCRIPTION
## Details

- Add ValidationErrorMessageBodyWriter to handle ValidationErrorMessage serialization for application/octet-stream media type
- Fix MessageBodyWriter not found error in /v1/private/traces/search endpoint when validation fails
- Add comprehensive unit tests for ValidationErrorMessageBodyWriter
- Ensure proper JSON serialization of validation errors for streaming endpoints

The fix should avoid the following issues:

```
MessageBodyWriter not found for media type=application/octet-stream, type=class io.dropwizard.jersey.validation.ValidationErrorMessage, genericType=class io.dropwizard.jersey.validation.ValidationErrorMessage.
```

```
akarta.ws.rs.InternalServerErrorException: HTTP 500 Internal Server Error
…lassfish.jersey.server.internal.MappableExceptionWrapperInterceptor.aroundWriteTo(MappableExceptionWrapperInterceptor.java:65)
                  at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:139)
                                at org.glassfish.jersey.message.internal.MessageBodyFactory.writeTo(MessageBodyFactory.java:1116)
                                    at org.glassfish.jersey.server.ServerRuntime$Responder.writeResponse(ServerRuntime.java:649)
                                  at org.glassfish.jersey.server.ServerRuntime$Responder.processResponse(ServerRuntime.java:380)
                                          at org.glassfish.jersey.server.ServerRuntime$Responder.process(ServerRuntime.java:426)
                                                      at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:264)
                                                                 at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
                                                                 at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
            
```

## Details

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing

## Documentation
