### PR TITLE
[OPIK-2479] [BE] Upgrade libexpat to mitigate CVEs in python-backend

### DIFF
--- a/apps/opik-python-backend/Dockerfile
+++ b/apps/opik-python-backend/Dockerfile
@@ -17,6 +17,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Runtime stage - minimal packages only
 FROM docker:28.4.0
 
+# First upgrading to latest available versions to mitigate CVEs
+RUN apk add --no-cache --upgrade libexpat
+
 # Only runtime dependencies needed
 RUN apk add --no-cache tini python3
 


### PR DESCRIPTION
## Details

This PR upgrades the libexpat package in the Python backend Docker image to address known Common Vulnerabilities and Exposures (CVEs). The upgrade is implemented in the runtime stage of the multi-stage Docker build process.

**Changes made:**
- Added `RUN apk add --no-cache --upgrade libexpat` command in the runtime stage of the Dockerfile
- This ensures the latest available version of libexpat is installed to mitigate security vulnerabilities

## Change checklist
<!-- Please check the type of changes made -->
- [X] User facing
- [ ] Documentation update

## Issues
- OPIK-2479 <!-- The Jira ticket (e.g. `OPIK-1234`) -->

## Testing
Tested locally with `./opik.sh --build`
- UI and BE work fine.
- Successfully executed an online evaluation.
- Successfully `sh` into the container and run `apk info -a libexpat`. The result version was the one without CVEs: `2.7.2-r0`.

## Documentation

No documentation updates required - this is an internal security improvement to the Docker image build process.