### PR TITLE
[NA] [Optimizer] Pin litellm version

### DIFF
--- a/sdks/opik_optimizer/pyproject.toml
+++ b/sdks/opik_optimizer/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "gepa>=0.0.7",
     "ujson",
     "hf_xet",
-    "litellm",
+    "litellm<=1.75.6",
     "mcp>=1.0.0",
     "opik>=1.7.17",
     "optuna",


### PR DESCRIPTION
## Details

More recent versions of litellm have an issue with logging:

```python
Traceback (most recent call last):
  File "/home/dblank/miniconda3/envs/py310/lib/python3.10/site-packages/litellm/litellm_core_utils/logging_worker.py", line 51, in _worker_loop
    coroutine = await self._queue.get()
  File "/home/dblank/miniconda3/envs/py310/lib/python3.10/asyncio/queues.py", line 159, in get
    await getter
asyncio.exceptions.CancelledError
Task exception was never retrieved
future: <Task finished name='Task-329' coro=<LoggingWorker._worker_loop() done, defined at /home/dblank/miniconda3/envs/py310/lib/python3.10/site-packages/litellm/litellm_core_utils/logging_worker.py:43> 
exception=RuntimeError('<Queue at 0x711b8c2eda20 maxsize=50000> is bound to a different event loop')>
```
This PR pins the version to avoid the problem, but can still be compatible with Opik SDK.

## Change checklist
- [x] Requirements

## Issues

Resolves issues while testing.

## Testing

N/A

## Documentation

N/A
