### PR TITLE
Update moved page internal links

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-06-20.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-06-20.mdx
@@ -1,5 +1,5 @@
 ## 🔌 Integrations and SDK
-- Added **CloudFlare's WorkersAI** integration ([docs](https://www.comet.com/docs/opik/reference/typescript-sdk/integrations/workers-ai))
+- Added **CloudFlare's WorkersAI** integration ([docs](https://www.comet.com/docs/opik/tracing/integrations/cloudflare-workers-ai))
 - **Google ADK** integration: tracing is now automatically propagated to all sub-agents in agentic systems with the new `track_adk_agent_recursive` feature, eliminating the need to manually add tracing to each sub-agent.
 - **Google ADK** integration: now we retrieve session-level information from the ADK framework to enrich the threads data.
 - **New in the SDK!** Real-time tracking for long-running spans/traces is now supported. When enabled (set `os.environ["OPIK_LOG_START_TRACE_SPAN"] = "True"` in your environment), you can see traces and spans update live in the UI—even for jobs that are still running. This makes debugging and monitoring long-running agents much more responsive and convenient.


### PR DESCRIPTION
## Details
Updates an internal link in the changelog to reflect the new path for the CloudFlare Workers AI integration documentation. This ensures all internal links point to the correct, moved pages after a recent file reorganization.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- OPIK- (Internal task to update moved links)

## Testing
Verified by searching for old paths across the documentation and confirming the updated link points to the correct location.

## Documentation
N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-45b06e7d-c73e-4e53-b07f-43517909fdf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45b06e7d-c73e-4e53-b07f-43517909fdf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

