### PR TITLE
[OPIK-2708] [SDK] Fix config lazy loading in TypeScript SDK

### DIFF
--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -14,6 +14,7 @@
         "chalk": "^5.4.1",
         "date-fns": "^3.5.0",
         "dotenv": "^16.5.0",
+        "fast-deep-equal": "^3.1.3",
         "fast-json-stable-stringify": "^2.1.0",
         "ini": "^5.0.0",
         "jest-diff": "^29.7.0",
@@ -6098,7 +6099,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {

--- a/sdks/typescript/src/opik/decorators/track.ts
+++ b/sdks/typescript/src/opik/decorators/track.ts
@@ -57,7 +57,7 @@ function logSpan({
   let spanTrace = trace;
 
   if (!spanTrace) {
-    spanTrace = trackOpikClient.trace({
+    spanTrace = getTrackOpikClient().trace({
       name,
       projectName,
     });
@@ -302,4 +302,15 @@ export function track(
   };
 }
 
-export const trackOpikClient = new OpikClient();
+let _cachedTrackOpikClient: OpikClient | null = null;
+
+export function getTrackOpikClient(): OpikClient {
+  if (_cachedTrackOpikClient === null) {
+    _cachedTrackOpikClient = new OpikClient();
+  }
+  return _cachedTrackOpikClient;
+}
+
+export function _resetTrackOpikClientCache(): void {
+  _cachedTrackOpikClient = null;
+}

--- a/sdks/typescript/src/opik/index.ts
+++ b/sdks/typescript/src/opik/index.ts
@@ -1,6 +1,6 @@
 export { OpikClient as Opik } from "@/client/Client";
 export type { OpikConfig } from "@/config/Config";
-export { getTrackContext, track, trackOpikClient } from "@/decorators/track";
+export { getTrackContext, track } from "@/decorators/track";
 export { generateId } from "@/utils/generateId";
 export { flushAll } from "@/utils/flushAll";
 export { disableLogger, logger, setLoggerLevel } from "@/utils/logger";

--- a/sdks/typescript/src/opik/utils/flushAll.ts
+++ b/sdks/typescript/src/opik/utils/flushAll.ts
@@ -1,12 +1,12 @@
 import { clients } from "@/client/Client";
 import { logger } from "@/utils/logger";
-import { trackOpikClient } from "@/decorators/track";
+import { getTrackOpikClient } from "@/decorators/track";
 
 export const flushAll = async () => {
   logger.debug("Starting flushAll operation");
   try {
     await Promise.all([
-      trackOpikClient.flush(),
+      getTrackOpikClient().flush(),
       ...clients.map((c) => c.flush()),
     ]);
     logger.debug("flushAll operation completed successfully");

--- a/sdks/typescript/tests/lazy-loading.test.ts
+++ b/sdks/typescript/tests/lazy-loading.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, beforeEach, afterEach, it } from "vitest";
+
+describe("Lazy loading config", () => {
+  const originalEnvironmentVariables = { ...process.env };
+
+  beforeEach(async () => {
+    // Clear environment variables to simulate missing config
+    delete process.env.OPIK_URL_OVERRIDE;
+    delete process.env.OPIK_API_KEY;
+    delete process.env.OPIK_WORKSPACE;
+    delete process.env.OPIK_PROJECT_NAME;
+    delete process.env.OPIK_CONFIG_PATH;
+
+    // Clear the cached client
+    const { _resetTrackOpikClientCache } = await import("@/decorators/track");
+    _resetTrackOpikClientCache();
+  });
+
+  afterEach(async () => {
+    // Restore original environment
+    process.env = { ...originalEnvironmentVariables };
+
+    // Clear the cached client
+    const { _resetTrackOpikClientCache } = await import("@/decorators/track");
+    _resetTrackOpikClientCache();
+  });
+
+  it("should not throw error when importing opik module without config", async () => {
+    // This test verifies the fix for https://github.com/comet-ml/opik/issues/3663
+    // Before fix: import would throw "Error: OPIK_API_KEY is not set"
+    // After fix: import should succeed, error only thrown when client is used
+
+    // Should not throw during import
+    const opikModule = await import("opik");
+    expect(opikModule).toBeDefined();
+    expect(opikModule.Opik).toBeDefined();
+    expect(opikModule.track).toBeDefined();
+  });
+
+  it("should throw error when using internal getTrackOpikClient without valid config", async () => {
+    // Set cloud URL but no API key to trigger validation error
+    process.env.OPIK_URL_OVERRIDE = "https://www.comet.com/opik/api";
+    delete process.env.OPIK_API_KEY;
+
+    // Import from internal path since it's not publicly exported
+    const { getTrackOpikClient } = await import("@/decorators/track");
+
+    expect(() => {
+      getTrackOpikClient();
+    }).toThrow("OPIK_API_KEY is not set");
+  });
+
+  it("should throw error when using track decorator function without valid config", async () => {
+    // Set cloud URL but no API key to trigger validation error
+    process.env.OPIK_URL_OVERRIDE = "https://www.comet.com/opik/api";
+    delete process.env.OPIK_API_KEY;
+
+    const { track } = await import("opik");
+
+    // Wrap a function with track decorator
+    const trackedFunction = track(function testFunction() {
+      return "test";
+    });
+
+    // The decorator wrapping itself should not throw
+    expect(trackedFunction).toBeDefined();
+
+    // But calling the wrapped function should throw when it tries to initialize the client
+    expect(() => {
+      trackedFunction();
+    }).toThrow("OPIK_API_KEY is not set");
+  });
+
+  it("should work correctly with valid local config", async () => {
+    // Set valid local config (local doesn't require API key)
+    process.env.OPIK_URL_OVERRIDE = "http://localhost:5173/api";
+    delete process.env.OPIK_API_KEY;
+    delete process.env.OPIK_WORKSPACE;
+
+    const { getTrackOpikClient } = await import("@/decorators/track");
+    const { Opik } = await import("opik");
+
+    // Should not throw with valid local config
+    const client = getTrackOpikClient();
+    expect(client).toBeDefined();
+    expect(client.config.apiUrl).toBe("http://localhost:5173/api");
+
+    // Regular Opik client should also work
+    const opik = new Opik();
+    expect(opik).toBeDefined();
+    expect(opik.config.apiUrl).toBe("http://localhost:5173/api");
+  });
+
+  it("should use flushAll to flush the track client", async () => {
+    // Set valid local config
+    process.env.OPIK_URL_OVERRIDE = "http://localhost:5173/api";
+    delete process.env.OPIK_API_KEY;
+
+    const { flushAll } = await import("opik");
+    const { getTrackOpikClient } = await import("@/decorators/track");
+
+    // Initialize the client
+    const client = getTrackOpikClient();
+    expect(client).toBeDefined();
+
+    // flushAll should flush the track client without throwing
+    await expect(flushAll()).resolves.not.toThrow();
+  });
+
+  it("should cache the client instance across multiple calls", async () => {
+    // Set valid local config
+    process.env.OPIK_URL_OVERRIDE = "http://localhost:5173/api";
+
+    // Import from internal path
+    const { getTrackOpikClient } = await import("@/decorators/track");
+
+    const client1 = getTrackOpikClient();
+    const client2 = getTrackOpikClient();
+
+    // Should return the same instance
+    expect(client1).toBe(client2);
+  });
+});

--- a/sdks/typescript/tests/track.test.ts
+++ b/sdks/typescript/tests/track.test.ts
@@ -1,10 +1,11 @@
-import { trackOpikClient } from "@/decorators/track";
+import { getTrackOpikClient } from "@/decorators/track";
 import { getTrackContext, track } from "opik";
 import { MockInstance } from "vitest";
 import { advanceToDelay } from "./utils";
 import { mockAPIFunction } from "./mockUtils";
 
 describe("Track decorator", () => {
+  let trackOpikClient: ReturnType<typeof getTrackOpikClient>;
   let createSpansSpy: MockInstance<
     typeof trackOpikClient.api.spans.createSpans
   >;
@@ -17,6 +18,8 @@ describe("Track decorator", () => {
   >;
 
   beforeEach(() => {
+    trackOpikClient = getTrackOpikClient();
+
     createSpansSpy = vi
       .spyOn(trackOpikClient.api.spans, "createSpans")
       .mockImplementation(mockAPIFunction);


### PR DESCRIPTION
## Details
- Convert trackOpikClient to lazy initialization pattern matching Python SDK
- Remove trackOpikClient and getTrackOpikClient from public exports
- Add getTrackOpikClient() getter function for internal use only
- Update flushAll.ts to use lazy getter
- Add comprehensive lazy loading tests
- Fix issue #3663 where import 'opik' threw OPIK_API_KEY error

Config validation now only happens when client is first used, not at import time. Users should use flushAll() instead of trackOpikClient.flush().

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #3663
- OPIK-2708

## Testing

## Documentation
