### PR TITLE
[OPIK-2572] [FE] Add ability to add new feedback score without closing queue annotation dialog

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/annotation-queues/FeedbackDefinitionsSelectBox.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/annotation-queues/FeedbackDefinitionsSelectBox.tsx
@@ -1,11 +1,15 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { ExternalLink } from "lucide-react";
 
 import LoadableSelectBox from "@/components/shared/LoadableSelectBox/LoadableSelectBox";
 import useFeedbackDefinitionsList from "@/api/feedback-definitions/useFeedbackDefinitionsList";
 import { DropdownOption } from "@/types/shared";
 import { FeedbackDefinition } from "@/types/feedback-definitions";
 import useAppStore from "@/store/AppStore";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 
 const DEFAULT_LOADED_FEEDBACK_DEFINITION_ITEMS = 1000;
 
@@ -79,9 +83,36 @@ const FeedbackDefinitionsSelectBox: React.FC<
         multiselect: false as const,
       };
 
+  const actionPanel = useMemo(
+    () => (
+      <div className="px-0.5">
+        <Separator className="my-1" />
+        <Button
+          variant="link"
+          className="w-full justify-start gap-1 px-2"
+          asChild
+        >
+          <Link
+            to="/$workspaceName/configuration"
+            params={{ workspaceName }}
+            search={{ tab: "feedback-definitions" }}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1"
+          >
+            <span>Add new feedback score</span>
+            <ExternalLink className="size-3" />
+          </Link>
+        </Button>
+      </div>
+    ),
+    [workspaceName],
+  );
+
   return (
     <LoadableSelectBox
       {...loadableSelectBoxProps}
+      actionPanel={actionPanel}
       onLoadMore={
         total > DEFAULT_LOADED_FEEDBACK_DEFINITION_ITEMS && !isLoadedMore
           ? loadMoreHandler


### PR DESCRIPTION
## Details

This PR adds a convenient "Add new feedback score" link at the bottom of the feedback definitions dropdown in the annotation queue dialog. This enhancement allows users to create new feedback scores without closing the annotation queue dialog, improving the user experience during the annotation workflow.

**Key Changes:**
- Added an action panel to the `FeedbackDefinitionsSelectBox` component
- The panel contains a link that opens the Configuration → Feedback Definitions tab in a new browser tab
- Used the `Separator` component for clean visual separation
- Integrated with the existing `LoadableSelectBox` component's `actionPanel` prop
- Utilized TanStack Router for type-safe navigation with proper workspace context

**User Impact:**
Users can now quickly add new feedback scores mid-annotation workflow without losing their place in the queue annotation dialog.
<img width="1307" height="937" alt="image" src="https://github.com/user-attachments/assets/0647365f-e98c-4175-bf95-d33871fa2a73" />

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2572

## Testing

**Manual Testing Steps:**
1. Open an annotation queue dialog
2. Click on the feedback definition dropdown
3. Scroll to the bottom of the dropdown list
4. Verify the "Add new feedback score" link is visible with an external link icon
5. Click the link
6. Verify it opens the Configuration page in a new tab
7. Verify the "Feedback Definitions" tab is automatically selected
8. Create a new feedback definition
9. Switch back to the original tab
10. Verify the annotation queue dialog is still open and functional

**Expected Behavior:**
- Link appears at the bottom of the feedback definitions dropdown
- Link opens in a new browser tab
- Configuration page opens with feedback-definitions tab active
- Original dialog remains open and functional

## Documentation

No documentation updates required - this is a UI enhancement that improves existing functionality without changing the API or requiring configuration changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add an action panel to the feedback definitions dropdown with a link to open Configuration → Feedback Definitions in a new tab for creating scores without closing the dialog.
> 
> - **Frontend**
>   - `apps/opik-frontend/src/components/pages-shared/annotation-queues/FeedbackDefinitionsSelectBox.tsx`:
>     - Add action panel with "Add new feedback score" link that opens workspace-scoped `/$workspaceName/configuration?tab=feedback-definitions` in a new tab.
>     - Integrate with `LoadableSelectBox` via `actionPanel`; utilize `Separator`, `Button`, `ExternalLink`, and TanStack Router `Link`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95b8fab432af1a3d4611e4d4437209817177817c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->