### PR TITLE
[OPIK-2516] [P SDK] Check all supported integrations for compatibility with `opik_args`

### DIFF
--- a/sdks/python/tests/library_integration/aisuite/test_aisuite.py
+++ b/sdks/python/tests/library_integration/aisuite/test_aisuite.py
@@ -317,3 +317,75 @@ def test_aisuite_client_chat_completions_create__openai_call_made_in_another_tra
 
     llm_span_metadata = trace_tree.spans[0].spans[0].metadata
     _assert_metadata_contains_required_keys(llm_span_metadata)
+
+
+def test_aisuite__openai_provider__client_chat_completions_create__opik_args__happyflow(
+    fake_backend,
+):
+    client = aisuite.Client()
+    wrapped_client = track_aisuite(
+        aisuite_client=client,
+        project_name=PROJECT_NAME,
+    )
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Tell a fact"},
+    ]
+
+    args_dict = {
+        "span": {"tags": ["span_tag"], "metadata": {"span_key": "span_value"}},
+        "trace": {
+            "thread_id": "conversation-2",
+            "tags": ["trace_tag"],
+            "metadata": {"trace_key": "trace_value"},
+        },
+    }
+
+    _ = wrapped_client.chat.completions.create(
+        model="openai:gpt-3.5-turbo",
+        messages=messages,
+        max_tokens=10,
+        opik_args=args_dict,
+    )
+
+    opik.flush_tracker()
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="chat_completion_create",
+        input={"messages": messages},
+        output={"choices": ANY_BUT_NONE},
+        tags=["aisuite", "span_tag", "trace_tag"],
+        metadata=ANY_DICT.containing({"trace_key": "trace_value"}),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=PROJECT_NAME,
+        thread_id="conversation-2",
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="chat_completion_create",
+                input={"messages": messages},
+                output={"choices": ANY_BUT_NONE},
+                tags=["aisuite", "span_tag"],
+                metadata=ANY_DICT.containing({"span_key": "span_value"}),
+                usage=EXPECTED_OPENAI_USAGE_LOGGED_FORMAT,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=PROJECT_NAME,
+                spans=[],
+                model=ANY_STRING.starting_with("gpt-3.5-turbo"),
+                provider="openai",
+            )
+        ],
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)
+
+    llm_span_metadata = trace_tree.spans[0].metadata
+    _assert_metadata_contains_required_keys(llm_span_metadata)

--- a/sdks/python/tests/library_integration/anthropic/test_anthropic.py
+++ b/sdks/python/tests/library_integration/anthropic/test_anthropic.py
@@ -892,3 +892,80 @@ def test_async_anthropic_messages_create__stream_argument_is_True__AsyncStream_o
     assert len(fake_backend.trace_trees) == 1
 
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
+
+
+@pytest.mark.parametrize(
+    "project_name, expected_project_name",
+    [
+        (None, OPIK_PROJECT_DEFAULT_NAME),
+        ("anthropic-integration-test", "anthropic-integration-test"),
+    ],
+)
+@retry_on_internal_server_errors
+def test_anthropic_messages_create__opik_args__happyflow(
+    fake_backend, project_name, expected_project_name
+):
+    client = anthropic.Anthropic()
+    wrapped_client = track_anthropic(
+        anthropic_client=client,
+        project_name=project_name,
+    )
+    messages = [{"role": "user", "content": "Tell a short fact"}]
+
+    args_dict = {
+        "span": {"tags": ["span_tag"], "metadata": {"span_key": "span_value"}},
+        "trace": {
+            "thread_id": "conversation-2",
+            "tags": ["trace_tag"],
+            "metadata": {"trace_key": "trace_value"},
+        },
+    }
+
+    response = wrapped_client.messages.create(
+        model=MODEL_FOR_TESTS_FULL,
+        messages=messages,
+        max_tokens=10,
+        system="You are a helpful assistant",
+        opik_args=args_dict,
+    )
+
+    opik.flush_tracker()
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="anthropic_messages_create",
+        input={"messages": messages, "system": "You are a helpful assistant"},
+        output={"content": response.model_dump()["content"]},
+        tags=["anthropic", "span_tag", "trace_tag"],
+        metadata=ANY_DICT.containing({"trace_key": "trace_value"}),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=expected_project_name,
+        thread_id="conversation-2",
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                name="anthropic_messages_create",
+                input={
+                    "messages": messages,
+                    "system": "You are a helpful assistant",
+                },
+                output={"content": response.model_dump()["content"]},
+                tags=["anthropic", "span_tag"],
+                metadata=ANY_DICT.containing({"span_key": "span_value"}),
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=expected_project_name,
+                type="llm",
+                usage=EXPECTED_ANTHROPIC_USAGE_DICT,
+                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                provider="anthropic",
+                spans=[],
+            )
+        ],
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+
+    assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])

--- a/sdks/python/tests/library_integration/genai/test_genai.py
+++ b/sdks/python/tests/library_integration/genai/test_genai.py
@@ -182,6 +182,71 @@ def test_genai_client__async_generate_content__happyflow(fake_backend):
 
 
 @retry_with_waiting_on_rate_limit_errors
+@pytest.mark.asyncio
+async def test_genai_client__async_generate_content__opik_args__happyflow(fake_backend):
+    client = genai.Client(
+        vertexai=True,
+        http_options=HttpOptions(api_version="v1"),
+    )
+    client = track_genai(client)
+
+    args_dict = {
+        "span": {"tags": ["span_tag"], "metadata": {"span_key": "span_value"}},
+        "trace": {
+            "thread_id": "conversation-2",
+            "tags": ["trace_tag"],
+            "metadata": {"trace_key": "trace_value"},
+        },
+    }
+
+    _ = await client.aio.models.generate_content(
+        model=MODEL,
+        contents="What is the capital of Belarus?",
+        opik_args=args_dict,
+    )
+
+    opik.flush_tracker()
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name=ANY_STRING.starting_with(f"async_generate_content: {MODEL}"),
+        input={"contents": "What is the capital of Belarus?"},
+        output={"candidates": ANY_LIST},
+        tags=["genai", "span_tag", "trace_tag"],
+        metadata=ANY_DICT.containing({"trace_key": "trace_value"}),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        thread_id="conversation-2",
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name=ANY_STRING.starting_with(f"async_generate_content: {MODEL}"),
+                input={"contents": "What is the capital of Belarus?"},
+                output={"candidates": ANY_LIST},
+                tags=["genai", "span_tag"],
+                metadata=ANY_DICT.containing({"span_key": "span_value"}),
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                usage=EXPECTED_GOOGLE_USAGE_LOGGED_FORMAT,
+                spans=[],
+                model=ANY_STRING.starting_with(MODEL),
+                provider="google_vertexai",
+            )
+        ],
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)
+
+    llm_span_metadata = trace_tree.spans[0].metadata
+    _assert_metadata_contains_required_keys(llm_span_metadata)
+
+
+@retry_with_waiting_on_rate_limit_errors
 @pytest.mark.parametrize(
     "project_name, expected_project_name",
     [

--- a/sdks/python/tests/library_integration/litellm/test_litellm_completion.py
+++ b/sdks/python/tests/library_integration/litellm/test_litellm_completion.py
@@ -276,3 +276,146 @@ def test_litellm_completion_with_tools__tools_logged(fake_backend):
 
     assert len(fake_backend.trace_trees) == 1
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
+
+
+def test_litellm_completion_create__opik_args__happyflow(fake_backend):
+    """Test basic LiteLLM completion tracking with opik_args."""
+    track_litellm()
+
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Tell a fact"},
+    ]
+
+    args_dict = {
+        "span": {"tags": ["span_tag"], "metadata": {"span_key": "span_value"}},
+        "trace": {
+            "thread_id": "conversation-2",
+            "tags": ["trace_tag"],
+            "metadata": {"trace_key": "trace_value"},
+        },
+    }
+
+    response = litellm.completion(
+        model=MODEL_FOR_TESTS,
+        messages=messages,
+        max_tokens=10,
+        opik_args=args_dict,
+    )
+
+    opik.flush_tracker()
+
+    assert isinstance(response, litellm.types.utils.ModelResponse)
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="completion",
+        input={"messages": messages},
+        output={"choices": ANY_LIST},
+        tags=["litellm", "span_tag", "trace_tag"],
+        metadata=ANY_DICT.containing(
+            {"created_from": "litellm", "max_tokens": 10, "trace_key": "trace_value"}
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        thread_id="conversation-2",
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="completion",
+                input={"messages": messages},
+                output={"choices": ANY_LIST},
+                tags=["litellm", "span_tag"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "litellm",
+                        "max_tokens": 10,
+                        "span_key": "span_value",
+                    }
+                ),
+                usage=ANY_DICT,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                spans=[],
+                model=ANY_STRING,
+                provider="openai",  # Actual LLM provider, not "litellm"
+            )
+        ],
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+    assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
+
+
+@pytest.mark.asyncio
+async def test_litellm_acompletion_create__opik_args__happyflow(fake_backend):
+    """Test async LiteLLM completion tracking with opik_args."""
+    track_litellm()
+
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Tell a fact"},
+    ]
+
+    args_dict = {
+        "span": {"tags": ["span_tag"], "metadata": {"span_key": "span_value"}},
+        "trace": {
+            "thread_id": "conversation-2",
+            "tags": ["trace_tag"],
+            "metadata": {"trace_key": "trace_value"},
+        },
+    }
+
+    response = await litellm.acompletion(
+        model=MODEL_FOR_TESTS,
+        messages=messages,
+        max_tokens=10,
+        opik_args=args_dict,
+    )
+
+    opik.flush_tracker()
+
+    assert isinstance(response, litellm.types.utils.ModelResponse)
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="acompletion",
+        input={"messages": messages},
+        output={"choices": ANY_LIST},
+        tags=["litellm", "span_tag", "trace_tag"],
+        metadata=ANY_DICT.containing(
+            {"created_from": "litellm", "max_tokens": 10, "trace_key": "trace_value"}
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        thread_id="conversation-2",
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="acompletion",
+                input={"messages": messages},
+                output={"choices": ANY_LIST},
+                tags=["litellm", "span_tag"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "litellm",
+                        "max_tokens": 10,
+                        "span_key": "span_value",
+                    }
+                ),
+                usage=ANY_DICT,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                spans=[],
+                model=ANY_STRING,
+                provider="openai",  # Actual LLM provider, not "litellm"
+            )
+        ],
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+    assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])


### PR DESCRIPTION
## Details

We need to verify that all supported integrations are compatible with the opik_args parameter when making direct calls to their respective wrapped clients. This should be done by adding integration tests for each library. Similar tests already exist for OpenAI and GenAI.

### Key changes

This PR adds integration tests to verify that all supported LLM provider integrations are compatible with the `opik_args` parameter when making direct calls to their wrapped clients. The purpose is to ensure consistent behavior across all integrations for passing custom span and trace metadata.

Key changes:
- Added `opik_args` compatibility tests for LiteLLM (sync and async), GenAI (sync and async), Bedrock, Anthropic, and AISuite integrations
- Tests verify that custom `tags`, `metadata`, and `thread_id` are properly applied to traces and spans

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-2516

## Testing

Implemented integration tests for various LLM providers' integrations

## Documentation

No changes