### PR TITLE
[NA][FE] fix tags column name collision in dataset items

### DIFF
--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsPage.tsx
@@ -59,6 +59,7 @@ import {
 import { useTruncationEnabled } from "@/components/server-sync-provider";
 import UseDatasetDropdown from "@/components/pages/DatasetItemsPage/UseDatasetDropdown";
 import { RESOURCE_TYPE } from "@/components/shared/ResourceLink/ResourceLink";
+import { DATASET_ITEM_DATA_PREFIX } from "@/constants/datasets";
 
 const getRowId = (d: DatasetItem) => d.id;
 
@@ -215,7 +216,7 @@ const DatasetItemsPage = () => {
     return (data?.columns ?? [])
       .sort((c1, c2) => c1.name.localeCompare(c2.name))
       .map<DynamicColumn>((c) => ({
-        id: `data.${c.name}`,
+        id: `${DATASET_ITEM_DATA_PREFIX}.${c.name}`,
         label: c.name,
         columnType: mapDynamicColumnTypesToColumnType(c.types),
       }));

--- a/apps/opik-frontend/src/constants/datasets.ts
+++ b/apps/opik-frontend/src/constants/datasets.ts
@@ -1,0 +1,1 @@
+export const DATASET_ITEM_DATA_PREFIX = "data";


### PR DESCRIPTION
## Details
Fixes the edge case where the dataset items' `data` contains a `tags` property which collides with the non-dynamic column `Tags`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-0000

## Testing
Tested manually by reproducing the issue first, then applying the fix and making sure it fixes the issue.

## Documentation
No need, this is a bugfix
