### PR TITLE
[OPIK-2449] [BE] Move data truncation to ingestion time

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000041_add_truncated_input_output_to_spans_and_traces_tables.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000041_add_truncated_input_output_to_spans_and_traces_tables.sql
@@ -4,8 +4,8 @@
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}'
     -- 10001 is used as the truncation threshold (10KB + 1 byte) for input/output columns
     ADD COLUMN IF NOT EXISTS truncation_threshold UInt64 DEFAULT 10001,
-    ADD COLUMN IF NOT EXISTS truncated_input String MATERIALIZED if(length(input) > truncation_threshold, substring(input, 1, truncation_threshold), input),
-    ADD COLUMN IF NOT EXISTS truncated_output String MATERIALIZED if(length(output) > truncation_threshold, substring(output, 1, truncation_threshold), output);
+    ADD COLUMN IF NOT EXISTS truncated_input String MATERIALIZED if(length(input) >= truncation_threshold, substring(input, 1, truncation_threshold), input),
+    ADD COLUMN IF NOT EXISTS truncated_output String MATERIALIZED if(length(output) >= truncation_threshold, substring(output, 1, truncation_threshold), output);
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans ON CLUSTER '{cluster}'
     -- 10001 is used as the truncation threshold (10KB + 1 byte) for input/output columns


### PR DESCRIPTION
## Details

This PR introduces new MATERIALIZED columns, which will truncate the input and output, preventing high memory consumption when querying traces and spans tables with large text or images. 

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2449

## Testing
NA

## Documentation
NA