### PR TITLE
[OPIK-2673] [FE] Hide "Upgrade" button for on-premise deployments

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -43,7 +43,7 @@ import { Organization, ORGANIZATION_ROLE_TYPE } from "./types";
 import useOrganizations from "./useOrganizations";
 import useUser from "./useUser";
 import useUserPermissions from "./useUserPermissions";
-import { buildUrl, isProduction } from "./utils";
+import { buildUrl, isOnPremise, isProduction } from "./utils";
 
 import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
 import useUserInvitedWorkspaces from "@/plugins/comet/useUserInvitedWorkspaces";
@@ -150,6 +150,7 @@ const UserMenu = () => {
   const renderUpgradeButton = () => {
     if (
       isProduction() &&
+      !isOnPremise() &&
       isOrganizationAdmin &&
       !isAcademic &&
       !hideUpgradeButton

--- a/apps/opik-frontend/src/plugins/comet/init.tsx
+++ b/apps/opik-frontend/src/plugins/comet/init.tsx
@@ -14,6 +14,7 @@ type EnvironmentVariablesOverwrite = {
   OPIK_POSTHOG_KEY: string;
   OPIK_POSTHOG_HOST: string;
   PRODUCTION: boolean;
+  ON_PREMISE: boolean;
 };
 
 declare global {

--- a/apps/opik-frontend/src/plugins/comet/utils.ts
+++ b/apps/opik-frontend/src/plugins/comet/utils.ts
@@ -5,6 +5,10 @@ export const isProduction = () => {
   return Boolean(window.environmentVariablesOverwrite?.PRODUCTION);
 };
 
+export const isOnPremise = () => {
+  return Boolean(window.environmentVariablesOverwrite?.ON_PREMISE);
+};
+
 export const buildUrl = (
   path: string,
   workspaceName?: string,


### PR DESCRIPTION
## Details

This PR adds logic to hide the "Upgrade" button in the user menu for on-premise deployments of Opik. The upgrade functionality is only relevant for cloud/hosted deployments and should not be shown to on-premise users.

### Changes made:
- Added new `isOnPremise()` utility function to check the `ON_PREMISE` environment variable
- Added `ON_PREMISE` to the environment variables type definition
- Updated the `renderUpgradeButton()` logic in `UserMenu.tsx` to check both production status and on-premise status
- The upgrade button now only renders when `isProduction() && !isOnPremise()` conditions are met

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2673

## Testing

The changes can be tested by:
1. Setting the `ON_PREMISE` environment variable to `true` in an on-premise deployment
2. Verifying that the "Upgrade" button is hidden in the user menu for organization admins
3. Confirming that the button still appears in production cloud deployments when `ON_PREMISE` is not set or is `false`

Manual testing in both environments is recommended to ensure the correct behavior.

## Documentation

No documentation updates required. This is an internal UI behavior change that aligns the frontend display with the deployment type.