### PR TITLE
[NA] [FE] Fix integration documentation links in UI

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/onboarding/FrameworkIntegrations/quickstart-integrations.ts
+++ b/apps/opik-frontend/src/components/pages-shared/onboarding/FrameworkIntegrations/quickstart-integrations.ts
@@ -61,7 +61,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logoWhite: openAIWhiteLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/openai.ipynb",
-    documentation: buildDocsUrl("/tracing/integrations/openai"),
+    documentation: buildDocsUrl("/integrations/openai"),
     code: openAiCode,
     // executionUrl: "openai/run_stream",
     executionLogs: integrationLogsMap.OpenAI,
@@ -71,7 +71,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: anthropicLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/anthropic.ipynb",
-    documentation: buildDocsUrl("/tracing/integrations/openai"),
+    documentation: buildDocsUrl("/integrations/openai"),
     code: anthropicCode,
     // executionUrl: "anthropic/run_stream",
     executionLogs: integrationLogsMap.Anthropic,
@@ -82,7 +82,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logoWhite: bedrockWhiteLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/bedrock.ipynb",
-    documentation: buildDocsUrl("/tracing/integrations/openai"),
+    documentation: buildDocsUrl("/integrations/openai"),
     code: bedrockCode,
     executionLogs: integrationLogsMap.Bedrock,
   },
@@ -91,7 +91,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: geminiLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/gemini.ipynb",
-    documentation: buildDocsUrl("/tracing/integrations/openai"),
+    documentation: buildDocsUrl("/integrations/openai"),
     code: geminiCode,
     executionLogs: integrationLogsMap.Gemini,
   },
@@ -100,7 +100,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: langChainLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/langchain.ipynb",
-    documentation: buildDocsUrl("/tracing/integrations/langchain"),
+    documentation: buildDocsUrl("/integrations/langchain"),
     code: langChainCode,
     executionLogs: integrationLogsMap.LangChain,
   },
@@ -109,7 +109,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: langGraphLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/langgraph.ipynb",
-    documentation: buildDocsUrl("/tracing/integrations/langchain"),
+    documentation: buildDocsUrl("/integrations/langchain"),
     code: langGraphCode,
     executionLogs: integrationLogsMap.LangGraph,
   },
@@ -118,7 +118,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: llamaIndexLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/llama-index.ipynb",
-    documentation: buildDocsUrl("/tracing/integrations/langchain"),
+    documentation: buildDocsUrl("/integrations/langchain"),
     code: llamaIndexCode,
     executionLogs: integrationLogsMap.LlamaIndex,
   },
@@ -127,7 +127,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: haystackLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/haystack.ipynb",
-    documentation: buildDocsUrl("/tracing/integrations/langchain"),
+    documentation: buildDocsUrl("/integrations/langchain"),
     code: haystackCode,
     executionLogs: integrationLogsMap.Haystack,
   },
@@ -136,7 +136,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: liteLLMLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/litellm.ipynb",
-    documentation: buildDocsUrl("/tracing/integrations/litellm"),
+    documentation: buildDocsUrl("/integrations/litellm"),
     code: liteLLMCode,
     executionLogs: integrationLogsMap.LiteLLM,
   },
@@ -145,7 +145,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: ragasLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/ragas.ipynb",
-    documentation: buildDocsUrl("/tracing/integrations/ragas"),
+    documentation: buildDocsUrl("/integrations/ragas"),
     code: ragasCode,
     executionLogs: integrationLogsMap.Ragas,
   },
@@ -154,7 +154,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: groqLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/groq.ipynb",
-    documentation: buildDocsUrl("/tracing/integrations/ragas"),
+    documentation: buildDocsUrl("/integrations/ragas"),
     code: groqCode,
     executionLogs: integrationLogsMap.Groq,
   },
@@ -163,7 +163,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: dspyLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/dspy.ipynb",
-    documentation: buildDocsUrl("/tracing/integrations/ragas"),
+    documentation: buildDocsUrl("/integrations/ragas"),
     code: dspyCode,
     executionLogs: integrationLogsMap.DSPy,
   },

--- a/apps/opik-frontend/src/components/pages-shared/onboarding/IntegrationExplorer/components/QuickInstallDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/onboarding/IntegrationExplorer/components/QuickInstallDialog.tsx
@@ -85,7 +85,7 @@ After verifying language compatibility, perform a full codebase scan with the fo
 
 ### Step 3: Discover Available Integrations
 
-After I confirm the LLM Touchpoints and entry point, find the list of supported integrations at https://www.comet.com/docs/opik/tracing/integrations/overview.md
+After I confirm the LLM Touchpoints and entry point, find the list of supported integrations at https://www.comet.com/docs/opik/integrations/overview.md
 
 ### Step 4: Deep Analysis Confirmed files for LLM Frameworks & SDKs
 

--- a/apps/opik-frontend/src/constants/integrations.ts
+++ b/apps/opik-frontend/src/constants/integrations.ts
@@ -103,7 +103,7 @@ export const INTEGRATIONS: Integration[] = [
     whiteIcon: openAIWhiteLogoUrl,
     code: openAiCode,
     installCommand: "pip install -U opik openai",
-    docsLink: buildDocsUrl("/tracing/integrations/openai"),
+    docsLink: buildDocsUrl("/integrations/openai"),
   },
   // TODO: Code snippet required
   // {
@@ -124,7 +124,7 @@ export const INTEGRATIONS: Integration[] = [
     icon: anthropicLogoUrl,
     code: anthropicCode,
     installCommand: "pip install -U opik anthropic",
-    docsLink: buildDocsUrl("/tracing/integrations/anthropic"),
+    docsLink: buildDocsUrl("/integrations/anthropic"),
   },
 
   {
@@ -136,7 +136,7 @@ export const INTEGRATIONS: Integration[] = [
     whiteIcon: bedrockWhiteLogoUrl,
     code: bedrockCode,
     installCommand: "pip install -U opik boto3",
-    docsLink: buildDocsUrl("/tracing/integrations/bedrock"),
+    docsLink: buildDocsUrl("/integrations/bedrock"),
   },
   {
     id: "gemini",
@@ -146,7 +146,7 @@ export const INTEGRATIONS: Integration[] = [
     icon: geminiLogoUrl,
     code: geminiCode,
     installCommand: "pip install -U opik google-genai",
-    docsLink: buildDocsUrl("/tracing/integrations/gemini"),
+    docsLink: buildDocsUrl("/integrations/gemini"),
   },
   {
     id: "ollama",
@@ -157,7 +157,7 @@ export const INTEGRATIONS: Integration[] = [
     whiteIcon: ollamaWhiteLogoUrl,
     code: ollamaCode,
     installCommand: "pip install -U opik ollama",
-    docsLink: buildDocsUrl("/tracing/integrations/ollama"),
+    docsLink: buildDocsUrl("/integrations/ollama"),
   },
   {
     id: "langchain",
@@ -167,7 +167,7 @@ export const INTEGRATIONS: Integration[] = [
     icon: langChainLogoUrl,
     code: langChainCode,
     installCommand: "pip install -U opik langchain langchain_openai",
-    docsLink: buildDocsUrl("/tracing/integrations/langchain"),
+    docsLink: buildDocsUrl("/integrations/langchain"),
   },
 
   {
@@ -178,7 +178,7 @@ export const INTEGRATIONS: Integration[] = [
     icon: langGraphLogoUrl,
     code: langGraphCode,
     installCommand: "pip install -U opik langgraph langchain",
-    docsLink: buildDocsUrl("/tracing/integrations/langgraph"),
+    docsLink: buildDocsUrl("/integrations/langgraph"),
   },
   {
     id: "llamaindex",
@@ -190,7 +190,7 @@ export const INTEGRATIONS: Integration[] = [
     installCommand:
       "pip install -U opik llama-index llama-index-agent-openai llama-index-llms-openai llama-index-callbacks-opik",
 
-    docsLink: buildDocsUrl("/tracing/integrations/llama_index"),
+    docsLink: buildDocsUrl("/integrations/llama_index"),
   },
   {
     id: "haystack",
@@ -200,7 +200,7 @@ export const INTEGRATIONS: Integration[] = [
     icon: haystackLogoUrl,
     code: haystackCode,
     installCommand: "pip install -U opik haystack-ai",
-    docsLink: buildDocsUrl("/tracing/integrations/haystack"),
+    docsLink: buildDocsUrl("/integrations/haystack"),
   },
   {
     id: "litellm",
@@ -210,7 +210,7 @@ export const INTEGRATIONS: Integration[] = [
     icon: liteLLMLogoUrl,
     code: liteLLMCode,
     installCommand: "pip install -U opik litellm",
-    docsLink: buildDocsUrl("/tracing/integrations/litellm"),
+    docsLink: buildDocsUrl("/integrations/litellm"),
   },
 
   {
@@ -221,7 +221,7 @@ export const INTEGRATIONS: Integration[] = [
     icon: crewaiLogoUrl,
     code: crewaiCode,
     installCommand: "pip install -U opik crewai crewai-tools",
-    docsLink: buildDocsUrl("/tracing/integrations/crewai"),
+    docsLink: buildDocsUrl("/integrations/crewai"),
   },
   {
     id: "dspy",
@@ -231,7 +231,7 @@ export const INTEGRATIONS: Integration[] = [
     icon: dspyLogoUrl,
     code: dspyCode,
     installCommand: "pip install -U opik dspy",
-    docsLink: buildDocsUrl("/tracing/integrations/dspy"),
+    docsLink: buildDocsUrl("/integrations/dspy"),
   },
   {
     id: "ragas",
@@ -241,7 +241,7 @@ export const INTEGRATIONS: Integration[] = [
     icon: ragasLogoUrl,
     code: ragasCode,
     installCommand: "pip install -U opik ragas",
-    docsLink: buildDocsUrl("/tracing/integrations/ragas"),
+    docsLink: buildDocsUrl("/integrations/ragas"),
   },
   {
     id: "groq",
@@ -251,7 +251,7 @@ export const INTEGRATIONS: Integration[] = [
     icon: groqLogoUrl,
     code: groqCode,
     installCommand: "pip install -U opik litellm",
-    docsLink: buildDocsUrl("/tracing/integrations/groq"),
+    docsLink: buildDocsUrl("/integrations/groq"),
   },
 
   {
@@ -262,7 +262,7 @@ export const INTEGRATIONS: Integration[] = [
     icon: googleAdkLogoUrl,
     code: adkCode,
     installCommand: "pip install -U opik google-adk litellm",
-    docsLink: buildDocsUrl("/tracing/integrations/adk"),
+    docsLink: buildDocsUrl("/integrations/adk"),
   },
   // TODO: Code snippet required
   // {
@@ -284,7 +284,7 @@ export const INTEGRATIONS: Integration[] = [
     whiteIcon: openrouterWhiteLogoUrl,
     code: openrouterCode,
     installCommand: "pip install -U opik openai",
-    docsLink: buildDocsUrl("/tracing/integrations/openrouter"),
+    docsLink: buildDocsUrl("/integrations/openrouter"),
   },
   {
     id: "autogen",
@@ -295,7 +295,7 @@ export const INTEGRATIONS: Integration[] = [
     code: autogenCode,
     installCommand:
       'pip install -U "autogen-agentchat" "autogen-ext[openai]" opik opentelemetry-sdk opentelemetry-instrumentation-openai opentelemetry-exporter-otlp',
-    docsLink: buildDocsUrl("/tracing/integrations/autogen"),
+    docsLink: buildDocsUrl("/integrations/autogen"),
   },
 
   {
@@ -307,7 +307,7 @@ export const INTEGRATIONS: Integration[] = [
     code: agnoCode,
     installCommand:
       "pip install -U opik agno openai opentelemetry-sdk opentelemetry-exporter-otlp openinference-instrumentation-agno yfinance",
-    docsLink: buildDocsUrl("/tracing/integrations/agno"),
+    docsLink: buildDocsUrl("/integrations/agno"),
   },
   {
     id: "deepseek",
@@ -317,7 +317,7 @@ export const INTEGRATIONS: Integration[] = [
     icon: deepseekLogoUrl,
     code: deepseekCode,
     installCommand: "pip install -U opik openai",
-    docsLink: buildDocsUrl("/tracing/integrations/deepseek"),
+    docsLink: buildDocsUrl("/integrations/deepseek"),
   },
   // TODO: custom UI required
   // {
@@ -340,7 +340,7 @@ export const INTEGRATIONS: Integration[] = [
     installCommand:
       "pip install -U opik guardrails-ai \nguardrails configure \nguardrails hub install hub://guardrails/politeness_check",
 
-    docsLink: buildDocsUrl("/tracing/integrations/guardrails-ai"),
+    docsLink: buildDocsUrl("/integrations/guardrails-ai"),
   },
 
   {
@@ -351,7 +351,7 @@ export const INTEGRATIONS: Integration[] = [
     icon: predibaseLogoUrl,
     code: predibaseCode,
     installCommand: "pip install -U opik predibase langchain",
-    docsLink: buildDocsUrl("/tracing/integrations/predibase"),
+    docsLink: buildDocsUrl("/integrations/predibase"),
   },
   // TODO: Not working, error
   // {
@@ -373,7 +373,7 @@ export const INTEGRATIONS: Integration[] = [
     icon: smolagentsLogoUrl,
     code: smolagentsCode,
     installCommand: "pip install -U opik 'smolagents[telemetry,toolkit]'",
-    docsLink: buildDocsUrl("/tracing/integrations/smolagents"),
+    docsLink: buildDocsUrl("/integrations/smolagents"),
   },
   // TODO: Outdated code
   // {


### PR DESCRIPTION
## Details

This PR updates the integration documentation links throughout the frontend UI to reflect the new URL structure. The integration documentation has been reorganized from `/tracing/integrations/[integration]` to `/integrations/[integration]`, and this change ensures all UI components point to the correct URLs.

### Changes Made:
- Updated documentation links in quickstart integrations configuration
- Fixed integration explorer dialog reference 
- Updated all integration constants to use the new URL pattern

The changes ensure users can successfully navigate to integration documentation from:
- Framework integrations onboarding flow
- Integration explorer dialog
- Integration cards and quick install dialogs

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves #NA <!-- No GitHub issue -->
- NA <!-- No Jira ticket - this is a maintenance fix -->

## Testing

### Manual Testing:
1. Navigate to the onboarding flow and click on any integration documentation link
2. Open the Integration Explorer and verify the overview link works
3. Test documentation links from integration cards in the UI
4. Confirm all links now correctly point to `/integrations/[integration]` instead of `/tracing/integrations/[integration]`

### Scenarios covered:
- All integration types (OpenAI, Anthropic, LangChain, etc.)
- Quick install dialog links
- Framework integration quickstart links
- Integration overview documentation link

## Documentation

No additional documentation updates needed - this change aligns the UI with the existing documentation URL restructuring that has already been completed.