### PR TITLE
[OPIK-3299] [P SDK] Made multimodal E2E test optional if OpenAI credentials is not available

### DIFF
--- a/sdks/python/tests/e2e/evaluation/test_multimodal.py
+++ b/sdks/python/tests/e2e/evaluation/test_multimodal.py
@@ -1,8 +1,13 @@
 from typing import Any, Dict, List
 
+import pytest
+
 import opik
 from opik import flush_tracker
 from opik.evaluation import evaluate_prompt, metrics
+
+from ...testlib import environment
+
 
 CAT_IMAGE_URL = "https://cataas.com/cat"
 PNG_DOG_DATA_URL = (
@@ -59,6 +64,9 @@ def _normalize_output(output: Any) -> str:
     return str(output).strip().lower()
 
 
+@pytest.mark.skipif(
+    not environment.has_openai_api_key(), reason="OPENAI_API_KEY is not set"
+)
 def test_evaluate_prompt_supports_multimodal_images(
     opik_client: opik.Opik,
     dataset_name: str,


### PR DESCRIPTION
## Details

Recently was introduced new E2E test for testing multimodal evaluation that requires valid OpenAI credentials to be present. Unfortunately, this credentials is not available for third party contributors that leads all e2e test runs to fail.
We need to avoid this by making this test optional.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-3299

## Testing

No new tests

## Documentation

No changes