### PR TITLE
[NA] [SDK] Fix linting issues in attachments_extractor

### DIFF
--- a/sdks/python/src/opik/api_objects/attachment/attachments_extractor.py
+++ b/sdks/python/src/opik/api_objects/attachment/attachments_extractor.py
@@ -52,22 +52,22 @@ class AttachmentsExtractor:
     ) -> List[attachment_context.AttachmentWithContext]:
         """
         Extract attachments from data and replace with placeholders.
-        
+
         Handles both dict and list at the top level, recursively processing
         nested structures to find and extract base64-encoded attachments.
-        
+
         Args:
             data: The data structure to process (dict or list)
             entity_type: Type of entity (span or trace)
             entity_id: ID of the entity
             project_name: Name of the project
             context: Context where data is located (input, output, or metadata)
-            
+
         Returns:
             List of extracted attachments with context
         """
         attachments: List[attachment_context.AttachmentWithContext] = []
-        
+
         if isinstance(data, dict):
             # For dicts, iterate over items and extract attachments from values
             for key, value in data.items():


### PR DESCRIPTION
## Details

Fixed trailing whitespace linting issues in the `attachments_extractor.py` file. This was an existing linting issue that has been resolved by removing trailing whitespace from docstring lines.

## Change checklist
<!-- Please check the type of changes made -->
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-
- NA

## Testing

Pre-commit hooks passed successfully, including ruff linting checks.

## Documentation

N/A