### PR TITLE
[OPIK-2954] [BE] Model qwen/qwen2.5-vl-32b-instruct vision support by pattern matching

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/ModelCapabilities.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/ModelCapabilities.java
@@ -17,13 +17,38 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 @UtilityClass
 public class ModelCapabilities {
 
+    // Hardcoded vision-capable models or patterns that should support vision
+    // This set of patterns overrides the JSON configuration to handle cases where:
+    // - The JSON uses different naming conventions (e.g., openrouter/ prefix)
+    // - Models are missing from the JSON
+    // - The JSON is not yet updated with new vision models
+    private static final Set<Pattern> VISION_MODEL_PATTERNS = Set.of(
+            // Made pattern more flexible to match anywhere in the name
+            Pattern.compile(".*qwen.*vl.*", Pattern.CASE_INSENSITIVE));
+
     private static final Map<String, ModelCapability> CAPABILITIES_BY_NORMALIZED_NAME = loadCapabilities();
 
+    /**
+     * Checks if a model name matches any of the hardcoded vision patterns.
+     */
+    private boolean matchesVisionPattern(String modelName) {
+        if (StringUtils.isBlank(modelName)) {
+            return false;
+        }
+        return VISION_MODEL_PATTERNS.stream().anyMatch(pattern -> pattern.matcher(modelName).matches());
+    }
+
     public boolean supportsVision(String modelName) {
+        if (matchesVisionPattern(modelName)) {
+            return true;
+        }
+
         return find(modelName).map(ModelCapability::supportsVision).orElse(false);
     }
 

--- a/apps/opik-backend/src/main/resources/model_prices_and_context_window.json
+++ b/apps/opik-backend/src/main/resources/model_prices_and_context_window.json
@@ -7076,17 +7076,6 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
-    "qwen/qwen2.5-vl-32b-instruct": {
-        "max_tokens": 128000,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "input_cost_per_token": 2e-07,
-        "output_cost_per_token": 6e-07,
-        "litellm_provider": "openrouter",
-        "mode": "chat",
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
     "deepinfra/Qwen/Qwen3-14B": {
         "max_tokens": 40960,
         "max_input_tokens": 40960,

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ModelCapabilitiesTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ModelCapabilitiesTest.java
@@ -1,0 +1,85 @@
+package com.comet.opik.domain.llm;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ModelCapabilitiesTest {
+
+    @Test
+    void supportsVisionReturnsTrueForKnownVisionModels() {
+        assertThat(ModelCapabilities.supportsVision("gpt-4-vision-preview")).isTrue();
+        assertThat(ModelCapabilities.supportsVision("gpt-4o")).isTrue();
+        assertThat(ModelCapabilities.supportsVision("claude-3-5-sonnet-20241022")).isTrue();
+        assertThat(ModelCapabilities.supportsVision("gemini-1.5-pro")).isTrue();
+    }
+
+    @Test
+    void supportsVisionReturnsFalseForNonVisionModels() {
+        assertThat(ModelCapabilities.supportsVision("gpt-3.5-turbo")).isFalse();
+        assertThat(ModelCapabilities.supportsVision("gpt-4")).isFalse();
+    }
+
+    @Test
+    void supportsVisionReturnsFalseForUnknownModels() {
+        assertThat(ModelCapabilities.supportsVision("unknown-model-12345")).isFalse();
+    }
+
+    @Test
+    void supportsVisionReturnsFalseForBlankModelName() {
+        assertThat(ModelCapabilities.supportsVision("")).isFalse();
+        assertThat(ModelCapabilities.supportsVision("   ")).isFalse();
+        assertThat(ModelCapabilities.supportsVision(null)).isFalse();
+    }
+
+    @Test
+    void supportsVisionReturnsTrueForModelsThatMatchVisionPattern() {
+        // Should be true because it matches the vision pattern
+        assertThat(ModelCapabilities.supportsVision("qwen/qwen2.5-vl-32b-instruct")).isTrue();
+        assertThat(ModelCapabilities.supportsVision("deepinfra/Qwen/Qwen2.5-VL-32B-Instruct")).isTrue();
+        // Should be false because it doesn't match the vision pattern
+        assertThat(ModelCapabilities.supportsVision("openrouter/qwen/qwen-2.5-coder-32b-instruct")).isFalse();
+    }
+
+    @Test
+    void supportsVisionIsCaseInsensitive() {
+        assertThat(ModelCapabilities.supportsVision("GPT-4-VISION-PREVIEW")).isTrue();
+        assertThat(ModelCapabilities.supportsVision("Gpt-4o")).isTrue();
+        assertThat(ModelCapabilities.supportsVision("CLAUDE-3-5-SONNET-20241022")).isTrue();
+    }
+
+    @Test
+    void supportsVisionMatchesModelWithoutProviderPrefix() {
+        // If stored as "provider/model", it should also match just "model"
+        assertThat(ModelCapabilities.supportsVision("gpt-4o")).isTrue();
+        assertThat(ModelCapabilities.supportsVision("openai/gpt-4o")).isTrue();
+    }
+
+    @Test
+    void supportsVisionHandlesWhitespace() {
+        assertThat(ModelCapabilities.supportsVision("  gpt-4o  ")).isTrue();
+        assertThat(ModelCapabilities.supportsVision("\tgpt-4o\n")).isTrue();
+    }
+
+    @Test
+    void supportsVisionHandlesColonSuffixes() {
+        // Colon suffixes are automatically stripped and matched to base model
+
+        // ✓ "qwen/qwen2.5-vl-32b-instruct:free" has explicit mapping
+        assertThat(ModelCapabilities.supportsVision("qwen/qwen2.5-vl-32b-instruct:free")).isTrue();
+
+        // ✓ "gpt-4o:free" falls back to "gpt-4o" (which exists in JSON and supports vision)
+        assertThat(ModelCapabilities.supportsVision("gpt-4o:free")).isTrue();
+
+        // ✗ "gpt-3.5-turbo:free" falls back to "gpt-3.5-turbo" (exists but doesn't support vision)
+        assertThat(ModelCapabilities.supportsVision("gpt-3.5-turbo:free")).isFalse();
+    }
+
+    @Test
+    void supportsVisionReturnsFalseForNonVisionModelVariations() {
+        // Even with different prefixes, non-vision models should return false
+        assertThat(ModelCapabilities.supportsVision("gpt-3.5-turbo")).isFalse();
+        assertThat(ModelCapabilities.supportsVision("openai/gpt-3.5-turbo")).isFalse();
+        assertThat(ModelCapabilities.supportsVision("GPT-3.5-TURBO")).isFalse();
+    }
+}


### PR DESCRIPTION
## Details

https://github.com/user-attachments/assets/44e21df8-105c-473c-bd7e-7349853aa41a


This PR implements vision support detection for Qwen VL models using pattern matching. The `ModelCapabilities.supportsVision()` method now checks against a hardcoded pattern (`.*qwen.*vl.*`) before falling back to JSON-based configuration. This approach handles cases where:
- Models are missing from the JSON configuration
- The JSON uses different naming conventions (e.g., openrouter/ vs deepinfra/ prefix)
- The JSON is not yet updated with new vision models

The pattern matching is case-insensitive and flexible, matching any model name containing "qwen" and "vl" in sequence.

Additionally, removed a duplicate entry for `qwen/qwen2.5-vl-32b-instruct` from the model prices JSON (the openrouter variant), keeping only the deepinfra variant to avoid confusion.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- OPIK-2954

## Testing
Added comprehensive test suite (`ModelCapabilitiesTest`) with 10 test cases covering:
- Pattern matching for qwen VL models (case insensitive)
- Known vision models (GPT-4, Claude, Gemini)
- Non-vision model detection
- Edge cases (null, blank, whitespace, colon suffixes)
- Provider prefix matching

All tests pass successfully.

## Documentation
No documentation changes required. This is an internal backend improvement to the model capabilities detection system.