### PR TITLE
[NA] [SDK] Relax litellm dependencies

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -48,7 +48,7 @@ setup(
         #   See: https://github.com/BerriAI/litellm/issues/14762
         # - Exclude versions 1.77.5-1.79.1: remove trace_id/parent_span_id passthrough, fixed in 1.79.2+
         #   See: https://github.com/BerriAI/litellm/pull/15529
-        "litellm<=1.77.1,>=1.79.2,!=1.75.0,!=1.75.1,!=1.75.2,!=1.75.3,!=1.75.4,!=1.75.5",
+        "litellm>=1.79.2,!=1.75.0,!=1.75.1,!=1.75.2,!=1.75.3,!=1.75.4,!=1.75.5,!=1.77.3,!=1.77.4,!=1.77.5,!=1.77.7,!=1.78.0,!=1.78.2,!=1.78.3,!=1.78.4,!=1.78.5,!=1.78.6,!=1.78.7,!=1.79.0,!=1.79.1",
         "openai",
         "pydantic-settings>=2.0.0,<3.0.0,!=2.9.0",
         "pydantic>=2.0.0,<3.0.0",


### PR DESCRIPTION
## Details

Now that [https://github.com/BerriAI/litellm/pull/15529](https://github.com/BerriAI/litellm/pull/15529) has been merged, we can go ahead and update the litellm dependency cap. All versions after 1.79.2 will now work

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-000

## Testing

Tests pass

## Documentation

N/A