### PR TITLE
[OPIK-4110] [DOCS] Add fern/img vs static/img note to documentation skill

### DIFF
--- a/.agents/skills/documentation/SKILL.md
+++ b/.agents/skills/documentation/SKILL.md
@@ -59,6 +59,12 @@ When documenting a feature, cover:
 - `CHANGELOG.md` - Main changelog
 - `.github/release-drafter.yml` - Release template
 
+## Images in documentation
+
+- **Use `fern/img`** for documentation images (e.g. `apps/opik-documentation/documentation/fern/img/...`).
+- **Do not use `static/img`** for new assets; it is a legacy folder used by external integrations and cannot be deleted.
+- Reference images in docs as `/img/...` (e.g. `/img/tracing/openai_integration.png`).
+
 ## Style
 
 - User perspective, not implementation details


### PR DESCRIPTION
## Details

Update the documentation skill (\.agents/skills/documentation/SKILL.md) with guidance on documentation images:

- Use `fern/img` for documentation images (e.g. under `apps/opik-documentation/documentation/fern/img/...`).
- Do not use `static/img` for new assets; it is a legacy folder used by external integrations and cannot be deleted.
- Reference images in docs as `/img/...` (e.g. `/img/tracing/openai_integration.png`).

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-4110

## Testing

N/A — documentation/agent skill update only.

## Documentation

Updated `.agents/skills/documentation/SKILL.md` (Images in documentation section).