### PR TITLE
[NA] [FE] Disable truncation in experiment comparison to show full trace data

### DIFF
--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -237,7 +237,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
       datasetId,
       experimentsIds,
       filters,
-      truncate: true,
+      truncate: false,
       page: page as number,
       size: size as number,
     },


### PR DESCRIPTION
## Details

This PR disables data truncation in the experiment comparison view to show full trace input/output data without the 10,001 character limit.

### Background
The `truncate` parameter was originally introduced in commit `b11a2a963` (November 2024) to handle base64 images in the experiment items table for performance reasons. However, the backend implementation has an unintended side effect: it not only replaces base64 images with `"[image]"` placeholders but also truncates **all text fields** to 10,001 characters using `substring()`.

### The Problem
Users viewing experiment comparison details were seeing truncated data in:
1. The main comparison table (when `truncate: true`)
2. The experiment output panel when a row is selected

This was particularly noticeable with the `long_string` field showing many "x" characters that were cut off mid-way.

### The Solution
Changed `truncate: true` to `truncate: false` in the main data fetching call for the experiment comparison table. This ensures users see complete data without artificial truncation.

**Note**: The export functionality already uses `truncate: false` (added in commit `c6cf193d6` - October 2025), so this change aligns the display view with the export behavior.

### Trade-offs
- **Performance**: May be slightly slower if there are very large base64 images in the data
- **User Experience**: Users now see complete, untruncated data which is more important for evaluation workflows

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- NA <!-- Investigation and fix during development -->

## Testing

### Manual Testing Steps
1. Navigate to experiment comparison page: `/default/experiments/{datasetId}/compare?experiments=["{experimentId}"]`
2. Select a row with long text content (>10,001 characters)
3. Verify in the side panel that the full content is displayed
4. Switch between Pretty/YAML/JSON views to confirm all formats show complete data
5. Verify the main table also shows complete data in the `long_string` column

### Tested Scenarios
- ✅ Experiment comparison with long text fields (10,000+ characters)
- ✅ Side panel displays full experiment output without truncation
- ✅ Table view shows complete `long_string` values
- ✅ Pretty, YAML, and JSON views all work correctly
- ✅ Export functionality continues to work (already used `truncate: false`)

## Documentation

No documentation changes required. This is a bug fix that restores expected behavior - users should always see complete data in the experiment comparison view.

### Related Files
- **Modified**: `apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx` (line 240)
