### PR TITLE
[NA] [FE] Add dependency validation to dev-runner scripts

### DIFF
--- a/scripts/dev-runner.ps1
+++ b/scripts/dev-runner.ps1
@@ -322,12 +322,23 @@ function Invoke-FrontendLint {
         
         Write-LogInfo "Typechecking frontend..."
         npm run typecheck
-        
+
         if ($LASTEXITCODE -eq 0) {
             Write-LogSuccess "Frontend typechecking completed successfully"
         }
         else {
             Write-LogError "Frontend typechecking failed"
+            exit 1
+        }
+
+        Write-LogInfo "Validating frontend dependencies..."
+        npm run deps:validate
+
+        if ($LASTEXITCODE -eq 0) {
+            Write-LogSuccess "Frontend dependency validation completed successfully"
+        }
+        else {
+            Write-LogError "Frontend dependency validation failed"
             exit 1
         }
     }

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -197,6 +197,14 @@ lint_frontend() {
         log_error "Frontend typechecking failed"
         exit 1
     fi
+
+    log_info "Validating frontend dependencies..."
+    if npm run deps:validate; then
+        log_success "Frontend dependency validation completed successfully"
+    else
+        log_error "Frontend dependency validation failed"
+        exit 1
+    fi
 }
 
 # Function to lint backend


### PR DESCRIPTION
## Details
Adds `npm run deps:validate` to the `--lint-fe` command in dev-runner scripts, ensuring dependency architecture validation runs as part of frontend linting.

**Changes:**
- `scripts/dev-runner.sh` - Added dependency validation step after typecheck
- `scripts/dev-runner.ps1` - Added dependency validation step after typecheck (Windows support)

This is a follow-up to PR #4948 which introduced dependency-cruiser configuration. Now developers running `--lint-fe` locally will also validate dependency architecture.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues
- NA
- Follow-up to #4948

## Testing
- Tested locally with `./scripts/dev-runner.sh --lint-fe`
- All three steps pass: linting, typechecking, dependency validation

## Documentation
- N/A (scripts are self-documenting)