### PR TITLE
[OPIK-2175] [SCRIPTS] Disable usage reporting for partial profile deployments

### DIFF
--- a/opik.ps1
+++ b/opik.ps1
@@ -204,6 +204,14 @@ function Send-InstallReport {
 
     $OpikUsageEnabled = $env:OPIK_USAGE_REPORT_ENABLED
 
+    # Configure usage reporting based on deployment mode
+    # $PROFILE_COUNT: if > 0, it's a partial profile; if = 0, it's full Opik
+    if ($script:PROFILE_COUNT -gt 0) {
+        # Partial profile mode - disable reporting
+        $OpikUsageEnabled = "false"
+        Write-DebugLog "[DEBUG] Disabling usage reporting due to not starting the full Opik suite"
+    }
+
     if ($OpikUsageEnabled -ne "true" -and $null -ne $OpikUsageEnabled) {
         Write-DebugLog "[DEBUG] Usage reporting is disabled. Skipping install report."
         return
@@ -627,13 +635,14 @@ if ($options -contains '--guardrails') {
     $options = $options | Where-Object { $_ -ne '--guardrails' }
 }
 
-# Validate mutually exclusive profile flags
-$profileCount = 0
-if ($INFRA) { $profileCount++ }
-if ($BACKEND) { $profileCount++ }
-if ($LOCAL_BE) { $profileCount++ }
+# Count active partial profiles
+$PROFILE_COUNT = 0
+if ($INFRA) { $PROFILE_COUNT++ }
+if ($BACKEND) { $PROFILE_COUNT++ }
+if ($LOCAL_BE) { $PROFILE_COUNT++ }
 
-if ($profileCount -gt 1) {
+# Validate mutually exclusive profile flags
+if ($PROFILE_COUNT -gt 1) {
     Write-Host "❌ Error: --infra, --backend, and --local-be flags are mutually exclusive."
     Write-Host "   Choose one of the following:"
     Write-Host "   • .\opik.ps1 --infra      (infrastructure services only)"


### PR DESCRIPTION
## Details

This PR modifies the Opik deployment scripts (`opik.sh` and `opik.ps1`) to automatically disable usage reporting when running partial Opik profiles. Previously, usage reporting was controlled only by the `OPIK_USAGE_REPORT_ENABLED` environment variable. Now, the scripts intelligently detect partial profile deployments and disable reporting automatically.

**Key Changes:**
- Renamed `profile_count`/`$profileCount` to `PROFILE_COUNT`/`$PROFILE_COUNT` to make it script-scoped
- Added automatic usage reporting configuration in `send_install_report()` function
- When `PROFILE_COUNT > 0` (indicating a partial profile like `--infra`, `--backend`, or `--local-be`), usage reporting is automatically disabled
- Full Opik suite deployments (no profile flags) continue to send usage reports as before

**Implementation Details:**
- Both shell scripts (bash and PowerShell) updated with consistent logic
- Usage reporting is now tied to deployment mode rather than requiring manual environment variable configuration
- Debug logging added to indicate when reporting is disabled due to partial profile mode

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-2175

## Testing

**Manual Testing Scenarios:**

1. **Full Opik Deployment** (usage reporting should be sent):
   ```bash
   ./opik.sh start
   ```
   Expected: Usage reports are sent (if `OPIK_USAGE_REPORT_ENABLED` not explicitly set to false)

2. **Partial Profile Deployment** (usage reporting should be disabled):
   ```bash
   ./opik.sh start --infra
   ./opik.sh start --backend
   ./opik.sh start --local-be
   ```
   Expected: No usage reports sent, debug log shows "Disabling usage reporting due to not starting the full Opik suite"

3. **Explicit Override** (manual control still works):
   ```bash
   export OPIK_USAGE_REPORT_ENABLED=false
   ./opik.sh start
   ```
   Expected: No usage reports sent regardless of profile mode

**Verification:**
- Shell script syntax validated with `bash -n opik.sh`
- Variable scoping tested to ensure `PROFILE_COUNT` is accessible in report function
- Logic tested across both bash and PowerShell implementations

## Documentation

- No external documentation updates required (internal deployment script behavior)
- Comments added in code to explain the usage reporting configuration logic