### PR TITLE
[OPIK-2454] [DOCS] Add scaling documentation page to self-host section

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -376,6 +376,9 @@ navigation:
       - page: Advanced clickhouse backup
         path: docs/self-host/backup.mdx
         slug: backup
+      - page: Scaling
+        path: docs/self-host/scaling.mdx
+        slug: scaling
       - section: Configuration
         slug: /configure
         contents:

--- a/apps/opik-documentation/documentation/fern/docs/self-host/scaling.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/scaling.mdx
@@ -1,0 +1,158 @@
+---
+subtitle: Comprehensive guide for scaling Opik in production environments
+---
+
+# Scaling Opik
+
+Opik is built to power mission-critical workloads at scale. Whether you're running a small proof of concept or a high-volume enterprise deployment, Opik adapts seamlessly to your needs. Its stateless architecture and powerful ClickHouse-backed storage make it highly resilient, horizontally scalable, and future-proof for your data growth.
+
+This guide outlines recommended configurations and best practices for running Opik in production.
+
+## Proven at Scale
+
+Opik is engineered to handle demanding, production-grade workloads. The following example demonstrates the robustness of a typical deployment:
+
+| Metric | Value |
+|--------|-------|
+| Select queries per second | Up to 80 |
+| Insert queries per second | Up to 20 |
+| Rows inserted per minute | Up to 75K |
+| Traces (count) | 40 million |
+| Traces (size) | 370 GB |
+| Spans (count) | 215 million |
+| Spans (size) | 3.1 TB |
+| Total data on disk | 5 TB |
+| Weekly data ingestion | 91 GB |
+| Share of ingestion (top 2 customers) | 50% |
+| Share of ingestion (2000 users) | 50% |
+
+A deployment of this scale is fully supported using:
+
+**Opik Services** — running on c7i.2xlarge instances with 3 replicas each:
+- Opik Backend
+- Opik Python Backend  
+- Opik Frontend
+
+**ClickHouse** — running on m7i.8xlarge instances with 2 replicas.
+
+This configuration provides both performance and reliability while leaving room for seamless expansion.
+
+## Built for Growth
+
+Opik is designed with flexibility at its core. As your data grows and query volumes increase, Opik grows with you.
+
+- **Horizontal scaling** — add more replicas of services to instantly handle more traffic
+- **Vertical scaling** — increase CPU, memory, or storage to handle denser workloads  
+- **Seamless elasticity** — scale out during peak usage and scale back during quieter periods
+
+For larger workloads, ClickHouse can be scaled to support enterprise-level deployments. A common configuration includes:
+
+- 62 CPU cores
+- 256 GB RAM
+- 25 TB disk space
+
+ClickHouse's read path can also scale horizontally by increasing replicas, ensuring Opik continues to deliver high performance as usage grows.
+
+## Resilient Services Cluster
+
+Opik services are stateless and fault-tolerant, ensuring high availability across environments. Recommended resources:
+
+| Environment | CPU (vCPU) | RAM (GB) |
+|-------------|------------|----------|
+| Development | 4 | 8 |
+| Production | 13 | 32 |
+
+### Instance Guidance
+
+| Deployment | Instance | vCPUs | Memory (GiB) |
+|------------|----------|-------|--------------|
+| Dev (small) | c7i.large | 2 | 4 |
+| Dev | c7i.xlarge | 4 | 8 |
+| Prod (small) | c7i.2xlarge | 8 | 16 |
+| Prod | c7i.4xlarge | 16 | 32 |
+
+### Backend Service (Scales to Demand)
+
+| Metric | Dev | Prod Small | Prod Large |
+|--------|-----|------------|------------|
+| Replicas | 2 | 5 | 7 |
+| CPU cores | 1 | 2 | 2 |
+| Memory (GiB) | 2 | 9 | 12 |
+
+### Frontend Service (Always Responsive)
+
+| Metric | Dev | Prod Small | Prod Large |
+|--------|-----|------------|------------|
+| Replicas | 2 | 3 | 5 |
+| CPU (millicores) | 5 | 50 | 50 |
+| Memory (MiB) | 16 | 32 | 64 |
+
+## ClickHouse: High-Performance Storage
+
+At the heart of Opik's scalability is ClickHouse, a proven, high-performance analytical database designed for large-scale workloads. Opik leverages ClickHouse for storing traces and spans, ensuring fast queries, robust ingestion, and uncompromising reliability.
+
+### Instance Types
+
+Memory-optimized instances are recommended, with a minimum 4:1 memory-to-CPU ratio:
+
+| Deployment | Instance |
+|------------|----------|
+| Small | m7i.2xlarge |
+| Medium | m7i.4xlarge |
+| Large | m7i.8xlarge |
+
+### Replication Strategy
+
+- **Development**: 1 replica
+- **Production**: 2 replicas
+
+Always scale vertically before adding more replicas for efficiency.
+
+### CPU & Memory Guidance
+
+Target 10–20% CPU utilization, with safe spikes up to 40–50%.
+
+Maintain at least a 4:1 memory-to-CPU ratio (extend to 8:1 for very large environments).
+
+| Deployment | CPU cores | Memory (GiB) |
+|------------|-----------|--------------|
+| Minimum | 2 | 8 |
+| Development | 4 | 16 |
+| Production (small) | 6 | 24 |
+| Production | 32 | 128 |
+
+### Disk Recommendations
+
+To ensure reliable performance under heavy load:
+
+| Volume | Value |
+|--------|-------|
+| Family | SSD |
+| Type | gp3 |
+| Size | 8–16 TiB (workload dependent) |
+| IOPS | 3000 |
+| Throughput | 250 MiB/s |
+
+Opik's ClickHouse layer is resilient even under sustained, large-scale ingestion, ensuring queries stay fast.
+
+## Managing System Tables
+
+System tables (e.g., `system.opentelemetry_span_log`) can grow quickly. To keep storage lean:
+
+- Configure TTL settings in ClickHouse, or
+- Perform periodic manual pruning
+
+## Why Opik Scales with Confidence
+
+- **Enterprise-ready** — built to support multi-terabyte data volumes
+- **Elastic & flexible** — easily adjust resources to match workload demands
+- **Robust & reliable** — designed for high availability and long-term stability
+- **Future-proof** — proven to support growing usage without redesign
+
+With Opik, you can start small and scale confidently, knowing your observability platform won't hold you back.
+
+## References
+
+- [Opik scalability and performance plan](https://github.com/comet-ml/opik/issues)
+- [Opik recommended resources (WIP)](https://github.com/comet-ml/opik/issues)
+- [ClickHouse sizing & hardware recommendations](https://clickhouse.com/docs/operations/requirements)


### PR DESCRIPTION
- Add comprehensive scaling documentation with marketing language
- Include proven performance metrics and scaling recommendations
- Cover Opik services, ClickHouse, and infrastructure guidance
- Position page after Advanced clickhouse backup section
- Add navigation entry in docs.yml

## Details

## Change checklist
- [ ] User facing
- [X] Documentation update

## Issues

- Resolves #
- OPIK-2454

## Testing

## Documentation
new doc page added