### PR TITLE
[OPIK-3270] [FE]: add refetchOnMount to prompts;

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
@@ -312,6 +312,7 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
               }
             }}
             onOpenChange={onPromptSelectBoxOpenChange}
+            refetchOnMount
           />
         </div>
         <TooltipWrapper content="Discard changes">

--- a/apps/opik-frontend/src/components/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
@@ -9,6 +9,7 @@ import { Separator } from "@/components/ui/separator";
 import LoadableSelectBox from "@/components/shared/LoadableSelectBox/LoadableSelectBox";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import usePromptsList from "@/api/prompts/usePromptsList";
+import useDeepMemo from "@/hooks/useDeepMemo";
 
 const DEFAULT_LOADED_PROMPTS = 1000;
 const MAX_LOADED_PROMPTS = 10000;
@@ -47,7 +48,7 @@ const PromptsSelectBox: React.FC<PromptsSelectBoxProps> = ({
     },
   );
 
-  const prompts = useMemo(
+  const prompts = useDeepMemo(
     () => promptsData?.content ?? [],
     [promptsData?.content],
   );


### PR DESCRIPTION
## Details
When loading a prompt in the Playground from the Prompt library, the prompt select appears unfilled, although the content is loaded properly.


## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-3270

## Testing

## Documentation
