### PR TITLE
[OPIK-3506] [FE] Additional UX improvements for Dashboard beta

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/dashboards/AddEditCloneDashboardDialog/AddEditCloneDashboardDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/dashboards/AddEditCloneDashboardDialog/AddEditCloneDashboardDialog.tsx
@@ -369,7 +369,7 @@ const AddEditCloneDashboardDialog: React.FC<
           )}
         </DialogAutoScrollBody>
 
-        <DialogFooter className="flex flex-row justify-between gap-2 border-t pt-4 sm:flex-row sm:justify-between">
+        <DialogFooter className="flex flex-row justify-between gap-2 sm:flex-row sm:justify-between">
           <div>
             {isCreateMode && currentStep === DialogStep.DETAILS && (
               <Button variant="outline" onClick={handleBack}>
@@ -380,11 +380,13 @@ const AddEditCloneDashboardDialog: React.FC<
           </div>
 
           <div className="flex gap-2">
-            <DialogClose asChild>
-              <Button variant="outline" disabled={isPending}>
-                Cancel
-              </Button>
-            </DialogClose>
+            {currentStep === DialogStep.DETAILS && (
+              <DialogClose asChild>
+                <Button variant="outline" disabled={isPending}>
+                  Cancel
+                </Button>
+              </DialogClose>
+            )}
 
             {currentStep === DialogStep.DETAILS && (
               <Button type="submit" form="dashboard-form" disabled={isPending}>

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsFeedbackScoresWidget/helpers.ts
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsFeedbackScoresWidget/helpers.ts
@@ -79,7 +79,7 @@ const buildFilterAndGroupTitle = (
   }
 
   if (hasGroups && groupByLabel) {
-    return `${baseLabel} by ${groupByLabel}`;
+    return `${baseLabel} grouped by ${groupByLabel}`;
   }
 
   return baseLabel;

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsEditor.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsEditor.tsx
@@ -54,7 +54,7 @@ import { CHART_TYPE } from "@/constants/chart";
 const METRIC_OPTIONS = [
   {
     value: METRIC_NAME_TYPE.FEEDBACK_SCORES,
-    label: "Trace feedback scores",
+    label: "Trace metrics",
     filterType: "trace" as const,
   },
   {
@@ -94,7 +94,7 @@ const METRIC_OPTIONS = [
   },
   {
     value: METRIC_NAME_TYPE.THREAD_FEEDBACK_SCORES,
-    label: "Thread feedback scores",
+    label: "Thread metrics",
     filterType: "thread" as const,
   },
 ];

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectMetricsWidget/helpers.ts
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectMetricsWidget/helpers.ts
@@ -6,12 +6,12 @@ const DEFAULT_TITLE = "Project metrics";
 
 const METRIC_LABELS: Record<string, string> = {
   [METRIC_NAME_TYPE.FEEDBACK_SCORES]: "Trace metrics",
-  [METRIC_NAME_TYPE.TRACE_COUNT]: "Trace count",
+  [METRIC_NAME_TYPE.TRACE_COUNT]: "Number of traces",
   [METRIC_NAME_TYPE.TRACE_DURATION]: "Trace duration",
   [METRIC_NAME_TYPE.TOKEN_USAGE]: "Token usage",
   [METRIC_NAME_TYPE.COST]: "Estimated cost",
   [METRIC_NAME_TYPE.FAILED_GUARDRAILS]: "Failed guardrails",
-  [METRIC_NAME_TYPE.THREAD_COUNT]: "Thread count",
+  [METRIC_NAME_TYPE.THREAD_COUNT]: "Number of threads",
   [METRIC_NAME_TYPE.THREAD_DURATION]: "Thread duration",
   [METRIC_NAME_TYPE.THREAD_FEEDBACK_SCORES]: "Thread metrics",
 };

--- a/apps/opik-frontend/src/components/shared/InlineEditableText/InlineEditableText.tsx
+++ b/apps/opik-frontend/src/components/shared/InlineEditableText/InlineEditableText.tsx
@@ -55,8 +55,10 @@ const InlineEditableText: React.FunctionComponent<InlineEditableTextProps> = ({
   const handleReset = useCallback(() => {
     if (defaultValue !== undefined) {
       setEditValue(defaultValue);
+      onChange("");
+      setIsEditing(false);
     }
-  }, [defaultValue]);
+  }, [defaultValue, onChange]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -152,38 +154,40 @@ const InlineEditableText: React.FunctionComponent<InlineEditableTextProps> = ({
 
   // Default/Hover state
   return (
-    <div
-      className={cn(
-        "group/inline-edit flex h-8 cursor-pointer items-center gap-1 overflow-hidden rounded-md transition-colors hover:bg-muted",
-        className,
-      )}
-      onClick={handleStartEdit}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          handleStartEdit();
-        }
-      }}
-    >
-      <div className="min-w-0 flex-1 pl-2">
-        <span
-          className={cn(
-            "block truncate text-sm leading-5",
-            isTitle ? "font-medium text-foreground" : "text-foreground",
-            !value && "text-muted-slate",
-          )}
-        >
-          {displayValue}
-        </span>
-      </div>
-      <div className="hidden h-full items-center pr-2 group-hover/inline-edit:flex">
-        <div className="flex size-7 items-center justify-center rounded">
-          <Pencil className="size-3.5 text-foreground" />
+    <TooltipWrapper content={displayValue} side="top">
+      <div
+        className={cn(
+          "group/inline-edit flex h-8 cursor-pointer items-center gap-1 overflow-hidden rounded-md transition-colors hover:bg-muted",
+          className,
+        )}
+        onClick={handleStartEdit}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleStartEdit();
+          }
+        }}
+      >
+        <div className="min-w-0 flex-1 pl-2">
+          <span
+            className={cn(
+              "block truncate text-sm leading-5",
+              isTitle ? "font-medium text-foreground" : "text-foreground",
+              !value && "text-muted-slate",
+            )}
+          >
+            {displayValue}
+          </span>
+        </div>
+        <div className="hidden h-full items-center pr-2 group-hover/inline-edit:flex">
+          <div className="flex size-7 items-center justify-center rounded">
+            <Pencil className="size-3.5 text-foreground" />
+          </div>
         </div>
       </div>
-    </div>
+    </TooltipWrapper>
   );
 };
 


### PR DESCRIPTION
## Details

This PR implements additional UX refinements for the Dashboard beta based on team feedback, focusing on consistency, clarity, and improved user interactions.

### Dialog UX Improvements
- **Removed footer separator**: Eliminated the top border (`border-t`) from the dialog footer for a cleaner visual appearance
- **Conditional Cancel button**: The Cancel button now only appears on the DETAILS step, not on the template selection (SELECT) step, reducing visual clutter when users are browsing templates

### Widget Title Consistency  
- **Unified metric naming**: Updated all project metric widget titles to match their dropdown labels exactly:
  - "Trace count" → "Number of traces"
  - "Thread count" → "Number of threads"
- **Consistent terminology**: Both the metric type selector and generated widget titles now use identical wording, eliminating confusion

### Enhanced Widget Text Visibility
- **Tooltip support**: Added tooltips to widget names and descriptions that wrap with `TooltipWrapper` component
- **Truncation handling**: When text is truncated due to space constraints, users can now hover to see the full content
- **Improved accessibility**: Better UX for widgets with longer titles or descriptions

### Improved Reset Button Behavior
- **Immediate mode exit**: Clicking the Reset button in inline editable text now:
  1. Resets the value to default
  2. Saves the change via `onChange("")`
  3. Immediately closes edit mode (`setIsEditing(false)`)
- **Better UX flow**: Users no longer need to manually close edit mode after resetting

### Clearer Group Titles in Experiment Widgets
- **Enhanced readability**: Changed widget title format from "X by Y" to "X grouped by Y"
- **Example**: "Filtered metrics grouped by Dataset" instead of "Filtered metrics by Dataset"
- **Reduced ambiguity**: The word "grouped" makes it immediately clear that data aggregation is happening

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves OPIK-3506

## Testing

### Manual Testing Performed

1. **Dialog Footer**
   - ✅ Verified no top border appears on dialog footer
   - ✅ Confirmed Cancel button only shows on DETAILS step
   - ✅ Checked that SELECT step (template picker) has no Cancel button

2. **Metric Naming**
   - ✅ Created widgets with "Number of traces" metric type
   - ✅ Created widgets with "Number of threads" metric type
   - ✅ Verified widget titles match dropdown labels exactly

3. **Widget Text Tooltips**
   - ✅ Created widgets with long titles (truncated)
   - ✅ Created widgets with long descriptions (truncated)
   - ✅ Verified tooltips appear on hover showing full text

4. **Reset Button**
   - ✅ Entered edit mode for widget title
   - ✅ Modified title from generated default
   - ✅ Clicked Reset button
   - ✅ Confirmed value reset to default and edit mode closed immediately

5. **Group Titles**
   - ✅ Created experiment widgets with groups
   - ✅ Verified titles show "grouped by" instead of just "by"
   - ✅ Examples tested: "Filtered metrics grouped by Dataset", "Accuracy grouped by Configuration"

### Quality Checks
- ✅ ESLint: No errors (0 warnings)
- ✅ TypeScript: Type checking passed
- ✅ All commits follow Opik conventions

## Documentation

N/A - These are UX polish improvements with no API or configuration changes. All changes are internal UI refinements that don't require documentation updates.