### PR TITLE
Add OpenAI TTS Models Tracking Support

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ModelCostData.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ModelCostData.java
@@ -14,6 +14,7 @@ public record ModelCostData(String litellmProvider,
         String outputCostPerVideoPerSecond,
         String cacheCreationInputTokenCost,
         String cacheReadInputTokenCost,
+        String inputCostPerCharacter,
         String mode,
         boolean supportsVision) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/ModelPrice.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/ModelPrice.java
@@ -14,10 +14,12 @@ public record ModelPrice(
         @NonNull BigDecimal cacheCreationInputTokenPrice,
         @NonNull BigDecimal cacheReadInputTokenPrice,
         @NonNull BigDecimal videoOutputPrice,
+        @NonNull BigDecimal inputPricePerCharacter,
         @NonNull BiFunction<ModelPrice, Map<String, Integer>, BigDecimal> calculator) {
 
     public static ModelPrice empty() {
         return new ModelPrice(
+                BigDecimal.ZERO,
                 BigDecimal.ZERO,
                 BigDecimal.ZERO,
                 BigDecimal.ZERO,

--- a/sdks/python/src/opik/integrations/openai/openai_audio_speech_decorator.py
+++ b/sdks/python/src/opik/integrations/openai/openai_audio_speech_decorator.py
@@ -1,0 +1,131 @@
+import logging
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+from typing_extensions import override
+
+from opik.types import LLMProvider
+import opik.dict_utils as dict_utils
+import opik.llm_usage as llm_usage
+from opik.api_objects import span
+from opik.decorator import arguments_helpers, base_track_decorator
+
+LOGGER = logging.getLogger(__name__)
+
+KWARGS_KEYS_TO_LOG_AS_INPUTS = ["input", "voice", "response_format", "speed"]
+RESPONSE_KEYS_TO_LOG_AS_OUTPUT = ["content_type", "audio_format"]
+
+
+class OpenaiAudioSpeechTrackDecorator(base_track_decorator.BaseTrackDecorator):
+    """
+    An implementation of BaseTrackDecorator designed specifically for tracking
+    calls of OpenAI's `audio.speech.create` function for Text-to-Speech.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.provider = "openai"
+
+    @override
+    def _start_span_inputs_preprocessor(
+        self,
+        func: Callable,
+        track_options: arguments_helpers.TrackOptions,
+        args: Tuple,
+        kwargs: Dict[str, Any],
+    ) -> arguments_helpers.StartSpanParameters:
+        assert (
+            kwargs is not None
+        ), "Expected kwargs to be not None in audio.speech.create(**kwargs)"
+
+        name = track_options.name if track_options.name is not None else func.__name__
+
+        metadata = track_options.metadata if track_options.metadata is not None else {}
+
+        input_data, new_metadata = dict_utils.split_dict_by_keys(
+            kwargs, keys=KWARGS_KEYS_TO_LOG_AS_INPUTS
+        )
+        metadata = dict_utils.deepmerge(metadata, new_metadata)
+        metadata.update(
+            {
+                "created_from": "openai",
+                "type": "openai_audio_speech",
+            }
+        )
+
+        tags = ["openai", "tts"]
+
+        result = arguments_helpers.StartSpanParameters(
+            name=name,
+            input=input_data,
+            type=track_options.type,
+            tags=tags,
+            metadata=metadata,
+            project_name=track_options.project_name,
+            model=kwargs.get("model", None),
+            provider=self.provider,
+        )
+
+        return result
+
+    @override
+    def _end_span_inputs_preprocessor(
+        self,
+        output: Any,
+        capture_output: bool,
+        current_span_data: span.SpanData,
+    ) -> arguments_helpers.EndSpanParameters:
+        output_data: Dict[str, Any] = {}
+        metadata: Dict[str, Any] = {}
+
+        if hasattr(output, "content_type"):
+            output_data["content_type"] = output.content_type
+        if hasattr(output, "response") and hasattr(output.response, "headers"):
+            content_type = output.response.headers.get("content-type")
+            if content_type:
+                output_data["content_type"] = content_type
+
+        opik_usage = None
+        if current_span_data.input is not None:
+            input_text = current_span_data.input.get("input", "")
+            if isinstance(input_text, str):
+                character_count = len(input_text)
+                usage_dict = {
+                    "character_count": character_count,
+                    "total_tokens": character_count,
+                    "prompt_tokens": character_count,
+                    "completion_tokens": 0,
+                }
+                opik_usage = llm_usage.try_build_opik_usage_or_log_error(
+                    provider=LLMProvider.OPENAI,
+                    usage=usage_dict,
+                    logger=LOGGER,
+                    error_message="Failed to log character usage from openai TTS call",
+                )
+
+        model = current_span_data.model
+
+        result = arguments_helpers.EndSpanParameters(
+            output=output_data if output_data else {"status": "completed"},
+            usage=opik_usage,
+            metadata=metadata,
+            model=model,
+            provider=self.provider,
+        )
+
+        return result
+
+    @override
+    def _streams_handler(
+        self,
+        output: Any,
+        capture_output: bool,
+        generations_aggregator: Optional[Callable[[List[Any]], Any]],
+    ) -> Optional[Any]:
+        NOT_A_STREAM = None
+        return NOT_A_STREAM

--- a/sdks/python/src/opik/llm_usage/openai_audio_speech_usage.py
+++ b/sdks/python/src/opik/llm_usage/openai_audio_speech_usage.py
@@ -1,0 +1,47 @@
+from typing import Dict, Any
+from . import base_original_provider_usage
+
+
+class OpenAIAudioSpeechUsage(base_original_provider_usage.BaseOriginalProviderUsage):
+    """OpenAI Audio Speech (TTS) API usage data."""
+
+    character_count: int
+    """The number of characters in the input text."""
+
+    total_tokens: int
+    """Total tokens (stores character count for TTS compatibility)."""
+
+    prompt_tokens: int
+    """Prompt tokens (stores character count for TTS compatibility)."""
+
+    completion_tokens: int
+    """Completion tokens (always 0 for TTS)."""
+
+    def to_backend_compatible_flat_dict(self, parent_key_prefix: str) -> Dict[str, int]:
+        result = {**self.__dict__}
+
+        return self.flatten_result_and_add_model_extra(
+            result=result, parent_key_prefix=parent_key_prefix
+        )
+
+    @classmethod
+    def from_original_usage_dict(
+        cls, usage_dict: Dict[str, Any]
+    ) -> "OpenAIAudioSpeechUsage":
+        usage_dict = {**usage_dict}
+
+        if "character_count" not in usage_dict:
+            raise KeyError("character_count is required for TTS usage")
+
+        character_count = usage_dict.pop("character_count")
+        total_tokens = usage_dict.pop("total_tokens", character_count)
+        prompt_tokens = usage_dict.pop("prompt_tokens", character_count)
+        completion_tokens = usage_dict.pop("completion_tokens", 0)
+
+        return cls(
+            character_count=character_count,
+            total_tokens=total_tokens,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            **usage_dict,
+        )

--- a/sdks/python/src/opik/llm_usage/opik_usage.py
+++ b/sdks/python/src/opik/llm_usage/opik_usage.py
@@ -8,6 +8,7 @@ from . import (
     unknown_usage,
     bedrock_usage,
     openai_responses_usage,
+    openai_audio_speech_usage,
 )
 import opik.dict_utils as dict_utils
 
@@ -17,6 +18,7 @@ ProviderUsage = Union[
     anthropic_usage.AnthropicUsage,
     bedrock_usage.BedrockUsage,
     openai_responses_usage.OpenAIResponsesUsage,
+    openai_audio_speech_usage.OpenAIAudioSpeechUsage,
     unknown_usage.UnknownUsage,
 ]
 
@@ -164,6 +166,27 @@ class OpikUsage(pydantic.BaseModel):
         return cls(
             completion_tokens=provider_usage.output_tokens,
             prompt_tokens=provider_usage.input_tokens,
+            total_tokens=provider_usage.total_tokens,
+            provider_usage=provider_usage,
+        )
+
+    @classmethod
+    def from_openai_audio_speech_dict(cls, usage: Dict[str, Any]) -> "OpikUsage":
+        """
+        Create OpikUsage from OpenAI Audio Speech (TTS) usage dict.
+
+        TTS models are billed by character count, not by token count.
+        For compatibility, we store character count in the token fields.
+        """
+        provider_usage = (
+            openai_audio_speech_usage.OpenAIAudioSpeechUsage.from_original_usage_dict(
+                usage
+            )
+        )
+
+        return cls(
+            completion_tokens=provider_usage.completion_tokens,
+            prompt_tokens=provider_usage.prompt_tokens,
             total_tokens=provider_usage.total_tokens,
             provider_usage=provider_usage,
         )

--- a/sdks/python/src/opik/llm_usage/opik_usage_factory.py
+++ b/sdks/python/src/opik/llm_usage/opik_usage_factory.py
@@ -13,6 +13,7 @@ _PROVIDER_TO_OPIK_USAGE_BUILDERS: Dict[
     LLMProvider.OPENAI: [
         opik_usage.OpikUsage.from_openai_completions_dict,
         opik_usage.OpikUsage.from_openai_responses_dict,
+        opik_usage.OpikUsage.from_openai_audio_speech_dict,
     ],
     LLMProvider.GOOGLE_VERTEXAI: [opik_usage.OpikUsage.from_google_dict],
     LLMProvider.GOOGLE_AI: [opik_usage.OpikUsage.from_google_dict],

--- a/sdks/python/tests/library_integration/openai/test_openai_audio_speech.py
+++ b/sdks/python/tests/library_integration/openai/test_openai_audio_speech.py
@@ -1,0 +1,236 @@
+from typing import Any, Dict
+
+import openai
+import pytest
+
+import opik
+from opik.config import OPIK_PROJECT_DEFAULT_NAME
+from opik.integrations.openai import track_openai
+from ...testlib import (
+    ANY_BUT_NONE,
+    ANY_DICT,
+    SpanModel,
+    TraceModel,
+    assert_equal,
+)
+
+pytestmark = pytest.mark.usefixtures("ensure_openai_configured")
+
+TTS_MODEL = "tts-1"
+TTS_MODEL_HD = "tts-1-hd"
+
+
+def _assert_metadata_contains_required_keys(metadata: Dict[str, Any]) -> None:
+    REQUIRED_METADATA_KEYS = [
+        "created_from",
+        "type",
+    ]
+    for key in REQUIRED_METADATA_KEYS:
+        assert key in metadata, f"Expected key '{key}' not found in metadata"
+
+
+@pytest.mark.parametrize(
+    "project_name, expected_project_name",
+    [
+        (None, OPIK_PROJECT_DEFAULT_NAME),
+        ("openai-tts-integration-test", "openai-tts-integration-test"),
+    ],
+)
+def test_openai_client_audio_speech_create__happyflow(
+    fake_backend, project_name, expected_project_name
+):
+    """Test that audio.speech.create is tracked correctly."""
+    client = openai.OpenAI()
+    wrapped_client = track_openai(
+        openai_client=client,
+        project_name=project_name,
+    )
+
+    input_text = "Hello, this is a test of text to speech."
+
+    # Call TTS API
+    response = wrapped_client.audio.speech.create(
+        model=TTS_MODEL,
+        voice="alloy",
+        input=input_text,
+    )
+
+    # Consume the response to ensure tracking completes
+    _ = response.content
+
+    opik.flush_tracker()
+
+    # Calculate expected character count for usage
+    expected_character_count = len(input_text)
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio_speech_create",
+        input=ANY_DICT.containing({"input": input_text, "voice": "alloy"}),
+        output=ANY_DICT,
+        tags=["openai", "tts"],
+        metadata=ANY_DICT,
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=expected_project_name,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio_speech_create",
+                input=ANY_DICT.containing({"input": input_text, "voice": "alloy"}),
+                output=ANY_DICT,
+                tags=["openai", "tts"],
+                metadata=ANY_DICT,
+                usage={
+                    "prompt_tokens": expected_character_count,
+                    "completion_tokens": 0,
+                    "total_tokens": expected_character_count,
+                    "original_usage.character_count": expected_character_count,
+                    "original_usage.total_tokens": expected_character_count,
+                    "original_usage.prompt_tokens": expected_character_count,
+                    "original_usage.completion_tokens": 0,
+                },
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=expected_project_name,
+                spans=[],
+                model=TTS_MODEL,
+                provider="openai",
+            )
+        ],
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)
+
+    llm_span_metadata = trace_tree.spans[0].metadata
+    _assert_metadata_contains_required_keys(llm_span_metadata)
+
+
+def test_openai_client_audio_speech_create__create_raises_an_error__span_and_trace_finished_gracefully(
+    fake_backend,
+):
+    """Test that errors during TTS creation are handled gracefully."""
+    client = openai.OpenAI()
+    wrapped_client = track_openai(client)
+
+    with pytest.raises(openai.OpenAIError):
+        # Invalid model should raise an error
+        _ = wrapped_client.audio.speech.create(
+            model="invalid-model",
+            voice="alloy",
+            input="Test",
+        )
+
+    opik.flush_tracker()
+
+    # Verify trace was created even with error
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    # Verify error info is logged
+    assert trace_tree.error_info is not None
+    assert "exception_type" in trace_tree.error_info
+
+
+def test_openai_client_audio_speech_create__in_tracked_function__span_attached_to_existing_trace(
+    fake_backend,
+):
+    """Test that TTS calls within a tracked function are properly nested."""
+    project_name = "openai-tts-integration-test"
+    input_text = "Nested TTS test."
+
+    @opik.track(project_name=project_name)
+    def tts_wrapper() -> bytes:
+        client = openai.OpenAI()
+        wrapped_client = track_openai(client, project_name=project_name)
+
+        response = wrapped_client.audio.speech.create(
+            model=TTS_MODEL,
+            voice="nova",
+            input=input_text,
+        )
+        return response.content
+
+    _ = tts_wrapper()
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    # Should have wrapper span with TTS span nested inside
+    assert trace_tree.name == "tts_wrapper"
+    assert len(trace_tree.spans) == 1
+
+    wrapper_span = trace_tree.spans[0]
+    assert len(wrapper_span.spans) == 1
+
+    tts_span = wrapper_span.spans[0]
+    assert tts_span.name == "audio_speech_create"
+    assert tts_span.model == TTS_MODEL
+    assert "tts" in tts_span.tags
+
+
+def test_openai_client_audio_speech_create__different_models__model_logged_correctly(
+    fake_backend,
+):
+    """Test that different TTS models are logged correctly."""
+    client = openai.OpenAI()
+    wrapped_client = track_openai(client)
+
+    input_text = "Testing HD model."
+
+    response = wrapped_client.audio.speech.create(
+        model=TTS_MODEL_HD,
+        voice="shimmer",
+        input=input_text,
+    )
+    _ = response.content
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    assert len(trace_tree.spans) == 1
+    tts_span = trace_tree.spans[0]
+    assert tts_span.model == TTS_MODEL_HD
+
+
+@pytest.mark.asyncio
+async def test_async_openai_client_audio_speech_create__happyflow(
+    fake_backend,
+):
+    """Test that async audio.speech.create is tracked correctly."""
+    client = openai.AsyncOpenAI()
+    wrapped_client = track_openai(client)
+
+    input_text = "Hello from async TTS."
+
+    response = await wrapped_client.audio.speech.create(
+        model=TTS_MODEL,
+        voice="alloy",
+        input=input_text,
+    )
+    _ = response.content
+
+    opik.flush_tracker()
+
+    expected_character_count = len(input_text)
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    assert trace_tree.name == "audio_speech_create"
+    assert len(trace_tree.spans) == 1
+
+    tts_span = trace_tree.spans[0]
+    assert tts_span.name == "audio_speech_create"
+    assert tts_span.model == TTS_MODEL
+    assert tts_span.provider == "openai"
+    assert "tts" in tts_span.tags
+    assert tts_span.usage["total_tokens"] == expected_character_count

--- a/sdks/python/tests/unit/llm_usage/test_openai_audio_speech_usage.py
+++ b/sdks/python/tests/unit/llm_usage/test_openai_audio_speech_usage.py
@@ -1,0 +1,90 @@
+import pydantic
+import pytest
+
+from opik.llm_usage.openai_audio_speech_usage import OpenAIAudioSpeechUsage
+
+
+def test_openai_audio_speech_usage_creation__happyflow():
+    usage_data = {
+        "character_count": 150,
+        "total_tokens": 150,
+        "prompt_tokens": 150,
+        "completion_tokens": 0,
+    }
+    usage = OpenAIAudioSpeechUsage.from_original_usage_dict(usage_data)
+    assert usage.character_count == 150
+    assert usage.total_tokens == 150
+    assert usage.prompt_tokens == 150
+    assert usage.completion_tokens == 0
+
+
+def test_openai_audio_speech_usage_creation__character_count_required():
+    """Test that character_count is required and KeyError is raised without it."""
+    usage_data = {
+        "total_tokens": 200,
+        "prompt_tokens": 200,
+        "completion_tokens": 0,
+    }
+    with pytest.raises(KeyError, match="character_count is required"):
+        OpenAIAudioSpeechUsage.from_original_usage_dict(usage_data)
+
+
+def test_openai_audio_speech_usage_creation__minimal_data():
+    """Test with minimal data - just character_count."""
+    usage_data = {
+        "character_count": 100,
+    }
+    usage = OpenAIAudioSpeechUsage.from_original_usage_dict(usage_data)
+    assert usage.character_count == 100
+    assert usage.total_tokens == 100  # defaults to character_count
+    assert usage.prompt_tokens == 100  # defaults to character_count
+    assert usage.completion_tokens == 0
+
+
+def test_openai_audio_speech_usage__to_backend_compatible_flat_dict__happyflow():
+    usage_data = {
+        "character_count": 150,
+        "total_tokens": 150,
+        "prompt_tokens": 150,
+        "completion_tokens": 0,
+    }
+    usage = OpenAIAudioSpeechUsage.from_original_usage_dict(usage_data)
+    flat_dict = usage.to_backend_compatible_flat_dict("original_usage")
+    assert flat_dict == {
+        "original_usage.character_count": 150,
+        "original_usage.total_tokens": 150,
+        "original_usage.prompt_tokens": 150,
+        "original_usage.completion_tokens": 0,
+    }
+
+
+def test_openai_audio_speech_usage__invalid_data_passed__validation_error_is_raised():
+    usage_data = {
+        "character_count": "invalid",
+        "total_tokens": None,
+    }
+    with pytest.raises(pydantic.ValidationError):
+        OpenAIAudioSpeechUsage.from_original_usage_dict(usage_data)
+
+
+def test_openai_audio_speech_usage__extra_unknown_keys_are_passed__fields_are_accepted():
+    usage_data = {
+        "character_count": 150,
+        "total_tokens": 150,
+        "prompt_tokens": 150,
+        "completion_tokens": 0,
+        "extra_integer": 99,
+        "ignored_string": "ignored",
+    }
+    usage = OpenAIAudioSpeechUsage.from_original_usage_dict(usage_data)
+    assert usage.character_count == 150
+    assert usage.extra_integer == 99
+
+    flat_dict = usage.to_backend_compatible_flat_dict("original_usage")
+    assert flat_dict == {
+        "original_usage.character_count": 150,
+        "original_usage.total_tokens": 150,
+        "original_usage.prompt_tokens": 150,
+        "original_usage.completion_tokens": 0,
+        "original_usage.extra_integer": 99,
+    }


### PR DESCRIPTION
## Details
TTS tracking via character count.

/claim #2202

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- [2202](https://github.com/comet-ml/opik/issues/2202)

## Testing
Added unit test. 
Run existing test suite: `pytest tests/unit/ -v --ignore=tests/unit/evaluation --ignore=tests/unit/api_objects`
Manual test script to verify TTS decorator logic with mocked inputs

## Documentation
