### PR TITLE
[OPIK-2328] [DOCS] Add Atlassian MCP server to Cursor

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -18,9 +18,9 @@
       }
     },
     "Atlassian": {
-      "command": "npx mcp-remote https://mcp.atlassian.com/v1/sse",
+      "command": "npx -y mcp-remote https://mcp.atlassian.com/v1/sse",
       "env": {},
       "args": []
-    }    
+    }
   }
 }

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -16,6 +16,11 @@
         "GITHUB_PERSONAL_ACCESS_TOKEN": "<GITHUB_PERSONAL_ACCESS_TOKEN>",
         "GITHUB_TOOLSETS": "repos,pull_requests"
       }
-    }
+    },
+    "Atlassian": {
+      "command": "npx mcp-remote https://mcp.atlassian.com/v1/sse",
+      "env": {},
+      "args": []
+    }    
   }
 }


### PR DESCRIPTION
## Details
This PR adds Atlassian MCP (Model Context Protocol) server configuration to enable Jira integration within Cursor IDE. The configuration sets up an Atlassian MCP server using npx that provides access to Jira functionality, allowing developers to interact with Jira tickets and workflows directly from their development environment.

## Change checklist
<!-- Please check the type of changes made -->
- [ ] User facing
- [x] Documentation update

## Issues
- Resolves # <!-- the GitHub issue this PR resolves (e.g. `#1234`) -->
- OPIK-2328 <!-- The Jira ticket (e.g. `OPIK-1234`) -->
- NA <!-- If no ticket, such as hotfixes etc. -->

## Testing
The Atlassian MCP server configuration has been tested locally to ensure proper npx setup and server connectivity. The server should be accessible through Cursor IDE's MCP integration for Jira operations.

## Documentation
Updated MCP configuration file `.cursor/mcp.json` with Atlassian server setup using npx and the official Atlassian MCP endpoint for Jira integration.