### PR TITLE
[OPIK-2238] [FE] Make agent graph button more discoverable by using primary variant

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsActionsPanel.tsx
@@ -348,7 +348,7 @@ const TraceDetailsActionsPanel: React.FunctionComponent<
             content={graph ? "Hide agent graph" : "Show agent graph"}
           >
             <Button
-              variant="secondary"
+              variant="default"
               size={isSmall ? "icon-sm" : "sm"}
               onClick={() => setGraph(!graph)}
             >


### PR DESCRIPTION
## Details
Changed the agent graph toggle button from `variant="secondary"` to `variant="default"` to make it more prominent and discoverable in the traces sidebar. This simple styling change makes the "Show/Hide agent graph" button stand out more, improving user experience when working with agent workflows.

The change affects only the button styling - all existing functionality remains unchanged.

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues
- Resolves #
- OPIK-2238

## Testing
<img width="384" height="66" alt="image" src="https://github.com/user-attachments/assets/46b15bbc-9423-49cf-8ea7-a8d461a63b6e" />
<img width="859" height="311" alt="image" src="https://github.com/user-attachments/assets/48fe388a-d8f9-4a83-9cff-755e79b68d6c" />


## Documentation
