### PR TITLE
[OPIK-2143] Experiment runs triggered via playground fail without reason

### DIFF
--- a/apps/opik-frontend/src/lib/playground.ts
+++ b/apps/opik-frontend/src/lib/playground.ts
@@ -125,6 +125,6 @@ export const parseCompletionOutput = (run: RunStreamingReturn) => {
     run.opikError ||
     run.providerError ||
     run.pythonProxyError ||
-    "Empty response was received from AI provider, please try again"
+    "The AI provider returned an empty response. Please, try again."
   );
 };


### PR DESCRIPTION
## Details
- fix error message for empty response in playground

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2143

## Testing
NA
## Documentation
NA