### PR TITLE
[NA]: Revert default boolean feedback definition

### DIFF
--- a/apps/opik-frontend/src/components/shared/AddEditFeedbackDefinitionDialog/FeedbackDefinitionDetails/BooleanFeedbackDefinitionDetails.tsx
+++ b/apps/opik-frontend/src/components/shared/AddEditFeedbackDefinitionDialog/FeedbackDefinitionDetails/BooleanFeedbackDefinitionDetails.tsx
@@ -19,7 +19,7 @@ const BooleanFeedbackDefinitionDetails: React.FunctionComponent<
 > = ({ onChange, details }) => {
   const [booleanDetails, setBooleanDetails] = useState<
     BooleanFeedbackDefinition["details"]
-  >(details ?? { true_label: "", false_label: "" });
+  >(details ?? { true_label: "Pass", false_label: "Fail" });
 
   useEffect(() => {
     const isValid =


### PR DESCRIPTION
## Details
To have a default for boolean type of feedback definitions, and keep the behavior consistent with the Numerical type

Reverts a small change in https://github.com/comet-ml/opik/pull/4273

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing

## Documentation
