### PR TITLE
[OPIK-2930] [FE] Disable Thread scope selection in Playground metric creation

### DIFF
--- a/apps/opik-frontend/src/api/playground/createLogPlaygroundProcessor.ts
+++ b/apps/opik-frontend/src/api/playground/createLogPlaygroundProcessor.ts
@@ -26,6 +26,7 @@ import {
 } from "@/types/providers";
 import { ProviderMessageType } from "@/types/llm";
 import { parseCompletionOutput } from "@/lib/playground";
+import { PLAYGROUND_PROJECT_NAME } from "@/constants/shared";
 
 export interface LogQueueParams extends RunStreamingReturn {
   promptId: string;
@@ -74,7 +75,6 @@ const createBatchExperimentItems = async (
   });
 };
 
-export const PLAYGROUND_PROJECT_NAME = "playground";
 const PLAYGROUND_TRACE_SPAN_NAME = "chat_completion_create";
 const USAGE_FIELDS_TO_SEND = [
   "completion_tokens",

--- a/apps/opik-frontend/src/components/pages-shared/automations/AddEditRuleDialog/AddEditRuleDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/automations/AddEditRuleDialog/AddEditRuleDialog.tsx
@@ -127,6 +127,7 @@ type AddEditRuleDialogProps = {
   rule?: EvaluatorsRule;
   projectName?: string; // Optional: project name for pre-selected projects
   datasetColumnNames?: string[]; // Optional: dataset column names from playground
+  hideScopeSelector?: boolean; // Optional: hide scope selector (e.g., for contexts that only support one scope)
 };
 
 const isPythonCodeRule = (rule: EvaluatorsRule) => {
@@ -150,6 +151,7 @@ const AddEditRuleDialog: React.FC<AddEditRuleDialogProps> = ({
   rule: defaultRule,
   projectName,
   datasetColumnNames,
+  hideScopeSelector = false,
 }) => {
   const isCodeMetricEnabled = useIsFeatureEnabled(
     FeatureToggleKeys.PYTHON_EVALUATOR_ENABLED,
@@ -457,39 +459,43 @@ const AddEditRuleDialog: React.FC<AddEditRuleDialogProps> = ({
                     }}
                   />
 
-                  <FormField
-                    control={form.control}
-                    name="scope"
-                    render={({ field }) => (
-                      <FormItem className="flex-1">
-                        <Label className="flex items-center">
-                          Scope{" "}
-                          <TooltipWrapper content="Choose whether the evaluation rule scores the entire thread or each individual trace. Thread-level rules assess the full conversation, while trace-level rules evaluate one model response at a time.">
-                            <Info className="ml-1 size-4 text-light-slate" />
-                          </TooltipWrapper>
-                        </Label>
-                        <FormControl>
-                          <Select
-                            value={field.value}
-                            onValueChange={handleScopeChange}
-                            disabled={isEdit}
-                          >
-                            <SelectTrigger>
-                              <SelectValue placeholder="Select scope" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value={EVALUATORS_RULE_SCOPE.trace}>
-                                Trace
-                              </SelectItem>
-                              <SelectItem value={EVALUATORS_RULE_SCOPE.thread}>
-                                Thread
-                              </SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </FormControl>
-                      </FormItem>
-                    )}
-                  />
+                  {!hideScopeSelector && (
+                    <FormField
+                      control={form.control}
+                      name="scope"
+                      render={({ field }) => (
+                        <FormItem className="flex-1">
+                          <Label className="flex items-center">
+                            Scope{" "}
+                            <TooltipWrapper content="Choose whether the evaluation rule scores the entire thread or each individual trace. Thread-level rules assess the full conversation, while trace-level rules evaluate one model response at a time.">
+                              <Info className="ml-1 size-4 text-light-slate" />
+                            </TooltipWrapper>
+                          </Label>
+                          <FormControl>
+                            <Select
+                              value={field.value}
+                              onValueChange={handleScopeChange}
+                              disabled={isEdit}
+                            >
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select scope" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value={EVALUATORS_RULE_SCOPE.trace}>
+                                  Trace
+                                </SelectItem>
+                                <SelectItem
+                                  value={EVALUATORS_RULE_SCOPE.thread}
+                                >
+                                  Thread
+                                </SelectItem>
+                              </SelectContent>
+                            </Select>
+                          </FormControl>
+                        </FormItem>
+                      )}
+                    />
+                  )}
                 </div>
 
                 <FormField

--- a/apps/opik-frontend/src/components/pages-shared/traces/TracesOrSpansPathsAutocomplete/TracesOrSpansPathsAutocomplete.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TracesOrSpansPathsAutocomplete/TracesOrSpansPathsAutocomplete.tsx
@@ -11,7 +11,7 @@ import useTracesOrSpansList, {
 import Autocomplete from "@/components/shared/Autocomplete/Autocomplete";
 import { PROJECTS_SELECT_QUERY_KEY } from "@/components/pages-shared/automations/ProjectsSelectBox";
 import { Project } from "@/types/projects";
-import { PLAYGROUND_PROJECT_NAME } from "@/api/playground/createLogPlaygroundProcessor";
+import { PLAYGROUND_PROJECT_NAME } from "@/constants/shared";
 
 type CachedProjectsData = { content: Project[]; total: number };
 

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/PlaygroundOutputActions.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/PlaygroundOutputActions.tsx
@@ -28,6 +28,7 @@ import ExplainerIcon from "@/components/shared/ExplainerIcon/ExplainerIcon";
 import { Separator } from "@/components/ui/separator";
 import { hasImagesInContent } from "@/lib/llm";
 import { supportsImageInput } from "@/lib/modelCapabilities";
+import { PLAYGROUND_PROJECT_NAME } from "@/constants/shared";
 import DatasetEmptyState from "./DatasetEmptyState";
 
 const EMPTY_DATASETS: Dataset[] = [];
@@ -78,7 +79,7 @@ const PlaygroundOutputActions = ({
     isLoading: isLoadingProject,
   } = useProjectByName(
     {
-      projectName: "playground",
+      projectName: PLAYGROUND_PROJECT_NAME,
     },
     {
       enabled: !!workspaceName,
@@ -216,13 +217,13 @@ const PlaygroundOutputActions = ({
       // If project doesn't exist (404), create it
       if (!projectId && isProjectNotFound) {
         const result = await createProjectMutation.mutateAsync({
-          project: { name: "playground" },
+          project: { name: PLAYGROUND_PROJECT_NAME },
         });
         projectId = result.id;
 
         // Refetch the project query to get the updated project data
         await queryClient.refetchQueries({
-          queryKey: ["project", { projectName: "playground" }],
+          queryKey: ["project", { projectName: PLAYGROUND_PROJECT_NAME }],
         });
       }
 
@@ -510,8 +511,9 @@ const PlaygroundOutputActions = ({
           }
         }}
         projectId={ruleDialogProjectId || playgroundProject?.id}
-        projectName="playground"
+        projectName={PLAYGROUND_PROJECT_NAME}
         datasetColumnNames={datasetColumns.map((c) => c.name)}
+        hideScopeSelector
       />
       <AddEditDatasetDialog
         open={isDatasetDialogOpen}

--- a/apps/opik-frontend/src/constants/shared.ts
+++ b/apps/opik-frontend/src/constants/shared.ts
@@ -7,6 +7,7 @@ import {
 } from "@/types/shared";
 
 export const DEMO_PROJECT_NAME = "Demo Project";
+export const PLAYGROUND_PROJECT_NAME = "playground";
 export const USER_FEEDBACK_NAME = "User feedback";
 export const USER_FEEDBACK_COLUMN_ID = `${COLUMN_FEEDBACK_SCORES_ID}.${USER_FEEDBACK_NAME}`;
 


### PR DESCRIPTION
## Details

This PR fixes a bug where users could select "Thread" scope when creating evaluation metrics in the Playground, even though the Playground doesn't create traces with threads. This led to unscored traces with no error messages, causing confusion.

**Changes implemented:**
- Added `PLAYGROUND_PROJECT_NAME` constant to `constants/shared.ts` for consistent reference across the codebase
- Modified `AddEditRuleDialog` to conditionally hide the "Thread" scope option when creating metrics in the Playground context
- Updated tooltip to explain why Thread scope is unavailable in Playground
- Disabled scope selector in Playground (only "Trace" option available)
- Consolidated all existing "playground" string references to use the new constant across 5 files

**Technical approach:**
- Uses `projectName` prop to detect Playground context
- Conditionally renders Thread scope option only for non-Playground projects
- Maintains backward compatibility for existing metrics with Thread scope

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves #N/A
- OPIK-2930

## Testing
**Manual testing scenarios:**
1. Navigate to Playground
2. Click "Create metric" button
3. Verify only "Trace" scope is available in the dropdown
4. Verify tooltip explains why Thread scope is unavailable
5. Navigate to a regular Project page
6. Create a metric and verify both "Trace" and "Thread" scopes are available
7. Edit an existing metric and verify scope selector is disabled as expected

**Test coverage:**
- Linting passed with no errors
- No new test files added (UI behavior change)

## Documentation
No documentation updates required. The UI change is self-explanatory with the updated tooltip text.