### PR TITLE
[NA] [DOCS] Add Notion MCP server to Cursor configuration

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -22,6 +22,11 @@
       "env": {},
       "args": []
     },
+    "Notion": {
+      "command": "npx -y mcp-remote https://mcp.notion.com/mcp",
+      "env": {},
+      "args": []
+    },
     "Playwright": {
       "command": "npx @playwright/mcp@latest",
       "env": {},


### PR DESCRIPTION
## Details

This PR adds Notion MCP server integration to the Cursor configuration, enabling AI-assisted development workflows with Notion workspace integration.

The Notion MCP server is configured as a remote MCP server that connects to `https://mcp.notion.com/mcp`, following the same pattern as other MCP integrations in the repository.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- NA

## Testing

- Verified JSON configuration is valid
- Configuration follows existing MCP server patterns (Atlassian, GitHub, Playwright)
- Remote MCP server endpoint is publicly accessible

## Documentation

Configuration change only - no documentation updates required. The Notion MCP server will be available for use once merged.