### PR TITLE
[OPIK-2493] [FE] Make user feedback column always visible on traces table

### DIFF
--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
@@ -526,16 +526,16 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
     setSelectedColumns,
   });
 
-  // Auto-select user feedback score column when it becomes available
-  useEffect(() => {
-    const isUserFeedbackColumnMissing = !selectedColumns.includes(
-      USER_FEEDBACK_COLUMN_ID,
-    );
+  const isUserFeedbackColumnMissing = !selectedColumns.includes(
+    USER_FEEDBACK_COLUMN_ID,
+  );
 
+  // Ensure "User Feedback" column is always selected
+  useEffect(() => {
     if (isUserFeedbackColumnMissing) {
       setSelectedColumns((prev) => [...prev, USER_FEEDBACK_COLUMN_ID]);
     }
-  }, [selectedColumns, setSelectedColumns]);
+  }, [isUserFeedbackColumnMissing, setSelectedColumns]);
 
   const scoresColumnsData = useMemo(() => {
     // Always include "User feedback" column, even if it has no data


### PR DESCRIPTION
## Details
This PR implements UX improvements to the traces table feedback scores display as specified in OPIK-2493.

<img width="1791" height="815" alt="image" src="https://github.com/user-attachments/assets/315de7b5-9f56-45bc-aa25-c8f2c4616277" />

### Changes Made:

#### Always Visible User Feedback Scores Column ✅
1. Column is always visible even when all cells are empty (important for new projects without feedback data)
2. Made button disabled, so it will be clearer when people wish to change columns, that this dynamic column, is actually a static one that can't be removed
3. Even after clicking hideAll columns, the column is quickly re-added, so it remains visible

### Technical Implementation:
- Modified `TracesSpansTab.tsx` to include static column definition with `COLUMN_FEEDBACK_SCORES_ID`, which is `disabled`
- Modified `TracesSpansTab.tsx` to ensure the column `COLUMN_FEEDBACK_SCORES_ID`, is always part of the `selectedColumns`

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- OPIK-2493

## Testing
- ✅ Tested with new projects (no feedback scores) - column is visible but shows "-"
- ✅ Tested that user feedback score column, is always visible, even after clicking **hideAll**
- ✅ All TypeScript, ESLint, and Prettier checks pass

## Documentation
No documentation updates needed for this UX improvement.

## Notes
Making the cells editable, will be in a separate PR