### PR TITLE
[NA] [DOCS] Add version compatibility section to Kubernetes deployment docs

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/self-host/kubernetes.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/kubernetes.mdx
@@ -205,6 +205,29 @@ Then, uninstall the opik:
 helm uninstall opik -n opik
 ```
 
+# Version Compatibility
+
+It's important to ensure that your Python SDK version matches your Kubernetes deployment version to avoid compatibility issues.
+
+## Check your current versions
+
+### Check Opik UI version
+You can check your current Opik deployment version in the UI by clicking on the user menu in the top right corner.
+
+### Check Python SDK version
+You can check your installed Python SDK version by running:
+
+```bash
+pip show opik
+```
+
+## Ensure version compatibility
+
+Make sure both versions match. If they don't match:
+
+1. **To update your Python SDK**: Run `pip install --upgrade opik==<VERSION>` where `<VERSION>` matches your Kubernetes deployment
+2. **To update your Kubernetes deployment**: Update the VERSION variable in the helm installation command to match your Python SDK version
+
 # Troubleshooting
 
 If you get this error when running helm


### PR DESCRIPTION
## Details
Added a Version Compatibility section to the Kubernetes deployment documentation to help users ensure their Python SDK version matches their Kubernetes deployment version. This prevents compatibility issues that can occur when there's a version mismatch between the SDK and deployment.

The section includes:
- Instructions on how to check the Opik UI version via the top right user menu
- Command to check Python SDK version using `pip show opik`
- Clear guidance on updating either the SDK or deployment to ensure version compatibility

## Change checklist
- [x] Documentation update

## Issues
- NA <!-- No specific ticket for this documentation improvement -->

## Testing
- Verified section placement before Troubleshooting section
- Confirmed proper markdown formatting and readability
- Ensured instructions are clear and actionable

## Documentation
Added comprehensive version compatibility guidance to the Kubernetes deployment documentation, positioned strategically before the Troubleshooting section where users would naturally look when encountering version-related issues.