### PR TITLE
[OPIK-2424] [BE] Fix duplicate feedback scores when same author exists in both legacy and authored tables

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueDAO.java
@@ -173,11 +173,13 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                 SELECT queue_id, count(1) AS items_count
                 FROM queue_items_final
                 GROUP BY queue_id
-            ), feedback_scores_combined AS (
+            ), feedback_scores_combined_raw AS (
                 SELECT entity_id,
                        name,
                        value,
-                       created_by
+                       created_by,
+                       last_updated_at,
+                       created_by AS author
                 FROM feedback_scores FINAL
                 WHERE workspace_id = :workspace_id
                     AND project_id IN (SELECT project_id FROM queues_final)
@@ -187,11 +189,32 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                     entity_id,
                     name,
                     value,
-                    created_by
+                    created_by,
+                    last_updated_at,
+                    author
                 FROM authored_feedback_scores FINAL
                 WHERE workspace_id = :workspace_id
                    AND project_id IN (SELECT project_id FROM queues_final)
                    AND entity_id IN (SELECT item_id FROM queue_items_final)
+            ), feedback_scores_with_ranking AS (
+                SELECT entity_id,
+                       name,
+                       value,
+                       created_by,
+                       last_updated_at,
+                       author,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY entity_id, name, author
+                           ORDER BY last_updated_at DESC
+                       ) as rn
+                FROM feedback_scores_combined_raw
+            ), feedback_scores_combined AS (
+                SELECT entity_id,
+                       name,
+                       value,
+                       created_by
+                FROM feedback_scores_with_ranking
+                WHERE rn = 1
             ), feedback_scores_combined_grouped AS (
                 SELECT
                     entity_id,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueDAO.java
@@ -174,7 +174,9 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                 FROM queue_items_final
                 GROUP BY queue_id
             ), feedback_scores_combined_raw AS (
-                SELECT entity_id,
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
                        name,
                        value,
                        created_by,
@@ -186,6 +188,8 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                     AND entity_id IN (SELECT item_id FROM queue_items_final)
                 UNION ALL
                 SELECT
+                    workspace_id,
+                    project_id,
                     entity_id,
                     name,
                     value,
@@ -197,14 +201,16 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                    AND project_id IN (SELECT project_id FROM queues_final)
                    AND entity_id IN (SELECT item_id FROM queue_items_final)
             ), feedback_scores_with_ranking AS (
-                SELECT entity_id,
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
                        name,
                        value,
                        created_by,
                        last_updated_at,
                        author,
                        ROW_NUMBER() OVER (
-                           PARTITION BY entity_id, name, author
+                           PARTITION BY workspace_id, project_id, entity_id, name, author
                            ORDER BY last_updated_at DESC
                        ) as rn
                 FROM feedback_scores_combined_raw

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -208,12 +208,14 @@ class ExperimentDAO {
                     ) AS s ON ei.trace_id = s.trace_id
                 )
                 GROUP BY experiment_id
-            ), feedback_scores_combined AS (
+            ), feedback_scores_combined_raw AS (
                 SELECT workspace_id,
                        project_id,
                        entity_id,
                        name,
-                       value
+                       value,
+                       last_updated_at,
+                       feedback_scores.last_updated_by AS author
                 FROM feedback_scores FINAL
                 WHERE entity_type = 'trace'
                   AND workspace_id = :workspace_id
@@ -224,11 +226,36 @@ class ExperimentDAO {
                     project_id,
                     entity_id,
                     name,
-                    value
+                    value,
+                    last_updated_at,
+                    author
                 FROM authored_feedback_scores FINAL
                 WHERE entity_type = 'trace'
                    AND workspace_id = :workspace_id
                    AND entity_id IN (SELECT trace_id FROM experiment_items_final)
+            ), feedback_scores_with_ranking AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       value,
+                       last_updated_at,
+                       author,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY workspace_id, project_id, entity_id, name, author
+                           ORDER BY last_updated_at DESC
+                       ) as rn
+                FROM feedback_scores_combined_raw
+            ), feedback_scores_combined AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       value,
+                       last_updated_at,
+                       author
+                FROM feedback_scores_with_ranking
+                WHERE rn = 1
             ), feedback_scores_combined_grouped AS (
                 SELECT
                     workspace_id,
@@ -439,12 +466,14 @@ class ExperimentDAO {
                     ) AS s ON ei.trace_id = s.trace_id
                 )
                 GROUP BY experiment_id
-            ), feedback_scores_combined AS (
+            ), feedback_scores_combined_raw AS (
                 SELECT workspace_id,
                        project_id,
                        entity_id,
                        name,
-                       value
+                       value,
+                       last_updated_at,
+                       feedback_scores.last_updated_by AS author
                 FROM feedback_scores FINAL
                 WHERE entity_type = 'trace'
                   AND workspace_id = :workspace_id
@@ -455,11 +484,36 @@ class ExperimentDAO {
                     project_id,
                     entity_id,
                     name,
-                    value
+                    value,
+                    last_updated_at,
+                    author
                 FROM authored_feedback_scores FINAL
                 WHERE entity_type = 'trace'
                    AND workspace_id = :workspace_id
                    AND entity_id IN (SELECT trace_id FROM experiment_items_final)
+            ), feedback_scores_with_ranking AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       value,
+                       last_updated_at,
+                       author,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY workspace_id, project_id, entity_id, name, author
+                           ORDER BY last_updated_at DESC
+                       ) as rn
+                FROM feedback_scores_combined_raw
+            ), feedback_scores_combined AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       value,
+                       last_updated_at,
+                       author
+                FROM feedback_scores_with_ranking
+                WHERE rn = 1
             ), feedback_scores_final AS (
                 SELECT
                     workspace_id,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -487,7 +487,7 @@ class SpanDAO {
             """;
 
     private static final String SELECT_BY_ID = """
-            WITH feedback_scores_combined AS (
+            WITH feedback_scores_combined_raw AS (
                 SELECT workspace_id,
                        project_id,
                        entity_id,
@@ -523,6 +523,41 @@ class SpanDAO {
                 WHERE entity_type = 'span'
                   AND workspace_id = :workspace_id
                   AND entity_id = :id
+            ), feedback_scores_with_ranking AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       category_name,
+                       value,
+                       reason,
+                       source,
+                       created_by,
+                       last_updated_by,
+                       created_at,
+                       last_updated_at,
+                       author,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY workspace_id, project_id, entity_id, name, author
+                           ORDER BY last_updated_at DESC
+                       ) as rn
+                FROM feedback_scores_combined_raw
+            ), feedback_scores_combined AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       category_name,
+                       value,
+                       reason,
+                       source,
+                       created_by,
+                       last_updated_by,
+                       created_at,
+                       last_updated_at,
+                       author
+                FROM feedback_scores_with_ranking
+                WHERE rn = 1
             ), feedback_scores_combined_grouped AS (
                 SELECT
                     workspace_id,
@@ -678,7 +713,7 @@ class SpanDAO {
                 LIMIT 1 BY id
               )
               GROUP BY workspace_id, project_id, entity_id
-            ), feedback_scores_combined AS (
+            ), feedback_scores_combined_raw AS (
                 SELECT workspace_id,
                        project_id,
                        entity_id,
@@ -714,6 +749,41 @@ class SpanDAO {
                 WHERE entity_type = 'span'
                   AND workspace_id = :workspace_id
                   AND project_id = :project_id
+            ), feedback_scores_with_ranking AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       category_name,
+                       value,
+                       reason,
+                       source,
+                       created_by,
+                       last_updated_by,
+                       created_at,
+                       last_updated_at,
+                       author,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY workspace_id, project_id, entity_id, name, author
+                           ORDER BY last_updated_at DESC
+                       ) as rn
+                FROM feedback_scores_combined_raw
+            ), feedback_scores_combined AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       category_name,
+                       value,
+                       reason,
+                       source,
+                       created_by,
+                       last_updated_by,
+                       created_at,
+                       last_updated_at,
+                       author
+                FROM feedback_scores_with_ranking
+                WHERE rn = 1
             ), feedback_scores_combined_grouped AS (
                 SELECT
                     workspace_id,
@@ -855,13 +925,14 @@ class SpanDAO {
             """;
 
     private static final String COUNT_BY_PROJECT_ID = """
-            WITH feedback_scores_combined AS (
+            WITH feedback_scores_combined_raw AS (
                 SELECT workspace_id,
                        project_id,
                        entity_id,
                        name,
                        value,
-                       last_updated_at
+                       last_updated_at,
+                       feedback_scores.last_updated_by AS author
                 FROM feedback_scores FINAL
                 WHERE entity_type = 'span'
                   AND workspace_id = :workspace_id
@@ -872,11 +943,34 @@ class SpanDAO {
                        entity_id,
                        name,
                        value,
-                       last_updated_at
+                       last_updated_at,
+                       author
                  FROM authored_feedback_scores FINAL
                  WHERE entity_type = 'span'
                    AND workspace_id = :workspace_id
                    AND project_id = :project_id
+             ), feedback_scores_with_ranking AS (
+                 SELECT workspace_id,
+                        project_id,
+                        entity_id,
+                        name,
+                        value,
+                        last_updated_at,
+                        author,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY workspace_id, project_id, entity_id, name, author
+                            ORDER BY last_updated_at DESC
+                        ) as rn
+                 FROM feedback_scores_combined_raw
+             ), feedback_scores_combined AS (
+                 SELECT workspace_id,
+                        project_id,
+                        entity_id,
+                        name,
+                        value,
+                        last_updated_at
+                 FROM feedback_scores_with_ranking
+                 WHERE rn = 1
              ), feedback_scores_final AS (
                 SELECT
                     workspace_id,
@@ -967,7 +1061,7 @@ class SpanDAO {
             """;
 
     private static final String SELECT_SPANS_STATS = """
-            WITH feedback_scores_combined AS (
+            WITH feedback_scores_combined_raw AS (
                 SELECT workspace_id,
                        project_id,
                        entity_id,
@@ -1003,6 +1097,41 @@ class SpanDAO {
                 WHERE entity_type = 'span'
                   AND workspace_id = :workspace_id
                   AND project_id = :project_id
+            ), feedback_scores_with_ranking AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       category_name,
+                       value,
+                       reason,
+                       source,
+                       created_by,
+                       last_updated_by,
+                       created_at,
+                       last_updated_at,
+                       author,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY workspace_id, project_id, entity_id, name, author
+                           ORDER BY last_updated_at DESC
+                       ) as rn
+                FROM feedback_scores_combined_raw
+            ), feedback_scores_combined AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       category_name,
+                       value,
+                       reason,
+                       source,
+                       created_by,
+                       last_updated_by,
+                       created_at,
+                       last_updated_at,
+                       author
+                FROM feedback_scores_with_ranking
+                WHERE rn = 1
             ), feedback_scores_combined_grouped AS (
                 SELECT
                     workspace_id,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -319,7 +319,7 @@ class TraceDAOImpl implements TraceDAO {
             """;
 
     private static final String SELECT_BY_ID = """
-            WITH feedback_scores_combined AS (
+            WITH feedback_scores_combined_raw AS (
                 SELECT workspace_id,
                        project_id,
                        entity_id,
@@ -356,7 +356,33 @@ class TraceDAOImpl implements TraceDAO {
                WHERE entity_type = 'trace'
                  AND workspace_id = :workspace_id
                  AND entity_id = :id
-            ),
+             ),
+             feedback_scores_with_ranking AS (
+                 SELECT workspace_id,
+                        *,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY workspace_id, project_id, entity_id, name, author
+                            ORDER BY last_updated_at DESC
+                        ) as rn
+                 FROM feedback_scores_combined_raw
+             ),
+             feedback_scores_combined AS (
+                 SELECT workspace_id,
+                     project_id,
+                     entity_id,
+                     name,
+                     category_name,
+                     value,
+                     reason,
+                     source,
+                     created_by,
+                     last_updated_by,
+                     created_at,
+                     last_updated_at,
+                     author
+                 FROM feedback_scores_with_ranking
+                 WHERE rn = 1
+             ),
             feedback_scores_combined_grouped AS (
                 SELECT
                      workspace_id,
@@ -816,13 +842,14 @@ class TraceDAOImpl implements TraceDAO {
             """;
 
     private static final String COUNT_BY_PROJECT_ID = """
-            WITH feedback_scores_combined AS (
+            WITH feedback_scores_combined_raw AS (
                 SELECT workspace_id,
                        project_id,
                        entity_id,
                        name,
                        value,
-                       last_updated_at
+                       last_updated_at,
+                   feedback_scores.last_updated_by AS author
                 FROM feedback_scores FINAL
                 WHERE entity_type = 'trace'
                   AND workspace_id = :workspace_id
@@ -833,11 +860,31 @@ class TraceDAOImpl implements TraceDAO {
                        entity_id,
                        name,
                        value,
-                       last_updated_at
+                       last_updated_at,
+                       author
                  FROM authored_feedback_scores FINAL
                  WHERE entity_type = 'trace'
                    AND workspace_id = :workspace_id
                    AND project_id = :project_id
+             ),
+             feedback_scores_with_ranking AS (
+                 SELECT workspace_id,
+                        *,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY workspace_id, project_id, entity_id, name, author
+                            ORDER BY last_updated_at DESC
+                        ) as rn
+                 FROM feedback_scores_combined_raw
+             ),
+             feedback_scores_combined AS (
+                 SELECT workspace_id,
+                     project_id,
+                     entity_id,
+                     name,
+                     value,
+                     last_updated_at
+                 FROM feedback_scores_with_ranking
+                 WHERE rn = 1
              ), feedback_scores_final AS (
                 SELECT
                     workspace_id,
@@ -1112,7 +1159,7 @@ class TraceDAOImpl implements TraceDAO {
                 WHERE workspace_id = :workspace_id
                 AND project_id IN :project_ids
                 GROUP BY workspace_id, project_id, trace_id
-            ), feedback_scores_combined AS (
+            ), feedback_scores_combined_raw AS (
                 SELECT
                     workspace_id,
                     project_id,
@@ -1150,7 +1197,33 @@ class TraceDAOImpl implements TraceDAO {
                 WHERE entity_type = 'trace'
                    AND workspace_id = :workspace_id
                    AND project_id IN :project_ids
-            ), feedback_scores_combined_grouped AS (
+             ),
+             feedback_scores_with_ranking AS (
+                 SELECT workspace_id,
+                        *,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY workspace_id, project_id, entity_id, name, author
+                            ORDER BY last_updated_at DESC
+                        ) as rn
+                 FROM feedback_scores_combined_raw
+             ),
+             feedback_scores_combined AS (
+                 SELECT workspace_id,
+                     project_id,
+                     entity_id,
+                     name,
+                     category_name,
+                     value,
+                     reason,
+                     source,
+                     created_by,
+                     last_updated_by,
+                     created_at,
+                     last_updated_at,
+                     author
+                 FROM feedback_scores_with_ranking
+                 WHERE rn = 1
+             ), feedback_scores_combined_grouped AS (
                 SELECT
                     workspace_id,
                     project_id,
@@ -1387,7 +1460,7 @@ class TraceDAOImpl implements TraceDAO {
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
                 AND thread_id IN (SELECT thread_id FROM traces_final)
-            ), feedback_scores_combined AS (
+            ), feedback_scores_combined_raw AS (
                 SELECT
                     workspace_id,
                     project_id,
@@ -1427,7 +1500,33 @@ class TraceDAOImpl implements TraceDAO {
                    AND workspace_id = :workspace_id
                    AND project_id = :project_id
                    AND entity_id IN (SELECT thread_model_id FROM trace_threads_final)
-            ), feedback_scores_combined_grouped AS (
+             ),
+             feedback_scores_with_ranking AS (
+                 SELECT workspace_id,
+                        *,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY workspace_id, project_id, entity_id, name, author
+                            ORDER BY last_updated_at DESC
+                        ) as rn
+                 FROM feedback_scores_combined_raw
+             ),
+             feedback_scores_combined AS (
+                 SELECT workspace_id,
+                     project_id,
+                     entity_id,
+                     name,
+                     category_name,
+                     value,
+                     reason,
+                     source,
+                     created_by,
+                     last_updated_by,
+                     created_at,
+                     last_updated_at,
+                     author
+                 FROM feedback_scores_with_ranking
+                 WHERE rn = 1
+             ), feedback_scores_combined_grouped AS (
                 SELECT
                     workspace_id,
                     project_id,
@@ -1618,7 +1717,7 @@ class TraceDAOImpl implements TraceDAO {
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
                 AND thread_id IN (SELECT thread_id FROM traces_final)
-            ), feedback_scores_combined AS (
+            ), feedback_scores_combined_raw AS (
                 SELECT
                     workspace_id,
                     project_id,
@@ -1658,7 +1757,33 @@ class TraceDAOImpl implements TraceDAO {
                    AND workspace_id = :workspace_id
                    AND project_id IN :project_id
                    AND entity_id IN (SELECT thread_model_id FROM trace_threads_final)
-            ), feedback_scores_combined_grouped AS (
+             ),
+             feedback_scores_with_ranking AS (
+                 SELECT workspace_id,
+                        *,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY workspace_id, project_id, entity_id, name, author
+                            ORDER BY last_updated_at DESC
+                        ) as rn
+                 FROM feedback_scores_combined_raw
+             ),
+             feedback_scores_combined AS (
+                 SELECT workspace_id,
+                     project_id,
+                     entity_id,
+                     name,
+                     category_name,
+                     value,
+                     reason,
+                     source,
+                     created_by,
+                     last_updated_by,
+                     created_at,
+                     last_updated_at,
+                     author
+                 FROM feedback_scores_with_ranking
+                 WHERE rn = 1
+             ), feedback_scores_combined_grouped AS (
                 SELECT
                     workspace_id,
                     project_id,
@@ -1892,7 +2017,7 @@ class TraceDAOImpl implements TraceDAO {
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
                 AND thread_id = :thread_id
-            ), feedback_scores_combined AS (
+            ), feedback_scores_combined_raw AS (
                 SELECT workspace_id,
                        project_id,
                        entity_id,
@@ -1931,7 +2056,33 @@ class TraceDAOImpl implements TraceDAO {
                    AND workspace_id = :workspace_id
                    AND project_id = :project_id
                    AND entity_id IN (SELECT thread_model_id FROM trace_threads_final)
-            ), feedback_scores_combined_grouped AS (
+             ),
+             feedback_scores_with_ranking AS (
+                 SELECT workspace_id,
+                        *,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY workspace_id, project_id, entity_id, name, author
+                            ORDER BY last_updated_at DESC
+                        ) as rn
+                 FROM feedback_scores_combined_raw
+             ),
+             feedback_scores_combined AS (
+                 SELECT workspace_id,
+                     project_id,
+                     entity_id,
+                     name,
+                     category_name,
+                     value,
+                     reason,
+                     source,
+                     created_by,
+                     last_updated_by,
+                     created_at,
+                     last_updated_at,
+                     author
+                 FROM feedback_scores_with_ranking
+                 WHERE rn = 1
+             ), feedback_scores_combined_grouped AS (
                 SELECT
                     workspace_id,
                     project_id,


### PR DESCRIPTION
## Details

This PR fixes a bug in the feedback scores query where entries for the same author would appear twice if they had scores in both the legacy `feedback_scores` table and the new `authored_feedback_scores` table. The issue occurred because the original query used `UNION ALL` without proper deduplication logic.

### Problem
When a user had a feedback score in the legacy table and then wanted to override it with a new score (creating an entry in the new table), both entries would appear in the results instead of the newer one overriding the older one.

### Solution
Refactored the TraceDAO query to use a 3-CTE approach:

1. **`feedback_scores_combined_raw`**: Performs `UNION ALL` of both tables
2. **`feedback_scores_with_ranking`**: Applies `ROW_NUMBER()` window function partitioned by `workspace_id`, `project_id`, `entity_id`, `name`, and `author`, ordering by `last_updated_at DESC`
3. **`feedback_scores_combined`**: Filters to keep only the most recent entry (`rn = 1`) for each author

This ensures that when the same author has entries in both tables, only the one with the latest `last_updated_at` timestamp is returned.

### Key Changes
- Modified SQL query in `TraceDAO.java` lines 519-594
- Added comprehensive test `testScoreTraceBySingleAuthorInBothTables` to verify the fix
- Fixed Reactor context issue in test by adding proper `contextWrite()` with `RequestContext.USER_NAME` and `RequestContext.WORKSPACE_ID`

## Change checklist
- [x] Backend change
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves OPIK-2424

## Testing
- Added new E2E test `testScoreTraceBySingleAuthorInBothTables` that:
  1. Creates a feedback score using the legacy table (via `feedbackScoreDAO.scoreEntity`)
  2. Creates a new score for the same author via the API (goes to new table)
  3. Verifies only one score appears in the results (the newer one)
- All existing tests continue to pass
- Manually verified the window function correctly ranks entries across both tables

## Documentation
No documentation changes required - this is an internal bug fix that maintains the existing API contract.