### PR TITLE
[OPIK-3502] [Python BE] Fix ScoreResult import and update json_schema_validator tests

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/studio/metrics.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/metrics.py
@@ -182,7 +182,7 @@ def _build_json_schema_validator_metric(params: Dict[str, Any], model: str) -> C
     def metric_fn(dataset_item, llm_output):
         schema = dataset_item.get(schema_key)
         if not schema:
-            from opik.evaluation.metrics import ScoreResult
+            from opik.evaluation.metrics.score_result import ScoreResult
             return ScoreResult(
                 value=0.0, 
                 name="json_schema_validator", 


### PR DESCRIPTION
## Details
Fix failing test `test_build_json_schema_validator_without_schema_raises_error` in `test_metrics_factory.py`.

### Root Cause
1. **Wrong import path**: `metrics.py` tried to import `ScoreResult` from `opik.evaluation.metrics` but it's located at `opik.evaluation.metrics.score_result`
2. **Outdated tests**: The `json_schema_validator` metric was refactored to read schema from dataset items (via `schema_key`) instead of requiring it at build time, but the tests weren't updated

### Changes
- **metrics.py**: Fix import path from `from opik.evaluation.metrics import ScoreResult` to `from opik.evaluation.metrics.score_result import ScoreResult`
- **test_metrics_factory.py**: Update tests to match new behavior:
  - Removed `test_build_json_schema_validator_without_schema_raises_error` (no longer raises at build time)
  - Updated `test_build_json_schema_validator_metric` to not pass outdated `json_schema` param
  - Added `test_build_json_schema_validator_metric_with_custom_schema_key` to test `schema_key` param
  - Added `test_json_schema_validator_missing_schema_returns_zero` to test runtime behavior

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-3502

## Documentation

## Testing
All 15 tests in `test_metrics_factory.py` pass:
```
pytest tests/test_metrics_factory.py -v
============================== 15 passed in 2.57s ==============================
```