### PR TITLE
[OPIK-2339] [BE] Truncate string content when `<url>?truncate=true`

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -463,3 +463,9 @@ feedbackScores:
   # Default: false
   # Description: Whether to write feedback scores by their author or not
   writeToAuthored: ${OPIK_FEEDBACK_SCORES_WRITE_TO_AUTHORED:-false}
+
+# Response formatting configuration
+responseFormatting:
+  # Default: 10001
+  # Description: Maximum size of input/output/metadata fields in responses (FE limit + 1)
+  truncationSize: ${OPIK_RESPONSE_TRUNCATION_SIZE:-10001}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
@@ -86,4 +86,7 @@ public class OpikConfiguration extends JobConfiguration {
 
     @Valid @NotNull @JsonProperty
     private FeedbackScoresConfig feedbackScores = new FeedbackScoresConfig();
+
+    @Valid @NotNull @JsonProperty
+    private ResponseFormattingConfig responseFormatting = new ResponseFormattingConfig();
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ResponseFormattingConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ResponseFormattingConfig.java
@@ -1,0 +1,14 @@
+package com.comet.opik.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.Data;
+
+@Data
+public class ResponseFormattingConfig {
+
+    @Valid @JsonProperty
+    @Positive private int truncationSize = 10001;
+
+}


### PR DESCRIPTION
## Details

Add text truncation when `truncate=true` to avoid returning too much data to data heavy tables. This is especially useful for the trace and spans table when input or output fields are very large.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-2339

## Testing

This change as not tested in draft state

## Documentation

No documentation updates required