### PR TITLE
[OPIK-2566] [SDK] Fix TypeScript integrations build and test configuration

### DIFF
--- a/sdks/typescript/src/opik/integrations/opik-gemini/package-lock.json
+++ b/sdks/typescript/src/opik/integrations/opik-gemini/package-lock.json
@@ -14,7 +14,6 @@
         "tsup": "^8.5.0",
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.42.0",
-        "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.0.5"
       },
       "engines": {
@@ -2803,13 +2802,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/google-auth-library": {
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
@@ -4560,27 +4552,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslog": {
       "version": "4.10.2",
       "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.10.2.tgz",
@@ -4851,26 +4822,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
-      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      },
-      "peerDependenciesMeta": {
-        "vite": {
-          "optional": true
-        }
       }
     },
     "node_modules/vitest": {

--- a/sdks/typescript/src/opik/integrations/opik-gemini/package.json
+++ b/sdks/typescript/src/opik/integrations/opik-gemini/package.json
@@ -72,7 +72,6 @@
     "tsup": "^8.5.0",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.42.0",
-    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.5"
   }
 }

--- a/sdks/typescript/src/opik/integrations/opik-gemini/src/decorators.ts
+++ b/sdks/typescript/src/opik/integrations/opik-gemini/src/decorators.ts
@@ -254,9 +254,14 @@ function wrapAsyncIterable<T>(
             candidates: structuredClone(finalChunkParsed.candidates),
           };
 
-          if (aggregatedOutput.candidates?.[0]?.content?.parts?.[0]) {
-            aggregatedOutput.candidates[0].content.parts[0].text =
-              accumulatedText;
+          // Type assertion for nested property access after structuredClone
+          const typedOutput = aggregatedOutput as {
+            candidates?: Array<{
+              content?: { parts?: Array<{ text?: string }> };
+            }>;
+          };
+          if (typedOutput.candidates?.[0]?.content?.parts?.[0]) {
+            typedOutput.candidates[0].content.parts[0].text = accumulatedText;
           }
         }
       }

--- a/sdks/typescript/src/opik/integrations/opik-gemini/vitest.config.ts
+++ b/sdks/typescript/src/opik/integrations/opik-gemini/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+});

--- a/sdks/typescript/src/opik/integrations/opik-langchain/package-lock.json
+++ b/sdks/typescript/src/opik/integrations/opik-langchain/package-lock.json
@@ -14,7 +14,6 @@
         "tsup": "^8.5.0",
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.42.0",
-        "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.0.5"
       },
       "engines": {
@@ -2921,13 +2920,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -4770,27 +4762,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslog": {
       "version": "4.9.3",
       "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.9.3.tgz",
@@ -5058,26 +5029,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
-      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      },
-      "peerDependenciesMeta": {
-        "vite": {
-          "optional": true
-        }
       }
     },
     "node_modules/vitest": {

--- a/sdks/typescript/src/opik/integrations/opik-langchain/package.json
+++ b/sdks/typescript/src/opik/integrations/opik-langchain/package.json
@@ -66,7 +66,6 @@
     "tsup": "^8.5.0",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.42.0",
-    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.5"
   }
 }

--- a/sdks/typescript/src/opik/integrations/opik-openai/package-lock.json
+++ b/sdks/typescript/src/opik/integrations/opik-openai/package-lock.json
@@ -14,7 +14,6 @@
         "tsup": "^8.5.0",
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.42.0",
-        "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.0.5"
       },
       "engines": {
@@ -2655,13 +2654,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -4269,27 +4261,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslog": {
       "version": "4.9.3",
       "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.9.3.tgz",
@@ -4561,26 +4532,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
-      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      },
-      "peerDependenciesMeta": {
-        "vite": {
-          "optional": true
-        }
       }
     },
     "node_modules/vitest": {

--- a/sdks/typescript/src/opik/integrations/opik-openai/package.json
+++ b/sdks/typescript/src/opik/integrations/opik-openai/package.json
@@ -66,7 +66,6 @@
     "tsup": "^8.5.0",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.42.0",
-    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.5"
   }
 }

--- a/sdks/typescript/src/opik/integrations/opik-openai/vitest.config.ts
+++ b/sdks/typescript/src/opik/integrations/opik-openai/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
- Add vitest.config.ts for opik-gemini and opik-openai integrations
- Remove unused vite-tsconfig-paths dependency from all integrations
- Add passWithNoTests option to allow CI to pass with no tests
- Fix TypeScript type errors in gemini decorators.ts
- Update package-lock.json files after dependency cleanup

This ensures all integrations (gemini, openai, langchain) can run their full CI pipeline successfully: build, test, lint, and typecheck.

## Details

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2566

## Testing

## Documentation
