### PR TITLE
[OPIK-3270] [FE] Prompt select is empty when loading prompt from library

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
@@ -82,7 +82,7 @@ const PromptsSelectBox: React.FC<PromptsSelectBoxProps> = ({
     }
 
     return options;
-  }, [prompts, value, selectedPromptData]);
+  }, [prompts, value, selectedPromptData, valueExistsInOptions]);
 
   const promptsTotal = promptsData?.total ?? 0;
 


### PR DESCRIPTION
## Details

When loading a prompt in the Playground from the Prompt library, the prompt select appears unfilled, although the content is loaded properly.

## Change checklist
- [x] User facing

## Issues

- OPIK-3270

## Testing

Tested locally.

## Documentation

N/A