### PR TITLE
[NA] Fixed `numpy` usage to have it as an optional dependency.

### DIFF
--- a/sdks/python/src/opik/evaluation/samplers/random_dataset_sampler.py
+++ b/sdks/python/src/opik/evaluation/samplers/random_dataset_sampler.py
@@ -1,12 +1,8 @@
-import logging
 from typing import List, Optional
 
 from opik.api_objects.dataset import dataset_item
 
 from . import base_dataset_sampler
-
-
-LOGGER = logging.getLogger(__name__)
 
 
 class RandomDatasetSampler(base_dataset_sampler.BaseDatasetSampler):
@@ -39,8 +35,9 @@ class RandomDatasetSampler(base_dataset_sampler.BaseDatasetSampler):
         try:
             import numpy as np
         except ImportError:
-            LOGGER.warning("To use RandomDatasetSampler, please install numpy.")
-            return data_items
+            raise ImportError(
+                "numpy is required for RandomDatasetSampler. Please install numpy to use this sampler."
+            )
 
         generator = np.random.default_rng(self.seed)
         return generator.choice(


### PR DESCRIPTION
## Details

The `RandomDatasetSampler` introduced mandatory Numpy dependency. 

This PR makes numpy an optional dependency for the RandomDatasetSampler class by moving the import from module-level to inside the sample method and adding graceful fallback behavior when numpy is not available.

### Key changes:

- Removes mandatory `numpy` import at module level
- Adds conditional `numpy` import with raising `ImportError` when not available while using `RandomDatasetSampler`

## Change checklist
- [x] User facing

## Issues

- NA

## Testing

Manually tested

## Documentation

No changes to the documentation