### PR TITLE
[OPIK-2175] [BE] Add local backend development mode to opik scripts

### DIFF
--- a/deployment/docker-compose/docker-compose.local-be.yaml
+++ b/deployment/docker-compose/docker-compose.local-be.yaml
@@ -1,0 +1,53 @@
+name: opik
+
+# Override for local backend development mode
+
+services:
+
+  # Expose infrastructure ports for local backend to connect
+  mysql:
+    ports:
+      - "3306:3306"
+
+  redis:
+    ports:
+      - "6379:6379"
+
+  clickhouse:
+    ports:
+      - "8123:8123" # ClickHouse HTTP port
+      - "9000:9000" # ClickHouse Native Protocol port
+
+  minio:
+    ports:
+      - "9001:9000"   # MinIO API Port
+      - "9090:9090"   # MinIO Web UI Console
+
+  # Disable the backend service entirely, meant to be run as local process
+  backend:
+    profiles: !override
+      - disabled
+
+  python-backend:
+    profiles: !override
+      - local-be
+    ports:
+      - "8000:8000" # Python backend HTTP port
+
+  demo-data-generator:
+    profiles: !override
+      - local-be
+
+  # Override frontend to not depend on backend and ensure it runs with local-be profile
+  frontend:
+    profiles: !override
+      - local-be
+    depends_on: !override
+      mysql:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      redis:
+        condition: service_healthy

--- a/deployment/docker-compose/docker-compose.override.yaml
+++ b/deployment/docker-compose/docker-compose.override.yaml
@@ -15,21 +15,17 @@ services:
   zookeeper:
     ports:
       - "2181:2181"
-      
+
   minio:
     ports:
       - "9001:9000"   # MinIO API Port
       - "9090:9090"   # MinIO Web UI Console
 
   backend:
-    ports:
+    ports: !override
       - "8080:8080" # Exposing backend HTTP port to host
       - "3003:3003" # Exposing backend OpenAPI specification port to host
 
   python-backend:
     ports:
       - "8000:8000" # Exposing Python backend HTTP port to host
-
-  frontend:
-    ports:
-      - "5173:5173" # Exposing frontend server port to host

--- a/deployment/docker-compose/nginx_local_be_local.conf
+++ b/deployment/docker-compose/nginx_local_be_local.conf
@@ -17,25 +17,8 @@ server {
 
     location /api/ {
         rewrite /api/(.*) /$1  break;
-        proxy_pass http://backend:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-
-        proxy_read_timeout 90;
-        proxy_connect_timeout 90;
-        proxy_send_timeout 90;
-
-        proxy_http_version 1.1;
-        client_max_body_size 500M;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-    }
-
-    location /guardrails/ {
-        rewrite /guardrails/(.*) /$1  break;
-        proxy_pass http://guardrails:5000;
+        # Proxy to local backend running on host machine
+        proxy_pass http://host.docker.internal:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Details

This PR introduces a new local backend development mode for the Opik scripts, allowing developers to run the backend service locally (outside Docker) while keeping all infrastructure services running in Docker containers.

### Key Features:
- **New `--local-be` flag** for both `opik.sh` and `opik.ps1` scripts
- **Infrastructure services exposed** on host ports (MySQL:3306, Redis:6379, ClickHouse:8123/9000, MinIO:9001/9090)
- **Backend service disabled** in Docker when using local-be mode
- **Frontend proxies to local backend** via nginx configuration at `http://localhost:8080`
- **Automatic flavor detection** with proper handling of combined flags (e.g., `--local-be --guardrails`)

### Implementation:
1. Created `docker-compose.local-be.yaml` override file that:
   - Exposes all infrastructure service ports
   - Disables backend service using `profiles: !override`
   - Configures python-backend and frontend for local-be profile
   - Removes backend dependency from frontend service

2. Created new nginx configuration `nginx_local_be_local.conf` that:
   - Proxies API requests to `host.docker.internal:8080` (local backend)
   - Includes proper logging configuration (stdout/stderr)
   - Sets appropriate timeouts and headers

3. Enhanced shell scripts (`opik.sh` and `opik.ps1`):
   - Added `LOCAL_BE` flag and `LOCAL_BE_CONTAINERS` array
   - Implemented mutually exclusive validation for `--infra`, `--backend`, and `--local-be`
   - Updated banner messages with local backend instructions
   - Added flavor management to prevent conflicts

4. Updated existing configurations:
   - Added logging config to `nginx_guardrails_local.conf`
   - Used `!override` directive in `docker-compose.override.yaml` for backend ports

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-2175

## Testing

- Manually tested both scripts.
- Tested new local-be flow, alone and in combination with other flags.
- Tested pre-existing flows, alone and in combination with other flags.

### Manual Testing Steps:
1. **Start local-be mode:**
   ```bash
   ./opik.sh --local-be
   # or
   .\opik.ps1 --local-be
   ```

2. **Verify infrastructure services are running:**
   - MySQL should be accessible on localhost:3306
   - Redis should be accessible on localhost:6379
   - ClickHouse should be accessible on localhost:8123
   - MinIO should be accessible on localhost:9001

3. **Start local backend:**
   - Run backend locally on port 8080
   - Verify it can connect to infrastructure services

4. **Access frontend:**
   - Navigate to http://localhost:5173
   - Verify API calls are proxied to local backend
   - Test functionality end-to-end

5. **Test flag combinations:**
   ```bash
   ./opik.sh --local-be --guardrails  # Should work
   ./opik.sh --local-be --backend     # Should fail with error
   ./opik.sh --local-be --infra       # Should fail with error
   ```

### Expected Behavior:
- Frontend should display instructions to start local backend on port 8080
- All API requests from frontend should route to `http://localhost:8080`
- Infrastructure services should be healthy and accessible
- Backend container should not be running

## Documentation
- https://docs.docker.com/reference/compose-file/merge/#replace-value
- https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/
- https://docs.docker.com/compose/releases/release-notes/#2294

### Updated Documentation:
- Enhanced `opik.sh` and `opik.ps1` help messages with `--local-be` option
- Added banner instructions for local backend development mode
- Inline comments in new configuration files explaining the setup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a --local-be mode to run the backend locally while infrastructure runs in Docker, including compose overrides, nginx proxying to localhost:8080, and script/help/banner updates.
> 
> - **Scripts (`opik.sh`, `opik.ps1`)**:
>   - Add `--local-be` flag with `LOCAL_BE` containers/profile and mutually exclusive validation with `--infra`/`--backend`.
>   - Update compose args to include `docker-compose.local-be.yaml` and `--profile local-be`; add start/verify command builders and banner messages for local mode.
>   - Manage `OPIK_FRONTEND_FLAVOR` with guardrails compatibility; minor UX/log message tweaks.
> - **Docker Compose**:
>   - New `deployment/docker-compose/docker-compose.local-be.yaml` to expose infra ports, disable `backend`, enable `python-backend`/`frontend` under `local-be` profile, and adjust dependencies.
>   - `docker-compose.override.yaml`: use `ports: !override` for `backend`; remove `frontend` port mapping section.
> - **Nginx**:
>   - New `nginx_local_be_local.conf` to proxy `/api/` to `host.docker.internal:8080`, add stdout/stderr logging and headers/timeouts.
>   - `nginx_guardrails_local.conf`: add header buffer settings and switch logs to stdout/stderr.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 996d23740463c0f1859640f405e24516d711ab66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->