### PR TITLE
[NA] [CI] Fix Python version quote in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build_and_publish_sdk.yaml
+++ b/.github/workflows/build_and_publish_sdk.yaml
@@ -53,7 +53,7 @@ jobs:
         - name: Set up Python 3.10
           uses: actions/setup-python@v3
           with:
-                python-version: 3.10
+                python-version: "3.10"
 
         - name: Build pip package
           run: |


### PR DESCRIPTION
## Details
Fix Python version configuration in `build_and_publish_sdk.yaml` workflow to use quoted string format (`"3.10"` instead of `3.10`) for consistency with GitHub Actions best practices. The `python-version` parameter should be a string value to ensure proper parsing by the `setup-python@v3` action.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves #
- OPIK- NA

## Testing
The change will be validated when the workflow runs on the next SDK build. The quoted string format is the recommended approach per GitHub Actions documentation and ensures consistent behavior across different action versions.

## Documentation
N/A