### PR TITLE
[OPIK-3132] Relax CSP to allow user-provided media and Google Fonts

### DIFF
--- a/deployment/helm_chart/opik/templates/configmap-frontend-nginx.yaml
+++ b/deployment/helm_chart/opik/templates/configmap-frontend-nginx.yaml
@@ -80,7 +80,7 @@ data:
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
         add_header X-XSS-Protection "0" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https: http:; media-src 'self' https: http:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' ws: wss: https:; object-src 'none'; base-uri 'self'; frame-ancestors 'none';" always;
         {{- if .Values.component.frontend.hstsEnabled }}
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         {{- end }}


### PR DESCRIPTION
## Details
Follow-up to #4804. Relaxes the Content-Security-Policy to support user content and required external resources:

**Changes to CSP directives:**
| Directive | Before | After | Reason |
|-----------|--------|-------|--------|
| `style-src` | `'self' 'unsafe-inline'` | `+ https://fonts.googleapis.com` | Google Fonts CSS |
| `img-src` | `'self' data: blob:` | `+ https: http:` | User-provided image URLs in traces |
| `media-src` | *(inherited default)* | `'self' https: http:` | User-provided video/audio URLs |
| `font-src` | `'self' data:` | `+ https://fonts.gstatic.com` | Google Fonts files (Inter, Ubuntu Mono) |
| `connect-src` | `'self' ws: wss:` | `+ https:` | External API calls (GitHub stars, stats) |

**Security-critical directives remain strict:**
- `script-src 'self' 'unsafe-inline' 'unsafe-eval'` - No external scripts allowed
- `frame-ancestors 'none'` - Clickjacking protection
- `object-src 'none'` - Plugin blocking
- `base-uri 'self'` - Base tag protection

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues
- OPIK-3132

## Testing
- Verified Google Fonts load correctly (Inter, Ubuntu Mono)
- Confirmed our video player can play videos from other domains in the test environment
<img width="1852" height="1228" alt="Screenshot 2026-01-19 at 14 23 48" src="https://github.com/user-attachments/assets/6ee08fb9-2d8d-471b-831b-26606df20fb8" />
- I see no CSP violations in browser console
 
## Documentation