### PR TITLE
[OPIK-2763] [FE] Refactor PrettyCell component to simplify truncation handling

### DIFF
--- a/apps/opik-frontend/src/components/shared/DataTableCells/PrettyCell.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableCells/PrettyCell.tsx
@@ -66,7 +66,7 @@ const PrettyCell = <TData,>(context: CellContext<TData, string | object>) => {
   const displayMessage = useMemo(() => {
     if (!value || hasExceededLimit) {
       return hasExceededLimit
-        ? rawValue.slice(0, maxDataLength) + "[truncated]"
+        ? rawValue.slice(0, maxDataLength) + " [truncated]"
         : "-";
     }
 


### PR DESCRIPTION
## Details

This PR refactors the `PrettyCell` component to streamline data truncation handling and improve code maintainability.

**Key Changes:**
- Removed `TruncationLimitExceededMessage` component and related UI elements (`HelpCircle` icon, `TruncationConfigPopover`)
- Consolidated `response` and `message` useMemo hooks into a single `displayMessage` hook
- Simplified truncation display: now shows partial data with `[truncated]` suffix instead of a warning message
- Moved HTML stripping logic earlier in the processing pipeline for better performance
- Improved memoization dependencies to reduce unnecessary re-renders

**Behavioral Changes:**
- **Before**: Truncated data showed "Preview limit exceeded ⓘ" with a help popover
- **After**: Truncated data shows actual content preview followed by `[truncated]` text

This change provides users with more immediate visibility into truncated data while maintaining performance optimizations.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-2763

## Testing

Tested scenarios:
- Data within truncation limits displays correctly
- Data exceeding truncation limits shows preview with `[truncated]` suffix
- Small row height shows tooltip with full content
- Large row height shows scrollable content
- HTML content is properly stripped from prettified messages
- Falsy values (null, undefined) display as "-"

## Documentation

N/A - Internal component refactoring without API or configuration changes.