### PR TITLE
[NA] [BE] Fix remaining start time query

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -1362,8 +1362,6 @@ class TraceDAOImpl implements TraceDAO {
                  GROUP BY trace_id
             )
             <if(project_stats)>
-            -- Note: Converting UUIDs in WHERE clause prevents index usage on id field.
-            -- Consider materializing timestamp from UUIDv7 into a separate indexed column if query performance becomes an issue.
             ,    error_count_current AS (
                     SELECT
                         project_id,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -86,7 +86,6 @@ import java.math.RoundingMode;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -1582,8 +1581,7 @@ class ProjectsResourceTest {
         // Use Instant.now() to match production query behavior which uses now() in ClickHouse
         // The test determinism comes from the trace UUID timestamps, not from the boundary calculation
         Instant now = Instant.now();
-        Instant lastWeekStart = now.atZone(ZoneOffset.UTC).toLocalDate().minusDays(7).atStartOfDay()
-                .toInstant(ZoneOffset.UTC);
+        Instant lastWeekStart = now.minus(7, ChronoUnit.DAYS).truncatedTo(ChronoUnit.DAYS);
         long recentErrorCount = traces.stream()
                 .filter(trace -> trace.errorInfo() != null)
                 .filter(trace -> {


### PR DESCRIPTION
## Details
Fix the remaining logic point to `start_time` instead of the trace ID.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing

## Documentation
