### PR TITLE
[NA][BE] rename `draftItemId` to `datasetItemId`

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItem.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItem.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 public record DatasetItem(
         @JsonView( {
                 DatasetItem.View.Public.class, DatasetItem.View.Write.class}) UUID id,
-        @JsonView({DatasetItem.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) UUID draftItemId,
+        @JsonView({DatasetItem.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) UUID datasetItemId,
         @JsonView({DatasetItem.View.Public.class, DatasetItem.View.Write.class}) UUID traceId,
         @JsonView({DatasetItem.View.Public.class, DatasetItem.View.Write.class}) UUID spanId,
         @JsonView({DatasetItem.View.Public.class, DatasetItem.View.Write.class}) @NotNull DatasetItemSource source,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
@@ -135,9 +135,9 @@ class DatasetItemResultMapper {
             Map<String, JsonNode> data = getData(row);
 
             // Check if dataset_item_id column exists in the result (only present for versioned items)
-            UUID draftItemId = null;
+            UUID datasetItemId = null;
             if (rowMetadata.contains("dataset_item_id")) {
-                draftItemId = Optional.ofNullable(row.get("dataset_item_id", String.class))
+                datasetItemId = Optional.ofNullable(row.get("dataset_item_id", String.class))
                         .filter(s -> !s.isBlank())
                         .map(UUID::fromString)
                         .orElse(null);
@@ -165,7 +165,7 @@ class DatasetItemResultMapper {
                             .map(Arrays::asList)
                             .map(Set::copyOf)
                             .orElse(null))
-                    .draftItemId(draftItemId)
+                    .datasetItemId(datasetItemId)
                     .experimentItems(getExperimentItems(row.get("experiment_items_array", List[].class)))
                     .lastUpdatedAt(row.get("last_updated_at", Instant.class))
                     .createdAt(row.get("created_at", Instant.class))

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1338,10 +1338,10 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 .map(item -> {
                     // Generate new stable ID for new items
                     UUID id = idGenerator.generateId();
-                    // Use draftItemId as the stable ID field
+                    // Use id as the stable ID field
                     return item.toBuilder()
                             .id(id)
-                            .draftItemId(id)
+                            .datasetItemId(id)
                             .datasetId(datasetId)
                             .build();
                 })
@@ -1369,7 +1369,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
             return Mono.error(new ClientErrorException(
                     Response.status(Response.Status.BAD_REQUEST)
                             .entity(new ErrorMessage(
-                                    List.of("Edited items must have an id or draftItemId")))
+                                    List.of("Edited items must have an id or datasetItemId")))
                             .build()));
         }
 
@@ -1403,7 +1403,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                 // Create map from dataset_item_id to existing item
                                 Map<UUID, DatasetItem> existingItemMap = existingItems.stream()
                                         .collect(Collectors.toMap(
-                                                DatasetItem::draftItemId,
+                                                DatasetItem::datasetItemId,
                                                 Function.identity()));
 
                                 // Merge partial changes with existing items
@@ -1445,7 +1445,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
     private DatasetItem mergeEditWithExisting(DatasetItem existingItem, DatasetItemEdit editItem,
             UUID datasetItemId, UUID datasetId) {
         return existingItem.toBuilder()
-                .draftItemId(datasetItemId) // Set stable ID
+                .datasetItemId(datasetItemId) // Set stable ID
                 .datasetId(datasetId)
                 .data(editItem.data() != null ? editItem.data() : existingItem.data())
                 // Source, traceId, spanId are always preserved from existing item
@@ -1555,12 +1555,12 @@ class DatasetItemServiceImpl implements DatasetItemService {
         UUID newVersionId = idGenerator.generateId();
 
         // All items are "added" for the first version
-        // Set draftItemId as the stable ID for each item
+        // Set datasetItemId as the stable ID for each item
         List<DatasetItem> addedItems = items.stream()
                 .map(item -> {
                     UUID stableId = item.id() != null ? item.id() : idGenerator.generateId();
                     return item.toBuilder()
-                            .draftItemId(stableId)
+                            .datasetItemId(stableId)
                             .datasetId(datasetId)
                             .build();
                 })
@@ -1613,14 +1613,14 @@ class DatasetItemServiceImpl implements DatasetItemService {
                         if (itemId != null && existingItemIds.contains(itemId)) {
                             // Existing item - treat as edit
                             editedItems.add(item.toBuilder()
-                                    .draftItemId(itemId)
+                                    .datasetItemId(itemId)
                                     .datasetId(datasetId)
                                     .build());
                         } else {
                             // New item - treat as add
                             UUID newItemId = itemId != null ? itemId : idGenerator.generateId();
                             addedItems.add(item.toBuilder()
-                                    .draftItemId(newItemId)
+                                    .datasetItemId(newItemId)
                                     .datasetId(datasetId)
                                     .build());
                         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -97,7 +97,7 @@ public interface DatasetItemVersionDAO {
      * </ul>
      * <p>
      * For items passed to this method:
-     * - Use {@code draftItemId} field as the stable ID (maintained across versions)
+     * - Use {@code datasetItemId} field as the stable ID (maintained across versions)
      * - The {@code id} field is ignored (row IDs are generated internally)
      *
      * @param datasetId the dataset ID
@@ -134,7 +134,7 @@ public interface DatasetItemVersionDAO {
      * Inserts items directly into a new version without copying from any base version.
      * <p>
      * For items passed to this method:
-     * - Use {@code draftItemId} field as the stable ID (maintained across versions)
+     * - Use {@code datasetItemId} field as the stable ID (maintained across versions)
      * - The {@code id} field is ignored (row IDs are generated internally)
      *
      * @param datasetId the dataset ID
@@ -1503,7 +1503,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
 
         // Collect all stable item IDs that are being edited (so we don't copy them from base)
         Set<UUID> editedItemIds = editedItems.stream()
-                .map(DatasetItem::draftItemId)
+                .map(DatasetItem::datasetItemId)
                 .collect(Collectors.toSet());
 
         // Combine deleted and edited IDs for exclusion when copying
@@ -1707,7 +1707,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             // Bind all item-specific parameters
             int i = 0;
             for (DatasetItem item : items) {
-                UUID stableItemId = item.draftItemId();
+                UUID stableItemId = item.datasetItemId();
                 Map<String, String> dataAsStrings = DatasetItemResultMapper.getOrDefault(item.data());
 
                 statement
@@ -1830,7 +1830,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
 
         return DatasetItem.builder()
                 .id(UUID.fromString(row.get("id", String.class)))
-                .draftItemId(UUID.fromString(row.get("dataset_item_id", String.class)))
+                .datasetItemId(UUID.fromString(row.get("dataset_item_id", String.class)))
                 .datasetId(UUID.fromString(row.get("dataset_id", String.class)))
                 .data(data.isEmpty() ? null : data)
                 .source(Optional.ofNullable(row.get("source", String.class))

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -203,7 +203,7 @@ class DatasetsResourceTest {
     public static final String[] IGNORED_FIELDS_LIST = {"feedbackScores", "createdAt", "lastUpdatedAt", "createdBy",
             "lastUpdatedBy", "comments"};
     public static final String[] IGNORED_FIELDS_DATA_ITEM = {"createdAt", "lastUpdatedAt", "experimentItems",
-            "createdBy", "lastUpdatedBy", "datasetId", "tags"};
+            "createdBy", "lastUpdatedBy", "datasetId", "tags", "datasetItemId"};
     public static final String[] DATASET_IGNORED_FIELDS = {"id", "createdAt", "lastUpdatedAt", "createdBy",
             "lastUpdatedBy", "experimentCount", "mostRecentExperimentAt", "lastCreatedExperimentAt",
             "datasetItemsCount", "lastCreatedOptimizationAt", "mostRecentOptimizationAt", "optimizationCount",


### PR DESCRIPTION
## Details
While working on the dataset versioning feature, we renamed the database field from `draft_item_id` to `dataset_item_id` and forgot to do so in the application code as well.
This id serves as the item's stable id that remains static between different versions of the dataset for comparison.
I verified with the frontend that this property is not in use. In addition the dataset versioning feature toggle is OFF so there's no risk of backwards incompatibility.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-0000

## Testing
Based on existing tests

## Documentation
No need.
