### PR TITLE
[OPIK-3935] Upgrade opik-optimizer to 3.0.0rc5

### DIFF
--- a/apps/opik-python-backend/requirements.txt
+++ b/apps/opik-python-backend/requirements.txt
@@ -29,4 +29,4 @@ redis==6.4.0
 rq==2.6.0
 opik-optimizer==3.0.0rc5
 gepa==0.0.17
-pyrate-limiter>=3.0.0
+pyrate-limiter>=3.0.0,<4.0.0


### PR DESCRIPTION
## Details

Upgrades `opik-optimizer` from `2.3.11` to `3.0.0rc5` for Optimization Studio.

This is a release candidate version that includes improvements to the optimizer algorithms.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-3935

## Testing

- Tested locally with Docker container
- Verified optimization jobs run successfully with the new version

## Documentation

N/A