### PR TITLE
[OPIK-3497]: show metrics based on unique timestamps, not only on the first line;

### DIFF
--- a/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricChartContainer.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/MetricChart/MetricChartContainer.tsx
@@ -112,20 +112,16 @@ const MetricContainerChart = ({
     const lines: string[] = [];
 
     // collect all unique time values from all traces
-    const allTimeValues = new Set<string>();
-    traces.forEach((trace) => {
-      trace.data?.forEach((entry) => {
-        allTimeValues.add(entry.time);
-      });
-    });
-    const sortedTimeValues = Array.from(allTimeValues).sort();
+    const sortedTimeValues = Array.from(
+      new Set(traces.flatMap((t) => t.data?.map((d) => d.time) ?? [])),
+    ).sort((a, b) => new Date(a).getTime() - new Date(b).getTime());
 
-    const timeToIndexMap = new Map<string, number>();
-    const transformedData: TransformedData[] = sortedTimeValues.map(
-      (time, index) => {
-        timeToIndexMap.set(time, index);
-        return { time };
-      },
+    const transformedData: TransformedData[] = sortedTimeValues.map((time) => ({
+      time,
+    }));
+
+    const timeToIndexMap = new Map<string, number>(
+      sortedTimeValues.map((time, index) => [time, index]),
     );
 
     traces.forEach((trace) => {
@@ -136,7 +132,7 @@ const MetricContainerChart = ({
       if (shouldInclude) {
         lines.push(trace.name);
 
-        trace.data.forEach((d) => {
+        trace.data?.forEach((d) => {
           const index = timeToIndexMap.get(d.time);
           if (index !== undefined && transformedData[index]) {
             transformedData[index][trace.name] = d.value;


### PR DESCRIPTION
## Details
In the screen below, you can see that it shows the points of a mocked response from prod [project](https://www.comet.com/opik/comet-demos/projects/0198ec68-6e06-7253-a20b-d35c9252b9ba/traces?traces_filters=%5B%5D&time_range=past30days&size=100&height=small&type=metrics&metrics_time_range=past30days&project_metrics_filters=%5B%5D&traces_metrics_filters=%5B%5D&threads_metrics_filters=%5B%5D&threads_height=small&threads_filters=%5B%5D):

<img width="1468" height="691" alt="image" src="https://github.com/user-attachments/assets/17d8de38-3c04-4549-bd03-dc438011458b" />

Fix:
**Before**: The code only used time values from the first trace (which only had 2 data points), causing all other traces' data to be truncated and misaligned.

**After**: The code now:
Collects all unique time values from all traces using a Set
Sorts them chronologically
Creates a time-to-index map for proper alignment
Maps each trace's data to the correct time slot using the actual time value (not array index)


## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-3497

## Testing

## Documentation
