### PR TITLE
[NA] [FE] Add dependency-cruiser for frontend architecture validation

### DIFF
--- a/.agents/rules/apps/opik-frontend/code-quality.mdc
+++ b/.agents/rules/apps/opik-frontend/code-quality.mdc
@@ -504,3 +504,25 @@ const UserManagement: React.FC = () => {
   );
 };
 ```
+
+## Dependency Architecture Rules
+
+**IMPORTANT: After modifying component imports, always run:**
+```bash
+cd apps/opik-frontend && npm run deps:validate
+```
+
+### Layer Hierarchy (one-way only)
+`ui → shared → pages-shared → pages`
+
+### Key Rules
+- No circular dependencies
+- No importing from higher layers (e.g., shared cannot import from pages)
+- No cross-page imports (pages/PageA cannot import from pages/PageB)
+- No project code importing from plugins (except PluginsStore)
+- API layer cannot import components (except use-toast.ts)
+
+### If Validation Fails
+1. Refactor imports to follow layer hierarchy
+2. Move shared code to appropriate layer
+3. Extract utilities to `lib/` folder

--- a/.agents/rules/apps/opik-frontend/frontend_rules.mdc
+++ b/.agents/rules/apps/opik-frontend/frontend_rules.mdc
@@ -60,4 +60,9 @@ const Component: React.FunctionComponent<Props> = ({ ...props }) => {
 - **Consider testing**: Custom hooks with complex state, components with significant conditional rendering
 - **Don't test**: Simple UI components without logic, third-party library integrations
 
+### Dependency Architecture
+**After modifying imports, run:** `cd apps/opik-frontend && npm run deps:validate`
+- Layer: `ui → shared → pages-shared → pages` (one-way only)
+- No circular deps, cross-page imports, or importing from plugins
+
 When building components, always follow the established patterns and refer to the detailed rules for comprehensive guidelines.

--- a/.github/workflows/frontend_linter.yml
+++ b/.github/workflows/frontend_linter.yml
@@ -34,3 +34,6 @@ jobs:
 
       - name: Type check
         run: npm run typecheck
+
+      - name: Dependency validation
+        run: npm run deps:validate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -414,7 +414,30 @@ scripts\dev-runner.ps1 --lint-fe  # Windows
 cd apps/opik-frontend
 npm run lint
 npm run typecheck # TypeScript type checking
+npm run deps:validate # Dependency architecture validation
 ````
+
+#### Dependency Architecture
+
+The frontend uses [dependency-cruiser](https://github.com/sverweij/dependency-cruiser) to enforce architectural boundaries. Run `npm run deps:validate` before committing component changes.
+
+**Layer hierarchy (one-way imports only):**
+```
+ui → shared → pages-shared → pages
+```
+
+Key rules:
+- **No circular dependencies** - Components must not create import cycles
+- **Layer isolation** - Lower layers cannot import from higher layers
+- **Plugin isolation** - Project code cannot import from plugins (only PluginsStore can)
+- **API isolation** - API layer cannot import React components (except `use-toast.ts`)
+
+If `deps:validate` fails with a NEW violation:
+1. Refactor to follow the layer hierarchy
+2. Move shared code to the appropriate layer
+3. Extract utilities to `lib/` folder
+
+See `.dependency-cruiser-known-violations.README.md` for existing violations that need fixing.
 
 #### Testing
 

--- a/apps/opik-frontend/.dependency-cruiser-known-violations.README.md
+++ b/apps/opik-frontend/.dependency-cruiser-known-violations.README.md
@@ -1,0 +1,83 @@
+# Known Dependency Violations
+
+This file documents the known dependency violations captured in `.dependency-cruiser-known-violations.json`.
+
+## Purpose
+
+The baseline file allows us to:
+1. **Prevent NEW violations** - Any new violation will fail the build
+2. **Track existing violations** - All current violations are documented
+3. **Gradually fix issues** - Remove entries as violations are resolved
+
+## Current Violations Summary
+
+### Circular Dependencies (12) - MUST FIX
+These create maintenance nightmares and potential runtime issues:
+- `useOpenAICompatibleModels` ↔ `provider.ts` ↔ `useLLMProviderModelsData`
+- `useProviderKeys` → `provider.ts` → `useLLMProviderModelsData` → `useOpenAICompatibleModels`
+- `MetricTag` ↔ `PlaygroundOutputScores`
+- `useDatasetItemData` ↔ `useDatasetItemFormHelpers` (2 locations)
+- FeedbackScoreTable cells ↔ `utils.ts` ↔ `constants.ts` (5 violations)
+
+### Shared → Pages-shared (35) - Refactor needed
+Components in `shared/` importing from `pages-shared/`:
+- Dashboard widgets importing from pages-shared
+- DataTableCells importing from pages-shared
+- TruncationConfigPopover, PromptImprovementDialog, etc.
+
+**Fix:** Move these components to `pages-shared/` or extract shared utilities
+
+### Pages-shared → Pages (8) - Extract shared code
+- `AddToDatasetDialog` → `AddEditDatasetDialog`
+- `DatasetSelectBox` → `AddEditDatasetDialog`
+- `ThreadDetailsPanel` → `WorkspacePreferencesTab/types.ts`
+- `ExperimentsRadarChart` → `useCompareExperimentsChartsData`
+
+**Fix:** Extract shared types/utilities to `pages-shared/` or `lib/`
+
+### Cross-page Imports (5) - Extract to pages-shared
+- `HomePage` → `ProjectsPage`, `OptimizationsPage`
+- `TracesPage` → `HomePageShared`
+
+**Fix:** Move shared dialogs/components to `pages-shared/`
+
+### Hooks → Components (1)
+- `useProviderOptions` → `ProviderGrid`
+
+**Fix:** Use composition pattern instead
+
+### Types → Components (2)
+- `dashboard.ts` → `DateRangeSelect`, `breakdown.ts`
+
+**Fix:** Move types to types folder, keep runtime code separate
+
+### API → Components (1)
+- `useProjectMetric` → `breakdown.ts`
+
+**Fix:** Move `breakdown.ts` to `lib/`
+
+## How to Fix
+
+1. Pick a violation from the list
+2. Refactor the code to fix it
+3. Run `npm run deps:validate` to verify
+4. Remove the fixed entry from `.dependency-cruiser-known-violations.json`
+5. Commit changes
+
+## Regenerating Baseline
+
+If you need to regenerate the baseline (after fixing violations):
+```bash
+npx depcruise src --config --output-type baseline > .dependency-cruiser-known-violations.json
+```
+
+## Adding to CI
+
+Add this to your CI pipeline to prevent new violations:
+```bash
+npm run deps:validate
+```
+
+The command will:
+- ✅ Pass if only known violations exist
+- ❌ Fail if any NEW violations are introduced

--- a/apps/opik-frontend/.dependency-cruiser-known-violations.json
+++ b/apps/opik-frontend/.dependency-cruiser-known-violations.json
@@ -1,0 +1,873 @@
+[
+  {
+    "type": "dependency",
+    "from": "src/api/projects/useProjectMetric.ts",
+    "to": "src/components/shared/Dashboard/widgets/ProjectMetricsWidget/breakdown.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-api-importing-components"
+    }
+  },
+  {
+    "type": "cycle",
+    "from": "src/api/provider-keys/useProviderKeys.ts",
+    "to": "src/lib/provider.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/lib/provider.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/hooks/useLLMProviderModelsData.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/hooks/useOpenAICompatibleModels.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/api/provider-keys/useProviderKeys.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/AuthorCell.tsx",
+    "to": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/utils.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/utils.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/constants.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/AuthorCell.tsx",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/ReasonCell.tsx",
+    "to": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/utils.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/utils.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/constants.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/ReasonCell.tsx",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/SourceCell.tsx",
+    "to": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/utils.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/utils.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/constants.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/SourceCell.tsx",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/TypeCell.tsx",
+    "to": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/utils.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/utils.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/constants.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/TypeCell.tsx",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/ValueCell.tsx",
+    "to": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/utils.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/utils.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/constants.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/ValueCell.tsx",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/components/pages/DatasetItemsPage/DatasetItemEditor/hooks/useDatasetItemData.ts",
+    "to": "src/components/pages/DatasetItemsPage/DatasetItemEditor/hooks/useDatasetItemFormHelpers.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/components/pages/DatasetItemsPage/DatasetItemEditor/hooks/useDatasetItemFormHelpers.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/components/pages/DatasetItemsPage/DatasetItemEditor/hooks/useDatasetItemData.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/components/pages/DatasetItemsPage/Legacy/DatasetItemEditor/hooks/useDatasetItemData.ts",
+    "to": "src/components/pages/DatasetItemsPage/Legacy/DatasetItemEditor/hooks/useDatasetItemFormHelpers.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/components/pages/DatasetItemsPage/Legacy/DatasetItemEditor/hooks/useDatasetItemFormHelpers.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/components/pages/DatasetItemsPage/Legacy/DatasetItemEditor/hooks/useDatasetItemData.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputScores/MetricTag.tsx",
+    "to": "src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputScores/PlaygroundOutputScores.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputScores/PlaygroundOutputScores.tsx",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/components/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputScores/MetricTag.tsx",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/hooks/useLLMProviderModelsData.ts",
+    "to": "src/lib/provider.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/lib/provider.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/hooks/useLLMProviderModelsData.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/hooks/useOpenAICompatibleModels.ts",
+    "to": "src/lib/provider.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/lib/provider.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/hooks/useLLMProviderModelsData.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/hooks/useOpenAICompatibleModels.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/pages/HomePage/GetStartedSection.tsx",
+    "to": "src/components/pages/HomePageShared/SetGuardrailDialog.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-page-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/pages/HomePage/ObservabilitySection.tsx",
+    "to": "src/components/pages/ProjectsPage/AddEditProjectDialog.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-page-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/pages/HomePage/OptimizationRunsSection.tsx",
+    "to": "src/components/pages/OptimizationsPage/AddOptimizationDialog/AddOptimizationDialog.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-page-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/pages/HomePage/OptimizationRunsSection.tsx",
+    "to": "src/components/pages/OptimizationsPage/OptimizationStatusCell.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-page-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/pages/TracesPage/TracesPage.tsx",
+    "to": "src/components/pages/HomePageShared/SetGuardrailDialog.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-page-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/hooks/useProviderOptions.ts",
+    "to": "src/components/pages-shared/llm/SetupProviderDialog/ProviderGrid.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-hooks-importing-components"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/pages-shared/experiments/ExperimentsRadarChart/ExperimentsRadarChart.tsx",
+    "to": "src/components/pages/CompareExperimentsPage/CompareExperimentsDetails/useCompareExperimentsChartsData.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-pages-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/pages-shared/llm/DatasetSelectBox/DatasetSelectBox.tsx",
+    "to": "src/components/pages/DatasetsPage/AddEditDatasetDialog.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-pages-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx",
+    "to": "src/components/pages/DatasetsPage/AddEditDatasetDialog.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-pages-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/pages-shared/traces/ThreadDetailsPanel/SetInactiveConfirmDialog.tsx",
+    "to": "src/components/pages/ConfigurationPage/WorkspacePreferencesTab/constants.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-pages-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/pages-shared/traces/ThreadDetailsPanel/SetInactiveConfirmDialog.tsx",
+    "to": "src/components/pages/ConfigurationPage/WorkspacePreferencesTab/types.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-pages-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx",
+    "to": "src/components/pages/ConfigurationPage/WorkspacePreferencesTab/constants.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-pages-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx",
+    "to": "src/components/pages/ConfigurationPage/WorkspacePreferencesTab/types.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-pages-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/PromptsTab.tsx",
+    "to": "src/components/pages/PromptPage/TryInPlaygroundButton.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-pages-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ExperimentsFeedbackScoresWidget/ExperimentsFeedbackScoresWidgetEditor.tsx",
+    "to": "src/components/pages-shared/experiments/ExperimentsSelectBox/ExperimentsSelectBox.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ExperimentsFeedbackScoresWidget/ExperimentsFeedbackScoresWidgetEditor.tsx",
+    "to": "src/components/pages-shared/experiments/FeedbackDefinitionsAndScoresSelectBox/FeedbackDefinitionsAndScoresSelectBox.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/ExperimentsLeaderboardWidgetEditor.tsx",
+    "to": "src/components/pages-shared/experiments/ExperimentsSelectBox/ExperimentsSelectBox.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/ExperimentsLeaderboardWidgetEditor.tsx",
+    "to": "src/components/pages-shared/experiments/useExperimentsFeedbackScores.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/helpers.ts",
+    "to": "src/components/pages-shared/experiments/scoresUtils.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsBreakdownSection.tsx",
+    "to": "src/components/pages-shared/traces/TracesOrSpansPathsAutocomplete/TracesOrSpansPathsAutocomplete.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsEditor.tsx",
+    "to": "src/components/pages-shared/automations/ProjectsSelectBox.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsEditor.tsx",
+    "to": "src/components/pages-shared/experiments/FeedbackDefinitionsAndScoresSelectBox/FeedbackDefinitionsAndScoresSelectBox.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsEditor.tsx",
+    "to": "src/components/pages-shared/traces/MetricDateRangeSelect/constants.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsWidget.tsx",
+    "to": "src/components/pages-shared/traces/MetricDateRangeSelect/constants.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsWidget.tsx",
+    "to": "src/components/pages-shared/traces/MetricDateRangeSelect/utils.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsWidget.tsx",
+    "to": "src/components/pages/TracesPage/MetricsTab/MetricChart/MetricChartContainer.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ProjectMetricsWidget/ProjectMetricsWidget.tsx",
+    "to": "src/components/pages/TracesPage/MetricsTab/utils.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ProjectStatsCardWidget/ProjectStatsCardEditor.tsx",
+    "to": "src/components/pages-shared/automations/ProjectsSelectBox.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ProjectStatsCardWidget/ProjectStatsCardWidget.tsx",
+    "to": "src/components/pages-shared/traces/MetricDateRangeSelect/constants.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/ProjectStatsCardWidget/ProjectStatsCardWidget.tsx",
+    "to": "src/components/pages-shared/traces/MetricDateRangeSelect/utils.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/shared/ExperimentWidgetDataSection/ExperimentWidgetDataSection.tsx",
+    "to": "src/components/pages-shared/experiments/DatasetSelectBox/DatasetSelectBox.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/shared/ExperimentWidgetDataSection/ExperimentWidgetDataSection.tsx",
+    "to": "src/components/pages-shared/experiments/ExperimentsPathsAutocomplete/ExperimentsPathsAutocomplete.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/shared/ProjectWidgetFiltersSection/ProjectWidgetFiltersSection.tsx",
+    "to": "src/components/pages-shared/traces/TracesOrSpansFeedbackScoresSelect/TracesOrSpansFeedbackScoresSelect.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/Dashboard/widgets/shared/ProjectWidgetFiltersSection/ProjectWidgetFiltersSection.tsx",
+    "to": "src/components/pages-shared/traces/TracesOrSpansPathsAutocomplete/TracesOrSpansPathsAutocomplete.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/DatasetVersionSelectBox/DatasetVersionSelectBox.tsx",
+    "to": "src/components/pages/DatasetsPage/AddEditDatasetDialog.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/DataTableCells/CommentsCell.tsx",
+    "to": "src/components/pages-shared/experiments/VerticallySplitCellWrapper/VerticallySplitCellWrapper.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/DataTableCells/CommentsCell.tsx",
+    "to": "src/components/pages-shared/traces/UserComment/UserComment.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/DataTableCells/CommentsCell.tsx",
+    "to": "src/components/pages-shared/traces/UserComment/UserCommentAvatar.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/DataTableCells/CommentsCell.tsx",
+    "to": "src/components/pages-shared/traces/UserComment/UserCommentAvatarList.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/DataTableCells/CommentsCell.tsx",
+    "to": "src/components/pages-shared/traces/UserComment/UserCommentHoverList.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/DataTableCells/CostCell.tsx",
+    "to": "src/components/pages-shared/experiments/VerticallySplitCellWrapper/VerticallySplitCellWrapper.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/DataTableCells/DurationCell.tsx",
+    "to": "src/components/pages-shared/experiments/VerticallySplitCellWrapper/VerticallySplitCellWrapper.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/DataTableCells/MediaCell.tsx",
+    "to": "src/components/pages-shared/attachments/ImagesListWrapper/ImagesListWrapper.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/DataTableCells/SpanTypeCell.tsx",
+    "to": "src/components/pages-shared/traces/TraceDetailsPanel/BaseTraceDataTypeIcon.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/DataTableCells/TraceCountCell.tsx",
+    "to": "src/components/pages-shared/experiments/useExperimentsTraceCountNavigation.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/ExperimentFeedbackScoresViewer/ExperimentFeedbackScoresViewer.tsx",
+    "to": "src/components/pages-shared/traces/FeedbackScoresEditor/FeedbackScoresEditor.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/ExperimentFeedbackScoresViewer/ExperimentFeedbackScoresViewer.tsx",
+    "to": "src/components/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/types.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/ExperimentFeedbackScoresViewer/ExperimentFeedbackScoresViewer.tsx",
+    "to": "src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/FeedbackScoreTable.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/PromptImprovementDialog/PromptImprovementDialog.tsx",
+    "to": "src/components/pages-shared/llm/PromptModelSelect/PromptModelSelect.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/TruncationConfigPopover/TruncationConfigPopover.tsx",
+    "to": "src/components/pages/ConfigurationPage/WorkspacePreferencesTab/constants.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/shared/TruncationConfigPopover/TruncationConfigPopover.tsx",
+    "to": "src/components/pages/ConfigurationPage/WorkspacePreferencesTab/types.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-shared-importing-pages"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/types/dashboard.ts",
+    "to": "src/components/shared/Dashboard/widgets/ProjectMetricsWidget/breakdown.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-types-with-side-effects"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/types/dashboard.ts",
+    "to": "src/components/shared/DateRangeSelect/index.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-types-with-side-effects"
+    }
+  },
+  {
+    "type": "module",
+    "from": "src/components/pages-shared/onboarding/HelpResources/HelpResources.tsx",
+    "to": "src/components/pages-shared/onboarding/HelpResources/HelpResources.tsx",
+    "rule": {
+      "severity": "info",
+      "name": "no-orphans"
+    }
+  },
+  {
+    "type": "module",
+    "from": "src/components/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/utils.ts",
+    "to": "src/components/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/utils.ts",
+    "rule": {
+      "severity": "info",
+      "name": "no-orphans"
+    }
+  },
+  {
+    "type": "module",
+    "from": "src/components/pages/DatasetItemsPage/DatasetItemEditorLegacy/hooks/useDatasetItemNavigation.ts",
+    "to": "src/components/pages/DatasetItemsPage/DatasetItemEditorLegacy/hooks/useDatasetItemNavigation.ts",
+    "rule": {
+      "severity": "info",
+      "name": "no-orphans"
+    }
+  }
+]

--- a/apps/opik-frontend/.dependency-cruiser.cjs
+++ b/apps/opik-frontend/.dependency-cruiser.cjs
@@ -1,0 +1,320 @@
+/** @type {import('dependency-cruiser').IConfiguration} */
+module.exports = {
+  forbidden: [
+    // ═══════════════════════════════════════════════════════════════
+    // CIRCULAR DEPENDENCY RULES
+    // ═══════════════════════════════════════════════════════════════
+    {
+      name: "no-circular",
+      severity: "error",
+      comment: "Circular dependencies lead to maintenance nightmares",
+      from: {},
+      to: {
+        circular: true,
+      },
+    },
+
+    // ═══════════════════════════════════════════════════════════════
+    // COMPONENT LAYER HIERARCHY (STRICT)
+    // ui → shared → pages-shared → pages (one-way only)
+    // ═══════════════════════════════════════════════════════════════
+    {
+      name: "no-ui-importing-shared",
+      severity: "error",
+      comment: "Base UI components must not import from shared components",
+      from: { path: "^src/components/ui/" },
+      to: { path: "^src/components/(shared|pages-shared|pages)/" },
+    },
+    {
+      name: "no-shared-importing-pages",
+      severity: "error",
+      comment: "Shared components must not import from page-specific components",
+      from: { path: "^src/components/shared/" },
+      to: { path: "^src/components/(pages-shared|pages)/" },
+    },
+    {
+      name: "no-pages-shared-importing-pages",
+      severity: "error",
+      comment: "Pages-shared components must not import from specific pages",
+      from: { path: "^src/components/pages-shared/" },
+      to: { path: "^src/components/pages/" },
+    },
+    {
+      name: "no-cross-page-imports",
+      severity: "error",
+      comment: "Pages should not import from other pages directly",
+      from: { path: "^src/components/pages/([^/]+)/" },
+      to: {
+        path: "^src/components/pages/([^/]+)/",
+        pathNot: "^src/components/pages/$1/", // Allow same page folder
+      },
+    },
+
+    // ═══════════════════════════════════════════════════════════════
+    // API LAYER ISOLATION
+    // Exception: use-toast.ts (it's a hook, not a component)
+    // ═══════════════════════════════════════════════════════════════
+    {
+      name: "no-api-importing-components",
+      severity: "error",
+      comment:
+        "API layer must not import React components (exception: use-toast.ts)",
+      from: { path: "^src/api/" },
+      to: {
+        path: "^src/components/",
+        // Only allow use-toast.ts - it's essentially a hook
+        pathNot: ["^src/components/ui/use-toast\\.ts$"],
+      },
+    },
+
+    // ═══════════════════════════════════════════════════════════════
+    // STORE RULES
+    // Exception: PluginsStore can import plugin-related components
+    // ═══════════════════════════════════════════════════════════════
+    {
+      name: "no-store-importing-components",
+      severity: "error",
+      comment: "Stores must not import components (exception: PluginsStore)",
+      from: { path: "^src/store/", pathNot: "^src/store/PluginsStore\\.ts$" },
+      to: { path: "^src/components/" },
+    },
+
+    // ═══════════════════════════════════════════════════════════════
+    // HOOKS RULES
+    // Exception: theme-provider and feature-toggles-provider
+    // ═══════════════════════════════════════════════════════════════
+    {
+      name: "no-hooks-importing-components",
+      severity: "error",
+      comment:
+        "Hooks must not import components (exception: app-level providers, ConfirmDialog)",
+      from: { path: "^src/hooks/" },
+      to: {
+        path: "^src/components/",
+        // Allow importing providers, use-toast (hook), and ConfirmDialog (for useNavigationBlocker)
+        pathNot: [
+          "^src/components/ui/use-toast\\.ts$",
+          "^src/components/theme-provider\\.tsx$",
+          "^src/components/feature-toggles-provider\\.tsx$",
+          "^src/components/shared/ConfirmDialog/",
+        ],
+      },
+    },
+
+    // ═══════════════════════════════════════════════════════════════
+    // TYPES & CONSTANTS ISOLATION
+    // ═══════════════════════════════════════════════════════════════
+    {
+      name: "no-types-with-side-effects",
+      severity: "error",
+      comment: "Types folder should only contain type definitions",
+      from: { path: "^src/types/" },
+      to: {
+        path: "^src/(components|api|store|hooks)/",
+      },
+    },
+    {
+      name: "no-constants-importing-runtime",
+      severity: "error",
+      comment: "Constants should not import runtime code",
+      from: { path: "^src/constants/" },
+      to: {
+        path: "^src/(components|api|store|hooks)/",
+        // Allowed exceptions:
+        pathNot: [
+          "\\.py$", // Python scripts used as template strings
+          "integration-logs\\.ts$", // Static log content
+          "^src/components/ui/tag\\.tsx$", // Tag component for experiments
+        ],
+      },
+    },
+
+    // ═══════════════════════════════════════════════════════════════
+    // LODASH IMPORT RULES
+    // ═══════════════════════════════════════════════════════════════
+    {
+      name: "no-lodash-default-import",
+      severity: "error",
+      comment:
+        "Use individual lodash imports for tree-shaking (import isString from 'lodash/isString')",
+      from: {},
+      to: {
+        path: "^lodash$",
+      },
+    },
+
+    // ═══════════════════════════════════════════════════════════════
+    // PLUGINS ISOLATION (STRICT)
+    // Plugins can import from project, but project cannot import from plugins
+    // Exception: PluginsStore.ts for plugin registration
+    // ═══════════════════════════════════════════════════════════════
+    {
+      name: "no-project-importing-plugins",
+      severity: "error",
+      comment: "Project code must not import from plugins",
+      from: {
+        path: "^src/",
+        pathNot: [
+          "^src/plugins/",
+          // Only PluginsStore can import plugins for registration
+          "^src/store/PluginsStore\\.ts$",
+        ],
+      },
+      to: {
+        path: "^src/plugins/",
+      },
+    },
+
+    // ═══════════════════════════════════════════════════════════════
+    // GENERAL BEST PRACTICES
+    // ═══════════════════════════════════════════════════════════════
+    {
+      name: "no-orphans",
+      severity: "info",
+      comment: "Orphan modules are not reachable from entry points",
+      from: {
+        orphan: true,
+        pathNot: [
+          "(^|/)\\.[^/]+\\.(js|cjs|mjs|ts|json)$", // dot files
+          "\\.d\\.ts$", // TypeScript declaration files
+          "(^|/)tsconfig\\.json$",
+          "(^|/)vite\\.config\\.",
+          "\\.test\\.(ts|tsx)$", // test files
+          "\\.spec\\.(ts|tsx)$",
+          "__mocks__",
+          "e2e/",
+        ],
+      },
+      to: {},
+    },
+    {
+      name: "no-deprecated-core",
+      severity: "warn",
+      comment: "Avoid using deprecated Node.js core modules",
+      from: {},
+      to: {
+        dependencyTypes: ["core"],
+        path: ["^punycode$", "^domain$", "^constants$", "^sys$", "^_stream"],
+      },
+    },
+    {
+      name: "not-to-unresolvable",
+      severity: "error",
+      comment: "Imports must be resolvable",
+      from: {},
+      to: {
+        couldNotResolve: true,
+      },
+    },
+    {
+      name: "no-duplicate-dep-types",
+      severity: "warn",
+      comment:
+        "Package should not be in both dependencies and devDependencies",
+      from: {},
+      to: {
+        moreThanOneDependencyType: true,
+        dependencyTypesNot: ["type-only"],
+      },
+    },
+  ],
+
+  options: {
+    doNotFollow: {
+      path: ["node_modules"],
+    },
+    exclude: {
+      path: [
+        "node_modules",
+        "\\.test\\.(ts|tsx)$",
+        "\\.spec\\.(ts|tsx)$",
+        "__tests__",
+        "__mocks__",
+        "e2e/",
+        "\\.d\\.ts$",
+      ],
+    },
+    includeOnly: {
+      path: "^src/",
+    },
+    tsPreCompilationDeps: true,
+    tsConfig: {
+      fileName: "tsconfig.json",
+    },
+    enhancedResolveOptions: {
+      exportsFields: ["exports"],
+      conditionNames: ["import", "require", "node", "default"],
+      mainFields: ["module", "main", "types"],
+    },
+    reporterOptions: {
+      dot: {
+        collapsePattern: "node_modules/(@[^/]+/[^/]+|[^/]+)",
+        theme: {
+          graph: {
+            splines: "ortho",
+            rankdir: "TB",
+            ranksep: "1",
+          },
+          modules: [
+            {
+              criteria: { source: "^src/api/" },
+              attributes: { fillcolor: "#ffcccc" },
+            },
+            {
+              criteria: { source: "^src/components/ui/" },
+              attributes: { fillcolor: "#ccffcc" },
+            },
+            {
+              criteria: { source: "^src/components/shared/" },
+              attributes: { fillcolor: "#ccccff" },
+            },
+            {
+              criteria: { source: "^src/components/pages-shared/" },
+              attributes: { fillcolor: "#ffffcc" },
+            },
+            {
+              criteria: { source: "^src/components/pages/" },
+              attributes: { fillcolor: "#ffccff" },
+            },
+            {
+              criteria: { source: "^src/hooks/" },
+              attributes: { fillcolor: "#ccffff" },
+            },
+            {
+              criteria: { source: "^src/store/" },
+              attributes: { fillcolor: "#ffddaa" },
+            },
+            {
+              criteria: { source: "^src/lib/" },
+              attributes: { fillcolor: "#dddddd" },
+            },
+            {
+              criteria: { source: "^src/plugins/" },
+              attributes: { fillcolor: "#e6ccff" },
+            },
+          ],
+          dependencies: [
+            {
+              criteria: { resolved: "^src/api/" },
+              attributes: { color: "#cc0000" },
+            },
+            {
+              criteria: { resolved: "^src/store/" },
+              attributes: { color: "#ff8800" },
+            },
+            {
+              criteria: { resolved: "^src/plugins/" },
+              attributes: { color: "#9933ff" },
+            },
+          ],
+        },
+      },
+      archi: {
+        collapsePattern: "^src/([^/]+)/",
+        theme: {
+          graph: { rankdir: "TB" },
+        },
+      },
+    },
+  },
+};

--- a/apps/opik-frontend/package-lock.json
+++ b/apps/opik-frontend/package-lock.json
@@ -131,6 +131,7 @@
         "@vitejs/plugin-react-swc": "^3.7.0",
         "@vitest/ui": "^3.0.5",
         "autoprefixer": "^10.4.19",
+        "dependency-cruiser": "^17.3.6",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
@@ -231,6 +232,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
       "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -877,7 +879,8 @@
     "node_modules/@codemirror/state": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
-      "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A=="
+      "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==",
+      "peer": true
     },
     "node_modules/@codemirror/theme-one-dark": {
       "version": "6.1.2",
@@ -894,6 +897,7 @@
       "version": "6.28.4",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.28.4.tgz",
       "integrity": "sha512-QScv95fiviSQ/CaVGflxAvvvDy/9wi0RFyDl4LkHHWiMr/UPebyuTspmYSeN5Nx6eujcPYwsQzA6ZIZucKZVHQ==",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.4.0",
         "style-mod": "^4.1.0",
@@ -914,6 +918,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -935,6 +940,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -999,6 +1005,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -5891,6 +5898,7 @@
       "version": "5.45.0",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.45.0.tgz",
       "integrity": "sha512-y272cKRJp1BvehrWG4ashOBuqBj1Qm2O6fgYJ9LYSHrLdsCXl74GbSVjUQTReUdHuRIl9cEOoyPa6HYag400lw==",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.45.0"
       },
@@ -5923,6 +5931,7 @@
       "version": "1.36.3",
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.36.3.tgz",
       "integrity": "sha512-587W8jYCUtK9HsPSkmSbxm9VHH+ullmAT/ttOIbMjqhKLg9Sb30Gg6NxzGlzxRSF0t6QSy28wt+4ChPREVizFA==",
+      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.31.16",
         "@tanstack/react-store": "^0.2.1",
@@ -6604,6 +6613,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.13.tgz",
       "integrity": "sha512-+bHoGiZb8UiQ0+WEtmph2IWQCjIqg8MDZMAV+ppRRhUZnquF5mQkP/9vpSwJClEiSM/C7fZZExPzfU0vJTyp8w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -6617,6 +6627,7 @@
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -6627,6 +6638,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -6725,6 +6737,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -7168,9 +7181,11 @@
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7185,6 +7200,39 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-jsx-walk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
+      "integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn-loose": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
+      "integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -7654,6 +7702,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001629",
         "electron-to-chromium": "^1.4.796",
@@ -7884,6 +7933,7 @@
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
       "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -8653,12 +8703,14 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "peer": true
     },
     "node_modules/cytoscape": {
       "version": "3.30.4",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.30.4.tgz",
       "integrity": "sha512-OxtlZwQl1WbwMmLiyPSEBuzeTIQnwZhJYYWFzZ2PhEHVFwpeaqNIkUzSiso00D98qk60l8Gwon2RP304d3BJ1A==",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -9033,6 +9085,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9175,6 +9228,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -9354,6 +9408,77 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dependency-cruiser": {
+      "version": "17.3.7",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-17.3.7.tgz",
+      "integrity": "sha512-WEEOrnf0eshNirg4CMWuB7kK+qVZ+fecW6EBJa6AomEFhDDZKi3Zel1Tyl4ihcWtiSDhF+vALQb8NJS+wQiwLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "8.15.0",
+        "acorn-jsx": "5.3.2",
+        "acorn-jsx-walk": "2.0.0",
+        "acorn-loose": "8.5.2",
+        "acorn-walk": "8.3.4",
+        "commander": "14.0.2",
+        "enhanced-resolve": "5.18.4",
+        "ignore": "7.0.5",
+        "interpret": "3.1.1",
+        "is-installed-globally": "1.0.0",
+        "json5": "2.2.3",
+        "picomatch": "4.0.3",
+        "prompts": "2.4.2",
+        "rechoir": "0.8.0",
+        "safe-regex": "2.1.1",
+        "semver": "7.7.3",
+        "tsconfig-paths-webpack-plugin": "4.2.0",
+        "watskeburt": "5.0.2"
+      },
+      "bin": {
+        "depcruise": "bin/dependency-cruise.mjs",
+        "depcruise-baseline": "bin/depcruise-baseline.mjs",
+        "depcruise-fmt": "bin/depcruise-fmt.mjs",
+        "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs",
+        "dependency-cruise": "bin/dependency-cruise.mjs",
+        "dependency-cruiser": "bin/dependency-cruise.mjs"
+      },
+      "engines": {
+        "node": "^20.12||^22||>=24"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/commander": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/dequal": {
@@ -9553,6 +9678,20 @@
       "optional": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.18.4",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
+      "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/entities": {
@@ -9828,6 +9967,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9883,6 +10023,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -10659,6 +10800,32 @@
         "node": "*"
       }
     },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-directory/node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/global-modules": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
@@ -10797,6 +10964,7 @@
       "integrity": "sha512-/zyxHbXriYJ8b9Urh43ILk/jd9tC07djURnJuAimJ3tJCOLOzOUp7dEHDwJOZyzROlrrooUhr/0INZIDBj1Bjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "entities": "^4.5.0",
         "webidl-conversions": "^7.0.0",
@@ -11250,6 +11418,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/interpret": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -11391,11 +11569,15 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11517,6 +11699,36 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-installed-globally/node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-map": {
@@ -11815,6 +12027,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -11999,6 +12212,16 @@
         "graceful-fs": "^4.1.11"
       }
     },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/known-css-properties": {
       "version": "0.34.0",
       "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.34.0.tgz",
@@ -12069,7 +12292,8 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
       "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lint-staged": {
       "version": "15.2.7",
@@ -14353,6 +14577,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -14540,6 +14765,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.1.tgz",
       "integrity": "sha512-b4dlw/9V8A71rLIDsSwVmak9z2DuBUB7CA1/wSdelNEzqsjoSPeADTWNO09lpH49Diy3/JIZ2bSPB1dI3LJCHg==",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -14634,6 +14860,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
       "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14680,6 +14907,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/prop-types": {
@@ -14787,6 +15028,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14811,6 +15053,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -14866,6 +15109,7 @@
       "version": "7.54.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
       "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -15200,6 +15444,40 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
+    "node_modules/rechoir": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/rechoir/node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -15232,6 +15510,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -15485,6 +15773,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.4.tgz",
       "integrity": "sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -15591,6 +15880,16 @@
       ],
       "optional": true
     },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
@@ -15632,6 +15931,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.5.tgz",
       "integrity": "sha512-oDfX1mukIlxacPdQqNb6mV2tVCrnE+P3nVYioy72V5tlk56CPNcO4TCuFcaCRKKfJ1M3lH95CleRS+dVKL2qMg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -15653,9 +15953,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -15813,6 +16114,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -16115,6 +16423,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
@@ -16179,6 +16497,7 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^2.7.1",
         "@csstools/css-tokenizer": "^2.4.1",
@@ -16604,6 +16923,7 @@
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.4.tgz",
       "integrity": "sha512-ZoyXOdJjISB7/BcLTR6SEsLgKtDStYyYZVLsUtWChO4Ps20CBad7lfJKVDiejocV4ME1hLmyY0WJE3hSDcmQ2A==",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -16658,6 +16978,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tar-fs": {
@@ -16772,6 +17106,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16906,6 +17241,54 @@
         }
       }
     },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tapable": "^2.2.1",
+        "tsconfig-paths": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -17025,6 +17408,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "devOptional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17412,6 +17796,7 @@
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -17561,6 +17946,7 @@
       "integrity": "sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "3.0.5",
         "@vitest/mocker": "3.0.5",
@@ -17711,6 +18097,19 @@
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/watskeburt": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-5.0.2.tgz",
+      "integrity": "sha512-8xIz2RALjwTA7kYeRtkiQ2uaFyr327T1GXJnVcGOoPuzQX2axpUXqeJPcgOEVemCWB2YveZjhWCcW/eZ3uTkZA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "watskeburt": "dist/run-cli.js"
+      },
+      "engines": {
+        "node": "^20.12||^22.13||>=24.0"
       }
     },
     "node_modules/web-namespaces": {

--- a/apps/opik-frontend/package.json
+++ b/apps/opik-frontend/package.json
@@ -24,7 +24,9 @@
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "e2e": "playwright test && playwright show-report",
     "e2e:debug": "playwright test --debug",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "deps:validate": "depcruise src --config --ignore-known .dependency-cruiser-known-violations.json",
+    "deps:baseline": "depcruise src --config --output-type baseline > .dependency-cruiser-known-violations.json"
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
@@ -126,6 +128,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.45.3",
+    "dependency-cruiser": "^17.3.6",
     "@tailwindcss/typography": "^0.5.16",
     "@tanstack/react-query-devtools": "^5.45.0",
     "@tanstack/router-devtools": "^1.36.3",


### PR DESCRIPTION
## Details
Introduces dependency-cruiser to the frontend project to enforce architectural boundaries and prevent dependency violations.

**Changes:**
- Add dependency-cruiser configuration (`.dependency-cruiser.cjs`) with strict rules:
  - Layer hierarchy enforcement: `ui → shared → pages-shared → pages`
  - Circular dependency detection
  - Plugin isolation (project cannot import from plugins)
  - API/Store/Hooks isolation rules
  - Lodash individual import enforcement
- Add baseline file (`.dependency-cruiser-known-violations.json`) tracking 68 existing violations
- Add `deps:validate` and `deps:baseline` npm scripts
- Integrate validation into CI pipeline (`frontend_linter.yml`)
- Update CONTRIBUTING.md with dependency architecture guidelines
- Update agent rules (`.agents/rules/apps/opik-frontend/`)

**Allowed Exceptions:**
- `useNavigationBlocker` → `ConfirmDialog`
- `PluginsStore` → components (for plugin registration)
- API → `use-toast.ts`
- Hooks → providers

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues
- NA

## Testing
- Run `npm run deps:validate` - passes with 68 known violations ignored
- Run `npm run lint` - passes
- Run `npm run typecheck` - passes
- CI integration verified

## Documentation
- Updated CONTRIBUTING.md with Dependency Architecture section
- Updated `.agents/rules/apps/opik-frontend/code-quality.mdc`
- Updated `.agents/rules/apps/opik-frontend/frontend_rules.mdc`
- Added `.dependency-cruiser-known-violations.README.md` documenting all violations to fix