### PR TITLE
[NA] [DOCS] Document name query parameter search behavior in OpenAPI spec

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResource.java
@@ -72,7 +72,7 @@ public class AnnotationQueuesResource {
     public Response findAnnotationQueues(
             @QueryParam("page") @Min(1) @DefaultValue("1") int page,
             @QueryParam("size") @Min(1) @DefaultValue("10") int size,
-            @QueryParam("name") String name,
+            @QueryParam("name") @Schema(description = "Filter annotation queues by name (partial match, case insensitive)") String name,
             @QueryParam("filters") String filters,
             @QueryParam("sorting") String sorting) {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResource.java
@@ -76,7 +76,7 @@ public class AutomationRuleEvaluatorsResource {
     @JsonView(View.Public.class)
     public Response find(@QueryParam("project_id") UUID projectId,
             @QueryParam("id") @Schema(description = "Filter automation rules with rule ID containing this value (partial match, like %id%)") String id,
-            @QueryParam("name") String name,
+            @QueryParam("name") @Schema(description = "Filter automation rule evaluators by name (partial match, case insensitive)") String name,
             @QueryParam("filters") String filters,
             @QueryParam("sorting") String sorting,
             @QueryParam("page") @Min(1) @DefaultValue("1") int page,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -139,7 +139,7 @@ public class DatasetsResource {
             @QueryParam("with_experiments_only") boolean withExperimentsOnly,
             @QueryParam("with_optimizations_only") boolean withOptimizationsOnly,
             @QueryParam("prompt_id") UUID promptId,
-            @QueryParam("name") String name,
+            @QueryParam("name") @Schema(description = "Filter datasets by name (partial match, case insensitive)") String name,
             @QueryParam("sorting") String sorting,
             @QueryParam("filters") String filters) {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -117,7 +117,7 @@ public class ExperimentsResource {
             @QueryParam("datasetId") UUID datasetId,
             @QueryParam("optimization_id") UUID optimizationId,
             @QueryParam("types") String typesQueryParam,
-            @QueryParam("name") String name,
+            @QueryParam("name") @Schema(description = "Filter experiments by name (partial match, case insensitive)") String name,
             @QueryParam("dataset_deleted") boolean datasetDeleted,
             @QueryParam("prompt_id") UUID promptId,
             @QueryParam("sorting") String sorting,
@@ -177,7 +177,7 @@ public class ExperimentsResource {
     public Response findGroups(
             @QueryParam("groups") String groupsQueryParam,
             @QueryParam("types") String typesQueryParam,
-            @QueryParam("name") String name,
+            @QueryParam("name") @Schema(description = "Filter experiments by name (partial match, case insensitive)") String name,
             @QueryParam("filters") String filters) {
 
         // Parse and validate groups parameter using GroupingFactory
@@ -215,7 +215,7 @@ public class ExperimentsResource {
     public Response findGroupsAggregations(
             @QueryParam("groups") String groupsQueryParam,
             @QueryParam("types") String typesQueryParam,
-            @QueryParam("name") String name,
+            @QueryParam("name") @Schema(description = "Filter experiments by name (partial match, case insensitive)") String name,
             @QueryParam("filters") String filters) {
 
         // Parse and validate groups parameter using GroupingFactory

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/FeedbackDefinitionResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/FeedbackDefinitionResource.java
@@ -64,7 +64,7 @@ public class FeedbackDefinitionResource {
     public Response find(
             @QueryParam("page") @Min(1) @DefaultValue("1") int page,
             @QueryParam("size") @Min(1) @DefaultValue("10") int size,
-            @QueryParam("name") String name,
+            @QueryParam("name") @Schema(description = "Filter feedback definitions by name (partial match, case insensitive)") String name,
             @QueryParam("type") FeedbackType type) {
 
         var criteria = FeedbackDefinitionCriteria.builder()

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/OptimizationsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/OptimizationsResource.java
@@ -89,7 +89,7 @@ public class OptimizationsResource {
             @QueryParam("page") @Min(1) @DefaultValue("1") int page,
             @QueryParam("size") @Min(1) @DefaultValue("10") int size,
             @QueryParam("dataset_id") UUID datasetId,
-            @QueryParam("name") String name,
+            @QueryParam("name") @Schema(description = "Filter optimizations by name (partial match, case insensitive)") String name,
             @QueryParam("dataset_deleted") Boolean datasetDeleted) {
 
         var searchCriteria = OptimizationSearchCriteria.builder()

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
@@ -88,7 +88,7 @@ public class ProjectsResource {
     public Response find(
             @QueryParam("page") @Min(1) @DefaultValue("1") int page,
             @QueryParam("size") @Min(1) @DefaultValue(PAGE_SIZE) int size,
-            @QueryParam("name") String name,
+            @QueryParam("name") @Schema(description = "Filter projects by name (partial match, case insensitive)") String name,
             @QueryParam("sorting") String sorting) {
 
         var criteria = ProjectCriteria.builder()
@@ -289,7 +289,7 @@ public class ProjectsResource {
     public Response getProjectStats(
             @QueryParam("page") @Min(1) @DefaultValue("1") int page,
             @QueryParam("size") @Min(1) @DefaultValue(PAGE_SIZE) int size,
-            @QueryParam("name") String name,
+            @QueryParam("name") @Schema(description = "Filter projects by name (partial match, case insensitive)") String name,
             @QueryParam("sorting") String sorting) {
 
         var criteria = ProjectCriteria.builder()

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
@@ -98,7 +98,7 @@ public class PromptResource {
     public Response getPrompts(
             @QueryParam("page") @Min(1) @DefaultValue("1") int page,
             @QueryParam("size") @Min(1) @DefaultValue("10") int size,
-            @QueryParam("name") String name,
+            @QueryParam("name") @Schema(description = "Filter prompts by name (partial match, case insensitive)") String name,
             @QueryParam("sorting") String sorting,
             @QueryParam("filters") String filters) {
 


### PR DESCRIPTION
## Details

This PR adds OpenAPI schema documentation to the `name` query parameter across all backend REST API endpoints that support name-based filtering. The documentation clarifies that name searches use partial matching (contains search pattern) and are case-insensitive.

### Changes Made

Added `@Schema(description = "Filter {entity} by name (partial match, case insensitive)")` documentation to the name query parameter in the following resources:

- **ExperimentsResource** (3 endpoints): findExperiments, findGroups, findGroupsAggregations
- **DatasetsResource**: findDatasets
- **PromptResource**: getPrompts
- **ProjectsResource** (2 endpoints): find, getProjectStats
- **AutomationRuleEvaluatorsResource**: find
- **AnnotationQueuesResource**: findAnnotationQueues
- **OptimizationsResource**: find
- **FeedbackDefinitionResource**: find

### Implementation Details

The name search behavior documented is:
- **Partial match**: Uses SQL `LIKE CONCAT('%', :name, '%')` pattern in MySQL and `ilike(name, CONCAT('%', :name, '%'))` in ClickHouse
- **Case insensitive**: Uses `ilike` in ClickHouse and case-insensitive `like` in MySQL

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues
- NA

## Testing
No new tests required. This is a documentation-only change that adds OpenAPI schema descriptions to existing query parameters. The underlying search functionality remains unchanged and is already tested.

## Documentation
Updated OpenAPI specifications for all name-based search endpoints in the backend REST API. This documentation will be reflected in the auto-generated API documentation and SDK code generation.