### PR TITLE
[NA]: Update pr-auto-assign.yml, to use the other jira token

### DIFF
--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_PAT_TO_ACCESS_GITHUB_API }}
     permissions:
       pull-requests: write
 


### PR DESCRIPTION
https://github.com/comet-ml/opik/issues/3411

Setting a different jira token, to add external users as assignee

## Details

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing

## Documentation
