### PR TITLE
[OPIK-2404] [FE] Add description fields to entities details page

### DIFF
--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
@@ -295,7 +295,7 @@ const DatasetItemsPage = () => {
           </h1>
         </div>
         {dataset?.description && (
-          <div className="text-muted-slate -mt-3 mb-4">
+          <div className="-mt-3 mb-4 text-muted-slate">
             {dataset.description}
           </div>
         )}

--- a/apps/opik-frontend/src/components/pages/PromptPage/PromptPage.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/PromptPage.tsx
@@ -46,7 +46,7 @@ const PromptPage: React.FunctionComponent = () => {
       </PageBodyStickyContainer>
       {prompt?.description && (
         <PageBodyStickyContainer
-          className="mb-4 -mt-3 flex min-h-8 items-center justify-between"
+          className="-mt-3 mb-4 flex min-h-8 items-center justify-between"
           direction="horizontal"
         >
           <div className="text-muted-slate">{prompt.description}</div>

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesPage.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesPage.tsx
@@ -68,7 +68,7 @@ const TracesPage = () => {
         </PageBodyStickyContainer>
         {project?.description && (
           <PageBodyStickyContainer
-            className="mb-4 -mt-3 flex min-h-8 items-center justify-between"
+            className="-mt-3 mb-4 flex min-h-8 items-center justify-between"
             direction="horizontal"
           >
             <div className="text-muted-slate">{project.description}</div>


### PR DESCRIPTION
## Details

This PR adds description field display to entity detail pages following the Figma design specifications. The implementation includes:

**Changes Made:**
- **TracesPage (Project Details)**: Added conditional description display below project title with consistent styling and layout
- **DatasetItemsPage (Dataset Details)**: Added conditional description display below dataset title using appropriate spacing
- **PromptPage (Prompt Details)**: Added conditional description display below prompt title with proper container styling
<img width="1454" height="932" alt="image" src="https://github.com/user-attachments/assets/c7cfbdb5-b14b-4661-aa3f-1c6fd3a504ff" />
<img width="1446" height="932" alt="image" src="https://github.com/user-attachments/assets/30dc95e4-d5bc-4c90-8e9a-2b05dc4539b1" />

**Technical Implementation:**
- Uses conditional rendering (`{entity?.description && ...}`) to only display descriptions when they exist
- Consistent styling with `text-muted-slate` color following design system
- Proper spacing with `-mt-3 mb-4` classes to maintain visual hierarchy
- Responsive layout using existing `PageBodyStickyContainer` components

**UI/UX Improvements:**
- Provides better context for users by showing entity descriptions
- Follows Figma design specifications for layout and styling
- Maintains consistent visual patterns across all entity detail pages

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2404

## Testing
- Manual testing verified description display on all three entity types (Project, Dataset, Prompt)
- Conditional rendering tested with entities that have and don't have descriptions
- Layout and styling verified across different screen sizes
- ESLint and TypeScript checks passed

## Documentation
No documentation changes required. This is a UI enhancement that adds description field display to existing entity detail pages without affecting APIs or configuration.