### PR TITLE
[NA][DOCS] Update Docs Banner Link

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -16,7 +16,7 @@ metadata:
   twitter:site: "@CometML"
 
 announcement:
-  message: "🎉 Join our Global AI Hackathon with <a href=\"https://www.encodeclub.com/programmes/comet-resolution-v2-hackathon?utm_source=opik-docs\" rel=\"nofollow\" target=\"_blank\">$30,000 in cash prizes</a> starting 13th Jan."
+  message: "🎉 Join our Global AI Hackathon with <a href=\"https://www.encodeclub.com/programmes/comet-resolution-v2-hackathon?utm_source=opik-docs\" rel=\"nofollow\" target=\"_blank\">$30,000 in cash prizes</a>."
 
 title: Opik Documentation
 favicon: img/logo.svg


### PR DESCRIPTION
## Details
Updated the docs banner link (annoucement) to Encode given the Luma event is now expired but hackathon is on-going.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing
Yaml change

## Documentation
N/A