### PR TITLE
[OPIK-3615] [FE] Add 'Select all' option to annotation queue feedback scores

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
@@ -298,6 +298,7 @@ const AddEditAnnotationQueueDialog: React.FunctionComponent<
                             onChange={field.onChange}
                             valueField="name"
                             multiselect
+                            showSelectAll
                             className={cn({
                               "border-destructive": Boolean(
                                 validationErrors?.message,

--- a/apps/opik-frontend/src/components/pages-shared/annotation-queues/FeedbackDefinitionsSelectBox.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/annotation-queues/FeedbackDefinitionsSelectBox.tsx
@@ -31,6 +31,7 @@ interface MultiSelectFeedbackDefinitionsProps
   value: string[];
   onChange: (value: string[]) => void;
   multiselect: true;
+  showSelectAll?: boolean;
 }
 
 type FeedbackDefinitionsSelectBoxProps =
@@ -74,6 +75,7 @@ const FeedbackDefinitionsSelectBox: React.FC<
         placeholder: "Select feedback definitions",
         onChange: props.onChange,
         multiselect: true as const,
+        showSelectAll: props.showSelectAll,
       }
     : {
         options,


### PR DESCRIPTION
## Details

<img width="808" height="860" alt="Screenshot 2026-01-05 at 14 17 36" src="https://github.com/user-attachments/assets/a4c8e6e9-93ad-4f0f-8258-520873dcf4a7" />


This PR adds a "Select all" option to the feedback scores selection dropdown in the annotation queue creation and edit dialogs. Previously, users had to manually select feedback scores one by one, which was tedious when including multiple scores.

The implementation leverages the existing `showSelectAll` functionality already built into the `LoadableSelectBox` component. The changes simply expose this feature through the `FeedbackDefinitionsSelectBox` wrapper and enable it in the annotation queue dialog.

**Changes:**
- Added `showSelectAll` prop to `MultiSelectFeedbackDefinitionsProps` interface in `FeedbackDefinitionsSelectBox`
- Passed the `showSelectAll` prop through to the underlying `LoadableSelectBox` component
- Enabled the feature in `AddEditAnnotationQueueDialog` by passing `showSelectAll={true}`

**User Impact:**
- Faster annotation queue setup when including many feedback scores
- Consistent UX with other multi-select components in the product
- Reduced manual effort and clicks

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3615

## Testing

**Manual Testing Performed:**
- ✅ Verified "Select all" checkbox appears at the bottom of the feedback scores dropdown
- ✅ Tested selecting all feedback scores with one click
- ✅ Tested deselecting all feedback scores
- ✅ Verified individual selection still works alongside "Select all"
- ✅ Tested in both create annotation queue and edit annotation queue dialogs
- ✅ Verified the select all respects search filtering (only selects filtered items)

**Test Steps:**
1. Navigate to Annotation Queues
2. Click "Create annotation queue" or edit an existing queue
3. Open the "Available feedback scores" dropdown
4. Verify "Select all" checkbox appears at the bottom
5. Click "Select all" - all visible feedback scores should be selected
6. Click again - all should be deselected
7. Test with search filter active - only filtered items should be selected

## Documentation

No documentation updates required. This is a UI enhancement that follows existing patterns in the product and requires no configuration changes.