### PR TITLE
[OPIK-2395] [P SDK] Add an installation and import check to the SDK CI

### DIFF
--- a/.github/workflows/sdk-e2e-tests.yaml
+++ b/.github/workflows/sdk-e2e-tests.yaml
@@ -17,6 +17,8 @@ env:
   OPIK_SENTRY_ENABLE: False
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
   OPENAI_ORG_ID: ${{ secrets.OPENAI_ORG_ID }}
+  OPIK_URL_OVERRIDE: http://localhost:5173/api
+  OPIK_CONSOLE_LOGGING_LEVEL: DEBUG
 jobs:
     run-e2e:
         name: SDK E2E Tests ${{matrix.python_version}}
@@ -63,14 +65,22 @@ jobs:
         - name: Install opik SDK
           run: |
             cd ${{ github.workspace }}/sdks/python
-            pip install -r tests/test_requirements.txt
             pip install .
+
+        - name: Run smoke tests
+          run: |
+            cd ${{ github.workspace }}/sdks/python
+            ./smoke_tests_runner.sh
+
+        - name: Install test requirements
+          run: |
+            cd ${{ github.workspace }}/sdks/python
+            pip install -r tests/test_requirements.txt
+            pip list
 
         - name: Run tests
           run: |
             cd ${{ github.workspace }}/sdks/python
-            export OPIK_URL_OVERRIDE=http://localhost:5173/api
-            export OPIK_CONSOLE_LOGGING_LEVEL=DEBUG
             pytest tests/e2e -vv --junitxml=${{ github.workspace }}/test_results_${{matrix.python_version}}.xml
 
         - name: Publish Test Report

--- a/sdks/python/tests/e2e_smoke/dry_run_import.py
+++ b/sdks/python/tests/e2e_smoke/dry_run_import.py
@@ -1,0 +1,22 @@
+import opik
+
+project_name = "e2e-smoke-test-project"
+
+
+@opik.track(
+    tags=["inner-tag1", "inner-tag2"],
+    metadata={"inner-metadata-key": "inner-metadata-value"},
+    project_name=project_name,
+)
+def hello(x: str) -> str:
+    result = f"Hello {x}!"
+    print(result)
+    return result
+
+
+def main():
+    hello("World")
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/python/tests/e2e_smoke/smoke_tests_runner.sh
+++ b/sdks/python/tests/e2e_smoke/smoke_tests_runner.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# This is script to execute smoke tests with naked OPIK installation
+#
+echo "░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░"
+echo ""
+echo "Running smoke tests..."
+echo ""
+
+# Find all Python files in current directory
+python_files=$(find . -maxdepth 1 -name "*.py" ! -name "__init__.py")
+
+# Check if any Python files were found
+if [ -z "$python_files" ]; then
+    echo "No Python files found in current directory"
+    exit 1
+fi
+
+# Track failures to report aggregate result at the end
+failed=0
+
+#echo "░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░"
+
+# Execute each Python file
+for file in $python_files; do
+    echo "═════════════════════════════════════════════════════════════════"
+    echo ""
+    echo ">>> Executing: $file"
+    python3 "$file"
+
+    # Check execution status
+    if [ $? -eq 0 ]; then
+        echo ">>> ✅ Test passed: $file"
+    else
+        echo ">>> ❌ Test failed: $file"
+        failed=1
+    fi
+    echo ""
+done
+
+echo "═════════════════════════════════════════════════════════════════"
+echo "▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓"
+echo ""
+
+# Final summary
+if [ $failed -eq 0 ]; then
+    echo ">>> ✅ All smoke tests completed successfully!"
+else
+    echo ">>> ❌ Some tests failed!"
+    exit 1
+fi
+
+echo ""
+echo "░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░"


### PR DESCRIPTION
## Details

We need a CI step that will install opik (non editable mode!), import some of our most important public modules, and that's it.
The goal is to make sure opik is installable and importable in an absolutely clear and fresh environment without any other dependencies installed separately.

### Key changes:

- Introduced `smoke_tests_runner.sh` script for running Python smoke tests.
- Updated SDK E2E workflow to include smoke testing setup and execution.
- Added initial smoke test files under `e2e_smoke` directory using OPIK tracking.
- Enhanced test installation order and environment variable setup for smoke tests.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-2395

## Testing

Manually tested, automatic tests added

## Documentation

No documentation changes