### PR TITLE
[OPIK-3959] [FE] Fix save dataset version workflow with enhanced success toast

### DIFF
--- a/apps/opik-frontend/src/api/datasets/useDatasetItemChangesMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetItemChangesMutation.ts
@@ -47,12 +47,6 @@ const useDatasetItemChangesMutation = (
       );
       return data;
     },
-    onSuccess: () => {
-      toast({
-        title: "Changes saved",
-        description: "Dataset version created successfully.",
-      });
-    },
     onError: (error: AxiosError) => {
       // Check for 409 Conflict
       if (error.response?.status === 409) {


### PR DESCRIPTION
## Details

Refactored the dataset version save workflow to improve user experience and fix issues with toast notifications:

- **Enhanced success feedback**: Moved success toast logic from mutation hook to parent component for better control and added actionable links to run experiments in SDK or Playground
- **Simplified component architecture**: Removed embedded mutation logic from `AddVersionDialog`, making it a pure presentation component that receives `onConfirm` callback and `isSubmitting` state
- **Improved error handling**: Added guard to prevent duplicate submissions when mutation is pending
- **Fixed duplicate notifications**: Removed duplicate toast notification from `useDatasetItemChangesMutation` that was causing confusing UX

The new toast provides users with immediate next steps after saving a dataset version, allowing them to quickly run experiments either in the SDK or Playground with a single click.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves #
- OPIK-3959

## Testing

**Manual testing performed:**
1. Created a dataset with items
2. Made changes to dataset items (add, edit, delete)
3. Clicked "Save changes" button
4. Verified that:
   - Only one success toast appears (not duplicate)
   - Toast contains actionable links to SDK and Playground
   - Links navigate correctly to experiment creation and playground
   - Cannot submit multiple times while mutation is pending
5. Tested conflict resolution flow (override dialog)
6. Verified toast appears correctly after override

**Quality checks:**
- ✅ ESLint: Passed
- ✅ TypeScript type checking: Passed

## Documentation

No documentation updates required - this is an internal UX improvement that doesn't change the API or user-facing behavior beyond improving the success feedback.