### PR TITLE
[NA][FE] Always expand JSON table rows in pretty mode

### DIFF
--- a/apps/opik-frontend/src/components/shared/JsonKeyValueTable/JsonKeyValueTable.tsx
+++ b/apps/opik-frontend/src/components/shared/JsonKeyValueTable/JsonKeyValueTable.tsx
@@ -219,7 +219,8 @@ const JsonKeyValueTable: React.FC<JsonKeyValueTableProps> = ({
   // Reset expansion state when data changes to ensure all sections are expanded by default
   useEffect(() => {
     setExpanded(initialExpanded);
-  }, [initialExpanded, setExpanded]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialExpanded]);
 
   const columns: ColumnDef<JsonRowData>[] = useMemo(
     () => [


### PR DESCRIPTION
## Details

Always expand all rows of JsonKeyValueTable in Pretty mode.

Before:

<img width="827" height="582" alt="Screenshot from 2025-10-15 09-47-45" src="https://github.com/user-attachments/assets/e635e4d1-3d21-454a-8b2b-747f0b75b585" />

After:

<img width="827" height="582" alt="Screenshot from 2025-10-15 09-48-56" src="https://github.com/user-attachments/assets/177b9d6d-d62b-4157-a444-f8e86c71fc7b" />


## Change checklist
- [x] User facing

## Issues

Resolves request from @alexkuzmik 

## Testing

Manual

## Documentation

N/A
