### PR TITLE
[OPIK-2350] [BE] Add TOGGLE_HUMAN_ANNOTATION_ENABLED feature flag

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -425,6 +425,9 @@ serviceToggles:
   # Default: false
   # Description: Whether or not OpikAI feature is enabled
   opikAIEnabled: ${TOGGLE_OPIK_AI_ENABLED:-"false"}
+  # Default: false
+  # Description: Whether or not Human Annotation feature is enabled
+  humanAnnotationEnabled: ${TOGGLE_HUMAN_ANNOTATION_ENABLED:-"false"}
 
 # Trace Thread configuration
 traceThreadConfig:

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
@@ -15,4 +15,6 @@ public class ServiceTogglesConfig {
     @NotNull boolean guardrailsEnabled;
     @JsonProperty
     @NotNull boolean opikAIEnabled;
+    @JsonProperty
+    @NotNull boolean humanAnnotationEnabled;
 }

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -293,6 +293,12 @@ serviceToggles:
   # Default: false
   # Description: Whether or not to enable the trace thread Python evaluator
   traceThreadPythonEvaluatorEnabled: "false"
+  # Default: false
+  # Description: Whether or not OpikAI feature is enabled
+  opikAIEnabled: "false"
+  # Default: false
+  # Description: Whether or not Human Annotation feature is enabled
+  humanAnnotationEnabled: "false"
 
 # Trace Thread configuration
 traceThreadConfig:


### PR DESCRIPTION
## Details
- Add humanAnnotationEnabled field to ServiceTogglesConfig.java
- Add TOGGLE_HUMAN_ANNOTATION_ENABLED to config.yml with default false
- Add configuration to test config file
- Feature flag will be accessible via /v1/private/toggles/ API endpoint

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2350

## Testing

## Documentation
