### PR TITLE
[OPIK-2356] [BE] Update trace and thread related endpoint to support filtering by annotation queue id

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/filter/Field.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/filter/Field.java
@@ -44,6 +44,7 @@ public interface Field {
     String LLM_SPAN_COUNT_QUERY_PARAM = "llm_span_count";
     String VERSION_COUNT_QUERY_PARAM = "version_count";
     String CUSTOM_QUERY_PARAM = "custom";
+    String ANNOTATION_QUEUE_IDS_QUERY_PARAM = "annotation_queue_ids";
 
     @JsonValue
     String getQueryParamField();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/filter/TraceField.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/filter/TraceField.java
@@ -28,6 +28,7 @@ public enum TraceField implements Field {
     VISIBILITY_MODE(VISIBILITY_MODE_QUERY_PARAM, FieldType.ENUM),
     ERROR_INFO(ERROR_INFO_QUERY_PARAM, FieldType.ERROR_CONTAINER),
     CUSTOM(CUSTOM_QUERY_PARAM, FieldType.CUSTOM),
+    ANNOTATION_QUEUE_IDS(ANNOTATION_QUEUE_IDS_QUERY_PARAM, FieldType.LIST),
     ;
 
     private final String queryParamField;

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/filter/TraceThreadField.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/filter/TraceThreadField.java
@@ -18,6 +18,7 @@ public enum TraceThreadField implements Field {
     FEEDBACK_SCORES(FEEDBACK_SCORES_QUERY_PARAM, FieldType.FEEDBACK_SCORES_NUMBER),
     STATUS(STATUS_QUERY_PARAM, FieldType.ENUM),
     TAGS(TAGS_QUERY_PARAM, FieldType.LIST),
+    ANNOTATION_QUEUE_IDS(ANNOTATION_QUEUE_IDS_QUERY_PARAM, FieldType.LIST),
     ;
 
     private final String queryParamField;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -721,6 +721,18 @@ class TraceDAOImpl implements TraceDAO {
                     LIMIT 1 BY id
                 )
                 GROUP BY workspace_id, project_id, entity_id
+            ), trace_annotation_queue_ids AS (
+                 SELECT trace_id,
+                        groupArray(id) AS annotation_queue_ids
+                 FROM (
+                    SELECT DISTINCT aq.id as id, aqi.item_id as trace_id
+                    FROM annotation_queue_items aqi
+                    JOIN annotation_queues aq ON aq.id = aqi.queue_id
+                    WHERE aq.scope = 'trace'
+                      AND workspace_id = :workspace_id
+                      AND project_id = :project_id
+                 ) AS annotation_queue_ids_with_trace_id
+                 GROUP BY trace_id
             )
             <if(feedback_scores_empty_filters)>
              , fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
@@ -749,10 +761,14 @@ class TraceDAOImpl implements TraceDAO {
                 <if(sort_has_span_statistics)>
                 LEFT JOIN spans_agg s ON t.id = s.trace_id
                 <endif>
+                <if(annotation_queue_filters)>
+                LEFT JOIN trace_annotation_queue_ids as taqi ON taqi.trace_id = t.id
+                <endif>
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
                 <if(last_received_id)> AND id \\< :last_received_id <endif>
                 <if(filters)> AND <filters> <endif>
+                <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
                 <if(feedback_scores_filters)>
                  AND id IN (
                     SELECT
@@ -910,6 +926,18 @@ class TraceDAOImpl implements TraceDAO {
                     LIMIT 1 BY entity_id, id
                 )
                 GROUP BY workspace_id, project_id, entity_type, entity_id
+            ), trace_annotation_queue_ids AS (
+                 SELECT trace_id,
+                        groupArray(id) AS annotation_queue_ids
+                 FROM (
+                    SELECT DISTINCT aq.id as id, aqi.item_id as trace_id
+                    FROM annotation_queue_items aqi
+                    JOIN annotation_queues aq ON aq.id = aqi.queue_id
+                    WHERE aq.scope = 'trace'
+                      AND workspace_id = :workspace_id
+                      AND project_id = :project_id
+                 ) AS annotation_queue_ids_with_trace_id
+                 GROUP BY trace_id
             )
             <if(feedback_scores_empty_filters)>
              , fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
@@ -945,9 +973,13 @@ class TraceDAOImpl implements TraceDAO {
                     <if(feedback_scores_empty_filters)>
                     LEFT JOIN fsc ON fsc.entity_id = traces.id
                     <endif>
+                    <if(annotation_queue_filters)>
+                    LEFT JOIN trace_annotation_queue_ids as taqi ON taqi.trace_id = traces.id
+                    <endif>
                     WHERE project_id = :project_id
                     AND workspace_id = :workspace_id
                     <if(filters)> AND <filters> <endif>
+                    <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
                     <if(feedback_scores_filters)>
                     AND id in (
                         SELECT
@@ -1288,6 +1320,18 @@ class TraceDAOImpl implements TraceDAO {
                     LIMIT 1 BY entity_id, id
                 )
                 GROUP BY workspace_id, project_id, entity_type, entity_id
+            ), trace_annotation_queue_ids AS (
+                 SELECT trace_id,
+                        groupArray(id) AS annotation_queue_ids
+                 FROM (
+                    SELECT DISTINCT aq.id as id, aqi.item_id as trace_id
+                    FROM annotation_queue_items aqi
+                    JOIN annotation_queues aq ON aq.id = aqi.queue_id
+                    WHERE aq.scope = 'trace'
+                      AND workspace_id = :workspace_id
+                      AND project_id IN :project_ids
+                 ) AS annotation_queue_ids_with_trace_id
+                 GROUP BY trace_id
             )
             <if(project_stats)>
             ,    error_count_current AS (
@@ -1344,9 +1388,13 @@ class TraceDAOImpl implements TraceDAO {
                 <if(feedback_scores_empty_filters)>
                 LEFT JOIN fsc ON fsc.entity_id = traces.id
                 <endif>
+                <if(annotation_queue_filters)>
+                LEFT JOIN trace_annotation_queue_ids as taqi ON taqi.trace_id = traces.id
+                <endif>
                 WHERE workspace_id = :workspace_id
                 AND project_id IN :project_ids
                 <if(filters)> AND <filters> <endif>
+                <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
                 <if(feedback_scores_filters)>
                 AND id IN (
                     SELECT
@@ -2712,6 +2760,9 @@ class TraceDAOImpl implements TraceDAO {
                                     traceAggregationFilters));
                     filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.FEEDBACK_SCORES)
                             .ifPresent(scoresFilters -> template.add("feedback_scores_filters", scoresFilters));
+                    filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE_ANNOTATION)
+                            .ifPresent(traceAnnotationFilters -> template.add("annotation_queue_filters",
+                                    traceAnnotationFilters));
                     filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE_THREAD)
                             .ifPresent(threadFilters -> template.add("trace_thread_filters", threadFilters));
                     filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.FEEDBACK_SCORES_IS_EMPTY)
@@ -2729,6 +2780,7 @@ class TraceDAOImpl implements TraceDAO {
                     filterQueryBuilder.bind(statement, filters, FilterStrategy.TRACE);
                     filterQueryBuilder.bind(statement, filters, FilterStrategy.TRACE_AGGREGATION);
                     filterQueryBuilder.bind(statement, filters, FilterStrategy.FEEDBACK_SCORES);
+                    filterQueryBuilder.bind(statement, filters, FilterStrategy.TRACE_ANNOTATION);
                     filterQueryBuilder.bind(statement, filters, FilterStrategy.TRACE_THREAD);
                     filterQueryBuilder.bind(statement, filters, FilterStrategy.FEEDBACK_SCORES_IS_EMPTY);
                 });

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -209,6 +209,7 @@ public class FilterQueryBuilder {
                     .put(TraceThreadField.FEEDBACK_SCORES, VALUE_ANALYTICS_DB)
                     .put(TraceThreadField.STATUS, STATUS_DB)
                     .put(TraceThreadField.TAGS, TAGS_DB)
+                    .put(TraceThreadField.ANNOTATION_QUEUE_IDS, ANNOTATION_QUEUE_IDS_ANALYTICS_DB)
                     .build());
 
     private static final Map<SpanField, String> SPAN_FIELDS_MAP = new EnumMap<>(
@@ -310,8 +311,7 @@ public class FilterQueryBuilder {
                 TraceField.THREAD_ID,
                 TraceField.GUARDRAILS,
                 TraceField.VISIBILITY_MODE,
-                TraceField.ERROR_INFO,
-                TraceField.ANNOTATION_QUEUE_IDS));
+                TraceField.ERROR_INFO));
 
         map.put(FilterStrategy.TRACE_AGGREGATION, Set.of(
                 TraceField.USAGE_COMPLETION_TOKENS,
@@ -320,8 +320,9 @@ public class FilterQueryBuilder {
                 TraceField.TOTAL_ESTIMATED_COST,
                 TraceField.LLM_SPAN_COUNT));
 
-        map.put(FilterStrategy.TRACE_ANNOTATION, Set.of(
-                TraceField.ANNOTATION_QUEUE_IDS));
+        map.put(FilterStrategy.ANNOTATION_AGGREGATION, Set.of(
+                TraceField.ANNOTATION_QUEUE_IDS,
+                TraceThreadField.ANNOTATION_QUEUE_IDS));
 
         map.put(FilterStrategy.SPAN, Set.of(
                 SpanField.ID,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -13,7 +13,6 @@ import com.comet.opik.api.filter.SpanField;
 import com.comet.opik.api.filter.TraceField;
 import com.comet.opik.api.filter.TraceThreadField;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.r2dbc.spi.Statement;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
@@ -80,6 +79,7 @@ public class FilterQueryBuilder {
     private static final String STATUS_DB = "status";
     public static final String FEEDBACK_DEFINITIONS_DB = "feedback_definitions";
     public static final String SCOPE_DB = "scope";
+    public static final String ANNOTATION_QUEUE_IDS_ANALYTICS_DB = "annotation_queue_ids";
 
     private static final Map<Operator, Map<FieldType, String>> ANALYTICS_DB_OPERATOR_MAP = new EnumMap<>(
             ImmutableMap.<Operator, Map<FieldType, String>>builder()
@@ -192,6 +192,7 @@ public class FilterQueryBuilder {
                     .put(TraceField.GUARDRAILS, GUARDRAILS_RESULT_DB)
                     .put(TraceField.VISIBILITY_MODE, VISIBILITY_MODE_DB)
                     .put(TraceField.ERROR_INFO, ERROR_INFO_DB)
+                    .put(TraceField.ANNOTATION_QUEUE_IDS, ANNOTATION_QUEUE_IDS_ANALYTICS_DB)
                     .build());
 
     private static final Map<TraceThreadField, String> TRACE_THREAD_FIELDS_MAP = new EnumMap<>(
@@ -289,115 +290,125 @@ public class FilterQueryBuilder {
                     .put(ExperimentsComparisonValidKnownField.OUTPUT, OUTPUT_ANALYTICS_DB)
                     .build());
 
-    private static final Map<FilterStrategy, Set<? extends Field>> FILTER_STRATEGY_MAP = new EnumMap<>(Map.of(
-            FilterStrategy.TRACE, EnumSet.copyOf(ImmutableSet.<TraceField>builder()
-                    .add(TraceField.ID)
-                    .add(TraceField.NAME)
-                    .add(TraceField.START_TIME)
-                    .add(TraceField.END_TIME)
-                    .add(TraceField.INPUT)
-                    .add(TraceField.OUTPUT)
-                    .add(TraceField.INPUT_JSON)
-                    .add(TraceField.OUTPUT_JSON)
-                    .add(TraceField.METADATA)
-                    .add(TraceField.TAGS)
-                    .add(TraceField.DURATION)
-                    .add(TraceField.THREAD_ID)
-                    .add(TraceField.GUARDRAILS)
-                    .add(TraceField.VISIBILITY_MODE)
-                    .add(TraceField.ERROR_INFO)
-                    .build()),
-            FilterStrategy.TRACE_AGGREGATION, EnumSet.copyOf(ImmutableSet.<TraceField>builder()
-                    .add(TraceField.USAGE_COMPLETION_TOKENS)
-                    .add(TraceField.USAGE_PROMPT_TOKENS)
-                    .add(TraceField.USAGE_TOTAL_TOKENS)
-                    .add(TraceField.TOTAL_ESTIMATED_COST)
-                    .add(TraceField.LLM_SPAN_COUNT)
-                    .build()),
-            FilterStrategy.SPAN, EnumSet.copyOf(ImmutableSet.<SpanField>builder()
-                    .add(SpanField.ID)
-                    .add(SpanField.NAME)
-                    .add(SpanField.START_TIME)
-                    .add(SpanField.END_TIME)
-                    .add(SpanField.INPUT)
-                    .add(SpanField.OUTPUT)
-                    .add(SpanField.INPUT_JSON)
-                    .add(SpanField.OUTPUT_JSON)
-                    .add(SpanField.METADATA)
-                    .add(SpanField.MODEL)
-                    .add(SpanField.PROVIDER)
-                    .add(SpanField.TOTAL_ESTIMATED_COST)
-                    .add(SpanField.TAGS)
-                    .add(SpanField.USAGE_COMPLETION_TOKENS)
-                    .add(SpanField.USAGE_PROMPT_TOKENS)
-                    .add(SpanField.USAGE_TOTAL_TOKENS)
-                    .add(SpanField.DURATION)
-                    .add(SpanField.ERROR_INFO)
-                    .add(SpanField.TYPE)
-                    .build()),
-            FilterStrategy.FEEDBACK_SCORES, ImmutableSet.<Field>builder()
-                    .add(TraceField.FEEDBACK_SCORES)
-                    .add(SpanField.FEEDBACK_SCORES)
-                    .add(ExperimentsComparisonValidKnownField.FEEDBACK_SCORES)
-                    .add(TraceThreadField.FEEDBACK_SCORES)
-                    .build(),
-            FilterStrategy.EXPERIMENT_ITEM, EnumSet.copyOf(ImmutableSet.<ExperimentsComparisonValidKnownField>builder()
-                    .add(ExperimentsComparisonValidKnownField.OUTPUT)
-                    .build()),
-            FilterStrategy.EXPERIMENT, ImmutableSet.<Field>builder()
-                    .add(ExperimentField.METADATA)
-                    .add(ExperimentField.DATASET_ID)
-                    .add(ExperimentField.PROMPT_IDS)
-                    .build(),
-            FilterStrategy.PROMPT, ImmutableSet.<Field>builder()
-                    .add(PromptField.ID)
-                    .add(PromptField.NAME)
-                    .add(PromptField.DESCRIPTION)
-                    .add(PromptField.CREATED_AT)
-                    .add(PromptField.LAST_UPDATED_AT)
-                    .add(PromptField.CREATED_BY)
-                    .add(PromptField.LAST_UPDATED_BY)
-                    .add(PromptField.TAGS)
-                    .add(PromptField.VERSION_COUNT)
-                    .build(),
-            FilterStrategy.DATASET, EnumSet.copyOf(ImmutableSet.<DatasetField>builder()
-                    .add(DatasetField.ID)
-                    .add(DatasetField.NAME)
-                    .add(DatasetField.DESCRIPTION)
-                    .add(DatasetField.TAGS)
-                    .add(DatasetField.CREATED_AT)
-                    .add(DatasetField.CREATED_BY)
-                    .add(DatasetField.LAST_UPDATED_AT)
-                    .add(DatasetField.LAST_UPDATED_BY)
-                    .add(DatasetField.LAST_CREATED_EXPERIMENT_AT)
-                    .add(DatasetField.LAST_CREATED_OPTIMIZATION_AT)
-                    .build()),
-            FilterStrategy.ANNOTATION_QUEUE, EnumSet.copyOf(ImmutableSet.<AnnotationQueueField>builder()
-                    .add(AnnotationQueueField.ID)
-                    .add(AnnotationQueueField.PROJECT_ID)
-                    .add(AnnotationQueueField.NAME)
-                    .add(AnnotationQueueField.DESCRIPTION)
-                    .add(AnnotationQueueField.INSTRUCTIONS)
-                    .add(AnnotationQueueField.FEEDBACK_DEFINITION_NAMES)
-                    .add(AnnotationQueueField.SCOPE)
-                    .add(AnnotationQueueField.CREATED_AT)
-                    .add(AnnotationQueueField.CREATED_BY)
-                    .add(AnnotationQueueField.LAST_UPDATED_AT)
-                    .add(AnnotationQueueField.LAST_UPDATED_BY)
-                    .build()),
-            FilterStrategy.TRACE_THREAD, EnumSet.copyOf(ImmutableSet.<TraceThreadField>builder()
-                    .add(TraceThreadField.ID)
-                    .add(TraceThreadField.NUMBER_OF_MESSAGES)
-                    .add(TraceThreadField.FIRST_MESSAGE)
-                    .add(TraceThreadField.LAST_MESSAGE)
-                    .add(TraceThreadField.DURATION)
-                    .add(TraceThreadField.CREATED_AT)
-                    .add(TraceThreadField.LAST_UPDATED_AT)
-                    .add(TraceThreadField.START_TIME)
-                    .add(TraceThreadField.END_TIME)
-                    .add(TraceThreadField.STATUS)
-                    .add(TraceThreadField.TAGS)
-                    .build())));
+    private static final Map<FilterStrategy, Set<? extends Field>> FILTER_STRATEGY_MAP = createFilterStrategyMap();
+
+    private static Map<FilterStrategy, Set<? extends Field>> createFilterStrategyMap() {
+        Map<FilterStrategy, Set<? extends Field>> map = new EnumMap<>(FilterStrategy.class);
+
+        map.put(FilterStrategy.TRACE, Set.of(
+                TraceField.ID,
+                TraceField.NAME,
+                TraceField.START_TIME,
+                TraceField.END_TIME,
+                TraceField.INPUT,
+                TraceField.OUTPUT,
+                TraceField.INPUT_JSON,
+                TraceField.OUTPUT_JSON,
+                TraceField.METADATA,
+                TraceField.TAGS,
+                TraceField.DURATION,
+                TraceField.THREAD_ID,
+                TraceField.GUARDRAILS,
+                TraceField.VISIBILITY_MODE,
+                TraceField.ERROR_INFO,
+                TraceField.ANNOTATION_QUEUE_IDS));
+
+        map.put(FilterStrategy.TRACE_AGGREGATION, Set.of(
+                TraceField.USAGE_COMPLETION_TOKENS,
+                TraceField.USAGE_PROMPT_TOKENS,
+                TraceField.USAGE_TOTAL_TOKENS,
+                TraceField.TOTAL_ESTIMATED_COST,
+                TraceField.LLM_SPAN_COUNT));
+
+        map.put(FilterStrategy.TRACE_ANNOTATION, Set.of(
+                TraceField.ANNOTATION_QUEUE_IDS));
+
+        map.put(FilterStrategy.SPAN, Set.of(
+                SpanField.ID,
+                SpanField.NAME,
+                SpanField.START_TIME,
+                SpanField.END_TIME,
+                SpanField.INPUT,
+                SpanField.OUTPUT,
+                SpanField.INPUT_JSON,
+                SpanField.OUTPUT_JSON,
+                SpanField.METADATA,
+                SpanField.MODEL,
+                SpanField.PROVIDER,
+                SpanField.TOTAL_ESTIMATED_COST,
+                SpanField.TAGS,
+                SpanField.USAGE_COMPLETION_TOKENS,
+                SpanField.USAGE_PROMPT_TOKENS,
+                SpanField.USAGE_TOTAL_TOKENS,
+                SpanField.DURATION,
+                SpanField.ERROR_INFO,
+                SpanField.TYPE));
+
+        map.put(FilterStrategy.FEEDBACK_SCORES, Set.of(
+                TraceField.FEEDBACK_SCORES,
+                SpanField.FEEDBACK_SCORES,
+                ExperimentsComparisonValidKnownField.FEEDBACK_SCORES,
+                TraceThreadField.FEEDBACK_SCORES));
+
+        map.put(FilterStrategy.EXPERIMENT_ITEM, Set.of(
+                ExperimentsComparisonValidKnownField.OUTPUT));
+
+        map.put(FilterStrategy.EXPERIMENT, Set.of(
+                ExperimentField.METADATA,
+                ExperimentField.DATASET_ID,
+                ExperimentField.PROMPT_IDS));
+
+        map.put(FilterStrategy.PROMPT, Set.of(
+                PromptField.ID,
+                PromptField.NAME,
+                PromptField.DESCRIPTION,
+                PromptField.CREATED_AT,
+                PromptField.LAST_UPDATED_AT,
+                PromptField.CREATED_BY,
+                PromptField.LAST_UPDATED_BY,
+                PromptField.TAGS,
+                PromptField.VERSION_COUNT));
+
+        map.put(FilterStrategy.DATASET, Set.of(
+                DatasetField.ID,
+                DatasetField.NAME,
+                DatasetField.DESCRIPTION,
+                DatasetField.TAGS,
+                DatasetField.CREATED_AT,
+                DatasetField.CREATED_BY,
+                DatasetField.LAST_UPDATED_AT,
+                DatasetField.LAST_UPDATED_BY,
+                DatasetField.LAST_CREATED_EXPERIMENT_AT,
+                DatasetField.LAST_CREATED_OPTIMIZATION_AT));
+
+        map.put(FilterStrategy.ANNOTATION_QUEUE, Set.of(
+                AnnotationQueueField.ID,
+                AnnotationQueueField.PROJECT_ID,
+                AnnotationQueueField.NAME,
+                AnnotationQueueField.DESCRIPTION,
+                AnnotationQueueField.INSTRUCTIONS,
+                AnnotationQueueField.FEEDBACK_DEFINITION_NAMES,
+                AnnotationQueueField.SCOPE,
+                AnnotationQueueField.CREATED_AT,
+                AnnotationQueueField.CREATED_BY,
+                AnnotationQueueField.LAST_UPDATED_AT,
+                AnnotationQueueField.LAST_UPDATED_BY));
+
+        map.put(FilterStrategy.TRACE_THREAD, Set.of(
+                TraceThreadField.ID,
+                TraceThreadField.NUMBER_OF_MESSAGES,
+                TraceThreadField.FIRST_MESSAGE,
+                TraceThreadField.LAST_MESSAGE,
+                TraceThreadField.DURATION,
+                TraceThreadField.CREATED_AT,
+                TraceThreadField.LAST_UPDATED_AT,
+                TraceThreadField.START_TIME,
+                TraceThreadField.END_TIME,
+                TraceThreadField.STATUS,
+                TraceThreadField.TAGS));
+
+        return map;
+    }
 
     private static final Set<FieldType> KEY_SUPPORTED_FIELDS_SET = EnumSet.of(
             FieldType.DICTIONARY,
@@ -459,8 +470,9 @@ public class FilterQueryBuilder {
     }
 
     private static boolean isFeedBackScore(Filter filter) {
-        return Set.of(TraceField.FEEDBACK_SCORES, SpanField.FEEDBACK_SCORES, TraceThreadField.FEEDBACK_SCORES,
-                ExperimentsComparisonValidKnownField.FEEDBACK_SCORES).contains(filter.field());
+        Set<Field> feedbackScoreFields = Set.of(TraceField.FEEDBACK_SCORES, SpanField.FEEDBACK_SCORES,
+                TraceThreadField.FEEDBACK_SCORES, ExperimentsComparisonValidKnownField.FEEDBACK_SCORES);
+        return feedbackScoreFields.contains(filter.field());
     }
 
     private String toAnalyticsDbFilter(Filter filter, int i, FilterStrategy filterStrategy) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterStrategy.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterStrategy.java
@@ -7,7 +7,7 @@ import static com.comet.opik.domain.filter.FilterQueryBuilder.JSONPATH_ROOT;
 public enum FilterStrategy {
     TRACE,
     TRACE_AGGREGATION,
-    TRACE_ANNOTATION,
+    ANNOTATION_AGGREGATION,
     SPAN,
     EXPERIMENT_ITEM,
     DATASET_ITEM,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterStrategy.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterStrategy.java
@@ -7,6 +7,7 @@ import static com.comet.opik.domain.filter.FilterQueryBuilder.JSONPATH_ROOT;
 public enum FilterStrategy {
     TRACE,
     TRACE_AGGREGATION,
+    TRACE_ANNOTATION,
     SPAN,
     EXPERIMENT_ITEM,
     DATASET_ITEM,


### PR DESCRIPTION
## Details
This implementation adds annotation queue filtering support to both trace and trace thread endpoints. The enhancement allows users to filter traces and trace threads based on annotation queue IDs, enabling more precise querying and organization of annotated data.

Key changes include:
• Added `ANNOTATION_QUEUE_IDS` field to `TraceField` and `TraceThreadField` enums for filter support
• Updated `FilterQueryBuilder` to map the new field to analytics database queries
• Introduced `ANNOTATION_AGGREGATION` filter strategy for proper query building and execution
• Enhanced filter mapping to support both trace and trace thread filtering scenarios

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2356

## Testing
Added comprehensive test coverage in `TracesResourceTest` including:
• Parameterized tests for annotation queue ID filtering functionality
• Integration tests with annotation queue resource client
• Validation of filter behavior across different trace and thread scenarios

## Documentation
No documentation files were updated in this PR. API documentation may need updates to reflect the new annotation queue filtering capability for users.