### PR TITLE
[NA] [DOCS] Add test requirements quickstart

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/contributing/python-sdk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/contributing/python-sdk.mdx
@@ -91,6 +91,9 @@ cd sdks/python # Ensure you are in this directory
 # Install test-specific requirements
 pip install -r tests/test_requirements.txt
 
+# Install unit test requirements
+pip install -r tests/unit/test_requirements.txt
+
 # Install pre-commit for linting checks (optional but good practice)
 pip install pre-commit
 


### PR DESCRIPTION
## Details
Added instruction to install unit test requirements (`tests/unit/test_requirements.txt`) in the Python SDK contributing guide. This helps developers set up their environment correctly when contributing to the Python SDK by ensuring all necessary test dependencies are installed.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues
- Resolves #
- OPIK- NA

## Testing
Documentation update only - no testing required.

## Documentation
Updated `apps/opik-documentation/documentation/fern/docs/contributing/python-sdk.mdx` to include the step for installing unit test requirements in the testing setup section.