### PR TITLE
[issue-2232] [BE] [FE] Add prompt version restore functionality

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
@@ -285,4 +285,28 @@ public class PromptResource {
         return Response.ok(promptVersion).build();
     }
 
+    @POST
+    @Path("/{promptId}/versions/{versionId}/restore")
+    @Operation(operationId = "restorePromptVersion", summary = "Restore prompt version", description = "Restore a prompt version by creating a new version with the content from the specified version", responses = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PromptVersion.class))),
+            @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = io.dropwizard.jersey.errors.ErrorMessage.class))),
+            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
+    })
+    @RateLimited
+    @JsonView({PromptVersion.View.Detail.class})
+    public Response restorePromptVersion(@PathParam("promptId") UUID promptId, @PathParam("versionId") UUID versionId) {
+
+        String workspaceId = requestContext.get().getWorkspaceId();
+
+        log.info("Restoring prompt version with id '{}' for prompt id '{}' on workspace_id '{}'",
+                versionId, promptId, workspaceId);
+
+        PromptVersion restoredVersion = promptService.restorePromptVersion(promptId, versionId);
+
+        log.info("Successfully restored prompt version with id '{}' for prompt id '{}' on workspace_id '{}'",
+                versionId, promptId, workspaceId);
+
+        return Response.ok(restoredVersion).build();
+    }
+
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -2492,6 +2492,76 @@ class PromptResourceTest {
                 assertThat(restoredVersion.commit()).isNotEqualTo(createdV2.commit());
             }
         }
+
+        @Test
+        @DisplayName("when trying to restore prompt version from a different prompt, then return not found")
+        void when__tryingToRestorePromptVersionFromDifferentPrompt__thenReturnNotFound() {
+            var prompt1 = factory.manufacturePojo(Prompt.class).toBuilder()
+                    .lastUpdatedBy(USER)
+                    .createdBy(USER)
+                    .template(null)
+                    .versionCount(0L)
+                    .latestVersion(null)
+                    .build();
+
+            UUID promptId1 = createPrompt(prompt1, API_KEY, TEST_WORKSPACE);
+
+            var prompt2 = factory.manufacturePojo(Prompt.class).toBuilder()
+                    .lastUpdatedBy(USER)
+                    .createdBy(USER)
+                    .template(null)
+                    .versionCount(0L)
+                    .latestVersion(null)
+                    .build();
+
+            UUID promptId2 = createPrompt(prompt2, API_KEY, TEST_WORKSPACE);
+
+            // Create first version to restore from
+            var promptVersion1 = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .id(null)
+                    .promptId(promptId1)
+                    .commit(null)
+                    .createdBy(USER)
+                    .variables(null)
+                    .template("Original template content")
+                    .changeDescription("First version")
+                    .build();
+
+            createPromptVersion(new CreatePromptVersion(prompt1.name(), promptVersion1), API_KEY,
+                    TEST_WORKSPACE);
+
+            // Create second version
+            var promptVersion2 = promptVersion1.toBuilder()
+                    .promptId(promptId2)
+                    .build();
+
+            var newpPromptVersion1 = promptVersion1.toBuilder()
+                    .commit(null)
+                    .createdBy(USER)
+                    .template("Modified template content")
+                    .changeDescription("Second version")
+                    .build();
+
+            var prompt2V1 = createPromptVersion(new CreatePromptVersion(prompt2.name(), promptVersion2), API_KEY,
+                    TEST_WORKSPACE);
+
+            createPromptVersion(new CreatePromptVersion(prompt1.name(), newpPromptVersion1), API_KEY,
+                    TEST_WORKSPACE);
+
+            // Now restore the first version
+            try (var actualResponse = client.target(RESOURCE_PATH.formatted(baseURI) + "/%s/versions/%s/restore"
+                            .formatted(prompt1.id(), prompt2V1.id()))
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
+                    .header(RequestContext.WORKSPACE_HEADER, TEST_WORKSPACE)
+                    .post(Entity.json(""))) {
+
+                assertThat(actualResponse.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+                assertThat(actualResponse.hasEntity()).isTrue();
+                assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
+                        .isEqualTo(new io.dropwizard.jersey.errors.ErrorMessage(404, "Prompt version not found for the specified prompt"));
+            }
+        }
     }
 
     private void retrievePromptVersionAndAssert(PromptVersionRetrieve retrieveRequest,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -2550,7 +2550,7 @@ class PromptResourceTest {
 
             // Now restore the first version
             try (var actualResponse = client.target(RESOURCE_PATH.formatted(baseURI) + "/%s/versions/%s/restore"
-                            .formatted(prompt1.id(), prompt2V1.id()))
+                    .formatted(promptId1, prompt2V1.id()))
                     .request()
                     .header(HttpHeaders.AUTHORIZATION, API_KEY)
                     .header(RequestContext.WORKSPACE_HEADER, TEST_WORKSPACE)
@@ -2559,7 +2559,8 @@ class PromptResourceTest {
                 assertThat(actualResponse.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
                 assertThat(actualResponse.hasEntity()).isTrue();
                 assertThat(actualResponse.readEntity(io.dropwizard.jersey.errors.ErrorMessage.class))
-                        .isEqualTo(new io.dropwizard.jersey.errors.ErrorMessage(404, "Prompt version not found for the specified prompt"));
+                        .isEqualTo(new io.dropwizard.jersey.errors.ErrorMessage(404,
+                                "Prompt version not found for the specified prompt"));
             }
         }
     }

--- a/apps/opik-documentation/documentation/fern/docs/faq.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/faq.mdx
@@ -88,6 +88,22 @@ from the top right of the page
   configurations.
 </Tip>
 
+### How do I find my workspace and project name?
+
+Your **workspace name** and **project name** are displayed in the Opik UI:
+
+**Workspace Name:**
+- Look at the top of the page in the breadcrumb navigation
+- It appears as the first item after "opik" in the breadcrumb path
+- Example: `opik > your-workspace-name > Projects > your-project-name`
+
+**Project Name:**
+- When you're inside a project, it appears as the main header in the content area
+- It's also the last item in the breadcrumb navigation
+- Example: `opik > your-workspace-name > Projects > your-project-name`
+
+You can also see your workspace information in the left sidebar under "Projects" which shows the count of projects in your workspace.
+
 ### Are there are rate limits on Opik Cloud?
 
 Yes, in order to ensure all users have a good experience we have implemented rate limits. When you encounter a rate limit,

--- a/apps/opik-frontend/src/api/prompts/useRestorePromptVersionMutation.ts
+++ b/apps/opik-frontend/src/api/prompts/useRestorePromptVersionMutation.ts
@@ -43,10 +43,8 @@ const useRestorePromptVersionMutation = () => {
         description: `Version ${versionId} has been restored successfully`,
       });
     },
-    onSettled: (data, error, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ["prompt", { promptId: variables.promptId }],
-      });
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["prompt-versions"] });
       return queryClient.invalidateQueries({ queryKey: ["prompts"] });
     },
   });

--- a/apps/opik-frontend/src/api/prompts/useRestorePromptVersionMutation.ts
+++ b/apps/opik-frontend/src/api/prompts/useRestorePromptVersionMutation.ts
@@ -38,7 +38,7 @@ const useRestorePromptVersionMutation = () => {
         variant: "destructive",
       });
     },
-    onSuccess: async ({ versionId }: UseRestorePromptVersionMutationParams) => {
+    onSuccess: async (_, { versionId }) => {
       toast({
         description: `Version ${versionId} has been restored successfully`,
       });

--- a/apps/opik-frontend/src/api/prompts/useRestorePromptVersionMutation.ts
+++ b/apps/opik-frontend/src/api/prompts/useRestorePromptVersionMutation.ts
@@ -1,0 +1,58 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import get from "lodash/get";
+
+import api, { PROMPTS_REST_ENDPOINT } from "@/api/api";
+import { useToast } from "@/components/ui/use-toast";
+import { PromptVersion } from "@/types/prompts";
+
+type UseRestorePromptVersionMutationParams = {
+  promptId: string;
+  versionId: string;
+  onSuccess: (promptVersion: PromptVersion) => void;
+};
+
+const useRestorePromptVersionMutation = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async ({
+      promptId,
+      versionId,
+    }: UseRestorePromptVersionMutationParams) => {
+      const { data } = await api.post(
+        `${PROMPTS_REST_ENDPOINT}${promptId}/versions/${versionId}/restore`,
+      );
+
+      return data;
+    },
+    onError: (error: AxiosError) => {
+      const message = get(
+        error,
+        ["response", "data", "message"],
+        error.message,
+      );
+
+      toast({
+        title: "Error",
+        description: message,
+        variant: "destructive",
+      });
+    },
+    onSuccess: async (data: PromptVersion, { onSuccess }) => {
+      toast({
+        title: "Version restored",
+        description: "The prompt version has been successfully restored.",
+      });
+
+      onSuccess(data);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["prompt-versions"] });
+      queryClient.invalidateQueries({ queryKey: ["prompt"] });
+    },
+  });
+};
+
+export default useRestorePromptVersionMutation;

--- a/apps/opik-frontend/src/api/prompts/useRestorePromptVersionMutation.ts
+++ b/apps/opik-frontend/src/api/prompts/useRestorePromptVersionMutation.ts
@@ -4,12 +4,10 @@ import get from "lodash/get";
 
 import api, { PROMPTS_REST_ENDPOINT } from "@/api/api";
 import { useToast } from "@/components/ui/use-toast";
-import { PromptVersion } from "@/types/prompts";
 
 type UseRestorePromptVersionMutationParams = {
   promptId: string;
   versionId: string;
-  onSuccess: (promptVersion: PromptVersion) => void;
 };
 
 const useRestorePromptVersionMutation = () => {
@@ -40,17 +38,16 @@ const useRestorePromptVersionMutation = () => {
         variant: "destructive",
       });
     },
-    onSuccess: async (data: PromptVersion, { onSuccess }) => {
+    onSuccess: async ({ versionId }: UseRestorePromptVersionMutationParams) => {
       toast({
-        title: "Version restored",
-        description: "The prompt version has been successfully restored.",
+        description: `Version ${versionId} has been restored successfully`,
       });
-
-      onSuccess(data);
     },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ["prompt-versions"] });
-      queryClient.invalidateQueries({ queryKey: ["prompt"] });
+    onSettled: (data, error, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["prompt", { promptId: variables.promptId }],
+      });
+      return queryClient.invalidateQueries({ queryKey: ["prompts"] });
     },
   });
 };

--- a/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/CommitHistory.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/CommitHistory.tsx
@@ -14,7 +14,7 @@ interface CommitHistoryProps {
   onVersionClick: (version: PromptVersion) => void;
   activeVersionId: string;
   onRestoreVersionClick: (version: PromptVersion) => void;
-  isLatestVersion: boolean;
+  latestVersionId?: string;
 }
 
 const CommitHistory = ({
@@ -22,7 +22,7 @@ const CommitHistory = ({
   onVersionClick,
   activeVersionId,
   onRestoreVersionClick,
-  isLatestVersion,
+  latestVersionId,
 }: CommitHistoryProps) => {
   const { toast } = useToast();
   const [hoveredVersionId, setHoveredVersionId] = useState<string | null>(null);
@@ -75,7 +75,7 @@ const CommitHistory = ({
                         <Copy />
                       </Button>
                     </TooltipWrapper>
-                    {!isLatestVersion && (
+                    {version.id !== latestVersionId && (
                       <TooltipWrapper content="Restore this version">
                         <Button
                           size="icon-3xs"

--- a/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/CommitHistory.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/CommitHistory.tsx
@@ -14,6 +14,7 @@ interface CommitHistoryProps {
   onVersionClick: (version: PromptVersion) => void;
   activeVersionId: string;
   onRestoreVersionClick: (version: PromptVersion) => void;
+  isLatestVersion: boolean;
 }
 
 const CommitHistory = ({
@@ -21,6 +22,7 @@ const CommitHistory = ({
   onVersionClick,
   activeVersionId,
   onRestoreVersionClick,
+  isLatestVersion,
 }: CommitHistoryProps) => {
   const { toast } = useToast();
   const [hoveredVersionId, setHoveredVersionId] = useState<string | null>(null);
@@ -73,18 +75,20 @@ const CommitHistory = ({
                         <Copy />
                       </Button>
                     </TooltipWrapper>
-                    <TooltipWrapper content="Restore this version">
-                      <Button
-                        size="icon-3xs"
-                        variant="minimal"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onRestoreVersionClick(version);
-                        }}
-                      >
-                        <Undo2 />
-                      </Button>
-                    </TooltipWrapper>
+                    {!isLatestVersion && (
+                      <TooltipWrapper content="Restore this version">
+                        <Button
+                          size="icon-3xs"
+                          variant="minimal"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onRestoreVersionClick(version);
+                          }}
+                        >
+                          <Undo2 />
+                        </Button>
+                      </TooltipWrapper>
+                    )}
                   </div>
                 )}
               </div>

--- a/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/CommitHistory.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/CommitHistory.tsx
@@ -36,7 +36,6 @@ const CommitHistory = ({
   return (
     <>
       <ul className="max-h-[500px] overflow-y-auto rounded border bg-background p-1">
-        <h2 className="comet-title-s">Commit history</h2>
         {versions?.map((version) => {
           return (
             <li

--- a/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/CommitHistory.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/CommitHistory.tsx
@@ -1,4 +1,4 @@
-import { Copy, GitCommitVertical } from "lucide-react";
+import { Copy, GitCommitVertical, Undo2 } from "lucide-react";
 import copy from "clipboard-copy";
 import { cn } from "@/lib/utils";
 
@@ -6,22 +6,37 @@ import { formatDate } from "@/lib/date";
 import React, { useState } from "react";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { PromptVersion } from "@/types/prompts";
+import useRestorePromptVersionMutation from "@/api/prompts/useRestorePromptVersionMutation";
 
 interface CommitHistoryProps {
   versions: PromptVersion[];
   onVersionClick: (version: PromptVersion) => void;
   activeVersionId: string;
+  promptId: string;
 }
 
 const CommitHistory = ({
   versions,
   onVersionClick,
   activeVersionId,
+  promptId,
 }: CommitHistoryProps) => {
   const { toast } = useToast();
   const [hoveredVersionId, setHoveredVersionId] = useState<string | null>(null);
+  const [restoreDialogOpen, setRestoreDialogOpen] = useState(false);
+  const [versionToRestore, setVersionToRestore] = useState<PromptVersion | null>(null);
+  
+  const restorePromptVersionMutation = useRestorePromptVersionMutation();
 
   const handleCopyClick = async (versionId: string) => {
     await copy(versionId);
@@ -31,50 +46,119 @@ const CommitHistory = ({
     });
   };
 
+  const handleRestoreClick = (version: PromptVersion) => {
+    setVersionToRestore(version);
+    setRestoreDialogOpen(true);
+  };
+
+  const handleRestoreConfirm = () => {
+    if (versionToRestore) {
+      restorePromptVersionMutation.mutate({
+        promptId,
+        versionId: versionToRestore.id,
+        onSuccess: (restoredVersion: PromptVersion) => {
+          toast({
+            description: `Version ${versionToRestore.commit} has been restored successfully`,
+          });
+          onVersionClick(restoredVersion);
+        },
+      });
+    }
+    setRestoreDialogOpen(false);
+    setVersionToRestore(null);
+  };
+
+  const handleRestoreCancel = () => {
+    setRestoreDialogOpen(false);
+    setVersionToRestore(null);
+  };
+
   return (
-    <ul className="max-h-[500px] overflow-y-auto rounded border bg-background p-1">
-      {versions?.map((version) => {
-        return (
-          <li
-            key={version.id}
-            className={cn(
-              "cursor-pointer hover:bg-primary-foreground rounded-sm px-4 py-2.5 flex flex-col",
-              {
-                "bg-primary-foreground": activeVersionId === version.id,
-              },
-            )}
-            onMouseEnter={() => setHoveredVersionId(version.id)}
-            onMouseLeave={() => setHoveredVersionId(null)}
-            onClick={() => onVersionClick(version)}
-          >
-            <div className="flex items-center gap-2">
-              <GitCommitVertical className="mt-auto size-4 shrink-0 text-muted-slate" />
-              <span
-                className={cn("comet-body-s truncate", {
-                  "comet-body-s-accented": activeVersionId === version.id,
-                })}
-              >
-                {version.commit}
-              </span>
-              {hoveredVersionId == version.id && (
-                <TooltipWrapper content="Copy code">
-                  <Button
-                    size="icon-3xs"
-                    variant="minimal"
-                    onClick={() => handleCopyClick(version.commit)}
-                  >
-                    <Copy />
-                  </Button>
-                </TooltipWrapper>
+    <>
+      <ul className="max-h-[500px] overflow-y-auto rounded border bg-background p-1">
+        <h2 className="comet-title-s">Commit history</h2>
+        {versions?.map((version) => {
+          return (
+            <li
+              key={version.id}
+              className={cn(
+                "cursor-pointer hover:bg-primary-foreground rounded-sm px-4 py-2.5 flex flex-col",
+                {
+                  "bg-primary-foreground": activeVersionId === version.id,
+                },
               )}
-            </div>
-            <p className="comet-body-s pl-6 text-light-slate">
-              {formatDate(version.created_at)}
-            </p>
-          </li>
-        );
-      })}
-    </ul>
+              onMouseEnter={() => setHoveredVersionId(version.id)}
+              onMouseLeave={() => setHoveredVersionId(null)}
+              onClick={() => onVersionClick(version)}
+            >
+              <div className="flex items-center gap-2">
+                <GitCommitVertical className="mt-auto size-4 shrink-0 text-muted-slate" />
+                <span
+                  className={cn("comet-body-s truncate", {
+                    "comet-body-s-accented": activeVersionId === version.id,
+                  })}
+                >
+                  {version.commit}
+                </span>
+                {hoveredVersionId == version.id && (
+                  <div className="flex gap-1">
+                    <TooltipWrapper content="Copy code">
+                      <Button
+                        size="icon-3xs"
+                        variant="minimal"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleCopyClick(version.commit);
+                        }}
+                      >
+                        <Copy />
+                      </Button>
+                    </TooltipWrapper>
+                    <TooltipWrapper content="Restore this version">
+                      <Button
+                        size="icon-3xs"
+                        variant="minimal"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleRestoreClick(version);
+                        }}
+                      >
+                        <Undo2 />
+                      </Button>
+                    </TooltipWrapper>
+                  </div>
+                )}
+              </div>
+              <p className="comet-body-s pl-6 text-light-slate">
+                {formatDate(version.created_at)}
+              </p>
+            </li>
+          );
+        })}
+      </ul>
+      
+      <Dialog open={restoreDialogOpen} onOpenChange={setRestoreDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Restore Version</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to restore version {versionToRestore?.commit}? This will create a new version with the content from {versionToRestore?.commit}.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={handleRestoreCancel}>
+              Cancel
+            </Button>
+            <Button 
+              onClick={handleRestoreConfirm}
+              disabled={restorePromptVersionMutation.isPending}
+            >
+              {restorePromptVersionMutation.isPending ? "Restoring..." : "Restore"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 };
 

--- a/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -147,7 +147,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
             activeVersionId={activeVersionId || ""}
             onVersionClick={(version) => setActiveVersionId(version.id)}
             onRestoreVersionClick={handleRestoreVersionClick}
-            isLatestVersion={activeVersionId === prompt.latest_version?.id}
+            latestVersionId={prompt.latest_version?.id}
           />
         </div>
       </div>

--- a/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -147,6 +147,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
             activeVersionId={activeVersionId || ""}
             onVersionClick={(version) => setActiveVersionId(version.id)}
             onRestoreVersionClick={handleRestoreVersionClick}
+            isLatestVersion={activeVersionId === prompt.latest_version?.id}
           />
         </div>
       </div>

--- a/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -139,6 +139,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
             versions={versions || []}
             activeVersionId={activeVersionId || ""}
             onVersionClick={(version) => setActiveVersionId(version.id)}
+            promptId={prompt?.id || ""}
           />
         </div>
       </div>

--- a/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -3,7 +3,7 @@ import { Info, Pencil } from "lucide-react";
 import { StringParam, useQueryParam } from "use-query-params";
 
 import { Button } from "@/components/ui/button";
-import { PromptWithLatestVersion } from "@/types/prompts";
+import { PromptVersion, PromptWithLatestVersion } from "@/types/prompts";
 import Loader from "@/components/shared/Loader/Loader";
 import CodeHighlighter, {
   SUPPORTED_LANGUAGE,
@@ -16,6 +16,7 @@ import usePromptVersionById from "@/api/prompts/usePromptVersionById";
 import TryInPlaygroundButton from "@/components/pages/PromptPage/TryInPlaygroundButton";
 import ExplainerIcon from "@/components/shared/ExplainerIcon/ExplainerIcon";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import RestoreVersionDialog from "./RestoreVersionDialog";
 
 interface PromptTabInterface {
   prompt?: PromptWithLatestVersion;
@@ -24,6 +25,8 @@ interface PromptTabInterface {
 const PromptTab = ({ prompt }: PromptTabInterface) => {
   const [openUseThisPrompt, setOpenUseThisPrompt] = useState(false);
   const [openEditPrompt, setOpenEditPrompt] = useState(false);
+  const [versionToRestore, setVersionToRestore] =
+    useState<PromptVersion | null>(null);
 
   const [activeVersionId, setActiveVersionId] = useQueryParam(
     "activeVersionId",
@@ -58,6 +61,10 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
   const handleOpenEditPrompt = (value: boolean) => {
     editPromptResetKeyRef.current = editPromptResetKeyRef.current + 1;
     setOpenEditPrompt(value);
+  };
+
+  const handleRestoreVersionClick = (version: PromptVersion) => {
+    setVersionToRestore(version);
   };
 
   useEffect(() => {
@@ -139,7 +146,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
             versions={versions || []}
             activeVersionId={activeVersionId || ""}
             onVersionClick={(version) => setActiveVersionId(version.id)}
-            promptId={prompt?.id || ""}
+            onRestoreVersionClick={handleRestoreVersionClick}
           />
         </div>
       </div>
@@ -156,6 +163,13 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
         promptName={prompt.name}
         template={activeVersion?.template || ""}
         metadata={activeVersion?.metadata}
+        onSetActiveVersionId={setActiveVersionId}
+      />
+
+      <RestoreVersionDialog
+        open={!!versionToRestore}
+        setOpen={(v) => setVersionToRestore(v ? versionToRestore : null)}
+        versionToRestore={versionToRestore}
         onSetActiveVersionId={setActiveVersionId}
       />
     </div>

--- a/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/RestoreVersionDialog.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/RestoreVersionDialog.tsx
@@ -31,12 +31,18 @@ const RestoreVersionDialog: React.FunctionComponent<
       return;
     }
 
-    restorePromptVersionMutation.mutate({
-      promptId: versionToRestore.prompt_id,
-      versionId: versionToRestore.id,
-    });
-    setOpen(false);
-    onSetActiveVersionId(versionToRestore.id);
+    restorePromptVersionMutation.mutate(
+      {
+        promptId: versionToRestore.prompt_id,
+        versionId: versionToRestore.id,
+      },
+      {
+        onSuccess(data) {
+          setOpen(false);
+          onSetActiveVersionId(data.versionId);
+        },
+      },
+    );
   };
 
   return (

--- a/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/RestoreVersionDialog.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/RestoreVersionDialog.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { PromptVersion } from "@/types/prompts";
+import useRestorePromptVersionMutation from "@/api/prompts/useRestorePromptVersionMutation";
+
+type RestoreVersionDialogProps = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  versionToRestore: PromptVersion | null;
+  onSetActiveVersionId: (versionId: string) => void;
+};
+
+const RestoreVersionDialog: React.FunctionComponent<
+  RestoreVersionDialogProps
+> = ({ open, setOpen, versionToRestore, onSetActiveVersionId }) => {
+  const restorePromptVersionMutation = useRestorePromptVersionMutation();
+  const isLoading = restorePromptVersionMutation.isPending;
+
+  const handleConfirm = () => {
+    if (!versionToRestore) {
+      return;
+    }
+
+    restorePromptVersionMutation.mutate({
+      promptId: versionToRestore.prompt_id,
+      versionId: versionToRestore.id,
+    });
+    setOpen(false);
+    onSetActiveVersionId(versionToRestore.id);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-lg sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>Restore Version</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to restore version{" "}
+            <span className="font-medium">{versionToRestore?.commit}</span>?
+            This will create a new version with the same content.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button
+            onClick={handleConfirm}
+            disabled={isLoading || !versionToRestore}
+          >
+            {isLoading ? "Restoring..." : "Restore"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default RestoreVersionDialog;


### PR DESCRIPTION
## Details

Enables the restoration of previous prompt versions by creating new versions with content from selected versions.

Backend changes:
- Add restorePromptVersion method to PromptService
- Add POST /prompts/{promptId}/versions/{versionId}/restore endpoint
- Add a comprehensive integration test for restore functionality

Frontend changes:
- Add useRestorePromptVersionMutation API hook
- Add restore button with Undo-2 icon to CommitHistory component
- Add confirmation modal for restore action
- Add a tooltip with 'Restore this version' message

Implements issue-2232: Add revert to previous version feature for prompts

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2232

## Testing

## Documentation
