### PR TITLE
[NA] [TS SDK] Fix TS vercel config

### DIFF
--- a/sdks/typescript/tsup.config.ts
+++ b/sdks/typescript/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
     noExternal: ["url-join"],
     entry: {
       index: "src/opik/index.ts",
-      "vercel/index": "src/opik/integrations/opik-vercel/index.ts",
+      "vercel/index": "src/opik/integrations/opik-vercel/src/index.ts",
     },
     format: ["cjs", "esm"],
     outDir: "dist",


### PR DESCRIPTION
## Details
The release was failing because line 8 of sdks/typescript/tsup.config.ts has an incorrect path:

  "vercel/index": "src/opik/integrations/vercel/index.ts",  // ❌ Wrong path

  However, the actual directory structure is:
  - The directory is named opik-vercel, not vercel
  - The actual file is at src/opik/integrations/opik-vercel/src/index.ts

  Root Cause

  This is likely due to:
  1. A recent rename from vercel to opik-vercel that wasn't reflected in the main tsup config
  2. Or the entry was added with an incorrect path

Made the change to fix this

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
NA

## Testing

## Documentation
