### PR TITLE
[NA] [DOCS] Add Google ADK section to agent graph logging documentation

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/tracing/log_agent_graph.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/log_agent_graph.mdx
@@ -7,7 +7,8 @@ Agent Graphs are a great way to visualize the flow of an agent and simplifies it
 Opik supports logging agent graphs for the following frameworks:
 
 1. LangGraph
-2. Manual Tracking
+2. Google Agent Development Kit (ADK)
+3. Manual Tracking
 
 ## LangGraph
 
@@ -22,6 +23,25 @@ opik_tracer = OpikTracer(graph=app.get_graph(xray=True))
 
 Opik will log the agent graph definition in the Opik dashboard which you can access by clicking on
 `Show Agent Graph` in the trace sidebar.
+
+## Google Agent Development Kit (ADK)
+
+Opik automatically generates visual representations of your agent workflows for Google ADK without requiring any additional configuration. Simply integrate Opik's OpikTracer callback as shown in the [ADK integration configuration guide](https://www.comet.com/docs/opik/integrations/adk#configuring-google-adk), and your agent graphs will be automatically captured and visualized.
+
+The graph automatically shows:
+- Agent hierarchy and relationships
+- Sequential execution flows
+- Parallel processing branches
+- Tool connections and dependencies
+- Loop structures and iterations
+
+For example, a basic weather and time agent will display its execution flow with all agent steps, LLM calls, and tool invocations:
+
+<Frame>
+  <img src="/img/tracing/adk/adk_weather_time_graph_screenshot.png" />
+</Frame>
+
+For more complex multi-agent architectures, the automatic graph visualization becomes even more valuable, providing clear visibility into nested agent hierarchies and complex execution patterns.
 
 ## Manual Tracking
 


### PR DESCRIPTION
## Details

This PR adds a new Google Agent Development Kit (ADK) section to the agent graph logging documentation. The section explains that Opik automatically generates visual representations of agent workflows for Google ADK without requiring any additional configuration.

### What's included:
- New Google ADK section in the agent graph logging documentation
- Link to the ADK integration configuration guide
- Description of what the agent graph automatically shows (hierarchy, execution flows, branches, tool connections, loop structures)
- Screenshot example of a weather_time_agent with automatic graph visualization
- Context about the value for complex multi-agent architectures

### Documentation update
- Added comprehensive documentation for Google ADK agent graph visualization

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- NA

## Testing
Documentation change - verified by reviewing the updated article structure and image inclusion.

## Documentation
Updated: `apps/opik-documentation/documentation/fern/docs/tracing/log_agent_graph.mdx`
- Added Google ADK framework support alongside existing LangGraph and Manual Tracking sections
- Included screenshot of automatic agent graph visualization from weather_time_agent example