### PR TITLE
[NA] [E2E][FE] Add test id to traces table columns button and fix tests

### DIFF
--- a/apps/opik-frontend/src/components/shared/ColumnsButton/ColumnsButton.tsx
+++ b/apps/opik-frontend/src/components/shared/ColumnsButton/ColumnsButton.tsx
@@ -189,7 +189,7 @@ const ColumnsButton = <TColumnData,>({
     <DropdownMenu onOpenChange={openStateChangeHandler}>
       <TooltipWrapper content="Columns">
         <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="icon-sm">
+          <Button variant="outline" size="icon-sm" data-testid="columns-button">
             <Columns3 className="size-3.5" />
           </Button>
         </DropdownMenuTrigger>

--- a/tests_end_to_end/typescript-tests/page-objects/dataset-items.page.ts
+++ b/tests_end_to_end/typescript-tests/page-objects/dataset-items.page.ts
@@ -12,7 +12,7 @@ export class DatasetItemsPage {
   }
 
   async removeDefaultColumns() {
-    await this.page.getByRole('button', { name: 'Columns' }).click();
+    await this.page.getByTestId('columns-button').click();
 
     const createdToggle = this.page
       .getByRole('button', { name: 'Created', exact: true })

--- a/tests_end_to_end/typescript-tests/page-objects/traces.page.ts
+++ b/tests_end_to_end/typescript-tests/page-objects/traces.page.ts
@@ -32,10 +32,10 @@ export class TracesPage {
     await this.page.waitForTimeout(1000);
 
     try {
-      await this.page.getByRole('button', { name: 'Columns' }).click({ timeout: 5000 });
+      await this.page.getByTestId('columns-button').click({ timeout: 5000 });
     } catch {
       await this.page.reload();
-      await this.page.getByRole('button', { name: 'Columns' }).click({ timeout: 5000 });
+      await this.page.getByTestId('columns-button').click({ timeout: 5000 });
     }
 
     try {


### PR DESCRIPTION
## Details
Added a test id to the columns button in the FE to facilitate a resilient locator in the E2E tests, and fixed the failing tests

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

NA

## Testing

## Documentation
