### PR TITLE
[OPIK-3465] [FE] Add copy suffix to duplicated widget titles

### DIFF
--- a/apps/opik-frontend/src/store/DashboardStore.ts
+++ b/apps/opik-frontend/src/store/DashboardStore.ts
@@ -286,7 +286,7 @@ export const useDashboardStore = create<DashboardStore<BaseDashboardConfig>>()(
           const newWidget: DashboardWidget = {
             id: uniqid(),
             type: widget.type,
-            title: widget.title,
+            title: `${widget.title} (copy)`,
             subtitle: widget.subtitle,
             config: widget.config || {},
           };


### PR DESCRIPTION
## Details

When duplicating a dashboard widget, the title now gets "(copy)" appended to distinguish it from the original widget. This provides better UX by making it clear which widget is the duplicate.

**Change:**
- Modified `DashboardStore.ts` to append " (copy)" suffix to the widget title when using the duplicate widget action

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-3465

## Testing

- Verified lint and type checks pass
- Manual testing: Duplicate a widget in a dashboard and confirm the copy has "(copy)" suffix in the title

## Documentation

N/A - UI behavior change, no documentation update required