### PR TITLE
[OPIK-2242] [BE] Fix validation error handling in stream endpoints

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/OpikApplication.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/OpikApplication.java
@@ -1,5 +1,6 @@
 package com.comet.opik;
 
+import com.comet.opik.api.error.ConstraintViolationExceptionMapper;
 import com.comet.opik.api.error.JsonProcessingExceptionMapper;
 import com.comet.opik.infrastructure.ConfigurationModule;
 import com.comet.opik.infrastructure.DatabaseUtils;
@@ -121,5 +122,6 @@ public class OpikApplication extends Application<OpikConfiguration> {
         jersey.property(ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR, true);
 
         jersey.register(JsonProcessingExceptionMapper.class);
+        jersey.register(ConstraintViolationExceptionMapper.class);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/error/ConstraintViolationExceptionMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/error/ConstraintViolationExceptionMapper.java
@@ -1,0 +1,31 @@
+package com.comet.opik.api.error;
+
+import io.dropwizard.jersey.validation.ValidationErrorMessage;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class ConstraintViolationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
+
+    @Override
+    public Response toResponse(ConstraintViolationException exception) {
+        log.warn("Validation constraint violation: '{}'", exception.getMessage());
+
+        List<String> errors = exception.getConstraintViolations()
+                .stream()
+                .map(ConstraintViolation::getMessage)
+                .collect(Collectors.toList());
+
+        ValidationErrorMessage validationErrorMessage = new ValidationErrorMessage(errors);
+
+        return Response.status(422)
+                .entity(validationErrorMessage)
+                .build();
+    }
+}


### PR DESCRIPTION
## Details
Fixed validation error handling issue in stream endpoints where invalid payloads were returning 500 errors instead of proper 422 validation errors. The issue was that Dropwizard's built-in validation handling wasn't working properly with `APPLICATION_OCTET_STREAM` endpoints.

**Root Cause**: The `/v1/private/experiments/items/stream` endpoint (and other stream endpoints) were not properly handling validation errors for `APPLICATION_OCTET_STREAM` responses. When validation failed, Dropwizard's built-in validation handling couldn't serialize the error response properly, resulting in a 500 error instead of the expected 422.

**Solution**: 
- Created `ConstraintViolationExceptionMapper` to properly handle `ConstraintViolationException` and convert it to a `ValidationErrorMessage` with 422 status code
- Registered the mapper in `OpikApplication` to ensure it's used for all endpoints
- Added comprehensive test to verify the fix works correctly

**Files Changed**:
- `apps/opik-backend/src/main/java/com/comet/opik/api/error/ConstraintViolationExceptionMapper.java` (new)
- `apps/opik-backend/src/main/java/com/comet/opik/OpikApplication.java` (updated)
- `apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java` (test added)

**Impact**: This fix affects all stream endpoints: experiments, experiment items, and dataset items, ensuring consistent validation error handling across the API.

## Change checklist
<!-- Please check the type of changes made -->
- [ ] User facing
- [x] Documentation update

## Issues
- Resolves # <!-- the GitHub issue this PR resolves (e.g. `#1234`) -->
- OPIK-2242 <!-- The Jira ticket (e.g. `OPIK-1234`) -->
- NA <!-- If no ticket, such as hotfixes etc. -->

## Testing
- Added comprehensive test `streamExperimentItems__whenInvalidPayload__thenReturn422WithValidationError` that verifies:
  - Invalid payloads return 422 status code instead of 500
  - Response body is properly serialized with validation error details
  - Error response contains expected validation error structure
- Test covers the specific scenario described in the Jira ticket
- All existing tests continue to pass
- Quality checks (compilation, spotless) pass

## Documentation
N/A - No documentation changes required for this internal API fix.