### PR TITLE
[NA] Revert "[SDK] Disable flaky test update span attachments"

### DIFF
--- a/sdks/python/tests/e2e/test_tracing.py
+++ b/sdks/python/tests/e2e/test_tracing.py
@@ -1134,7 +1134,6 @@ def test_tracked_function__update_current_span__with_attachments(
     )
 
 
-@pytest.mark.skip(reason="Flaky test - disabled temporarily")
 def test_opik_client__update_span_with_attachments__original_fields_preserved_but_some_are_patched(
     opik_client: opik.Opik, attachment_data_file
 ):


### PR DESCRIPTION
## Details section.
Restores SDK E2E tests disabled in comet-ml/opik#3516, as tests are not flaky after https://github.com/comet-ml/opik/pull/3502

## Change checklist


## Issues


## Testing 


## Documentation

