### PR TITLE
[OPIK-3776][BE] fix batch add tag to all items

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -638,6 +638,17 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                 log.info("Batch updated '{}' items by filters for dataset '{}', baseVersion='{}'",
                                         updatedCount, datasetId, baseVersionId);
 
+                                // Copy unchanged items (those NOT matching the filters)
+                                // Special case: empty filters list means "select all" - no unchanged items to copy
+                                if (batchUpdate.filters() != null && batchUpdate.filters().isEmpty()) {
+                                    // Empty filters means all items were updated - nothing to copy
+                                    log.info("Empty filters (select all) - skipping copy of unchanged items");
+                                    return createVersionMetadata(
+                                            datasetId, newVersionId, baseVersionId,
+                                            updatedCount, 0L, true,
+                                            workspaceId, userName);
+                                }
+
                                 // Copy unchanged items using copyVersionItems (exclude matching filters)
                                 return versionDao.copyVersionItems(datasetId, baseVersionId, newVersionId,
                                         batchUpdate.filters(), copyUuids)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -1919,9 +1919,13 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
     public Mono<Long> batchUpdateItems(@NonNull UUID datasetId, @NonNull UUID baseVersionId,
             @NonNull UUID newVersionId, @NonNull DatasetItemBatchUpdate batchUpdate, @NonNull List<UUID> uuids) {
 
-        // Early return if no IDs or filters provided
-        if ((batchUpdate.ids() == null || batchUpdate.ids().isEmpty())
-                && (batchUpdate.filters() == null || batchUpdate.filters().isEmpty())) {
+        // Early return ONLY if IDs are explicitly empty AND filters are null (not provided at all)
+        // Note: empty filters list means "select all items", so we should NOT early return in that case
+        boolean hasIds = batchUpdate.ids() != null && !batchUpdate.ids().isEmpty();
+        boolean hasFilters = batchUpdate.filters() != null; // null means not provided, empty list means "select all"
+
+        if (!hasIds && !hasFilters) {
+            // Neither IDs nor filters provided - nothing to update
             return Mono.just(0L);
         }
 


### PR DESCRIPTION
## Details
While testing we noticed that when batch adding a tag to all items, nothing happens.
Exploring the code I found an early return in case of empty filters list. This is wrong. Empty filters list denote "all items". 
This PR fixes it.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-3776

## Testing
Added a test covering the correct behavior.

## Documentation
No need
