### PR TITLE
[OPIK-3924] [FE] Add force_sorting parameter for experiment leaderboard ranking

### DIFF
--- a/apps/opik-frontend/src/api/datasets/useExperimentsList.ts
+++ b/apps/opik-frontend/src/api/datasets/useExperimentsList.ts
@@ -22,6 +22,7 @@ export type UseExperimentsListParams = {
   size: number;
   queryKey?: string;
   experimentIds?: string[];
+  forceSorting?: boolean;
 };
 
 export type UseExperimentsListResponse = {
@@ -44,6 +45,7 @@ export const getExperimentsList = async (
     size,
     page,
     experimentIds,
+    forceSorting,
   }: UseExperimentsListParams,
 ) => {
   const { data } = await api.get(EXPERIMENTS_REST_ENDPOINT, {
@@ -57,6 +59,7 @@ export const getExperimentsList = async (
       ...(optimizationId && { optimization_id: optimizationId }),
       ...(types && { types: JSON.stringify(types) }),
       ...(experimentIds && { experiment_ids: JSON.stringify(experimentIds) }),
+      ...(forceSorting && { force_sorting: true }),
       size,
       page,
     },

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/ExperimentsLeaderboardWidget.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/ExperimentsLeaderboardWidget.tsx
@@ -185,6 +185,7 @@ const ExperimentsLeaderboardWidget: React.FunctionComponent<
       size: isSelectExperimentsMode(dataSource)
         ? MAX_MAX_EXPERIMENTS
         : maxRowsValue,
+      forceSorting: true,
     },
     {
       placeholderData: keepPreviousData,
@@ -206,6 +207,7 @@ const ExperimentsLeaderboardWidget: React.FunctionComponent<
       page: 1,
       size: MAX_MAX_EXPERIMENTS,
       queryKey: "experiments-ranking",
+      forceSorting: true,
     },
     {
       placeholderData: keepPreviousData,


### PR DESCRIPTION
## Details

This PR adds a `force_sorting` parameter to the experiments list API calls in the frontend for the Experiments Leaderboard Widget. This ensures that experiment rankings are consistently sorted according to backend logic.

### Changes Made:
- Added `forceSorting` optional parameter to `UseExperimentsListParams` type in `useExperimentsList.ts` and updated `getExperimentsList` function to pass `force_sorting: true` query parameter when `forceSorting` is enabled
- Modified `ExperimentsLeaderboardWidget` to always pass `forceSorting: true` for both main experiment list and ranking queries

This change ensures deterministic sorting behavior for experiment leaderboards displayed in dashboard widgets.

Any other usage of this endpoint from the FE, remains without the `force_sorting` query param, which defaults to `false` in the BE.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3924

## Testing

The changes affect the frontend API layer and the Experiments Leaderboard Widget component. 

I manually verified:
1. Experiment leaderboard widget displays experiments in correct sorted order
2. API calls include the `force_sorting=true` query parameter when widget is rendered
3. Other API calls don't include them, for example from the experiments UI table.

## Documentation

N/A - This is an internal API parameter change that doesn't require user-facing documentation updates.