### PR TITLE
[OPIK-1994] [FE] Add prompt link to experiment details page

### DIFF
--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
@@ -179,6 +179,15 @@ const CompareExperimentsDetails: React.FunctionComponent<
           resource={RESOURCE_TYPE.dataset}
           asTag
         />
+        {experiment?.prompt_versions &&
+          experiment.prompt_versions.length > 0 && (
+            <ResourceLink
+              id={experiment.prompt_versions[0].prompt_id}
+              name={`Prompt ${experiment.prompt_versions[0].commit}`}
+              resource={RESOURCE_TYPE.prompt}
+              asTag
+            />
+          )}
       </div>
       {renderSubSection()}
       {renderCharts()}


### PR DESCRIPTION
## Details
<img width="2043" height="1077" alt="image" src="https://github.com/user-attachments/assets/70efd2b7-fb9a-4c84-9622-c240ffefd66f" />

Added prompt link next to dataset link in experiment header section. The link displays the prompt commit hash and appears only when the experiment has associated prompt versions.

Implements OPIK-1994: experiment-link

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-1994

## Testing

## Documentation
