### PR TITLE
[OPIK-3199] [FE] Add subtitle for Alerts page

### DIFF
--- a/apps/opik-frontend/src/components/pages/AlertsPage/AlertsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/AlertsPage/AlertsPage.tsx
@@ -44,6 +44,8 @@ import {
 } from "@/components/shared/DataTable/utils";
 import { Separator } from "@/components/ui/separator";
 import AlertsActionsPanel from "@/components/pages/AlertsPage/AlertsActionsPanel";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import ExplainerDescription from "@/components/shared/ExplainerDescription/ExplainerDescription";
 
 export const getRowId = (a: Alert) => a.id!;
 
@@ -304,9 +306,15 @@ const AlertsPage: React.FunctionComponent = () => {
 
   return (
     <div className="pt-6">
-      <h1 className="comet-title-l">Alerts</h1>
+      <div className="mb-1 flex items-center justify-between">
+        <h1 className="comet-title-l">Alerts</h1>
+      </div>
+      <ExplainerDescription
+        className="mb-4"
+        {...EXPLAINERS_MAP[EXPLAINER_ID.whats_an_alert]}
+      />
 
-      <div className="mt-6">
+      <div className="mt-2">
         <div className="mb-4 flex items-center justify-between gap-8">
           <div className="flex items-center gap-2">
             <SearchInput

--- a/apps/opik-frontend/src/constants/explainers.ts
+++ b/apps/opik-frontend/src/constants/explainers.ts
@@ -78,6 +78,7 @@ export enum EXPLAINER_ID {
   prompt_generation_learn_more = "prompt_generation_learn_more",
   prompt_improvement_learn_more = "prompt_improvement_learn_more",
   prompt_improvement_optimizer = "prompt_improvement_optimizer",
+  whats_an_alert = "whats_an_alert",
 }
 
 export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
@@ -548,5 +549,11 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     description:
       "Looking for advanced optimization algorithms? Check out the Opik optimizer!",
     docLink: "/agent_optimization/opik_optimizer/overview",
+  },
+  [EXPLAINER_ID.whats_an_alert]: {
+    id: EXPLAINER_ID.whats_an_alert,
+    description:
+      "Monitor important events in your project and get notified when something needs your attention.",
+    docLink: "/production/alerts",
   },
 };


### PR DESCRIPTION
## Details
Add subtitle for Alerts page

<img width="1718" height="680" alt="Screenshot 2025-11-28 at 09 24 04" src="https://github.com/user-attachments/assets/31f689cf-2926-437f-b22d-4d1c5d00a103" />

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-3199

## Testing
NA

## Documentation
NA