### PR TITLE
[NA]: Replace OpikIcon with CometIcon in AppNetworkStatus component, in comet debugging mode

### DIFF
--- a/apps/opik-frontend/src/components/layout/AppNetworkStatus/AppNetworkStatus.tsx
+++ b/apps/opik-frontend/src/components/layout/AppNetworkStatus/AppNetworkStatus.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils";
 
-import OpikIcon from "@/icons/opik.svg?react";
+import CometIcon from "@/icons/comet.svg?react";
 import { usePingBackend } from "@/api/debug/useIsAlive";
 import useIsNetworkOnline from "@/hooks/useIsNetworkOnline";
 import { WifiOffIcon, WifiIcon, SatelliteDishIcon } from "lucide-react";
@@ -40,7 +40,7 @@ const AppNetworkStatus = () => {
             }
           >
             <span>
-              <OpikIcon className="size-5" />
+              <CometIcon className="size-5" />
             </span>
           </TooltipWrapper>
         </div>


### PR DESCRIPTION
## Details
For branding, and to avoid duplicate with app copy version's icon (OpikIcon).

## Change checklist
- [X] User facing
- [X] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing

## Documentation
