### PR TITLE
[OPIK-3680][FE]: fix a bug with empty datasets for demo in otpimization studio;

### DIFF
--- a/apps/opik-frontend/src/api/datasets/useGetOrCreateDemoDataset.ts
+++ b/apps/opik-frontend/src/api/datasets/useGetOrCreateDemoDataset.ts
@@ -9,7 +9,8 @@ import {
 
 /**
  * Hook to create a demo dataset for optimization templates.
- * Creates dataset and populates with items. If dataset already exists, uses it.
+ * Creates dataset and populates with items. If dataset already exists but is empty,
+ * it will be populated with items.
  */
 const useGetOrCreateDemoDataset = () => {
   const queryClient = useQueryClient();
@@ -46,8 +47,11 @@ const useGetOrCreateDemoDataset = () => {
         const dataset = newDataset || datasets?.content?.[0];
         if (!dataset?.id) return null;
 
-        // Only add items if dataset was newly created
-        if (newDataset) {
+        // add items if dataset was newly created OR if existing dataset is empty
+        const shouldAddItems =
+          newDataset || (dataset && dataset.dataset_items_count === 0);
+
+        if (shouldAddItems) {
           await api.put(`${DATASETS_REST_ENDPOINT}items`, {
             dataset_id: dataset.id,
             items: datasetItems.map((item: DemoDatasetItem) => ({


### PR DESCRIPTION


## Details
When a demo dataset for optimization templates already existed but was empty (had 0 items), the system would not populate it with demo data. This left users with empty datasets that were unusable.

### What Was Changed
* Improved Demo Dataset Population Logic (useGetOrCreateDemoDataset.ts)
  * Before: Demo dataset items were only added when a dataset was newly created
  * After: Demo dataset items are now added in two cases:
      * When a dataset is newly created, OR
      * When an existing dataset is empty (has dataset_items_count === 0)

This ensures users don't end up with empty demo datasets that appear broken

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-3680

## Testing

## Documentation
