### PR TITLE
[OPIK-3614] [FE] Add navigation link from annotation queue to traces/threads

### DIFF
--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
@@ -22,6 +22,7 @@ import ExportAnnotatedDataButton from "@/components/pages/AnnotationQueuePage/Ex
 import AnnotationQueueProgressTag from "@/components/pages/AnnotationQueuePage/AnnotationQueueProgressTag";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import ScopeTag from "@/components/pages/AnnotationQueuePage/ScopeTag";
+import ViewQueueItemsButton from "@/components/pages/AnnotationQueuePage/ViewQueueItemsButton";
 
 const AnnotationQueuePage: React.FunctionComponent = () => {
   const [tab = "items", setTab] = useQueryParam("tab", StringParam);
@@ -69,6 +70,7 @@ const AnnotationQueuePage: React.FunctionComponent = () => {
         <h1 className="comet-title-l truncate break-words">{queueName}</h1>
         {annotationQueue && (
           <div className="flex items-center gap-2">
+            <ViewQueueItemsButton annotationQueue={annotationQueue} />
             <CopySMELinkButton annotationQueue={annotationQueue} />
             <EditAnnotationQueueButton annotationQueue={annotationQueue} />
             <ExportAnnotatedDataButton annotationQueue={annotationQueue} />

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ViewQueueItemsButton.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/ViewQueueItemsButton.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { ArrowRight } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
+import {
+  ANNOTATION_QUEUE_SCOPE,
+  AnnotationQueue,
+} from "@/types/annotation-queues";
+import { useActiveWorkspaceName } from "@/store/AppStore";
+
+interface ViewQueueItemsButtonProps {
+  annotationQueue: AnnotationQueue;
+}
+
+const ViewQueueItemsButton: React.FunctionComponent<
+  ViewQueueItemsButtonProps
+> = ({ annotationQueue }) => {
+  const navigate = useNavigate();
+  const workspaceName = useActiveWorkspaceName();
+
+  const isTraceQueue = annotationQueue.scope === ANNOTATION_QUEUE_SCOPE.TRACE;
+  const itemType = isTraceQueue ? "traces" : "threads";
+
+  const handleClick = () => {
+    navigate({
+      to: "/$workspaceName/projects/$projectId/traces",
+      params: {
+        workspaceName,
+        projectId: annotationQueue.project_id,
+      },
+      search: {
+        type: itemType,
+      },
+    });
+  };
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleClick}>
+      <ArrowRight className="mr-2 size-4" />
+      View all {itemType}
+    </Button>
+  );
+};
+
+ViewQueueItemsButton.displayName = "ViewQueueItemsButton";
+
+export default ViewQueueItemsButton;


### PR DESCRIPTION
## Details

This PR adds a navigation button from annotation queue pages to the traces/threads list view. The button appears in the header actions section alongside existing buttons (Copy SME Link, Edit, Export, Open SME).

**Key Implementation Details:**
- Created new `ViewQueueItemsButton` component that determines queue type (trace vs thread) based on `annotationQueue.scope`
- Button navigates to `/$workspaceName/projects/$projectId/traces` with `type` search parameter set to either "traces" or "threads"
- Follows the same UI/UX pattern as the existing "View all traces" button in ThreadDetailsPanel
- Uses `ArrowRight` icon and `outline` variant with `sm` size for consistency

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-3614

## Testing

**Manual Testing:**
- TypeScript compilation passes (`npm run typecheck`)
- ESLint passes with no errors (`npm run lint`)
- Button correctly determines queue type based on `scope` field
- Navigation logic follows existing patterns from `ThreadDetailsPanel` and `NoQueueItemsPage`

**Test Scenarios:**
1. Trace-based annotation queues show "View all traces" button
2. Thread-based annotation queues show "View all threads" button
3. Clicking the button navigates to traces page with correct `type` parameter
4. Button position is consistent with other action buttons in the header

## Documentation

No documentation updates required - this is a UI enhancement that follows existing navigation patterns.