### PR TITLE
[NA] [P SDK] Add compatibility with old backend for text prompt retrieving

### DIFF
--- a/sdks/python/src/opik/api_objects/prompt/client.py
+++ b/sdks/python/src/opik/api_objects/prompt/client.py
@@ -143,11 +143,11 @@ class PromptClient:
                 commit=commit,
             )
 
-            skip_text_prompt_validation_for_old_backend = (
+            should_skip_validation = (
                 prompt_version.template_structure is None
                 and raise_if_not_template_structure == "text"
             )
-            if skip_text_prompt_validation_for_old_backend:
+            if should_skip_validation:
                 return prompt_version
 
             # Client-side validation for template_structure if requested and not skipped


### PR DESCRIPTION
## Details
Skipped template structure validation for text prompts in the SDK if template_structure is not provided in the BE response (old BE case)

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-NA

## Testing
-
## Documentation
-