### PR TITLE
[CUST-4437] [BE] Fix NPE when creating prompt version with null templateStructure

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/CreatePromptVersion.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/CreatePromptVersion.java
@@ -18,4 +18,14 @@ public record CreatePromptVersion(@JsonView( {
         @JsonView({PromptVersion.View.Detail.class}) @NotNull @Valid PromptVersion version,
         @JsonView({
                 PromptVersion.View.Detail.class}) @Schema(description = "Template structure for the prompt: 'text' or 'chat'. Note: This field is only used when creating a new prompt. If a prompt with the given name already exists, this field is ignored and the existing prompt's template structure is used. Template structure is immutable after prompt creation.", defaultValue = "text") TemplateStructure templateStructure){
+
+    /**
+     * Returns the template structure, defaulting to TEXT if not provided.
+     * This ensures backwards compatibility for clients that don't send this field
+     * (e.g., TypeScript SDK which doesn't support ChatPrompt yet).
+     */
+    @Override
+    public TemplateStructure templateStructure() {
+        return templateStructure == null ? TemplateStructure.TEXT : templateStructure;
+    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -227,7 +227,8 @@ class PromptServiceImpl implements PromptService {
             // Template structure is immutable after prompt creation.
             log.debug(
                     "Prompt '{}' already exists with template_structure '{}'. Ignoring requested template_structure '{}'.",
-                    name, prompt.templateStructure().getValue(), templateStructure.getValue());
+                    name, prompt.templateStructure().getValue(),
+                    templateStructure != null ? templateStructure.getValue() : null);
             return prompt;
         }
 


### PR DESCRIPTION
# User description
## Details

Fixes a `NullPointerException` when creating a prompt version via the TypeScript SDK when:
1. The prompt already exists in the database
2. The `templateStructure` parameter is null (not provided by the SDK)

**Additionally**, adds backwards compatibility by defaulting `templateStructure` to `TEXT` at the API level when not provided. This is needed because:
- The TypeScript SDK doesn't support ChatPrompt yet (added in [PR #3987](https://github.com/comet-ml/opik/pull/3987) for Python SDK only)
- The TS SDK doesn't send `templateStructure` field
- For backwards compatibility, prompts should default to `TEXT` structure

### Root Cause

The issue occurred in `PromptService.getOrCreatePrompt()` where a debug log statement called `.getValue()` on the `templateStructure` parameter without null checking, causing a 500 error.

### Changes

1. **Fix NPE in `PromptService.java`**: Added null safety check for the `templateStructure` parameter in the log message

2. **Backwards Compatibility in `CreatePromptVersion.java`**: Added default accessor that returns `TEXT` when `templateStructure` is null - applied at API layer for cleaner design:
   ```java
   @Override
   public TemplateStructure templateStructure() {
       return templateStructure == null ? TemplateStructure.TEXT : templateStructure;
   }
   ```

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves CUST-4437

## Testing
- Added parameterized test `when__templateStructureIsNull__thenHandleCorrectly` covering:
  - `promptExists=true`: Verifies NPE fix when adding version to existing prompt
  - `promptExists=false`: Verifies new prompts default to TEXT templateStructure
- Both test cases pass successfully

## Documentation
No documentation changes required.

## Follow-up
TypeScript SDK ChatPrompt support (similar to Python SDK) can be added in a separate PR - tracked separately.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
PromptServiceImpl_getOrCreatePrompt_("PromptServiceImpl.getOrCreatePrompt"):::modified
CreatePromptVersion_templateStructure_("CreatePromptVersion.templateStructure"):::added
PromptServiceImpl_getOrCreatePrompt_ -- "Adds default templateStructure for backward compatibility handling nulls" --> CreatePromptVersion_templateStructure_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Resolves a <code>NullPointerException</code> in <code>PromptService</code> by adding a null safety check for <code>templateStructure</code> during logging, preventing a 500 error when creating prompt versions. Implements backwards compatibility in <code>CreatePromptVersion</code> by defaulting <code>templateStructure</code> to <code>TEXT</code> when not provided, ensuring proper handling for clients like the TypeScript SDK that do not send this field.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/comet-ml/opik/4405?tool=ast&topic=Fix+NPE+in+PromptService>Fix NPE in PromptService</a>
        </td><td>Fixes a <code>NullPointerException</code> in <code>PromptService.getOrCreatePrompt()</code> by adding a null check before calling <code>.getValue()</code> on the <code>templateStructure</code> parameter in a debug log statement, which previously caused a server error when <code>templateStructure</code> was null.<details><summary>Modified files (1)</summary><ul><li>apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alexkuzmik</td><td>OPIK-2982-P-SDK-BE-FE-...</td><td>December 04, 2025</td></tr>
<tr><td>danield@comet.com</td><td>OPIK-2994-UX-Prompt-na...</td><td>November 10, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/comet-ml/opik/4405?tool=ast&topic=Add+Backwards+Comp.>Add Backwards Comp.</a>
        </td><td>Adds backwards compatibility by overriding the <code>templateStructure()</code> method in <code>CreatePromptVersion</code> to return <code>TemplateStructure.TEXT</code> if the provided <code>templateStructure</code> is null, accommodating clients that do not send this field.<details><summary>Modified files (2)</summary><ul><li>apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java</li>
<li>apps/opik-backend/src/main/java/com/comet/opik/api/CreatePromptVersion.java</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alexkuzmik</td><td>OPIK-2982-P-SDK-BE-FE-...</td><td>December 04, 2025</td></tr>
<tr><td>thiagoh@comet.com</td><td>NA-BE-Upgrade-MySQL-co...</td><td>November 03, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/comet-ml/opik/4405?tool=ast>(Baz)</a>.