### PR TITLE
[OPIK-2641] [FE] Add thread cost display to Thread sidebar header

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
@@ -327,7 +327,9 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
           </TooltipWrapper>
           {!isUndefined(thread?.total_estimated_cost) && (
             <TooltipWrapper
-              content={`Estimated cost ${formatCost(thread?.total_estimated_cost)}`}
+              content={`Estimated cost ${formatCost(
+                thread?.total_estimated_cost,
+              )}`}
             >
               <div className="flex flex-nowrap items-center gap-x-1.5 px-1 text-muted-slate">
                 <Coins className="size-4 shrink-0" />


### PR DESCRIPTION
## Details

This PR adds cost display to the Thread sidebar view header, showing the thread's estimated cost alongside existing metadata (start time, message count, and duration).

**Changes made:**
- Added `Coins` icon import from `lucide-react`
- Added `formatCost` utility import from `@/lib/money`
- Added `isUndefined` import from `lodash`
- Added conditional cost display section in Thread header (only shows when cost data exists)
- Cost displays in short format (e.g., `$0.03`) with full value in tooltip (e.g., `Estimated cost $0.034`)

**Design decisions:**
- Follows the existing pattern used in `TraceDataViewer` component for cost display
- Uses conditional rendering to only show cost when `total_estimated_cost` is available
- Maintains consistent styling with other metadata items in the header
- Positioned after duration, following the natural progression of metadata

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2641

## Testing

**Manual testing steps:**
1. Start the frontend application
2. Navigate to a project with threads
3. Open the Thread sidebar view
4. Verify that threads with cost data display the cost icon and value
5. Hover over the cost to see the full estimated cost in the tooltip
6. Verify that threads without cost data do not show the cost section

Tested manually in local env
<img width="757" height="429" alt="SCR-20251009-unvu" src="https://github.com/user-attachments/assets/fed6cca5-4a35-44fc-83a1-cce204feebb7" />


**Scenarios covered:**
- Thread with cost data: displays cost with Coins icon
- Thread without cost data: cost section is hidden
- Cost tooltip: shows full formatted cost value
- Cost formatting: uses short format in display, full format in tooltip

## Documentation

No documentation updates required for this change. The feature follows existing UI patterns and is self-explanatory within the interface.

**Related tickets:**
- Part of larger cost display initiative (OPIK-2639: Display total cost across projects)
- Related to OPIK-2640: Total Project cost in the project view