### PR TITLE
[NA] [dev] Allow to work with docker-compose

### DIFF
--- a/opik.sh
+++ b/opik.sh
@@ -143,7 +143,7 @@ get_docker_compose_cmd() {
     exit 1
   fi
 
-  local cmd="$compose_cmd -f $script_dir/deployment/docker-compose/docker-compose.yaml"
+  local cmd="${compose_cmd} -f $script_dir/deployment/docker-compose/docker-compose.yaml"
   if [[ "$PORT_MAPPING" == "true" ]]; then
     cmd="$cmd -f $script_dir/deployment/docker-compose/docker-compose.override.yaml"
   fi


### PR DESCRIPTION
## Details

This allows opik.sh to work with `docker-compose` or `docker compose`.

## Change checklist

N/A

## Issues

Wouldn't work on my system without this change.

## Testing

Verified.

## Documentation

N/A
