### PR TITLE
[OPIK-2437] [FE] Clean up PostHog configuration

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/posthog/index.ts
+++ b/apps/opik-frontend/src/plugins/comet/posthog/index.ts
@@ -5,8 +5,6 @@ export const initPosthog = (key?: string, host?: string) => {
 
   posthog.init(key, {
     api_host: host,
-    capture_pageview: false,
-    capture_pageleave: true,
     defaults: "2025-05-24",
   });
 };


### PR DESCRIPTION
## Details
This pull request makes a small change to the PostHog analytics initialization in the frontend plugin. The configuration now removes explicit settings for capturing pageviews and page leaves, likely reverting to default PostHog behavior. No other functionality is affected.

- Removed `capture_pageview` and `capture_pageleave` options from the `posthog.init` configuration in `index.ts`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2437

## Testing

## Documentation
