### PR TITLE
[NA] [FE] Fixed UI issues when optimizer baseline score was 0

### DIFF
--- a/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/ObjectiveScoreCell.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/ObjectiveScoreCell.tsx
@@ -2,19 +2,62 @@ import React from "react";
 import { CellContext } from "@tanstack/react-table";
 import get from "lodash/get";
 import isNumber from "lodash/isNumber";
+import isUndefined from "lodash/isUndefined";
+import { TrendingUp, TrendingDown, MoveRight } from "lucide-react";
 
 import { formatNumericData } from "@/lib/utils";
 import CellWrapper from "@/components/shared/DataTableCells/CellWrapper";
 import PercentageTrend from "@/components/shared/PercentageTrend/PercentageTrend";
+import { Tag } from "@/components/ui/tag";
 
 type CustomMeta = {
   scoreMap: Record<string, { score: number; percentage?: number }>;
+  baseScore?: number;
 };
 
 const ObjectiveScoreCell = (context: CellContext<unknown, unknown>) => {
   const id = get(context.row.original, "id", "");
   const { custom } = context.column.columnDef.meta ?? {};
-  const { scoreMap } = (custom ?? {}) as CustomMeta;
+  const { scoreMap, baseScore } = (custom ?? {}) as CustomMeta;
+
+  const scoreData = scoreMap[id];
+  const score = scoreData?.score;
+  const percentage = scoreData?.percentage;
+
+  let trendElement = null;
+  let showScore = true;
+
+  if (!isUndefined(percentage)) {
+    trendElement = <PercentageTrend percentage={percentage} />;
+  } else if (isNumber(baseScore) && isNumber(score)) {
+    const diff = score - baseScore;
+    showScore = false;
+
+    if (diff !== 0) {
+      const Icon = diff > 0 ? TrendingUp : TrendingDown;
+      const variant = diff > 0 ? "green" : "red";
+
+      trendElement = (
+        <Tag size="md" variant={variant} className="flex-row flex-nowrap gap-1">
+          <div className="flex max-w-full items-center justify-between gap-0.5">
+            <Icon className="size-3 shrink-0" />
+            <div className="min-w-8 text-right">
+              {formatNumericData(Math.abs(diff))}
+            </div>
+          </div>
+        </Tag>
+      );
+    } else {
+      trendElement = (
+        <Tag size="md" variant="gray" className="flex-row flex-nowrap gap-1">
+          <div className="flex max-w-full items-center justify-between gap-0.5">
+            <MoveRight className="size-3 shrink-0" />
+            <div className="min-w-8 text-right">0</div>
+          </div>
+        </Tag>
+      );
+    }
+  }
 
   return (
     <CellWrapper
@@ -22,10 +65,8 @@ const ObjectiveScoreCell = (context: CellContext<unknown, unknown>) => {
       tableMetadata={context.table.options.meta}
       className="gap-2"
     >
-      {isNumber(scoreMap[id]?.score)
-        ? formatNumericData(scoreMap[id]?.score)
-        : "-"}
-      <PercentageTrend percentage={scoreMap[id]?.percentage} />
+      {showScore && (isNumber(score) ? formatNumericData(score) : "-")}
+      {trendElement}
     </CellWrapper>
   );
 };


### PR DESCRIPTION
## Details

When the baseline score for an optimization run was 0, there were a number of issues:
1. No "Best prompt" tag in the chart
2. No scores in the table
3. No prompt diff
<img width="1512" height="823" alt="Screenshot 2025-11-18 at 14 29 12" src="https://github.com/user-attachments/assets/b9a800f6-e909-4b10-afec-cf2c248acc75" />

This PR addresses all of these:
<img width="1512" height="822" alt="Screenshot 2025-11-18 at 14 11 45" src="https://github.com/user-attachments/assets/57e08234-559a-41cc-bc81-21641d6262ce" />

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-000

## Testing

Tested locally

## Documentation
N/A