### PR TITLE
[OPIK-3556] [FE] Add dashboard count display in sidebar

### DIFF
--- a/apps/opik-frontend/src/components/layout/SideBar/SideBar.tsx
+++ b/apps/opik-frontend/src/components/layout/SideBar/SideBar.tsx
@@ -27,6 +27,7 @@ import useExperimentsList from "@/api/datasets/useExperimentsList";
 import useRulesList from "@/api/automations/useRulesList";
 import useOptimizationsList from "@/api/optimizations/useOptimizationsList";
 import useAlertsList from "@/api/alerts/useAlertsList";
+import useDashboardsList from "@/api/dashboards/useDashboardsList";
 import { OnChangeFn } from "@/types/shared";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -76,6 +77,7 @@ const MENU_ITEMS: MenuItemGroup[] = [
         type: MENU_ITEM_TYPE.router,
         icon: ChartLine,
         label: "Dashboards",
+        count: "dashboards",
         featureFlag: FeatureToggleKeys.DASHBOARDS_ENABLED,
       },
     ],
@@ -209,6 +211,9 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
   const isOptimizationStudioEnabled = useIsFeatureEnabled(
     FeatureToggleKeys.OPTIMIZATION_STUDIO_ENABLED,
   );
+  const isDashboardsEnabled = useIsFeatureEnabled(
+    FeatureToggleKeys.DASHBOARDS_ENABLED,
+  );
   const LogoComponent = usePluginsStore((state) => state.Logo);
   const SidebarInviteDevButton = usePluginsStore(
     (state) => state.SidebarInviteDevButton,
@@ -330,6 +335,18 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
     },
   );
 
+  const { data: dashboardsData } = useDashboardsList(
+    {
+      workspaceName,
+      page: 1,
+      size: 1,
+    },
+    {
+      placeholderData: keepPreviousData,
+      enabled: expanded && isDashboardsEnabled,
+    },
+  );
+
   const countDataMap: Record<string, number | undefined> = {
     projects: projectData?.total,
     datasets: datasetsData?.total,
@@ -339,6 +356,7 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
     optimizations: optimizationsData?.total,
     annotation_queues: annotationQueuesData?.total,
     alerts: alertsData?.total,
+    dashboards: dashboardsData?.total,
   };
 
   const indicatorDataMap: Record<string, boolean> = {


### PR DESCRIPTION
## Details

Before:

<img width="1897" height="406" alt="image" src="https://github.com/user-attachments/assets/e34f97fc-6c63-442a-bacc-8f4cd126f42d" />


After:

<img width="1900" height="394" alt="image" src="https://github.com/user-attachments/assets/1d9c2823-3931-4d4c-aeb8-ee54f24f63c3" />


Added dashboard count badge next to the Dashboards menu item in the sidebar navigation. This enhancement provides users with a quick visual indicator of the number of dashboards available, following the same UX pattern established for Projects, Datasets, Experiments, and other menu items.

**Implementation:**
- Imported `useDashboardsList` hook from the dashboards API module
- Added dashboard count query with `keepPreviousData` optimization for smooth transitions
- Added `dashboards` entry to `countDataMap` to provide count data to menu items
- Added `count: "dashboards"` property to the Dashboards menu item configuration
- Query only executes when sidebar is expanded and the dashboards feature flag is enabled, optimizing performance

**Technical Details:**
- Query uses `page: 1, size: 1` parameters to minimize data transfer while still receiving the total count
- Follows the established pattern used by all other sidebar menu items with counts
- Respects the `DASHBOARDS_ENABLED` feature flag to prevent unnecessary API calls when feature is disabled
- Uses TanStack Query's `keepPreviousData` to prevent loading flickers during navigation

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- OPIK-3556

## Testing

**Manual Testing:**
1. Open Opik application with dashboards feature flag enabled
2. Navigate to any page with sidebar visible
3. Expand sidebar if collapsed
4. Verify dashboard count appears next to "Dashboards" menu item
5. Create a new dashboard and verify count updates
6. Delete a dashboard and verify count decrements
7. When no dashboards exist, verify "0" is displayed

**Automated Testing:**
- Pre-commit hooks passed: ESLint and TypeScript type checking
- Unit tests for sidebar component pass (existing test coverage for similar count patterns)

## Documentation

No documentation changes required - this is a UI enhancement that follows existing patterns and doesn't introduce new concepts or APIs.