### PR TITLE
[NA] [BE] Refactor query ordering in `ExperimentDAO`

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -166,7 +166,7 @@ class ExperimentDAO {
                 <if(lastRetrievedId)> AND id \\< :lastRetrievedId <endif>
                 <if(prompt_ids)>AND (prompt_id IN :prompt_ids OR hasAny(mapKeys(prompt_versions), :prompt_ids))<endif>
                 <if(filters)> AND <filters> <endif>
-                ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
+                ORDER BY (workspace_id, dataset_id, id) DESC
                 <if(limit &&
                 !feedback_scores_filters &&
                 !feedback_scores_empty_filters &&


### PR DESCRIPTION
## Details

Removed `last_updated_at` from the query's `ORDER BY` clause to simplify ordering logic and improve performance.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-NA

## Testing

Nothing added

## Documentation

Nothing added