### PR TITLE
[OPIK-2581] [FE] Add return to annotation queue button and resume functionality

### DIFF
--- a/apps/opik-frontend/src/components/pages/SMEFlowPage/AnnotationView/AnnotationView.tsx
+++ b/apps/opik-frontend/src/components/pages/SMEFlowPage/AnnotationView/AnnotationView.tsx
@@ -4,6 +4,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { Card } from "@/components/ui/card";
 import TraceDataViewer from "./TraceDataViewer";
 import SMEFlowLayout from "../SMEFlowLayout";
+import ReturnToAnnotationQueueButton from "../ReturnToAnnotationQueueButton";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import CommentAndScoreViewer from "@/components/pages/SMEFlowPage/AnnotationView/CommentAndScoreViewer";
@@ -78,37 +79,43 @@ const AnnotationView: React.FunctionComponent<AnnotationViewProps> = ({
       header={header}
       footer={
         <>
-          <div className="comet-body-s flex items-center text-light-slate">
-            {currentIndex + 1} of {queueItems.length}
+          <ReturnToAnnotationQueueButton />
+          <div className="flex items-center gap-2">
+            <div className="comet-body-s flex items-center text-light-slate">
+              {currentIndex + 1} of {queueItems.length}
+            </div>
+            <TooltipWrapper content="Previous item" hotkeys={LEFT_HOTKEYS}>
+              <Button
+                variant="outline"
+                onClick={handlePrevious}
+                disabled={isFirstItem}
+              >
+                <ChevronLeft className="mr-2 size-4" />
+                Previous
+              </Button>
+            </TooltipWrapper>
+            <TooltipWrapper content="Skip to next item" hotkeys={RIGHT_HOTKEYS}>
+              <Button
+                variant="outline"
+                onClick={handleNext}
+                disabled={isLastItem}
+              >
+                Skip
+                <ChevronRight className="ml-2 size-4" />
+              </Button>
+            </TooltipWrapper>
+            <TooltipWrapper
+              content="Submit and continue"
+              hotkeys={ENTER_HOTKEYS}
+            >
+              <Button
+                onClick={handleSubmit}
+                disabled={!validationState.canSubmit}
+              >
+                {isLastUnprocessedItem ? "Submit & Complete" : "Submit + Next"}
+              </Button>
+            </TooltipWrapper>
           </div>
-          <TooltipWrapper content="Previous item" hotkeys={LEFT_HOTKEYS}>
-            <Button
-              variant="outline"
-              onClick={handlePrevious}
-              disabled={isFirstItem}
-            >
-              <ChevronLeft className="mr-2 size-4" />
-              Previous
-            </Button>
-          </TooltipWrapper>
-          <TooltipWrapper content="Skip to next item" hotkeys={RIGHT_HOTKEYS}>
-            <Button
-              variant="outline"
-              onClick={handleNext}
-              disabled={isLastItem}
-            >
-              Skip
-              <ChevronRight className="ml-2 size-4" />
-            </Button>
-          </TooltipWrapper>
-          <TooltipWrapper content="Submit and continue" hotkeys={ENTER_HOTKEYS}>
-            <Button
-              onClick={handleSubmit}
-              disabled={!validationState.canSubmit}
-            >
-              {isLastUnprocessedItem ? "Submit & Complete" : "Submit + Next"}
-            </Button>
-          </TooltipWrapper>
         </>
       }
     >

--- a/apps/opik-frontend/src/components/pages/SMEFlowPage/CompletionView/CompletionView.tsx
+++ b/apps/opik-frontend/src/components/pages/SMEFlowPage/CompletionView/CompletionView.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Card } from "@/components/ui/card";
 import SMEFlowLayout from "../SMEFlowLayout";
+import ReturnToAnnotationQueueButton from "../ReturnToAnnotationQueueButton";
 
 interface CompletionViewProps {
   header: React.ReactNode;
@@ -10,7 +11,7 @@ const CompletionView: React.FunctionComponent<CompletionViewProps> = ({
   header,
 }) => {
   return (
-    <SMEFlowLayout header={header}>
+    <SMEFlowLayout header={header} footer={<ReturnToAnnotationQueueButton />}>
       <Card className="h-full p-6 pt-14 text-center">
         <div className="mb-5 h-8 text-[32px]">🎉</div>
         <h3 className="comet-title-l">All items completed!</h3>

--- a/apps/opik-frontend/src/components/pages/SMEFlowPage/GetStartedView/GetStartedView.tsx
+++ b/apps/opik-frontend/src/components/pages/SMEFlowPage/GetStartedView/GetStartedView.tsx
@@ -5,11 +5,16 @@ import { Button } from "@/components/ui/button";
 import InstructionsContent from "@/components/pages-shared/annotation-queues/InstructionsContent";
 import ScoresContent from "@/components/pages-shared/annotation-queues/ScoresContent";
 import SMEFlowLayout from "../SMEFlowLayout";
+import ReturnToAnnotationQueueButton from "../ReturnToAnnotationQueueButton";
 import { useSMEFlow } from "../SMEFlowContext";
 
 const GetStartedView: React.FC = () => {
-  const { annotationQueue, canStartAnnotation, handleStartAnnotating } =
-    useSMEFlow();
+  const {
+    annotationQueue,
+    canStartAnnotation,
+    handleStartAnnotating,
+    processedCount,
+  } = useSMEFlow();
 
   if (!annotationQueue) {
     return null;
@@ -29,9 +34,17 @@ const GetStartedView: React.FC = () => {
         </>
       }
       footer={
-        <Button onClick={handleStartAnnotating} disabled={!canStartAnnotation}>
-          Start annotating
-        </Button>
+        <>
+          <ReturnToAnnotationQueueButton />
+          <div className="flex gap-2">
+            <Button
+              onClick={handleStartAnnotating}
+              disabled={!canStartAnnotation}
+            >
+              {processedCount > 0 ? "Resume annotating" : "Start annotating"}
+            </Button>
+          </div>
+        </>
       }
     >
       <div className="flex flex-col gap-8">

--- a/apps/opik-frontend/src/components/pages/SMEFlowPage/ReturnToAnnotationQueueButton.tsx
+++ b/apps/opik-frontend/src/components/pages/SMEFlowPage/ReturnToAnnotationQueueButton.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { ArrowLeft } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
+import useAppStore from "@/store/AppStore";
+
+const ReturnToAnnotationQueueButton: React.FC = () => {
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+
+  return (
+    <Link to="/$workspaceName/annotation-queues" params={{ workspaceName }}>
+      <Button variant="ghost" aria-label="Return to annotation queue">
+        <ArrowLeft className="mr-2 size-4" />
+        Return to annotation queue
+      </Button>
+    </Link>
+  );
+};
+
+export default ReturnToAnnotationQueueButton;

--- a/apps/opik-frontend/src/components/pages/SMEFlowPage/SMEFlowLayout.tsx
+++ b/apps/opik-frontend/src/components/pages/SMEFlowPage/SMEFlowLayout.tsx
@@ -18,7 +18,7 @@ const SMEFlowLayout: React.FC<SMEFlowLayoutProps> = ({
         {children}
       </div>
       {footer && (
-        <div className="flex justify-end gap-2 border-t border-border pb-6 pt-4">
+        <div className="flex justify-between gap-2 border-t border-border pb-6 pt-4">
           {footer}
         </div>
       )}


### PR DESCRIPTION
## Details

Enhanced the SME flow with improved navigation and user experience:

- **Created reusable component**: `ReturnToAnnotationQueueButton` component with ghost button variant and ArrowLeft icon, enabling consistent "return to queue" functionality across all SME flow pages
- **Added navigation button**: Integrated "Return to annotation queue" button in footer of GetStartedView, AnnotationView, and CompletionView pages, allowing users to exit the SME flow at any point
- **Improved footer layout**: Updated `SMEFlowLayout` to use `justify-between` layout, positioning the return button on the left while keeping action buttons (start/skip/submit) on the right
- **Enhanced button text**: Implemented conditional "Resume annotating" button text when `processedCount > 0`, providing clearer context for users returning to an in-progress queue
- **Improved UI consistency**: Grouped right-side footer buttons in flex containers for better visual organization and spacing

## Change checklist
<!-- Please check the type of changes made -->
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves # <!-- the GitHub issue this PR resolves (e.g. `#1234`) -->
- OPIK-2581
- NA <!-- If no ticket, such as hotfixes etc. -->

## Testing

**UI Testing Scenarios**:
- Verified "Return to annotation queue" button appears and functions correctly on all 3 SME flow pages
- Confirmed button styling (ghost variant) and icon (ArrowLeft) match design specifications
- Tested button alignment: left-aligned return button, right-aligned action buttons
- Validated conditional button text: "Start annotating" vs "Resume annotating" based on `processedCount`
- Ensured footer layout responds correctly with button groups
- Verified navigation back to annotation queue list works correctly from all pages

**Manual Testing Steps**:
1. Navigate to an SME flow (instructions page)
2. Verify "Return to annotation queue" button appears on the left side of footer
3. Click "Return to annotation queue" → should navigate to `/$workspaceName/annotation-queues`
4. Return to SME flow with no items processed → verify button shows "Start annotating"
5. Process at least one item → return to instructions page → verify button shows "Resume annotating"
6. Navigate to annotation view → verify return button appears on left, navigation controls on right
7. Complete all items → navigate to completion view → verify return button appears

## Documentation

N/A - No documentation updates required for UI changes