### PR TITLE
[OPIK-3547] [FE] Fix CSV upload validation failing on Windows

### DIFF
--- a/apps/opik-frontend/src/lib/file.test.ts
+++ b/apps/opik-frontend/src/lib/file.test.ts
@@ -33,6 +33,17 @@ describe("validateCsvFile", () => {
     });
   });
 
+  it("should accept .csv file with empty MIME type (Windows behavior)", async () => {
+    // On Windows, browsers often return empty string for file.type on CSV files
+    const mockFile = new File(["col1,col2\nval1,val2"], "test.csv", {
+      type: "",
+    });
+    const mockData = [{ col1: "val1", col2: "val2" }];
+    vi.mocked(csv2json).mockResolvedValue(mockData);
+    const result = await validateCsvFile(mockFile, maxSize, maxItems);
+    expect(result).toEqual({ data: mockData });
+  });
+
   it("should return an error if CSV parsing fails", async () => {
     const mockFile = new File(["content"], "test.csv", { type: "text/csv" });
     vi.mocked(csv2json).mockRejectedValue(new Error("Parsing error"));

--- a/apps/opik-frontend/src/lib/file.ts
+++ b/apps/opik-frontend/src/lib/file.ts
@@ -33,7 +33,7 @@ export async function validateCsvFile(
     return { error: `File exceeds maximum size (${maxSize}MB).` };
   }
 
-  if (!file.type || !file.type.includes("text/csv")) {
+  if (!file.name.toLowerCase().endsWith(".csv")) {
     return { error: "File must be in .csv format" };
   }
 


### PR DESCRIPTION
## Details
Fix CSV file upload validation error on Windows where users see "File must be in .csv format" error even for valid CSV files.

**Root cause**: The `validateCsvFile()` function was checking `file.type` (MIME type) which returns an empty string on Windows due to missing MIME type registry associations for CSV files.

**Solution**: Replace MIME type check with file extension validation (`file.name.toLowerCase().endsWith(".csv")`), which is:
- Consistent with the existing CSV mode validation path
- Reliable across all operating systems
- Safe because content validation (`csv2json`) catches invalid files anyway

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3547

## Testing
- Added test case for empty MIME type scenario (simulating Windows behavior)
- All 8 existing tests pass
- Manual testing: CSV files with empty MIME type now pass validation

## Documentation
N/A - Internal bug fix, no documentation changes required