### PR TITLE
[OPIK-2240] [BE] Fix demo data issue with threads

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
+++ b/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
@@ -435,11 +435,8 @@ def create_demo_chatbot_project(base_url: str, workspace_name, comet_api_key):
 
             while not done and attempts < max_attempts:
                 try:
-                    thread_data = client.rest_client.traces.get_trace_thread(thread_id=thread, project_name=project_name)
-                    if thread_data.status == "inactive":
-                        done = True
-                    else:
-                        client.rest_client.traces.close_trace_thread(thread_id=thread, project_name=project_name)
+                    client.rest_client.traces.close_trace_thread(thread_id=thread, project_name=project_name)
+                    done = True
                 except Exception as e:
                     logger.error(f"Error closing thread {thread} attempt {attempts}: {e}")
                     attempts += 1
@@ -473,7 +470,7 @@ def create_demo_chatbot_project(base_url: str, workspace_name, comet_api_key):
                     time.sleep(0.5)
 
         # Process all threads concurrently using ThreadPoolExecutor
-        with ThreadPoolExecutor(max_workers=min(len(threads), 10)) as executor:
+        with ThreadPoolExecutor(max_workers=min(len(threads), 4)) as executor:
             # Submit all thread processing tasks
             future_to_thread = {executor.submit(process_thread, thread): thread for thread in threads}
 

--- a/apps/opik-python-backend/tests/test_demo_data_generator.py
+++ b/apps/opik-python-backend/tests/test_demo_data_generator.py
@@ -84,26 +84,6 @@ def test_create_demo_data_structure(httpserver):
         "created_at": "2024-01-01T00:00:00Z"
     })
 
-    httpserver.expect_request("/v1/private/traces/threads/retrieve", method="POST").respond_with_json({
-        "id": str(uuid6.uuid7()),
-        "projectId": str(uuid6.uuid7()),
-        "workspaceId": "default",
-        "threadModelId": str(uuid6.uuid7()),
-        "startTime": "2024-01-01T00:00:00Z",
-        "endTime": "2024-01-01T00:00:00Z",
-        "duration": 0,
-        "firstMessage": {
-            "role": "user",
-            "content": "What is the best LLM evaluation tool?"
-        },
-        "lastMessage": {
-            "role": "assistant",
-            "content": "Comet"
-        },
-        "feedbackScores": [],
-        "status": "inactive"
-    })
-
     # Mock specific optimization ID update (for the PUT request with specific ID)
     httpserver.expect_request(re.compile(r"/v1/private/optimizations/.*"), method="PUT").respond_with_data(status=204)
 


### PR DESCRIPTION
## Details

Since its launch, we have seen spikes on threads related to endpoints. This PR aims to reduce concurrence to minimize overhead on the backend side. Additionally, we have removed the call to get the threads, as it could cause even more contention. 

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
OPIK-2240

## Testing
NA

## Documentation
NA