### PR TITLE
[OPIK-3127] [FE] Trigger experiment finished alert for playground experiments

### DIFF
--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/useActionButtonActions.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/useActionButtonActions.tsx
@@ -121,6 +121,12 @@ const useActionButtonActions = ({
           queryKey: [PROJECTS_KEY],
         });
       },
+      onExperimentItemsComplete: () => {
+        // Invalidate experiments to refresh the experiments list
+        queryClient.invalidateQueries({
+          queryKey: ["experiments"],
+        });
+      },
     };
   }, [
     queryClient,
@@ -168,6 +174,9 @@ const useActionButtonActions = ({
       async (combination: DatasetItemPromptCombination) =>
         processCombination(combination, logProcessor),
       () => {
+        // Signal that all logs have been sent
+        logProcessor.finishLogging();
+
         setIsRunning(false);
         isToStopRef.current = false;
         abortControllersRef.current.clear();


### PR DESCRIPTION
## Details


https://github.com/user-attachments/assets/43d3cd96-47a2-407e-b009-63ae85df1a9f



This PR implements experiment lifecycle management for playground experiments, enabling the system to trigger an "experiment finished" alert when all experiment items are logged and processed.

**Implementation:**
- Added `finishLogging` method to `LogProcessor` interface to signal when all experiment items have been logged
- Implemented `finishExperiments` function that calls the `/experiments/finish` API endpoint
- Added state tracking with two flags:
  - `areExperimentsCreated`: Set when the experiments queue drains
  - `isLoggingFinished`: Set when `finishLogging()` is called and all batches are flushed
- Implemented `tryFinishExperiments` logic that only finishes experiments when both conditions are met
- Added `onExperimentItemsComplete` callback that invalidates experiment queries to refresh the UI

**Files changed:**
- `createLogPlaygroundProcessor.ts`: Core logging processor with experiment lifecycle management
- `useActionButtonActions.tsx`: Integration of finish logic and UI refresh

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3127

## Testing

The implementation ensures experiments are properly finished by:
1. Flushing all batches (spans, traces, experiment items)
2. Waiting for the experiments queue to drain (all experiments created)
3. Calling the finish API endpoint with all experiment IDs
4. Refreshing the UI to reflect the updated experiment status

**Testing scenarios:**
- Single prompt execution in playground
- Multiple prompt/dataset combinations
- Error handling when finish API call fails

## Documentation

N/A - No documentation changes required for this internal implementation.