### PR TITLE
[OPIK-2506] [FE] Add OPENAI_API_KEY environment variable to the experiment creation boilerplate code

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog.tsx
@@ -202,6 +202,8 @@ const AddExperimentDialog: React.FunctionComponent<
 from opik import Opik
 from opik.evaluation import evaluate
 
+# os.environ["OPENAI_API_KEY"] = "OpenAI API key goes here"
+
 # INJECT_OPIK_CONFIGURATION
 
 ${importString}


### PR DESCRIPTION
## Details

The boilerplate code for creating a new experiment does not set the OPENAI_API_KEY environment variable, which causes errors if the variable hasn’t already been configured in the user’s environment. We need to fix this by adding a hint to inform users that this variable must be set beforehand.

```python
os.environ["OPIK_URL_OVERRIDE"] = "http://localhost:5173/api"
# os.environ["OPENAI_API_KEY"] = "OpenAI API key goes here"
```

### Key changes
This PR adds a commented environment variable hint for OPENAI_API_KEY in the experiment creation boilerplate code to help users avoid errors when the key isn't already configured in their environment.

- Adds a commented line showing how to set the OPENAI_API_KEY environment variable
- Improves the boilerplate code template with better guidance for users

## After changes:

<img width="1634" height="1192" alt="Screenshot 2025-09-25 at 14 30 19" src="https://github.com/user-attachments/assets/093f2e30-ea4f-44a2-8b54-ea2875abbb50" />


## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-2506

## Testing

No tests affected

## Documentation

Create experiment boilerplate code template was improved.
