### PR TITLE
[NA] Fix Docker multi-arch builds for all images

### DIFF
--- a/.github/workflows/build_and_push_docker.yaml
+++ b/.github/workflows/build_and_push_docker.yaml
@@ -61,8 +61,8 @@ jobs:
             MERGE_MATRIX=$(echo "$MERGE_MATRIX" | jq '.exclude += [{"image_type":"comet"}]')
           fi
           
-          # Exclude arm64 if not a release build or if guardrails backend
-          if [[ "${{ inputs.is_release }}" != "true" ]] || [[ "${{ inputs.image }}" == "opik-guardrails-backend" ]]; then
+          # Exclude arm64 if guardrails backend
+          if [[ "${{ inputs.image }}" == "opik-guardrails-backend" ]]; then
             BUILD_MATRIX=$(echo "$BUILD_MATRIX" | jq '.exclude += [{"platform":"arm64"}]')
           fi
           
@@ -258,10 +258,8 @@ jobs:
           echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
           if [[ "${{ inputs.image }}" == "opik-guardrails-backend" ]]; then
             echo "Built for platforms: linux/amd64" >> $GITHUB_STEP_SUMMARY
-          elif [[ "${{ inputs.is_release }}" == "true" ]]; then
-            echo "Built for platforms: linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
           else
-            echo "Built for platforms: linux/amd64" >> $GITHUB_STEP_SUMMARY
+            echo "Built for platforms: linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
           fi
           echo "- [View on GitHub Container Registry](https://github.com/${{ github.repository }}/pkgs/container/opik%2F${{ steps.set_vars.outputs.image_name }})" >> $GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
Remove is_release condition that was limiting arm64 builds to releases only. Now all images (except guardrails-backend) will build for both amd64 and arm64.

## Details

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing

## Documentation
