### PR TITLE
[OPIK-2579] [FE] Improve queues page header layout and information display

### DIFF
--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
@@ -20,6 +20,7 @@ import PageBodyScrollContainer from "@/components/layout/PageBodyScrollContainer
 import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
 import CopySMELinkButton from "@/components/pages/AnnotationQueuePage/CopySMELinkButton";
 import OpenSMELinkButton from "@/components/pages/AnnotationQueuePage/OpenSMELinkButton";
+import EditAnnotationQueueButton from "@/components/pages/AnnotationQueuePage/EditAnnotationQueueButton";
 
 const AnnotationQueuePage: React.FunctionComponent = () => {
   const [tab = "items", setTab] = useQueryParam("tab", StringParam);
@@ -68,6 +69,7 @@ const AnnotationQueuePage: React.FunctionComponent = () => {
         {annotationQueue && (
           <div className="flex items-center gap-2">
             <CopySMELinkButton annotationQueue={annotationQueue} />
+            <EditAnnotationQueueButton annotationQueue={annotationQueue} />
             <OpenSMELinkButton annotationQueue={annotationQueue} />
           </div>
         )}

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ConfigurationTab/ConfigurationTab.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ConfigurationTab/ConfigurationTab.tsx
@@ -4,11 +4,6 @@ import Loader from "@/components/shared/Loader/Loader";
 import InstructionsSection from "@/components/pages/AnnotationQueuePage/ConfigurationTab/InstructionsSection";
 import ScoresSection from "@/components/pages/AnnotationQueuePage/ConfigurationTab/ScoresSection";
 import ReviewersSection from "@/components/pages/AnnotationQueuePage/ConfigurationTab/ReviewersSection";
-import OpenSMELinkButton from "@/components/pages/AnnotationQueuePage/OpenSMELinkButton";
-import CopySMELinkButton from "@/components/pages/AnnotationQueuePage/CopySMELinkButton";
-import EditAnnotationQueueButton from "@/components/pages/AnnotationQueuePage/EditAnnotationQueueButton";
-import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
-import { Separator } from "@/components/ui/separator";
 
 interface ConfigurationTabProps {
   annotationQueue?: AnnotationQueue;
@@ -22,25 +17,11 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
   }
 
   return (
-    <>
-      <PageBodyStickyContainer
-        className="-mt-4 flex flex-wrap items-center justify-end gap-x-8 gap-y-2 py-4"
-        direction="bidirectional"
-        limitWidth
-      >
-        <div className="flex items-center gap-2">
-          <OpenSMELinkButton annotationQueue={annotationQueue} />
-          <EditAnnotationQueueButton annotationQueue={annotationQueue} />
-          <Separator orientation="vertical" className="mx-2 h-4" />
-          <CopySMELinkButton annotationQueue={annotationQueue} />
-        </div>
-      </PageBodyStickyContainer>
-      <div className="px-6">
-        <InstructionsSection annotationQueue={annotationQueue} />
-        <ScoresSection annotationQueue={annotationQueue} />
-        <ReviewersSection annotationQueue={annotationQueue} />
-      </div>
-    </>
+    <div className="px-6">
+      <InstructionsSection annotationQueue={annotationQueue} />
+      <ScoresSection annotationQueue={annotationQueue} />
+      <ReviewersSection annotationQueue={annotationQueue} />
+    </div>
   );
 };
 

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/CopySMELinkButton.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/CopySMELinkButton.tsx
@@ -29,7 +29,7 @@ const CopySMELinkButton: React.FC<CopySMELinkButtonProps> = ({
   return (
     <Button size="sm" variant="outline" onClick={handleCopySMELink}>
       <Copy className="mr-1.5 size-3.5" />
-      Share queue
+      Share
     </Button>
   );
 };

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/EditAnnotationQueueButton.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/EditAnnotationQueueButton.tsx
@@ -31,7 +31,7 @@ const EditAnnotationQueueButton: React.FunctionComponent<
       />
       <Button size="sm" variant="outline" onClick={handleOpenEditDialog}>
         <Pencil className="mr-1.5 size-3.5" />
-        Edit queue
+        Edit
       </Button>
     </>
   );

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/OpenSMELinkButton.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/OpenSMELinkButton.tsx
@@ -26,7 +26,7 @@ const OpenSMELinkButton: React.FunctionComponent<OpenSMELinkButtonProps> = ({
     >
       <Button size="sm">
         <SquareArrowOutUpRight className="mr-1.5 size-3.5" />
-        Annotate queue
+        Annotate
       </Button>
     </Link>
   );

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
@@ -61,8 +61,6 @@ import FeedbackScoreHeader from "@/components/shared/DataTableHeaders/FeedbackSc
 import FeedbackScoreCell from "@/components/shared/DataTableCells/FeedbackScoreCell";
 import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
 import PageBodyStickyTableWrapper from "@/components/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
-import CopySMELinkButton from "@/components/pages/AnnotationQueuePage/CopySMELinkButton";
-import EditAnnotationQueueButton from "@/components/pages/AnnotationQueuePage/EditAnnotationQueueButton";
 import QueueItemActionsPanel from "@/components/pages/AnnotationQueuePage/QueueItemsTab/QueueItemActionsPanel";
 import QueueItemRowActionsCell from "@/components/pages/AnnotationQueuePage/QueueItemsTab/QueueItemRowActionsCell";
 import NoQueueItemsPage from "@/components/pages/AnnotationQueuePage/QueueItemsTab/NoQueueItemsPage";
@@ -75,7 +73,6 @@ import { createFilter } from "@/lib/filters";
 import SelectBox, {
   SelectBoxProps,
 } from "@/components/shared/SelectBox/SelectBox";
-import OpenSMELinkButton from "@/components/pages/AnnotationQueuePage/OpenSMELinkButton";
 
 const SHARED_COLUMNS: ColumnData<Thread>[] = [
   {
@@ -522,8 +519,6 @@ const ThreadQueueItemsTab: React.FunctionComponent<
           />
         </div>
         <div className="flex items-center gap-2">
-          <OpenSMELinkButton annotationQueue={annotationQueue} />
-          <EditAnnotationQueueButton annotationQueue={annotationQueue} />
           <QueueItemActionsPanel
             items={selectedRows}
             annotationQueueId={annotationQueue.id}
@@ -541,7 +536,6 @@ const ThreadQueueItemsTab: React.FunctionComponent<
             onOrderChange={setColumnsOrder}
             sections={columnSections}
           />
-          <CopySMELinkButton annotationQueue={annotationQueue} />
         </div>
       </PageBodyStickyContainer>
       <DataTable

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
@@ -64,8 +64,6 @@ import PrettyCell from "@/components/shared/DataTableCells/PrettyCell";
 import FeedbackScoreHeader from "@/components/shared/DataTableHeaders/FeedbackScoreHeader";
 import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
 import PageBodyStickyTableWrapper from "@/components/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
-import CopySMELinkButton from "@/components/pages/AnnotationQueuePage/CopySMELinkButton";
-import EditAnnotationQueueButton from "@/components/pages/AnnotationQueuePage/EditAnnotationQueueButton";
 import QueueItemActionsPanel from "@/components/pages/AnnotationQueuePage/QueueItemsTab/QueueItemActionsPanel";
 import QueueItemRowActionsCell from "@/components/pages/AnnotationQueuePage/QueueItemsTab/QueueItemRowActionsCell";
 import NoQueueItemsPage from "@/components/pages/AnnotationQueuePage/QueueItemsTab/NoQueueItemsPage";
@@ -79,7 +77,6 @@ import { useDynamicColumnsCache } from "@/hooks/useDynamicColumnsCache";
 import SelectBox, {
   SelectBoxProps,
 } from "@/components/shared/SelectBox/SelectBox";
-import OpenSMELinkButton from "@/components/pages/AnnotationQueuePage/OpenSMELinkButton";
 
 const TRACE_COLUMNS: ColumnData<Trace>[] = [
   {
@@ -567,8 +564,6 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
           />
         </div>
         <div className="flex items-center gap-2">
-          <OpenSMELinkButton annotationQueue={annotationQueue} />
-          <EditAnnotationQueueButton annotationQueue={annotationQueue} />
           <QueueItemActionsPanel
             items={selectedRows}
             annotationQueueId={annotationQueue.id}
@@ -586,7 +581,6 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
             onOrderChange={setColumnsOrder}
             sections={columnSections}
           />
-          <CopySMELinkButton annotationQueue={annotationQueue} />
         </div>
       </PageBodyStickyContainer>
       <DataTable


### PR DESCRIPTION
## Details

This PR improves the annotation queues page header by reorganizing tags, information display, and action buttons for better usability and space efficiency.

### Tag and Information Layout Changes
- **Moved Thread/Trace tag to date row**: Consolidated the scope tag with date information and capitalized "Thread" and "Trace" for consistency
- **Added project tag**: Displays the project name as a clickable tag that links to the project page, similar to the dataset tag pattern used in experiments
- **Added feedback score tags**: Shows allocated feedback scores with their average values, using a pen icon indicator on a separate row

### Button Organization Changes
- **Consolidated action buttons to header**: Moved Share, Edit, and Annotate buttons to the top-level header next to the queue name for better visibility
- **Shortened button labels**: Changed "Share queue" → "Share", "Edit queue" → "Edit", "Annotate queue" → "Annotate" to save space
- **Removed duplicate buttons**: Cleaned up buttons from individual tab locations (Queue Items and Configuration tabs) since they're now in the main header
- **Updated button styling**: Share and Edit buttons use outline variant, Annotate uses primary variant
<img width="1839" height="933" alt="image" src="https://github.com/user-attachments/assets/2b2895ac-a465-4eb5-9b07-dd7d169e9513" />

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2579

## Testing

**Manual Testing**:
- ✅ Verified header displays correctly in both Thread and Trace queue modes
- ✅ Confirmed project tag links to correct project page
- ✅ Validated feedback score tags show allocated scores only
- ✅ Tested all three action buttons work correctly from header
- ✅ Checked button labels are shortened appropriately
- ✅ Verified buttons are removed from tab-specific locations

**Quality Checks**:
- ✅ ESLint: No errors
- ✅ Stylelint: No errors
- ✅ TypeScript: No type errors

## Documentation

N/A - UI-only changes, no documentation updates required.