### PR TITLE
[NA] [BE] Fix dashboard test method visibility for JUnit MethodSource

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DashboardsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DashboardsResourceTest.java
@@ -398,7 +398,7 @@ class DashboardsResourceTest {
                     .containsExactlyElementsOf(expectedDashboards.stream().map(Dashboard::id).toList());
         }
 
-        private Stream<Arguments> findDashboards__whenSortingByValidFields__thenReturnDashboardsSorted() {
+        static Stream<Arguments> findDashboards__whenSortingByValidFields__thenReturnDashboardsSorted() {
             Comparator<Dashboard> idComparator = Comparator.comparing(Dashboard::id);
             Comparator<Dashboard> nameComparator = Comparator.comparing(Dashboard::name, String.CASE_INSENSITIVE_ORDER);
             Comparator<Dashboard> createdAtComparator = Comparator.comparing(Dashboard::createdAt);


### PR DESCRIPTION
## Details
Fix for the test failure in PR #4322 where `DashboardsResourceTest$SortDashboards.findDashboards__whenSortingByValidFields__thenReturnDashboardsSorted` method was marked as `private`, causing JUnit's `@MethodSource` to fail with:

> org.junit.platform.commons.PreconditionViolationException: Method 'private java.util.stream.Stream<org.junit.jupiter.params.provider.Arguments> ...'

Changed the method from `private` to package-private (no modifier) to allow JUnit to access it.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- NA (hotfix for test failure)

## Testing
- Backend tests should now pass

## Documentation
N/A