### PR TITLE
[OPIK-2638]: add time to traces;

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TagList/TagList.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TagList/TagList.tsx
@@ -64,6 +64,7 @@ const TagList: React.FunctionComponent<TagListProps> = ({
       tags={tags}
       onAddTag={handleAddTag}
       onDeleteTag={handleDeleteTag}
+      size="sm"
     />
   );
 };

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -24,7 +24,7 @@ import TagList from "../TagList/TagList";
 import InputOutputTab from "./InputOutputTab";
 import MetadataTab from "./MatadataTab";
 import AgentGraphTab from "./AgentGraphTab";
-import { formatDuration } from "@/lib/date";
+import { formatDuration, formatDate } from "@/lib/date";
 import isUndefined from "lodash/isUndefined";
 import { formatCost } from "@/lib/money";
 import TraceDataViewerActionsPanel from "@/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewerActionsPanel";
@@ -98,9 +98,25 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
   );
 
   const duration = formatDuration(data.duration);
+  const start_time = data.start_time
+    ? formatDate(data.start_time, { includeSeconds: true })
+    : "";
+  const end_time = data.end_time
+    ? formatDate(data.end_time, { includeSeconds: true })
+    : "";
   const estimatedCost = data.total_estimated_cost;
   const model = get(data, "model", null);
   const provider = get(data, "provider", null);
+
+  const durationTooltip = (
+    <div>
+      Duration in seconds: {duration}
+      <p>
+        {start_time}
+        {end_time ? ` - ${end_time}` : ""}
+      </p>
+    </div>
+  );
 
   return (
     <div className="size-full max-w-full overflow-auto">
@@ -133,7 +149,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
             )}
           />
           <div className="comet-body-s-accented flex w-full items-center gap-3 overflow-x-hidden text-muted-slate">
-            <TooltipWrapper content={`Duration in seconds: ${duration}`}>
+            <TooltipWrapper content={durationTooltip}>
               <div
                 className="comet-body-xs-accented flex items-center gap-1 text-muted-slate"
                 data-testid="data-viewer-duration"

--- a/apps/opik-frontend/src/components/pages/HomePage/HomePageChart.tsx
+++ b/apps/opik-frontend/src/components/pages/HomePage/HomePageChart.tsx
@@ -72,7 +72,7 @@ const HomePageChart: React.FC<MetricOverviewChartProps> = ({
     ({ payload }: ChartTooltipRenderHeaderArguments) => {
       return (
         <div className="comet-body-xs mb-1 text-light-slate">
-          {formatDate(payload?.[0]?.payload?.date, true)} UTC
+          {formatDate(payload?.[0]?.payload?.date, { utc: true })} UTC
         </div>
       );
     },

--- a/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricBarChart.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricBarChart.tsx
@@ -62,7 +62,7 @@ const MetricBarChart = ({
     ({ payload }: ChartTooltipRenderHeaderArguments) => {
       return (
         <div className="comet-body-xs mb-1 text-light-slate">
-          {formatDate(payload?.[0]?.payload?.time, true)} UTC
+          {formatDate(payload?.[0]?.payload?.time, { utc: true })} UTC
         </div>
       );
     },

--- a/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricLineChart.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricLineChart.tsx
@@ -72,7 +72,7 @@ const MetricLineChart = ({
     ({ payload }: ChartTooltipRenderHeaderArguments) => {
       return (
         <div className="comet-body-xs mb-1 text-light-slate">
-          {formatDate(payload?.[0]?.payload?.time, true)} UTC
+          {formatDate(payload?.[0]?.payload?.time, { utc: true })} UTC
         </div>
       );
     },

--- a/apps/opik-frontend/src/components/shared/TagListRenderer/TagListRenderer.tsx
+++ b/apps/opik-frontend/src/components/shared/TagListRenderer/TagListRenderer.tsx
@@ -15,6 +15,7 @@ export type TagListRendererProps = {
   onAddTag: (tag: string) => void;
   onDeleteTag: (tag: string) => void;
   align?: "start" | "end";
+  size?: "md" | "sm";
 };
 
 const TagListRenderer: React.FC<TagListRendererProps> = ({
@@ -22,10 +23,14 @@ const TagListRenderer: React.FC<TagListRendererProps> = ({
   onAddTag,
   onDeleteTag,
   align = "end",
+  size = "md",
 }) => {
   const { toast } = useToast();
   const [open, setOpen] = useState(false);
   const [newTag, setNewTag] = useState<string>("");
+
+  const tagSizeClass = size === "sm" ? "w-3" : "w-4";
+  const tagMarginClass = size === "sm" ? "mx-0" : "mx-1";
 
   const handleAddTag = () => {
     if (!newTag) return;
@@ -46,7 +51,7 @@ const TagListRenderer: React.FC<TagListRendererProps> = ({
 
   return (
     <div className="flex min-h-7 w-full flex-wrap items-center gap-1.5 overflow-x-hidden">
-      <Tag className="mx-1 size-4 text-muted-slate" />
+      <Tag className={`${tagMarginClass} ${tagSizeClass} text-muted-slate`} />
       {[...tags].sort().map((tag) => {
         return (
           <RemovableTag

--- a/apps/opik-frontend/src/lib/date.ts
+++ b/apps/opik-frontend/src/lib/date.ts
@@ -14,8 +14,19 @@ dayjs.extend(duration);
 const FORMATTED_DATE_STRING_REGEXP =
   /^(0[1-9]|1[0-2])\/(0[1-9]|[12][0-9]|3[01])\/(\d{2}|\d{4})\s(0[1-9]|1[0-2]):([0-5][0-9])\s(AM|PM)$/;
 
-export const formatDate = (value: string, utc: boolean = false) => {
-  const dateTimeFormat = "MM/DD/YY hh:mm A";
+type FormatDateConfig = {
+  utc?: boolean;
+  includeSeconds?: boolean;
+};
+
+export const formatDate = (
+  value: string,
+  { utc = false, includeSeconds = false }: FormatDateConfig = {},
+) => {
+  const dateTimeFormat = includeSeconds
+    ? "MM/DD/YY hh:mm:ss A"
+    : "MM/DD/YY hh:mm A";
+
   if (isString(value) && dayjs(value).isValid()) {
     if (utc) {
       return dayjs(value).utc().format(dateTimeFormat);


### PR DESCRIPTION
## Details
- Align the tag icon 
<img width="1488" height="649" alt="image" src="https://github.com/user-attachments/assets/f6ad1a23-bf8b-45ab-970d-1a798ffc091c" />

- Add trace start and end dates to a tooltip of duration
<img width="1497" height="724" alt="image" src="https://github.com/user-attachments/assets/5bc11134-07f3-41a6-8f67-4598f3d62cf4" />


## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2638

## Testing
- Tested manually

## Documentation
