### PR TITLE
[OPIK-2479] [INFRA] Fix critical and high vulnerabilities

### DIFF
--- a/apps/opik-backend/Dockerfile
+++ b/apps/opik-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.9-amazoncorretto-21-al2023 AS build
+FROM maven:3.9.11-amazoncorretto-21-al2023 AS build
 
 WORKDIR /opt/opik-backend
 
@@ -12,7 +12,7 @@ RUN mvn versions:set -DnewVersion=${OPIK_VERSION} && \
     mvn clean package -DskipTests
 
 ###############################
-FROM amazoncorretto:21.0.7-al2023
+FROM amazoncorretto:21.0.8-al2023
 
 RUN yum update -y && yum install -y shadow ca-certificates openssl perl dos2unix \
     && yum clean all

--- a/apps/opik-backend/pom.xml
+++ b/apps/opik-backend/pom.xml
@@ -70,7 +70,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.1.Final</version>
+                <version>4.2.6.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/apps/opik-frontend/Dockerfile
+++ b/apps/opik-frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20.19.0-alpine3.20 AS builder
+FROM node:20.19.5-alpine3.22 AS builder
 
 WORKDIR /opt/frontend
 

--- a/apps/opik-python-backend/Dockerfile
+++ b/apps/opik-python-backend/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build to reduce final image size
-FROM docker:27.5.1 AS builder
+FROM docker:28.4.0 AS builder
 
 # Build dependencies (only needed during pip install)
 RUN apk add --no-cache tini python3 py3-pip build-base python3-dev musl-dev gcc libffi-dev && \
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 ##############################################################
 # Runtime stage - minimal packages only
-FROM docker:27.5.1
+FROM docker:28.4.0
 
 # Only runtime dependencies needed
 RUN apk add --no-cache tini python3


### PR DESCRIPTION
## Details
This PR updates critical dependency versions and base Docker images to fix identified security vulnerabilities across all Opik applications. The changes include:

**Backend Infrastructure:**
- Updated Maven base image from `3.9.9` to `3.9.11` in backend Dockerfile
- Updated Amazon Corretto JDK from `21.0.7` to `21.0.8` in backend Dockerfile  
- Updated Netty BOM dependency from `4.2.1.Final` to `4.2.6.Final` in backend pom.xml

**Frontend Infrastructure:**
- Updated Node.js base image from `20.19.0-alpine3.20` to `20.19.5-alpine3.22` in frontend Dockerfile

**Python Backend Infrastructure:**
- Updated Docker base image from `27.5.1` to `28.4.0` in python-backend Dockerfile

These updates address critical and high-severity vulnerabilities while maintaining compatibility with existing functionality.

## Change checklist
<!-- Please check the type of changes made -->
- [X] User facing
- [ ] Documentation update

## Issues
- OPIK-2479 <!-- The Jira ticket (e.g. `OPIK-1234`) -->

## Testing
Tested locally with `./opik.sh --build`
- UI and BE work fine.
- Successfully executed an online evaluation.

Those cover all scenarios for the updated files.

The changes are limited to dependency version updates and base image updates. Testing scenarios include:

- **Build Verification**: All Docker images build successfully with updated base images
- **Runtime Testing**: Applications start and function correctly with updated dependencies
- **Integration Testing**: No regression in functionality across backend, frontend, and python-backend services

## Documentation
No documentation updates required as these are internal infrastructure dependency updates that do not affect user-facing APIs or configuration.