### PR TITLE
[OPIK-3993] [FE] [SDK] Log all model parameters as experiment config

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/llm/PromptModelSettings/providerConfigs/GeminiModelConfigs.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/llm/PromptModelSettings/providerConfigs/GeminiModelConfigs.tsx
@@ -13,6 +13,7 @@ import isUndefined from "lodash/isUndefined";
 import SelectBox from "@/components/shared/SelectBox/SelectBox";
 import { Label } from "@/components/ui/label";
 import ExplainerIcon from "@/components/shared/ExplainerIcon/ExplainerIcon";
+import { supportsGeminiThinkingLevel } from "@/lib/modelUtils";
 
 interface geminiModelConfigsProps {
   configs: LLMGeminiConfigsType;
@@ -25,9 +26,8 @@ const GeminiModelConfigs = ({
   model,
   onChange,
 }: geminiModelConfigsProps) => {
-  const isGemini3Pro = model === PROVIDER_MODEL_TYPE.GEMINI_3_PRO;
+  const hasThinkingLevel = supportsGeminiThinkingLevel(model);
   const isGemini3Flash = model === PROVIDER_MODEL_TYPE.GEMINI_3_FLASH;
-  const hasThinkingLevel = isGemini3Pro || isGemini3Flash;
 
   // Get appropriate options based on model
   // Flash supports all 4 levels (minimal, low, medium, high)

--- a/apps/opik-frontend/src/components/pages-shared/llm/PromptModelSettings/providerConfigs/VertexAIModelConfigs.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/llm/PromptModelSettings/providerConfigs/VertexAIModelConfigs.tsx
@@ -11,6 +11,7 @@ import isUndefined from "lodash/isUndefined";
 import SelectBox from "@/components/shared/SelectBox/SelectBox";
 import { Label } from "@/components/ui/label";
 import ExplainerIcon from "@/components/shared/ExplainerIcon/ExplainerIcon";
+import { supportsVertexAIThinkingLevel } from "@/lib/modelUtils";
 
 interface VertexAIModelConfigsProps {
   configs: LLMVertexAIConfigsType;
@@ -23,7 +24,7 @@ const VertexAIModelConfigs = ({
   model,
   onChange,
 }: VertexAIModelConfigsProps) => {
-  const isGemini3Pro = model === PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_PRO;
+  const hasThinkingLevel = supportsVertexAIThinkingLevel(model);
 
   return (
     <div className="flex w-72 flex-col gap-6">
@@ -75,7 +76,7 @@ const VertexAIModelConfigs = ({
         />
       )}
 
-      {isGemini3Pro && (
+      {hasThinkingLevel && (
         <div className="space-y-2">
           <div className="flex items-center space-x-2">
             <Label htmlFor="thinkingLevel" className="text-sm font-medium">

--- a/apps/opik-frontend/src/lib/modelUtils.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.ts
@@ -33,6 +33,35 @@ export const getDefaultTemperatureForModel = (
 };
 
 /**
+ * Checks if a Gemini model supports thinking level parameter
+ * Currently Gemini 3 Pro and Gemini 3 Flash support thinking level
+ *
+ * @param model - The model type to check
+ * @returns true if the model supports thinking level, false otherwise
+ */
+export const supportsGeminiThinkingLevel = (
+  model?: PROVIDER_MODEL_TYPE | "",
+): boolean => {
+  return (
+    model === PROVIDER_MODEL_TYPE.GEMINI_3_PRO ||
+    model === PROVIDER_MODEL_TYPE.GEMINI_3_FLASH
+  );
+};
+
+/**
+ * Checks if a Vertex AI model supports thinking level parameter
+ * Currently only Vertex AI Gemini 3 Pro supports thinking level
+ *
+ * @param model - The model type to check
+ * @returns true if the model supports thinking level, false otherwise
+ */
+export const supportsVertexAIThinkingLevel = (
+  model?: PROVIDER_MODEL_TYPE | "",
+): boolean => {
+  return model === PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_PRO;
+};
+
+/**
  * Updates provider config to ensure reasoning models have temperature >= 1.0
  * This function ensures that OpenAI reasoning models (GPT-5 family, O-series)
  * have their temperature set to at least 1.0, as they don't support temperature < 1

--- a/apps/opik-frontend/src/lib/playground.ts
+++ b/apps/opik-frontend/src/lib/playground.ts
@@ -8,7 +8,12 @@ import {
   DEFAULT_VERTEX_AI_CONFIGS,
   DEFAULT_CUSTOM_CONFIGS,
 } from "@/constants/llm";
-import { getDefaultTemperatureForModel } from "@/lib/modelUtils";
+import {
+  getDefaultTemperatureForModel,
+  isReasoningModel,
+  supportsGeminiThinkingLevel,
+  supportsVertexAIThinkingLevel,
+} from "@/lib/modelUtils";
 import {
   LLMAnthropicConfigsType,
   LLMGeminiConfigsType,
@@ -36,7 +41,7 @@ export const getDefaultConfigByProvider = (
   const providerType = parseComposedProviderType(provider);
 
   if (providerType === PROVIDER_TYPE.OPEN_AI) {
-    return {
+    const config: LLMOpenAIConfigsType = {
       temperature: getDefaultTemperatureForModel(model),
       maxCompletionTokens: DEFAULT_OPEN_AI_CONFIGS.MAX_COMPLETION_TOKENS,
       topP: DEFAULT_OPEN_AI_CONFIGS.TOP_P,
@@ -44,7 +49,14 @@ export const getDefaultConfigByProvider = (
       presencePenalty: DEFAULT_OPEN_AI_CONFIGS.PRESENCE_PENALTY,
       throttling: DEFAULT_OPEN_AI_CONFIGS.THROTTLING,
       maxConcurrentRequests: DEFAULT_OPEN_AI_CONFIGS.MAX_CONCURRENT_REQUESTS,
-    } as LLMOpenAIConfigsType;
+    };
+
+    // Add reasoningEffort default for reasoning models
+    if (isReasoningModel(model)) {
+      config.reasoningEffort = "medium";
+    }
+
+    return config;
   }
 
   if (providerType === PROVIDER_TYPE.ANTHROPIC) {
@@ -82,23 +94,37 @@ export const getDefaultConfigByProvider = (
   }
 
   if (providerType === PROVIDER_TYPE.GEMINI) {
-    return {
+    const config: LLMGeminiConfigsType = {
       temperature: DEFAULT_GEMINI_CONFIGS.TEMPERATURE,
       maxCompletionTokens: DEFAULT_GEMINI_CONFIGS.MAX_COMPLETION_TOKENS,
       topP: DEFAULT_GEMINI_CONFIGS.TOP_P,
       throttling: DEFAULT_GEMINI_CONFIGS.THROTTLING,
       maxConcurrentRequests: DEFAULT_GEMINI_CONFIGS.MAX_CONCURRENT_REQUESTS,
-    } as LLMGeminiConfigsType;
+    };
+
+    // Add thinkingLevel default for Gemini 3 models
+    if (supportsGeminiThinkingLevel(model)) {
+      config.thinkingLevel = "high";
+    }
+
+    return config;
   }
 
   if (providerType === PROVIDER_TYPE.VERTEX_AI) {
-    return {
+    const config: LLMVertexAIConfigsType = {
       temperature: DEFAULT_VERTEX_AI_CONFIGS.TEMPERATURE,
       maxCompletionTokens: DEFAULT_VERTEX_AI_CONFIGS.MAX_COMPLETION_TOKENS,
       topP: DEFAULT_VERTEX_AI_CONFIGS.TOP_P,
       throttling: DEFAULT_VERTEX_AI_CONFIGS.THROTTLING,
       maxConcurrentRequests: DEFAULT_VERTEX_AI_CONFIGS.MAX_CONCURRENT_REQUESTS,
-    } as LLMVertexAIConfigsType;
+    };
+
+    // Add thinkingLevel default for Vertex AI Gemini 3 Pro model
+    if (supportsVertexAIThinkingLevel(model)) {
+      config.thinkingLevel = "low";
+    }
+
+    return config;
   }
 
   if (providerType === PROVIDER_TYPE.CUSTOM) {


### PR DESCRIPTION
## Details

This PR implements automatic logging of model parameters (temperature, top_p, reasoning_effort, thinking_level, etc.) as experiment configuration, improving observability and reproducibility of experiments.


https://github.com/user-attachments/assets/c4359579-1e2f-4278-abe7-f7c50f55b758



Frontend (Playground):
- Added utility functions `supportsGeminiThinkingLevel()` and `supportsVertexAIThinkingLevel()` in `modelUtils.ts`
- Updated default config generation in `playground.ts` to include `reasoningEffort: "medium"` for OpenAI reasoning models, `thinkingLevel: "high"` for Gemini 3 models, and `thinkingLevel: "low"` for Vertex AI Gemini 3 Pro
- Refactored Gemini and Vertex AI config components to use the new utility functions

Python SDK:
- Created new `model_defaults.py` module with default parameter detection for OpenAI, Anthropic, Gemini, and Vertex AI models
- Updated integrations (OpenAI, Anthropic, GenAI) to include default model parameters in span metadata
- Enhanced `evaluator.py` to auto-populate experiment config by extracting model configuration from the first LLM span in traces when `experiment_config` is not explicitly provided

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-3993

## Testing

- Playground: Verify that when running experiments from playground, the model parameters are correctly logged to experiment config
- SDK: Run an evaluation without explicit `experiment_config` parameter and verify that model parameters (model, provider, temperature, top_p, etc.) are automatically extracted from spans and saved to experiment config
- Verify default parameters are included in span metadata for OpenAI, Anthropic, Gemini, and Vertex AI integrations

## Documentation

No documentation updates required - this is an automatic enhancement that improves experiment observability without requiring user action
