### PR TITLE
[issue-3305] [HELM] Use binami legacy images for minio and mysql in default values

### DIFF
--- a/.github/workflows/trigger_test_env_on_label.yaml
+++ b/.github/workflows/trigger_test_env_on_label.yaml
@@ -28,6 +28,7 @@ jobs:
     with:
       version: ""
       is_release: false
+      build_guardrails: false
       ref: ${{ github.event.pull_request.head.ref }}
 
   trigger_deployment:

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -331,6 +331,7 @@ Call opik api on http://localhost:5173/api
 | minio.provisioning.extraCommands[0] | string | `"mc alias set s3 http://opik-minio:9000 THAAIOSFODNN7EXAMPLE LESlrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY --api S3v4"` |  |
 | minio.provisioning.extraCommands[1] | string | `"mc mb --ignore-existing s3/public"` |  |
 | minio.provisioning.extraCommands[2] | string | `"mc anonymous set download s3/public/"` |  |
+| minio.provisioning.image.repository | string | `"bitnamilegacy/os-shell"` |  |
 | mysql.auth.rootPassword | string | `"opik"` |  |
 | mysql.enabled | bool | `true` |  |
 | mysql.fullnameOverride | string | `"opik-mysql"` |  |

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -323,6 +323,7 @@ Call opik api on http://localhost:5173/api
 | minio.disableWebUI | bool | `true` |  |
 | minio.enabled | bool | `true` |  |
 | minio.fullnameOverride | string | `"opik-minio"` |  |
+| minio.image.repository | string | `"bitnamilegacy/minio"` |  |
 | minio.mode | string | `"standalone"` |  |
 | minio.persistence.enabled | bool | `true` |  |
 | minio.persistence.size | string | `"50Gi"` |  |
@@ -333,6 +334,7 @@ Call opik api on http://localhost:5173/api
 | mysql.auth.rootPassword | string | `"opik"` |  |
 | mysql.enabled | bool | `true` |  |
 | mysql.fullnameOverride | string | `"opik-mysql"` |  |
+| mysql.image.repository | string | `"bitnamilegacy/mysql"` |  |
 | mysql.initdbScripts."createdb.sql" | string | `"CREATE DATABASE IF NOT EXISTS opik DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;\nCREATE USER IF NOT EXISTS 'opik'@'%' IDENTIFIED BY 'opik';\nGRANT ALL ON `opik`.* TO 'opik'@'%';\nFLUSH PRIVILEGES;"` |  |
 | nameOverride | string | `"opik"` |  |
 | nodeSelector | object | `{}` |  |

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -303,6 +303,8 @@ minio:
     rootPassword: "LESlrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
   provisioning:
     enabled: true
+    image:
+      repository: bitnamilegacy/os-shell
     extraCommands:
       - mc alias set s3 http://opik-minio:9000 THAAIOSFODNN7EXAMPLE LESlrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY --api S3v4
       - mc mb --ignore-existing s3/public

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -277,6 +277,8 @@ component:
 
 mysql:
   enabled: true
+  image:
+    repository: bitnamilegacy/mysql
   fullnameOverride: opik-mysql
   auth:
     rootPassword: "opik"
@@ -289,6 +291,8 @@ mysql:
 
 minio:
   enabled: true
+  image:
+    repository: bitnamilegacy/minio
   mode: standalone
   disableWebUI: true
   persistence:


### PR DESCRIPTION
## Details
- Use binami legacy images for minio and mysql in default values
- update trigger-opik-adhok-env workflow not to build guardrail image

## Change checklist
- [V] User facing
- [ ] Documentation update

## Issues

- Resolves #3305


## Testing

## Documentation
