### PR TITLE
[NA] [E2E] Update online scoring tests and remove networkidle waits

### DIFF
--- a/tests_end_to_end/tests_end_to_end_ts/.cursor/agents/playwright-test-healer.md
+++ b/tests_end_to_end/tests_end_to_end_ts/.cursor/agents/playwright-test-healer.md
@@ -1,9 +1,6 @@
 ---
 name: playwright-test-healer
-description: Use this agent when you need to debug and fix failing Playwright tests. Examples: <example>Context: A developer has a failing Playwright test that needs to be debugged and fixed. user: 'The login test is failing, can you fix it?' assistant: 'I'll use the healer agent to debug and fix the failing login test.' <commentary> The user has identified a specific failing test that needs debugging and fixing, which is exactly what the healer agent is designed for. </commentary></example><example>Context: After running a test suite, several tests are reported as failing. user: 'Test user-registration.spec.ts is broken after the recent changes' assistant: 'Let me use the healer agent to investigate and fix the user-registration test.' <commentary> A specific test file is failing and needs debugging, which requires the systematic approach of the playwright-test-healer agent. </commentary></example>
-tools: Glob, Grep, Read, Write, Edit, MultiEdit, mcp__playwright-test__browser_console_messages, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_generate_locator, mcp__playwright-test__browser_network_requests, mcp__playwright-test__browser_snapshot, mcp__playwright-test__test_debug, mcp__playwright-test__test_list, mcp__playwright-test__test_run
-model: sonnet
-color: red
+model: fast
 ---
 
 You are the Playwright Test Healer, an expert test automation engineer specializing in debugging and

--- a/tests_end_to_end/tests_end_to_end_ts/typescript-tests/page-objects/ai-providers-config.page.ts
+++ b/tests_end_to_end/tests_end_to_end_ts/typescript-tests/page-objects/ai-providers-config.page.ts
@@ -13,7 +13,6 @@ export class AIProvidersConfigPage extends BasePage {
 
   async goto(): Promise<void> {
     await super.goto();
-    await this.page.waitForLoadState('networkidle');
   }
 
   async searchProviderByName(providerName: string): Promise<void> {
@@ -25,8 +24,7 @@ export class AIProvidersConfigPage extends BasePage {
   async addProvider(providerType: 'OpenAI' | 'Anthropic', apiKey: string): Promise<void> {
     await this.addProviderButton.click();
 
-    await this.page.getByRole('combobox').click();
-    await this.page.getByRole('option', { name: providerType }).click();
+    await this.page.getByRole('button', { name: providerType }).click();
 
     await this.page.getByLabel('API key').fill(apiKey);
 

--- a/tests_end_to_end/tests_end_to_end_ts/typescript-tests/page-objects/experiments.page.ts
+++ b/tests_end_to_end/tests_end_to_end_ts/typescript-tests/page-objects/experiments.page.ts
@@ -11,7 +11,6 @@ export class ExperimentsPage extends BasePage {
 
   async goto(): Promise<void> {
     await super.goto();
-    await this.page.waitForLoadState('networkidle');
   }
 
   async searchExperiment(name: string): Promise<void> {

--- a/tests_end_to_end/tests_end_to_end_ts/typescript-tests/page-objects/feedback-scores.page.ts
+++ b/tests_end_to_end/tests_end_to_end_ts/typescript-tests/page-objects/feedback-scores.page.ts
@@ -19,7 +19,6 @@ export class FeedbackScoresPage extends BasePage {
 
   async goto(): Promise<void> {
     await super.goto();
-    await this.page.waitForLoadState('networkidle');
   }
 
   async searchFeedback(name: string): Promise<void> {

--- a/tests_end_to_end/tests_end_to_end_ts/typescript-tests/page-objects/playground.page.ts
+++ b/tests_end_to_end/tests_end_to_end_ts/typescript-tests/page-objects/playground.page.ts
@@ -32,7 +32,6 @@ export class PlaygroundPage extends BasePage {
 
   async goto(): Promise<void> {
     await super.goto();
-    await this.page.waitForLoadState('networkidle');
   }
 
   async selectModel(providerName: string, modelName: string): Promise<void> {
@@ -163,7 +162,6 @@ export class PlaygroundPage extends BasePage {
     }
 
     console.log('Waiting for response...');
-    await this.page.waitForLoadState('networkidle');
     await this.page.waitForTimeout(2000);
   }
 

--- a/tests_end_to_end/tests_end_to_end_ts/typescript-tests/page-objects/prompts.page.ts
+++ b/tests_end_to_end/tests_end_to_end_ts/typescript-tests/page-objects/prompts.page.ts
@@ -11,7 +11,6 @@ export class PromptsPage extends BasePage {
 
   async goto(): Promise<void> {
     await super.goto();
-    await this.page.waitForLoadState('networkidle');
   }
 
   async searchPrompt(name: string): Promise<void> {
@@ -38,7 +37,6 @@ export class PromptsPage extends BasePage {
   async clickPrompt(name: string): Promise<void> {
     await this.searchPrompt(name);
     await this.page.getByRole('link', { name }).first().click();
-    await this.page.waitForLoadState('networkidle');
   }
 
   async deletePrompt(name: string): Promise<void> {
@@ -77,12 +75,10 @@ export class PromptDetailsPage {
     await this.saveButton.click();
 
     await this.page.waitForTimeout(1000);
-    await this.page.waitForLoadState('networkidle');
   }
 
   async switchToCommitsTab(): Promise<void> {
     await this.commitsTab.click();
-    await this.page.waitForLoadState('networkidle');
   }
 
   async getAllCommitVersions(): Promise<Record<string, string>> {

--- a/tests_end_to_end/tests_end_to_end_ts/typescript-tests/page-objects/traces.page.ts
+++ b/tests_end_to_end/tests_end_to_end_ts/typescript-tests/page-objects/traces.page.ts
@@ -35,7 +35,6 @@ export class TracesPage {
       await this.page.getByRole('button', { name: 'Columns' }).click({ timeout: 5000 });
     } catch {
       await this.page.reload();
-      await this.page.waitForLoadState('networkidle', { timeout: 10000 });
       await this.page.getByRole('button', { name: 'Columns' }).click({ timeout: 5000 });
     }
 


### PR DESCRIPTION
## Details
Removing all networkidle waits (bad practice causing occasional flakiness) and updating online scoring tests by fixing AI provider locators (from combobox with options to plain buttons)

## Change checklist
- [x] E2E tests

## Issues
NA

## Testing

## Documentation
