### PR TITLE
[OPIK-3442] [TS SDK] link prompts with trace/span

### DIFF
--- a/sdks/typescript/src/opik/tracer/Span.ts
+++ b/sdks/typescript/src/opik/tracer/Span.ts
@@ -1,6 +1,8 @@
 import { OpikClient } from "@/client/Client";
-import type { Span as ISpan, SpanUpdate } from "@/rest_api/api";
+import type { Span as ISpan } from "@/rest_api/api";
 import { generateId } from "@/utils/generateId";
+import type { SpanUpdateData } from "./types";
+import { UpdateService } from "./UpdateService";
 
 export interface SavedSpan extends ISpan {
   id: string;
@@ -32,17 +34,17 @@ export class Span {
     });
   };
 
-  public update = (
-    updates: Omit<
-      SpanUpdate,
-      "traceId" | "parentSpanId" | "projectId" | "projectName"
-    >
-  ) => {
+  public update = (updates: SpanUpdateData) => {
+    const processedUpdates = UpdateService.processSpanUpdate(
+      updates,
+      this.data.metadata
+    );
+
     const spanUpdates = {
       parentSpanId: this.data.parentSpanId,
       projectName: this.data.projectName ?? this.opik.config.projectName,
       traceId: this.data.traceId,
-      ...updates,
+      ...processedUpdates,
     };
 
     this.opik.spanBatchQueue.update(this.data.id, spanUpdates);

--- a/sdks/typescript/src/opik/tracer/Trace.ts
+++ b/sdks/typescript/src/opik/tracer/Trace.ts
@@ -1,11 +1,9 @@
 import { OpikClient } from "@/client/Client";
-import type {
-  Span as ISpan,
-  Trace as ITrace,
-  TraceUpdate,
-} from "@/rest_api/api";
+import type { Span as ISpan, Trace as ITrace } from "@/rest_api/api";
 import { generateId } from "@/utils/generateId";
 import { SavedSpan, Span } from "./Span";
+import type { TraceUpdateData } from "./types";
+import { UpdateService } from "./UpdateService";
 
 export interface SavedTrace extends ITrace {
   id: string;
@@ -62,10 +60,15 @@ export class Trace {
     return span;
   };
 
-  public update = (updates: Omit<TraceUpdate, "projectId">) => {
+  public update = (updates: TraceUpdateData) => {
+    const processedUpdates = UpdateService.processTraceUpdate(
+      updates,
+      this.data.metadata
+    );
+
     const traceUpdates = {
       projectName: this.data.projectName ?? this.opik.config.projectName,
-      ...updates,
+      ...processedUpdates,
     };
 
     this.opik.traceBatchQueue.update(this.data.id, traceUpdates);

--- a/sdks/typescript/src/opik/tracer/UpdateService.ts
+++ b/sdks/typescript/src/opik/tracer/UpdateService.ts
@@ -1,0 +1,159 @@
+import type { Prompt } from "@/prompt/Prompt";
+import type * as OpikApi from "@/rest_api/api";
+import type { PromptInfoDict, TraceUpdateData, SpanUpdateData } from "./types";
+
+/**
+ * Service for processing trace and span updates with prompts support.
+ * Handles serialization of prompts and merging into metadata.
+ */
+export class UpdateService {
+  /**
+   * Serializes a Prompt object to info dict format.
+   * Matches Python SDK serialization format.
+   *
+   * @param prompt - Prompt instance to serialize
+   * @returns Serialized prompt in info dict format
+   */
+  private static serializePromptToInfoDict(prompt: Prompt): PromptInfoDict {
+    return {
+      name: prompt.name,
+      ...(prompt.id && { id: prompt.id }),
+      version: {
+        ...(prompt.versionId && { id: prompt.versionId }),
+        ...(prompt.commit && { commit: prompt.commit }),
+        template: prompt.prompt,
+      },
+    };
+  }
+
+  /**
+   * Converts JsonListString to an object suitable for merging.
+   * Handles string (JSON parsing), array, and object types.
+   *
+   * @param metadata - Metadata in JsonListString format
+   * @returns Object representation of metadata, or empty object if conversion fails
+   */
+  private static normalizeMetadata(
+    metadata: OpikApi.JsonListString | undefined
+  ): Record<string, unknown> {
+    if (!metadata) {
+      return {};
+    }
+
+    // If it's already an object (not an array), use it directly
+    if (typeof metadata === "object" && !Array.isArray(metadata)) {
+      return metadata;
+    }
+
+    // If it's a string, try to parse it as JSON
+    if (typeof metadata === "string") {
+      try {
+        const parsed = JSON.parse(metadata);
+        // If parsed result is an object (not array), use it
+        if (typeof parsed === "object" && !Array.isArray(parsed)) {
+          return parsed;
+        }
+      } catch {
+        // If parsing fails, we can't merge - return empty object
+        // The original string will be lost, but we can't merge into a string
+      }
+    }
+
+    // For arrays or unparseable strings, we can't merge prompts into them
+    // Return empty object - prompts will be the only metadata
+    // Note: This means non-object metadata will be replaced when prompts are added
+    return {};
+  }
+
+  /**
+   * Merges prompts into metadata under "opik_prompts" key.
+   * Preserves existing metadata and new metadata fields when they are objects.
+   * Non-object metadata (strings/arrays) will be replaced with prompt metadata.
+   *
+   * @param existingMetadata - Current metadata from trace/span
+   * @param newMetadata - New metadata from update call
+   * @param prompts - Array of Prompt objects to serialize
+   * @returns Merged metadata with prompts
+   */
+  private static mergePromptsIntoMetadata(
+    existingMetadata: OpikApi.JsonListString | undefined,
+    newMetadata: OpikApi.JsonListString | undefined,
+    prompts: Prompt[]
+  ): OpikApi.JsonListString {
+    const serializedPrompts = prompts.map((p) =>
+      this.serializePromptToInfoDict(p)
+    );
+
+    const existingObj = this.normalizeMetadata(existingMetadata);
+    const newObj = this.normalizeMetadata(newMetadata);
+
+    return {
+      ...existingObj,
+      ...newObj,
+      opik_prompts: serializedPrompts,
+    };
+  }
+
+  /**
+   * Processes trace update by extracting prompts and merging into metadata.
+   * Returns processed update ready for batch queue.
+   *
+   * @param updates - Trace update with optional prompts
+   * @param existingMetadata - Current trace metadata
+   * @returns Processed trace update without prompts field
+   */
+  static processTraceUpdate(
+    updates: TraceUpdateData,
+    existingMetadata?: OpikApi.JsonListString
+  ): Omit<OpikApi.TraceUpdate, "projectId"> {
+    const { prompts, ...restUpdates } = updates;
+
+    if (!prompts || prompts.length === 0) {
+      return restUpdates;
+    }
+
+    const mergedMetadata = this.mergePromptsIntoMetadata(
+      existingMetadata,
+      restUpdates.metadata,
+      prompts
+    );
+
+    return {
+      ...restUpdates,
+      metadata: mergedMetadata,
+    };
+  }
+
+  /**
+   * Processes span update by extracting prompts and merging into metadata.
+   * Returns processed update ready for batch queue.
+   *
+   * @param updates - Span update with optional prompts
+   * @param existingMetadata - Current span metadata
+   * @returns Processed span update without prompts field
+   */
+  static processSpanUpdate(
+    updates: SpanUpdateData,
+    existingMetadata?: OpikApi.JsonListString
+  ): Omit<
+    OpikApi.SpanUpdate,
+    "traceId" | "parentSpanId" | "projectId" | "projectName"
+  > {
+    const { prompts, ...restUpdates } = updates;
+
+    if (!prompts || prompts.length === 0) {
+      return restUpdates;
+    }
+
+    const mergedMetadata = this.mergePromptsIntoMetadata(
+      existingMetadata,
+      restUpdates.metadata,
+      prompts
+    );
+
+    return {
+      ...restUpdates,
+      metadata: mergedMetadata,
+    };
+  }
+}

--- a/sdks/typescript/src/opik/tracer/types.ts
+++ b/sdks/typescript/src/opik/tracer/types.ts
@@ -1,0 +1,37 @@
+import type { Prompt } from "@/prompt/Prompt";
+import type * as OpikApi from "@/rest_api/api";
+
+/**
+ * Prompt information dictionary format for serialization.
+ * Matches Python SDK format for prompt metadata storage.
+ */
+export interface PromptInfoDict {
+  name: string;
+  id?: string;
+  version: {
+    id?: string;
+    commit?: string;
+    template: string;
+  };
+}
+
+/**
+ * Extended TraceUpdate type that includes prompts field.
+ * Allows associating prompt versions with trace updates.
+ */
+export interface TraceUpdateData
+  extends Omit<OpikApi.TraceUpdate, "projectId"> {
+  prompts?: Prompt[];
+}
+
+/**
+ * Extended SpanUpdate type that includes prompts field.
+ * Allows associating prompt versions with span updates.
+ */
+export interface SpanUpdateData
+  extends Omit<
+    OpikApi.SpanUpdate,
+    "traceId" | "parentSpanId" | "projectId" | "projectName"
+  > {
+  prompts?: Prompt[];
+}

--- a/sdks/typescript/tests/integration/api/trace-span-prompts.test.ts
+++ b/sdks/typescript/tests/integration/api/trace-span-prompts.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeAll, afterEach, afterAll } from "vitest";
+import { Opik } from "@/index";
+import type { PromptInfoDict } from "@/tracer/types";
+import {
+  shouldRunIntegrationTests,
+  getIntegrationTestStatus,
+} from "./shouldRunIntegrationTests";
+
+const shouldRunApiTests = shouldRunIntegrationTests();
+
+// Test constants
+const TEST_TIMEOUT = 40000;
+const WAIT_FOR_TIMEOUT_SECONDS = 30;
+
+// Helper type for metadata
+interface TraceMetadata {
+  [key: string]: unknown;
+  opik_prompts?: PromptInfoDict[];
+}
+
+describe.skipIf(!shouldRunApiTests)("Trace Prompts Integration Tests", () => {
+  let client: Opik;
+  const testProjectName = `test-prompts-${Date.now()}`;
+  const createdPromptIds: string[] = [];
+
+  beforeAll(() => {
+    if (shouldRunApiTests) {
+      console.log(getIntegrationTestStatus());
+      client = new Opik({ projectName: testProjectName });
+    }
+  });
+
+  afterEach(async () => {
+    // Clean up created prompts
+    if (createdPromptIds.length > 0) {
+      try {
+        await client.deletePrompts(createdPromptIds);
+      } catch (error) {
+        console.warn("Failed to delete prompts during cleanup:", error);
+      }
+      createdPromptIds.length = 0;
+    }
+  });
+
+  afterAll(async () => {
+    if (client) {
+      await client.flush();
+    }
+  });
+
+  /**
+   * Helper to search for traces and wait for them to be indexed
+   */
+  const searchWithWait = async (
+    filterString: string,
+    expectedCount: number,
+    timeout: number = WAIT_FOR_TIMEOUT_SECONDS
+  ) => {
+    return await client.searchTraces({
+      projectName: testProjectName,
+      filterString,
+      waitForAtLeast: expectedCount,
+      waitForTimeout: timeout,
+    });
+  };
+
+  /**
+   * Helper to verify prompt structure matches PromptInfoDict format
+   */
+  const verifyPromptInfoDict = (
+    promptInfo: PromptInfoDict,
+    expectedName: string,
+    expectedTemplate: string
+  ) => {
+    expect(promptInfo.name).toBe(expectedName);
+    expect(promptInfo.id).toBeDefined();
+    expect(typeof promptInfo.id).toBe("string");
+    expect(promptInfo.version).toBeDefined();
+    expect(promptInfo.version.template).toBe(expectedTemplate);
+    expect(promptInfo.version.id).toBeDefined();
+    expect(typeof promptInfo.version.id).toBe("string");
+    expect(promptInfo.version.commit).toBeDefined();
+    expect(typeof promptInfo.version.commit).toBe("string");
+  };
+
+  it(
+    "should attach single prompt to trace and serialize to metadata.opik_prompts",
+    async () => {
+      const timestamp = Date.now();
+      const promptName = `test-prompt-trace-${timestamp}`;
+      const promptTemplate = "Answer the question: {{question}}";
+      const traceName = `trace-with-prompt-${timestamp}`;
+
+      // Create a prompt
+      const prompt = await client.createPrompt({
+        name: promptName,
+        prompt: promptTemplate,
+        metadata: { testCase: "single-trace-prompt" },
+      });
+      createdPromptIds.push(prompt.id);
+
+      // Create a trace
+      const trace = client.trace({
+        name: traceName,
+        input: { query: "test input" },
+      });
+
+      // Update trace with prompt
+      trace.update({ prompts: [prompt] });
+      trace.end();
+
+      await client.flush();
+
+      // Search for the trace
+      const results = await searchWithWait(`name = "${traceName}"`, 1);
+
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      const foundTrace = results.find((t) => t.name === traceName);
+      expect(foundTrace).toBeDefined();
+
+      // Verify metadata.opik_prompts exists and is an array
+      const metadata = foundTrace?.metadata as TraceMetadata;
+      expect(metadata.opik_prompts).toBeDefined();
+      expect(Array.isArray(metadata.opik_prompts)).toBe(true);
+      expect(metadata.opik_prompts).toHaveLength(1);
+
+      // Verify prompt structure
+      const serializedPrompt = metadata.opik_prompts![0];
+      verifyPromptInfoDict(serializedPrompt, promptName, promptTemplate);
+    },
+    TEST_TIMEOUT
+  );
+
+  it(
+    "should attach multiple prompts to trace and preserve order",
+    async () => {
+      const timestamp = Date.now();
+      const traceName = `trace-multiple-prompts-${timestamp}`;
+
+      // Create 3 different prompts
+      const prompt1 = await client.createPrompt({
+        name: `prompt-1-${timestamp}`,
+        prompt: "First prompt: {{var1}}",
+      });
+      createdPromptIds.push(prompt1.id);
+
+      const prompt2 = await client.createPrompt({
+        name: `prompt-2-${timestamp}`,
+        prompt: "Second prompt: {{var2}}",
+      });
+      createdPromptIds.push(prompt2.id);
+
+      const prompt3 = await client.createPrompt({
+        name: `prompt-3-${timestamp}`,
+        prompt: "Third prompt: {{var3}}",
+      });
+      createdPromptIds.push(prompt3.id);
+
+      // Create a trace
+      const trace = client.trace({
+        name: traceName,
+        input: { query: "test input" },
+      });
+
+      // Update trace with multiple prompts
+      trace.update({ prompts: [prompt1, prompt2, prompt3] });
+      trace.end();
+
+      await client.flush();
+
+      // Search for the trace
+      const results = await searchWithWait(`name = "${traceName}"`, 1);
+
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      const foundTrace = results.find((t) => t.name === traceName);
+      expect(foundTrace).toBeDefined();
+
+      // Verify metadata.opik_prompts has 3 prompts
+      const metadata = foundTrace?.metadata as TraceMetadata;
+      expect(metadata.opik_prompts).toBeDefined();
+      expect(Array.isArray(metadata.opik_prompts)).toBe(true);
+      expect(metadata.opik_prompts).toHaveLength(3);
+
+      // Verify each prompt structure and order
+      verifyPromptInfoDict(
+        metadata.opik_prompts![0],
+        `prompt-1-${timestamp}`,
+        "First prompt: {{var1}}"
+      );
+      verifyPromptInfoDict(
+        metadata.opik_prompts![1],
+        `prompt-2-${timestamp}`,
+        "Second prompt: {{var2}}"
+      );
+      verifyPromptInfoDict(
+        metadata.opik_prompts![2],
+        `prompt-3-${timestamp}`,
+        "Third prompt: {{var3}}"
+      );
+    },
+    TEST_TIMEOUT
+  );
+
+  it(
+    "should preserve existing metadata when adding prompts to trace",
+    async () => {
+      const timestamp = Date.now();
+      const traceName = `trace-metadata-preservation-${timestamp}`;
+      const promptName = `prompt-metadata-test-${timestamp}`;
+
+      // Create a prompt
+      const prompt = await client.createPrompt({
+        name: promptName,
+        prompt: "Test: {{test}}",
+      });
+      createdPromptIds.push(prompt.id);
+
+      // Create a trace with existing metadata
+      const trace = client.trace({
+        name: traceName,
+        input: { query: "test" },
+        metadata: { customKey: "customValue", originalField: 123 },
+      });
+
+      // Update trace with prompts and additional metadata
+      trace.update({
+        prompts: [prompt],
+        metadata: { newField: "newValue" },
+      });
+      trace.end();
+
+      await client.flush();
+
+      // Search for the trace
+      const results = await searchWithWait(`name = "${traceName}"`, 1);
+      const foundTrace = results.find((t) => t.name === traceName);
+      expect(foundTrace).toBeDefined();
+
+      // Verify all metadata fields are present
+      const metadata = foundTrace?.metadata as TraceMetadata;
+
+      // Original metadata
+      expect(metadata.customKey).toBe("customValue");
+      expect(metadata.originalField).toBe(123);
+
+      // New metadata
+      expect(metadata.newField).toBe("newValue");
+
+      // Prompts metadata
+      expect(metadata.opik_prompts).toBeDefined();
+      expect(metadata.opik_prompts).toHaveLength(1);
+      verifyPromptInfoDict(
+        metadata.opik_prompts![0],
+        promptName,
+        "Test: {{test}}"
+      );
+    },
+    TEST_TIMEOUT
+  );
+});


### PR DESCRIPTION
# User description
## Details
Enhanced the TypeScript SDK to support associating prompt versions with traces and spans through a new prompts field in their update() methods. This aligns the TypeScript SDK behavior with the Python SDK for prompt tracking.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-3442

## Testing

## Documentation

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
Trace_update_("Trace.update"):::added
UpdateService_processTraceUpdate_("UpdateService.processTraceUpdate"):::added
Span_update_("Span.update"):::added
UpdateService_processSpanUpdate_("UpdateService.processSpanUpdate"):::added
UpdateService_mergePromptsIntoMetadata_("UpdateService.mergePromptsIntoMetadata"):::added
UpdateService_serializePromptToInfoDict_("UpdateService.serializePromptToInfoDict"):::added
Trace_update_ -- "Processes trace updates, merging prompt metadata into existing metadata." --> UpdateService_processTraceUpdate_
Span_update_ -- "Processes span updates, merging prompt metadata into existing metadata." --> UpdateService_processSpanUpdate_
UpdateService_processTraceUpdate_ -- "Merges serialized prompts into trace metadata under 'opik_prompts'." --> UpdateService_mergePromptsIntoMetadata_
UpdateService_processSpanUpdate_ -- "Merges serialized prompts into span metadata under 'opik_prompts'." --> UpdateService_mergePromptsIntoMetadata_
UpdateService_mergePromptsIntoMetadata_ -- "Serializes Prompt objects into dictionary format for metadata merging." --> UpdateService_serializePromptToInfoDict_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Extends the TypeScript SDK's <code>Span</code> and <code>Trace</code> update methods to support associating prompt versions with traces and spans. Introduces an <code>UpdateService</code> to serialize prompt objects into a <code>PromptInfoDict</code> format and merge them into the <code>metadata.opik_prompts</code> field, aligning behavior with the Python SDK for prompt tracking.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>y.boikodevelop@gmail.com</td><td>OPIK-685-JS-SDK-openai...</td><td>May 20, 2025</td></tr>
<tr><td>fernando@comet.com</td><td>OPIK-928-TypeScript-SD...</td><td>February 18, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/comet-ml/opik/4427?tool=ast>(Baz)</a>.