### PR TITLE
[OPIK-3502] [BE] Simplify optimization endpoints - return studioConfig always

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/OptimizationsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/OptimizationsResource.java
@@ -202,58 +202,6 @@ public class OptimizationsResource {
     // ==================== Studio Endpoints ====================
 
     @GET
-    @Path("/studio")
-    @Operation(operationId = "findStudioOptimizations", summary = "Find Studio optimizations", description = "Find Studio optimizations", responses = {
-            @ApiResponse(responseCode = "200", description = "Studio optimizations resource", content = @Content(schema = @Schema(implementation = Optimization.OptimizationPage.class))),
-            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))
-    })
-    @JsonView(Optimization.View.Public.class)
-    public Response findStudio(
-            @QueryParam("page") @Min(1) @DefaultValue("1") int page,
-            @QueryParam("size") @Min(1) @DefaultValue("10") int size,
-            @QueryParam("dataset_id") UUID datasetId,
-            @QueryParam("name") String name,
-            @QueryParam("dataset_deleted") Boolean datasetDeleted,
-            @QueryParam("filters") String filters) {
-
-        List<OptimizationFilter> parsedFilters = (List<OptimizationFilter>) filtersFactory.newFilters(filters,
-                OptimizationFilter.LIST_TYPE_REFERENCE);
-
-        var searchCriteria = OptimizationSearchCriteria.builder()
-                .datasetId(datasetId)
-                .name(name)
-                .datasetDeleted(datasetDeleted)
-                .studioOnly(true)
-                .filters(parsedFilters)
-                .entityType(EntityType.TRACE)
-                .build();
-
-        log.info("Finding Studio optimizations by '{}', page '{}', size '{}'", searchCriteria, page, size);
-        var optimizations = optimizationService.find(page, size, searchCriteria)
-                .contextWrite(ctx -> setRequestContext(ctx, requestContext))
-                .block();
-
-        log.info("Found Studio optimizations by '{}', count '{}', page '{}', size '{}'",
-                searchCriteria, optimizations.size(), page, size);
-        return Response.ok().entity(optimizations).build();
-    }
-
-    @GET
-    @Path("/studio/{id}")
-    @Operation(operationId = "getStudioOptimizationById", summary = "Get Studio optimization by id", description = "Get Studio optimization with config included", responses = {
-            @ApiResponse(responseCode = "200", description = "Studio optimization resource", content = @Content(schema = @Schema(implementation = Optimization.class))),
-            @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))})
-    @JsonView(Optimization.View.Public.class)
-    public Response getStudio(@PathParam("id") UUID id) {
-        log.info("Getting Studio optimization by id '{}'", id);
-        var optimization = optimizationService.getById(id, true)
-                .contextWrite(ctx -> setRequestContext(ctx, requestContext))
-                .block();
-        log.info("Got Studio optimization by id '{}', datasetId '{}'", optimization.id(), optimization.datasetId());
-        return Response.ok().entity(optimization).build();
-    }
-
-    @GET
     @Path("/studio/{id}/cancel")
     @Operation(operationId = "cancelStudioOptimizations", summary = "Cancel Studio optimizations", description = "Cancel Studio optimizations by id", responses = {
             @ApiResponse(responseCode = "501", description = "Not Implemented")})

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/OptimizationResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/OptimizationResourceClient.java
@@ -176,61 +176,6 @@ public class OptimizationResourceClient {
         }
     }
 
-    public Optimization.OptimizationPage findStudio(String apiKey, String workspaceName, int page, int size,
-            UUID datasetId, String name, List<? extends Filter> filters, int expectedStatus) {
-        WebTarget webTarget = client.target(RESOURCE_PATH.formatted(baseURI))
-                .path("studio")
-                .queryParam("page", page)
-                .queryParam("size", size);
-
-        if (datasetId != null) {
-            webTarget = webTarget.queryParam("dataset_id", datasetId);
-        }
-
-        if (name != null) {
-            webTarget = webTarget.queryParam("name", name);
-        }
-
-        if (CollectionUtils.isNotEmpty(filters)) {
-            webTarget = webTarget.queryParam("filters", TestUtils.toURLEncodedQueryParam(filters));
-        }
-
-        try (var response = webTarget
-                .request()
-                .header(HttpHeaders.AUTHORIZATION, apiKey)
-                .header(RequestContext.WORKSPACE_HEADER, workspaceName)
-                .get()) {
-
-            assertThat(response.getStatus()).isEqualTo(expectedStatus);
-            return response.readEntity(Optimization.OptimizationPage.class);
-        }
-    }
-
-    // Overloaded method without filters for backward compatibility
-    public Optimization.OptimizationPage findStudio(String apiKey, String workspaceName, int page, int size,
-            UUID datasetId, String name, int expectedStatus) {
-        return findStudio(apiKey, workspaceName, page, size, datasetId, name, null, expectedStatus);
-    }
-
-    public Optimization getStudio(UUID id, String apiKey, String workspaceName, int expectedStatus) {
-        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
-                .path("studio")
-                .path(id.toString())
-                .request()
-                .header(HttpHeaders.AUTHORIZATION, apiKey)
-                .header(RequestContext.WORKSPACE_HEADER, workspaceName)
-                .get()) {
-
-            assertThat(response.getStatus()).isEqualTo(expectedStatus);
-
-            if (expectedStatus == HttpStatus.SC_OK) {
-                return response.readEntity(Optimization.class);
-            }
-
-            return null;
-        }
-    }
-
     public void cancelStudio(UUID id, String apiKey, String workspaceName, int expectedStatus) {
         try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
                 .path("studio")

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
@@ -750,8 +750,10 @@ class OptimizationsResourceTest {
             var id = optimizationResourceClient.create(optimization, API_KEY, TEST_WORKSPACE_NAME);
             var actualOptimization = optimizationResourceClient.get(id, API_KEY, TEST_WORKSPACE_NAME, 200);
 
-            assertThat(actualOptimization.studioConfig()).isNull(); // Scrubbed by default
-            assertOptimization(optimization.toBuilder().studioConfig(null).build(), actualOptimization);
+            // studioConfig is now returned (opikApiKey is null since it's @JsonIgnore)
+            assertThat(actualOptimization.studioConfig()).isNotNull();
+            assertThat(actualOptimization.studioConfig()).isEqualTo(studioConfig);
+            assertOptimization(optimization, actualOptimization);
 
             ArgumentCaptor<OptimizationCreated> captor = ArgumentCaptor.forClass(OptimizationCreated.class);
             Mockito.verify(defaultEventBus).post(captor.capture());
@@ -807,7 +809,7 @@ class OptimizationsResourceTest {
                     .isTrue();
 
             // Verify opikApiKey is NOT returned when retrieving the optimization
-            var studioResponse = optimizationResourceClient.getStudio(id, API_KEY, TEST_WORKSPACE_NAME, 200);
+            var studioResponse = optimizationResourceClient.get(id, API_KEY, TEST_WORKSPACE_NAME, 200);
             assertThat(studioResponse.studioConfig()).isNotNull();
             assertThat(studioResponse.studioConfig().opikApiKey()).isNull();
 
@@ -836,8 +838,8 @@ class OptimizationsResourceTest {
         }
 
         @Test
-        @DisplayName("Find Studio optimizations using dedicated endpoint")
-        void findStudioOptimizations() {
+        @DisplayName("Find optimizations returns studioConfig when present")
+        void findOptimizationsReturnsStudioConfig() {
             // Mock target workspace
             String apiKey = UUID.randomUUID().toString();
             String workspaceName = "test-workspace-" + UUID.randomUUID();
@@ -858,20 +860,30 @@ class OptimizationsResourceTest {
                     .build();
             var studioId = optimizationResourceClient.create(studioOptimization, apiKey, workspaceName);
 
-            // Find using dedicated Studio endpoint
-            var page = optimizationResourceClient.findStudio(apiKey, workspaceName, 1, 10, null, null, null, 200);
+            // Find all optimizations - both should be returned
+            var page = optimizationResourceClient.find(apiKey, workspaceName, 1, 10, null, null, null, 200);
 
-            // Should only return Studio optimizations
-            assertThat(page.content()).isNotEmpty();
-            assertThat(page.content()).hasSize(1);
-            assertThat(page.content().get(0).id()).isEqualTo(studioId);
-            // Studio config should be included by default in studio endpoint
-            assertThat(page.content().get(0).studioConfig()).isNotNull();
+            // Should return both optimizations
+            assertThat(page.content()).hasSize(2);
+
+            // Studio optimization should have studioConfig included
+            var studioOpt = page.content().stream()
+                    .filter(opt -> opt.id().equals(studioId))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(studioOpt.studioConfig()).isNotNull();
+
+            // Regular optimization should have null studioConfig
+            var regularOpt = page.content().stream()
+                    .filter(opt -> opt.id().equals(regularId))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(regularOpt.studioConfig()).isNull();
         }
 
         @Test
-        @DisplayName("Get Studio optimization by ID using dedicated endpoint")
-        void getStudioOptimizationById() {
+        @DisplayName("Get optimization by ID returns studioConfig when present")
+        void getOptimizationByIdReturnsStudioConfig() {
             var studioConfig = createStudioConfig();
             var optimization = optimizationResourceClient.createPartialOptimization()
                     .studioConfig(studioConfig)
@@ -879,8 +891,8 @@ class OptimizationsResourceTest {
 
             var id = optimizationResourceClient.create(optimization, API_KEY, TEST_WORKSPACE_NAME);
 
-            // Get using dedicated Studio endpoint
-            var actualOptimization = optimizationResourceClient.getStudio(id, API_KEY, TEST_WORKSPACE_NAME, 200);
+            // Get using standard endpoint
+            var actualOptimization = optimizationResourceClient.get(id, API_KEY, TEST_WORKSPACE_NAME, 200);
 
             // Studio config should be included (opikApiKey is null in both since it's @JsonIgnore)
             assertThat(actualOptimization).isNotNull();
@@ -900,7 +912,7 @@ class OptimizationsResourceTest {
             var id = optimizationResourceClient.create(optimization, API_KEY, TEST_WORKSPACE_NAME);
 
             // Verify initial state - should have studio_config and INITIALIZED status
-            var initialOptimization = optimizationResourceClient.getStudio(id, API_KEY, TEST_WORKSPACE_NAME, 200);
+            var initialOptimization = optimizationResourceClient.get(id, API_KEY, TEST_WORKSPACE_NAME, 200);
             assertThat(initialOptimization.studioConfig()).isNotNull();
             assertThat(initialOptimization.studioConfig()).isEqualTo(studioConfig);
             assertThat(initialOptimization.status()).isEqualTo(OptimizationStatus.INITIALIZED);
@@ -912,7 +924,7 @@ class OptimizationsResourceTest {
             optimizationResourceClient.update(id, runningUpdate, API_KEY, TEST_WORKSPACE_NAME, 204);
 
             // Verify studio_config is preserved after RUNNING update
-            var runningOptimization = optimizationResourceClient.getStudio(id, API_KEY, TEST_WORKSPACE_NAME, 200);
+            var runningOptimization = optimizationResourceClient.get(id, API_KEY, TEST_WORKSPACE_NAME, 200);
             assertThat(runningOptimization.status()).isEqualTo(OptimizationStatus.RUNNING);
             assertThat(runningOptimization.studioConfig()).isNotNull();
             assertThat(runningOptimization.studioConfig()).isEqualTo(studioConfig);
@@ -924,7 +936,7 @@ class OptimizationsResourceTest {
             optimizationResourceClient.update(id, completedUpdate, API_KEY, TEST_WORKSPACE_NAME, 204);
 
             // Verify studio_config is still preserved after COMPLETED update
-            var completedOptimization = optimizationResourceClient.getStudio(id, API_KEY, TEST_WORKSPACE_NAME, 200);
+            var completedOptimization = optimizationResourceClient.get(id, API_KEY, TEST_WORKSPACE_NAME, 200);
             assertThat(completedOptimization.status()).isEqualTo(OptimizationStatus.COMPLETED);
             assertThat(completedOptimization.studioConfig()).isNotNull();
             assertThat(completedOptimization.studioConfig()).isEqualTo(studioConfig);
@@ -1034,21 +1046,6 @@ class OptimizationsResourceTest {
             assertThat(completedPage.content()).hasSize(1);
             assertThat(completedPage.content().get(0).id()).isEqualTo(regularCompletedOptId);
             assertThat(completedPage.content().get(0).status()).isEqualTo(OptimizationStatus.COMPLETED);
-
-            // Test 3: Filter by INITIALIZED + studio_only - should get 1 (studio only)
-            var studioInitializedPage = optimizationResourceClient.findStudio(apiKey, workspaceName, 1, 10,
-                    null, null, List.of(initializedFilter), 200);
-
-            assertThat(studioInitializedPage.content()).hasSize(1);
-            assertThat(studioInitializedPage.content().get(0).id()).isEqualTo(studioOptId);
-            assertThat(studioInitializedPage.content().get(0).status()).isEqualTo(OptimizationStatus.INITIALIZED);
-            assertThat(studioInitializedPage.content().get(0).studioConfig()).isNotNull();
-
-            // Test 4: Filter by COMPLETED + studio_only - should get 0 (no completed studio optimizations)
-            var studioCompletedPage = optimizationResourceClient.findStudio(apiKey, workspaceName, 1, 10,
-                    null, null, List.of(completedFilter), 200);
-
-            assertThat(studioCompletedPage.content()).isEmpty();
         }
 
         @Test


### PR DESCRIPTION
## Details
Frontend requested to simplify the optimization API by eliminating the separate `/studio` and `/studio/{id}` endpoints. Now the standard endpoints return `studioConfig` when present.

This is not only simpler, but also allows to fetch both types at the same time, with studio ones with the proper configuration. So it's better, it's the original API design.

**Changes:**
- `GET /optimizations` - now returns `studioConfig` for studio optimizations
- `GET /optimizations/{id}` - now returns `studioConfig` when present
- Removed `GET /optimizations/studio` endpoint
- Removed `GET /optimizations/studio/{id}` endpoint
- Kept `GET /optimizations/studio/{id}/logs` and `GET /optimizations/studio/{id}/cancel` endpoints

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3502

## Testing
- All optimization tests pass (32 tests)
- Verified studioConfig is returned when present
- Verified regular optimizations still return null studioConfig

## Documentation
N/A - API simplification, endpoints removed