### PR TITLE
[OPIK-2654] [BE] Update Redis subscribers default config

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -494,9 +494,9 @@ traceThreadConfig:
   # Default: 100
   # Description: Maximum number of messages returned within a Redis Stream get
   consumerBatchSize: ${OPIK_REDIS_TRACE_THREAD_CONSUMER_BATCH_SIZE:-100}
-  # Default: 200 milliseconds
+  # Default: 500ms
   # Description: How often the trace thread consumer will check Redis for new messages (in milliseconds)
-  poolingInterval: ${OPIK_REDIS_TRACE_THREAD_POOLING_INTERVAL:-200 milliseconds}
+  poolingInterval: ${OPIK_REDIS_TRACE_THREAD_POOLING_INTERVAL:-500ms}
   # Default: 5s
   # Description: Timeout for blocking read operations on Redis streams (long polling duration)
   longPollingDuration: ${OPIK_REDIS_TRACE_THREAD_LONG_POLLING_DURATION:-5s}
@@ -512,7 +512,7 @@ traceThreadConfig:
   # Default: 300ms
   # Description: The time to wait for the close trace threads job to acquire the lock before giving up
   closeTraceThreadJobLockWaitTime: ${OPIK_CLOSE_TRACE_THREAD_JOB_LOCK_WAIT_TIME:-300ms}
-  # Default: 1000
+  # Default: 2000
   # Description: The maximum number of item to process in a single close trace thread run
   closeTraceThreadMaxItemPerRun: ${OPIK_CLOSE_TRACE_THREAD_MAX_ITEM_PER_RUN:-2000}
 

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -214,10 +214,10 @@ onlineScoring:
   # Default: online_scoring
   # Description: A consumer group name so multiple instances can share the stream load
   consumerGroupName: 'online_scoring'
-  # Default: 3
+  # Default: 5
   # Description: Maximum number of messages returned within a Redis Stream get
   # This is the global default value, can be overridden per stream
-  consumerBatchSize: 3
+  consumerBatchSize: 5
   ## scorer: options from AutomationRuleEvaluatorType
   ## streamName: the name of the stream in redis
   ## codec: 'json' when there are non-java consumers, 'java' for java consumers only
@@ -353,9 +353,9 @@ traceThreadConfig:
   # Default: 100
   # Description: Maximum number of messages returned within a Redis Stream get
   consumerBatchSize: 100
-  # Default: 200 ms
+  # Default: 500ms
   # Description: How often the trace thread consumer will check Redis for new messages (in milliseconds)
-  poolingInterval: 200ms
+  poolingInterval: 500ms
   # Default: 5s
   # Description: Timeout for blocking read operations on Redis streams (long polling duration)
   longPollingDuration: 5s
@@ -371,7 +371,7 @@ traceThreadConfig:
   # Default: 300ms
   # Description: The time to wait for the close trace threads job to acquire the lock before giving up
   closeTraceThreadJobLockWaitTime: 300ms
-  # Default: 1000
+  # Default: 2000
   # Description: The maximum number of item to process in a single close trace thread run
   closeTraceThreadMaxItemPerRun: 2000
 


### PR DESCRIPTION
## Details

This PR updates the default configuration values for Redis stream subscribers to improve performance and resource utilization based on learnings described in OPIK-2654.

### Configuration Changes:

**Trace Thread Polling Interval**: Increased from `200ms` to `500ms`
   - Reduces CPU utilization while maintaining acceptable message processing latency
   - More sustainable polling rate for the Redis stream consumers

**Test config**
   - Aligns test configuration with production patterns

These changes are part of the follow-up improvements to prevent the Redis high memory usage and optimize stream consumer performance.

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues
- OPIK-2654

## Testing
- Local testing.
- Will be verified in later stages, by reviewing metrics and logs.
- Will be monitored when deploying to prod, by reviewing metrics and logs.

## Documentation

Updated configuration files with revised default values:
- `apps/opik-backend/config.yml` - Production configuration
- `apps/opik-backend/src/test/resources/config-test.yml` - Test configuration

