### PR TITLE
feat(openai): Add TTS (Text-to-Speech) tracking support

### DIFF
--- a/sdks/python/src/opik/integrations/openai/openai_tts_decorator.py
+++ b/sdks/python/src/opik/integrations/openai/openai_tts_decorator.py
@@ -1,0 +1,303 @@
+"""
+Decorator for OpenAI Text-to-Speech (TTS) methods.
+
+This decorator tracks calls to:
+* `openai_client.audio.speech.create()`
+* `openai_client.audio.speech.with_streaming_response.create()`
+
+The TTS API does not return token usage, but we track:
+- Input text length (characters) for cost estimation
+- Model used
+- Voice used
+- Response format and other parameters
+
+OpenAI TTS pricing (as of 2024):
+- tts-1: $0.015 per 1,000 characters
+- tts-1-hd: $0.030 per 1,000 characters
+- gpt-4o-mini-tts: $0.012 per 1,000 characters
+"""
+
+import logging
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+
+from typing_extensions import override
+
+import opik.dict_utils as dict_utils
+from opik.api_objects import span
+from opik.decorator import arguments_helpers, base_track_decorator
+
+LOGGER = logging.getLogger(__name__)
+
+# Keys from kwargs to log as input
+TTS_KWARGS_KEYS_TO_LOG_AS_INPUTS = [
+    "input",
+    "voice",
+]
+
+# Keys to include in metadata (not as primary input)
+TTS_KWARGS_KEYS_FOR_METADATA = [
+    "response_format",
+    "speed",
+    "instructions",
+]
+
+
+class OpenaiTTSTrackDecorator(base_track_decorator.BaseTrackDecorator):
+    """
+    Decorator for tracking OpenAI TTS (audio.speech) methods.
+
+    Handles both sync and async versions, as well as streaming responses.
+    """
+
+    def __init__(self, provider: str = "openai") -> None:
+        super().__init__()
+        self.provider = provider
+
+    @override
+    def _start_span_inputs_preprocessor(
+        self,
+        func: Callable,
+        track_options: arguments_helpers.TrackOptions,
+        args: Tuple,
+        kwargs: Dict[str, Any],
+    ) -> arguments_helpers.StartSpanParameters:
+        assert kwargs is not None, (
+            "Expected kwargs to be not None in audio.speech.create(**kwargs)"
+        )
+
+        name = track_options.name if track_options.name is not None else func.__name__
+
+        metadata = track_options.metadata if track_options.metadata is not None else {}
+
+        # Split input and metadata keys
+        input_data, extra_metadata = dict_utils.split_dict_by_keys(
+            kwargs, keys=TTS_KWARGS_KEYS_TO_LOG_AS_INPUTS
+        )
+
+        # Also extract metadata-specific keys
+        _, additional_metadata = dict_utils.split_dict_by_keys(
+            kwargs, keys=TTS_KWARGS_KEYS_FOR_METADATA
+        )
+
+        metadata = dict_utils.deepmerge(metadata, extra_metadata)
+        metadata = dict_utils.deepmerge(metadata, additional_metadata)
+
+        # Add standard metadata
+        metadata.update(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+            }
+        )
+
+        # Add input character count for cost estimation
+        input_text = kwargs.get("input", "")
+        if input_text:
+            metadata["input_characters"] = len(input_text)
+
+        tags = ["openai", "tts"]
+        model = kwargs.get("model", None)
+
+        result = arguments_helpers.StartSpanParameters(
+            name=name,
+            input=input_data,
+            type=track_options.type,
+            tags=tags,
+            metadata=metadata,
+            project_name=track_options.project_name,
+            model=model,
+            provider=self.provider,
+        )
+
+        return result
+
+    @override
+    def _end_span_inputs_preprocessor(
+        self,
+        output: Any,
+        capture_output: bool,
+        current_span_data: span.SpanData,
+    ) -> arguments_helpers.EndSpanParameters:
+        """
+        Process the TTS response.
+
+        Note: OpenAI TTS returns binary audio content, not a structured response
+        with usage information. We track completion but cannot extract token usage.
+        """
+        # TTS returns binary content (HttpxBinaryResponseContent or similar)
+        # We don't log the binary content as output, just mark completion
+        output_data: Dict[str, Any] = {
+            "status": "completed",
+        }
+
+        # Try to get content type if available
+        if hasattr(output, "content_type"):
+            output_data["content_type"] = output.content_type
+
+        # Try to get content length if available
+        if hasattr(output, "content"):
+            try:
+                content = output.content
+                if content:
+                    output_data["content_length_bytes"] = len(content)
+            except Exception:
+                pass
+
+        metadata: Dict[str, Any] = {}
+
+        # Get model from current span data if available
+        model = (
+            current_span_data.model
+            if hasattr(current_span_data, "model")
+            else None
+        )
+
+        result = arguments_helpers.EndSpanParameters(
+            output=output_data,
+            usage=None,  # TTS doesn't return token usage
+            metadata=metadata,
+            model=model,
+            provider=self.provider,
+        )
+
+        return result
+
+    @override
+    def _streams_handler(
+        self,
+        output: Any,
+        capture_output: bool,
+        generations_aggregator: Optional[Callable[[List[Any]], Any]],
+    ) -> Optional[Any]:
+        """
+        Handle streaming responses.
+
+        For TTS streaming, we wrap the response to track when streaming completes.
+        """
+        # Check if this is a streaming response context manager
+        # OpenAI's with_streaming_response.create() returns an AbstractContextManager
+        # that yields the response when entered
+
+        NOT_A_STREAM = None
+        return NOT_A_STREAM
+
+
+class OpenaiTTSStreamingResponseDecorator(base_track_decorator.BaseTrackDecorator):
+    """
+    Decorator specifically for tracking TTS streaming responses.
+
+    This handles the context manager returned by audio.speech.with_streaming_response.create()
+    """
+
+    def __init__(self, provider: str = "openai") -> None:
+        super().__init__()
+        self.provider = provider
+
+    @override
+    def _start_span_inputs_preprocessor(
+        self,
+        func: Callable,
+        track_options: arguments_helpers.TrackOptions,
+        args: Tuple,
+        kwargs: Dict[str, Any],
+    ) -> arguments_helpers.StartSpanParameters:
+        assert kwargs is not None, (
+            "Expected kwargs to be not None in audio.speech.with_streaming_response.create(**kwargs)"
+        )
+
+        name = track_options.name if track_options.name is not None else func.__name__
+
+        metadata = track_options.metadata if track_options.metadata is not None else {}
+
+        # Split input and metadata keys
+        input_data, extra_metadata = dict_utils.split_dict_by_keys(
+            kwargs, keys=TTS_KWARGS_KEYS_TO_LOG_AS_INPUTS
+        )
+
+        # Also extract metadata-specific keys
+        _, additional_metadata = dict_utils.split_dict_by_keys(
+            kwargs, keys=TTS_KWARGS_KEYS_FOR_METADATA
+        )
+
+        metadata = dict_utils.deepmerge(metadata, extra_metadata)
+        metadata = dict_utils.deepmerge(metadata, additional_metadata)
+
+        metadata.update(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+                "streaming": True,
+            }
+        )
+
+        # Add input character count for cost estimation
+        input_text = kwargs.get("input", "")
+        if input_text:
+            metadata["input_characters"] = len(input_text)
+
+        tags = ["openai", "tts", "streaming"]
+        model = kwargs.get("model", None)
+
+        result = arguments_helpers.StartSpanParameters(
+            name=name,
+            input=input_data,
+            type=track_options.type,
+            tags=tags,
+            metadata=metadata,
+            project_name=track_options.project_name,
+            model=model,
+            provider=self.provider,
+        )
+
+        return result
+
+    @override
+    def _end_span_inputs_preprocessor(
+        self,
+        output: Any,
+        capture_output: bool,
+        current_span_data: span.SpanData,
+    ) -> arguments_helpers.EndSpanParameters:
+        """
+        Process the streaming TTS response.
+
+        The output is a context manager, so we just mark it as initiated.
+        """
+        output_data: Dict[str, Any] = {
+            "status": "stream_initiated",
+        }
+
+        metadata: Dict[str, Any] = {}
+
+        model = (
+            current_span_data.model
+            if hasattr(current_span_data, "model")
+            else None
+        )
+
+        result = arguments_helpers.EndSpanParameters(
+            output=output_data,
+            usage=None,
+            metadata=metadata,
+            model=model,
+            provider=self.provider,
+        )
+
+        return result
+
+    @override
+    def _streams_handler(
+        self,
+        output: Any,
+        capture_output: bool,
+        generations_aggregator: Optional[Callable[[List[Any]], Any]],
+    ) -> Optional[Any]:
+        NOT_A_STREAM = None
+        return NOT_A_STREAM

--- a/sdks/python/src/opik/integrations/openai/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/openai/opik_tracker.py
@@ -38,6 +38,8 @@ def track_openai(
     * `openai_client.videos.create()`, `videos.create_and_poll()`, `videos.poll()`,
       `videos.list()`, `videos.delete()`, `videos.remix()`, `videos.download_content()`,
       and `write_to_file()` on downloaded content
+    * `openai_client.audio.speech.create()` - Text-to-Speech generation
+    * `openai_client.audio.speech.with_streaming_response.create()` - Streaming TTS
 
     Can be used within other Opik-tracked functions.
 
@@ -60,6 +62,9 @@ def track_openai(
 
     if hasattr(openai_client, "videos"):
         _patch_openai_videos(openai_client, project_name)
+
+    if hasattr(openai_client, "audio"):
+        _patch_openai_audio(openai_client, project_name)
 
     return openai_client
 
@@ -238,3 +243,52 @@ def _patch_openai_videos(
             project_name=project_name,
         )
         openai_client.videos.list = decorator(openai_client.videos.list)
+
+
+def _patch_openai_audio(
+    openai_client: OpenAIClient,
+    project_name: Optional[str] = None,
+) -> None:
+    """Patch OpenAI audio API methods for tracking.
+
+    Currently supports:
+    - audio.speech.create() - Text-to-Speech generation
+    - audio.speech.with_streaming_response.create() - Streaming TTS
+    """
+    from . import openai_tts_decorator
+
+    provider = _get_provider(openai_client)
+
+    # Patch audio.speech if available
+    if hasattr(openai_client.audio, "speech"):
+        tts_decorator_factory = openai_tts_decorator.OpenaiTTSTrackDecorator(
+            provider=provider
+        )
+        tts_streaming_decorator_factory = (
+            openai_tts_decorator.OpenaiTTSStreamingResponseDecorator(provider=provider)
+        )
+
+        # Patch audio.speech.create
+        if hasattr(openai_client.audio.speech, "create"):
+            tts_create_decorator = tts_decorator_factory.track(
+                type="llm",
+                name="audio.speech.create",
+                project_name=project_name,
+            )
+            openai_client.audio.speech.create = tts_create_decorator(
+                openai_client.audio.speech.create
+            )
+
+        # Patch audio.speech.with_streaming_response.create
+        if hasattr(openai_client.audio.speech, "with_streaming_response"):
+            if hasattr(openai_client.audio.speech.with_streaming_response, "create"):
+                tts_streaming_create_decorator = tts_streaming_decorator_factory.track(
+                    type="llm",
+                    name="audio.speech.with_streaming_response.create",
+                    project_name=project_name,
+                )
+                openai_client.audio.speech.with_streaming_response.create = (
+                    tts_streaming_create_decorator(
+                        openai_client.audio.speech.with_streaming_response.create
+                    )
+                )

--- a/sdks/python/tests/library_integration/openai/constants.py
+++ b/sdks/python/tests/library_integration/openai/constants.py
@@ -3,6 +3,11 @@ from ...testlib import ANY_BUT_NONE
 MODEL_FOR_TESTS = "gpt-4o-mini"
 VIDEO_MODEL_FOR_TESTS = "sora-2"
 VIDEO_SIZE_FOR_TESTS = "720x1280"  # Lowest resolution for faster/cheaper tests
+
+# TTS (Text-to-Speech) constants
+TTS_MODEL_FOR_TESTS = "tts-1"  # Cheapest TTS model
+TTS_VOICE_FOR_TESTS = "alloy"
+
 EXPECTED_OPENAI_USAGE_LOGGED_FORMAT = {
     "prompt_tokens": ANY_BUT_NONE,
     "completion_tokens": ANY_BUT_NONE,

--- a/sdks/python/tests/library_integration/openai/test_openai_tts.py
+++ b/sdks/python/tests/library_integration/openai/test_openai_tts.py
@@ -1,0 +1,432 @@
+"""
+Tests for OpenAI TTS (Text-to-Speech) tracking integration.
+
+These tests verify that the Opik integration correctly tracks:
+- audio.speech.create() calls
+- audio.speech.with_streaming_response.create() calls
+- Input text and parameters
+- Model and voice metadata
+- Character count for cost estimation
+"""
+
+import os
+import tempfile
+
+import openai
+import pytest
+
+import opik
+from opik.config import OPIK_PROJECT_DEFAULT_NAME
+from opik.integrations.openai import track_openai
+from ...testlib import (
+    ANY_BUT_NONE,
+    ANY_DICT,
+    ANY_STRING,
+    SpanModel,
+    TraceModel,
+    assert_equal,
+)
+
+# TTS model for testing - use the cheapest option
+TTS_MODEL_FOR_TESTS = "tts-1"
+TTS_VOICE_FOR_TESTS = "alloy"
+
+# TTS tests use real API calls which cost money, skip unless explicitly enabled
+SKIP_EXPENSIVE_TESTS = os.environ.get("OPIK_TEST_EXPENSIVE", "").lower() not in (
+    "1",
+    "true",
+    "yes",
+)
+
+
+# =============================================================================
+# Tests that require real OpenAI API calls (expensive)
+# =============================================================================
+
+
+@pytest.mark.skipif(
+    SKIP_EXPENSIVE_TESTS,
+    reason="Expensive tests disabled. Set OPIK_TEST_EXPENSIVE=1 to enable.",
+)
+@pytest.mark.usefixtures("ensure_openai_configured")
+def test_openai_client_audio_speech_create__happyflow(fake_backend):
+    """
+    Test audio.speech.create - the main TTS method.
+
+    This test verifies:
+    1. Trace and span structure
+    2. Input logging (input text and voice)
+    3. Metadata contains input_characters for cost calculation
+    4. Model and provider are correctly populated
+    5. Tags are applied correctly
+    """
+    client = openai.OpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "Hello, this is a test of the text to speech API."
+
+    response = wrapped_client.audio.speech.create(
+        model=TTS_MODEL_FOR_TESTS,
+        voice=TTS_VOICE_FOR_TESTS,
+        input=input_text,
+    )
+
+    # Verify we got audio content back
+    assert response.content is not None
+    assert len(response.content) > 0
+
+    opik.flush_tracker()
+
+    # Verify trace structure
+    assert len(fake_backend.trace_trees) == 1
+
+    EXPECTED_TRACE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio.speech.create",
+        input={"input": input_text, "voice": TTS_VOICE_FOR_TESTS},
+        output=ANY_DICT.containing({"status": "completed"}),
+        tags=["openai", "tts"],
+        metadata=ANY_DICT.containing(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+                "input_characters": len(input_text),
+            }
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=OPIK_PROJECT_DEFAULT_NAME,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio.speech.create",
+                input={"input": input_text, "voice": TTS_VOICE_FOR_TESTS},
+                output=ANY_DICT.containing({"status": "completed"}),
+                tags=["openai", "tts"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "openai",
+                        "type": "openai_tts",
+                        "input_characters": len(input_text),
+                    }
+                ),
+                usage=None,  # TTS doesn't return token usage
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=OPIK_PROJECT_DEFAULT_NAME,
+                spans=[],
+                model=TTS_MODEL_FOR_TESTS,
+                provider="openai",
+            )
+        ],
+    )
+
+    trace_tree = fake_backend.trace_trees[0]
+    assert_equal(EXPECTED_TRACE, trace_tree)
+
+
+@pytest.mark.skipif(
+    SKIP_EXPENSIVE_TESTS,
+    reason="Expensive tests disabled. Set OPIK_TEST_EXPENSIVE=1 to enable.",
+)
+@pytest.mark.usefixtures("ensure_openai_configured")
+def test_openai_client_audio_speech_create__with_custom_project_name(fake_backend):
+    """
+    Test that custom project_name is correctly applied to TTS spans.
+    """
+    client = openai.OpenAI()
+    custom_project = "tts-integration-test"
+    wrapped_client = track_openai(openai_client=client, project_name=custom_project)
+
+    input_text = "Testing custom project name."
+
+    _ = wrapped_client.audio.speech.create(
+        model=TTS_MODEL_FOR_TESTS,
+        voice=TTS_VOICE_FOR_TESTS,
+        input=input_text,
+    )
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    assert trace_tree.project_name == custom_project
+    assert trace_tree.spans[0].project_name == custom_project
+
+
+@pytest.mark.skipif(
+    SKIP_EXPENSIVE_TESTS,
+    reason="Expensive tests disabled. Set OPIK_TEST_EXPENSIVE=1 to enable.",
+)
+@pytest.mark.usefixtures("ensure_openai_configured")
+def test_openai_client_audio_speech_create__with_optional_parameters(fake_backend):
+    """
+    Test that optional parameters (response_format, speed) are tracked in metadata.
+    """
+    client = openai.OpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "Testing optional parameters."
+
+    response = wrapped_client.audio.speech.create(
+        model=TTS_MODEL_FOR_TESTS,
+        voice=TTS_VOICE_FOR_TESTS,
+        input=input_text,
+        response_format="mp3",
+        speed=1.0,
+    )
+
+    assert response.content is not None
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    # Check that optional parameters are in metadata
+    metadata = trace_tree.spans[0].metadata
+    assert metadata.get("response_format") == "mp3"
+    assert metadata.get("speed") == 1.0
+
+
+@pytest.mark.skipif(
+    SKIP_EXPENSIVE_TESTS,
+    reason="Expensive tests disabled. Set OPIK_TEST_EXPENSIVE=1 to enable.",
+)
+@pytest.mark.usefixtures("ensure_openai_configured")
+def test_openai_client_audio_speech_create__write_to_file(fake_backend):
+    """
+    Test TTS with writing output to file.
+    """
+    client = openai.OpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "This audio will be saved to a file."
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_path = os.path.join(temp_dir, "speech.mp3")
+
+        response = wrapped_client.audio.speech.create(
+            model=TTS_MODEL_FOR_TESTS,
+            voice=TTS_VOICE_FOR_TESTS,
+            input=input_text,
+        )
+
+        # Write to file
+        response.write_to_file(output_path)
+
+        # Verify file was created
+        assert os.path.exists(output_path)
+        assert os.path.getsize(output_path) > 0
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+
+
+@pytest.mark.skipif(
+    SKIP_EXPENSIVE_TESTS,
+    reason="Expensive tests disabled. Set OPIK_TEST_EXPENSIVE=1 to enable.",
+)
+@pytest.mark.usefixtures("ensure_openai_configured")
+def test_openai_client_audio_speech_with_streaming_response__happyflow(fake_backend):
+    """
+    Test audio.speech.with_streaming_response.create for streaming TTS.
+    """
+    client = openai.OpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "Testing streaming response for TTS."
+
+    with wrapped_client.audio.speech.with_streaming_response.create(
+        model=TTS_MODEL_FOR_TESTS,
+        voice=TTS_VOICE_FOR_TESTS,
+        input=input_text,
+    ) as response:
+        # Read the streamed content
+        content = response.read()
+        assert len(content) > 0
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+
+    EXPECTED_TRACE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio.speech.with_streaming_response.create",
+        input={"input": input_text, "voice": TTS_VOICE_FOR_TESTS},
+        output=ANY_DICT.containing({"status": "stream_initiated"}),
+        tags=["openai", "tts", "streaming"],
+        metadata=ANY_DICT.containing(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+                "streaming": True,
+                "input_characters": len(input_text),
+            }
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=OPIK_PROJECT_DEFAULT_NAME,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio.speech.with_streaming_response.create",
+                input={"input": input_text, "voice": TTS_VOICE_FOR_TESTS},
+                output=ANY_DICT.containing({"status": "stream_initiated"}),
+                tags=["openai", "tts", "streaming"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "openai",
+                        "type": "openai_tts",
+                        "streaming": True,
+                        "input_characters": len(input_text),
+                    }
+                ),
+                usage=None,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=OPIK_PROJECT_DEFAULT_NAME,
+                spans=[],
+                model=TTS_MODEL_FOR_TESTS,
+                provider="openai",
+            )
+        ],
+    )
+
+    trace_tree = fake_backend.trace_trees[0]
+    assert_equal(EXPECTED_TRACE, trace_tree)
+
+
+@pytest.mark.skipif(
+    SKIP_EXPENSIVE_TESTS,
+    reason="Expensive tests disabled. Set OPIK_TEST_EXPENSIVE=1 to enable.",
+)
+@pytest.mark.usefixtures("ensure_openai_configured")
+def test_openai_client_audio_speech__nested_in_tracked_function(fake_backend):
+    """
+    Test that TTS calls work correctly when nested inside other tracked functions.
+    """
+    client = openai.OpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    @opik.track(name="generate_audio_response")
+    def generate_audio_response(text: str) -> bytes:
+        response = wrapped_client.audio.speech.create(
+            model=TTS_MODEL_FOR_TESTS,
+            voice=TTS_VOICE_FOR_TESTS,
+            input=text,
+        )
+        return response.content
+
+    input_text = "This is nested inside a tracked function."
+    audio_content = generate_audio_response(input_text)
+
+    assert len(audio_content) > 0
+
+    opik.flush_tracker()
+
+    # Should have one trace with nested spans
+    assert len(fake_backend.trace_trees) == 1
+
+    trace_tree = fake_backend.trace_trees[0]
+    assert trace_tree.name == "generate_audio_response"
+
+    # The TTS call should be a child span
+    assert len(trace_tree.spans) == 1
+    parent_span = trace_tree.spans[0]
+    assert parent_span.name == "generate_audio_response"
+
+    # TTS span should be nested under the parent
+    assert len(parent_span.spans) == 1
+    tts_span = parent_span.spans[0]
+    assert tts_span.name == "audio.speech.create"
+    assert tts_span.model == TTS_MODEL_FOR_TESTS
+
+
+@pytest.mark.skipif(
+    SKIP_EXPENSIVE_TESTS,
+    reason="Expensive tests disabled. Set OPIK_TEST_EXPENSIVE=1 to enable.",
+)
+@pytest.mark.usefixtures("ensure_openai_configured")
+@pytest.mark.asyncio
+async def test_async_openai_client_audio_speech_create__happyflow(fake_backend):
+    """
+    Test async audio.speech.create method.
+    """
+    client = openai.AsyncOpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "Testing async TTS API."
+
+    response = await wrapped_client.audio.speech.create(
+        model=TTS_MODEL_FOR_TESTS,
+        voice=TTS_VOICE_FOR_TESTS,
+        input=input_text,
+    )
+
+    assert response.content is not None
+    assert len(response.content) > 0
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+
+    trace_tree = fake_backend.trace_trees[0]
+    assert trace_tree.name == "audio.speech.create"
+    assert trace_tree.spans[0].model == TTS_MODEL_FOR_TESTS
+    assert "tts" in trace_tree.tags
+
+
+# =============================================================================
+# Tests that do NOT require real OpenAI API calls (can run without credentials)
+# =============================================================================
+
+
+def test_openai_client_track_openai__already_tracked_client_not_patched_twice():
+    """
+    Test that calling track_openai twice on the same client doesn't double-patch.
+    """
+    # Use dummy api key to avoid needing real credentials
+    client = openai.OpenAI(api_key="dummy")
+
+    wrapped_client_1 = track_openai(openai_client=client)
+    wrapped_client_2 = track_openai(openai_client=wrapped_client_1)
+
+    # Should be the same object
+    assert wrapped_client_1 is wrapped_client_2
+
+
+def test_openai_client_audio_speech_has_expected_attributes():
+    """
+    Test that the OpenAI client has the expected audio.speech attributes.
+    """
+    # Use dummy api key to avoid needing real credentials
+    client = openai.OpenAI(api_key="dummy")
+    wrapped_client = track_openai(openai_client=client)
+
+    assert hasattr(wrapped_client, "audio")
+    assert hasattr(wrapped_client.audio, "speech")
+    assert hasattr(wrapped_client.audio.speech, "create")
+    assert hasattr(wrapped_client.audio.speech, "with_streaming_response")
+    assert hasattr(wrapped_client.audio.speech.with_streaming_response, "create")
+
+
+def test_openai_async_client_audio_speech_has_expected_attributes():
+    """
+    Test that the async OpenAI client has the expected audio.speech attributes.
+    """
+    # Use dummy api key to avoid needing real credentials
+    client = openai.AsyncOpenAI(api_key="dummy")
+    wrapped_client = track_openai(openai_client=client)
+
+    assert hasattr(wrapped_client, "audio")
+    assert hasattr(wrapped_client.audio, "speech")
+    assert hasattr(wrapped_client.audio.speech, "create")
+    assert hasattr(wrapped_client.audio.speech, "with_streaming_response")
+    assert hasattr(wrapped_client.audio.speech.with_streaming_response, "create")


### PR DESCRIPTION
# Add OpenAI TTS (Text-to-Speech) Tracking Support

## Summary

This PR adds tracking support for OpenAI's Text-to-Speech (TTS) API, addressing [#2202](https://github.com/comet-ml/opik/issues/2202).

## What's Implemented

### New Files
- `sdks/python/src/opik/integrations/openai/openai_tts_decorator.py` - Decorator classes for TTS tracking
- `sdks/python/tests/library_integration/openai/test_openai_tts.py` - Comprehensive test suite

### Modified Files
- `sdks/python/src/opik/integrations/openai/opik_tracker.py` - Added `_patch_openai_audio()` function
- `sdks/python/tests/library_integration/openai/constants.py` - Added TTS test constants

## Features

### Tracked Methods
- `openai_client.audio.speech.create()` - Standard TTS generation
- `openai_client.audio.speech.with_streaming_response.create()` - Streaming TTS

### Tracked Data
- **Input**: Text to convert, voice selection
- **Metadata**:
  - `created_from`: "openai"
  - `type`: "openai_tts"
  - `input_characters`: Character count for cost estimation
  - `response_format`: Audio format (mp3, opus, etc.)
  - `speed`: Playback speed
  - `streaming`: Boolean flag for streaming calls
- **Model**: tts-1, tts-1-hd, gpt-4o-mini-tts
- **Provider**: "openai" (or custom base URL host)
- **Tags**: ["openai", "tts"] (with "streaming" for streaming calls)

### Cost Tracking Note
OpenAI TTS doesn't return token usage like chat completions. Instead, pricing is based on character count:
- tts-1: $0.015 per 1,000 characters
- tts-1-hd: $0.030 per 1,000 characters
- gpt-4o-mini-tts: $0.012 per 1,000 characters

We track `input_characters` in metadata to enable cost calculation.

## Supported Clients
- ✅ `openai.OpenAI` (sync)
- ✅ `openai.AsyncOpenAI` (async)

## Example Usage

```python
import openai
from opik.integrations.openai import track_openai

client = openai.OpenAI()
wrapped_client = track_openai(client)

# Standard TTS
response = wrapped_client.audio.speech.create(
    model="tts-1",
    voice="alloy",
    input="Hello, world!",
)
response.write_to_file("output.mp3")

# Streaming TTS
with wrapped_client.audio.speech.with_streaming_response.create(
    model="tts-1",
    voice="alloy",
    input="Hello, world!",
) as response:
    content = response.read()
```

## Tests

The test suite includes:
- ✅ Happy flow for `audio.speech.create()`
- ✅ Custom project name handling
- ✅ Optional parameters (response_format, speed)
- ✅ File writing functionality
- ✅ Streaming response support
- ✅ Nested tracking within `@opik.track` functions
- ✅ Async client support
- ✅ Double-patching prevention
- ✅ Attribute existence verification

Tests that require real API calls are marked with `@pytest.mark.skipif(SKIP_EXPENSIVE_TESTS, ...)` and can be enabled with `OPIK_TEST_EXPENSIVE=1`.

## How to Test

```bash
cd sdks/python

# Run non-API tests (always work)
pytest tests/library_integration/openai/test_openai_tts.py -v -k "not expensive"

# Run all tests including API calls (requires OPENAI_API_KEY)
OPIK_TEST_EXPENSIVE=1 pytest tests/library_integration/openai/test_openai_tts.py -v
```

## Checklist

- [x] Added new decorator following existing patterns (similar to videos decorator)
- [x] Updated `track_openai()` to patch audio.speech methods
- [x] Added comprehensive tests
- [x] Supports both sync and async clients
- [x] Tracks character count for cost estimation
- [x] Follows existing code style and patterns

Closes #2202
