### PR TITLE
[NA] [SDK] fix: remove return statements from finally blocks in stream_patchers.py

### DIFF
--- a/sdks/python/src/opik/integrations/openai/stream_patchers.py
+++ b/sdks/python/src/opik/integrations/openai/stream_patchers.py
@@ -64,22 +64,20 @@ def patch_sync_stream(
                 error_info = error_info_collector.collect(exception)
                 raise exception
             finally:
-                if not hasattr(self, "opik_tracked_instance"):
-                    return
-
-                delattr(self, "opik_tracked_instance")
-                output = (
-                    generations_aggregator(accumulated_items)
-                    if error_info is None
-                    else None
-                )
-                finally_callback(
-                    output=output,
-                    error_info=error_info,
-                    capture_output=True,
-                    generators_span_to_end=self.span_to_end,
-                    generators_trace_to_end=self.trace_to_end,
-                )
+                if hasattr(self, "opik_tracked_instance"):
+                    delattr(self, "opik_tracked_instance")
+                    output = (
+                        generations_aggregator(accumulated_items)
+                        if error_info is None
+                        else None
+                    )
+                    finally_callback(
+                        output=output,
+                        error_info=error_info,
+                        capture_output=True,
+                        generators_span_to_end=self.span_to_end,
+                        generators_trace_to_end=self.trace_to_end,
+                    )
 
         return wrapper
 
@@ -129,22 +127,20 @@ def patch_async_stream(
                 error_info = error_info_collector.collect(exception)
                 raise exception
             finally:
-                if not hasattr(self, "opik_tracked_instance"):
-                    return
-
-                delattr(self, "opik_tracked_instance")
-                output = (
-                    generations_aggregator(accumulated_items)
-                    if error_info is None
-                    else None
-                )
-                finally_callback(
-                    output=output,
-                    error_info=error_info,
-                    capture_output=True,
-                    generators_span_to_end=self.span_to_end,
-                    generators_trace_to_end=self.trace_to_end,
-                )
+                if hasattr(self, "opik_tracked_instance"):
+                    delattr(self, "opik_tracked_instance")
+                    output = (
+                        generations_aggregator(accumulated_items)
+                        if error_info is None
+                        else None
+                    )
+                    finally_callback(
+                        output=output,
+                        error_info=error_info,
+                        capture_output=True,
+                        generators_span_to_end=self.span_to_end,
+                        generators_trace_to_end=self.trace_to_end,
+                    )
 
         return wrapper
 


### PR DESCRIPTION
## Details

Follow-up to PR #4275 which fixed the same issue in `opik_client.py` and `streamer.py` but missed this file.

Remove return statements from finally blocks in `stream_patchers.py` to eliminate `SyntaxWarning` in Python 3.14+. Python 3.14 deprecates `return` statements inside `finally` blocks as they can silently swallow exceptions.

Changes made:
- `sdks/python/src/opik/integrations/openai/stream_patchers.py`: Refactored both sync and async stream wrappers to use positive conditionals instead of early returns in finally blocks

## Change checklist

- [x] Code follows project style guidelines
- [x] Changes are backwards compatible
- [x] No new dependencies added

## Issues

N/A - Proactive fix for Python 3.14 compatibility

## Testing

- No behavioral changes, only refactoring to avoid deprecated syntax
- Logic is equivalent: instead of `if not X: return; do_stuff()` we now have `if X: do_stuff()`

## Documentation

No documentation changes needed - internal implementation detail only.