### PR TITLE
[OPIK-3586] [FE] Expose app version in frontend via /version.json

### DIFF
--- a/apps/opik-frontend/Dockerfile
+++ b/apps/opik-frontend/Dockerfile
@@ -21,6 +21,9 @@ ENV NODE_OPTIONS="--max-old-space-size=8192"
 ARG BUILD_MODE=production
 RUN npm run build -- --mode $BUILD_MODE
 
+# Create version.json for checking version
+RUN echo "{\"version\": \"$VITE_APP_VERSION\"}" > dist/version.json
+
 # Production stage
 # Using nginx alpine image with OpenTelemetry support
 FROM nginx:1.29.4-alpine-otel AS nginx

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -303,6 +303,8 @@ services:
     build:
       context: ../../apps/opik-frontend
       dockerfile: Dockerfile
+      args:
+        OPIK_VERSION: ${OPIK_VERSION:-latest}
     #   cache_from:
     #     - alpine:latest
     #     - nginx:1.29.3-alpine-otel


### PR DESCRIPTION
## Details
This PR adds a build step to the frontend Dockerfile to generate a
`version.json` file in the distribution directory, containing the
application version. This file allows automation tools to check the
deployed version via `curl <url>/version.json`.

It also updates `docker-compose.yaml` to pass the `OPIK_VERSION` build argument to the frontend service, ensuring the version is correctly populated during local builds.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-3586

## Testing

## Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the frontend Docker build process to automatically generate version metadata during compilation.
  * Enhanced Docker Compose configuration to pass version information to the frontend service build.
  * Application build artifacts now include version descriptor for identification and tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->