### PR TITLE
[OPIK-2673] [FE] Hide "Upgrade" button in on-prem deployments

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -43,7 +43,7 @@ import { Organization, ORGANIZATION_ROLE_TYPE } from "./types";
 import useOrganizations from "./useOrganizations";
 import useUser from "./useUser";
 import useUserPermissions from "./useUserPermissions";
-import { buildUrl } from "./utils";
+import { buildUrl, isProduction } from "./utils";
 
 import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
 import useUserInvitedWorkspaces from "@/plugins/comet/useUserInvitedWorkspaces";
@@ -148,7 +148,12 @@ const UserMenu = () => {
   };
 
   const renderUpgradeButton = () => {
-    if (isOrganizationAdmin && !isAcademic && !hideUpgradeButton) {
+    if (
+      isProduction() &&
+      isOrganizationAdmin &&
+      !isAcademic &&
+      !hideUpgradeButton
+    ) {
       return (
         <a
           href={buildUrl(

--- a/apps/opik-frontend/src/plugins/comet/init.tsx
+++ b/apps/opik-frontend/src/plugins/comet/init.tsx
@@ -13,6 +13,7 @@ type EnvironmentVariablesOverwrite = {
   OPIK_NEW_RELIC_APP_ID: string;
   OPIK_POSTHOG_KEY: string;
   OPIK_POSTHOG_HOST: string;
+  PRODUCTION: boolean;
 };
 
 declare global {

--- a/apps/opik-frontend/src/plugins/comet/utils.ts
+++ b/apps/opik-frontend/src/plugins/comet/utils.ts
@@ -1,6 +1,10 @@
 const BASE_URL = import.meta.env.VITE_BASE_COMET_URL || "/";
 const FROM_PARAM = "?from=llm";
 
+export const isProduction = () => {
+  return Boolean(window.environmentVariablesOverwrite?.PRODUCTION);
+};
+
 export const buildUrl = (
   path: string,
   workspaceName?: string,


### PR DESCRIPTION
## Details
This change conditionally hides the "Upgrade" button in the UserMenu component for non-production deployments (on-prem and STSaaS). The button previously showed an irrelevant path to EM admin in these deployment types, where upgrade functionality is not applicable.

Implementation:
- Added `isProduction()` utility function to check the `PRODUCTION` environment variable
- Updated `renderUpgradeButton()` logic to include production check
- Added `PRODUCTION` to the EnvironmentVariablesOverwrite type definition

The upgrade button will now only appear when:
1. Running in production environment (`PRODUCTION === true`)
2. User is an organization admin
3. User is not academic
4. `hideUpgradeButton` flag is not set

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves #
- OPIK-2673

## Testing
Tested by verifying:
- Upgrade button is hidden in on-prem/STSaaS deployments (when `PRODUCTION` is false)
- Upgrade button still appears in production deployments for organization admins
- No impact on existing conditions (academic users, hideUpgradeButton flag)
- All existing UserMenu functionality remains intact

## Documentation
N/A - UI behavior change only, no configuration or API changes