### PR TITLE
[OPIK-3926] [CI] Fix GitHub token for automated PR workflows

### DIFF
--- a/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
+++ b/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
@@ -9,9 +9,6 @@ jobs:
   update-open-api-spec-and-fern-code:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions:
-      contents: write       # To push the branch
-      pull-requests: write  # To create the PR
 
     steps:
       - name: Checkout Repository
@@ -76,7 +73,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.COMET_ACTION_CREATE_PR }}
           branch: ${{ env.BRANCH_NAME }}
           title: "[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code"
           body: |

--- a/.github/workflows/span_cost_upload_daily.yml
+++ b/.github/workflows/span_cost_upload_daily.yml
@@ -9,9 +9,6 @@ jobs:
   update-span-cost:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: write       # To push the branch
-      pull-requests: write  # To create the PR
 
     steps:
       - name: Checkout Repository
@@ -40,7 +37,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.COMET_ACTION_CREATE_PR }}
           branch: ${{ env.BRANCH_NAME }}
           title: "[NA] [BE] Update model prices file"
           body: |


### PR DESCRIPTION
## Details

Updated GitHub Actions workflows to use `COMET_ACTION_CREATE_PR` token instead of `GITHUB_TOKEN` for creating pull requests. This ensures automated PRs have proper permissions to be created successfully.

**Why this change:**
The default `GITHUB_TOKEN` has limited permissions and cannot trigger subsequent workflow runs or create PRs in certain scenarios. Using `COMET_ACTION_CREATE_PR` (a Personal Access Token with the appropriate permissions) ensures that automated PRs are created successfully and can trigger the required CI/CD pipelines.

**Files modified:**
- `.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml`
- `.github/workflows/span_cost_upload_daily.yml`

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves
- OPIK-3926

## Testing

1. Verify workflow syntax is valid
2. Test the workflows manually:
   - Navigate to the Actions tab
   - Select "Update Span Cost Daily" workflow
   - Click "Run workflow" with `guy/OPIK-3926_fix-workflow` to trigger manually
   - Verify PR is created successfully and trigger the subsequent workflow.
 
## Documentation