### PR TITLE
[NA] [FE] Remove unused @swc/helpers dependency

### DIFF
--- a/apps/opik-frontend/package-lock.json
+++ b/apps/opik-frontend/package-lock.json
@@ -5457,17 +5457,6 @@
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
       "dev": true
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/@swc/types": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.8.tgz",


### PR DESCRIPTION
## Details
This change appeared in git diff every time `npm install` is run.

Removed the unused `@swc/helpers` (v0.5.15) dependency from the frontend package-lock.json. This dependency was marked as optional and a peer dependency, indicating it was not actively used by the application.

**Changes made:**
- Removed `@swc/helpers` dependency entry from `apps/opik-frontend/package-lock.json`
- Cleaned up 11 lines of unused dependency configuration

This cleanup helps reduce the dependency tree and potential security surface area.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- NA

## Testing
- ✅ Ran `npm run lint` - passed successfully
- ✅ Ran `npm run typecheck` - passed successfully
- ✅ No code changes, only dependency cleanup in package-lock.json

## Documentation
N/A - This is a dependency cleanup with no user-facing or functional changes.