### PR TITLE
[OPIK-3169][BE] proper failure indication for CSV empty header

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -54,7 +54,6 @@ import jakarta.inject.Provider;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
@@ -505,8 +504,8 @@ public class DatasetsResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Operation(operationId = "createDatasetItemsFromCsv", summary = "Create dataset items from CSV file", description = "Create dataset items from uploaded CSV file. CSV should have headers in the first row. Processing happens asynchronously in batches.", responses = {
             @ApiResponse(responseCode = "202", description = "Accepted - CSV processing started"),
-            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = com.comet.opik.api.error.ErrorMessage.class))),
-            @ApiResponse(responseCode = "404", description = "Not Found - CSV upload feature is disabled", content = @Content(schema = @Schema(implementation = com.comet.opik.api.error.ErrorMessage.class))),
+            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
+            @ApiResponse(responseCode = "404", description = "Not Found - CSV upload feature is disabled", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
     })
     @RateLimited
     public Response createDatasetItemsFromCsv(
@@ -524,14 +523,7 @@ public class DatasetsResource {
 
         log.info("CSV upload request for dataset '{}' on workspaceId '{}'", datasetId, workspaceId);
 
-        try {
-            csvProcessor.processUploadedCsv(fileInputStream, datasetId, workspaceId, userName, visibility);
-        } catch (BadRequestException exception) {
-            log.warn("CSV validation failed for dataset '{}': '{}'", datasetId, exception.getMessage());
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity(new com.comet.opik.api.error.ErrorMessage(List.of(exception.getMessage())))
-                    .build();
-        }
+        csvProcessor.processUploadedCsv(fileInputStream, datasetId, workspaceId, userName, visibility);
 
         log.info("CSV upload accepted for dataset '{}' on workspaceId '{}', processing asynchronously", datasetId,
                 workspaceId);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CsvDatasetItemProcessor.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CsvDatasetItemProcessor.java
@@ -82,7 +82,7 @@ public class CsvDatasetItemProcessor {
             tempFile = bufferToTempFile(inputStream);
         } catch (IOException e) {
             log.error("Failed to buffer CSV file to temp storage for dataset '{}'", datasetId, e);
-            throw new InternalServerErrorException("Failed to process CSV file: " + e.getMessage());
+            throw new InternalServerErrorException("Failed to process CSV file");
         }
 
         // Validate CSV headers synchronously BEFORE starting async processing
@@ -166,10 +166,10 @@ public class CsvDatasetItemProcessor {
             if (message != null && message.contains("header name is missing")) {
                 throw new BadRequestException("CSV contains empty header names. All column headers must have a name.");
             }
-            throw new BadRequestException("Invalid CSV format: " + message);
+            throw new BadRequestException("Invalid CSV format");
         } catch (IOException e) {
             log.error("Failed to validate CSV headers", e);
-            throw new BadRequestException("Failed to read CSV file: " + e.getMessage());
+            throw new BadRequestException("Failed to read CSV file");
         }
     }
 
@@ -291,7 +291,7 @@ public class CsvDatasetItemProcessor {
                 return totalProcessed;
             } catch (IOException e) {
                 log.warn("Failed to process CSV file for dataset '{}'", datasetId, e);
-                throw new BadRequestException("Failed to read CSV file: " + e.getMessage());
+                throw new BadRequestException("Failed to read CSV file");
             }
         }).subscribeOn(Schedulers.boundedElastic());
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsCsvUploadResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsCsvUploadResourceTest.java
@@ -306,11 +306,11 @@ class DatasetsCsvUploadResourceTest {
                     .as("Test case: %s", testDescription)
                     .isEqualTo(HttpStatus.SC_BAD_REQUEST);
 
-            // Verify error response contains errors array with appropriate message
+            // Verify error response contains message with appropriate error description
             String errorResponse = response.readEntity(String.class);
             assertThat(errorResponse)
-                    .as("Test case: %s - should contain errors field", testDescription)
-                    .contains("\"errors\"");
+                    .as("Test case: %s - should contain message field", testDescription)
+                    .contains("\"message\"");
             assertThat(errorResponse)
                     .as("Test case: %s - should mention empty header names", testDescription)
                     .contains("empty header names");


### PR DESCRIPTION
## Details
Display a failure message when CSV header is invalid. This is important since the processing is done asynchronously and the user is not aware about the error.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-3169

## Testing
- Covered by tests
- Tested manually to see the proper error message

## Documentation
No need
