### PR TITLE
[NA] [BE] Fix ClassCastException in OnlineScoringEngine for JSON values

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -411,7 +411,8 @@ public class OnlineScoringEngine {
         }
 
         try {
-            return JsonPath.parse(forcedObject).read(path);
+            var value = JsonPath.parse(forcedObject).read(path);
+            return value != null ? value.toString() : null;
         } catch (Exception e) {
             log.warn("couldn't find path inside json, trying flat structure, path={}, json={}", path, json, e);
             return Optional.ofNullable(forcedObject.get(path.replace("$.", "")))

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
@@ -734,6 +734,77 @@ class OnlineScoringEngineTest {
                 arguments("subObject.nestedKey", "{\"subObject\":{\"nestedKey\":\"expected-value\"}}"));
     }
 
+    private static Stream<Arguments> testExtractFromJsonWithDifferentValueTypes() {
+        return Stream.of(
+                // ===== TOP-LEVEL KEYS =====
+                // JSON scalars: Strings, Numbers (Integers and Decimals), Booleans, Null
+                arguments("key", "{\"key\":\"text\"}", "text"),
+                arguments("key", "{\"key\":123}", "123"),
+                arguments("key", "{\"key\":1.23}", "1.23"),
+                arguments("key", "{\"key\":true}", "true"),
+                arguments("key", "{\"key\":null}", ""),
+                // JSON objects
+                arguments("key", "{\"key\":{\"object\":\"text\"}}", "{object&#61;text}"),
+                arguments("key", "{\"key\":{\"object\":123}}", "{object&#61;123}"),
+                arguments("key", "{\"key\":{\"object\":1.23}}", "{object&#61;1.23}"),
+                arguments("key", "{\"key\":{\"object\":true}}", "{object&#61;true}"),
+                arguments("key", "{\"key\":{\"object\":null}}", "{object&#61;null}"),
+                arguments("key", "{\"key\":{\"a\":1,\"b\":2}}", "{a&#61;1, b&#61;2}"),
+                arguments("key", "{\"key\":{}}", "{}"),
+                // JSON Arrays
+                arguments("key", "{\"key\":[\"a\",\"b\"]}", "[a, b]"),
+                arguments("key", "{\"key\":[1,2]}", "[1, 2]"),
+                arguments("key", "{\"key\":[1.2,3.4]}", "[1.2, 3.4]"),
+                arguments("key", "{\"key\":[true,false]}", "[true, false]"),
+                arguments("key", "{\"key\":[null,null]}", "[null, null]"),
+                arguments("key", "{\"key\":[]}", "[]"),
+
+                // ===== NESTED KEYS =====
+                // JSON scalars: Strings, Numbers (Integers and Decimals), Booleans, Null
+                // Types other than String under nested keys were causing the original production bug
+                arguments("nested.key", "{\"nested\":{\"key\":\"text\"}}", "text"),
+                arguments("nested.key", "{\"nested\":{\"key\":123}}", "123"),
+                arguments("nested.key", "{\"nested\":{\"key\":1.23}}", "1.23"),
+                arguments("nested.key", "{\"nested\":{\"key\":true}}", "true"),
+                arguments("nested.key", "{\"nested\":{\"key\":null}}", ""),
+                // Objects (with all scalar types inside)
+                arguments("nested.key", "{\"nested\":{\"key\":{\"object\":\"text\"}}}", "{object&#61;text}"),
+                arguments("nested.key", "{\"nested\":{\"key\":{\"object\":123}}}", "{object&#61;123}"),
+                arguments("nested.key", "{\"nested\":{\"key\":{\"object\":1.23}}}", "{object&#61;1.23}"),
+                arguments("nested.key", "{\"nested\":{\"key\":{\"object\":true}}}", "{object&#61;true}"),
+                arguments("nested.key", "{\"nested\":{\"key\":{\"object\":null}}}", "{object&#61;null}"),
+                arguments("nested.key", "{\"nested\":{\"key\":{\"x\":10,\"y\":20}}}", "{x&#61;10, y&#61;20}"),
+                arguments("nested.key", "{\"nested\":{\"key\":{}}}", "{}"),
+                // Arrays (with all scalar types)
+                arguments("nested.key", "{\"nested\":{\"key\":[\"a\",\"b\"]}}", "[a, b]"),
+                arguments("nested.key", "{\"nested\":{\"key\":[1,2]}}", "[1, 2]"),
+                arguments("nested.key", "{\"nested\":{\"key\":[1.2,3.4]}}", "[1.2, 3.4]"),
+                arguments("nested.key", "{\"nested\":{\"key\":[true,false]}}", "[true, false]"),
+                arguments("nested.key", "{\"nested\":{\"key\":[null,null]}}", "[null, null]"),
+                arguments("nested.key", "{\"nested\":{\"key\":[]}}", "[]"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("renderMessages should handle different JSON value types without ClassCastException")
+    void testExtractFromJsonWithDifferentValueTypes(String key, String jsonBody, String expectedValue) {
+        var variables = Map.of("testVar", "input." + key);
+        var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                .input(JsonUtils.getJsonNodeFromString(jsonBody))
+                .build();
+
+        // Render a message using the variable
+        var template = List.of(LlmAsJudgeMessage.builder()
+                .role(ChatMessageType.USER)
+                .content("Test value: {{testVar}}")
+                .build());
+        var rendered = OnlineScoringEngine.renderMessages(template, variables, trace);
+        assertThat(rendered).hasSize(1);
+        var userMessage = rendered.getFirst();
+        assertThat(userMessage).isInstanceOf(UserMessage.class);
+        assertThat(((UserMessage) userMessage).singleText()).contains("Test value: " + expectedValue);
+    }
+
     @Test
     @DisplayName("should handle multimodal content with multiple images")
     void shouldHandleMultimodalContent_whenMultipleImages() {


### PR DESCRIPTION
## Details

Fixed a critical bug in the `OnlineScoringEngine` that was causing `ClassCastException` when processing trace data with non-string JSON values in nested keys during online scoring evaluation.

### Root Cause
When extracting values from JSON using JsonPath, the library returns typed Java objects:
- Numbers → `Integer`, `Double`
- Booleans → `Boolean`
- Objects → `Map`
- Arrays → `List`
- Strings → `String`

The original code assumed all extracted values were strings, leading to `ClassCastException` when variable mappings pointed to non-string values in nested paths (e.g., `input.nested.numberField`).

### Solution
Modified the `extractFromJson()` method to call `.toString()` on the extracted value, ensuring consistent string conversion for all JSON types:
- Numbers: `123` → `"123"`, `1.23` → `"1.23"`
- Booleans: `true` → `"true"`
- Null: `null` → `""`
- Objects: `{a:1, b:2}` → `"{a=1, b=2}"`
- Arrays: `[1,2,3]` → `"[1, 2, 3]"`

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues
- NA

## Testing

Added comprehensive parameterized test `testExtractFromJsonWithDifferentValueTypes()` which validates that `renderMessages()` handles all JSON value types without throwing `ClassCastException`, covering:
- All JSON scalar types (String, Integer, Double, Boolean, Null)
- Complex types (Objects, Arrays) with all scalar types inside
- Both top-level and nested key paths
  - Nested key was the problematic one.
- Empty objects and empty arrays
- Total of 26 test cases ensuring robust handling of all JSON value types

***This test was capable of reproducing the issue prior to the fix:***

```java
arguments("nested.key", "{\"nested\":{\"key\":123}}", "123")
// Before: ClassCastException trying to cast Integer to String
// After: Successfully converts 123 to "123"
```

### Manual Testing
This will be regressed by our CI, as it caught the issue previously.

Manual testing can be done with these steps:
1. Create an automation rule with variables mapping to nested non-string fields
2. Create a trace with input/output containing nested numbers, booleans, objects, or arrays
3. Verify the online scoring engine processes the trace without errors
4. Verify scores are generated.
5. Verify rule logs show success.

## Documentation
N/A - Internal bug fix, no user-facing documentation changes needed.