### PR TITLE
[NA] [DOCS] Add FAQ section for finding workspace and project names

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/faq.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/faq.mdx
@@ -57,6 +57,22 @@ from the top right of the page
   configurations.
 </Tip>
 
+### How do I find my workspace and project name?
+
+Your **workspace name** and **project name** are displayed in the Opik UI:
+
+**Workspace Name:**
+- Look at the top of the page in the breadcrumb navigation
+- It appears as the first item after "opik" in the breadcrumb path
+- Example: `opik > your-workspace-name > Projects > Project Name`
+
+**Project Name:**
+- When you're inside a project, it appears as the main header in the content area
+- It's also the last item in the breadcrumb navigation
+- Example: `opik > Workspace > Projects > Your Project Name`
+
+You can also see your workspace information in the left sidebar under "Projects" which shows the count of projects in your workspace.
+
 ### Are there are rate limits on Opik Cloud?
 
 Yes, in order to ensure all users have a good experience we have implemented rate limits. When you encounter a rate limit,


### PR DESCRIPTION
## Details
Added a new FAQ section to help users locate their workspace and project names in the Opik UI. This addresses a common user question about where to find these configuration values needed for SDK setup.

The new FAQ section explains:
- **Workspace Name**: Found in the breadcrumb navigation at the top of the page
- **Project Name**: Displayed as the main header when inside a project, also visible in the breadcrumb
- Provides clear examples of the breadcrumb format: `opik > workspace-name > Projects > Project Name`
- Mentions additional context available in the left sidebar

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- NA

## Testing
- Verified the FAQ section renders correctly in the documentation
- Confirmed the information matches the actual UI layout
- No code changes requiring testing

## Documentation
- Updated `apps/opik-documentation/documentation/fern/docs/faq.mdx`
- Added new FAQ section "How do I find my workspace and project name?" in the Opik Cloud section
- Positioned after the API key question as it's related to configuration
