### PR TITLE
[NA] [BE] Make OpenTelemetry configuration parameters configurable

### DIFF
--- a/apps/opik-backend/entrypoint.sh
+++ b/apps/opik-backend/entrypoint.sh
@@ -13,8 +13,13 @@ echo "OTEL_VERSION=$OTEL_VERSION"
 
 if [[ "${OPIK_OTEL_SDK_ENABLED}" == "true" && "${OTEL_VERSION}" != "" && "${OTEL_EXPORTER_OTLP_ENDPOINT}" != "" ]];then
     echo "Downloading Open Telemetry Java Agent"
-    export OTEL_RESOURCE_ATTRIBUTES="service.name=opik-backend,service.version=${OPIK_VERSION}"
-    curl -L -o /tmp/opentelemetry-javaagent.jar https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_VERSION}/opentelemetry-javaagent.jar
+    OTEL_SERVICE_NAME="${OTEL_SERVICE_NAME:-opik-backend}"
+    # Only set OTEL_RESOURCE_ATTRIBUTES if not already provided
+    if [ -z "$OTEL_RESOURCE_ATTRIBUTES" ]; then
+        export OTEL_RESOURCE_ATTRIBUTES="service.name=${OTEL_SERVICE_NAME},service.version=${OPIK_VERSION}"
+    fi
+    OTEL_JAVAAGENT_DOWNLOAD_URL="${OTEL_JAVAAGENT_DOWNLOAD_URL:-https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_VERSION}/opentelemetry-javaagent.jar}"
+    curl -L -o /tmp/opentelemetry-javaagent.jar "${OTEL_JAVAAGENT_DOWNLOAD_URL}"
 
     # Add Opik telemetry extension to the agent
     if [ -f "/opt/opik/opik-telemetry-extension.jar" ]; then


### PR DESCRIPTION
## Details

This change makes hardcoded OpenTelemetry (OTEL) configuration parameters in the opik-backend service configurable via environment variables while maintaining full backwards compatibility with existing deployments.

### Changes

**New configurable environment variables:**
- `OTEL_SERVICE_NAME` (default: `"opik-backend"`) - Configures the service name in OTEL resource attributes
- `OTEL_JAVAAGENT_DOWNLOAD_URL` (default: GitHub release URL with `${OTEL_VERSION}`) - Allows specifying custom download URLs for the OTEL Java agent (e.g., mirrors, private repos, air-gapped environments)

**Enhanced behavior:**
- `OTEL_RESOURCE_ATTRIBUTES` is now only set if not already provided by the user, giving users full control when needed

### Use Cases

This change enables:
- Custom service names for multi-instance deployments
- Using custom mirrors or CDN for OTEL agent downloads
- Using private artifact repositories
- Air-gapped/offline environments with locally hosted agents

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues
- NA

## Testing
- Manual testing: 
  - Verified default behavior unchanged when env vars not set
  - Verified custom OTEL_SERVICE_NAME is properly used in resource attributes
  - Verified custom OTEL_JAVAAGENT_DOWNLOAD_URL downloads from specified location

## Documentation
N/A