### PR TITLE
[OPIK-2348] [FE] Add dataset items download functionality

### DIFF
--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsActionsPanel.tsx
@@ -50,7 +50,9 @@ const DatasetItemsActionsPanel: React.FunctionComponent<
 
   const generateFileName = useCallback(
     (extension = "csv") => {
-      return `${slugify(datasetName, { lower: true })}-dataset-items.${extension}`;
+      return `${slugify(datasetName, {
+        lower: true,
+      })}-dataset-items.${extension}`;
     },
     [datasetName],
   );

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsActionsPanel.tsx
@@ -1,30 +1,59 @@
 import React, { useCallback, useRef, useState } from "react";
 import { Trash } from "lucide-react";
+import get from "lodash/get";
+import slugify from "slugify";
 
 import { Button } from "@/components/ui/button";
 import { DatasetItem } from "@/types/datasets";
 import useDatasetItemBatchDeleteMutation from "@/api/datasets/useDatasetItemBatchDeleteMutation";
 import ConfirmDialog from "@/components/shared/ConfirmDialog/ConfirmDialog";
+import ExportToButton from "@/components/shared/ExportToButton/ExportToButton";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 
-type DatasetItemsActionsPanelsProps = {
+type DatasetItemsActionsPanelProps = {
   datasetItems: DatasetItem[];
+  columnsToExport: string[];
+  datasetName: string;
+  dynamicColumns: string[];
 };
 
 const DatasetItemsActionsPanel: React.FunctionComponent<
-  DatasetItemsActionsPanelsProps
-> = ({ datasetItems }) => {
+  DatasetItemsActionsPanelProps
+> = ({ datasetItems, columnsToExport, datasetName, dynamicColumns }) => {
   const resetKeyRef = useRef(0);
   const [open, setOpen] = useState<boolean>(false);
-  const disabled = !datasetItems?.length;
 
   const { mutate } = useDatasetItemBatchDeleteMutation();
+  const disabled = !datasetItems?.length;
 
   const deleteDatasetItemsHandler = useCallback(() => {
     mutate({
       ids: datasetItems.map((i) => i.id),
     });
   }, [datasetItems, mutate]);
+
+  const mapRowData = useCallback(() => {
+    return datasetItems.map((item) => {
+      return columnsToExport.reduce<Record<string, unknown>>((acc, column) => {
+        // Check if this column is a dynamic dataset column
+        if (dynamicColumns.includes(column)) {
+          // Dynamic columns are stored in the item.data object
+          acc[column] = get(item.data, column, "");
+        } else {
+          // Handle direct properties like id, created_at, etc.
+          acc[column] = get(item, column, "");
+        }
+        return acc;
+      }, {});
+    });
+  }, [datasetItems, columnsToExport, dynamicColumns]);
+
+  const generateFileName = useCallback(
+    (extension = "csv") => {
+      return `${slugify(datasetName, { lower: true })}-dataset-items.${extension}`;
+    },
+    [datasetName],
+  );
 
   return (
     <div className="flex items-center gap-2">
@@ -34,9 +63,14 @@ const DatasetItemsActionsPanel: React.FunctionComponent<
         setOpen={setOpen}
         onConfirm={deleteDatasetItemsHandler}
         title="Delete dataset items"
-        description="Deleting dataset items will also remove the related sample data from any linked experiments. This action can’t be undone. Are you sure you want to continue?"
+        description="Deleting dataset items will also remove the related sample data from any linked experiments. This action can't be undone. Are you sure you want to continue?"
         confirmText="Delete dataset items"
         confirmButtonVariant="destructive"
+      />
+      <ExportToButton
+        disabled={disabled || columnsToExport.length === 0}
+        getData={mapRowData}
+        generateFileName={generateFileName}
       />
       <TooltipWrapper content="Delete">
         <Button

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
@@ -229,6 +229,17 @@ const DatasetItemsPage = () => {
     ];
   }, [columnsData, columnsOrder, handleRowClick, selectedColumns]);
 
+  const columnsToExport = useMemo(() => {
+    return columns
+      .map((c) => get(c, "accessorKey", ""))
+      .filter((c) =>
+        c === COLUMN_SELECT_ID
+          ? false
+          : selectedColumns.includes(c) ||
+            (DEFAULT_COLUMN_PINNING.left || []).includes(c),
+      );
+  }, [columns, selectedColumns]);
+
   const handleNewDatasetItemClick = useCallback(() => {
     setOpenDialog(true);
     resetDialogKeyRef.current = resetDialogKeyRef.current + 1;
@@ -297,7 +308,12 @@ const DatasetItemsPage = () => {
       <div className="mb-4 flex items-center justify-between gap-8">
         <div className="flex items-center gap-2"></div>
         <div className="flex items-center gap-2">
-          <DatasetItemsActionsPanel datasetItems={selectedRows} />
+          <DatasetItemsActionsPanel 
+            datasetItems={selectedRows} 
+            columnsToExport={columnsToExport}
+            datasetName={dataset?.name || "dataset"}
+            dynamicColumns={dynamicColumnsIds}
+          />
           <Separator orientation="vertical" className="mx-2 h-4" />
           <DataTableRowHeightSelector
             type={height as ROW_HEIGHT}

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
@@ -308,8 +308,8 @@ const DatasetItemsPage = () => {
       <div className="mb-4 flex items-center justify-between gap-8">
         <div className="flex items-center gap-2"></div>
         <div className="flex items-center gap-2">
-          <DatasetItemsActionsPanel 
-            datasetItems={selectedRows} 
+          <DatasetItemsActionsPanel
+            datasetItems={selectedRows}
             columnsToExport={columnsToExport}
             datasetName={dataset?.name || "dataset"}
             dynamicColumns={dynamicColumnsIds}


### PR DESCRIPTION
## Details
Added export functionality to dataset items page similar to traces, spans, and experiment items:

- Enhanced DatasetItemsActionsPanel with ExportToButton component
- Added CSV/JSON export support for dataset items with proper data mapping
- Implemented columnsToExport calculation for dynamic dataset columns
- Fixed data mapping to handle nested data fields in dataset items
- Added proper filename generation following project conventions

Implements OPIK-2348: Add download button for Dataset items export

## Change checklist
- [X] User facing
- [] Documentation update

## Issues

- Resolves #
- OPIK-2348

## Testing
Manually tested.

## Documentation
NA