### PR TITLE
[OPIK-2650] [BE] Fix `project_id` parameter error in demo data generator

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
+++ b/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
@@ -311,6 +311,9 @@ def create_demo_evaluation_project(context: DemoDataContext, base_url: str, work
                 if "parent_span_id" in span:
                     new_parent_span_id = get_new_uuid(context, span["parent_span_id"])
                     span["parent_span_id"] = new_parent_span_id
+                # Remove fields that shouldn't be in the span data
+                span.pop("project_id", None)
+                span.pop("workspace_id", None)
                 client.span(**span)
 
             client.flush()
@@ -451,6 +454,9 @@ def create_demo_chatbot_project(context: DemoDataContext, base_url: str, workspa
                 if "parent_span_id" in span:
                     new_parent_span_id = get_new_uuid(context, span["parent_span_id"])
                     span["parent_span_id"] = new_parent_span_id
+                # Remove fields that shouldn't be in the span data
+                span.pop("project_id", None)
+                span.pop("workspace_id", None)
                 client.span(**span)
 
             client.flush()
@@ -587,6 +593,9 @@ def create_demo_optimizer_project(context: DemoDataContext, base_url: str, works
                 if "parent_span_id" in span:
                     new_parent_span_id = get_new_uuid(context, span["parent_span_id"])
                     span["parent_span_id"] = new_parent_span_id
+                # Remove fields that shouldn't be in the span data
+                span.pop("project_id", None)
+                span.pop("workspace_id", None)
                 client.span(**span)
 
             client.flush()


### PR DESCRIPTION
## Details
Fixed a bug in the demo data generator where `project_id` and `workspace_id` fields were being passed to `client.span()` calls, causing a TypeError. The fields are now properly removed before calling the span method.

The issue occurred in three functions:
- `create_demo_evaluation_project()`
- `create_demo_chatbot_project()`
- `create_demo_optimizer_project()`

Each function was creating span dictionaries that included `project_id` and `workspace_id` fields from the demo data, but these fields are not valid parameters for the `Opik.span()` method.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-2650

## Testing
- All existing tests pass (39 passed, 2 skipped)
- Specifically tested:
  - `test_create_demo_data_structure` - PASSED
  - `test_create_demo_data_idempotence` - PASSED
  
The fix ensures that `project_id` and `workspace_id` are removed from span dictionaries before calling `client.span()`, preventing the TypeError that was occurring when demo data was being generated.

## Documentation
No documentation changes needed - this is an internal bug fix.