### PR TITLE
[NA] [SDK] Disable flaky test update span attachments

### DIFF
--- a/sdks/python/tests/e2e/test_tracing.py
+++ b/sdks/python/tests/e2e/test_tracing.py
@@ -1134,6 +1134,7 @@ def test_tracked_function__update_current_span__with_attachments(
     )
 
 
+@pytest.mark.skip(reason="Flaky test - disabled temporarily")
 def test_opik_client__update_span_with_attachments__original_fields_preserved_but_some_are_patched(
     opik_client: opik.Opik, attachment_data_file
 ):


### PR DESCRIPTION
## Details
Disabled a flaky E2E test in the Python SDK that was causing intermittent test failures. The test `test_opik_client__update_span_with_attachments__original_fields_preserved_but_some_are_patched` has been temporarily disabled with a `@pytest.mark.skip` decorator to prevent CI pipeline interruptions while the underlying issue is investigated and fixed.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- NA

## Testing
The test is now skipped and will not run in CI. The skip decorator includes a clear reason: "Flaky test - disabled temporarily"

## Documentation
N/A - No documentation changes required for this test maintenance task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Temporarily skip flaky test `test_opik_client__update_span_with_attachments__original_fields_preserved_but_some_are_patched` in `sdks/python/tests/e2e/test_tracing.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6414c9b8007375d292130c2f534b221d89337c7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->