### PR TITLE
Fix NavigationTag using plainDatasetId instead of composite datasetId

### DIFF
--- a/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/PlaygroundOutputActions.tsx
+++ b/apps/opik-frontend/src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/PlaygroundOutputActions.tsx
@@ -428,7 +428,7 @@ const PlaygroundOutputActions = ({
             <div className="mt-2.5">
               <NavigationTag
                 resource={RESOURCE_TYPE.experiment}
-                id={datasetId}
+                id={plainDatasetId}
                 name={
                   createdExperiments.length === 1 ? "Experiment" : "Experiments"
                 }


### PR DESCRIPTION
## Summary

- Fixed NavigationTag component in PlaygroundOutputActions to use `plainDatasetId` instead of `datasetId`
- This ensures proper navigation when clicking on the experiment tag after creating experiments from playground outputs

## Changes

- Updated the `id` prop of NavigationTag from `datasetId` (composite ID) to `plainDatasetId` (plain dataset ID)

## Test plan

- [ ] Create experiments from playground outputs
- [ ] Verify that clicking on the "Experiment" or "Experiments" navigation tag properly navigates to the experiment page
- [ ] Confirm no navigation errors occur