### PR TITLE
[OPIK-2175] [BE] Add database migrations to dev-runner script

### DIFF
--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -193,6 +193,8 @@ run_db_migrations() {
 
     # Run MySQL (state DB) migrations
     log_info "Running MySQL (state DB) migrations..."
+    # Set the database name environment variable for MySQL migrations
+    export STATE_DB_DATABASE_NAME="opik"
     if java -jar "$JAR_FILE" db migrate config.yml; then
         log_success "MySQL migrations completed successfully"
     else

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -202,6 +202,8 @@ run_db_migrations() {
 
     # Run ClickHouse (analytics DB) migrations
     log_info "Running ClickHouse (analytics DB) migrations..."
+    # Set the database name environment variable for ClickHouse migrations
+    export ANALYTICS_DB_DATABASE_NAME="opik"
     if java -jar "$JAR_FILE" dbAnalytics migrate config.yml; then
         log_success "ClickHouse migrations completed successfully"
     else

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -253,9 +253,6 @@ start_backend() {
         fi
     fi
 
-    # Run database migrations before starting the backend
-    run_db_migrations
-
     log_debug "Starting backend with JAR: $JAR_FILE"
     log_debug "Command: java -jar $JAR_FILE server config.yml"
 
@@ -516,21 +513,23 @@ verify_services() {
 # Function to restart services (stop, build, start)
 restart_services() {
     log_info "=== Restarting Opik Development Environment ==="
-    log_info "Step 1/8: Stopping frontend..."
+    log_info "Step 1/9: Stopping frontend..."
     stop_frontend
-    log_info "Step 2/8: Stopping backend..."
+    log_info "Step 2/9: Stopping backend..."
     stop_backend
-    log_info "Step 3/8: Stopping infrastructure..."
+    log_info "Step 3/9: Stopping infrastructure..."
     stop_infrastructure
-    log_info "Step 4/8: Starting infrastructure..."
+    log_info "Step 4/9: Starting infrastructure..."
     start_infrastructure
-    log_info "Step 5/8: Building backend..."
+    log_info "Step 5/9: Building backend..."
     build_backend
-    log_info "Step 6/8: Building frontend..."
+    log_info "Step 6/9: Building frontend..."
     build_frontend
-    log_info "Step 7/8: Starting backend (includes DB migrations)..."
+    log_info "Step 7/9: Running DB migrations..."
+    run_db_migrations
+    log_info "Step 8/9: Starting backend..."
     start_backend
-    log_info "Step 8/8: Starting frontend..."
+    log_info "Step 9/9: Starting frontend..."
     start_frontend
     log_success "=== Restart Complete ==="
     verify_services
@@ -543,7 +542,7 @@ show_usage() {
     echo "Options:"
     echo "  --build-be     - Build backend"
     echo "  --build-fe     - Build frontend"
-    echo "  --migrate      - Run database migrations (MySQL, ClickHouse etc.)"
+    echo "  --migrate      - Run database migrations"
     echo "  --start        - Start all services (without building)"
     echo "  --stop         - Stop all services"
     echo "  --restart      - Stop, build, and start all services (DEFAULT IF NO OPTIONS PROVIDED)"
@@ -613,10 +612,12 @@ case "${1:-}" in
         build_frontend
         ;;
     "--migrate")
+        start_infrastructure
         run_db_migrations
         ;;
     "--start")
         start_infrastructure
+        run_db_migrations
         start_backend
         start_frontend
         verify_services

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -119,6 +119,7 @@ build_backend() {
     log_debug "Backend directory: $BACKEND_DIR"
     cd "$BACKEND_DIR" || { log_error "Backend directory not found"; exit 1; }
 
+    # resolve.skip=true skips swagger, adjust if any future interference
     log_debug "Running: mvn clean install -T 1C -Dmaven.test.skip=true -Dspotless.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.test.compile.skip=true -Dmaven.test.resources.skip=true -Dmaven.compiler.useIncrementalCompilation=false -Dresolve.skip=true"
     if mvn clean install -T 1C -Dmaven.test.skip=true -Dspotless.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.test.compile.skip=true -Dmaven.test.resources.skip=true -Dmaven.compiler.useIncrementalCompilation=false -Dresolve.skip=true; then
         log_success "Backend build completed successfully"
@@ -173,8 +174,8 @@ lint_backend() {
 print_migrations_recovery_message() {
     log_error "To recover, you may need to clean up Docker volumes (WARNING: ALL DATA WILL BE LOST):"
     log_error "  1. Stop all services: $0 --stop"
-    log_error "  2. Remove Docker volumes: docker volume prune -a -f"
-    log_error "  3. Continue your current flow: $ORIGINAL_COMMAND"
+    log_error "  2. Remove Docker volumes (DANGER): docker volume prune -a -f"
+    log_error "  3. Run again your current flow: $ORIGINAL_COMMAND"
 }
 
 # Function to run database migrations

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 # Variables
 DEBUG_MODE=${DEBUG_MODE:-false}
+ORIGINAL_COMMAND="$0 $*"
 
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
@@ -171,9 +172,9 @@ lint_backend() {
 
 print_migrations_recovery_message() {
     log_error "To recover, you may need to clean up Docker volumes (WARNING: ALL DATA WILL BE LOST):"
-    log_error "  1. Stop all services: ./dev-runner.sh --stop"
+    log_error "  1. Stop all services: ./scripts/dev-runner.sh --stop"
     log_error "  2. Remove Docker volumes: docker volume prune -f"
-    log_error "  3. Restart services: ./dev-runner.sh --restart"
+    log_error "  3. Continue your current flow: $ORIGINAL_COMMAND"
 }
 
 # Function to run database migrations

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -173,7 +173,7 @@ lint_backend() {
 print_migrations_recovery_message() {
     log_error "To recover, you may need to clean up Docker volumes (WARNING: ALL DATA WILL BE LOST):"
     log_error "  1. Stop all services: ./scripts/dev-runner.sh --stop"
-    log_error "  2. Remove Docker volumes: docker volume prune -f"
+    log_error "  2. Remove Docker volumes: docker volume prune -a -f"
     log_error "  3. Continue your current flow: $ORIGINAL_COMMAND"
 }
 

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -119,8 +119,8 @@ build_backend() {
     log_debug "Backend directory: $BACKEND_DIR"
     cd "$BACKEND_DIR" || { log_error "Backend directory not found"; exit 1; }
 
-    log_debug "Running: mvn clean install -DskipTests"
-    if mvn clean install -DskipTests; then
+    log_debug "Running: mvn clean install -T 1C -Dmaven.test.skip=true -Dspotless.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.test.compile.skip=true -Dmaven.test.resources.skip=true -Dmaven.compiler.useIncrementalCompilation=false -Dresolve.skip=true"
+    if mvn clean install -T 1C -Dmaven.test.skip=true -Dspotless.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.test.compile.skip=true -Dmaven.test.resources.skip=true -Dmaven.compiler.useIncrementalCompilation=false -Dresolve.skip=true; then
         log_success "Backend build completed successfully"
     else
         log_error "Backend build failed"

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -172,7 +172,7 @@ lint_backend() {
 
 print_migrations_recovery_message() {
     log_error "To recover, you may need to clean up Docker volumes (WARNING: ALL DATA WILL BE LOST):"
-    log_error "  1. Stop all services: ./scripts/dev-runner.sh --stop"
+    log_error "  1. Stop all services: $0 --stop"
     log_error "  2. Remove Docker volumes: docker volume prune -a -f"
     log_error "  3. Continue your current flow: $ORIGINAL_COMMAND"
 }

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -206,6 +206,8 @@ run_db_migrations() {
     log_info "Running ClickHouse (analytics DB) migrations..."
     # Set the database name environment variable for ClickHouse migrations
     export ANALYTICS_DB_DATABASE_NAME="opik"
+    # Set the connection URL to ensure connection to opik database
+    export ANALYTICS_DB_MIGRATIONS_URL="jdbc:clickhouse://localhost:8123"
     if java -jar "$JAR_FILE" dbAnalytics migrate config.yml; then
         log_success "ClickHouse migrations completed successfully"
     else


### PR DESCRIPTION
## Details

This PR adds database migration functionality to the dev-runner script to ensure database schema is properly set up during development environment startup.

### Key Changes:
- Added `run_db_migrations()` function that handles both MySQL (state DB) and ClickHouse (analytics DB) migrations
- Added `--migrate` option to run migrations independently
- Updated `--restart` flow to include database migrations (now 9 steps instead of 8)
- Added `start_services()` function for starting without rebuilding
- Enhanced error handling with recovery instructions for migration failures
- Added environment variable configuration for database names

### Migration Process:
1. **MySQL Migrations**: Uses `java -jar "$JAR_FILE" db migrate config.yml` with `STATE_DB_DATABASE_NAME="opik"`
2. **ClickHouse Migrations**: Uses `java -jar "$JAR_FILE" dbAnalytics migrate config.yml` with `ANALYTICS_DB_DATABASE_NAME="opik"`

### Error Recovery:
- Provides clear instructions for Docker volume cleanup when migrations fail
- Includes TODO comments for future liquibase-clickhouse clear-checksums support

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-2175

## Testing

- Tested the migration functionality with both MySQL and ClickHouse databases
- Verified error handling and recovery instructions
- Confirmed integration with existing dev-runner workflow

## Documentation

- Updated script usage documentation with new `--migrate` option
- Added inline comments explaining migration process and error recovery