### PR TITLE
[NA] [BE] Add configurable HTTP ports for application and admin connectors

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -172,7 +172,7 @@ authentication:
 # https://www.dropwizard.io/en/stable/manual/configuration.html#servers
 server:
   # Default: false
-  # Description: Whether to enable virtual threads for Jetty’s thread pool.
+  # Description: Whether to enable virtual threads for Jetty's thread pool.
   enableVirtualThreads: ${ENABLE_VIRTUAL_THREADS:-false}
   # https://www.dropwizard.io/en/stable/manual/configuration.html#gzip
   gzip:
@@ -185,7 +185,15 @@ server:
   # Description: Maximum size of request headers to prevent 431 errors from long URLs with many filters
   applicationConnectors:
     - type: http
+      # Default: 8080
+      # Description: The port on which the application HTTP connector listens
+      port: ${SERVER_APPLICATION_PORT:-8080}
       maxRequestHeaderSize: ${SERVER_MAX_REQUEST_HEADER_SIZE:-16KB}
+  adminConnectors:
+    - type: http
+      # Default: 8081
+      # Description: The port on which the admin HTTP connector listens
+      port: ${SERVER_ADMIN_PORT:-8081}
 
 # Jackson JSON processing configuration
 # Controls limits for JSON deserialization to prevent memory exhaustion

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -134,7 +134,7 @@ authentication:
 # https://www.dropwizard.io/en/stable/manual/configuration.html#servers
 server:
   # Default: false
-  # Description: Whether to enable virtual threads for Jetty’s thread pool.
+  # Description: Whether to enable virtual threads for Jetty's thread pool.
   enableVirtualThreads: false
   # https://www.dropwizard.io/en/stable/manual/configuration.html#gzip
   gzip:
@@ -147,7 +147,15 @@ server:
   # Description: Maximum size of request headers to prevent 431 errors from long URLs with many filters
   applicationConnectors:
     - type: http
+      # Default: 8080
+      # Description: The port on which the application HTTP connector listens
+      port: 8080
       maxRequestHeaderSize: 16KB
+  adminConnectors:
+    - type: http
+      # Default: 8081
+      # Description: The port on which the admin HTTP connector listens
+      port: 8081
 
 # Jackson JSON processing configuration
 # Controls limits for JSON deserialization to prevent memory exhaustion


### PR DESCRIPTION
## Details

This PR adds explicit port configuration to the Dropwizard server configuration, making both application and admin HTTP connector ports configurable via environment variables.

### Changes Made

**Configuration Updates:**
- Added `SERVER_APPLICATION_PORT` environment variable for application connector (defaults to `8080`)
- Added `SERVER_ADMIN_PORT` environment variable for admin connector (defaults to `8081`)
- Added explicit `adminConnectors` section to server configuration
- Applied changes to both production (`config.yml`) and test (`config-test.yml`) configurations

**Benefits:**
- Enables deployment flexibility by allowing port configuration without modifying YAML files
- Follows Dropwizard best practices for server connector configuration
- Maintains backward compatibility with default ports (8080 for application, 8081 for admin)
- Consistent with existing project conventions for environment variable naming

## Change checklist
<!-- Please check the type of changes made -->
- [X] User facing
- [ ] Documentation update

## Issues
- NA <!-- If no ticket, such as hotfixes etc. -->

## Testing

**Manual Testing:**
- Verified service starts with default ports (8080, 8081)
- Tested port override via environment variables:
  ```bash
  SERVER_APPLICATION_PORT=9090 SERVER_ADMIN_PORT=9091 ./scripts/dev-runner.sh --start
  ```
- Passed CI build: confirmed test configuration works correctly.
- Verified backwards compatibility by testing it with: `opik.sh --build`


## Documentation

**Configuration Reference:**
- Follows [Dropwizard Configuration Reference](https://www.dropwizard.io/en/stable/manual/configuration.html#servers) for server connector configuration
- Inline YAML comments document the new environment variables and their default values
- Maintains consistency with existing environment variable naming patterns (`SERVER_*` prefix)

**New Environment Variables:**
- `SERVER_APPLICATION_PORT` - Application HTTP connector port (default: 8080)
- `SERVER_ADMIN_PORT` - Admin HTTP connector port (default: 8081)