### PR TITLE
[OPIK-3599] [FE] Fix workspace roles menu UI alignment

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/WorkspaceRolePopover.tsx
+++ b/apps/opik-frontend/src/plugins/comet/WorkspaceRolePopover.tsx
@@ -10,7 +10,11 @@ const WorkspaceRolePopover = ({
   options,
 }: ReturnType<typeof useManageUsersRolePopover>) => {
   return (
-    <SelectContent align="start" className="w-[280px] p-2">
+    <SelectContent
+      align="start"
+      position="item-aligned"
+      className="w-[280px] p-2"
+    >
       {options.map((option) => {
         const isSelected = controlValue === option.value;
         const selectItem = (


### PR DESCRIPTION
## Details

Fixed the workspace role selection dropdown alignment issue in the collaborators management UI. Added `position="item-aligned"` to the `SelectContent` component to ensure the dropdown menu aligns properly with the trigger element.

**Changes:**
- Added `position="item-aligned"` prop to `SelectContent` in `WorkspaceRolePopover.tsx`
- This ensures the role selection dropdown properly aligns with the select trigger

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-3599

## Testing

- Visual verification that the role selection dropdown now aligns correctly with the trigger element in the collaborators tab
- Tested role selection functionality remains intact

## Documentation

N/A - UI fix only, no documentation changes required