### PR TITLE
[NA] Update .gitignore, to ignore .cursor symlink file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ pip-log.txt
 .mcp.json
 
 # Cursor
-.cursor/
+.cursor
 !tests_end_to_end/.cursor/
 
 # charts


### PR DESCRIPTION
## Details
In addition to ignoring the .cursor/ folder, we should also not commit the .cursor symlink file

<img width="852" height="543" alt="image" src="https://github.com/user-attachments/assets/8517d05e-c497-49c3-b42d-507a9f11b699" />


## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
Following https://github.com/comet-ml/opik/pull/4890 updates, where the SOT of agent configuration moved to `.agents` folder

- Resolves #
- OPIK-

## Testing

## Documentation
