### PR TITLE
[NA] [FE] Enable silent mode in JSON parser for prettify functionality

### DIFF
--- a/apps/opik-frontend/src/lib/traces.ts
+++ b/apps/opik-frontend/src/lib/traces.ts
@@ -549,7 +549,7 @@ export const prettifyMessage = (
 
     // attempt to improve JSON string if the message is serialised JSON string
     if (isString(processedMessage)) {
-      const json = safelyParseJSON(processedMessage);
+      const json = safelyParseJSON(processedMessage, true);
 
       if (!isEmpty(json)) {
         processedMessage = JSON.stringify(json, null, 2);


### PR DESCRIPTION
## Details

Enabled silent mode in the `safelyParseJSON` function call within the `prettifyMessage` function in `apps/opik-frontend/src/lib/traces.ts`. This prevents console errors from being logged when attempting to parse and prettify JSON strings during trace message processing.

The `safelyParseJSON` function already supported a `silent` parameter to suppress error logging, and this change passes `true` to enable that mode for the prettify functionality.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-
- NA

## Testing

Tested manually in the frontend application by triggering JSON parsing in trace message prettification. Verified that invalid JSON no longer generates console errors while valid JSON is still properly prettified.

## Documentation

N/A - Internal implementation detail with no API or configuration changes.