### PR TITLE
[OPIK-4047] Add new GitHub team for Opik Optimizer developers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,6 +17,6 @@
 
 /deployment/ @comet-ml/comet-devops @comet-ml/deployment-team @comet-ml/comet-opik-devs
 
-/sdks/opik_optimizer @vincentkoc @dsblank @comet-ml/comet-opik-devs
+/sdks/opik_optimizer @comet-ml/comet-opik-optimizer-devs @comet-ml/comet-opik-devs
 
 /tests_end_to_end/ @comet-ml/comet-qa @comet-ml/comet-opik-devs


### PR DESCRIPTION
## Details
This PR introduces a new GitHub team `@comet-ml/comet-opik-optimizer-devs` as code owners for the Opik Optimizer SDK directory (`/sdks/opik_optimizer`).

This change ensures that the Opik Optimizer team is automatically notified and required to review PRs that affect the optimizer SDK codebase.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves OPIK-4047

## Testing
- Verified CODEOWNERS syntax is correct
- The new team will be automatically tagged on PRs affecting `/sdks/opik_optimizer`

## Documentation
- Updated `.github/CODEOWNERS` file to include the new team

## Prerequisites
⚠️ **Important**: The GitHub team `@comet-ml/comet-opik-optimizer-devs` must be created in the GitHub organization before merging this PR.