### PR TITLE
[OPIK-3026] [FE] Fix sidebar expansion during navigation

### DIFF
--- a/apps/opik-frontend/src/components/layout/PageLayout/PageLayout.tsx
+++ b/apps/opik-frontend/src/components/layout/PageLayout/PageLayout.tsx
@@ -30,8 +30,22 @@ const PageLayout = () => {
   const RetentionBanner = usePluginsStore((state) => state.RetentionBanner);
 
   // Force sidebar collapsed on mobile, use stored preference on desktop
-  const isMobile =
-    typeof window !== "undefined" && window.innerWidth < MOBILE_BREAKPOINT;
+  // Use state to prevent recalculation on every render
+  const [isMobile, setIsMobile] = useState(() => {
+    return typeof window !== "undefined" && window.innerWidth < MOBILE_BREAKPOINT;
+  });
+
+  // Add resize listener to update mobile state only when window is actually resized
+  useEffect(() => {
+    const handleResize = () => {
+      const mobile = window.innerWidth < MOBILE_BREAKPOINT;
+      setIsMobile(mobile);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   const expanded = isMobile ? false : storedExpanded;
 
   // Show welcome wizard if enabled and not completed


### PR DESCRIPTION
## Details

This PR fixes a bug where the sidebar would unexpectedly expand when navigating between pages. The issue was caused by inefficient mobile detection logic that recalculated on every component render.

### Root Cause
The `PageLayout` component was evaluating `window.innerWidth` on every render, including during navigation. This caused:
- Race conditions during page transitions
- Unnecessary CSS transitions
- Visual jank and sidebar expansion during navigation

### Solution
Replaced inline mobile detection with proper React state management:
- Uses `useState` with lazy initialization for mobile state
- Implements `useEffect` with resize listener for actual viewport changes
- Properly cleans up event listener on unmount
- Mobile state only updates on actual window resize, not during renders

### Changes Made
- **File**: `apps/opik-frontend/src/components/layout/PageLayout/PageLayout.tsx`
- Replaced inline `window.innerWidth` check with stateful mobile detection
- Added proper window resize listener with cleanup

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves #NA
- OPIK-3026

## Testing

### Manual Testing Scenarios
1. **Desktop Navigation**: Navigate between pages on desktop (>1024px) - sidebar should remain expanded/collapsed as set
2. **Mobile Navigation**: Navigate on mobile (<1024px) - sidebar should remain collapsed
3. **Window Resize**: Resize browser window across 1024px breakpoint - sidebar should respond to actual resize only
4. **Multiple Navigations**: Navigate rapidly between pages - no flickering or expansion should occur

### Expected Behavior
- ✅ Sidebar state persists across navigation
- ✅ No visual jank or expansion during page transitions
- ✅ Smooth transition only on actual window resize
- ✅ Proper cleanup of event listeners

## Documentation
- Jira ticket updated with investigation findings and fix details
- Manual testing instructions provided in Jira comments