### PR TITLE
Add service labels to service.yaml helm template

### DIFF
--- a/deployment/helm_chart/opik/templates/service.yaml
+++ b/deployment/helm_chart/opik/templates/service.yaml
@@ -8,6 +8,8 @@ metadata:
   labels:
     {{- include "opik.labels" $  | nindent 4 }}
     {{- with $value.service.labels | default "" }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     component: {{ include "opik.name" $ }}-{{ $key | lower }}
   {{- if $value.service.annotations }}
   annotations:


### PR DESCRIPTION
#Closes https://github.com/comet-ml/opik/issues/3783

## Details
Currently it is not possible to add custom labels to the kubernetes service.
This PR introduces this feature.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues


## Testing

## Documentation
