### PR TITLE
[NA] [BE] Add OpenTelemetry metrics to RateLimitInterceptor with HTTP route and method attributes

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/ratelimit/RateLimitInterceptorTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/ratelimit/RateLimitInterceptorTest.java
@@ -1,0 +1,307 @@
+package com.comet.opik.infrastructure.ratelimit;
+
+import com.comet.opik.infrastructure.RateLimitConfig;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import jakarta.inject.Provider;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
+import jakarta.ws.rs.OPTIONS;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Method;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RateLimitInterceptor Tests")
+class RateLimitInterceptorTest {
+
+    @Mock
+    private Provider<RequestContext> requestContextProvider;
+
+    @Mock
+    private Provider<RateLimitService> rateLimitServiceProvider;
+
+    @Mock
+    private RateLimitConfig rateLimitConfig;
+
+    @Mock
+    private RateLimitService rateLimitService;
+
+    @Mock
+    private RequestContext requestContext;
+
+    @Mock
+    private MethodInvocation methodInvocation;
+
+    private RateLimitInterceptor interceptor;
+
+    @BeforeEach
+    void setUp() {
+        interceptor = new RateLimitInterceptor(requestContextProvider, rateLimitServiceProvider, rateLimitConfig);
+    }
+
+    @Nested
+    @DisplayName("HTTP Route Extraction Tests")
+    class HttpRouteExtractionTests {
+
+        @Test
+        void extractHttpRoute_whenClassAndMethodHavePaths_shouldCombineCorrectly() throws Exception {
+            // Given
+            Method method = TestResource.class.getMethod("testMethod");
+            when(methodInvocation.getMethod()).thenReturn(method);
+
+            // When
+            String route = extractHttpRoute(methodInvocation);
+
+            // Then
+            assertThat(route).isEqualTo("/v1/private/test/method");
+        }
+
+        @Test
+        void extractHttpRoute_whenClassPathEndsWithSlash_shouldNotAddExtraSlash() throws Exception {
+            // Given
+            Method method = TestResourceWithTrailingSlash.class.getMethod("testMethod");
+            when(methodInvocation.getMethod()).thenReturn(method);
+
+            // When
+            String route = extractHttpRoute(methodInvocation);
+
+            // Then
+            assertThat(route).isEqualTo("/v1/private/test/method");
+        }
+
+        @Test
+        void extractHttpRoute_whenMethodPathStartsWithSlash_shouldNotAddExtraSlash() throws Exception {
+            // Given
+            Method method = TestResourceWithLeadingSlash.class.getMethod("testMethod");
+            when(methodInvocation.getMethod()).thenReturn(method);
+
+            // When
+            String route = extractHttpRoute(methodInvocation);
+
+            // Then
+            assertThat(route).isEqualTo("/v1/private/test/method");
+        }
+
+        @Test
+        void extractHttpRoute_whenOnlyClassHasPath_shouldReturnClassPath() throws Exception {
+            // Given
+            Method method = TestResource.class.getMethod("methodWithoutPath");
+            when(methodInvocation.getMethod()).thenReturn(method);
+
+            // When
+            String route = extractHttpRoute(methodInvocation);
+
+            // Then
+            assertThat(route).isEqualTo("/v1/private/test");
+        }
+
+        @Test
+        void extractHttpRoute_whenOnlyMethodHasPath_shouldReturnMethodPath() throws Exception {
+            // Given
+            Method method = TestResourceWithoutClassPath.class.getMethod("testMethod");
+            when(methodInvocation.getMethod()).thenReturn(method);
+
+            // When
+            String route = extractHttpRoute(methodInvocation);
+
+            // Then
+            assertThat(route).isEqualTo("/v1/private/test/method");
+        }
+
+        @Test
+        void extractHttpRoute_whenNoPaths_shouldReturnUnknown() throws Exception {
+            // Given
+            Method method = TestResourceWithoutPaths.class.getMethod("testMethod");
+            when(methodInvocation.getMethod()).thenReturn(method);
+
+            // When
+            String route = extractHttpRoute(methodInvocation);
+
+            // Then
+            assertThat(route).isEqualTo("unknown");
+        }
+
+        @Test
+        void extractHttpRoute_whenExceptionOccurs_shouldReturnUnknown() throws Exception {
+            // Given
+            when(methodInvocation.getMethod()).thenThrow(new RuntimeException("Test exception"));
+
+            // When
+            String route = extractHttpRoute(methodInvocation);
+
+            // Then
+            assertThat(route).isEqualTo("unknown");
+        }
+    }
+
+    @Nested
+    @DisplayName("HTTP Method Extraction Tests")
+    class HttpMethodExtractionTests {
+
+        @ParameterizedTest
+        @MethodSource("httpMethodProvider")
+        void extractHttpMethod_whenMethodHasHttpAnnotation_shouldReturnCorrectMethod(
+                Class<?> resourceClass, String methodName, String expectedMethod) throws Exception {
+            // Given
+            Method method = resourceClass.getMethod(methodName);
+            when(methodInvocation.getMethod()).thenReturn(method);
+
+            // When
+            String httpMethod = extractHttpMethod(methodInvocation);
+
+            // Then
+            assertThat(httpMethod).isEqualTo(expectedMethod);
+        }
+
+        @Test
+        void extractHttpMethod_whenNoHttpAnnotation_shouldReturnUnknown() throws Exception {
+            // Given
+            Method method = TestResourceWithoutHttpMethod.class.getMethod("testMethod");
+            when(methodInvocation.getMethod()).thenReturn(method);
+
+            // When
+            String httpMethod = extractHttpMethod(methodInvocation);
+
+            // Then
+            assertThat(httpMethod).isEqualTo("unknown");
+        }
+
+        @Test
+        void extractHttpMethod_whenExceptionOccurs_shouldReturnUnknown() throws Exception {
+            // Given
+            when(methodInvocation.getMethod()).thenThrow(new RuntimeException("Test exception"));
+
+            // When
+            String httpMethod = extractHttpMethod(methodInvocation);
+
+            // Then
+            assertThat(httpMethod).isEqualTo("unknown");
+        }
+
+        static Stream<Arguments> httpMethodProvider() {
+            return Stream.of(
+                    Arguments.of(TestResource.class, "getMethod", "GET"),
+                    Arguments.of(TestResource.class, "postMethod", "POST"),
+                    Arguments.of(TestResource.class, "putMethod", "PUT"),
+                    Arguments.of(TestResource.class, "deleteMethod", "DELETE"),
+                    Arguments.of(TestResource.class, "patchMethod", "PATCH"),
+                    Arguments.of(TestResource.class, "headMethod", "HEAD"),
+                    Arguments.of(TestResource.class, "optionsMethod", "OPTIONS"));
+        }
+    }
+
+    // Helper method to access private extractHttpRoute method
+    private String extractHttpRoute(MethodInvocation invocation) throws Exception {
+        Method method = RateLimitInterceptor.class.getDeclaredMethod("extractHttpRoute", MethodInvocation.class);
+        method.setAccessible(true);
+        return (String) method.invoke(interceptor, invocation);
+    }
+
+    // Helper method to access private extractHttpMethod method
+    private String extractHttpMethod(MethodInvocation invocation) throws Exception {
+        Method method = RateLimitInterceptor.class.getDeclaredMethod("extractHttpMethod", MethodInvocation.class);
+        method.setAccessible(true);
+        return (String) method.invoke(interceptor, invocation);
+    }
+
+    // Test resource classes for different scenarios
+    @Path("/v1/private/test")
+    static class TestResource {
+        @GET
+        @Path("/method")
+        public void getMethod() {
+        }
+
+        @POST
+        @Path("/post")
+        public void postMethod() {
+        }
+
+        @PUT
+        @Path("/put")
+        public void putMethod() {
+        }
+
+        @DELETE
+        @Path("/delete")
+        public void deleteMethod() {
+        }
+
+        @PATCH
+        @Path("/patch")
+        public void patchMethod() {
+        }
+
+        @HEAD
+        @Path("/head")
+        public void headMethod() {
+        }
+
+        @OPTIONS
+        @Path("/options")
+        public void optionsMethod() {
+        }
+
+        @POST
+        @Path("/method")
+        public void testMethod() {
+        }
+
+        @POST
+        public void methodWithoutPath() {
+        }
+    }
+
+    @Path("/v1/private/test/")
+    static class TestResourceWithTrailingSlash {
+        @POST
+        @Path("method")
+        public void testMethod() {
+        }
+    }
+
+    @Path("/v1/private/test")
+    static class TestResourceWithLeadingSlash {
+        @POST
+        @Path("/method")
+        public void testMethod() {
+        }
+    }
+
+    @Path("/v1/private/test")
+    static class TestResourceWithoutClassPath {
+        @POST
+        @Path("/method")
+        public void testMethod() {
+        }
+    }
+
+    static class TestResourceWithoutPaths {
+        public void testMethod() {
+        }
+    }
+
+    static class TestResourceWithoutHttpMethod {
+        public void testMethod() {
+        }
+    }
+}


### PR DESCRIPTION
## Details
This PR adds OpenTelemetry metrics to the RateLimitInterceptor to track the number of entities created/updated through rate-limited endpoints. The metric includes both HTTP route and HTTP method as attributes for better observability.

### Changes Made:
- Added `opik.resources.entities` LongCounter metric to track entity operations
- Implemented `extractHttpRoute()` method to extract HTTP routes from JAX-RS `@Path` annotations
- Implemented `extractHttpMethod()` method to extract HTTP methods from JAX-RS HTTP method annotations (`@GET`, `@POST`, etc.)
- Added comprehensive unit tests covering route extraction, method extraction, and error handling scenarios
- Metric is recorded with `http_route` and `http_request_method` attributes

### Technical Implementation:
- Uses OpenTelemetry's `LongCounter` for cumulative metric collection
- Extracts route information by combining class-level and method-level `@Path` annotations
- Extracts HTTP method using the `@HttpMethod` meta-annotation present on JAX-RS HTTP method annotations
- Includes proper error handling that returns "unknown" for both route and method when extraction fails
- Metric is only recorded for successfully executed rate-limited methods

## Change checklist
<!-- Please check the type of changes made -->
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves # <!-- the GitHub issue this PR resolves (e.g. `#1234`) -->
- OPIK- <!-- The Jira ticket (e.g. `OPIK-1234`) -->
- NA <!-- If no ticket, such as hotfixes etc. -->

## Testing
- Added comprehensive unit tests for HTTP route extraction covering various JAX-RS annotation combinations
- Added parameterized tests for HTTP method extraction covering all standard HTTP methods
- Added tests for error handling scenarios
- All tests pass successfully (16 tests, 0 failures, 0 errors)
- Verified compilation and existing functionality remains intact

## Documentation
No documentation updates required - this is an internal observability enhancement that doesn't change the public API.