### PR TITLE
[NA] [DX] Update GitHub MCP server to use envFile parameter

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -9,13 +9,10 @@
         "-e",
         "GITHUB_PERSONAL_ACCESS_TOKEN",
         "-e",
-        "GITHUB_TOOLSETS",
+        "GITHUB_TOOLSETS=repos,pull_requests,issues",
         "ghcr.io/github/github-mcp-server"
       ],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}",
-        "GITHUB_TOOLSETS": "repos,pull_requests,issues"
-      }
+      "envFile": "${workspaceFolder}/.env.local"
     },
     "Atlassian": {
       "command": "npx -y mcp-remote https://mcp.atlassian.com/v1/sse",


### PR DESCRIPTION
## Details

Update GitHub MCP server configuration to use the new `envFile` parameter introduced in Cursor's MCP. This change improves the developer experience by allowing developers to keep a single copy of environment variables in `.env.local` at the project root instead of duplicating them in the home directory's `mcp.json` file.

The change removes the `env` section with hardcoded environment variable references and replaces it with `envFile` pointing to `${workspaceFolder}/.env.local`, which aligns with Cursor's updated MCP configuration format documented at https://cursor.com/docs/context/mcp.

This simplifies the setup process as developers can now:
- Keep all environment variables in one place (`.env.local`)
- Avoid duplicating configuration between project and home directory
- Follow the `.env.template` file that already describes how to set up `.env.local`

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves #
- OPIK-NA
- NA

## Testing

Manual testing:
1. Verified that the GitHub MCP server configuration loads correctly with the new `envFile` parameter
2. Confirmed that environment variables from `.env.local` are properly loaded
3. Tested that GitHub MCP tools are accessible after the configuration change

## Documentation

Updated `.cursor/mcp.json` to use the new `envFile` parameter format. The existing `.env.template` file already documents how to set up `.env.local` for local development.