### PR TITLE
[NA]: Pr Auto Assign: Allow fail for external collaborators

### DIFF
--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -55,5 +55,7 @@ jobs:
 
           echo "Attempting to assign PR #$PR_NUMBER to $ASSIGN_USER_LOGIN"
           # Note: If the user is already assigned, this command will succeed without error.
-          gh pr edit "$PR_NUMBER" --add-assignee "$ASSIGN_USER_LOGIN" --repo "${{ github.repository }}" || true
+          gh pr edit "$PR_NUMBER" --add-assignee "$ASSIGN_USER_LOGIN" --repo "${{ github.repository }}" || {
+            echo "❌ Failed to assign PR #$PR_NUMBER to $ASSIGN_USER_LOGIN, likely an external collaborator"
+          }
           echo "Successfully assigned PR #$PR_NUMBER to $ASSIGN_USER_LOGIN"


### PR DESCRIPTION
## Details
It's a temp solution... will be resolved in another https://github.com/comet-ml/opik/pull/3752, whether it's to exclude external from workflow, or have someone else assigned, when clicking on "Approve workflows to run"

## Change checklist
- [x] User facing

## Issues
- NA
## Testing

## Documentation
