### PR TITLE
[OPIK-3353] [BE] Add time range filter to spans subqueries for improved query performance

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -964,6 +964,8 @@ class TraceDAOImpl implements TraceDAO {
                     FROM spans FINAL
                     WHERE workspace_id = :workspace_id
                       AND project_id = :project_id
+                      <if(uuid_from_time)>AND trace_id >= :uuid_from_time<endif>
+                      <if(uuid_to_time)>AND trace_id \\<= :uuid_to_time<endif>
                     ORDER BY (workspace_id, project_id, trace_id, parent_span_id, id) DESC, last_updated_at DESC
                     LIMIT 1 BY id
                 ) AS s ON sfs.entity_id = s.id
@@ -1035,6 +1037,8 @@ class TraceDAOImpl implements TraceDAO {
                 FROM spans final
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
+                <if(uuid_from_time)>AND trace_id >= :uuid_from_time<endif>
+                <if(uuid_to_time)>AND trace_id \\<= :uuid_to_time<endif>
                 GROUP BY workspace_id, project_id, trace_id
             ), comments_agg AS (
                 SELECT
@@ -1412,6 +1416,8 @@ class TraceDAOImpl implements TraceDAO {
                     FROM spans FINAL
                     WHERE workspace_id = :workspace_id
                       AND project_id = :project_id
+                      <if(uuid_from_time)>AND trace_id >= :uuid_from_time<endif>
+                      <if(uuid_to_time)>AND trace_id \\<= :uuid_to_time<endif>
                     ORDER BY (workspace_id, project_id, trace_id, parent_span_id, id) DESC, last_updated_at DESC
                     LIMIT 1 BY id
                 ) AS s ON sfs.entity_id = s.id


### PR DESCRIPTION
## Details

This PR adds time range filters (`uuid_from_time` and `uuid_to_time`) to spans table scans in the trace queries. Previously, when filtering traces by time range (`from_time`/`to_time` parameters), the time filter was only applied to the `traces` table but not to the `spans` table joins, causing full scans of the spans table for the entire project.

### Changes

Added conditional time filters to spans subqueries:
- `<if(uuid_from_time)>AND trace_id >= :uuid_from_time<endif>`
- `<if(uuid_to_time)>AND trace_id <= :uuid_to_time<endif>`

### Updated Locations

1. **`span_feedback_scores_with_trace_id`** CTE - The spans INNER JOIN that fetches span feedback scores
2. **`spans_agg`** CTE - The spans aggregation that calculates usage, cost, and span counts

### Affected Queries

- `SELECT_BY_PROJECT_ID` - Main traces listing query
- `COUNT_BY_PROJECT_ID` - Traces count query

### Performance Impact

When using `from_time` and/or `to_time` query parameters, spans will now be filtered by `trace_id` bounds, significantly reducing the number of granules scanned for projects with large historical data.

**Before:** Spans table scanned for entire project (all granules)
**After:** Spans table filtered by time range (only relevant granules)

Since UUIDv7 embeds timestamps, filtering by `trace_id >= uuid_from_time` allows ClickHouse to use the primary index to skip irrelevant granules.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3353

## Testing

The time filters are conditionally applied only when `uuid_from_time`/`uuid_to_time` are present in the search criteria. Existing functionality without time filtering remains unchanged.

### Manual testing:
1. Query traces with `from_time` parameter
2. Check ClickHouse query logs to verify time filters appear in spans CTEs

### Documentation
N/A

