### PR TITLE
[OPIK-3121] Update Python backend URLs to use configurable port

### DIFF
--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -160,7 +160,7 @@ services:
       AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-LESlrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY}
       IS_MINIO: true
       S3_URL: http://minio:9000
-      PYTHON_EVALUATOR_URL: http://python-backend:8000
+      PYTHON_EVALUATOR_URL: ${PYTHON_EVALUATOR_URL:-http://python-backend:${PYTHON_BACKEND_PORT:-8000}}
       TOGGLE_GUARDRAILS_ENABLED: ${TOGGLE_GUARDRAILS_ENABLED:-"false"}
       TOGGLE_WELCOME_WIZARD_ENABLED: ${TOGGLE_WELCOME_WIZARD_ENABLED:-"true"}
       CORS: ${CORS:-false}
@@ -248,7 +248,7 @@ services:
     hostname: demo-data-generator
     environment:
       CREATE_DEMO_DATA: ${CREATE_DEMO_DATA:-true}
-      PYTHON_BACKEND_URL: ${PYTHON_BACKEND_URL:-http://python-backend:8000}
+      PYTHON_BACKEND_URL: ${PYTHON_BACKEND_URL:-http://python-backend:${PYTHON_BACKEND_PORT:-8000}}
     command: [ "sh", "-c", "./demo_data_entrypoint.sh" ]
     depends_on:
       frontend:


### PR DESCRIPTION
## Details

This PR is a follow-up to #4111, which added the `PYTHON_BACKEND_PORT` environment variable to make the Python backend port configurable.

This PR updates the docker-compose URLs that reference the Python backend to use the configurable port instead of the hardcoded 8000, while maintaining the ability to override complete URLs.

### Changes:
- Updated `PYTHON_EVALUATOR_URL` to support both full URL override and port-only configuration
- Updated `PYTHON_BACKEND_URL` to support both full URL override and port-only configuration

### Design Decision - Maintaining Maximum Flexibility:

Both environment variables now support two levels of configuration:

1. **Full URL override**: Set the complete URL environment variable to override hostname, port, and protocol
   - `PYTHON_EVALUATOR_URL=https://custom-host:9000`
   - `PYTHON_BACKEND_URL=https://custom-host:9000`

2. **Port-only override**: Set `PYTHON_BACKEND_PORT` to change just the port while keeping the default hostname
   - `PYTHON_BACKEND_PORT=8001`

3. **Default behavior**: Neither set, uses `http://python-backend:8000`

**Implementation:**
- `PYTHON_EVALUATOR_URL: ${PYTHON_EVALUATOR_URL:-http://python-backend:${PYTHON_BACKEND_PORT:-8000}}`
- `PYTHON_BACKEND_URL: ${PYTHON_BACKEND_URL:-http://python-backend:${PYTHON_BACKEND_PORT:-8000}}`

This maintains backward compatibility while adding the new port configuration feature.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves # N/A
- OPIK-3121

## Testing
Configuration options to test:
1. **Port-only override**: `PYTHON_BACKEND_PORT=8001`
   - Backend connects to Python backend at `http://python-backend:8001`
   - Demo data generator connects to `http://python-backend:8001`

2. **Full URL override**: `PYTHON_EVALUATOR_URL=https://custom-host:9000`
   - Backend uses the custom URL for Python evaluator

3. **Full URL override**: `PYTHON_BACKEND_URL=https://custom-host:9000`
   - Demo data generator uses the custom URL

4. **Default behavior**: No env vars set
   - Both use `http://python-backend:8000`

## Documentation
No documentation updates needed - this is an infrastructure configuration change that maintains backward compatibility with existing deployments.