### PR TITLE
[OPIK-2681] [FE][BE] Add dataset item filtering in playground

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/filter/DatasetItemField.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/filter/DatasetItemField.java
@@ -18,6 +18,7 @@ public enum DatasetItemField implements Field {
     LAST_UPDATED_AT(LAST_UPDATED_AT_QUERY_PARAM, FieldType.DATE_TIME),
     CREATED_BY(CREATED_BY_QUERY_PARAM, FieldType.STRING),
     LAST_UPDATED_BY(LAST_UPDATED_BY_QUERY_PARAM, FieldType.STRING),
+    CUSTOM(CUSTOM_QUERY_PARAM, FieldType.CUSTOM),
     ;
 
     private final String queryParamField;

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/filter/DatasetItemFilter.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/filter/DatasetItemFilter.java
@@ -71,11 +71,23 @@ public class DatasetItemFilter extends FilterImpl {
         if (!DatasetItemDynamicField.validType(type)) {
             return null;
         }
+
+        // For dataset items, the SQL query builder expects the full path (e.g., "data.size")
+        // in the queryParamField to properly detect and format dynamic field access
+        String queryParamField = buildQueryParamField(customField, key);
+
         return toBuilder()
-                .field(mapField(customField, type))
+                .field(mapField(queryParamField, type))
                 .operator(operator)
                 .key(key)
                 .value(value)
                 .build();
+    }
+
+    private String buildQueryParamField(String customField, String key) {
+        if (key == null || key.isEmpty()) {
+            return customField;
+        }
+        return customField + "." + key;
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceFilterTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceFilterTest.java
@@ -1,0 +1,239 @@
+package com.comet.opik.api.resources.v1.priv;
+
+import com.comet.opik.api.Dataset;
+import com.comet.opik.api.DatasetItem;
+import com.comet.opik.api.DatasetItemBatch;
+import com.comet.opik.api.filter.DatasetItemField;
+import com.comet.opik.api.filter.DatasetItemFilter;
+import com.comet.opik.api.filter.Operator;
+import com.comet.opik.api.resources.utils.AuthTestUtils;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.DatasetResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.redis.testcontainers.RedisContainer;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static com.comet.opik.api.DatasetItem.DatasetItemPage;
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.api.resources.utils.TestUtils.toURLEncodedQueryParam;
+import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+/**
+ * Integration tests for dataset item filtering functionality.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Dataset Item Filtering:")
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class DatasetsResourceFilterTest {
+
+    private static final String BASE_RESOURCE_URI = "%s/v1/private/datasets";
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+    private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE = ClickHouseContainerUtils.newClickHouseContainer(ZOOKEEPER_CONTAINER);
+
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    @RegisterApp
+    private final TestDropwizardAppExtension APP;
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    private String baseURI;
+    private ClientSupport client;
+    private DatasetResourceClient datasetResourceClient;
+
+    {
+        Startables.deepStart(REDIS, MYSQL, CLICKHOUSE, ZOOKEEPER_CONTAINER).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        DatabaseAnalyticsFactory databaseAnalyticsFactory = ClickHouseContainerUtils
+                .newDatabaseAnalyticsFactory(CLICKHOUSE, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE);
+
+        APP = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                MYSQL.getJdbcUrl(), databaseAnalyticsFactory, wireMock.runtimeInfo(), REDIS.getRedisURI());
+    }
+
+    @BeforeAll
+    void setUpAll(ClientSupport client) {
+        this.baseURI = TestUtils.getBaseUrl(client);
+        this.client = client;
+        this.datasetResourceClient = new DatasetResourceClient(client, baseURI);
+
+        ClientSupportUtils.config(client);
+    }
+
+    @AfterAll
+    void tearDownAll() {
+        wireMock.server().stop();
+    }
+
+    private void mockTargetWorkspace(String apiKey, String workspaceName, String workspaceId) {
+        AuthTestUtils.mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId,
+                UUID.randomUUID().toString());
+    }
+
+    private UUID createAndAssert(Dataset dataset, String apiKey, String workspaceName) {
+        return datasetResourceClient.createDataset(dataset, apiKey, workspaceName);
+    }
+
+    private void putAndAssert(DatasetItemBatch batch, String workspaceName, String apiKey) {
+        datasetResourceClient.createDatasetItems(batch, workspaceName, apiKey);
+    }
+
+    private DatasetItem createDatasetItemWithData(Map<String, String> dataMap) {
+        Map<String, JsonNode> jsonDataMap = new HashMap<>();
+        for (Map.Entry<String, String> entry : dataMap.entrySet()) {
+            jsonDataMap.put(entry.getKey(), TextNode.valueOf(entry.getValue()));
+        }
+
+        return factory.manufacturePojo(DatasetItem.class).toBuilder()
+                .id(null)
+                .data(jsonDataMap)
+                .build();
+    }
+
+    Stream<Arguments> filterTestCases() {
+        return Stream.of(
+                arguments(
+                        Named.of("numeric field with >=", "size >= 20000000"),
+                        DatasetItemFilter.builder()
+                                .field(DatasetItemField.CUSTOM)
+                                .operator(Operator.GREATER_THAN_EQUAL)
+                                .key("data.size|number")
+                                .value("20000000")
+                                .build(),
+                        Named.of("expected: 2 items with size >= 20M", 2)),
+                arguments(
+                        Named.of("string field with contains", "tags contains 'sky'"),
+                        DatasetItemFilter.builder()
+                                .field(DatasetItemField.CUSTOM)
+                                .operator(Operator.CONTAINS)
+                                .key("data.tags|string")
+                                .value("sky")
+                                .build(),
+                        Named.of("expected: 2 items containing 'sky'", 2)),
+                arguments(
+                        Named.of("string field with equals", "type = 'video'"),
+                        DatasetItemFilter.builder()
+                                .field(DatasetItemField.CUSTOM)
+                                .operator(Operator.EQUAL)
+                                .key("data.type|string")
+                                .value("video")
+                                .build(),
+                        Named.of("expected: 2 items with type=video", 2)),
+                arguments(
+                        Named.of("numeric field with <", "duration < 60"),
+                        DatasetItemFilter.builder()
+                                .field(DatasetItemField.CUSTOM)
+                                .operator(Operator.LESS_THAN)
+                                .key("data.duration|number")
+                                .value("60")
+                                .build(),
+                        Named.of("expected: 2 items with duration < 60", 2)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("filterTestCases")
+    @DisplayName("filter dataset items by dynamic fields")
+    void filterDatasetItems__whenFilteringByDynamicFields__thenReturnMatchingItems(
+            String description,
+            DatasetItemFilter filter,
+            int expectedCount) {
+
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        // Given: Create a dataset with items
+        var dataset = factory.manufacturePojo(Dataset.class).toBuilder().id(null).build();
+        var datasetId = createAndAssert(dataset, apiKey, workspaceName);
+
+        var items = List.of(
+                createDatasetItemWithData(Map.of("size", "1000000", "type", "video")),
+                createDatasetItemWithData(Map.of("size", "20781167", "type", "video")),
+                createDatasetItemWithData(Map.of("size", "500000", "type", "image")),
+                createDatasetItemWithData(Map.of("size", "30000000", "type", "video")),
+                createDatasetItemWithData(Map.of("tags", "clouds, sunlight, view")),
+                createDatasetItemWithData(Map.of("tags", "nature, calm, sky")),
+                createDatasetItemWithData(Map.of("tags", "urban, city, buildings")),
+                createDatasetItemWithData(Map.of("tags", "landscape, sky, mountains")),
+                createDatasetItemWithData(Map.of("duration", "120")),
+                createDatasetItemWithData(Map.of("duration", "45")),
+                createDatasetItemWithData(Map.of("duration", "180")),
+                createDatasetItemWithData(Map.of("duration", "30")));
+
+        var batch = factory.manufacturePojo(DatasetItemBatch.class).toBuilder()
+                .items(items)
+                .datasetId(datasetId)
+                .datasetName(null)
+                .build();
+
+        putAndAssert(batch, workspaceName, apiKey);
+
+        // When: Apply filter
+        var filters = List.of(filter);
+
+        try (var actualResponse = client.target(BASE_RESOURCE_URI.formatted(baseURI))
+                .path(datasetId.toString())
+                .path("items")
+                .queryParam("filters", toURLEncodedQueryParam(filters))
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .get()) {
+
+            // Then: Should return matching items
+            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+            assertThat(actualResponse.hasEntity()).isTrue();
+
+            var actualEntity = actualResponse.readEntity(DatasetItemPage.class);
+            assertThat(actualEntity.content()).hasSize(expectedCount);
+        }
+    }
+}

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputs.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputs.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect } from "react";
+import { JsonParam, useQueryParam } from "use-query-params";
 import PlaygroundOutputTable from "@/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundOutputTable";
 import PlaygroundOutputActions from "@/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/PlaygroundOutputActions";
 import PlaygroundOutput from "@/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutput";
 import { usePromptIds, useSetDatasetVariables } from "@/store/PlaygroundStore";
 import useDatasetItemsList from "@/api/datasets/useDatasetItemsList";
 import { DatasetItem, DatasetItemColumn } from "@/types/datasets";
+import { Filters } from "@/types/filters";
 
 interface PlaygroundOutputsProps {
   workspaceName: string;
@@ -23,10 +25,15 @@ const PlaygroundOutputs = ({
   const promptIds = usePromptIds();
   const setDatasetVariables = useSetDatasetVariables();
 
+  const [filters = [], setFilters] = useQueryParam("filters", JsonParam, {
+    updateType: "replaceIn",
+  });
+
   const { data: datasetItemsData, isLoading: isLoadingDatasetItems } =
     useDatasetItemsList(
       {
         datasetId: datasetId!,
+        filters: filters as Filters,
         page: 1,
         size: 1000,
         truncate: true,
@@ -79,6 +86,8 @@ const PlaygroundOutputs = ({
         workspaceName={workspaceName}
         onChangeDatasetId={onChangeDatasetId}
         loadingDatasetItems={isLoadingDatasetItems}
+        filters={filters as Filters}
+        onFiltersChange={setFilters}
       />
       {renderResult()}
     </div>


### PR DESCRIPTION
## Details

This PR adds filtering functionality for dataset items in the playground. Users can now filter dataset items using the existing FiltersButton component, and when they click 'Run', the playground will execute only on the filtered dataset items.

**Frontend Changes:**
- Added filter state management in PlaygroundOutputs using useQueryParam
- Integrated FiltersButton component in PlaygroundOutputActions
- Modified filters.ts to properly transform dataset item dynamic field filters (data.columnName) to the backend format (field='custom', key='data.columnName|type')

**Backend Changes:**
- Added CUSTOM field to DatasetItemField enum for dynamic field filtering
- Modified DatasetItemFilter.buildFromCustom to combine customField and key to form the full path (e.g., 'data.size')
- Updated FiltersFactory to support type encoding/decoding in the key parameter for custom fields
- Added comprehensive parameterized tests for filtering numeric and string fields with various operators

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves OPIK-2681

## Testing
- Added comprehensive backend tests in DatasetsResourceFilterTest.java
- Tests cover filtering by:
  - Numeric fields with >= and < operators
  - String fields with contains and equals operators
- Manual testing verified filtering works correctly in the playground UI
- All filters correctly transform frontend format to backend SQL queries

## Documentation
- No documentation changes required as this uses existing filtering UI patterns