### PR TITLE
[OPIK-2405] [CONFIG] Add issues to toolset to Github MCP server

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -14,7 +14,7 @@
       ],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "<GITHUB_PERSONAL_ACCESS_TOKEN>",
-        "GITHUB_TOOLSETS": "repos,pull_requests"
+        "GITHUB_TOOLSETS": "repos,pull_requests,issues"
       }
     },
     "Atlassian": {


### PR DESCRIPTION
## Details
Added "issues" to the GITHUB_TOOLSETS environment variable in `.cursor/mcp.json` to enable GitHub issues functionality in the MCP server configuration. This allows the GitHub MCP server to access and manage GitHub issues in addition to repositories and pull requests.

## Change checklist
<!-- Please check the type of changes made -->
- [ ] User facing
- [x] Documentation update

## Issues
- OPIK-2405 <!-- The Jira ticket (e.g. `OPIK-1234`) -->

## Testing
- Tested locally.

## Documentation
- https://github.com/github/github-mcp-server?tab=readme-ov-file#available-toolsets