### PR TITLE
[NA] [SDK] Remove name parameter from search_prompts method

### DIFF
--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -1279,14 +1279,11 @@ class Opik:
         )
         return self.get_prompt_history(name)
 
-    def search_prompts(
-        self, name: Optional[str] = None, filter_string: Optional[str] = None
-    ) -> List[Prompt]:
+    def search_prompts(self, filter_string: Optional[str] = None) -> List[Prompt]:
         """
         Retrieve the latest prompt versions for the given search parameters.
 
         Parameters:
-            name: The substring of the prompt name to search for. If you have an exact name, consider using the `get_prompt` method instead since the name is a unique identifier.
             filter_string: A filter string to narrow down the search using Opik Query Language (OQL).
                 The format is: "<COLUMN> <OPERATOR> <VALUE> [AND <COLUMN> <OPERATOR> <VALUE>]*"
 


### PR DESCRIPTION
 ## Details
 Removes the `name` parameter from the `search_prompts` method that was accidentally reintroduced during a merge conflict resolution. The parameter was previously removed but got added back due to incorrect conflict resolution.

 ## Change checklist
 - [x] User facing
 - [ ] Documentation update

 ## Issues
 - NA

 ## Testing
 - Parameter successfully removed from method signature
 - Docstring updated to remove parameter documentation
 - Code passes linting and formatting checks

 ## Documentation
 No additional documentation updates needed - this is a parameter removal that reverts an accidental reintroduction.