### PR TITLE
[NA] [BE] Fix nested cache deadlock in AutomationRuleEvaluatorService

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/AutomationRuleEvaluatorService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/AutomationRuleEvaluatorService.java
@@ -409,8 +409,24 @@ class AutomationRuleEvaluatorServiceImpl implements AutomationRuleEvaluatorServi
         });
     }
 
+    /**
+     * Find all automation rule evaluators for a project.
+     * <p>
+     * <strong>WARNING:</strong> Do NOT add {@code @Cacheable} annotation to this method.
+     * This method delegates to the 3-parameter {@link #findAll(UUID, String, AutomationRuleEvaluatorType)}
+     * which already has caching. Adding {@code @Cacheable} here would create nested cache operations
+     * that cause nested {@code Mono.block()} calls, leading to reactor threading violations and
+     * Redis timeout exceptions.
+     * </p>
+     *
+     * @param projectId the project ID
+     * @param workspaceId the workspace ID
+     * @param <E> the entity type
+     * @param <F> the filter type
+     * @param <T> the automation rule evaluator type
+     * @return list of automation rule evaluators
+     */
     @Override
-    @Cacheable(name = "automation_rule_evaluators_find_all", key = "$projectId + '-' + $workspaceId", returnType = AutomationRuleEvaluator.class, wrapperType = List.class)
     public <E, F extends Filter, T extends AutomationRuleEvaluator<E, F>> List<T> findAll(
             @NonNull UUID projectId, @NonNull String workspaceId) {
         return findAll(projectId, workspaceId, null);

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/cache/CacheEvict.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/cache/CacheEvict.java
@@ -7,6 +7,29 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotation to evict entries from the cache.
+ * <p>
+ * <strong>CRITICAL WARNING - Avoid Nested Cache Operations:</strong>
+ * </p>
+ * <p>
+ * Do NOT use this annotation on overloaded methods where one delegates to another.
+ * When two overloaded methods both have {@code @CacheEvict} and one delegates to the other,
+ * it creates <strong>nested cache operations</strong> that cause:
+ * </p>
+ * <ul>
+ *   <li>Nested {@code Mono.block()} calls within the cache interceptor</li>
+ *   <li>Reactor threading violations</li>
+ *   <li>Redis timeout exceptions ({@code RedisTimeoutException})</li>
+ *   <li>Thread pool exhaustion under load</li>
+ * </ul>
+ * <p>
+ * <strong>Safe Usage:</strong> Only annotate the actual implementation method, not delegating methods.
+ * </p>
+ *
+ * @see Cacheable
+ * @see CachePut
+ */
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
@@ -29,7 +52,7 @@ public @interface CacheEvict {
      * @return whether the key is a pattern or not. Default is false.
      *
      * @see <a href="https://redis.io/commands/KEYS">Redis KEYS command documentation</a>
-     *
+     * <p>
      * This is useful when you want to evict multiple keys that match a pattern.
      * */
     boolean keyUsesPatternMatching() default false;

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/cache/CachePut.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/cache/CachePut.java
@@ -7,6 +7,29 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotation to update the cache with method results.
+ * <p>
+ * <strong>CRITICAL WARNING - Avoid Nested Cache Operations:</strong>
+ * </p>
+ * <p>
+ * Do NOT use this annotation on overloaded methods where one delegates to another.
+ * When two overloaded methods both have {@code @CachePut} and one delegates to the other,
+ * it creates <strong>nested cache operations</strong> that cause:
+ * </p>
+ * <ul>
+ *   <li>Nested {@code Mono.block()} calls within the cache interceptor</li>
+ *   <li>Reactor threading violations</li>
+ *   <li>Redis timeout exceptions ({@code RedisTimeoutException})</li>
+ *   <li>Thread pool exhaustion under load</li>
+ * </ul>
+ * <p>
+ * <strong>Safe Usage:</strong> Only annotate the actual implementation method, not delegating methods.
+ * </p>
+ *
+ * @see Cacheable
+ * @see CacheEvict
+ */
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/cache/Cacheable.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/cache/Cacheable.java
@@ -7,6 +7,55 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotation to enable caching on method results.
+ * <p>
+ * <strong>CRITICAL WARNING - Avoid Nested Cache Operations:</strong>
+ * </p>
+ * <p>
+ * Do NOT use this annotation on overloaded methods where one delegates to another.
+ * When two overloaded methods both have {@code @Cacheable} and one delegates to the other,
+ * it creates <strong>nested cache operations</strong> that cause:
+ * </p>
+ * <ul>
+ *   <li>Nested {@code Mono.block()} calls within the cache interceptor</li>
+ *   <li>Reactor threading violations</li>
+ *   <li>Redis timeout exceptions ({@code RedisTimeoutException})</li>
+ *   <li>Thread pool exhaustion under load</li>
+ * </ul>
+ * <p>
+ * <strong>Correct Pattern:</strong>
+ * </p>
+ * <pre>{@code
+ * // ✅ CORRECT: Only the implementation has @Cacheable
+ * public List<Item> findAll(UUID projectId, String workspaceId) {
+ *     return findAll(projectId, workspaceId, null);  // Delegates, NO annotation
+ * }
+ *
+ * @Cacheable(name = "items", key = "...")
+ * public List<Item> findAll(UUID projectId, String workspaceId, Type type) {
+ *     // Implementation with caching
+ * }
+ * }</pre>
+ * <p>
+ * <strong>Incorrect Pattern (causes deadlock):</strong>
+ * </p>
+ * <pre>{@code
+ * // ❌ WRONG: Both methods have @Cacheable - creates nested cache operations
+ * @Cacheable(name = "items", key = "...")
+ * public List<Item> findAll(UUID projectId, String workspaceId) {
+ *     return findAll(projectId, workspaceId, null);  // Nested cache!
+ * }
+ *
+ * @Cacheable(name = "items", key = "...")
+ * public List<Item> findAll(UUID projectId, String workspaceId, Type type) {
+ *     // Implementation
+ * }
+ * }</pre>
+ *
+ * @see CachePut
+ * @see CacheEvict
+ */
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited


### PR DESCRIPTION
## Details

Fixed a critical nested cache annotation deadlock issue that was causing Redis timeout exceptions in production. The bug occurred when two overloaded methods both had `@Cacheable` annotations and one delegated to the other, creating nested `Mono.block()` calls that violated Reactor threading rules.

**Reviewed the whole service and no other occurrences of this problem found in any caching annotation: `@Cacheable`, `@CachePut`, `@CacheEvict`**.

**Root Cause:**
- `AutomationRuleEvaluatorService.findAll(UUID, String)` had `@Cacheable` and delegated to
- `AutomationRuleEvaluatorService.findAll(UUID, String, AutomationRuleEvaluatorType)` which also had `@Cacheable`
- This created nested cache operations causing `RedisTimeoutException` under load

**Solution:**
1. Removed `@Cacheable` from the delegating 2-parameter method in production code in `AutomationRuleEvaluatorService`
2. Added comprehensive Javadoc warnings to all cache annotation classes (`@Cacheable`, `@CachePut`, `@CacheEvict`)
3. Added Javadoc to the fixed method explaining the pattern
4. Created tests demonstrating both the problem and correct usage

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues
- NA <!-- Hotfix for production Redis timeout issue -->

## Testing
Added comprehensive tests in `CacheManagerTest` and `CachedService`
1.  Demonstrates the nested cache deadlock issue
2. Verifies the fix works correctly

**Manual Testing:**
- Will be verified in CI tests after deploying to staging. It always reproduced in this environment.

## Documentation

**Code Documentation:**
- Added comprehensive Javadoc to `@Cacheable`, `@CachePut`, and `@CacheEvict` annotations with:
  - Critical warnings about nested cache operations
  - Correct and incorrect usage patterns
  - Code examples showing safe patterns
- Added Javadoc to fixed methods explaining the pattern and warnings
- Added structured Javadoc to test methods explaining the technical flow
- Test files with comprehensive documentation