### PR TITLE
[OPIK-2566] [SDK] Add ESLint configuration and dependencies to TypeSc…

### DIFF
--- a/sdks/typescript/src/opik/integrations/opik-gemini/eslint.config.js
+++ b/sdks/typescript/src/opik/integrations/opik-gemini/eslint.config.js
@@ -1,0 +1,15 @@
+import globals from "globals";
+import pluginJs from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+  { files: ["src/**/*.{js,mjs,cjs,ts}", "tests/**/*.{js,mjs,cjs,ts}"] },
+  { languageOptions: { globals: globals.browser } },
+  pluginJs.configs.recommended,
+  ...tseslint.configs.recommended,
+];
+

--- a/sdks/typescript/src/opik/integrations/opik-gemini/package-lock.json
+++ b/sdks/typescript/src/opik/integrations/opik-gemini/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@eslint/js": "^9.20.0",
         "eslint": "^9.34.0",
+        "globals": "^15.14.0",
         "prettier": "^3.6.2",
         "tsup": "^8.5.0",
         "typescript": "^5.9.2",
@@ -542,6 +544,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/js": {
@@ -2790,11 +2804,10 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },

--- a/sdks/typescript/src/opik/integrations/opik-gemini/package.json
+++ b/sdks/typescript/src/opik/integrations/opik-gemini/package.json
@@ -67,7 +67,9 @@
     "opik": "^1.7.25"
   },
   "devDependencies": {
+    "@eslint/js": "^9.20.0",
     "eslint": "^9.34.0",
+    "globals": "^15.14.0",
     "prettier": "^3.6.2",
     "tsup": "^8.5.0",
     "typescript": "^5.9.2",

--- a/sdks/typescript/src/opik/integrations/opik-langchain/package-lock.json
+++ b/sdks/typescript/src/opik/integrations/opik-langchain/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.3",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@eslint/js": "^9.20.0",
         "eslint": "^9.34.0",
+        "globals": "^15.14.0",
         "prettier": "^3.6.2",
         "tsup": "^8.5.0",
         "typescript": "^5.9.2",
@@ -610,6 +612,18 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
@@ -2908,11 +2922,10 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },

--- a/sdks/typescript/src/opik/integrations/opik-langchain/package.json
+++ b/sdks/typescript/src/opik/integrations/opik-langchain/package.json
@@ -61,7 +61,9 @@
     "opik": "^1.8.37"
   },
   "devDependencies": {
+    "@eslint/js": "^9.20.0",
     "eslint": "^9.34.0",
+    "globals": "^15.14.0",
     "prettier": "^3.6.2",
     "tsup": "^8.5.0",
     "typescript": "^5.9.2",

--- a/sdks/typescript/src/opik/integrations/opik-openai/package-lock.json
+++ b/sdks/typescript/src/opik/integrations/opik-openai/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@eslint/js": "^9.20.0",
         "eslint": "^9.34.0",
+        "globals": "^15.14.0",
         "prettier": "^3.6.2",
         "tsup": "^8.5.0",
         "typescript": "^5.9.2",
@@ -551,6 +553,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/js": {
@@ -2642,11 +2656,10 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },

--- a/sdks/typescript/src/opik/integrations/opik-openai/package.json
+++ b/sdks/typescript/src/opik/integrations/opik-openai/package.json
@@ -61,7 +61,9 @@
     "opik": "^1.7.25"
   },
   "devDependencies": {
+    "@eslint/js": "^9.20.0",
     "eslint": "^9.34.0",
+    "globals": "^15.14.0",
     "prettier": "^3.6.2",
     "tsup": "^8.5.0",
     "typescript": "^5.9.2",


### PR DESCRIPTION
## Details
Add ESLint configuration and dependencies to ts sdk integrations
## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2566

## Testing

## Documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ESLint config to `opik-gemini` and introduces `@eslint/js` and `globals` dev deps across `opik-gemini`, `opik-langchain`, and `opik-openai` with lockfile updates.
> 
> - **ESLint setup**
>   - Add `sdks/typescript/src/opik/integrations/opik-gemini/eslint.config.js` using `@eslint/js`, `typescript-eslint`, and `globals.browser`; ignores `dist/**` and `node_modules/**`.
> - **Dev dependencies**
>   - Add `@eslint/js` and `globals` to `devDependencies` in:
>     - `opik-gemini/package.json`
>     - `opik-langchain/package.json`
>     - `opik-openai/package.json`
> - **Lockfiles**
>   - Update `package-lock.json` for the above packages; include `@eslint/js` and bump `globals` to `^15.15.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 667e52d4ae2908eb4fb883456c8186107e1c4610. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->