### PR TITLE
[OPIK-1990] unify the column names

### DIFF
--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
@@ -97,7 +97,7 @@ const SHARED_COLUMNS: ColumnData<Thread>[] = [
   },
   {
     id: "number_of_messages",
-    label: "No. of messages",
+    label: "Message count",
     type: COLUMN_TYPE.number,
     accessorFn: (row) =>
       isNumber(row.number_of_messages) ? `${row.number_of_messages}` : "-",

--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
@@ -171,7 +171,7 @@ export const DEFAULT_COLUMNS: ColumnData<GroupedExperiment>[] = [
   },
   {
     id: "total_estimated_cost",
-    label: "Total Est. Cost",
+    label: "Total estimated cost",
     type: COLUMN_TYPE.cost,
     cell: CostCell as never,
     aggregatedCell: CostCell.Aggregation as never,
@@ -181,7 +181,7 @@ export const DEFAULT_COLUMNS: ColumnData<GroupedExperiment>[] = [
   },
   {
     id: "total_estimated_cost_avg",
-    label: "Avg. Cost per Trace",
+    label: "Cost per trace (avg.)",
     type: COLUMN_TYPE.cost,
     cell: CostCell as never,
     aggregatedCell: CostCell.Aggregation as never,

--- a/apps/opik-frontend/src/components/pages/HomePage/EvaluationSection.tsx
+++ b/apps/opik-frontend/src/components/pages/HomePage/EvaluationSection.tsx
@@ -54,7 +54,7 @@ export const COLUMNS = convertColumnDataToColumn<Experiment, Experiment>(
     },
     {
       id: "trace_count",
-      label: "Nb of items",
+      label: "Item count",
       type: COLUMN_TYPE.number,
     },
     {

--- a/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
@@ -159,7 +159,7 @@ const ProjectsPage: React.FunctionComponent = () => {
       },
       {
         id: "usage.total_tokens",
-        label: "Total tokens (average)",
+        label: "Total tokens (avg.)",
         type: COLUMN_TYPE.number,
         accessorFn: (row) =>
           row.usage && isNumber(row.usage.total_tokens)
@@ -168,7 +168,7 @@ const ProjectsPage: React.FunctionComponent = () => {
       },
       {
         id: "usage.prompt_tokens",
-        label: "Input tokens (average)",
+        label: "Input tokens (avg.)",
         type: COLUMN_TYPE.number,
         accessorFn: (row) =>
           row.usage && isNumber(row.usage.prompt_tokens)
@@ -177,7 +177,7 @@ const ProjectsPage: React.FunctionComponent = () => {
       },
       {
         id: "usage.completion_tokens",
-        label: "Output tokens (average)",
+        label: "Output tokens (avg.)",
         type: COLUMN_TYPE.number,
         accessorFn: (row) =>
           row.usage && isNumber(row.usage.completion_tokens)

--- a/apps/opik-frontend/src/components/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
@@ -157,7 +157,7 @@ export const DEFAULT_COLUMNS: ColumnData<GroupedExperiment>[] = [
   },
   {
     id: "total_estimated_cost",
-    label: "Total Est. Cost",
+    label: "Total estimated cost",
     type: COLUMN_TYPE.cost,
     cell: CostCell as never,
     aggregatedCell: CostCell.Aggregation as never,
@@ -167,7 +167,7 @@ export const DEFAULT_COLUMNS: ColumnData<GroupedExperiment>[] = [
   },
   {
     id: "total_estimated_cost_avg",
-    label: "Avg. Cost per Trace",
+    label: "Cost per trace (avg.)",
     type: COLUMN_TYPE.cost,
     cell: CostCell as never,
     aggregatedCell: CostCell.Aggregation as never,

--- a/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/ThreadMetricsSection.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/ThreadMetricsSection.tsx
@@ -42,7 +42,7 @@ const THREAD_FILTER_COLUMNS: ColumnData<Thread>[] = [
   },
   {
     id: "number_of_messages",
-    label: "No. of messages",
+    label: "Message count",
     type: COLUMN_TYPE.number,
   },
   {

--- a/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsTab.tsx
@@ -101,7 +101,7 @@ const SHARED_COLUMNS: ColumnData<Thread>[] = [
   },
   {
     id: "number_of_messages",
-    label: "No. of messages",
+    label: "Message count",
     type: COLUMN_TYPE.number,
     accessorFn: (row) =>
       isNumber(row.number_of_messages) ? `${row.number_of_messages}` : "-",


### PR DESCRIPTION
## Details
This pull request standardizes and clarifies the column labels across multiple pages in the frontend. The main focus is on improving label consistency, making terminology more concise and user-friendly, especially for numerical and cost-related columns.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-1990

## Testing

## Documentation
