### PR TITLE
[OPIK-3126] [FE] Fix tags column collision in playground table

### DIFF
--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundOutputTable.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundOutputTable.tsx
@@ -106,7 +106,7 @@ const PlaygroundOutputTable = ({
       .map(
         (c, i) =>
           ({
-            id: c.name,
+            id: `variables.${c.name}`,
             label: c.name,
             type: mapDynamicColumnTypesToColumnType(c.types),
             customMeta: {


### PR DESCRIPTION
## Details
Fixes the edge case where the playground table's dynamic columns (from dataset data) can collide with static columns like "Tags". This is similar to the fix in PR #4119 for the dataset items page.

The playground table now prefixes dynamic column IDs with `variables.` to prevent naming conflicts between:
- Dynamic columns from dataset data (e.g., `variables.tags` when dataset has a tags field)
- Static columns (e.g., `tags` for the dataset item tags column)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3126

## Testing
Tested manually with a dataset containing a `tags` field in the data. Verified that:
- Both tags columns display correctly (one from dataset data, one showing dataset item tags)
- No column name collision errors occur
- Column IDs are properly prefixed with `variables.` for dynamic columns

## Documentation
No documentation needed - this is a bugfix