### PR TITLE
[OPIK-2351] [BE] Add description field for feedback-definition resource

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackDefinition.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackDefinition.java
@@ -72,11 +72,12 @@ public abstract sealed class FeedbackDefinition<T> {
         @NotNull @JsonView({View.Public.class, View.Create.class, View.Update.class})
         private final NumericalFeedbackDetail details;
 
-        @ConstructorProperties({"id", "name", "details", "createdAt", "createdBy", "lastUpdatedAt",
+        @ConstructorProperties({"id", "name", "description", "details", "createdAt", "createdBy", "lastUpdatedAt",
                 "lastUpdatedBy"})
-        public NumericalFeedbackDefinition(UUID id, @NotBlank String name, @NotNull NumericalFeedbackDetail details,
-                Instant createdAt, String createdBy, Instant lastUpdatedAt, String lastUpdatedBy) {
-            super(id, name, createdAt, createdBy, lastUpdatedAt, lastUpdatedBy);
+        public NumericalFeedbackDefinition(UUID id, @NotBlank String name, @Nullable String description,
+                @NotNull NumericalFeedbackDetail details, Instant createdAt, String createdBy,
+                Instant lastUpdatedAt, String lastUpdatedBy) {
+            super(id, name, description, createdAt, createdBy, lastUpdatedAt, lastUpdatedBy);
             this.details = details;
         }
 
@@ -110,11 +111,12 @@ public abstract sealed class FeedbackDefinition<T> {
         @NotNull @JsonView({View.Public.class, View.Create.class, View.Update.class})
         private final CategoricalFeedbackDetail details;
 
-        @ConstructorProperties({"id", "name", "details", "createdAt", "createdBy", "lastUpdatedAt",
+        @ConstructorProperties({"id", "name", "description", "details", "createdAt", "createdBy", "lastUpdatedAt",
                 "lastUpdatedBy"})
-        public CategoricalFeedbackDefinition(UUID id, @NotBlank String name, @NotNull CategoricalFeedbackDetail details,
-                Instant createdAt, String createdBy, Instant lastUpdatedAt, String lastUpdatedBy) {
-            super(id, name, createdAt, createdBy, lastUpdatedAt, lastUpdatedBy);
+        public CategoricalFeedbackDefinition(UUID id, @NotBlank String name, @Nullable String description,
+                @NotNull CategoricalFeedbackDetail details, Instant createdAt, String createdBy,
+                Instant lastUpdatedAt, String lastUpdatedBy) {
+            super(id, name, description, createdAt, createdBy, lastUpdatedAt, lastUpdatedBy);
             this.details = details;
         }
 
@@ -150,6 +152,10 @@ public abstract sealed class FeedbackDefinition<T> {
 
     @NotBlank @JsonView({View.Public.class, View.Create.class, View.Update.class})
     private final String name;
+
+    @Nullable @Size(max = 500) @JsonView({View.Public.class, View.Create.class, View.Update.class})
+    @Schema(description = "Optional description for the feedback definition", example = "This feedback definition is used to rate response quality")
+    private final String description;
 
     /**
      * JSON is ignored as details type is polymorphic per subclass, so it's excluded from the Swagger definition

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackDefinition.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackDefinition.java
@@ -74,7 +74,7 @@ public abstract sealed class FeedbackDefinition<T> {
 
         @ConstructorProperties({"id", "name", "description", "details", "createdAt", "createdBy", "lastUpdatedAt",
                 "lastUpdatedBy"})
-        public NumericalFeedbackDefinition(UUID id, @NotBlank String name, @Nullable String description,
+        public NumericalFeedbackDefinition(UUID id, @NotBlank String name, String description,
                 @NotNull NumericalFeedbackDetail details, Instant createdAt, String createdBy,
                 Instant lastUpdatedAt, String lastUpdatedBy) {
             super(id, name, description, createdAt, createdBy, lastUpdatedAt, lastUpdatedBy);
@@ -113,7 +113,7 @@ public abstract sealed class FeedbackDefinition<T> {
 
         @ConstructorProperties({"id", "name", "description", "details", "createdAt", "createdBy", "lastUpdatedAt",
                 "lastUpdatedBy"})
-        public CategoricalFeedbackDefinition(UUID id, @NotBlank String name, @Nullable String description,
+        public CategoricalFeedbackDefinition(UUID id, @NotBlank String name, String description,
                 @NotNull CategoricalFeedbackDetail details, Instant createdAt, String createdBy,
                 Instant lastUpdatedAt, String lastUpdatedBy) {
             super(id, name, description, createdAt, createdBy, lastUpdatedAt, lastUpdatedBy);
@@ -153,7 +153,7 @@ public abstract sealed class FeedbackDefinition<T> {
     @NotBlank @JsonView({View.Public.class, View.Create.class, View.Update.class})
     private final String name;
 
-    @Nullable @Size(max = 500) @JsonView({View.Public.class, View.Create.class, View.Update.class})
+    @Size(max = 255, message = "Description cannot exceed 255 characters") @JsonView({View.Public.class, View.Create.class, View.Update.class})
     @Schema(description = "Optional description for the feedback definition", example = "This feedback definition is used to rate response quality")
     private final String description;
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CategoricalFeedbackDefinitionDefinitionModel.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CategoricalFeedbackDefinitionDefinitionModel.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 public record CategoricalFeedbackDefinitionDefinitionModel(
         UUID id,
         String name,
+        String description,
         @Json CategoricalFeedbackDetail details,
         Instant createdAt,
         String createdBy,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackDefinitionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackDefinitionDAO.java
@@ -26,11 +26,11 @@ import static com.comet.opik.domain.FeedbackDefinitionModel.FeedbackType;
 @RegisterArgumentFactory(UUIDArgumentFactory.class)
 public interface FeedbackDefinitionDAO {
 
-    @SqlUpdate("INSERT INTO feedback_definitions(id, name, `type`, details, workspace_id, created_by, last_updated_by) VALUES (:feedback.id, :feedback.name, :feedback.type, :feedback.details, :workspaceId, :feedback.createdBy, :feedback.lastUpdatedBy)")
+    @SqlUpdate("INSERT INTO feedback_definitions(id, name, description, `type`, details, workspace_id, created_by, last_updated_by) VALUES (:feedback.id, :feedback.name, :feedback.description, :feedback.type, :feedback.details, :workspaceId, :feedback.createdBy, :feedback.lastUpdatedBy)")
     <T> void save(@Bind("workspaceId") String workspaceId,
             final @BindMethods("feedback") FeedbackDefinitionModel<T> feedback);
 
-    @SqlUpdate("UPDATE feedback_definitions SET name = :feedback.name, `type` = :feedback.type, details = :feedback.details, last_updated_by = :feedback.lastUpdatedBy WHERE id = :id AND workspace_id = :workspaceId")
+    @SqlUpdate("UPDATE feedback_definitions SET name = :feedback.name, description = :feedback.description, `type` = :feedback.type, details = :feedback.details, last_updated_by = :feedback.lastUpdatedBy WHERE id = :id AND workspace_id = :workspaceId")
     <T> void update(@Bind("id") UUID id, @BindMethods("feedback") FeedbackDefinitionModel<T> feedback,
             @Bind("workspaceId") String workspaceId);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackDefinitionModel.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackDefinitionModel.java
@@ -16,6 +16,8 @@ public sealed interface FeedbackDefinitionModel<T>
 
     String name();
 
+    String description();
+
     @Json
     T details();
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/NumericalFeedbackDefinitionDefinitionModel.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/NumericalFeedbackDefinitionDefinitionModel.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 public record NumericalFeedbackDefinitionDefinitionModel(
         UUID id,
         String name,
+        String description,
         @Json NumericalFeedbackDetail details,
         Instant createdAt,
         String createdBy,

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000024_add_description_field_to_feedback_definitions.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000024_add_description_field_to_feedback_definitions.sql
@@ -2,7 +2,7 @@
 --changeset BorisTkachenko:000024_add_description_field_to_feedback_definitions
 --comment: Add description field to feedback_definitions table for enhanced user annotation experience
 
-ALTER TABLE feedback_definitions ADD COLUMN description MEDIUMTEXT DEFAULT NULL;
+ALTER TABLE feedback_definitions ADD COLUMN description VARCHAR(255) DEFAULT NULL;
 
 --rollback ALTER TABLE feedback_definitions DROP COLUMN description;
 

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000024_add_description_field_to_feedback_definitions.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000024_add_description_field_to_feedback_definitions.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+--changeset BorisTkachenko:000024_add_description_field_to_feedback_definitions
+--comment: Add description field to feedback_definitions table for enhanced user annotation experience
+
+ALTER TABLE feedback_definitions ADD COLUMN description MEDIUMTEXT DEFAULT NULL;
+
+--rollback ALTER TABLE feedback_definitions DROP COLUMN description;
+

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FeedbackDefinitionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FeedbackDefinitionResourceTest.java
@@ -1098,7 +1098,6 @@ class FeedbackDefinitionResourceTest {
                         .containsExactly("details.min has to be smaller than details.max");
             }
         }
-
     }
 
     @Nested
@@ -1138,18 +1137,16 @@ class FeedbackDefinitionResourceTest {
         @Test
         void update() {
 
-            String name = UUID.randomUUID().toString();
-            String name2 = UUID.randomUUID().toString();
+            String nameUpdated = UUID.randomUUID().toString();
+            String descriptionUpdated = UUID.randomUUID().toString();
 
-            var feedbackDefinition = factory.manufacturePojo(FeedbackDefinition.CategoricalFeedbackDefinition.class)
-                    .toBuilder()
-                    .name(name)
-                    .build();
+            var feedbackDefinition = factory.manufacturePojo(FeedbackDefinition.CategoricalFeedbackDefinition.class);
 
             UUID id = create(feedbackDefinition, API_KEY, TEST_WORKSPACE);
 
             var feedbackDefinition1 = feedbackDefinition.toBuilder()
-                    .name(name2)
+                    .name(nameUpdated)
+                    .description(descriptionUpdated)
                     .build();
 
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
@@ -1174,7 +1171,8 @@ class FeedbackDefinitionResourceTest {
             assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
             var actualEntity = actualResponse.readEntity(FeedbackDefinition.CategoricalFeedbackDefinition.class);
 
-            assertThat(actualEntity.getName()).isEqualTo(name2);
+            assertThat(actualEntity.getName()).isEqualTo(nameUpdated);
+            assertThat(actualEntity.getDescription()).isEqualTo(descriptionUpdated);
             assertThat(actualEntity.getDetails().getCategories())
                     .isEqualTo(feedbackDefinition.getDetails().getCategories());
         }


### PR DESCRIPTION
## Details

- Add description MEDIUMTEXT column to feedback_definitions table via Liquibase migration
- Update FeedbackDefinitionModel interface and implementations to include description field
- Add description field to FeedbackDefinition API DTOs
- Update DAO SQL queries to handle description field in INSERT/UPDATE operations
- Extend existing tests to validate description field functionality in create/update workflows

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2351

## Testing
Covered by integration tests

## Documentation
NA
