### PR TITLE
[OPIK-3982] [FE]: jinja prompt types are not changed into mustache ones;

### DIFF
--- a/apps/opik-frontend/src/api/prompts/useCreatePromptVersionMutation.ts
+++ b/apps/opik-frontend/src/api/prompts/useCreatePromptVersionMutation.ts
@@ -4,7 +4,11 @@ import get from "lodash/get";
 
 import api, { PROMPTS_REST_ENDPOINT } from "@/api/api";
 import { useToast } from "@/components/ui/use-toast";
-import { PromptVersion, PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
+import {
+  PromptVersion,
+  PROMPT_TEMPLATE_STRUCTURE,
+  PROMPT_TYPE,
+} from "@/types/prompts";
 
 type UseCreatePromptVersionMutationParams = {
   name: string;
@@ -12,6 +16,7 @@ type UseCreatePromptVersionMutationParams = {
   metadata?: object;
   changeDescription?: string;
   templateStructure?: PROMPT_TEMPLATE_STRUCTURE;
+  type?: PROMPT_TYPE;
   onSuccess: (promptVersion: PromptVersion) => void;
 };
 
@@ -26,6 +31,7 @@ const useCreatePromptVersionMutation = () => {
       metadata,
       changeDescription,
       templateStructure,
+      type,
     }: UseCreatePromptVersionMutationParams) => {
       const { data } = await api.post(`${PROMPTS_REST_ENDPOINT}versions`, {
         name,
@@ -33,6 +39,7 @@ const useCreatePromptVersionMutation = () => {
           template,
           ...(metadata && { metadata }),
           ...(changeDescription && { change_description: changeDescription }),
+          ...(type && { type }),
         },
         ...(templateStructure && { template_structure: templateStructure }),
       });

--- a/apps/opik-frontend/src/api/prompts/usePromptCreateMutation.ts
+++ b/apps/opik-frontend/src/api/prompts/usePromptCreateMutation.ts
@@ -5,12 +5,13 @@ import isObject from "lodash/isObject";
 
 import api, { PROMPTS_REST_ENDPOINT } from "@/api/api";
 import { useToast } from "@/components/ui/use-toast";
-import { Prompt } from "@/types/prompts";
+import { Prompt, PROMPT_TYPE } from "@/types/prompts";
 import { extractIdFromLocation } from "@/lib/utils";
 
 interface CreatePromptTemplate {
   template: string;
   metadata?: object;
+  type?: PROMPT_TYPE;
 }
 
 type UsePromptCreateMutationParams = {

--- a/apps/opik-frontend/src/components/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog.tsx
@@ -140,12 +140,15 @@ const AddNewPromptVersionDialog: React.FC<AddNewPromptVersionDialogProps> = ({
 
     if (isEdit) {
       if (selectedPrompt) {
+        const promptType = selectedPrompt?.latest_version?.type;
+
         newVersionMutate({
           name: selectedPrompt?.name,
           template,
           changeDescription,
           ...(finalMetadata && { metadata: finalMetadata }),
           ...(templateStructure && { templateStructure }),
+          ...(promptType && { type: promptType }),
           onSuccess: (data) =>
             onSave(data, selectedPrompt?.name, selectedPrompt?.id),
         });

--- a/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/EditPromptVersionDialog.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/EditPromptVersionDialog.tsx
@@ -46,7 +46,7 @@ import {
 import LLMPromptMessages from "@/components/pages-shared/llm/LLMPromptMessages/LLMPromptMessages";
 import { LLMMessage } from "@/types/llm";
 import ChatPromptRawView from "@/components/pages-shared/llm/ChatPromptRawView/ChatPromptRawView";
-import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
+import { PROMPT_TEMPLATE_STRUCTURE, PROMPT_TYPE } from "@/types/prompts";
 
 enum PROMPT_PREVIEW_MODE {
   write = "write",
@@ -61,6 +61,7 @@ type EditPromptVersionDialogProps = {
   metadata?: object;
   promptName: string;
   templateStructure?: PROMPT_TEMPLATE_STRUCTURE;
+  type?: PROMPT_TYPE;
   onSetActiveVersionId: (versionId: string) => void;
 };
 
@@ -71,6 +72,7 @@ const EditPromptVersionDialog: React.FC<EditPromptVersionDialogProps> = ({
   metadata: promptMetadata,
   promptName,
   templateStructure,
+  type: promptType,
   onSetActiveVersionId,
 }) => {
   const isChatPrompt = templateStructure === PROMPT_TEMPLATE_STRUCTURE.CHAT;
@@ -147,6 +149,7 @@ const EditPromptVersionDialog: React.FC<EditPromptVersionDialogProps> = ({
       changeDescription,
       ...(metadata && { metadata: safelyParseJSON(metadata) }),
       ...(templateStructure && { templateStructure }),
+      ...(promptType && { type: promptType }),
       onSuccess: (data) => {
         onSetActiveVersionId(data.id);
       },

--- a/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -244,6 +244,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
         template={activeVersion?.template || ""}
         metadata={activeVersion?.metadata}
         templateStructure={prompt.template_structure}
+        type={activeVersion?.type}
         onSetActiveVersionId={setActiveVersionId}
       />
 

--- a/apps/opik-frontend/src/types/prompts.ts
+++ b/apps/opik-frontend/src/types/prompts.ts
@@ -3,6 +3,11 @@ export enum PROMPT_TEMPLATE_STRUCTURE {
   TEXT = "text",
 }
 
+export enum PROMPT_TYPE {
+  MUSTACHE = "mustache",
+  JINJA2 = "jinja2",
+}
+
 export interface Prompt {
   id: string;
   name: string;
@@ -28,4 +33,5 @@ export interface PromptVersion {
   prompt_id: string;
   created_at: string;
   tags?: string[];
+  type?: PROMPT_TYPE;
 }


### PR DESCRIPTION
## Details
Peviously, when users edited a Jinja2 prompt through the frontend, the new version would incorrectly revert to the default mustache template type. This happened because the frontend wasn't preserving the type field when creating new prompt versions. With this fix, the UI now correctly reads and passes the existing prompt's template type (mustache or jinja2) when saving changes, ensuring prompts created via the SDK maintain their intended template engine. Users can now confidently edit their Jinja2 prompts in the Prompt Library and Playground without losing template functionality.


https://github.com/user-attachments/assets/ed2b632f-6311-4568-9939-05100f2f654f


## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-3982

## Testing

## Documentation
