### PR TITLE
[OPIK-2143] Experiment runs triggered via playground fail without reason

### DIFF
--- a/apps/opik-frontend/src/api/playground/createLogPlaygroundProcessor.ts
+++ b/apps/opik-frontend/src/api/playground/createLogPlaygroundProcessor.ts
@@ -25,6 +25,7 @@ import {
   PROVIDER_TYPE,
 } from "@/types/providers";
 import { ProviderMessageType } from "@/types/llm";
+import { parseCompletionOutput } from "@/lib/playground";
 
 export interface LogQueueParams extends RunStreamingReturn {
   promptId: string;
@@ -87,7 +88,7 @@ const getTraceFromRun = (run: LogQueueParams): LogTrace => {
     startTime: run.startTime,
     endTime: run.endTime,
     input: { messages: run.providerMessages },
-    output: { output: run.result || run.providerError },
+    output: { output: parseCompletionOutput(run) },
   };
 };
 

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/usePromptDatasetItemCombination.ts
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/usePromptDatasetItemCombination.ts
@@ -16,6 +16,7 @@ import mustache from "mustache";
 import cloneDeep from "lodash/cloneDeep";
 import set from "lodash/set";
 import isObject from "lodash/isObject";
+import { parseCompletionOutput } from "@/lib/playground";
 
 export interface DatasetItemPromptCombination {
   datasetItem?: DatasetItem;
@@ -157,9 +158,6 @@ const usePromptDatasetItemCombination = ({
           },
         });
 
-        const error =
-          run.opikError || run.providerError || run.pythonProxyError;
-
         updateOutput(prompt.id, datasetItemId, {
           isLoading: false,
         });
@@ -176,8 +174,13 @@ const usePromptDatasetItemCombination = ({
           datasetItemId: datasetItemId,
         });
 
-        if (error) {
-          throw new Error(error);
+        if (
+          run.opikError ||
+          run.providerError ||
+          run.pythonProxyError ||
+          !run.result
+        ) {
+          throw new Error(parseCompletionOutput(run));
         }
       } catch (error) {
         const typedError = error as Error;

--- a/apps/opik-frontend/src/lib/playground.ts
+++ b/apps/opik-frontend/src/lib/playground.ts
@@ -24,6 +24,7 @@ import {
   ModelResolver,
   ProviderResolver,
 } from "@/hooks/useLLMProviderModelsData";
+import { RunStreamingReturn } from "@/api/playground/useCompletionProxyStreaming";
 
 export const getDefaultConfigByProvider = (
   provider?: PROVIDER_TYPE | "",
@@ -116,4 +117,14 @@ export const generateDefaultPrompt = ({
     ...initPrompt,
     id: generateRandomString(),
   };
+};
+
+export const parseCompletionOutput = (run: RunStreamingReturn) => {
+  return (
+    run.result ||
+    run.opikError ||
+    run.providerError ||
+    run.pythonProxyError ||
+    "Empty response was received from AI provider, please try again"
+  );
 };


### PR DESCRIPTION
## Details

This PR fixes an issue where experiment runs triggered via the playground would fail without providing a clear reason to users when AI providers return empty responses.

**Changes made:**
- **Added `parseCompletionOutput` utility function** in `lib/playground.ts` that provides a fallback message when AI providers return empty responses
- **Updated error handling** in `usePromptDatasetItemCombination.ts` to check for empty results and provide meaningful error messages
- **Enhanced trace logging** in `createLogPlaygroundProcessor.ts` to use the new parsing function for consistent output handling

The fix ensures that when an AI provider returns an empty response, users see the message "Empty response was received from AI provider, please try again" instead of experiencing a silent failure.
<img width="2560" height="934" alt="image" src="https://github.com/user-attachments/assets/9b1d846e-0468-4947-b47e-4b2c5308c91e" />

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2143

## Testing

**Scenarios covered:**
- Experiment runs with empty AI provider responses now display meaningful error messages
- Normal experiment runs continue to work as expected
- Error handling preserves existing provider-specific error messages (opikError, providerError, pythonProxyError)

**Steps to reproduce the original issue:**
1. Navigate to Playground
2. Configure an AI provider that returns empty responses
3. Run an experiment
4. Previously: Silent failure with no error message
5. Now: Clear error message explaining the empty response

**Manual testing:**
- Tested playground functionality with various AI providers
- Verified error messages appear correctly in experiment runs
- Confirmed trace logging includes appropriate output data

## Documentation

No documentation updates required - this is an internal bug fix that improves user experience without changing the public API.