### PR TITLE
[OPIK-3308] [P SDK] Implement skipping of library integration tests if specific credentials are not provided

### DIFF
--- a/sdks/python/tests/e2e_library_integration/conftest.py
+++ b/sdks/python/tests/e2e_library_integration/conftest.py
@@ -13,14 +13,9 @@ OPIK_E2E_LIB_INTEGRATION_TESTS_PROJECT_NAME: Final[str] = (
 )
 
 
-# Define a condition to skip the entire package
-def should_skip_package():
-    return not environment.has_openai_api_key()
-
-
 @pytest.fixture(scope="session", autouse=True)
 def skip_all_tests_in_package(request):
-    if should_skip_package():
+    if environment.should_skip_library_integration_tests():
         pytest.skip(
             "Skipping entire 'E2E library integration tests' because authorization credentials not found",
             allow_module_level=True,

--- a/sdks/python/tests/library_integration/conftest.py
+++ b/sdks/python/tests/library_integration/conftest.py
@@ -11,14 +11,9 @@ def reset_tracing_to_config_default():
     opik.reset_tracing_to_config_default()
 
 
-# Define a condition to skip the entire package
-def should_skip_package():
-    return not environment.has_openai_api_key()
-
-
 @pytest.fixture(scope="session", autouse=True)
 def skip_all_tests_in_package(request):
-    if should_skip_package():
+    if environment.should_skip_library_integration_tests():
         pytest.skip(
             "Skipping entire 'library integration tests' because authorization credentials not found",
             allow_module_level=True,

--- a/sdks/python/tests/testlib/environment.py
+++ b/sdks/python/tests/testlib/environment.py
@@ -17,3 +17,18 @@ def has_openai_api_key():
         and "OPENAI_ORG_ID" in os.environ
         and len(os.environ["OPENAI_ORG_ID"]) > 0
     )
+
+
+def should_skip_library_integration_tests():
+    """
+    Determines whether library integration tests should be skipped.
+
+    This function checks the availability of the OpenAI API key to decide
+    whether the library integration tests should be executed. If the API key
+    is not available, the function returns True, indicating that tests should
+    be skipped.
+
+    Returns:
+        bool: True if integration tests should be skipped, otherwise False.
+    """
+    return not has_openai_api_key()


### PR DESCRIPTION
## Details
We have a bunch of framework integration tests that is dependent on the availability of API_KEY credentials to be executed. When running on PRs from third-party contributors all these tests fail making unnecessary noise in the build results.

We need to implement mechanism to skip such tests if there are no API_KEY credentials found. This will improve PR UX for third-party contributors.

## Key Changes:
This PR implements a mechanism to skip library integration tests when OpenAI API credentials are not available, improving the PR experience for third-party contributors by avoiding unnecessary test failures due to missing credentials.

- Added automatic test skipping based on OpenAI API key availability
- Applied skip logic to both `library_integration` and `e2e_library_integration` test suites
- Implemented centralized credential checking through `environment.should_skip_library_integration_tests()`

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-3308

## Testing

Manually tested

## Documentation

No changes