### PR TITLE
[NA][BE] remove conditional response

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -16,7 +16,6 @@ import com.comet.opik.api.DatasetItemStreamRequest;
 import com.comet.opik.api.DatasetItemsDelete;
 import com.comet.opik.api.DatasetUpdate;
 import com.comet.opik.api.DatasetVersion;
-import com.comet.opik.api.DatasetVersionSummary;
 import com.comet.opik.api.ExperimentItem;
 import com.comet.opik.api.PageColumns;
 import com.comet.opik.api.Visibility;
@@ -33,7 +32,6 @@ import com.comet.opik.domain.DatasetExpansionService;
 import com.comet.opik.domain.DatasetItemSearchCriteria;
 import com.comet.opik.domain.DatasetItemService;
 import com.comet.opik.domain.DatasetService;
-import com.comet.opik.domain.DatasetVersionMapper;
 import com.comet.opik.domain.DatasetVersionService;
 import com.comet.opik.domain.EntityType;
 import com.comet.opik.domain.IdGenerator;
@@ -429,13 +427,11 @@ public class DatasetsResource {
     @Path("/items")
     @Operation(operationId = "createOrUpdateDatasetItems", summary = "Create/update dataset items", description = "Create/update dataset items based on dataset item id", responses = {
             @ApiResponse(responseCode = "204", description = "No content"),
-            @ApiResponse(responseCode = "200", description = "Dataset version summary", content = @Content(schema = @Schema(implementation = DatasetVersionSummary.class))),
     })
     @RateLimited
     public Response createDatasetItems(
             @RequestBody(content = @Content(schema = @Schema(implementation = DatasetItemBatch.class))) @JsonView({
-                    DatasetItem.View.Write.class}) @NotNull @Valid DatasetItemBatch batch,
-            @QueryParam("respond_with_latest_version") @DefaultValue("false") boolean respondWithLatestVersion) {
+                    DatasetItem.View.Write.class}) @NotNull @Valid DatasetItemBatch batch) {
 
         // Generate ids for items without ids before the retryable operation
         List<DatasetItem> items = batch.items().stream().map(item -> {
@@ -452,20 +448,13 @@ public class DatasetsResource {
 
         DatasetItemBatch batchWithIds = new DatasetItemBatch(batch.datasetName(), batch.datasetId(), items);
 
-        DatasetVersion version = itemService.save(batchWithIds)
+        itemService.save(batchWithIds)
                 .contextWrite(ctx -> setRequestContext(ctx, requestContext))
                 .retryWhen(RetryUtils.handleConnectionError())
                 .block();
         log.info("Saved dataset items batch by datasetId '{}', datasetName '{}', size '{}' on workspaceId '{}'",
                 batch.datasetId(), batch.datasetName(), batch.items().size(), workspaceId);
 
-        // If query parameter is set, versioning is enabled, and we have a version, return the summary
-        if (respondWithLatestVersion && featureFlags.isDatasetVersioningEnabled() && version != null) {
-            DatasetVersionSummary summary = DatasetVersionMapper.INSTANCE.toDatasetVersionSummary(version);
-            return Response.ok(summary).build();
-        }
-
-        // Default behavior: return 204 No Content
         return Response.noContent().build();
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -14,7 +14,6 @@ import com.comet.opik.api.DatasetItemStreamRequest;
 import com.comet.opik.api.DatasetItemUpdate;
 import com.comet.opik.api.DatasetItemsDelete;
 import com.comet.opik.api.DatasetVersion;
-import com.comet.opik.api.DatasetVersionSummary;
 import com.comet.opik.api.DatasetVersionTag;
 import com.comet.opik.api.DatasetVersionUpdate;
 import com.comet.opik.api.Experiment;
@@ -2248,56 +2247,6 @@ class DatasetVersionResourceTest {
         }
 
         @Test
-        @DisplayName("Success: PUT /items with respond_with_latest_version=true returns DatasetVersionSummary")
-        void putItems_whenRespondWithLatestVersionTrue_thenReturnsDatasetVersionSummary() {
-            // given
-            var datasetName = UUID.randomUUID().toString();
-            var datasetId = createDataset(datasetName);
-
-            var items = IntStream.range(0, 3)
-                    .mapToObj(i -> {
-                        DatasetItem item = factory.manufacturePojo(DatasetItem.class);
-                        Map<String, JsonNode> data = Map.of(
-                                "input", JsonUtils.getJsonNodeFromString("\"test input " + i + "\""),
-                                "output", JsonUtils.getJsonNodeFromString("\"test output " + i + "\""));
-                        return item.toBuilder()
-                                .id(null)
-                                .source(DatasetItemSource.MANUAL)
-                                .traceId(null)
-                                .spanId(null)
-                                .data(data)
-                                .build();
-                    })
-                    .toList();
-
-            var batch = DatasetItemBatch.builder()
-                    .datasetId(datasetId)
-                    .items(items)
-                    .build();
-
-            // when - PUT with respond_with_latest_version=true
-            try (var actualResponse = client.target("%s/v1/private/datasets".formatted(baseURI))
-                    .path("items")
-                    .queryParam("respond_with_latest_version", "true")
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .put(Entity.json(batch))) {
-
-                // then
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
-                assertThat(actualResponse.hasEntity()).isTrue();
-
-                var versionSummary = actualResponse.readEntity(DatasetVersionSummary.class);
-                assertThat(versionSummary).isNotNull();
-                assertThat(versionSummary.id()).isNotNull();
-                assertThat(versionSummary.versionHash()).isNotNull();
-                assertThat(versionSummary.versionName()).isEqualTo("v1");
-                assertThat(versionSummary.tags()).contains("latest");
-            }
-        }
-
-        @Test
         @DisplayName("Success: PUT /items without query param returns 204 (backward compatibility)")
         void putItems_whenRespondWithLatestVersionNotSet_thenReturnsNoContent() {
             // given
@@ -2336,90 +2285,6 @@ class DatasetVersionResourceTest {
                 // then - should return 204 No Content (backward compatible)
                 assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(204);
                 assertThat(actualResponse.hasEntity()).isFalse();
-            }
-        }
-
-        @Test
-        @DisplayName("Success: PUT /items with respond_with_latest_version=true returns updated version on subsequent calls")
-        void putItems_whenRespondWithLatestVersionTrue_thenReturnsUpdatedVersionSummary() {
-            // given
-            var datasetName = UUID.randomUUID().toString();
-            var datasetId = createDataset(datasetName);
-
-            // Create first version
-            var items1 = IntStream.range(0, 2)
-                    .mapToObj(i -> {
-                        DatasetItem item = factory.manufacturePojo(DatasetItem.class);
-                        Map<String, JsonNode> data = Map.of(
-                                "input", JsonUtils.getJsonNodeFromString("\"test input " + i + "\""),
-                                "output", JsonUtils.getJsonNodeFromString("\"test output " + i + "\""));
-                        return item.toBuilder()
-                                .id(null)
-                                .source(DatasetItemSource.MANUAL)
-                                .traceId(null)
-                                .spanId(null)
-                                .data(data)
-                                .build();
-                    })
-                    .toList();
-
-            var batch1 = DatasetItemBatch.builder()
-                    .datasetId(datasetId)
-                    .items(items1)
-                    .build();
-
-            DatasetVersionSummary version1Summary;
-            try (var response1 = client.target("%s/v1/private/datasets".formatted(baseURI))
-                    .path("items")
-                    .queryParam("respond_with_latest_version", "true")
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .put(Entity.json(batch1))) {
-
-                assertThat(response1.getStatusInfo().getStatusCode()).isEqualTo(200);
-                version1Summary = response1.readEntity(DatasetVersionSummary.class);
-                assertThat(version1Summary.versionName()).isEqualTo("v1");
-            }
-
-            // when - Create second version
-            var items2 = IntStream.range(2, 4)
-                    .mapToObj(i -> {
-                        DatasetItem item = factory.manufacturePojo(DatasetItem.class);
-                        Map<String, JsonNode> data = Map.of(
-                                "input", JsonUtils.getJsonNodeFromString("\"test input " + i + "\""),
-                                "output", JsonUtils.getJsonNodeFromString("\"test output " + i + "\""));
-                        return item.toBuilder()
-                                .id(null)
-                                .source(DatasetItemSource.MANUAL)
-                                .traceId(null)
-                                .spanId(null)
-                                .data(data)
-                                .build();
-                    })
-                    .toList();
-
-            var batch2 = DatasetItemBatch.builder()
-                    .datasetId(datasetId)
-                    .items(items2)
-                    .build();
-
-            try (var response2 = client.target("%s/v1/private/datasets".formatted(baseURI))
-                    .path("items")
-                    .queryParam("respond_with_latest_version", "true")
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .put(Entity.json(batch2))) {
-
-                // then
-                assertThat(response2.getStatusInfo().getStatusCode()).isEqualTo(200);
-                var version2Summary = response2.readEntity(DatasetVersionSummary.class);
-                assertThat(version2Summary).isNotNull();
-                assertThat(version2Summary.id()).isNotEqualTo(version1Summary.id());
-                assertThat(version2Summary.versionHash()).isNotEqualTo(version1Summary.versionHash());
-                assertThat(version2Summary.versionName()).isEqualTo("v2");
-                assertThat(version2Summary.tags()).contains("latest");
             }
         }
     }

--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -1450,12 +1450,6 @@ paths:
       summary: Create/update dataset items
       description: Create/update dataset items based on dataset item id
       operationId: createOrUpdateDatasetItems
-      parameters:
-      - name: respond_with_latest_version
-        in: query
-        schema:
-          type: boolean
-          default: false
       requestBody:
         content:
           application/json:
@@ -1464,12 +1458,6 @@ paths:
       responses:
         "204":
           description: No content
-        "200":
-          description: Dataset version summary
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DatasetVersionSummary"
   /v1/private/datasets/items/from-csv:
     post:
       tags:

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -1450,12 +1450,6 @@ paths:
       summary: Create/update dataset items
       description: Create/update dataset items based on dataset item id
       operationId: createOrUpdateDatasetItems
-      parameters:
-      - name: respond_with_latest_version
-        in: query
-        schema:
-          type: boolean
-          default: false
       requestBody:
         content:
           application/json:
@@ -1464,12 +1458,6 @@ paths:
       responses:
         "204":
           description: No content
-        "200":
-          description: Dataset version summary
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DatasetVersionSummary"
   /v1/private/datasets/items/from-csv:
     post:
       tags:

--- a/sdks/python/src/opik/rest_api/datasets/client.py
+++ b/sdks/python/src/opik/rest_api/datasets/client.py
@@ -18,7 +18,6 @@ from ..types.dataset_public import DatasetPublic
 from ..types.dataset_version_diff import DatasetVersionDiff
 from ..types.dataset_version_page_public import DatasetVersionPagePublic
 from ..types.dataset_version_public import DatasetVersionPublic
-from ..types.dataset_version_summary import DatasetVersionSummary
 from ..types.json_node import JsonNode
 from ..types.page_columns import PageColumns
 from ..types.project_stats_public import ProjectStatsPublic
@@ -253,19 +252,16 @@ class DatasetsClient:
         self,
         *,
         items: typing.Sequence[DatasetItemWrite],
-        respond_with_latest_version: typing.Optional[bool] = None,
         dataset_name: typing.Optional[str] = OMIT,
         dataset_id: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
-    ) -> DatasetVersionSummary:
+    ) -> None:
         """
         Create/update dataset items based on dataset item id
 
         Parameters
         ----------
         items : typing.Sequence[DatasetItemWrite]
-
-        respond_with_latest_version : typing.Optional[bool]
 
         dataset_name : typing.Optional[str]
             If null, dataset_id must be provided
@@ -278,8 +274,7 @@ class DatasetsClient:
 
         Returns
         -------
-        DatasetVersionSummary
-            Dataset version summary
+        None
 
         Examples
         --------
@@ -290,11 +285,7 @@ class DatasetsClient:
         }, )], )
         """
         _response = self._raw_client.create_or_update_dataset_items(
-            items=items,
-            respond_with_latest_version=respond_with_latest_version,
-            dataset_name=dataset_name,
-            dataset_id=dataset_id,
-            request_options=request_options,
+            items=items, dataset_name=dataset_name, dataset_id=dataset_id, request_options=request_options
         )
         return _response.data
 
@@ -1432,19 +1423,16 @@ class AsyncDatasetsClient:
         self,
         *,
         items: typing.Sequence[DatasetItemWrite],
-        respond_with_latest_version: typing.Optional[bool] = None,
         dataset_name: typing.Optional[str] = OMIT,
         dataset_id: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
-    ) -> DatasetVersionSummary:
+    ) -> None:
         """
         Create/update dataset items based on dataset item id
 
         Parameters
         ----------
         items : typing.Sequence[DatasetItemWrite]
-
-        respond_with_latest_version : typing.Optional[bool]
 
         dataset_name : typing.Optional[str]
             If null, dataset_id must be provided
@@ -1457,8 +1445,7 @@ class AsyncDatasetsClient:
 
         Returns
         -------
-        DatasetVersionSummary
-            Dataset version summary
+        None
 
         Examples
         --------
@@ -1472,11 +1459,7 @@ class AsyncDatasetsClient:
         asyncio.run(main())
         """
         _response = await self._raw_client.create_or_update_dataset_items(
-            items=items,
-            respond_with_latest_version=respond_with_latest_version,
-            dataset_name=dataset_name,
-            dataset_id=dataset_id,
-            request_options=request_options,
+            items=items, dataset_name=dataset_name, dataset_id=dataset_id, request_options=request_options
         )
         return _response.data
 

--- a/sdks/python/src/opik/rest_api/datasets/raw_client.py
+++ b/sdks/python/src/opik/rest_api/datasets/raw_client.py
@@ -28,7 +28,6 @@ from ..types.dataset_public import DatasetPublic
 from ..types.dataset_version_diff import DatasetVersionDiff
 from ..types.dataset_version_page_public import DatasetVersionPagePublic
 from ..types.dataset_version_public import DatasetVersionPublic
-from ..types.dataset_version_summary import DatasetVersionSummary
 from ..types.json_node import JsonNode
 from ..types.page_columns import PageColumns
 from ..types.project_stats_public import ProjectStatsPublic
@@ -346,19 +345,16 @@ class RawDatasetsClient:
         self,
         *,
         items: typing.Sequence[DatasetItemWrite],
-        respond_with_latest_version: typing.Optional[bool] = None,
         dataset_name: typing.Optional[str] = OMIT,
         dataset_id: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
-    ) -> HttpResponse[DatasetVersionSummary]:
+    ) -> HttpResponse[None]:
         """
         Create/update dataset items based on dataset item id
 
         Parameters
         ----------
         items : typing.Sequence[DatasetItemWrite]
-
-        respond_with_latest_version : typing.Optional[bool]
 
         dataset_name : typing.Optional[str]
             If null, dataset_id must be provided
@@ -371,15 +367,11 @@ class RawDatasetsClient:
 
         Returns
         -------
-        HttpResponse[DatasetVersionSummary]
-            Dataset version summary
+        HttpResponse[None]
         """
         _response = self._client_wrapper.httpx_client.request(
             "v1/private/datasets/items",
             method="PUT",
-            params={
-                "respond_with_latest_version": respond_with_latest_version,
-            },
             json={
                 "dataset_name": dataset_name,
                 "dataset_id": dataset_id,
@@ -395,14 +387,7 @@ class RawDatasetsClient:
         )
         try:
             if 200 <= _response.status_code < 300:
-                _data = typing.cast(
-                    DatasetVersionSummary,
-                    parse_obj_as(
-                        type_=DatasetVersionSummary,  # type: ignore
-                        object_=_response.json(),
-                    ),
-                )
-                return HttpResponse(response=_response, data=_data)
+                return HttpResponse(response=_response, data=None)
             _response_json = _response.json()
         except JSONDecodeError:
             raise ApiError(status_code=_response.status_code, headers=dict(_response.headers), body=_response.text)
@@ -2037,19 +2022,16 @@ class AsyncRawDatasetsClient:
         self,
         *,
         items: typing.Sequence[DatasetItemWrite],
-        respond_with_latest_version: typing.Optional[bool] = None,
         dataset_name: typing.Optional[str] = OMIT,
         dataset_id: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
-    ) -> AsyncHttpResponse[DatasetVersionSummary]:
+    ) -> AsyncHttpResponse[None]:
         """
         Create/update dataset items based on dataset item id
 
         Parameters
         ----------
         items : typing.Sequence[DatasetItemWrite]
-
-        respond_with_latest_version : typing.Optional[bool]
 
         dataset_name : typing.Optional[str]
             If null, dataset_id must be provided
@@ -2062,15 +2044,11 @@ class AsyncRawDatasetsClient:
 
         Returns
         -------
-        AsyncHttpResponse[DatasetVersionSummary]
-            Dataset version summary
+        AsyncHttpResponse[None]
         """
         _response = await self._client_wrapper.httpx_client.request(
             "v1/private/datasets/items",
             method="PUT",
-            params={
-                "respond_with_latest_version": respond_with_latest_version,
-            },
             json={
                 "dataset_name": dataset_name,
                 "dataset_id": dataset_id,
@@ -2086,14 +2064,7 @@ class AsyncRawDatasetsClient:
         )
         try:
             if 200 <= _response.status_code < 300:
-                _data = typing.cast(
-                    DatasetVersionSummary,
-                    parse_obj_as(
-                        type_=DatasetVersionSummary,  # type: ignore
-                        object_=_response.json(),
-                    ),
-                )
-                return AsyncHttpResponse(response=_response, data=_data)
+                return AsyncHttpResponse(response=_response, data=None)
             _response_json = _response.json()
         except JSONDecodeError:
             raise ApiError(status_code=_response.status_code, headers=dict(_response.headers), body=_response.text)

--- a/sdks/typescript/src/opik/rest_api/api/resources/datasets/client/Client.ts
+++ b/sdks/typescript/src/opik/rest_api/api/resources/datasets/client/Client.ts
@@ -466,20 +466,14 @@ export class Datasets {
     public createOrUpdateDatasetItems(
         request: OpikApi.DatasetItemBatchWrite,
         requestOptions?: Datasets.RequestOptions,
-    ): core.HttpResponsePromise<OpikApi.DatasetVersionSummary> {
+    ): core.HttpResponsePromise<void> {
         return core.HttpResponsePromise.fromPromise(this.__createOrUpdateDatasetItems(request, requestOptions));
     }
 
     private async __createOrUpdateDatasetItems(
         request: OpikApi.DatasetItemBatchWrite,
         requestOptions?: Datasets.RequestOptions,
-    ): Promise<core.WithRawResponse<OpikApi.DatasetVersionSummary>> {
-        const { respondWithLatestVersion, ..._body } = request;
-        const _queryParams: Record<string, string | string[] | object | object[] | null> = {};
-        if (respondWithLatestVersion != null) {
-            _queryParams["respond_with_latest_version"] = respondWithLatestVersion.toString();
-        }
-
+    ): Promise<core.WithRawResponse<void>> {
         const _response = await core.fetcher({
             url: urlJoin(
                 (await core.Supplier.get(this._options.baseUrl)) ??
@@ -500,24 +494,15 @@ export class Datasets {
                 ...requestOptions?.headers,
             },
             contentType: "application/json",
-            queryParameters: _queryParams,
             requestType: "json",
-            body: serializers.DatasetItemBatchWrite.jsonOrThrow(_body, { unrecognizedObjectKeys: "strip" }),
+            body: serializers.DatasetItemBatchWrite.jsonOrThrow(request, { unrecognizedObjectKeys: "strip" }),
             timeoutMs: requestOptions?.timeoutInSeconds != null ? requestOptions.timeoutInSeconds * 1000 : 60000,
             maxRetries: requestOptions?.maxRetries,
             withCredentials: true,
             abortSignal: requestOptions?.abortSignal,
         });
         if (_response.ok) {
-            return {
-                data: serializers.DatasetVersionSummary.parseOrThrow(_response.body, {
-                    unrecognizedObjectKeys: "passthrough",
-                    allowUnrecognizedUnionMembers: true,
-                    allowUnrecognizedEnumValues: true,
-                    breadcrumbsPrefix: ["response"],
-                }),
-                rawResponse: _response.rawResponse,
-            };
+            return { data: undefined, rawResponse: _response.rawResponse };
         }
 
         if (_response.error.reason === "status-code") {

--- a/sdks/typescript/src/opik/rest_api/api/resources/datasets/client/requests/DatasetItemBatchWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/api/resources/datasets/client/requests/DatasetItemBatchWrite.ts
@@ -16,7 +16,6 @@ import * as OpikApi from "../../../../index";
  *     }
  */
 export interface DatasetItemBatchWrite {
-    respondWithLatestVersion?: boolean;
     /** If null, dataset_id must be provided */
     datasetName?: string;
     /** If null, dataset_name must be provided */

--- a/sdks/typescript/src/opik/rest_api/serialization/resources/datasets/client/requests/DatasetItemBatchWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/resources/datasets/client/requests/DatasetItemBatchWrite.ts
@@ -9,7 +9,7 @@ import { DatasetItemWrite } from "../../../../types/DatasetItemWrite";
 
 export const DatasetItemBatchWrite: core.serialization.Schema<
     serializers.DatasetItemBatchWrite.Raw,
-    Omit<OpikApi.DatasetItemBatchWrite, "respondWithLatestVersion">
+    OpikApi.DatasetItemBatchWrite
 > = core.serialization.object({
     datasetName: core.serialization.property("dataset_name", core.serialization.string().optional()),
     datasetId: core.serialization.property("dataset_id", core.serialization.string().optional()),


### PR DESCRIPTION
## Details
In a previous PR, a conditional response was introduced to create dataset items endpoint. This was for the FE use in the dataset versioning feature.
That didn't play well with the autogenerated fern types. Therefore, we decided to revert this change and fix it differently.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-0000

## Testing
Covered by existing tests.

## Documentation
No need.
