### PR TITLE
[OPIK-2623] bugfix: don't truncate big payloads

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentReinjectorService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentReinjectorService.java
@@ -146,7 +146,8 @@ public class AttachmentReinjectorService {
     private Mono<JsonNode> reinjectIntoJson(JsonNode node, List<AttachmentInfo> attachments,
             String workspaceId) {
         if (node == null || node.isNull()) {
-            return Mono.just(node);
+            // Return a NullNode instead of null to avoid NPE in Mono.just()
+            return Mono.just(objectMapper.getNodeFactory().nullNode());
         }
 
         // Convert JsonNode to string

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
@@ -89,7 +89,7 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
   const { data: trace, isPending: isTracePending } = useTraceById(
     {
       traceId,
-      truncate: true, // Get truncated trace, attachments fetched separately
+      truncate: false, // Disabled for now: Get truncated trace, attachments fetched separately
     },
     {
       placeholderData: keepPreviousData,
@@ -108,7 +108,7 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
       projectId,
       page: 1,
       size: MAX_SPANS_LOAD_SIZE,
-      truncate: true, // Get truncated spans, attachments fetched separately
+      truncate: false, // Disabled for now: Get truncated spans, attachments fetched separately
     },
     {
       placeholderData: keepPreviousData,


### PR DESCRIPTION
## Details
This is a quick PR to fix behavior for CUST-3778, as big payloads were being truncated due to the 'truncate' flag being reused for both input/output big payloads truncation and attachments truncation/reinjection.

So on this PR we stop requesting the truncation and fix a NPE when the payload is null.

Full solution will be in the next PR, converting the reuse of the flag in two different flags.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #CUST-3778
- OPIK-2623

## Testing

## Documentation
