### PR TITLE
[OPIK-3337] [Python BE] bumping opik sdk and optimizer

### DIFF
--- a/apps/opik-python-backend/requirements.txt
+++ b/apps/opik-python-backend/requirements.txt
@@ -6,7 +6,7 @@ docker==7.1.0
 Flask==3.1.0
 gunicorn==23.0.0
 uuid6==2024.7.10
-opik==1.9.31
+opik==1.9.37
 idna==3.10
 itsdangerous==2.2.0
 Jinja2==3.1.6
@@ -27,5 +27,5 @@ schedule==1.2.1
 tiktoken==0.9.0
 redis==6.4.0
 rq==2.6.0
-opik-optimizer==2.3.5
+opik-optimizer==2.3.6
 gepa==0.0.17


### PR DESCRIPTION
## Details

Bumping Opik sdk and optimizer to fix OPIK-3337, as optimizer 2.3.5 was recreating optimizations. 

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-3337

## Testing

## Documentation
