### PR TITLE
[OPIK-3777] [FE] Fix pagination size bug when adding tags to dataset items

### DIFF
--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsTab/DatasetItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsTab/DatasetItemsTab.tsx
@@ -178,19 +178,13 @@ const DatasetItemsTab: React.FC<DatasetItemsTabProps> = ({
   const isDraftMode = useIsDraftMode();
   const deletedIds = useDeletedIds();
 
-  // Compute effective size for draft mode: use 100 if in draft mode and size is default (10)
-  const effectiveSize = useMemo(
-    () => (isDraftMode && size === 10 ? 100 : (size as number)),
-    [isDraftMode, size],
-  );
-
   const { data, isPending, isPlaceholderData, isFetching } =
     useDatasetItemsWithDraft(
       {
         datasetId,
         filters: transformedFilters,
         page: page as number,
-        size: effectiveSize,
+        size: size as number,
         search: search!,
         truncate: false,
       },
@@ -214,7 +208,7 @@ const DatasetItemsTab: React.FC<DatasetItemsTabProps> = ({
       datasetId,
       filters: transformedFilters,
       page: page as number,
-      size: effectiveSize,
+      size: size as number,
       search: search!,
       truncate: false,
     },
@@ -652,7 +646,7 @@ const DatasetItemsTab: React.FC<DatasetItemsTabProps> = ({
             <DataTablePagination
               page={page as number}
               pageChange={setPage}
-              size={effectiveSize}
+              size={size as number}
               sizeChange={setSize}
               total={data?.total ?? 0}
               isLoadingTotal={isProcessing}


### PR DESCRIPTION
## Details

Fixed a bug where adding tags to individual dataset items would cause the pagination page size to unexpectedly change to 100, even when the user had selected a different page size.

The issue was caused by the `effectiveSize` calculation that forced the page size to 100 when in draft mode and the size was the default (10). This logic has been removed, and the component now always uses the user's selected page size directly, regardless of draft mode.

**Changes:**
- Removed the `effectiveSize` useMemo calculation that checked for draft mode and default size
- Updated all references from `effectiveSize` to `size as number` to use the user's selected page size directly
- This ensures pagination size remains consistent when adding tags or making other draft changes

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-3777

## Testing

**Steps to reproduce the bug (before fix):**
1. Open a dataset in the UI with page size less than 100 (e.g., 10 or 25)
2. Check the box near one of the items
3. Add a tag
4. **Expected:** Pagination size remains the same
5. **Actual (before fix):** Pagination size changes to 100

**Verification (after fix):**
1. Open a dataset in the UI with any page size
2. Check the box near one of the items
3. Add a tag
4. Verify pagination size remains unchanged
5. Verify pagination controls work correctly

## Documentation

N/A - No documentation changes required for this bug fix.