### PR TITLE
[OPIK-3614] [FE] Add navigation link from annotation queue to traces/threads

### DIFF
--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
@@ -19,6 +19,7 @@ import CopySMELinkButton from "@/components/pages/AnnotationQueuePage/CopySMELin
 import OpenSMELinkButton from "@/components/pages/AnnotationQueuePage/OpenSMELinkButton";
 import EditAnnotationQueueButton from "@/components/pages/AnnotationQueuePage/EditAnnotationQueueButton";
 import ExportAnnotatedDataButton from "@/components/pages/AnnotationQueuePage/ExportAnnotatedDataButton";
+import ViewQueueItemsButton from "@/components/pages/AnnotationQueuePage/ViewQueueItemsButton";
 import AnnotationQueueProgressTag from "@/components/pages/AnnotationQueuePage/AnnotationQueueProgressTag";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import ScopeTag from "@/components/pages/AnnotationQueuePage/ScopeTag";
@@ -69,6 +70,7 @@ const AnnotationQueuePage: React.FunctionComponent = () => {
         <h1 className="comet-title-l truncate break-words">{queueName}</h1>
         {annotationQueue && (
           <div className="flex items-center gap-2">
+            <ViewQueueItemsButton annotationQueue={annotationQueue} />
             <CopySMELinkButton annotationQueue={annotationQueue} />
             <EditAnnotationQueueButton annotationQueue={annotationQueue} />
             <ExportAnnotatedDataButton annotationQueue={annotationQueue} />

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ViewQueueItemsButton.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ViewQueueItemsButton.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { ArrowRight, ListTree, MessagesSquare } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+
+import {
+  AnnotationQueue,
+  ANNOTATION_QUEUE_SCOPE,
+} from "@/types/annotation-queues";
+import { Button } from "@/components/ui/button";
+import useAppStore from "@/store/AppStore";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
+import { generateAnnotationQueueIdFilter } from "@/lib/filters";
+
+interface ViewQueueItemsButtonProps {
+  annotationQueue: AnnotationQueue;
+}
+
+const ViewQueueItemsButton: React.FunctionComponent<
+  ViewQueueItemsButtonProps
+> = ({ annotationQueue }) => {
+  const navigate = useNavigate();
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+
+  const isTraceQueue = annotationQueue.scope === ANNOTATION_QUEUE_SCOPE.TRACE;
+  const isThreadQueue = annotationQueue.scope === ANNOTATION_QUEUE_SCOPE.THREAD;
+
+  const handleClick = () => {
+    if (isTraceQueue) {
+      navigate({
+        to: "/$workspaceName/projects/$projectId/traces",
+        params: {
+          projectId: annotationQueue.project_id,
+          workspaceName,
+        },
+        search: {
+          traces_filters: generateAnnotationQueueIdFilter(annotationQueue.id),
+        },
+      });
+    } else if (isThreadQueue) {
+      navigate({
+        to: "/$workspaceName/projects/$projectId/traces",
+        params: {
+          projectId: annotationQueue.project_id,
+          workspaceName,
+        },
+        search: {
+          type: "threads",
+          threads_filters: generateAnnotationQueueIdFilter(annotationQueue.id),
+        },
+      });
+    }
+  };
+
+  const tooltipContent = isTraceQueue
+    ? "View all traces in this annotation queue"
+    : "View all threads in this annotation queue";
+
+  const buttonText = isTraceQueue ? "View traces" : "View threads";
+
+  const Icon = isTraceQueue ? ListTree : MessagesSquare;
+
+  return (
+    <TooltipWrapper content={tooltipContent}>
+      <Button size="sm" variant="outline" onClick={handleClick}>
+        <Icon className="mr-1.5 size-3.5" />
+        {buttonText}
+        <ArrowRight className="ml-1.5 size-3.5" />
+      </Button>
+    </TooltipWrapper>
+  );
+};
+
+export default ViewQueueItemsButton;

--- a/apps/opik-frontend/src/lib/filters.ts
+++ b/apps/opik-frontend/src/lib/filters.ts
@@ -116,6 +116,19 @@ export const generateExperimentIdFilter = (experimentId?: string) => {
   ];
 };
 
+export const generateAnnotationQueueIdFilter = (annotationQueueId?: string) => {
+  if (!annotationQueueId) return [];
+
+  return [
+    createFilter({
+      field: "annotation_queue_ids",
+      type: COLUMN_TYPE.list,
+      operator: "contains",
+      value: annotationQueueId,
+    }),
+  ];
+};
+
 const processTimeFilter: (filter: Filter) => Filter | Filter[] = (filter) => {
   switch (filter.operator) {
     case "=":


### PR DESCRIPTION
## Details

Added a navigation button to the annotation queue page that allows users to quickly navigate to the traces or threads view with the annotation queue filter pre-applied.

**Changes:**
- Added `ViewQueueItemsButton` component that displays "View traces" for trace-scoped queues or "View threads" for thread-scoped queues
- Button navigates to the project's traces page with the `annotation_queue_ids` filter pre-applied
- For thread-scoped queues, navigates to the threads tab with the appropriate filter
- Added `generateAnnotationQueueIdFilter` helper function in `filters.ts`
- Button follows the existing UI patterns (outline variant, sm size, consistent icon placement)

**User Value:**
- Quick access to see all traces/threads in an annotation queue
- Enables users to review items outside the annotation flow
- Consistent navigation pattern across experiments, playground, and annotation queues
- Reduces friction in workflow - one click instead of manual navigation and filtering

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3614

## Testing

1. Navigate to an annotation queue page
2. Verify the "View traces" or "View threads" button appears based on queue scope
3. Click the button and verify navigation to traces/threads page with the queue filter applied
4. Verify the filter correctly shows only items belonging to the annotation queue

**Screenshot:**
<!-- Add screenshot of the new button in the annotation queue page header -->

## Documentation

No documentation updates needed - this is a UI enhancement that follows existing patterns.