### PR TITLE
[OPIK-2615] [DOCS] Remove Unsupported E2E Test Instructions from Frontend Contribution Guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,8 +376,9 @@ npm run typecheck # TypeScript type checking
 
 #### Testing
 
-```
-npm run e2e # End-to-end tests
+```bash
+cd apps/opik-frontend
+npm run test # Unit tests for utilities and helpers
 ```
 
 ### Contributing to the backend

--- a/apps/opik-documentation/documentation/fern/docs/contributing/frontend.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/contributing/frontend.mdx
@@ -194,7 +194,7 @@ Before submitting a Pull Request, please ensure your code passes the following c
   </Tab>
 </Tabs>
 
-#### Type Checking and E2E Tests
+#### Type Checking and Unit Tests
 
 Run these commands from the `apps/opik-frontend` directory:
 
@@ -202,7 +202,7 @@ Run these commands from the `apps/opik-frontend` directory:
 cd apps/opik-frontend
 
 npm run typecheck # TypeScript type checking
-npm run e2e       # End-to-end tests
+npm run test      # Unit tests for utilities and helpers
 ```
 
 ### 5. Submitting a Pull Request

--- a/apps/opik-frontend/e2e/README.md
+++ b/apps/opik-frontend/e2e/README.md
@@ -1,0 +1,18 @@
+# E2E Tests Directory
+
+**Status:** Not Maintained
+
+This directory contains Playwright end-to-end tests from early project development. These tests are **not maintained** and are kept for historical reference only.
+
+## Current Testing Approach
+
+**Frontend testing:**
+
+- Unit tests for utilities and complex logic
+- Run: `npm run test`
+- Location: `apps/opik-frontend/src/**/*.test.tsx`
+
+**End-to-end testing:**
+
+- Full-stack e2e tests at repository root: `tests_end_to_end/`
+- Not required for frontend contributions


### PR DESCRIPTION
## Details

This PR updates the frontend contribution documentation to remove references to unsupported E2E tests. The project initially invested several weeks in E2E tests early in development, but they are no longer maintained or run as part of the CI/CD pipeline. This change clarifies the current testing approach for contributors.

### What changed:
- ✅ Updated `frontend.mdx`: Changed "Type Checking and E2E Tests" → "Type Checking and Unit Tests"
- ✅ Updated `CONTRIBUTING.md`: Replaced `npm run e2e` with `npm run test` for unit tests
- ✅ Created `apps/opik-frontend/e2e/README.md`: Documents the historical context and current status of E2E tests
- ✅ Added clear notes: E2E tests are not maintained; contributors should focus on unit tests

### Why:
Contributors were being instructed to run `npm run e2e` which references unmaintained tests. This created confusion and wasted time for new contributors. The documentation now accurately reflects that:
- ✅ **Supported**: Unit tests via `npm run test`
- ✅ **Available**: Full-stack E2E tests in `tests_end_to_end/` (not required for frontend contributions)
- ❌ **Not maintained**: Frontend-specific E2E tests in `apps/opik-frontend/e2e/`

## Change checklist
- [x] Documentation update

## Issues
- Resolves https://comet-ml.atlassian.net/browse/OPIK-2615

## Testing
- Documentation changes verified for accuracy
- Markdown/MDX syntax validated
- Cross-references checked for validity

## Documentation
Updated files:
- `CONTRIBUTING.md` - Updated Testing section with current testing approach
- `apps/opik-documentation/documentation/fern/docs/contributing/frontend.mdx` - Updated to reflect unit testing focus
- `apps/opik-frontend/e2e/README.md` (NEW) - Added context about E2E test directory status