### PR TITLE
[OPIK-0000] [P SDK] Skip multimodal e2e test due to flakiness

### DIFF
--- a/sdks/python/tests/e2e/evaluation/test_multimodal.py
+++ b/sdks/python/tests/e2e/evaluation/test_multimodal.py
@@ -64,6 +64,9 @@ def _normalize_output(output: Any) -> str:
     return str(output).strip().lower()
 
 
+@pytest.mark.skip(
+    reason="This test is very flaky and requires a major refactor if not removal"
+)
 @pytest.mark.skipif(
     not environment.has_openai_api_key(), reason="OPENAI_API_KEY is not set"
 )


### PR DESCRIPTION
## Details

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing

## Documentation
