### PR TITLE
[OPIK-2431] [SDK] Patchfix e2e Tests Broken on Python SDK

### DIFF
--- a/sdks/python/src/opik/api_objects/span/span_client.py
+++ b/sdks/python/src/opik/api_objects/span/span_client.py
@@ -388,6 +388,8 @@ def update_span(
         total_cost=total_cost,
     )
 
+    message_streamer.put(update_span_message)
+
     if attachments is not None:
         for attachment_data in attachments:
             create_attachment_message = attachment_converters.attachment_to_message(
@@ -398,5 +400,3 @@ def update_span(
                 url_override=url_override,
             )
             message_streamer.put(create_attachment_message)
-
-    message_streamer.put(update_span_message)


### PR DESCRIPTION
## Details
Python E2E tests broken and can't merge due to failing tests. Git blame: github.com/comet-ml/opik/commit/25bbc4682e7ade46d620407f02b80b4b556ff34f

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-2431 (related to this change)

## Testing
Locally verified tests

## Documentation
n.a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders `update_span` to publish `UpdateSpanMessage` before queuing span attachment messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6ef49f01b5baca50d6b3030cbacd94bb40e63b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->