### PR TITLE
[NA] [SDK] Update Fern SDK generators to latest versions

### DIFF
--- a/sdks/code_generation/fern/fern.config.json
+++ b/sdks/code_generation/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "Opik",
-  "version": "0.56.34"
+  "version": "1.9.2"
 }

--- a/sdks/code_generation/fern/generators.yml
+++ b/sdks/code_generation/fern/generators.yml
@@ -11,10 +11,11 @@ groups:
           location: local-file-system
           path: ../../python/src/opik/rest_api
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.51.5
+        version: 3.34.3
         output:
           location: local-file-system
           path: ../../typescript/src/opik/rest_api
         config:
           outputSourceFiles: true
           includeCredentialsOnCrossOriginRequests: true
+          formDataSupport: Node18


### PR DESCRIPTION
## Details

This PR updates the Fern SDK generation dependencies to their latest versions:

- **Fern CLI**: Updated from `0.56.34` to `1.9.2` (major version bump)
- **TypeScript SDK Generator**: Updated from `0.51.5` to `3.34.3` (major version bump)
- **TypeScript SDK Configuration**: Added `formDataSupport: Node18` to enable proper form data handling in Node.js 18+ environments

These updates bring the latest Fern SDK generator features, bug fixes, and improvements. The `formDataSupport: Node18` configuration ensures compatibility with modern Node.js versions for form data handling in the generated TypeScript SDK.

Note: TypeScript SDK is already constrained to node versions 18+ so we're not deprecating any functionality by adding this.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves #
- OPIK-NA
- NA

## Testing

- Verified JSON and YAML configuration files are valid
- SDK generation should be tested after merge to ensure:
  - Python SDK generates correctly with new Fern CLI version
  - TypeScript SDK generates correctly with new generator version
  - Form data support works as expected in Node.js 18+ environments

## Documentation

N/A - No documentation changes required for dependency updates. If there are breaking changes in the generated SDKs, documentation will be updated in a follow-up PR.