### PR TITLE
[NA] [BE] Fix AttachmentStripperServiceTest mock cleanup

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/attachment/AttachmentStripperServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/attachment/AttachmentStripperServiceTest.java
@@ -3,7 +3,6 @@ package com.comet.opik.domain.attachment;
 import com.comet.opik.api.attachment.EntityType;
 import com.comet.opik.infrastructure.AttachmentsConfig;
 import com.comet.opik.infrastructure.OpikConfiguration;
-import com.comet.opik.infrastructure.S3Config;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.eventbus.EventBus;
@@ -31,9 +30,6 @@ import static org.mockito.Mockito.when;
 class AttachmentStripperServiceTest {
 
     @Mock
-    private S3Config s3Config;
-
-    @Mock
     private AttachmentsConfig attachmentsConfig;
 
     @Mock
@@ -59,7 +55,6 @@ class AttachmentStripperServiceTest {
         when(attachmentsConfig.getStripMinSize()).thenReturn(5000L);
 
         // Mock OpikConfiguration to return the configs
-        when(opikConfiguration.getS3Config()).thenReturn(s3Config);
         when(opikConfiguration.getAttachmentsConfig()).thenReturn(attachmentsConfig);
 
         // Use OpenTelemetry no-op implementation and EventBus mock for async uploads


### PR DESCRIPTION
## Details
Removed unused S3Config mock from AttachmentStripperServiceTest. The mock was defined but never used in any test methods, making then failed due to non-lenient configuration. 

## Change checklist
<!-- Please check the type of changes made -->
- [ ] User facing
- [ ] Documentation update

## Issues
- NA

## Testing
All 8 existing tests in AttachmentStripperServiceTest pass successfully:
- Tests run: 8, Failures: 0, Errors: 0, Skipped: 0

## Documentation
N/A - Internal test cleanup with no impact on public APIs or user-facing documentation.