### PR TITLE
[NA] [BE] Disable span LLM as Judge feature

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -541,9 +541,9 @@ serviceToggles:
   # Default: false
   # Description: Whether or not to enable the trace thread Python evaluator
   traceThreadPythonEvaluatorEnabled: ${TOGGLE_TRACE_THREAD_PYTHON_EVALUATOR_ENABLED:-"true"}
-  # Default: true
+  # Default: false
   # Description: Whether or not to enable the span LLM as Judge evaluator
-  spanLlmAsJudgeEnabled: ${TOGGLE_SPAN_LLM_AS_JUDGE_ENABLED:-"true"}
+  spanLlmAsJudgeEnabled: ${TOGGLE_SPAN_LLM_AS_JUDGE_ENABLED:-"false"}
   # Default: false
   # Description: Whether or not OpikAI feature is enabled
   opikAIEnabled: ${TOGGLE_OPIK_AI_ENABLED:-"false"}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/ManualEvaluationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/ManualEvaluationService.java
@@ -148,8 +148,13 @@ class ManualEvaluationServiceImpl implements ManualEvaluationService {
                     traceThreadRules.add(traceThreadLlmAsJudge);
                 case AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython traceThreadPython ->
                     traceThreadRules.add(traceThreadPython);
-                case AutomationRuleEvaluatorSpanLlmAsJudge spanLlmAsJudge ->
-                    spanLlmAsJudgeRules.add(spanLlmAsJudge);
+                case AutomationRuleEvaluatorSpanLlmAsJudge spanLlmAsJudge -> {
+                    if (serviceTogglesConfig.isSpanLlmAsJudgeEnabled()) {
+                        spanLlmAsJudgeRules.add(spanLlmAsJudge);
+                    } else {
+                        log.info("Span LLM as Judge evaluator is disabled, skipping rule '{}'", rule.getId());
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Details

This PR disables the span LLM-as-Judge online scoring feature. The feature is disabled through the `TOGGLE_SPAN_LLM_AS_JUDGE_ENABLED` flag and comprehensive toggle checks across all related components.

### Changes Made:

1. **Configuration**
   - Set `TOGGLE_SPAN_LLM_AS_JUDGE_ENABLED` default to `false` (was `true`)

2. **Event Production**
   - Wrapped `SpansCreated` event posting with toggle check in both:
     - Single span creation
     - Batch span creation
   - Prevents events from being posted to the event bus when feature is disabled

3. **Stream Producer**
   - There's a pre-existing check on this flag already, no need for further changes.

4. **Stream Consumer**
   - Added `ServiceTogglesConfig` dependency injection
   - Overrode `start()` method to check toggle before starting consumer
   - Prevents Redis stream consumer from starting when feature is disabled

5. **Manual Evaluations**
   - Added toggle check during rule categorization (early filtering)
   - Prevents span LLM-as-Judge rules from being processed in manual evaluations
   - Avoids orphaned messages in Redis when feature is disabled

***When the feature is disabled (default state now):***
- ✅ No automatic online scoring for spans
- ✅ Stream consumer won't start (no processing overhead)
- ✅ Manual evaluations will skip span LLM-as-Judge rules
- ✅ No orphaned messages accumulating in Redis streams
- ✅ Consistent behavior across all evaluation paths

## Change checklist
<!-- Please check the type of changes made -->
- [X] User facing
- [ ] Documentation update

## Issues
- NA <!-- If no ticket, such as hotfixes etc. -->

## Testing

- ✅ Existing test coverage validates toggle behavior in `OnlineScoringSpanSamplerTest`
- ✅ Manually tested locally
- Deployment to stg and CI tests will regress changes.

## Documentation
- Updated `apps/opik-backend/config.yml` with new default value for `TOGGLE_SPAN_LLM_AS_JUDGE_ENABLED`
