### PR TITLE
[OPIK-2591] [BE] Add support for `thread_id` for OpenTelemetry endpoint.

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMappingRule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMappingRule.java
@@ -52,6 +52,8 @@ public enum OpenTelemetryMappingRule {
 
     USAGE("usage", false, "Logfire", Outcome.USAGE, SpanType.llm),
 
+    THREAD_ID("thread_id", false, "General", Outcome.METADATA),
+
     SMOLAGENTS("smolagents.", true, "Smolagents", Outcome.METADATA);
 
     private final String rule;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
@@ -36,6 +36,7 @@ import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -388,6 +389,66 @@ class OpenTelemetryResourceTest {
             assertThat(span.input().get("all_messages").isArray()).isEqualTo(Boolean.TRUE);
 
             assertThat(span.output().get("tool_responses").isArray()).isEqualTo(Boolean.TRUE);
+        }
+
+        @Test
+        @DisplayName("test thread_id support in OpenTelemetry")
+        void testThreadIdSupport() {
+            String workspaceName = UUID.randomUUID().toString();
+            mockTargetWorkspace(okApikey, workspaceName, WORKSPACE_ID);
+
+            var otelTraceId = UUID.randomUUID().toString().getBytes();
+            var parentSpanId = UUID.randomUUID().toString().getBytes();
+            String threadId = "test-thread-123";
+
+            // Create a root span with thread_id attribute
+            var rootSpan = Span.newBuilder()
+                    .setName("root span")
+                    .setTraceId(ByteString.copyFrom(otelTraceId))
+                    .setSpanId(ByteString.copyFrom(parentSpanId))
+                    .setStartTimeUnixNano((System.currentTimeMillis() - 1_000) * 1_000_000L)
+                    .setEndTimeUnixNano(System.currentTimeMillis() * 1_000_000L)
+                    .addAttributes(KeyValue.newBuilder()
+                            .setKey("thread_id")
+                            .setValue(AnyValue.newBuilder().setStringValue(threadId))
+                            .build())
+                    .build();
+
+            // Create a child span
+            var childSpan = Span.newBuilder()
+                    .setName("child span")
+                    .setTraceId(ByteString.copyFrom(otelTraceId))
+                    .setParentSpanId(ByteString.copyFrom(parentSpanId))
+                    .setSpanId(ByteString.copyFrom(UUID.randomUUID().toString().getBytes()))
+                    .setStartTimeUnixNano((System.currentTimeMillis() - 500) * 1_000_000L)
+                    .setEndTimeUnixNano(System.currentTimeMillis() * 1_000_000L)
+                    .build();
+
+            var otelSpans = List.of(rootSpan, childSpan);
+
+            // Calculate expected Opik trace ID
+            var minTimestamp = otelSpans.stream().map(Span::getStartTimeUnixNano).min(Long::compareTo).orElseThrow();
+            var minTimestampMs = Duration.ofNanos(minTimestamp).toMillis();
+            var expectedOpikTraceId = OpenTelemetryMapper.convertOtelIdToUUIDv7(otelTraceId, minTimestampMs);
+
+            // Send the spans
+            sendProtobufTraces(otelSpans, "Test Project", workspaceName, okApikey, true, null);
+
+            // Verify the trace was created with the correct thread_id
+            Trace trace = traceResourceClient.getById(expectedOpikTraceId, workspaceName, okApikey);
+            assertThat(trace.id()).isEqualTo(expectedOpikTraceId);
+            assertThat(trace.threadId()).isEqualTo(threadId);
+
+            // Verify the spans were created
+            var generatedSpanPage = spanResourceClient.getByTraceIdAndProject(expectedOpikTraceId, "Test Project", workspaceName, okApikey);
+            assertThat(generatedSpanPage.size()).isEqualTo(2);
+
+            // Verify the root span has thread_id in metadata
+            var rootSpanFromDb = generatedSpanPage.content().stream()
+                    .filter(span -> span.parentSpanId() == null)
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(rootSpanFromDb.metadata().get("thread_id").asText()).isEqualTo(threadId);
         }
 
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
@@ -36,13 +36,13 @@ import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -440,7 +440,8 @@ class OpenTelemetryResourceTest {
             assertThat(trace.threadId()).isEqualTo(threadId);
 
             // Verify the spans were created
-            var generatedSpanPage = spanResourceClient.getByTraceIdAndProject(expectedOpikTraceId, "Test Project", workspaceName, okApikey);
+            var generatedSpanPage = spanResourceClient.getByTraceIdAndProject(expectedOpikTraceId,
+                    "Test Project", workspaceName, okApikey);
             assertThat(generatedSpanPage.size()).isEqualTo(2);
 
             // Verify the root span has thread_id in metadata

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1,10 +1,16 @@
 package com.comet.opik.domain;
 
+import com.comet.opik.api.Span;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -178,5 +184,30 @@ class OpenTelemetryMapperTest {
 
         assertTrue(testNode.has("testKey"));
         assertEquals("{Analyze: \"value\"}", testNode.get("testKey").asText());
+    }
+
+    @Test
+    void testThreadIdMappingRule() {
+        // Test that thread_id attribute is mapped to metadata
+        var attributes = List.of(
+                KeyValue.newBuilder()
+                        .setKey("thread_id")
+                        .setValue(AnyValue.newBuilder().setStringValue("test-thread-123"))
+                        .build()
+        );
+
+        var spanBuilder = Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
+
+        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null);
+
+        var span = spanBuilder.build();
+
+        // Verify thread_id is stored in metadata
+        assertTrue(span.metadata().has("thread_id"));
+        assertEquals("test-thread-123", span.metadata().get("thread_id").asText());
     }
 }

--- a/apps/opik-documentation/documentation/fern/docs/tracing/opentelemetry/python-sdk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/opentelemetry/python-sdk.mdx
@@ -71,6 +71,10 @@ def main():
         conversation_span.set_attribute("conversation.id", "conv_12345")
         conversation_span.set_attribute("conversation.type", "weather_inquiry")
 
+        # Add thread ID as an attribute to the parent span to group related spans into
+        # a single conversational thread
+        conversation_span.set_attribute("thread_id", "user_12345")
+
         # Process the user request
 
         # Simulate initial processing
@@ -121,3 +125,6 @@ if __name__ == "__main__":
     print("\nSpans have been sent to OpenTelemetry collector.")
     print("If you configured Comet.com, you can view the traces in your Comet project.")
 ```
+
+Using `thread_id` as a span attribute allows you to group related spans into a single conversational thread.
+Created threads can be used to evaluate multi-turn conversations as described in the [Multi-turn conversations](/evaluation/evaluate_threads) guide.


### PR DESCRIPTION
## Details

At the moment, OPIK’s OpenTelemetry endpoint does not support providing a thread_id. This is a limitation, as it prevents users from grouping traces into threads—a fairly common use case.
A possible solution would be to include thread_id in the OpenTelemetry span metadata.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #3441 
- OPIK-2591

## Testing

Implemented related unit tests

## Documentation

Added usage example of `thread_id` into related documentation section: https://www.comet.com/docs/opik/integrations/opentelemetry-python-sdk