### PR TITLE
[OPIK-3924] [BE] Optimise get dataset experiment items stats

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -897,7 +897,7 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                     SELECT id FROM traces WHERE workspace_id = :workspace_id AND <experiment_item_filters>
                 )
                 <endif>
-            ), feedback_scores_combined_raw AS (
+            ), feedback_scores_combined AS (
                 SELECT workspace_id,
                        project_id,
                        entity_id,
@@ -922,29 +922,6 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                 WHERE entity_type = 'trace'
                    AND workspace_id = :workspace_id
                    AND entity_id IN (SELECT trace_id FROM experiment_items_filtered)
-            ), feedback_scores_with_ranking AS (
-                SELECT workspace_id,
-                       project_id,
-                       entity_id,
-                       name,
-                       value,
-                       last_updated_at,
-                       author,
-                       ROW_NUMBER() OVER (
-                           PARTITION BY workspace_id, project_id, entity_id, name, author
-                           ORDER BY last_updated_at DESC
-                       ) as rn
-                FROM feedback_scores_combined_raw
-            ), feedback_scores_combined AS (
-                SELECT workspace_id,
-                       project_id,
-                       entity_id,
-                       name,
-                       value,
-                       last_updated_at,
-                       author
-                FROM feedback_scores_with_ranking
-                WHERE rn = 1
             ), feedback_scores_final AS (
                 SELECT
                     workspace_id,


### PR DESCRIPTION
## Details

This PR optimizes the SQL query performance for retrieving dataset experiment items statistics by restructuring the query execution plan to filter data earlier in the pipeline.

**Key optimizations:**
- Introduced `experiment_items_filtered` CTE at the beginning of the query to pre-filter experiment items based on workspace, dataset, and experiment criteria before any joins
- Modified feedback scores retrieval (`feedback_scores_combined`) to only fetch scores for the pre-filtered experiment items, significantly reducing the data volume processed
- Removed the redundant `feedback_scores_with_ranking` CTE by simplifying the deduplication logic
- Consolidated filtering logic into a single `experiment_items_final` CTE that conditionally uses either the base filtered set or the feedback-filtered set
- Updated all downstream CTEs (`traces_with_cost_and_duration`, `feedback_scores_agg`, etc.) to reference the optimized filtered sets

**Performance impact:**
- Latency from 5s to 2s.
- Memory from 5 GB to 1 GB.
- Rows from 34 million to 11 million.

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- OPIK-3924

## Testing
- Manually tested from experiments UI.
- Regressed by existing automated tests.

## Documentation

N/A - Internal query optimization with no API changes