### PR TITLE
[OPIK-2578] [FE] Update success message for adding items to annotation queue

### DIFF
--- a/apps/opik-frontend/src/api/annotation-queues/useAnnotationQueueAddItemsMutation.ts
+++ b/apps/opik-frontend/src/api/annotation-queues/useAnnotationQueueAddItemsMutation.ts
@@ -31,12 +31,6 @@ const useAnnotationQueueAddItemsMutation = () => {
 
       return data;
     },
-
-    onSuccess: () => {
-      toast({
-        description: "Items added to annotation queue successfully",
-      });
-    },
     onError: (error: AxiosError) => {
       const message = get(
         error,


### PR DESCRIPTION
## Details
Updated the success toast notification when items are added to an annotation queue to be more informative and actionable:

**Changes:**
- Removed simple success toast from the mutation hook (`useAnnotationQueueAddItemsMutation`)
- Added enhanced success toast in the component (`AddToQueueDialog`) with:
  - Title: "Items added to annotation queue"
  - Descriptive message about the next steps
  - Action button "Go to annotation queue" that navigates directly to the queue

**Architecture:**
- Keep mutation hook focused on API calls and error handling
- Move success toast with navigation logic to the component layer
- Separate success handler callback for better code organization and testability

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves # N/A
- OPIK-2578

## Testing
**Manual Testing:**
1. Navigate to traces or threads page
2. Select one or more items
3. Click "Add to queue" and select an annotation queue
4. Verify the new success toast appears with:
   - Title: "Items added to annotation queue"
   - Description explaining next steps
   - "Go to annotation queue" button
5. Click the button to verify it navigates to the correct annotation queue page

**Test Coverage:**
- No new unit tests required (UI toast notification change)
- Existing mutation tests remain valid

## Documentation
No documentation updates required - this is a UI improvement to an existing feature.