### PR TITLE
[OPIK-3337] [SDK] Skip creating optimization when optimization_id is provided

### DIFF
--- a/sdks/opik_optimizer/src/opik_optimizer/utils/core.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/utils/core.py
@@ -69,15 +69,23 @@ class OptimizationContextManager:
         self.optimization: Optimization | None = None
 
     def __enter__(self) -> Optimization | None:
-        """Create and return the optimization."""
+        """Get existing optimization or create a new one."""
         try:
-            self.optimization = self.client.create_optimization(
-                dataset_name=self.dataset_name,
-                objective_name=self.objective_name,
-                name=self.name,
-                metadata=self.metadata,
-                optimization_id=self.optimization_id,
-            )
+            if self.optimization_id:
+                # If optimization_id is provided, get the existing optimization
+                # instead of creating a new one. This is used by Optimization Studio
+                # where the optimization is pre-created by the Java backend.
+                self.optimization = self.client.get_optimization_by_id(
+                    self.optimization_id
+                )
+            else:
+                # Create a new optimization
+                self.optimization = self.client.create_optimization(
+                    dataset_name=self.dataset_name,
+                    objective_name=self.objective_name,
+                    name=self.name,
+                    metadata=self.metadata,
+                )
 
             if self.optimization:
                 return self.optimization


### PR DESCRIPTION
## Details
When `OptimizationContextManager` receives an `optimization_id` parameter (e.g., from Optimization Studio where the Java backend pre-creates the optimization), it now calls `get_optimization_by_id()` instead of `create_optimization()`.

This prevents the SDK from creating duplicate optimization records with different metadata (name, dataset_id) that would overwrite the original Studio optimization and lose the `studio_config`.

**Before**: SDK always called `create_optimization()`, even when `optimization_id` was provided, causing duplicate records in ClickHouse.

**After**: SDK checks if `optimization_id` is provided and fetches the existing optimization instead of creating a new one.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-3337

## Testing
- Manual integration testing with Optimization Studio to confirm `studio_config` is preserved after status updates

## Documentation
N/A - Internal SDK behavior change