### PR TITLE
[issue-3706] [FE] Fix Safari dropdown rendering issue in model selector

### DIFF
--- a/apps/opik-frontend/src/components/ui/select.tsx
+++ b/apps/opik-frontend/src/components/ui/select.tsx
@@ -86,7 +86,7 @@ const SelectContent = React.forwardRef<
         className={cn(
           "p-1",
           position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+            "w-full min-w-[var(--radix-select-trigger-width)]",
         )}
       >
         {children}


### PR DESCRIPTION
## Details
Fixed a Safari-specific rendering bug where dropdown content in the model selector (and all other Select components) was invisible when opened. The issue was caused by Safari's improper handling of CSS variable heights (`h-[var(--radix-select-trigger-height)]`) in Radix UI's popper positioning context.

The fix removes the height constraint from the SelectContent viewport, allowing Safari to properly calculate the viewport height based on content while maintaining the intended width behavior across all browsers.

Before:
<img width="506" height="227" alt="Screenshot 2025-10-17 at 19 19 24" src="https://github.com/user-attachments/assets/cc34eb96-a065-4f21-9ba9-567198cb8b47" />

After:
<img width="487" height="315" alt="Screenshot 2025-10-17 at 19 40 51" src="https://github.com/user-attachments/assets/027473f6-7964-4369-9301-e5e67a859538" />

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- #3706

## Testing
Manually tested the model dropdown in the Playground page on Safari. The dropdown now properly displays:
- Provider list with icons
- Search functionality
- "No configured providers" message when applicable
- "Manage AI providers" button

All Select component usages across the codebase should be tested:
- PromptModelSelect (Playground)
- SelectBox (generic wrapper)
- ProviderSelect
- DateRangeSelect
- TracesSpansTab
- AnnotateRow
- TraceDetailsActionsPanel
- AddEditRuleDialog
- WelcomeWizardDialog
- OpenAIModelConfigs
- TimePicker

## Documentation
No documentation changes needed - this is a browser compatibility bugfix.