### PR TITLE
[OPIK-2857] [DOCS] fix broken docs links

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/parameter_optimizer.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/parameter_optimizer.mdx
@@ -13,7 +13,7 @@ The `ParameterOptimizer` uses Bayesian optimization to tune LLM call parameters 
 </Note>
 
 <Info>
-  Have questions about `ParameterOptimizer`? Our [Optimizer & SDK FAQ](/agent_optimization/opik_optimizer/faq)
+  Have questions about `ParameterOptimizer`? Our [Optimizer & SDK FAQ](/agent_optimization/faq)
   answers common questions, including when to use this optimizer, how parameters like `default_n_trials` and `local_search_ratio`
   work, and how to define custom parameter search spaces.
 </Info>
@@ -281,9 +281,6 @@ You can optimize nested parameters in `model_kwargs`:
 The ParameterOptimizer supports all models available through LiteLLM. This provides broad
 compatibility with providers like OpenAI, Azure OpenAI, Anthropic, Google, and many others,
 including locally hosted models.
-
-For detailed instructions on how to specify different models and configure providers, please refer
-to the main [LiteLLM Support for Optimizers documentation page](/agent_optimization/opik_optimizer/litellm_support).
 
 ### Configuration Example using LiteLLM model string
 

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/best_practices/prompt_engineering.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/best_practices/prompt_engineering.mdx
@@ -156,14 +156,7 @@ Evolutionary or genetic algorithms can be applied to "evolve" prompts over gener
 
 ## Systematic Prompt Optimization with Opik Agent Optimizer
 
-While the techniques above are valuable for manual prompt engineering, the [Opik Agent Optimizer SDK](/agent_optimization/opik_optimizer/quickstart) offers a systematic and data-driven way to automate and enhance this process. By leveraging a dataset and evaluation metrics, optimizers can explore a vast design space to find high-performing prompts.
-
-<Note>
-  All optimizers require a `model` parameter during initialization, which specifies the LLM to be used. Thanks to
-  **LiteLLM integration**, you can specify models from various providers (OpenAI, Azure, Anthropic, Gemini, local
-  models, etc.) using the LiteLLM model string format. See the [LiteLLM Support for
-  Optimizers](/agent_optimization/opik_optimizer/litellm_support) page for more details.
-</Note>
+While the techniques above are valuable for manual prompt engineering, the [Opik Agent Optimizer SDK](/agent_optimization/optimizer-cookbooks/optimizer_introduction_cookbook) offers a systematic and data-driven way to automate and enhance this process. By leveraging a dataset and evaluation metrics, optimizers can explore a vast design space to find high-performing prompts.
 
 We provide several distinct optimization algorithms, each suited for different scenarios:
 
@@ -171,4 +164,4 @@ We provide several distinct optimization algorithms, each suited for different s
 2.  [**Few-shot Bayesian Optimizer**](/agent_optimization/algorithms/fewshot_bayesian_optimizer): Finds the optimal set and number of few-shot examples for **chat models** by using Bayesian optimization.
 3.  [**Evolutionary Optimizer**](/agent_optimization/algorithms/evolutionary_optimizer): Evolves prompts using genetic algorithms, capable of multi-objective optimization (e.g., performance vs. length) and using LLMs for advanced genetic operations.
 
-Refer to each optimizer's specific documentation to understand its strengths and how it aligns with different prompt engineering challenges. For general guidance on getting started, see the [Opik Agent Optimizer Quickstart](/agent_optimization/opik_optimizer/quickstart).
+Refer to each optimizer's specific documentation to understand its strengths and how it aligns with different prompt engineering challenges. For general guidance on getting started, see the [Opik Agent Optimizer Quickstart](/agent_optimization/optimizer-cookbooks/optimizer_introduction_cookbook).

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/opik_optimizer/concepts.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/opik_optimizer/concepts.mdx
@@ -40,7 +40,7 @@ examples, or tool interactions.
   </Accordion>
   <Accordion title="ChatPrompt">
     The object to optimize which contains your chat messages with placeholders for variables that change on each example.
-    See the [API Reference](/agent_optimization/opik_optimizer/reference#chatprompt).
+    See the [API Reference](/agent_optimization/api-reference#chatprompt).
   </Accordion>
   <Accordion title="Metric">
     An object defining how to measure the performance of a prompt. The metric functions should accept two parameters:
@@ -79,6 +79,6 @@ examples, or tool interactions.
 - Refer to the [API Reference](/agent_optimization/api-reference) for detailed configuration options.
 
 <Info>
-  📓 Want to see these concepts in action? Check out our [Example Projects & Cookbooks](/agent_optimization/opik_optimizer/quickstart)
+  📓 Want to see these concepts in action? Check out our [Example Projects & Cookbooks](/agent_optimization/optimizer-cookbooks/optimizer_introduction_cookbook)
   for step-by-step, runnable Colab notebooks.
 </Info>

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/opik_optimizer/faq.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/opik_optimizer/faq.mdx
@@ -23,7 +23,7 @@ description: "Find answers to common questions about Opik Agent Optimizer, inclu
   2. A dataset of examples to optimizer on, you can start with as little as 10
   3. A metric to evaluate the performance of the prompt
 
-  Once you have these, check out the [Quickstart Guide](/agent_optimization/opik_optimizer/overview)
+  Once you have these, check out the [Quickstart Guide](/agent_optimization/overview)
   to run your first optimization.
   </Accordion>
   <Accordion title="Can you help me optimize my prompt ?">
@@ -37,18 +37,18 @@ description: "Find answers to common questions about Opik Agent Optimizer, inclu
 <AccordionGroup>
   <Accordion title="What are the supported optimization algorithms?">
   Opik Agent Optimizer supports a wide range of optimization algorithms including:
-  - [Hierarchical Reflective Optimization](/agent_optimization/opik_optimizer/algorithms/hierarchical_reflective_optimizer)
-  - [GEPA Optimization](/agent_optimization/opik_optimizer/algorithms/gepa_optimizer)
-  - [Evolutionary Optimization](/agent_optimization/opik_optimizer/algorithms/evolutionary_optimizer)
-  - [Few-shot Bayesian Optimization](/agent_optimization/opik_optimizer/algorithms/few_shot_bayesian_optimizer)
-  - [MetaPrompt Optimization](/agent_optimization/opik_optimizer/algorithms/meta_prompt_optimizer)
+  - [Hierarchical Reflective Optimization](/agent_optimization/algorithms/hierarchical_reflective_optimizer)
+  - [GEPA Optimization](/agent_optimization/algorithms/gepa_optimizer)
+  - [Evolutionary Optimization](/agent_optimization/algorithms/evolutionary_optimizer)
+  - [Few-shot Bayesian Optimization](/agent_optimization/algorithms/fewshot_bayesian_optimizer)
+  - [MetaPrompt Optimization](/agent_optimization/algorithms/metaprompt_optimizer)
 
   If you would like us to add a new optimization algorithm, simply create an issue on our
   [GitHub repository](https://github.com/comet-ml/opik/issues) and we will be happy to add it !
   </Accordion>
   <Accordion title="How do I choose the right optimizer for my task?">
   Knowing which optimizer to use depends on your specific needs. As a rule of thumb, we recommend
-  starting with the [Hierarchical Reflective Optimization](/agent_optimization/opik_optimizer/algorithms/hierarchical_reflective_optimizer)
+  starting with the [Hierarchical Reflective Optimization](/agent_optimization/algorithms/hierarchical_reflective_optimizer)
   as this has been shown to be a strong baseline for most tasks.
 
   You can also try to use:
@@ -82,10 +82,6 @@ description: "Find answers to common questions about Opik Agent Optimizer, inclu
   - Mistral AI (e.g., Mistral-7B-Instruct, Mistral-7B-Instruct-Pro)
   - Locally hosted models (e.g., via Ollama, Hugging Face Inference Endpoints)
   - And many others supported by LiteLLM.
-
-  For comprehensive details on how to specify different model providers, pass API keys, and
-  configure endpoints, please refer to our dedicated
-  [LiteLLM Support for Optimizers guide](/agent_optimization/opik_optimizer/litellm_support).
   </Accordion>
   <Accordion title="The performance is not improving, what should I do?">
   There are a few things you can try to improve the performance of your optimization:
@@ -198,6 +194,6 @@ description: "Find answers to common questions about Opik Agent Optimizer, inclu
 
 ## Next Steps
 
-- Explore [API Reference](/agent_optimization/opik_optimizer/reference) for detailed technical documentation.
+- Explore [API Reference](/agent_optimization/api-reference) for detailed technical documentation.
 - Review the individual Optimizer pages under [Optimization Algorithms](/agent_optimization/overview#optimization-algorithms).
-- Check out the [Quickstart Guide](/agent_optimization/opik_optimizer/quickstart).
+- Check out the [Quickstart Guide](/agent_optimization/optimizer-cookbooks/optimizer_introduction_cookbook).

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/overview.mdx
@@ -245,5 +245,5 @@ results might change if you use a different model, configuration, dataset and st
 3. Refer to the [API Reference](/agent_optimization/api-reference) for detailed configuration options.
 
 <Info>
-  🚀 Want to see Opik Agent Optimizer in action? Check out our [Example Projects & Cookbooks](/agent_optimization/opik_optimizer/quickstart) for runnable Colab notebooks covering real-world optimization workflows, including HotPotQA and synthetic data generation.
+  🚀 Want to see Opik Agent Optimizer in action? Check out our [Example Projects & Cookbooks](/agent_optimization/optimizer-cookbooks/optimizer_introduction_cookbook) for runnable Colab notebooks covering real-world optimization workflows, including HotPotQA and synthetic data generation.
 </Info>

--- a/apps/opik-documentation/documentation/fern/docs/prompt_engineering/improve.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/prompt_engineering/improve.mdx
@@ -129,4 +129,4 @@ A high-quality improved prompt must be clear enough that no further clarificatio
 
 ## Advanced Optimization
 
-For production-critical prompts requiring systematic optimization with automated evaluation and dataset integration, explore the [Opik Agent Optimizer](/agent_optimization/opik_optimizer/overview).
+For production-critical prompts requiring systematic optimization with automated evaluation and dataset integration, explore the [Opik Agent Optimizer](/agent_optimization/overview).

--- a/apps/opik-documentation/documentation/fern/docs/tracing/concepts.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/concepts.mdx
@@ -165,7 +165,7 @@ Now that you understand the core concepts, explore these resources to dive deepe
 - [Metrics overview](/evaluation/metrics/overview) - Available evaluation metrics
 
 ### Optimization:
-- [Agent Optimization concepts](/agent_optimization/opik_optimizer/concepts) - Core optimization concepts
+- [Agent Optimization concepts](/agent_optimization/optimizer-concepts) - Core optimization concepts
 - [Optimization algorithms](/agent_optimization/overview) - Available optimization strategies
 - [Best practices](/agent_optimization/best_practices/prompt_engineering) - Optimization best practices
 

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/litellm.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/litellm.mdx
@@ -119,7 +119,7 @@ chunks = list(response)
 ## Using Opik with the LiteLLM Proxy Server
 
 <Info>
-  **Opik Agent Optimizer & LiteLLM**: Beyond tracing, the Opik Agent Optimizer SDK also leverages LiteLLM for comprehensive model support within its optimization algorithms. This allows you to use a wide range of LLMs (including local ones) for prompt optimization tasks. Learn more on the [LiteLLM Support for Optimizers page](/agent_optimization/opik_optimizer/litellm_support).
+  **Opik Agent Optimizer & LiteLLM**: Beyond tracing, the Opik Agent Optimizer SDK also leverages LiteLLM for comprehensive model support within its optimization algorithms. This allows you to use a wide range of LLMs (including local ones) for prompt optimization tasks.
 </Info>
 
 ### Configuring the LiteLLM Proxy Server


### PR DESCRIPTION
## Details
During documentation review, we discovered approximately 15 broken internal links throughout the Opik documentation. These links were causing 404 errors and poor user experience when navigating the agent optimization documentation.

  The main issues were:
  1. Links using the pattern /agent_optimization/opik_optimizer/* pointing to non-existent pages
  2. References to pages that were moved or never created (e.g., litellm_support)
  3. Inconsistent URL structure across different documentation sections

  Solution

  Systematically fixed all broken links by:
  - Updating paths from /agent_optimization/opik_optimizer/* to correct /agent_optimization/* structure
  - Redirecting quickstart links to the actual cookbook page: /agent_optimization/optimizer-cookbooks/optimizer_introduction_cookbook
  - Fixing API reference links to point to /agent_optimization/api-reference
  - Correcting algorithm documentation links to use /agent_optimization/algorithms/* (without the opik_optimizer/ segment)
  - Removing sentences referencing non-existent documentation (LiteLLM support page)

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues
OPIK-2857

## Testing

## Documentation
