### PR TITLE
[OPIK-3967] [FE] Fix metadata column primitive value display

### DIFF
--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
@@ -73,6 +73,7 @@ import DataTableNoData from "@/components/shared/DataTableNoData/DataTableNoData
 import DataTablePagination from "@/components/shared/DataTablePagination/DataTablePagination";
 import LinkCell from "@/components/shared/DataTableCells/LinkCell";
 import CodeCell from "@/components/shared/DataTableCells/CodeCell";
+import AutodetectCell from "@/components/shared/DataTableCells/AutodetectCell";
 import ListCell from "@/components/shared/DataTableCells/ListCell";
 import CostCell from "@/components/shared/DataTableCells/CostCell";
 import ErrorCell from "@/components/shared/DataTableCells/ErrorCell";
@@ -740,14 +741,11 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
             return "-";
           }
 
-          // Format arrays and objects as JSON
-          if (isArray(value) || isObject(value)) {
-            return JSON.stringify(value, null, 2);
-          }
-
-          return String(value);
+          // Return raw value - AutodetectCell will handle type detection
+          // and display primitives as text, objects/arrays as JSON
+          return value;
         },
-        cell: CodeCell as never,
+        cell: AutodetectCell as never,
       };
     }) as ColumnData<BaseTraceData>[];
 
@@ -942,6 +940,11 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
         id: "error_info",
         label: "Errors",
         type: COLUMN_TYPE.errors,
+      },
+      {
+        id: COLUMN_METADATA_ID,
+        label: "Metadata",
+        type: COLUMN_TYPE.dictionary,
       },
       {
         id: COLUMN_FEEDBACK_SCORES_ID,


### PR DESCRIPTION
## Details

This PR fixes the display of primitive values (strings, numbers, booleans) in individual metadata field columns. Previously, primitive values were displayed with escaped quotes (e.g., `"customer_123"` appeared as `"\"customer_123\""`).

### Changes Made

1. **Replaced CodeCell with AutodetectCell** for individual metadata field columns (`Metadata.field_name`)
   - AutodetectCell automatically detects value types
   - Primitives (strings, numbers, booleans) → displayed as plain text using TextCell
   - Objects and arrays → displayed as formatted JSON using CodeCell

2. **Simplified accessorFn logic** in `metadataColumnsData`
   - Removed unnecessary `JSON.stringify()` wrapping for primitive values
   - Returns raw values directly, letting AutodetectCell handle type detection

3. **Added "Metadata" filter option** to filtersColumnData
   - Users can now filter traces/spans by metadata fields

### Technical Implementation

- **File Modified**: `apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx`
- **Pattern**: Follows the same approach used in `DatasetItemsTab` and `ExperimentItemsTab` for dynamic columns
- **Backward Compatible**: The generic "Metadata" column continues to use CodeCell to display the full metadata object as JSON

### User Impact

**Before:**
- Metadata column with string value `"customer_123"` displayed as: `"\"customer_123\""`
- Extra quotes made primitive values harder to read

**After:**
- Metadata column with string value `"customer_123"` displays as: `customer_123`
- Clean, readable display for all primitive types
- Objects and arrays still display as formatted JSON

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves OPIK-3967

## Testing

### Manual Testing Steps
1. Navigate to Traces page
2. Add metadata field columns using the Columns button (e.g., `Metadata.customer_id`)
3. Verify primitive values display without extra quotes:
   - Strings: `customer_123` (not `"\"customer_123\""`)
   - Numbers: `42` (not `"42"`)
   - Booleans: `true` (not `"true"`)
4. Verify objects/arrays still display as formatted JSON
5. Verify the generic "Metadata" column still shows full metadata object as JSON
6. Test filtering by metadata fields using the Filters button

### Quality Checks
- ✅ ESLint passed
- ✅ TypeScript type checking passed
- ✅ No breaking changes to existing functionality

## Documentation

No documentation updates required - this is a bug fix that improves the existing UI behavior without changing the API or adding new features.