### PR TITLE
[OPIK-3817] [FE] Group bar charts by metric instead of experiment

### DIFF
--- a/apps/opik-frontend/src/components/shared/Charts/BarChart/BarChart.tsx
+++ b/apps/opik-frontend/src/components/shared/Charts/BarChart/BarChart.tsx
@@ -79,9 +79,9 @@ const BarChart: React.FunctionComponent<BarChartProps> = ({
 
   const defaultTooltipHeader = useCallback(
     ({ payload }: ChartTooltipRenderHeaderArguments) => {
-      const xValue = payload?.[0]?.payload?.[xAxisKey];
+      const name = payload?.[0]?.payload?.[xAxisKey];
       return (
-        <div className="comet-body-xs mb-1 text-light-slate">{xValue}</div>
+        <div className="comet-body-xs-accented truncate pb-1.5">{name}</div>
       );
     },
     [xAxisKey],

--- a/apps/opik-frontend/src/components/shared/Charts/LineChart/LineChart.tsx
+++ b/apps/opik-frontend/src/components/shared/Charts/LineChart/LineChart.tsx
@@ -83,9 +83,9 @@ const LineChart: React.FunctionComponent<LineChartProps> = ({
 
   const defaultTooltipHeader = useCallback(
     ({ payload }: ChartTooltipRenderHeaderArguments) => {
-      const xValue = payload?.[0]?.payload?.[xAxisKey];
+      const name = payload?.[0]?.payload?.[xAxisKey];
       return (
-        <div className="comet-body-xs mb-1 text-light-slate">{xValue}</div>
+        <div className="comet-body-xs-accented truncate pb-1.5">{name}</div>
       );
     },
     [xAxisKey],


### PR DESCRIPTION
## Details

Changed bar chart grouping in the Experiments Feedback Scores widget to group by metric instead of experiment. This makes it easier to compare experiment performance for specific metrics at a glance, as bars for the same metric are now displayed side-by-side.
<img width="1320" height="868" alt="image" src="https://github.com/user-attachments/assets/d01d3f27-5938-466f-9456-14ac263e4b2b" />


**Key changes:**
- Modified data transformation logic to group bar charts by metric (X-axis shows metrics, each experiment becomes a bar series)
- Added `createUniqueEntityLabels` helper function to handle duplicate experiment names by appending experiment ID when needed
- Unified transformation logic for radar and bar charts to eliminate code duplication
- Updated chart tooltip headers for consistency across chart types

**Implementation:**
- When `chartType === CHART_TYPE.bar`, data is now transformed so each metric becomes a data point with experiment values as properties
- Experiment names are used as bar series keys in the chart configuration
- Duplicate experiment names are automatically disambiguated with format: `"Experiment_name (experiment_id)"`

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves #
- OPIK-3817

## Testing

Tested locally with:
- Multiple experiments with different metrics
- Multiple experiments with duplicate names (verified ID disambiguation)
- Single and multiple metrics
- Grouped and ungrouped experiment views
- Verified tooltips display correctly with metric names

## Documentation
N/A