### PR TITLE
[NA] [BE] Remove unnecessary @NonNull annotations from ExperimentResponseBuilder

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentResponseBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentResponseBuilder.java
@@ -48,9 +48,9 @@ public class ExperimentResponseBuilder {
     }
 
     public ExperimentGroupAggregationsResponse buildGroupAggregationsResponse(
-            @NonNull List<ExperimentGroupAggregationItem> groupItems,
+            List<ExperimentGroupAggregationItem> groupItems,
             @NonNull ExperimentGroupEnrichInfoHolder enrichInfoHolder,
-            @NonNull List<GroupBy> groups) {
+            List<GroupBy> groups) {
         var contentMap = new HashMap<String, GroupContentWithAggregations>();
 
         if (CollectionUtils.isEmpty(groupItems) || CollectionUtils.isEmpty(groups)) {


### PR DESCRIPTION
## Details

This PR addresses a follow-up review comment from PR #4333 (https://github.com/comet-ml/opik/pull/4333#discussion_r1889698622).

### Changes Made

Removed `@NonNull` annotations from two parameters in the `buildGroupAggregationsResponse()` method:
- `List<ExperimentGroupAggregationItem> groupItems` 
- `List<GroupBy> groups`

### Rationale

The `@NonNull` annotations were unnecessary because:

1. **`CollectionUtils.isEmpty()` handles nulls gracefully** - Apache Commons Collections' `isEmpty()` method returns `true` for both null and empty collections
2. **Early return on null/empty** - The method checks both parameters with `CollectionUtils.isEmpty()` on line 56 and returns a valid empty `ExperimentGroupAggregationsResponse` if either is null or empty
3. **No null access risk** - Both parameters are only accessed in for-loops after confirming they're non-null and non-empty

### Why This Improves the Code

- **More resilient** - Avoids throwing unnecessary `NullPointerException`s when null collections are passed
- **Cleaner API** - Allows callers to pass null without defensive checks
- **Consistent with existing patterns** - Other methods in the codebase use similar null-safe patterns with `CollectionUtils`

Note: The `@NonNull` annotation on `enrichInfoHolder` was intentionally kept as it's used throughout the method without null checks.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- NA (Follow-up from #4333)

## Testing
- ✅ Compilation successful with `mvn compile -DskipTests`
- ✅ Code formatting passed (Spotless validation)
- ✅ Logic verified - method handles null inputs gracefully

## Documentation
N/A - Internal code improvement