### PR TITLE
[OPIK-2768] [BE] Pass opikApiKey via header for Optimization Studio

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/OptimizationStudioConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/OptimizationStudioConfig.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -15,7 +16,8 @@ import java.util.List;
  * Configuration for Optimization Studio runs.
  * This represents the full payload sent from the frontend to create a Studio optimization.
  *
- * The opikApiKey is only required for cloud deployments, as it'll be used to automate SDK in behalf of the user.
+ * The opikApiKey is internal-only: populated server-side from the request header, never serialized to clients.
+ * Required for cloud deployments, as it'll be used to automate SDK in behalf of the user.
  */
 @Builder(toBuilder = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -25,7 +27,7 @@ public record OptimizationStudioConfig(
         @NotNull @Valid StudioLlmModel llmModel,
         @NotNull @Valid StudioEvaluation evaluation,
         @NotNull @Valid StudioOptimizer optimizer,
-        String opikApiKey) {
+        @JsonIgnore String opikApiKey) {
 
     @Builder(toBuilder = true)
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RequestContext.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RequestContext.java
@@ -26,6 +26,8 @@ public class RequestContext {
     public static final String RATE_LIMIT_RESET = "RateLimit-Reset";
 
     public static final String PROJECT_NAME = "projectName";
+    // used by Optimization Studio to pass the Opik API key to the optimizer job, while keeping auth as is
+    public static final String OPIK_API_KEY = "opikApiKey";
 
     private String userName;
     private String workspaceId;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/OptimizationResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/OptimizationResourceClient.java
@@ -12,6 +12,7 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import uk.co.jemos.podam.api.PodamFactory;
@@ -40,11 +41,20 @@ public class OptimizationResourceClient {
     }
 
     public UUID create(Optimization optimization, String apiKey, String workspaceName) {
-        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
+        return create(optimization, apiKey, workspaceName, null);
+    }
+
+    public UUID create(Optimization optimization, String apiKey, String workspaceName, String opikApiKey) {
+        var requestBuilder = client.target(RESOURCE_PATH.formatted(baseURI))
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, apiKey)
-                .header(RequestContext.WORKSPACE_HEADER, workspaceName)
-                .post(Entity.json(optimization))) {
+                .header(RequestContext.WORKSPACE_HEADER, workspaceName);
+
+        if (StringUtils.isNotBlank(opikApiKey)) {
+            requestBuilder = requestBuilder.header(RequestContext.OPIK_API_KEY, opikApiKey);
+        }
+
+        try (var response = requestBuilder.post(Entity.json(optimization))) {
             assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CREATED);
             return TestUtils.getIdFromLocation(response.getLocation());
         }


### PR DESCRIPTION
## Details
This PR adds support for passing the Opik API key to the Python worker via a dedicated header for Optimization Studio runs.

### Changes:
- Added `OPIK_API_KEY` constant to `RequestContext` for the header name
- Added `opikApiKey` field to `OptimizationStudioConfig` with `@JsonIgnore` annotation (not serialized/deserialized)
- In `OptimizationsResource.create()`, extract the API key from the `opikApiKey` header and inject it into the `studioConfig`
- The API key is passed to the Python worker via Redis but never returned in API responses

### Security:
- `@JsonIgnore` ensures the API key is never exposed to clients via the API
- The field is populated server-side only

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2768

## Documentation

## Testing
- Updated `createStudioOptimization__thenVerifyRedisJobEnqueued` to verify:
  - API key from header is stored in Redis job data
  - API key is NOT returned when retrieving the optimization
- All 32 tests pass