### PR TITLE
[NA] [SDK] Enforce Py3.8 Support for mypy and Fix ADK Error

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,6 +4,7 @@ ignore_missing_imports = true
 disallow_untyped_defs = true
 disallow_untyped_calls = true
 check_untyped_defs = true
+python_version = "3.8"
 
 [tool.uv]
 managed = false

--- a/sdks/python/src/opik/integrations/adk/graph/subgraph_edges_builders.py
+++ b/sdks/python/src/opik/integrations/adk/graph/subgraph_edges_builders.py
@@ -1,6 +1,5 @@
 from typing import List, Optional
 from . import nodes
-import itertools
 
 
 def build_edge_definitions_for_parallel_subagents(
@@ -16,7 +15,7 @@ def build_edge_definitions_for_sequential_subagents(
         return [f"{children[0].name}"]
 
     result: List[str] = []
-    for current, next in itertools.pairwise(children):
+    for current, next in zip(children, children[1:]):
         edge_definition = f"{current.name} ==> {next.name}"
         result.append(edge_definition)
 


### PR DESCRIPTION
## Details
mypy is not defaulting to lowest python version supported `py3.8`. Once updated error flagged for ADK integration `sdks/python/src/opik/integrations/adk/graph/subgraph_edges_builders.py:19: error: Module has no attribute "pairwise"  [attr-defined]` which this also resolves.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing
Unit tests passing

## Documentation
n.a.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets mypy to Python 3.8 and updates sequential edge building to use zip for Py3.8 compatibility.
> 
> - **Config**:
>   - Set `python_version = "3.8"` in `sdks/python/pyproject.toml` for `mypy`.
> - **ADK Graph**:
>   - In `subgraph_edges_builders.py`, update `build_edge_definitions_for_sequential_subagents` to use `zip(children, children[1:])` instead of `itertools.pairwise` for Python 3.8 compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76f49d94b6020363d60c39857b1a778afce33883. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->