### PR TITLE
[NA] [E2E] Fix Opik client management in test helper service

### DIFF
--- a/tests_end_to_end/tests_end_to_end_ts/test-helper-service/app.py
+++ b/tests_end_to_end/tests_end_to_end_ts/test-helper-service/app.py
@@ -36,6 +36,10 @@ def authenticate_if_needed():
     # Check if API key already exists
     if os.environ.get("OPIK_API_KEY"):
         print("✅ API key already set, skipping authentication")
+        # Still ensure OPIK_URL_OVERRIDE is set even if API key exists
+        if not os.environ.get("OPIK_URL_OVERRIDE"):
+            os.environ["OPIK_URL_OVERRIDE"] = f"{base_url}/api"
+            print(f"📍 Setting API URL: {os.environ.get('OPIK_URL_OVERRIDE')}")
         return
 
     # Get credentials from environment

--- a/tests_end_to_end/tests_end_to_end_ts/test-helper-service/routes/datasets.py
+++ b/tests_end_to_end/tests_end_to_end_ts/test-helper-service/routes/datasets.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, request, jsonify
-import opik
+import os
+from opik import Opik
 from opik.rest_api.core.api_error import ApiError
 import time
 import logging
@@ -9,7 +10,12 @@ logger = logging.getLogger(__name__)
 
 
 def get_opik_client():
-    return opik.Opik()
+    """Get configured Opik SDK client"""
+    return Opik(
+        api_key=os.getenv("OPIK_API_KEY", None),
+        workspace=os.getenv("OPIK_WORKSPACE", None),
+        host=os.getenv("OPIK_URL_OVERRIDE", None),
+    )
 
 
 @datasets_bp.route("/create", methods=["POST"])
@@ -52,10 +58,8 @@ def update_dataset():
     dataset = client.get_dataset(dataset_name)
     dataset_id = dataset.id
 
-    from opik.rest_api.client import OpikApi
-
-    api_client = OpikApi()
-    api_client.datasets.update_dataset(id=dataset_id, name=new_name)
+    # Use the rest_client from the Opik client which is already properly configured
+    client.rest_client.datasets.update_dataset(id=dataset_id, name=new_name)
 
     return jsonify({"id": dataset_id, "name": new_name})
 

--- a/tests_end_to_end/tests_end_to_end_ts/test-helper-service/routes/prompts.py
+++ b/tests_end_to_end/tests_end_to_end_ts/test-helper-service/routes/prompts.py
@@ -3,10 +3,8 @@
 from flask import Blueprint, request, abort
 from werkzeug.exceptions import HTTPException
 import time
-from opik import Prompt
 from .utils import (
     get_opik_client,
-    get_opik_api_client,
     build_error_response,
     success_response,
     validate_required_fields,
@@ -38,7 +36,8 @@ def create_prompt():
     name = data["name"]
     prompt_text = data["prompt"]
 
-    prompt = Prompt(name=name, prompt=prompt_text)
+    client = get_opik_client()
+    prompt = client.create_prompt(name=name, prompt=prompt_text)
 
     return success_response(
         {
@@ -90,7 +89,8 @@ def update_prompt():
     name = data["name"]
     prompt_text = data["prompt"]
 
-    prompt = Prompt(name=name, prompt=prompt_text)
+    client = get_opik_client()
+    prompt = client.create_prompt(name=name, prompt=prompt_text)
 
     return success_response(
         {
@@ -107,14 +107,15 @@ def delete_prompt():
     validate_required_fields(data, ["name"])
 
     name = data["name"]
-    api_client = get_opik_api_client()
+    client = get_opik_client()
 
-    prompts_response = api_client.prompts.get_prompts(name=name)
+    # Use the rest_client from the Opik client which is already properly configured
+    prompts_response = client.rest_client.prompts.get_prompts(name=name)
 
     if not prompts_response.content or len(prompts_response.content) == 0:
         abort(404, f"Prompt not found: {name}")
 
     prompt = prompts_response.content[0]
-    api_client.prompts.delete_prompt(id=prompt.id)
+    client.rest_client.prompts.delete_prompt(id=prompt.id)
 
     return success_response({"name": name})


### PR DESCRIPTION
## Details
Some tests were getting 500 errors on cloud environments due to the helper service hitting the default localhost link. Fixed by re-initializing the client on call so that it gets the correct URL and API link.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

NA

## Testing

## Documentation
