### PR TITLE
[OPIK-771] [FE] UX improvements for traces sidebar

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TagList/TagList.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TagList/TagList.tsx
@@ -10,6 +10,7 @@ type TagListProps = {
   projectId: string;
   traceId: string;
   spanId?: string;
+  className?: string;
 };
 
 const TagList: React.FunctionComponent<TagListProps> = ({
@@ -18,6 +19,7 @@ const TagList: React.FunctionComponent<TagListProps> = ({
   projectId,
   traceId,
   spanId,
+  className,
 }) => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const traceUpdateMutation = useTraceUpdateMutation();
@@ -65,6 +67,7 @@ const TagList: React.FunctionComponent<TagListProps> = ({
       onAddTag={handleAddTag}
       onDeleteTag={handleDeleteTag}
       size="sm"
+      className={className}
     />
   );
 };

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -288,15 +288,14 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
               </TooltipWrapper>
             )}
           </div>
-          <div className="pl-1">
-            <TagList
-              data={data}
-              tags={data.tags}
-              projectId={projectId}
-              traceId={traceId}
-              spanId={spanId}
-            />
-          </div>
+          <TagList
+            data={data}
+            tags={data.tags}
+            projectId={projectId}
+            traceId={traceId}
+            spanId={spanId}
+            className="pl-1"
+          />
         </div>
 
         <Tabs defaultValue="input" value={selectedTab!} onValueChange={setTab}>

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsActionsPanel.tsx
@@ -74,10 +74,7 @@ type TraceDetailsActionsPanelProps = {
   spanId: string;
   threadId?: string;
   setThreadId?: OnChangeFn<string | null | undefined>;
-  onClose: () => void;
-  hasPreviousRow?: boolean;
-  hasNextRow?: boolean;
-  onRowChange?: (shift: number) => void;
+  onDelete: () => void;
   isSpansLazyLoading: boolean;
   search?: string;
   setSearch: OnChangeFn<string | undefined>;
@@ -98,10 +95,7 @@ const TraceDetailsActionsPanel: React.FunctionComponent<
   spanId,
   threadId,
   setThreadId,
-  onClose,
-  hasPreviousRow,
-  hasNextRow,
-  onRowChange,
+  onDelete,
   isSpansLazyLoading,
   search,
   setSearch,
@@ -153,27 +147,12 @@ const TraceDetailsActionsPanel: React.FunctionComponent<
   });
 
   const handleTraceDelete = useCallback(() => {
-    // Navigate to previous/next trace before deleting, or close if it's the only trace
-    if (hasPreviousRow && onRowChange) {
-      onRowChange(-1);
-    } else if (hasNextRow && onRowChange) {
-      onRowChange(1);
-    } else {
-      onClose();
-    }
+    onDelete();
     mutate({
       traceId,
       projectId,
     });
-  }, [
-    hasPreviousRow,
-    hasNextRow,
-    onRowChange,
-    onClose,
-    mutate,
-    traceId,
-    projectId,
-  ]);
+  }, [onDelete, mutate, traceId, projectId]);
 
   const getDataToExport = useCallback(
     (treeData: Array<Trace | Span>) => {

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
@@ -171,6 +171,17 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
     };
   }, [spanId, traceId, handleRowSelect, flattenedTree]);
 
+  const handleTraceDelete = useCallback(() => {
+    // Navigate to previous/next trace before deleting, or close if it's the only trace
+    if (hasPreviousRow && onRowChange) {
+      onRowChange(-1);
+    } else if (hasNextRow && onRowChange) {
+      onRowChange(1);
+    } else {
+      onClose();
+    }
+  }, [hasPreviousRow, hasNextRow, onRowChange, onClose]);
+
   const renderContent = () => {
     if (isTracePending || isSpansPending) {
       return <Loader />;
@@ -265,10 +276,7 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
           threadId={trace?.thread_id}
           setThreadId={setThreadId}
           projectId={projectId}
-          onClose={onClose}
-          hasPreviousRow={hasPreviousRow}
-          hasNextRow={hasNextRow}
-          onRowChange={onRowChange}
+          onDelete={handleTraceDelete}
           isSpansLazyLoading={isSpansLazyLoading}
           search={search}
           setSearch={setSearch}


### PR DESCRIPTION
## Details


https://github.com/user-attachments/assets/c36994fb-1c3d-4101-8747-3b0e0e65dba2



This PR implements UX improvements for the traces sidebar panel:

- **Added Created at timestamp pill**: Displays when the trace/span was created with a calendar icon in the trace data viewer header
- **Improved trace deletion behavior**: When a trace is deleted from the sidebar, instead of closing the panel, it now navigates to the previous or next trace (if available), providing a smoother workflow when reviewing multiple traces
- **Adjusted left indentation**: Minor styling adjustment for better visual alignment of pills and tags

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-771

## Testing

1. Open a project with multiple traces
2. Click on a trace to open the sidebar panel
3. Verify the Created at timestamp is displayed with a calendar icon
4. Delete a trace and verify it navigates to the previous/next trace instead of closing the panel
5. If it is the only trace, verify the panel closes as expected

## Documentation

N/A - UI improvements only