### PR TITLE
[OPIK-2092] [M1][FE] Test integration with BE and test webhook functionality

### DIFF
--- a/apps/opik-frontend/src/api/alerts/useWebhookTestMutation.ts
+++ b/apps/opik-frontend/src/api/alerts/useWebhookTestMutation.ts
@@ -9,7 +9,7 @@ const testWebhook = async (
   alert: Partial<Alert>,
 ): Promise<WebhookTestResult> => {
   const { data } = await api.post<WebhookTestResult>(
-    `${ALERTS_REST_ENDPOINT}/webhook/test`,
+    `${ALERTS_REST_ENDPOINT}webhooks/tests`,
     alert,
   );
   return data;


### PR DESCRIPTION
## Details

This PR fixes the API endpoint URL for the webhook test functionality in the frontend. The endpoint path has been updated from `/webhook/test` to `/webhooks/tests` to align with the backend API implementation.

**Change Summary:**
- Updated the webhook test endpoint URL in `useWebhookTestMutation.ts`
- Changed from `${ALERTS_REST_ENDPOINT}/webhook/test` to `${ALERTS_REST_ENDPOINT}webhooks/tests`

This ensures proper integration between the frontend and backend for testing webhook configurations.

## Change checklist
- [] User facing
- [ ] Documentation update

## Issues
- OPIK-2092


## Testing

**Tested Scenarios:**
- Webhook test functionality successfully sends test requests to the correct backend endpoint
- Error handling works correctly when webhook test fails
- Toast notifications display appropriate success/error messages

## Documentation
