### PR TITLE
[NA] [DOCS] Add start_time format FAQ entry with universal ISO 8601 format specification

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/faq.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/faq.mdx
@@ -21,6 +21,37 @@ Opik currently provides official SDKs for:
 
 These SDKs are actively maintained and regularly updated. For other languages, you can use our REST API directly - see our [API documentation](/docs/opik/reference/rest-api/overview) for details.
 
+### What format should I use for start_time?
+
+The `start_time` field supports **ISO 8601 datetime format** with UTC timezone. For best compatibility across all Opik SDKs and the backend, use:
+
+```
+2024-01-01T10:20:30.123456Z
+```
+
+**Format specification:**
+- Pattern: `YYYY-MM-DDTHH:MM:SS.ffffffZ`
+- Timezone: UTC (always with `Z` suffix)
+- Precision: Microseconds (6 decimal places)
+
+**Examples:**
+- `2024-01-01T10:20:30Z` (seconds only)
+- `2024-01-01T10:20:30.123Z` (milliseconds)
+- `2024-01-01T10:20:30.123456Z` (microseconds - recommended)
+
+This format is supported by:
+- Python SDK
+- TypeScript SDK  
+- Java Backend
+- Frontend UI
+- ClickHouse Database
+
+**Why UTC with Z suffix?**
+- Avoids timezone conversion issues
+- Universally supported across programming languages
+- Explicitly indicates UTC timezone
+- RFC 3339 compliant
+
 ### Can I use Opik to monitor my LLM application in production?
 
 Yes, Opik has been designed from the ground up to be used to monitor production applications. If you are self-hosting the


### PR DESCRIPTION
## Details
Added comprehensive FAQ entry for start_time format specification to help users understand the correct datetime format to use across all Opik SDKs and backend. The entry includes:

- Universal ISO 8601 format recommendation: `2024-01-01T10:20:30.123456Z`
- Format specification with pattern breakdown
- Multiple precision examples (seconds, milliseconds, microseconds)
- Cross-stack compatibility information
- Rationale for UTC with Z suffix recommendation

This addresses a common user question about datetime format requirements and provides clear guidance for API usage.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues
- NA

## Testing
- No code changes - documentation only

## Documentation
- Added FAQ entry in `apps/opik-documentation/documentation/fern/docs/faq.mdx`
- Provides universal format that works across entire Opik stack
- Includes practical examples and format specification