### PR TITLE
[OPIK-2598] [BE][FE] Add search, filtering, and sorting to online evaluation page

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/evaluators/AutomationRuleEvaluator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/evaluators/AutomationRuleEvaluator.java
@@ -115,12 +115,13 @@ public abstract sealed class AutomationRuleEvaluator<T> implements AutomationRul
                     View.Public.class}) int page,
             @JsonView({View.Public.class}) int size,
             @JsonView({View.Public.class}) long total,
-            @JsonView({View.Public.class}) List<AutomationRuleEvaluator<?>> content)
+            @JsonView({View.Public.class}) List<AutomationRuleEvaluator<?>> content,
+            @JsonView({View.Public.class}) List<String> sortableBy)
             implements
                 Page<AutomationRuleEvaluator<?>>{
 
-        public static AutomationRuleEvaluatorPage empty(int page) {
-            return new AutomationRuleEvaluatorPage(page, 0, 0, List.of());
+        public static AutomationRuleEvaluatorPage empty(int page, List<String> sortableBy) {
+            return new AutomationRuleEvaluatorPage(page, 0, 0, List.of(), sortableBy);
         }
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/filter/AutomationRuleEvaluatorField.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/filter/AutomationRuleEvaluatorField.java
@@ -1,0 +1,22 @@
+package com.comet.opik.api.filter;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum AutomationRuleEvaluatorField implements Field {
+    ID(ID_QUERY_PARAM, FieldType.STRING_STATE_DB),
+    NAME(NAME_QUERY_PARAM, FieldType.STRING_STATE_DB),
+    TYPE(TYPE_QUERY_PARAM, FieldType.ENUM),
+    ENABLED(ENABLED_QUERY_PARAM, FieldType.STRING_STATE_DB),
+    SAMPLING_RATE(SAMPLING_RATE_QUERY_PARAM, FieldType.NUMBER),
+    PROJECT_ID(PROJECT_ID_QUERY_PARAM, FieldType.STRING_STATE_DB),
+    CREATED_AT(CREATED_AT_QUERY_PARAM, FieldType.DATE_TIME_STATE_DB),
+    LAST_UPDATED_AT(LAST_UPDATED_AT_QUERY_PARAM, FieldType.DATE_TIME_STATE_DB),
+    CREATED_BY(CREATED_BY_QUERY_PARAM, FieldType.STRING_STATE_DB),
+    LAST_UPDATED_BY(LAST_UPDATED_BY_QUERY_PARAM, FieldType.STRING_STATE_DB);
+
+    private final String queryParamField;
+    private final FieldType type;
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/filter/AutomationRuleEvaluatorFilter.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/filter/AutomationRuleEvaluatorFilter.java
@@ -1,0 +1,29 @@
+package com.comet.opik.api.filter;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@SuperBuilder(toBuilder = true)
+public class AutomationRuleEvaluatorFilter extends FilterImpl {
+
+    public static final TypeReference<List<AutomationRuleEvaluatorFilter>> LIST_TYPE_REFERENCE = new TypeReference<>() {
+    };
+
+    @JsonCreator
+    public AutomationRuleEvaluatorFilter(
+            @JsonProperty(value = "field", required = true) AutomationRuleEvaluatorField field,
+            @JsonProperty(value = "operator", required = true) Operator operator,
+            @JsonProperty("key") String key,
+            @JsonProperty(value = "value", required = true) String value) {
+        super(field, operator, key, value);
+    }
+
+    @Override
+    public Filter build(String decodedValue) {
+        return toBuilder().value(decodedValue).build();
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/filter/Field.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/filter/Field.java
@@ -51,6 +51,9 @@ public interface Field {
     String ANNOTATION_QUEUE_IDS_QUERY_PARAM = "annotation_queue_ids";
     String WEBHOOK_URL_QUERY_PARAM = "webhook_url";
     String WEBHOOK_SECRET_TOKEN_QUERY_PARAM = "webhook_secret_token";
+    String ENABLED_QUERY_PARAM = "enabled";
+    String SAMPLING_RATE_QUERY_PARAM = "sampling_rate";
+    String PROJECT_ID_QUERY_PARAM = "project_id";
 
     @JsonValue
     String getQueryParamField();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResource.java
@@ -6,7 +6,12 @@ import com.comet.opik.api.LogCriteria;
 import com.comet.opik.api.Page;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluator;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorUpdate;
+import com.comet.opik.api.filter.AutomationRuleEvaluatorFilter;
+import com.comet.opik.api.filter.FiltersFactory;
+import com.comet.opik.api.sorting.AutomationRuleEvaluatorSortingFactory;
+import com.comet.opik.api.sorting.SortingField;
 import com.comet.opik.domain.evaluators.AutomationRuleEvaluatorService;
+import com.comet.opik.domain.sorting.SortingQueryBuilder;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.ratelimit.RateLimited;
 import com.fasterxml.jackson.annotation.JsonView;
@@ -40,6 +45,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.URI;
+import java.util.List;
 import java.util.UUID;
 
 import static com.comet.opik.api.LogItem.LogPage;
@@ -58,6 +64,9 @@ public class AutomationRuleEvaluatorsResource {
 
     private final @NonNull AutomationRuleEvaluatorService service;
     private final @NonNull Provider<RequestContext> requestContext;
+    private final @NonNull FiltersFactory filtersFactory;
+    private final @NonNull AutomationRuleEvaluatorSortingFactory sortingFactory;
+    private final @NonNull SortingQueryBuilder sortingQueryBuilder;
 
     @GET
     @Operation(operationId = "findEvaluators", summary = "Find project Evaluators", description = "Find project Evaluators", responses = {
@@ -66,13 +75,22 @@ public class AutomationRuleEvaluatorsResource {
     @JsonView(View.Public.class)
     public Response find(@QueryParam("project_id") UUID projectId,
             @QueryParam("name") String name,
+            @QueryParam("filters") String filters,
+            @QueryParam("sorting") String sorting,
             @QueryParam("page") @Min(1) @DefaultValue("1") int page,
             @QueryParam("size") @Min(1) @DefaultValue("10") int size) {
 
         String workspaceId = requestContext.get().getWorkspaceId();
         log.info("Looking for automated evaluators for project id '{}' on workspaceId '{}' (page {})", projectId,
                 workspaceId, page);
-        Page<AutomationRuleEvaluator<?>> evaluatorPage = service.find(projectId, workspaceId, name, page, size);
+
+        var queryFilters = filtersFactory.newFilters(filters, AutomationRuleEvaluatorFilter.LIST_TYPE_REFERENCE);
+        List<SortingField> sortingFields = sortingFactory.newSorting(sorting);
+        String sortingFieldsSql = sortingQueryBuilder.toOrderBySql(sortingFields, sortingFactory.getFieldMapping());
+        List<String> sortableBy = sortingFactory.getSortableFields();
+
+        Page<AutomationRuleEvaluator<?>> evaluatorPage = service.find(projectId, workspaceId, name, queryFilters,
+                sortingFieldsSql, sortableBy, page, size);
         log.info("Found {} automated evaluators for project id '{}' on workspaceId '{}' (page {}, total {})",
                 evaluatorPage.size(), projectId, workspaceId, page, evaluatorPage.total());
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/AutomationRuleEvaluatorSortingFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/AutomationRuleEvaluatorSortingFactory.java
@@ -1,0 +1,54 @@
+package com.comet.opik.api.sorting;
+
+import com.google.common.collect.ImmutableMap;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.comet.opik.api.sorting.SortableFields.CREATED_AT;
+import static com.comet.opik.api.sorting.SortableFields.CREATED_BY;
+import static com.comet.opik.api.sorting.SortableFields.ENABLED;
+import static com.comet.opik.api.sorting.SortableFields.ID;
+import static com.comet.opik.api.sorting.SortableFields.LAST_UPDATED_AT;
+import static com.comet.opik.api.sorting.SortableFields.LAST_UPDATED_BY;
+import static com.comet.opik.api.sorting.SortableFields.NAME;
+import static com.comet.opik.api.sorting.SortableFields.PROJECT_ID;
+import static com.comet.opik.api.sorting.SortableFields.SAMPLING_RATE;
+import static com.comet.opik.api.sorting.SortableFields.TYPE;
+
+@Singleton
+public class AutomationRuleEvaluatorSortingFactory extends SortingFactory {
+
+    private static final Map<String, String> FIELD_TO_DB_COLUMN_MAP = ImmutableMap.<String, String>builder()
+            .put(ID, "rule.id")
+            .put(NAME, "rule.name")
+            .put(TYPE, "evaluator.type")
+            .put(ENABLED, "rule.enabled")
+            .put(SAMPLING_RATE, "rule.sampling_rate")
+            .put(PROJECT_ID, "rule.project_id")
+            .put(CREATED_AT, "evaluator.created_at")
+            .put(LAST_UPDATED_AT, "evaluator.last_updated_at")
+            .put(CREATED_BY, "evaluator.created_by")
+            .put(LAST_UPDATED_BY, "evaluator.last_updated_by")
+            .build();
+
+    @Override
+    public List<String> getSortableFields() {
+        return List.of(
+                ID,
+                NAME,
+                TYPE,
+                ENABLED,
+                SAMPLING_RATE,
+                PROJECT_ID,
+                CREATED_AT,
+                LAST_UPDATED_AT,
+                CREATED_BY,
+                LAST_UPDATED_BY);
+    }
+
+    public Map<String, String> getFieldMapping() {
+        return FIELD_TO_DB_COLUMN_MAP;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortableFields.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortableFields.java
@@ -44,4 +44,7 @@ public class SortableFields {
     public static final String INSTRUCTIONS = "instructions";
     public static final String WEBHOOK_URL = "webhook_url";
     public static final String WEBHOOK_SECRET_TOKEN = "webhook_secret_token";
+    public static final String ENABLED = "enabled";
+    public static final String SAMPLING_RATE = "sampling_rate";
+    public static final String FILTERS = "filters";
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/AutomationRuleEvaluatorCriteria.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/AutomationRuleEvaluatorCriteria.java
@@ -2,9 +2,11 @@ package com.comet.opik.domain.evaluators;
 
 import com.comet.opik.api.evaluators.AutomationRule;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
+import com.comet.opik.api.filter.Filter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Builder;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -13,7 +15,8 @@ import java.util.UUID;
 public record AutomationRuleEvaluatorCriteria(
         AutomationRuleEvaluatorType type,
         String name,
-        Set<UUID> ids) {
+        Set<UUID> ids,
+        List<? extends Filter> filters) {
 
     public AutomationRule.AutomationRuleAction action() {
         return AutomationRule.AutomationRuleAction.EVALUATOR;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/AutomationRuleEvaluatorService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/AutomationRuleEvaluatorService.java
@@ -13,7 +13,10 @@ import com.comet.opik.api.evaluators.AutomationRuleEvaluatorUpdateTraceThreadLlm
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorUpdateTraceThreadUserDefinedMetricPython;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorUpdateUserDefinedMetricPython;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorUserDefinedMetricPython;
+import com.comet.opik.api.filter.Filter;
 import com.comet.opik.domain.IdGenerator;
+import com.comet.opik.domain.filter.FilterQueryBuilder;
+import com.comet.opik.domain.filter.FilterStrategy;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.cache.CacheEvict;
 import com.comet.opik.infrastructure.cache.Cacheable;
@@ -33,6 +36,7 @@ import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -57,7 +61,8 @@ public interface AutomationRuleEvaluatorService {
     void delete(@NonNull Set<UUID> ids, UUID projectId, @NonNull String workspaceId);
 
     AutomationRuleEvaluatorPage find(UUID projectId, @NonNull String workspaceId,
-            String name, int page, int size);
+            String name, List<? extends Filter> filters, String sortingFieldsSql, List<String> sortableBy, int page,
+            int size);
 
     <E, T extends AutomationRuleEvaluator<E>> List<T> findAll(@NonNull UUID projectId, @NonNull String workspaceId);
 
@@ -75,6 +80,7 @@ class AutomationRuleEvaluatorServiceImpl implements AutomationRuleEvaluatorServi
     private final @NonNull TransactionTemplate template;
     private final @NonNull AutomationRuleEvaluatorLogsDAO logsDAO;
     private final @NonNull OpikConfiguration opikConfiguration;
+    private final @NonNull FilterQueryBuilder filterQueryBuilder;
 
     @Override
     @CacheEvict(name = "automation_rule_evaluators_find_all", key = "$projectId + '-' + $workspaceId")
@@ -284,19 +290,34 @@ class AutomationRuleEvaluatorServiceImpl implements AutomationRuleEvaluatorServi
     public AutomationRuleEvaluatorPage find(UUID projectId,
             @NonNull String workspaceId,
             String name,
+            List<? extends Filter> filters,
+            String sortingFieldsSql,
+            List<String> sortableBy,
             int pageNum, int size) {
 
         log.debug("Finding AutomationRuleEvaluators with name pattern '{}' in projectId '{}' and workspaceId '{}'",
                 name, projectId, workspaceId);
 
+        String filtersSQL = Optional.ofNullable(filters)
+                .flatMap(f -> filterQueryBuilder.toAnalyticsDbFilters(f, FilterStrategy.AUTOMATION_RULE_EVALUATOR))
+                .orElse(null);
+
+        Map<String, Object> filterMapping = Optional.ofNullable(filters)
+                .map(filterQueryBuilder::toStateSQLMapping)
+                .orElse(Map.of());
+
         return template.inTransaction(READ_ONLY, handle -> {
             var dao = handle.attach(AutomationRuleEvaluatorDAO.class);
-            var criteria = AutomationRuleEvaluatorCriteria.builder().name(name).build();
+            var criteria = AutomationRuleEvaluatorCriteria.builder()
+                    .name(name)
+                    .filters(filters)
+                    .build();
             var total = dao.findCount(workspaceId, projectId, criteria);
             var offset = (pageNum - 1) * size;
 
             List<AutomationRuleEvaluator<?>> automationRuleEvaluators = List.copyOf(
-                    dao.find(workspaceId, projectId, criteria, offset, size)
+                    dao.find(workspaceId, projectId, criteria, sortingFieldsSql, filtersSQL, filterMapping, offset,
+                            size)
                             .stream()
                             .map(evaluator -> switch (evaluator) {
                                 case LlmAsJudgeAutomationRuleEvaluatorModel llmAsJudge ->
@@ -314,7 +335,8 @@ class AutomationRuleEvaluatorServiceImpl implements AutomationRuleEvaluatorServi
                     projectId);
             return new AutomationRuleEvaluatorPage(pageNum, automationRuleEvaluators.size(),
                     total,
-                    automationRuleEvaluators);
+                    automationRuleEvaluators,
+                    sortableBy);
         });
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -2,6 +2,7 @@ package com.comet.opik.domain.filter;
 
 import com.comet.opik.api.filter.AlertField;
 import com.comet.opik.api.filter.AnnotationQueueField;
+import com.comet.opik.api.filter.AutomationRuleEvaluatorField;
 import com.comet.opik.api.filter.DatasetField;
 import com.comet.opik.api.filter.DatasetItemField;
 import com.comet.opik.api.filter.ExperimentField;
@@ -88,6 +89,9 @@ public class FilterQueryBuilder {
     public static final String ANNOTATION_QUEUE_IDS_ANALYTICS_DB = "annotation_queue_ids";
     private static final String WEBHOOK_URL_DB = "webhook_url";
     private static final String WEBHOOK_SECRET_TOKEN_DB = "webhook_secret_token";
+    private static final String ENABLED_DB = "enabled";
+    private static final String SAMPLING_RATE_DB = "sampling_rate";
+    private static final String TYPE_DB = "type";
 
     private static final Map<Operator, Map<FieldType, String>> ANALYTICS_DB_OPERATOR_MAP = new EnumMap<>(
             ImmutableMap.<Operator, Map<FieldType, String>>builder()
@@ -320,6 +324,20 @@ public class FilterQueryBuilder {
                     .put(AlertField.LAST_UPDATED_BY, LAST_UPDATED_BY_DB)
                     .build());
 
+    private static final Map<AutomationRuleEvaluatorField, String> AUTOMATION_RULE_EVALUATOR_FIELDS_MAP = new EnumMap<>(
+            ImmutableMap.<AutomationRuleEvaluatorField, String>builder()
+                    .put(AutomationRuleEvaluatorField.ID, "rule." + ID_DB)
+                    .put(AutomationRuleEvaluatorField.NAME, "rule." + NAME_DB)
+                    .put(AutomationRuleEvaluatorField.TYPE, "evaluator." + TYPE_DB)
+                    .put(AutomationRuleEvaluatorField.ENABLED, "rule." + ENABLED_DB)
+                    .put(AutomationRuleEvaluatorField.SAMPLING_RATE, "rule." + SAMPLING_RATE_DB)
+                    .put(AutomationRuleEvaluatorField.PROJECT_ID, "rule." + PROJECT_ID_DB)
+                    .put(AutomationRuleEvaluatorField.CREATED_AT, "evaluator." + CREATED_AT_DB)
+                    .put(AutomationRuleEvaluatorField.LAST_UPDATED_AT, "evaluator." + LAST_UPDATED_AT_DB)
+                    .put(AutomationRuleEvaluatorField.CREATED_BY, "evaluator." + CREATED_BY_DB)
+                    .put(AutomationRuleEvaluatorField.LAST_UPDATED_BY, "evaluator." + LAST_UPDATED_BY_DB)
+                    .build());
+
     private static final Map<ExperimentsComparisonValidKnownField, String> EXPERIMENTS_COMPARISON_FIELDS_MAP = new EnumMap<>(
             ImmutableMap.<ExperimentsComparisonValidKnownField, String>builder()
                     .put(ExperimentsComparisonValidKnownField.FEEDBACK_SCORES, VALUE_ANALYTICS_DB)
@@ -464,6 +482,18 @@ public class FilterQueryBuilder {
                 AlertField.CREATED_BY,
                 AlertField.LAST_UPDATED_BY));
 
+        map.put(FilterStrategy.AUTOMATION_RULE_EVALUATOR, Set.of(
+                AutomationRuleEvaluatorField.ID,
+                AutomationRuleEvaluatorField.NAME,
+                AutomationRuleEvaluatorField.TYPE,
+                AutomationRuleEvaluatorField.ENABLED,
+                AutomationRuleEvaluatorField.SAMPLING_RATE,
+                AutomationRuleEvaluatorField.PROJECT_ID,
+                AutomationRuleEvaluatorField.CREATED_AT,
+                AutomationRuleEvaluatorField.LAST_UPDATED_AT,
+                AutomationRuleEvaluatorField.CREATED_BY,
+                AutomationRuleEvaluatorField.LAST_UPDATED_BY));
+
         return map;
     }
 
@@ -561,6 +591,8 @@ public class FilterQueryBuilder {
             case DatasetItemField datasetItemField -> DATASET_ITEM_FIELDS_MAP.get(datasetItemField);
             case AnnotationQueueField annotationQueueField -> ANNOTATION_QUEUE_FIELDS_MAP.get(annotationQueueField);
             case AlertField alertField -> ALERT_FIELDS_MAP.get(alertField);
+            case AutomationRuleEvaluatorField automationRuleEvaluatorField ->
+                AUTOMATION_RULE_EVALUATOR_FIELDS_MAP.get(automationRuleEvaluatorField);
             default -> {
 
                 if (field.isDynamic(filterStrategy)) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterStrategy.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterStrategy.java
@@ -18,7 +18,8 @@ public enum FilterStrategy {
     PROMPT,
     DATASET,
     ANNOTATION_QUEUE,
-    ALERT;
+    ALERT,
+    AUTOMATION_RULE_EVALUATOR;
 
     public static final String DYNAMIC_FIELD = ":dynamicField%1$d";
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/sorting/SortingQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/sorting/SortingQueryBuilder.java
@@ -7,24 +7,35 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Slf4j
 public class SortingQueryBuilder {
     public String toOrderBySql(@NonNull List<SortingField> sorting) {
+        return toOrderBySql(sorting, null);
+    }
+
+    public String toOrderBySql(@NonNull List<SortingField> sorting, Map<String, String> fieldMapping) {
         if (sorting.isEmpty()) {
             return null;
         }
 
+        Function<SortingField, String> fieldMapper = fieldMapping != null
+                ? sortingField -> fieldMapping.getOrDefault(sortingField.field(), sortingField.dbField())
+                : SortingField::dbField;
+
         return sorting.stream()
                 .map(sortingField -> {
+                    String dbField = fieldMapper.apply(sortingField);
 
                     // Handle null direction for dynamic fields
                     if (sortingField.handleNullDirection().isEmpty()) {
-                        return "%s %s".formatted(sortingField.dbField(), getDirection(sortingField));
+                        return "%s %s".formatted(dbField, getDirection(sortingField));
                     } else {
-                        return "(%s, %s) %s".formatted(sortingField.dbField(), sortingField.handleNullDirection(),
+                        return "(%s, %s) %s".formatted(dbField, sortingField.handleNullDirection(),
                                 getDirection(sortingField));
                     }
                 })

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AutomationRuleEvaluatorResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AutomationRuleEvaluatorResourceClient.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.apache.http.HttpStatus;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import static com.comet.opik.api.LogItem.LogPage;
@@ -86,6 +88,47 @@ public class AutomationRuleEvaluatorResourceClient {
         assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(expectedStatus);
 
         return actualResponse;
+    }
+
+    public AutomationRuleEvaluator.AutomationRuleEvaluatorPage findEvaluatorPage(
+            UUID projectId,
+            String name,
+            String filters,
+            String sorting,
+            Integer page,
+            Integer size,
+            String workspaceName,
+            String apiKey) {
+        var target = client.target(RESOURCE_PATH.formatted(baseURI));
+        if (projectId != null) {
+            target = target.queryParam("project_id", projectId);
+        }
+        if (name != null) {
+            target = target.queryParam("name", name);
+        }
+        if (filters != null) {
+            target = target.queryParam("filters", URLEncoder.encode(filters, StandardCharsets.UTF_8));
+        }
+        if (sorting != null) {
+            target = target.queryParam("sorting", URLEncoder.encode(sorting, StandardCharsets.UTF_8));
+        }
+        if (page != null) {
+            target = target.queryParam("page", page);
+        }
+        if (size != null) {
+            target = target.queryParam("size", size);
+        }
+
+        var actualResponse = target
+                .request()
+                .header(WORKSPACE_HEADER, workspaceName)
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .get();
+
+        assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
+
+        return actualResponse.readEntity(AutomationRuleEvaluator.AutomationRuleEvaluatorPage.class);
     }
 
     public Response updateEvaluator(

--- a/apps/opik-frontend/src/api/automations/useRulesList.ts
+++ b/apps/opik-frontend/src/api/automations/useRulesList.ts
@@ -5,10 +5,16 @@ import api, {
   QueryConfig,
 } from "@/api/api";
 import { EvaluatorsRule } from "@/types/automations";
+import { Filters } from "@/types/filters";
+import { processFilters } from "@/lib/filters";
+import { Sorting } from "@/types/sorting";
+import { processSorting } from "@/lib/sorting";
 
 type UseRulesListParams = {
   workspaceName?: string;
   projectId?: string;
+  filters?: Filters;
+  sorting?: Sorting;
   search?: string;
   page: number;
   size: number;
@@ -16,12 +22,13 @@ type UseRulesListParams = {
 
 export type UseRulesListResponse = {
   content: EvaluatorsRule[];
+  sortable_by: string[];
   total: number;
 };
 
 const getRulesList = async (
   { signal }: QueryFunctionContext,
-  { projectId, search, size, page }: UseRulesListParams,
+  { projectId, filters, sorting, search, size, page }: UseRulesListParams,
 ) => {
   const { data } = await api.get<UseRulesListResponse>(
     `${AUTOMATIONS_REST_ENDPOINT}evaluators`,
@@ -29,6 +36,8 @@ const getRulesList = async (
       signal,
       params: {
         project_id: projectId,
+        ...processFilters(filters),
+        ...processSorting(sorting),
         ...(search && { name: search }),
         size,
         page,

--- a/apps/opik-frontend/src/components/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
+++ b/apps/opik-frontend/src/components/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
@@ -1,10 +1,16 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { NumberParam, StringParam, useQueryParam } from "use-query-params";
+import {
+  JsonParam,
+  NumberParam,
+  StringParam,
+  useQueryParam,
+} from "use-query-params";
 import useLocalStorageState from "use-local-storage-state";
 import { keepPreviousData } from "@tanstack/react-query";
 import {
   ColumnDef,
   ColumnPinningState,
+  ColumnSort,
   RowSelectionState,
 } from "@tanstack/react-table";
 
@@ -27,6 +33,7 @@ import SearchInput from "@/components/shared/SearchInput/SearchInput";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import ColumnsButton from "@/components/shared/ColumnsButton/ColumnsButton";
+import FiltersButton from "@/components/shared/FiltersButton/FiltersButton";
 import DataTable from "@/components/shared/DataTable/DataTable";
 import DataTableNoData from "@/components/shared/DataTableNoData/DataTableNoData";
 import DataTablePagination from "@/components/shared/DataTablePagination/DataTablePagination";
@@ -57,7 +64,7 @@ const DEFAULT_COLUMNS: ColumnData<EvaluatorsRule>[] = [
     cell: IdCell as never,
   },
   {
-    id: "project",
+    id: "project_id",
     label: "Project",
     type: COLUMN_TYPE.string,
     cell: ResourceCell as never,
@@ -91,7 +98,7 @@ const DEFAULT_COLUMNS: ColumnData<EvaluatorsRule>[] = [
     type: COLUMN_TYPE.number,
   },
   {
-    id: "scope",
+    id: "type",
     label: "Scope",
     type: COLUMN_TYPE.string,
     accessorFn: (row) => capitalizeFirstLetter(getUIRuleScope(row.type)),
@@ -115,13 +122,14 @@ const DEFAULT_SELECTED_COLUMNS: string[] = [
   "created_at",
   "sampling_rate",
   "enabled",
-  "project",
-  "scope",
+  "project_id",
+  "type",
 ];
 
 const SELECTED_COLUMNS_KEY = "workspace-rules-selected-columns";
 const COLUMNS_WIDTH_KEY = "workspace-rules-columns-width";
 const COLUMNS_ORDER_KEY = "workspace-rules-columns-order";
+const COLUMNS_SORT_KEY = "workspace-rules-columns-sort";
 const PAGINATION_SIZE_KEY = "workspace-rules-pagination-size";
 
 export const OnlineEvaluationPage: React.FC = () => {
@@ -130,6 +138,19 @@ export const OnlineEvaluationPage: React.FC = () => {
 
   const [search = "", setSearch] = useQueryParam("search", StringParam, {
     updateType: "replaceIn",
+  });
+
+  const [filters = [], setFilters] = useQueryParam(`filters`, JsonParam, {
+    updateType: "replaceIn",
+  });
+
+  const [sortedColumns, setSortedColumns] = useQueryParamAndLocalStorageState<
+    ColumnSort[]
+  >({
+    localStorageKey: COLUMNS_SORT_KEY,
+    queryKey: `sorting`,
+    defaultValue: [],
+    queryParamConfig: JsonParam,
   });
 
   const [page = 1, setPage] = useQueryParam("page", NumberParam, {
@@ -153,13 +174,19 @@ export const OnlineEvaluationPage: React.FC = () => {
       page: page as number,
       size: size as number,
       search: search as string,
+      filters,
+      sorting: sortedColumns,
     },
     {
       placeholderData: keepPreviousData,
     },
   );
 
-  const noData = !search;
+  const sortableBy: string[] = useMemo(
+    () => data?.sortable_by ?? [],
+    [data?.sortable_by],
+  );
+  const noData = !search && filters.length === 0;
   const noDataText = noData ? `There are no rules yet` : "No search results";
 
   const rows: EvaluatorsRule[] = useMemo(() => data?.content ?? [], [data]);
@@ -195,12 +222,14 @@ export const OnlineEvaluationPage: React.FC = () => {
         id: COLUMN_NAME_ID,
         label: "Name",
         type: COLUMN_TYPE.string,
+        sortable: sortableBy.includes("name"),
       }),
       ...convertColumnDataToColumn<EvaluatorsRule, EvaluatorsRule>(
         DEFAULT_COLUMNS,
         {
           columnsOrder,
           selectedColumns,
+          sortableColumns: sortableBy,
         },
       ),
       {
@@ -216,7 +245,7 @@ export const OnlineEvaluationPage: React.FC = () => {
         cell: RuleRowActionsCell,
       }),
     ];
-  }, [columnsOrder, selectedColumns]);
+  }, [columnsOrder, selectedColumns, sortableBy]);
 
   const resizeConfig = useMemo(
     () => ({
@@ -225,6 +254,16 @@ export const OnlineEvaluationPage: React.FC = () => {
       onColumnResize: setColumnsWidth,
     }),
     [columnsWidth, setColumnsWidth],
+  );
+
+  const sortConfig = useMemo(
+    () => ({
+      enabled: true,
+      enabledMultiSorting: false,
+      sorting: sortedColumns,
+      setSorting: setSortedColumns,
+    }),
+    [sortedColumns, setSortedColumns],
   );
 
   const handleNewRuleClick = useCallback(() => {
@@ -265,10 +304,15 @@ export const OnlineEvaluationPage: React.FC = () => {
           <SearchInput
             searchText={search as string}
             setSearchText={setSearch}
-            placeholder="Search by ID"
+            placeholder="Search by name"
             className="w-[320px]"
             dimension="sm"
           ></SearchInput>
+          <FiltersButton
+            columns={DEFAULT_COLUMNS}
+            filters={filters}
+            onChange={setFilters}
+          ></FiltersButton>
         </div>
         <div className="flex items-center gap-2">
           <RulesActionsPanel rules={selectedRows} />
@@ -288,6 +332,7 @@ export const OnlineEvaluationPage: React.FC = () => {
       <DataTable
         columns={columns}
         data={rows}
+        sortConfig={sortConfig}
         resizeConfig={resizeConfig}
         selectionConfig={{
           rowSelection,


### PR DESCRIPTION
## Details

Added search, filtering, and sorting functionality to the online evaluation page. Backend now supports filtering by project, name, enabled status, and sampling rate, plus sorting by all major fields including name, type, and project. Frontend integrated with filters UI, search, and sortable columns. Includes comprehensive integration tests.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-2598

## Testing

- Added integration tests for sorting (name, type, sampling_rate, enabled, project_id)
- Tests use random strings and URL-encoded JSON parameters
- All 6 sorting tests passing

## Documentation

N/A