### PR TITLE
[OPIK-3321] [FE] Fix image rendering in experiment comparison for small/medium row heights

### DIFF
--- a/apps/opik-frontend/src/components/shared/DataTableCells/MediaCell.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableCells/MediaCell.tsx
@@ -10,10 +10,10 @@ import CellTooltipWrapper from "@/components/shared/DataTableCells/CellTooltipWr
 const MediaCell = <TData,>(context: CellContext<TData, unknown>) => {
   const value = context.getValue() as string;
 
-  const rowHeight =
-    context.column.columnDef.meta?.overrideRowHeight ??
-    context.table.options.meta?.rowHeight ??
-    ROW_HEIGHT.small;
+  // Use only the user's row height setting, not overrideRowHeight
+  // overrideRowHeight is for layout purposes only (e.g., split cells in experiment comparison)
+  // The user's row height selection should determine whether images or links are displayed
+  const rowHeight = context.table.options.meta?.rowHeight ?? ROW_HEIGHT.small;
 
   const isBig = rowHeight === ROW_HEIGHT.large;
 


### PR DESCRIPTION
## Details

Fixes a UI rendering issue when comparing experiments with datasets containing images.

**Problem:** Images were always displayed in experiment comparison tables even when the row height was set to "small" or "medium". The expected behavior is that images should only be displayed when rows are in "large" mode - for small/medium heights, the image URL/link should be shown instead.

**Root Cause:** `MediaCell` was using `overrideRowHeight` (which is set to `ROW_HEIGHT.large` for split cells in experiment comparison) to determine whether to show images. This caused images to always render regardless of the user's row height selection.

**Fix:** Changed `MediaCell` to only use the user's selected row height setting (`context.table.options.meta?.rowHeight`) to determine whether to display images or links. The `overrideRowHeight` is still passed to `CellWrapper` for layout/styling purposes.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3321

## Testing

1. Navigate to an experiment comparison page with a dataset containing images
2. Set row height to "small" or "medium"
3. Verify that image URLs are shown as text links instead of rendered images
4. Set row height to "large"
5. Verify that images are now rendered

tested manually in the dataset page and in experiment compare page

<img width="1463" height="769" alt="SCR-20251202-phgi" src="https://github.com/user-attachments/assets/e4e309f9-fe7b-4402-bc5f-7b8befc80c78" />

<img width="1304" height="962" alt="SCR-20251202-pghe" src="https://github.com/user-attachments/assets/94aebfb5-0e8c-4e2f-810e-5f98573c48c9" />

<img width="1339" height="823" alt="SCR-20251202-pggb" src="https://github.com/user-attachments/assets/f850d787-c64f-4b0a-a21e-eb19f54c58d1" />
<img width="1325" height="938" alt="SCR-20251202-pgez" src="https://github.com/user-attachments/assets/0e23fc94-710c-402e-8418-b6a56c9f1435" />

<img width="1419" height="754" alt="SCR-20251202-phhg" src="https://github.com/user-attachments/assets/a5457e46-95bc-492a-8a89-61fa8e632dd3" />


## Documentation

No documentation changes required - this is a bug fix that restores expected behavior.