### PR TITLE
[OPIK-2175] [SCRIPTS] Add FE to local BE API endpoints URL

### DIFF
--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -263,6 +263,10 @@ start_frontend() {
         log_debug "Frontend debug mode enabled - NODE_ENV=development"
     fi
 
+    # Configure frontend to talk to local backend
+    export VITE_BASE_API_URL="http://localhost:8080"
+    log_info "Frontend API base URL (VITE_BASE_API_URL) set to: $VITE_BASE_API_URL"
+
     log_debug "Starting frontend with: npm run start"
 
     # Start frontend in background with interactive mode disabled


### PR DESCRIPTION
## Details
This change configures the frontend to communicate with the local backend by setting the `VITE_BASE_API_URL` environment variable in the `scripts/dev-runner.sh` script. This ensures the frontend correctly points to the backend API when running in local development mode.

**What was changed:**
- Added `export VITE_BASE_API_URL="http://localhost:8080"` to the `start_frontend()` function in `scripts/dev-runner.sh`
- Added informational logging to indicate the API base URL being used

**Why this change was made:**
- Improves local development setup by ensuring frontend can communicate with the local backend
- Provides clear configuration and logging for troubleshooting development environment issues
- Makes the development workflow more reliable

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-2175

## Testing
- Manually tested locally: `start`, `stop` and `restart` (default) commands.
- FE properly communicates with BE without further configuration after this change.
- Priorly to the change, it was required to update `apps/opik-frontend/.env.development`.

## Documentation
- See: https://vite.dev/guide/env-and-mode.html

This change affects the local development setup. The script now clearly logs which API base URL is being used for the frontend.