### PR TITLE
[NA] [FE] Implement clean Docker logging without rotation and with optional OTEL export

### DIFF
--- a/apps/opik-frontend/Dockerfile
+++ b/apps/opik-frontend/Dockerfile
@@ -57,10 +57,14 @@ RUN rm -f /etc/nginx/nginx.conf.default && \
     sed -i 's,listen       \[::\]:80;,listen       \[::\]:8080;,' /etc/nginx/nginx.conf && \
     sed -i '/user nginx/d' /etc/nginx/nginx.conf && \
     sed -i 's/error_log\ \/var\/log\/nginx\/error.log/error_log\ \/dev\/stderr/' /etc/nginx/nginx.conf && \
-    sed -i 's/access_log\ \/dev\/stdout/access_log\ \/var\/log\/nginx\/access.log/' /etc/nginx/nginx.conf
-RUN mkdir -p /var/cache/nginx /var/log/nginx /run && \
-    chown -R nginx:nginx /var/cache/nginx /var/log/nginx /etc/nginx /run /var/run && \
-    chmod -R g+w /var/cache/nginx /var/log/nginx /etc/nginx /run /var/run
+    sed -i '/http {/a\    access_log off;' /etc/nginx/nginx.conf
+RUN mkdir -p /var/cache/nginx /run && \
+    chown -R nginx:nginx /var/cache/nginx /etc/nginx /run /var/run && \
+    chmod -R g+w /var/cache/nginx /etc/nginx /run /var/run && \
+    mkdir -p /var/log/nginx && \
+    ln -sf /dev/stderr /var/log/nginx/error.log && \
+    ln -sf /dev/stdout /var/log/nginx/access.log && \
+    chown -R nginx:nginx /var/log/nginx
 
 # Copy the built files from the builder stage
 COPY --from=builder /opt/frontend/dist /usr/share/nginx/html

--- a/apps/opik-frontend/Dockerfile
+++ b/apps/opik-frontend/Dockerfile
@@ -64,7 +64,10 @@ RUN mkdir -p /var/cache/nginx /run && \
     mkdir -p /var/log/nginx && \
     ln -sf /dev/stderr /var/log/nginx/error.log && \
     ln -sf /dev/stdout /var/log/nginx/access.log && \
-    chown -R nginx:nginx /var/log/nginx
+    chown -R nginx:nginx /var/log/nginx && \
+    # Create Fluent Bit position DB directory
+    mkdir -p /var/log/fluent-bit && \
+    chown -R nginx:nginx /var/log/fluent-bit
 
 # Copy the built files from the builder stage
 COPY --from=builder /opt/frontend/dist /usr/share/nginx/html

--- a/apps/opik-frontend/Dockerfile
+++ b/apps/opik-frontend/Dockerfile
@@ -64,10 +64,7 @@ RUN mkdir -p /var/cache/nginx /run && \
     mkdir -p /var/log/nginx && \
     ln -sf /dev/stderr /var/log/nginx/error.log && \
     ln -sf /dev/stdout /var/log/nginx/access.log && \
-    chown -R nginx:nginx /var/log/nginx && \
-    # Create Fluent Bit position DB directory
-    mkdir -p /var/log/fluent-bit && \
-    chown -R nginx:nginx /var/log/fluent-bit
+    chown -R nginx:nginx /var/log/nginx
 
 # Copy the built files from the builder stage
 COPY --from=builder /opt/frontend/dist /usr/share/nginx/html

--- a/deployment/docker-compose/fluent-bit.conf
+++ b/deployment/docker-compose/fluent-bit.conf
@@ -18,6 +18,8 @@
     Refresh_Interval  1
     Skip_Empty_Lines  On
     Read_from_Head    On
+    # Database for position tracking - prevents duplicate logs on restart
+    DB                /var/log/fluent-bit/pos.db
 
 # Collect Fluent Bit's own metrics
 [INPUT]

--- a/deployment/docker-compose/fluent-bit.conf
+++ b/deployment/docker-compose/fluent-bit.conf
@@ -9,17 +9,15 @@
     HTTP_Listen   0.0.0.0
     HTTP_Port     2020
 
+# nginx logs to stdout - read from container's stdout stream
+# This reads from the same stream that docker logs shows
 [INPUT]
     Name              tail
-    Path              /var/log/nginx/access.log
-    Path_Key          file
+    Path              /proc/1/fd/1
     Tag               nginx.access
     Refresh_Interval  1
     Skip_Empty_Lines  On
     Read_from_Head    On
-    
-    # Database for position tracking
-    DB                /var/log/fluent-bit/pos.db
 
 # Collect Fluent Bit's own metrics
 [INPUT]

--- a/deployment/docker-compose/fluent-bit.conf
+++ b/deployment/docker-compose/fluent-bit.conf
@@ -18,8 +18,8 @@
     Refresh_Interval  1
     Skip_Empty_Lines  On
     Read_from_Head    On
-    # Database for position tracking - prevents duplicate logs on restart
-    DB                /var/log/fluent-bit/pos.db
+    # Note: Position DB not needed for stream-based logging (/proc/1/fd/1)
+    # Stream resets on container restart, Docker handles lifecycle
 
 # Collect Fluent Bit's own metrics
 [INPUT]

--- a/deployment/docker-compose/nginx_default_local.conf
+++ b/deployment/docker-compose/nginx_default_local.conf
@@ -4,9 +4,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Standard access logging for Fluent Bit
-    access_log /var/log/nginx/access.log;
-    error_log /var/log/nginx/error.log;
+    # K8s file-based logging - for log collectors
+    #access_log /var/log/nginx/access.log;
+    #error_log /var/log/nginx/error.log;
+
+    # Clean Docker logging - no files, no rotation, no accumulation
+    access_log /dev/stdout;
+    error_log /dev/stderr;
 
     location /api/ {
         rewrite /api/(.*) /$1  break;


### PR DESCRIPTION
## Details

This PR implements a clean Docker logging solution for the frontend container that eliminates the need for manual log rotation while providing optional OTEL export capabilities.

### Key Changes:
- **Dockerfile**: Modified nginx logging configuration and created symlinks from log files to Docker streams
- **nginx_default_local.conf**: Added clean Docker logging directives (stdout/stderr) with commented K8s file-based options
- **fluent-bit.conf**: Configured Fluent Bit to read from container stdout stream for OTEL export

### Solution Features:
- **No log rotation needed** - Docker handles log management automatically  
- **Zero disk space usage** - All logs go to Docker streams via symlinks
- **Dual mode operation**: 
   - `ENABLE_OTEL_LOG_EXPORT=false`: Clean Docker-only logging
   - `ENABLE_OTEL_LOG_EXPORT=true`: Docker logging + OTEL export via Fluent Bit
   - **K8s ready** - Easy configuration switch for Kubernetes deployments
   - **Production tested** - Verified working with both logging modes

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves # NA
- NA

## Testing

Comprehensive testing performed:
- ✅ Docker-only logging mode (no files created, logs in docker logs)
- ✅ OTEL export mode (Fluent Bit successfully reads and exports logs)
- ✅ No permission denied errors (symlinks working correctly)
- ✅ K8s compatibility verified (file paths exist for log collectors)
- ✅ Traffic generation confirmed that both modes capture access logs

## Documentation
- Updated nginx configuration with clean logging directives
- Added comments explaining K8s vs Docker logging modes  
- Fluent Bit configuration documented for OTEL export