### PR TITLE
[OPIK-3717][BE] respond with latest version summary

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionMapper.java
@@ -10,7 +10,7 @@ import org.mapstruct.factory.Mappers;
 import java.util.UUID;
 
 @Mapper
-interface DatasetVersionMapper {
+public interface DatasetVersionMapper {
 
     DatasetVersionMapper INSTANCE = Mappers.getMapper(DatasetVersionMapper.class);
 


### PR DESCRIPTION
## Details
This PR extends the `PUT /datasets/{id}/items` to respond with the latest version's summary.
To maintain backwards compatibility, the latest version summary will be responded iff the query parameter `respond_with_latest_version` is set.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-3717

## Testing
Added positive and negative test coverage

## Documentation
No need
