### PR TITLE
[OPIK-2309] [FE] Add clickable links in trace metadata

### DIFF
--- a/apps/opik-frontend/package-lock.json
+++ b/apps/opik-frontend/package-lock.json
@@ -42,6 +42,7 @@
         "@types/diff": "^5.2.2",
         "@types/md5": "^2.3.5",
         "@types/segment-analytics": "^0.0.38",
+        "@uiw/codemirror-extensions-hyper-link": "^4.25.1",
         "@uiw/codemirror-theme-github": "^4.23.3",
         "@uiw/react-codemirror": "^4.23.10",
         "async": "^3.2.6",
@@ -6520,6 +6521,19 @@
         "@codemirror/language": ">=6.0.0",
         "@codemirror/lint": ">=6.0.0",
         "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/codemirror-extensions-hyper-link": {
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-hyper-link/-/codemirror-extensions-hyper-link-4.25.1.tgz",
+      "integrity": "sha512-BVp+bnPI0LtqYXAPFWBqpLLLICoD8QsTAC/KQVRf7l+MO8FXCP0F/4WoM724eU4/2bcLefBkK1gBgCB1+Ug1CQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
         "@codemirror/state": ">=6.0.0",
         "@codemirror/view": ">=6.0.0"
       }

--- a/apps/opik-frontend/package.json
+++ b/apps/opik-frontend/package.json
@@ -59,6 +59,7 @@
     "@types/diff": "^5.2.2",
     "@types/md5": "^2.3.5",
     "@types/segment-analytics": "^0.0.38",
+    "@uiw/codemirror-extensions-hyper-link": "^4.25.1",
     "@uiw/codemirror-theme-github": "^4.23.3",
     "@uiw/react-codemirror": "^4.23.10",
     "async": "^3.2.6",

--- a/apps/opik-frontend/src/components/shared/SyntaxHighlighter/CodeMirrorHighlighter.tsx
+++ b/apps/opik-frontend/src/components/shared/SyntaxHighlighter/CodeMirrorHighlighter.tsx
@@ -10,6 +10,7 @@ import { EXTENSION_MAP } from "./constants";
 import { CodeOutput } from "./types";
 import SyntaxHighlighterLayout from "./SyntaxHighlighterLayout";
 import SyntaxHighlighterSearch from "./SyntaxHighlighterSearch";
+import { hyperLink } from "@uiw/codemirror-extensions-hyper-link";
 
 export interface CodeMirrorHighlighterProps {
   searchValue?: string;
@@ -82,6 +83,7 @@ const CodeMirrorHighlighter: React.FC<CodeMirrorHighlighterProps> = ({
           EditorView.contentAttributes.of({ tabindex: "0" }),
           searchPanelTheme,
           searchExtension,
+          hyperLink,
         ]}
         maxHeight="700px"
         onCreateEditor={handleCreateEditor}


### PR DESCRIPTION
## Details
<img width="1358" height="1083" alt="image" src="https://github.com/user-attachments/assets/58a82137-9f61-4b84-a589-1debbad3ee10" />

This pull request introduces the `@uiw/codemirror-extensions-hyper-link` package to the project and integrates hyperlink support into the `CodeMirrorHighlighter` component. The main focus is to enhance the code editor with clickable hyperlink functionality.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2309

## Testing

## Documentation
