### PR TITLE
[NA] [SDK] fix: remove return statements from finally blocks for Python 3.14 compatibility

### DIFF
--- a/sdks/python/src/opik/decorator/base_track_decorator.py
+++ b/sdks/python/src/opik/decorator/base_track_decorator.py
@@ -336,25 +336,24 @@ class BaseTrackDecorator(abc.ABC):
                 )
                 error_info = error_info_collector.collect(exception)
                 func_exception = exception
-            finally:
-                stream_or_stream_manager = self._streams_handler(
-                    result,
-                    track_options.capture_output,
-                    track_options.generations_aggregator,
-                )
-                if stream_or_stream_manager is not None:
-                    return stream_or_stream_manager
 
-                self._after_call(
-                    output=result,
-                    error_info=error_info,
-                    capture_output=track_options.capture_output,
-                    flush=track_options.flush,
-                )
-                if func_exception is not None:
-                    raise func_exception
-                else:
-                    return result
+            stream_or_stream_manager = self._streams_handler(
+                result,
+                track_options.capture_output,
+                track_options.generations_aggregator,
+            )
+            if stream_or_stream_manager is not None:
+                return stream_or_stream_manager
+
+            self._after_call(
+                output=result,
+                error_info=error_info,
+                capture_output=track_options.capture_output,
+                flush=track_options.flush,
+            )
+            if func_exception is not None:
+                raise func_exception
+            return result
 
         wrapper.opik_tracked = True  # type: ignore
 
@@ -390,25 +389,24 @@ class BaseTrackDecorator(abc.ABC):
                 )
                 error_info = error_info_collector.collect(exception)
                 func_exception = exception
-            finally:
-                stream_or_stream_manager = self._streams_handler(
-                    result,
-                    track_options.capture_output,
-                    track_options.generations_aggregator,
-                )
-                if stream_or_stream_manager is not None:
-                    return stream_or_stream_manager
 
-                self._after_call(
-                    output=result,
-                    error_info=error_info,
-                    capture_output=track_options.capture_output,
-                    flush=track_options.flush,
-                )
-                if func_exception is not None:
-                    raise func_exception
-                else:
-                    return result
+            stream_or_stream_manager = self._streams_handler(
+                result,
+                track_options.capture_output,
+                track_options.generations_aggregator,
+            )
+            if stream_or_stream_manager is not None:
+                return stream_or_stream_manager
+
+            self._after_call(
+                output=result,
+                error_info=error_info,
+                capture_output=track_options.capture_output,
+                flush=track_options.flush,
+            )
+            if func_exception is not None:
+                raise func_exception
+            return result
 
         wrapper.opik_tracked = True  # type: ignore
         return wrapper

--- a/sdks/python/src/opik/synchronization.py
+++ b/sdks/python/src/opik/synchronization.py
@@ -40,15 +40,14 @@ def until(
     while True:
         try:
             if function():
-                break
+                return True
         except Exception:
             LOGGER.debug(
                 f"{function.__name__} raised error in 'until' function.", exc_info=True
             )
             if not allow_errors:
                 raise
-        finally:
-            if (time.time() - start_time) > max_try_seconds:
-                return False
-            time.sleep(sleep)
-    return True
+
+        if (time.time() - start_time) > max_try_seconds:
+            return False
+        time.sleep(sleep)


### PR DESCRIPTION
## Details

Remove return statements from finally blocks to eliminate `SyntaxWarning` in Python 3.14+. Python 3.14 deprecates `return` statements inside `finally` blocks as they can silently swallow exceptions.

Changes made:
- `src/opik/api_objects/opik_client.py`: Refactored `_report()` to use early return pattern instead of return in finally
- `src/opik/message_processing/streamer.py`: Refactored `close()` to track success state and return after finally block

## Change checklist

- [x] Code follows project style guidelines
- [x] Changes are backwards compatible
- [x] No new dependencies added

## Issues

N/A - Proactive fix for upcoming Python 3.14 compatibility

## Testing

- Existing unit tests pass
- Existing e2e tests pass
- No behavioral changes, only refactoring to avoid deprecated syntax

## Documentation

No documentation changes needed - internal implementation detail only.