### PR TITLE
[OPIK-2554] Remove support for deploy-pr-public

### DIFF
--- a/.github/workflows/trigger_test_env_on_label.yaml
+++ b/.github/workflows/trigger_test_env_on_label.yaml
@@ -84,6 +84,8 @@ jobs:
     steps:
       - name: Trigger deployment via repository dispatch
         uses: actions/github-script@v7
+        env:
+          VERSION_NAME: ${{ needs.build-apps.outputs.version }}
         with:
           github-token: ${{ secrets.DEPLOYMENT_TRIGGER_TOKEN }}
           script: |
@@ -93,7 +95,7 @@ jobs:
               event_type: 'deploy-opik-test-env',
               client_payload: {
                 pr_number: '${{ github.event.number }}',
-                version_name: '${{ needs.build-apps.outputs.version }}'
+                version_name: process.env.VERSION_NAME
               }
             });
             
@@ -109,7 +111,7 @@ jobs:
               ### Access Information
               - **URL:** https://pr-${{ github.event.number }}.dev.comet.com
               - **Namespace:** pr-${{ github.event.number }}
-              - **Version:** ${{ needs.build-apps.outputs.version }}
+              - **Version:** ${process.env.VERSION_NAME}
                      
               You can monitor the deployment progress [here](https://github.com/comet-ml/comet-deployment/actions/workflows/deploy_opik_adhoc_env.yaml).`
             });


### PR DESCRIPTION
## Details
- Remove support for deploy-pr-public
- Use old label test-environment
- 
## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2554

## Testing

## Documentation
