### PR TITLE
[NA] [FE] Fix YAML formatting error

### DIFF
--- a/apps/opik-frontend/src/components/shared/SyntaxHighlighter/utils.ts
+++ b/apps/opik-frontend/src/components/shared/SyntaxHighlighter/utils.ts
@@ -15,7 +15,9 @@ export const generateSyntaxHighlighterCode = (
   prettifyConfig?: PrettifyConfig,
 ): CodeOutput => {
   const response = prettifyConfig
-    ? prettifyMessage(data)
+    ? prettifyMessage(data, {
+        inputType: prettifyConfig.fieldType,
+      })
     : {
         message: data,
         prettified: false,


### PR DESCRIPTION
## Details

The YAML view of Input/Output data in expanded view stopped working properly after a recent change. The `\n` characters that previously appeared as properly formatted line breaks in YAML were now being displayed as literal characters without any line breaks or formatting.

### Root Cause
The issue was caused by a recent refactoring commit (`6381ceddf`) that removed the `type` parameter from the `prettifyMessage` function call in `generateSyntaxHighlighterCode`. However, the `prettifyMessage` function still needed this context information to properly handle input vs output data formatting.

### The Problem
In `/home/dsblank/comet/opik/apps/opik-frontend/src/components/shared/SyntaxHighlighter/utils.ts`, the code was changed from:
```typescript
prettifyMessage(data, { type: prettifyConfig.fieldType })
```
to:
```typescript
prettifyMessage(data)
```

This meant that the `prettifyMessage` function no longer knew whether it was processing input or output data, so it couldn't apply the correct field priorities for text extraction, leading to improper YAML formatting where `\n` characters were displayed literally instead of being converted to actual line breaks.

### The Fix
Updated the `generateSyntaxHighlighterCode` function to pass the correct configuration:
```typescript
prettifyMessage(data, { inputType: prettifyConfig.fieldType })
```

This restores the proper context-aware text extraction that allows the YAML formatter to correctly handle newlines and other formatting.

### Result
The YAML view should now properly display line breaks and formatting in the Input/Output data expanded view, just as it did before the refactoring.

## Technical Details
The `prettifyMessage` function uses different field priorities for input vs output data:
- **Input fields**: `["question", "messages", "user_input", "query", "input_prompt", "prompt", "sys.query", "input", "output"]`
- **Output fields**: `["answer", "output", "response", "input"]`

Without the proper context, the function couldn't determine which fields to prioritize when extracting text content, leading to improper formatting of the extracted data before it was converted to YAML.


## Change checklist
- [x] User facing

## Issues

Resolves issue mentioned by user.

## Testing

N/A

## Documentation

N/A