### PR TITLE
[OPIK-2768] [BE] Add opikApiKey to OptimizationStudioConfig for cloud deployments

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/OptimizationStudioConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/OptimizationStudioConfig.java
@@ -14,6 +14,8 @@ import java.util.List;
 /**
  * Configuration for Optimization Studio runs.
  * This represents the full payload sent from the frontend to create a Studio optimization.
+ *
+ * The opikApiKey is only required for cloud deployments, as it'll be used to automate SDK in behalf of the user.
  */
 @Builder(toBuilder = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -22,7 +24,8 @@ public record OptimizationStudioConfig(
         @NotNull @Valid StudioPrompt prompt,
         @NotNull @Valid StudioLlmModel llmModel,
         @NotNull @Valid StudioEvaluation evaluation,
-        @NotNull @Valid StudioOptimizer optimizer) {
+        @NotNull @Valid StudioOptimizer optimizer,
+        String opikApiKey) {
 
     @Builder(toBuilder = true)
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
@@ -176,7 +176,9 @@ class OptimizationServiceImpl implements OptimizationService {
                                             }
                                         }
 
-                                        String opikApiKey = ctx.getOrDefault(RequestContext.API_KEY, null);
+                                        String opikApiKey = newOptimization.studioConfig() != null
+                                                ? newOptimization.studioConfig().opikApiKey()
+                                                : null;
 
                                         enqueueStudioOptimizationJob(newOptimization, workspaceId, workspaceName,
                                                 opikApiKey);


### PR DESCRIPTION
## Details
Add `opik_api_key` field to `OptimizationStudioConfig` so the frontend can pass the user's API key for cloud deployments. This key is used by the Python worker to authenticate with the Opik SDK on behalf of the user.

### Changes
- Added optional `opikApiKey` field to `OptimizationStudioConfig.java`
- Updated `OptimizationService.java` to read API key from config instead of `RequestContext`

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2768

## Testing
- Compiles successfully
- Frontend needs to include `opik_api_key` in the `studio_config` payload

## Documentation
N/A - Internal API change, frontend will need to be updated to pass the API key