### PR TITLE
[OPIK-3267] [FE] Stop click propagation around checkboxes

### DIFF
--- a/apps/opik-frontend/src/components/shared/DataTable/utils.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTable/utils.tsx
@@ -389,7 +389,7 @@ export const generateGroupedRowCellDef = <TData, TValue>(
         <CellWrapper
           metadata={context.column.columnDef.meta}
           tableMetadata={context.table.options.meta}
-          className="h-11 items-center pr-2 py-0 px-0"
+          className="h-11 items-center p-0 pr-2"
           stopClickPropagation
         >
           <div


### PR DESCRIPTION
## Details

This small PR prevents clicking outside a checkbox (but inside the cell) to be ignored rather than selecting the row, and losing all of the previously selected items. Very annoying!

## Change checklist
- [x] User facing

## Issues

- OPIK-3267

## Testing

Tested locally.

## Documentation

N/A