### PR TITLE
[NA] [DOCS] Fix SDK section links in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ For production or larger-scale self-hosted deployments, Opik can be installed on
 
 ## 💻 Opik Client SDK
 
-Opik provides a suite of client libraries and a REST API to interact with the Opik server. This includes SDKs for Python, TypeScript, and Ruby (via OpenTelemetry), allowing for seamless integration into your workflows. For detailed API and SDK references, see the [Opik Client Reference Documentation](https://www.comet.com/docs/opik/reference/overview).
+Opik provides a suite of client libraries and a REST API to interact with the Opik server. This includes SDKs for Python, TypeScript, and Ruby (via OpenTelemetry), allowing for seamless integration into your workflows. For detailed API and SDK references, see the [Opik Client Reference Documentation](https://www.comet.com/docs/opik/reference/overview?from=llm&utm_source=opik&utm_medium=github&utm_content=reference_link&utm_campaign=opik).
 
 ### Python SDK Quick Start
 
@@ -180,7 +180,7 @@ opik configure
 ```
 
 > [!TIP]
-> You can also call `opik.configure(use_local=True)` from your Python code to configure the SDK to run on a local self-hosted installation, or provide API key and workspace details directly for Comet.com. Refer to the [Python SDK documentation](https://www.comet.com/docs/opik/python-sdk-reference/) for more configuration options.
+> You can also call `opik.configure(use_local=True)` from your Python code to configure the SDK to run on a local self-hosted installation, or provide API key and workspace details directly for Comet.com. Refer to the [Python SDK documentation](https://www.comet.com/docs/opik/python-sdk-reference/?from=llm&utm_source=opik&utm_medium=github&utm_content=python_sdk_docs_link&utm_campaign=opik) for more configuration options.
 
 You are now ready to start logging traces using the [Python SDK](https://www.comet.com/docs/opik/python-sdk-reference/?from=llm&utm_source=opik&utm_medium=github&utm_content=sdk_link2&utm_campaign=opik).
 

--- a/readme_CN.md
+++ b/readme_CN.md
@@ -158,7 +158,7 @@ Opik 安装脚本现在支持针对不同开发场景的服务配置文件：
 
 ## 💻 Opik 客户端 SDK
 
-Opik 提供一系列客户端库和 REST API 与 Opik 服务端交互，包含 Python、TypeScript 和 Ruby（通过 OpenTelemetry）SDK，方便集成到各类工作流中。详细 API 与 SDK 参考见 [客户端参考文档](https://www.comet.com/docs/opik/reference/overview)。
+Opik 提供一系列客户端库和 REST API 与 Opik 服务端交互，包含 Python、TypeScript 和 Ruby（通过 OpenTelemetry）SDK，方便集成到各类工作流中。详细 API 与 SDK 参考见 [客户端参考文档](https://www.comet.com/docs/opik/reference/overview?from=llm&utm_source=opik&utm_medium=github&utm_content=reference_link&utm_campaign=opik)。
 
 ### Python SDK 快速开始
 
@@ -179,7 +179,7 @@ opik configure
 ```
 
 > [!TIP]  
-> 您也可以在代码中调用 `opik.configure(use_local=True)` 来配置本地自托管，或直接在代码中提供 API key 和 workspace。更多配置选项请参阅 [Python SDK 文档](https://www.comet.com/docs/opik/python-sdk-reference/)。
+> 您也可以在代码中调用 `opik.configure(use_local=True)` 来配置本地自托管，或直接在代码中提供 API key 和 workspace。更多配置选项请参阅 [Python SDK 文档](https://www.comet.com/docs/opik/python-sdk-reference/?from=llm&utm_source=opik&utm_medium=github&utm_content=python_sdk_docs_link&utm_campaign=opik)。
 
 现在您可以使用 [Python SDK](https://www.comet.com/docs/opik/python-sdk-reference/?from=llm&utm_source=opik&utm_medium=github&utm_content=sdk_link2&utm_campaign=opik) 记录跟踪！
 

--- a/readme_JP.md
+++ b/readme_JP.md
@@ -158,7 +158,7 @@ Opikインストールスクリプトは、異なる開発シナリオ向けの�
 
 ## 💻 OpikクライアントSDK
 
-Opikは、Opikサーバーとやり取りするためのクライアントライブラリ群とREST APIを提供します。Python、TypeScript、Ruby（OpenTelemetry経由）のSDKがあり、ワークフローへのシームレスな統合が可能です。詳細は [Opikクライアントリファレンス](https://www.comet.com/docs/opik/reference/overview) をご覧ください。
+Opikは、Opikサーバーとやり取りするためのクライアントライブラリ群とREST APIを提供します。Python、TypeScript、Ruby（OpenTelemetry経由）のSDKがあり、ワークフローへのシームレスな統合が可能です。詳細は [Opikクライアントリファレンス](https://www.comet.com/docs/opik/reference/overview?from=llm&utm_source=opik&utm_medium=github&utm_content=reference_link&utm_campaign=opik) をご覧ください。
 
 ### Python SDKクイックスタート
 
@@ -181,7 +181,7 @@ opik configure
 ```
 
 > [!TIP]
-> Pythonコード内で `opik.configure(use_local=True)` を呼び出してローカルセルフホスト構成にしたり、APIキーとワークスペースを直接指定することも可能です。詳細は [Python SDKドキュメント](https://www.comet.com/docs/opik/python-sdk-reference/) を参照してください。
+> Pythonコード内で `opik.configure(use_local=True)` を呼び出してローカルセルフホスト構成にしたり、APIキーとワークスペースを直接指定することも可能です。詳細は [Python SDKドキュメント](https://www.comet.com/docs/opik/python-sdk-reference/?from=llm&utm_source=opik&utm_medium=github&utm_content=python_sdk_docs_link&utm_campaign=opik) を参照してください。
 
 これで [Python SDK](https://www.comet.com/docs/opik/python-sdk-reference/?from=llm&utm_source=opik&utm_medium=github&utm_content=sdk_link2&utm_campaign=opik) を使ったトレースのログ記録が可能になります。
 

--- a/readme_KO.md
+++ b/readme_KO.md
@@ -158,7 +158,7 @@ Opik 설치 스크립트는 다양한 개발 시나리오를 위한 service prof
 
 ## 💻 Opik 클라이언트 SDK
 
-Opik은 Opik 서버와 상호작용할 수 있는 클라이언트 라이브러리 suite와 REST API를 제공합니다. Python, TypeScript, Ruby(OpenTelemetry 사용) SDK를 지원하여 워크플로우에 손쉽게 통합할 수 있습니다. 상세한 API 및 SDK 레퍼런스는 [Opik Client Reference Documentation](https://www.comet.com/docs/opik/reference/overview)을 확인하세요.
+Opik은 Opik 서버와 상호작용할 수 있는 클라이언트 라이브러리 suite와 REST API를 제공합니다. Python, TypeScript, Ruby(OpenTelemetry 사용) SDK를 지원하여 워크플로우에 손쉽게 통합할 수 있습니다. 상세한 API 및 SDK 레퍼런스는 [Opik Client Reference Documentation](https://www.comet.com/docs/opik/reference/overview?from=llm&utm_source=opik&utm_medium=github&utm_content=reference_link&utm_campaign=opik)을 확인하세요.
 
 ### Python SDK Quick Start
 
@@ -179,7 +179,7 @@ opik configure
 ```
 
 > [!TIP]
-> Python 코드에서 `opik.configure(use_local=True)`를 호출하여 로컬 self-hosted 설치를 위한 SDK 설정을 할 수도 있고, Comet.com을 위해 API 키와 workspace 정보를 직접 제공할 수도 있습니다. 더 많은 설정 옵션은 [Python SDK documentation](https://www.comet.com/docs/opik/python-sdk-reference/)을 참조하세요.
+> Python 코드에서 `opik.configure(use_local=True)`를 호출하여 로컬 self-hosted 설치를 위한 SDK 설정을 할 수도 있고, Comet.com을 위해 API 키와 workspace 정보를 직접 제공할 수도 있습니다. 더 많은 설정 옵션은 [Python SDK documentation](https://www.comet.com/docs/opik/python-sdk-reference/?from=llm&utm_source=opik&utm_medium=github&utm_content=python_sdk_docs_link&utm_campaign=opik)을 참조하세요.
 
 이제 [Python SDK](https://www.comet.com/docs/opik/python-sdk-reference/?from=llm&utm_source=opik&utm_medium=github&utm_content=sdk_link2&utm_campaign=opik)로 trace 로깅을 시작할 준비가 되었습니다.
 

--- a/readme_PT_BR.md
+++ b/readme_PT_BR.md
@@ -159,7 +159,7 @@ Para implantações de produção ou em maior escala, o Opik pode ser instalado 
 
 ## 💻 SDK Cliente Opik
 
-O Opik fornece um conjunto de bibliotecas cliente e uma API REST para interagir com o servidor Opik. Isso inclui SDKs para Python, TypeScript e Ruby (via OpenTelemetry), permitindo integração fluida em seus fluxos de trabalho. Para referências de API e SDK, consulte a [Documentação de Referência do Cliente Opik](https://www.comet.com/docs/opik/reference/overview).
+O Opik fornece um conjunto de bibliotecas cliente e uma API REST para interagir com o servidor Opik. Isso inclui SDKs para Python, TypeScript e Ruby (via OpenTelemetry), permitindo integração fluida em seus fluxos de trabalho. Para referências de API e SDK, consulte a [Documentação de Referência do Cliente Opik](https://www.comet.com/docs/opik/reference/overview?from=llm&utm_source=opik&utm_medium=github&utm_content=reference_link&utm_campaign=opik).
 
 ### Início Rápido com o SDK Python
 
@@ -182,7 +182,7 @@ opik configure
 ```
 
 > [!TIP]
-> Você também pode chamar `opik.configure(use_local=True)` do seu código Python para configurar o SDK para execução local self-hosted, ou fornecer a chave de API e workspace diretamente para Comet.com. Consulte a [documentação do SDK Python](https://www.comet.com/docs/opik/python-sdk-reference/) para mais opções de configuração.
+> Você também pode chamar `opik.configure(use_local=True)` do seu código Python para configurar o SDK para execução local self-hosted, ou fornecer a chave de API e workspace diretamente para Comet.com. Consulte a [documentação do SDK Python](https://www.comet.com/docs/opik/python-sdk-reference/?from=llm&utm_source=opik&utm_medium=github&utm_content=python_sdk_docs_link&utm_campaign=opik) para mais opções de configuração.
 
 Agora você está pronto para começar a registrar traces usando o [SDK Python](https://www.comet.com/docs/opik/python-sdk-reference/?from=llm&utm_source=opik&utm_medium=github&utm_content=sdk_link2&utm_campaign=opik).
 


### PR DESCRIPTION
## Details

Fixed broken links in README files by replacing relative paths with absolute URLs pointing to the Comet documentation site. Updated links in the main README.md and all localized versions (CN, JP, KO, PT_BR).

This affected both README links in the repo and also in [pypi](https://pypi.org/project/opik/).

**Changes:**
- Updated Opik Client Reference Documentation link: `apps/opik-documentation/documentation/fern/docs/reference/overview.mdx` → `https://www.comet.com/docs/opik/reference/overview`
- Updated Python SDK documentation link: `apps/opik-documentation/documentation/fern/docs/reference/python-sdk/` → `https://www.comet.com/docs/opik/python-sdk-reference/`

**Files changed:**
- README.md
- readme_CN.md
- readme_JP.md
- readme_KO.md
- readme_PT_BR.md

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues
- Resolves #
- OPIK- NA

## Testing

Manually verified that the updated links point to the correct Comet documentation pages:
- [Opik Client Reference Documentation](https://www.comet.com/docs/opik/reference/overview)
- [Python SDK documentation](https://www.comet.com/docs/opik/python-sdk-reference/)

## Documentation

Updated README files (main and localized versions) with corrected documentation links.