### PR TITLE
[OPIK-3460] [FE] Show active sorting column and direction

### DIFF
--- a/apps/opik-frontend/src/components/shared/DataTableHeaders/useSortableHeader.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableHeaders/useSortableHeader.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ArrowDown, ArrowUp } from "lucide-react";
+import { ArrowDownWideNarrow, ArrowUpNarrowWide } from "lucide-react";
 import { Column } from "@tanstack/react-table";
 import { cn } from "@/lib/utils";
 import { Separator } from "@/components/ui/separator";
@@ -23,7 +23,10 @@ export const useSortableHeader = <TData,>({
 
     if (!direction && !nextDirection) return null;
 
-    const Icon = (direction || nextDirection) === "asc" ? ArrowUp : ArrowDown;
+    const Icon =
+      (direction || nextDirection) === "asc"
+        ? ArrowUpNarrowWide
+        : ArrowDownWideNarrow;
     return (
       <>
         {withSeparator && (
@@ -37,8 +40,8 @@ export const useSortableHeader = <TData,>({
         )}
         <Icon
           className={cn(
-            "shrink-0 hidden size-3.5 group-hover:inline",
-            direction && "inline",
+            "hidden size-3.5 shrink-0 group-hover:inline",
+            direction && "inline text-foreground-secondary",
           )}
         />
       </>


### PR DESCRIPTION
## Details
As a user, I want to clearly see which column is currently sorted and the sorting direction (ascending or descending), so I can easily understand how the data is ordered.

### Changes:
- Updated sort icons to use `ArrowUpNarrowWide` (ascending) and `ArrowDownWideNarrow` (descending)
- Added `text-foreground-secondary` (#5155F5) color to active sort icon
- Icon is visible on hover for sortable columns
- Icon is always visible and highlighted when sorting is active
- Clicking the sort icon toggles direction (Ascending → Descending → Ascending)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3460

## Testing
- Verified sort icons display correctly on hover
- Verified active sort column shows highlighted icon with correct direction
- Verified clicking toggles sort direction and updates icon immediately

## Documentation
N/A