### PR TITLE
[OPIK-3915] [FE] Add rerun flow for optimization studio

### DIFF
--- a/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsHeader.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsHeader.tsx
@@ -1,17 +1,20 @@
 import React from "react";
-import { X } from "lucide-react";
+import { RotateCw, X } from "lucide-react";
 import { Tag } from "@/components/ui/tag";
 import { Button } from "@/components/ui/button";
+import { useNavigate } from "@tanstack/react-router";
 import { OPTIMIZATION_STATUS } from "@/types/optimizations";
 import { STATUS_TO_VARIANT_MAP } from "@/constants/experiments";
 import { IN_PROGRESS_OPTIMIZATION_STATUSES } from "@/lib/optimizations";
 import useOptimizationStopMutation from "@/api/optimizations/useOptimizationStopMutation";
+import useAppStore from "@/store/AppStore";
 
 type CompareOptimizationsHeaderProps = {
   title: string;
   status?: OPTIMIZATION_STATUS;
   optimizationId?: string;
   isStudioOptimization?: boolean;
+  canRerun?: boolean;
 };
 
 const CompareOptimizationsHeader: React.FC<CompareOptimizationsHeaderProps> = ({
@@ -19,7 +22,10 @@ const CompareOptimizationsHeader: React.FC<CompareOptimizationsHeaderProps> = ({
   status,
   optimizationId,
   isStudioOptimization,
+  canRerun,
 }) => {
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const navigate = useNavigate();
   const { mutate: stopOptimization, isPending: isStoppingOptimization } =
     useOptimizationStopMutation();
 
@@ -32,6 +38,15 @@ const CompareOptimizationsHeader: React.FC<CompareOptimizationsHeaderProps> = ({
   const handleStop = () => {
     if (!optimizationId) return;
     stopOptimization({ optimizationId });
+  };
+
+  const handleRerun = () => {
+    if (!optimizationId) return;
+    navigate({
+      to: "/$workspaceName/optimizations/new",
+      params: { workspaceName },
+      search: { rerun: optimizationId },
+    });
   };
 
   return (
@@ -48,16 +63,26 @@ const CompareOptimizationsHeader: React.FC<CompareOptimizationsHeaderProps> = ({
           </Tag>
         )}
       </div>
-      {canStop && (
-        <Button
-          variant="destructive"
-          size="sm"
-          onClick={handleStop}
-          disabled={isStoppingOptimization}
-        >
-          <X className="mr-2 size-4" />
-          Stop Execution
-        </Button>
+      {(canStop || canRerun) && (
+        <div className="flex items-center gap-2">
+          {canRerun && (
+            <Button variant="outline" size="sm" onClick={handleRerun}>
+              <RotateCw className="mr-2 size-4" />
+              Rerun
+            </Button>
+          )}
+          {canStop && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={handleStop}
+              disabled={isStoppingOptimization}
+            >
+              <X className="mr-2 size-4" />
+              Stop Execution
+            </Button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsPage.tsx
@@ -4,6 +4,7 @@ import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer
 import Loader from "@/components/shared/Loader/Loader";
 import OptimizationProgressChartContainer from "@/components/pages-shared/experiments/OptimizationProgressChart";
 import { OPTIMIZATION_VIEW_TYPE } from "@/components/pages/CompareOptimizationsPage/OptimizationViewSelector";
+import { OPTIMIZATION_STATUS } from "@/types/optimizations";
 import { useCompareOptimizationsData } from "./useCompareOptimizationsData";
 import { useCompareOptimizationsColumns } from "./useCompareOptimizationsColumns";
 import CompareOptimizationsHeader from "./CompareOptimizationsHeader";
@@ -60,6 +61,13 @@ const CompareOptimizationsPage: React.FC = () => {
   }
 
   const isStudioOptimization = Boolean(optimization?.studio_config);
+  const canRerun =
+    isStudioOptimization &&
+    Boolean(optimization?.id) &&
+    optimization?.status &&
+    [OPTIMIZATION_STATUS.COMPLETED, OPTIMIZATION_STATUS.CANCELLED].includes(
+      optimization.status,
+    );
   const showTrialsView =
     !isStudioOptimization || view === OPTIMIZATION_VIEW_TYPE.TRIALS;
 
@@ -75,6 +83,7 @@ const CompareOptimizationsPage: React.FC = () => {
           status={optimization?.status}
           optimizationId={optimization?.id}
           isStudioOptimization={isStudioOptimization}
+          canRerun={canRerun}
         />
       </PageBodyStickyContainer>
 

--- a/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPage.tsx
+++ b/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPage.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryParam, StringParam } from "use-query-params";
 import useAppStore from "@/store/AppStore";
 import useGetOrCreateDemoDataset from "@/api/datasets/useGetOrCreateDemoDataset";
+import useOptimizationById from "@/api/optimizations/useOptimizationById";
 import {
   OptimizationConfigFormType,
   OptimizationConfigSchema,
@@ -16,6 +17,7 @@ import Loader from "@/components/shared/Loader/Loader";
 const OptimizationsNewPage: React.FC = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const [templateId] = useQueryParam("template", StringParam);
+  const [rerunId] = useQueryParam("rerun", StringParam);
   const { getOrCreateDataset } = useGetOrCreateDemoDataset();
   const datasetCreationRef = useRef<string | null>(null);
   const [isPreparingDataset, setIsPreparingDataset] = useState(false);
@@ -25,9 +27,22 @@ const OptimizationsNewPage: React.FC = () => {
     [templateId],
   );
 
+  const { data: rerunOptimization, isPending: isRerunPending } =
+    useOptimizationById(
+      { optimizationId: rerunId || "" },
+      {
+        enabled: Boolean(rerunId),
+      },
+    );
+
+  const rerunData = useMemo(
+    () => (rerunOptimization?.studio_config ? rerunOptimization : null),
+    [rerunOptimization],
+  );
+
   const defaultValues = useMemo(() => {
-    return convertOptimizationStudioToFormData(templateData);
-  }, [templateData]);
+    return convertOptimizationStudioToFormData(rerunData || templateData);
+  }, [rerunData, templateData]);
 
   const form = useForm<OptimizationConfigFormType>({
     resolver: zodResolver(OptimizationConfigSchema),
@@ -37,13 +52,14 @@ const OptimizationsNewPage: React.FC = () => {
 
   // Reset form when template changes
   useEffect(() => {
-    form.reset(convertOptimizationStudioToFormData(templateData));
+    form.reset(convertOptimizationStudioToFormData(rerunData || templateData));
     datasetCreationRef.current = null;
-  }, [templateData, form]);
+  }, [rerunData, templateData, form]);
 
   // Create demo dataset when template with dataset_items is selected
   useEffect(() => {
     const internalCreateOrGetDataset = async () => {
+      if (rerunData) return;
       const templateIdToCreate = templateData?.id;
       if (
         templateData?.dataset_items &&
@@ -65,7 +81,11 @@ const OptimizationsNewPage: React.FC = () => {
     };
 
     internalCreateOrGetDataset();
-  }, [templateData, getOrCreateDataset, form, workspaceName]);
+  }, [rerunData, templateData, getOrCreateDataset, form, workspaceName]);
+
+  if (isRerunPending) {
+    return <Loader message="Loading optimization..." />;
+  }
 
   if (isPreparingDataset) {
     return <Loader message="Preparing a dataset..." />;


### PR DESCRIPTION
## Details
Add a rerun action on finished optimization runs that opens the optimization studio config page prefilled from the run's stored studio config, and skip demo dataset creation when rerunning.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-3915

## Testing
Not run (not requested).

## Documentation
N/A
