### PR TITLE
[NA] [DOCS] Fix broken link in Google Gemini documentation

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/models.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/models.mdx
@@ -211,7 +211,7 @@ await evaluatePrompt({
 });
 ```
 
-For a complete list of available models, see the [Vercel AI SDK Google provider documentation](https://sdk.vercel.ai/providers/ai-sdk-providers/google).
+For a complete list of available models, see the [Vercel AI SDK Google provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai#model-capabilities).
 
 ## Using Models in Opik
 


### PR DESCRIPTION
## Details

Fixed broken link in the Google Gemini documentation section. Updated the Vercel AI SDK Google provider documentation URL from the old `sdk.vercel.ai` domain to the correct `ai-sdk.dev` domain with the proper path.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- NA

## Testing

Verified the new link resolves correctly and points to the correct documentation page.

## Documentation

Updated link in `apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/models.mdx` for the Google Gemini provider documentation reference.