### PR TITLE
[NA] [BE] Prevent nested cache deadlocks

### DIFF
--- a/apps/opik-backend/pom.xml
+++ b/apps/opik-backend/pom.xml
@@ -313,6 +313,11 @@
             <artifactId>tika-core</artifactId>
             <version>3.2.0</version>
         </dependency>
+        <dependency>
+            <groupId>io.vavr</groupId>
+            <artifactId>vavr</artifactId>
+            <version>0.10.7</version>
+        </dependency>
 
         <!-- Test -->
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/cache/CacheManager.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/cache/CacheManager.java
@@ -5,13 +5,35 @@ import lombok.NonNull;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
+import java.util.concurrent.CompletionStage;
 
+/**
+ * Cache management interface providing both reactive and non-reactive APIs.
+ *
+ * <p><b>API Types:</b></p>
+ * <ul>
+ *   <li><b>Reactive API</b>: Methods without {@code Sync} or {@code Async} suffix (e.g., {@code get()}, {@code put()})
+ *      are designed for use with reactive methods that return {@code Mono} or {@code Flux}.</li>
+ *   <li><b>Non-Reactive API</b>: Methods with {@code Sync} or {@code Async} suffix are designed for non-reactive methods:
+ *     <ul>
+ *       <li><b>Synchronous</b>: Methods with {@code Sync} suffix (e.g., {@code getSync()}) block until the result is available.</li>
+ *       <li><b>Asynchronous</b>: Methods with {@code Async} suffix (e.g., {@code putAsync()}) return {@link CompletionStage} for non-blocking operations without reactiveness.</li>
+ *     </ul>
+ *   </li>
+ * </ul>
+ */
 public interface CacheManager {
 
+    // Reactive API (for reactive methods returning Mono/Flux)
     Mono<Boolean> evict(@NonNull String key, boolean usePatternMatching);
     Mono<Boolean> put(@NonNull String key, @NonNull Object value, @NonNull Duration ttlDuration);
     <T> Mono<T> get(@NonNull String key, @NonNull Class<T> clazz);
     <T> Mono<T> get(@NonNull String key, @NonNull TypeReference<T> clazz);
     Mono<Boolean> contains(@NonNull String key);
 
+    // Non-reactive API (both synchronous and asynchronous methods without reactiveness)
+    CompletionStage<Boolean> evictAsync(String key, boolean usePatternMatching);
+    CompletionStage<Void> putAsync(String key, Object value, Duration ttlDuration);
+    <T> T getSync(String key, Class<T> clazz);
+    <T> T getSync(String key, TypeReference<T> clazz);
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedisCacheManager.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedisCacheManager.java
@@ -6,16 +6,21 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import org.redisson.api.RedissonClient;
 import org.redisson.api.RedissonReactiveClient;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
+import java.util.concurrent.CompletionStage;
 
 @RequiredArgsConstructor
 class RedisCacheManager implements CacheManager {
 
     private final @NonNull RedissonReactiveClient redisClient;
+    private final @NonNull RedissonClient nonReactiveRedisClient;
+
+    // Reactive API (for reactive methods returning Mono/Flux)
 
     public Mono<Boolean> evict(@NonNull String key, boolean usePatternMatching) {
         if (usePatternMatching) {
@@ -50,5 +55,40 @@ class RedisCacheManager implements CacheManager {
 
     public Mono<Boolean> contains(@NonNull String key) {
         return redisClient.getBucket(key).isExists();
+    }
+
+    // Non-reactive API (both synchronous and asynchronous methods without reactiveness)
+
+    @Override
+    public CompletionStage<Boolean> evictAsync(@NonNull String key, boolean usePatternMatching) {
+        if (usePatternMatching) {
+            return nonReactiveRedisClient.getKeys().deleteByPatternAsync(key)
+                    .thenApplyAsync(count -> count > 0);
+        }
+        return nonReactiveRedisClient.getBucket(key).deleteAsync();
+    }
+
+    @Override
+    public CompletionStage<Void> putAsync(@NonNull String key, @NonNull Object value, @NonNull Duration ttlDuration) {
+        var json = JsonUtils.writeValueAsString(value);
+        return nonReactiveRedisClient.getBucket(key).setAsync(json, ttlDuration);
+    }
+
+    @Override
+    public <T> T getSync(@NonNull String key, @NonNull Class<T> clazz) {
+        var json = nonReactiveRedisClient.<String>getBucket(key).get();
+        if (StringUtils.isEmpty(json)) {
+            return null;
+        }
+        return JsonUtils.readValue(json, clazz);
+    }
+
+    @Override
+    public <T> T getSync(@NonNull String key, @NonNull TypeReference<T> typeReference) {
+        var json = nonReactiveRedisClient.<String>getBucket(key).get();
+        if (StringUtils.isEmpty(json)) {
+            return null;
+        }
+        return JsonUtils.readValue(json, typeReference);
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/TestUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/TestUtils.java
@@ -10,6 +10,9 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
 
 @UtilityClass
 public class TestUtils {
@@ -26,5 +29,16 @@ public class TestUtils {
 
     public static String getBaseUrl(ClientSupport client) {
         return "http://localhost:%d".formatted(client.getPort());
+    }
+
+    /**
+     * Waits for the specified duration.
+     * Prefer this over {@code Thread.sleep()} or {@code Mono.delay().block()} for waiting in tests.
+     *
+     * @param millis duration to wait in milliseconds
+     */
+    public static void waitForMillis(long millis) {
+        await().pollDelay(millis, TimeUnit.MILLISECONDS)
+                .until(() -> true);
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
+import static com.comet.opik.api.resources.utils.TestUtils.waitForMillis;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -413,10 +414,5 @@ class BaseRedisSubscriberTest {
         await().atMost(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 // Verify messages were removed from stream
                 .untilAsserted(() -> assertThat(stream.size().block()).isEqualTo(pendingMessages));
-    }
-
-    private void waitForMillis(long millis) {
-        await().pollDelay(millis, TimeUnit.MILLISECONDS)
-                .until(() -> true);
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/cache/CacheManagerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/cache/CacheManagerTest.java
@@ -12,23 +12,31 @@ import com.comet.opik.extensions.RegisterApp;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
 import com.redis.testcontainers.RedisContainer;
+import io.vavr.Function3;
 import lombok.extern.slf4j.Slf4j;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.mysql.MySQLContainer;
-import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.api.resources.utils.TestUtils.waitForMillis;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DropwizardAppExtensionProvider.class)
@@ -39,6 +47,8 @@ class CacheManagerTest {
     private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
     private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
     private final ClickHouseContainer CLICKHOUSE = ClickHouseContainerUtils.newClickHouseContainer(ZOOKEEPER_CONTAINER);
+
+    private static final long CACHE_ASYNC_WAIT_MILLIS = 50;
 
     static final String CACHE_NAME_1 = "test";
     static final String CACHE_NAME_2 = "test2";
@@ -76,112 +86,131 @@ class CacheManagerTest {
                         .build());
     }
 
+    // Non-reactive tests
+
     @Test
     void testCacheable__whenCacheableExpire__shouldCallRealMethodAgain(CachedService service) {
-
-        String id = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
         // first call, should call real method
         var dto = service.get(id, workspaceId);
+
+        assertThat(dto).isNotNull();
+
+        // wait for the cache put async to complete
+        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
 
         // second call, should return cached value
         var dto2 = service.get(id, workspaceId);
 
-        Assertions.assertThat(dto).isEqualTo(dto2);
+        assertThat(dto).isEqualTo(dto2);
 
         // wait for cache to expire
-        Mono.delay(Duration.ofMillis(1000)).block();
+        waitForMillis(1000);
 
         // third call, should call real method again
         var dto3 = service.get(id, workspaceId);
 
-        Assertions.assertThat(dto).isNotEqualTo(dto3);
+        assertThat(dto).isNotEqualTo(dto3);
     }
 
     @Test
     void testCachePut__whenCachePut__shouldUpdateCache(CachedService service) {
-
-        String id = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
         // first call, should call real method
         var dto = service.get(id, workspaceId);
+
+        assertThat(dto).isNotNull();
+
+        // wait for the cache put async to complete
+        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
 
         // second call, should return cached value
         var dto2 = service.get(id, workspaceId);
 
-        Assertions.assertThat(dto).isEqualTo(dto2);
+        assertThat(dto).isEqualTo(dto2);
 
         // update value
-        var updatedDto = new CachedService.DTO(id, workspaceId, UUID.randomUUID().toString());
-        updatedDto = service.update(id, workspaceId, updatedDto);
+        var dtoUpdate = new CachedService.DTO(id, workspaceId, UUID.randomUUID().toString());
+        var updatedDto = service.update(id, workspaceId, dtoUpdate);
+
+        // wait for the cache put async to complete
+        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
 
         // third call, should return updated value
         var dto3 = service.get(id, workspaceId);
 
-        Assertions.assertThat(updatedDto).isEqualTo(dto3);
+        assertThat(updatedDto).isEqualTo(dto3);
     }
 
     @Test
     void testCacheEvict__whenCacheEvict__shouldRemoveCache(CachedService service) {
-
-        String id = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
         // first call, should call real method
         var dto = service.get(id, workspaceId);
+
+        assertThat(dto).isNotNull();
+
+        // wait for the cache put async to complete
+        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
 
         // second call, should return cached value
         var dto2 = service.get(id, workspaceId);
 
-        Assertions.assertThat(dto).isEqualTo(dto2);
+        assertThat(dto).isEqualTo(dto2);
 
         // evict cache
         service.evict(id, workspaceId);
 
+        // wait for the cache evict async to complete
+        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
+
         // third call, should call real method again
         var dto3 = service.get(id, workspaceId);
 
-        Assertions.assertThat(dto).isNotEqualTo(dto3);
+        assertThat(dto).isNotEqualTo(dto3);
     }
+
+    // Reactive tests (Mono)
 
     @Test
     void testCacheable__whenCacheableExpire__shouldCallRealMethodAgain2(CachedService service) {
-
-        String id = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
         // first call, should call real method
         var dto = service.get2(id, workspaceId).block();
+
+        assertThat(dto).isNotNull();
 
         // second call, should return cached value
         var dto2 = service.get2(id, workspaceId).block();
 
-        Assertions.assertThat(dto).isEqualTo(dto2);
+        assertThat(dto).isEqualTo(dto2);
 
         // wait for cache to expire
-        Mono.delay(Duration.ofMillis(200)).block();
+        waitForMillis(200);
 
         // third call, should call real method again
         var dto3 = service.get2(id, workspaceId).block();
 
-        Assertions.assertThat(dto).isNotEqualTo(dto3);
+        assertThat(dto).isNotEqualTo(dto3);
     }
 
     @Test
     void testCachePut__whenCachePut__shouldUpdateCache2(CachedService service) {
-
-        String id = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
         // first call, should call real method
         var dto = service.get2(id, workspaceId).block();
+
+        assertThat(dto).isNotNull();
 
         // second call, should return cached value
         var dto2 = service.get2(id, workspaceId).block();
 
-        Assertions.assertThat(dto).isEqualTo(dto2);
+        assertThat(dto).isEqualTo(dto2);
 
         // update value
         var updatedDto = new CachedService.DTO(id, workspaceId, UUID.randomUUID().toString());
@@ -190,22 +219,22 @@ class CacheManagerTest {
         // third call, should return updated value
         var dto3 = service.get2(id, workspaceId).block();
 
-        Assertions.assertThat(updatedDto).isEqualTo(dto3);
+        assertThat(updatedDto).isEqualTo(dto3);
     }
 
     @Test
     void testCacheEvict__whenCacheEvict__shouldRemoveCache2(CachedService service) {
-
-        String id = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
         // first call, should call real method
         var dto = service.get2(id, workspaceId).block();
+
+        assertThat(dto).isNotNull();
 
         // second call, should return cached value
         var dto2 = service.get2(id, workspaceId).block();
 
-        Assertions.assertThat(dto).isEqualTo(dto2);
+        assertThat(dto).isEqualTo(dto2);
 
         // evict cache
         service.evict2(id, workspaceId).block();
@@ -213,221 +242,407 @@ class CacheManagerTest {
         // third call, should call real method again
         var dto3 = service.get2(id, workspaceId).block();
 
-        Assertions.assertThat(dto).isNotEqualTo(dto3);
+        assertThat(dto).isNotEqualTo(dto3);
+    }
+
+    @Test
+    void testCacheEvict__whenCacheEvictWithValue__shouldRemoveCacheAndReturnValue2(CachedService service) {
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+        // first call, should call real method
+        var dto = service.get2(id, workspaceId).block();
+
+        assertThat(dto).isNotNull();
+
+        // second call, should return cached value
+        var dto2 = service.get2(id, workspaceId).block();
+
+        assertThat(dto).isEqualTo(dto2);
+
+        // evict cache and get return value
+        var evictResult = service.evict2WithValue(id, workspaceId).block();
+
+        // verify evict method returned a value
+        assertThat(evictResult).isNotNull();
+        assertThat(evictResult.id()).isEqualTo(id);
+        assertThat(evictResult.workspaceId()).isEqualTo(workspaceId);
+
+        // third call, should call real method again (cache was evicted)
+        var dto3 = service.get2(id, workspaceId).block();
+
+        assertThat(dto).isNotEqualTo(dto3);
     }
 
     //Test error handling
 
     @Test
     void testCacheable__whenKeyInvalidExpression__shouldIgnoreCache(CachedService service) {
-
-        String id = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
         // first call, should call real method
         var dto = service.getWithKeyInvalidExpression(id, workspaceId);
 
-        // second call, should return cached value
+        assertThat(dto).isNotNull();
+
+        // wait like if there was cache put async to complete
+        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
+
+        // second call, should call real method again due to invalid key expression
         var dto2 = service.getWithKeyInvalidExpression(id, workspaceId);
 
-        Assertions.assertThat(dto).isNotEqualTo(dto2);
+        assertThat(dto).isNotEqualTo(dto2);
     }
 
     @Test
     void testCacheable__whenAnExceptionHappens__shouldIgnoreCacheAndPropagateIt(CachedService service) {
-
-        String id = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
         // first call, should call real method
-        Assertions.assertThatThrownBy(() -> service.getWithException(id, workspaceId))
+        assertThatThrownBy(() -> service.getWithException(id, workspaceId))
                 .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    void testCachePut__whenAnExceptionHappens__shouldIgnoreCacheAndPropagateIt(CachedService service) {
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+        var dto = new CachedService.DTO(id, workspaceId, UUID.randomUUID().toString());
+        // should propagate exception without caching
+        assertThatThrownBy(() -> service.updateWithException(id, workspaceId, dto))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Simulate runtime exception on update");
+    }
+
+    @Test
+    void testCacheEvict__whenAnExceptionHappens__shouldIgnoreCacheAndPropagateIt(CachedService service) {
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+        // should propagate exception without evicting cache
+        assertThatThrownBy(() -> service.evictWithException(id, workspaceId))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Simulate runtime exception on evict");
     }
 
     @Test
     void testCacheable__whenKeyInvalidExpression__shouldIgnoreCache2(CachedService service) {
-
-        String id = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
         // first call, should call real method
         var dto = service.get2WithInvalidKeyExpression(id, workspaceId).block();
+
+        assertThat(dto).isNotNull();
 
         // second call, should return cached value
         var dto2 = service.get2WithInvalidKeyExpression(id, workspaceId).block();
 
-        Assertions.assertThat(dto).isNotEqualTo(dto2);
+        assertThat(dto).isNotEqualTo(dto2);
     }
 
     @Test
     void testCacheable__whenAnExceptionHappens__shouldIgnoreCacheAndPropagateIt2(CachedService service) {
-
-        String id = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
         // first call, should call real method
-        Assertions.assertThatThrownBy(() -> service.get2WithException(id, workspaceId).block())
+        assertThatThrownBy(() -> service.get2WithException(id, workspaceId).block())
                 .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    void testCacheable__whenFluxWithException__shouldIgnoreCacheAndPropagateIt(CachedService service) {
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+        // should propagate exception without caching
+        assertThatThrownBy(() -> service.getFluxWithException(id, workspaceId).collectList().block())
+                .isInstanceOf(IndexOutOfBoundsException.class)
+                .hasMessageContaining("Simulate runtime exception in Flux");
+    }
+
+    @Test
+    void testCachePut__whenAnExceptionHappens__shouldIgnoreCacheAndPropagateIt2(CachedService service) {
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+        var dto = new CachedService.DTO(id, workspaceId, UUID.randomUUID().toString());
+        // should propagate exception without caching
+        assertThatThrownBy(() -> service.update2WithException(id, workspaceId, dto).block())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Simulate runtime exception on update");
+    }
+
+    @Test
+    void testCacheEvict__whenAnExceptionHappens__shouldIgnoreCacheAndPropagateIt2(CachedService service) {
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+        // should propagate exception without evicting cache
+        assertThatThrownBy(() -> service.evict2WithException(id, workspaceId).block())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Simulate runtime exception on evict");
     }
 
     // Test collection
 
     @Test
     void testCacheable__whenCacheableCollection__shouldCallRealMethodAgain(CachedService service) {
-
-        String id = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
         // first call, should call real method
         var dto = service.getCollection(id, workspaceId);
+
+        assertThat(dto).hasSize(1);
+
+        // wait for the cache put async to complete
+        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
 
         // second call, should return cached value
         var dto2 = service.getCollection(id, workspaceId);
 
-        Assertions.assertThat(dto).isEqualTo(dto2);
+        assertThat(dto).containsExactlyElementsOf(dto2);
     }
 
     @Test
     void testCacheable__whenCacheableCollection__shouldCallRealMethodAgain2(CachedService service) {
-
-        String id = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
         // first call, should call real method
         var dto = service.getCollection2(id, workspaceId).block();
+
+        assertThat(dto).hasSize(1);
 
         // second call, should return cached value
         var dto2 = service.getCollection2(id, workspaceId).block();
 
-        Assertions.assertThat(dto).isEqualTo(dto2);
+        assertThat(dto).containsExactlyElementsOf(dto2);
     }
 
     // Test Flux
 
     @Test
     void testCacheable__whenCacheableFlux__shouldCallRealMethodAgain(CachedService service) {
-
-        String id = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
         // first call, should call real method
         var dto = service.getFlux(id, workspaceId).collectList().block();
+        assertThat(dto).hasSize(2);
 
-        Mono.delay(Duration.ofMillis(50)).block();
+        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
 
         // second call, should return cached value
         var dto2 = service.getFlux(id, workspaceId).collectList().block();
 
-        Assertions.assertThat(dto).isEqualTo(dto2);
+        assertThat(dto).containsExactlyElementsOf(dto2);
 
-        Mono.delay(Duration.ofMillis(500)).block();
+        // wait for cache to expire
+        waitForMillis(500);
 
         // third call, should call real method again
         var dto3 = service.getFlux(id, workspaceId).collectList().block();
 
-        Assertions.assertThat(dto).isNotEqualTo(dto3);
+        assertThat(dto).doesNotContainAnyElementsOf(dto3);
     }
 
     @Test
     void testCacheable__whenCacheableFlux__shouldCallRealMethodAgain2(CachedService service) {
-
-        String id = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
         // first call, should call real method
         var dto = service.getFlux2(id, workspaceId).collectList().block();
 
-        Mono.delay(Duration.ofMillis(50)).block();
+        assertThat(dto).hasSize(2);
+
+        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
 
         // second call, should return cached value
         var dto2 = service.getFlux2(id, workspaceId).collectList().block();
 
-        Assertions.assertThat(dto).isEqualTo(dto2);
+        assertThat(dto).containsExactlyElementsOf(dto2);
 
-        Mono.delay(Duration.ofMillis(500)).block();
+        // wait for cache to expire
+        waitForMillis(500);
 
         // third call, should call real method again
-        var dto3 = service.getFlux(id, workspaceId).collectList().block();
+        var dto3 = service.getFlux2(id, workspaceId).collectList().block();
 
-        Assertions.assertThat(dto).isNotEqualTo(dto3);
+        assertThat(dto).doesNotContainAnyElementsOf(dto3);
     }
 
-    // Test nested cache annotation issue
+    // Test null/empty values are not cached
+
+    @Test
+    void testCacheable__whenNullValue__shouldNotCache(CachedService service) {
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+        // first call, should call real method and return null
+        var result1 = service.getWithNullValue(id, workspaceId);
+        assertThat(result1).isNull();
+
+        // wait for potential cache put async to complete
+        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
+
+        // second call, should call real method again (null was not cached)
+        var result2 = service.getWithNullValue(id, workspaceId);
+        assertThat(result2).isNull();
+    }
+
+    @Test
+    void testCachePut__whenNullValue__shouldNotCache(CachedService service) {
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+        var dto = new CachedService.DTO(id, workspaceId, UUID.randomUUID().toString());
+
+        // first, cache a valid value
+        var cachedDto = service.update(id, workspaceId, dto);
+
+        assertThat(cachedDto).isNotNull();
+
+        // wait for cache put async to complete
+        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
+
+        // verify value is cached
+        var fromCache = service.get(id, workspaceId);
+
+        assertThat(fromCache).isEqualTo(cachedDto);
+
+        // now try to put null value
+        var nullResult = service.updateWithNullValue(id, workspaceId, dto);
+        assertThat(nullResult).isNull();
+
+        // wait for potential cache put async to complete
+        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
+
+        // verify cache still has the old value (null was not cached)
+        var stillCached = service.get(id, workspaceId);
+
+        assertThat(stillCached).isEqualTo(cachedDto);
+    }
+
+    @Test
+    void testCacheable__whenEmptyMono__shouldNotCache(CachedService service) {
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+        // first call, should call real method and return empty
+        var result1 = service.get2WithEmptyValue(id, workspaceId).block();
+
+        assertThat(result1).isNull();
+
+        // second call, should call real method again (empty was not cached)
+        var result2 = service.get2WithEmptyValue(id, workspaceId).block();
+
+        assertThat(result2).isNull();
+    }
+
+    @Test
+    void testCachePut__whenEmptyMono__shouldNotCache(CachedService service) {
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+        var dto = new CachedService.DTO(id, workspaceId, UUID.randomUUID().toString());
+        // first, cache a valid value
+        var cachedDto = service.update2(id, workspaceId, dto).block();
+
+        assertThat(cachedDto).isNotNull();
+
+        // verify value is cached
+        var fromCache = service.get2(id, workspaceId).block();
+
+        assertThat(fromCache).isEqualTo(cachedDto);
+
+        // now try to put empty value
+        var emptyResult = service.update2WithEmptyValue(id, workspaceId, dto).block();
+
+        assertThat(emptyResult).isNull();
+
+        // verify cache still has the old value (empty was not cached)
+        var stillCached = service.get2(id, workspaceId).block();
+
+        assertThat(stillCached).isEqualTo(cachedDto);
+    }
+
+    @Test
+    void testCacheable__whenEmptyFlux__shouldNotCache(CachedService service) {
+        var id = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+        // first call, should call real method and return empty
+        var result1 = service.getFluxWithEmptyValue(id, workspaceId).collectList().block();
+
+        assertThat(result1).isEmpty();
+
+        // wait for potential cache put async to complete
+        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
+
+        // second call, should call real method again (empty was not cached)
+        var result2 = service.getFluxWithEmptyValue(id, workspaceId).collectList().block();
+
+        assertThat(result2).isEmpty();
+    }
+
+    // Test nested cache annotation
+
+    Stream<Function3<CachedService, String, String, List<CachedService.DTO>>> testCacheable__whenNestedCacheAnnotations__shouldWorkCorrectly() {
+        return Stream.of(
+                // Call 2-param overload
+                (service, id, workspaceId) -> service.getOverloadedWithNestedCache(id, workspaceId),
+                // Call 3-param overload with null
+                (service, id, workspaceId) -> service.getOverloadedWithNestedCache(id, workspaceId, null));
+    }
 
     /**
-     * This test demonstrates the nested cache annotation deadlock issue.
-     * When two overloaded methods both have @Cacheable and one delegates to the other,
-     * it creates nested Mono.block() calls that can cause Redis timeout exceptions.
-     * <p>
-     * This reproduces the issue found in AutomationRuleEvaluatorService where:
+     * This test demonstrates that nested cache annotation, while not desirable, works fine.
+     * Two overloaded methods both have @Cacheable and one delegates to the other.
+     * There was a fix for an issue found originally in AutomationRuleEvaluatorService where:
      * <ul>
      *   <li>findAll(projectId, workspaceId) had @Cacheable and delegated to</li>
      *   <li>findAll(projectId, workspaceId, type) which also had @Cacheable</li>
      * </ul>
      * <p>
-     * <strong>What happens with nested cache operations:</strong>
-     * <ol>
-     *   <li>First @Cacheable on getOverloadedWithNestedCache(id, workspaceId)
-     *       <ul>
-     *         <li>Cache miss, proceeds with Mono.defer() and invocation.proceed()</li>
-     *         <li>Inside this, the method delegates to getOverloadedWithNestedCache(id, workspaceId, null)</li>
-     *       </ul>
-     *   </li>
-     *   <li>Second @Cacheable on getOverloadedWithNestedCache(id, workspaceId, type)
-     *       <ul>
-     *         <li>Another cache operation NESTED inside the first</li>
-     *         <li>Creates nested Mono.block() which violates Reactor threading rules</li>
-     *       </ul>
-     *   </li>
-     * </ol>
-     * <p>
-     * <strong>Expected behavior:</strong> May timeout or cause reactor threading violations.
      */
-    @Test
-    void testCacheable__whenNestedCacheAnnotations__shouldCauseIssue(CachedService service) {
-        var id = UUID.randomUUID().toString();
-        var workspaceId = UUID.randomUUID().toString();
-        try {
-            var result = service.getOverloadedWithNestedCache(id, workspaceId);
-
-            // If it doesn't time out, verify it at least works functionally
-            Assertions.assertThat(result).isNotNull();
-            Assertions.assertThat(result).hasSize(1);
-            // Note: In production with high load, this would likely time out
-            // In tests with low concurrency, it might succeed but is still problematic
-            log.info("Nested cache call succeeded unexpectedly: '{}'", result);
-        } catch (Exception exception) {
-            log.error("Expected exception due to nested cache annotations", exception);
-            // Expected: RedisTimeoutException or reactor threading violation
-            // This is the bug we're demonstrating
-            Assertions.assertThat(exception)
-                    .satisfiesAnyOf(
-                            ex -> Assertions.assertThat(ex).hasMessageContaining("timeout"),
-                            ex -> Assertions.assertThat(ex).hasMessageContaining("Redis"),
-                            ex -> Assertions.assertThat(ex).hasMessageContaining("block"));
-        }
-    }
-
-    /**
-     * This test demonstrates the FIXED version where only the implementation method has @Cacheable.
-     * The delegating method has NO cache annotation, avoiding nested cache operations.
-     * <p>
-     * This is the fix applied to AutomationRuleEvaluatorService.
-     */
-    @Test
-    void testCacheable__whenFixedOverloadedMethods__shouldWorkCorrectly(CachedService service) {
+    @ParameterizedTest
+    @MethodSource
+    void testCacheable__whenNestedCacheAnnotations__shouldWorkCorrectly(
+            Function3<CachedService, String, String, List<CachedService.DTO>> methodCall,
+            CachedService service) {
         var id = UUID.randomUUID().toString();
         var workspaceId = UUID.randomUUID().toString();
         // First call through 2-param method
-        var result1 = service.getOverloadedFixed(id, workspaceId);
-        // Second call should return cached value from the 3-param method's cache
-        var result2 = service.getOverloadedFixed(id, workspaceId);
+        var result1 = service.getOverloadedWithNestedCache(id, workspaceId);
+        assertThat(result1).hasSize(1);
 
-        // Both calls should succeed without timeout
-        Assertions.assertThat(result1).isNotNull();
-        Assertions.assertThat(result2).isNotNull();
-        // Values should be identical (from cache)
-        Assertions.assertThat(result1).isEqualTo(result2);
-        Assertions.assertThat(result1.getFirst().value()).isEqualTo(result2.getFirst().value());
+        // wait for the cache put async to complete
+        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
+
+        // Second call using the parameterized method variant
+        var result2 = methodCall.apply(service, id, workspaceId);
+
+        assertThat(result1).containsExactlyElementsOf(result2);
+    }
+
+    @Test
+    void testCacheable__whenHighConcurrencyNonReactiveMethods__shouldNotDeadlock(CachedService service)
+            throws InterruptedException {
+        var threadPoolSize = 50;
+        var totalTasks = 100;
+        var results = new ConcurrentHashMap<String, List<CachedService.DTO>>();
+        var executor = Executors.newFixedThreadPool(threadPoolSize);
+        try {
+            IntStream.range(0, totalTasks).forEach(i -> executor.submit(() -> {
+                var id = UUID.randomUUID().toString();
+                var workspaceId = UUID.randomUUID().toString();
+                var result = service.getOverloadedWithNestedCache(id, workspaceId);
+                results.put(id, result);
+            }));
+
+            executor.shutdown();
+            var completed = executor.awaitTermination(2, TimeUnit.SECONDS);
+
+            // Verify all tasks completed without timeout or deadlock
+            assertThat(completed).isTrue();
+            assertThat(results).hasSize(totalTasks);
+            // Verify all DTOs are not null
+            assertThat(results.values().stream().flatMap(List::stream).toList())
+                    .isNotEmpty()
+                    .doesNotContainNull()
+                    .hasSize(totalTasks);
+        } finally {
+            if (!executor.isTerminated()) {
+                executor.shutdownNow();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Details

This PR fixes a critical issue with nested cache operations that could cause Redis timeout exceptions and deadlocks in the Opik backend. The problem occurred when non-reactive methods with `@Cacheable` annotations delegated to other cached methods, creating nested `Mono.block()` calls that violated Reactor threading rules.

### Root Cause
When non-reactive methods used cache annotations, the `CacheInterceptor` would wrap all operations in reactive `Mono` types and block on them. This approach failed when:
- Method A with `@Cacheable` delegates to Method B with `@Cacheable`
- Both methods trigger cache operations that use `Mono.block()`
- Nested blocking calls on the same thread cause Redis client timeouts

### Solution
The fix introduces a clean separation between reactive and non-reactive cache operations:

1. **New CacheManager API**: Added synchronous (`getSync()`) and asynchronous (`putAsync()`, `evictAsync()`) methods specifically for non-reactive code paths
2. **Dual Redis Clients**: Injected both `RedissonClient` and `RedissonReactiveClient`, sharing the same underlying connection pool to avoid resource duplication
3. **CacheInterceptor Refactoring**: 
   - Non-reactive methods now use synchronous cache reads and fire-and-forget async writes/evictions
   - Reactive methods continue using the reactive API
   - Eliminated all nested `Mono.block()` calls
4. **Improved Error Handling**: Added proper exception handling to gracefully degrade on cache failures

### Additional changes
- **Dependencies**: Added Vavr 0.10.7 for functional programming support

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- NA

## Testing

- **CacheManagerTest**: Extended with 20+ new test cases covering:
  - Non-reactive cache operations with async put/evict
  - Reactive cache operations (Mono and Flux)
  - Exception propagation for all cache operations
  - Null and empty value handling (should not be cached)
  - Nested cache annotations (regression test)
  - High concurrency test with 50 threads and 100 tasks to verify no deadlocks

### Manual Testing
1. Run the backend with the fix applied
2. Trigger operations that use nested cached methods (e.g., AutomationRuleEvaluatorService)
3. Verify no Redis timeout exceptions occur under load
4. Monitor cache hit/miss rates remain consistent

## Documentation
- Added comprehensive JavaDoc to `CacheManager` interface explaining reactive vs non-reactive APIs
- Added code comments explaining the async cache strategy for eventual consistency