### PR TITLE
[OPIK-3614] [FE] Add navigation link from annotation queue to traces/threads

### DIFF
--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
@@ -19,6 +19,7 @@ import CopySMELinkButton from "@/components/pages/AnnotationQueuePage/CopySMELin
 import OpenSMELinkButton from "@/components/pages/AnnotationQueuePage/OpenSMELinkButton";
 import EditAnnotationQueueButton from "@/components/pages/AnnotationQueuePage/EditAnnotationQueueButton";
 import ExportAnnotatedDataButton from "@/components/pages/AnnotationQueuePage/ExportAnnotatedDataButton";
+import ViewAllItemsButton from "@/components/pages/AnnotationQueuePage/ViewAllItemsButton";
 import AnnotationQueueProgressTag from "@/components/pages/AnnotationQueuePage/AnnotationQueueProgressTag";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import ScopeTag from "@/components/pages/AnnotationQueuePage/ScopeTag";
@@ -69,6 +70,7 @@ const AnnotationQueuePage: React.FunctionComponent = () => {
         <h1 className="comet-title-l truncate break-words">{queueName}</h1>
         {annotationQueue && (
           <div className="flex items-center gap-2">
+            <ViewAllItemsButton annotationQueue={annotationQueue} />
             <CopySMELinkButton annotationQueue={annotationQueue} />
             <EditAnnotationQueueButton annotationQueue={annotationQueue} />
             <ExportAnnotatedDataButton annotationQueue={annotationQueue} />

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ViewAllItemsButton.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ViewAllItemsButton.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { ArrowUpRight } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+
+import {
+  ANNOTATION_QUEUE_SCOPE,
+  AnnotationQueue,
+} from "@/types/annotation-queues";
+import { Button } from "@/components/ui/button";
+import useAppStore from "@/store/AppStore";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
+import { createFilter } from "@/lib/filters";
+
+interface ViewAllItemsButtonProps {
+  annotationQueue: AnnotationQueue;
+}
+
+const ViewAllItemsButton: React.FunctionComponent<ViewAllItemsButtonProps> = ({
+  annotationQueue,
+}) => {
+  const navigate = useNavigate();
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+
+  const isTraceQueue = annotationQueue.scope === ANNOTATION_QUEUE_SCOPE.TRACE;
+
+  const handleClick = () => {
+    const filter = createFilter({
+      id: "annotation_queue_ids",
+      field: "annotation_queue_ids",
+      value: annotationQueue.id,
+      operator: "contains",
+    });
+
+    if (isTraceQueue) {
+      navigate({
+        to: "/$workspaceName/projects/$projectId/traces",
+        params: {
+          workspaceName,
+          projectId: annotationQueue.project_id,
+        },
+        search: {
+          traces_filters: [filter],
+        },
+      });
+    } else {
+      navigate({
+        to: "/$workspaceName/projects/$projectId/traces",
+        params: {
+          workspaceName,
+          projectId: annotationQueue.project_id,
+        },
+        search: {
+          type: "threads",
+          threads_filters: [filter],
+        },
+      });
+    }
+  };
+
+  const tooltipContent = isTraceQueue
+    ? "View all traces in this queue"
+    : "View all threads in this queue";
+
+  const buttonLabel = isTraceQueue ? "View all traces" : "View all threads";
+
+  return (
+    <TooltipWrapper content={tooltipContent}>
+      <Button size="sm" variant="outline" onClick={handleClick}>
+        {buttonLabel}
+        <ArrowUpRight className="ml-1.5 size-3.5" />
+      </Button>
+    </TooltipWrapper>
+  );
+};
+
+export default ViewAllItemsButton;


### PR DESCRIPTION
## Details
Added a "View all traces" / "View all threads" button to the annotation queue page header. This button navigates users to the project's traces or threads view with a pre-applied filter for `annotation_queue_ids`, allowing them to see all items that are part of the current annotation queue.

**Key changes:**
- Created new `ViewAllItemsButton` component that determines whether to navigate to traces or threads based on the queue's scope
- Added the button to the annotation queue page header, positioned before the copy SME link button
- Uses `createFilter` utility to construct the appropriate filter for `annotation_queue_ids`
- Includes appropriate tooltips ("View all traces in this queue" / "View all threads in this queue")

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3614

## Testing
- Verified navigation to traces view with correct filter for trace-scoped queues
- Verified navigation to threads view with correct filter for thread-scoped queues
- Confirmed the filter displays correctly in the target view

## Documentation
N/A - UI feature that is self-explanatory