### PR TITLE
[OPIK-2515] Limit the max height to 450 px for the image in the no data pages

### DIFF
--- a/apps/opik-frontend/src/components/shared/NoDataPage/NoDataPage.tsx
+++ b/apps/opik-frontend/src/components/shared/NoDataPage/NoDataPage.tsx
@@ -35,7 +35,7 @@ const NoDataPage: React.FC<NoDataPageProps> = ({
         <div className="comet-body-s max-w-[570px] px-4 pb-8 pt-4 text-center text-muted-slate">
           {description}
         </div>
-        <div className="flex w-full flex-auto overflow-hidden">
+        <div className="flex max-h-[450px] w-full flex-auto overflow-hidden">
           <img
             className="m-auto max-h-full max-w-full rounded-md border object-cover"
             src={imageUrl}


### PR DESCRIPTION
## Details
Limit the max height to 450 px for the image in the no data pages

## Change checklist
- [ x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2515

## Testing

## Documentation
