### PR TITLE
[OPIK-2455] [P SDK] Update SDK documentation to provide more details about `opik_args` feature

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openai.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openai.mdx
@@ -111,6 +111,36 @@ Cost information is automatically captured and displayed in the Opik UI, includi
   View the complete list of supported models and providers on the [Supported Models](/tracing/supported_models) page.
 </Tip>
 
+## Grouping traces into conversational threads using `thread_id`
+
+Threads in Opik are collections of traces that are grouped together using a unique `thread_id`.
+
+The `thread_id` can be passed to the OpenAI client as a parameter, which will be used to group all traces into a single thread.
+
+```python
+import openai
+
+from opik.integrations.openai import track_openai
+
+client = openai.OpenAI()
+wrapped_client = track_openai(
+    openai_client=client,
+    project_name="opik_args demo",
+)
+messages = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What is Opik?"},
+]
+
+_ = wrapped_client.responses.create(
+    model="gpt-4o-mini",
+    input=messages,
+    opik_args={"trace": {"thread_id": "f174a"}}
+)
+```
+
+More information on logging chat conversations can be found in the [Log conversations](/tracing/log_chat_conversations) section.
+
 ## Supported OpenAI methods
 
 The `track_openai` wrapper supports the following OpenAI methods:

--- a/apps/opik-documentation/documentation/fern/docs/tracing/log_chat_conversations.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/log_chat_conversations.mdx
@@ -160,6 +160,20 @@ You can log chat conversations by specifying the `thread_id` parameter when usin
   response.
 </Note>
 
+If you can’t or prefer not to modify the body of the tracked function, you can pass the `thread_id` using the `opik_args` parameter instead:
+
+```python
+import opik
+
+@opik.track()
+def chat_message(input_text):
+    return "Opik is an Open Source GenAI platform"
+
+opik_args={"trace": {"thread_id": "f174a"}}
+chat_message("What is Opik ?", opik_args=opik_args)
+chat_message("Who is Opik?", opik_args=opik_args)
+```
+
 ## Thread ID Best Practices
 
 ### Generating Thread IDs
@@ -271,6 +285,46 @@ with trace(workflow_name="Agent Conversation", group_id=thread_id):
     # All agent interactions within this context share the thread_id
     result1 = await Runner.run(agent, "First question")
     result2 = await Runner.run(agent, "Follow-up question")
+```
+
+#### GenAI Integration
+
+```python
+from google import genai
+from opik.integrations.genai import track_genai
+
+client = genai.Client()
+gemini_client = track_genai(client, project_name="opik_args demo")
+
+response = gemini_client.models.generate_content(
+    model="gemini-2.0-flash",
+    contents="What is Opik?",
+    opik_args={"trace": {"thread_id": "f174a"}}
+)
+```
+
+#### OpenAI Integration
+
+```python
+import openai
+
+from opik.integrations.openai import track_openai
+
+client = openai.OpenAI()
+wrapped_client = track_openai(
+    openai_client=client,
+    project_name="opik_args demo",
+)
+messages = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What is Opik?"},
+]
+
+_ = wrapped_client.responses.create(
+    model="gpt-4o-mini",
+    input=messages,
+    opik_args={"trace": {"thread_id": "f174a"}}
+)
 ```
 
 ### Thread Management in Production

--- a/apps/opik-documentation/documentation/fern/docs/tracing/log_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/log_traces.mdx
@@ -298,13 +298,12 @@ def llm_chain(input_text):
 
 You can learn more about the `opik_context` module in the [opik_context reference docs](https://www.comet.com/docs/opik/python-sdk-reference/opik_context/index.html).
 
-#### Logging additional data using opik_args parameter
+Also, you can use the `opik_args` parameter to pass additional configuration to traced functions, including `tags`, `metadata`, and trace-level settings like `thread_id`.
+This parameter can be used in two ways: implicitly or explicitly.
 
-The `opik_args` parameter allows you to pass additional configuration to traced functions, including span tags, metadata, and trace-level settings like `thread_id`. This parameter can be used in two ways:
+##### Implicit `opik_args` (functions without `opik_args` parameter)
 
-##### Implicit opik_args (functions without opik_args parameter)
-
-When your function doesn't explicitly declare an `opik_args` parameter, you can still pass opik_args when calling the function. The decorator will handle it internally:
+When your function doesn't explicitly declare an `opik_args` parameter, you can still pass `opik_args` when calling the function. The decorator will handle it internally:
 
 ```python
 import opik
@@ -332,9 +331,9 @@ result = llm_chain(
 )
 ```
 
-##### Explicit opik_args (functions with opik_args parameter)
+##### Explicit `opik_args` (functions with `opik_args` parameter)
 
-When your function explicitly declares an `opik_args` parameter, it will receive the opik_args value directly. This is useful for propagating configuration through nested function calls:
+When your function explicitly declares an `opik_args` parameter, it will receive the `opik_args` value directly. This is useful for propagating configuration through nested function calls:
 
 ```python
 from typing import Optional, Dict, Any
@@ -364,7 +363,7 @@ result = parent_function(
 )
 ```
 
-##### The opik_args structure
+##### The `opik_args` structure
 
 The `opik_args` parameter accepts a dictionary with the following structure:
 
@@ -384,12 +383,11 @@ opik_args = {
 
 Both `"span"` and `"trace"` sections are optional - you can include either or both as needed.
 
-
 #### Configuring the project name
 
 You can configure the project you want the trace to be logged to using the `project_name` parameter of the `@track` decorator:
 
-```python {pytest_codeblocks_skip=true}
+```python
 import opik
 
 @opik.track(project_name="my_project")
@@ -444,6 +442,52 @@ You can disable the logging of traces and spans using the environment variable `
 import os
 
 os.environ["OPIK_TRACK_DISABLE"] = "true"
+```
+
+### Configuring the `thread_id`
+
+You can group multiple traces into a single conversational thread by updating each created trace with a specific `thread_id` parameter.
+Often, this isn’t possible directly because tracing occurs inside a function you can’t modify. In such cases, you can use the `opik_args` parameter to pass the `thread_id` to the function, as shown below:
+
+```python
+from google import genai
+from opik.integrations.genai import track_genai
+
+client = genai.Client()
+gemini_client = track_genai(client, project_name="opik_args demo")
+
+response = gemini_client.models.generate_content(
+    model="gemini-2.0-flash",
+    contents="What is Opik?",
+    opik_args={"trace": {"thread_id": "f174a"}}
+)
+
+print(response.text)
+
+```
+
+Also, you can pass it to the function with `opik.track` decorator:
+
+```python
+from google import genai
+
+import opik
+from opik.integrations.genai import track_genai
+
+client = genai.Client()
+gemini_client = track_genai(client)
+
+@opik.track(project_name="opik_args demo")
+def chat_message(input_text):
+    response = gemini_client.models.generate_content(
+        model="gemini-2.0-flash",
+        contents=input_text
+    )
+    return response.text
+
+opik_args={"trace": {"thread_id": "f174a"}}
+chat_message("What is Opik ?", opik_args=opik_args)
+chat_message("Who is Opik?", opik_args=opik_args)
 ```
 
 ### Using the low-level Opik client

--- a/sdks/python/tests/library_integration/genai/test_genai.py
+++ b/sdks/python/tests/library_integration/genai/test_genai.py
@@ -582,3 +582,83 @@ def test_genai_client__async_generate_content_stream_called_inside_another_track
 
     llm_span_metadata = trace_tree.spans[0].spans[0].metadata
     _assert_metadata_contains_required_keys(llm_span_metadata)
+
+
+@retry_with_waiting_on_rate_limit_errors
+@pytest.mark.parametrize(
+    "project_name, expected_project_name",
+    [
+        (None, OPIK_PROJECT_DEFAULT_NAME),
+        ("genai-integration-test", "genai-integration-test"),
+    ],
+)
+def test_genai_client__generate_content__opik_args__happyflow(
+    fake_backend, project_name, expected_project_name
+):
+    # test that opik_args are passed to the logged traces and spans
+    client = genai.Client(
+        vertexai=True,
+        http_options=HttpOptions(api_version="v1"),
+    )
+    client = track_genai(client, project_name=project_name)
+
+    args_dict = {
+        "span": {"tags": ["span_tag"], "metadata": {"span_key": "span_value"}},
+        "trace": {
+            "thread_id": "conversation-2",
+            "tags": ["trace_tag"],
+            "metadata": {"trace_key": "trace_value"},
+        },
+    }
+
+    client.models.generate_content(
+        model=MODEL,
+        contents="What is the capital of Belarus?",
+        config=GenerateContentConfig(max_output_tokens=10),
+        opik_args=args_dict,
+    )
+
+    opik.flush_tracker()
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name=ANY_STRING.starting_with(f"generate_content: {MODEL}"),
+        input={"contents": "What is the capital of Belarus?", "config": ANY_BUT_NONE},
+        output={"candidates": ANY_LIST},
+        tags=["genai", "span_tag", "trace_tag"],
+        metadata=ANY_DICT.containing({"trace_key": "trace_value"}),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=expected_project_name,
+        thread_id="conversation-2",
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name=ANY_STRING.starting_with(f"generate_content: {MODEL}"),
+                input={
+                    "contents": "What is the capital of Belarus?",
+                    "config": ANY_BUT_NONE,
+                },
+                output={"candidates": ANY_LIST},
+                tags=["genai", "span_tag"],
+                metadata=ANY_DICT.containing({"span_key": "span_value"}),
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                usage=EXPECTED_GOOGLE_USAGE_LOGGED_FORMAT,
+                project_name=expected_project_name,
+                spans=[],
+                model=ANY_STRING.starting_with(MODEL),
+                provider="google_vertexai",
+            )
+        ],
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)
+
+    llm_span_metadata = trace_tree.spans[0].metadata
+    _assert_metadata_contains_required_keys(llm_span_metadata)

--- a/sdks/python/tests/library_integration/openai/test_openai_responses.py
+++ b/sdks/python/tests/library_integration/openai/test_openai_responses.py
@@ -649,3 +649,80 @@ def test_openai_client_responses_parse_raises_an_error__span_and_trace_finished_
     trace_tree = fake_backend.trace_trees[0]
 
     assert_equal(EXPECTED_TRACE_TREE, trace_tree)
+
+
+@pytest.mark.parametrize(
+    "project_name, expected_project_name",
+    [
+        (None, OPIK_PROJECT_DEFAULT_NAME),
+        ("openai-integration-test", "openai-integration-test"),
+    ],
+)
+def test_openai_client_responses_create__opik_args__happyflow(
+    fake_backend, project_name, expected_project_name
+):
+    # test that opik_args are passed to the logged traces and spans
+    client = openai.OpenAI()
+    wrapped_client = track_openai(
+        openai_client=client,
+        project_name=project_name,
+    )
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Tell a fact"},
+    ]
+
+    args_dict = {
+        "span": {"tags": ["span_tag"], "metadata": {"span_key": "span_value"}},
+        "trace": {
+            "thread_id": "conversation-2",
+            "tags": ["trace_tag"],
+            "metadata": {"trace_key": "trace_value"},
+        },
+    }
+
+    _ = wrapped_client.responses.create(
+        model=MODEL_FOR_TESTS, input=messages, max_output_tokens=50, opik_args=args_dict
+    )
+
+    opik.flush_tracker()
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="responses_create",
+        input={"input": messages},
+        output={"output": ANY_BUT_NONE, "reasoning": ANY},
+        tags=["openai", "span_tag", "trace_tag"],
+        metadata=ANY_DICT.containing({"trace_key": "trace_value"}),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=expected_project_name,
+        thread_id="conversation-2",
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="responses_create",
+                input={"input": messages},
+                output={"output": ANY_BUT_NONE, "reasoning": ANY},
+                tags=["openai", "span_tag"],
+                metadata=ANY_DICT.containing({"span_key": "span_value"}),
+                usage=EXPECTED_OPENAI_USAGE_LOGGED_FORMAT,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=expected_project_name,
+                spans=[],
+                model=ANY_STRING.starting_with(MODEL_FOR_TESTS),
+                provider="openai",
+            )
+        ],
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)
+
+    llm_span_metadata = trace_tree.spans[0].metadata
+    _assert_metadata_contains_required_keys(llm_span_metadata)


### PR DESCRIPTION
## Details
The current docs are very focused on the technicalities of change rather than the user value. It's also going to be quite hard for users to find this functionality through search or by reading through the docs.Would be great if we could:
In "Log traces":

- Merge most of the content to the Logging additional data section, this is essentially an alternative to the update_current_trace method
- Add a new section that is focused on the passing of the thread_id that focuses on the log trace to a conversation user value
- Add this way of logging conversations to the [Log conversation](https://opik-preview-8daaead1-2f84-47ce-ae31-a228a87efa4d.docs.buildwithfern.com/docs/opik/tracing/log_chat_conversations#logging-conversations) page
Add this to each of the relevant integration documentation pages as this is where this request originated from

### Key changes

This PR updates the Python SDK documentation to provide more comprehensive guidance on using the `opik_args` feature, with a particular focus on its practical applications for logging conversational threads and additional trace metadata.

- Enhanced documentation structure by reorganizing content to emphasize user value over technical details
- Added comprehensive examples showing how to use `opik_args` with `thread_id` for conversation logging
- Integrated `opik_args` usage examples into relevant integration documentation pages

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-2455

## Testing

Added additional library integration tests

## Documentation

Updated relevant documentation sections