### PR TITLE
[OPIK-2522] renamed opik-configure to opik-ts

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -695,9 +695,9 @@ navigation:
           - page: Overview
             path: docs/reference/typescript-sdk/overview.mdx
             slug: overview
-          - page: Opik Configure
-            path: docs/reference/typescript-sdk/opik-configure.mdx
-            slug: opik-configure
+          - page: Opik TS
+            path: docs/reference/typescript-sdk/opik-ts.mdx
+            slug: opik-ts
           - section: Evaluation
             slug: evaluation
             contents:

--- a/apps/opik-documentation/documentation/fern/docs/quickstart.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/quickstart.mdx
@@ -69,7 +69,7 @@ popular integrations:
         Configure the Opik TypeScript SDK by running the interactive CLI tool:
 
         ```bash
-        npx opik-configure
+        npx opik-ts configure
         ```
 
         This will detect your project setup, install required dependencies, and help you configure environment variables.
@@ -160,7 +160,7 @@ popular integrations:
         Configure the Opik TypeScript SDK by running the interactive CLI tool:
 
         ```bash
-        npx opik-configure
+        npx opik-ts configure
         ```
 
         This will detect your project setup, install required dependencies, and help you configure environment variables.
@@ -212,7 +212,7 @@ popular integrations:
         Configure the Opik AI Vercel SDK by running the interactive CLI tool:
 
         ```bash
-        npx opik-configure
+        npx opik-ts configure
         ```
 
         This will detect your project setup, install required dependencies, and help you configure environment variables.
@@ -466,6 +466,7 @@ popular integrations:
     </CardGroup>
 
     **[View all 30+ integrations →](/integrations/overview)**
+
   </Tab>
 </Tabs>
 
@@ -474,14 +475,14 @@ popular integrations:
 After running your application, you will start seeing your traces in your Opik dashboard:
 
 <video
-    src="/img/tracing/quickstart.mp4"
-    width="854"
-    height="480"
-    autoPlay
-    muted
-    loop
-    playsInline
-    preload="auto"
+  src="/img/tracing/quickstart.mp4"
+  width="854"
+  height="480"
+  autoPlay
+  muted
+  loop
+  playsInline
+  preload="auto"
 />
 
 If you don't see traces appearing, reach out to us on [Slack](https://chat.comet.com) or raise an issue on [GitHub](https://github.com/comet-ml/opik/issues) and we'll help you troubleshoot.

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/opik-ts.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/opik-ts.mdx
@@ -1,9 +1,9 @@
 ---
-title: Opik Configure - Interactive Setup Tool
+title: Opik TS - Interactive Setup Tool
 description: A guided CLI tool for quickly integrating Opik SDK into your Node.js/TypeScript projects with automatic configuration and setup.
 ---
 
-The Opik Configure is an interactive command-line tool that streamlines the process of adding Opik observability to your Node.js and TypeScript applications. It automatically detects your project setup, installs dependencies, and configures tracing for your LLM integrations.
+The Opik TS is an interactive command-line tool that streamlines the process of adding Opik observability to your Node.js and TypeScript applications. It automatically detects your project setup, installs dependencies, and configures tracing for your LLM integrations.
 
 ## Features
 
@@ -18,7 +18,7 @@ The Opik Configure is an interactive command-line tool that streamlines the proc
 Run the CLI in your project directory:
 
 ```bash
-npx opik-configure
+npx opik-ts configure
 ```
 
 The CLI will guide you through:
@@ -42,40 +42,49 @@ The CLI will guide you through:
 
 The CLI supports several command-line options for customization:
 
-| Option            | Type    | Default           | Description                                                    | Environment Variable           |
-| ----------------- | ------- | ----------------- | -------------------------------------------------------------- | ------------------------------ |
-| `--help`          | boolean | -                 | Display help information                                       | -                              |
-| `--version`       | boolean | -                 | Show version number                                            | -                              |
-| `--debug`         | boolean | `false`           | Enable verbose logging for troubleshooting                     | `OPIK_CONFIGURE_DEBUG`         |
-| `--default`       | boolean | `true`            | Use default options for all prompts (non-interactive)          | `OPIK_CONFIGURE_DEFAULT`       |
-| `--force-install` | boolean | `false`           | Force package installation even if peer dependency checks fail | `OPIK_CONFIGURE_FORCE_INSTALL` |
-| `--install-dir`   | string  | current directory | Specify custom installation directory                          | `OPIK_CONFIGURE_INSTALL_DIR`   |
+| Option            | Type    | Default           | Description                                                    | Environment Variable    |
+| ----------------- | ------- | ----------------- | -------------------------------------------------------------- | ----------------------- |
+| `--help`          | boolean | -                 | Display help information                                       | -                       |
+| `--version`       | boolean | -                 | Show version number                                            | -                       |
+| `--debug`         | boolean | `false`           | Enable verbose logging for troubleshooting                     | `OPIK_TS_DEBUG`         |
+| `--default`       | boolean | `true`            | Use default options for all prompts (non-interactive)          | `OPIK_TS_DEFAULT`       |
+| `--force-install` | boolean | `false`           | Force package installation even if peer dependency checks fail | `OPIK_TS_FORCE_INSTALL` |
+| `--install-dir`   | string  | current directory | Specify custom installation directory                          | `OPIK_TS_INSTALL_DIR`   |
+| `--use-local`     | boolean | `false`           | Skip deployment selection and configure for local development  | `OPIK_TS_USE_LOCAL`     |
 
 ### Examples
 
 **Verbose debugging mode:**
 
 ```bash
-npx opik-configure --debug
+npx opik-ts configure --debug
 ```
 
 **Non-interactive mode with defaults:**
 
 ```bash
-npx opik-configure --default
+npx opik-ts configure --default
 ```
 
 **Install in a specific directory:**
 
 ```bash
-npx opik-configure --install-dir=./my-app
+npx opik-ts configure --install-dir=./my-app
 ```
 
 **Force installation (skip peer dependency checks):**
 
 ```bash
-npx opik-configure --force-install
+npx opik-ts configure --force-install
 ```
+
+**Local development setup:**
+
+```bash
+npx opik-ts configure --use-local
+```
+
+This will skip the deployment selection step and automatically configure your environment for local development (localhost:5173).
 
 ## Environment Configuration
 
@@ -104,7 +113,7 @@ If you encounter permission errors during installation:
 
 ```bash
 # Use --force-install to bypass peer dependency checks
-npx opik-configure --force-install
+npx opik-ts configure --force-install
 ```
 
 ### Package Manager Issues
@@ -112,7 +121,7 @@ npx opik-configure --force-install
 If the CLI fails to detect your package manager:
 
 1. Ensure you have a `package.json` in your project directory
-2. Try running the CLI with debug mode: `npx opik-configure --debug`
+2. Try running the CLI with debug mode: `npx opik-ts configure --debug`
 3. Manually specify your package manager by selecting it from the prompts
 
 ### Environment Variable Setup
@@ -139,7 +148,7 @@ If traces aren't appearing in Opik:
 Enable verbose logging to troubleshoot issues:
 
 ```bash
-npx opik-configure --debug
+npx opik-ts configure --debug
 ```
 
 This will show detailed information about:
@@ -155,7 +164,7 @@ For automated deployments, use the non-interactive mode:
 
 ```bash
 # In your CI/CD pipeline
-npx opik-configure --default --force-install
+npx opik-ts configure --default --force-install
 ```
 
 Set environment variables beforehand:
@@ -163,7 +172,7 @@ Set environment variables beforehand:
 ```bash
 export OPIK_API_KEY="your-api-key"
 export OPENAI_API_KEY="your-openai-key"
-npx opik-configure --default
+npx opik-ts configure --default
 ```
 
 ## Next Steps

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/overview.mdx
@@ -22,12 +22,12 @@ For a complete list of TypeScript/JavaScript integrations and other language int
 
 ## Installation
 
-### Option 1: Using the Opik Configure (Recommended)
+### Option 1: Using the Opik TS (Recommended)
 
-The fastest way to get started is using the [Opik Configure](/reference/typescript-sdk/opik-configure), an interactive CLI tool that sets up Opik automatically in your project:
+The fastest way to get started is using the [Opik TS](/reference/typescript-sdk/opik-ts), an interactive CLI tool that sets up Opik automatically in your project:
 
 ```bash
-npx opik-configure
+npx opik-ts configure
 ```
 
 The CLI will:

--- a/sdks/typescript/src/opik/configure/README.md
+++ b/sdks/typescript/src/opik/configure/README.md
@@ -1,28 +1,44 @@
-# Opik Configure ✨
+# Opik TS ✨
 
-The Opik configure tool helps you quickly add Opik SDK to your Node.js project
-for LLM observability and tracing.
+The Opik TS tool helps you quickly add Opik SDK to your Node.js project for LLM
+observability and tracing.
 
 > **⚠️ Experimental:** This tool is still in an experimental phase.
 
 # Usage
 
+## Quick Start
+
 ```bash
-npx opik-configure
+npx opik-ts configure
 ```
+
+This will guide you through the setup process interactively.
+
+## Quick Local Setup
+
+For local development with a local Opik instance:
+
+```bash
+npx opik-ts configure --use-local
+```
+
+This skips API key and workspace prompts and automatically configures for local
+deployment (http://localhost:5173/api).
 
 # Options
 
 The following CLI arguments are available:
 
-| Option            | Description                                                | Type    | Default | Environment Variable           |
-| ----------------- | ---------------------------------------------------------- | ------- | ------- | ------------------------------ |
-| `--help`          | Show help                                                  | boolean |         |                                |
-| `--version`       | Show version number                                        | boolean |         |                                |
-| `--debug`         | Enable verbose logging                                     | boolean | `false` | `OPIK_CONFIGURE_DEBUG`         |
-| `--default`       | Use default options for all prompts                        | boolean | `true`  | `OPIK_CONFIGURE_DEFAULT`       |
-| `--force-install` | Force install packages even if peer dependency checks fail | boolean | `false` | `OPIK_CONFIGURE_FORCE_INSTALL` |
-| `--install-dir`   | Directory to install Opik SDK in                           | string  |         | `OPIK_CONFIGURE_INSTALL_DIR`   |
+| Option            | Description                                                            | Type    | Default | Environment Variable    |
+| ----------------- | ---------------------------------------------------------------------- | ------- | ------- | ----------------------- |
+| `--help`          | Show help                                                              | boolean |         |                         |
+| `--version`       | Show version number                                                    | boolean |         |                         |
+| `--debug`         | Enable verbose logging                                                 | boolean | `false` | `OPIK_TS_DEBUG`         |
+| `--default`       | Use default options for all prompts                                    | boolean | `true`  | `OPIK_TS_DEFAULT`       |
+| `--force-install` | Force install packages even if peer dependency checks fail             | boolean | `false` | `OPIK_TS_FORCE_INSTALL` |
+| `--install-dir`   | Directory to install Opik SDK in                                       | string  |         | `OPIK_TS_INSTALL_DIR`   |
+| `--use-local`     | Configure for local deployment (skips API key/workspace setup prompts) | boolean | `false` | `OPIK_TS_USE_LOCAL`     |
 
 # Development
 
@@ -37,7 +53,7 @@ To build and use the tool globally:
 ```bash
 pnpm build
 pnpm link --global
-opik-configure [options]
+opik-ts [options]
 ```
 
 ## Contributing

--- a/sdks/typescript/src/opik/configure/bin.ts
+++ b/sdks/typescript/src/opik/configure/bin.ts
@@ -20,58 +20,76 @@ if (!satisfies(process.version, NODE_VERSION_RANGE)) {
 import type { WizardOptions } from './src/utils/types';
 import { runWizard } from './src/run';
 import { isNonInteractiveEnvironment } from './src/utils/environment';
+import { runDoctor } from './src/doctor';
 import clack from './src/utils/clack';
 
-if (isNonInteractiveEnvironment()) {
-  clack.intro(chalk.inverse(`Opik Configure`));
-
-  clack.log.error(
-    'This installer requires an interactive terminal (TTY) to run.\n' +
-      'It appears you are running in a non-interactive environment.\n' +
-      'Please run the CLI in an interactive terminal.',
-  );
-  process.exit(1);
-}
-
 yargs(hideBin(process.argv))
-  .env('OPIK_CONFIGURE')
+  .scriptName('opik-ts')
+  .env('OPIK_TS')
   // global options
   .options({
     debug: {
       default: false,
-      describe: 'Enable verbose logging\nenv: OPIK_CONFIGURE_DEBUG',
+      describe: 'Enable verbose logging\nenv: OPIK_TS_DEBUG',
       type: 'boolean',
     },
     default: {
       default: true,
-      describe:
-        'Use default options for all prompts\nenv: OPIK_CONFIGURE_DEFAULT',
+      describe: 'Use default options for all prompts\nenv: OPIK_TS_DEFAULT',
       type: 'boolean',
     },
   })
   .command(
-    ['$0'],
-    'Run the Opik SDK setup CLI',
+    'configure',
+    'Run the Opik SDK setup configure',
     (yargs) => {
       return yargs.options({
         'force-install': {
           default: false,
           describe:
-            'Force install packages even if peer dependency checks fail\nenv: OPIK_CONFIGURE_FORCE_INSTALL',
+            'Force install packages even if peer dependency checks fail\nenv: OPIK_TS_FORCE_INSTALL',
           type: 'boolean',
         },
         'install-dir': {
           describe:
-            'Directory to install Opik SDK in\nenv: OPIK_CONFIGURE_INSTALL_DIR',
+            'Directory to install Opik SDK in\nenv: OPIK_TS_INSTALL_DIR',
           type: 'string',
+        },
+        'use-local': {
+          default: false,
+          describe:
+            'Configure for local deployment (skips API key/workspace setup)\nenv: OPIK_TS_USE_LOCAL',
+          type: 'boolean',
         },
       });
     },
     (argv) => {
+      // Check for interactive terminal for configure command
+      if (isNonInteractiveEnvironment()) {
+        clack.intro(chalk.inverse(`Opik TS`));
+
+        clack.log.error(
+          'This installer requires an interactive terminal (TTY) to run.\n' +
+            'It appears you are running in a non-interactive environment.\n' +
+            'Please run the CLI in an interactive terminal.',
+        );
+        process.exit(1);
+      }
+
       const options = { ...argv };
       void runWizard(options as unknown as WizardOptions);
     },
   )
+  .command(
+    'doctor',
+    'Run health checks for Opik SDK installation',
+    () => {},
+    () => {
+      void runDoctor();
+    },
+  )
+  .demandCommand(1, 'Error: command required')
+  .showHelpOnFail(true)
   .help()
   .alias('help', 'h')
   .version()

--- a/sdks/typescript/src/opik/configure/package-lock.json
+++ b/sdks/typescript/src/opik/configure/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "opik-configure",
+  "name": "opik-ts",
   "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "opik-configure",
+      "name": "opik-ts",
       "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -31,7 +31,7 @@
         "zod-to-json-schema": "^3.24.6"
       },
       "bin": {
-        "opik-configure": "dist/bin.js"
+        "opik-ts": "dist/bin.js"
       },
       "devDependencies": {
         "@babel/types": "~7.21.4",

--- a/sdks/typescript/src/opik/configure/package.json
+++ b/sdks/typescript/src/opik/configure/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opik-configure",
+  "name": "opik-ts",
   "version": "0.1.2",
   "homepage": "https://github.com/comet-ml/opik",
   "repository": "https://github.com/comet-ml/opik",
@@ -16,7 +16,7 @@
     "llm"
   ],
   "bin": {
-    "opik-configure": "dist/bin.js"
+    "opik-ts": "dist/bin.js"
   },
   "publishConfig": {
     "access": "public"

--- a/sdks/typescript/src/opik/configure/src/doctor.ts
+++ b/sdks/typescript/src/opik/configure/src/doctor.ts
@@ -1,0 +1,263 @@
+import { satisfies } from 'semver';
+import chalk from 'chalk';
+import clack from './utils/clack';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { OPIK_ENV_VARS, OPIK_ENV_VAR_DESCRIPTIONS } from './lib/env-constants';
+import {
+  readEnvFiles,
+  getEnvVarWithSource,
+  type EnvFileCache,
+} from './utils/environment';
+import { maskApiKey } from './utils/mask';
+
+const NODE_VERSION_RANGE = '>=18.17.0';
+
+interface HealthCheck {
+  name: string;
+  status: boolean;
+  message: string;
+}
+
+enum DeploymentType {
+  LOCAL = 'local',
+  CLOUD_OR_SELF_HOSTED = 'cloud-or-self-hosted',
+  UNKNOWN = 'unknown',
+}
+
+type EnvVarCondition = DeploymentType | 'always' | 'optional';
+
+interface EnvVarCheckConfig {
+  required: boolean;
+  condition: EnvVarCondition;
+}
+
+const ENV_VAR_CHECKS_CONFIG: Record<string, EnvVarCheckConfig> = {
+  [OPIK_ENV_VARS.URL_OVERRIDE]: {
+    required: true,
+    condition: 'always',
+  },
+  [OPIK_ENV_VARS.API_KEY]: {
+    required: true,
+    condition: DeploymentType.CLOUD_OR_SELF_HOSTED,
+  },
+  [OPIK_ENV_VARS.WORKSPACE]: {
+    required: true,
+    condition: DeploymentType.CLOUD_OR_SELF_HOSTED,
+  },
+  [OPIK_ENV_VARS.PROJECT_NAME]: {
+    required: false,
+    condition: 'optional',
+  },
+};
+
+function detectDeploymentType(urlOverride: string | undefined): DeploymentType {
+  if (!urlOverride) {
+    return DeploymentType.UNKNOWN;
+  }
+
+  const url = urlOverride.toLowerCase();
+  const isLocal =
+    url.includes('localhost') ||
+    url.includes('127.0.0.1') ||
+    url.includes('0.0.0.0');
+
+  return isLocal ? DeploymentType.LOCAL : DeploymentType.CLOUD_OR_SELF_HOSTED;
+}
+
+function getDeploymentTypeLabel(deploymentType: DeploymentType): string {
+  switch (deploymentType) {
+    case DeploymentType.LOCAL:
+      return 'Local deployment';
+    case DeploymentType.CLOUD_OR_SELF_HOSTED:
+      return 'Cloud/Self-hosted deployment';
+    case DeploymentType.UNKNOWN:
+      return 'Unknown deployment';
+  }
+}
+
+function checkNodeVersion(): HealthCheck {
+  const isValid = satisfies(process.version, NODE_VERSION_RANGE);
+  return {
+    name: 'Node.js version',
+    status: isValid,
+    message: isValid
+      ? `${process.version} (meets requirement: ${NODE_VERSION_RANGE})`
+      : `${process.version} (requires: ${NODE_VERSION_RANGE})`,
+  };
+}
+
+function checkOpikInPackageJson(): HealthCheck {
+  const packageJsonPath = join(process.cwd(), 'package.json');
+
+  if (!existsSync(packageJsonPath)) {
+    return {
+      name: 'Opik SDK in package.json',
+      status: false,
+      message: 'package.json not found',
+    };
+  }
+
+  try {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    const dependencies = {
+      ...packageJson.dependencies,
+      ...packageJson.devDependencies,
+    };
+
+    const opikVersion = dependencies['opik'];
+    if (opikVersion) {
+      return {
+        name: 'Opik SDK in package.json',
+        status: true,
+        message: `Installed (${opikVersion})`,
+      };
+    }
+
+    return {
+      name: 'Opik SDK in package.json',
+      status: false,
+      message: 'Not installed',
+    };
+  } catch {
+    return {
+      name: 'Opik SDK in package.json',
+      status: false,
+      message: 'Failed to parse package.json',
+    };
+  }
+}
+
+function checkOpikInNodeModules(): HealthCheck {
+  const opikModulePath = join(process.cwd(), 'node_modules', 'opik');
+  const exists = existsSync(opikModulePath);
+
+  return {
+    name: 'Opik SDK in node_modules',
+    status: exists,
+    message: exists ? 'Present' : 'Not found',
+  };
+}
+
+function checkEnvironmentVariables(
+  deploymentType: DeploymentType,
+  envFileCache: EnvFileCache,
+): HealthCheck[] {
+  const checks: HealthCheck[] = [];
+
+  for (const [varName, config] of Object.entries(ENV_VAR_CHECKS_CONFIG)) {
+    // Skip checks that don't apply to current deployment type
+    if (
+      config.condition !== 'always' &&
+      config.condition !== 'optional' &&
+      config.condition !== deploymentType
+    ) {
+      continue;
+    }
+
+    const envVar = getEnvVarWithSource(varName, envFileCache);
+    const hasValue = !!envVar.value;
+
+    // Determine if this variable is required based on deployment type
+    const isRequired =
+      config.condition === 'always' || config.condition === deploymentType;
+
+    // Build status and message
+    let status: boolean;
+    let message: string;
+
+    if (hasValue) {
+      status = true;
+      if (varName === OPIK_ENV_VARS.URL_OVERRIDE) {
+        const typeLabel = getDeploymentTypeLabel(deploymentType);
+        message = `Set (${typeLabel}) [from ${envVar.source}]`;
+      } else if (varName === OPIK_ENV_VARS.PROJECT_NAME) {
+        message = `Set to "${envVar.value}" [from ${envVar.source}]`;
+      } else if (varName === OPIK_ENV_VARS.API_KEY) {
+        message = `Set to ${maskApiKey(envVar.value)} [from ${envVar.source}]`;
+      } else {
+        message = `Set [from ${envVar.source}]`;
+      }
+    } else {
+      status = !isRequired;
+      const description =
+        OPIK_ENV_VAR_DESCRIPTIONS[
+          varName as keyof typeof OPIK_ENV_VAR_DESCRIPTIONS
+        ];
+      if (isRequired) {
+        const requiredContext =
+          config.condition === DeploymentType.CLOUD_OR_SELF_HOSTED
+            ? ' (required for Cloud/Self-hosted)'
+            : '';
+        message = `Not set - ${description}${requiredContext}`;
+      } else {
+        message = 'Not set (will use default)';
+      }
+    }
+
+    checks.push({
+      name: `Environment variable: ${varName}`,
+      status,
+      message,
+    });
+  }
+
+  return checks;
+}
+
+function displayResults(checks: HealthCheck[]): void {
+  clack.log.step('Health Check Results:\n');
+
+  for (const check of checks) {
+    if (check.status) {
+      clack.log.success(`✓ ${check.name}: ${check.message}`);
+    } else {
+      clack.log.error(`✗ ${check.name}: ${check.message}`);
+    }
+  }
+}
+
+function determineOutcome(checks: HealthCheck[]): void {
+  const allPassed = checks.every((check) => check.status);
+
+  if (allPassed) {
+    clack.outro(chalk.green('All checks passed!'));
+  } else {
+    clack.outro(
+      chalk.yellow(
+        'Some checks failed. Run "npx opik-ts configure" to set up Opik SDK.',
+      ),
+    );
+    process.exit(1);
+  }
+}
+
+export async function runDoctor(): Promise<void> {
+  clack.intro(chalk.inverse(`Opik TS Doctor`));
+
+  const checks: HealthCheck[] = [];
+
+  // Read .env files once at the start
+  const envFileCache = readEnvFiles();
+
+  // System checks
+  checks.push(checkNodeVersion());
+
+  // SDK installation checks
+  checks.push(checkOpikInPackageJson());
+  checks.push(checkOpikInNodeModules());
+
+  // Environment variable checks
+  const urlOverrideVar = getEnvVarWithSource(
+    OPIK_ENV_VARS.URL_OVERRIDE,
+    envFileCache,
+  );
+  const deploymentType = detectDeploymentType(
+    urlOverrideVar.value || undefined,
+  );
+  checks.push(...checkEnvironmentVariables(deploymentType, envFileCache));
+
+  // Display and determine outcome
+  displayResults(checks);
+  determineOutcome(checks);
+}

--- a/sdks/typescript/src/opik/configure/src/nodejs/node-wizard.ts
+++ b/sdks/typescript/src/opik/configure/src/nodejs/node-wizard.ts
@@ -70,7 +70,7 @@ export async function runNodejsWizard(options: WizardOptions): Promise<void> {
 
   debug('Getting project data');
   const { projectApiKey, host, workspaceName, projectName, deploymentType } =
-    await getOrAskForProjectData();
+    await getOrAskForProjectData({ useLocal: options.useLocal });
   debug(
     `Project data obtained: deploymentType=${deploymentType}, workspace=${workspaceName}, project=${projectName}`,
   );

--- a/sdks/typescript/src/opik/configure/src/run.ts
+++ b/sdks/typescript/src/opik/configure/src/run.ts
@@ -21,6 +21,7 @@ type Args = {
   forceInstall?: boolean;
   installDir?: string;
   default?: boolean;
+  useLocal?: boolean;
 };
 
 export async function runWizard(argv: Args) {
@@ -52,6 +53,7 @@ export async function runWizard(argv: Args) {
     forceInstall: finalArgs.forceInstall ?? false,
     installDir: resolvedInstallDir,
     default: finalArgs.default ?? false,
+    useLocal: finalArgs.useLocal ?? false,
   };
 
   analytics.setTag('debug', wizardOptions.debug);

--- a/sdks/typescript/src/opik/configure/src/utils/environment.ts
+++ b/sdks/typescript/src/opik/configure/src/utils/environment.ts
@@ -1,4 +1,6 @@
 import readEnv from 'read-env';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
 import { IS_DEV } from '../lib/constants';
 
 export function isNonInteractiveEnvironment(): boolean {
@@ -17,4 +19,84 @@ export function readEnvironment(): Record<string, unknown> {
   const result = readEnv('OPIK_CONFIGURE');
 
   return result;
+}
+
+export interface EnvFileCache {
+  envFilePath: string | undefined;
+  envContent: string;
+}
+
+export interface EnvVarSource {
+  value: string;
+  source: 'process.env' | '.env.local' | '.env' | 'not-found';
+}
+
+/**
+ * Reads .env files from the current working directory.
+ * Prioritizes .env.local over .env if both exist.
+ * This should be called once and the result cached to avoid repeated file reads.
+ */
+export function readEnvFiles(): EnvFileCache {
+  const cwd = process.cwd();
+  const dotEnvLocalFilePath = join(cwd, '.env.local');
+  const dotEnvFilePath = join(cwd, '.env');
+
+  if (existsSync(dotEnvLocalFilePath)) {
+    return {
+      envFilePath: dotEnvLocalFilePath,
+      envContent: readFileSync(dotEnvLocalFilePath, 'utf8'),
+    };
+  }
+
+  if (existsSync(dotEnvFilePath)) {
+    return {
+      envFilePath: dotEnvFilePath,
+      envContent: readFileSync(dotEnvFilePath, 'utf8'),
+    };
+  }
+
+  return {
+    envFilePath: undefined,
+    envContent: '',
+  };
+}
+
+/**
+ * Gets an environment variable value and its source.
+ * Checks in order: process.env, then cached .env file content.
+ * @param varName - The environment variable name to look up
+ * @param envFileCache - Cached env file content from readEnvFiles() to avoid repeated file reads
+ */
+export function getEnvVarWithSource(
+  varName: string,
+  envFileCache: EnvFileCache,
+): EnvVarSource {
+  // Check process.env first (highest priority)
+  if (process.env[varName]) {
+    return {
+      value: process.env[varName]!,
+      source: 'process.env',
+    };
+  }
+
+  // Check .env files from cache
+  if (envFileCache.envContent) {
+    const regex = new RegExp(`^${varName}=(.*)$`, 'm');
+    const match = envFileCache.envContent.match(regex);
+
+    if (match && match[1]) {
+      const source = envFileCache.envFilePath?.endsWith('.env.local')
+        ? '.env.local'
+        : '.env';
+      return {
+        value: match[1],
+        source: source as '.env.local' | '.env',
+      };
+    }
+  }
+
+  return {
+    value: '',
+    source: 'not-found',
+  };
 }

--- a/sdks/typescript/src/opik/configure/src/utils/mask.ts
+++ b/sdks/typescript/src/opik/configure/src/utils/mask.ts
@@ -1,0 +1,22 @@
+/**
+ * Utility functions for masking sensitive information in terminal output
+ */
+
+/**
+ * Masks an API key for safe display in terminal output
+ * Shows first 4 and last 4 characters, masks the middle with "..."
+ *
+ * @param apiKey - The API key to mask (can be undefined or null)
+ * @returns Masked API key in format "abcd...wxyz" or "(empty)" if no key provided
+ *
+ * @example
+ * maskApiKey('abcdefghijklmnop') // Returns: 'abcd...mnop'
+ * maskApiKey('short') // Returns: 'short' (keys <= 8 chars are not masked)
+ * maskApiKey('') // Returns: '(empty)'
+ * maskApiKey(undefined) // Returns: '(empty)'
+ */
+export function maskApiKey(apiKey: string | undefined | null): string {
+  if (!apiKey) return '(empty)';
+  if (apiKey.length <= 8) return apiKey;
+  return `${apiKey.substring(0, 4)}...${apiKey.substring(apiKey.length - 4)}`;
+}

--- a/sdks/typescript/src/opik/configure/src/utils/types.ts
+++ b/sdks/typescript/src/opik/configure/src/utils/types.ts
@@ -30,6 +30,12 @@ export type WizardOptions = {
    * Whether to select the default option for all questions automatically.
    */
   default: boolean;
+
+  /**
+   * Whether to configure for local deployment.
+   * When true, skips API key and workspace prompts and uses local defaults.
+   */
+  useLocal?: boolean;
 };
 
 export interface Feature {


### PR DESCRIPTION
## Details
- opik-configure to opik-ts
- --use-local flag support
- opik-ts doctor command 
- opik-ts configure command
- documentation updates 
- ApiKey masked

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-2522

## Testing

## Documentation
