### PR TITLE
[OPIK-2586] Add system information to telemetry events

### DIFF
--- a/opik.ps1
+++ b/opik.ps1
@@ -89,7 +89,8 @@ function Get-SystemInfo {
         $dockerCmd = Get-Command docker -ErrorAction SilentlyContinue
         if ($dockerCmd) {
             $dockerOutput = (docker --version 2>&1 | Out-String).Trim()
-            if ($dockerOutput -match 'Docker version ([\d.]+)') {
+            # Extract version: "Docker version 26.1.4, build..." -> "26.1.4"
+            if ($dockerOutput -match 'Docker version ([^,\s]+)') {
                 $dockerVersion = $Matches[1]
             }
         }
@@ -105,10 +106,9 @@ function Get-SystemInfo {
         $dockerCmd = Get-Command docker -ErrorAction SilentlyContinue
         if ($dockerCmd) {
             $composeOutput = (docker compose version 2>&1 | Out-String).Trim()
-            if ($composeOutput -match 'version ([\d.]+)') {
-                $dockerComposeVersion = $Matches[1]
-            } elseif ($composeOutput -match '[\d.]+') {
-                $dockerComposeVersion = $Matches[0]
+            # Extract version: "Docker Compose version v2.27.1-desktop.1" -> "v2.27.1-desktop.1"
+            if ($composeOutput -match 'Docker Compose version (.+)$') {
+                $dockerComposeVersion = $Matches[1].Trim()
             }
         }
         
@@ -117,8 +117,8 @@ function Get-SystemInfo {
             $dockerComposeCmd = Get-Command docker-compose -ErrorAction SilentlyContinue
             if ($dockerComposeCmd) {
                 $composeV1Output = (docker-compose version --short 2>&1 | Out-String).Trim()
-                if ($composeV1Output -match '[\d.]+') {
-                    $dockerComposeVersion = $Matches[0]
+                if (-not [string]::IsNullOrWhiteSpace($composeV1Output)) {
+                    $dockerComposeVersion = $composeV1Output
                 }
             }
         }


### PR DESCRIPTION
## Details
Adds system information (OS, Python version, Docker version, Docker Compose version) to the `opik_os_install_started` BI event to better understand why users fail to complete the installation scripts.

This enhancement helps the team diagnose installation issues by collecting diagnostic information about the user's environment at the start of the installation process.

## Changes
### opik.sh (Bash)
- Added `get_system_info()` function to safely collect system information
- Modified `send_install_report` to include system info in `opik_os_install_started` event payload
- All system info collection wrapped in error handling with "unknown" fallback values
- Added debug logging for troubleshooting

### opik.ps1 (PowerShell)
- Added `Get-SystemInfo` function with PowerShell-specific implementation
- Modified `Send-InstallReport` to include system info in event payload
- Comprehensive try-catch blocks with fallback values
- Added debug logging for troubleshooting

### System Information Collected
- **OS**: macOS version, Linux distribution, or Windows version
- **Python version**: python3 or python command
- **Docker version**: Docker engine version
- **Docker Compose version**: Docker Compose plugin version

## Safety Features
✅ All commands wrapped in error handling  
✅ Fallback to "unknown" when commands fail  
✅ Script continues even if info gathering fails  
✅ Debug mode shows collected system information  

## Testing
- [x] Functions safely handle missing commands and return "unknown" as fallback
- [x] Script continues even if system info gathering fails
- [x] Debug mode shows collected system information

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves OPIK-2586

## Documentation
NA, this wont require docs