### PR TITLE
[OPIK-3409] [FE] Simplify experiment leaderboard widget title and fix dataset ID key

### DIFF
--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/ExperimentsLeaderboardWidget.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/ExperimentsLeaderboardWidget.tsx
@@ -309,8 +309,11 @@ const ExperimentsLeaderboardWidget: React.FunctionComponent<
         sortable: sortableColumns?.includes("name") || false,
         customMeta: {
           nameKey: "name",
-          idKey: "id",
+          idKey: "dataset_id",
           resource: RESOURCE_TYPE.experiment,
+          getSearch: (data: Experiment) => ({
+            experiments: [data.id],
+          }),
         },
       }),
     );

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/helpers.ts
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/helpers.ts
@@ -172,16 +172,6 @@ export const getDefaultConfig = () => ({
   sorting: [],
 });
 
-export const calculateTitle = (config: Record<string, unknown>) => {
-  const enableRanking = config.enableRanking as boolean;
-  const rankingMetric = config.rankingMetric as string | undefined;
-
-  if (enableRanking && rankingMetric) {
-    return `Experiment leaderboard (${formatMetricName(rankingMetric)})`;
-  }
-  return "Experiment leaderboard";
-};
-
 export const parseMetadataKeys = (experiments: Experiment[]): string[] => {
   const allKeys = experiments.reduce<string[]>((acc, exp) => {
     if (exp.metadata) {
@@ -192,18 +182,6 @@ export const parseMetadataKeys = (experiments: Experiment[]): string[] => {
   }, []);
 
   return uniq(allKeys).sort();
-};
-
-export const formatMetricName = (metric: string): string => {
-  const metricLabels: Record<string, string> = {
-    "duration.p50": "Duration (avg.)",
-    "duration.p90": "Duration (p90)",
-    "duration.p99": "Duration (p99)",
-    trace_count: "Trace count",
-    total_estimated_cost: "Total cost",
-    total_estimated_cost_avg: "Cost per trace",
-  };
-  return metricLabels[metric] || metric;
 };
 
 export const formatConfigColumnName = (key: string): string => {
@@ -246,5 +224,5 @@ export const getRankingFilters = (
 
 export const widgetHelpers = {
   getDefaultConfig,
-  calculateTitle,
+  calculateTitle: () => "Experiment leaderboard",
 };


### PR DESCRIPTION
## Details

This PR simplifies the experiment leaderboard widget implementation following discussion with the product team. The changes include:

- Changed `idKey` from `'id'` to `'dataset_id'` for proper experiment identification in the leaderboard
- Added `getSearch` function to enable experiment filtering functionality
- Removed dynamic title calculation logic (`calculateTitle` function) and simplified to a static "Experiment leaderboard" title
- Removed unused `formatMetricName` helper function

**Note:** This is a follow-up PR after discussion with the product team.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3409

## Testing

Manual testing performed:
- Verified experiment leaderboard widget displays correctly with static title
- Confirmed dataset ID key change works properly for experiment identification
- Tested experiment filtering functionality with the new `getSearch` function

## Documentation

N/A - No documentation changes required for this simplification.