### PR TITLE
[OPIK-2993] [FE] Add additional tooltips

### DIFF
--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
@@ -15,6 +15,7 @@ import DateTag from "@/components/shared/DateTag/DateTag";
 import useCompareExperimentsChartsData from "@/components/pages/CompareExperimentsPage/CompareExperimentsDetails/useCompareExperimentsChartsData";
 import ExperimentsRadarChart from "@/components/pages-shared/experiments/ExperimentsRadarChart/ExperimentsRadarChart";
 import ExperimentsBarChart from "@/components/pages-shared/experiments/ExperimentsBarChart/ExperimentsBarChart";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 
 type CompareExperimentsDetailsProps = {
   experimentsIds: string[];
@@ -107,7 +108,9 @@ const CompareExperimentsDetails: React.FunctionComponent<
     } else {
       return (
         <div className="flex h-11 items-center gap-2">
-          <PenLine className="size-4 shrink-0" />
+          <TooltipWrapper content="Feedback scores">
+            <PenLine className="size-4 shrink-0" />
+          </TooltipWrapper>
           <div className="flex gap-1 overflow-x-auto">
             {sortBy(experiment?.feedback_scores ?? [], "name").map(
               (feedbackScore) => {

--- a/apps/opik-frontend/src/components/shared/TagListRenderer/TagListRenderer.tsx
+++ b/apps/opik-frontend/src/components/shared/TagListRenderer/TagListRenderer.tsx
@@ -9,6 +9,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/components/ui/use-toast";
 import RemovableTag from "@/components/shared/RemovableTag/RemovableTag";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 
 export type TagListRendererProps = {
   tags: string[];
@@ -51,7 +52,9 @@ const TagListRenderer: React.FC<TagListRendererProps> = ({
 
   return (
     <div className="flex min-h-7 w-full flex-wrap items-center gap-1.5 overflow-x-hidden">
-      <Tag className={`${tagMarginClass} ${tagSizeClass} text-muted-slate`} />
+      <TooltipWrapper content="Tags list">
+        <Tag className={`${tagMarginClass} ${tagSizeClass} text-muted-slate`} />
+      </TooltipWrapper>
       {[...tags].sort().map((tag) => {
         return (
           <RemovableTag


### PR DESCRIPTION
## Details

This PR adds tooltips to improve user experience by providing hover text for icon elements in the Opik UI. The changes enhance UI clarity without affecting functionality.

**Implementation:**
- Added `TooltipWrapper` component to wrap icon elements in two locations:
  - Feedback scores icon (PenLine) in CompareExperimentsDetails component with tooltip text "Feedback scores"
  - Tags list icon (Tag) in TagListRenderer component with tooltip text "Tags list"

**Changes:**
- Modified `CompareExperimentsDetails.tsx`: Added tooltip to feedback scores icon
- Modified `TagListRenderer.tsx`: Added tooltip to tags list icon

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- OPIK-2993

## Testing

**Manual Testing:**
- Hover over the feedback scores icon in the Compare Experiments page to see the "Feedback scores" tooltip
- Hover over the tags icon in any component using TagListRenderer to see the "Tags list" tooltip
- Verify tooltips appear with correct text and styling
- Ensure no regression in existing functionality

## Documentation

N/A - Minor UI enhancement requiring no documentation updates.