### PR TITLE
[NA] [DOCS] Add conversation logging section to CrewAI integration documentation

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/crewai.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/crewai.mdx
@@ -185,3 +185,30 @@ Cost information is automatically captured and displayed in the Opik UI, includi
 <Tip>
   View the complete list of supported models and providers on the [Supported Models](/tracing/supported_models) page.
 </Tip>
+
+## Grouping traces into conversational threads using `thread_id`
+
+Threads in Opik are collections of traces that are grouped together using a unique `thread_id`.
+
+The `thread_id` can be passed to the CrewAI crew as a parameter, which will be used to group all traces into a single thread.
+
+```python
+from crewai import Agent, Crew, Task, Process
+from opik.integrations.crewai import track_crewai
+
+track_crewai(project_name="crewai-integration-demo")
+
+# Define your crew (using the example from above)
+my_crew = YourCrewName().crew()
+
+# Pass thread_id via opik_args
+args_dict = {
+    "trace": {
+        "thread_id": "conversation-2",
+    },
+}
+
+result = my_crew.kickoff(opik_args=args_dict)
+```
+
+More information on logging chat conversations can be found in the [Log conversations](/tracing/log_chat_conversations) section.


### PR DESCRIPTION
## Details

Added a new section "Grouping traces into conversational threads using `thread_id`" to the CrewAI integration documentation. This section explains how to use the `thread_id` parameter to group CrewAI traces into conversational threads, matching the pattern used in other integrations like OpenAI.

The section includes:
- Clear explanation of threads in Opik
- Code example showing how to pass `thread_id` via `opik_args` parameter
- Reference link to the detailed "Log conversations" documentation

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves # NA
- OPIK- NA

## Testing

- Verified the documentation renders correctly with proper markdown formatting
- Checked that code examples follow the established pattern from test files
- Confirmed no linting errors in the updated documentation file

## Documentation

- Updated `apps/opik-documentation/documentation/fern/docs/tracing/integrations/crewai.mdx` with new conversation logging section