### PR TITLE
[NA] Fix Docker version tagging to use semver-compliant build metadata

### DIFF
--- a/.github/workflows/build_apps.yml
+++ b/.github/workflows/build_apps.yml
@@ -91,7 +91,7 @@ jobs:
                     fixedBranchName="${fixedBranchName%?}"
                   done
                 fi
-                VERSION="${BASE_VERSION}+${fixedBranchName}-${{ github.run_number }}"
+                VERSION="${BASE_VERSION}-${fixedBranchName}-${{ github.run_number }}"
               fi
             fi
             echo "version=${VERSION}" | tee -a $GITHUB_OUTPUT


### PR DESCRIPTION
## Details

The GitHub Actions workflow for building Docker images currently generates version tags that are **not valid semantic versions**, causing Helm template errors when using `semverCompare`.

### Problem

**Current format:**
```
1.9.15.idoberko2-opik-3077-3322
```

This has **4 dot-separated parts** (`1.9.15.idoberko2`) instead of the required 3 (`MAJOR.MINOR.PATCH`), making it invalid according to [semver.org](https://semver.org/).

**Error in Helm:**
```
Error: UPGRADE FAILED: template: comet-ml/templates/opik/opik-configmap.yaml:26:8: 
executing "comet-ml/templates/opik/opik-configmap.yaml" at 
<semverCompare "<1.7.1" .Values.opik.component.backend.image.tag>: 
error calling semverCompare: Invalid Semantic Version
```

### Solution

**New format:**
```
1.9.15+idoberko2-opik-3077-3322
```

Changed the separator from `.` (dot) to `+` (plus) on line 94 of `.github/workflows/build_apps.yml`:

```diff
- VERSION="${BASE_VERSION}.${fixedBranchName}-${{ github.run_number }}"
+ VERSION="${BASE_VERSION}+${fixedBranchName}-${{ github.run_number }}"
```

This uses **build metadata** (the `+` suffix), which is explicitly allowed by semantic versioning spec:
> A pre-release version MAY be denoted by appending a hyphen and a series of dot separated identifiers immediately following the patch version. **Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers immediately following the patch or pre-release version.**

## Change checklist
- [x] Bug fix (non-breaking change)
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves # NA (hotfix for Helm deployment issue)

## Testing

**Before:**
- Branch builds create tags like `1.9.15.idoberko2-opik-3077-3322`
- Helm templates using `semverCompare` fail to parse

**After:**
- Branch builds will create tags like `1.9.15+idoberko2-opik-3077-3322`
- Valid semver format that can be parsed by `semverCompare`
- Docker still accepts these tags (Docker doesn't enforce semver)

**Validation:**
```bash
# Valid semver with build metadata
echo "1.9.15+idoberko2-opik-3077-3322" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(\+.+)?$'
# Returns: 1.9.15+idoberko2-opik-3077-3322 ✅
```

## Documentation

No documentation changes needed - this is an internal CI/CD fix.

## Related PRs

- comet-ml/comet-ml-helm-chart#373 - Adds fallback handling in Helm template for non-semver tags