### PR TITLE
[OPIK-0000] Disable metrics loggign in pydantic-ai configuration guide

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/pydantic-ai.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/pydantic-ai.mdx
@@ -59,6 +59,7 @@ sure the data is logged to Opik:
         ```bash
         export OTEL_EXPORTER_OTLP_ENDPOINT=https://www.comet.com/opik/api/v1/private/otel
         export OTEL_EXPORTER_OTLP_HEADERS='Authorization=<your-api-key>,Comet-Workspace=default'
+        export OTEL_METRICS_EXPORTER=none
         ```
 
         <Tip>
@@ -79,6 +80,7 @@ sure the data is logged to Opik:
         ```bash wordWrap
         export OTEL_EXPORTER_OTLP_ENDPOINT=https://<comet-deployment-url>/opik/api/v1/private/otel
         export OTEL_EXPORTER_OTLP_HEADERS='Authorization=<your-api-key>,Comet-Workspace=default'
+        export OTEL_METRICS_EXPORTER=none
         ```
 
         <Tip>
@@ -100,6 +102,7 @@ sure the data is logged to Opik:
 
     ```bash
     export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:5173/api/v1/private/otel
+    export OTEL_METRICS_EXPORTER=none
     ```
 
     <Tip>


### PR DESCRIPTION
## Details
Just a small documentation update to avoid 404 error when using pydantic-ai OTLP integration.

## Change checklist
- [X] User facing
- [X] Documentation update

## Issues

- Resolves #3973
- OPIK-0000

## Testing
-
## Documentation
Updated