### PR TITLE
[OPIK-3121] Add configurable HTTP port for Python backend

### DIFF
--- a/apps/opik-python-backend/entrypoint.sh
+++ b/apps/opik-python-backend/entrypoint.sh
@@ -58,11 +58,15 @@ else
   INSTRUMENTATION_CMD=""
 fi
 
+# Configure port with environment variable
+PYTHON_BACKEND_PORT=${PYTHON_BACKEND_PORT:-8000}
+echo "PYTHON_BACKEND_PORT=$PYTHON_BACKEND_PORT"
+
 # Single parameterized gunicorn command
 $INSTRUMENTATION_CMD gunicorn --access-logfile '-' \
   --access-logformat '{"body_bytes_sent": %(B)s, "http_referer": "%(f)s", "http_user_agent": "%(a)s", "remote_addr": "%(h)s", "remote_user": "%(u)s", "request_length": 0, "request_time": %(L)s, "request": "%(r)s", "source": "gunicorn", "status": %(s)s, "time_local": "%(t)s", "time": %(T)s, "x_forwarded_for": "%(h)s"}' \
   --workers 1 \
   --threads "$NUM_THREADS" \
   --worker-class gthread \
-  --bind=0.0.0.0:8000 \
+  --bind=0.0.0.0:$PYTHON_BACKEND_PORT \
   --chdir ./src 'opik_backend:create_app()'

--- a/deployment/docker-compose/docker-compose.override.yaml
+++ b/deployment/docker-compose/docker-compose.override.yaml
@@ -28,4 +28,4 @@ services:
 
   python-backend:
     ports:
-      - "8000:8000" # Exposing Python backend HTTP port to host
+      - "${PYTHON_BACKEND_PORT:-8000}:${PYTHON_BACKEND_PORT:-8000}" # Exposing Python backend HTTP port to host

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -207,8 +207,9 @@ services:
       PYTHON_CODE_EXECUTOR_ALLOW_NETWORK: "false"
       OPIK_VERSION: ${OPIK_VERSION:-latest}
       OPIK_REVERSE_PROXY_URL: ${OPIK_REVERSE_PROXY_URL:-http://frontend:5173/api}
+      PYTHON_BACKEND_PORT: ${PYTHON_BACKEND_PORT:-8000}
     healthcheck:
-      test: [ "CMD", "sh", "-c", "if [ -f /opt/opik-python-backend/src/opik_backend/healthcheck.py ]; then wget --spider --quiet http://127.0.0.1:8000/healthcheck; else exit 0; fi" ]
+      test: [ "CMD", "sh", "-c", "if [ -f /opt/opik-python-backend/src/opik_backend/healthcheck.py ]; then wget --spider --quiet http://127.0.0.1:$${PYTHON_BACKEND_PORT:-8000}/healthcheck; else exit 0; fi" ]
       interval: 2s
       timeout: 60s
       retries: 30


### PR DESCRIPTION
## Details

This PR adds support for configurable HTTP port in the opik-python-backend service, following the same pattern implemented for the main backend service in commit 9277040c434d12cb28b09d765dc44fb5392822e4.

### Changes:
- Added `PYTHON_BACKEND_PORT` environment variable with 8000 as default value
- Updated `entrypoint.sh` to use the new environment variable for gunicorn binding
- Updated docker-compose files to support the configurable port
- Updated healthcheck command to use the environment variable

This allows deployments to customize the Python backend port when needed, improving flexibility for different deployment scenarios.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves # N/A
- OPIK-3121

## Testing
- Manual testing can be done by setting `PYTHON_BACKEND_PORT` environment variable to a different port (e.g., 8001) and verifying the service starts on the configured port
- Default behavior (port 8000) remains unchanged when the environment variable is not set

## Documentation
No documentation updates needed - this is an infrastructure configuration change that maintains backward compatibility with existing deployments.