### PR TITLE
[OPIK-13745] [FE]: reset dataset vars when there is no dataset picked;

### DIFF
--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputs.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputs.tsx
@@ -67,9 +67,12 @@ const PlaygroundOutputs = ({
   const handleChangeDatasetId = useCallback(
     (id: string | null) => {
       resetDatasetFilters();
+      if (!id) {
+        setDatasetVariables([]);
+      }
       onChangeDatasetId(id);
     },
-    [onChangeDatasetId, resetDatasetFilters],
+    [onChangeDatasetId, resetDatasetFilters, setDatasetVariables],
   );
 
   const renderResult = () => {

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompts.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompts.tsx
@@ -19,6 +19,7 @@ import {
   useClearCreatedExperiments,
   useSetSelectedRuleIds,
   useResetDatasetFilters,
+  useSetDatasetVariables,
 } from "@/store/PlaygroundStore";
 import useLastPickedModel from "@/hooks/useLastPickedModel";
 import useLLMProviderModelsData from "@/hooks/useLLMProviderModelsData";
@@ -47,6 +48,7 @@ const PlaygroundPrompts = ({
   const setSelectedRuleIds = useSetSelectedRuleIds();
   const setIsRunning = useSetIsRunning();
   const resetDatasetFilters = useResetDatasetFilters();
+  const setDatasetVariables = useSetDatasetVariables();
   const resetKeyRef = useRef(0);
   const scrollToPromptRef = useRef<string>("");
   const [open, setOpen] = useState<boolean>(false);
@@ -89,6 +91,7 @@ const PlaygroundPrompts = ({
     clearCreatedExperiments();
     setIsRunning(false);
     resetDatasetFilters();
+    setDatasetVariables([]);
     onResetHeight();
   }, [
     providerKeys,
@@ -101,6 +104,7 @@ const PlaygroundPrompts = ({
     clearCreatedExperiments,
     setIsRunning,
     resetDatasetFilters,
+    setDatasetVariables,
     onResetHeight,
   ]);
 


### PR DESCRIPTION
## Details
Now, when a user picks resets a playground or a dataset, it hides the variables from prompts hint

https://github.com/user-attachments/assets/77c73cc4-a255-452a-8cde-7e2ba61f301f



## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-13745

## Testing

## Documentation
