### PR TITLE
[OPIK-4102] [SDK] OPIK_OPTIMIZATION_STUDIO env for SDK to be aware of studio

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/jobs/optimizer.py
+++ b/apps/opik-python-backend/src/opik_backend/jobs/optimizer.py
@@ -120,6 +120,9 @@ def process_optimizer_job(*args: Any, **kwargs: Any) -> Dict[str, Any]:
             **LLM_API_KEYS,  # OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.
         }
         
+        # Mark subprocess as Optimization Studio execution (SDK display behavior).
+        env_vars["OPIK_OPTIMIZATION_STUDIO"] = "true"
+        
         # Pass Opik API key if provided (for cloud deployment)
         if context.opik_api_key:
             env_vars["OPIK_API_KEY"] = context.opik_api_key


### PR DESCRIPTION
## Details
We added support for `OPIK_OPTIMIZATION_STUDIO` in v3 of Optimizer SDK so the SDK is aware its being run from the Optimization Studio UI. For now this flag hides the optimization run URL from the header but can later be used for other features.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-4102

## Testing
n.a - config change

## Documentation
n.a