### PR TITLE
[OPIK-2613] [FE] Change sampling rate display from "0 to 1" to "0 to 100%" in Online Evaluation rules

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/automations/AddEditRuleDialog/RuleFilteringSection.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/automations/AddEditRuleDialog/RuleFilteringSection.tsx
@@ -31,6 +31,7 @@ import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
 import { EvaluationRuleFormType } from "./schema";
 import ExplainerIcon from "@/components/shared/ExplainerIcon/ExplainerIcon";
 import { Description } from "@/components/ui/description";
+import round from "lodash/round";
 
 // Trace-specific columns for automation rule filtering
 export const TRACE_FILTER_COLUMNS: ColumnData<TRACE_DATA_TYPE>[] = [
@@ -379,14 +380,17 @@ const RuleFilteringSection: React.FC<RuleFilteringSectionProps> = ({
               render={({ field }) => (
                 <SliderInputControl
                   min={0}
-                  max={1}
-                  step={0.01}
-                  defaultValue={DEFAULT_SAMPLING_RATE}
-                  value={field.value}
-                  onChange={field.onChange}
+                  max={100}
+                  step={1}
+                  defaultValue={DEFAULT_SAMPLING_RATE * 100}
+                  value={round((field.value ?? DEFAULT_SAMPLING_RATE) * 100, 1)}
+                  onChange={(displayValue) =>
+                    field.onChange(round(displayValue, 1) / 100)
+                  }
                   id="sampling_rate"
                   label="Sampling rate"
                   tooltip="Percentage of traces to evaluate"
+                  suffix="%"
                 />
               )}
             />

--- a/apps/opik-frontend/src/components/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
+++ b/apps/opik-frontend/src/components/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
@@ -7,6 +7,7 @@ import {
   ColumnPinningState,
   RowSelectionState,
 } from "@tanstack/react-table";
+import round from "lodash/round";
 
 import {
   COLUMN_ID_ID,
@@ -89,6 +90,7 @@ const DEFAULT_COLUMNS: ColumnData<EvaluatorsRule>[] = [
     id: "sampling_rate",
     label: "Sampling rate",
     type: COLUMN_TYPE.number,
+    accessorFn: (row) => `${round(row.sampling_rate * 100, 1)}%`,
   },
   {
     id: "scope",

--- a/apps/opik-frontend/src/components/pages/TracesPage/RulesTab/RulesTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/RulesTab/RulesTab.tsx
@@ -7,6 +7,7 @@ import {
   ColumnPinningState,
   RowSelectionState,
 } from "@tanstack/react-table";
+import round from "lodash/round";
 
 import {
   COLUMN_ID_ID,
@@ -79,6 +80,7 @@ const DEFAULT_COLUMNS: ColumnData<EvaluatorsRule>[] = [
     id: "sampling_rate",
     label: "Sampling rate",
     type: COLUMN_TYPE.number,
+    accessorFn: (row) => `${round(row.sampling_rate * 100, 1)}%`,
   },
   {
     id: "scope",

--- a/apps/opik-frontend/src/components/shared/SliderInputControl/SliderInputControl.tsx
+++ b/apps/opik-frontend/src/components/shared/SliderInputControl/SliderInputControl.tsx
@@ -20,6 +20,7 @@ interface SliderInputControlProps {
   label: string;
   tooltip?: TooltipWrapperProps["content"];
   resetDisabled?: boolean;
+  suffix?: string;
 }
 
 const SliderInputControl = ({
@@ -33,6 +34,7 @@ const SliderInputControl = ({
   label,
   tooltip,
   resetDisabled,
+  suffix,
 }: SliderInputControlProps) => {
   const sliderId = `${id}-slider`;
   const inputId = `${id}-input`;
@@ -103,7 +105,7 @@ const SliderInputControl = ({
           )}
           <Input
             id={inputId}
-            className="box-content w-[var(--input-width)] max-w-[5ch] border px-2 py-0 text-right [&:not(:focus)]:border-transparent"
+            className="box-content w-[var(--input-width)] max-w-[5ch] border px-2 py-0 text-right [&:not(:focus)]:border-transparent [&:not(:focus)]:px-0.5"
             style={
               {
                 "--input-width": `${localValue?.length}ch`,
@@ -116,6 +118,14 @@ const SliderInputControl = ({
             variant="ghost"
             max={max}
           />
+          {suffix && (
+            <label
+              htmlFor={inputId}
+              className="cursor-text text-sm text-muted-foreground"
+            >
+              {suffix}
+            </label>
+          )}
         </div>
       </div>
       <Slider


### PR DESCRIPTION
## Details

Changed the sampling rate display from decimal format (0 to 1) to percentage format (0% to 100%) in the Online Evaluation rules to improve user experience and reduce confusion.

### Changes Made:

1. **SliderInputControl Component** (`SliderInputControl.tsx`)
   - Added optional `suffix` prop to display text next to input (e.g., "%")
   - Suffix is rendered as a separate element, not part of the input value
   - Component remains generic and reusable for other use cases

2. **RuleFilteringSection** (`RuleFilteringSection.tsx`)
   - Changed slider range from 0-1 to 0-100
   - Changed step from 0.01 to 1
   - Encapsulated conversion logic: Display (0-100%) ↔ Storage (0.0-1.0)
   - Backend continues to receive decimal values (0.0 to 1.0) - no breaking changes

3. **Table Columns** (OnlineEvaluationPage & RulesTab)
   - Updated sampling_rate columns to display as percentages
   - Uses `round` from lodash for consistent rounding to 1 decimal place
   - Format: `XX.X%` (e.g., `50.0%`, `75.5%`)

### Key Features:
- ✅ **User-friendly display**: Shows intuitive 0-100% range
- ✅ **Backend compatibility**: Still stores 0.0-1.0 decimal values
- ✅ **Consistent formatting**: Percentage display in both form and table
- ✅ **Generic component**: SliderInputControl can be reused with any suffix
- ✅ **Precise rounding**: Uses lodash `round` for 1 decimal place precision

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves N/A (Internal Jira ticket)
- OPIK-2613

## Testing

### Manual Testing Steps:

1. **Create/Edit Rule Modal:**
   - Navigate to Online Evaluation → Create a new rule
   - Verify sampling rate slider displays 0-100 with "%" suffix
   - Test slider: Should snap to whole numbers (0, 1, 2, ..., 100)
   - Test input: Type values and verify they stay between 0-100
   - Verify the "%" symbol appears next to the input (not inside it)

2. **Table Display:**
   - Navigate to Online Evaluation page
   - Verify "Sampling rate" column displays values as percentages (e.g., "50.0%")
   - Navigate to Traces → Rules tab
   - Verify "Sampling rate" column displays values as percentages

3. **Backend Compatibility:**
   - Create a rule with sampling rate 50% (should store as 0.5)
   - Edit an existing rule and verify the display shows correct percentage
   - Verify API requests still send decimal values (check network tab)

4. **Edge Cases:**
   - Test with 0% (should store as 0.0)
   - Test with 100% (should store as 1.0)
   - Test with decimal values like 75.5% (should store as 0.755)

## Documentation

No documentation updates required - this is a UI improvement that maintains backward compatibility with the backend API.