### PR TITLE
[issue-3999] [FE] Make online evaluation trace structure more robust

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/TracesOrSpansPathsAutocomplete/TracesOrSpansPathsAutocomplete.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TracesOrSpansPathsAutocomplete/TracesOrSpansPathsAutocomplete.tsx
@@ -66,6 +66,20 @@ const TracesOrSpansPathsAutocomplete: React.FC<
     },
   );
 
+  const { data: dataNonTruncated, isPending: isPendingNonTruncated } =
+    useTracesOrSpansList(
+      {
+        projectId,
+        type,
+        page: 1,
+        size: 10,
+        truncate: false,
+      },
+      {
+        enabled: isProjectId,
+      },
+    );
+
   // Get project name from prop if provided, otherwise look up from cached projects data
   const projectName = useMemo(() => {
     // If projectName is provided as prop, use it directly
@@ -91,7 +105,13 @@ const TracesOrSpansPathsAutocomplete: React.FC<
   }, [projectId, queryClient, projectNameProp]);
 
   const items = useMemo(() => {
-    const hasTraces = data?.content && data.content.length > 0;
+    // Combine both truncated (100) and non-truncated (10) traces
+    // Truncated traces maximize chance of catching changes in structure
+    // Non-truncated traces provide fallback for complete JSON paths
+    const truncatedTraces = data?.content || [];
+    const nonTruncatedTraces = dataNonTruncated?.content || [];
+    const allTraces = [...truncatedTraces, ...nonTruncatedTraces];
+    const hasTraces = allTraces.length > 0;
     const isPlaygroundProject = projectName === PLAYGROUND_PROJECT_NAME;
 
     let baseSuggestions: string[] = [];
@@ -100,8 +120,8 @@ const TracesOrSpansPathsAutocomplete: React.FC<
     if (isPlaygroundProject && !hasTraces) {
       baseSuggestions = PLAYGROUND_DEFAULT_SUGGESTIONS;
     } else {
-      // Otherwise, use the existing logic to extract paths from traces
-      baseSuggestions = (data?.content || []).reduce<string[]>((acc, d) => {
+      // Extract paths from all traces (truncated + non-truncated)
+      baseSuggestions = allTraces.reduce<string[]>((acc, d) => {
         return acc.concat(
           rootKeys.reduce<string[]>(
             (internalAcc, key) =>
@@ -135,7 +155,15 @@ const TracesOrSpansPathsAutocomplete: React.FC<
         value ? p.toLowerCase().includes(value.toLowerCase()) : true,
       )
       .sort();
-  }, [data, rootKeys, value, excludeRoot, projectName, datasetColumnNames]);
+  }, [
+    data,
+    dataNonTruncated,
+    rootKeys,
+    value,
+    excludeRoot,
+    projectName,
+    datasetColumnNames,
+  ]);
 
   return (
     <Autocomplete
@@ -143,7 +171,7 @@ const TracesOrSpansPathsAutocomplete: React.FC<
       onValueChange={onValueChange}
       items={items}
       hasError={hasError}
-      isLoading={isProjectId ? isPending : false}
+      isLoading={isProjectId ? isPending || isPendingNonTruncated : false}
       placeholder={placeholder}
     />
   );


### PR DESCRIPTION
## Details

Prior to this change, we would fetch the first 100 traces in a project in `truncated=true` mode to populate the input / output variable mapping in the online evaluation creation modal. We fetched truncated data because it can be an issue to fetch 100 non truncated traces (slow queries and lot's of data to download) but the downside of this approach is that users would have to enter the schema manually if they had large traces.

In this change we update the logic to:
1. Fetch 100 traces with `truncated=true`: Allows us to better infer the trace schema in the majority of cases
2. Fetch 10 traces with `truncated=false`: Fallback in case all traces are very large
This provides a good balance between performance and providing the trace schema in cases where all traces are long.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #3999 

## Testing

Tested manually

## Documentation

N/A