### PR TITLE
[OPIK-3409] [FE] Experiment Leaderboard in Opik

### DIFF
--- a/apps/opik-frontend/src/api/datasets/useExperimentsList.ts
+++ b/apps/opik-frontend/src/api/datasets/useExperimentsList.ts
@@ -21,6 +21,7 @@ export type UseExperimentsListParams = {
   page: number;
   size: number;
   queryKey?: string;
+  experimentIds?: string[];
 };
 
 export type UseExperimentsListResponse = {
@@ -42,6 +43,7 @@ export const getExperimentsList = async (
     search,
     size,
     page,
+    experimentIds,
   }: UseExperimentsListParams,
 ) => {
   const { data } = await api.get(EXPERIMENTS_REST_ENDPOINT, {
@@ -54,6 +56,7 @@ export const getExperimentsList = async (
       ...(search && { name: search }),
       ...(optimizationId && { optimization_id: optimizationId }),
       ...(types && { types: JSON.stringify(types) }),
+      ...(experimentIds && { experiment_ids: JSON.stringify(experimentIds) }),
       size,
       page,
     },

--- a/apps/opik-frontend/src/components/pages-shared/experiments/scoresUtils.ts
+++ b/apps/opik-frontend/src/components/pages-shared/experiments/scoresUtils.ts
@@ -1,0 +1,74 @@
+import {
+  COLUMN_EXPERIMENT_SCORES_ID,
+  COLUMN_FEEDBACK_SCORES_ID,
+  SCORE_TYPE_EXPERIMENT,
+  SCORE_TYPE_FEEDBACK,
+  ScoreType,
+  AggregatedFeedbackScore,
+} from "@/types/shared";
+
+// Build score column ID from score name and type
+export const buildScoreColumnId = (
+  scoreName: string,
+  scoreType: ScoreType = SCORE_TYPE_FEEDBACK,
+): string => {
+  const prefix =
+    scoreType === SCORE_TYPE_EXPERIMENT
+      ? COLUMN_EXPERIMENT_SCORES_ID
+      : COLUMN_FEEDBACK_SCORES_ID;
+  return `${prefix}.${scoreName}`;
+};
+
+// Build display label with "(avg)" for feedback scores
+export const buildScoreLabel = (
+  scoreName: string,
+  scoreType: ScoreType = SCORE_TYPE_FEEDBACK,
+): string => {
+  return scoreType === SCORE_TYPE_EXPERIMENT ? scoreName : `${scoreName} (avg)`;
+};
+
+// Parse score column ID to extract score name and type
+export type ParsedScoreColumn = {
+  scoreName: string;
+  scoreType: ScoreType;
+};
+
+export const parseScoreColumnId = (
+  columnId: string,
+): ParsedScoreColumn | null => {
+  if (columnId.startsWith(`${COLUMN_EXPERIMENT_SCORES_ID}.`)) {
+    return {
+      scoreName: columnId.substring(COLUMN_EXPERIMENT_SCORES_ID.length + 1),
+      scoreType: SCORE_TYPE_EXPERIMENT,
+    };
+  }
+  if (columnId.startsWith(`${COLUMN_FEEDBACK_SCORES_ID}.`)) {
+    return {
+      scoreName: columnId.substring(COLUMN_FEEDBACK_SCORES_ID.length + 1),
+      scoreType: SCORE_TYPE_FEEDBACK,
+    };
+  }
+  return null;
+};
+
+// Type for rows that have score properties
+export type RowWithScores = {
+  experiment_scores?: AggregatedFeedbackScore[];
+  feedback_scores?: AggregatedFeedbackScore[];
+};
+
+// Get score from row by column ID - automatically parses ID and retrieves correct score
+export const getExperimentScore = (
+  columnId: string,
+  row: RowWithScores,
+): AggregatedFeedbackScore | undefined => {
+  const parsed = parseScoreColumnId(columnId);
+  if (!parsed) return undefined;
+
+  const scores =
+    parsed.scoreType === SCORE_TYPE_EXPERIMENT
+      ? row.experiment_scores
+      : row.feedback_scores;
+
+  return scores?.find((s) => s.name === parsed.scoreName);
+};

--- a/apps/opik-frontend/src/components/pages-shared/experiments/useExperimentsFeedbackScores.ts
+++ b/apps/opik-frontend/src/components/pages-shared/experiments/useExperimentsFeedbackScores.ts
@@ -2,21 +2,31 @@ import { useMemo } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
 
 import {
-  COLUMN_EXPERIMENT_SCORES_ID,
-  COLUMN_FEEDBACK_SCORES_ID,
   COLUMN_TYPE,
   DynamicColumn,
-  SCORE_TYPE_EXPERIMENT,
+  SCORE_TYPE_FEEDBACK,
 } from "@/types/shared";
 import useExperimentsFeedbackScoresNames from "@/api/datasets/useExperimentsFeedbackScoresNames";
+import { buildScoreColumnId, buildScoreLabel } from "./scoresUtils";
 
-export const useExperimentsFeedbackScores = () => {
+interface UseExperimentsFeedbackScoresOptions {
+  experimentIds?: string[];
+  refetchInterval?: number;
+}
+
+export const useExperimentsFeedbackScores = (
+  options: UseExperimentsFeedbackScoresOptions = {},
+) => {
+  const { experimentIds, refetchInterval = 30000 } = options;
+
   const { data: feedbackScoresData, isPending: isFeedbackScoresPending } =
     useExperimentsFeedbackScoresNames(
-      {},
+      {
+        experimentsIds: experimentIds,
+      },
       {
         placeholderData: keepPreviousData,
-        refetchInterval: 30000,
+        refetchInterval,
       },
     );
 
@@ -24,15 +34,12 @@ export const useExperimentsFeedbackScores = () => {
     return (feedbackScoresData?.scores ?? [])
       .sort((c1, c2) => c1.name.localeCompare(c2.name))
       .map<DynamicColumn>((c) => {
-        const prefix =
-          c.type === SCORE_TYPE_EXPERIMENT
-            ? COLUMN_EXPERIMENT_SCORES_ID
-            : COLUMN_FEEDBACK_SCORES_ID;
+        const scoreType = c.type || SCORE_TYPE_FEEDBACK;
         return {
-          id: `${prefix}.${c.name}`,
-          label: c.name,
+          id: buildScoreColumnId(c.name, scoreType),
+          label: buildScoreLabel(c.name, scoreType),
           columnType: COLUMN_TYPE.number,
-          type: c.type,
+          type: scoreType,
         };
       });
   }, [feedbackScoresData?.scores]);

--- a/apps/opik-frontend/src/components/pages-shared/experiments/useExperimentsTableConfig.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/experiments/useExperimentsTableConfig.tsx
@@ -19,10 +19,9 @@ import {
   COLUMN_TYPE,
   COLUMN_DATASET_ID,
   COLUMN_METADATA_ID,
-  AggregatedFeedbackScore,
   SCORE_TYPE_FEEDBACK,
-  SCORE_TYPE_EXPERIMENT,
 } from "@/types/shared";
+import { getExperimentScore, RowWithScores } from "./scoresUtils";
 import { convertColumnDataToColumn, isColumnSortable } from "@/lib/table";
 import {
   buildGroupFieldName,
@@ -149,49 +148,23 @@ export const useExperimentsTableConfig = <
   }, []);
 
   const scoresColumnsData = useMemo(() => {
-    const getScoreByName = (
-      scores: AggregatedFeedbackScore[] | undefined,
-      scoreName: string,
-    ) => scores?.find((f) => f.name === scoreName);
-
     return [
       ...dynamicScoresColumns.map(
         ({ label, id, columnType, type: scoreType }) => {
           const actualType = scoreType || SCORE_TYPE_FEEDBACK;
-          const isExperimentScore = actualType === SCORE_TYPE_EXPERIMENT;
 
-          // Extract conditional values
-          const displayLabel = isExperimentScore ? label : `${label} (avg)`;
-          const scoresKey = isExperimentScore
-            ? "experiment_scores"
-            : "feedback_scores";
-
-          // Common fields
           const columnData: ColumnData<T> = {
             id,
-            label: displayLabel,
+            label,
             type: columnType,
             scoreType: actualType,
             header: FeedbackScoreHeader as never,
             cell: FeedbackScoreCell as never,
             aggregatedCell: FeedbackScoreCell.Aggregation as never,
-            accessorFn: (row: T) => {
-              const rowWithScores = row as T & {
-                feedback_scores?: AggregatedFeedbackScore[];
-                experiment_scores?: AggregatedFeedbackScore[];
-              };
-              const scores = rowWithScores[scoresKey];
-              return getScoreByName(scores, label);
-            },
+            accessorFn: (row) => getExperimentScore(id, row as RowWithScores),
             customMeta: {
-              accessorFn: (aggregation: ExperimentsAggregations) => {
-                const aggWithScores = aggregation as ExperimentsAggregations & {
-                  feedback_scores?: AggregatedFeedbackScore[];
-                  experiment_scores?: AggregatedFeedbackScore[];
-                };
-                const scores = aggWithScores[scoresKey];
-                return getScoreByName(scores, label)?.value;
-              },
+              accessorFn: (aggregation: ExperimentsAggregations) =>
+                getExperimentScore(id, aggregation)?.value,
             },
           };
 

--- a/apps/opik-frontend/src/components/shared/Dashboard/DashboardWidget/DashboardWidget.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/DashboardWidget/DashboardWidget.tsx
@@ -21,7 +21,7 @@ const DashboardWidgetRoot: React.FunctionComponent<
   DashboardWidgetRootProps
 > = ({ children, className }) => {
   return (
-    <div className="group h-full">
+    <div className="group/widget h-full">
       <Card
         className={cn(
           "flex h-full flex-col gap-2 rounded-md px-2 pb-2 pt-1",

--- a/apps/opik-frontend/src/components/shared/Dashboard/DashboardWidget/DashboardWidgetActions.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/DashboardWidget/DashboardWidgetActions.tsx
@@ -12,7 +12,7 @@ const DashboardWidgetActions: React.FunctionComponent<
   return (
     <div
       className={cn(
-        "flex items-center gap-2 opacity-0 transition-opacity group-hover:opacity-100",
+        "flex items-center gap-2 opacity-0 transition-opacity group-hover/widget:opacity-100",
         className,
       )}
     >

--- a/apps/opik-frontend/src/components/shared/Dashboard/DashboardWidget/DashboardWidgetHeader.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/DashboardWidget/DashboardWidgetHeader.tsx
@@ -47,7 +47,9 @@ const DashboardWidgetHeader: React.FunctionComponent<
         <div
           className={cn(
             "flex w-full items-center justify-center pb-0.5 transition-opacity",
-            menuOpen ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+            menuOpen
+              ? "opacity-100"
+              : "opacity-0 group-hover/widget:opacity-100",
           )}
         >
           {dragHandle}
@@ -80,7 +82,9 @@ const DashboardWidgetHeader: React.FunctionComponent<
           <div
             className={cn(
               "flex shrink-0 items-center gap-2 transition-opacity",
-              menuOpen ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+              menuOpen
+                ? "opacity-100"
+                : "opacity-0 group-hover/widget:opacity-100",
             )}
           >
             {actionsWithHandler}

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/ExperimentsLeaderboardTableWrapper.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/ExperimentsLeaderboardTableWrapper.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { DataTableWrapperProps } from "@/components/shared/DataTable/DataTableWrapper";
+import { TABLE_WRAPPER_ATTRIBUTE } from "@/components/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
+
+const ExperimentsLeaderboardTableWrapper: React.FC<DataTableWrapperProps> = ({
+  children,
+}) => {
+  return (
+    <div
+      className="comet-sticky-table relative h-full overflow-auto [&_thead[data-sticky-vertical]]:top-0"
+      {...{ [TABLE_WRAPPER_ATTRIBUTE]: "" }}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default ExperimentsLeaderboardTableWrapper;

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/ExperimentsLeaderboardWidget.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/ExperimentsLeaderboardWidget.tsx
@@ -1,0 +1,496 @@
+import React, { memo, useMemo, useCallback } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { keepPreviousData } from "@tanstack/react-query";
+import { ColumnDef } from "@tanstack/react-table";
+import get from "lodash/get";
+import isNumber from "lodash/isNumber";
+import isArray from "lodash/isArray";
+import { Trophy } from "lucide-react";
+
+import DashboardWidget from "@/components/shared/Dashboard/DashboardWidget/DashboardWidget";
+import DataTable from "@/components/shared/DataTable/DataTable";
+import ExperimentsLeaderboardTableWrapper from "./ExperimentsLeaderboardTableWrapper";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
+
+import {
+  DashboardWidgetComponentProps,
+  ExperimentsLeaderboardWidgetType,
+  EXPERIMENT_DATA_SOURCE,
+} from "@/types/dashboard";
+import {
+  useDashboardStore,
+  selectUpdateWidget,
+  selectConfig,
+} from "@/store/DashboardStore";
+import useAppStore from "@/store/AppStore";
+import useExperimentsList from "@/api/datasets/useExperimentsList";
+import { Experiment } from "@/types/datasets";
+import { Sorting } from "@/types/sorting";
+import { getRowId } from "@/components/shared/DataTable/utils";
+import {
+  COLUMN_TYPE,
+  SCORE_TYPE_FEEDBACK,
+  COLUMN_METADATA_ID,
+  DynamicColumn,
+  ColumnData,
+} from "@/types/shared";
+import { RESOURCE_TYPE } from "@/components/shared/ResourceLink/ResourceLink";
+import ResourceCell from "@/components/shared/DataTableCells/ResourceCell";
+import AutodetectCell from "@/components/shared/DataTableCells/AutodetectCell";
+import RankingCell from "@/components/shared/DataTableCells/RankingCell";
+import RankingHeader from "@/components/shared/DataTableHeaders/RankingHeader";
+import {
+  formatConfigColumnName,
+  PREDEFINED_COLUMNS,
+  DEFAULT_MAX_ROWS,
+  MIN_MAX_ROWS,
+  MAX_MAX_ROWS,
+  getExperimentListParams,
+  isSelectExperimentsMode,
+  parseScoreColumnId,
+  getExperimentScore,
+  buildScoreLabel,
+  getRankingSorting,
+  getRankingFilters,
+} from "./helpers";
+import { convertColumnDataToColumn, mapColumnDataFields } from "@/lib/table";
+import FeedbackScoreHeader from "@/components/shared/DataTableHeaders/FeedbackScoreHeader";
+import FeedbackScoreCell from "@/components/shared/DataTableCells/FeedbackScoreCell";
+
+const RANK_COLUMN_ID = "rank";
+const NAME_COLUMN_ID = "name";
+
+const ExperimentsLeaderboardWidget: React.FunctionComponent<
+  DashboardWidgetComponentProps
+> = ({ sectionId, widgetId, preview = false }) => {
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+
+  const widget = useDashboardStore(
+    useShallow((state) => {
+      if (preview) {
+        return state.previewWidget;
+      }
+      if (!sectionId || !widgetId) return null;
+      const section = state.sections.find((s) => s.id === sectionId);
+      return section?.widgets.find((w) => w.id === widgetId);
+    }),
+  );
+
+  const updateWidget = useDashboardStore(selectUpdateWidget);
+  const globalConfig = useDashboardStore(selectConfig);
+  const onAddEditWidgetCallback = useDashboardStore(
+    (state) => state.onAddEditWidgetCallback,
+  );
+
+  const handleEdit = useCallback(() => {
+    if (sectionId && widgetId) {
+      onAddEditWidgetCallback?.({ sectionId, widgetId });
+    }
+  }, [sectionId, widgetId, onAddEditWidgetCallback]);
+
+  const widgetConfig = widget?.config as
+    | ExperimentsLeaderboardWidgetType["config"]
+    | undefined;
+
+  const config = useMemo(() => widgetConfig || {}, [widgetConfig]);
+
+  const {
+    dataSource = EXPERIMENT_DATA_SOURCE.SELECT_EXPERIMENTS,
+    filters = [],
+    selectedColumns = [],
+    enableRanking = true,
+    rankingMetric,
+    rankingDirection = true,
+    columnsWidth = {},
+    columnsOrder = [],
+    scoresColumnsOrder = [],
+    metadataColumnsOrder = [],
+    maxRows,
+    sorting: savedSorting = [],
+    overrideDefaults = false,
+  } = config;
+
+  const maxRowsValue = useMemo(() => {
+    if (!isNumber(maxRows)) {
+      return DEFAULT_MAX_ROWS;
+    }
+    return Math.max(MIN_MAX_ROWS, Math.min(MAX_MAX_ROWS, maxRows));
+  }, [maxRows]);
+
+  const experimentIds = useMemo(() => {
+    if (overrideDefaults) {
+      return widgetConfig?.experimentIds || [];
+    }
+    return globalConfig?.experimentIds || [];
+  }, [
+    globalConfig?.experimentIds,
+    widgetConfig?.experimentIds,
+    overrideDefaults,
+  ]);
+
+  const experimentListParams = getExperimentListParams({
+    dataSource,
+    experimentIds,
+    filters,
+  });
+
+  const rankingSorting = useMemo(
+    () => getRankingSorting({ rankingMetric, rankingDirection }),
+    [rankingMetric, rankingDirection],
+  );
+
+  const apiSorting = useMemo(() => {
+    if (savedSorting && savedSorting.length > 0) {
+      return savedSorting;
+    }
+    if (enableRanking && rankingSorting) {
+      return rankingSorting;
+    }
+    return undefined;
+  }, [savedSorting, enableRanking, rankingSorting]);
+
+  const { data: experimentsData, isPending } = useExperimentsList(
+    {
+      workspaceName,
+      filters: experimentListParams.filters,
+      experimentIds: experimentListParams.experimentIds,
+      sorting: apiSorting,
+      page: 1,
+      size: isSelectExperimentsMode(dataSource) ? MAX_MAX_ROWS : maxRowsValue,
+    },
+    {
+      placeholderData: keepPreviousData,
+      enabled: experimentListParams.isEnabled,
+    },
+  );
+
+  const rankingFilters = useMemo(
+    () => getRankingFilters(rankingMetric, experimentListParams.filters),
+    [rankingMetric, experimentListParams.filters],
+  );
+
+  const { data: rankingData } = useExperimentsList(
+    {
+      workspaceName,
+      filters: rankingFilters,
+      experimentIds: experimentListParams.experimentIds,
+      sorting: rankingSorting,
+      page: 1,
+      size: MAX_MAX_ROWS,
+      queryKey: "experiments-ranking",
+    },
+    {
+      placeholderData: keepPreviousData,
+      enabled:
+        experimentListParams.isEnabled && enableRanking && !!rankingMetric,
+    },
+  );
+
+  const experiments = experimentsData?.content ?? [];
+  const sortableColumns = useMemo(
+    () => experimentsData?.sortable_by ?? [],
+    [experimentsData?.sortable_by],
+  );
+
+  // Build ranking map: experimentId -> rank position
+  const rankingMap = useMemo(() => {
+    if (!enableRanking || !rankingData?.content) {
+      return undefined;
+    }
+    const map = new Map<string, number>();
+    rankingData.content.forEach((exp, index) => {
+      map.set(exp.id, index + 1);
+    });
+    return map;
+  }, [enableRanking, rankingData?.content]);
+
+  const selectedScoreColumns = useMemo(() => {
+    const scoreColumnIds = [...selectedColumns];
+
+    if (
+      enableRanking &&
+      rankingMetric &&
+      !scoreColumnIds.includes(rankingMetric)
+    ) {
+      scoreColumnIds.push(rankingMetric);
+    }
+
+    return scoreColumnIds
+      .map((colId) => {
+        const parsed = parseScoreColumnId(colId);
+        if (!parsed) return null;
+        return {
+          id: colId,
+          label: buildScoreLabel(parsed.scoreName, parsed.scoreType),
+          columnType: COLUMN_TYPE.number,
+          type: parsed.scoreType,
+        } as DynamicColumn;
+      })
+      .filter((col): col is DynamicColumn => col !== null);
+  }, [selectedColumns, enableRanking, rankingMetric]);
+
+  // Build metadata columns data
+  const metadataColumnsData = useMemo<ColumnData<Experiment>[]>(() => {
+    return selectedColumns
+      .filter((colId) => colId.startsWith(`${COLUMN_METADATA_ID}.`))
+      .map((colId) => {
+        const metaKey = colId.substring(COLUMN_METADATA_ID.length + 1);
+        return {
+          id: colId,
+          label: formatConfigColumnName(metaKey),
+          type: COLUMN_TYPE.string,
+          accessorFn: (row: Experiment) => get(row.metadata, metaKey),
+          cell: AutodetectCell as never,
+        };
+      });
+  }, [selectedColumns]);
+
+  const scoresColumnsData = useMemo<ColumnData<Experiment>[]>(() => {
+    return selectedScoreColumns.map((scoreCol) => {
+      const actualType = scoreCol.type || SCORE_TYPE_FEEDBACK;
+      const isRankingMetric = enableRanking && scoreCol.id === rankingMetric;
+
+      return {
+        id: scoreCol.id,
+        label: scoreCol.label,
+        type: scoreCol.columnType,
+        scoreType: actualType,
+        accessorFn: (row: Experiment) => getExperimentScore(scoreCol.id, row),
+        header: FeedbackScoreHeader as never,
+        cell: FeedbackScoreCell as never,
+        customMeta: isRankingMetric
+          ? {
+              prefixIcon: (
+                <TooltipWrapper
+                  content={`Ranking metric (${
+                    rankingDirection ? "higher is better" : "lower is better"
+                  })`}
+                >
+                  <Trophy className="mr-1 size-3.5 shrink-0 text-yellow-500" />
+                </TooltipWrapper>
+              ),
+            }
+          : undefined,
+      };
+    });
+  }, [selectedScoreColumns, enableRanking, rankingMetric, rankingDirection]);
+
+  // Build table columns
+  const tableColumns = useMemo(() => {
+    const allColumns: ColumnDef<Experiment>[] = [];
+
+    // 1. Rank column (if enabled)
+    if (enableRanking) {
+      allColumns.push(
+        mapColumnDataFields<Experiment, Experiment>({
+          id: RANK_COLUMN_ID,
+          label: "Rank",
+          type: COLUMN_TYPE.number,
+          header: RankingHeader as never,
+          cell: RankingCell as never,
+          size: 50,
+          sortable: false,
+          customMeta: {
+            getRank: (rowId: string) => rankingMap?.get(rowId),
+          },
+        }),
+      );
+    }
+
+    // 2. Name column (always shown)
+    allColumns.push(
+      mapColumnDataFields<Experiment, Experiment>({
+        id: NAME_COLUMN_ID,
+        label: "Name",
+        type: COLUMN_TYPE.string,
+        cell: ResourceCell as never,
+        sortable: sortableColumns?.includes("name") || false,
+        customMeta: {
+          nameKey: "name",
+          idKey: "id",
+          resource: RESOURCE_TYPE.experiment,
+        },
+      }),
+    );
+
+    // 3. Predefined columns (using helper)
+    allColumns.push(
+      ...convertColumnDataToColumn<Experiment, Experiment>(PREDEFINED_COLUMNS, {
+        columnsOrder,
+        selectedColumns,
+        sortableColumns,
+      }),
+    );
+
+    // 4. Metadata columns (using helper)
+    allColumns.push(
+      ...convertColumnDataToColumn<Experiment, Experiment>(
+        metadataColumnsData,
+        {
+          columnsOrder: metadataColumnsOrder,
+          sortableColumns,
+        },
+      ),
+    );
+
+    // 5. Feedback score columns (using helper)
+    allColumns.push(
+      ...convertColumnDataToColumn<Experiment, Experiment>(scoresColumnsData, {
+        columnsOrder: scoresColumnsOrder,
+        sortableColumns,
+      }),
+    );
+
+    return allColumns;
+  }, [
+    enableRanking,
+    rankingMap,
+    selectedColumns,
+    columnsOrder,
+    metadataColumnsData,
+    metadataColumnsOrder,
+    scoresColumnsData,
+    scoresColumnsOrder,
+    sortableColumns,
+  ]);
+
+  const resizeConfig = useMemo(
+    () => ({
+      enabled: true,
+      columnSizing: columnsWidth,
+      onColumnResize: (updater: unknown) => {
+        if (!preview && sectionId && widgetId) {
+          const newWidths =
+            typeof updater === "function"
+              ? updater(columnsWidth)
+              : (updater as Record<string, number>);
+          updateWidget(sectionId, widgetId, {
+            config: {
+              ...config,
+              columnsWidth: newWidths,
+            },
+          });
+        }
+      },
+    }),
+    [columnsWidth, preview, sectionId, widgetId, config, updateWidget],
+  );
+
+  const sortConfig = useMemo(() => {
+    const sorting: Sorting = isArray(savedSorting) ? savedSorting : [];
+
+    return {
+      enabled: true,
+      enabledMultiSorting: false,
+      sorting,
+      setSorting: (updaterOrValue: unknown) => {
+        if (!sectionId || !widgetId) return;
+
+        const newSorting =
+          typeof updaterOrValue === "function"
+            ? updaterOrValue(sorting)
+            : (updaterOrValue as Sorting);
+
+        updateWidget(sectionId, widgetId, {
+          config: {
+            ...config,
+            sorting: newSorting,
+          },
+        });
+      },
+    };
+  }, [savedSorting, sectionId, widgetId, config, updateWidget]);
+
+  if (!widget) {
+    return null;
+  }
+
+  const noData = experiments.length === 0;
+
+  const renderContent = () => {
+    if (isSelectExperimentsMode(dataSource) && experimentIds.length === 0) {
+      return (
+        <DashboardWidget.EmptyState
+          title="Experiments not configured"
+          message="This widget needs experiments to display data. Select default experiments for the dashboard or set custom ones in the widget settings."
+          onAction={!preview ? handleEdit : undefined}
+          actionLabel="Configure widget"
+        />
+      );
+    }
+
+    if (isPending && experimentListParams.isEnabled) {
+      return (
+        <div className="flex size-full min-h-32 items-center justify-center">
+          <Spinner />
+        </div>
+      );
+    }
+
+    if (noData) {
+      return (
+        <DashboardWidget.EmptyState
+          title="No data available"
+          message="No experiments match the current filters"
+          onAction={!preview ? handleEdit : undefined}
+          actionLabel="Configure widget"
+        />
+      );
+    }
+
+    return (
+      <div
+        className={cn(
+          "h-full",
+          preview &&
+            "[&_a]:pointer-events-none [&_button]:pointer-events-none [&_th]:pointer-events-none",
+        )}
+      >
+        <DataTable
+          columns={tableColumns}
+          data={experiments}
+          resizeConfig={preview ? undefined : resizeConfig}
+          sortConfig={preview ? undefined : sortConfig}
+          getRowId={getRowId}
+          TableWrapper={ExperimentsLeaderboardTableWrapper}
+          stickyHeader
+        />
+      </div>
+    );
+  };
+
+  return (
+    <DashboardWidget>
+      {preview ? (
+        <DashboardWidget.PreviewHeader />
+      ) : (
+        <DashboardWidget.Header
+          title={widget.title || widget.generatedTitle || ""}
+          subtitle={widget.subtitle}
+          actions={
+            <DashboardWidget.ActionsMenu
+              sectionId={sectionId!}
+              widgetId={widgetId!}
+              widgetTitle={widget.title}
+            />
+          }
+          dragHandle={<DashboardWidget.DragHandle />}
+        />
+      )}
+      <DashboardWidget.Content>{renderContent()}</DashboardWidget.Content>
+    </DashboardWidget>
+  );
+};
+
+const arePropsEqual = (
+  prev: DashboardWidgetComponentProps,
+  next: DashboardWidgetComponentProps,
+) => {
+  if (prev.preview !== next.preview) return false;
+  if (prev.preview && next.preview) return true;
+  return prev.sectionId === next.sectionId && prev.widgetId === next.widgetId;
+};
+
+export default memo(ExperimentsLeaderboardWidget, arePropsEqual);

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/ExperimentsLeaderboardWidgetEditor.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/ExperimentsLeaderboardWidgetEditor.tsx
@@ -1,0 +1,471 @@
+import React, {
+  useMemo,
+  forwardRef,
+  useImperativeHandle,
+  useEffect,
+  useCallback,
+} from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import get from "lodash/get";
+import isEmpty from "lodash/isEmpty";
+import isNumber from "lodash/isNumber";
+import { Filter, ListChecks } from "lucide-react";
+
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Description } from "@/components/ui/description";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+
+import ExperimentWidgetDataSection from "@/components/shared/Dashboard/widgets/shared/ExperimentWidgetDataSection/ExperimentWidgetDataSection";
+import ExperimentsSelectBox from "@/components/pages-shared/experiments/ExperimentsSelectBox/ExperimentsSelectBox";
+import WidgetOverrideDefaultsSection from "@/components/shared/Dashboard/widgets/shared/WidgetOverrideDefaultsSection/WidgetOverrideDefaultsSection";
+import WidgetRankingSettingsSection from "@/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/WidgetRankingSettingsSection";
+import ColumnsButton from "@/components/shared/ColumnsButton/ColumnsButton";
+
+import { cn } from "@/lib/utils";
+import { Filters } from "@/types/filters";
+
+import {
+  DashboardWidget,
+  EXPERIMENT_DATA_SOURCE,
+  ExperimentsLeaderboardWidgetType,
+  WidgetEditorHandle,
+} from "@/types/dashboard";
+import {
+  useDashboardStore,
+  selectUpdatePreviewWidget,
+  selectConfig,
+} from "@/store/DashboardStore";
+import {
+  ExperimentsLeaderboardWidgetSchema,
+  ExperimentsLeaderboardWidgetFormData,
+} from "./schema";
+import WidgetEditorBaseLayout from "@/components/shared/Dashboard/WidgetConfigDialog/WidgetEditorBaseLayout";
+import {
+  parseMetadataKeys,
+  formatConfigColumnName,
+  PREDEFINED_COLUMNS,
+  DEFAULT_MAX_ROWS,
+  MIN_MAX_ROWS,
+  MAX_MAX_ROWS,
+  getExperimentListParams,
+} from "./helpers";
+import useExperimentsList from "@/api/datasets/useExperimentsList";
+import useAppStore from "@/store/AppStore";
+import { useExperimentsFeedbackScores } from "@/components/pages-shared/experiments/useExperimentsFeedbackScores";
+import { COLUMN_METADATA_ID, COLUMN_TYPE } from "@/types/shared";
+
+const ExperimentsLeaderboardWidgetEditor = forwardRef<WidgetEditorHandle>(
+  (_, ref) => {
+    const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+    const widgetData = useDashboardStore(
+      (state) => state.previewWidget!,
+    ) as DashboardWidget & ExperimentsLeaderboardWidgetType;
+    const updatePreviewWidget = useDashboardStore(selectUpdatePreviewWidget);
+    const globalConfig = useDashboardStore(selectConfig);
+
+    const { config } = widgetData;
+
+    const dataSource =
+      config.dataSource || EXPERIMENT_DATA_SOURCE.SELECT_EXPERIMENTS;
+
+    const filters = config.filters || [];
+    const overrideDefaults = config.overrideDefaults || false;
+    const selectedColumns = config.selectedColumns || [];
+
+    const experimentIds = useMemo(() => {
+      if (overrideDefaults) {
+        return config.experimentIds || [];
+      }
+      return globalConfig?.experimentIds || [];
+    }, [globalConfig?.experimentIds, config.experimentIds, overrideDefaults]);
+
+    const enableRanking = config.enableRanking ?? true;
+    const rankingMetric = config.rankingMetric;
+    const rankingDirection = config.rankingDirection ?? true;
+    const columnsOrder = config.columnsOrder || [];
+
+    const scoresColumnsOrder = useMemo(
+      () => config.scoresColumnsOrder || [],
+      [config.scoresColumnsOrder],
+    );
+
+    const metadataColumnsOrder = useMemo(
+      () => config.metadataColumnsOrder || [],
+      [config.metadataColumnsOrder],
+    );
+
+    const maxRows = config.maxRows || DEFAULT_MAX_ROWS;
+
+    const form = useForm<ExperimentsLeaderboardWidgetFormData>({
+      resolver: zodResolver(ExperimentsLeaderboardWidgetSchema),
+      mode: "onTouched",
+      defaultValues: {
+        dataSource,
+        filters,
+        experimentIds: config.experimentIds || [],
+        selectedColumns,
+        overrideDefaults,
+        enableRanking,
+        rankingMetric,
+        rankingDirection,
+        columnsOrder,
+        scoresColumnsOrder,
+        metadataColumnsOrder,
+        maxRows: String(maxRows),
+      },
+    });
+
+    const currentFilters = form.watch("filters") || [];
+    const watchedDataSource = form.watch("dataSource");
+
+    useEffect(() => {
+      if (form.formState.errors.filters) {
+        form.clearErrors("filters");
+      }
+    }, [currentFilters.length, form]);
+
+    const { dynamicScoresColumns } = useExperimentsFeedbackScores({
+      experimentIds:
+        dataSource === EXPERIMENT_DATA_SOURCE.SELECT_EXPERIMENTS
+          ? experimentIds
+          : undefined,
+      refetchInterval: 0,
+    });
+
+    const experimentListParams = getExperimentListParams({
+      dataSource,
+      experimentIds,
+      filters,
+    });
+
+    const { data: experimentsData } = useExperimentsList(
+      {
+        workspaceName,
+        experimentIds: experimentListParams.experimentIds,
+        filters: experimentListParams.filters,
+        page: 1,
+        size: 100,
+      },
+      {
+        enabled: experimentListParams.isEnabled,
+      },
+    );
+
+    const availableMetadataKeys = useMemo(() => {
+      if (!experimentsData?.content) return [];
+      return parseMetadataKeys(experimentsData.content);
+    }, [experimentsData]);
+
+    useImperativeHandle(ref, () => ({
+      submit: async () => {
+        return await form.trigger();
+      },
+      isValid: form.formState.isValid,
+    }));
+
+    const updateWidgetConfig = useCallback(
+      (partialConfig: Partial<typeof config>) => {
+        updatePreviewWidget({
+          config: {
+            ...config,
+            ...partialConfig,
+          },
+        });
+      },
+      [config, updatePreviewWidget],
+    );
+
+    const handleDataSourceChange = (value: string) => {
+      const newDataSource = value as EXPERIMENT_DATA_SOURCE;
+      form.setValue("dataSource", newDataSource, { shouldValidate: true });
+      updateWidgetConfig({ dataSource: newDataSource });
+    };
+
+    const handleFiltersChange = (newFilters: Filters) => {
+      updateWidgetConfig({ filters: newFilters });
+    };
+
+    const handleExperimentIdsChange = (newExperimentIds: string[]) => {
+      form.setValue("experimentIds", newExperimentIds);
+      updateWidgetConfig({ experimentIds: newExperimentIds });
+    };
+
+    const handleSelectedColumnsChange = (newSelectedColumns: string[]) => {
+      form.setValue("selectedColumns", newSelectedColumns);
+      updateWidgetConfig({ selectedColumns: newSelectedColumns });
+    };
+
+    const handleEnableRankingChange = (checked: boolean) => {
+      form.setValue("enableRanking", checked, { shouldValidate: true });
+      updateWidgetConfig({ enableRanking: checked });
+    };
+
+    const handleRankingMetricChange = (value: string) => {
+      form.setValue("rankingMetric", value, { shouldValidate: true });
+      updateWidgetConfig({ rankingMetric: value });
+    };
+
+    const handleRankingHigherIsBetterChange = (value: boolean) => {
+      form.setValue("rankingDirection", value);
+      updateWidgetConfig({ rankingDirection: value });
+    };
+
+    const handleColumnsOrderChange = (newOrder: string[]) => {
+      form.setValue("columnsOrder", newOrder);
+      updateWidgetConfig({ columnsOrder: newOrder });
+    };
+
+    const handleScoresColumnsOrderChange = useCallback(
+      (newOrder: string[]) => {
+        form.setValue("scoresColumnsOrder", newOrder);
+        updateWidgetConfig({ scoresColumnsOrder: newOrder });
+      },
+      [form, updateWidgetConfig],
+    );
+
+    const handleMetadataColumnsOrderChange = useCallback(
+      (newOrder: string[]) => {
+        form.setValue("metadataColumnsOrder", newOrder);
+        updateWidgetConfig({ metadataColumnsOrder: newOrder });
+      },
+      [form, updateWidgetConfig],
+    );
+
+    const handleMaxRowsChange = (value: string) => {
+      form.setValue("maxRows", value, {
+        shouldValidate: true,
+      });
+      const numValue = isEmpty(value) ? undefined : parseInt(value, 10);
+      updateWidgetConfig({
+        maxRows: isNumber(numValue) ? numValue : undefined,
+      });
+    };
+
+    const dynamicMetadataColumns = useMemo(() => {
+      return availableMetadataKeys.map((key) => ({
+        id: `${COLUMN_METADATA_ID}.${key}`,
+        label: formatConfigColumnName(key),
+        columnType: COLUMN_TYPE.string,
+      }));
+    }, [availableMetadataKeys]);
+
+    const columnSections = useMemo(
+      () => [
+        {
+          title: "Configuration",
+          columns: dynamicMetadataColumns,
+          order: metadataColumnsOrder,
+          onOrderChange: handleMetadataColumnsOrderChange,
+        },
+        {
+          title: "Feedback scores",
+          columns: dynamicScoresColumns,
+          order: scoresColumnsOrder,
+          onOrderChange: handleScoresColumnsOrderChange,
+        },
+      ],
+      [
+        dynamicMetadataColumns,
+        dynamicScoresColumns,
+        handleMetadataColumnsOrderChange,
+        handleScoresColumnsOrderChange,
+        metadataColumnsOrder,
+        scoresColumnsOrder,
+      ],
+    );
+
+    return (
+      <Form {...form}>
+        <WidgetEditorBaseLayout>
+          <div className="space-y-4">
+            <div className="flex items-start justify-between">
+              <div className="flex-1 pr-4">
+                <div className="flex flex-col gap-0.5 px-0.5">
+                  <Label className="comet-body-s-accented">Columns</Label>
+                  <Description>
+                    Select and reorder columns to display.
+                  </Description>
+                </div>
+              </div>
+              <ColumnsButton
+                columns={PREDEFINED_COLUMNS}
+                selectedColumns={selectedColumns}
+                onSelectionChange={handleSelectedColumnsChange}
+                order={columnsOrder}
+                onOrderChange={handleColumnsOrderChange}
+                sections={columnSections}
+              />
+            </div>
+
+            <WidgetRankingSettingsSection
+              control={form.control}
+              dynamicScoresColumns={dynamicScoresColumns}
+              onEnableRankingChange={handleEnableRankingChange}
+              onRankingMetricChange={handleRankingMetricChange}
+              onRankingHigherIsBetterChange={handleRankingHigherIsBetterChange}
+            />
+
+            <WidgetOverrideDefaultsSection
+              value={form.watch("overrideDefaults") || false}
+              onChange={(value) => {
+                form.setValue("overrideDefaults", value, {
+                  shouldValidate: true,
+                });
+                updateWidgetConfig({ overrideDefaults: value });
+              }}
+              description="Turn this on to override the dashboard's default experiments for this widget."
+            >
+              <div className="space-y-4">
+                <FormField
+                  control={form.control}
+                  name="dataSource"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Experiment override</FormLabel>
+                      <FormControl>
+                        <ToggleGroup
+                          type="single"
+                          variant="ghost"
+                          value={
+                            field.value ||
+                            EXPERIMENT_DATA_SOURCE.SELECT_EXPERIMENTS
+                          }
+                          onValueChange={(value) => {
+                            if (value) {
+                              field.onChange(value);
+                              handleDataSourceChange(value);
+                            }
+                          }}
+                          className="w-fit justify-start"
+                        >
+                          <ToggleGroupItem
+                            value={EXPERIMENT_DATA_SOURCE.SELECT_EXPERIMENTS}
+                            aria-label="Manual selection"
+                            className="gap-1.5"
+                          >
+                            <ListChecks className="size-3.5" />
+                            <span>Manual selection</span>
+                          </ToggleGroupItem>
+                          <ToggleGroupItem
+                            value={EXPERIMENT_DATA_SOURCE.FILTER_AND_GROUP}
+                            aria-label="Filter experiments"
+                            className="gap-1.5"
+                          >
+                            <Filter className="size-3.5" />
+                            <span>Filter experiments</span>
+                          </ToggleGroupItem>
+                        </ToggleGroup>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {watchedDataSource ===
+                  EXPERIMENT_DATA_SOURCE.FILTER_AND_GROUP && (
+                  <>
+                    <ExperimentWidgetDataSection
+                      control={form.control}
+                      filtersFieldName="filters"
+                      filters={filters}
+                      onFiltersChange={handleFiltersChange}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="maxRows"
+                      render={({ field, formState }) => {
+                        const validationErrors = get(formState.errors, [
+                          "maxRows",
+                        ]);
+                        return (
+                          <FormItem>
+                            <FormLabel>Maximum rows</FormLabel>
+                            <FormControl>
+                              <Input
+                                type="number"
+                                min={MIN_MAX_ROWS}
+                                max={MAX_MAX_ROWS}
+                                value={field.value ?? ""}
+                                onChange={(e) => {
+                                  const value = e.target.value;
+                                  handleMaxRowsChange(value);
+                                }}
+                                className={cn({
+                                  "border-destructive": Boolean(
+                                    validationErrors?.message,
+                                  ),
+                                })}
+                              />
+                            </FormControl>
+                            <Description>
+                              Number of experiments to display ({MIN_MAX_ROWS}-
+                              {MAX_MAX_ROWS})
+                            </Description>
+                            <FormMessage />
+                          </FormItem>
+                        );
+                      }}
+                    />
+                  </>
+                )}
+
+                {watchedDataSource ===
+                  EXPERIMENT_DATA_SOURCE.SELECT_EXPERIMENTS && (
+                  <FormField
+                    control={form.control}
+                    name="experimentIds"
+                    render={({ field, formState }) => {
+                      const validationErrors = get(formState.errors, [
+                        "experimentIds",
+                      ]);
+                      return (
+                        <FormItem>
+                          <FormLabel>Select experiments</FormLabel>
+                          <FormControl>
+                            <ExperimentsSelectBox
+                              value={field.value || []}
+                              onValueChange={(value) => {
+                                field.onChange(value);
+                                handleExperimentIdsChange(value);
+                              }}
+                              multiselect
+                              showClearButton
+                              className={cn("flex-1", {
+                                "border-destructive": Boolean(
+                                  validationErrors?.message,
+                                ),
+                              })}
+                            />
+                          </FormControl>
+                          <Description>
+                            Choose specific experiments to show in this widget.
+                          </Description>
+                          <FormMessage />
+                        </FormItem>
+                      );
+                    }}
+                  />
+                )}
+              </div>
+            </WidgetOverrideDefaultsSection>
+          </div>
+        </WidgetEditorBaseLayout>
+      </Form>
+    );
+  },
+);
+
+ExperimentsLeaderboardWidgetEditor.displayName =
+  "ExperimentsLeaderboardWidgetEditor";
+
+export default ExperimentsLeaderboardWidgetEditor;

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/WidgetRankingSettingsSection.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/WidgetRankingSettingsSection.tsx
@@ -1,0 +1,153 @@
+import React, { useMemo } from "react";
+import { Control, FieldValues, Path, useWatch } from "react-hook-form";
+import get from "lodash/get";
+import { TrendingUp, TrendingDown } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Description } from "@/components/ui/description";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import SelectBox from "@/components/shared/SelectBox/SelectBox";
+import { cn } from "@/lib/utils";
+import { DropdownOption } from "@/types/shared";
+import { DynamicColumn } from "@/types/shared";
+
+interface WidgetRankingSettingsSectionProps<T extends FieldValues> {
+  control: Control<T>;
+  dynamicScoresColumns: DynamicColumn[];
+  onEnableRankingChange: (checked: boolean) => void;
+  onRankingMetricChange: (value: string) => void;
+  onRankingHigherIsBetterChange: (value: boolean) => void;
+}
+
+const WidgetRankingSettingsSection = <T extends FieldValues>({
+  control,
+  dynamicScoresColumns,
+  onEnableRankingChange,
+  onRankingMetricChange,
+  onRankingHigherIsBetterChange,
+}: WidgetRankingSettingsSectionProps<T>) => {
+  const rankingOptions: DropdownOption<string>[] = useMemo(() => {
+    return dynamicScoresColumns.map((col) => ({
+      value: col.id,
+      label: col.label,
+    }));
+  }, [dynamicScoresColumns]);
+
+  const currentEnableRanking = useWatch({
+    control,
+    name: "enableRanking" as Path<T>,
+  });
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 pr-4">
+          <div className="flex flex-col gap-0.5 px-0.5">
+            <Label className="comet-body-s-accented">Enable ranking</Label>
+            <Description>
+              Show rank numbers based on primary ranking metric.
+            </Description>
+          </div>
+        </div>
+        <FormField
+          control={control}
+          name={"enableRanking" as Path<T>}
+          render={({ field }) => (
+            <Switch
+              checked={field.value ?? false}
+              onCheckedChange={(checked) => {
+                field.onChange(checked);
+                onEnableRankingChange(checked);
+              }}
+              size="sm"
+            />
+          )}
+        />
+      </div>
+      {currentEnableRanking && (
+        <div className="space-y-3 rounded-md border border-border p-3">
+          <FormField
+            control={control}
+            name={"rankingMetric" as Path<T>}
+            render={({ field, formState }) => {
+              const validationErrors = get(formState.errors, ["rankingMetric"]);
+
+              return (
+                <FormItem>
+                  <FormLabel>Primary ranking metric</FormLabel>
+                  <FormControl>
+                    <SelectBox
+                      value={field.value || ""}
+                      onChange={(value) => {
+                        field.onChange(value);
+                        onRankingMetricChange(value);
+                      }}
+                      options={rankingOptions}
+                      placeholder="Select ranking metric"
+                      className={cn({
+                        "border-destructive": Boolean(
+                          validationErrors?.message,
+                        ),
+                      })}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              );
+            }}
+          />
+          <FormField
+            control={control}
+            name={"rankingDirection" as Path<T>}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Ranking order</FormLabel>
+                <FormControl>
+                  <ToggleGroup
+                    type="single"
+                    variant="ghost"
+                    value={field.value === false ? "lower" : "higher"}
+                    onValueChange={(value) => {
+                      if (value) {
+                        const isHigher = value === "higher";
+                        field.onChange(isHigher);
+                        onRankingHigherIsBetterChange(isHigher);
+                      }
+                    }}
+                    className="w-fit justify-start"
+                  >
+                    <ToggleGroupItem
+                      value="higher"
+                      aria-label="Higher is better"
+                      className="gap-1.5"
+                    >
+                      <TrendingUp className="size-3.5" />
+                      <span>Higher is better</span>
+                    </ToggleGroupItem>
+                    <ToggleGroupItem
+                      value="lower"
+                      aria-label="Lower is better"
+                      className="gap-1.5"
+                    >
+                      <TrendingDown className="size-3.5" />
+                      <span>Lower is better</span>
+                    </ToggleGroupItem>
+                  </ToggleGroup>
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WidgetRankingSettingsSection;

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/helpers.ts
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/helpers.ts
@@ -1,0 +1,250 @@
+import uniq from "lodash/uniq";
+import get from "lodash/get";
+
+import { EXPERIMENT_DATA_SOURCE } from "@/types/dashboard";
+import { Experiment } from "@/types/datasets";
+import {
+  COLUMN_TYPE,
+  ColumnData,
+  COLUMN_ID_ID,
+  COLUMN_DATASET_ID,
+} from "@/types/shared";
+import { Filters } from "@/types/filters";
+import { createFilter, isFilterValid } from "@/lib/filters";
+import IdCell from "@/components/shared/DataTableCells/IdCell";
+import DurationCell from "@/components/shared/DataTableCells/DurationCell";
+import TraceCountCell from "@/components/shared/DataTableCells/TraceCountCell";
+import CostCell from "@/components/shared/DataTableCells/CostCell";
+import ResourceCell from "@/components/shared/DataTableCells/ResourceCell";
+import MultiResourceCell from "@/components/shared/DataTableCells/MultiResourceCell";
+import ListCell from "@/components/shared/DataTableCells/ListCell";
+import { RESOURCE_TYPE } from "@/components/shared/ResourceLink/ResourceLink";
+import { getJSONPaths } from "@/lib/utils";
+import { formatDate } from "@/lib/date";
+import { parseScoreColumnId } from "@/components/pages-shared/experiments/scoresUtils";
+
+export {
+  parseScoreColumnId,
+  getExperimentScore,
+  buildScoreLabel,
+} from "@/components/pages-shared/experiments/scoresUtils";
+
+export const isSelectExperimentsMode = (dataSource: EXPERIMENT_DATA_SOURCE) =>
+  dataSource === EXPERIMENT_DATA_SOURCE.SELECT_EXPERIMENTS;
+
+interface ExperimentListParamsInput {
+  dataSource: EXPERIMENT_DATA_SOURCE;
+  experimentIds: string[];
+  filters: Filters;
+}
+
+export const getExperimentListParams = ({
+  dataSource,
+  experimentIds,
+  filters,
+}: ExperimentListParamsInput) => {
+  const isSelectMode = isSelectExperimentsMode(dataSource);
+  const validFilters = filters.filter(isFilterValid);
+  return {
+    experimentIds: isSelectMode ? experimentIds : undefined,
+    filters: !isSelectMode ? validFilters : undefined,
+    isEnabled: isSelectMode ? experimentIds.length > 0 : true,
+  };
+};
+
+export const DEFAULT_MAX_ROWS = 20;
+export const MIN_MAX_ROWS = 1;
+export const MAX_MAX_ROWS = 100;
+
+export const PREDEFINED_COLUMNS: ColumnData<Experiment>[] = [
+  {
+    id: COLUMN_ID_ID,
+    label: "ID",
+    type: COLUMN_TYPE.string,
+    cell: IdCell as never,
+  },
+  {
+    id: COLUMN_DATASET_ID,
+    label: "Dataset",
+    type: COLUMN_TYPE.string,
+    cell: ResourceCell as never,
+    customMeta: {
+      nameKey: "dataset_name",
+      idKey: "dataset_id",
+      resource: RESOURCE_TYPE.dataset,
+    },
+  },
+  {
+    id: "tags",
+    label: "Tags",
+    type: COLUMN_TYPE.list,
+    iconType: "tags",
+    accessorFn: (row) => row.tags || [],
+    cell: ListCell as never,
+  },
+  {
+    id: "created_at",
+    label: "Created",
+    type: COLUMN_TYPE.time,
+    accessorFn: (row) => formatDate(row.created_at),
+  },
+  {
+    id: "created_by",
+    label: "Created by",
+    type: COLUMN_TYPE.string,
+  },
+  {
+    id: "duration.p50",
+    label: "Duration (avg.)",
+    type: COLUMN_TYPE.duration,
+    accessorFn: (row) => row.duration?.p50,
+    cell: DurationCell as never,
+  },
+  {
+    id: "duration.p90",
+    label: "Duration (p90)",
+    type: COLUMN_TYPE.duration,
+    accessorFn: (row) => row.duration?.p90,
+    cell: DurationCell as never,
+  },
+  {
+    id: "duration.p99",
+    label: "Duration (p99)",
+    type: COLUMN_TYPE.duration,
+    accessorFn: (row) => row.duration?.p99,
+    cell: DurationCell as never,
+  },
+  {
+    id: "prompt",
+    label: "Prompt commit",
+    type: COLUMN_TYPE.list,
+    accessorFn: (row) => get(row, ["prompt_versions"], []),
+    cell: MultiResourceCell as never,
+    customMeta: {
+      nameKey: "commit",
+      idKey: "prompt_id",
+      resource: RESOURCE_TYPE.prompt,
+      getSearch: (data: Experiment) => ({
+        activeVersionId: get(data, "id", null),
+      }),
+    },
+  },
+  {
+    id: "trace_count",
+    label: "Trace count",
+    type: COLUMN_TYPE.number,
+    cell: TraceCountCell as never,
+    customMeta: {
+      tooltip: "View experiment traces",
+    },
+  },
+  {
+    id: "total_estimated_cost",
+    label: "Total estimated cost",
+    type: COLUMN_TYPE.cost,
+    cell: CostCell as never,
+  },
+  {
+    id: "total_estimated_cost_avg",
+    label: "Cost per trace (avg.)",
+    type: COLUMN_TYPE.cost,
+    cell: CostCell as never,
+  },
+];
+
+export const DEFAULT_SELECTED_COLUMNS: string[] = [
+  COLUMN_DATASET_ID,
+  "created_at",
+  "duration.p50",
+];
+
+export const getDefaultConfig = () => ({
+  overrideDefaults: false,
+  dataSource: EXPERIMENT_DATA_SOURCE.SELECT_EXPERIMENTS,
+  experimentIds: [],
+  selectedColumns: DEFAULT_SELECTED_COLUMNS,
+  enableRanking: true,
+  columnsOrder: DEFAULT_SELECTED_COLUMNS,
+  scoresColumnsOrder: [],
+  metadataColumnsOrder: [],
+  columnsWidth: {},
+  maxRows: DEFAULT_MAX_ROWS,
+  sorting: [],
+});
+
+export const calculateTitle = (config: Record<string, unknown>) => {
+  const enableRanking = config.enableRanking as boolean;
+  const rankingMetric = config.rankingMetric as string | undefined;
+
+  if (enableRanking && rankingMetric) {
+    return `Experiment leaderboard (${formatMetricName(rankingMetric)})`;
+  }
+  return "Experiment leaderboard";
+};
+
+export const parseMetadataKeys = (experiments: Experiment[]): string[] => {
+  const allKeys = experiments.reduce<string[]>((acc, exp) => {
+    if (exp.metadata) {
+      const paths = getJSONPaths(exp.metadata, "", [], true);
+      acc.push(...paths);
+    }
+    return acc;
+  }, []);
+
+  return uniq(allKeys).sort();
+};
+
+export const formatMetricName = (metric: string): string => {
+  const metricLabels: Record<string, string> = {
+    "duration.p50": "Duration (avg.)",
+    "duration.p90": "Duration (p90)",
+    "duration.p99": "Duration (p99)",
+    trace_count: "Trace count",
+    total_estimated_cost: "Total cost",
+    total_estimated_cost_avg: "Cost per trace",
+  };
+  return metricLabels[metric] || metric;
+};
+
+export const formatConfigColumnName = (key: string): string => {
+  return `config.${key}`;
+};
+
+interface GetRankingSortingParams {
+  rankingMetric?: string;
+  rankingDirection?: boolean;
+}
+
+export const getRankingSorting = ({
+  rankingMetric,
+  rankingDirection = true,
+}: GetRankingSortingParams) => {
+  if (!rankingMetric) return undefined;
+  return [{ id: rankingMetric, desc: rankingDirection }];
+};
+
+export const getRankingFilters = (
+  rankingMetric: string | undefined,
+  existingFilters: Filters = [],
+): Filters => {
+  if (!rankingMetric) return existingFilters;
+
+  const parsedScore = parseScoreColumnId(rankingMetric);
+
+  return parsedScore
+    ? [
+        ...existingFilters,
+        createFilter({
+          id: `ranking-filter-${rankingMetric}`,
+          field: parsedScore.scoreType,
+          operator: "is_not_empty",
+          key: parsedScore.scoreName,
+        }),
+      ]
+    : existingFilters;
+};
+
+export const widgetHelpers = {
+  getDefaultConfig,
+  calculateTitle,
+};

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/schema.ts
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/schema.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+import isString from "lodash/isString";
+import isNumber from "lodash/isNumber";
+import isEmpty from "lodash/isEmpty";
+import { EXPERIMENT_DATA_SOURCE } from "@/types/dashboard";
+import { FiltersArraySchema } from "@/components/shared/FiltersAccordionSection/schema";
+import { MIN_MAX_ROWS, MAX_MAX_ROWS } from "./helpers";
+
+const ColumnSortSchema = z.object({
+  id: z.string(),
+  desc: z.boolean(),
+});
+
+export const ExperimentsLeaderboardWidgetSchema = z
+  .object({
+    overrideDefaults: z.boolean(),
+    dataSource: z.nativeEnum(EXPERIMENT_DATA_SOURCE),
+    experimentIds: z.array(z.string()).optional(),
+    filters: FiltersArraySchema.optional(),
+    selectedColumns: z.array(z.string()),
+    enableRanking: z.boolean(),
+    rankingMetric: z.string().optional(),
+    rankingDirection: z.boolean().optional(),
+    columnsOrder: z.array(z.string()).optional(),
+    scoresColumnsOrder: z.array(z.string()).optional(),
+    metadataColumnsOrder: z.array(z.string()).optional(),
+    columnsWidth: z.record(z.string(), z.number()).optional(),
+    maxRows: z.string().optional(),
+    sorting: z.array(ColumnSortSchema).optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.enableRanking) {
+        return !isEmpty(data.rankingMetric) && isString(data.rankingMetric);
+      }
+      return true;
+    },
+    {
+      message: "Ranking metric is required when ranking is enabled",
+      path: ["rankingMetric"],
+    },
+  )
+  .refine(
+    (data) => {
+      if (
+        data.dataSource === EXPERIMENT_DATA_SOURCE.FILTER_AND_GROUP &&
+        data.overrideDefaults
+      ) {
+        if (isEmpty(data.maxRows)) {
+          return false;
+        }
+        const numValue = parseInt(data.maxRows!, 10);
+        return (
+          isNumber(numValue) &&
+          numValue >= MIN_MAX_ROWS &&
+          numValue <= MAX_MAX_ROWS
+        );
+      }
+      return true;
+    },
+    {
+      message: `Maximum rows is required and must be between ${MIN_MAX_ROWS} and ${MAX_MAX_ROWS}`,
+      path: ["maxRows"],
+    },
+  );
+
+export type ExperimentsLeaderboardWidgetFormData = z.infer<
+  typeof ExperimentsLeaderboardWidgetSchema
+>;

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/shared/ExperimentWidgetDataSection/ExperimentWidgetDataSection.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/shared/ExperimentWidgetDataSection/ExperimentWidgetDataSection.tsx
@@ -39,6 +39,12 @@ const EXPERIMENT_DATA_COLUMNS: ColumnData<ExperimentColumnData>[] = [
     disposable: true,
   },
   {
+    id: "tags",
+    label: "Tags",
+    type: COLUMN_TYPE.list,
+    iconType: "tags",
+  },
+  {
     id: COLUMN_METADATA_ID,
     label: "Configuration",
     type: COLUMN_TYPE.dictionary,
@@ -48,9 +54,9 @@ const EXPERIMENT_DATA_COLUMNS: ColumnData<ExperimentColumnData>[] = [
 interface ExperimentWidgetDataSectionProps<T extends FieldValues> {
   control: Control<T>;
   filtersFieldName: FieldPath<T>;
-  groupsFieldName: FieldPath<T>;
+  groupsFieldName?: FieldPath<T> | "";
   filters: Filters;
-  groups: Groups;
+  groups?: Groups;
   onFiltersChange?: (filters: Filters) => void;
   onGroupsChange?: (groups: Groups) => void;
   className?: string;
@@ -73,7 +79,7 @@ const ExperimentWidgetDataSection = <T extends FieldValues>({
 
   const { field: groupsField } = useController({
     control,
-    name: groupsFieldName,
+    name: (groupsFieldName || "groups") as FieldPath<T>,
   });
 
   const dataConfig = useMemo(
@@ -128,6 +134,8 @@ const ExperimentWidgetDataSection = <T extends FieldValues>({
 
   const setGroups = useCallback(
     (groupsOrUpdater: Groups | ((prev: Groups) => Groups)) => {
+      if (!groupsFieldName) return;
+
       let updatedGroups: Groups;
 
       if (isFunction(groupsOrUpdater)) {
@@ -140,7 +148,7 @@ const ExperimentWidgetDataSection = <T extends FieldValues>({
       groupsField.onChange(updatedGroups);
       onGroupsChange?.(updatedGroups);
     },
-    [groupsField, onGroupsChange],
+    [groupsFieldName, groupsField, onGroupsChange],
   );
 
   const { errors: formErrors } = useFormState({ control });
@@ -159,7 +167,7 @@ const ExperimentWidgetDataSection = <T extends FieldValues>({
         )
       : undefined;
 
-  const groupErrors = formErrors[groupsFieldName];
+  const groupErrors = groupsFieldName ? formErrors[groupsFieldName] : undefined;
   const parsedGroupErrors =
     groupErrors && isArray(groupErrors)
       ? (groupErrors as unknown[]).map((e) =>
@@ -170,8 +178,9 @@ const ExperimentWidgetDataSection = <T extends FieldValues>({
   return (
     <div className={cn("flex flex-col", className)}>
       <Description className="mb-4">
-        Add filters to focus on specific experiments and group them by
-        configuration to aggregate feedback scores.
+        {groupsFieldName
+          ? "Add filters to focus on specific experiments and group them by configuration to aggregate feedback scores."
+          : "Add filters to focus on specific experiments."}
       </Description>
 
       <FiltersAccordionSection
@@ -183,17 +192,19 @@ const ExperimentWidgetDataSection = <T extends FieldValues>({
         errors={parsedFilterErrors}
       />
 
-      <GroupsAccordionSection
-        columns={EXPERIMENT_DATA_COLUMNS as ColumnData<unknown>[]}
-        config={dataConfig}
-        groups={groups}
-        onChange={setGroups}
-        label="Group by"
-        errors={parsedGroupErrors}
-        className="w-full"
-        hideSorting
-        hideBorder
-      />
+      {groupsFieldName && (
+        <GroupsAccordionSection
+          columns={EXPERIMENT_DATA_COLUMNS as ColumnData<unknown>[]}
+          config={dataConfig}
+          groups={groups || []}
+          onChange={setGroups}
+          label="Group by"
+          errors={parsedGroupErrors}
+          className="w-full"
+          hideSorting
+          hideBorder
+        />
+      )}
     </div>
   );
 };

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/widgetRegistry.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/widgetRegistry.tsx
@@ -1,4 +1,10 @@
-import { NotebookText, ChartLine, Hash, FlaskConical } from "lucide-react";
+import {
+  NotebookText,
+  ChartLine,
+  Hash,
+  FlaskConical,
+  Trophy,
+} from "lucide-react";
 import {
   WidgetResolver,
   WidgetComponents,
@@ -17,6 +23,9 @@ import { widgetHelpers as projectStatsCardHelpers } from "./ProjectStatsCardWidg
 import ExperimentsFeedbackScoresWidget from "./ExperimentsFeedbackScoresWidget/ExperimentsFeedbackScoresWidget";
 import ExperimentsFeedbackScoresWidgetEditor from "./ExperimentsFeedbackScoresWidget/ExperimentsFeedbackScoresWidgetEditor";
 import { widgetHelpers as experimentsFeedbackScoresHelpers } from "./ExperimentsFeedbackScoresWidget/helpers";
+import ExperimentsLeaderboardWidget from "./ExperimentsLeaderboardWidget/ExperimentsLeaderboardWidget";
+import ExperimentsLeaderboardWidgetEditor from "./ExperimentsLeaderboardWidget/ExperimentsLeaderboardWidgetEditor";
+import { widgetHelpers as experimentLeaderboardHelpers } from "./ExperimentsLeaderboardWidget/helpers";
 
 export const widgetResolver: WidgetResolver = (
   type: string,
@@ -86,6 +95,22 @@ export const widgetResolver: WidgetResolver = (
           disabled: false,
         },
       };
+    case WIDGET_TYPES.EXPERIMENT_LEADERBOARD:
+      return {
+        Widget: ExperimentsLeaderboardWidget,
+        Editor: ExperimentsLeaderboardWidgetEditor,
+        getDefaultConfig: experimentLeaderboardHelpers.getDefaultConfig,
+        calculateTitle: experimentLeaderboardHelpers.calculateTitle,
+        metadata: {
+          title: "Experiment leaderboard",
+          description:
+            "Rank and compare experiments across multiple metrics in a sortable table.",
+          icon: <Trophy className="size-4" />,
+          category: WIDGET_CATEGORY.EVALUATION,
+          iconColor: "text-[#FFD700]",
+          disabled: false,
+        },
+      };
     default:
       return {
         Widget: TextMarkdownWidget,
@@ -110,6 +135,7 @@ export const getAllWidgetTypes = (): string[] => {
     WIDGET_TYPES.PROJECT_METRICS,
     WIDGET_TYPES.PROJECT_STATS_CARD,
     WIDGET_TYPES.EXPERIMENTS_FEEDBACK_SCORES,
+    WIDGET_TYPES.EXPERIMENT_LEADERBOARD,
     WIDGET_TYPES.TEXT_MARKDOWN,
   ];
 };

--- a/apps/opik-frontend/src/components/shared/DataTableCells/RankingCell.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableCells/RankingCell.tsx
@@ -1,0 +1,54 @@
+import { CellContext } from "@tanstack/react-table";
+import { Medal } from "lucide-react";
+
+import CellWrapper from "@/components/shared/DataTableCells/CellWrapper";
+import { cn } from "@/lib/utils";
+
+const MEDAL_COLORS: Record<number, string> = {
+  1: "text-yellow-500",
+  2: "text-slate-400",
+  3: "text-amber-700",
+};
+
+interface CustomMeta {
+  getRank: (rowId: string) => number | undefined;
+}
+
+interface RowWithId {
+  id: string;
+}
+
+const RankingCell = <TData extends RowWithId>(
+  context: CellContext<TData, unknown>,
+) => {
+  const customMeta = context.column.columnDef.meta?.custom as
+    | CustomMeta
+    | undefined;
+  const rowId = context.row.original.id;
+  const rank = customMeta?.getRank(rowId);
+  const medalColor = rank ? MEDAL_COLORS[rank] : null;
+
+  return (
+    <CellWrapper
+      metadata={context.column.columnDef.meta}
+      tableMetadata={context.table.options.meta}
+    >
+      <div className="flex items-center justify-center">
+        {rank === undefined ? (
+          <span className="comet-body-s text-slate-400">—</span>
+        ) : (
+          <>
+            {medalColor && (
+              <Medal className={cn("size-3.5 shrink-0", medalColor)} />
+            )}
+            <span className={cn("comet-code", medalColor && "ml-1")}>
+              {rank}
+            </span>
+          </>
+        )}
+      </div>
+    </CellWrapper>
+  );
+};
+
+export default RankingCell;

--- a/apps/opik-frontend/src/components/shared/DataTableHeaders/FeedbackScoreHeader.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableHeaders/FeedbackScoreHeader.tsx
@@ -12,7 +12,8 @@ const FeedbackScoreHeader = <TData,>(
 ) => {
   const { column } = context;
   const { header, custom } = column.columnDef.meta ?? {};
-  const { colorMap, feedbackKey } = (custom ?? {}) as FeedbackScoreCustomMeta;
+  const { colorMap, feedbackKey, prefixIcon } = (custom ??
+    {}) as FeedbackScoreCustomMeta;
 
   // Use color from colorMap if available, otherwise fall back to default
   const color =
@@ -31,6 +32,7 @@ const FeedbackScoreHeader = <TData,>(
       className={className}
       onClick={onClickHandler}
     >
+      {prefixIcon}
       <div
         className="mr-0.5 size-2 shrink-0 rounded-[2px] bg-[--color-bg]"
         style={{ "--color-bg": color } as React.CSSProperties}

--- a/apps/opik-frontend/src/components/shared/DataTableHeaders/RankingHeader.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableHeaders/RankingHeader.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { HeaderContext } from "@tanstack/react-table";
+import { Trophy } from "lucide-react";
+
+import HeaderWrapper from "@/components/shared/DataTableHeaders/HeaderWrapper";
+
+const RankingHeader = <TData,>(context: HeaderContext<TData, unknown>) => {
+  return (
+    <HeaderWrapper
+      metadata={context.column.columnDef.meta}
+      tableMetadata={context.table.options.meta}
+    >
+      <Trophy className="size-3.5 shrink-0 text-yellow-500" />
+    </HeaderWrapper>
+  );
+};
+
+export default RankingHeader;

--- a/apps/opik-frontend/src/lib/dashboard/layout.ts
+++ b/apps/opik-frontend/src/lib/dashboard/layout.ts
@@ -26,6 +26,8 @@ export const getWidgetSizeConfig = (type: string): WidgetSizeConfig => {
       return { w: 2, h: 4, minW: 1, minH: 4 };
     case WIDGET_TYPE.EXPERIMENTS_FEEDBACK_SCORES:
       return { w: 2, h: 4, minW: 2, minH: 4 };
+    case WIDGET_TYPE.EXPERIMENT_LEADERBOARD:
+      return { w: 6, h: 6, minW: 4, minH: 4 };
     default:
       return { w: 2, h: 2, minW: MIN_WIDGET_WIDTH, minH: MIN_WIDGET_HEIGHT };
   }

--- a/apps/opik-frontend/src/store/DashboardStore.ts
+++ b/apps/opik-frontend/src/store/DashboardStore.ts
@@ -259,7 +259,7 @@ export const useDashboardStore = create<DashboardStore<BaseDashboardConfig>>()(
           const newWidget: DashboardWidget = {
             ...widget,
             id: uniqid(),
-            title: `${widget.title} (copy)`,
+            title: `${widget.title || widget.generatedTitle || ""} (copy)`,
           };
 
           const size = getLayoutItemSize(section.layout, widgetId);

--- a/apps/opik-frontend/src/types/dashboard.ts
+++ b/apps/opik-frontend/src/types/dashboard.ts
@@ -3,12 +3,14 @@ import { DateRangeSerializedValue } from "@/components/shared/DateRangeSelect";
 import { TRACE_DATA_TYPE } from "@/constants/traces";
 import { Groups } from "@/types/groups";
 import { CHART_TYPE } from "@/constants/chart";
+import { Sorting } from "@/types/sorting";
 
 export enum WIDGET_TYPE {
   PROJECT_METRICS = "project_metrics",
   PROJECT_STATS_CARD = "project_stats_card",
   TEXT_MARKDOWN = "text_markdown",
   EXPERIMENTS_FEEDBACK_SCORES = "experiments_feedback_scores",
+  EXPERIMENT_LEADERBOARD = "experiment_leaderboard",
 }
 
 export enum EXPERIMENT_DATA_SOURCE {
@@ -79,11 +81,32 @@ export interface ExperimentsFeedbackScoresWidgetType {
   } & Record<string, unknown>;
 }
 
+export interface ExperimentsLeaderboardWidgetType {
+  type: WIDGET_TYPE.EXPERIMENT_LEADERBOARD;
+  config: {
+    overrideDefaults?: boolean;
+    dataSource?: EXPERIMENT_DATA_SOURCE;
+    experimentIds?: string[];
+    filters?: Filters;
+    selectedColumns?: string[];
+    enableRanking?: boolean;
+    rankingMetric?: string;
+    rankingDirection?: boolean;
+    columnsOrder?: string[];
+    scoresColumnsOrder?: string[];
+    metadataColumnsOrder?: string[];
+    columnsWidth?: Record<string, number>;
+    maxRows?: number;
+    sorting?: Sorting;
+  } & Record<string, unknown>;
+}
+
 type WidgetConfigUnion =
   | ProjectMetricsWidget
   | TextMarkdownWidget
   | ProjectStatsCardWidget
   | ExperimentsFeedbackScoresWidgetType
+  | ExperimentsLeaderboardWidgetType
   | {
       type: string;
       config: Record<string, unknown>;

--- a/apps/opik-frontend/src/types/feedback-scores.ts
+++ b/apps/opik-frontend/src/types/feedback-scores.ts
@@ -1,4 +1,7 @@
+import { ReactNode } from "react";
+
 export type FeedbackScoreCustomMeta = {
   feedbackKey?: string;
   colorMap?: Record<string, string>;
+  prefixIcon?: ReactNode;
 };


### PR DESCRIPTION
## Details

https://github.com/user-attachments/assets/458918ac-f05d-4391-bbf3-83b9aa05c9a5



This PR implements the Experiment Leaderboard widget feature for Opik dashboards. The widget allows users to display and rank experiments based on selected metrics, providing a competitive leaderboard view similar to offerings from competitors.

**Frontend Changes:**
- Implemented new `ExperimentLeaderboardWidget` component with ranking functionality
- Added widget editor (`ExperimentLeaderboardWidgetEditor`) with comprehensive configuration options
- Created ranking settings section (`WidgetRankingSettingsSection`) for metric-based ranking configuration
- Added new table components: `RankingCell` and `RankingHeader` for displaying experiment rankings
- Updated experiment list API hook to support filtering by experiment IDs
- Enhanced feedback scores hook to accept experiment IDs filter
- Fixed CSS hover states for dashboard widgets (changed from `group-hover` to `group-hover/widget`)

The widget supports two data source modes:
- **Select Experiments**: Manually select specific experiments to display
- **Use Dashboard Defaults**: Use experiments configured at the dashboard level

Users can configure ranking metrics, column selection, filters, and row limits to customize their leaderboard view.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves #
- OPIK-3409
- NA

## Testing

**Manual Testing:**
1. Navigate to a dashboard and add the Experiment Leaderboard widget
2. Configure widget settings:
   - Select data source (manual experiments or dashboard defaults)
   - Choose ranking metric
   - Configure columns and filters
   - Set maximum rows
3. Verify experiments are displayed and ranked correctly based on selected metric
4. Test widget editing and configuration persistence
5. Verify empty states when no experiments are selected or match filters
6. Test widget behavior with different experiment sets and metrics

## Documentation

N/A - This is a new feature that will require documentation updates in a follow-up PR.