### PR TITLE
[OPIK-2569] [P SDK] Implement `Opik.update_trace()` method to make it easier to update trace

### DIFF
--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -607,6 +607,12 @@ class Opik:
         Returns:
             None
         """
+        if not trace_id or not project_name:
+            raise ValueError(
+                "trace_id and project_name must be provided and can not be None or empty, "
+                f"trace_id: {trace_id}, project_name: {project_name}"
+            )
+
         trace_client.update_trace(
             trace_id=trace_id,
             project_name=project_name,

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -26,7 +26,7 @@ from .experiment import rest_operations as experiment_rest_operations
 from .prompt import Prompt, PromptType
 from .prompt.client import PromptClient
 from .threads import threads_client
-from .trace import migration as trace_migration
+from .trace import migration as trace_migration, trace_client
 from .. import (
     config,
     datetime_helpers,
@@ -562,6 +562,62 @@ class Opik:
             error_info=error_info,
             total_cost=total_cost,
             attachments=attachments,
+        )
+
+    def update_trace(
+        self,
+        trace_id: str,
+        project_name: str,
+        end_time: Optional[datetime.datetime] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        input: Optional[Dict[str, Any]] = None,
+        output: Optional[Dict[str, Any]] = None,
+        tags: Optional[List[Any]] = None,
+        error_info: Optional[ErrorInfoDict] = None,
+        thread_id: Optional[str] = None,
+    ) -> None:
+        """
+        Update the trace attributes.
+
+        This method should only be used after the trace has been fully created and stored.
+        If called before or immediately after trace creation, the update may silently fail or result in incorrect data.
+
+        This method uses two parameters to identify the trace:
+            - `trace_id`
+            - `project_name`
+
+        These parameters **must match exactly** the values used when the trace was created.
+        If any of them are incorrect, the update may not apply and no error will be raised.
+
+        All other parameters are optional and will update the corresponding fields in the trace.
+        If a parameter is not provided, the existing value will remain unchanged.
+
+        Args:
+            trace_id: The unique identifier for the trace.
+            project_name: The project name to which the trace belongs.
+            end_time: The end time of the trace.
+            metadata: Additional metadata to be associated with the trace.
+            input: The input data for the trace.
+            output: The output data for the trace.
+            tags: A list of tags to be associated with the trace.
+            error_info: The dictionary with error information (typically used when the trace function has failed).
+            thread_id: Used to group multiple traces into a thread.
+                The identifier is user-defined and has to be unique per project.
+
+        Returns:
+            None
+        """
+        trace_client.update_trace(
+            trace_id=trace_id,
+            project_name=project_name,
+            message_streamer=self._streamer,
+            end_time=end_time,
+            metadata=metadata,
+            input=input,
+            output=output,
+            tags=tags,
+            error_info=error_info,
+            thread_id=thread_id,
         )
 
     def log_spans_feedback_scores(

--- a/sdks/python/src/opik/api_objects/trace/trace_client.py
+++ b/sdks/python/src/opik/api_objects/trace/trace_client.py
@@ -97,9 +97,10 @@ class Trace:
         Returns:
             None
         """
-        update_trace_message = messages.UpdateTraceMessage(
+        update_trace(
             trace_id=self.id,
             project_name=self._project_name,
+            message_streamer=self._streamer,
             end_time=end_time,
             metadata=metadata,
             input=input,
@@ -108,7 +109,6 @@ class Trace:
             error_info=error_info,
             thread_id=thread_id,
         )
-        self._streamer.put(update_trace_message)
 
     def span(
         self,
@@ -215,3 +215,29 @@ class Trace:
         )
 
         self._streamer.put(add_trace_feedback_batch_message)
+
+
+def update_trace(
+    trace_id: str,
+    project_name: str,
+    message_streamer: streamer.Streamer,
+    end_time: Optional[datetime.datetime] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    input: Optional[Dict[str, Any]] = None,
+    output: Optional[Dict[str, Any]] = None,
+    tags: Optional[List[Any]] = None,
+    error_info: Optional[ErrorInfoDict] = None,
+    thread_id: Optional[str] = None,
+) -> None:
+    update_trace_message = messages.UpdateTraceMessage(
+        trace_id=trace_id,
+        project_name=project_name,
+        end_time=end_time,
+        metadata=metadata,
+        input=input,
+        output=output,
+        tags=tags,
+        error_info=error_info,
+        thread_id=thread_id,
+    )
+    message_streamer.put(update_trace_message)

--- a/sdks/python/src/opik/api_objects/trace/trace_client.py
+++ b/sdks/python/src/opik/api_objects/trace/trace_client.py
@@ -229,6 +229,30 @@ def update_trace(
     error_info: Optional[ErrorInfoDict] = None,
     thread_id: Optional[str] = None,
 ) -> None:
+    """
+    Update an existing trace with new information.
+    This function sends an UpdateTraceMessage to the provided message_streamer,
+    allowing you to update various fields of a trace, such as its end time,
+    metadata, input, output, tags, error information and thread association.
+
+    Args:
+        trace_id: The unique identifier of the trace to update.
+        project_name: The name of the project associated with the trace.
+        message_streamer: The message streamer used to send the update.
+        end_time: The end time of the trace. Defaults to None.
+        metadata: Additional metadata for the trace. Defaults to None.
+        input: Input data associated with the trace. Defaults to None.
+        output: Output data associated with the trace. Defaults to None.
+        tags: List of tags to associate with the trace. Defaults to None.
+        error_info: Error information related to the trace. Defaults to None.
+        thread_id : The thread ID associated with the trace. Defaults to None.
+    Returns:
+        None
+    Usage Notes:
+        - This function does not return a value; it sends an update message to the message streamer.
+        - All parameters except trace_id, project_name and message_streamer are optional.
+        - Only the fields provided will be updated in the trace.
+    """
     update_trace_message = messages.UpdateTraceMessage(
         trace_id=trace_id,
         project_name=project_name,

--- a/sdks/python/tests/e2e/test_tracing.py
+++ b/sdks/python/tests/e2e/test_tracing.py
@@ -1188,3 +1188,64 @@ def test_opik_client__update_span_with_attachments__original_fields_preserved_bu
         data_sizes=data_sizes,
         timeout=30,
     )
+
+
+def test_opik_client__update_trace__happy_flow(opik_client: opik.Opik):
+    # test that the trace update works
+    project_name = "update_trace_happy_flow"
+    trace_name = "trace_name"
+    trace = opik_client.trace(
+        name=trace_name,
+        input={"input": "trace-input-value"},
+        output={"output": "trace-output-value"},
+        tags=["trace-tag"],
+        metadata={"trace-metadata-key": "trace-metadata-value"},
+        project_name=project_name,
+    )
+
+    opik_client.flush()
+
+    # verify that the trace was saved
+    verifiers.verify_trace(
+        opik_client=opik_client,
+        trace_id=trace.id,
+        name=trace_name,
+        input={"input": "trace-input-value"},
+        output={"output": "trace-output-value"},
+        metadata={"trace-metadata-key": "trace-metadata-value"},
+        tags=["trace-tag"],
+        project_name=project_name,
+    )
+
+    #
+    # update the trace with new values
+    #
+    new_metadata = {"new-trace-metadata-key": "new-trace-metadata-value"}
+    new_tags = ["new-trace-tag"]
+    new_input = {"input": "new-trace-input-value"}
+    new_output = {"output": "new-trace-output-value"}
+    thread_id = id_helpers.generate_id()
+    opik_client.update_trace(
+        trace_id=trace.id,
+        project_name=project_name,
+        metadata=new_metadata,
+        tags=new_tags,
+        input=new_input,
+        output=new_output,
+        thread_id=thread_id,
+    )
+
+    opik_client.flush()
+
+    # verify that the trace was updated
+    verifiers.verify_trace(
+        opik_client=opik_client,
+        trace_id=trace.id,
+        name=trace_name,
+        input=new_input,
+        output=new_output,
+        metadata=new_metadata,
+        tags=new_tags,
+        thread_id=thread_id,
+        project_name=project_name,
+    )

--- a/sdks/python/tests/unit/api_objects/test_opik_client.py
+++ b/sdks/python/tests/unit/api_objects/test_opik_client.py
@@ -1,0 +1,23 @@
+import pytest
+
+from opik.api_objects import opik_client
+
+
+@pytest.mark.parametrize(
+    "trace_id,project_name",
+    [
+        (None, "some-project"),
+        ("some-trace-id", None),
+        (None, None),
+        ("", "some-project"),
+        ("some-trace-id", ""),
+        ("", ""),
+    ],
+)
+def test_opik_client__update_trace__missing_mandatory_parameters__error_raised(
+    trace_id, project_name
+):
+    opik_client_ = opik_client.Opik()
+
+    with pytest.raises(ValueError):
+        opik_client_.update_trace(trace_id=trace_id, project_name=project_name)


### PR DESCRIPTION
## Details
Now it is a bit complicated to update the trace from user script which leads to confusing errors like saving parts of the trace in the different workspaces.

### Key changes

This PR implements a new update_trace() method for the Opik client to simplify trace updates and prevent workspace confusion. The implementation adds validation, documentation, and comprehensive test coverage.

- Introduced `update_trace` function in `OpikClient` for updating trace attributes such as metadata, tags, input, output, and more.
- Updated `trace_client` with `update_trace` implementation to handle and stream trace update messages.

## Change checklist
- [ x] User facing
- [ ] Documentation update

## Issues

- OPIK-2569

## Testing

Implemented unit and E2E test

## Documentation

Created docstring for new function