### PR TITLE
[NA] [FE] Send organizationId param for username autocomplete

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/InviteUsersPopover.tsx
+++ b/apps/opik-frontend/src/plugins/comet/InviteUsersPopover.tsx
@@ -49,6 +49,7 @@ const InviteUsersPopover: React.FC<InviteUsersPopoverProps> = ({
   const { data: users = [], isLoading } = useUsernameAutocomplete(
     {
       query: searchQuery,
+      organizationId,
     },
     {
       enabled:

--- a/apps/opik-frontend/src/plugins/comet/api/useUsernameAutocomplete.ts
+++ b/apps/opik-frontend/src/plugins/comet/api/useUsernameAutocomplete.ts
@@ -3,7 +3,7 @@ import api, { QueryConfig } from "../api";
 
 interface UseUsernameAutocompleteParams {
   query: string;
-  organizationId?: string;
+  organizationId: string;
   excludedWorkspaceId?: string;
 }
 


### PR DESCRIPTION
## Details

This change ensures the `organizationId` parameter is properly passed to the username autocomplete API endpoint. The parameter was previously optional but is now required to ensure correct filtering of users within the organization context.

### Changes:
- Updated `useUsernameAutocomplete` hook to make `organizationId` a required parameter (was optional)
- Modified `InviteUsersPopover` component to pass `organizationId` to the autocomplete hook

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- CM-13852

## Testing

- Manual testing of the invite users popover to verify username autocomplete correctly filters by organization

## Documentation

N/A