### PR TITLE
[NA] [SDK] Add better error for OPENAI_ORG_ID for intergration tests

### DIFF
--- a/sdks/python/tests/conftest.py
+++ b/sdks/python/tests/conftest.py
@@ -200,7 +200,9 @@ def temp_file_15mb():
 def ensure_openai_configured():
     # don't use assertion here to prevent printing os.environ with all env variables
     if not environment.has_openai_api_key():
-        raise Exception("OpenAI not configured! Ensure you have set the OPENAI_API_KEY and OPENAI_ORG_ID environment variables.")
+        raise Exception(
+            "OpenAI not configured! Ensure you have set the OPENAI_API_KEY and OPENAI_ORG_ID environment variables."
+        )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Details
Some external contributors might not be aware why OPENAI intergration tests fail when running locally, added a better error message to make this explicit.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing
n/a

## Documentation
n/a