### PR TITLE
[OPIK-3933] [FE] Add A/B test for default prompt message in Playground

### DIFF
--- a/apps/opik-frontend/src/lib/playground.ts
+++ b/apps/opik-frontend/src/lib/playground.ts
@@ -123,6 +123,7 @@ interface GenerateDefaultPromptParams {
   lastPickedModel?: PROVIDER_MODEL_TYPE | "";
   providerResolver: ProviderResolver;
   modelResolver: ModelResolver;
+  initialMessageContent?: string;
 }
 
 export const generateDefaultPrompt = ({
@@ -131,13 +132,18 @@ export const generateDefaultPrompt = ({
   lastPickedModel,
   providerResolver,
   modelResolver,
+  initialMessageContent,
 }: GenerateDefaultPromptParams): PlaygroundPromptType => {
   const modelByDefault = modelResolver(lastPickedModel || "", setupProviders);
   const provider = providerResolver(modelByDefault);
 
   return {
     name: "Prompt",
-    messages: [generateDefaultLLMPromptMessage()],
+    messages: [
+      generateDefaultLLMPromptMessage({
+        content: initialMessageContent ?? "",
+      }),
+    ],
     model: modelByDefault,
     provider,
     configs: getDefaultConfigByProvider(provider, modelByDefault),


### PR DESCRIPTION
## Details

This PR implements an A/B test to evaluate whether showing a default prompt message in the Playground improves user engagement compared to an empty message field.

**Problem:**
Currently, when users first open the Playground, they see an empty message field. This may create friction for new users who are unsure what to try.

**Solution:**
- Implemented PostHog feature flag `playground-default-prompt-message` to A/B test showing a default message
- Test variant shows: "In 2-3 sentences, describe what an LLM is and the main challenge of using them."
- Control variant shows empty message (current behavior)

**Key Design Decisions:**
1. **Lazy evaluation**: PostHog feature flag is only called inside `useEffect` when `promptCount === 0`, ensuring users loading existing playground state from localStorage are not tracked, preventing skewed A/B test results
2. **Graceful degradation**: Try-catch wrapper ensures the feature works even when PostHog is not initialized (e.g., on-premise deployments)
3. **Minimal scope**: Only affects initial playground creation, not "Add prompt" button or "Reset playground" actions (which users expect to be empty)

## Change checklist
<!-- Please check the type of changes made -->
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves # <!-- the GitHub issue this PR resolves (e.g. `#1234`) -->
- OPIK-3933 <!-- The Jira ticket (e.g. `OPIK-1234`) -->

## Testing

**Manual Testing:**
1. **Test Variant (with default message):**
   - Clear browser localStorage for the app
   - Set PostHog feature flag `playground-default-prompt-message` to "test" variant
   - Navigate to Playground
   - Verify default message appears: "In 2-3 sentences, describe what an LLM is and the main challenge of using them."

2. **Control Variant (empty message):**
   - Clear browser localStorage for the app
   - Set PostHog feature flag to "control" variant or disable it
   - Navigate to Playground
   - Verify message field is empty (current behavior)

3. **Existing State (no A/B test impact):**
   - Create a playground prompt with custom content
   - Refresh the page
   - Verify your custom content is loaded (not replaced by default message)
   - Confirm PostHog feature flag is NOT evaluated (check browser console if logging added)

4. **PostHog Not Initialized:**
   - Test on environment without PostHog configuration
   - Verify Playground loads with empty message (graceful fallback)
   - Confirm no JavaScript errors in console

5. **Other Actions Unaffected:**
   - Click "Add prompt" button → should create empty prompt
   - Click "Reset playground" → should create empty prompt
   - Load prompt from library → should use saved content

**Files Changed:**
- `PlaygroundPrompts.tsx`: A/B test implementation with PostHog
- `playground.ts`: Added `initialMessageContent` optional parameter
- `llm.ts`: No changes (kept `generateDefaultLLMPromptMessage` with empty content)

## Documentation

No documentation updates required. This is an internal A/B test that doesn't change user-facing documentation. The feature flag will be configured in PostHog dashboard.

**PostHog Configuration Needed:**
- Feature flag name: `playground-default-prompt-message`
- Variants: `control` (empty message) and `test` (default message)
- Target: New users visiting Playground for the first time