### PR TITLE
[OPIK-3469] [Python BE] Add pre-subprocess logs to Optimization Studio UI

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/jobs/optimizer.py
+++ b/apps/opik-python-backend/src/opik_backend/jobs/optimizer.py
@@ -146,12 +146,20 @@ def process_optimizer_job(*args, **kwargs):
             span.set_attribute("workspace_id", context.workspace_id)
             span.set_attribute("workspace_name", context.workspace_name)
             
+            # Log to standard logger first (for Grafana) - before collector creation
+            # This ensures we have context even if collector creation fails
+            logger.info(
+                f"Processing Optimization Studio job: {context.optimization_id} "
+                f"for workspace: {context.workspace_name}"
+            )
+            
             # Create log collector early so we can capture pre-subprocess logs
             log_collector = create_optimization_log_collector(
                 workspace_id=context.workspace_id,
                 optimization_id=context.optimization_id,
             )
             
+            # Also log to Redis for UI visibility
             _log_to_redis(
                 log_collector, "info",
                 f"Processing Optimization Studio job: {context.optimization_id} "


### PR DESCRIPTION
## Details
This PR adds visibility for logs that occur **before** the isolated subprocess starts in Optimization Studio.

Previously, errors like "dataset has 0 items" or configuration validation failures were only logged to container stdout (Grafana) but not visible in the Optimization Studio logs UI.

### Changes

**`optimizer.py`**
- Added `_log_to_redis()` helper that logs to both standard logger (Grafana) AND Redis (UI)
- Create log collector early (before any processing) to capture pre-subprocess messages
- All important messages now go to both destinations:
  - Job start: "Processing Optimization Studio job..."
  - Subprocess start: "Starting optimization subprocess..."
  - Errors: Any exception is logged before re-raising
  - Completion: "Optimization completed successfully"

**`subprocess_logger.py`**
- Added `add_log_line()` method to `RedisBatchLogCollector` for direct line injection
- Allows the main process to push formatted log lines to Redis

### Benefits
- Errors before subprocess (dataset validation, config parsing) now visible in UI
- Users can see the full optimization lifecycle in the logs panel
- Debugging is easier - no need to check Grafana for pre-subprocess errors

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues
- OPIK-3469

## Testing
1. Start an optimization with an empty dataset
2. Check the logs panel - should now show the error message
3. Start a successful optimization - should see job start/end messages

## Documentation
N/A - internal logging improvement
