### PR TITLE
[OPIK-2515] [FE] Remove Human Annotation feature toggle and related logic

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -448,9 +448,6 @@ serviceToggles:
   # Default: false
   # Description: Whether or not OpikAI feature is enabled
   opikAIEnabled: ${TOGGLE_OPIK_AI_ENABLED:-"false"}
-  # Default: false
-  # Description: Whether or not Human Annotation feature is enabled
-  humanAnnotationEnabled: ${TOGGLE_HUMAN_ANNOTATION_ENABLED:-"false"}
 
 # Trace Thread configuration
 traceThreadConfig:

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
@@ -15,6 +15,4 @@ public class ServiceTogglesConfig {
     @NotNull boolean guardrailsEnabled;
     @JsonProperty
     @NotNull boolean opikAIEnabled;
-    @JsonProperty
-    @NotNull boolean humanAnnotationEnabled;
 }

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -303,8 +303,6 @@ serviceToggles:
   # Description: Whether or not OpikAI feature is enabled
   opikAIEnabled: "false"
   # Default: false
-  # Description: Whether or not Human Annotation feature is enabled
-  humanAnnotationEnabled: "false"
 
 # Trace Thread configuration
 traceThreadConfig:

--- a/apps/opik-frontend/src/components/feature-toggles-provider.tsx
+++ b/apps/opik-frontend/src/components/feature-toggles-provider.tsx
@@ -19,7 +19,6 @@ const DEFAULT_STATE: FeatureToggles = {
   [FeatureToggleKeys.GUARDRAILS_ENABLED]: false,
   [FeatureToggleKeys.TOGGLE_OPIK_AI_ENABLED]: false,
   [FeatureToggleKeys.TOGGLE_ALERTS_ENABLED]: false,
-  [FeatureToggleKeys.TOGGLE_HUMAN_ANNOTATION_ENABLED]: false,
 };
 
 const initialState: FeatureTogglesState = {

--- a/apps/opik-frontend/src/components/layout/SideBar/SideBar.tsx
+++ b/apps/opik-frontend/src/components/layout/SideBar/SideBar.tsx
@@ -109,7 +109,6 @@ const MENU_ITEMS: MenuItemGroup[] = [
         icon: UserPen,
         label: "Annotation queues",
         count: "annotation_queues",
-        featureFlag: FeatureToggleKeys.TOGGLE_HUMAN_ANNOTATION_ENABLED,
       },
     ],
   },
@@ -182,10 +181,6 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
   const LogoComponent = usePluginsStore((state) => state.Logo);
   const SidebarInviteDevButton = usePluginsStore(
     (state) => state.SidebarInviteDevButton,
-  );
-
-  const isAnnotationQueuesEnabled = useIsFeatureEnabled(
-    FeatureToggleKeys.TOGGLE_HUMAN_ANNOTATION_ENABLED,
   );
 
   const { data: projectData } = useProjectsList(
@@ -268,7 +263,7 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
     },
     {
       placeholderData: keepPreviousData,
-      enabled: expanded && isAnnotationQueuesEnabled,
+      enabled: expanded,
     },
   );
 

--- a/apps/opik-frontend/src/components/pages-shared/annotation-queues/InstructionsContent.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/annotation-queues/InstructionsContent.tsx
@@ -9,14 +9,13 @@ interface InstructionsContentProps {
 const InstructionsContent: React.FunctionComponent<
   InstructionsContentProps
 > = ({ annotationQueue }) => {
-  if (!annotationQueue.instructions) {
-    return null;
-  }
-
   return (
     <div className="rounded-lg border bg-background">
       <div className="p-6">
-        <MarkdownPreview>{annotationQueue.instructions}</MarkdownPreview>
+        <MarkdownPreview>
+          {annotationQueue?.instructions ||
+            "No instructions were provided for this annotation queue"}
+        </MarkdownPreview>
       </div>
     </div>
   );

--- a/apps/opik-frontend/src/components/pages-shared/traces/AddToDropdown/AddToDropdown.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/AddToDropdown/AddToDropdown.tsx
@@ -8,44 +8,27 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { useIsFeatureEnabled } from "@/components/feature-toggles-provider";
-import { FeatureToggleKeys } from "@/types/feature-toggles";
 import { Span, Trace, Thread } from "@/types/traces";
 import AddToDatasetDialog from "@/components/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog";
 import AddToQueueDialog from "@/components/pages-shared/traces/AddToQueueDialog/AddToQueueDialog";
 import { isObjectSpan, isObjectThread } from "@/lib/traces";
 
-// scope property is needed only in case when we have TOGGLE_HUMAN_ANNOTATION_ENABLED,
-// to be able to hide this button in case we are on the thread page or sidebar
-// all this functionality should be deleted when the feature flag is be deleted
-type AddToDropdownScope = "trace" | "span" | "thread";
-
 export type AddToDropdownProps = {
   rows: Array<Trace | Span | Thread>;
-  scope?: AddToDropdownScope[];
   disabled?: boolean;
 };
 
 const AddToDropdown: React.FunctionComponent<AddToDropdownProps> = ({
   rows,
-  scope,
   disabled = false,
 }) => {
   const resetKeyRef = useRef(0);
   const [open, setOpen] = useState<number>(0);
 
-  const annotationQueuesEnabled = useIsFeatureEnabled(
-    FeatureToggleKeys.TOGGLE_HUMAN_ANNOTATION_ENABLED,
-  );
-
   const isThread = isObjectThread(rows[0]);
   const isSpan = isObjectSpan(rows[0]);
   const showAddToDataset = !isThread;
-  const showAddToQueue = (isThread || !isSpan) && annotationQueuesEnabled;
-
-  const isOnlyAnnotationScope = scope?.length === 1 && scope[0] === "thread";
-
-  if (!showAddToQueue && isOnlyAnnotationScope) return null;
+  const showAddToQueue = isThread || !isSpan;
 
   return (
     <>

--- a/apps/opik-frontend/src/components/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
@@ -482,7 +482,7 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
           </Button>
         </div>
         <div className="flex gap-2 pl-6">
-          <AddToDropdown rows={rows} scope={["thread"]} />
+          <AddToDropdown rows={rows} />
           <DetailsActionSectionToggle
             activeSection={currentActiveSection}
             setActiveSection={setActiveSection}

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewerActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewerActionsPanel.tsx
@@ -26,7 +26,7 @@ const TraceDataViewerActionsPanel: React.FunctionComponent<
 
   return (
     <>
-      <AddToDropdown rows={rows} scope={["trace", "span"]} />
+      <AddToDropdown rows={rows} />
 
       <DetailsActionSectionToggle
         activeSection={activeSection}

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ConfigurationTab/InstructionsSection.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ConfigurationTab/InstructionsSection.tsx
@@ -9,10 +9,6 @@ interface InstructionsSectionProps {
 const InstructionsSection: React.FunctionComponent<
   InstructionsSectionProps
 > = ({ annotationQueue }) => {
-  if (!annotationQueue.instructions) {
-    return null;
-  }
-
   return (
     <div>
       <h2 className="comet-title-s truncate break-words pb-3 pt-2">

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/NoQueueItemsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/NoQueueItemsPage.tsx
@@ -48,20 +48,6 @@ const NoQueueItemsPage: React.FC<NoQueueItemsPageProps> = ({
       className={className}
       buttons={
         <>
-          {annotationQueue?.project_id && (
-            <Button variant="outline" asChild>
-              <Link
-                to="/$workspaceName/projects/$projectId/traces"
-                params={{
-                  workspaceName,
-                  projectId: annotationQueue.project_id,
-                }}
-              >
-                <ExternalLink className="mr-2 size-4" />
-                Go to project
-              </Link>
-            </Button>
-          )}
           <Button variant="secondary" asChild>
             <a
               href={buildDocsUrl(
@@ -75,6 +61,23 @@ const NoQueueItemsPage: React.FC<NoQueueItemsPageProps> = ({
               Read documentation
             </a>
           </Button>
+          {annotationQueue?.project_id && (
+            <Button variant="outline" asChild>
+              <Link
+                to="/$workspaceName/projects/$projectId/traces"
+                params={{
+                  workspaceName,
+                  projectId: annotationQueue.project_id,
+                }}
+                search={{
+                  type: isTraceQueue ? "traces" : "threads",
+                }}
+              >
+                <ExternalLink className="mr-2 size-4" />
+                {isTraceQueue ? "Go to traces" : "Go to threads"}
+              </Link>
+            </Button>
+          )}
         </>
       }
     />

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/NoQueueItemsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/NoQueueItemsPage.tsx
@@ -1,9 +1,14 @@
 import React from "react";
-import { Book } from "lucide-react";
+import { Book, ExternalLink } from "lucide-react";
+import { Link } from "@tanstack/react-router";
 import noData from "/images/no-data-annotation-queue.png";
 import { Button } from "@/components/ui/button";
 import { buildDocsUrl } from "@/lib/utils";
-import { ANNOTATION_QUEUE_SCOPE } from "@/types/annotation-queues";
+import {
+  ANNOTATION_QUEUE_SCOPE,
+  AnnotationQueue,
+} from "@/types/annotation-queues";
+import { useActiveWorkspaceName } from "@/store/AppStore";
 
 type NoDataWrapperProps = {
   title: string;
@@ -16,6 +21,7 @@ type NoDataWrapperProps = {
 
 type NoQueueItemsPageProps = {
   queueScope: ANNOTATION_QUEUE_SCOPE;
+  annotationQueue?: AnnotationQueue;
   openAddItemsDialog?: () => void;
   height?: number;
   Wrapper: React.FC<NoDataWrapperProps>;
@@ -24,10 +30,12 @@ type NoQueueItemsPageProps = {
 
 const NoQueueItemsPage: React.FC<NoQueueItemsPageProps> = ({
   queueScope,
+  annotationQueue,
   Wrapper,
   height,
   className,
 }) => {
+  const workspaceName = useActiveWorkspaceName();
   const isTraceQueue = queueScope === ANNOTATION_QUEUE_SCOPE.TRACE;
   const itemType = isTraceQueue ? "traces" : "threads";
 
@@ -40,9 +48,26 @@ const NoQueueItemsPage: React.FC<NoQueueItemsPageProps> = ({
       className={className}
       buttons={
         <>
+          {annotationQueue?.project_id && (
+            <Button variant="outline" asChild>
+              <Link
+                to="/$workspaceName/projects/$projectId/traces"
+                params={{
+                  workspaceName,
+                  projectId: annotationQueue.project_id,
+                }}
+              >
+                <ExternalLink className="mr-2 size-4" />
+                Go to project
+              </Link>
+            </Button>
+          )}
           <Button variant="secondary" asChild>
             <a
-              href={buildDocsUrl("/production/annotation-queues")}
+              href={buildDocsUrl(
+                "/evaluation/annotation_queues",
+                "#adding-content-to-your-queue",
+              )}
               target="_blank"
               rel="noreferrer"
             >

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
@@ -200,7 +200,11 @@ const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
   left: [COLUMN_SELECT_ID, COLUMN_ID_ID],
 };
 
-const DEFAULT_SELECTED_COLUMNS: string[] = ["first_message", "last_message"];
+const DEFAULT_SELECTED_COLUMNS: string[] = [
+  "first_message",
+  "last_message",
+  "comments",
+];
 
 const SELECTED_COLUMNS_KEY = "queue-thread-selected-columns";
 const COLUMNS_WIDTH_KEY = "queue-thread-columns-width";

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
@@ -487,6 +487,7 @@ const ThreadQueueItemsTab: React.FunctionComponent<
     return (
       <NoQueueItemsPage
         queueScope={annotationQueue.scope}
+        annotationQueue={annotationQueue}
         Wrapper={NoDataPage}
         height={278}
         className="px-6"

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
@@ -229,7 +229,12 @@ const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
   left: [COLUMN_SELECT_ID, COLUMN_ID_ID],
 };
 
-const DEFAULT_SELECTED_COLUMNS: string[] = ["name", "input", "output"];
+const DEFAULT_SELECTED_COLUMNS: string[] = [
+  "name",
+  "input",
+  "output",
+  "comments",
+];
 
 const SELECTED_COLUMNS_KEY = "queue-trace-selected-columns";
 const COLUMNS_WIDTH_KEY = "queue-trace-columns-width";

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
@@ -531,6 +531,7 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
     return (
       <NoQueueItemsPage
         queueScope={annotationQueue.scope}
+        annotationQueue={annotationQueue}
         Wrapper={NoDataPage}
         height={278}
         className="px-6"

--- a/apps/opik-frontend/src/components/pages/SMEFlowPage/SMEFlowContext.tsx
+++ b/apps/opik-frontend/src/components/pages/SMEFlowPage/SMEFlowContext.tsx
@@ -324,7 +324,12 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
 
   const search = useSearch({ strict: false }) as { queueId?: string };
   const { queueId } = search;
-  const currentUserName = useLoggedInUserName();
+
+  // If the user is not defined, use "admin" as the user name
+  // it happens for deployment without comet plugin, and BE automatically
+  // sets the user name to "admin", we need to mimic this behavior in FE
+  // to have correcly working feedback scores and comments
+  const currentUserName = useLoggedInUserName() ?? "admin";
 
   const { mutate: createTraceComment } = useCreateTraceCommentMutation();
   const { mutate: createThreadComment } = useCreateThreadCommentMutation();

--- a/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsActionsPanel.tsx
@@ -81,7 +81,7 @@ const ThreadsActionsPanel: React.FunctionComponent<
         confirmText="Delete threads"
         confirmButtonVariant="destructive"
       />
-      <AddToDropdown rows={rows} disabled={disabled} scope={["thread"]} />
+      <AddToDropdown rows={rows} disabled={disabled} />
       <ExportToButton
         disabled={disabled || columnsToExport.length === 0}
         getData={mapRowData}

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesPage.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesPage.tsx
@@ -25,9 +25,6 @@ const TracesPage = () => {
   const isGuardrailsEnabled = useIsFeatureEnabled(
     FeatureToggleKeys.GUARDRAILS_ENABLED,
   );
-  const isHumanAnnotationEnabled = useIsFeatureEnabled(
-    FeatureToggleKeys.TOGGLE_HUMAN_ANNOTATION_ENABLED,
-  );
 
   const [type = TRACE_DATA_TYPE.traces, setType] = useQueryParam(
     "type",
@@ -101,11 +98,9 @@ const TracesPage = () => {
               <TabsTrigger variant="underline" value="rules">
                 Online evaluation
               </TabsTrigger>
-              {isHumanAnnotationEnabled && (
-                <TabsTrigger variant="underline" value="annotation-queues">
-                  Annotation queues
-                </TabsTrigger>
-              )}
+              <TabsTrigger variant="underline" value="annotation-queues">
+                Annotation queues
+              </TabsTrigger>
             </TabsList>
           </PageBodyStickyContainer>
           <TabsContent value={TRACE_DATA_TYPE.traces}>
@@ -131,11 +126,9 @@ const TracesPage = () => {
           <TabsContent value="rules">
             <RulesTab projectId={projectId} />
           </TabsContent>
-          {isHumanAnnotationEnabled && (
-            <TabsContent value="annotation-queues">
-              <AnnotationQueuesTab projectId={projectId} />
-            </TabsContent>
-          )}
+          <TabsContent value="annotation-queues">
+            <AnnotationQueuesTab projectId={projectId} />
+          </TabsContent>
         </Tabs>
       </PageBodyScrollContainer>
       {isGuardrailsEnabled && (

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesActionsPanel.tsx
@@ -102,11 +102,7 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
         type={type}
         onSuccess={onClearSelection}
       />
-      <AddToDropdown
-        rows={rows}
-        disabled={disabled}
-        scope={["trace", "span"]}
-      />
+      <AddToDropdown rows={rows} disabled={disabled} />
       <TooltipWrapper content="Add tags">
         <Button
           variant="outline"

--- a/apps/opik-frontend/src/types/feature-toggles.ts
+++ b/apps/opik-frontend/src/types/feature-toggles.ts
@@ -5,5 +5,4 @@ export enum FeatureToggleKeys {
   GUARDRAILS_ENABLED = "guardrails_enabled",
   TOGGLE_OPIK_AI_ENABLED = "opik_aienabled",
   TOGGLE_ALERTS_ENABLED = "alerts_enabled",
-  TOGGLE_HUMAN_ANNOTATION_ENABLED = "human_annotation_enabled",
 }


### PR DESCRIPTION
## Details
This PR removes the Human Annotation feature toggle and all related logic from both backend and frontend. The feature has been fully implemented and is now enabled by default.

### Changes Made:
- **Backend**: Removed feature toggle configuration from `ServiceTogglesConfig.java` and `config.yml`
- **Frontend**: Removed feature toggle checks and related UI components across multiple pages
- **Components Updated**: 
  - SideBar navigation
  - Annotation queue pages (InstructionsSection, QueueItemsTab components)
  - Traces page components (ThreadDetailsPanel, TraceDataViewerActionsPanel)
  - SMEFlowPage context
  - Various action panels and dropdowns

### Technical Details:
- Removed unused imports and feature toggle references
- Updated default column selections to include 'comments'
- Enhanced error handling for missing instructions
- Added conditional project link display based on queue type
- Updated SMEFlowContext to default user name to "admin" when not logged in

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- Resolves OPIK-2515

## Testing
- [x] Backend compilation successful
- [x] Frontend linting and TypeScript checks passed
- [x] All feature toggle references removed
- [x] UI components updated to work without feature toggle

## Documentation
- Updated configuration files to remove feature toggle
- Code comments updated to reflect removal of feature toggle logic