### PR TITLE
[OPIK-3753] [FE] [BE] Remove dashboard feature toggle support

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -588,9 +588,6 @@ serviceToggles:
   # Default: true
   # Description: Whether or not export/download functionality is enabled
   exportEnabled: ${TOGGLE_EXPORT_ENABLED:-"true"}
-  # Default: true
-  # Description: Whether or not Dashboards feature is enabled
-  dashboardsEnabled: ${TOGGLE_DASHBOARDS_ENABLED:-"true"}
   # Default: false
   # Description: Whether or not dataset versioning feature is enabled
   datasetVersioningEnabled: ${TOGGLE_DATASET_VERSIONING_ENABLED:-"false"}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
@@ -30,8 +30,6 @@ public class ServiceTogglesConfig {
     @JsonProperty
     @NotNull boolean optimizationStudioEnabled;
     @JsonProperty
-    @NotNull boolean dashboardsEnabled;
-    @JsonProperty
     @NotNull boolean datasetVersioningEnabled;
     // LLM Provider feature flags
     @JsonProperty

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -432,9 +432,6 @@ serviceToggles:
   # Default: true
   # Description: Whether or not export/download functionality is enabled
   exportEnabled: "true"
-  # Default: true
-  # Description: Whether or not Dashboards feature is enabled
-  dashboardsEnabled: "true"
   # Default: false for testing (legacy mode)
   # Description: Whether or not dataset versioning feature is enabled
   datasetVersioningEnabled: "false"

--- a/apps/opik-frontend/src/components/feature-toggles-provider.tsx
+++ b/apps/opik-frontend/src/components/feature-toggles-provider.tsx
@@ -26,8 +26,7 @@ const DEFAULT_STATE: FeatureToggles = {
   [FeatureToggleKeys.OPTIMIZATION_STUDIO_ENABLED]: false,
   [FeatureToggleKeys.SPAN_LLM_AS_JUDGE_ENABLED]: false,
   [FeatureToggleKeys.SPAN_USER_DEFINED_METRIC_PYTHON_ENABLED]: false,
-  [FeatureToggleKeys.DASHBOARDS_ENABLED]: false,
-  // LLM Provider feature flags - default false (server controls actual values)
+  // LLM Provider feature flags - default false
   [FeatureToggleKeys.OPENAI_PROVIDER_ENABLED]: false,
   [FeatureToggleKeys.ANTHROPIC_PROVIDER_ENABLED]: false,
   [FeatureToggleKeys.GEMINI_PROVIDER_ENABLED]: false,

--- a/apps/opik-frontend/src/components/layout/SideBar/SideBar.tsx
+++ b/apps/opik-frontend/src/components/layout/SideBar/SideBar.tsx
@@ -45,7 +45,6 @@ import SidebarMenuItem, {
   MenuItemGroup,
 } from "@/components/layout/SideBar/MenuItem/SidebarMenuItem";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
-import { useIsFeatureEnabled } from "@/components/feature-toggles-provider";
 import { ACTIVE_OPTIMIZATION_FILTER } from "@/lib/optimizations";
 
 const HOME_PATH = "/$workspaceName/home";
@@ -78,7 +77,6 @@ const MENU_ITEMS: MenuItemGroup[] = [
         icon: ChartLine,
         label: "Dashboards",
         count: "dashboards",
-        featureFlag: FeatureToggleKeys.DASHBOARDS_ENABLED,
       },
     ],
   },
@@ -200,9 +198,6 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
   const { open: openQuickstart } = useOpenQuickStartDialog();
 
   const { activeWorkspaceName: workspaceName } = useAppStore();
-  const isDashboardsEnabled = useIsFeatureEnabled(
-    FeatureToggleKeys.DASHBOARDS_ENABLED,
-  );
   const LogoComponent = usePluginsStore((state) => state.Logo);
   const SidebarInviteDevButton = usePluginsStore(
     (state) => state.SidebarInviteDevButton,
@@ -326,7 +321,7 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
     },
     {
       placeholderData: keepPreviousData,
-      enabled: expanded && isDashboardsEnabled,
+      enabled: expanded,
     },
   );
 

--- a/apps/opik-frontend/src/components/pages-shared/dashboards/ViewSelector/ViewSelector.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/dashboards/ViewSelector/ViewSelector.tsx
@@ -6,8 +6,6 @@ import {
   useDashboardStore,
   selectHasUnsavedChanges,
 } from "@/store/DashboardStore";
-import { useIsFeatureEnabled } from "@/components/feature-toggles-provider";
-import { FeatureToggleKeys } from "@/types/feature-toggles";
 
 export enum VIEW_TYPE {
   DETAILS = "details",
@@ -21,14 +19,8 @@ interface ViewSelectorProps {
 
 const ViewSelector: React.FC<ViewSelectorProps> = ({ value, onChange }) => {
   const hasUnsavedChanges = useDashboardStore(selectHasUnsavedChanges);
-  const isDashboardsEnabled = useIsFeatureEnabled(
-    FeatureToggleKeys.DASHBOARDS_ENABLED,
-  );
   const disabled = value === VIEW_TYPE.DASHBOARDS && hasUnsavedChanges;
 
-  if (!isDashboardsEnabled) {
-    return null;
-  }
   const content = (
     <ToggleGroup
       type="single"

--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
@@ -20,8 +20,6 @@ import { generateExperimentIdFilter } from "@/lib/filters";
 import ViewSelector, {
   VIEW_TYPE,
 } from "@/components/pages-shared/dashboards/ViewSelector/ViewSelector";
-import { useIsFeatureEnabled } from "@/components/feature-toggles-provider";
-import { FeatureToggleKeys } from "@/types/feature-toggles";
 import { Separator } from "@/components/ui/separator";
 
 type ExperimentScoreTagsProps = {
@@ -81,11 +79,6 @@ const CompareExperimentsDetails: React.FunctionComponent<
   const title = !isCompare
     ? experiment?.name
     : `Compare (${experimentsIds.length})`;
-
-  // TODO: Remove when dashboards are enabled by default - this entire expand/collapse charts feature will be replaced by dashboard view
-  const isDashboardsEnabled = useIsFeatureEnabled(
-    FeatureToggleKeys.DASHBOARDS_ENABLED,
-  );
 
   const [showCharts = true, setShowCharts] = useQueryParam(
     "chartsExpanded",
@@ -217,14 +210,10 @@ const CompareExperimentsDetails: React.FunctionComponent<
           {isCompare &&
             view !== VIEW_TYPE.DASHBOARDS &&
             renderCompareFeedbackScoresButton()}
-          {isDashboardsEnabled && (
-            <>
-              {isCompare && view !== VIEW_TYPE.DASHBOARDS && (
-                <Separator orientation="vertical" className="mx-2 h-6" />
-              )}
-              <ViewSelector value={view} onChange={onViewChange} />
-            </>
+          {isCompare && view !== VIEW_TYPE.DASHBOARDS && (
+            <Separator orientation="vertical" className="mx-2 h-6" />
           )}
+          <ViewSelector value={view} onChange={onViewChange} />
         </div>
       </div>
       <div className="mb-1 flex gap-2 overflow-x-auto">

--- a/apps/opik-frontend/src/types/feature-toggles.ts
+++ b/apps/opik-frontend/src/types/feature-toggles.ts
@@ -11,7 +11,6 @@ export enum FeatureToggleKeys {
   DATASET_VERSIONING_ENABLED = "dataset_versioning_enabled",
   SPAN_LLM_AS_JUDGE_ENABLED = "span_llm_as_judge_enabled",
   SPAN_USER_DEFINED_METRIC_PYTHON_ENABLED = "span_user_defined_metric_python_enabled",
-  DASHBOARDS_ENABLED = "dashboards_enabled",
   OPTIMIZATION_STUDIO_ENABLED = "optimization_studio_enabled",
   // LLM Provider feature flags
   OPENAI_PROVIDER_ENABLED = "openai_provider_enabled",


### PR DESCRIPTION
## Details

Remove the `dashboardsEnabled` feature toggle from both frontend and backend codebase. The Dashboard feature is now permanently enabled and no longer requires toggle support.

**Backend Changes:**
- Removed `dashboardsEnabled` field from `ServiceTogglesConfig.java`
- Removed `dashboardsEnabled` configuration from `config.yml` and `config-test.yml`

**Frontend Changes:**
- Removed `DASHBOARDS_ENABLED` from `FeatureToggleKeys` enum
- Removed dashboard toggle from `feature-toggles-provider` default state
- Removed feature flag checks from `SideBar`, `ViewSelector`, and `CompareExperimentsDetails` components
- Cleaned up unused imports (`useIsFeatureEnabled` where no longer needed)

The dashboard feature is now always available without any toggle checks.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-3753

## Testing

- Backend compilation verified with `mvn compile -DskipTests`
- Frontend linting passes (`npm run lint`)
- TypeScript type checking passes (`npx tsc --noEmit`)
- Manual testing: Verified dashboards page loads correctly and sidebar shows dashboards menu item without toggle checks
- Local development environment verified: Dashboards feature works correctly with CORS enabled

## Documentation

N/A - No documentation changes required for this internal cleanup