### PR TITLE
[OPIK-2352] [BE] Add annotation queues table and create endpoint

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AnnotationQueue.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AnnotationQueue.java
@@ -1,0 +1,75 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record AnnotationQueue(
+        @JsonView( {
+                AnnotationQueue.View.Public.class, AnnotationQueue.View.Write.class}) @Nullable UUID id,
+        @JsonView({AnnotationQueue.View.Public.class, AnnotationQueue.View.Write.class}) @NotNull UUID projectId,
+        @JsonView({AnnotationQueue.View.Public.class, AnnotationQueue.View.Write.class}) @NotBlank String name,
+        @JsonView({AnnotationQueue.View.Public.class,
+                AnnotationQueue.View.Write.class}) String description,
+        @JsonView({AnnotationQueue.View.Public.class,
+                AnnotationQueue.View.Write.class}) String instructions,
+        @JsonView({AnnotationQueue.View.Public.class, AnnotationQueue.View.Write.class}) @NotNull AnnotationScope scope,
+        @JsonView({AnnotationQueue.View.Public.class,
+                AnnotationQueue.View.Write.class}) @Nullable Boolean commentsEnabled,
+        @JsonView({AnnotationQueue.View.Public.class,
+                AnnotationQueue.View.Write.class}) @Nullable List<UUID> feedbackDefinitions,
+        @JsonView({
+                AnnotationQueue.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String workspaceId,
+        @JsonView({
+                AnnotationQueue.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant createdAt,
+        @JsonView({
+                AnnotationQueue.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,
+        @JsonView({
+                AnnotationQueue.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
+        @JsonView({
+                AnnotationQueue.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy){
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum AnnotationScope {
+        TRACE("trace"),
+        THREAD("thread");
+
+        @JsonValue
+        private final String value;
+
+        @JsonCreator
+        public static AnnotationScope fromString(String value) {
+            return Arrays.stream(values())
+                    .filter(scope -> scope.value.equals(value))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("Unknown annotation scope '%s'".formatted(value)));
+        }
+    }
+
+    public static class View {
+        public static class Public {
+        }
+
+        public static class Write {
+        }
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AnnotationQueueBatch.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AnnotationQueueBatch.java
@@ -1,0 +1,22 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Schema(description = "Batch of annotation queues to create")
+public record AnnotationQueueBatch(
+        @JsonView( {
+                AnnotationQueue.View.Write.class}) @NotNull @Size(min = 1, max = 1000, message = "Batch size must be between 1 and 1000") @Valid @Schema(description = "List of annotation queues to create") List<AnnotationQueue> annotationQueues){
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AnnotationQueueBatch.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AnnotationQueueBatch.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
-import java.util.List;
+import java.util.SequencedSet;
 
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -18,5 +18,5 @@ import java.util.List;
 @Schema(description = "Batch of annotation queues to create")
 public record AnnotationQueueBatch(
         @JsonView( {
-                AnnotationQueue.View.Write.class}) @NotNull @Size(min = 1, max = 1000, message = "Batch size must be between 1 and 1000") @Valid @Schema(description = "List of annotation queues to create") List<AnnotationQueue> annotationQueues){
+                AnnotationQueue.View.Write.class}) @NotNull @Size(min = 1, max = 1000, message = "Batch size must be between 1 and 1000") @Valid @Schema(description = "List of annotation queues to create") SequencedSet<AnnotationQueue> annotationQueues){
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResource.java
@@ -1,0 +1,74 @@
+package com.comet.opik.api.resources.v1.priv;
+
+import com.codahale.metrics.annotation.Timed;
+import com.comet.opik.api.AnnotationQueue;
+import com.comet.opik.domain.AnnotationQueueService;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.ratelimit.RateLimited;
+import com.fasterxml.jackson.annotation.JsonView;
+import io.dropwizard.jersey.errors.ErrorMessage;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import static com.comet.opik.utils.AsyncUtils.setRequestContext;
+
+@Path("/v1/private/annotation-queues")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Timed
+@Slf4j
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+@Tag(name = "Annotation Queues", description = "Private annotation queue operations")
+public class AnnotationQueuesResource {
+
+    private final @NonNull AnnotationQueueService annotationQueueService;
+    private final @NonNull Provider<RequestContext> requestContext;
+
+    @POST
+    @Operation(operationId = "createAnnotationQueue", summary = "Create annotation queue", description = "Create annotation queue for human annotation workflows", responses = {
+            @ApiResponse(responseCode = "201", description = "Created", headers = {
+                    @Header(name = "Location", required = true, example = "${basePath}/v1/private/annotation-queues/{id}", schema = @Schema(implementation = String.class))}),
+            @ApiResponse(responseCode = "422", description = "Unprocessable Content", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
+            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
+            @ApiResponse(responseCode = "409", description = "Conflict", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))
+    })
+    @RateLimited
+    public Response createAnnotationQueue(
+            @RequestBody(content = @Content(schema = @Schema(implementation = AnnotationQueue.class))) @JsonView(AnnotationQueue.View.Write.class) @NotNull @Valid AnnotationQueue annotationQueue,
+            @Context UriInfo uriInfo) {
+
+        String workspaceId = requestContext.get().getWorkspaceId();
+        log.info("Creating annotation queue with name '{}', projectId '{}', workspaceId '{}'",
+                annotationQueue.name(), annotationQueue.projectId(), workspaceId);
+
+        var id = annotationQueueService.create(annotationQueue)
+                .contextWrite(ctx -> setRequestContext(ctx, requestContext))
+                .block();
+
+        var uri = uriInfo.getAbsolutePathBuilder().path("/%s".formatted(id)).build();
+        log.info("Created annotation queue with id '{}', name '{}', projectId '{}', workspaceId '{}'",
+                id, annotationQueue.name(), annotationQueue.projectId(), workspaceId);
+
+        return Response.created(uri).build();
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueDAO.java
@@ -1,0 +1,100 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.AnnotationQueue;
+import com.google.inject.ImplementedBy;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Statement;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
+
+import java.util.UUID;
+
+import static com.comet.opik.domain.AsyncContextUtils.bindUserNameAndWorkspaceContext;
+import static com.comet.opik.utils.AsyncUtils.makeMonoContextAware;
+
+@ImplementedBy(AnnotationQueueDAOImpl.class)
+public interface AnnotationQueueDAO {
+
+    Mono<Void> create(AnnotationQueue annotationQueue);
+}
+
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+@Slf4j
+class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
+
+    private static final String INSERT_STATEMENT = """
+            INSERT INTO annotation_queues (
+                id,
+                workspace_id,
+                project_id,
+                name,
+                description,
+                instructions,
+                scope,
+                comments_enabled,
+                feedback_definitions,
+                created_by,
+                last_updated_by
+            ) VALUES (
+                :id,
+                :workspace_id,
+                :project_id,
+                :name,
+                :description,
+                :instructions,
+                :scope,
+                :comments_enabled,
+                :feedback_definitions,
+                :user_name,
+                :user_name
+            )
+            """;
+
+    private final @NonNull ConnectionFactory connectionFactory;
+    private final @NonNull @Named("Database Analytics Database Name") String databaseName;
+
+    @Override
+    public Mono<Void> create(@NonNull AnnotationQueue annotationQueue) {
+        log.info("Creating annotation queue with id '{}', name '{}', project '{}'",
+                annotationQueue.id(), annotationQueue.name(), annotationQueue.projectId());
+
+        return Mono.from(connectionFactory.create())
+                .flatMap(connection -> create(annotationQueue, connection))
+                .then()
+                .doFinally(signalType -> {
+                    if (signalType == SignalType.ON_COMPLETE) {
+                        log.info("Created annotation queue with id '{}'", annotationQueue.id());
+                    }
+                });
+    }
+
+    private Mono<? extends Result> create(AnnotationQueue annotationQueue, Connection connection) {
+        Statement statement = connection.createStatement(INSERT_STATEMENT)
+                .bind("id", annotationQueue.id())
+                .bind("project_id", annotationQueue.projectId())
+                .bind("name", annotationQueue.name())
+                .bind("description", annotationQueue.description() != null ? annotationQueue.description() : "")
+                .bind("instructions", annotationQueue.instructions() != null ? annotationQueue.instructions() : "")
+                .bind("scope", annotationQueue.scope().getValue())
+                .bind("comments_enabled",
+                        annotationQueue.commentsEnabled() != null ? annotationQueue.commentsEnabled() : true);
+
+        // Handle array binding for feedback_definitions
+        if (annotationQueue.feedbackDefinitions() != null && !annotationQueue.feedbackDefinitions().isEmpty()) {
+            statement.bind("feedback_definitions", annotationQueue.feedbackDefinitions().toArray(UUID[]::new));
+        } else {
+            statement.bind("feedback_definitions", new UUID[0]);
+        }
+
+        return makeMonoContextAware(bindUserNameAndWorkspaceContext(statement));
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueDAO.java
@@ -7,23 +7,25 @@ import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Statement;
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.stringtemplate.v4.ST;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SignalType;
 
+import java.util.List;
 import java.util.UUID;
 
 import static com.comet.opik.domain.AsyncContextUtils.bindUserNameAndWorkspaceContext;
 import static com.comet.opik.utils.AsyncUtils.makeMonoContextAware;
+import static com.comet.opik.utils.TemplateUtils.getQueryItemPlaceHolder;
 
 @ImplementedBy(AnnotationQueueDAOImpl.class)
 public interface AnnotationQueueDAO {
 
-    Mono<Void> create(AnnotationQueue annotationQueue);
+    Mono<Void> createBatch(List<AnnotationQueue> annotationQueues);
 }
 
 @Singleton
@@ -31,7 +33,7 @@ public interface AnnotationQueueDAO {
 @Slf4j
 class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
 
-    private static final String INSERT_STATEMENT = """
+    private static final String BATCH_INSERT = """
             INSERT INTO annotation_queues (
                 id,
                 workspace_id,
@@ -44,57 +46,66 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                 feedback_definitions,
                 created_by,
                 last_updated_by
-            ) VALUES (
-                :id,
-                :workspace_id,
-                :project_id,
-                :name,
-                :description,
-                :instructions,
-                :scope,
-                :comments_enabled,
-                :feedback_definitions,
-                :user_name,
-                :user_name
-            )
+            ) VALUES
+                <items:{item |
+                    (
+                        :id<item.index>,
+                        :workspace_id,
+                        :project_id<item.index>,
+                        :name<item.index>,
+                        :description<item.index>,
+                        :instructions<item.index>,
+                        :scope<item.index>,
+                        :comments_enabled<item.index>,
+                        :feedback_definitions<item.index>,
+                        :user_name,
+                        :user_name
+                    )
+                    <if(item.hasNext)>,<endif>
+                }>
+            ;
             """;
 
     private final @NonNull ConnectionFactory connectionFactory;
-    private final @NonNull @Named("Database Analytics Database Name") String databaseName;
 
     @Override
-    public Mono<Void> create(@NonNull AnnotationQueue annotationQueue) {
-        log.info("Creating annotation queue with id '{}', name '{}', project '{}'",
-                annotationQueue.id(), annotationQueue.name(), annotationQueue.projectId());
+    public Mono<Void> createBatch(@NonNull List<AnnotationQueue> annotationQueues) {
+        log.info("Creating annotation queue batch with '{}' items", annotationQueues.size());
 
         return Mono.from(connectionFactory.create())
-                .flatMap(connection -> create(annotationQueue, connection))
+                .flatMap(connection -> createBatch(annotationQueues, connection))
                 .then()
                 .doFinally(signalType -> {
                     if (signalType == SignalType.ON_COMPLETE) {
-                        log.info("Created annotation queue with id '{}'", annotationQueue.id());
+                        log.info("Created annotation queue batch with '{}' items", annotationQueues.size());
                     }
                 });
     }
 
-    private Mono<? extends Result> create(AnnotationQueue annotationQueue, Connection connection) {
-        Statement statement = connection.createStatement(INSERT_STATEMENT)
-                .bind("id", annotationQueue.id())
-                .bind("project_id", annotationQueue.projectId())
-                .bind("name", annotationQueue.name())
-                .bind("description", annotationQueue.description() != null ? annotationQueue.description() : "")
-                .bind("instructions", annotationQueue.instructions() != null ? annotationQueue.instructions() : "")
-                .bind("scope", annotationQueue.scope().getValue())
-                .bind("comments_enabled",
-                        annotationQueue.commentsEnabled() != null ? annotationQueue.commentsEnabled() : true);
+    private Mono<? extends Result> createBatch(List<AnnotationQueue> annotationQueues, Connection connection) {
+        var queryItems = getQueryItemPlaceHolder(annotationQueues.size());
+        var template = new ST(BATCH_INSERT).add("items", queryItems);
 
-        // Handle array binding for feedback_definitions
-        if (annotationQueue.feedbackDefinitions() != null && !annotationQueue.feedbackDefinitions().isEmpty()) {
-            statement.bind("feedback_definitions", annotationQueue.feedbackDefinitions().toArray(UUID[]::new));
-        } else {
-            statement.bind("feedback_definitions", new UUID[0]);
+        Statement statement = connection.createStatement(template.render());
+
+        int i = 0;
+        for (AnnotationQueue annotationQueue : annotationQueues) {
+            statement.bind("id" + i, annotationQueue.id())
+                    .bind("project_id" + i, annotationQueue.projectId())
+                    .bind("name" + i, annotationQueue.name())
+                    .bind("description" + i, annotationQueue.description() != null ? annotationQueue.description() : "")
+                    .bind("instructions" + i,
+                            annotationQueue.instructions() != null ? annotationQueue.instructions() : "")
+                    .bind("scope" + i, annotationQueue.scope().getValue())
+                    .bind("comments_enabled" + i, annotationQueue.commentsEnabled())
+                    .bind("feedback_definitions" + i,
+                            annotationQueue.feedbackDefinitions() != null
+                                    ? annotationQueue.feedbackDefinitions().toArray(UUID[]::new)
+                                    : new UUID[]{});
+            i++;
         }
 
-        return makeMonoContextAware(bindUserNameAndWorkspaceContext(statement));
+        return makeMonoContextAware(
+                bindUserNameAndWorkspaceContext(statement));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueService.java
@@ -1,0 +1,55 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.AnnotationQueue;
+import com.google.inject.ImplementedBy;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@ImplementedBy(AnnotationQueueServiceImpl.class)
+public interface AnnotationQueueService {
+
+    Mono<UUID> create(@NonNull AnnotationQueue annotationQueue);
+}
+
+@Singleton
+@RequiredArgsConstructor(onConstructor = @__(@Inject))
+@Slf4j
+class AnnotationQueueServiceImpl implements AnnotationQueueService {
+
+    private final @NonNull AnnotationQueueDAO annotationQueueDAO;
+    private final @NonNull IdGenerator idGenerator;
+
+    @Override
+    @WithSpan
+    public Mono<UUID> create(@NonNull AnnotationQueue annotationQueue) {
+        UUID id = annotationQueue.id() == null ? idGenerator.generateId() : annotationQueue.id();
+        IdGenerator.validateVersion(id, "AnnotationQueue");
+
+        log.info("Creating annotation queue with id '{}', name '{}', project '{}'",
+                id, annotationQueue.name(), annotationQueue.projectId());
+
+        var newAnnotationQueue = annotationQueue.toBuilder()
+                .id(id)
+                .commentsEnabled(annotationQueue.commentsEnabled() != null ? annotationQueue.commentsEnabled() : true)
+                .feedbackDefinitions(annotationQueue.feedbackDefinitions() != null
+                        ? annotationQueue.feedbackDefinitions()
+                        : List.of())
+                .createdAt(Instant.now())
+                .lastUpdatedAt(Instant.now())
+                .build();
+
+        return annotationQueueDAO.create(newAnnotationQueue)
+                .thenReturn(id)
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueService.java
@@ -54,7 +54,7 @@ class AnnotationQueueServiceImpl implements AnnotationQueueService {
 
         return annotationQueue.toBuilder()
                 .id(id)
-                .commentsEnabled(annotationQueue.commentsEnabled() != null ? annotationQueue.commentsEnabled() : true)
+                .commentsEnabled(annotationQueue.commentsEnabled() != null ? annotationQueue.commentsEnabled() : false)
                 .feedbackDefinitions(annotationQueue.feedbackDefinitions() != null
                         ? annotationQueue.feedbackDefinitions()
                         : List.of())

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000037_add_annotation_queues_table.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000037_add_annotation_queues_table.sql
@@ -1,0 +1,26 @@
+--liquibase formatted sql
+--changeset borystkachenko:000037_add_annotation_queues_table
+--comment: Create annotation-queues table for human annotation workflows
+
+CREATE TABLE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME}.annotation_queues ON CLUSTER '{cluster}'
+(
+    id              FixedString(36),
+    workspace_id    String,
+    project_id      FixedString(36),
+    name            String,
+    description     String               DEFAULT '',
+    instructions    String               DEFAULT '',
+    scope           Enum8('trace' = 1, 'thread' = 2),
+    comments_enabled Boolean             DEFAULT true,
+    feedback_definitions Array(FixedString(36)),
+    created_at      DateTime64(9, 'UTC') DEFAULT now64(9),
+    created_by      String               DEFAULT '',
+    last_updated_at DateTime64(9, 'UTC') DEFAULT now64(9),
+    last_updated_by String               DEFAULT ''
+)
+ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/${ANALYTICS_DB_DATABASE_NAME}/annotation_queues', '{replica}', last_updated_at)
+ORDER BY (workspace_id, project_id, id)
+SETTINGS index_granularity = 8192;
+
+--rollback DROP TABLE IF EXISTS ${ANALYTICS_DB_DATABASE_NAME}.annotation_queues ON CLUSTER '{cluster}';
+

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000037_add_annotation_queues_table.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000037_add_annotation_queues_table.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME}.annotation_queues ON CL
     description     String               DEFAULT '',
     instructions    String               DEFAULT '',
     scope           Enum8('trace' = 1, 'thread' = 2),
-    comments_enabled Boolean             DEFAULT true,
+    comments_enabled Boolean             DEFAULT false,
     feedback_definitions Array(FixedString(36)),
     created_at      DateTime64(9, 'UTC') DEFAULT now64(9),
     created_by      String               DEFAULT '',

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AnnotationQueuesResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AnnotationQueuesResourceClient.java
@@ -1,0 +1,43 @@
+package com.comet.opik.api.resources.utils.resources;
+
+import com.comet.opik.api.AnnotationQueue;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.HttpHeaders;
+import lombok.RequiredArgsConstructor;
+import org.apache.hc.core5.http.HttpStatus;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RequiredArgsConstructor
+public class AnnotationQueuesResourceClient {
+
+    private static final String RESOURCE_PATH = "%s/v1/private/annotation-queues";
+
+    private final ClientSupport client;
+    private final String baseURI;
+    private final PodamFactory podamFactory;
+
+    public UUID createAnnotationQueue(AnnotationQueue annotationQueue, String apiKey, String workspaceName,
+            int expectedStatus) {
+        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(RequestContext.WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(annotationQueue))) {
+
+            assertThat(response.getStatus()).isEqualTo(expectedStatus);
+
+            if (expectedStatus != HttpStatus.SC_CREATED) {
+                return null;
+            }
+
+            return TestUtils.getIdFromLocation(response.getLocation());
+        }
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AnnotationQueuesResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AnnotationQueuesResourceClient.java
@@ -1,16 +1,15 @@
 package com.comet.opik.api.resources.utils.resources;
 
 import com.comet.opik.api.AnnotationQueue;
-import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.AnnotationQueueBatch;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.HttpHeaders;
 import lombok.RequiredArgsConstructor;
-import org.apache.hc.core5.http.HttpStatus;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import uk.co.jemos.podam.api.PodamFactory;
 
-import java.util.UUID;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,21 +22,16 @@ public class AnnotationQueuesResourceClient {
     private final String baseURI;
     private final PodamFactory podamFactory;
 
-    public UUID createAnnotationQueue(AnnotationQueue annotationQueue, String apiKey, String workspaceName,
+    public void createAnnotationQueueBatch(List<AnnotationQueue> annotationQueues, String apiKey, String workspaceName,
             int expectedStatus) {
         try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("batch")
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, apiKey)
                 .header(RequestContext.WORKSPACE_HEADER, workspaceName)
-                .post(Entity.json(annotationQueue))) {
+                .post(Entity.json(AnnotationQueueBatch.builder().annotationQueues(annotationQueues).build()))) {
 
             assertThat(response.getStatus()).isEqualTo(expectedStatus);
-
-            if (expectedStatus != HttpStatus.SC_CREATED) {
-                return null;
-            }
-
-            return TestUtils.getIdFromLocation(response.getLocation());
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AnnotationQueuesResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AnnotationQueuesResourceClient.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import uk.co.jemos.podam.api.PodamFactory;
 
-import java.util.List;
+import java.util.SequencedSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,7 +22,8 @@ public class AnnotationQueuesResourceClient {
     private final String baseURI;
     private final PodamFactory podamFactory;
 
-    public void createAnnotationQueueBatch(List<AnnotationQueue> annotationQueues, String apiKey, String workspaceName,
+    public void createAnnotationQueueBatch(SequencedSet<AnnotationQueue> annotationQueues, String apiKey,
+            String workspaceName,
             int expectedStatus) {
         try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
                 .path("batch")

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResourceTest.java
@@ -33,12 +33,12 @@ import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import uk.co.jemos.podam.api.PodamFactory;
 
+import java.util.List;
 import java.util.UUID;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
 import static com.comet.opik.api.resources.utils.WireMockUtils.WireMockRuntime;
 import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("Annotation Queues Resource Test")
@@ -124,13 +124,8 @@ class AnnotationQueuesResourceTest {
                     .projectId(projectId)
                     .build();
 
-            // When
-            var annotationQueueId = annotationQueuesResourceClient.createAnnotationQueue(
-                    annotationQueue, API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
-
-            // Then
-            assertThat(annotationQueueId).isNotNull();
-            assertThat(annotationQueueId.version()).isEqualTo(7); // UUID v7 validation
+            annotationQueuesResourceClient.createAnnotationQueueBatch(
+                    List.of(annotationQueue), API_KEY, TEST_WORKSPACE, HttpStatus.SC_NO_CONTENT);
         }
 
         @Test
@@ -142,7 +137,7 @@ class AnnotationQueuesResourceTest {
                     .projectId(null) // Invalid
                     .build();
 
-            annotationQueuesResourceClient.createAnnotationQueue(annotationQueue, API_KEY, TEST_WORKSPACE,
+            annotationQueuesResourceClient.createAnnotationQueueBatch(List.of(annotationQueue), API_KEY, TEST_WORKSPACE,
                     SC_UNPROCESSABLE_ENTITY);
         }
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResourceTest.java
@@ -33,6 +33,7 @@ import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import uk.co.jemos.podam.api.PodamFactory;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.UUID;
 
@@ -125,7 +126,7 @@ class AnnotationQueuesResourceTest {
                     .build();
 
             annotationQueuesResourceClient.createAnnotationQueueBatch(
-                    List.of(annotationQueue), API_KEY, TEST_WORKSPACE, HttpStatus.SC_NO_CONTENT);
+                    new LinkedHashSet<>(List.of(annotationQueue)), API_KEY, TEST_WORKSPACE, HttpStatus.SC_NO_CONTENT);
         }
 
         @Test
@@ -137,7 +138,8 @@ class AnnotationQueuesResourceTest {
                     .projectId(null) // Invalid
                     .build();
 
-            annotationQueuesResourceClient.createAnnotationQueueBatch(List.of(annotationQueue), API_KEY, TEST_WORKSPACE,
+            annotationQueuesResourceClient.createAnnotationQueueBatch(new LinkedHashSet<>(List.of(annotationQueue)),
+                    API_KEY, TEST_WORKSPACE,
                     SC_UNPROCESSABLE_ENTITY);
         }
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResourceTest.java
@@ -1,0 +1,149 @@
+package com.comet.opik.api.resources.v1.priv;
+
+import com.comet.opik.api.AnnotationQueue;
+import com.comet.opik.api.Project;
+import com.comet.opik.api.resources.utils.AuthTestUtils;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.AnnotationQueuesResourceClient;
+import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.redis.testcontainers.RedisContainer;
+import org.apache.hc.core5.http.HttpStatus;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.lifecycle.Startables;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.UUID;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.api.resources.utils.WireMockUtils.WireMockRuntime;
+import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Annotation Queues Resource Test")
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class AnnotationQueuesResourceTest {
+
+    private static final String API_KEY = UUID.randomUUID().toString();
+    private static final String USER = UUID.randomUUID().toString();
+    private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+    private static final String TEST_WORKSPACE = UUID.randomUUID().toString();
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE_CONTAINER = ClickHouseContainerUtils
+            .newClickHouseContainer(ZOOKEEPER_CONTAINER);
+    private final MySQLContainer<?> MYSQL = MySQLContainerUtils.newMySQLContainer();
+    private final WireMockRuntime wireMock;
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(REDIS, MYSQL, CLICKHOUSE_CONTAINER, ZOOKEEPER_CONTAINER).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
+                CLICKHOUSE_CONTAINER, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE_CONTAINER);
+
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                MYSQL.getJdbcUrl(),
+                databaseAnalyticsFactory,
+                wireMock.runtimeInfo(),
+                REDIS.getRedisURI());
+    }
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+    private String baseURI;
+    private ClientSupport client;
+    private ProjectResourceClient projectResourceClient;
+    private AnnotationQueuesResourceClient annotationQueuesResourceClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport client) {
+        this.baseURI = TestUtils.getBaseUrl(client);
+        this.client = client;
+
+        ClientSupportUtils.config(client);
+
+        this.projectResourceClient = new ProjectResourceClient(client, baseURI, factory);
+        this.annotationQueuesResourceClient = new AnnotationQueuesResourceClient(client, baseURI, factory);
+
+        mockTargetWorkspace(API_KEY, TEST_WORKSPACE, WORKSPACE_ID);
+    }
+
+    @AfterAll
+    void tearDownAll() {
+        wireMock.server().stop();
+    }
+
+    private void mockTargetWorkspace(String apiKey, String workspaceName, String workspaceId) {
+        AuthTestUtils.mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, USER);
+    }
+
+    @Nested
+    @DisplayName("Create Annotation Queue")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class CreateAnnotationQueue {
+
+        @Test
+        @DisplayName("should create annotation queue when valid request")
+        void createAnnotationQueue() {
+            // Given - Create a project first for the annotation queue
+            var project = factory.manufacturePojo(Project.class);
+            var projectId = projectResourceClient.createProject(project, API_KEY, TEST_WORKSPACE);
+
+            var annotationQueue = factory.manufacturePojo(AnnotationQueue.class)
+                    .toBuilder()
+                    .id(null) // Will be generated
+                    .projectId(projectId)
+                    .build();
+
+            // When
+            var annotationQueueId = annotationQueuesResourceClient.createAnnotationQueue(
+                    annotationQueue, API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+
+            // Then
+            assertThat(annotationQueueId).isNotNull();
+            assertThat(annotationQueueId.version()).isEqualTo(7); // UUID v7 validation
+        }
+
+        @Test
+        @DisplayName("should reject request when project_id is null")
+        void createAnnotationQueueWhenProjectIdNullShouldReject() {
+            // Given
+            var annotationQueue = factory.manufacturePojo(AnnotationQueue.class)
+                    .toBuilder()
+                    .projectId(null) // Invalid
+                    .build();
+
+            annotationQueuesResourceClient.createAnnotationQueue(annotationQueue, API_KEY, TEST_WORKSPACE,
+                    SC_UNPROCESSABLE_ENTITY);
+        }
+    }
+}


### PR DESCRIPTION
## Details
Implements the foundational annotation queue endpoint for human annotation workflows. This adds a new private API endpoint for creating annotation queues that can be associated with projects and configured for different annotation scopes.

**Key Implementation:**
- **AnnotationQueue API Model**: Record-based data model with JsonView patterns, validation annotations, and AnnotationScope enum (TRACE/THREAD)
- **REST Endpoint**: POST `/v1/private/annotation-queues` with proper OpenAPI documentation, rate limiting, and error handling
- **Data Access Layer**: Reactive R2DBC implementation for ClickHouse with proper context binding and array handling
- **Business Logic**: Service layer with UUID v7 generation, default value setting, and OpenTelemetry instrumentation
- **Database Migration**: ClickHouse table creation with cluster support and ReplicatedReplacingMergeTree engine
- **Test Coverage**: Comprehensive integration tests with containerized dependencies and validation testing

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- Resolves # <!-- No GitHub issue -->
- OPIK-2352

## Testing
- Integration tests verify successful annotation queue creation with valid requests
- Validation tests ensure proper error handling for missing required fields (project_id)
- Test infrastructure includes proper container setup (ClickHouse, MySQL, Redis) and client utilities
- UUID v7 validation ensures proper ID generation

## Documentation
- OpenAPI/Swagger documentation added for the new endpoint with comprehensive response codes
- Database migration includes proper comments and rollback procedures
- Code includes extensive logging for debugging and monitoring