### PR TITLE
[OPIK-2566] [SDK] Update TypeScript integration dependencies

### DIFF
--- a/sdks/typescript/src/opik/integrations/opik-gemini/package.json
+++ b/sdks/typescript/src/opik/integrations/opik-gemini/package.json
@@ -67,7 +67,12 @@
     "opik": "^1.7.25"
   },
   "devDependencies": {
-    "typescript": "^5.7.2",
+    "eslint": "^9.34.0",
+    "prettier": "^3.6.2",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.2",
+    "typescript-eslint": "^8.42.0",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.5"
   }
 }

--- a/sdks/typescript/src/opik/integrations/opik-openai/package.json
+++ b/sdks/typescript/src/opik/integrations/opik-openai/package.json
@@ -61,7 +61,12 @@
     "opik": "^1.7.25"
   },
   "devDependencies": {
-    "typescript": "^5.7.2",
+    "eslint": "^9.34.0",
+    "prettier": "^3.6.2",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.2",
+    "typescript-eslint": "^8.42.0",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.5"
   }
 }


### PR DESCRIPTION
## Details
Update TypeScript integration dependencies
## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2566

## Testing

## Documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds linting/formatting/build tooling and bumps TypeScript to ^5.9.2 in `opik-gemini` and `opik-openai` packages.
> 
> - **TypeScript integrations**:
>   - **Dev tooling**: Add `eslint`, `prettier`, `tsup`, `typescript-eslint`, and `vite-tsconfig-paths` in `sdks/typescript/src/opik/integrations/opik-gemini/package.json` and `sdks/typescript/src/opik/integrations/opik-openai/package.json`.
>   - **TypeScript**: Bump `typescript` from `^5.7.2` to `^5.9.2` in both packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78ff752e3305a9eb559d84011424936a18174ca3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->