### PR TITLE
[OPIK-2435] Onboarding test prompt path update

### DIFF
--- a/apps/opik-frontend/src/components/shared/OnboardingOverlay/steps/StartPreference.tsx
+++ b/apps/opik-frontend/src/components/shared/OnboardingOverlay/steps/StartPreference.tsx
@@ -23,7 +23,7 @@ const StartPreference: React.FC = () => {
         <OnboardingStep.AnswerCard option={OPTIONS.TRACE_APP} />
 
         <Link
-          to="/$workspaceName/prompts"
+          to="/$workspaceName/playground"
           params={{ workspaceName }}
           className="w-full"
         >


### PR DESCRIPTION
## Details
This pull request introduces a small change to the onboarding overlay component, specifically updating the navigation link for one of the onboarding steps. The destination for the link has been changed to direct users to the playground instead of the prompts page.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2435

## Testing

## Documentation
