### PR TITLE
[OPIK-2517] [FE] Add custom metrics documentation link to evaluators section

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog.tsx
@@ -11,6 +11,9 @@ import { SheetTitle } from "@/components/ui/sheet";
 import ApiKeyCard from "@/components/pages-shared/onboarding/ApiKeyCard/ApiKeyCard";
 import GoogleColabCard from "@/components/pages-shared/onboarding/GoogleColabCard/GoogleColabCard";
 import ConfiguredCodeHighlighter from "@/components/pages-shared/onboarding/ConfiguredCodeHighlighter/ConfiguredCodeHighlighter";
+import { buildDocsUrl } from "@/lib/utils";
+import { SquareArrowOutUpRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 export enum EVALUATOR_MODEL {
   equals = "equals",
@@ -318,6 +321,19 @@ eval_results = evaluate(
             <div className="comet-title-s">Select evaluators</div>
             {generateList("Heuristics metrics", HEURISTICS_MODELS_OPTIONS)}
             {generateList("LLM Judges", LLM_JUDGES_MODELS_OPTIONS)}
+            <div className="mt-4">
+              <Button variant="secondary" asChild>
+                <a
+                  href={buildDocsUrl("/evaluation/metrics/custom_metric")}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center"
+                >
+                  Learn about custom metrics
+                  <SquareArrowOutUpRight className="ml-1 size-4" />
+                </a>
+              </Button>
+            </div>
           </div>
           <div className="flex w-full max-w-[700px] flex-col gap-2 rounded-md border border-border p-6">
             <div className="comet-body-s text-foreground-secondary">


### PR DESCRIPTION
## Details
Added a documentation link to the custom metrics page in the AddExperimentDialog evaluators section. The implementation follows established UI patterns by using a Button component with secondary variant and includes an external link icon for clear user indication.

**Changes made:**
- Added imports for `buildDocsUrl`, `SquareArrowOutUpRight` icon, and `Button` component
- Implemented documentation link in the evaluators section with proper external link attributes
- Used consistent styling with `flex items-center` for proper alignment
- Link opens in new tab with `target="_blank"` and `rel="noreferrer"` for security

## Change checklist
<!-- Please check the type of changes made -->
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves # <!-- the GitHub issue this PR resolves (e.g. `#1234`) -->
- OPIK-2517 <!-- The Jira ticket (e.g. `OPIK-1234`) -->
- NA <!-- If no ticket, such as hotfixes etc. -->

## Testing
- Verified the link appears correctly in the evaluators section
- Confirmed external link icon displays properly
- Tested that link opens in new tab with correct URL
- Validated button styling matches existing UI patterns
- Ensured proper alignment with "Select evaluators" heading

## Documentation
N/A - This change adds a link to existing documentation rather than updating documentation files.