### PR TITLE
[OPIK-3116][FE] user friendly error message for duplicate dataset name

### DIFF
--- a/apps/opik-frontend/src/api/datasets/useDatasetCreateMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetCreateMutation.ts
@@ -40,8 +40,9 @@ const useDatasetCreateMutation = () => {
       const errors = get(error, ["response", "data", "errors"], []);
       const message =
         Array.isArray(errors) && errors.length > 0
-          ? errors[0]
-          : get(error, ["response", "data", "message"], error.message);
+          ? errors.join("; ")
+          : get(error, ["response", "data", "message"], error.message) ||
+            "An unknown error occurred while creating a dataset. Please try again.";
 
       toast({
         title: "Error",


### PR DESCRIPTION
## Details
This PR adjusts the frontend to match the error message structure returned by the backend.

**Before:**
<img width="1903" height="988" alt="image" src="https://github.com/user-attachments/assets/c678851f-c45b-4943-a6ef-93e1ff490eb6" />

**After:**
<img width="662" height="276" alt="image" src="https://github.com/user-attachments/assets/3254be1f-e434-4aa6-b6a4-b52f498cf286" />

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3116

## Testing
Tested manually to make sure the error message is user friendly. Attached screenshot above.

## Documentation
No need.
