### PR TITLE
[OPIK-3898] [BE] Remove sorting limitation for experiments and datasets

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceIntegrationTest.java
@@ -15,7 +15,6 @@ import com.comet.opik.domain.DatasetService;
 import com.comet.opik.domain.DatasetVersionService;
 import com.comet.opik.domain.Streamer;
 import com.comet.opik.domain.filter.FilterQueryBuilder;
-import com.comet.opik.domain.workspaces.WorkspaceMetadataService;
 import com.comet.opik.infrastructure.FeatureFlags;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.db.IdGeneratorImpl;
@@ -63,7 +62,6 @@ class DatasetsResourceIntegrationTest {
     private static final DatasetExpansionService expansionService = mock(DatasetExpansionService.class);
     private static final DatasetVersionService versionService = mock(DatasetVersionService.class);
     private static final RequestContext requestContext = mock(RequestContext.class);
-    private static final WorkspaceMetadataService workspaceMetadataService = mock(WorkspaceMetadataService.class);
     private static final CsvDatasetItemProcessor csvProcessor = mock(CsvDatasetItemProcessor.class);
     private static final FeatureFlags featureFlags = mock(FeatureFlags.class);
     public static final SortingFactoryDatasets sortingFactory = new SortingFactoryDatasets();
@@ -76,7 +74,7 @@ class DatasetsResourceIntegrationTest {
                 .addResource(new DatasetsResource(
                         service, itemService, expansionService, versionService, () -> requestContext,
                         new FiltersFactory(new FilterQueryBuilder()),
-                        new IdGeneratorImpl(), new Streamer(), sortingFactory, workspaceMetadataService, csvProcessor,
+                        new IdGeneratorImpl(), new Streamer(), sortingFactory, csvProcessor,
                         featureFlags, csvExportService))
                 .addProvider(JsonNodeMessageBodyWriter.class)
                 .addProvider(MultiPartFeature.class)


### PR DESCRIPTION
## Details

The workspace size-based sorting limitation was incorrectly applied to experiments and dataset items endpoints. This limitation (calculated from spans table size) is only appropriate for traces and spans endpoints since those are the tables that can become very large.

Experiments and dataset items have their own tables with proper indexes and don't need this restriction based on spans data.

### Changes:
- Removed `WorkspaceMetadataService` dependency from `ExperimentsResource`
- Removed `WorkspaceMetadataService` dependency from `DatasetsResource`
- Removed sorting limitation checks (`cannotUseDynamicSorting()`) from both resources
- Updated tests to reflect the new behavior (sorting always enabled)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3898

## Testing
- Ran `DatasetsResourceIntegrationTest` - all tests pass
- Ran `DatasetsResourceTest#findDatasetItemsWithExperimentItems__dynamicSortingEnabled` - passes
- Ran `ExperimentsResourceTest#find__*` tests - all pass
- Ran `mvn spotless:apply` and `mvn compile`

## Documentation
N/A - no API changes, just removal of an internal limitation