### PR TITLE
[CUST-4492] Update experiment panel to not use truncated data

### DIFF
--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsPanel/CompareExperimentsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsPanel/CompareExperimentsPanel.tsx
@@ -18,7 +18,6 @@ import useDatasetItemById from "@/api/datasets/useDatasetItemById";
 import useCompareExperimentsList from "@/api/datasets/useCompareExperimentsList";
 import useAppStore from "@/store/AppStore";
 import { useDatasetIdFromCompareExperimentsURL } from "@/hooks/useDatasetIdFromCompareExperimentsURL";
-import { createFilter } from "@/lib/filters";
 import { COLUMN_TYPE } from "@/types/shared";
 import DataTab from "@/components/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/DataTab";
 
@@ -58,12 +57,13 @@ const CompareExperimentsPanel: React.FunctionComponent<
       datasetId,
       experimentsIds,
       filters: [
-        createFilter({
+        {
+          id: "",
           field: "id",
           type: COLUMN_TYPE.string,
           operator: "=",
           value: experimentsCompareId as string,
-        }),
+        },
       ],
       truncate: false,
       page: 1,


### PR DESCRIPTION
## Details

The experiment compare panel was getting it's data from the table which is truncated by default for performance reasons rather than fetching the un-truncated data which is what we do for other panels. This updates the panel to fetch it own data following other patterns in the app.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- CUST-4492

## Testing

N/A

## Documentation
N/A