### PR TITLE
[OPIK-2567] [FE] Improve dataset and annotation queue creation UI from traces table

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/annotation-queues/FeedbackDefinitionsSelectBox.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/annotation-queues/FeedbackDefinitionsSelectBox.tsx
@@ -100,7 +100,7 @@ const FeedbackDefinitionsSelectBox: React.FC<
             rel="noopener noreferrer"
             className="flex items-center gap-1"
           >
-            <span>Add new feedback score</span>
+            <span>Add new feedback definition</span>
             <ExternalLink className="size-3" />
           </Link>
         </Button>

--- a/apps/opik-frontend/src/components/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from "react";
 import get from "lodash/get";
 import isUndefined from "lodash/isUndefined";
-import { Database, MessageCircleWarning } from "lucide-react";
+import { Database, MessageCircleWarning, Plus } from "lucide-react";
 import { keepPreviousData } from "@tanstack/react-query";
 
 import { Span, Trace } from "@/types/traces";
@@ -29,7 +29,7 @@ import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
 import { ToastAction } from "@/components/ui/toast";
 import { useNavigateToExperiment } from "@/hooks/useNavigateToExperiment";
 
-const DEFAULT_SIZE = 5;
+const DEFAULT_SIZE = 100;
 
 type AddToDatasetDialogProps = {
   rows: Array<Trace | Span>;
@@ -219,22 +219,27 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
                 EXPLAINER_ID.why_would_i_want_to_add_traces_to_a_dataset
               ]}
             />
-            <div className="flex gap-2.5">
-              <SearchInput
-                searchText={search}
-                setSearchText={setSearch}
-              ></SearchInput>
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="comet-title-xs">Select a dataset</h3>
               <Button
-                variant="secondary"
+                variant="ghost"
+                size="sm"
+                className="h-7"
                 onClick={() => {
                   setOpen(false);
                   setOpenDialog(true);
                 }}
                 disabled={noValidRows}
               >
+                <Plus className="mr-2 size-4" />
                 Create new dataset
               </Button>
             </div>
+            <SearchInput
+              searchText={search}
+              setSearchText={setSearch}
+              className="w-full"
+            />
             {renderAlert()}
             <div className="my-4 flex max-h-[400px] min-h-36 max-w-full flex-col justify-stretch overflow-y-auto">
               {renderListItems()}
@@ -257,6 +262,7 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
         open={openDialog}
         setOpen={setOpenDialog}
         onDatasetCreated={addToDatasetHandler}
+        hideUpload={true}
       />
     </>
   );

--- a/apps/opik-frontend/src/components/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
@@ -219,7 +219,7 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
                 EXPLAINER_ID.why_would_i_want_to_add_traces_to_a_dataset
               ]}
             />
-            <div className="mb-4 flex items-center justify-between">
+            <div className="my-2 flex items-center justify-between">
               <h3 className="comet-title-xs">Select a dataset</h3>
               <Button
                 variant="ghost"

--- a/apps/opik-frontend/src/components/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
@@ -224,7 +224,6 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-7"
                 onClick={() => {
                   setOpen(false);
                   setOpenDialog(true);

--- a/apps/opik-frontend/src/components/pages-shared/traces/AddToQueueDialog/AddToQueueDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/AddToQueueDialog/AddToQueueDialog.tsx
@@ -203,19 +203,18 @@ const AddToQueueDialog: React.FunctionComponent<AddToQueueDialogProps> = ({
               className="mb-4"
               {...EXPLAINERS_MAP[EXPLAINER_ID.what_are_annotation_queues]}
             />
-            <div className="flex items-center justify-between mb-4">
+            <div className="mb-4 flex items-center justify-between">
               <h3 className="comet-title-xs">Select an annotation queue</h3>
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-7"
                 onClick={() => {
                   setOpen(false);
                   setOpenDialog(true);
                 }}
                 disabled={noValidRows}
               >
-                <Plus className="mr-2 h-4 w-4" />
+                <Plus className="mr-2 size-4" />
                 Create new annotation queue
               </Button>
             </div>

--- a/apps/opik-frontend/src/components/pages-shared/traces/AddToQueueDialog/AddToQueueDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/AddToQueueDialog/AddToQueueDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { UserPen, MessageCircleWarning } from "lucide-react";
+import { UserPen, MessageCircleWarning, Plus } from "lucide-react";
 import { keepPreviousData } from "@tanstack/react-query";
 
 import { Thread, Trace } from "@/types/traces";
@@ -30,7 +30,7 @@ import { createFilter } from "@/lib/filters";
 import { getAnnotationQueueItemId } from "@/lib/annotation-queues";
 import { isObjectThread } from "@/lib/traces";
 
-const DEFAULT_SIZE = 5;
+const DEFAULT_SIZE = 100;
 
 type AddToQueueDialogProps = {
   rows: Array<Trace | Thread>;
@@ -203,22 +203,27 @@ const AddToQueueDialog: React.FunctionComponent<AddToQueueDialogProps> = ({
               className="mb-4"
               {...EXPLAINERS_MAP[EXPLAINER_ID.what_are_annotation_queues]}
             />
-            <div className="flex gap-2.5">
-              <SearchInput
-                searchText={search}
-                setSearchText={setSearch}
-              ></SearchInput>
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="comet-title-xs">Select an annotation queue</h3>
               <Button
-                variant="secondary"
+                variant="ghost"
+                size="sm"
+                className="h-7"
                 onClick={() => {
                   setOpen(false);
                   setOpenDialog(true);
                 }}
                 disabled={noValidRows}
               >
+                <Plus className="mr-2 h-4 w-4" />
                 Create new annotation queue
               </Button>
             </div>
+            <SearchInput
+              searchText={search}
+              setSearchText={setSearch}
+              className="w-full"
+            />
             {renderAlert()}
             <div className="my-4 flex max-h-[400px] min-h-36 max-w-full flex-col justify-stretch overflow-y-auto">
               {renderListItems()}

--- a/apps/opik-frontend/src/components/pages-shared/traces/AddToQueueDialog/AddToQueueDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/AddToQueueDialog/AddToQueueDialog.tsx
@@ -203,7 +203,7 @@ const AddToQueueDialog: React.FunctionComponent<AddToQueueDialogProps> = ({
               className="mb-4"
               {...EXPLAINERS_MAP[EXPLAINER_ID.what_are_annotation_queues]}
             />
-            <div className="mb-4 flex items-center justify-between">
+            <div className="my-2 flex items-center justify-between">
               <h3 className="comet-title-xs">Select an annotation queue</h3>
               <Button
                 variant="ghost"

--- a/apps/opik-frontend/src/components/pages/DatasetsPage/AddEditDatasetDialog.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetsPage/AddEditDatasetDialog.tsx
@@ -39,11 +39,12 @@ type AddEditDatasetDialogProps = {
   open: boolean;
   setOpen: (open: boolean) => void;
   onDatasetCreated?: (dataset: Dataset) => void;
+  hideUpload?: boolean;
 };
 
 const AddEditDatasetDialog: React.FunctionComponent<
   AddEditDatasetDialogProps
-> = ({ dataset, open, setOpen, onDatasetCreated }) => {
+> = ({ dataset, open, setOpen, onDatasetCreated, hideUpload }) => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const { toast } = useToast();
 
@@ -242,7 +243,7 @@ const AddEditDatasetDialog: React.FunctionComponent<
               maxLength={255}
             />
           </div>
-          {!isEdit && (
+          {!isEdit && !hideUpload && (
             <div className="flex flex-col gap-2 pb-4">
               <Label>Upload a CSV (optional)</Label>
               <Description className="tracking-normal">


### PR DESCRIPTION
## Details

This PR improves the user experience when creating datasets and annotation queues from the traces table by:

**Dataset Creation Dialog (`AddToDatasetDialog`)**:
- Increased pagination from 5 to 100 items for better visibility
- Reorganized UI layout with clearer hierarchy:
  - Added "Select a dataset" title (`.comet-title-xs`)
  - Moved "Create new dataset" button next to title as a small ghost button
  - Added Plus icon to the create button for better visual clarity
  - Made search input full-width for improved usability

**Annotation Queue Dialog (`AddToQueueDialog`)**:
- Applied consistent UI improvements matching dataset dialog:
  - Increased pagination from 5 to 100 items
  - Added "Select an annotation queue" title
  - Repositioned "Create new annotation queue" button with ghost styling
  - Full-width search input

**Dataset Creation Form (`AddEditDatasetDialog`)**:
- Added `hideUpload` prop to conditionally hide CSV upload section
- CSV upload is now hidden when creating a dataset from selected traces, preventing user confusion about whether to upload CSV or use selected traces

These changes provide a more intuitive and consistent user experience across both dataset and annotation queue workflows.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2567

## Testing
- Manual testing of dataset creation flow from traces table
- Manual testing of annotation queue creation flow from traces table
- Verified linting and type checking passes
- Confirmed UI layout is consistent between dataset and queue dialogs
- Tested that CSV upload is properly hidden when creating from traces

## Documentation
N/A - UI/UX improvements only, no API or configuration changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increases list size to 100, refactors headers/actions and search in add dialogs, adds Plus icons, and introduces hideUpload to conditionally hide CSV upload when creating datasets from traces; updates feedback label text.
> 
> - **Dialogs (traces)**:
>   - **Add to dataset (`AddToDatasetDialog`)**:
>     - Increase `DEFAULT_SIZE` from `5` to `100` for pagination.
>     - Restructure header: add "Select a dataset" title; move "Create new dataset" to a small ghost button with `Plus` icon; make `SearchInput` full-width.
>     - Pass `hideUpload={true}` to `AddEditDatasetDialog`.
>   - **Add to annotation queue (`AddToQueueDialog`)**:
>     - Increase `DEFAULT_SIZE` from `5` to `100`.
>     - Similar header restructure: title, ghost create button with `Plus`, full-width search.
> - **Dataset form (`AddEditDatasetDialog`)**:
>   - Add optional `hideUpload` prop; hide CSV upload when `!isEdit && hideUpload`.
> - **Feedback definitions select box**:
>   - Update action label text to "Add new feedback definition".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60785cb3045473c351dea41e50d7495f74dbe79d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->