### PR TITLE
[NA] [DOCS] Fix local development guide links in contributing documentation

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/contributing/backend.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/contributing/backend.mdx
@@ -169,7 +169,7 @@ We provide multiple ways to develop the backend. Choose the approach that best f
   </Tab>
 </Tabs>
 
-For comprehensive documentation on all development modes, troubleshooting, and advanced workflows, see our [Local Development Guide](/contributing/local-development).
+For comprehensive documentation on all development modes, troubleshooting, and advanced workflows, see our [Local Development Guide](/contributing/guides/local-development).
 
 ### 4. Code Formatting
 

--- a/apps/opik-documentation/documentation/fern/docs/contributing/frontend.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/contributing/frontend.mdx
@@ -170,7 +170,7 @@ We provide multiple ways to develop the frontend. Choose the approach that best 
   </Tab>
 </Tabs>
 
-For comprehensive documentation on all development modes, troubleshooting, and advanced workflows, see our [Local Development Guide](/contributing/local-development).
+For comprehensive documentation on all development modes, troubleshooting, and advanced workflows, see our [Local Development Guide](/contributing/guides/local-development).
 
 ### 4. Code Quality Checks
 


### PR DESCRIPTION
## Details

Fixed broken documentation links in the backend and frontend contributing guides. Updated the Local Development Guide links to point to the correct path `/contributing/guides/local-development` instead of the incorrect `/contributing/local-development`.

This ensures that users reading the contributing documentation can properly navigate to the comprehensive local development guide.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues
- Resolves #
- OPIK-NA
- NA

## Testing

Verified that the links now point to the correct documentation path. The changes were made in:
- `apps/opik-documentation/documentation/fern/docs/contributing/backend.mdx`
- `apps/opik-documentation/documentation/fern/docs/contributing/frontend.mdx`

## Documentation

Updated documentation links in:
- Backend contributing guide (`backend.mdx`)
- Frontend contributing guide (`frontend.mdx`)

Both files now correctly reference `/contributing/guides/local-development` instead of `/contributing/local-development`.