### PR TITLE
[NA] [FE][BE] Add navigation from trace tree to spans table filtered by trace_id

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/filter/SpanField.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/filter/SpanField.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum SpanField implements Field {
     ID(ID_QUERY_PARAM, FieldType.STRING),
+    TRACE_ID(TRACE_ID_QUERY_PARAM, FieldType.STRING),
     NAME(NAME_QUERY_PARAM, FieldType.STRING),
     START_TIME(START_TIME_QUERY_PARAM, FieldType.DATE_TIME),
     END_TIME(END_TIME_QUERY_PARAM, FieldType.DATE_TIME),

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
@@ -187,6 +187,7 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
             <TraceTreeViewer
               trace={trace}
               spans={spansData?.content}
+              projectId={projectId}
               rowId={spanId || traceId}
               onSelectRow={handleRowSelect}
               search={search}

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
@@ -834,6 +834,11 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
       ...(type === TRACE_DATA_TYPE.spans
         ? [
             {
+              id: "trace_id",
+              label: "Trace ID",
+              type: COLUMN_TYPE.string,
+            },
+            {
               id: "type",
               label: "Type",
               type: COLUMN_TYPE.category,


### PR DESCRIPTION
## Details
Adds a clickable link in the trace tree viewer that allows users to navigate directly to the spans table view, pre-filtered by the current trace_id. This makes it easier to view all spans of a trace in a tabular format.

### Changes:
- **Backend**: Add `TRACE_ID` as a filterable field in `SpanField` enum
- **Frontend**: 
  - Add clickable 'items' link in trace tree viewer header
  - Navigate to spans table with trace_id filter pre-applied
  - Add trace_id to the list of filterable columns in spans tab

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- NA

## Testing
- Navigate to a trace details panel
- Click on the 'X items' link in the trace tree header
- Verify it navigates to the spans table filtered by trace_id
- Verify the trace_id filter shows correctly in the filter bar