### PR TITLE
[OPIK-3931] [FE] Add "Open in Playground" feature for traces and spans

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/llm/LLMPromptMessages/LLMPromptMessage.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/llm/LLMPromptMessages/LLMPromptMessage.tsx
@@ -4,7 +4,14 @@ import React, {
   useImperativeHandle,
   forwardRef,
 } from "react";
-import { ChevronDown, CopyPlus, GripHorizontal, Trash } from "lucide-react";
+import {
+  ChevronDown,
+  CopyPlus,
+  GripHorizontal,
+  Trash,
+  Info,
+  X,
+} from "lucide-react";
 import CodeMirror from "@uiw/react-codemirror";
 import { EditorView } from "@codemirror/view";
 import { useSortable } from "@dnd-kit/sortable";
@@ -20,7 +27,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
-import { LLM_MESSAGE_ROLE, LLMMessage } from "@/types/llm";
+import { LLM_MESSAGE_ROLE, LLMMessage, MessageSourceType } from "@/types/llm";
 
 import { cn } from "@/lib/utils";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
@@ -58,6 +65,43 @@ const MESSAGE_TYPE_OPTIONS = [
     value: LLM_MESSAGE_ROLE.user,
   },
 ];
+
+// Source annotation label and color mapping
+const SOURCE_ANNOTATION_CONFIG: Record<
+  MessageSourceType,
+  { label: string; color: string; icon: string }
+> = {
+  system_config: {
+    label: "System",
+    color: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400",
+    icon: "⚙️",
+  },
+  user_input: {
+    label: "User Input",
+    color: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+    icon: "👤",
+  },
+  tool_output: {
+    label: "Tool Output",
+    color: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+    icon: "🔧",
+  },
+  llm_response: {
+    label: "LLM Response",
+    color: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+    icon: "🤖",
+  },
+  merged: {
+    label: "Merged",
+    color: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400",
+    icon: "🔀",
+  },
+  trace_input: {
+    label: "Trace Input",
+    color: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400",
+    icon: "📍",
+  },
+};
 
 export interface LLMPromptMessageHandle {
   insertAtCursor: (text: string) => void;
@@ -115,7 +159,8 @@ const LLMPromptMessage = forwardRef<
   ) => {
     const [isHoldActionsVisible, setIsHoldActionsVisible] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
-    const { id, role, content } = message;
+    const [showSourceAnnotation, setShowSourceAnnotation] = useState(true);
+    const { id, role, content, sourceAnnotation } = message;
 
     const { active, attributes, listeners, setNodeRef, transform, transition } =
       useSortable({ id });
@@ -303,6 +348,48 @@ const LLMPromptMessage = forwardRef<
                     promptVariables={promptVariables}
                     disabled={disabled}
                   />
+                )}
+                {/* Source Annotation Badge */}
+                {sourceAnnotation && showSourceAnnotation && (
+                  <div className="mt-2 flex items-center gap-1.5">
+                    <TooltipWrapper
+                      content={
+                        sourceAnnotation.description ||
+                        `Source: ${sourceAnnotation.type}`
+                      }
+                      side="top"
+                    >
+                      <div
+                        className={cn(
+                          "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium",
+                          SOURCE_ANNOTATION_CONFIG[sourceAnnotation.type]
+                            ?.color || SOURCE_ANNOTATION_CONFIG.trace_input.color,
+                        )}
+                      >
+                        <span>
+                          {SOURCE_ANNOTATION_CONFIG[sourceAnnotation.type]
+                            ?.icon || "📍"}
+                        </span>
+                        <span>
+                          {sourceAnnotation.sourceSpanName
+                            ? `From: ${sourceAnnotation.sourceSpanName}`
+                            : SOURCE_ANNOTATION_CONFIG[sourceAnnotation.type]
+                                ?.label || "Trace Input"}
+                        </span>
+                        <Info className="size-3 opacity-60" />
+                      </div>
+                    </TooltipWrapper>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowSourceAnnotation(false);
+                      }}
+                      className="rounded p-0.5 text-muted-foreground opacity-60 transition-opacity hover:bg-muted hover:opacity-100"
+                      title="Hide source annotation"
+                    >
+                      <X className="size-3" />
+                    </button>
+                  </div>
                 )}
               </>
             )}

--- a/apps/opik-frontend/src/components/pages-shared/traces/OpenInPlaygroundDialog/OpenInPlaygroundDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/OpenInPlaygroundDialog/OpenInPlaygroundDialog.tsx
@@ -1,0 +1,264 @@
+import React, { useMemo } from "react";
+import { Link } from "@tanstack/react-router";
+import {
+  AlertTriangle,
+  MessageSquare,
+  Play,
+  Cpu,
+  Building2,
+  Settings,
+  Loader2,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Span, Trace, SPAN_TYPE } from "@/types/traces";
+import { LLM_MESSAGE_ROLE } from "@/types/llm";
+import {
+  extractPlaygroundData,
+  PlaygroundPrefillData,
+} from "@/lib/playground/extractPlaygroundData";
+import BaseTraceDataTypeIcon from "@/components/pages-shared/traces/TraceDetailsPanel/BaseTraceDataTypeIcon";
+import { TRACE_TYPE_FOR_TREE } from "@/constants/traces";
+import useProviderKeys from "@/api/provider-keys/useProviderKeys";
+import useAppStore from "@/store/AppStore";
+import useLLMProviderModelsData from "@/hooks/useLLMProviderModelsData";
+
+interface OpenInPlaygroundDialogProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  onConfirm: () => void;
+  selectedItem: Trace | Span | undefined;
+  treeData: Array<Trace | Span>;
+  isPlaygroundEmpty: boolean;
+  isLoading?: boolean;
+}
+
+const OpenInPlaygroundDialog: React.FC<OpenInPlaygroundDialogProps> = ({
+  open,
+  setOpen,
+  onConfirm,
+  selectedItem,
+  treeData,
+  isPlaygroundEmpty,
+  isLoading = false,
+}) => {
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+
+  // Get configured providers
+  const { data: providerKeysData } = useProviderKeys({ workspaceName });
+  const configuredProviders = useMemo(() => {
+    return providerKeysData?.content?.map((c) => c.ui_composed_provider) || [];
+  }, [providerKeysData]);
+
+  const { calculateModelProvider } = useLLMProviderModelsData();
+
+  // Extract preview data
+  const previewData = useMemo<PlaygroundPrefillData | null>(() => {
+    if (!selectedItem) return null;
+    return extractPlaygroundData(selectedItem, treeData);
+  }, [selectedItem, treeData]);
+
+  // Check if the detected provider is configured
+  const providerStatus = useMemo(() => {
+    if (!previewData?.provider) {
+      return { isConfigured: true, provider: null }; // No provider detected, will use default
+    }
+
+    // Check if the provider is in the configured list
+    const isConfigured = configuredProviders.some(
+      (p) =>
+        p.toLowerCase() === previewData.provider?.toLowerCase() ||
+        p.toLowerCase().includes(previewData.provider?.toLowerCase() || ""),
+    );
+
+    // Also check by model if provider not directly found
+    if (!isConfigured && previewData.model) {
+      const modelProvider = calculateModelProvider(
+        previewData.model as Parameters<typeof calculateModelProvider>[0],
+      );
+      if (modelProvider && configuredProviders.includes(modelProvider)) {
+        return { isConfigured: true, provider: previewData.provider };
+      }
+    }
+
+    return { isConfigured, provider: previewData.provider };
+  }, [previewData, configuredProviders, calculateModelProvider]);
+
+  // Count messages by role
+  const messageCounts = useMemo(() => {
+    if (!previewData?.messages) return null;
+
+    const counts: Record<string, number> = {};
+    previewData.messages.forEach((msg) => {
+      const role = msg.role || "unknown";
+      counts[role] = (counts[role] || 0) + 1;
+    });
+
+    return counts;
+  }, [previewData]);
+
+  // Format message counts for display
+  const messageCountsDisplay = useMemo(() => {
+    if (!messageCounts) return "";
+
+    const parts: string[] = [];
+    if (messageCounts[LLM_MESSAGE_ROLE.system]) {
+      parts.push(`${messageCounts[LLM_MESSAGE_ROLE.system]} system`);
+    }
+    if (messageCounts[LLM_MESSAGE_ROLE.user]) {
+      parts.push(`${messageCounts[LLM_MESSAGE_ROLE.user]} user`);
+    }
+    if (messageCounts[LLM_MESSAGE_ROLE.assistant]) {
+      parts.push(`${messageCounts[LLM_MESSAGE_ROLE.assistant]} assistant`);
+    }
+    if (messageCounts[LLM_MESSAGE_ROLE.tool_execution_result]) {
+      parts.push(`${messageCounts[LLM_MESSAGE_ROLE.tool_execution_result]} tool`);
+    }
+
+    return parts.join(", ");
+  }, [messageCounts]);
+
+  // Determine source type
+  const isSpan = selectedItem && "trace_id" in selectedItem && "type" in selectedItem;
+  const spanType = isSpan ? (selectedItem as Span).type : TRACE_TYPE_FOR_TREE;
+  const sourceName = selectedItem?.name || "Unknown";
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-lg sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Play className="size-5" />
+            Open in Playground
+          </DialogTitle>
+          <DialogDescription>
+            Preview what will be loaded into the Playground
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-2">
+          {/* Source Info */}
+          <div className="flex items-start gap-3 rounded-md border bg-muted/30 p-3">
+            <div className="mt-0.5">
+              <BaseTraceDataTypeIcon
+                type={spanType as SPAN_TYPE | typeof TRACE_TYPE_FOR_TREE}
+              />
+            </div>
+            <div className="flex flex-col gap-0.5">
+              <span className="comet-body-s-accented">Source</span>
+              <span className="comet-body-s text-muted-foreground">
+                {isSpan ? "Span" : "Trace"}: {sourceName}
+              </span>
+            </div>
+          </div>
+
+          {/* Messages Info */}
+          <div className="flex items-start gap-3 rounded-md border bg-muted/30 p-3">
+            <MessageSquare className="mt-0.5 size-5 text-muted-foreground" />
+            <div className="flex flex-col gap-0.5">
+              <span className="comet-body-s-accented">Messages</span>
+              <span className="comet-body-s text-muted-foreground">
+                {previewData?.messages?.length || 0} messages
+                {messageCountsDisplay && ` (${messageCountsDisplay})`}
+              </span>
+            </div>
+          </div>
+
+          {/* Model Info */}
+          <div className="flex items-start gap-3 rounded-md border bg-muted/30 p-3">
+            <Cpu className="mt-0.5 size-5 text-muted-foreground" />
+            <div className="flex flex-col gap-0.5">
+              <span className="comet-body-s-accented">Model</span>
+              <span className="comet-body-s text-muted-foreground">
+                {previewData?.model || "Not detected (will use default)"}
+              </span>
+            </div>
+          </div>
+
+          {/* Provider Info */}
+          {previewData?.provider && (
+            <div className="flex items-start gap-3 rounded-md border bg-muted/30 p-3">
+              <Building2 className="mt-0.5 size-5 text-muted-foreground" />
+              <div className="flex flex-col gap-0.5">
+                <span className="comet-body-s-accented">Provider</span>
+                <span className="comet-body-s text-muted-foreground">
+                  {previewData.provider}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* Warning if provider not configured */}
+          {!providerStatus.isConfigured && providerStatus.provider && (
+            <div className="flex items-start gap-3 rounded-md border border-warning bg-warning-box-bg p-3">
+              <Settings className="mt-0.5 size-5 text-warning" />
+              <div className="flex flex-col gap-0.5">
+                <span className="comet-body-s-accented text-warning">
+                  Provider Not Configured
+                </span>
+                <span className="comet-body-s text-muted-foreground">
+                  The provider &quot;{providerStatus.provider}&quot; is not
+                  configured. You can still open in Playground, but you&apos;ll
+                  need to select a different model or{" "}
+                  <Link
+                    to="/$workspaceName/configuration"
+                    params={{ workspaceName }}
+                    search={{ tab: "ai-providers" }}
+                    className="text-primary underline hover:no-underline"
+                    onClick={() => setOpen(false)}
+                  >
+                    configure the provider
+                  </Link>{" "}
+                  first.
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* Warning if playground has content */}
+          {!isPlaygroundEmpty && (
+            <div className="flex items-start gap-3 rounded-md border border-warning bg-warning-box-bg p-3">
+              <AlertTriangle className="mt-0.5 size-5 text-warning" />
+              <div className="flex flex-col gap-0.5">
+                <span className="comet-body-s-accented text-warning">
+                  Warning
+                </span>
+                <span className="comet-body-s text-muted-foreground">
+                  This will replace your current Playground content. Unsaved
+                  changes will be lost.
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <DialogClose asChild>
+            <Button onClick={onConfirm} disabled={isLoading}>
+              {isLoading ? (
+                <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+              ) : (
+                <Play className="mr-1.5 size-3.5" />
+              )}
+              {isLoading ? "Loading..." : "Open in Playground"}
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default OpenInPlaygroundDialog;

--- a/apps/opik-frontend/src/components/pages-shared/traces/OpenInPlaygroundDialog/index.ts
+++ b/apps/opik-frontend/src/components/pages-shared/traces/OpenInPlaygroundDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./OpenInPlaygroundDialog";

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -50,6 +50,7 @@ type TraceDataViewerProps = {
   setActiveSection: (v: DetailsActionSectionValue) => void;
   isSpansLazyLoading: boolean;
   search?: string;
+  treeData: Array<Trace | Span>;
 };
 
 const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
@@ -62,6 +63,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
   setActiveSection,
   isSpansLazyLoading,
   search,
+  treeData,
 }) => {
   const type = get(data, "type", TRACE_TYPE_FOR_TREE);
   const tokens = data.usage?.total_tokens;
@@ -182,6 +184,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
                 activeSection={activeSection}
                 setActiveSection={setActiveSection}
                 layoutSize={layoutSize}
+                treeData={treeData}
               />
             )}
           />

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewerActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewerActionsPanel.tsx
@@ -1,25 +1,35 @@
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
+import { Play } from "lucide-react";
 
 import { Span, Trace } from "@/types/traces";
+import { Button } from "@/components/ui/button";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import AddToDropdown from "@/components/pages-shared/traces/AddToDropdown/AddToDropdown";
+import OpenInPlaygroundDialog from "@/components/pages-shared/traces/OpenInPlaygroundDialog";
 import {
   DetailsActionSection,
   DetailsActionSectionToggle,
   DetailsActionSectionValue,
+  ButtonLayoutSize,
 } from "@/components/pages-shared/traces/DetailsActionSection";
-import { ButtonLayoutSize } from "@/components/pages-shared/traces/DetailsActionSection";
 import { isObjectSpan } from "@/lib/traces";
+import { canOpenInPlayground } from "@/lib/playground/extractPlaygroundData";
+import useOpenInPlayground from "@/hooks/useOpenInPlayground";
 
 type TraceDataViewerActionsPanelProps = {
   layoutSize: ButtonLayoutSize;
   data: Trace | Span;
   activeSection: DetailsActionSectionValue | null;
   setActiveSection: (v: DetailsActionSectionValue) => void;
+  treeData: Array<Trace | Span>;
 };
 
 const TraceDataViewerActionsPanel: React.FunctionComponent<
   TraceDataViewerActionsPanelProps
-> = ({ data, activeSection, setActiveSection, layoutSize }) => {
+> = ({ data, activeSection, setActiveSection, layoutSize, treeData }) => {
+  const [playgroundDialogOpen, setPlaygroundDialogOpen] = useState(false);
+  const { openInPlayground, isPlaygroundEmpty } = useOpenInPlayground();
+
   const rows = useMemo(() => (data ? [data] : []), [data]);
 
   const annotationCount = data.feedback_scores?.length;
@@ -28,6 +38,19 @@ const TraceDataViewerActionsPanel: React.FunctionComponent<
   const isSpan = isObjectSpan(data);
   const dataType = isSpan ? "spans" : "traces";
 
+  // Check if this item can be opened in playground
+  const canOpen = canOpenInPlayground(data);
+
+  const handleOpenInPlayground = useCallback(() => {
+    setPlaygroundDialogOpen(true);
+  }, []);
+
+  const handleConfirmOpenInPlayground = useCallback(() => {
+    openInPlayground(data, treeData);
+  }, [openInPlayground, data, treeData]);
+
+  const isSmall = layoutSize === ButtonLayoutSize.Small;
+
   return (
     <>
       <AddToDropdown
@@ -35,6 +58,19 @@ const TraceDataViewerActionsPanel: React.FunctionComponent<
         selectedRows={rows}
         dataType={dataType}
       />
+
+      {canOpen && (
+        <TooltipWrapper content="Open in Playground">
+          <Button
+            variant="outline"
+            size={isSmall ? "icon-sm" : "sm"}
+            onClick={handleOpenInPlayground}
+          >
+            <Play className="size-3.5" />
+            {!isSmall && <span className="ml-1.5">Playground</span>}
+          </Button>
+        </TooltipWrapper>
+      )}
 
       <DetailsActionSectionToggle
         activeSection={activeSection}
@@ -49,6 +85,15 @@ const TraceDataViewerActionsPanel: React.FunctionComponent<
         layoutSize={layoutSize}
         count={annotationCount}
         type={DetailsActionSection.Annotations}
+      />
+
+      <OpenInPlaygroundDialog
+        open={playgroundDialogOpen}
+        setOpen={setPlaygroundDialogOpen}
+        onConfirm={handleConfirmOpenInPlayground}
+        selectedItem={data}
+        treeData={treeData}
+        isPlaygroundEmpty={isPlaygroundEmpty}
       />
     </>
   );

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsActionsPanel.tsx
@@ -68,6 +68,7 @@ import {
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 import useOpenInPlayground from "@/hooks/useOpenInPlayground";
 import { canOpenInPlayground } from "@/lib/playground/extractPlaygroundData";
+import OpenInPlaygroundDialog from "@/components/pages-shared/traces/OpenInPlaygroundDialog";
 
 const SEARCH_SPACE_RESERVATION = 200;
 
@@ -111,6 +112,8 @@ const TraceDetailsActionsPanel: React.FunctionComponent<
   setActiveSection,
 }) => {
   const [popupOpen, setPopupOpen] = useState<boolean>(false);
+  const [playgroundConfirmOpen, setPlaygroundConfirmOpen] =
+    useState<boolean>(false);
   const [isSmall, setIsSmall] = useState<boolean>(false);
   const isGuardrailsEnabled = useIsFeatureEnabled(
     FeatureToggleKeys.GUARDRAILS_ENABLED,
@@ -122,7 +125,7 @@ const TraceDetailsActionsPanel: React.FunctionComponent<
   const { toast } = useToast();
 
   const { mutate } = useTraceDeleteMutation();
-  const { openInPlayground } = useOpenInPlayground();
+  const { openInPlayground, isPlaygroundEmpty } = useOpenInPlayground();
 
   const hasThread = Boolean(setThreadId && threadId);
 
@@ -138,6 +141,13 @@ const TraceDetailsActionsPanel: React.FunctionComponent<
   }, [selectedItem]);
 
   const handleOpenInPlayground = useCallback(() => {
+    if (selectedItem) {
+      // Always show preview dialog for better UX
+      setPlaygroundConfirmOpen(true);
+    }
+  }, [selectedItem]);
+
+  const handleConfirmOpenInPlayground = useCallback(() => {
     if (selectedItem) {
       openInPlayground(selectedItem, treeData);
     }
@@ -624,9 +634,17 @@ const TraceDetailsActionsPanel: React.FunctionComponent<
           setOpen={setPopupOpen}
           onConfirm={handleTraceDelete}
           title="Delete trace"
-          description="Deleting a trace will also remove the trace data from related experiment samples. This action can’t be undone. Are you sure you want to continue?"
+          description="Deleting a trace will also remove the trace data from related experiment samples. This action can't be undone. Are you sure you want to continue?"
           confirmText="Delete trace"
           confirmButtonVariant="destructive"
+        />
+        <OpenInPlaygroundDialog
+          open={playgroundConfirmOpen}
+          setOpen={setPlaygroundConfirmOpen}
+          onConfirm={handleConfirmOpenInPlayground}
+          selectedItem={selectedItem}
+          treeData={treeData}
+          isPlaygroundEmpty={isPlaygroundEmpty}
         />
       </div>
     </div>

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
@@ -208,6 +208,7 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
               setActiveSection={setActiveSection}
               isSpansLazyLoading={isSpansLazyLoading}
               search={search}
+              treeData={treeData}
             />
           </ResizablePanel>
           {Boolean(activeSection) && (

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutput.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutput.tsx
@@ -1,5 +1,6 @@
-import React from "react";
-import { ListTree } from "lucide-react";
+import React, { useState, useMemo } from "react";
+import { ListTree, GitCompare, FileText, ChevronDown } from "lucide-react";
+import { diffWords, Change } from "diff";
 
 import { cn } from "@/lib/utils";
 import PlaygroundOutputLoader from "@/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputLoader/PlaygroundOutputLoader";
@@ -9,6 +10,7 @@ import {
   useOutputStaleStatusByPromptDatasetItemId,
   useOutputValueByPromptDatasetItemId,
   useTraceIdByPromptDatasetItemId,
+  useTraceContext,
 } from "@/store/PlaygroundStore";
 import { generateTracesURL } from "@/lib/annotation-queues";
 import useAppStore from "@/store/AppStore";
@@ -16,6 +18,15 @@ import useProjectByName from "@/api/projects/useProjectByName";
 import { PLAYGROUND_PROJECT_NAME } from "@/constants/shared";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+type OutputViewMode = "current" | "original" | "diff";
 
 interface PlaygroundOutputProps {
   promptId: string;
@@ -30,6 +41,9 @@ const PlaygroundOutput = ({
   const isLoading = useOutputLoadingByPromptDatasetItemId(promptId);
   const stale = useOutputStaleStatusByPromptDatasetItemId(promptId);
   const traceId = useTraceIdByPromptDatasetItemId(promptId);
+  const traceContext = useTraceContext();
+
+  const [viewMode, setViewMode] = useState<OutputViewMode>("current");
 
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
 
@@ -41,6 +55,71 @@ const PlaygroundOutput = ({
       enabled: !!traceId && !!workspaceName,
     },
   );
+
+  const originalOutput = traceContext?.originalOutput;
+  const hasOriginalOutput = Boolean(originalOutput);
+  const hasCurrentOutput = Boolean(value);
+  const canShowDiff = hasOriginalOutput && hasCurrentOutput;
+
+  // Compute diff changes for side-by-side view
+  const diffChanges = useMemo(() => {
+    if (!canShowDiff) return [];
+    return diffWords(originalOutput || "", value || "");
+  }, [originalOutput, value, canShowDiff]);
+
+  // Render original text with removed parts highlighted
+  const renderOriginalWithDiff = (changes: Change[]) => {
+    return (
+      <div className="whitespace-pre-wrap">
+        {changes.map((change, index) => {
+          if (change.added) {
+            // Skip added parts in original view
+            return null;
+          }
+          if (change.removed) {
+            // Highlight removed parts
+            return (
+              <span
+                key={index}
+                className="rounded-sm bg-diff-removed-bg px-0.5 text-diff-removed-text line-through"
+              >
+                {change.value}
+              </span>
+            );
+          }
+          // Unchanged parts
+          return <span key={index}>{change.value}</span>;
+        })}
+      </div>
+    );
+  };
+
+  // Render current text with added parts highlighted
+  const renderCurrentWithDiff = (changes: Change[]) => {
+    return (
+      <div className="whitespace-pre-wrap">
+        {changes.map((change, index) => {
+          if (change.removed) {
+            // Skip removed parts in current view
+            return null;
+          }
+          if (change.added) {
+            // Highlight added parts
+            return (
+              <span
+                key={index}
+                className="rounded-sm bg-diff-added-bg px-0.5 text-diff-added-text"
+              >
+                {change.value}
+              </span>
+            );
+          }
+          // Unchanged parts
+          return <span key={index}>{change.value}</span>;
+        })}
+      </div>
+    );
+  };
 
   const handleTraceLinkClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -55,11 +134,74 @@ const PlaygroundOutput = ({
     }
   };
 
+  const renderViewModeLabel = () => {
+    switch (viewMode) {
+      case "original":
+        return "Original Output";
+      case "diff":
+        return "Side by Side";
+      default:
+        return "Current Output";
+    }
+  };
+
   const renderContent = () => {
     if (isLoading && !value) {
       return <PlaygroundOutputLoader />;
     }
 
+    // Show original output
+    if (viewMode === "original" && hasOriginalOutput) {
+      return (
+        <div className="flex flex-col gap-2">
+          <div className="comet-body-xs flex items-center gap-1 text-muted-slate">
+            <FileText className="size-3" />
+            <span>Original output from trace</span>
+          </div>
+          <MarkdownPreview className="text-muted-foreground">
+            {originalOutput}
+          </MarkdownPreview>
+        </div>
+      );
+    }
+
+    // Show side-by-side comparison view with diff highlighting
+    if (viewMode === "diff" && canShowDiff) {
+      return (
+        <div className="flex h-full flex-col gap-3">
+          <div className="grid h-full grid-cols-2 gap-4">
+            {/* Original Output with removed parts highlighted */}
+            <div className="flex flex-col gap-2">
+              <div className="comet-body-xs flex items-center gap-1.5 font-medium text-muted-slate">
+                <FileText className="size-3" />
+                <span>Original (from trace)</span>
+                <span className="ml-1 rounded bg-diff-removed-bg px-1 text-[10px] text-diff-removed-text">
+                  removed
+                </span>
+              </div>
+              <div className="comet-body-s flex-1 overflow-auto rounded-md border border-border bg-muted/20 p-3">
+                {renderOriginalWithDiff(diffChanges)}
+              </div>
+            </div>
+            {/* Current Output with added parts highlighted */}
+            <div className="flex flex-col gap-2">
+              <div className="comet-body-xs flex items-center gap-1.5 font-medium text-primary">
+                <FileText className="size-3" />
+                <span>Current (playground)</span>
+                <span className="ml-1 rounded bg-diff-added-bg px-1 text-[10px] text-diff-added-text">
+                  added
+                </span>
+              </div>
+              <div className="comet-body-s flex-1 overflow-auto rounded-md border border-primary/30 bg-primary/5 p-3">
+                {renderCurrentWithDiff(diffChanges)}
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // Default: show current output
     return (
       <MarkdownPreview
         className={cn({
@@ -75,7 +217,56 @@ const PlaygroundOutput = ({
 
   return (
     <div className="size-full min-w-[var(--min-prompt-width)]">
-      <p className="comet-body-s-accented my-3">{outputLabel}</p>
+      <div className="my-3 flex items-center justify-between">
+        <p className="comet-body-s-accented">{outputLabel}</p>
+
+        {/* View mode selector - only show if we have original output from trace */}
+        {hasOriginalOutput && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1 text-xs"
+              >
+                {viewMode === "diff" && <GitCompare className="size-3" />}
+                {viewMode === "original" && <FileText className="size-3" />}
+                {viewMode === "current" && <FileText className="size-3" />}
+                {renderViewModeLabel()}
+                <ChevronDown className="size-3" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuRadioGroup
+                value={viewMode}
+                onValueChange={(v) => setViewMode(v as OutputViewMode)}
+              >
+                <DropdownMenuRadioItem value="current">
+                  <FileText className="mr-2 size-3.5" />
+                  Current Output
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="original">
+                  <FileText className="mr-2 size-3.5" />
+                  Original Output (from trace)
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem
+                  value="diff"
+                  disabled={!canShowDiff}
+                  className={cn({ "opacity-50": !canShowDiff })}
+                >
+                  <GitCompare className="mr-2 size-3.5" />
+                  Side by Side
+                  {!hasCurrentOutput && (
+                    <span className="ml-1 text-xs text-muted-foreground">
+                      - Run first
+                    </span>
+                  )}
+                </DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
       <div className="comet-body-s group relative min-h-52 rounded-lg border bg-background p-3">
         {traceId && playgroundProject?.id && (
           <TooltipWrapper content="Click to open original trace">

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -407,12 +407,7 @@ const PlaygroundPrompt = ({
 
   return (
     <div
-      className="h-[var(--prompt-height)] w-full min-w-[var(--min-prompt-width)]"
-      style={
-        {
-          "--prompt-height": "calc(100% - 64px)",
-        } as React.CSSProperties
-      }
+      className="h-[calc(100%-64px)] w-full min-w-[var(--min-prompt-width)]"
       ref={setRef}
     >
       <div className="mb-2 flex h-8 items-center justify-between">

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/TraceContextSidebar/TraceContextSidebar.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/TraceContextSidebar/TraceContextSidebar.tsx
@@ -1,0 +1,308 @@
+import React, { useState, useMemo } from "react";
+import {
+  Brain,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  ExternalLink,
+  Hash,
+  PanelLeftClose,
+  PanelLeftOpen,
+  X,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
+import {
+  PlaygroundTraceContext,
+  TraceContextSpan,
+} from "@/lib/playground/extractPlaygroundData";
+import { SPANS_COLORS_MAP, TRACE_TYPE_FOR_TREE } from "@/constants/traces";
+import { formatDuration } from "@/lib/date";
+import BaseTraceDataTypeIcon from "@/components/pages-shared/traces/TraceDetailsPanel/BaseTraceDataTypeIcon";
+
+interface TraceContextSidebarProps {
+  traceContext: PlaygroundTraceContext;
+  workspaceName: string;
+  onClose: () => void;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+}
+
+interface SpanTreeNodeProps {
+  span: TraceContextSpan;
+  allSpans: TraceContextSpan[];
+  level: number;
+}
+
+const SpanTreeNode: React.FC<SpanTreeNodeProps> = ({
+  span,
+  allSpans,
+  level,
+}) => {
+  const [expanded, setExpanded] = useState(true);
+
+  // Find children of this span
+  const children = useMemo(() => {
+    if (span.type === "trace") {
+      // For trace, find spans with no parent or parent pointing to trace
+      return allSpans.filter(
+        (s) =>
+          s.type !== "trace" && (!s.parentSpanId || s.parentSpanId === span.id),
+      );
+    }
+    return allSpans.filter((s) => s.parentSpanId === span.id);
+  }, [span, allSpans]);
+
+  const hasChildren = children.length > 0;
+  const spanColor =
+    SPANS_COLORS_MAP[span.type] || SPANS_COLORS_MAP[TRACE_TYPE_FOR_TREE];
+
+  return (
+    <div className="flex flex-col">
+      <div
+        className={cn(
+          "group flex items-center gap-2 rounded-md py-1.5 pr-2",
+          span.isSource ? "bg-primary-100" : "hover:bg-muted",
+        )}
+        style={{ paddingLeft: `${level * 14 + 6}px` }}
+      >
+        {hasChildren ? (
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="flex size-4 shrink-0 items-center justify-center rounded hover:bg-muted"
+          >
+            {expanded ? (
+              <ChevronDown className="size-3 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="size-3 text-muted-foreground" />
+            )}
+          </button>
+        ) : (
+          <span className="size-4 shrink-0" />
+        )}
+
+        <BaseTraceDataTypeIcon type={span.type} />
+
+        <span
+          className={cn(
+            "comet-body-xs truncate",
+            span.isSource ? "font-medium" : "text-muted-slate",
+          )}
+          title={span.name}
+        >
+          {span.name}
+        </span>
+
+        {span.isSource && (
+          <span
+            className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium"
+            style={{
+              backgroundColor: spanColor,
+              color: "white",
+            }}
+          >
+            Source
+          </span>
+        )}
+      </div>
+
+      {hasChildren && expanded && (
+        <div className="flex flex-col">
+          {children.map((child) => (
+            <SpanTreeNode
+              key={child.id}
+              span={child}
+              allSpans={allSpans}
+              level={level + 1}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const TraceContextSidebar: React.FC<TraceContextSidebarProps> = ({
+  traceContext,
+  workspaceName,
+  onClose,
+  collapsed = false,
+  onToggleCollapse,
+}) => {
+  // Build URL that opens the trace details panel directly
+  // Format: /workspace/projects/projectId/traces?type=traces&trace=traceId&span=spanId
+  const traceUrl = useMemo(() => {
+    const baseUrl = `/${workspaceName}/projects/${traceContext.projectId}/traces`;
+    const params = new URLSearchParams();
+    params.set("type", "traces");
+    params.set("trace", traceContext.traceId);
+    if (traceContext.sourceSpan) {
+      params.set("span", traceContext.sourceSpan.id);
+    }
+    return `${baseUrl}?${params.toString()}`;
+  }, [workspaceName, traceContext]);
+
+  // Find the root trace node
+  const rootNode = useMemo(() => {
+    return traceContext.traceStructure.find((s) => s.type === "trace");
+  }, [traceContext.traceStructure]);
+
+  if (collapsed) {
+    return (
+      <div className="flex h-full w-11 shrink-0 flex-col items-center border-r py-4">
+        <TooltipWrapper content="Show trace context" side="right">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onToggleCollapse}
+            className="mb-4"
+          >
+            <PanelLeftOpen className="size-4" />
+          </Button>
+        </TooltipWrapper>
+        <span
+          className="comet-body-xs font-medium text-muted-foreground"
+          style={{
+            writingMode: "vertical-rl",
+            textOrientation: "mixed",
+            transform: "rotate(180deg)",
+          }}
+        >
+          Trace Context
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-64 shrink-0 flex-col border-r">
+      {/* Header */}
+      <div className="flex h-11 items-center justify-between border-b px-4">
+        <span className="comet-body-s-accented text-foreground-secondary">
+          Trace Context
+        </span>
+        <div className="flex items-center gap-0.5">
+          {onToggleCollapse && (
+            <TooltipWrapper content="Collapse" side="bottom">
+              <Button variant="ghost" size="icon-xs" onClick={onToggleCollapse}>
+                <PanelLeftClose className="size-3.5" />
+              </Button>
+            </TooltipWrapper>
+          )}
+          <TooltipWrapper content="Close" side="bottom">
+            <Button variant="ghost" size="icon-xs" onClick={onClose}>
+              <X className="size-3.5" />
+            </Button>
+          </TooltipWrapper>
+        </div>
+      </div>
+
+      {/* Trace Info */}
+      <div className="border-b px-4 py-3">
+        <div className="comet-body-xs mb-2 font-medium text-muted-slate">
+          Source Trace
+        </div>
+        <div className="flex items-center gap-2">
+          <BaseTraceDataTypeIcon type={TRACE_TYPE_FOR_TREE} />
+          <span
+            className="comet-body-s truncate font-medium"
+            title={traceContext.traceName}
+          >
+            {traceContext.traceName}
+          </span>
+        </div>
+      </div>
+
+      {/* Source Span Info */}
+      {traceContext.sourceSpan && (
+        <div className="border-b px-4 py-3">
+          <div className="comet-body-xs mb-2 font-medium text-muted-slate">
+            Editing From
+          </div>
+          <div className="flex flex-col gap-2.5">
+            <div className="flex items-center gap-2">
+              <BaseTraceDataTypeIcon type={traceContext.sourceSpan.type} />
+              <span
+                className="comet-body-s truncate"
+                title={traceContext.sourceSpan.name}
+              >
+                {traceContext.sourceSpan.name}
+              </span>
+            </div>
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
+              {traceContext.sourceSpan.model && (
+                <TooltipWrapper content="Model" side="bottom">
+                  <span className="comet-body-xs flex items-center gap-1.5 text-muted-slate">
+                    <Brain className="size-3" />
+                    {traceContext.sourceSpan.model}
+                  </span>
+                </TooltipWrapper>
+              )}
+              {traceContext.sourceSpan.duration !== undefined && (
+                <TooltipWrapper content="Duration" side="bottom">
+                  <span className="comet-body-xs flex items-center gap-1.5 text-muted-slate">
+                    <Clock className="size-3" />
+                    {formatDuration(traceContext.sourceSpan.duration)}
+                  </span>
+                </TooltipWrapper>
+              )}
+              {traceContext.sourceSpan.totalTokens !== undefined && (
+                <TooltipWrapper content="Total tokens" side="bottom">
+                  <span className="comet-body-xs flex items-center gap-1.5 text-muted-slate">
+                    <Hash className="size-3" />
+                    {traceContext.sourceSpan.totalTokens.toLocaleString()}
+                  </span>
+                </TooltipWrapper>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Model Info */}
+      {traceContext.originalModel && (
+        <div className="border-b bg-warning-box-bg px-4 py-2.5">
+          <div className="comet-body-xs text-warning-box-text">
+            <span className="font-medium">Original model:</span>{" "}
+            {traceContext.originalModel}
+            {traceContext.originalProvider && (
+              <span className="opacity-75">
+                {" "}
+                ({traceContext.originalProvider})
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Trace Tree */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="comet-body-xs px-4 py-2.5 font-medium text-muted-slate">
+          Trace Structure
+        </div>
+        <div className="flex-1 overflow-y-auto px-3 pb-3">
+          {rootNode && (
+            <SpanTreeNode
+              span={rootNode}
+              allSpans={traceContext.traceStructure}
+              level={0}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Footer with link */}
+      <div className="border-t px-4 py-3">
+        <Button variant="outline" size="sm" className="w-full" asChild>
+          <a href={traceUrl} target="_blank" rel="noopener noreferrer">
+            <ExternalLink className="mr-1.5 size-3.5" />
+            View Full Trace
+          </a>
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default TraceContextSidebar;

--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/TraceContextSidebar/index.ts
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/TraceContextSidebar/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./TraceContextSidebar";
+export type { default as TraceContextSidebarProps } from "./TraceContextSidebar";

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TraceRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TraceRowActionsCell.tsx
@@ -1,0 +1,175 @@
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import { CellContext } from "@tanstack/react-table";
+import { MoreHorizontal, Play, Copy, Trash } from "lucide-react";
+import copy from "clipboard-copy";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import CellWrapper from "@/components/shared/DataTableCells/CellWrapper";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
+import ConfirmDialog from "@/components/shared/ConfirmDialog/ConfirmDialog";
+import OpenInPlaygroundDialog from "@/components/pages-shared/traces/OpenInPlaygroundDialog";
+import { useToast } from "@/components/ui/use-toast";
+import useOpenInPlayground from "@/hooks/useOpenInPlayground";
+import useTraceDeleteMutation from "@/api/traces/useTraceDeleteMutation";
+import useSpansList from "@/api/traces/useSpansList";
+import { canOpenInPlayground } from "@/lib/playground/extractPlaygroundData";
+import { Span, Trace } from "@/types/traces";
+
+type CustomMeta = {
+  projectId: string;
+};
+
+const MAX_SPANS_LOAD_SIZE = 500;
+
+const TraceRowActionsCell: React.FC<CellContext<Trace | Span, unknown>> = (
+  context,
+) => {
+  const { custom } = context.column.columnDef.meta ?? {};
+  const { projectId } = (custom ?? {}) as CustomMeta;
+
+  const resetKeyRef = useRef(0);
+  const item = context.row.original;
+  const [deleteOpen, setDeleteOpen] = useState<boolean>(false);
+  const [playgroundOpen, setPlaygroundOpen] = useState<boolean>(false);
+
+  const { toast } = useToast();
+  const { mutate: deleteTrace } = useTraceDeleteMutation();
+  const { openInPlayground, isPlaygroundEmpty } = useOpenInPlayground();
+
+  // Check if this is a trace (not a span)
+  const isTrace = !("trace_id" in item);
+  const traceId = isTrace ? item.id : (item as Span).trace_id;
+
+  // Fetch spans when dialog is open (for full context)
+  const { data: spansData, isPending: isSpansLoading } = useSpansList(
+    {
+      projectId,
+      traceId,
+      page: 1,
+      size: MAX_SPANS_LOAD_SIZE,
+    },
+    {
+      enabled: playgroundOpen && Boolean(traceId) && Boolean(projectId),
+    },
+  );
+
+  // Combine trace/span with its spans for full tree data
+  const fullTreeData = useMemo(() => {
+    const spans = spansData?.content || [];
+    // If we have the trace, include it with its spans
+    if (isTrace) {
+      return [item, ...spans];
+    }
+    // If we have a span, include all spans from the same trace
+    return spans;
+  }, [item, spansData?.content, isTrace]);
+
+  // Check if can open in playground
+  const canOpen = canOpenInPlayground(item);
+
+  const handleDelete = useCallback(() => {
+    if (isTrace) {
+      deleteTrace({
+        traceId: item.id,
+        projectId,
+      });
+    }
+  }, [deleteTrace, item.id, projectId, isTrace]);
+
+  const handleCopyId = useCallback(() => {
+    copy(item.id);
+    toast({
+      description: `${isTrace ? "Trace" : "Span"} ID copied to clipboard`,
+    });
+  }, [item.id, isTrace, toast]);
+
+  const handleOpenInPlayground = useCallback(() => {
+    setPlaygroundOpen(true);
+    resetKeyRef.current = resetKeyRef.current + 1;
+  }, []);
+
+  const handleConfirmOpenInPlayground = useCallback(() => {
+    // Use full tree data if available, otherwise fall back to just the item
+    openInPlayground(item, fullTreeData.length > 1 ? fullTreeData : [item]);
+  }, [openInPlayground, item, fullTreeData]);
+
+  return (
+    <CellWrapper
+      metadata={context.column.columnDef.meta}
+      tableMetadata={context.table.options.meta}
+      className="justify-end p-0"
+      stopClickPropagation
+    >
+      <OpenInPlaygroundDialog
+        key={`playground-${resetKeyRef.current}`}
+        open={playgroundOpen}
+        setOpen={setPlaygroundOpen}
+        onConfirm={handleConfirmOpenInPlayground}
+        selectedItem={item}
+        treeData={fullTreeData.length > 1 ? fullTreeData : [item]}
+        isPlaygroundEmpty={isPlaygroundEmpty}
+        isLoading={playgroundOpen && isSpansLoading}
+      />
+      {isTrace && (
+        <ConfirmDialog
+          key={`delete-${resetKeyRef.current}`}
+          open={deleteOpen}
+          setOpen={setDeleteOpen}
+          onConfirm={handleDelete}
+          title="Delete trace"
+          description="Deleting a trace will also remove the trace data from related experiment samples. This action can't be undone. Are you sure you want to continue?"
+          confirmText="Delete trace"
+          confirmButtonVariant="destructive"
+        />
+      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="minimal" size="icon" className="-mr-2.5">
+            <span className="sr-only">Actions menu</span>
+            <MoreHorizontal className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-52">
+          {canOpen && (
+            <>
+              <DropdownMenuItem onClick={handleOpenInPlayground}>
+                <Play className="mr-2 size-4" />
+                Open in Playground
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          )}
+          <TooltipWrapper content={item.id} side="left">
+            <DropdownMenuItem onClick={handleCopyId}>
+              <Copy className="mr-2 size-4" />
+              Copy {isTrace ? "trace" : "span"} ID
+            </DropdownMenuItem>
+          </TooltipWrapper>
+          {isTrace && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => {
+                  setDeleteOpen(true);
+                  resetKeyRef.current = resetKeyRef.current + 1;
+                }}
+              >
+                <Trash className="mr-2 size-4" />
+                Delete trace
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </CellWrapper>
+  );
+};
+
+export default TraceRowActionsCell;

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
@@ -112,6 +112,7 @@ import {
   USER_FEEDBACK_NAME,
 } from "@/constants/shared";
 import { useTruncationEnabled } from "@/components/server-sync-provider";
+import TraceRowActionsCell from "@/components/pages/TracesPage/TracesSpansTab/TraceRowActionsCell";
 
 const getRowId = (d: Trace | Span) => d.id;
 
@@ -1017,6 +1018,17 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
           sortableColumns: sortableBy,
         },
       ),
+      // Row actions column (always last)
+      mapColumnDataFields<BaseTraceData, Span | Trace>({
+        id: "actions",
+        label: "",
+        type: COLUMN_TYPE.string,
+        size: 48,
+        cell: TraceRowActionsCell as never,
+        customMeta: {
+          projectId,
+        },
+      }),
     ];
   }, [
     handleRowClick,
@@ -1030,6 +1042,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
     metadataMainColumnOrder,
     metadataColumnsData,
     metadataColumnsOrder,
+    projectId,
   ]);
 
   const columnsToExport = useMemo(() => {

--- a/apps/opik-frontend/src/hooks/useOpenInPlayground.ts
+++ b/apps/opik-frontend/src/hooks/useOpenInPlayground.ts
@@ -1,6 +1,7 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import useAppStore from "@/store/AppStore";
+import { usePromptMap } from "@/store/PlaygroundStore";
 import { Span, Trace } from "@/types/traces";
 import {
   extractPlaygroundData,
@@ -17,6 +18,18 @@ export const PLAYGROUND_PREFILL_KEY = "opik-playground-prefill";
 const useOpenInPlayground = () => {
   const navigate = useNavigate();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const promptMap = usePromptMap();
+
+  // Check if playground is empty (same logic as useLoadPlayground)
+  const isPlaygroundEmpty = useMemo(() => {
+    const keys = Object.keys(promptMap);
+
+    return (
+      keys.length === 1 &&
+      promptMap[keys[0]]?.messages?.length === 1 &&
+      promptMap[keys[0]]?.messages[0]?.content === ""
+    );
+  }, [promptMap]);
 
   const openInPlayground = useCallback(
     (data: Trace | Span, allData?: Array<Trace | Span>) => {
@@ -35,7 +48,7 @@ const useOpenInPlayground = () => {
     [navigate, workspaceName],
   );
 
-  return { openInPlayground };
+  return { openInPlayground, isPlaygroundEmpty };
 };
 
 /**

--- a/apps/opik-frontend/src/lib/playground/extractPlaygroundData.ts
+++ b/apps/opik-frontend/src/lib/playground/extractPlaygroundData.ts
@@ -1,13 +1,68 @@
 import { Span, Trace, SPAN_TYPE } from "@/types/traces";
-import { LLMMessage, LLM_MESSAGE_ROLE, ProviderMessageType } from "@/types/llm";
+import {
+  LLMMessage,
+  LLM_MESSAGE_ROLE,
+  ProviderMessageType,
+  MessageSourceAnnotation,
+  MessageSourceType,
+} from "@/types/llm";
 import { generateRandomString } from "@/lib/utils";
 import isArray from "lodash/isArray";
 import isObject from "lodash/isObject";
+
+/**
+ * Simplified span info for trace context display
+ */
+export interface TraceContextSpan {
+  id: string;
+  name: string;
+  type: SPAN_TYPE | "trace";
+  parentSpanId?: string;
+  isSource: boolean; // Whether this is the span being edited
+  model?: string;
+  provider?: string;
+  duration?: number;
+  totalTokens?: number;
+}
+
+/**
+ * Source span metadata for the playground
+ */
+export interface SourceSpanInfo {
+  id: string;
+  name: string;
+  type: SPAN_TYPE;
+  model?: string;
+  provider?: string;
+  duration?: number;
+  totalTokens?: number;
+}
+
+/**
+ * Trace context for understanding where playground data came from
+ */
+export interface PlaygroundTraceContext {
+  traceId: string;
+  traceName: string;
+  projectId: string;
+  projectName?: string;
+  // The span this was extracted from (undefined if from trace directly)
+  sourceSpan?: SourceSpanInfo;
+  // Simplified trace structure for context sidebar
+  traceStructure: TraceContextSpan[];
+  // Original model from trace (may differ from resolved model)
+  originalModel?: string;
+  originalProvider?: string;
+  // Original output from the trace/span for comparison
+  originalOutput?: string;
+}
 
 export interface PlaygroundPrefillData {
   messages: LLMMessage[];
   model?: string;
   provider?: string;
+  // NEW: Trace context for "Trace-Aware Playground Mode"
+  traceContext?: PlaygroundTraceContext;
 }
 
 /**
@@ -54,14 +109,69 @@ const getRoleFromMessage = (msg: Record<string, unknown>): string => {
 };
 
 /**
- * Convert a message object to LLMMessage format
+ * Determine source annotation type based on message role
  */
-const convertToLLMMessage = (msg: Record<string, unknown>): LLMMessage => {
+const getSourceTypeForRole = (role: LLM_MESSAGE_ROLE): MessageSourceType => {
+  switch (role) {
+    case LLM_MESSAGE_ROLE.system:
+      return "system_config";
+    case LLM_MESSAGE_ROLE.user:
+      return "user_input";
+    case LLM_MESSAGE_ROLE.assistant:
+    case LLM_MESSAGE_ROLE.ai:
+      return "llm_response";
+    case LLM_MESSAGE_ROLE.tool_execution_result:
+      return "tool_output";
+    default:
+      return "trace_input";
+  }
+};
+
+/**
+ * Convert a message object to LLMMessage format with source annotation
+ */
+const convertToLLMMessage = (
+  msg: Record<string, unknown>,
+  sourceSpanName?: string,
+): LLMMessage => {
   const role = getRoleFromMessage(msg);
+  const mappedRole = mapRoleToLLMMessageRole(role);
+  const sourceType = getSourceTypeForRole(mappedRole);
+
+  const sourceAnnotation: MessageSourceAnnotation = {
+    type: sourceType,
+    sourceSpanName,
+  };
+
+  // Add description based on role
+  switch (sourceType) {
+    case "system_config":
+      sourceAnnotation.description = "System message from trace";
+      break;
+    case "user_input":
+      sourceAnnotation.description = sourceSpanName
+        ? `User input from "${sourceSpanName}"`
+        : "User input from trace";
+      break;
+    case "llm_response":
+      sourceAnnotation.description = sourceSpanName
+        ? `LLM response from "${sourceSpanName}"`
+        : "LLM response from trace";
+      break;
+    case "tool_output":
+      sourceAnnotation.description = sourceSpanName
+        ? `Tool output from "${sourceSpanName}"`
+        : "Tool execution result";
+      break;
+    default:
+      sourceAnnotation.description = "From trace input";
+  }
+
   return {
     id: generateRandomString(),
-    role: mapRoleToLLMMessageRole(role),
+    role: mappedRole,
     content: (msg as ProviderMessageType).content,
+    sourceAnnotation,
   };
 };
 
@@ -86,6 +196,67 @@ const isMessagesArray = (
     (typeof (firstItem as Record<string, unknown>).role === "string" ||
       typeof (firstItem as Record<string, unknown>).type === "string")
   );
+};
+
+/**
+ * Extract output as a string for comparison
+ * Handles various output formats from LLM calls
+ */
+const extractOutputAsString = (output: unknown): string | undefined => {
+  if (!output) return undefined;
+
+  // If output is already a string
+  if (typeof output === "string") return output;
+
+  // If output is an object
+  if (isObject(output)) {
+    const outputObj = output as Record<string, unknown>;
+
+    // Check for common output structures
+    // OpenAI format: { choices: [{ message: { content: "..." } }] }
+    if (isArray(outputObj.choices)) {
+      const firstChoice = (outputObj.choices as Array<Record<string, unknown>>)[0];
+      if (firstChoice?.message && isObject(firstChoice.message)) {
+        const message = firstChoice.message as Record<string, unknown>;
+        if (typeof message.content === "string") {
+          return message.content;
+        }
+      }
+    }
+
+    // Direct content field
+    if (typeof outputObj.content === "string") {
+      return outputObj.content;
+    }
+
+    // Message with content
+    if (outputObj.message && isObject(outputObj.message)) {
+      const message = outputObj.message as Record<string, unknown>;
+      if (typeof message.content === "string") {
+        return message.content;
+      }
+    }
+
+    // Response field (common in some APIs)
+    if (typeof outputObj.response === "string") {
+      return outputObj.response;
+    }
+
+    // Text field
+    if (typeof outputObj.text === "string") {
+      return outputObj.text;
+    }
+
+    // Output field
+    if (typeof outputObj.output === "string") {
+      return outputObj.output;
+    }
+
+    // Fallback: stringify the entire output
+    return JSON.stringify(output, null, 2);
+  }
+
+  return undefined;
 };
 
 /**
@@ -116,7 +287,10 @@ const hasNonEmptyInput = (input: unknown): boolean => {
  * - Array of messages directly
  * - Plain object/string - converted to a user message
  */
-const extractMessagesFromInput = (input: unknown): LLMMessage[] => {
+const extractMessagesFromInput = (
+  input: unknown,
+  sourceSpanName?: string,
+): LLMMessage[] => {
   // Case 1: Input has a messages property
   if (isObject(input) && "messages" in input) {
     const messages = (input as { messages: unknown }).messages;
@@ -124,7 +298,7 @@ const extractMessagesFromInput = (input: unknown): LLMMessage[] => {
       // Handle empty messages array
       if (messages.length === 0) return [];
       return messages.map((msg) =>
-        convertToLLMMessage(msg as Record<string, unknown>),
+        convertToLLMMessage(msg as Record<string, unknown>, sourceSpanName),
       );
     }
   }
@@ -134,7 +308,7 @@ const extractMessagesFromInput = (input: unknown): LLMMessage[] => {
     // Handle empty array
     if (input.length === 0) return [];
     return input.map((msg) =>
-      convertToLLMMessage(msg as Record<string, unknown>),
+      convertToLLMMessage(msg as Record<string, unknown>, sourceSpanName),
     );
   }
 
@@ -147,6 +321,13 @@ const extractMessagesFromInput = (input: unknown): LLMMessage[] => {
       id: generateRandomString(),
       role: LLM_MESSAGE_ROLE.user,
       content,
+      sourceAnnotation: {
+        type: "trace_input",
+        description: sourceSpanName
+          ? `Input from "${sourceSpanName}"`
+          : "Input from trace",
+        sourceSpanName,
+      },
     },
   ];
 };
@@ -178,17 +359,85 @@ const findBestLLMSpan = (spans: Span[]): Span | undefined => {
 };
 
 /**
- * Extract playground prefill data from a span
+ * Build trace structure from trace and spans for context sidebar
+ */
+const buildTraceStructure = (
+  trace: Trace,
+  spans: Span[],
+  sourceId: string,
+): TraceContextSpan[] => {
+  const structure: TraceContextSpan[] = [];
+
+  // Add trace as root
+  structure.push({
+    id: trace.id,
+    name: trace.name,
+    type: "trace",
+    isSource: trace.id === sourceId,
+    duration: trace.duration,
+    totalTokens: trace.usage?.total_tokens,
+  });
+
+  // Add all spans
+  spans.forEach((span) => {
+    structure.push({
+      id: span.id,
+      name: span.name,
+      type: span.type,
+      parentSpanId: span.parent_span_id || trace.id,
+      isSource: span.id === sourceId,
+      model: span.model,
+      provider: span.provider,
+      duration: span.duration,
+      totalTokens: span.usage?.total_tokens,
+    });
+  });
+
+  return structure;
+};
+
+/**
+ * Extract playground prefill data from a span with full trace context
  */
 export const extractPlaygroundDataFromSpan = (
   span: Span,
+  trace?: Trace,
+  allSpans?: Span[],
 ): PlaygroundPrefillData => {
-  const messages = extractMessagesFromInput(span.input);
+  const messages = extractMessagesFromInput(span.input, span.name);
+
+  // Extract original output from the span
+  const originalOutput = extractOutputAsString(span.output);
+
+  // Build trace context if we have trace info
+  let traceContext: PlaygroundTraceContext | undefined;
+  if (trace) {
+    traceContext = {
+      traceId: trace.id,
+      traceName: trace.name,
+      projectId: trace.project_id,
+      projectName: trace.workspace_name,
+      sourceSpan: {
+        id: span.id,
+        name: span.name,
+        type: span.type,
+        model: span.model,
+        provider: span.provider,
+        duration: span.duration,
+        totalTokens: span.usage?.total_tokens,
+      },
+      traceStructure: buildTraceStructure(trace, allSpans || [], span.id),
+      originalModel: span.model,
+      originalProvider: span.provider,
+      originalOutput,
+    };
+  }
 
   return {
     messages,
     model: span.model,
     provider: span.provider,
+    traceContext,
   };
 };
 
@@ -205,22 +454,43 @@ export const extractPlaygroundDataFromTrace = (
 
   // Only use LLM span if it has non-empty input
   if (llmSpan && hasNonEmptyInput(llmSpan.input)) {
-    return extractPlaygroundDataFromSpan(llmSpan);
+    return extractPlaygroundDataFromSpan(llmSpan, trace, spans);
   }
 
   // Fall back to trace input, but keep model/provider from LLM span if available
-  const messages = extractMessagesFromInput(trace.input);
+  const messages = extractMessagesFromInput(trace.input, trace.name);
+
+  // Extract original output - prefer LLM span output, fall back to trace output
+  const originalOutput =
+    extractOutputAsString(llmSpan?.output) ||
+    extractOutputAsString(trace.output);
+
+  // Build trace context even when using trace input
+  const traceContext: PlaygroundTraceContext = {
+    traceId: trace.id,
+    traceName: trace.name,
+    projectId: trace.project_id,
+    projectName: trace.workspace_name,
+    // No source span when loading from trace directly
+    sourceSpan: undefined,
+    traceStructure: buildTraceStructure(trace, spans || [], trace.id),
+    originalModel: llmSpan?.model,
+    originalProvider: llmSpan?.provider,
+    originalOutput,
+  };
 
   return {
     messages,
     model: llmSpan?.model,
     provider: llmSpan?.provider,
+    traceContext,
   };
 };
 
 /**
  * Extract playground prefill data from either a trace or span
  * Automatically determines the best source for messages and model info
+ * Now includes full trace context for "Trace-Aware Playground Mode"
  */
 export const extractPlaygroundData = (
   data: Trace | Span,
@@ -228,14 +498,20 @@ export const extractPlaygroundData = (
 ): PlaygroundPrefillData => {
   const isSpan = "trace_id" in data && "type" in data;
 
-  if (isSpan) {
-    return extractPlaygroundDataFromSpan(data as Span);
-  }
-
-  // For traces, also pass any available spans
+  // Separate traces and spans from allData
   const spans = allData?.filter(
     (item): item is Span => "trace_id" in item && "type" in item,
   );
+
+  if (isSpan) {
+    const span = data as Span;
+    // Try to find the parent trace from allData
+    const trace = allData?.find(
+      (item): item is Trace =>
+        !("trace_id" in item) && item.id === span.trace_id,
+    );
+    return extractPlaygroundDataFromSpan(span, trace, spans);
+  }
 
   return extractPlaygroundDataFromTrace(data as Trace, spans);
 };

--- a/apps/opik-frontend/src/store/PlaygroundStore.ts
+++ b/apps/opik-frontend/src/store/PlaygroundStore.ts
@@ -7,6 +7,7 @@ import { Filters } from "@/types/filters";
 import isUndefined from "lodash/isUndefined";
 import get from "lodash/get";
 import lodashSet from "lodash/set";
+import { PlaygroundTraceContext } from "@/lib/playground/extractPlaygroundData";
 
 interface PlaygroundOutput {
   isLoading: boolean;
@@ -100,6 +101,8 @@ export type PlaygroundStore = {
   datasetSize: number;
   progressTotal: number;
   progressCompleted: number;
+  // Trace context for "Trace-Aware Playground Mode"
+  traceContext: PlaygroundTraceContext | null;
 
   setPromptMap: (
     promptIds: string[],
@@ -134,6 +137,8 @@ export type PlaygroundStore = {
   resetDatasetFilters: () => void;
   setProgress: (completed: number, total: number) => void;
   resetProgress: () => void;
+  setTraceContext: (context: PlaygroundTraceContext | null) => void;
+  clearTraceContext: () => void;
 };
 
 const usePlaygroundStore = create<PlaygroundStore>()(
@@ -152,6 +157,7 @@ const usePlaygroundStore = create<PlaygroundStore>()(
       datasetSize: 100,
       progressTotal: 0,
       progressCompleted: 0,
+      traceContext: null,
 
       updatePrompt: (promptId, changes) => {
         set((state) => {
@@ -366,6 +372,22 @@ const usePlaygroundStore = create<PlaygroundStore>()(
           };
         });
       },
+      setTraceContext: (context) => {
+        set((state) => {
+          return {
+            ...state,
+            traceContext: context,
+          };
+        });
+      },
+      clearTraceContext: () => {
+        set((state) => {
+          return {
+            ...state,
+            traceContext: null,
+          };
+        });
+      },
     }),
     {
       name: "PLAYGROUND_STATE",
@@ -535,5 +557,14 @@ export const useSetProgress = () =>
 
 export const useResetProgress = () =>
   usePlaygroundStore((state) => state.resetProgress);
+
+export const useTraceContext = () =>
+  usePlaygroundStore((state) => state.traceContext);
+
+export const useSetTraceContext = () =>
+  usePlaygroundStore((state) => state.setTraceContext);
+
+export const useClearTraceContext = () =>
+  usePlaygroundStore((state) => state.clearTraceContext);
 
 export default usePlaygroundStore;

--- a/apps/opik-frontend/src/types/llm.ts
+++ b/apps/opik-frontend/src/types/llm.ts
@@ -29,6 +29,24 @@ export type MessageContent =
   | string
   | Array<TextPart | ImagePart | VideoPart | AudioPart>;
 
+/**
+ * Source annotation for messages loaded from traces
+ * Helps users understand where each message originated
+ */
+export type MessageSourceType =
+  | "system_config" // Original system message from config
+  | "user_input" // Direct user input
+  | "tool_output" // Output from a tool span
+  | "llm_response" // Response from an LLM
+  | "merged" // Combined from multiple sources (e.g., RAG context + user query)
+  | "trace_input"; // Generic input from trace
+
+export interface MessageSourceAnnotation {
+  type: MessageSourceType;
+  description?: string; // e.g., "From retriever span output"
+  sourceSpanName?: string; // Name of the span this came from
+}
+
 export interface LLMMessage {
   id: string;
   content: MessageContent;
@@ -36,6 +54,8 @@ export interface LLMMessage {
   promptId?: string;
   promptVersionId?: string;
   autoImprove?: boolean;
+  // Source annotation for trace-aware playground mode
+  sourceAnnotation?: MessageSourceAnnotation;
 }
 
 export type ProviderMessageType = Omit<LLMMessage, "id"> & {


### PR DESCRIPTION
## Details

Add the ability to open a trace or span directly in the Playground with its input messages pre-filled. This creates a smooth debugging workflow where users can observe a trace, then immediately iterate on the prompt without manual copy-pasting.

### What it does:
- Adds "Open in Playground" menu item in the trace/span details panel actions dropdown
- Extracts messages from trace/span input (supports multiple formats: messages array, direct array, plain objects/strings)
- Pre-fills the Playground with extracted messages and auto-selects the model if detected
- Shows a toast notification confirming the trace was loaded

### Files created:
- `src/lib/playground/extractPlaygroundData.ts` - Utility to extract playground-compatible data from traces/spans
- `src/hooks/useOpenInPlayground.ts` - Hook for navigation with data storage

### Files modified:
- `src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsActionsPanel.tsx` - Added menu item
- `src/components/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompts.tsx` - Added prefill loading logic

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3931

## Testing
1. Navigate to a trace with LLM input messages
2. Click the ⋮ menu → "Open in Playground"
3. Verify messages are pre-filled in the Playground
4. Verify model is auto-selected if available
5. Test with different input formats (messages array, plain string, object)

## Documentation
N/A