### PR TITLE
[NA] [SDK] Fix TypeScript SDK typecheck errors

### DIFF
--- a/sdks/typescript/src/opik/rest_api/api/types/AutomationRuleEvaluator.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/AutomationRuleEvaluator.ts
@@ -44,7 +44,6 @@ export namespace AutomationRuleEvaluator {
         createdBy?: string;
         lastUpdatedAt?: Date;
         lastUpdatedBy?: string;
-        filters: Record<string, unknown>[];
         action: "evaluator";
     }
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/AutomationRuleEvaluatorObjectObjectPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/AutomationRuleEvaluatorObjectObjectPublic.ts
@@ -45,7 +45,6 @@ export namespace AutomationRuleEvaluatorObjectObjectPublic {
         createdBy?: string;
         lastUpdatedAt?: Date;
         lastUpdatedBy?: string;
-        filters: Record<string, unknown>[];
         action: "evaluator";
     }
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/AutomationRuleEvaluatorPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/AutomationRuleEvaluatorPublic.ts
@@ -45,7 +45,6 @@ export namespace AutomationRuleEvaluatorPublic {
         createdBy?: string;
         lastUpdatedAt?: Date;
         lastUpdatedBy?: string;
-        filters: OpikApi.FilterPublic[];
         action: "evaluator";
     }
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/AutomationRuleEvaluatorWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/AutomationRuleEvaluatorWrite.ts
@@ -39,7 +39,6 @@ export namespace AutomationRuleEvaluatorWrite {
         name: string;
         samplingRate?: number;
         enabled?: boolean;
-        filters: OpikApi.FilterWrite[];
         action: "evaluator";
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/AutomationRuleEvaluator.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/AutomationRuleEvaluator.ts
@@ -22,9 +22,6 @@ const _Base = core.serialization.object({
     createdBy: core.serialization.property("created_by", core.serialization.string().optional()),
     lastUpdatedAt: core.serialization.property("last_updated_at", core.serialization.date().optional()),
     lastUpdatedBy: core.serialization.property("last_updated_by", core.serialization.string().optional()),
-    filters: core.serialization.list(
-        core.serialization.record(core.serialization.string(), core.serialization.unknown()),
-    ),
     action: core.serialization.stringLiteral("evaluator"),
 });
 export const AutomationRuleEvaluator: core.serialization.Schema<
@@ -84,7 +81,6 @@ export declare namespace AutomationRuleEvaluator {
         created_by?: string | null;
         last_updated_at?: string | null;
         last_updated_by?: string | null;
-        filters: Record<string, unknown>[];
         action: "evaluator";
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/AutomationRuleEvaluatorObjectObjectPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/AutomationRuleEvaluatorObjectObjectPublic.ts
@@ -22,9 +22,6 @@ const _Base = core.serialization.object({
     createdBy: core.serialization.property("created_by", core.serialization.string().optional()),
     lastUpdatedAt: core.serialization.property("last_updated_at", core.serialization.date().optional()),
     lastUpdatedBy: core.serialization.property("last_updated_by", core.serialization.string().optional()),
-    filters: core.serialization.list(
-        core.serialization.record(core.serialization.string(), core.serialization.unknown()),
-    ),
     action: core.serialization.stringLiteral("evaluator"),
 });
 export const AutomationRuleEvaluatorObjectObjectPublic: core.serialization.Schema<
@@ -84,7 +81,6 @@ export declare namespace AutomationRuleEvaluatorObjectObjectPublic {
         created_by?: string | null;
         last_updated_at?: string | null;
         last_updated_by?: string | null;
-        filters: Record<string, unknown>[];
         action: "evaluator";
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/AutomationRuleEvaluatorPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/AutomationRuleEvaluatorPublic.ts
@@ -23,7 +23,6 @@ const _Base = core.serialization.object({
     createdBy: core.serialization.property("created_by", core.serialization.string().optional()),
     lastUpdatedAt: core.serialization.property("last_updated_at", core.serialization.date().optional()),
     lastUpdatedBy: core.serialization.property("last_updated_by", core.serialization.string().optional()),
-    filters: core.serialization.list(FilterPublic),
     action: core.serialization.stringLiteral("evaluator"),
 });
 export const AutomationRuleEvaluatorPublic: core.serialization.Schema<
@@ -83,7 +82,6 @@ export declare namespace AutomationRuleEvaluatorPublic {
         created_by?: string | null;
         last_updated_at?: string | null;
         last_updated_by?: string | null;
-        filters: FilterPublic.Raw[];
         action: "evaluator";
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/AutomationRuleEvaluatorWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/AutomationRuleEvaluatorWrite.ts
@@ -17,7 +17,6 @@ const _Base = core.serialization.object({
     name: core.serialization.string(),
     samplingRate: core.serialization.property("sampling_rate", core.serialization.number().optional()),
     enabled: core.serialization.boolean().optional(),
-    filters: core.serialization.list(FilterWrite),
     action: core.serialization.stringLiteral("evaluator"),
 });
 export const AutomationRuleEvaluatorWrite: core.serialization.Schema<
@@ -71,7 +70,6 @@ export declare namespace AutomationRuleEvaluatorWrite {
         name: string;
         sampling_rate?: number | null;
         enabled?: boolean | null;
-        filters: FilterWrite.Raw[];
         action: "evaluator";
     }
 }


### PR DESCRIPTION
## Details

Fixed type conflicts in the TypeScript SDK's AutomationRuleEvaluator types that were introduced by recent backend changes that added support for span-level LLM-as-Judge automation rule evaluators #4264.

The backend made `AutomationRuleEvaluator` generic with different filter types for different evaluators (`TraceFilter`, `SpanFilter`, `TraceThreadFilter`).

When the OpenAPI spec was regenerated and the TypeScript SDK was generated via Fern, the type definitions had conflicting `filters` properties:
- Each specific evaluator type (e.g., `AutomationRuleEvaluatorLlmAsJudge`) defines `filters` with its own specific type (e.g., `TraceFilter[]`)
- The `_Base` interface also defined `filters` with a generic type (`Record<string, unknown>[]` or `FilterPublic[]`)
- When TypeScript tried to merge these interfaces, it failed with type conflicts

**Solution**: Removed the `filters` property from all `_Base` interfaces since each evaluator variant already has its own properly-typed `filters` property. This allows each variant to define its own filter type without conflicts.

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues
- NA

## Testing

Manual verification:
- Confirmed all `filters` type conflict errors are resolved with ` npm run typecheck`.
## Documentation

N/A - This is a bug fix for generated SDK code that restores correct TypeScript type definitions.