### PR TITLE
[NA][FE] Fix modal text for large CSV uploads

### DIFF
--- a/apps/opik-frontend/src/components/pages/DatasetsPage/AddEditDatasetDialog.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetsPage/AddEditDatasetDialog.tsx
@@ -301,15 +301,23 @@ const AddEditDatasetDialog: React.FunctionComponent<
                   message={
                     <div>
                       <div className="comet-body-s-accented text-center">
-                        Processing the CSV
+                        {isCsvUploadEnabled
+                          ? "Upload in progress..."
+                          : "Processing the CSV"}
                       </div>
-                      <div className="comet-body-s mt-2 text-center text-light-slate">
-                        This should take less than a minute. <br /> You can
-                        safely close this popup while we work.
-                      </div>
-                      <div className="mt-4 flex items-center justify-center">
-                        <Button onClick={() => setOpen(false)}>Close</Button>
-                      </div>
+                      {!isCsvUploadEnabled && (
+                        <>
+                          <div className="comet-body-s mt-2 text-center text-light-slate">
+                            This should take less than a minute. <br /> You can
+                            safely close this popup while we work.
+                          </div>
+                          <div className="mt-4 flex items-center justify-center">
+                            <Button onClick={() => setOpen(false)}>
+                              Close
+                            </Button>
+                          </div>
+                        </>
+                      )}
                     </div>
                   }
                 />


### PR DESCRIPTION
## Details
When CSV upload toggle is ON, change modal text to 'Upload in progress...' and remove the close button option, since large files can take minutes to process.

The old text 'This should take less than a minute' with close button is now only shown when the toggle is OFF (JSON mode with 1000 row limit).

This is how the modal looks like when the toggle is on:
<img width="583" height="715" alt="image" src="https://github.com/user-attachments/assets/819f6825-55b0-492e-bb01-a63293d13d69" />

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-0000

## Testing
Tested manually with toggle on and off.

## Documentation
Not needed
