### PR TITLE
[OPIK-2740] [FE] Add Slack integration alert type and metadata fields

### DIFF
--- a/apps/opik-frontend/src/api/alerts/useWebhookExamplesQuery.ts
+++ b/apps/opik-frontend/src/api/alerts/useWebhookExamplesQuery.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import { ALERT_EVENT_TYPE } from "@/types/alerts";
+import { QueryConfig } from "@/api/api";
+import { ALERT_EVENT_TYPE, ALERT_TYPE } from "@/types/alerts";
 import { ALERTS_KEY, ALERTS_REST_ENDPOINT } from "@/api/api";
 import api from "@/api/api";
 
@@ -7,16 +8,29 @@ export type WebhookExamplesResponse = {
   response_examples: Record<ALERT_EVENT_TYPE, string | object>;
 };
 
-const getWebhookExamples = async (): Promise<WebhookExamplesResponse> => {
+type UseWebhookExamplesQueryParams = {
+  alertType?: ALERT_TYPE;
+};
+
+const getWebhookExamples = async (
+  params: UseWebhookExamplesQueryParams,
+): Promise<WebhookExamplesResponse> => {
   const { data } = await api.get<WebhookExamplesResponse>(
     `${ALERTS_REST_ENDPOINT}webhooks/examples`,
+    {
+      params: params.alertType ? { alert_type: params.alertType } : undefined,
+    },
   );
   return data;
 };
 
-export default function useWebhookExamplesQuery() {
+export default function useWebhookExamplesQuery(
+  params: UseWebhookExamplesQueryParams = {},
+  options?: QueryConfig<WebhookExamplesResponse>,
+) {
   return useQuery({
-    queryKey: [ALERTS_KEY, "webhook-examples"],
-    queryFn: getWebhookExamples,
+    queryKey: [ALERTS_KEY, { ...params, type: "webhook-examples" }],
+    queryFn: () => getWebhookExamples(params),
+    ...options,
   });
 }

--- a/apps/opik-frontend/src/components/pages/ConfigurationPage/AlertsTab/AddEditAlertPage/TestWebhookSection.tsx
+++ b/apps/opik-frontend/src/components/pages/ConfigurationPage/AlertsTab/AddEditAlertPage/TestWebhookSection.tsx
@@ -44,6 +44,11 @@ const TestWebhookSection: React.FunctionComponent<TestWebhookSectionProps> = ({
     name: "triggers",
   });
 
+  const alertType = useWatch({
+    control: form.control,
+    name: "alertType",
+  });
+
   const triggerItems = useMemo(() => {
     if (!triggers?.length) return [];
 
@@ -196,6 +201,7 @@ const TestWebhookSection: React.FunctionComponent<TestWebhookSectionProps> = ({
               <AccordionContent className="px-3">
                 <WebhookPayloadExample
                   eventType={item.eventType}
+                  alertType={alertType}
                   actionButton={
                     <Button
                       type="button"

--- a/apps/opik-frontend/src/components/pages/ConfigurationPage/AlertsTab/AddEditAlertPage/WebhookPayloadExample.tsx
+++ b/apps/opik-frontend/src/components/pages/ConfigurationPage/AlertsTab/AddEditAlertPage/WebhookPayloadExample.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
 import isString from "lodash/isString";
-import { ALERT_EVENT_TYPE } from "@/types/alerts";
+import { ALERT_EVENT_TYPE, ALERT_TYPE } from "@/types/alerts";
 import useWebhookExamplesQuery from "@/api/alerts/useWebhookExamplesQuery";
 import CodeHighlighter, {
   SUPPORTED_LANGUAGE,
@@ -10,13 +10,16 @@ import { safelyParseJSON } from "@/lib/utils";
 
 type WebhookPayloadExampleProps = {
   eventType: ALERT_EVENT_TYPE;
+  alertType?: ALERT_TYPE;
   actionButton?: React.ReactNode;
 };
 
 const WebhookPayloadExample: React.FunctionComponent<
   WebhookPayloadExampleProps
-> = ({ eventType, actionButton }) => {
-  const { data: examples, isPending } = useWebhookExamplesQuery();
+> = ({ eventType, alertType, actionButton }) => {
+  const { data: examples, isPending } = useWebhookExamplesQuery({
+    alertType,
+  });
 
   const formattedPayload = useMemo(() => {
     if (!examples || !examples.response_examples?.[eventType]) {

--- a/apps/opik-frontend/src/components/pages/ConfigurationPage/AlertsTab/AddEditAlertPage/schema.ts
+++ b/apps/opik-frontend/src/components/pages/ConfigurationPage/AlertsTab/AddEditAlertPage/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ALERT_EVENT_TYPE } from "@/types/alerts";
+import { ALERT_EVENT_TYPE, ALERT_TYPE } from "@/types/alerts";
 
 export const HeaderSchema = z.object({
   key: z.string().min(1, { message: "Header key is required" }),
@@ -17,6 +17,7 @@ export const AlertFormSchema = z
       .string({ required_error: "Alert name is required" })
       .min(1, { message: "Alert name is required" }),
     enabled: z.boolean().default(true),
+    alertType: z.nativeEnum(ALERT_TYPE).default(ALERT_TYPE.general),
     url: z
       .string({ required_error: "Endpoint URL is required" })
       .min(1, { message: "Endpoint URL is required" })

--- a/apps/opik-frontend/src/components/pages/ConfigurationPage/AlertsTab/AlertsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/ConfigurationPage/AlertsTab/AlertsTab.tsx
@@ -3,6 +3,7 @@ import { keepPreviousData } from "@tanstack/react-query";
 import useLocalStorageState from "use-local-storage-state";
 import { JsonParam, StringParam, useQueryParam } from "use-query-params";
 import { useNavigate } from "@tanstack/react-router";
+import capitalize from "lodash/capitalize";
 
 import useAlertsList from "@/api/alerts/useAlertsList";
 import AlertsRowActionsCell from "@/components/pages/ConfigurationPage/AlertsTab/AlertsRowActionsCell";
@@ -17,7 +18,7 @@ import SearchInput from "@/components/shared/SearchInput/SearchInput";
 import FiltersButton from "@/components/shared/FiltersButton/FiltersButton";
 import { Button } from "@/components/ui/button";
 import useAppStore from "@/store/AppStore";
-import { Alert } from "@/types/alerts";
+import { Alert, ALERT_TYPE } from "@/types/alerts";
 import {
   COLUMN_NAME_ID,
   COLUMN_SELECT_ID,
@@ -57,6 +58,15 @@ export const DEFAULT_COLUMNS: ColumnData<Alert>[] = [
     label: "ID",
     type: COLUMN_TYPE.string,
     cell: IdCell as never,
+  },
+  {
+    id: "alert_type",
+    label: "Type",
+    type: COLUMN_TYPE.string,
+    accessorFn: (row) => {
+      if (!row.alert_type) return capitalize(ALERT_TYPE.general);
+      return capitalize(row.alert_type);
+    },
   },
   {
     id: "webhook_url",
@@ -110,6 +120,11 @@ export const FILTERS_COLUMNS: ColumnData<Alert>[] = [
     type: COLUMN_TYPE.string,
   },
   {
+    id: "alert_type",
+    label: "Type",
+    type: COLUMN_TYPE.category,
+  },
+  {
     id: "webhook_url",
     label: "Endpoint",
     type: COLUMN_TYPE.string,
@@ -137,6 +152,7 @@ export const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
 };
 
 export const DEFAULT_SELECTED_COLUMNS: string[] = [
+  "alert_type",
   "webhook_url",
   "triggers",
   "created_by",
@@ -172,6 +188,23 @@ const AlertsTab: React.FunctionComponent = () => {
   );
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
+  const filtersConfig = useMemo(
+    () => ({
+      rowsMap: {
+        alert_type: {
+          keyComponentProps: {
+            options: Object.values(ALERT_TYPE).map((type) => ({
+              value: type,
+              label: capitalize(type),
+            })),
+            placeholder: "Select type",
+          },
+        },
+      } as Record<string, { keyComponentProps: Record<string, unknown> }>,
+    }),
+    [],
+  );
 
   const { data, isPending } = useAlertsList(
     {
@@ -286,6 +319,7 @@ const AlertsTab: React.FunctionComponent = () => {
             columns={FILTERS_COLUMNS}
             filters={filters}
             onChange={setFilters}
+            config={filtersConfig}
           />
         </div>
 

--- a/apps/opik-frontend/src/lib/utils.ts
+++ b/apps/opik-frontend/src/lib/utils.ts
@@ -21,6 +21,10 @@ export const buildDocsUrl = (path: string = "", hash: string = "") => {
   return `${BASE_DOCUMENTATION_URL}${path}?from=llm${hash}`;
 };
 
+export const buildFullBaseUrl = () => {
+  return new URL(import.meta.env.VITE_BASE_URL, location.origin).toString();
+};
+
 export const isSameDomainUrl = (url: string) => {
   try {
     const resolvedUrl = new URL(url, window.location.href);

--- a/apps/opik-frontend/src/types/alerts.ts
+++ b/apps/opik-frontend/src/types/alerts.ts
@@ -13,6 +13,11 @@ export enum ALERT_TRIGGER_CONFIG_TYPE {
   "threshold:feedback_score" = "threshold:feedback_score",
 }
 
+export enum ALERT_TYPE {
+  general = "general",
+  slack = "slack",
+}
+
 export interface AlertTriggerConfig {
   id?: string;
   alert_trigger_id?: string;
@@ -45,10 +50,16 @@ export interface Webhook {
   last_updated_by?: string;
 }
 
+export interface AlertMetadata {
+  base_url?: string;
+}
+
 export interface Alert {
   id?: string;
   name: string;
   enabled: boolean;
+  alert_type?: ALERT_TYPE;
+  metadata?: AlertMetadata;
   webhook: Webhook;
   triggers: AlertTrigger[];
   created_at?: string;


### PR DESCRIPTION
## Details

This PR implements frontend support for Slack integration in the alerts system by introducing alert type selection and metadata fields. The implementation includes:

- Added new `ALERT_TYPE` enum with `general` and `slack` options
- Implemented alert type dropdown in alert creation/edit form with filtering capability
- Added `metadata` field to store Slack-specific configuration (base URL)
- Enhanced webhook examples API to accept alert type parameter for type-specific payload examples
- Updated alerts table to display and filter by alert type
- Integrated base URL generation for Slack webhook configuration

The changes enable users to create and manage Slack-specific alerts with appropriate configurations while maintaining backward compatibility with general alerts.


https://github.com/user-attachments/assets/fb74c429-10a4-4020-b04b-51b12fddef32



## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2740

## Testing

The implementation has been tested with:
- Alert type selection in create/edit forms
- Alert type filtering in the alerts table
- Webhook payload examples reflecting the selected alert type
- Base URL metadata generation for Slack alerts
- Backward compatibility with existing general alerts

## Documentation

No documentation updates required for this frontend implementation. Backend API documentation will be updated separately as part of the backend integration work.