### PR TITLE
[OPIK-1487] [FE] Fix long legends in Metrics tab charts with scrollbar

### DIFF
--- a/apps/opik-frontend/src/components/shared/ChartHorizontalLegendContent/ChartHorizontalLegendContent.tsx
+++ b/apps/opik-frontend/src/components/shared/ChartHorizontalLegendContent/ChartHorizontalLegendContent.tsx
@@ -40,7 +40,7 @@ const ChartHorizontalLegendContent = React.forwardRef<
     >
       <div
         className={
-          "group inline-flex max-w-full flex-wrap items-center justify-center space-x-2"
+          "group inline-flex max-w-full max-h-20 overflow-y-auto flex-wrap items-center justify-center space-x-2 gap-y-1"
         }
       >
         {payload.map((item, idx) => {

--- a/apps/opik-frontend/src/components/shared/ChartHorizontalLegendContent/ChartHorizontalLegendContent.tsx
+++ b/apps/opik-frontend/src/components/shared/ChartHorizontalLegendContent/ChartHorizontalLegendContent.tsx
@@ -40,7 +40,7 @@ const ChartHorizontalLegendContent = React.forwardRef<
     >
       <div
         className={
-          "group inline-flex max-w-full max-h-20 overflow-y-auto flex-wrap items-center justify-center space-x-2 gap-y-1"
+          "group inline-flex max-h-20 max-w-full flex-wrap items-center justify-center gap-y-1 space-x-2 overflow-y-auto"
         }
       >
         {payload.map((item, idx) => {


### PR DESCRIPTION
## Details
- Add max-h-20 overflow-y-auto to horizontal chart legends
- Constrains legends to ~80px height with scrollbar when needed
- Fixes overwhelming UI when charts have 25+ legend items

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-1487

## Testing
<img width="778" height="382" alt="Screenshot 2025-09-04 at 21 39 31" src="https://github.com/user-attachments/assets/8ebd77a6-f3c8-4f9d-8fe5-10fe30c6db32" />

## Documentation
