### PR TITLE
[OPIK-2856] [SDK] Fix demo data span time shifts to match traces

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
+++ b/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
@@ -178,19 +178,18 @@ def get_time_shift(context: DemoDataContext, trace_id):
         return time_shift
     return datetime.timedelta(0)
 
-def process_traces_with_time_shift(traces, spans, context: DemoDataContext, client: opik.Opik):
+def process_traces_with_time_shift(traces, context: DemoDataContext, client: opik.Opik):
     """
     Process traces with proper time shifts and time-based UUIDs.
     
     Shifts all trace timestamps to present time while preserving temporal relationships,
     and generates time-based UUIDs for consistent ordering.
     
-    Calculates time shift from the latest end_time across both traces and spans
+    Calculates time shift from the latest end_time across traces only
     to ensure all data is brought to present while preserving time distances.
     
     Parameters:
     - traces: List of trace dictionaries to process
-    - spans: List of span dictionaries (used to calculate time shift)
     - context: DemoDataContext object holding state
     - client: opik.Opik client for logging traces
     
@@ -357,7 +356,7 @@ def create_demo_evaluation_project(context: DemoDataContext, base_url: str, work
 
             evaluation_traces = experiment_traces_grouped_by_project[project_id]
             evaluation_spans = experiment_spans_grouped_by_project[project_id]
-            time_shift = process_traces_with_time_shift(evaluation_traces, evaluation_spans, context, client)
+            time_shift = process_traces_with_time_shift(evaluation_traces, context, client)
             process_spans_with_time_shift(evaluation_spans, time_shift, context, client)
             client.flush()
             
@@ -456,7 +455,7 @@ def create_demo_chatbot_project(context: DemoDataContext, base_url: str, workspa
             # Extract thread IDs before processing traces
             threads = [trace["thread_id"] for trace in demo_traces if "thread_id" in trace and trace["thread_id"] is not None]
             
-            time_shift = process_traces_with_time_shift(demo_traces, demo_spans, context, client)
+            time_shift = process_traces_with_time_shift(demo_traces, context, client)
             process_spans_with_time_shift(demo_spans, time_shift, context, client)
             client.flush()
 
@@ -546,7 +545,7 @@ def create_demo_optimizer_project(context: DemoDataContext, base_url: str, works
 
             evaluation_traces = experiment_traces_grouped_by_project[project_id]
             evaluation_spans = experiment_spans_grouped_by_project[project_id]
-            time_shift = process_traces_with_time_shift(evaluation_traces, evaluation_spans, context, client)
+            time_shift = process_traces_with_time_shift(evaluation_traces, context, client)
             process_spans_with_time_shift(evaluation_spans, time_shift, context, client)
             client.flush()
 

--- a/apps/opik-python-backend/tests/test_time_shift_distances.py
+++ b/apps/opik-python-backend/tests/test_time_shift_distances.py
@@ -51,10 +51,9 @@ class TestTimeShiftDistances:
         assert original_trace_distance == shifted_trace_distance, \
             f"Trace time distance changed: {original_trace_distance}s → {shifted_trace_distance}s"
         
-        # Verify that we actually shifted the data (time_shift should be positive/reasonable)
-        # Demo data is from August, so shift should be 70+ days
-        assert time_shift.days > 60, \
-            f"Time shift is too small: {time_shift.days} days (expected ~70 days for August to November)"
+        # Ensure that the time shift is positive (i.e., demo data is not from today)
+        assert time_shift.days > 0, \
+            f"Time shift is not positive: {time_shift.days} days (expected demo data to be in the past)"
     
     def test_experiment_data_time_distances_preserved(self):
         """


### PR DESCRIPTION
## Details
This PR fixes a critical bug in the demo data generator where spans were not receiving the same time shift as their parent traces, causing them to have incorrect dates. Now all traces and spans are shifted uniformly while preserving all temporal relationships.

### Changes Made
- Fixed demo data generator to apply correct time shifts to spans
- Extracted reusable `process_traces_with_time_shift()` helper function
- Extracted reusable `process_spans_with_time_shift()` helper function  
- Calculate time shift from traces only, then reuse same shift for spans
- Apply identical time shift to both traces and spans to preserve all time distances

### Results
- Demo traces (2025-07-28 to 2025-08-27) → shifted to present time
- Demo spans (2025-08-27) → same as latest trace
- Experiment spans (2025-08-20) → 6 days before latest trace (distance preserved!)
- Eliminated 60+ lines of code duplication across three functions
- All temporal relationships preserved while bringing data to present date

## Change checklist
- [x] User facing
- [ ] Documentation update

## Testing
- All existing tests passing (2 tests)
- Added 4 new comprehensive tests verifying time distance preservation
- `test_demo_data_time_distances_preserved` - verifies distances preserved
- `test_experiment_data_time_distances_preserved` - verifies all projects
- `test_demo_spans_all_shifted_to_latest_trace_date` - verifies correct shift
- `test_experiment_spans_maintain_earlier_dates` - verifies offset preservation

Run tests with: `pytest tests/test_time_shift_distances.py tests/test_demo_data_generator.py -v`

## Issues
- OPIK-2856

## Documentation
NA