### PR TITLE
[OPIK-3275] [FE] Fix duplicate video attachments in playground trace

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/AttachmentsList.test.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/AttachmentsList.test.tsx
@@ -1,0 +1,231 @@
+import { describe, it, expect } from "vitest";
+import uniqBy from "lodash/uniqBy";
+import { ATTACHMENT_TYPE, ParsedMediaData } from "@/types/attachments";
+
+// Test the deduplication logic used in AttachmentsList component
+describe("AttachmentsList deduplication logic", () => {
+  it("should deduplicate attachments with the same URL", () => {
+    const attachments = [
+      {
+        name: "video.mp4",
+        url: "https://example.com/video.mp4",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+    ];
+
+    const media: ParsedMediaData[] = [
+      {
+        name: "video.mp4",
+        url: "https://example.com/video.mp4",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+    ];
+
+    const combined = [...attachments, ...media];
+    const deduplicated = uniqBy(combined, "url");
+
+    // Should only have one entry for the video URL
+    expect(deduplicated).toHaveLength(1);
+    expect(deduplicated[0].url).toBe("https://example.com/video.mp4");
+  });
+
+  it("should keep first occurrence when deduplicating", () => {
+    const attachments = [
+      {
+        name: "backend-name.mp4",
+        url: "https://example.com/video.mp4",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+    ];
+
+    const media: ParsedMediaData[] = [
+      {
+        name: "frontend-name.mp4",
+        url: "https://example.com/video.mp4",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+    ];
+
+    const combined = [...attachments, ...media];
+    const deduplicated = uniqBy(combined, "url");
+
+    // Should keep the first occurrence (from attachments)
+    expect(deduplicated).toHaveLength(1);
+    expect(deduplicated[0].name).toBe("backend-name.mp4");
+  });
+
+  it("should not deduplicate different URLs", () => {
+    const attachments = [
+      {
+        name: "video1.mp4",
+        url: "https://example.com/video1.mp4",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+    ];
+
+    const media: ParsedMediaData[] = [
+      {
+        name: "video2.mp4",
+        url: "https://example.com/video2.mp4",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+    ];
+
+    const combined = [...attachments, ...media];
+    const deduplicated = uniqBy(combined, "url");
+
+    // Should have both videos
+    expect(deduplicated).toHaveLength(2);
+    expect(deduplicated[0].url).toBe("https://example.com/video1.mp4");
+    expect(deduplicated[1].url).toBe("https://example.com/video2.mp4");
+  });
+
+  it("should handle video URL passed as image in playground", () => {
+    // Simulates the bug scenario: video URL added to image field in playground
+    const attachments = [
+      {
+        name: "video.mp4",
+        url: "https://cdn.example.com/video.mp4",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+    ];
+
+    const media: ParsedMediaData[] = [
+      {
+        name: "video.mp4",
+        url: "https://cdn.example.com/video.mp4",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+    ];
+
+    const combined = [...attachments, ...media];
+    const deduplicated = uniqBy(combined, "url");
+
+    // Should only show one attachment, not two
+    expect(deduplicated).toHaveLength(1);
+    expect(deduplicated[0].url).toBe("https://cdn.example.com/video.mp4");
+    expect(deduplicated[0].type).toBe(ATTACHMENT_TYPE.VIDEO);
+  });
+
+  it("should handle multiple duplicates and unique items", () => {
+    const attachments = [
+      {
+        name: "video1.mp4",
+        url: "https://example.com/video1.mp4",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+      {
+        name: "image1.jpg",
+        url: "https://example.com/image1.jpg",
+        type: ATTACHMENT_TYPE.IMAGE,
+      },
+    ];
+
+    const media: ParsedMediaData[] = [
+      {
+        name: "video1.mp4",
+        url: "https://example.com/video1.mp4",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+      {
+        name: "video2.mp4",
+        url: "https://example.com/video2.mp4",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+    ];
+
+    const combined = [...attachments, ...media];
+    const deduplicated = uniqBy(combined, "url");
+
+    // Should have 3 unique items: video1, image1, video2
+    expect(deduplicated).toHaveLength(3);
+    expect(deduplicated.find((d) => d.url.includes("video1"))).toBeDefined();
+    expect(deduplicated.find((d) => d.url.includes("image1"))).toBeDefined();
+    expect(deduplicated.find((d) => d.url.includes("video2"))).toBeDefined();
+  });
+
+  it("should handle empty attachments", () => {
+    const attachments: typeof media = [];
+    const media: ParsedMediaData[] = [
+      {
+        name: "video.mp4",
+        url: "https://example.com/video.mp4",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+    ];
+
+    const combined = [...attachments, ...media];
+    const deduplicated = uniqBy(combined, "url");
+
+    expect(deduplicated).toHaveLength(1);
+    expect(deduplicated[0].url).toBe("https://example.com/video.mp4");
+  });
+
+  it("should handle empty media", () => {
+    const attachments = [
+      {
+        name: "video.mp4",
+        url: "https://example.com/video.mp4",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+    ];
+    const media: ParsedMediaData[] = [];
+
+    const combined = [...attachments, ...media];
+    const deduplicated = uniqBy(combined, "url");
+
+    expect(deduplicated).toHaveLength(1);
+    expect(deduplicated[0].url).toBe("https://example.com/video.mp4");
+  });
+
+  it("should handle URLs with query parameters", () => {
+    const attachments = [
+      {
+        name: "video.mp4",
+        url: "https://example.com/video.mp4?quality=high&size=large",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+    ];
+
+    const media: ParsedMediaData[] = [
+      {
+        name: "video.mp4",
+        url: "https://example.com/video.mp4?quality=high&size=large",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+    ];
+
+    const combined = [...attachments, ...media];
+    const deduplicated = uniqBy(combined, "url");
+
+    // Should deduplicate even with query parameters
+    expect(deduplicated).toHaveLength(1);
+    expect(deduplicated[0].url).toBe(
+      "https://example.com/video.mp4?quality=high&size=large",
+    );
+  });
+
+  it("should treat URLs with different query parameters as different", () => {
+    const attachments = [
+      {
+        name: "video.mp4",
+        url: "https://example.com/video.mp4?quality=high",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+    ];
+
+    const media: ParsedMediaData[] = [
+      {
+        name: "video.mp4",
+        url: "https://example.com/video.mp4?quality=low",
+        type: ATTACHMENT_TYPE.VIDEO,
+      },
+    ];
+
+    const combined = [...attachments, ...media];
+    const deduplicated = uniqBy(combined, "url");
+
+    // Different query parameters = different URLs
+    expect(deduplicated).toHaveLength(2);
+  });
+});

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/AttachmentsList.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/AttachmentsList.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
+import uniqBy from "lodash/uniqBy";
 import { Span, Trace } from "@/types/traces";
 import useAttachmentsList from "@/api/attachments/useAttachmentsList";
 import { isObjectSpan } from "@/lib/traces";
@@ -64,7 +65,7 @@ const AttachmentsList: React.FC<AttachmentsListProps> = ({ data, media }) => {
   );
 
   const previewDataArray = useMemo(() => {
-    return [
+    const combined = [
       ...attachments.map((attachment) => ({
         name: attachment.file_name,
         url: attachment.link,
@@ -76,6 +77,11 @@ const AttachmentsList: React.FC<AttachmentsListProps> = ({ data, media }) => {
         type: media.type,
       })),
     ];
+
+    // Deduplicate by URL to prevent showing the same media twice
+    // This can happen when a video URL is passed as an image in the playground
+    // and gets detected both by backend attachments and frontend media detection
+    return uniqBy(combined, "url");
   }, [attachments, media]);
 
   const hasAttachments = previewDataArray.length > 0;


### PR DESCRIPTION
## Details

Fixed an issue where video URLs passed as images in the playground would appear twice in the trace attachments section. The problem occurred because:

1. When a video URL is added to the image field in the playground, it gets sent to the backend and stored as an attachment
2. The frontend media detection also detects the same video URL from the input data
3. Both sources were combined without deduplication, resulting in duplicate attachments

The fix adds URL-based deduplication when combining backend attachments and frontend-detected media in the `AttachmentsList` component using `uniqBy` from lodash.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-3275

## Testing

- Added comprehensive unit tests in `AttachmentsList.test.tsx` covering:
  - Deduplication of attachments with the same URL
  - Handling of video URLs passed as images in playground
  - Multiple duplicates and unique items
  - Empty attachments and media arrays
  - URLs with query parameters
- All existing tests pass:
  - `AttachmentsList.test.tsx`: 9 tests pass
  - `images.test.ts`: 28 tests pass
  - `media.test.ts`: 19 tests pass
- Linter passes with no errors

## Documentation

No documentation changes required - this is an internal bug fix that improves the existing functionality without changing the user-facing API or behavior.