### PR TITLE
[OPIK-2584] [FE] Add export annotated data button to annotation queue page

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/annotation-queues/AnnotationQueueProgress.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/annotation-queues/AnnotationQueueProgress.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { AnnotationQueue } from "@/types/annotation-queues";
+
+interface AnnotationQueueProgressProps {
+  annotationQueue: AnnotationQueue;
+  children: (progressInfo: {
+    averageProgress: number;
+    progressPercentage: number;
+    itemsCount: number;
+  }) => React.ReactNode;
+}
+
+const AnnotationQueueProgress: React.FunctionComponent<
+  AnnotationQueueProgressProps
+> = ({ annotationQueue, children }) => {
+  const { items_count: itemsCount, reviewers } = annotationQueue;
+
+  if (!reviewers || reviewers.length === 0) {
+    return null;
+  }
+
+  const averageProgress =
+    reviewers.reduce((sum, reviewer) => sum + reviewer.status, 0) /
+    reviewers.length;
+  const progressPercentage =
+    itemsCount > 0 ? Math.round((averageProgress / itemsCount) * 100) : 0;
+
+  return (
+    <HoverCard>
+      <HoverCardTrigger asChild>
+        {children({
+          averageProgress: Math.round(averageProgress),
+          progressPercentage,
+          itemsCount,
+        })}
+      </HoverCardTrigger>
+      <HoverCardContent className="w-64">
+        <div className="space-y-2">
+          <h4 className="comet-title-xs">Progress by Reviewer</h4>
+          <div className="space-y-1">
+            {reviewers.map((reviewer) => {
+              const reviewerProgress =
+                itemsCount > 0
+                  ? Math.round((reviewer.status / itemsCount) * 100)
+                  : 0;
+              return (
+                <div
+                  key={reviewer.username}
+                  className="flex items-center justify-between"
+                >
+                  <span className="comet-body-s">{reviewer.username}</span>
+                  <span className="comet-body-s text-muted-foreground">
+                    {reviewer.status}/{itemsCount} ({reviewerProgress}%)
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  );
+};
+
+export default AnnotationQueueProgress;

--- a/apps/opik-frontend/src/components/pages-shared/annotation-queues/AnnotationQueueProgressCell.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/annotation-queues/AnnotationQueueProgressCell.tsx
@@ -1,17 +1,13 @@
 import { CellContext } from "@tanstack/react-table";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card";
 import CellWrapper from "@/components/shared/DataTableCells/CellWrapper";
 import { AnnotationQueue } from "@/types/annotation-queues";
+import AnnotationQueueProgress from "@/components/pages-shared/annotation-queues/AnnotationQueueProgress";
 
 const AnnotationQueueProgressCell = (
   context: CellContext<AnnotationQueue, unknown>,
 ) => {
   const queue = context.row.original;
-  const { items_count: itemsCount, reviewers } = queue;
+  const { reviewers } = queue;
 
   if (!reviewers || reviewers.length === 0) {
     return (
@@ -26,50 +22,20 @@ const AnnotationQueueProgressCell = (
     );
   }
 
-  const averageProgress =
-    reviewers.reduce((sum, reviewer) => sum + reviewer.status, 0) /
-    reviewers.length;
-  const progressPercentage =
-    itemsCount > 0 ? Math.round((averageProgress / itemsCount) * 100) : 0;
-
   return (
     <CellWrapper
       metadata={context.column.columnDef.meta}
       tableMetadata={context.table.options.meta}
     >
-      <HoverCard>
-        <HoverCardTrigger asChild>
+      <AnnotationQueueProgress annotationQueue={queue}>
+        {({ averageProgress, progressPercentage, itemsCount }) => (
           <div className="flex size-full cursor-pointer items-center overflow-hidden py-0.5">
             <span className="comet-body-s">
-              {Math.round(averageProgress)}/{itemsCount} ({progressPercentage}%)
+              {averageProgress}/{itemsCount} ({progressPercentage}%)
             </span>
           </div>
-        </HoverCardTrigger>
-        <HoverCardContent className="w-64">
-          <div className="space-y-2">
-            <h4 className="comet-title-xs">Progress by Reviewer</h4>
-            <div className="space-y-1">
-              {reviewers.map((reviewer) => {
-                const reviewerProgress =
-                  itemsCount > 0
-                    ? Math.round((reviewer.status / itemsCount) * 100)
-                    : 0;
-                return (
-                  <div
-                    key={reviewer.username}
-                    className="flex items-center justify-between"
-                  >
-                    <span className="comet-body-s">{reviewer.username}</span>
-                    <span className="comet-body-s text-muted-foreground">
-                      {reviewer.status}/{itemsCount} ({reviewerProgress}%)
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        </HoverCardContent>
-      </HoverCard>
+        )}
+      </AnnotationQueueProgress>
     </CellWrapper>
   );
 };

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
@@ -21,6 +21,8 @@ import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer
 import CopySMELinkButton from "@/components/pages/AnnotationQueuePage/CopySMELinkButton";
 import OpenSMELinkButton from "@/components/pages/AnnotationQueuePage/OpenSMELinkButton";
 import EditAnnotationQueueButton from "@/components/pages/AnnotationQueuePage/EditAnnotationQueueButton";
+import ExportAnnotatedDataButton from "@/components/pages/AnnotationQueuePage/ExportAnnotatedDataButton";
+import AnnotationQueueProgressTag from "@/components/pages/AnnotationQueuePage/AnnotationQueueProgressTag";
 
 const AnnotationQueuePage: React.FunctionComponent = () => {
   const [tab = "items", setTab] = useQueryParam("tab", StringParam);
@@ -70,6 +72,7 @@ const AnnotationQueuePage: React.FunctionComponent = () => {
           <div className="flex items-center gap-2">
             <CopySMELinkButton annotationQueue={annotationQueue} />
             <EditAnnotationQueueButton annotationQueue={annotationQueue} />
+            <ExportAnnotatedDataButton annotationQueue={annotationQueue} />
             <OpenSMELinkButton annotationQueue={annotationQueue} />
           </div>
         )}
@@ -105,6 +108,9 @@ const AnnotationQueuePage: React.FunctionComponent = () => {
               resource={RESOURCE_TYPE.project}
               asTag
             />
+          )}
+          {annotationQueue && (
+            <AnnotationQueueProgressTag annotationQueue={annotationQueue} />
           )}
         </div>
         <div className="flex h-11 items-center gap-2">

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/AnnotationQueueProgressTag.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/AnnotationQueueProgressTag.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Tag } from "@/components/ui/tag";
+import { AnnotationQueue } from "@/types/annotation-queues";
+import AnnotationQueueProgress from "@/components/pages-shared/annotation-queues/AnnotationQueueProgress";
+
+interface AnnotationQueueProgressTagProps {
+  annotationQueue: AnnotationQueue;
+}
+
+const AnnotationQueueProgressTag: React.FunctionComponent<
+  AnnotationQueueProgressTagProps
+> = ({ annotationQueue }) => {
+  return (
+    <AnnotationQueueProgress annotationQueue={annotationQueue}>
+      {({ averageProgress, progressPercentage, itemsCount }) => (
+        <Tag variant="gray" size="md" className="cursor-pointer">
+          Progress: {averageProgress}/{itemsCount} ({progressPercentage}%)
+        </Tag>
+      )}
+    </AnnotationQueueProgress>
+  );
+};
+
+export default AnnotationQueueProgressTag;

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/CopySMELinkButton.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/CopySMELinkButton.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { Copy } from "lucide-react";
 import { generateSMEURL } from "@/lib/annotation-queues";
 import useAppStore from "@/store/AppStore";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 
 interface CopySMELinkButtonProps {
   annotationQueue: AnnotationQueue;
@@ -27,10 +28,12 @@ const CopySMELinkButton: React.FC<CopySMELinkButtonProps> = ({
   }, [annotationQueue.id, toast, workspaceName]);
 
   return (
-    <Button size="sm" variant="outline" onClick={handleCopySMELink}>
-      <Copy className="mr-1.5 size-3.5" />
-      Share
-    </Button>
+    <TooltipWrapper content="Share annotation queue link">
+      <Button size="sm" variant="outline" onClick={handleCopySMELink}>
+        <Copy className="mr-1.5 size-3.5" />
+        Share
+      </Button>
+    </TooltipWrapper>
   );
 };
 

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/EditAnnotationQueueButton.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/EditAnnotationQueueButton.tsx
@@ -3,6 +3,7 @@ import { AnnotationQueue } from "@/types/annotation-queues";
 import AddEditAnnotationQueueDialog from "@/components/pages-shared/annotation-queues/AddEditAnnotationQueueDialog";
 import { Button } from "@/components/ui/button";
 import { Pencil } from "lucide-react";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 
 interface EditAnnotationQueueButtonProps {
   annotationQueue: AnnotationQueue;
@@ -29,10 +30,12 @@ const EditAnnotationQueueButton: React.FunctionComponent<
         projectId={annotationQueue.project_id}
         scope={annotationQueue.scope}
       />
-      <Button size="sm" variant="outline" onClick={handleOpenEditDialog}>
-        <Pencil className="mr-1.5 size-3.5" />
-        Edit
-      </Button>
+      <TooltipWrapper content="Edit annotation queue">
+        <Button size="sm" variant="outline" onClick={handleOpenEditDialog}>
+          <Pencil className="mr-1.5 size-3.5" />
+          Edit
+        </Button>
+      </TooltipWrapper>
     </>
   );
 };

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
@@ -1,0 +1,301 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { Download } from "lucide-react";
+import { saveAs } from "file-saver";
+import { json2csv } from "json-2-csv";
+import isObject from "lodash/isObject";
+import isEmpty from "lodash/isEmpty";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { createFilter } from "@/lib/filters";
+import useTracesList from "@/api/traces/useTracesList";
+import useThreadsList from "@/api/traces/useThreadsList";
+import { keepPreviousData } from "@tanstack/react-query";
+import {
+  ANNOTATION_QUEUE_SCOPE,
+  AnnotationQueue,
+} from "@/types/annotation-queues";
+import { Trace, Thread } from "@/types/traces";
+import {
+  getFeedbackScoresByUser,
+  getCommentsByUser,
+} from "@/lib/annotation-queues";
+import { prettifyMessage } from "@/lib/traces";
+import { JsonNode } from "@/types/shared";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
+
+const MAX_EXPORT_ITEMS = 15000;
+const MESSAGES_KEYS = ["input", "output", "first_message", "last_message"];
+
+type ExportAnnotatedDataButtonProps = {
+  annotationQueue: AnnotationQueue;
+  disabled?: boolean;
+};
+
+interface ReviewerData {
+  comment?: string;
+  [key: string]: string | number | undefined;
+}
+
+interface ExportTraceData {
+  id: string;
+  input: JsonNode;
+  output: JsonNode;
+  metadata: object;
+  [reviewerName: string]: unknown;
+}
+
+interface ExportThreadData {
+  id: string;
+  first_message: JsonNode;
+  last_message: JsonNode;
+  [reviewerName: string]: unknown;
+}
+
+const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
+  annotationQueue,
+  disabled = false,
+}) => {
+  const [open, setOpen] = useState(false);
+
+  const reviewers = useMemo(
+    () => annotationQueue.reviewers?.map((r) => r.username) ?? [],
+    [annotationQueue.reviewers],
+  );
+
+  const feedbackDefinitionNames = useMemo(
+    () => annotationQueue.feedback_definition_names ?? [],
+    [annotationQueue.feedback_definition_names],
+  );
+
+  const annotationQueueFilter = useMemo(() => {
+    if (!annotationQueue?.id) return [];
+    return [
+      createFilter({
+        field: "annotation_queue_ids",
+        value: annotationQueue.id,
+        operator: "contains",
+      }),
+    ];
+  }, [annotationQueue?.id]);
+
+  const { data: tracesData, isLoading: isTracesLoading } = useTracesList(
+    {
+      projectId: annotationQueue.project_id,
+      page: 1,
+      size: MAX_EXPORT_ITEMS,
+      sorting: [],
+      filters: annotationQueueFilter,
+      search: "",
+      truncate: false,
+    },
+    {
+      enabled:
+        annotationQueue.scope === ANNOTATION_QUEUE_SCOPE.TRACE &&
+        !!annotationQueue.project_id,
+      placeholderData: keepPreviousData,
+    },
+  );
+
+  const { data: threadsData, isLoading: isThreadsLoading } = useThreadsList(
+    {
+      projectId: annotationQueue.project_id,
+      page: 1,
+      size: MAX_EXPORT_ITEMS,
+      sorting: [],
+      filters: annotationQueueFilter,
+      search: "",
+    },
+    {
+      enabled:
+        annotationQueue.scope === ANNOTATION_QUEUE_SCOPE.THREAD &&
+        !!annotationQueue.project_id,
+      placeholderData: keepPreviousData,
+    },
+  );
+
+  const isLoading = isTracesLoading || isThreadsLoading;
+
+  const getTracesExportData = useCallback((): ExportTraceData[] => {
+    if (!tracesData?.content) return [];
+
+    return tracesData.content.map((trace: Trace) => {
+      const baseData: ExportTraceData = {
+        id: trace.id,
+        input: prettifyMessage(trace.input, { type: "input" })
+          .message as JsonNode,
+        output: prettifyMessage(trace.output, { type: "output" })
+          .message as JsonNode,
+        metadata: trace.metadata ?? {},
+      };
+
+      reviewers.forEach((reviewerName) => {
+        const reviewerData: ReviewerData = {};
+
+        const comments = getCommentsByUser(trace.comments, reviewerName);
+        if (comments.length > 0) {
+          reviewerData.comment = comments.join("; ");
+        }
+
+        const feedbackScores = getFeedbackScoresByUser(
+          trace.feedback_scores ?? [],
+          reviewerName,
+          feedbackDefinitionNames,
+        );
+
+        feedbackScores.forEach((score) => {
+          reviewerData[score.name] = score.value;
+          if (score.reason) {
+            reviewerData[`${score.name}.reason`] = score.reason;
+          }
+        });
+
+        baseData[reviewerName] = reviewerData;
+      });
+
+      return baseData;
+    });
+  }, [tracesData, reviewers, feedbackDefinitionNames]);
+
+  const getThreadsExportData = useCallback((): ExportThreadData[] => {
+    if (!threadsData?.content) return [];
+
+    return threadsData.content.map((thread: Thread) => {
+      const baseData: ExportThreadData = {
+        id: thread.id,
+        first_message: prettifyMessage(thread.first_message, { type: "input" })
+          .message as JsonNode,
+        last_message: prettifyMessage(thread.last_message, { type: "output" })
+          .message as JsonNode,
+      };
+
+      reviewers.forEach((reviewerName) => {
+        const reviewerData: ReviewerData = {};
+
+        const comments = getCommentsByUser(thread.comments, reviewerName);
+        if (comments.length > 0) {
+          reviewerData.comment = comments.join("; ");
+        }
+
+        const feedbackScores = getFeedbackScoresByUser(
+          thread.feedback_scores ?? [],
+          reviewerName,
+          feedbackDefinitionNames,
+        );
+
+        feedbackScores.forEach((score) => {
+          reviewerData[score.name] = score.value;
+          if (score.reason) {
+            reviewerData[`${score.name}.reason`] = score.reason;
+          }
+        });
+
+        if (!isEmpty(reviewerData)) {
+          baseData[reviewerName] = reviewerData;
+        }
+      });
+
+      return baseData;
+    });
+  }, [threadsData, reviewers, feedbackDefinitionNames]);
+
+  const getData = useCallback(() => {
+    if (annotationQueue.scope === ANNOTATION_QUEUE_SCOPE.TRACE) {
+      return getTracesExportData() as unknown as Record<string, unknown>[];
+    }
+    return getThreadsExportData() as unknown as Record<string, unknown>[];
+  }, [annotationQueue.scope, getTracesExportData, getThreadsExportData]);
+
+  const generateFileName = useCallback(
+    (extension: string) => {
+      const scope = annotationQueue.scope.toLowerCase();
+      return `annotated-${scope}-${annotationQueue.name}.${extension}`;
+    },
+    [annotationQueue.name, annotationQueue.scope],
+  );
+
+  const exportCSVHandler = useCallback(() => {
+    const data = getData();
+    if (data.length === 0) {
+      return;
+    }
+
+    const processedData = data.map((row) => {
+      return {
+        ...row,
+        ...MESSAGES_KEYS.reduce(
+          (acc, key) => {
+            if (isObject(row[key])) {
+              acc[key] = JSON.stringify(row[key], null, 2);
+            }
+            return acc;
+          },
+          {} as Record<string, unknown>,
+        ),
+      };
+    });
+
+    const blob = new Blob(
+      [
+        json2csv(processedData, {
+          arrayIndexesAsKeys: true,
+          escapeHeaderNestedDots: false,
+        }),
+      ],
+      {
+        type: "text/csv;charset=utf-8",
+      },
+    );
+    saveAs(blob, generateFileName("csv"));
+    setOpen(false);
+  }, [getData, generateFileName]);
+
+  const exportJSONHandler = useCallback(() => {
+    const data = getData();
+    if (data.length === 0) {
+      return;
+    }
+
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: "application/json;charset=utf-8;",
+    });
+    saveAs(blob, generateFileName("json"));
+    setOpen(false);
+  }, [getData, generateFileName]);
+
+  const hasData =
+    (tracesData?.content?.length ?? 0) > 0 ||
+    (threadsData?.content?.length ?? 0) > 0;
+
+  return (
+    <TooltipWrapper content="Export annotated data">
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={
+              disabled || isLoading || !hasData || reviewers.length === 0
+            }
+          >
+            <Download className="mr-1.5 size-3.5" />
+            Export
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-52">
+          <DropdownMenuItem onClick={exportCSVHandler}>As CSV</DropdownMenuItem>
+          <DropdownMenuItem onClick={exportJSONHandler}>
+            As JSON
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </TooltipWrapper>
+  );
+};
+
+export default ExportAnnotatedDataButton;

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
@@ -155,7 +155,9 @@ const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
           }
         });
 
-        baseData[reviewerName] = reviewerData;
+        if (!isEmpty(reviewerData)) {
+          baseData[reviewerName] = reviewerData;
+        }
       });
 
       return baseData;
@@ -206,9 +208,9 @@ const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
 
   const getData = useCallback(() => {
     if (annotationQueue.scope === ANNOTATION_QUEUE_SCOPE.TRACE) {
-      return getTracesExportData() as unknown as Record<string, unknown>[];
+      return getTracesExportData();
     }
-    return getThreadsExportData() as unknown as Record<string, unknown>[];
+    return getThreadsExportData();
   }, [annotationQueue.scope, getTracesExportData, getThreadsExportData]);
 
   const generateFileName = useCallback(

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/OpenSMELinkButton.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/OpenSMELinkButton.tsx
@@ -5,6 +5,7 @@ import { Link } from "@tanstack/react-router";
 import { AnnotationQueue } from "@/types/annotation-queues";
 import { Button } from "@/components/ui/button";
 import useAppStore from "@/store/AppStore";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 
 interface OpenSMELinkButtonProps {
   annotationQueue: AnnotationQueue;
@@ -16,19 +17,21 @@ const OpenSMELinkButton: React.FunctionComponent<OpenSMELinkButtonProps> = ({
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
 
   return (
-    <Link
-      to="/$workspaceName/sme"
-      params={{ workspaceName }}
-      search={{
-        queueId: annotationQueue.id,
-      }}
-      target="_blank"
-    >
-      <Button size="sm">
-        <SquareArrowOutUpRight className="mr-1.5 size-3.5" />
-        Annotate
-      </Button>
-    </Link>
+    <TooltipWrapper content="Start annotating">
+      <Link
+        to="/$workspaceName/sme"
+        params={{ workspaceName }}
+        search={{
+          queueId: annotationQueue.id,
+        }}
+        target="_blank"
+      >
+        <Button size="sm">
+          <SquareArrowOutUpRight className="mr-1.5 size-3.5" />
+          Annotate
+        </Button>
+      </Link>
+    </TooltipWrapper>
   );
 };
 

--- a/apps/opik-frontend/src/lib/annotation-queues.ts
+++ b/apps/opik-frontend/src/lib/annotation-queues.ts
@@ -1,6 +1,10 @@
-import { Thread, Trace } from "@/types/traces";
+import { Thread, Trace, TraceFeedbackScore } from "@/types/traces";
 import get from "lodash/get";
+import isNumber from "lodash/isNumber";
+import omit from "lodash/omit";
 import { isObjectThread } from "@/lib/traces";
+import { CommentItem, CommentItems } from "@/types/comment";
+import { hasValuesByAuthor } from "@/lib/feedback-scores";
 
 export const generateSMEURL = (workspace: string, id: string): string => {
   const basePath = import.meta.env.VITE_BASE_URL || "/";
@@ -30,3 +34,79 @@ export const generateTracesURL = (
 
 export const getAnnotationQueueItemId = (item: Trace | Thread) =>
   isObjectThread(item) ? get(item, "thread_model_id", "") : get(item, "id", "");
+
+export const getFeedbackScoresByUser = (
+  feedbackScores: TraceFeedbackScore[],
+  userName: string | undefined,
+  feedbackDefinitionNames: string[],
+): TraceFeedbackScore[] => {
+  if (!userName) return [];
+
+  return feedbackScores
+    .filter(
+      (feedbackScore) =>
+        feedbackScore && feedbackDefinitionNames.includes(feedbackScore.name),
+    )
+    .map((feedbackScore): TraceFeedbackScore | undefined => {
+      if (!userName) return feedbackScore;
+
+      if (hasValuesByAuthor(feedbackScore)) {
+        const userValue = feedbackScore.value_by_author?.[userName];
+        if (userValue) {
+          const rawValue = userValue.value;
+          return {
+            name: feedbackScore.name,
+            value: isNumber(rawValue) ? rawValue : 0,
+            reason: userValue.reason ?? "",
+            category_name: userValue.category_name ?? "",
+            source: userValue.source,
+            created_by: userName,
+            last_updated_at: userValue.last_updated_at,
+            last_updated_by: userName,
+          };
+        }
+      } else if (userName === feedbackScore.last_updated_by) {
+        return omit(feedbackScore, "value_by_author");
+      }
+    })
+    .filter((score): score is TraceFeedbackScore => score !== undefined);
+};
+
+export const getLastCommentByUser = (
+  comments: CommentItems | undefined,
+  userName: string | undefined,
+): CommentItem | undefined => {
+  if (!comments || !userName) return undefined;
+
+  const userComments = comments.filter(
+    (comment) => comment.created_by === userName,
+  );
+  if (userComments.length === 0) return undefined;
+
+  return userComments.reduce((latest, current) =>
+    new Date(current.created_at) > new Date(latest.created_at)
+      ? current
+      : latest,
+  );
+};
+
+export const getCommentsByUser = (
+  comments: CommentItems | undefined,
+  userName: string | undefined,
+): string[] => {
+  if (!comments || !userName) return [];
+
+  return comments
+    .filter((comment) => comment.created_by === userName)
+    .map((comment) => comment.text);
+};
+
+export const formatFeedbackScoresForExport = (
+  feedbackScores: TraceFeedbackScore[],
+): Array<{ name: string; value: number; reason?: string }> => {
+  return feedbackScores.map((score) => ({
+    name: score.name,
+    value: score.value,
+    reason: score.reason,
+  }));
+};

--- a/apps/opik-frontend/src/lib/annotation-queues.ts
+++ b/apps/opik-frontend/src/lib/annotation-queues.ts
@@ -48,8 +48,6 @@ export const getFeedbackScoresByUser = (
         feedbackScore && feedbackDefinitionNames.includes(feedbackScore.name),
     )
     .map((feedbackScore): TraceFeedbackScore | undefined => {
-      if (!userName) return feedbackScore;
-
       if (hasValuesByAuthor(feedbackScore)) {
         const userValue = feedbackScore.value_by_author?.[userName];
         if (userValue) {


### PR DESCRIPTION
## Details

This PR adds a comprehensive export functionality for annotated data in annotation queues, allowing users to export traces and threads with reviewer-specific annotations to CSV or JSON formats.

### Key Features Implemented:

1. **Export Annotated Data Button**
   - New dropdown button with "Export as CSV" and "Export as JSON" options
   - Disabled when no reviewers are assigned to the queue
   - Added tooltip: "Export annotated data"

2. **Per-Reviewer Data Export**
   - CSV format: Creates columns per reviewer (`[reviewer_name].comment`, `[reviewer_name].[feedback_score_name]`, `[reviewer_name].[feedback_score_name].reason`)
   - JSON format: Creates nested objects per reviewer with comments and feedback scores
   - Handles multiple reviewers and their individual annotations

3. **CSV Export Enhancements**
   - Integrates `json2csv` library for robust CSV generation
   - Prettifies message fields (`input`, `output`, `first_message`, `last_message`) for better readability
   - Replaces `undefined` and `null` values with empty strings
   - Proper handling of nested reviewer data

4. **Code Refactoring & Reusability**
   - Extracted common annotation queue logic into `lib/annotation-queues.ts`:
     - `getFeedbackScoresByUser()` - Filters feedback scores by user with multi-author support
     - `getCommentsByUser()` - Retrieves all comments by a specific user
     - `getLastCommentByUser()` - Gets the most recent comment by a user
   - Refactored `SMEFlowContext` to use shared utilities
   - Created reusable `AnnotationQueueProgress` component using render props pattern
   - Refactored `AnnotationQueueProgressCell` to use shared component

5. **UI Improvements**
   - Added tooltips to all action buttons (Share, Edit, Export, Annotate)
   - Added progress tag to AnnotationQueuePage with hover card showing per-reviewer progress
   - Consistent UI patterns across annotation queue components

### Technical Implementation:

- Uses React Query for data fetching with proper loading states
- Filters data based on annotation queue ID only (consistent with SME page)
- Supports up to 15,000 items per export
- Proper TypeScript typing for export data structures
- Memory-efficient processing with streaming where applicable

<img width="1929" height="932" alt="image" src="https://github.com/user-attachments/assets/cae16297-7f82-4779-bd32-cbf8214fc0b1" />

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves #<!-- GitHub issue if applicable -->
- OPIK-2584
- NA

## Testing

### Manual Testing:
1. Navigate to an annotation queue page with reviewers assigned
2. Click the "Export" button to see CSV and JSON options
3. Export as CSV - verify per-reviewer columns are created correctly
4. Export as JSON - verify nested reviewer structure
5. Verify tooltips appear on all action buttons
6. Verify progress tag displays correctly with hover card
7. Verify export button is disabled when no reviewers are assigned

### Automated Testing:
- TypeScript compilation passes (`npx tsc --noEmit`)
- Linting passes (`npm run lint`)
- All existing tests remain passing

## Documentation
- Updated component structure in `pages/AnnotationQueuePage`
- Created new shared utilities in `lib/annotation-queues.ts`
- Created reusable `AnnotationQueueProgress` component in `pages-shared/annotation-queues`