### PR TITLE
[OPIK-2363] [FE] Fix SME Flow annotation issues

### DIFF
--- a/apps/opik-frontend/src/components/pages/SMEFlowPage/AnnotationView/CommentAndScoreViewer.tsx
+++ b/apps/opik-frontend/src/components/pages/SMEFlowPage/AnnotationView/CommentAndScoreViewer.tsx
@@ -6,6 +6,7 @@ import { useSMEFlow } from "../SMEFlowContext";
 
 const CommentAndScoreViewer: React.FC = () => {
   const {
+    currentItem,
     currentAnnotationState,
     annotationQueue,
     updateComment,
@@ -24,6 +25,7 @@ const CommentAndScoreViewer: React.FC = () => {
       <Separator orientation="horizontal" className="my-4" />
 
       <FeedbackScoresEditor
+        key={currentItem?.id}
         feedbackScores={currentAnnotationState.scores}
         onUpdateFeedbackScore={updateFeedbackScore}
         onDeleteFeedbackScore={deleteFeedbackScore}

--- a/apps/opik-frontend/src/components/pages/SMEFlowPage/AnnotationView/ThreadDataViewer.tsx
+++ b/apps/opik-frontend/src/components/pages/SMEFlowPage/AnnotationView/ThreadDataViewer.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
+import last from "lodash/last";
 import { Thread } from "@/types/traces";
 import { useSMEFlow } from "../SMEFlowContext";
 import useTracesList from "@/api/traces/useTracesList";
@@ -24,7 +25,8 @@ const ThreadDataViewer: React.FunctionComponent = () => {
         },
       ],
       page: 1,
-      size: 100,
+      size: 1000,
+      truncate: true,
     },
     {
       enabled: !!thread?.id,
@@ -32,11 +34,15 @@ const ThreadDataViewer: React.FunctionComponent = () => {
     },
   );
 
-  const traces = useMemo(() => tracesData?.content ?? [], [tracesData]);
+  const traces = useMemo(
+    () =>
+      (tracesData?.content ?? []).sort((t1, t2) => t1.id.localeCompare(t2.id)),
+    [tracesData],
+  );
 
   return (
     <div className="pr-4">
-      <TraceMessages traces={traces} traceId={traces[0]?.id} />
+      <TraceMessages traces={traces} traceId={last(traces)?.id} />
     </div>
   );
 };


### PR DESCRIPTION
## Details
Fixed two issues in the SME Flow Page annotation view:

1. **Feedback scores state management**: Added `currentItem` to context and `key` prop to `FeedbackScoresEditor` to ensure proper state reset when switching between annotation items
2. **Thread trace ordering**: Fixed trace ordering in thread view by sorting traces by ID and using the last trace instead of the first one for display

## Change checklist
<!-- Please check the type of changes made -->
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves # <!-- the GitHub issue this PR resolves (e.g. `#1234`) -->
- OPIK-2363 <!-- The Jira ticket (e.g. `OPIK-1234`) -->
- NA <!-- If no ticket, such as hotfixes etc. -->

## Testing
- Verified feedback scores reset properly when switching between annotation items
- Confirmed thread traces are displayed in correct order
- Tested annotation workflow end-to-end

## Documentation
N/A - No documentation changes required for these bug fixes