### PR TITLE
[OPIK-3211] [BE] Replace manual JSON traversal with JSONPath library

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/FilterEvaluationServiceBase.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/FilterEvaluationServiceBase.java
@@ -146,7 +146,13 @@ public abstract class FilterEvaluationServiceBase<E> {
         String normalizedKey = normalizeJsonPath(key);
 
         // Normalize the path to ensure it starts with $. for JSONPath
-        String jsonPath = normalizedKey.startsWith("$") ? normalizedKey : "$." + normalizedKey;
+        // If key is blank, return root path "$" instead of "$." which JsonPath rejects
+        String jsonPath;
+        if (StringUtils.isBlank(normalizedKey)) {
+            jsonPath = "$";
+        } else {
+            jsonPath = normalizedKey.startsWith("$") ? normalizedKey : "$." + normalizedKey;
+        }
 
         try {
             String jsonString;


### PR DESCRIPTION
# User description
## Details

- Replace custom navigateJsonPath() method with Jayway JSONPath library
- Simplify extractNestedValue() to use JsonPath.read() with configuration
- Add JSON_PATH_CONFIG with options for null handling and exception suppression
- Remove ~115 lines of manual path parsing code
- Maintains backward compatibility with existing path formats
- All 110 AutomationRuleEvaluatorsResourceTest tests passing

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-3211

## Testing
NA 

## Documentation
NA

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
FilterEvaluationServiceBase_extractNestedValue_("FilterEvaluationServiceBase.extractNestedValue"):::modified
FilterEvaluationServiceBase_normalizeJsonPath_("FilterEvaluationServiceBase.normalizeJsonPath"):::added
JSONPATH_("JSONPATH"):::added
FilterEvaluationServiceBase_extractNestedValue_ -- "Now calls normalizeJsonPath to convert numeric dot notation." --> FilterEvaluationServiceBase_normalizeJsonPath_
FilterEvaluationServiceBase_extractNestedValue_ -- "Uses JSONPATH to parse JSON and extract nested values." --> JSONPATH_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Refactor the <code>FilterEvaluationServiceBase</code> component to replace its custom JSON path traversal implementation with the robust Jayway JSONPath library, simplifying the <code>extractNestedValue</code> method for more efficient and reliable nested field extraction.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>thiagoh@comet.com</td><td>OPIK-3210-FE-Add-span-...</td><td>December 02, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/comet-ml/opik/4313?tool=ast>(Baz)</a>.