### PR TITLE
[NA] Improve --quick-restart mode to dev-runner scripts to spin infra

### DIFF
--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -759,18 +759,30 @@ restart_services() {
 
 # Function for quick restart (only rebuild backend, keep infrastructure running)
 quick_restart_services() {
-    log_info "=== Quick Restart (Backend Only) ==="
-    log_info "Step 1/6: Stopping frontend..."
+    log_info "=== Quick Restart (Backend, Frontend (if needed), Infrastructure (if not running)) ==="
+    
+    # Check if infrastructure is running, start if not
+    log_info "Step 1/7: Checking infrastructure..."
+    if verify_infrastructure; then
+        log_info "Infrastructure is already running, skipping infrastructure start"
+    else
+        log_warning "Infrastructure is not running, starting it now..."
+        start_infrastructure
+        log_info "Running DB migrations..."
+        run_db_migrations
+    fi
+    
+    log_info "Step 2/7: Stopping frontend..."
     stop_frontend
-    log_info "Step 2/6: Stopping backend..."
+    log_info "Step 3/7: Stopping backend..."
     stop_backend
-    log_info "Step 3/6: Building backend..."
+    log_info "Step 4/7: Building backend..."
     build_backend
-    log_info "Step 4/6: Starting backend..."
+    log_info "Step 5/7: Starting backend..."
     start_backend
     
     # Check if package.json has changed since last npm install
-    log_info "Step 5/6: Checking frontend dependencies..."
+    log_info "Step 6/7: Checking frontend dependencies..."
     local package_json="$FRONTEND_DIR/package.json"
     local package_lock="$FRONTEND_DIR/package-lock.json"
     local node_modules="$FRONTEND_DIR/node_modules"
@@ -794,7 +806,7 @@ quick_restart_services() {
         build_frontend
     fi
     
-    log_info "Step 6/6: Starting frontend..."
+    log_info "Step 7/7: Starting frontend..."
     start_frontend
     log_success "=== Quick Restart Complete ==="
     verify_services


### PR DESCRIPTION
## Details

Improve `--quick-restart` mode to both dev-runner scripts for faster backend iteration - to spin infra in case not running already

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues
- NA

## Testing
Manually tested quick restart with infrastructure running and stopped.

## Documentation
Updated help text in both scripts.