### PR TITLE
fix(optimizer): correct dataset key names for validation in trial config (OPIK-3820)

### DIFF
--- a/sdks/opik_optimizer/src/opik_optimizer/base_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/base_optimizer.py
@@ -555,6 +555,11 @@ class BaseOptimizer(ABC):
                     additional_metadata=None,
                     validation_dataset=context.validation_dataset,
                     build_optimizer_version=_OPTIMIZER_VERSION,
+                    training_dataset=(
+                        context.dataset
+                        if context.validation_dataset is not None
+                        else None
+                    ),
                 ),
             )
             coerced_score = self._coerce_score(baseline_score)

--- a/sdks/opik_optimizer/src/opik_optimizer/core/state.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/core/state.py
@@ -178,6 +178,7 @@ def prepare_experiment_config(
     additional_metadata: dict[str, Any] | None,
     is_single_prompt_optimization: bool,
     build_optimizer_version: str,
+    training_dataset: Dataset | None = None,
 ) -> dict[str, Any]:
     project_name = optimizer.project_name
 
@@ -214,12 +215,18 @@ def prepare_experiment_config(
         tools = serialize_tools(prompt)
         prompt_project_name = {prompt_name_attr: getattr(prompt, "project_name", None)}
 
+    # When using train/validation split, training_dataset identifies the training
+    # dataset so we always set dataset_training/dataset_validation keys correctly
+    # (OPIK-3820: avoid showing validation data under "dataset_training" keys).
+    dataset_for_training_keys = (
+        training_dataset if training_dataset is not None else dataset
+    )
     base_config: dict[str, Any] = {
         "project_name": project_name,
         "agent_config": agent_config,
         "metric": metric.__name__,
-        "dataset_training": dataset.name,
-        "dataset_training_id": dataset.id,
+        "dataset_training": dataset_for_training_keys.name,
+        "dataset_training_id": dataset_for_training_keys.id,
         "optimizer": optimizer.__class__.__name__,
         "optimizer_metadata": build_optimizer_metadata(
             optimizer, build_optimizer_version


### PR DESCRIPTION
## Summary

Fixes [OPIK-3820](https://comet-ml.atlassian.net/browse/OPIK-3820): when using the Optimizer with Train/Validation splits, the Trial Configuration tab was showing validation dataset values under keys named `dataset_training` and `dataset_training_id` instead of `dataset_validation` and `dataset_validation_id`.

## Root cause

`prepare_experiment_config()` always set `dataset_training` / `dataset_training_id` from the `dataset` argument (the dataset used for the current evaluation). When a trial was evaluated on the **validation** dataset, `dataset` was the validation dataset, so those keys incorrectly pointed to validation data.

## Changes

1. **`sdks/opik_optimizer/src/opik_optimizer/core/state.py`**
   - Added optional parameter `training_dataset: Dataset | None = None` to `prepare_experiment_config()`.
   - When `training_dataset` is provided (train/validation split), use it for `dataset_training` / `dataset_training_id`; otherwise keep using `dataset` (no split).
   - Validation keys (`dataset_validation` / `dataset_validation_id`) are unchanged and still set from `validation_dataset` when present.

2. **`sdks/opik_optimizer/src/opik_optimizer/base_optimizer.py`**
   - In baseline evaluation, when `context.validation_dataset` is not None, pass `training_dataset=context.dataset` so that trial config always has correct training vs validation keys.

## Testing

- Ran relevant unit tests: `tests/unit/core/` and `tests/unit/algorithms/` (14 tests passed).
- Pre-commit (ruff, mypy, etc.) passed.

[OPIK-3820]: https://comet-ml.atlassian.net/browse/OPIK-3820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ