### PR TITLE
[OPIK-4027] [FE] Update invite user copy to clarify email vs username search

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/InviteUsersPopover.tsx
+++ b/apps/opik-frontend/src/plugins/comet/InviteUsersPopover.tsx
@@ -140,8 +140,8 @@ const InviteUsersPopover: React.FC<InviteUsersPopoverProps> = ({
     if (!searchQuery || isQueryTooShort) {
       return (
         <div className="comet-body-s flex h-full items-center justify-center text-muted-slate">
-          Type at least {MIN_USERNAME_LENGTH} characters or enter an email
-          address
+          Enter an email address, or search by username ({MIN_USERNAME_LENGTH}+
+          characters) for users in your organization
         </div>
       );
     }
@@ -152,7 +152,8 @@ const InviteUsersPopover: React.FC<InviteUsersPopoverProps> = ({
     if (!hasResults && !showEmailRow && !isLoading) {
       return (
         <div className="comet-body-s flex h-full items-center justify-center text-muted-slate">
-          No users found. You can also invite by email address
+          No users found. Enter an email address to invite, or search by
+          username for organization members
         </div>
       );
     }


### PR DESCRIPTION
## Details

This PR updates the invite user copy in the InviteUsersPopover component to clarify the distinction between email and username search functionality.

**Changes:**
- Updated placeholder message to prioritize email as the primary method and clarify that username search (3+ characters) is for users in the organization
- Updated "no users found" message to be consistent and clarify that username search is for organization members
- Clarifies that the 3+ character requirement refers to username, not workspace name, addressing user confusion

**Problem addressed:**
Users were confused by the previous copy "Type at least 3 characters or enter an email address" which suggested workspace name search was possible. The updated copy makes it clear that:
- Email addresses work for inviting anyone
- Username search (3+ characters) only works for existing organization members

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves #
- OPIK-4027

## Testing

- Verified placeholder message displays correctly when search query is too short
- Verified "no users found" message displays correctly when no results are found
- Tested that both messages are clear and consistent
- Confirmed copy accurately reflects functionality (email works universally, username search is organization-only)

## Documentation

N/A - No documentation changes required for this UI copy update.