### PR TITLE
[OPIK-3958] [DOCS] Add Ollama setup to AI providers (Opik configuration only)

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/configuration/ai_providers.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/configuration/ai_providers.mdx
@@ -59,7 +59,6 @@ Opik supports integration with various AI providers, including:
 - VertexAI
 - Azure OpenAI
 - Amazon Bedrock
-- LM Studio (coming soon)
 - Ollama (local or self-hosted, OpenAI-compatible)
 - vLLM / any other OpenAI API-compliant provider
 


### PR DESCRIPTION
## Details

Adds an Ollama subsection to the AI providers documentation under Provider-Specific Setup. Covers only Opik configuration: how to add an Ollama provider (name, URL ending with `/v1`, optional API key), test connection, discover models, and save. No Ollama version or run/install instructions.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues
- OPIK-3958

## Testing
NA

## Documentation
- `apps/opik-documentation/documentation/fern/docs/configuration/ai_providers.mdx` — new "Ollama" subsection and updated Supported Providers list.