### PR TITLE
[NA] [DevOps] Allow cursor extension publish action to be run manually

### DIFF
--- a/.github/workflows/publish_cursor_extension.yml
+++ b/.github/workflows/publish_cursor_extension.yml
@@ -1,9 +1,7 @@
 name: Publish Cursor Extension
 
 on:
-  release:
-    types:
-        - created
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Details

This PR updates the GitHub Actions workflow for publishing the Cursor extension to allow manual triggering instead of automatic triggering on release creation.

Replaces automatic release-based triggering with manual workflow dispatch
Enables on-demand publishing of the Cursor extension for testing and deployment flexibility

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-0000

## Testing

Will be tested manually by doing a release

## Documentation

N/A