### PR TITLE
[NA] [SDK] Restrict LiteLLM to <1.77.5 due to trace payload indentation bug

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -42,7 +42,9 @@ setup(
         "httpx",  # some older version of openai/litellm are broken with httpx>=0.28.0
         "rapidfuzz>=3.0.0,<4.0.0",
         # Exclude litellm 1.75.0-1.75.5 (broken callbacks system)
-        "litellm!=1.75.0,!=1.75.1,!=1.75.2,!=1.75.3,!=1.75.4,!=1.75.5",
+        # Cap at 1.77.4: version 1.77.5+ removes trace_id/parent_span_id passthrough
+        # See: https://github.com/BerriAI/litellm/commit/dd4fa371fa59ef635a86ea3788639c456019fa59
+        "litellm<1.77.5,!=1.75.0,!=1.75.1,!=1.75.2,!=1.75.3,!=1.75.4,!=1.75.5",
         "openai",
         "pydantic-settings>=2.0.0,<3.0.0,!=2.9.0",
         "pydantic>=2.0.0,<3.0.0",


### PR DESCRIPTION
## Details

This PR restricts LiteLLM to version `<1.77.5` to prevent a breaking change introduced in LiteLLM commit [dd4fa371](https://github.com/BerriAI/litellm/commit/dd4fa371fa59ef635a86ea3788639c456019fa59).

**Root Cause:** 
In LiteLLM v1.77.5+, the `payload.append()` block for trace data (lines 319-332 in `litellm/integrations/opik/opik.py`) was dedented by 4 spaces, moving it outside of its intended conditional scope. This causes the trace payload to be created unconditionally instead of only when appropriate, which breaks Opik's evaluation trace context by overwriting evaluation trace metadata.

**Solution:**
Cap LiteLLM at version 1.77.4 until the upstream issue is fixed. We already have exclusions for versions 1.75.0-1.75.5 due to a broken callbacks system, so this adds an upper bound to prevent the indentation bug.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- NA

## Testing

**Verification:**
1. The version constraint `litellm<1.77.5` prevents installation of problematic versions
2. Existing LiteLLM integration tests continue to pass
3. Evaluation with LiteLLM models (via `LitellmChatModel`) maintains proper trace context

## Documentation

No documentation changes required. This is a dependency constraint update to prevent a breaking change in an external library.