### PR TITLE
[NA] [BE] Reduce cost of thread exists check from close threads endpoint

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -104,6 +104,8 @@ public interface TraceService {
     Mono<Long> countTraces(Set<UUID> projectIds);
 
     Flux<TraceThread> threadsSearch(int limit, @NonNull TraceSearchCriteria criteria);
+
+    Mono<List<TraceThread>> getMinimalThreadInfoByIds(UUID projectId, Set<String> threadId);
 }
 
 @Slf4j
@@ -546,6 +548,12 @@ class TraceServiceImpl implements TraceService {
     public Flux<TraceThread> threadsSearch(int limit, @NonNull TraceSearchCriteria criteria) {
         return findProjectAndVerifyVisibility(criteria)
                 .flatMapMany(it -> dao.threadsSearch(limit, it));
+    }
+
+    @Override
+    public Mono<List<TraceThread>> getMinimalThreadInfoByIds(@NonNull UUID projectId, @NonNull Set<String> threadId) {
+        return dao.getMinimalThreadInfoByIds(projectId, threadId)
+                .switchIfEmpty(Mono.just(List.of()));
     }
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
@@ -77,7 +77,6 @@ public interface TraceThreadService {
 class TraceThreadServiceImpl implements TraceThreadService {
 
     private static final Duration LOCK_DURATION = Duration.ofSeconds(5);
-    private static final int BATCH_THREAD_PROCESSING_CONCURRENCY = 5;
 
     private final @NonNull TraceThreadDAO traceThreadDAO;
     private final @NonNull TraceThreadIdService traceThreadIdService;
@@ -397,26 +396,50 @@ class TraceThreadServiceImpl implements TraceThreadService {
             return Mono.empty();
         }
 
-        return Flux.fromIterable(threadIds)
-                .flatMap(threadId -> verifyAndCreateThreadIfNeed(projectId, threadId),
-                        Math.min(threadIds.size(), BATCH_THREAD_PROCESSING_CONCURRENCY)) // Limit the concurrency to BATCH_THREAD_PROCESSING_CONCURRENCY
-                .then();
+        return verifyAndCreateThreadIfNeed(projectId, threadIds);
     }
 
-    private Mono<UUID> verifyAndCreateThreadIfNeed(UUID projectId, String threadId) {
-        return traceService.getThreadById(projectId, threadId)
-                .switchIfEmpty(Mono.error(new NotFoundException("Thread '%s' not found:".formatted(threadId))))
+    private Mono<Void> verifyAndCreateThreadIfNeed(UUID projectId, Set<String> threadIds) {
+        return traceService.getMinimalThreadInfoByIds(projectId, threadIds)
+                .flatMap(existingThreads -> validateIfAllThreadsExist(threadIds, existingThreads))
+                .flatMapMany(Flux::fromIterable)
                 // If the trace thread exists on the trace table, let's check if it has a trace thread model id
-                .flatMap(traceThread -> getOrCreateThreadId(projectId, threadId)
-                        .map(threadModelId -> traceThread.toBuilder().threadModelId(threadModelId).build()))
+                .flatMap(traceThread -> {
+                    if (traceThread.threadModelId() != null) {
+                        return Mono.just(traceThread);
+                    }
+                    // If it does not have a trace thread model id, create a new one
+                    return getOrCreateThreadId(projectId, traceThread.id())
+                            .map(id -> traceThread.toBuilder().threadModelId(id).build());
+                })
                 // If it has a trace thread model id, check if the trace thread entity exists in the database
                 .flatMap(traceThread -> traceThreadDAO.findByThreadModelId(traceThread.threadModelId(), projectId)
                         .map(TraceThreadModel::id)
                         //If it does not exist, create a new one
                         .switchIfEmpty(Mono.deferContextual(ctx -> {
                             String userName = ctx.get(RequestContext.USER_NAME);
-                            return createTraceThread(projectId, threadId, traceThread, userName);
-                        })));
+                            return createTraceThread(projectId, traceThread.id(), traceThread, userName);
+                        })))
+                .then();
+    }
+
+    private Mono<List<TraceThread>> validateIfAllThreadsExist(Set<String> threadIds,
+            List<TraceThread> existingThreads) {
+        Set<String> existingThreadIdIds = existingThreads.stream()
+                .map(TraceThread::id)
+                .collect(Collectors.toSet());
+
+        // Find threadIds that do not exist in the trace table
+        Set<String> missingThreadIds = threadIds.stream()
+                .filter(threadId -> !existingThreadIdIds.contains(threadId))
+                .collect(Collectors.toSet());
+
+        if (!missingThreadIds.isEmpty()) {
+            return Mono.error(new NotFoundException("Thread '%s' not found:".formatted(missingThreadIds)));
+        }
+
+        // If all threadIds exist, return any of them to continue the flow
+        return Mono.just(existingThreads);
     }
 
     private Mono<UUID> createTraceThread(UUID projectId, String threadId, TraceThread traceThread, String userName) {


### PR DESCRIPTION
## Details

To reduce the cost of thread existence checks from the close threads endpoint, we've created a new query that returns the minimal data needed to check it and makes it if necessary. This should reduce the overhead caused by the current query.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- NA

## Testing
Current tests should validate the functionality.

## Documentation
NA