### PR TITLE
[OPIK-2564] [FE] hide upgrade button for get started page

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from "@tanstack/react-router";
+import { Link, useMatches, useNavigate } from "@tanstack/react-router";
 import copy from "clipboard-copy";
 import sortBy from "lodash/sortBy";
 import {
@@ -52,11 +52,15 @@ import useInviteMembersURL from "@/plugins/comet/useInviteMembersURL";
 
 const UserMenu = () => {
   const navigate = useNavigate();
+  const matches = useMatches();
   const { toast } = useToast();
   const { theme, themeOptions, CurrentIcon, handleThemeSelect } =
     useThemeOptions();
   const [openQuickstart, setOpenQuickstart] = useState(false);
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const hideUpgradeButton = matches.some(
+    (match) => match.staticData?.hideUpgradeButton,
+  );
 
   const { data: user } = useUser();
   const { data: organizations, isLoading } = useOrganizations({
@@ -145,7 +149,7 @@ const UserMenu = () => {
   };
 
   const renderUpgradeButton = () => {
-    if (isOrganizationAdmin && !isAcademic) {
+    if (isOrganizationAdmin && !isAcademic && !hideUpgradeButton) {
       return (
         <a
           href={buildUrl(

--- a/apps/opik-frontend/src/router.tsx
+++ b/apps/opik-frontend/src/router.tsx
@@ -41,6 +41,15 @@ import OptimizationPage from "@/components/pages/OptimizationPage/OptimizationPa
 import CompareOptimizationsPage from "@/components/pages/CompareOptimizationsPage/CompareOptimizationsPage";
 import CompareTrialsPage from "@/components/pages/CompareTrialsPage/CompareTrialsPage";
 
+declare module "@tanstack/react-router" {
+  interface StaticDataRouteOption {
+    hideUpgradeButton?: boolean;
+    title?: string;
+    param?: string;
+    paramValue?: string;
+  }
+}
+
 const TanStackRouterDevtools =
   process.env.NODE_ENV === "production"
     ? () => null // Render nothing in production
@@ -119,6 +128,9 @@ const getStartedRoute = createRoute({
   path: "/$workspaceName/get-started",
   getParentRoute: () => workspaceGuardPartialLayoutRoute,
   component: NewQuickstartPage,
+  staticData: {
+    hideUpgradeButton: true,
+  },
 });
 
 // ----------- home


### PR DESCRIPTION
## Details
This pull request introduces a mechanism to conditionally hide the "Upgrade" button in the `UserMenu` based on route-specific configuration. The main changes involve extending the router's static data options, passing the new flag via route definitions, and updating the menu logic to respect this flag.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2564

## Testing

## Documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hide the UserMenu Upgrade button on the get-started page using a new route staticData flag and corresponding router/type updates.
> 
> - **UserMenu (`UserMenu.tsx`)**:
>   - Read route `staticData` via `useMatches()` and compute `hideUpgradeButton`.
>   - Suppress `Upgrade` button when `isOrganizationAdmin && !isAcademic && !hideUpgradeButton`.
> - **Router (`router.tsx`)**:
>   - Extend `@tanstack/react-router` `StaticDataRouteOption` to include `hideUpgradeButton` (and existing metadata fields).
>   - Set `staticData.hideUpgradeButton: true` on `/$workspaceName/get-started` route to hide the upgrade button on that page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb68567927325e00cae2e7309cece6419f8012d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->