### PR TITLE
[OPIK-2407] [P SDK]Failed to build OpikUsage for provider LLMProvider.GOOGLE_VERTEXAI

### DIFF
--- a/sdks/python/src/opik/llm_usage/google_usage.py
+++ b/sdks/python/src/opik/llm_usage/google_usage.py
@@ -1,11 +1,13 @@
 from typing import Optional, Dict, Any
+
+
 from . import base_original_provider_usage
 
 
 class GoogleGeminiUsage(base_original_provider_usage.BaseOriginalProviderUsage):
     """Google AI / VertexAI calls token usage data. Updated 11.03.2025"""
 
-    candidates_token_count: int
+    candidates_token_count: Optional[int]
     """Number of tokens in the response(s)."""
 
     prompt_token_count: int
@@ -25,4 +27,8 @@ class GoogleGeminiUsage(base_original_provider_usage.BaseOriginalProviderUsage):
 
     @classmethod
     def from_original_usage_dict(cls, usage: Dict[str, Any]) -> "GoogleGeminiUsage":
+        # Handle None values by converting them to 0 for candidates_token_count
+        if usage.get("candidates_token_count") is None:
+            usage = usage.copy()
+            usage["candidates_token_count"] = 0
         return cls(**usage)

--- a/sdks/python/src/opik/llm_usage/opik_usage.py
+++ b/sdks/python/src/opik/llm_usage/opik_usage.py
@@ -93,22 +93,24 @@ class OpikUsage(pydantic.BaseModel):
         # The completions token should include both the candidates token_count and the thought tokens. Usage differs depending on the models and between VertexAI and Google AI
         # See https://github.com/BerriAI/litellm/pull/10141#discussion_r2052272035
         # Do something similar as: https://github.com/BerriAI/litellm/blob/4854482af4a2a56060bbfeb4345bce4f1bb7ec41/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py#L980-L995
+        candidates_token_count = (
+            0
+            if provider_usage.candidates_token_count is None
+            else provider_usage.candidates_token_count
+        )
+        total_token_count = provider_usage.prompt_token_count + candidates_token_count
 
-        if (
-            provider_usage.total_token_count
-            == provider_usage.prompt_token_count + provider_usage.candidates_token_count
-        ):
-            completion_tokens = provider_usage.candidates_token_count
+        if provider_usage.total_token_count == total_token_count:
+            completion_tokens = candidates_token_count
         elif provider_usage.thoughts_token_count is not None:
             completion_tokens = (
-                provider_usage.candidates_token_count
-                + provider_usage.thoughts_token_count
+                candidates_token_count + provider_usage.thoughts_token_count
             )
         else:
             LOGGER.debug(
                 "Something is wrong in Google usage, completion_tokens might be invalid"
             )
-            completion_tokens = provider_usage.candidates_token_count
+            completion_tokens = candidates_token_count
 
         return cls(
             completion_tokens=completion_tokens,

--- a/sdks/python/src/opik/llm_usage/opik_usage_factory.py
+++ b/sdks/python/src/opik/llm_usage/opik_usage_factory.py
@@ -27,15 +27,17 @@ def build_opik_usage(
 ) -> opik_usage.OpikUsage:
     build_functions = _PROVIDER_TO_OPIK_USAGE_BUILDERS[provider]
 
+    exc = None
     for build_function in build_functions:
         try:
             result = build_function(usage)
             return result
-        except Exception:
+        except Exception as exc_info:
+            exc = exc_info
             pass
 
     raise ValueError(
-        f"Failed to build OpikUsage for provider {provider} and usage {usage}"
+        f"Failed to build OpikUsage for provider {provider} and usage {usage}, reason: {exc}"
     )
 
 

--- a/sdks/python/tests/unit/llm_usage/test_opik_usage_factory.py
+++ b/sdks/python/tests/unit/llm_usage/test_opik_usage_factory.py
@@ -29,3 +29,20 @@ def test_opik_usage_factory__anthropic_happyflow():
 
     assert result.provider_usage.input_tokens == 10
     assert result.provider_usage.output_tokens == 20
+
+
+def test_opik_usage_factory__vertex_ai_none_candidates_token_count__happy_flow():
+    result = llm_usage.build_opik_usage(
+        provider=opik.LLMProvider.GOOGLE_VERTEXAI,
+        usage={
+            "cached_content_token_count": None,
+            "candidates_token_count": None,
+            "prompt_token_count": 7859,
+            "thoughts_token_count": None,
+            "total_token_count": 7859,
+        },
+    )
+
+    assert result.completion_tokens == 0
+    assert result.prompt_tokens == 7859
+    assert result.total_tokens == 7859


### PR DESCRIPTION
## Details
Improved token usage handling and add fallback for missing candidate tokens.

- Refactored token count comparison logic in `opik_usage`.
- Updated `GoogleGeminiUsage` to handle `None` values for `candidates_token_count` with a default of 0.
- Enhanced exception reporting in `opik_usage_factory` to capture and log detailed error reasons.
- Added a unit test case to verify handling `None` values in `candidates_token_count`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-2407

## Testing

Added unit test

## Documentation

No documentation changes