### PR TITLE
[OPIK-3385] [FE] Fix video previews not loading in playground

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/attachments/VideoThumbnail/VideoThumbnail.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/attachments/VideoThumbnail/VideoThumbnail.tsx
@@ -158,22 +158,23 @@ const isCrossOrigin = (url: string): boolean => {
  * ```
  */
 const VideoThumbnail: React.FC<VideoThumbnailProps> = ({ videoUrl, name }) => {
-  // For cross-origin URLs, skip thumbnail generation and use ReactPlayer directly
-  // This avoids CORS errors from canvas-based thumbnail generation
-  if (isCrossOrigin(videoUrl)) {
-    return <FallbackVideoPlayer url={videoUrl} />;
-  }
+  const isVideoUrlCrossOrigin = isCrossOrigin(videoUrl);
 
   // Only generate thumbnail when component is visible in viewport
   const { ref: containerRef, inView: isVisible } =
     useInView(INTERSECTION_OPTIONS);
 
-  // Generate thumbnail from video (same-origin only)
+  // Generate thumbnail from video (will be skipped for cross-origin URLs in render)
   const { thumbnailUrl, isLoading, hasError } = useVideoThumbnail(
     videoUrl,
     {},
-    isVisible,
+    isVisible && !isVideoUrlCrossOrigin,
   );
+
+  // For cross-origin URLs, use ReactPlayer directly to avoid CORS errors
+  if (isVideoUrlCrossOrigin) {
+    return <FallbackVideoPlayer url={videoUrl} />;
+  }
 
   // Render error state for same-origin videos that failed
   if (hasThumbnailFailed(hasError, isLoading, thumbnailUrl)) {


### PR DESCRIPTION
## Details

This PR fixes video thumbnails not displaying in the playground dataset table when using cross-origin video URLs (e.g., S3 URLs).

### Root Cause
The `VideoThumbnail` component was attempting to use HTML5 canvas to extract video frames for thumbnail generation. This fails for cross-origin videos due to CORS restrictions - browsers block pixel-level access to cross-origin media when using canvas (known as "tainted canvas").

### Solution
For cross-origin videos, the component now:
1. Detects if the video URL is cross-origin using the `isCrossOrigin()` helper
2. Skips canvas-based thumbnail generation entirely
3. Uses ReactPlayer directly to display the video, which can play cross-origin videos without needing pixel access

For same-origin videos, the existing optimized canvas-based thumbnail generation continues to work.

### Benefits
- ✅ Video thumbnails now display properly for cross-origin URLs
- ✅ No more CORS errors in the console
- ✅ Better performance - skips failed thumbnail generation attempts
- ✅ Works in playground dataset tables, tooltips, and fullscreen dialogs

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3385

## Testing
Tested with S3 video URLs in the playground:
1. Load dataset with video URLs in playground
2. Video thumbnails display correctly in the dataset table
3. Clicking on videos opens fullscreen player
4. No CORS errors in console

## Documentation
N/A