### PR TITLE
[OPIK-2573] [FE] Fix "Add to" dropdown UI - remove redundant text

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/AddToDropdown/AddToDropdown.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/AddToDropdown/AddToDropdown.tsx
@@ -65,7 +65,7 @@ const AddToDropdown: React.FunctionComponent<AddToDropdownProps> = ({
               disabled={disabled}
             >
               <Database className="mr-2 size-4" />
-              Add to dataset
+              Dataset
             </DropdownMenuItem>
           )}
           {showAddToQueue && (
@@ -77,7 +77,7 @@ const AddToDropdown: React.FunctionComponent<AddToDropdownProps> = ({
               disabled={disabled}
             >
               <UserPen className="mr-2 size-4" />
-              Add to annotation queue
+              Annotation queue
             </DropdownMenuItem>
           )}
         </DropdownMenuContent>


### PR DESCRIPTION
## Details

Fixed UX issue where the "Add to" dropdown in traces/spans output table showed redundant text ("add to add to dataset/annotation queue").

**Changes**:
- Removed "Add to" prefix from dropdown menu items in `AddToDropdown.tsx`
- Button text remains "Add to" (unchanged)
- Menu items now display only "Dataset" and "Annotation queue"

**Result**: Cleaner, more professional UI with no redundant text.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2573
- Parent: OPIK-2571

## Testing

**Manual Testing**:
- Open traces or spans page
- Click the "Add to" dropdown button
- Verify menu items display "Dataset" and "Annotation queue" (without "Add to" prefix)
- Confirm both options still work correctly (open respective dialogs)
- Tested in both light and dark themes
- Verified responsive behavior

**Expected Result**:
- Before: Dropdown shows "Add to" → "Add to dataset" (creating redundancy)
- After: Dropdown shows "Add to" → "Dataset" (clean and concise)

## Documentation

No documentation changes needed - this is a minor UI text improvement that doesn't affect functionality or require user documentation updates.