### PR TITLE
[OPIK-3668] [FE] Fix annotation queue caching issues for last item and deleted changes

### DIFF
--- a/apps/opik-frontend/src/components/pages/SMEFlowPage/SMEFlowContext.tsx
+++ b/apps/opik-frontend/src/components/pages/SMEFlowPage/SMEFlowContext.tsx
@@ -426,7 +426,9 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
   }, [setCurrentView, unprocessedIds, allItemIds]);
 
   const handleNext = useCallback(() => {
-    if (currentItem && hasUnsavedChanges(currentAnnotationState)) {
+    // Always cache the current annotation state when navigating away
+    // This ensures that any changes (including deletions) are preserved
+    if (currentItem) {
       setCachedAnnotationStates((prev) => ({
         ...prev,
         [getAnnotationQueueItemId(currentItem)]: cloneDeep(
@@ -481,10 +483,21 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
   }, [currentIndex, getNextUnprocessedIndex]);
 
   const handlePrevious = useCallback(() => {
+    // Always cache the current annotation state when navigating away
+    // This ensures that any changes (including deletions) are preserved
+    if (currentItem) {
+      setCachedAnnotationStates((prev) => ({
+        ...prev,
+        [getAnnotationQueueItemId(currentItem)]: cloneDeep(
+          currentAnnotationState,
+        ),
+      }));
+    }
+
     if (currentIndex > 0) {
       setCurrentIndex(currentIndex - 1);
     }
-  }, [currentIndex]);
+  }, [currentIndex, currentItem, currentAnnotationState]);
 
   const updateComment = useCallback((text: string) => {
     setCurrentAnnotationState((prev) => ({


### PR DESCRIPTION
   ## Details


https://github.com/user-attachments/assets/bf852fed-8564-4890-9014-702a3f08459b



   Fixed two related bugs in the annotation queue navigation caching system:
   
   1. **Last item's unsaved changes were being discarded** - The `handlePrevious` function had no caching logic, causing data loss when navigating away from the last item (which can only be navigated from using "Previous")
   
   2. **Deleted cached changes would reappear** - Conditional caching (only when `hasUnsavedChanges`) didn't update the cache when users deleted previously cached data, causing the old data to reappear
   
   **Solution:** Changed both navigation functions to always cache the current annotation state, ensuring all changes (additions, modifications, and deletions) are consistently preserved.
   
   ## Change checklist
   - [x] User facing
   - [ ] Documentation update
   
   ## Issues
   - Resolves #[GitHub issue number if applicable]
   - OPIK-3668
   
   ## Testing
   **Test Case 1: Last Item Preservation**
   - Navigate to last item in queue
   - Add unsaved comment/feedback score
   - Click "Previous" then "Next"
   - ✅ Changes are preserved
   
   **Test Case 2: Deletion Persistence**
   - Add unsaved changes to any item
   - Navigate away and back (changes cached)
   - Delete the changes
   - Navigate away and back
   - ✅ Deletions persist (data doesn't reappear)
   
   **Test Case 3: Multiple Navigation Cycles**
   - Tested navigation in both directions with various changes
   - ✅ Latest state always preserved correctly
   
   ## Documentation
   No documentation updates needed - internal bug fix with no API changes.