### PR TITLE
[OPIK-3290] [FE] Fix model selection persistence for custom providers in dataset expansion

### DIFF
--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetExpansionDialog.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetExpansionDialog.tsx
@@ -74,7 +74,7 @@ const DatasetExpansionDialog: React.FunctionComponent<
   });
 
   const providerKeys = useMemo(() => {
-    return providerKeysData?.content?.map((c) => c.provider) || [];
+    return providerKeysData?.content?.map((c) => c.ui_composed_provider) || [];
   }, [providerKeysData]);
 
   const { calculateModelProvider, calculateDefaultModel } =

--- a/apps/opik-frontend/src/hooks/useLoadPlayground.ts
+++ b/apps/opik-frontend/src/hooks/useLoadPlayground.ts
@@ -59,7 +59,7 @@ const useLoadPlayground = () => {
   }, [promptMap]);
 
   const providerKeys = useMemo(() => {
-    return providerKeysData?.content?.map((c) => c.provider) || [];
+    return providerKeysData?.content?.map((c) => c.ui_composed_provider) || [];
   }, [providerKeysData]);
 
   const loadPlayground = useCallback(


### PR DESCRIPTION
## Details

Fixed custom provider model selection in the "Expand Dataset with AI" dialog. The issue was caused by using the wrong provider field (`c.provider` instead of `c.ui_composed_provider`) when mapping provider keys, which resulted in format mismatches during validation.

**Root Cause:**
- `c.provider` returns base provider type only (e.g., `'custom-llm'`)
- `c.ui_composed_provider` returns full composed format (e.g., `'custom-llm:without headers'`)
- Model validation was failing because `calculateModelProvider` returns the composed format, but the provider keys array only contained base formats

**Solution:**
Changed provider key mapping in both `DatasetExpansionDialog.tsx` and `useLoadPlayground.ts` to use `ui_composed_provider` field, ensuring format consistency across the validation flow.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3290

## Testing

**Manual Testing:**
1. Configure a custom LLM provider in workspace settings
2. Navigate to a dataset
3. Click "Expand Dataset with AI"
4. Select a custom provider model from the dropdown
5. ✅ Verify the model selection persists and displays correctly
6. Close and reopen the dialog
7. ✅ Verify the previously selected model is still displayed

**Affected Features:**
- Dataset expansion with custom provider models
- Playground model selection (preventive fix)

## Documentation

No documentation changes required. This is an internal bug fix that resolves a validation issue for custom provider models in self-hosted deployments.