### PR TITLE
[OPIK-2726] [FE] Fix UI crash when viewing traces with base64 image URLs

### DIFF
--- a/apps/opik-frontend/src/lib/conversationMarkdown.ts
+++ b/apps/opik-frontend/src/lib/conversationMarkdown.ts
@@ -134,9 +134,12 @@ export const convertConversationToMarkdown = (
         );
 
         if (toolResponse && toolResponse.content) {
+          const toolResponseContent = isString(toolResponse.content)
+            ? toolResponse.content
+            : JSON.stringify(toolResponse.content);
           lines.push(``);
           lines.push(`&nbsp;&nbsp;&nbsp;&nbsp;**Response:**`);
-          lines.push(`&nbsp;&nbsp;&nbsp;&nbsp;${toolResponse.content.trim()}`);
+          lines.push(`&nbsp;&nbsp;&nbsp;&nbsp;${toolResponseContent.trim()}`);
         }
 
         lines.push(`</details>`);
@@ -147,8 +150,9 @@ export const convertConversationToMarkdown = (
     }
 
     // Add content if present
-    if (content.trim()) {
-      lines.push(content.trim());
+    const contentStr = isString(content) ? content : JSON.stringify(content);
+    if (contentStr.trim()) {
+      lines.push(contentStr.trim());
     }
 
     // Close the role section


### PR DESCRIPTION
## Details

This PR fixes a critical UI crash that occurs when viewing traces containing base64 image URLs from the OpenAI SDK integration. The root cause was that the `conversationMarkdown.ts` module attempted to call `.trim()` on content that wasn't always a string, resulting in the error "El.trim is not a function".

**Changes made:**
- Added type checking to ensure content is converted to a string before calling `.trim()`
- Applied the fix to both message content and tool response content
- Content that isn't a string is now safely converted to JSON string representation

This defensive programming approach ensures the UI can handle various content types, including complex objects like base64 image URLs, without crashing.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #N/A
- OPIK-2726

## Testing

**Manual testing steps:**
1. Use the Opik OpenAI SDK integration to create a completion with base64 image URLs:
```python
client.chat.completions.create(
    model="gpt-5-nano",
    messages=[ 
        { "role": "user", "content": [
            {"type": "text", "text": prompt},
            {"type": "image_url", "image_url": {"url": image}}
        ] }
    ],
)
```
2. Navigate to the trace view or Span table in the UI
3. Verify the page loads without crashing
4. Verify trace content is displayed correctly

**Expected behavior:**
- No "El.trim is not a function" error
- Traces with base64 images display properly
- Span table remains accessible

## Documentation

N/A - This is a bug fix with no new features or API changes.