### PR TITLE
[OPIK-2422] fix multiple empty reasons aggregation

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -520,7 +520,7 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                     name,
                     arrayStringConcat(categories, ', ') AS category_name,
                     IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
+                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '\\<no reason>', x), reasons), ', ')) AS reason,
                     arrayElement(sources, 1) AS source,
                     mapFromArrays(
                         authors,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -520,7 +520,7 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                     name,
                     arrayStringConcat(categories, ', ') AS category_name,
                     IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                    arrayStringConcat(reasons, ', ') AS reason,
+                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
                     arrayElement(sources, 1) AS source,
                     mapFromArrays(
                         authors,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
@@ -28,6 +28,8 @@ public interface FeedbackScoreMapper {
 
     FeedbackScoreMapper INSTANCE = Mappers.getMapper(FeedbackScoreMapper.class);
 
+    String EMPTY_REASON_PLACEHOLDER = "<no reason>";
+
     @Mapping(target = "categoryName", expression = "java(item.categoryName())")
     @Mapping(target = "name", expression = "java(item.name())")
     @Mapping(target = "value", expression = "java(item.value())")

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -593,7 +593,7 @@ class SpanDAO {
                     name,
                     arrayStringConcat(categories, ', ') AS category_name,
                     IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                    arrayStringConcat(reasons, ', ') AS reason,
+                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
                     arrayElement(sources, 1) AS source,
                     mapFromArrays(
                             authors,
@@ -819,7 +819,7 @@ class SpanDAO {
                     name,
                     arrayStringConcat(categories, ', ') AS category_name,
                     IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                    arrayStringConcat(reasons, ', ') AS reason,
+                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
                     arrayElement(sources, 1) AS source,
                     mapFromArrays(
                             authors,
@@ -1173,7 +1173,7 @@ class SpanDAO {
                     name,
                     arrayStringConcat(categories, ', ') AS category_name,
                     IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                    arrayStringConcat(reasons, ', ') AS reason,
+                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
                     arrayElement(sources, 1) AS source,
                     mapFromArrays(
                             authors,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -819,7 +819,7 @@ class SpanDAO {
                     name,
                     arrayStringConcat(categories, ', ') AS category_name,
                     IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
+                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '\\<no reason>', x), reasons), ', ')) AS reason,
                     arrayElement(sources, 1) AS source,
                     mapFromArrays(
                             authors,
@@ -1173,7 +1173,7 @@ class SpanDAO {
                     name,
                     arrayStringConcat(categories, ', ') AS category_name,
                     IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
+                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '\\<no reason>', x), reasons), ', ')) AS reason,
                     arrayElement(sources, 1) AS source,
                     mapFromArrays(
                             authors,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -415,10 +415,7 @@ class TraceDAOImpl implements TraceDAO {
                      name,
                      arrayStringConcat(categories, ', ') AS category_name,
                      IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                     IF(length(reasons) = 1,
-                        IF(arrayElement(reasons, 1) = '', '', arrayElement(reasons, 1)),
-                        arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')
-                     ) AS reason,
+                     IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
                      arrayElement(sources, 1) AS source,
                      mapFromArrays(
                              authors,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -415,7 +415,10 @@ class TraceDAOImpl implements TraceDAO {
                      name,
                      arrayStringConcat(categories, ', ') AS category_name,
                      IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                     arrayStringConcat(reasons, ', ') AS reason,
+                     IF(length(reasons) = 1,
+                        IF(arrayElement(reasons, 1) = '', '', arrayElement(reasons, 1)),
+                        arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')
+                     ) AS reason,
                      arrayElement(sources, 1) AS source,
                      mapFromArrays(
                              authors,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -637,7 +637,7 @@ class TraceDAOImpl implements TraceDAO {
                     name,
                     arrayStringConcat(categories, ', ') AS category_name,
                     IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                    arrayStringConcat(reasons, ', ') AS reason,
+                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
                     arrayElement(sources, 1) AS source,
                     mapFromArrays(
                             authors,
@@ -1295,7 +1295,7 @@ class TraceDAOImpl implements TraceDAO {
                    name,
                    arrayStringConcat(categories, ', ') AS category_name,
                    IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                   arrayStringConcat(reasons, ', ') AS reason,
+                   IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
                    arrayElement(sources, 1) AS source,
                    mapFromArrays(
                        authors,
@@ -1614,7 +1614,7 @@ class TraceDAOImpl implements TraceDAO {
                     name,
                     arrayStringConcat(categories, ', ') AS category_name,
                     IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                    arrayStringConcat(reasons, ', ') AS reason,
+                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
                     arrayElement(sources, 1) AS source,
                     mapFromArrays(
                         authors,
@@ -1891,7 +1891,7 @@ class TraceDAOImpl implements TraceDAO {
                     name,
                     arrayStringConcat(categories, ', ') AS category_name,
                     IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                    arrayStringConcat(reasons, ', ') AS reason,
+                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
                     arrayElement(sources, 1) AS source,
                     mapFromArrays(
                         authors,
@@ -2214,7 +2214,7 @@ class TraceDAOImpl implements TraceDAO {
                     name,
                     arrayStringConcat(categories, ', ') AS category_name,
                     IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                    arrayStringConcat(reasons, ', ') AS reason,
+                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
                     arrayElement(sources, 1) AS source,
                     mapFromArrays(
                         authors,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -637,7 +637,7 @@ class TraceDAOImpl implements TraceDAO {
                     name,
                     arrayStringConcat(categories, ', ') AS category_name,
                     IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
+                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '\\<no reason>', x), reasons), ', ')) AS reason,
                     arrayElement(sources, 1) AS source,
                     mapFromArrays(
                             authors,
@@ -1295,7 +1295,7 @@ class TraceDAOImpl implements TraceDAO {
                    name,
                    arrayStringConcat(categories, ', ') AS category_name,
                    IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                   IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
+                   IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '\\<no reason>', x), reasons), ', ')) AS reason,
                    arrayElement(sources, 1) AS source,
                    mapFromArrays(
                        authors,
@@ -1614,7 +1614,7 @@ class TraceDAOImpl implements TraceDAO {
                     name,
                     arrayStringConcat(categories, ', ') AS category_name,
                     IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
+                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '\\<no reason>', x), reasons), ', ')) AS reason,
                     arrayElement(sources, 1) AS source,
                     mapFromArrays(
                         authors,
@@ -1891,7 +1891,7 @@ class TraceDAOImpl implements TraceDAO {
                     name,
                     arrayStringConcat(categories, ', ') AS category_name,
                     IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value,
-                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '<no reason>', x), reasons), ', ')) AS reason,
+                    IF(length(reasons) = 1, arrayElement(reasons, 1), arrayStringConcat(arrayMap(x -> if(x = '', '\\<no reason>', x), reasons), ', ')) AS reason,
                     arrayElement(sources, 1) AS source,
                     mapFromArrays(
                         authors,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
@@ -808,8 +808,14 @@ public class MultiValueFeedbackScoresE2ETest {
         traceResourceClient.feedbackScore(traceId, score1, TEST_WORKSPACE, API_KEY1);
 
         // assert feedback score reason is empty for backwards compatibility
-        var actualSingleScore = traceResourceClient.getById(traceId, TEST_WORKSPACE, API_KEY2);
-        assertThat(getTraceScore(actualSingleScore).reason()).isNull();
+        var actualSingleScoreById = traceResourceClient.getById(traceId, TEST_WORKSPACE, API_KEY2);
+        assertThat(getTraceScore(actualSingleScoreById).reason()).isNull();
+
+        var actualSingleScoreByFind = traceResourceClient.getTraces(projectName, null, API_KEY2,
+                TEST_WORKSPACE, null, null, 5, Map.of()).content().stream()
+                .filter(t -> t.id().equals(traceId)).findFirst()
+                .orElseThrow(() -> new AssertionError("Trace with id " + traceId + " not found"));
+        assertThat(getTraceScore(actualSingleScoreByFind).reason()).isNull();
 
         var score2 = factory.manufacturePojo(FeedbackScore.class).toBuilder()
                 .name(score1.name())
@@ -818,8 +824,15 @@ public class MultiValueFeedbackScoresE2ETest {
         traceResourceClient.feedbackScore(traceId, score2, TEST_WORKSPACE, API_KEY2);
 
         // assert feedback score reason has placeholders
-        var actualMultiScores = traceResourceClient.getById(traceId, TEST_WORKSPACE, API_KEY2);
-        assertThat(getTraceScore(actualMultiScores).reason())
+        var actualMultiScoresById = traceResourceClient.getById(traceId, TEST_WORKSPACE, API_KEY2);
+        assertThat(getTraceScore(actualMultiScoresById).reason())
+                .isEqualTo("%s, %s".formatted(EMPTY_REASON_PLACEHOLDER, EMPTY_REASON_PLACEHOLDER));
+
+        var actualMultiScoresByFind = traceResourceClient.getTraces(projectName, null, API_KEY2,
+                TEST_WORKSPACE, null, null, 5, Map.of()).content().stream()
+                .filter(t -> t.id().equals(traceId)).findFirst()
+                .orElseThrow(() -> new AssertionError("Trace with id " + traceId + " not found"));
+        assertThat(getTraceScore(actualMultiScoresByFind).reason())
                 .isEqualTo("%s, %s".formatted(EMPTY_REASON_PLACEHOLDER, EMPTY_REASON_PLACEHOLDER));
     }
 


### PR DESCRIPTION
## Details
When an entity had multiple scores with empty reasons, the UI showed ", " as the aggregated reason. This PR changes the logic as follows:
1. Backwards compatibility: if the entity has a single score with empty reason - the reason field will be `null`
2. If the entity has multiple scores with empty reason - every empty reason will show as `<no reason>`

The alternative for 2 above was to omit empty reasons which would have introduced ambiguity to which score the reason belongs.

**Example:**
An entity has two scores:
- score: 1, reason: "looks good"
- score: 0, reason: `null`

If we were to omit empty scores, the eventual reason would be `looks good`. The user cannot tell which score had this reason.
However, in the suggested solution, the eventual reason will be `looks good, <no reason>`, in which there is no ambiguity.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2422

## Testing
Added tests that cover the fixes

## Documentation
No documentation update is required as this is a bug fix