### PR TITLE
[OPIK-3823][OPIK-3823] Enhance Helm chart publishing workflow

### DIFF
--- a/.github/workflows/publish_helm_chart.yaml
+++ b/.github/workflows/publish_helm_chart.yaml
@@ -96,7 +96,7 @@ jobs:
             # 1. Set timestamp for the newly packaged chart from source repo tag
             NEW_CHART_FILE="opik-${VERSION}.tgz"
             if [ -f "$NEW_CHART_FILE" ]; then
-              NEW_CHART_TIME=$(cd ../src && git log -1 --format="%cI" "$VERSION")
+              NEW_CHART_TIME=$(cd ../src && git log -1 --format="%cI" "$VERSION" || true)
               if [ -n "$NEW_CHART_TIME" ]; then
                 touch -d "$NEW_CHART_TIME" "$NEW_CHART_FILE"
                 echo "Set $NEW_CHART_FILE mtime to $NEW_CHART_TIME (from source tag)"


### PR DESCRIPTION
## Details
Enhance Helm chart publishing workflow by adding a step to synchronize chart timestamps with the filesystem. This ensures that the 'created' field in index.yaml reflects the correct modification times of chart files. Additionally, updated the helm repo index command to merge with the existing index.yaml.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-3823

## Testing

## Documentation
