### PR TITLE
[OPIK-3961] [FE] Refine Experiment Item Navigation: Remove ID filter

### DIFF
--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/ExperimentDataset.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/ExperimentDataset.tsx
@@ -21,8 +21,6 @@ import { RESOURCE_TYPE } from "@/components/shared/ResourceLink/ResourceLink";
 import { useDatasetIdFromCompareExperimentsURL } from "@/hooks/useDatasetIdFromCompareExperimentsURL";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
-import { createFilter } from "@/lib/filters";
-import { COLUMN_TYPE } from "@/types/shared";
 
 const COLLAPSE_KEYS_BUTTON_WIDTH = 340;
 
@@ -106,14 +104,6 @@ const ExperimentDataset = ({ data, datasetItemId }: ExperimentDatasetProps) => {
               resource={RESOURCE_TYPE.datasetItem}
               search={{
                 row: datasetItemId,
-                filters: [
-                  createFilter({
-                    field: "id",
-                    type: COLUMN_TYPE.string,
-                    operator: "=",
-                    value: datasetItemId,
-                  }),
-                ],
               }}
               tooltipContent="View this item in the dataset"
               className="h-8"


### PR DESCRIPTION
## Details

This PR removes the ID filter from the experiment item navigation to the dataset items page. Previously, when clicking "View in dataset" from an experiment item, the navigation included a filter that showed only the specific dataset item, which could be confusing for users.

**Changes:**
- Removed the `filters` parameter from the `NavigationTag` component in `ExperimentDataset.tsx`
- Removed unused imports (`createFilter` and `COLUMN_TYPE`)
- Kept the `row` parameter to maintain the side panel opening behavior

**User Experience Improvement:**
- Users now see the full dataset items list (unfiltered) when navigating from an experiment item
- The specific dataset item still opens in the side panel via the `row` parameter
- Users can browse all items without being confused by a pre-applied filter

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-3961

## Testing

**Manual Testing Steps:**
1. Navigate to the Compare Experiments page
2. Select an experiment item to view
3. Click "View in dataset" NavigationTag
4. Verify that the Dataset Items page shows all items (no filter applied)
5. Verify that the specific dataset item opens in the side panel
6. Verify that users can browse other items or close the side panel

**Automated Testing:**
- ✅ ESLint passed with no errors
- ✅ TypeScript type checking passed with no errors
- ✅ No lint warnings related to the changes

## Documentation

No documentation updates needed - this is a UX improvement that simplifies existing behavior.