### PR TITLE
[issue-28001] [FE] Add version tags to prompt comparison view

### DIFF
--- a/apps/opik-frontend/src/components/pages/PromptPage/CommitsTab/ComparePromptVersionDialog.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/CommitsTab/ComparePromptVersionDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import last from "lodash/last";
 import first from "lodash/first";
 import isEqual from "fast-deep-equal";
@@ -101,18 +101,22 @@ const ComparePromptVersionDialog: React.FunctionComponent<
     }
   }, [open, versionOptions, versions]);
 
-  const renderTagsWithSeparator = useCallback((tags: string[] | undefined) => {
+  const renderTagsWithSeparator = (tags: string[] | undefined) => {
     if (!tags || tags.length === 0) return null;
 
     return (
-      <span className="inline-flex items-center gap-1.5">
-        <span className="text-xs text-muted-slate/60 transition-opacity">
+      <>
+        <span className="shrink-0 text-xs text-muted-slate/60 transition-opacity">
           ·
         </span>
-        <VersionTags tags={tags} />
-      </span>
+        <VersionTags
+          tags={tags}
+          containerClassName="max-w-[320px]"
+          maxVisibleTags={5}
+        />
+      </>
     );
-  }, []);
+  };
 
   const generateTitle = (
     version: PromptVersion | undefined,
@@ -136,14 +140,12 @@ const ComparePromptVersionDialog: React.FunctionComponent<
             renderTrigger={(value) => {
               const option = versionOptions.find((o) => o.value === value);
               return (
-                <div className="flex min-w-0 items-center gap-1.5">
-                  <span className="shrink-0">
-                    {option?.label} ({option?.description})
+                <span className="comet-body-s truncate">
+                  {option?.label}{" "}
+                  <span className="text-light-slate">
+                    {option?.description}
                   </span>
-                  <span className="inline-flex origin-left scale-[0.90]">
-                    {renderTagsWithSeparator(option?.tags)}
-                  </span>
-                </div>
+                </span>
               );
             }}
             renderOption={(
@@ -153,12 +155,18 @@ const ComparePromptVersionDialog: React.FunctionComponent<
                 <SelectItem
                   key={option.value}
                   value={option.value}
-                  description={option.description}
                   disabled={option.disabled}
                 >
-                  <div className="flex min-w-0 items-center gap-1.5">
-                    <span className="shrink-0">{option.label}</span>
-                    {renderTagsWithSeparator(option.tags)}
+                  <div className="flex min-w-0 flex-col gap-0.5">
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      <span className="comet-body-s-accented shrink-0">
+                        {option.label}
+                      </span>
+                      {renderTagsWithSeparator(option.tags)}
+                    </div>
+                    <span className="comet-body-s text-light-slate">
+                      {option.description}
+                    </span>
                   </div>
                 </SelectItem>
               );
@@ -168,12 +176,16 @@ const ComparePromptVersionDialog: React.FunctionComponent<
       );
     } else {
       return (
-        <div className="-mb-2 px-0.5">
-          <span className="comet-body-s-accented mr-2">{version.commit}</span>
-          <span className="comet-body-s mr-2 text-light-slate">
+        <div className="-mb-2 flex flex-col gap-0.5 px-0.5">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className="comet-body-s-accented shrink-0">
+              {version.commit}
+            </span>
+            {renderTagsWithSeparator(version.tags)}
+          </div>
+          <span className="comet-body-s text-light-slate">
             {formatDate(version.created_at)}
           </span>
-          {renderTagsWithSeparator(version.tags)}
         </div>
       );
     }

--- a/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/VersionTags.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/VersionTags.tsx
@@ -3,24 +3,39 @@ import ColoredTag from "@/components/shared/ColoredTag/ColoredTag";
 import TagListTooltipContent from "@/components/shared/TagListTooltipContent/TagListTooltipContent";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import { useVisibleTags } from "@/hooks/useVisibleTags";
+import { cn } from "@/lib/utils";
 
 interface VersionTagsProps {
   tags: string[];
+  containerClassName?: string;
+  maxVisibleTags?: number;
 }
 
-const VersionTags: React.FC<VersionTagsProps> = ({ tags }) => {
-  const { visibleItems, hasMoreItems, remainingCount } = useVisibleTags(tags);
+const VersionTags: React.FC<VersionTagsProps> = ({
+  tags,
+  containerClassName,
+  maxVisibleTags,
+}) => {
+  const { visibleItems, hasMoreItems, remainingCount } = useVisibleTags(
+    tags,
+    maxVisibleTags,
+  );
 
   if (!tags || tags.length === 0) return null;
 
   return (
-    <div className="flex max-w-[160px] shrink flex-nowrap items-center gap-0.5 overflow-hidden">
+    <div
+      className={cn(
+        "flex max-w-[200px] shrink flex-nowrap items-center gap-1 overflow-hidden",
+        containerClassName,
+      )}
+    >
       {visibleItems.map((tag) => (
         <ColoredTag
           key={tag}
           label={tag}
           size="sm"
-          className="min-w-0 max-w-[65px] shrink origin-left scale-[0.85] truncate"
+          className="min-w-0 max-w-[80px] shrink truncate"
         />
       ))}
       {hasMoreItems && (

--- a/apps/opik-frontend/src/hooks/useVisibleTags.ts
+++ b/apps/opik-frontend/src/hooks/useVisibleTags.ts
@@ -3,7 +3,6 @@ import { useMemo } from "react";
 interface UseVisibleTagsReturn {
   sortedItems: string[];
   visibleItems: string[];
-  hiddenItems: string[];
   hasMoreItems: boolean;
   remainingCount: number;
 }
@@ -20,14 +19,12 @@ export const useVisibleTags = (
   return useMemo(() => {
     const sortedItems = sortTags(tags);
     const visibleItems = sortedItems.slice(0, maxVisible);
-    const hiddenItems = sortedItems.slice(maxVisible);
     const hasMoreItems = sortedItems.length > maxVisible;
     const remainingCount = Math.max(0, sortedItems.length - maxVisible);
 
     return {
       sortedItems,
       visibleItems,
-      hiddenItems,
       hasMoreItems,
       remainingCount,
     };


### PR DESCRIPTION
## Details

This PR adds version tags display to the prompt comparison dialog, improving visibility of tagged versions during comparison.

**Key Changes:**
- Added version tags display in the compare prompt version dialog dropdown
- Modified version title display to include tags alongside commit and date information
- Tags are now shown on the dropdown options
- Refactored `useVisibleTags` hook to use a single `useMemo` for better performance


https://github.com/user-attachments/assets/1e653b28-d81f-41d3-a323-92e88f41d3ff

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves #2801

## Testing

**Manual Testing:**
- Tested prompt version comparison dialog with versions that have tags
- Verified tags display correctly in dropdown options
- Verified tags display correctly in the version title when not using dropdown
- Tested with versions without tags to ensure graceful handling
- Tested combinations with and without version tags.
- Tested long tags.
- Tested many tags.

## Documentation

No documentation updates required - this is a UI enhancement to existing functionality.