### PR TITLE
[OPIK-3416] [FE] Add Dashboard view support to Traces page

### DIFF
--- a/apps/opik-frontend/src/components/layout/SideBar/SideBar.tsx
+++ b/apps/opik-frontend/src/components/layout/SideBar/SideBar.tsx
@@ -15,7 +15,7 @@ import {
   ChevronRight,
   SparklesIcon,
   UserPen,
-  BarChart3,
+  ChartLine,
   Zap,
 } from "lucide-react";
 import { keepPreviousData } from "@tanstack/react-query";
@@ -74,7 +74,7 @@ const MENU_ITEMS: MenuItemGroup[] = [
         id: "dashboards",
         path: "/$workspaceName/dashboards",
         type: MENU_ITEM_TYPE.router,
-        icon: BarChart3,
+        icon: ChartLine,
         label: "Dashboards",
         featureFlag: FeatureToggleKeys.DASHBOARDS_ENABLED,
       },

--- a/apps/opik-frontend/src/components/pages-shared/dashboards/AddEditCloneDashboardDialog/DashboardDialogSelectStep.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/dashboards/AddEditCloneDashboardDialog/DashboardDialogSelectStep.tsx
@@ -1,21 +1,10 @@
 import React from "react";
-import { ChartLine, SquareDashedMousePointer, Activity } from "lucide-react";
-import { TEMPLATE_ID } from "@/types/dashboard";
-import {
-  DASHBOARD_TEMPLATES,
-  TEMPLATE_OPTIONS_ORDER,
-} from "@/lib/dashboard/templates";
+import { SquareDashedMousePointer } from "lucide-react";
+import { TEMPLATE_LIST } from "@/lib/dashboard/templates";
 
 interface DashboardDialogSelectStepProps {
   onSelect: (templateId: string) => void;
 }
-
-const TEMPLATE_ICONS: Record<TEMPLATE_ID, React.ReactNode> = {
-  [TEMPLATE_ID.PROJECT_METRICS]: (
-    <ChartLine className="size-4 text-[#5899DA]" />
-  ),
-  [TEMPLATE_ID.PERFORMANCE]: <Activity className="size-4 text-[#EF6868]" />,
-};
 
 const DashboardDialogSelectStep: React.FunctionComponent<
   DashboardDialogSelectStepProps
@@ -24,19 +13,17 @@ const DashboardDialogSelectStep: React.FunctionComponent<
     <div className="flex flex-col gap-4">
       {/* Template cards grid */}
       <div className="grid grid-cols-2 gap-4">
-        {TEMPLATE_OPTIONS_ORDER.map((templateId) => {
-          const template = DASHBOARD_TEMPLATES[templateId];
-          const icon = TEMPLATE_ICONS[templateId];
-
+        {TEMPLATE_LIST.map((template) => {
+          const Icon = template.icon;
           return (
             <button
-              key={templateId}
-              onClick={() => onSelect(templateId)}
+              key={template.id}
+              onClick={() => onSelect(template.type)}
               className="flex flex-col gap-1 rounded-md border border-border bg-background p-4 text-left transition-colors hover:border-primary hover:bg-muted"
             >
               <div className="flex h-5 items-center gap-2">
                 <div className="flex size-4 shrink-0 items-center justify-center">
-                  {icon}
+                  <Icon className={template.iconColor} />
                 </div>
                 <h4 className="comet-body-s-accented text-foreground">
                   {template.title}
@@ -50,7 +37,6 @@ const DashboardDialogSelectStep: React.FunctionComponent<
         })}
       </div>
 
-      {/* Separator */}
       <div className="flex items-center gap-2.5">
         <div className="h-px flex-1 bg-slate-200" />
         <p className="comet-body-xs text-light-slate">
@@ -59,7 +45,6 @@ const DashboardDialogSelectStep: React.FunctionComponent<
         <div className="h-px flex-1 bg-slate-200" />
       </div>
 
-      {/* Empty dashboard option */}
       <button
         onClick={() => onSelect("")}
         className="flex h-20 items-center gap-1 rounded-md border border-border bg-background p-4 text-left transition-colors hover:border-primary hover:bg-muted"
@@ -67,7 +52,7 @@ const DashboardDialogSelectStep: React.FunctionComponent<
         <div className="flex flex-1 flex-col gap-1">
           <div className="flex items-center gap-2">
             <div className="flex size-4 shrink-0 items-center justify-center">
-              <SquareDashedMousePointer className="size-4 text-[#945FCF]" />
+              <SquareDashedMousePointer className="text-template-icon-scratch" />
             </div>
             <h4 className="comet-body-s-accented text-foreground">
               Start from scratch

--- a/apps/opik-frontend/src/components/pages-shared/dashboards/DashboardContent/DashboardContent.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/dashboards/DashboardContent/DashboardContent.tsx
@@ -1,0 +1,95 @@
+import React, { useState, useCallback, useEffect } from "react";
+
+import {
+  useDashboardStore,
+  selectAddWidget,
+  selectUpdateWidget,
+  selectHasUnsavedChanges,
+} from "@/store/DashboardStore";
+import DashboardSectionsContainer from "@/components/shared/Dashboard/Dashboard";
+import AddSectionButton from "@/components/shared/Dashboard/DashboardSection/AddSectionButton";
+import WidgetConfigDialog from "@/components/shared/Dashboard/WidgetConfigDialog/WidgetConfigDialog";
+import useNavigationBlocker from "@/hooks/useNavigationBlocker";
+import {
+  DashboardWidget,
+  WIDGET_TYPE,
+  AddWidgetConfig,
+  UpdateWidgetConfig,
+} from "@/types/dashboard";
+
+const DashboardContent: React.FunctionComponent = () => {
+  const hasUnsavedChanges = useDashboardStore(selectHasUnsavedChanges);
+  const [widgetDialogOpen, setWidgetDialogOpen] = useState(false);
+  const [targetSectionId, setTargetSectionId] = useState<string | null>(null);
+  const [targetWidgetId, setTargetWidgetId] = useState<string | null>(null);
+
+  const addSection = useDashboardStore((state) => state.addSection);
+  const addWidget = useDashboardStore(selectAddWidget);
+  const updateWidget = useDashboardStore(selectUpdateWidget);
+
+  useEffect(() => {
+    useDashboardStore
+      .getState()
+      .setOnAddEditWidgetCallback(({ sectionId, widgetId }) => {
+        setTargetSectionId(sectionId);
+        setTargetWidgetId(widgetId || null);
+        setWidgetDialogOpen(true);
+      });
+
+    return () => {
+      useDashboardStore.getState().setOnAddEditWidgetCallback(null);
+    };
+  }, []);
+
+  const handleSaveWidget = useCallback(
+    (widgetData: Partial<DashboardWidget>) => {
+      if (!targetSectionId) return;
+
+      if (targetWidgetId) {
+        updateWidget(targetSectionId, targetWidgetId, {
+          title: widgetData.title,
+          subtitle: widgetData.subtitle,
+          config: widgetData.config,
+        } as UpdateWidgetConfig);
+      } else if (widgetData.type && widgetData.title) {
+        addWidget(targetSectionId, {
+          type: widgetData.type as WIDGET_TYPE,
+          title: widgetData.title,
+          subtitle: widgetData.subtitle,
+          config: widgetData.config || {},
+        } as AddWidgetConfig);
+      }
+    },
+    [targetSectionId, targetWidgetId, addWidget, updateWidget],
+  );
+
+  const { DialogComponent } = useNavigationBlocker({
+    condition: hasUnsavedChanges,
+    title: "You have unsaved changes",
+    description:
+      "If you leave now, your changes will be lost. Are you sure you want to continue?",
+    confirmText: "Leave without saving",
+    cancelText: "Stay on page",
+  });
+
+  return (
+    <>
+      <DashboardSectionsContainer />
+
+      <div className="text-clip rounded-md">
+        <AddSectionButton onAddSection={addSection} />
+      </div>
+
+      <WidgetConfigDialog
+        open={widgetDialogOpen}
+        onOpenChange={setWidgetDialogOpen}
+        sectionId={targetSectionId || ""}
+        widgetId={targetWidgetId || undefined}
+        onSave={handleSaveWidget}
+      />
+      {DialogComponent}
+    </>
+  );
+};
+
+export default DashboardContent;

--- a/apps/opik-frontend/src/components/pages-shared/dashboards/DashboardSaveActions/DashboardSaveActions.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/dashboards/DashboardSaveActions/DashboardSaveActions.tsx
@@ -8,31 +8,45 @@ import {
   ButtonWithDropdownContent,
   ButtonWithDropdownItem,
 } from "@/components/ui/button-with-dropdown";
+import { Separator } from "@/components/ui/separator";
 import ConfirmDialog from "@/components/shared/ConfirmDialog/ConfirmDialog";
 import { useToast } from "@/components/ui/use-toast";
 import AddEditCloneDashboardDialog from "@/components/pages-shared/dashboards/AddEditCloneDashboardDialog/AddEditCloneDashboardDialog";
-import { useDashboardStore } from "@/store/DashboardStore";
+import {
+  useDashboardStore,
+  selectHasUnsavedChanges,
+} from "@/store/DashboardStore";
 import { Dashboard } from "@/types/dashboard";
 
 interface DashboardSaveActionsProps {
-  hasUnsavedChanges: boolean;
   onSave: () => Promise<void>;
   onDiscard: () => void;
   dashboard: Dashboard;
+  isTemplate?: boolean;
+  navigateOnCreate?: boolean;
+  onDashboardCreated?: (dashboardId: string) => void;
+  defaultProjectId?: string;
 }
 
 const DashboardSaveActions: React.FunctionComponent<
   DashboardSaveActionsProps
-> = ({ hasUnsavedChanges, onSave, onDiscard, dashboard }) => {
+> = ({
+  onSave,
+  onDiscard,
+  dashboard,
+  isTemplate = false,
+  navigateOnCreate = true,
+  onDashboardCreated,
+  defaultProjectId,
+}) => {
+  const hasUnsavedChanges = useDashboardStore(selectHasUnsavedChanges);
   const resetKeyRef = useRef(0);
   const [showDiscardDialog, setShowDiscardDialog] = useState(false);
   const [saveAsDialogOpen, setSaveAsDialogOpen] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const { toast } = useToast();
 
-  const getDashboardConfig = useDashboardStore(
-    (state) => state.getDashboardConfig,
-  );
+  const getDashboard = useDashboardStore((state) => state.getDashboard);
 
   const dashboardWithCurrentConfigRef = useRef(dashboard);
 
@@ -72,15 +86,19 @@ const DashboardSaveActions: React.FunctionComponent<
     // Get fresh config when opening the dialog
     dashboardWithCurrentConfigRef.current = {
       ...dashboard,
-      config: getDashboardConfig(),
+      config: getDashboard(),
     };
     setSaveAsDialogOpen(true);
     resetKeyRef.current = resetKeyRef.current + 1;
-  }, [dashboard, getDashboardConfig]);
+  }, [dashboard, getDashboard]);
 
   if (!hasUnsavedChanges) {
     return null;
   }
+
+  const discardDescription = isTemplate
+    ? "All unsaved changes will be removed. This will return the template to its original state."
+    : "All unsaved changes will be removed. This will return the dashboard to its last saved version.";
 
   return (
     <>
@@ -93,29 +111,37 @@ const DashboardSaveActions: React.FunctionComponent<
         Discard changes
       </Button>
 
-      <ButtonWithDropdown>
-        <ButtonWithDropdownTrigger
-          variant="default"
-          size="sm"
-          onPrimaryClick={handleSave}
-          disabled={isSaving}
-        >
-          Save changes
-        </ButtonWithDropdownTrigger>
-        <ButtonWithDropdownContent align="end">
-          <ButtonWithDropdownItem onClick={handleSaveAsClick}>
-            <Copy className="mr-2 size-4" />
-            Save as new
-          </ButtonWithDropdownItem>
-        </ButtonWithDropdownContent>
-      </ButtonWithDropdown>
+      {isTemplate ? (
+        <Button size="sm" onClick={handleSaveAsClick} disabled={isSaving}>
+          Save as new dashboard
+        </Button>
+      ) : (
+        <ButtonWithDropdown>
+          <ButtonWithDropdownTrigger
+            variant="default"
+            size="sm"
+            onPrimaryClick={handleSave}
+            disabled={isSaving}
+          >
+            Save changes
+          </ButtonWithDropdownTrigger>
+          <ButtonWithDropdownContent align="end">
+            <ButtonWithDropdownItem onClick={handleSaveAsClick}>
+              <Copy className="mr-2 size-4" />
+              Save as new
+            </ButtonWithDropdownItem>
+          </ButtonWithDropdownContent>
+        </ButtonWithDropdown>
+      )}
+
+      <Separator orientation="vertical" className="mx-2 h-4" />
 
       <ConfirmDialog
         open={showDiscardDialog}
         setOpen={setShowDiscardDialog}
         onConfirm={handleConfirmDiscard}
         title="Discard changes?"
-        description="All unsaved changes will be removed. This will return the dashboard to its last saved version."
+        description={discardDescription}
         confirmText="Discard changes"
         cancelText="Cancel"
         confirmButtonVariant="destructive"
@@ -127,7 +153,12 @@ const DashboardSaveActions: React.FunctionComponent<
         open={saveAsDialogOpen}
         setOpen={setSaveAsDialogOpen}
         dashboard={dashboardWithCurrentConfigRef.current}
-        onSuccess={onDiscard}
+        onCreateSuccess={(dashboardId) => {
+          onDiscard();
+          onDashboardCreated?.(dashboardId);
+        }}
+        navigateOnCreate={navigateOnCreate}
+        defaultProjectId={defaultProjectId}
       />
     </>
   );

--- a/apps/opik-frontend/src/components/pages-shared/dashboards/DashboardSelectBox/DashboardSelectBox.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/dashboards/DashboardSelectBox/DashboardSelectBox.tsx
@@ -1,0 +1,342 @@
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import { ChevronDown, Plus } from "lucide-react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import AddEditCloneDashboardDialog, {
+  DashboardDialogMode,
+} from "@/components/pages-shared/dashboards/AddEditCloneDashboardDialog/AddEditCloneDashboardDialog";
+import useDashboardsList from "@/api/dashboards/useDashboardsList";
+import { cn } from "@/lib/utils";
+import useAppStore from "@/store/AppStore";
+import { TEMPLATE_LIST } from "@/lib/dashboard/templates";
+import { isTemplateId } from "@/lib/dashboard/utils";
+import { Dashboard } from "@/types/dashboard";
+import SearchInput from "@/components/shared/SearchInput/SearchInput";
+import ConfirmDialog from "@/components/shared/ConfirmDialog/ConfirmDialog";
+import useDashboardBatchDeleteMutation from "@/api/dashboards/useDashboardBatchDeleteMutation";
+import { SelectItem } from "./SelectItem";
+import { TriggerContent } from "./TriggerContent";
+
+const DEFAULT_LOADED_DASHBOARDS = 1000;
+const MAX_LOADED_DASHBOARDS = 10000;
+
+interface DashboardSelectBoxProps {
+  value: string | null;
+  onChange: (id: string | null) => void;
+  disabled?: boolean;
+  buttonClassName?: string;
+  onDashboardCreated?: (dashboardId: string) => void;
+  onDashboardDeleted?: (deletedDashboardId: string) => void;
+  defaultProjectId?: string;
+}
+
+interface DialogState {
+  isOpen: boolean;
+  mode: DashboardDialogMode;
+  dashboard?: Dashboard;
+}
+
+interface DeleteState {
+  isOpen: boolean;
+  dashboard?: Dashboard;
+}
+
+const DashboardSelectBox: React.FC<DashboardSelectBoxProps> = ({
+  value,
+  onChange,
+  disabled = false,
+  buttonClassName,
+  onDashboardCreated,
+  onDashboardDeleted,
+  defaultProjectId,
+}) => {
+  const [isLoadedMore, setIsLoadedMore] = useState(false);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const resetDialogKeyRef = useRef(0);
+
+  const [dialogState, setDialogState] = useState<DialogState>({
+    isOpen: false,
+    mode: "create",
+  });
+
+  const [deleteState, setDeleteState] = useState<DeleteState>({
+    isOpen: false,
+  });
+
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const deleteDashboardMutation = useDashboardBatchDeleteMutation();
+
+  const { data: dashboardsData } = useDashboardsList(
+    {
+      workspaceName,
+      page: 1,
+      size: !isLoadedMore ? DEFAULT_LOADED_DASHBOARDS : MAX_LOADED_DASHBOARDS,
+    },
+    {
+      enabled: Boolean(workspaceName),
+    },
+  );
+
+  const dashboards = useMemo(
+    () => dashboardsData?.content || [],
+    [dashboardsData?.content],
+  );
+  const dashboardTotal = dashboardsData?.total;
+
+  const filteredTemplates = useMemo(() => {
+    return TEMPLATE_LIST.filter((template) =>
+      template.title.toLowerCase().includes(search.toLowerCase()),
+    );
+  }, [search]);
+
+  const filteredDashboards = useMemo(() => {
+    return dashboards.filter((dashboard) =>
+      dashboard.name.toLowerCase().includes(search.toLowerCase()),
+    );
+  }, [dashboards, search]);
+
+  const selectedItem = useMemo(() => {
+    if (isTemplateId(value)) {
+      return TEMPLATE_LIST.find((t) => t.id === value);
+    }
+    return dashboards.find((d) => d.id === value);
+  }, [value, dashboards]);
+
+  const handleChangeDashboardId = useCallback(
+    (id: string) => {
+      if (value !== id) {
+        onChange(id);
+        setIsDropdownOpen(false);
+      }
+    },
+    [onChange, value],
+  );
+
+  const handleEditDashboard = useCallback((dashboard: Dashboard) => {
+    resetDialogKeyRef.current = resetDialogKeyRef.current + 1;
+    setDialogState({ isOpen: true, mode: "edit", dashboard });
+    setIsDropdownOpen(false);
+  }, []);
+
+  const handleDuplicateDashboard = useCallback((dashboard: Dashboard) => {
+    resetDialogKeyRef.current = resetDialogKeyRef.current + 1;
+    setDialogState({ isOpen: true, mode: "clone", dashboard });
+    setIsDropdownOpen(false);
+  }, []);
+
+  const handleDeleteDashboard = useCallback((dashboard: Dashboard) => {
+    setDeleteState({ isOpen: true, dashboard });
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    if (!deleteState.dashboard) return;
+
+    const deletedDashboardId = deleteState.dashboard.id;
+
+    deleteDashboardMutation.mutate(
+      {
+        ids: [deletedDashboardId],
+      },
+      {
+        onSuccess: () => {
+          if (onDashboardDeleted) {
+            onDashboardDeleted(deletedDashboardId);
+          }
+        },
+      },
+    );
+
+    setDeleteState({ isOpen: false });
+    setIsDropdownOpen(false);
+  }, [deleteState.dashboard, deleteDashboardMutation, onDashboardDeleted]);
+
+  const handleCreateNew = useCallback(() => {
+    resetDialogKeyRef.current = resetDialogKeyRef.current + 1;
+    setIsDropdownOpen(false);
+    setDialogState({ isOpen: true, mode: "create" });
+  }, []);
+
+  const handleDialogCreateSuccess = useCallback(
+    (dashboardId: string) => {
+      if (onDashboardCreated) {
+        onDashboardCreated(dashboardId);
+      }
+    },
+    [onDashboardCreated],
+  );
+
+  const closeDialog = useCallback((open: boolean) => {
+    if (!open) {
+      setDialogState({ isOpen: false, mode: "create" });
+    }
+  }, []);
+
+  const hasResults =
+    filteredTemplates.length > 0 || filteredDashboards.length > 0;
+  const showSeparator =
+    filteredTemplates.length > 0 && filteredDashboards.length > 0;
+  const shouldShowLoadMore =
+    (dashboardTotal || 0) > DEFAULT_LOADED_DASHBOARDS && !isLoadedMore;
+
+  const handleOpenChange = useCallback((open: boolean) => {
+    setIsDropdownOpen(open);
+    if (!open) {
+      setSearch("");
+    }
+  }, []);
+
+  return (
+    <>
+      <DropdownMenu open={isDropdownOpen} onOpenChange={handleOpenChange}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            className={cn("group justify-between px-3", buttonClassName, {
+              "disabled:cursor-not-allowed disabled:border-input disabled:bg-muted-disabled disabled:text-muted-gray disabled:placeholder:text-muted-gray hover:disabled:shadow-none":
+                disabled,
+            })}
+            size="sm"
+            variant="outline"
+            disabled={disabled}
+            type="button"
+          >
+            <TriggerContent selectedItem={selectedItem} />
+            <ChevronDown className="ml-2 size-4 shrink-0 text-light-slate group-disabled:text-muted-gray" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          className="w-[300px] max-w-[300px] p-0 pt-12"
+          align="end"
+          onCloseAutoFocus={(e) => e.preventDefault()}
+        >
+          <div
+            className="absolute inset-x-1 top-1 h-11"
+            onKeyDown={(e) => e.stopPropagation()}
+          >
+            <SearchInput
+              searchText={search}
+              setSearchText={setSearch}
+              placeholder="Search"
+              variant="ghost"
+            />
+            <Separator className="mt-1" />
+          </div>
+
+          <div className="max-h-[40vh] overflow-y-auto overflow-x-hidden p-1">
+            {!hasResults ? (
+              <div className="flex min-h-24 flex-col items-center justify-center px-6 py-4">
+                <div className="comet-body-s text-center text-muted-slate">
+                  No search results
+                </div>
+              </div>
+            ) : (
+              <>
+                {filteredTemplates.length > 0 && (
+                  <>
+                    <DropdownMenuLabel>Prebuilt dashboards</DropdownMenuLabel>
+                    {filteredTemplates.map((template) => (
+                      <SelectItem
+                        key={template.id}
+                        id={template.id}
+                        name={template.title}
+                        description={template.description}
+                        icon={template.icon}
+                        iconColor={template.iconColor}
+                        isSelected={value === template.id}
+                        onSelect={handleChangeDashboardId}
+                      />
+                    ))}
+                  </>
+                )}
+
+                {showSeparator && <DropdownMenuSeparator className="my-1.5" />}
+
+                {filteredDashboards.length > 0 && (
+                  <>
+                    <DropdownMenuLabel>Your dashboards</DropdownMenuLabel>
+                    {filteredDashboards.map((dashboard) => (
+                      <SelectItem
+                        key={dashboard.id}
+                        id={dashboard.id}
+                        name={dashboard.name}
+                        description={dashboard.description}
+                        isSelected={value === dashboard.id}
+                        onSelect={handleChangeDashboardId}
+                        dashboard={dashboard}
+                        onEdit={handleEditDashboard}
+                        onDuplicate={handleDuplicateDashboard}
+                        onDelete={handleDeleteDashboard}
+                      />
+                    ))}
+                  </>
+                )}
+              </>
+            )}
+          </div>
+
+          {shouldShowLoadMore && (
+            <>
+              <Separator />
+              <div className="flex flex-wrap items-center justify-between px-5 py-2">
+                <div className="comet-body-s text-light-slate">
+                  {`Showing first ${DEFAULT_LOADED_DASHBOARDS} items.`}
+                </div>
+                <Button
+                  variant="link"
+                  onClick={() => setIsLoadedMore(true)}
+                  type="button"
+                >
+                  Load more
+                </Button>
+              </div>
+            </>
+          )}
+
+          <Separator />
+          <div className="p-1">
+            <div
+              className="flex h-10 cursor-pointer items-center rounded-md px-4 hover:bg-primary-foreground"
+              onClick={handleCreateNew}
+            >
+              <div className="comet-body-s flex items-center gap-2 text-primary">
+                <Plus className="size-3.5 shrink-0" />
+                <span>Create new dashboard</span>
+              </div>
+            </div>
+          </div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AddEditCloneDashboardDialog
+        key={resetDialogKeyRef.current}
+        mode={dialogState.mode}
+        dashboard={dialogState.dashboard}
+        open={dialogState.isOpen}
+        setOpen={closeDialog}
+        onCreateSuccess={handleDialogCreateSuccess}
+        navigateOnCreate={false}
+        defaultProjectId={defaultProjectId}
+      />
+
+      <ConfirmDialog
+        open={deleteState.isOpen}
+        setOpen={(open) => setDeleteState({ isOpen: open })}
+        onConfirm={confirmDelete}
+        title="Delete dashboard"
+        description={`Are you sure you want to delete "${deleteState.dashboard?.name}"? This action cannot be undone.`}
+        confirmText="Delete"
+        confirmButtonVariant="destructive"
+      />
+    </>
+  );
+};
+
+export default DashboardSelectBox;

--- a/apps/opik-frontend/src/components/pages-shared/dashboards/DashboardSelectBox/SelectItem.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/dashboards/DashboardSelectBox/SelectItem.tsx
@@ -1,0 +1,172 @@
+import React from "react";
+import {
+  ChartLine,
+  Check,
+  Copy,
+  MoreVertical,
+  Pencil,
+  Trash2,
+} from "lucide-react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Dashboard } from "@/types/dashboard";
+
+interface SelectItemProps {
+  id: string;
+  name: string;
+  description?: string;
+  icon?: React.ComponentType<{ className?: string }>;
+  iconColor?: string;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+  // Optional actions for user dashboards
+  dashboard?: Dashboard;
+  onEdit?: (dashboard: Dashboard) => void;
+  onDuplicate?: (dashboard: Dashboard) => void;
+  onDelete?: (dashboard: Dashboard) => void;
+}
+
+export const SelectItem: React.FC<SelectItemProps> = ({
+  id,
+  name,
+  description,
+  icon,
+  iconColor,
+  isSelected,
+  onSelect,
+  dashboard,
+  onEdit,
+  onDuplicate,
+  onDelete,
+}) => {
+  const Icon = icon || ChartLine;
+  const hasActions = dashboard && onEdit && onDuplicate && onDelete;
+
+  // Use DropdownMenuItem for templates (better keyboard navigation)
+  if (!hasActions) {
+    return (
+      <DropdownMenuItem
+        className={cn(
+          "min-h-12 cursor-pointer items-start gap-2 py-2 pl-6",
+          isSelected && "bg-primary-foreground",
+        )}
+        onSelect={() => onSelect(id)}
+      >
+        {isSelected && (
+          <Check
+            className="absolute left-1 top-2.5 size-3.5 text-foreground"
+            strokeWidth="3"
+          />
+        )}
+        <Icon
+          className={cn(
+            "mt-0.5 size-4 shrink-0",
+            iconColor ? iconColor : "text-muted-slate",
+          )}
+        />
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="comet-body-s truncate">{name}</div>
+          {description && (
+            <TooltipWrapper content={description}>
+              <div className="comet-body-xs line-clamp-2 text-muted-foreground">
+                {description}
+              </div>
+            </TooltipWrapper>
+          )}
+        </div>
+      </DropdownMenuItem>
+    );
+  }
+
+  // Use div for dashboards (to support nested dropdown menu)
+  return (
+    <div
+      className={cn(
+        "group relative flex min-h-12 cursor-pointer items-start gap-2 rounded-md py-2 pl-6 pr-4 hover:bg-primary-foreground",
+        isSelected && "bg-primary-foreground",
+      )}
+      onClick={() => onSelect(id)}
+    >
+      {isSelected && (
+        <Check
+          className="absolute left-1 top-2.5 size-3.5 text-foreground"
+          strokeWidth="3"
+        />
+      )}
+      <Icon
+        className={cn(
+          "mt-0.5 size-4 shrink-0",
+          iconColor ? iconColor : "text-muted-slate",
+        )}
+      />
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="comet-body-s truncate">{name}</div>
+        {description && (
+          <TooltipWrapper content={description}>
+            <div className="comet-body-xs line-clamp-2 text-muted-foreground">
+              {description}
+            </div>
+          </TooltipWrapper>
+        )}
+      </div>
+      {dashboard && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="mt-0.5 opacity-0 group-hover:opacity-100"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <MoreVertical className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            side="right"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit?.(dashboard);
+              }}
+            >
+              <Pencil className="mr-2 size-4" />
+              Edit
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                onDuplicate?.(dashboard);
+              }}
+            >
+              <Copy className="mr-2 size-4" />
+              Duplicate
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete?.(dashboard);
+              }}
+              className="text-destructive focus:text-destructive"
+            >
+              <Trash2 className="mr-2 size-4" />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
+  );
+};

--- a/apps/opik-frontend/src/components/pages-shared/dashboards/DashboardSelectBox/TriggerContent.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/dashboards/DashboardSelectBox/TriggerContent.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+import { TEMPLATE_LIST } from "@/lib/dashboard/templates";
+import { Dashboard } from "@/types/dashboard";
+
+interface TriggerContentProps {
+  selectedItem: (typeof TEMPLATE_LIST)[number] | Dashboard | null | undefined;
+}
+
+export const TriggerContent: React.FC<TriggerContentProps> = ({
+  selectedItem,
+}) => {
+  if (!selectedItem) {
+    return (
+      <span className="truncate font-normal text-light-slate">
+        Select a dashboard
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex min-w-0 items-center">
+      <span className="shrink-0 text-muted-slate">Dashboard:</span>
+      <span className="ml-1 truncate">
+        {"name" in selectedItem
+          ? selectedItem.name
+          : "title" in selectedItem
+            ? selectedItem.title
+            : ""}
+      </span>
+    </div>
+  );
+};

--- a/apps/opik-frontend/src/components/pages-shared/dashboards/ViewSelector/ViewSelector.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/dashboards/ViewSelector/ViewSelector.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { Table, ChartLine } from "lucide-react";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
+import {
+  useDashboardStore,
+  selectHasUnsavedChanges,
+} from "@/store/DashboardStore";
+import { useIsFeatureEnabled } from "@/components/feature-toggles-provider";
+import { FeatureToggleKeys } from "@/types/feature-toggles";
+
+export enum VIEW_TYPE {
+  DETAILS = "details",
+  DASHBOARDS = "dashboards",
+}
+
+interface ViewSelectorProps {
+  value: VIEW_TYPE;
+  onChange: (value: VIEW_TYPE) => void;
+}
+
+const ViewSelector: React.FC<ViewSelectorProps> = ({ value, onChange }) => {
+  const hasUnsavedChanges = useDashboardStore(selectHasUnsavedChanges);
+  const isDashboardsEnabled = useIsFeatureEnabled(
+    FeatureToggleKeys.DASHBOARDS_ENABLED,
+  );
+  const disabled = value === VIEW_TYPE.DASHBOARDS && hasUnsavedChanges;
+
+  if (!isDashboardsEnabled) {
+    return null;
+  }
+  const content = (
+    <ToggleGroup
+      type="single"
+      value={value}
+      onValueChange={(val) => !disabled && val && onChange(val as VIEW_TYPE)}
+      variant="ghost"
+      className="w-fit"
+    >
+      <ToggleGroupItem
+        value={VIEW_TYPE.DETAILS}
+        size="sm"
+        className="gap-2"
+        disabled={disabled}
+      >
+        <Table className="size-3" />
+        Details
+      </ToggleGroupItem>
+      <ToggleGroupItem
+        value={VIEW_TYPE.DASHBOARDS}
+        size="sm"
+        className="gap-2"
+        disabled={disabled}
+      >
+        <ChartLine className="size-3" />
+        Dashboards
+      </ToggleGroupItem>
+    </ToggleGroup>
+  );
+
+  if (disabled) {
+    return (
+      <TooltipWrapper content="Save or discard your changes before switching">
+        <div>{content}</div>
+      </TooltipWrapper>
+    );
+  }
+
+  return content;
+};
+
+export default ViewSelector;

--- a/apps/opik-frontend/src/components/pages-shared/dashboards/hooks/useDashboardLifecycle.ts
+++ b/apps/opik-frontend/src/components/pages-shared/dashboards/hooks/useDashboardLifecycle.ts
@@ -1,0 +1,90 @@
+import { useEffect, useMemo } from "react";
+
+import {
+  useDashboardStore,
+  selectSetWidgetResolver,
+  selectClearDashboard,
+} from "@/store/DashboardStore";
+import useDashboardById from "@/api/dashboards/useDashboardById";
+import { widgetResolver } from "@/components/shared/Dashboard/widgets/widgetRegistry";
+import { useDashboardSave } from "./useDashboardSave";
+import { Dashboard } from "@/types/dashboard";
+import { isTemplateId } from "@/lib/dashboard/utils";
+import { TEMPLATE_LIST } from "@/lib/dashboard/templates";
+
+interface UseDashboardLifecycleParams {
+  dashboardId: string | null;
+  enabled?: boolean;
+}
+
+interface UseDashboardLifecycleReturn {
+  dashboard: Dashboard | undefined;
+  isPending: boolean;
+  save: () => Promise<void>;
+  discard: () => void;
+  isTemplate: boolean;
+}
+
+export const useDashboardLifecycle = ({
+  dashboardId,
+  enabled = true,
+}: UseDashboardLifecycleParams): UseDashboardLifecycleReturn => {
+  const isTemplate = isTemplateId(dashboardId);
+
+  const templateDashboard = useMemo(() => {
+    if (!isTemplate || !dashboardId) return undefined;
+
+    const template = TEMPLATE_LIST.find((t) => t.id === dashboardId);
+    if (!template) return undefined;
+
+    return {
+      id: template.id,
+      name: template.title,
+      description: template.description,
+      workspace_id: "",
+      config: template.config,
+      created_at: "",
+      last_updated_at: "",
+    } as Dashboard;
+  }, [isTemplate, dashboardId]);
+
+  const { data: backendDashboard, isPending: isBackendPending } =
+    useDashboardById(
+      { dashboardId: dashboardId || "" },
+      { enabled: Boolean(dashboardId) && enabled && !isTemplate },
+    );
+
+  const dashboard = isTemplate ? templateDashboard : backendDashboard;
+  const isPending = isTemplate ? false : isBackendPending;
+
+  const loadDashboardFromBackend = useDashboardStore(
+    (state) => state.loadDashboardFromBackend,
+  );
+  const clearDashboard = useDashboardStore(selectClearDashboard);
+  const setWidgetResolver = useDashboardStore(selectSetWidgetResolver);
+
+  useEffect(() => {
+    if (dashboard?.config) {
+      loadDashboardFromBackend(dashboard.config);
+    }
+    return () => clearDashboard();
+  }, [clearDashboard, dashboard, loadDashboardFromBackend]);
+
+  useEffect(() => {
+    setWidgetResolver(widgetResolver);
+    return () => setWidgetResolver(null);
+  }, [setWidgetResolver]);
+
+  const { save, discard } = useDashboardSave({
+    dashboardId: dashboardId || "",
+    enabled: Boolean(dashboardId && dashboard) && enabled,
+  });
+
+  return {
+    dashboard,
+    isPending,
+    save,
+    discard,
+    isTemplate,
+  };
+};

--- a/apps/opik-frontend/src/components/pages/DashboardPage/DashboardPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DashboardPage/DashboardPage.tsx
@@ -1,93 +1,39 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useCallback } from "react";
 import { useParams } from "@tanstack/react-router";
 
 import {
   useDashboardStore,
-  selectAddSection,
-  selectAddWidget,
-  selectUpdateWidget,
   selectSetConfig,
-  selectClearConfig,
-  selectClearDashboard,
-  selectSetOnAddEditWidgetCallback,
-  selectSetWidgetResolver,
-  selectConfig,
+  selectMixedConfig,
 } from "@/store/DashboardStore";
-import useDashboardById from "@/api/dashboards/useDashboardById";
 import useBreadcrumbsStore from "@/store/BreadcrumbsStore";
 import { useMetricDateRangeCore } from "@/components/pages-shared/traces/MetricDateRangeSelect/useMetricDateRangeCore";
 import { DEFAULT_DATE_PRESET } from "@/components/pages-shared/traces/MetricDateRangeSelect/constants";
 import MetricDateRangeSelect from "@/components/pages-shared/traces/MetricDateRangeSelect/MetricDateRangeSelect";
 import { DateRangeSerializedValue } from "@/components/shared/DateRangeSelect";
-import DashboardSectionsContainer from "@/components/shared/Dashboard/Dashboard";
-import AddSectionButton from "@/components/shared/Dashboard/DashboardSection/AddSectionButton";
-import WidgetConfigDialog from "@/components/shared/Dashboard/WidgetConfigDialog/WidgetConfigDialog";
 import Loader from "@/components/shared/Loader/Loader";
-import useNavigationBlocker from "@/hooks/useNavigationBlocker";
 import { Separator } from "@/components/ui/separator";
-import { useDashboardSave } from "./useDashboardSave";
+import { useDashboardLifecycle } from "@/components/pages-shared/dashboards/hooks/useDashboardLifecycle";
 import DashboardSaveActions from "@/components/pages-shared/dashboards/DashboardSaveActions/DashboardSaveActions";
 import DashboardProjectSettingsButton from "@/components/pages-shared/dashboards/DashboardProjectSettingsButton/DashboardProjectSettingsButton";
 import ShareDashboardButton from "@/components/pages-shared/dashboards/ShareDashboardButton/ShareDashboardButton";
-import {
-  DashboardWidget,
-  WIDGET_TYPE,
-  AddWidgetConfig,
-  UpdateWidgetConfig,
-  AddEditWidgetCallbackParams,
-} from "@/types/dashboard";
-import { createWidgetResolver } from "@/components/shared/Dashboard/widgets/widgetRegistry";
+import DashboardContent from "@/components/pages-shared/dashboards/DashboardContent/DashboardContent";
 
 const DashboardPage: React.FunctionComponent = () => {
   const { dashboardId } = useParams({ strict: false }) as {
     dashboardId: string;
   };
   const setBreadcrumbParam = useBreadcrumbsStore((state) => state.setParam);
-  const [widgetDialogOpen, setWidgetDialogOpen] = useState(false);
-  const [targetSectionId, setTargetSectionId] = useState<string | null>(null);
-  const [targetWidgetId, setTargetWidgetId] = useState<string | null>(null);
 
-  const { data: dashboard, isPending } = useDashboardById(
-    { dashboardId },
-    { enabled: Boolean(dashboardId) },
-  );
+  const { dashboard, isPending, save, discard } = useDashboardLifecycle({
+    dashboardId,
+    enabled: Boolean(dashboardId),
+  });
 
-  const addSection = useDashboardStore(selectAddSection);
-  const addWidget = useDashboardStore(selectAddWidget);
-  const updateWidget = useDashboardStore(selectUpdateWidget);
-  const loadDashboardFromBackend = useDashboardStore(
-    (state) => state.loadDashboardFromBackend,
-  );
-  const config = useDashboardStore(selectConfig);
+  const config = useDashboardStore(selectMixedConfig);
   const setConfig = useDashboardStore(selectSetConfig);
-  const clearConfig = useDashboardStore(selectClearConfig);
-  const clearDashboard = useDashboardStore(selectClearDashboard);
-  const setOnAddEditWidgetCallback = useDashboardStore(
-    selectSetOnAddEditWidgetCallback,
-  );
-  const setWidgetResolver = useDashboardStore(selectSetWidgetResolver);
 
   const dateRangeValue = config?.dateRange || DEFAULT_DATE_PRESET;
-
-  useEffect(() => {
-    if (dashboard?.config) {
-      loadDashboardFromBackend(dashboard.config);
-    }
-  }, [dashboard, loadDashboardFromBackend]);
-
-  const { hasUnsavedChanges, save, discard } = useDashboardSave({
-    dashboardId,
-    enabled: Boolean(dashboardId && dashboard),
-  });
-
-  const { DialogComponent } = useNavigationBlocker({
-    condition: hasUnsavedChanges,
-    title: "You have unsaved changes",
-    description:
-      "If you leave now, your changes will be lost. Are you sure you want to continue?",
-    confirmText: "Leave without saving",
-    cancelText: "Stay on page",
-  });
 
   useEffect(() => {
     if (dashboard?.name) {
@@ -109,57 +55,6 @@ const DashboardPage: React.FunctionComponent = () => {
       setValue: handleDateRangeValueChange,
     });
 
-  const handleOpenWidgetDialog = useCallback(
-    ({ sectionId, widgetId }: AddEditWidgetCallbackParams) => {
-      setTargetSectionId(sectionId);
-      setTargetWidgetId(widgetId || null);
-      setWidgetDialogOpen(true);
-    },
-    [],
-  );
-
-  const handleSaveWidget = (widgetData: Partial<DashboardWidget>) => {
-    if (!targetSectionId) return;
-
-    if (targetWidgetId) {
-      updateWidget(targetSectionId, targetWidgetId, {
-        title: widgetData.title,
-        subtitle: widgetData.subtitle,
-        config: widgetData.config,
-      } as UpdateWidgetConfig);
-    } else if (widgetData.type && widgetData.title) {
-      addWidget(targetSectionId, {
-        type: widgetData.type as WIDGET_TYPE,
-        title: widgetData.title,
-        subtitle: widgetData.subtitle,
-        config: widgetData.config || {},
-      } as AddWidgetConfig);
-    }
-  };
-
-  useEffect(() => {
-    setOnAddEditWidgetCallback(handleOpenWidgetDialog);
-  }, [handleOpenWidgetDialog, setOnAddEditWidgetCallback]);
-
-  useEffect(() => {
-    const resolver = createWidgetResolver();
-    setWidgetResolver(resolver);
-  }, [setWidgetResolver]);
-
-  useEffect(() => {
-    return () => {
-      clearDashboard();
-      clearConfig();
-      setOnAddEditWidgetCallback(null);
-      setWidgetResolver(null);
-    };
-  }, [
-    clearDashboard,
-    clearConfig,
-    setOnAddEditWidgetCallback,
-    setWidgetResolver,
-  ]);
-
   if (isPending) {
     return <Loader />;
   }
@@ -173,8 +68,8 @@ const DashboardPage: React.FunctionComponent = () => {
   }
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between gap-4 pb-4 pt-6">
+    <>
+      <div className="sticky top-0 z-10 -mx-6 flex items-center justify-between gap-4 bg-soft-background px-6 pb-3 pt-6">
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <h1 className="comet-title-l truncate break-words">
             {dashboard.name}
@@ -187,14 +82,10 @@ const DashboardPage: React.FunctionComponent = () => {
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <DashboardSaveActions
-            hasUnsavedChanges={hasUnsavedChanges}
             onSave={save}
             onDiscard={discard}
             dashboard={dashboard}
           />
-          {hasUnsavedChanges && (
-            <Separator orientation="vertical" className="mx-2 h-4" />
-          )}
           <MetricDateRangeSelect
             value={dateRange}
             onChangeValue={handleDateRangeChange}
@@ -207,25 +98,10 @@ const DashboardPage: React.FunctionComponent = () => {
           <DashboardProjectSettingsButton />
         </div>
       </div>
-
-      <div className="flex-1 overflow-auto">
-        <DashboardSectionsContainer />
-
-        <div className="text-clip rounded-md">
-          <AddSectionButton onAddSection={addSection} />
-        </div>
-
-        <WidgetConfigDialog
-          open={widgetDialogOpen}
-          onOpenChange={setWidgetDialogOpen}
-          sectionId={targetSectionId || ""}
-          widgetId={targetWidgetId || undefined}
-          onSave={handleSaveWidget}
-        />
+      <div className="pb-4 pt-1">
+        <DashboardContent />
       </div>
-
-      {DialogComponent}
-    </div>
+    </>
   );
 };
 

--- a/apps/opik-frontend/src/components/pages/TracesPage/DashboardsTab/DashboardsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/DashboardsTab/DashboardsTab.tsx
@@ -1,0 +1,176 @@
+import React, { useCallback, useEffect } from "react";
+import { StringParam } from "use-query-params";
+
+import Loader from "@/components/shared/Loader/Loader";
+import { DateRangeSerializedValue } from "@/components/shared/DateRangeSelect";
+import MetricDateRangeSelect from "@/components/pages-shared/traces/MetricDateRangeSelect/MetricDateRangeSelect";
+import DashboardSaveActions from "@/components/pages-shared/dashboards/DashboardSaveActions/DashboardSaveActions";
+import DashboardContent from "@/components/pages-shared/dashboards/DashboardContent/DashboardContent";
+import DashboardSelectBox from "@/components/pages-shared/dashboards/DashboardSelectBox/DashboardSelectBox";
+import { useMetricDateRangeCore } from "@/components/pages-shared/traces/MetricDateRangeSelect/useMetricDateRangeCore";
+import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
+import { useDashboardLifecycle } from "@/components/pages-shared/dashboards/hooks/useDashboardLifecycle";
+import {
+  useDashboardStore,
+  selectSetConfig,
+  selectConfig,
+  selectSetRuntimeConfig,
+  selectHasUnsavedChanges,
+} from "@/store/DashboardStore";
+import { DEFAULT_DATE_PRESET } from "@/components/pages-shared/traces/MetricDateRangeSelect/constants";
+import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
+import { TEMPLATE_LIST } from "@/lib/dashboard/templates";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
+
+const DASHBOARD_QUERY_PARAM_KEY = "dashboardId";
+const DASHBOARD_LOCAL_STORAGE_KEY_PREFIX = "opik-project-dashboard";
+
+interface DashboardsTabProps {
+  projectId: string;
+}
+
+const DashboardsTab: React.FunctionComponent<DashboardsTabProps> = ({
+  projectId,
+}) => {
+  const [dashboardId, setDashboardId] = useQueryParamAndLocalStorageState({
+    localStorageKey: DASHBOARD_LOCAL_STORAGE_KEY_PREFIX,
+    queryKey: DASHBOARD_QUERY_PARAM_KEY,
+    defaultValue: null as string | null,
+    queryParamConfig: StringParam,
+    syncQueryWithLocalStorageOnInit: true,
+  });
+
+  useEffect(() => {
+    if (!dashboardId && TEMPLATE_LIST.length > 0) {
+      setDashboardId(TEMPLATE_LIST[0].id);
+    }
+  }, [dashboardId, setDashboardId]);
+
+  const { dashboard, isPending, save, discard, isTemplate } =
+    useDashboardLifecycle({
+      dashboardId: dashboardId || null,
+      enabled: Boolean(dashboardId),
+    });
+
+  const hasUnsavedChanges = useDashboardStore(selectHasUnsavedChanges);
+
+  const config = useDashboardStore(selectConfig);
+  const setConfig = useDashboardStore(selectSetConfig);
+  const setRuntimeConfig = useDashboardStore(selectSetRuntimeConfig);
+
+  useEffect(() => {
+    setRuntimeConfig({ projectIds: [projectId] });
+
+    return () => {
+      setRuntimeConfig({});
+    };
+  }, [projectId, setRuntimeConfig]);
+
+  const dateRangeValue = config?.dateRange || DEFAULT_DATE_PRESET;
+
+  const handleDateRangeValueChange = useCallback(
+    (value: DateRangeSerializedValue) => {
+      if (!config) return;
+      setConfig({ ...config, dateRange: value });
+    },
+    [config, setConfig],
+  );
+
+  const { dateRange, handleDateRangeChange, minDate, maxDate } =
+    useMetricDateRangeCore({
+      value: dateRangeValue,
+      setValue: handleDateRangeValueChange,
+    });
+
+  const handleDashboardCreated = useCallback(
+    (newDashboardId: string) => {
+      setDashboardId(newDashboardId);
+    },
+    [setDashboardId],
+  );
+
+  const handleDashboardDeleted = useCallback(
+    (deletedDashboardId: string) => {
+      if (dashboardId === deletedDashboardId) {
+        setDashboardId(TEMPLATE_LIST[0]?.id || null);
+      }
+    },
+    [dashboardId, setDashboardId],
+  );
+
+  const dashboardSelectBox = (
+    <DashboardSelectBox
+      value={dashboardId || null}
+      onChange={setDashboardId}
+      buttonClassName="w-[300px]"
+      onDashboardCreated={handleDashboardCreated}
+      onDashboardDeleted={handleDashboardDeleted}
+      defaultProjectId={projectId}
+      disabled={hasUnsavedChanges}
+    />
+  );
+
+  return (
+    <>
+      <PageBodyStickyContainer
+        className="flex items-center justify-between gap-4 pb-3 pt-2"
+        direction="bidirectional"
+        limitWidth
+      >
+        {hasUnsavedChanges ? (
+          <TooltipWrapper content="Save or discard your changes before switching">
+            <div>{dashboardSelectBox}</div>
+          </TooltipWrapper>
+        ) : (
+          dashboardSelectBox
+        )}
+
+        <div className="flex shrink-0 items-center gap-2">
+          {dashboard && (
+            <DashboardSaveActions
+              onSave={save}
+              onDiscard={discard}
+              dashboard={dashboard}
+              isTemplate={isTemplate}
+              navigateOnCreate={false}
+              onDashboardCreated={handleDashboardCreated}
+              defaultProjectId={projectId}
+            />
+          )}
+          <MetricDateRangeSelect
+            value={dateRange}
+            onChangeValue={handleDateRangeChange}
+            minDate={minDate}
+            maxDate={maxDate}
+            hideAlltime
+          />
+        </div>
+      </PageBodyStickyContainer>
+
+      <div className="px-6 pb-4 pt-1">
+        {isPending && <Loader />}
+
+        {!isPending && !dashboardId && (
+          <div className="flex h-full items-center justify-center">
+            <p className="text-muted-foreground">
+              No dashboard selected. Please select or create a dashboard.
+            </p>
+          </div>
+        )}
+
+        {!isPending && dashboardId && !dashboard && (
+          <div className="flex h-full items-center justify-center">
+            <p className="text-muted-foreground">
+              Dashboard could not be loaded. Please select another dashboard
+              from the dropdown.
+            </p>
+          </div>
+        )}
+
+        {!isPending && dashboard && <DashboardContent />}
+      </div>
+    </>
+  );
+};
+
+export default DashboardsTab;

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesPage.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesPage.tsx
@@ -11,12 +11,17 @@ import ThreadsTab from "@/components/pages/TracesPage/ThreadsTab/ThreadsTab";
 import MetricsTab from "@/components/pages/TracesPage/MetricsTab/MetricsTab";
 import RulesTab from "@/components/pages/TracesPage/RulesTab/RulesTab";
 import AnnotationQueuesTab from "@/components/pages/TracesPage/AnnotationQueuesTab/AnnotationQueuesTab";
+import DashboardsTab from "@/components/pages/TracesPage/DashboardsTab/DashboardsTab";
 import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 import { Construction } from "lucide-react";
 import { useState } from "react";
 import { useIsFeatureEnabled } from "@/components/feature-toggles-provider";
 import SetGuardrailDialog from "../HomePageShared/SetGuardrailDialog";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
+import ViewSelector, {
+  VIEW_TYPE,
+} from "@/components/pages-shared/dashboards/ViewSelector/ViewSelector";
 
 const TracesPage = () => {
   const projectId = useProjectIdFromURL();
@@ -28,6 +33,14 @@ const TracesPage = () => {
 
   const [type = TRACE_DATA_TYPE.traces, setType] = useQueryParam(
     "type",
+    StringParam,
+    {
+      updateType: "replaceIn",
+    },
+  );
+
+  const [view = VIEW_TYPE.DETAILS, setView] = useQueryParam(
+    "view",
     StringParam,
     {
       updateType: "replaceIn",
@@ -47,34 +60,9 @@ const TracesPage = () => {
 
   const openGuardrailsDialog = () => setIsGuardrailsDialogOpened(true);
 
-  return (
-    <>
-      <PageBodyScrollContainer>
-        <PageBodyStickyContainer
-          className="mb-4 mt-6 flex items-center justify-between"
-          direction="horizontal"
-        >
-          <h1
-            data-testid="traces-page-title"
-            className="comet-title-l truncate break-words"
-          >
-            {projectName}
-          </h1>
-          {isGuardrailsEnabled && (
-            <Button variant="outline" size="sm" onClick={openGuardrailsDialog}>
-              <Construction className="mr-1.5 size-3.5" />
-              Set a guardrail
-            </Button>
-          )}
-        </PageBodyStickyContainer>
-        {project?.description && (
-          <PageBodyStickyContainer
-            className="-mt-3 mb-4 flex min-h-8 items-center justify-between"
-            direction="horizontal"
-          >
-            <div className="text-muted-slate">{project.description}</div>
-          </PageBodyStickyContainer>
-        )}
+  const renderContent = () => {
+    if (view === VIEW_TYPE.DETAILS) {
+      return (
         <Tabs
           defaultValue="traces"
           value={type as string}
@@ -130,6 +118,55 @@ const TracesPage = () => {
             <AnnotationQueuesTab projectId={projectId} />
           </TabsContent>
         </Tabs>
+      );
+    }
+
+    if (view === VIEW_TYPE.DASHBOARDS) {
+      return <DashboardsTab projectId={projectId} />;
+    }
+
+    return null;
+  };
+
+  return (
+    <>
+      <PageBodyScrollContainer>
+        <PageBodyStickyContainer
+          className="mb-4 mt-6 flex items-center justify-between"
+          direction="horizontal"
+        >
+          <h1
+            data-testid="traces-page-title"
+            className="comet-title-l truncate break-words"
+          >
+            {projectName}
+          </h1>
+          <div className="flex shrink-0 items-center gap-2">
+            {isGuardrailsEnabled && (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={openGuardrailsDialog}
+                >
+                  <Construction className="mr-1.5 size-3.5" />
+                  Set a guardrail
+                </Button>
+                <Separator orientation="vertical" className="h-4" />
+              </>
+            )}
+            <ViewSelector value={view as VIEW_TYPE} onChange={setView} />
+          </div>
+        </PageBodyStickyContainer>
+        {project?.description && (
+          <PageBodyStickyContainer
+            className="-mt-3 mb-4 flex min-h-8 items-center justify-between"
+            direction="horizontal"
+          >
+            <div className="text-muted-slate">{project.description}</div>
+          </PageBodyStickyContainer>
+        )}
+        {renderContent()}
       </PageBodyScrollContainer>
       {isGuardrailsEnabled && (
         <SetGuardrailDialog

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsFeedbackScoresWidget/ExperimentsFeedbackScoresWidget.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsFeedbackScoresWidget/ExperimentsFeedbackScoresWidget.tsx
@@ -308,7 +308,7 @@ const ExperimentsFeedbackScoresWidget: React.FunctionComponent<
       return (
         <DashboardWidget.EmptyState
           title="No data available"
-          message="Configure filters to display experiment feedback scores"
+          message="Configure filters to display experiment metrics"
           onAction={!preview ? handleEdit : undefined}
           actionLabel="Configure widget"
         />

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsEditor.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsEditor.tsx
@@ -23,7 +23,7 @@ import ProjectsSelectBox from "@/components/pages-shared/automations/ProjectsSel
 import ProjectWidgetFiltersSection from "@/components/shared/Dashboard/widgets/shared/ProjectWidgetFiltersSection/ProjectWidgetFiltersSection";
 
 import { cn } from "@/lib/utils";
-import { useDashboardStore } from "@/store/DashboardStore";
+import { useDashboardStore, selectMixedConfig } from "@/store/DashboardStore";
 
 import get from "lodash/get";
 
@@ -114,9 +114,10 @@ const ProjectMetricsEditor = forwardRef<
     [widgetConfig?.threadFilters],
   );
 
-  const globalProjectId = useDashboardStore(
-    (state) => state.config?.projectIds?.[0],
-  );
+  const globalProjectId = useDashboardStore((state) => {
+    const config = selectMixedConfig(state);
+    return config?.projectIds?.[0];
+  });
   const projectId = localProjectId || globalProjectId || "";
 
   const selectedMetric = METRIC_OPTIONS.find((m) => m.value === metricType);

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsWidget.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsWidget.tsx
@@ -6,7 +6,7 @@ import {
   INTERVAL_TYPE,
   METRIC_NAME_TYPE,
 } from "@/api/projects/useProjectMetric";
-import { useDashboardStore } from "@/store/DashboardStore";
+import { useDashboardStore, selectMixedConfig } from "@/store/DashboardStore";
 import { DashboardWidgetComponentProps } from "@/types/dashboard";
 import { Filter } from "@/types/filters";
 import { isFilterValid } from "@/lib/filters";
@@ -27,10 +27,13 @@ const ProjectMetricsWidget: React.FunctionComponent<
   DashboardWidgetComponentProps
 > = ({ sectionId, widgetId, preview = false }) => {
   const globalConfig = useDashboardStore(
-    useShallow((state) => ({
-      projectId: state.config?.projectIds?.[0],
-      dateRange: state.config?.dateRange ?? DEFAULT_DATE_PRESET,
-    })),
+    useShallow((state) => {
+      const config = selectMixedConfig(state);
+      return {
+        projectId: config?.projectIds?.[0],
+        dateRange: config?.dateRange ?? DEFAULT_DATE_PRESET,
+      };
+    }),
   );
 
   const widget = useDashboardStore(

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectStatsCardWidget/ProjectStatsCardEditor.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectStatsCardWidget/ProjectStatsCardEditor.tsx
@@ -25,7 +25,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Description } from "@/components/ui/description";
 import SelectBox from "@/components/shared/SelectBox/SelectBox";
-import { useDashboardStore } from "@/store/DashboardStore";
+import { useDashboardStore, selectMixedConfig } from "@/store/DashboardStore";
 import ProjectsSelectBox from "@/components/pages-shared/automations/ProjectsSelectBox";
 import ProjectWidgetFiltersSection from "@/components/shared/Dashboard/widgets/shared/ProjectWidgetFiltersSection/ProjectWidgetFiltersSection";
 import {
@@ -64,9 +64,10 @@ const ProjectStatsCardEditor = forwardRef<
     [widgetConfig?.spanFilters],
   );
 
-  const globalProjectId = useDashboardStore(
-    (state) => state.config?.projectIds?.[0],
-  );
+  const globalProjectId = useDashboardStore((state) => {
+    const config = selectMixedConfig(state);
+    return config?.projectIds?.[0];
+  });
   const projectId = localProjectId || globalProjectId || "";
   const isTraceSource = source === TRACE_DATA_TYPE.traces;
 

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectStatsCardWidget/ProjectStatsCardWidget.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectStatsCardWidget/ProjectStatsCardWidget.tsx
@@ -3,7 +3,7 @@ import { useShallow } from "zustand/react/shallow";
 
 import DashboardWidget from "@/components/shared/Dashboard/DashboardWidget/DashboardWidget";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
-import { useDashboardStore } from "@/store/DashboardStore";
+import { useDashboardStore, selectMixedConfig } from "@/store/DashboardStore";
 import { DashboardWidgetComponentProps } from "@/types/dashboard";
 import { Filter } from "@/types/filters";
 import { isFilterValid } from "@/lib/filters";
@@ -39,10 +39,13 @@ const ProjectStatsCardWidget: React.FunctionComponent<
   DashboardWidgetComponentProps
 > = ({ sectionId, widgetId, preview = false }) => {
   const globalConfig = useDashboardStore(
-    useShallow((state) => ({
-      projectId: state.config?.projectIds?.[0],
-      dateRange: state.config?.dateRange ?? DEFAULT_DATE_PRESET,
-    })),
+    useShallow((state) => {
+      const config = selectMixedConfig(state);
+      return {
+        projectId: config?.projectIds?.[0],
+        dateRange: config?.dateRange ?? DEFAULT_DATE_PRESET,
+      };
+    }),
   );
 
   const widget = useDashboardStore(

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/widgetRegistry.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/widgetRegistry.tsx
@@ -15,99 +15,99 @@ import ExperimentsFeedbackScoresWidget from "./ExperimentsFeedbackScoresWidget/E
 import ExperimentsFeedbackScoresWidgetEditor from "./ExperimentsFeedbackScoresWidget/ExperimentsFeedbackScoresWidgetEditor";
 import { WIDGET_TYPES } from "@/lib/dashboard/utils";
 
-export const createWidgetResolver = (): WidgetResolver => {
-  return (type: string): WidgetComponents => {
-    switch (type) {
-      case WIDGET_TYPES.PROJECT_METRICS:
-        return {
-          Widget: ProjectMetricsWidget,
-          Editor: ProjectMetricsEditor,
-          getDefaultConfig: () => ({
-            chartType: CHART_TYPE.line,
-          }),
-          calculateTitle: () => "",
-          metadata: {
-            title: "Project metrics",
-            description:
-              "Visualize project metrics like latency, cost, or usage over time using charts.",
-            icon: <ChartLine className="size-4" />,
-            category: WIDGET_CATEGORY.OBSERVABILITY,
-            iconColor: "text-[#5899DA]",
-            disabled: false,
-          },
-        };
-      case WIDGET_TYPES.TEXT_MARKDOWN:
-        return {
-          Widget: TextMarkdownWidget,
-          Editor: TextMarkdownEditor,
-          getDefaultConfig: () => ({}),
-          calculateTitle: () => "",
-          metadata: {
-            title: "Markdown text",
-            description:
-              "Add markdown or text for explanations, labels, or annotations.",
-            icon: <NotebookText className="size-4" />,
-            category: WIDGET_CATEGORY.GENERAL,
-            iconColor: "text-[#EF6868]",
-            disabled: false,
-          },
-        };
-      case WIDGET_TYPES.PROJECT_STATS_CARD:
-        return {
-          Widget: ProjectStatsCardWidget,
-          Editor: ProjectStatsCardEditor,
-          getDefaultConfig: () => ({
-            source: "traces" as const,
-          }),
-          calculateTitle: () => "",
-          metadata: {
-            title: "Project statistics",
-            description:
-              "Highlight key project numbers at a glance, such as average latency, or total cost.",
-            icon: <Hash className="size-4" />,
-            category: WIDGET_CATEGORY.OBSERVABILITY,
-            iconColor: "text-[#19A979]",
-            disabled: false,
-          },
-        };
-      case WIDGET_TYPES.EXPERIMENTS_FEEDBACK_SCORES:
-        return {
-          Widget: ExperimentsFeedbackScoresWidget,
-          Editor: ExperimentsFeedbackScoresWidgetEditor,
-          getDefaultConfig: () => ({
-            filters: [],
-            groups: [],
-            chartType: CHART_TYPE.line,
-          }),
-          calculateTitle: () => "",
-          metadata: {
-            title: "Experiments feedback scores",
-            description:
-              "Visualize experiment feedback scores with filtering and grouping options.",
-            icon: <FlaskConical className="size-4" />,
-            category: WIDGET_CATEGORY.EVALUATION,
-            iconColor: "text-[#9B59B6]",
-            disabled: false,
-          },
-        };
-      default:
-        return {
-          Widget: TextMarkdownWidget,
-          Editor: TextMarkdownEditor,
-          getDefaultConfig: () => ({}),
-          calculateTitle: () => "",
-          metadata: {
-            title: "Markdown text",
-            description:
-              "Add markdown or text for explanations, labels, or annotations.",
-            icon: <NotebookText className="size-4" />,
-            category: WIDGET_CATEGORY.GENERAL,
-            iconColor: "text-[#EF6868]",
-            disabled: false,
-          },
-        };
-    }
-  };
+export const widgetResolver: WidgetResolver = (
+  type: string,
+): WidgetComponents => {
+  switch (type) {
+    case WIDGET_TYPES.PROJECT_METRICS:
+      return {
+        Widget: ProjectMetricsWidget,
+        Editor: ProjectMetricsEditor,
+        getDefaultConfig: () => ({
+          chartType: CHART_TYPE.line,
+        }),
+        calculateTitle: () => "",
+        metadata: {
+          title: "Project metrics",
+          description:
+            "Visualize project metrics like latency, cost, or usage over time using charts.",
+          icon: <ChartLine className="size-4" />,
+          category: WIDGET_CATEGORY.OBSERVABILITY,
+          iconColor: "text-[#5899DA]",
+          disabled: false,
+        },
+      };
+    case WIDGET_TYPES.TEXT_MARKDOWN:
+      return {
+        Widget: TextMarkdownWidget,
+        Editor: TextMarkdownEditor,
+        getDefaultConfig: () => ({}),
+        calculateTitle: () => "",
+        metadata: {
+          title: "Markdown text",
+          description:
+            "Add markdown or text for explanations, labels, or annotations.",
+          icon: <NotebookText className="size-4" />,
+          category: WIDGET_CATEGORY.GENERAL,
+          iconColor: "text-[#EF6868]",
+          disabled: false,
+        },
+      };
+    case WIDGET_TYPES.PROJECT_STATS_CARD:
+      return {
+        Widget: ProjectStatsCardWidget,
+        Editor: ProjectStatsCardEditor,
+        getDefaultConfig: () => ({
+          source: "traces" as const,
+        }),
+        calculateTitle: () => "",
+        metadata: {
+          title: "Project statistics",
+          description:
+            "Highlight key project numbers at a glance, such as average latency, or total cost.",
+          icon: <Hash className="size-4" />,
+          category: WIDGET_CATEGORY.OBSERVABILITY,
+          iconColor: "text-[#19A979]",
+          disabled: false,
+        },
+      };
+    case WIDGET_TYPES.EXPERIMENTS_FEEDBACK_SCORES:
+      return {
+        Widget: ExperimentsFeedbackScoresWidget,
+        Editor: ExperimentsFeedbackScoresWidgetEditor,
+        getDefaultConfig: () => ({
+          filters: [],
+          groups: [],
+          chartType: CHART_TYPE.line,
+        }),
+        calculateTitle: () => "",
+        metadata: {
+          title: "Experiments metrics",
+          description:
+            "Visualize experiment metrics with filtering and grouping options.",
+          icon: <FlaskConical className="size-4" />,
+          category: WIDGET_CATEGORY.EVALUATION,
+          iconColor: "text-[#9B59B6]",
+          disabled: false,
+        },
+      };
+    default:
+      return {
+        Widget: TextMarkdownWidget,
+        Editor: TextMarkdownEditor,
+        getDefaultConfig: () => ({}),
+        calculateTitle: () => "",
+        metadata: {
+          title: "Markdown text",
+          description:
+            "Add markdown or text for explanations, labels, or annotations.",
+          icon: <NotebookText className="size-4" />,
+          category: WIDGET_CATEGORY.GENERAL,
+          iconColor: "text-[#EF6868]",
+          disabled: false,
+        },
+      };
+  }
 };
 
 export const getAllWidgetTypes = (): string[] => {

--- a/apps/opik-frontend/src/lib/dashboard/templates.ts
+++ b/apps/opik-frontend/src/lib/dashboard/templates.ts
@@ -1,15 +1,23 @@
-import { DashboardTemplate, WIDGET_TYPE, TEMPLATE_ID } from "@/types/dashboard";
-import { DASHBOARD_VERSION } from "@/lib/dashboard/utils";
+import {
+  DashboardTemplate,
+  WIDGET_TYPE,
+  TEMPLATE_TYPE,
+} from "@/types/dashboard";
+import { DASHBOARD_VERSION, createTemplateId } from "@/lib/dashboard/utils";
 import { DEFAULT_DATE_PRESET } from "@/components/pages-shared/traces/MetricDateRangeSelect/constants";
 import { METRIC_NAME_TYPE } from "@/api/projects/useProjectMetric";
 import { CHART_TYPE } from "@/constants/chart";
 import { TRACE_DATA_TYPE } from "@/constants/traces";
+import { LayoutDashboard, SquareActivity } from "lucide-react";
 
 const PROJECT_METRICS_TEMPLATE: DashboardTemplate = {
-  id: TEMPLATE_ID.PROJECT_METRICS,
+  id: createTemplateId(TEMPLATE_TYPE.PROJECT_METRICS),
+  type: TEMPLATE_TYPE.PROJECT_METRICS,
   title: "Project metrics",
   description:
     "Track token usage, cost, and performance metrics for traces and threads",
+  icon: LayoutDashboard,
+  iconColor: "text-template-icon-metrics",
   config: {
     version: DASHBOARD_VERSION,
     sections: [
@@ -201,10 +209,13 @@ const PROJECT_METRICS_TEMPLATE: DashboardTemplate = {
 };
 
 const PERFORMANCE_OVERVIEW_TEMPLATE: DashboardTemplate = {
-  id: TEMPLATE_ID.PERFORMANCE,
-  title: "Performance Overview",
+  id: createTemplateId(TEMPLATE_TYPE.PROJECT_PERFORMANCE),
+  type: TEMPLATE_TYPE.PROJECT_PERFORMANCE,
+  title: "Performance overview",
   description:
     "Comprehensive performance monitoring including traces, threads, quality metrics, and latency",
+  icon: SquareActivity,
+  iconColor: "text-template-icon-performance",
   config: {
     version: DASHBOARD_VERSION,
     sections: [
@@ -459,12 +470,12 @@ const PERFORMANCE_OVERVIEW_TEMPLATE: DashboardTemplate = {
   },
 };
 
-export const DASHBOARD_TEMPLATES: Record<TEMPLATE_ID, DashboardTemplate> = {
-  [TEMPLATE_ID.PROJECT_METRICS]: PROJECT_METRICS_TEMPLATE,
-  [TEMPLATE_ID.PERFORMANCE]: PERFORMANCE_OVERVIEW_TEMPLATE,
+export const DASHBOARD_TEMPLATES: Record<TEMPLATE_TYPE, DashboardTemplate> = {
+  [TEMPLATE_TYPE.PROJECT_METRICS]: PROJECT_METRICS_TEMPLATE,
+  [TEMPLATE_TYPE.PROJECT_PERFORMANCE]: PERFORMANCE_OVERVIEW_TEMPLATE,
 };
 
-export const TEMPLATE_OPTIONS_ORDER: TEMPLATE_ID[] = [
-  TEMPLATE_ID.PROJECT_METRICS,
-  TEMPLATE_ID.PERFORMANCE,
+export const TEMPLATE_LIST: DashboardTemplate[] = [
+  PERFORMANCE_OVERVIEW_TEMPLATE,
+  PROJECT_METRICS_TEMPLATE,
 ];

--- a/apps/opik-frontend/src/lib/dashboard/utils.ts
+++ b/apps/opik-frontend/src/lib/dashboard/utils.ts
@@ -11,6 +11,7 @@ import {
   WIDGET_TYPE,
   AddWidgetConfig,
   WidgetResolver,
+  TEMPLATE_TYPE,
 } from "@/types/dashboard";
 import { areLayoutsEqual } from "@/lib/dashboard/layout";
 import { isLooseEqual } from "@/lib/utils";
@@ -18,6 +19,16 @@ import { DEFAULT_DATE_PRESET } from "@/components/pages-shared/traces/MetricDate
 
 export const DASHBOARD_VERSION = 1;
 const DEFAULT_SECTION_NAME = "New section";
+
+const TEMPLATE_ID_PREFIX = "template:";
+
+export const createTemplateId = (templateId: TEMPLATE_TYPE): string => {
+  return `${TEMPLATE_ID_PREFIX}${templateId}`;
+};
+
+export const isTemplateId = (id: string | null): boolean => {
+  return id?.startsWith(TEMPLATE_ID_PREFIX) ?? false;
+};
 
 export const WIDGET_TYPES = WIDGET_TYPE;
 

--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -74,6 +74,11 @@
     --chart-tick-stroke: #373d4d;
     --chart-grid-stroke: #f1f5f8;
 
+    /* Template icon colors */
+    --template-icon-metrics: #5899da;
+    --template-icon-performance: #ef6868;
+    --template-icon-scratch: #945fcf;
+
     /* DataTable colors */
 
     /* Trace thread colors */
@@ -283,6 +288,11 @@
     /* Chart colors */
     --chart-tick-stroke: #a3a3a3;
     --chart-grid-stroke: #303030;
+
+    /* Template icon colors - Dark Mode */
+    --template-icon-metrics: #5899da;
+    --template-icon-performance: #ef6868;
+    --template-icon-scratch: #945fcf;
 
     /* Diff colors - Dark Mode */
     --diff-removed-bg: #7f1d1d;

--- a/apps/opik-frontend/src/store/DashboardStore.ts
+++ b/apps/opik-frontend/src/store/DashboardStore.ts
@@ -36,11 +36,13 @@ interface DashboardStoreState<TConfig = BaseDashboardConfig> {
   version: number;
   lastModified: number;
   config: TConfig | null;
+  runtimeConfig: Partial<TConfig>;
   onAddEditWidgetCallback:
     | ((params: AddEditWidgetCallbackParams) => void)
     | null;
   widgetResolver: WidgetResolver | null;
   previewWidget: DashboardWidget | null;
+  hasUnsavedChanges: boolean;
 }
 
 /**
@@ -78,32 +80,28 @@ interface DashboardActions<TConfig = BaseDashboardConfig> {
 
   // Config operations
   setConfig: (config: TConfig) => void;
-  getConfig: () => TConfig | null;
-  clearConfig: () => void;
+  setRuntimeConfig: (runtimeConfig: Partial<TConfig>) => void;
 
   // Callback operations
   setOnAddEditWidgetCallback: (
     callback: ((params: AddEditWidgetCallbackParams) => void) | null,
   ) => void;
-  getOnAddEditWidgetCallback: () =>
-    | ((params: AddEditWidgetCallbackParams) => void)
-    | null;
 
   // Widget resolver operations
   setWidgetResolver: (resolver: WidgetResolver | null) => void;
-  getWidgetResolver: () => WidgetResolver | null;
 
   // Preview widget operations
   setPreviewWidget: (widget: DashboardWidget | null) => void;
-  getPreviewWidget: () => DashboardWidget | null;
+
+  // Unsaved changes operations
+  setHasUnsavedChanges: (hasChanges: boolean) => void;
 
   // Utility operations
   clearDashboard: () => void;
-  resetDashboard: () => void;
 
   // Backend sync operations
   loadDashboardFromBackend: (dashboardState: DashboardState) => void;
-  getDashboardConfig: () => DashboardState;
+  getDashboard: () => DashboardState;
 
   // Getters (computed values)
   getSectionById: (sectionId: string) => DashboardSection | undefined;
@@ -139,9 +137,11 @@ export const useDashboardStore = create<DashboardStore<BaseDashboardConfig>>()(
         version: initialDashboard.version,
         lastModified: initialDashboard.lastModified,
         config: initialDashboard.config,
+        runtimeConfig: {},
         onAddEditWidgetCallback: null,
         widgetResolver: null,
         previewWidget: null,
+        hasUnsavedChanges: false,
 
         // Section Actions
         addSection: (title?: string) => {
@@ -469,12 +469,8 @@ export const useDashboardStore = create<DashboardStore<BaseDashboardConfig>>()(
           set({ config }, false, "setConfig");
         },
 
-        getConfig: () => {
-          return get().config;
-        },
-
-        clearConfig: () => {
-          set({ config: null }, false, "clearConfig");
+        setRuntimeConfig: (runtimeConfig) => {
+          set({ runtimeConfig }, false, "setRuntimeConfig");
         },
 
         // Callback Actions
@@ -486,17 +482,9 @@ export const useDashboardStore = create<DashboardStore<BaseDashboardConfig>>()(
           );
         },
 
-        getOnAddEditWidgetCallback: () => {
-          return get().onAddEditWidgetCallback;
-        },
-
         // Widget Resolver Actions
         setWidgetResolver: (resolver) => {
           set({ widgetResolver: resolver }, false, "setWidgetResolver");
-        },
-
-        getWidgetResolver: () => {
-          return get().widgetResolver;
         },
 
         // Preview Widget Actions
@@ -504,8 +492,9 @@ export const useDashboardStore = create<DashboardStore<BaseDashboardConfig>>()(
           set({ previewWidget: widget }, false, "setPreviewWidget");
         },
 
-        getPreviewWidget: () => {
-          return get().previewWidget;
+        // Unsaved Changes Actions
+        setHasUnsavedChanges: (hasChanges) => {
+          set({ hasUnsavedChanges: hasChanges }, false, "setHasUnsavedChanges");
         },
 
         // Utility Actions
@@ -516,22 +505,10 @@ export const useDashboardStore = create<DashboardStore<BaseDashboardConfig>>()(
               sections: emptyDashboard.sections,
               version: emptyDashboard.version,
               lastModified: Date.now(),
+              config: emptyDashboard.config,
             },
             false,
             "clearDashboard",
-          );
-        },
-
-        resetDashboard: () => {
-          const defaultDashboard = generateEmptyDashboard();
-          set(
-            {
-              sections: defaultDashboard.sections,
-              version: defaultDashboard.version,
-              lastModified: defaultDashboard.lastModified,
-            },
-            false,
-            "resetDashboard",
           );
         },
 
@@ -550,7 +527,7 @@ export const useDashboardStore = create<DashboardStore<BaseDashboardConfig>>()(
           );
         },
 
-        getDashboardConfig: () => {
+        getDashboard: () => {
           const state = get();
           return {
             sections: state.sections,
@@ -594,27 +571,7 @@ export const useDashboardStore = create<DashboardStore<BaseDashboardConfig>>()(
 export const selectSectionIds = (state: DashboardStore) =>
   state.sections.map((s) => s.id);
 
-export const selectSectionById =
-  (sectionId: string) => (state: DashboardStore) =>
-    getSectionById(state.sections, sectionId);
-
-export const selectWidgetsBySectionId =
-  (sectionId: string) => (state: DashboardStore) => {
-    const section = getSectionById(state.sections, sectionId);
-    return section?.widgets || [];
-  };
-
-export const selectLayoutBySectionId =
-  (sectionId: string) => (state: DashboardStore) => {
-    const section = getSectionById(state.sections, sectionId);
-    return section?.layout || [];
-  };
-
 export const selectSections = (state: DashboardStore) => state.sections;
-
-export const selectVersion = (state: DashboardStore) => state.version;
-
-export const selectLastModified = (state: DashboardStore) => state.lastModified;
 
 /**
  * Action Selectors (stable references)
@@ -641,13 +598,26 @@ export const selectUpdateWidget = (state: DashboardStore) => state.updateWidget;
 export const selectMoveWidget = (state: DashboardStore) => state.moveWidget;
 export const selectUpdateLayout = (state: DashboardStore) => state.updateLayout;
 
+export const selectMixedConfig = <TConfig = BaseDashboardConfig>(
+  state: DashboardStore<TConfig>,
+) => {
+  if (!state.config) return null;
+  return {
+    ...state.config,
+    ...state.runtimeConfig,
+  } as TConfig;
+};
+
 export const selectConfig = <TConfig = BaseDashboardConfig>(
   state: DashboardStore<TConfig>,
 ) => state.config;
+
 export const selectSetConfig = (state: DashboardStore<BaseDashboardConfig>) =>
   state.setConfig;
-export const selectClearConfig = (state: DashboardStore<BaseDashboardConfig>) =>
-  state.clearConfig;
+
+export const selectSetRuntimeConfig = (
+  state: DashboardStore<BaseDashboardConfig>,
+) => state.setRuntimeConfig;
 export const selectClearDashboard = (
   state: DashboardStore<BaseDashboardConfig>,
 ) => state.clearDashboard;
@@ -675,3 +645,11 @@ export const selectPreviewWidget = (
 export const selectSetPreviewWidget = (
   state: DashboardStore<BaseDashboardConfig>,
 ) => state.setPreviewWidget;
+
+// Unsaved changes selectors
+export const selectHasUnsavedChanges = (
+  state: DashboardStore<BaseDashboardConfig>,
+) => state.hasUnsavedChanges;
+export const selectSetHasUnsavedChanges = (
+  state: DashboardStore<BaseDashboardConfig>,
+) => state.setHasUnsavedChanges;

--- a/apps/opik-frontend/src/types/dashboard.ts
+++ b/apps/opik-frontend/src/types/dashboard.ts
@@ -17,17 +17,11 @@ export enum WIDGET_CATEGORY {
   GENERAL = "general",
 }
 
-export enum DASHBOARD_CREATION_TYPE {
-  EMPTY = "empty",
-  TEMPLATE = "template",
-}
-
-export enum TEMPLATE_ID {
+export enum TEMPLATE_TYPE {
   PROJECT_METRICS = "project-metrics",
-  PERFORMANCE = "performance",
+  PROJECT_PERFORMANCE = "project-performance",
 }
 
-// Widget-specific type definitions with discriminator
 export interface ProjectMetricsWidget {
   type: WIDGET_TYPE.PROJECT_METRICS;
   config: {
@@ -232,7 +226,10 @@ export interface WidgetConfigDialogProps {
 
 export interface DashboardTemplate {
   id: string;
+  type: TEMPLATE_TYPE;
   title: string;
   description: string;
+  icon: React.ComponentType<{ className?: string }>;
+  iconColor: string;
   config: DashboardState;
 }

--- a/apps/opik-frontend/tailwind.config.ts
+++ b/apps/opik-frontend/tailwind.config.ts
@@ -115,6 +115,11 @@ module.exports = {
         "warning-box-text": "hsl(var(--warning-box-text))",
         "warning-box-icon-bg": "hsl(var(--warning-box-icon-bg))",
         "warning-box-icon-text": "hsl(var(--warning-box-icon-text))",
+
+        /* Template icon colors */
+        "template-icon-metrics": "var(--template-icon-metrics)",
+        "template-icon-performance": "var(--template-icon-performance)",
+        "template-icon-scratch": "var(--template-icon-scratch)",
       },
       borderRadius: {
         xxl: "calc(var(--radius) + 4px)",
@@ -158,8 +163,5 @@ module.exports = {
       );
     },
   ],
-  safelist: [
-    "playground-table",
-    "comet-compare-optimizations-table",
-  ],
+  safelist: ["playground-table", "comet-compare-optimizations-table"],
 };


### PR DESCRIPTION
# User description
<img width="1726" height="927" alt="image" src="https://github.com/user-attachments/assets/b387389f-17c3-4cb0-80c4-afcae8a0d484" />
<img width="1716" height="928" alt="image" src="https://github.com/user-attachments/assets/45a43c56-aa21-49d9-8e4c-a1538c8cc00b" />
<img width="1703" height="930" alt="image" src="https://github.com/user-attachments/assets/e0e5baab-148c-4ff8-b833-336864c3d909" />

## Details

This PR introduces dashboard view functionality to the Traces page, enabling users to switch between traditional table/outputs view and customizable dashboard views. This is part of the Custom Dashboards epic (OPIK-3012).

### Key Changes

**View Toggle System**
- Added `ViewSelector` component with "Outputs" and "Dashboards" toggle buttons
- Implemented view state persistence using query parameters (`?view=outputs|dashboards`)
- Maintained backward compatibility with existing table view

**Dashboard Integration**
- Created new `DashboardsTab` component for the Traces page
- Added `DashboardSelectBox` for selecting between saved dashboards and pre-built templates
- Implemented template support with icons, descriptions, and initial configurations
- Added project-scoped dashboard functionality with automatic date range filtering

**Shared Components & Hooks**
- Extracted reusable `DashboardContent` component from Dashboard page
- Created `DashboardSelectBox` with template browsing and dashboard management
- Implemented `useDashboardLifecycle` hook for unified dashboard lifecycle management
- Moved and enhanced `useDashboardSave` hook to shared location

**Dashboard Types & Templates**
- Updated dashboard types to support template system with metadata (icons, colors, descriptions)
- Renamed `TEMPLATE_ID` to `TEMPLATE_TYPE` for consistency
- Enhanced `DashboardTemplate` interface with visual metadata

**Widget System Updates**
- Modified widget registry to support project-scoped widgets
- Updated `ProjectMetricsWidget` and `ProjectStatsCardWidget` to accept runtime project IDs
- Enhanced widget configuration system for dynamic project filtering

**Store & State Management**
- Enhanced `DashboardStore` with runtime configuration for project IDs
- Simplified dashboard state management with improved lifecycle handling

### Component Architecture

```
TracesPage
├── ViewSelector (Outputs/Dashboards toggle)
├── Outputs View (existing functionality)
└── DashboardsTab
    ├── DashboardSelectBox (dashboard/template selector)
    ├── MetricDateRangeSelect
    ├── DashboardSaveActions
    └── DashboardContent (shared dashboard renderer)
```

### Files Changed
- **7 new files**: `DashboardContent.tsx`, `DashboardSelectBox/` components, `ViewSelector.tsx`, `DashboardsTab.tsx`, `useDashboardLifecycle.ts`
- **1 moved file**: `useDashboardSave.ts` (from DashboardPage to shared hooks)
- **17 modified files**: Including `TracesPage.tsx`, `DashboardPage.tsx`, widget components, store, types, and styles

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves #
- OPIK-3416
- Part of Epic: OPIK-3012 (Custom Dashboards)

## Testing

**Manual Testing Scenarios**
1. **View Toggle**
   - Navigate to Traces page
   - Click "Dashboards" button in view selector
   - Verify dashboard view loads with default template
   - Switch back to "Outputs" and verify table view works
   - Verify view selection persists in URL and across page refreshes

2. **Dashboard Selection**
   - Open dashboard selector dropdown
   - Verify pre-built templates are displayed with icons and descriptions
   - Select different templates and verify they load correctly
   - Create a new dashboard and verify it appears in the selector

3. **Dashboard Functionality**
   - Verify widgets display project-specific trace data
   - Test date range selector updates dashboard data
   - Verify dashboard save/discard actions work correctly
   - Test dashboard editing and modification

4. **Data Filtering**
   - Verify widgets automatically filter to current project
   - Test date range changes update all widgets
   - Verify metrics display correct values for the project

5. **Backward Compatibility**
   - Verify existing Dashboard page functionality remains unchanged
   - Test that existing dashboards still work correctly
   - Verify no regressions in table/outputs view

**Tested Browsers**
- Chrome (latest)
- Safari (latest)
- Firefox (latest)

## Documentation

### Updated
- Component structure and organization (moved shared components)
- Dashboard type definitions and templates
- Widget configuration patterns

### New Documentation Needed
- User guide for dashboard view on Traces page (to be added in follow-up)
- Template system documentation
- Widget development guide for project-scoped widgets

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
TracesPage_("TracesPage"):::modified
DashboardsTab_("DashboardsTab"):::added
useDashboardLifecycle_("useDashboardLifecycle"):::added
selectHasUnsavedChanges_("selectHasUnsavedChanges"):::added
selectConfig_("selectConfig"):::added
selectSetConfig_("selectSetConfig"):::modified
selectSetRuntimeConfig_("selectSetRuntimeConfig"):::added
selectClearDashboard_("selectClearDashboard"):::modified
selectSetWidgetResolver_("selectSetWidgetResolver"):::modified
widgetResolver_("widgetResolver"):::modified
useDashboardSave_("useDashboardSave"):::modified
selectSetHasUnsavedChanges_("selectSetHasUnsavedChanges"):::added
DashboardPage_("DashboardPage"):::modified
selectMixedConfig_("selectMixedConfig"):::added
DashboardContent_("DashboardContent"):::added
selectAddWidget_("selectAddWidget"):::modified
selectUpdateWidget_("selectUpdateWidget"):::modified
TracesPage_ -- "Adds dashboards view rendering in TracesPage." --> DashboardsTab_
DashboardsTab_ -- "Manages dashboard data lifecycle in DashboardsTab." --> useDashboardLifecycle_
DashboardsTab_ -- "Checks for unsaved dashboard changes in DashboardsTab." --> selectHasUnsavedChanges_
DashboardsTab_ -- "Retrieves current dashboard config in DashboardsTab." --> selectConfig_
DashboardsTab_ -- "Updates dashboard config in store from DashboardsTab." --> selectSetConfig_
DashboardsTab_ -- "Sets runtime config like projectIds in DashboardsTab." --> selectSetRuntimeConfig_
useDashboardLifecycle_ -- "Clears dashboard state on lifecycle changes." --> selectClearDashboard_
useDashboardLifecycle_ -- "Sets widgetResolver for dashboard widgets lifecycle." --> selectSetWidgetResolver_
useDashboardLifecycle_ -- "Uses widgetResolver to resolve widget components." --> widgetResolver_
useDashboardSave_ -- "Updates unsaved changes state in dashboard store." --> selectSetHasUnsavedChanges_
useDashboardSave_ -- "Reads unsaved changes state for dashboard tracking." --> selectHasUnsavedChanges_
DashboardPage_ -- "Manages dashboard lifecycle in DashboardPage." --> useDashboardLifecycle_
DashboardPage_ -- "Gets combined dashboard config including runtimeConfig." --> selectMixedConfig_
DashboardPage_ -- "Updates dashboard config in store from DashboardPage." --> selectSetConfig_
DashboardPage_ -- "Renders dashboard UI content in DashboardPage." --> DashboardContent_
DashboardContent_ -- "Adds widgets to dashboard store in DashboardContent." --> selectAddWidget_
DashboardContent_ -- "Updates widgets in dashboard store in DashboardContent." --> selectUpdateWidget_
DashboardContent_ -- "Checks unsaved changes in dashboard store in DashboardContent." --> selectHasUnsavedChanges_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Integrates a new dashboard view into the <code>TracesPage</code>, allowing users to switch between traditional outputs and customizable dashboards. Introduces a <code>ViewSelector</code> component and a dedicated <code>DashboardsTab</code> that leverages shared dashboard components and lifecycle management for project-scoped data visualization.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/comet-ml/opik/4420?tool=ast&topic=Integrate+Traces+Dashboard>Integrate Traces Dashboard</a>
        </td><td>Adds a dashboard view to the <code>TracesPage</code>, enabling users to toggle between outputs and dashboards, select from templates or existing dashboards, and view project-specific metrics.<details><summary>Modified files (9)</summary><ul><li>apps/opik-frontend/tailwind.config.ts</li>
<li>apps/opik-frontend/src/main.scss</li>
<li>apps/opik-frontend/src/components/pages/TracesPage/TracesPage.tsx</li>
<li>apps/opik-frontend/src/components/pages/TracesPage/DashboardsTab/DashboardsTab.tsx</li>
<li>apps/opik-frontend/src/components/pages-shared/dashboards/ViewSelector/ViewSelector.tsx</li>
<li>apps/opik-frontend/src/components/pages-shared/dashboards/DashboardSelectBox/TriggerContent.tsx</li>
<li>apps/opik-frontend/src/components/pages-shared/dashboards/DashboardSelectBox/TemplateItem.tsx</li>
<li>apps/opik-frontend/src/components/pages-shared/dashboards/DashboardSelectBox/DashboardSelectBox.tsx</li>
<li>apps/opik-frontend/src/components/pages-shared/dashboards/DashboardSelectBox/DashboardItem.tsx</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/comet-ml/opik/4420?tool=ast&topic=Refactor+Dashboard+Core>Refactor Dashboard Core</a>
        </td><td>Refactors the core dashboard logic by extracting shared components like <code>DashboardContent</code> and <code>useDashboardLifecycle</code>, enhancing the <code>DashboardStore</code> with runtime configurations and unsaved changes tracking, and updating dashboard templates and widget configurations for project-scoped data.<details><summary>Modified files (16)</summary><ul><li>apps/opik-frontend/src/components/pages-shared/dashboards/AddEditCloneDashboardDialog/DashboardDialogSelectStep.tsx</li>
<li>apps/opik-frontend/src/components/pages-shared/dashboards/hooks/useDashboardSave.ts</li>
<li>apps/opik-frontend/src/types/dashboard.ts</li>
<li>apps/opik-frontend/src/store/DashboardStore.ts</li>
<li>apps/opik-frontend/src/lib/dashboard/utils.ts</li>
<li>apps/opik-frontend/src/lib/dashboard/templates.ts</li>
<li>apps/opik-frontend/src/components/shared/Dashboard/widgets/widgetRegistry.tsx</li>
<li>apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectStatsCardWidget/ProjectStatsCardWidget.tsx</li>
<li>apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectStatsCardWidget/ProjectStatsCardEditor.tsx</li>
<li>apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsWidget.tsx</li>
<li>apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsEditor.tsx</li>
<li>apps/opik-frontend/src/components/pages/DashboardPage/DashboardPage.tsx</li>
<li>apps/opik-frontend/src/components/pages-shared/dashboards/DashboardSaveActions/DashboardSaveActions.tsx</li>
<li>apps/opik-frontend/src/components/pages-shared/dashboards/DashboardContent/DashboardContent.tsx</li>
<li>apps/opik-frontend/src/components/pages-shared/dashboards/AddEditCloneDashboardDialog/AddEditCloneDashboardDialog.tsx</li>
<li>apps/opik-frontend/src/components/pages-shared/dashboards/hooks/useDashboardLifecycle.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>andriid@comet.com</td><td>OPIK-3378-FE-Add-dashb...</td><td>December 11, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/comet-ml/opik/4420?tool=ast>(Baz)</a>.