### PR TITLE
[OPIK-3614] [FE] Add navigation link from annotation queue to traces/threads

### DIFF
--- a/apps/opik-frontend/package-lock.json
+++ b/apps/opik-frontend/package-lock.json
@@ -231,7 +231,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
       "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -878,8 +877,7 @@
     "node_modules/@codemirror/state": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
-      "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==",
-      "peer": true
+      "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A=="
     },
     "node_modules/@codemirror/theme-one-dark": {
       "version": "6.1.2",
@@ -896,7 +894,6 @@
       "version": "6.28.4",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.28.4.tgz",
       "integrity": "sha512-QScv95fiviSQ/CaVGflxAvvvDy/9wi0RFyDl4LkHHWiMr/UPebyuTspmYSeN5Nx6eujcPYwsQzA6ZIZucKZVHQ==",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.4.0",
         "style-mod": "^4.1.0",
@@ -917,7 +914,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -939,7 +935,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -1004,7 +999,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -5897,7 +5891,6 @@
       "version": "5.45.0",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.45.0.tgz",
       "integrity": "sha512-y272cKRJp1BvehrWG4ashOBuqBj1Qm2O6fgYJ9LYSHrLdsCXl74GbSVjUQTReUdHuRIl9cEOoyPa6HYag400lw==",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.45.0"
       },
@@ -5930,7 +5923,6 @@
       "version": "1.36.3",
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.36.3.tgz",
       "integrity": "sha512-587W8jYCUtK9HsPSkmSbxm9VHH+ullmAT/ttOIbMjqhKLg9Sb30Gg6NxzGlzxRSF0t6QSy28wt+4ChPREVizFA==",
-      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.31.16",
         "@tanstack/react-store": "^0.2.1",
@@ -6612,7 +6604,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.13.tgz",
       "integrity": "sha512-+bHoGiZb8UiQ0+WEtmph2IWQCjIqg8MDZMAV+ppRRhUZnquF5mQkP/9vpSwJClEiSM/C7fZZExPzfU0vJTyp8w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -6626,7 +6617,6 @@
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -6637,7 +6627,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -6736,7 +6725,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -7183,7 +7171,6 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7667,7 +7654,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001629",
         "electron-to-chromium": "^1.4.796",
@@ -7898,7 +7884,6 @@
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
       "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -8668,14 +8653,12 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "peer": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/cytoscape": {
       "version": "3.30.4",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.30.4.tgz",
       "integrity": "sha512-OxtlZwQl1WbwMmLiyPSEBuzeTIQnwZhJYYWFzZ2PhEHVFwpeaqNIkUzSiso00D98qk60l8Gwon2RP304d3BJ1A==",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -9050,7 +9033,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9193,7 +9175,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -9847,7 +9828,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9903,7 +9883,6 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -10818,7 +10797,6 @@
       "integrity": "sha512-/zyxHbXriYJ8b9Urh43ILk/jd9tC07djURnJuAimJ3tJCOLOzOUp7dEHDwJOZyzROlrrooUhr/0INZIDBj1Bjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "entities": "^4.5.0",
         "webidl-conversions": "^7.0.0",
@@ -11837,7 +11815,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -12092,8 +12069,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
       "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lint-staged": {
       "version": "15.2.7",
@@ -14377,7 +14353,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -14565,7 +14540,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.1.tgz",
       "integrity": "sha512-b4dlw/9V8A71rLIDsSwVmak9z2DuBUB7CA1/wSdelNEzqsjoSPeADTWNO09lpH49Diy3/JIZ2bSPB1dI3LJCHg==",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -14660,7 +14634,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
       "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14814,7 +14787,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14839,7 +14811,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -14895,7 +14866,6 @@
       "version": "7.54.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
       "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -15515,7 +15485,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.4.tgz",
       "integrity": "sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -15663,7 +15632,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.5.tgz",
       "integrity": "sha512-oDfX1mukIlxacPdQqNb6mV2tVCrnE+P3nVYioy72V5tlk56CPNcO4TCuFcaCRKKfJ1M3lH95CleRS+dVKL2qMg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -16211,7 +16179,6 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^2.7.1",
         "@csstools/css-tokenizer": "^2.4.1",
@@ -16637,7 +16604,6 @@
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.4.tgz",
       "integrity": "sha512-ZoyXOdJjISB7/BcLTR6SEsLgKtDStYyYZVLsUtWChO4Ps20CBad7lfJKVDiejocV4ME1hLmyY0WJE3hSDcmQ2A==",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -16806,7 +16772,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17060,7 +17025,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17448,7 +17412,6 @@
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -17598,7 +17561,6 @@
       "integrity": "sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "3.0.5",
         "@vitest/mocker": "3.0.5",

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
@@ -22,6 +22,7 @@ import ExportAnnotatedDataButton from "@/components/pages/AnnotationQueuePage/Ex
 import AnnotationQueueProgressTag from "@/components/pages/AnnotationQueuePage/AnnotationQueueProgressTag";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import ScopeTag from "@/components/pages/AnnotationQueuePage/ScopeTag";
+import ViewAllItemsButton from "@/components/pages/AnnotationQueuePage/ViewAllItemsButton";
 
 const AnnotationQueuePage: React.FunctionComponent = () => {
   const [tab = "items", setTab] = useQueryParam("tab", StringParam);
@@ -69,6 +70,7 @@ const AnnotationQueuePage: React.FunctionComponent = () => {
         <h1 className="comet-title-l truncate break-words">{queueName}</h1>
         {annotationQueue && (
           <div className="flex items-center gap-2">
+            <ViewAllItemsButton annotationQueue={annotationQueue} />
             <CopySMELinkButton annotationQueue={annotationQueue} />
             <EditAnnotationQueueButton annotationQueue={annotationQueue} />
             <ExportAnnotatedDataButton annotationQueue={annotationQueue} />

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ViewAllItemsButton.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ViewAllItemsButton.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { ArrowRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  ANNOTATION_QUEUE_SCOPE,
+  AnnotationQueue,
+} from "@/types/annotation-queues";
+import { COLUMN_TYPE } from "@/types/shared";
+import { createFilter } from "@/lib/filters";
+import useAppStore from "@/store/AppStore";
+import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
+
+interface ViewAllItemsButtonProps {
+  annotationQueue: AnnotationQueue;
+}
+
+const ViewAllItemsButton: React.FC<ViewAllItemsButtonProps> = ({
+  annotationQueue,
+}) => {
+  const navigate = useNavigate();
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+
+  const isTraceQueue = annotationQueue.scope === ANNOTATION_QUEUE_SCOPE.TRACE;
+  const isThreadQueue = annotationQueue.scope === ANNOTATION_QUEUE_SCOPE.THREAD;
+
+  const handleClick = () => {
+    const filter = createFilter({
+      id: "annotation_queue_ids",
+      field: "annotation_queue_ids",
+      type: COLUMN_TYPE.list,
+      operator: "contains",
+      value: annotationQueue.id,
+    });
+
+    if (isTraceQueue) {
+      navigate({
+        to: "/$workspaceName/projects/$projectId/traces",
+        params: {
+          projectId: annotationQueue.project_id,
+          workspaceName,
+        },
+        search: {
+          type: TRACE_DATA_TYPE.traces,
+          traces_filters: [filter],
+        },
+      });
+    } else if (isThreadQueue) {
+      navigate({
+        to: "/$workspaceName/projects/$projectId/traces",
+        params: {
+          projectId: annotationQueue.project_id,
+          workspaceName,
+        },
+        search: {
+          type: "threads",
+          threads_filters: [filter],
+        },
+      });
+    }
+  };
+
+  const buttonText = isTraceQueue ? "View all traces" : "View all threads";
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleClick}>
+      {buttonText}
+      <ArrowRight className="ml-2 size-4" />
+    </Button>
+  );
+};
+
+export default ViewAllItemsButton;


### PR DESCRIPTION
## Details

This PR adds a "View all traces" or "View all threads" button to the annotation queue page, allowing users to quickly navigate to the traces/threads page with the annotation queue filter pre-applied.

### Changes made:
- Created new `ViewAllItemsButton` component that:
  - Displays "View all traces" for trace-scoped queues
  - Displays "View all threads" for thread-scoped queues
  - Navigates to the appropriate page with annotation queue filter applied
  - Uses the `annotation_queue_ids` filter to show only items in the current queue
- Integrated the button into the `AnnotationQueuePage` header alongside existing action buttons
- Updated package-lock.json (dependency resolution changes)

### Design decisions:
- Button placed in the header next to other action buttons for consistent UX
- Uses the existing filter system to maintain consistency with other filtering features
- Automatically determines the correct navigation target based on queue scope (trace vs thread)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3614

## Testing

### Manual testing steps:
1. Navigate to an annotation queue page (trace-scoped)
2. Verify "View all traces" button appears in the header
3. Click the button and verify navigation to traces page with correct filter
4. Verify the traces page shows only items from the annotation queue
5. Repeat steps 1-4 for a thread-scoped annotation queue

### Test scenarios covered:
- Navigation from trace-scoped annotation queue to traces page
- Navigation from thread-scoped annotation queue to threads page
- Filter is correctly applied with annotation queue ID
- Button text changes based on queue scope

## Documentation
No documentation updates required - this is a UI enhancement that follows existing patterns.