### PR TITLE
[OPIK-2667] [FE]: fix a bug with scrolling for selects with models;

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/llm/PromptModelSelect/PromptModelSelect.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/llm/PromptModelSelect/PromptModelSelect.tsx
@@ -300,30 +300,32 @@ const PromptModelSelect = ({
       >
         {renderSelectTrigger()}
         <SelectContent onKeyDown={handleKeyDown} className="p-0">
-          <div className="relative flex h-10 items-center justify-center gap-1 pl-6">
-            <Search className="absolute left-2 size-4 text-light-slate" />
-            <Input
-              ref={inputRef}
-              className="outline-0"
-              placeholder="Search model"
-              value={filterValue}
-              variant="ghost"
-              onChange={(e) => setFilterValue(e.target.value)}
-            />
+          <div className="flex h-full flex-col">
+            <div className="relative flex h-10 items-center justify-center gap-1 pl-6">
+              <Search className="absolute left-2 size-4 text-light-slate" />
+              <Input
+                ref={inputRef}
+                className="outline-0"
+                placeholder="Search model"
+                value={filterValue}
+                variant="ghost"
+                onChange={(e) => setFilterValue(e.target.value)}
+              />
+            </div>
+            <SelectSeparator />
+            <div className="flex-1 overflow-y-auto">{renderOptions()}</div>
+            <SelectSeparator />
+            <Button
+              variant="link"
+              className="h-10 w-full"
+              onClick={() => {
+                resetDialogKeyRef.current += 1;
+                setOpenConfigDialog(true);
+              }}
+            >
+              Manage AI providers
+            </Button>
           </div>
-          <SelectSeparator />
-          {renderOptions()}
-          <SelectSeparator />
-          <Button
-            variant="link"
-            className="size-full"
-            onClick={() => {
-              resetDialogKeyRef.current += 1;
-              setOpenConfigDialog(true);
-            }}
-          >
-            Manage AI providers
-          </Button>
         </SelectContent>
       </Select>
       <ManageAIProviderDialog


### PR DESCRIPTION
## Details
Now, the list with options has a container that takes the height as the last element of SelectContent. And if it doesn't fit, it adds scrolling, which should resolve an issue raised by a user

<img width="691" height="699" alt="image" src="https://github.com/user-attachments/assets/8218bf70-c004-4a89-bef3-de994573cd15" />
with a smaller height
<img width="689" height="760" alt="image" src="https://github.com/user-attachments/assets/23e6e99d-3b5c-4bcf-bee9-aa97e1e21f3d" />

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues
https://github.com/comet-ml/opik/issues/3468
- Resolves #
- OPIK-2667

## Testing

## Documentation
