### PR TITLE
[NA] [FE] Fix playground isRunning state reset issue

### DIFF
--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/useActionButtonActions.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/useActionButtonActions.tsx
@@ -68,6 +68,7 @@ const useActionButtonActions = ({
   }, [resetOutputMap, clearCreatedExperiments, setIsRunning]);
 
   const stopAll = useCallback(() => {
+    setIsRunning(false);
     // nothing to stop
     if (abortControllersRef.current.size === 0) {
       return;
@@ -76,7 +77,6 @@ const useActionButtonActions = ({
     isToStopRef.current = true;
     abortControllersRef.current.forEach((controller) => controller.abort());
     abortControllersRef.current.clear();
-    setIsRunning(false);
   }, [setIsRunning]);
 
   const storeExperiments = useCallback(

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompts.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompts.tsx
@@ -10,6 +10,7 @@ import {
   useAddPrompt,
   usePromptCount,
   usePromptIds,
+  useSetIsRunning,
   useSetPromptMap,
 } from "@/store/PlaygroundStore";
 import useLastPickedModel from "@/hooks/useLastPickedModel";
@@ -33,6 +34,7 @@ const PlaygroundPrompts = ({
   const promptCount = usePromptCount();
   const addPrompt = useAddPrompt();
   const setPromptMap = useSetPromptMap();
+  const setIsRunning = useSetIsRunning();
   const resetKeyRef = useRef(0);
   const scrollToPromptRef = useRef<string>("");
   const [open, setOpen] = useState<boolean>(false);
@@ -64,6 +66,7 @@ const PlaygroundPrompts = ({
       modelResolver: calculateDefaultModel,
     });
     setPromptMap([newPrompt.id], { [newPrompt.id]: newPrompt });
+    setIsRunning(false);
     onResetHeight();
   }, [
     providerKeys,
@@ -71,6 +74,7 @@ const PlaygroundPrompts = ({
     calculateModelProvider,
     calculateDefaultModel,
     setPromptMap,
+    setIsRunning,
     onResetHeight,
   ]);
 


### PR DESCRIPTION
## Details

Fixed a state management issue in the Playground where the `isRunning` flag wasn't being reset correctly in two scenarios:

1. **Stop button**: Moved `setIsRunning(false)` to the beginning of the `stopAll()` function to ensure the state updates immediately when the stop button is clicked, before aborting controllers
2. **Playground reset**: Added `setIsRunning(false)` call in the `resetPrompts()` function to ensure the running state is cleared when users reset the playground

This ensures the UI correctly reflects the execution state and prevents the playground from appearing stuck in a "running" state.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves # N/A
- NA

## Testing

Manual testing steps:
1. Start a playground execution
2. Click the stop button → Verify `isRunning` state resets correctly and UI updates immediately
3. Start another playground execution  
4. Click the reset button → Verify `isRunning` state resets correctly and UI updates immediately
5. Verify no console errors or state inconsistencies

## Documentation

N/A - Internal bug fix with no API or configuration changes