### PR TITLE
[OPIK-2769] [BE] Fix RQ timestamp format to use microsecond precision

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/queues/RqJobMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/queues/RqJobMapper.java
@@ -7,20 +7,40 @@ import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 
 @Mapper(componentModel = "jakarta")
 interface RqJobMapper {
 
     RqJobMapper INSTANCE = Mappers.getMapper(RqJobMapper.class);
 
-    @Mapping(target = "createdAt", source = "message.createdAt", qualifiedByName = "instantToString")
-    @Mapping(target = "enqueuedAt", source = "message.enqueuedAt", qualifiedByName = "instantToString")
+    /**
+     * ISO-8601 formatter with microsecond precision (6 digits).
+     * Python RQ's strptime uses %f which only supports up to 6 decimal places.
+     * Java's Instant.toString() produces nanoseconds (9 digits) which breaks RQ.
+     */
+    DateTimeFormatter RQ_TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'")
+            .withZone(ZoneOffset.UTC);
+
+    @Mapping(target = "createdAt", source = "message.createdAt", qualifiedByName = "instantToRqTimestamp")
+    @Mapping(target = "enqueuedAt", source = "message.enqueuedAt", qualifiedByName = "instantToRqTimestamp")
     @Mapping(target = "description", source = "description")
     @Mapping(target = "timeout", source = "message.timeoutInSec")
     RqJobHash toHash(@NonNull QueueMessage message, @NonNull String description, @NonNull String data);
 
-    @Named("instantToString")
-    static String instantToString(Instant instant) {
-        return instant != null ? instant.toString() : null;
+    /**
+     * Convert Instant to RQ-compatible timestamp string with microsecond precision.
+     * RQ expects format: yyyy-MM-ddTHH:mm:ss.ffffffZ (6 decimal places max)
+     */
+    @Named("instantToRqTimestamp")
+    static String instantToRqTimestamp(Instant instant) {
+        if (instant == null) {
+            return null;
+        }
+        // Truncate to microseconds (6 digits) for Python RQ compatibility
+        Instant truncated = instant.truncatedTo(ChronoUnit.MICROS);
+        return RQ_TIMESTAMP_FORMAT.format(truncated);
     }
 }


### PR DESCRIPTION
## Details

Java's `Instant.toString()` produces nanosecond precision timestamps (9 decimal digits), but Python RQ's `strptime` with `%f` format specifier only supports microseconds (6 decimal digits). This causes timestamp parsing failures when Python RQ workers try to process jobs created by the Java backend.

**Error observed:**
```
ValueError: time data '2025-12-15T10:25:41.546536753Z' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'
```

As this works in a local deploy but not in staging environment, that might suggest different JVMs do it differently, and we need to make sure they have a single behaviour.

**Fix:**
- Truncate `Instant` to microsecond precision using `truncatedTo(ChronoUnit.MICROS)`
- Use explicit `DateTimeFormatter` with exactly 6 decimal places (`SSSSSS`)

This ensures all timestamps sent to RQ are compatible with Python's datetime parsing.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2769

## Testing

- Verified compilation succeeds
- Timestamps now produce format like `2025-12-15T10:25:41.546536Z` (6 digits) instead of `2025-12-15T10:25:41.546536753Z` (9 digits)

## Documentation

No documentation changes required - this is an internal fix for Java-Python interoperability.