### PR TITLE
[NA] [BE] Enable dashboards feature flag by default

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -573,9 +573,9 @@ serviceToggles:
   # Default: true
   # Description: Whether or not export/download functionality is enabled
   exportEnabled: ${TOGGLE_EXPORT_ENABLED:-"true"}
-  # Default: false
+  # Default: true
   # Description: Whether or not Dashboards feature is enabled
-  dashboardsEnabled: ${TOGGLE_DASHBOARDS_ENABLED:-"false"}
+  dashboardsEnabled: ${TOGGLE_DASHBOARDS_ENABLED:-"true"}
   # Default: false
   # Description: Whether or not dataset versioning feature is enabled
   datasetVersioningEnabled: ${TOGGLE_DATASET_VERSIONING_ENABLED:-"false"}
@@ -769,4 +769,3 @@ freeModel:
   # Description: API key for the endpoint (optional for auth-less endpoints)
   # Default: empty
   apiKey: ${OPIK_FREE_MODEL_API_KEY:-}
-

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -432,9 +432,9 @@ serviceToggles:
   # Default: true
   # Description: Whether or not export/download functionality is enabled
   exportEnabled: "true"
-  # Default: false
+  # Default: true
   # Description: Whether or not Dashboards feature is enabled
-  dashboardsEnabled: "false"
+  dashboardsEnabled: "true"
   # Default: true for testing
   # Description: Whether or not dataset versioning feature is enabled
   datasetVersioningEnabled: "true"


### PR DESCRIPTION
## Details
Enabled the dashboards feature toggle by default in backend configuration. This change updates the default value for `dashboardsEnabled` from `false` to `true` in both:
- Main backend configuration (`config.yml`)
- Test configuration (`config-test.yml`)

This allows the dashboards feature to be enabled by default for all deployments unless explicitly disabled via the `TOGGLE_DASHBOARDS_ENABLED` environment variable.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves # 
- NA

## Testing
No new tests required. The configuration change is validated by existing backend tests and Spotless formatting checks, which pass successfully.

## Documentation
Updated configuration files:
- `apps/opik-backend/config.yml` - Changed default value and comment for dashboardsEnabled
- `apps/opik-backend/src/test/resources/config-test.yml` - Changed default value and comment for dashboardsEnabled