### PR TITLE
[OPIK-3646] Add Jira-Headless-CI MCP configuration for GitHub Actions

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -23,7 +23,16 @@
       "command": "uvx",
       "args": ["mcp-atlassian"],
       "envFile": "${workspaceFolder}/.env.local"
-    },    
+    },
+    "Jira-Headless-CI": {
+      "command": "uvx",
+      "args": ["mcp-atlassian"],
+      "env": {
+        "JIRA_URL": "${JIRA_URL}",
+        "JIRA_USERNAME": "${JIRA_USERNAME}",
+        "JIRA_API_TOKEN": "${JIRA_API_TOKEN}"
+      }
+    },
     "Notion": {
       "command": "npx -y mcp-remote https://mcp.notion.com/mcp",
       "env": {},


### PR DESCRIPTION
## Details

This PR adds a new `Jira-Headless-CI` MCP server configuration to `.cursor/mcp.json` for headless Jira integration in GitHub Actions CI pipelines.

### What Changed

Added a new MCP server entry that uses environment variables directly (instead of `.env.local` file) to enable AI agents to interact with Jira tickets automatically in CI environments where secrets are passed as GitHub Secrets.

### Configuration Added

```json
"Jira-Headless-CI": {
  "command": "uvx",
  "args": ["mcp-atlassian"],
  "env": {
    "JIRA_URL": "${JIRA_URL}",
    "JIRA_USERNAME": "${JIRA_USERNAME}",
    "JIRA_API_TOKEN": "${JIRA_API_TOKEN}"
  }
}
```

### Key Differences

- **Existing `Jira-Headless`**: Uses `envFile: "${workspaceFolder}/.env.local"` for local development
- **New `Jira-Headless-CI`**: Uses `env` with variable substitution for CI/GitHub Actions

### Use Cases

- Auto-update ticket status when PR is opened
- Post PR link to Jira ticket
- AI agent reads ticket details for context
- Post development progress comments to Jira

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-3646

## Testing

- ✅ Validated JSON syntax is correct
- ✅ Configuration follows existing MCP server patterns
- ✅ Environment variable substitution format matches Cursor MCP specification

## Documentation

This change adds infrastructure configuration for CI/GitHub Actions workflows. The configuration enables headless Jira MCP operations in automated environments where secrets are passed as environment variables rather than through `.env.local` files.