### PR TITLE
[OPIK-3395] [FE] clear cache if dataset is not selected

### DIFF
--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputs.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputs.tsx
@@ -85,7 +85,7 @@ const PlaygroundOutputs = ({
     },
     {
       enabled: !!datasetId,
-      placeholderData: keepPreviousData,
+      placeholderData: datasetId ? keepPreviousData : undefined,
     },
   );
 


### PR DESCRIPTION
# User description
## Details
- clear cache if dataset is not selected

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-3395

## Testing

## Documentation

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adjust the <code>PlaygroundOutputs</code> component to conditionally manage data caching, ensuring previous data is cleared when no dataset is selected.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>BorisTkachenko</td><td>Enchance-dataset-items...</td><td>December 05, 2025</td></tr>
<tr><td>aadereiko@gmail.com</td><td>OPIK-13745-reset-datas...</td><td>November 27, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/comet-ml/opik/4407?tool=ast>(Baz)</a>.