### PR TITLE
[OPIK-2357] [FE] Add description field to feedback definition dialog

### DIFF
--- a/apps/opik-frontend/src/components/pages/ConfigurationPage/FeedbackDefinitionsTab/FeedbackDefinitionsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/ConfigurationPage/FeedbackDefinitionsTab/FeedbackDefinitionsTab.tsx
@@ -52,6 +52,11 @@ export const DEFAULT_COLUMNS: ColumnData<FeedbackDefinition>[] = [
     cell: IdCell as never,
   },
   {
+    id: "description",
+    label: "Description",
+    type: COLUMN_TYPE.string,
+  },
+  {
     id: "type",
     label: "Type",
     type: COLUMN_TYPE.string,

--- a/apps/opik-frontend/src/components/shared/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.tsx
+++ b/apps/opik-frontend/src/components/shared/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.tsx
@@ -96,7 +96,7 @@ const AddEditFeedbackDefinitionDialog: React.FunctionComponent<
       details,
       name,
       type,
-      ...(description && { description }),
+      description,
     } as CreateFeedbackDefinition;
   }, [details, name, type, description]);
 

--- a/apps/opik-frontend/src/components/shared/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.tsx
+++ b/apps/opik-frontend/src/components/shared/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import useAppStore from "@/store/AppStore";
 import {
   CreateFeedbackDefinition,
@@ -70,6 +71,9 @@ const AddEditFeedbackDefinitionDialog: React.FunctionComponent<
   const [name, setName] = useState<CreateFeedbackDefinition["name"]>(
     feedbackDefinition?.name ?? "",
   );
+  const [description, setDescription] = useState<
+    CreateFeedbackDefinition["description"]
+  >(feedbackDefinition?.description ?? "");
   const [type, setType] = useState<CreateFeedbackDefinition["type"]>(
     feedbackDefinition?.type ?? FEEDBACK_DEFINITION_TYPE.categorical,
   );
@@ -92,8 +96,9 @@ const AddEditFeedbackDefinitionDialog: React.FunctionComponent<
       details,
       name,
       type,
+      ...(description && { description }),
     } as CreateFeedbackDefinition;
-  }, [details, name, type]);
+  }, [details, name, type, description]);
 
   const submitHandler = useCallback(() => {
     if (!composedFeedbackDefinition) return;
@@ -127,6 +132,17 @@ const AddEditFeedbackDefinitionDialog: React.FunctionComponent<
             placeholder="Feedback definition name"
             value={name}
             onChange={(event) => setName(event.target.value)}
+          />
+        </div>
+        <div className="flex flex-col gap-2 pb-4">
+          <Label htmlFor="feedbackDefinitionDescription">Description</Label>
+          <Textarea
+            id="feedbackDefinitionDescription"
+            placeholder="Feedback definition description"
+            className="min-h-20"
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            maxLength={255}
           />
         </div>
         <div className="flex flex-col gap-2 pb-4">

--- a/apps/opik-frontend/src/types/feedback-definitions.ts
+++ b/apps/opik-frontend/src/types/feedback-definitions.ts
@@ -20,6 +20,7 @@ export interface NumericalFeedbackDefinition {
 
 export type CreateFeedbackDefinition = {
   name: string;
+  description?: string;
 } & (CategoricalFeedbackDefinition | NumericalFeedbackDefinition);
 
 export type FeedbackDefinition = CreateFeedbackDefinition & {


### PR DESCRIPTION
## Details

This PR adds an optional description field to the feedback definition creation and editing dialog. Users can now provide additional context and details when creating or editing feedback definitions to help clarify their purpose and usage.

**Key Changes:**
- Added `description` field to `CreateFeedbackDefinition` TypeScript interface as an optional property
- Enhanced `AddEditFeedbackDefinitionDialog` component with a `Textarea` input for description
- Added proper form state management for the description field
- Included character limit validation (255 characters max)
- Added description field to the composed feedback definition object when creating/updating

## Change checklist
<!-- Please check the type of changes made -->
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2357 <!-- The Jira ticket -->

## Testing
- Manual testing of feedback definition creation dialog with description field
- Validation of character limit enforcement (255 characters)
- Testing of both create and edit modes for existing feedback definitions
- UI/UX validation of textarea component integration and form layout

## Documentation
No additional documentation updates required - this is a straightforward UI enhancement that extends existing feedback definition functionality.