### PR TITLE
[OPIK-2328] [DOCS] Add Playwright MCP server

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -21,6 +21,11 @@
       "command": "npx -y mcp-remote https://mcp.atlassian.com/v1/sse",
       "env": {},
       "args": []
+    },
+    "Playwright": {
+      "command": "npx @playwright/mcp@latest",
+      "env": {},
+      "args": []
     }
   }
 }


### PR DESCRIPTION
## Details
Added Playwright MCP server configuration to `.cursor/mcp.json` to enable browser automation capabilities within Cursor IDE. This enhancement allows developers to use Playwright's browser automation features directly through the MCP (Model Context Protocol) integration.

The configuration adds a new "Playwright" MCP server entry that uses the latest `@playwright/mcp` package, providing seamless browser testing and automation capabilities for development workflows.

## Change checklist
<!-- Please check the type of changes made -->
- [ ] User facing
- [x] Documentation update

## Issues
- OPIK-2328 <!-- The Jira ticket (e.g. `OPIK-1234`) -->

## Testing
- Validated JSON syntax of the updated `.cursor/mcp.json` configuration file
- Manually tested with Cursor.

## Documentation
- https://github.com/microsoft/playwright-mcp