### PR TITLE
[NA] [SDK] Update TypeScript configuration to exclude NodePre18StreamWrapper.ts in the source paths

### DIFF
--- a/sdks/typescript/tsconfig.json
+++ b/sdks/typescript/tsconfig.json
@@ -28,6 +28,7 @@
     "src/opik/integrations/opik-openai",
     "src/opik/integrations/opik-gemini",
     "src/opik/integrations/opik-vercel",
-    "src/opik/configure"
+    "src/opik/configure",
+    "src/opik/rest_api/core/fetcher/stream-wrappers/NodePre18StreamWrapper.ts"
   ]
 }


### PR DESCRIPTION
## Details

Updated TypeScript SDK configuration to exclude `NodePre18StreamWrapper.ts` from the source paths in `tsconfig.json`. This file is a legacy wrapper for Node.js versions prior to 18 and should not be included in the TypeScript compilation paths.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-NA

## Testing

TypeScript compilation verified to exclude the legacy file from source paths.

## Documentation

N/A