### PR TITLE
[OPIK-3445] [FE] Fix span output mapping for span-level online rules

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
@@ -17,6 +17,7 @@ import { Label } from "@/components/ui/label";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
 import { parsePythonMethodParameters } from "@/lib/pythonArgumentsParser";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
+import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 
 type PythonCodeRuleDetailsProps = {
   form: UseFormReturn<EvaluationRuleFormType>;
@@ -35,6 +36,12 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
 
   const scope = form.watch("scope");
   const isThreadScope = scope === EVALUATORS_RULE_SCOPE.thread;
+  const isSpanScope = scope === EVALUATORS_RULE_SCOPE.span;
+
+  // Determine the type for autocomplete based on scope
+  const autocompleteType = isSpanScope
+    ? TRACE_DATA_TYPE.spans
+    : TRACE_DATA_TYPE.traces;
 
   return (
     <>
@@ -114,6 +121,7 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                 errorText="Code parsing error. The variables cannot be extracted."
                 projectName={projectName}
                 datasetColumnNames={datasetColumnNames}
+                type={autocompleteType}
                 includeIntermediateNodes
               />
             );


### PR DESCRIPTION
## Details

This PR fixes an issue where span-level online rules couldn't properly map span output in the Python code editor autocomplete.

### Changes:
- Added logic to determine the autocomplete data type based on the rule scope
- When scope is `span`, the autocomplete now uses `TRACE_DATA_TYPE.spans` instead of traces
- This ensures span-level rules get accurate span field suggestions for output mapping

### Implementation:
- Imported `TRACE_DATA_TYPE` from `useTracesOrSpansList` hook
- Added `isSpanScope` check to determine current scope
- Created `autocompleteType` variable that dynamically selects between span and trace data types
- Passed the correct `type` prop to the autocomplete component

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-3445

## Testing

- Verified that span-level online rules now show span-specific field suggestions
- Confirmed trace-level and thread-level rules continue to work correctly

## Documentation

N/A - No documentation changes required

