### PR TITLE
[NA][BE][FE] fix dataset items batch update by filter

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemBatchUpdate.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemBatchUpdate.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 public record DatasetItemBatchUpdate(
         @Size(min = 1, max = 1000) @Schema(description = "List of dataset item IDs to update (max 1000). Mutually exclusive with 'filters'.") Set<UUID> ids,
         @Valid List<@NotNull @Valid DatasetItemFilter> filters,
+        @Schema(description = "Dataset ID. Required when using 'filters', optional when using 'ids'.") UUID datasetId,
         @NotNull @Valid @Schema(description = "Update to apply to all dataset items", required = true) DatasetItemUpdate update,
         @Schema(description = "If true, merge tags with existing tags instead of replacing them. Default: false. When using 'filters', this is automatically set to true.") Boolean mergeTags) {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/DatasetItemBatchUpdateValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/DatasetItemBatchUpdateValidator.java
@@ -37,6 +37,14 @@ public class DatasetItemBatchUpdateValidator
             return false;
         }
 
+        // Validate that datasetId is provided when using filters
+        if (hasFilters && batchUpdate.datasetId() == null) {
+            context.buildConstraintViolationWithTemplate(
+                    "'dataset_id' is required when using 'filters'. This ensures updates are scoped to a specific dataset.")
+                    .addConstraintViolation();
+            return false;
+        }
+
         return true;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -258,7 +258,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
     @WithSpan
     public Mono<Void> batchUpdate(@NonNull DatasetItemBatchUpdate batchUpdate) {
-        return dao.bulkUpdate(batchUpdate.ids(), batchUpdate.filters(), batchUpdate.update(),
+        return dao.bulkUpdate(batchUpdate.ids(), batchUpdate.datasetId(), batchUpdate.filters(), batchUpdate.update(),
                 batchUpdate.mergeTags());
     }
 

--- a/apps/opik-frontend/src/api/datasets/useDatasetItemBatchUpdateMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetItemBatchUpdateMutation.ts
@@ -27,6 +27,7 @@ const useDatasetItemBatchUpdateMutation = () => {
 
   return useMutation({
     mutationFn: async ({
+      datasetId,
       itemIds,
       item,
       mergeTags,
@@ -43,6 +44,7 @@ const useDatasetItemBatchUpdateMutation = () => {
         ];
 
         payload = {
+          dataset_id: datasetId,
           filters: processFiltersArray(combinedFilters),
           update: item,
           merge_tags: mergeTags,


### PR DESCRIPTION
## Details
When dataset items batch update was extended to support filters, it was done in a way that doesn't receive the `dataset_id` property.

The bug: update dataset items by filter might affect other datasets and not just the one that is viewed.

This PR fixes that by extending the payload to receive a `dataset_id` and validates that it is specified in case of batch update by filters.

In addition, it extends the frontend to set this property.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-0000

## Testing
Tested manually and added tests covering this logic.

## Documentation
No need
