### PR TITLE
[NA] Skip failing multimodal e2e test

### DIFF
--- a/sdks/python/tests/e2e/evaluation/test_multimodal.py
+++ b/sdks/python/tests/e2e/evaluation/test_multimodal.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List
 import opik
 from opik import flush_tracker
 from opik.evaluation import evaluate_prompt, metrics
-
+import pytest
 
 CAT_IMAGE_URL = "https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg"
 PNG_DOG_DATA_URL = (
@@ -60,6 +60,9 @@ def _normalize_output(output: Any) -> str:
     return str(output).strip().lower()
 
 
+@pytest.mark.skip(
+    reason="1) Test started failing 17.11.2025. 2) Test should be skipped in UI if credentials are not provided"
+)
 def test_evaluate_prompt_supports_multimodal_images(
     opik_client: opik.Opik,
     dataset_name: str,


### PR DESCRIPTION
## Details
Started failing 17.11.2025 with no visible updates, requires investigation and looking into third-party updates (probably litellm and openai)

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing
-
## Documentation
-