### PR TITLE
[OPIK-3530] [SDK] Fix Hierarchical optimizer recreating optimizations

### DIFF
--- a/sdks/opik_optimizer/pyproject.toml
+++ b/sdks/opik_optimizer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opik_optimizer"
-version = "2.3.8"
+version = "2.3.9"
 description = "Agent optimization with Opik"
 authors = [
     {name = "Comet ML", email = "support@comet.com"}

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/hierarchical_reflective_optimizer/hierarchical_reflective_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/hierarchical_reflective_optimizer/hierarchical_reflective_optimizer.py
@@ -408,15 +408,20 @@ class HierarchicalReflectiveOptimizer(BaseOptimizer):
         # Set project name from parameter
         self.project_name = project_name
 
-        optimization = self.opik_client.create_optimization(
-            dataset_name=dataset.name,
-            objective_name=getattr(metric, "__name__", str(metric)),
-            metadata=self._build_optimization_metadata(),
-            name=self.name,
-            optimization_id=optimization_id,
-        )
+        # If optimization_id is provided (e.g., from Optimization Studio), fetch the existing
+        # optimization instead of creating a new one
+        if optimization_id:
+            optimization = self.opik_client.get_optimization_by_id(optimization_id)
+            logger.debug(f"Using existing optimization with ID: {optimization.id}")
+        else:
+            optimization = self.opik_client.create_optimization(
+                dataset_name=dataset.name,
+                objective_name=getattr(metric, "__name__", str(metric)),
+                metadata=self._build_optimization_metadata(),
+                name=self.name,
+            )
+            logger.debug(f"Created optimization with ID: {optimization.id}")
         self.current_optimization_id = optimization.id
-        logger.debug(f"Created optimization with ID: {optimization.id}")
 
         reporting.display_header(
             algorithm=self.__class__.__name__,


### PR DESCRIPTION
## Details
When `optimization_id` is provided (e.g., from Optimization Studio), the Hierarchical Reflective Optimizer was incorrectly creating a new optimization instead of using the existing one. This fix checks if an `optimization_id` is passed and fetches the existing optimization via `opik_client.get_optimization_by_id()` rather than always calling `create_optimization()`.

Also bumps version to 2.3.9 to trigger a release.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-3530

## Testing
- Verified locally that when `optimization_id` is provided, the optimizer fetches the existing optimization
- Confirmed no duplicate optimization is created when running from Optimization Studio

## Documentation
N/A - internal behavior fix, no API changes