### PR TITLE
[NA] [BE] Add support to multi thread closure

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/TraceThreadBatchIdentifier.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/TraceThreadBatchIdentifier.java
@@ -5,14 +5,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 import java.util.List;
 import java.util.UUID;
-
-import static com.comet.opik.utils.ValidationUtils.NULL_OR_NOT_BLANK;
 
 /**
  * Identifier for batch thread operations that supports both single and multiple thread IDs.
@@ -25,6 +22,6 @@ import static com.comet.opik.utils.ValidationUtils.NULL_OR_NOT_BLANK;
 public record TraceThreadBatchIdentifier(
         String projectName,
         UUID projectId,
-        @Pattern(regexp = NULL_OR_NOT_BLANK, message = "must not be blank") String threadId, // For backward compatibility
+        String threadId, // For backward compatibility
         @Size(min = 1, max = 1000) List<@NotBlank String> threadIds) { // For batch operations
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/TraceThreadBatchIdentifier.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/TraceThreadBatchIdentifier.java
@@ -1,0 +1,26 @@
+package com.comet.opik.api;
+
+import com.comet.opik.api.validation.TraceThreadBatchIdentifierValidation;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Identifier for batch thread operations that supports both single and multiple thread IDs.
+ * This DTO maintains backward compatibility with TraceThreadIdentifier while allowing batch operations.
+ */
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@TraceThreadBatchIdentifierValidation
+public record TraceThreadBatchIdentifier(
+        String projectName,
+        UUID projectId,
+        String threadId, // For backward compatibility
+        @Size(min = 1, max = 1000) List<String> threadIds) { // For batch operations
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/TraceThreadBatchIdentifier.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/TraceThreadBatchIdentifier.java
@@ -4,11 +4,15 @@ import com.comet.opik.api.validation.TraceThreadBatchIdentifierValidation;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 import java.util.List;
 import java.util.UUID;
+
+import static com.comet.opik.utils.ValidationUtils.NULL_OR_NOT_BLANK;
 
 /**
  * Identifier for batch thread operations that supports both single and multiple thread IDs.
@@ -21,6 +25,6 @@ import java.util.UUID;
 public record TraceThreadBatchIdentifier(
         String projectName,
         UUID projectId,
-        String threadId, // For backward compatibility
-        @Size(min = 1, max = 1000) List<String> threadIds) { // For batch operations
+        @Pattern(regexp = NULL_OR_NOT_BLANK, message = "must not be blank") String threadId, // For backward compatibility
+        @Size(min = 1, max = 1000) List<@NotBlank String> threadIds) { // For batch operations
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -17,6 +17,7 @@ import com.comet.opik.api.Trace.TracePage;
 import com.comet.opik.api.TraceBatch;
 import com.comet.opik.api.TraceSearchStreamRequest;
 import com.comet.opik.api.TraceThread;
+import com.comet.opik.api.TraceThreadBatchIdentifier;
 import com.comet.opik.api.TraceThreadIdentifier;
 import com.comet.opik.api.TraceThreadSearchStreamRequest;
 import com.comet.opik.api.TraceThreadUpdate;
@@ -77,6 +78,7 @@ import jakarta.ws.rs.core.UriInfo;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.glassfish.jersey.server.ChunkedOutput;
 import reactor.core.publisher.Flux;
 
@@ -680,6 +682,20 @@ public class TracesResource {
                 .id();
     }
 
+    private UUID validateProjectIdentifier(TraceThreadBatchIdentifier identifier, String workspaceId) {
+        // Verify project visibility
+        if (identifier.projectId() != null) {
+            return projectService.get(identifier.projectId()).id();
+        }
+
+        // If the project name is provided, find the project by name
+        return projectService.findByNames(workspaceId, List.of(identifier.projectName()))
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> ErrorUtils.failWithNotFoundName("Project", identifier.projectName()))
+                .id();
+    }
+
     @POST
     @Path("/threads/delete")
     @Operation(operationId = "deleteTraceThreads", summary = "Delete trace threads", description = "Delete trace threads", responses = {
@@ -728,26 +744,31 @@ public class TracesResource {
 
     @PUT
     @Path("/threads/close")
-    @Operation(operationId = "closeTraceThread", summary = "Close trace thread", description = "Close trace thread", responses = {
+    @Operation(operationId = "closeTraceThread", summary = "Close trace thread(s)", description = "Close one or multiple trace threads. Supports both single thread_id and multiple thread_ids for batch operations.", responses = {
             @ApiResponse(responseCode = "204", description = "No Content"),
             @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))
     })
     public Response closeTraceThread(
-            @RequestBody(content = @Content(schema = @Schema(implementation = TraceThreadIdentifier.class))) @NotNull @Valid TraceThreadIdentifier identifier) {
+            @RequestBody(content = @Content(schema = @Schema(implementation = TraceThreadBatchIdentifier.class))) @NotNull @Valid TraceThreadBatchIdentifier identifier) {
 
         String workspaceId = requestContext.get().getWorkspaceId();
 
         // Validate project identifier and get projectId
         UUID projectId = validateProjectIdentifier(identifier, workspaceId);
 
-        log.info("Close trace thread_id: '{}' and project_id: '{}' on workspace_id: '{}'", identifier.threadId(),
+        // Handle both single and batch operations
+        List<String> threadIds = CollectionUtils.isNotEmpty(identifier.threadIds())
+                ? identifier.threadIds()
+                : List.of(identifier.threadId());
+
+        log.info("Close trace thread_ids: '{}' and project_id: '{}' on workspace_id: '{}'", threadIds,
                 projectId, workspaceId);
 
-        traceThreadService.closeThread(projectId, identifier.threadId())
+        traceThreadService.closeThreads(projectId, threadIds)
                 .contextWrite(ctx -> setRequestContext(ctx, requestContext))
                 .block();
 
-        log.info("Closed trace thread_id: '{}' and project_id: '{}' on workspace_id: '{}'", identifier.threadId(),
+        log.info("Closed trace thread_ids: '{}' and project_id: '{}' on workspace_id: '{}'", threadIds,
                 projectId, workspaceId);
 
         return Response.noContent().build();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/TraceThreadBatchIdentifierValidation.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/TraceThreadBatchIdentifierValidation.java
@@ -1,0 +1,23 @@
+package com.comet.opik.api.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = TraceThreadBatchIdentifierValidator.class)
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TraceThreadBatchIdentifierValidation {
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/TraceThreadBatchIdentifierValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/TraceThreadBatchIdentifierValidator.java
@@ -1,0 +1,52 @@
+package com.comet.opik.api.validation;
+
+import com.comet.opik.api.TraceThreadBatchIdentifier;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.apache.commons.lang3.StringUtils;
+
+public class TraceThreadBatchIdentifierValidator
+        implements
+            ConstraintValidator<TraceThreadBatchIdentifierValidation, TraceThreadBatchIdentifier> {
+
+    @Override
+    public boolean isValid(TraceThreadBatchIdentifier identifier, ConstraintValidatorContext context) {
+        if (identifier == null) {
+            return false;
+        }
+
+        boolean isValid = true;
+        context.disableDefaultConstraintViolation();
+
+        // Validate project identifier (projectName OR projectId)
+        boolean hasProjectName = StringUtils.isNotBlank(identifier.projectName());
+        boolean hasProjectId = identifier.projectId() != null;
+
+        if (!hasProjectName && !hasProjectId) {
+            context.buildConstraintViolationWithTemplate("Either 'projectName' or 'projectId' must be provided.")
+                    .addConstraintViolation();
+            isValid = false;
+        }
+
+        // Validate thread identifiers (threadIds not null OR threadId not blank)
+        // Note: We check for null threadIds, not empty, because @Size annotation handles empty list validation
+        boolean hasThreadIds = identifier.threadIds() != null;
+        boolean hasThreadId = StringUtils.isNotBlank(identifier.threadId());
+
+        if (!hasThreadIds && !hasThreadId) {
+            context.buildConstraintViolationWithTemplate("Either 'threadId' or 'threadIds' must be provided.")
+                    .addConstraintViolation();
+            isValid = false;
+        }
+
+        // Validate that both threadId and threadIds are not provided at the same time
+        if (hasThreadId && hasThreadIds) {
+            context.buildConstraintViolationWithTemplate(
+                    "Cannot provide both 'threadId' and 'threadIds'. Use 'threadId' for single operations or 'threadIds' for batch operations.")
+                    .addConstraintViolation();
+            isValid = false;
+        }
+
+        return isValid;
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
@@ -12,6 +12,7 @@ import com.comet.opik.api.Trace;
 import com.comet.opik.api.TraceBatch;
 import com.comet.opik.api.TraceSearchStreamRequest;
 import com.comet.opik.api.TraceThread;
+import com.comet.opik.api.TraceThreadBatchIdentifier;
 import com.comet.opik.api.TraceThreadIdentifier;
 import com.comet.opik.api.TraceThreadSearchStreamRequest;
 import com.comet.opik.api.TraceThreadUpdate;
@@ -542,6 +543,21 @@ public class TraceResourceClient extends BaseCommentResourceClient {
                 .header(WORKSPACE_HEADER, workspaceName)
                 .put(Entity.json(TraceThreadIdentifier.builder().projectId(projectId).projectName(projectName)
                         .threadId(threadId).build()))) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+        }
+    }
+
+    public void closeTraceThreads(List<String> threadIds, UUID projectId, String projectName, String apiKey,
+            String workspaceName) {
+        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("threads")
+                .path("close")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .put(Entity.json(TraceThreadBatchIdentifier.builder().projectId(projectId).projectName(projectName)
+                        .threadIds(threadIds).build()))) {
 
             assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
         }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/validation/TraceThreadBatchIdentifierValidatorTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/validation/TraceThreadBatchIdentifierValidatorTest.java
@@ -1,0 +1,233 @@
+package com.comet.opik.api.validation;
+
+import com.comet.opik.api.TraceThreadBatchIdentifier;
+import com.comet.opik.podam.PodamFactoryUtils;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TraceThreadBatchIdentifierValidatorTest {
+
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        var validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @Test
+    void validateWhenValidSingleThreadIdWithProjectName() {
+        // Given
+        var identifier = TraceThreadBatchIdentifier.builder()
+                .projectName("test-project")
+                .threadId("thread-123")
+                .build();
+
+        // When
+        Set<ConstraintViolation<TraceThreadBatchIdentifier>> violations = validator.validate(identifier);
+
+        // Then
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void validateWhenValidSingleThreadIdWithProjectId() {
+        // Given
+        var identifier = TraceThreadBatchIdentifier.builder()
+                .projectId(UUID.randomUUID())
+                .threadId("thread-123")
+                .build();
+
+        // When
+        Set<ConstraintViolation<TraceThreadBatchIdentifier>> violations = validator.validate(identifier);
+
+        // Then
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void validateWhenValidBatchThreadIdsWithProjectName() {
+        // Given
+        var identifier = TraceThreadBatchIdentifier.builder()
+                .projectName("test-project")
+                .threadIds(List.of("thread-1", "thread-2", "thread-3"))
+                .build();
+
+        // When
+        Set<ConstraintViolation<TraceThreadBatchIdentifier>> violations = validator.validate(identifier);
+
+        // Then
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void validateWhenValidBatchThreadIdsWithProjectId() {
+        // Given
+        var identifier = TraceThreadBatchIdentifier.builder()
+                .projectId(UUID.randomUUID())
+                .threadIds(List.of("thread-1", "thread-2", "thread-3"))
+                .build();
+
+        // When
+        Set<ConstraintViolation<TraceThreadBatchIdentifier>> violations = validator.validate(identifier);
+
+        // Then
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void validateWhenNoProjectIdentifierThrowsValidationError() {
+        // Given
+        var identifier = TraceThreadBatchIdentifier.builder()
+                .threadId("thread-123")
+                .build();
+
+        // When
+        Set<ConstraintViolation<TraceThreadBatchIdentifier>> violations = validator.validate(identifier);
+
+        // Then
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage())
+                .isEqualTo("Either 'projectName' or 'projectId' must be provided.");
+    }
+
+    @Test
+    void validateWhenNoThreadIdentifierThrowsValidationError() {
+        // Given
+        var identifier = TraceThreadBatchIdentifier.builder()
+                .projectName("test-project")
+                .build();
+
+        // When
+        Set<ConstraintViolation<TraceThreadBatchIdentifier>> violations = validator.validate(identifier);
+
+        // Then
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage())
+                .isEqualTo("Either 'threadId' or 'threadIds' must be provided.");
+    }
+
+    @Test
+    void validateWhenBothThreadIdAndThreadIdsProvidedThrowsValidationError() {
+        // Given
+        var identifier = TraceThreadBatchIdentifier.builder()
+                .projectName("test-project")
+                .threadId("thread-123")
+                .threadIds(List.of("thread-1", "thread-2"))
+                .build();
+
+        // When
+        Set<ConstraintViolation<TraceThreadBatchIdentifier>> violations = validator.validate(identifier);
+
+        // Then
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage())
+                .isEqualTo(
+                        "Cannot provide both 'threadId' and 'threadIds'. Use 'threadId' for single operations or 'threadIds' for batch operations.");
+    }
+
+    @Test
+    void validateWhenMultipleValidationErrorsOccur() {
+        // Given - No project identifier and no thread identifier
+        var identifier = TraceThreadBatchIdentifier.builder().build();
+
+        // When
+        Set<ConstraintViolation<TraceThreadBatchIdentifier>> violations = validator.validate(identifier);
+
+        // Then
+        assertThat(violations).hasSize(2);
+        var messages = violations.stream()
+                .map(ConstraintViolation::getMessage)
+                .toList();
+        assertThat(messages).containsExactlyInAnyOrder(
+                "Either 'projectName' or 'projectId' must be provided.",
+                "Either 'threadId' or 'threadIds' must be provided.");
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidProjectIdentifierCases")
+    void validateWhenInvalidProjectIdentifier(String projectName, UUID projectId, String expectedMessage) {
+        // Given
+        var identifier = TraceThreadBatchIdentifier.builder()
+                .projectName(projectName)
+                .projectId(projectId)
+                .threadId("thread-123")
+                .build();
+
+        // When
+        Set<ConstraintViolation<TraceThreadBatchIdentifier>> violations = validator.validate(identifier);
+
+        // Then
+        if (expectedMessage != null) {
+            assertThat(violations).hasSize(1);
+            assertThat(violations.iterator().next().getMessage()).isEqualTo(expectedMessage);
+        } else {
+            assertThat(violations).isEmpty();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidThreadIdentifierCases")
+    void validateWhenInvalidThreadIdentifier(String threadId, List<String> threadIds, String expectedMessage) {
+        // Given
+        var identifier = TraceThreadBatchIdentifier.builder()
+                .projectName("test-project")
+                .threadId(threadId)
+                .threadIds(threadIds)
+                .build();
+
+        // When
+        Set<ConstraintViolation<TraceThreadBatchIdentifier>> violations = validator.validate(identifier);
+
+        // Then
+        if (expectedMessage != null) {
+            assertThat(violations).hasSize(1);
+            assertThat(violations.iterator().next().getMessage()).isEqualTo(expectedMessage);
+        } else {
+            assertThat(violations).isEmpty();
+        }
+    }
+
+    private static Stream<Arguments> invalidProjectIdentifierCases() {
+        return Stream.of(
+                // Valid cases
+                Arguments.of("valid-project", null, null),
+                Arguments.of(null, UUID.randomUUID(), null),
+                Arguments.of("valid-project", UUID.randomUUID(), null),
+
+                // Invalid cases
+                Arguments.of(null, null, "Either 'projectName' or 'projectId' must be provided."),
+                Arguments.of("", null, "Either 'projectName' or 'projectId' must be provided."),
+                Arguments.of("   ", null, "Either 'projectName' or 'projectId' must be provided."));
+    }
+
+    private static Stream<Arguments> invalidThreadIdentifierCases() {
+        return Stream.of(
+                // Valid cases
+                Arguments.of("valid-thread", null, null),
+                Arguments.of(null, List.of("thread-1", "thread-2"), null),
+
+                // Invalid cases
+                Arguments.of(null, null, "Either 'threadId' or 'threadIds' must be provided."),
+                Arguments.of("", null, "Either 'threadId' or 'threadIds' must be provided."),
+                Arguments.of("   ", null, "Either 'threadId' or 'threadIds' must be provided."),
+                Arguments.of(null, List.of(), "size must be between 1 and 1000"),
+                Arguments.of("thread-1", List.of("thread-2"),
+                        "Cannot provide both 'threadId' and 'threadIds'. Use 'threadId' for single operations or 'threadIds' for batch operations."));
+    }
+}


### PR DESCRIPTION
## Details

- Add support for multi-thread closure so we can reduce the number of individual calls to close threads on Demo Data. The endpoint remains the same; we only added the `threadIds` property, which accepts a list of thread IDs. 

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- NA

## Testing
NA

## Documentation
NA