### PR TITLE
[OPIK-3718] [FE] Remove underline from Name and ID columns

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/experiments/useExperimentsTableConfig.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/experiments/useExperimentsTableConfig.tsx
@@ -45,7 +45,7 @@ import {
 } from "@/components/shared/DataTable/utils";
 import { useDynamicColumnsCache } from "@/hooks/useDynamicColumnsCache";
 import { DELETED_ENTITY_LABEL, GROUPING_KEY } from "@/constants/groups";
-import { ExperimentsAggregations } from "@/types/datasets";
+import { Experiment, ExperimentsAggregations } from "@/types/datasets";
 
 export type UseExperimentsTableConfigProps<T> = {
   storageKeyPrefix: string;
@@ -294,7 +294,21 @@ export const useExperimentsTableConfig = <
 
     const firstColumn =
       hasGrouping && nameColumn
-        ? generateDataRowCellDef<T>(nameColumn, checkboxClickHandler)
+        ? generateDataRowCellDef<T>(
+            {
+              ...nameColumn,
+              cell: ResourceCell as never,
+              customMeta: {
+                nameKey: "name",
+                idKey: "dataset_id",
+                resource: RESOURCE_TYPE.experiment,
+                getSearch: (data: Experiment) => ({
+                  experiments: [data.id],
+                }),
+              },
+            },
+            checkboxClickHandler,
+          )
         : generateSelectColumDef<T>();
 
     const regularColumns = convertColumnDataToColumn<T, T>(

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
@@ -29,11 +29,7 @@ import {
 import { Thread } from "@/types/traces";
 import { ThreadStatus } from "@/types/thread";
 import { AnnotationQueue } from "@/types/annotation-queues";
-import {
-  convertColumnDataToColumn,
-  injectColumnCallback,
-  migrateSelectedColumns,
-} from "@/lib/table";
+import { convertColumnDataToColumn, migrateSelectedColumns } from "@/lib/table";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import {
   generateActionsColumDef,
@@ -50,7 +46,7 @@ import DataTable from "@/components/shared/DataTable/DataTable";
 import DataTableNoData from "@/components/shared/DataTableNoData/DataTableNoData";
 import DataTablePagination from "@/components/shared/DataTablePagination/DataTablePagination";
 import NoDataPage from "@/components/shared/NoDataPage/NoDataPage";
-import LinkCell from "@/components/shared/DataTableCells/LinkCell";
+import IdCell from "@/components/shared/DataTableCells/IdCell";
 import PrettyCell from "@/components/shared/DataTableCells/PrettyCell";
 import DurationCell from "@/components/shared/DataTableCells/DurationCell";
 import CostCell from "@/components/shared/DataTableCells/CostCell";
@@ -154,10 +150,7 @@ const DEFAULT_COLUMNS: ColumnData<Thread>[] = [
     id: COLUMN_ID_ID,
     label: "ID",
     type: COLUMN_TYPE.string,
-    cell: LinkCell as never,
-    customMeta: {
-      asId: true,
-    },
+    cell: IdCell as never,
     sortable: true,
   },
   ...SHARED_COLUMNS,
@@ -434,7 +427,7 @@ const ThreadQueueItemsTab: React.FunctionComponent<
 
     return [
       generateSelectColumDef<Thread>(),
-      ...injectColumnCallback(convertedColumns, COLUMN_ID_ID, handleRowClick),
+      ...convertedColumns,
       ...convertColumnDataToColumn<Thread, Thread>(scoresColumnsData, {
         columnsOrder: scoresColumnsOrder,
         selectedColumns,
@@ -448,7 +441,6 @@ const ThreadQueueItemsTab: React.FunctionComponent<
       }),
     ];
   }, [
-    handleRowClick,
     sortableBy,
     columnsOrder,
     selectedColumns,

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
@@ -52,6 +52,7 @@ import DataTable from "@/components/shared/DataTable/DataTable";
 import DataTableNoData from "@/components/shared/DataTableNoData/DataTableNoData";
 import DataTablePagination from "@/components/shared/DataTablePagination/DataTablePagination";
 import NoDataPage from "@/components/shared/NoDataPage/NoDataPage";
+import IdCell from "@/components/shared/DataTableCells/IdCell";
 import LinkCell from "@/components/shared/DataTableCells/LinkCell";
 import CodeCell from "@/components/shared/DataTableCells/CodeCell";
 import ListCell from "@/components/shared/DataTableCells/ListCell";
@@ -84,10 +85,7 @@ const TRACE_COLUMNS: ColumnData<Trace>[] = [
     id: COLUMN_ID_ID,
     label: "ID",
     type: COLUMN_TYPE.string,
-    cell: LinkCell as never,
-    customMeta: {
-      asId: true,
-    },
+    cell: IdCell as never,
     sortable: true,
   },
   {
@@ -467,6 +465,21 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
     [workspaceName, annotationQueue.project_id],
   );
 
+  const handleThreadIdClick = useCallback(
+    (row: Trace) => {
+      if (!row || !row.thread_id) return;
+
+      const url = generateTracesURL(
+        workspaceName,
+        annotationQueue.project_id,
+        "threads",
+        row.thread_id,
+      );
+      window.open(url, "_blank");
+    },
+    [workspaceName, annotationQueue.project_id],
+  );
+
   const columns = useMemo(() => {
     const convertedColumns = convertColumnDataToColumn<Trace, Trace>(
       TRACE_COLUMNS,
@@ -479,7 +492,11 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
 
     return [
       generateSelectColumDef<Trace>(),
-      ...injectColumnCallback(convertedColumns, COLUMN_ID_ID, handleRowClick),
+      ...injectColumnCallback(
+        convertedColumns,
+        "thread_id",
+        handleThreadIdClick,
+      ),
       ...convertColumnDataToColumn<Trace, Trace>(scoresColumnsData, {
         columnsOrder: scoresColumnsOrder,
         selectedColumns,
@@ -499,7 +516,7 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
     scoresColumnsData,
     scoresColumnsOrder,
     annotationQueue.id,
-    handleRowClick,
+    handleThreadIdClick,
   ]);
 
   const sortConfig = useMemo(

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuesPage/AnnotationQueuesPage.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuesPage/AnnotationQueuesPage.tsx
@@ -29,6 +29,7 @@ import SearchInput from "@/components/shared/SearchInput/SearchInput";
 import FeedbackScoreListCell from "@/components/shared/DataTableCells/FeedbackScoreListCell";
 import IdCell from "@/components/shared/DataTableCells/IdCell";
 import ListCell from "@/components/shared/DataTableCells/ListCell";
+import TextCell from "@/components/shared/DataTableCells/TextCell";
 import ResourceCell from "@/components/shared/DataTableCells/ResourceCell";
 import TagCell from "@/components/shared/DataTableCells/TagCell";
 import AnnotateQueueCell from "@/components/pages-shared/annotation-queues/AnnotateQueueCell";
@@ -130,13 +131,8 @@ const DEFAULT_COLUMNS: ColumnData<AnnotationQueue>[] = [
     id: COLUMN_NAME_ID,
     label: "Name",
     type: COLUMN_TYPE.string,
-    cell: ResourceCell as never,
+    cell: TextCell as never,
     sortable: true,
-    customMeta: {
-      nameKey: "name",
-      idKey: "id",
-      resource: RESOURCE_TYPE.annotationQueue,
-    },
   },
   ...SHARED_COLUMNS,
   {

--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -46,7 +46,7 @@ import DataTablePagination from "@/components/shared/DataTablePagination/DataTab
 import DataTableNoData from "@/components/shared/DataTableNoData/DataTableNoData";
 import DataTableRowHeightSelector from "@/components/shared/DataTableRowHeightSelector/DataTableRowHeightSelector";
 import SearchInput from "@/components/shared/SearchInput/SearchInput";
-import LinkCell from "@/components/shared/DataTableCells/LinkCell";
+import IdCell from "@/components/shared/DataTableCells/IdCell";
 import AutodetectCell from "@/components/shared/DataTableCells/AutodetectCell";
 import CompareExperimentsOutputCell from "@/components/pages-shared/experiments/CompareExperimentsOutputCell/CompareExperimentsOutputCell";
 import CompareExperimentsFeedbackScoreCell from "@/components/pages-shared/experiments/CompareExperimentsFeedbackScoreCell/CompareExperimentsFeedbackScoreCell";
@@ -576,12 +576,8 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         id: COLUMN_ID_ID,
         label: "ID (Dataset item)",
         type: COLUMN_TYPE.string,
-        cell: LinkCell as never,
+        cell: IdCell as never,
         verticalAlignment: calculateVerticalAlignment(experimentsCount),
-        customMeta: {
-          callback: handleRowClick,
-          asId: true,
-        },
         size: 180,
         sortable: isColumnSortable(COLUMN_ID_ID, sortableColumns),
         explainer: EXPLAINERS_MAP[EXPLAINER_ID.whats_the_dataset_item],
@@ -681,7 +677,6 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
     return retVal;
   }, [
     experimentsCount,
-    handleRowClick,
     datasetColumnsData,
     selectedColumns,
     outputColumnsData,

--- a/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsPage.tsx
@@ -49,7 +49,6 @@ const CompareOptimizationsPage: React.FC = () => {
 
   const { columnsDef, columns } = useCompareOptimizationsColumns({
     optimization,
-    optimizationId,
     scoreMap,
     columnsOrder,
     selectedColumns,

--- a/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/useCompareOptimizationsColumns.ts
+++ b/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/useCompareOptimizationsColumns.ts
@@ -20,10 +20,9 @@ import { formatDate } from "@/lib/date";
 import { toString } from "@/lib/utils";
 import { convertColumnDataToColumn } from "@/lib/table";
 import IdCell from "@/components/shared/DataTableCells/IdCell";
-import ResourceCell from "@/components/shared/DataTableCells/ResourceCell";
+import TextCell from "@/components/shared/DataTableCells/TextCell";
 import ObjectiveScoreCell from "@/components/pages/CompareOptimizationsPage/ObjectiveScoreCell";
 import FeedbackScoreHeader from "@/components/shared/DataTableHeaders/FeedbackScoreHeader";
-import { RESOURCE_TYPE } from "@/components/shared/ResourceLink/ResourceLink";
 
 type ScoreData = {
   score: number;
@@ -32,7 +31,6 @@ type ScoreData = {
 
 type UseCompareOptimizationsColumnsParams = {
   optimization: Optimization | undefined;
-  optimizationId: string;
   scoreMap: Record<string, ScoreData>;
   columnsOrder: string[];
   selectedColumns: string[];
@@ -41,7 +39,6 @@ type UseCompareOptimizationsColumnsParams = {
 
 export const useCompareOptimizationsColumns = ({
   optimization,
-  optimizationId,
   scoreMap,
   columnsOrder,
   selectedColumns,
@@ -55,19 +52,8 @@ export const useCompareOptimizationsColumns = ({
         id: COLUMN_NAME_ID,
         label: "Trial",
         type: COLUMN_TYPE.string,
-        cell: ResourceCell as never,
+        cell: TextCell as never,
         sortable: true,
-        customMeta: {
-          nameKey: "name",
-          idKey: "dataset_id",
-          resource: RESOURCE_TYPE.trial,
-          getParams: () => ({
-            optimizationId,
-          }),
-          getSearch: (data: Experiment) => ({
-            trials: [data.id],
-          }),
-        },
       },
       {
         id: COLUMN_ID_ID,
@@ -142,7 +128,6 @@ export const useCompareOptimizationsColumns = ({
     optimization?.objective_name,
     scoreMap,
     optimization?.studio_config?.optimizer?.type,
-    optimizationId,
   ]);
 
   const columns = useMemo(() => {

--- a/apps/opik-frontend/src/components/pages/DashboardsPage/DashboardsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DashboardsPage/DashboardsPage.tsx
@@ -14,7 +14,7 @@ import DataTable from "@/components/shared/DataTable/DataTable";
 import DataTableNoData from "@/components/shared/DataTableNoData/DataTableNoData";
 import DataTablePagination from "@/components/shared/DataTablePagination/DataTablePagination";
 import IdCell from "@/components/shared/DataTableCells/IdCell";
-import ResourceCell from "@/components/shared/DataTableCells/ResourceCell";
+import TextCell from "@/components/shared/DataTableCells/TextCell";
 import useDashboardsList from "@/api/dashboards/useDashboardsList";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import { Dashboard } from "@/types/dashboard";
@@ -43,7 +43,6 @@ import {
   generateSelectColumDef,
   getRowId,
 } from "@/components/shared/DataTable/utils";
-import { RESOURCE_TYPE } from "@/components/shared/ResourceLink/ResourceLink";
 
 const SELECTED_COLUMNS_KEY = "dashboards-selected-columns";
 const SELECTED_COLUMNS_KEY_V2 = `${SELECTED_COLUMNS_KEY}-v2`;
@@ -74,13 +73,8 @@ const DashboardsPage: React.FunctionComponent = () => {
         id: COLUMN_NAME_ID,
         label: "Name",
         type: COLUMN_TYPE.string,
-        cell: ResourceCell as never,
+        cell: TextCell as never,
         sortable: true,
-        customMeta: {
-          nameKey: "name",
-          idKey: "id",
-          resource: RESOURCE_TYPE.dashboard,
-        },
       },
       {
         id: "id",

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsTab/DatasetItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsTab/DatasetItemsTab.tsx
@@ -51,7 +51,7 @@ import { convertColumnDataToColumn, injectColumnCallback } from "@/lib/table";
 import { buildDocsUrl } from "@/lib/utils";
 import DataTableNoData from "@/components/shared/DataTableNoData/DataTableNoData";
 import AutodetectCell from "@/components/shared/DataTableCells/AutodetectCell";
-import LinkCell from "@/components/shared/DataTableCells/LinkCell";
+import IdCell from "@/components/shared/DataTableCells/IdCell";
 import ListCell from "@/components/shared/DataTableCells/ListCell";
 import { formatDate } from "@/lib/date";
 import { mapDynamicColumnTypesToColumnType } from "@/lib/filters";
@@ -358,10 +358,7 @@ const DatasetItemsTab: React.FC<DatasetItemsTabProps> = ({
         id: COLUMN_ID_ID,
         label: "ID",
         type: COLUMN_TYPE.string,
-        cell: LinkCell as never,
-        customMeta: {
-          asId: true,
-        },
+        cell: IdCell as never,
       },
       ...dynamicDatasetColumns.map(
         ({ label, id, columnType }) =>

--- a/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetsPage.tsx
@@ -13,7 +13,7 @@ import DataTable from "@/components/shared/DataTable/DataTable";
 import DataTablePagination from "@/components/shared/DataTablePagination/DataTablePagination";
 import DataTableNoData from "@/components/shared/DataTableNoData/DataTableNoData";
 import IdCell from "@/components/shared/DataTableCells/IdCell";
-import ResourceCell from "@/components/shared/DataTableCells/ResourceCell";
+import TextCell from "@/components/shared/DataTableCells/TextCell";
 import ListCell from "@/components/shared/DataTableCells/ListCell";
 import useDatasetsList from "@/api/datasets/useDatasetsList";
 import { Dataset } from "@/types/datasets";
@@ -39,7 +39,6 @@ import {
   generateActionsColumDef,
   generateSelectColumDef,
 } from "@/components/shared/DataTable/utils";
-import { RESOURCE_TYPE } from "@/components/shared/ResourceLink/ResourceLink";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
 import ExplainerDescription from "@/components/shared/ExplainerDescription/ExplainerDescription";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
@@ -58,12 +57,7 @@ export const DEFAULT_COLUMNS: ColumnData<Dataset>[] = [
     id: COLUMN_NAME_ID,
     label: "Name",
     type: COLUMN_TYPE.string,
-    cell: ResourceCell as never,
-    customMeta: {
-      nameKey: "name",
-      idKey: "id",
-      resource: RESOURCE_TYPE.dataset,
-    },
+    cell: TextCell as never,
   },
   {
     id: "id",

--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
@@ -54,7 +54,6 @@ import { Card } from "@/components/ui/card";
 import useGroupedExperimentsList, {
   GroupedExperiment,
 } from "@/hooks/useGroupedExperimentsList";
-import { Experiment } from "@/types/datasets";
 import { useExperimentsTableConfig } from "@/components/pages-shared/experiments/useExperimentsTableConfig";
 import {
   FILTER_AND_GROUP_COLUMNS,
@@ -160,16 +159,8 @@ const ExperimentsPage: React.FC = () => {
         id: COLUMN_NAME_ID,
         label: "Name",
         type: COLUMN_TYPE.string,
-        cell: ResourceCell as never,
+        cell: TextCell as never,
         sortable: true,
-        customMeta: {
-          nameKey: "name",
-          idKey: "dataset_id",
-          resource: RESOURCE_TYPE.experiment,
-          getSearch: (data: Experiment) => ({
-            experiments: [data.id],
-          }),
-        },
         size: 200,
       },
       {

--- a/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
@@ -17,7 +17,7 @@ import DataTablePagination from "@/components/shared/DataTablePagination/DataTab
 import IdCell from "@/components/shared/DataTableCells/IdCell";
 import DurationCell from "@/components/shared/DataTableCells/DurationCell";
 import CostCell from "@/components/shared/DataTableCells/CostCell";
-import ResourceCell from "@/components/shared/DataTableCells/ResourceCell";
+import TextCell from "@/components/shared/DataTableCells/TextCell";
 import useProjectWithStatisticsList from "@/hooks/useProjectWithStatisticsList";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import { ProjectWithStatistic } from "@/types/projects";
@@ -47,7 +47,6 @@ import {
   generateActionsColumDef,
   generateSelectColumDef,
 } from "@/components/shared/DataTable/utils";
-import { RESOURCE_TYPE } from "@/components/shared/ResourceLink/ResourceLink";
 import FeedbackScoreListCell from "@/components/shared/DataTableCells/FeedbackScoreListCell";
 import { useIsFeatureEnabled } from "@/components/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
@@ -98,13 +97,8 @@ const ProjectsPage: React.FunctionComponent = () => {
         id: COLUMN_NAME_ID,
         label: "Name",
         type: COLUMN_TYPE.string,
-        cell: ResourceCell as never,
+        cell: TextCell as never,
         sortable: true,
-        customMeta: {
-          nameKey: "name",
-          idKey: "id",
-          resource: RESOURCE_TYPE.project,
-        },
       },
       {
         id: "id",

--- a/apps/opik-frontend/src/components/pages/PromptsPage/PromptsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptsPage/PromptsPage.tsx
@@ -6,7 +6,7 @@ import DataTable from "@/components/shared/DataTable/DataTable";
 import DataTablePagination from "@/components/shared/DataTablePagination/DataTablePagination";
 import DataTableNoData from "@/components/shared/DataTableNoData/DataTableNoData";
 import IdCell from "@/components/shared/DataTableCells/IdCell";
-import ResourceCell from "@/components/shared/DataTableCells/ResourceCell";
+import TextCell from "@/components/shared/DataTableCells/TextCell";
 import ListCell from "@/components/shared/DataTableCells/ListCell";
 import Loader from "@/components/shared/Loader/Loader";
 import { Button } from "@/components/ui/button";
@@ -38,7 +38,6 @@ import {
   ColumnSort,
   RowSelectionState,
 } from "@tanstack/react-table";
-import { RESOURCE_TYPE } from "@/components/shared/ResourceLink/ResourceLink";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
 import ExplainerDescription from "@/components/shared/ExplainerDescription/ExplainerDescription";
 import { JsonParam, StringParam, useQueryParam } from "use-query-params";
@@ -58,13 +57,8 @@ export const DEFAULT_COLUMNS: ColumnData<Prompt>[] = [
     id: COLUMN_NAME_ID,
     label: "Name",
     type: COLUMN_TYPE.string,
-    cell: ResourceCell as never,
+    cell: TextCell as never,
     sortable: true,
-    customMeta: {
-      nameKey: "name",
-      idKey: "id",
-      resource: RESOURCE_TYPE.prompt,
-    },
   },
   {
     id: "id",

--- a/apps/opik-frontend/src/components/pages/TracesPage/AnnotationQueuesTab/AnnotationQueuesTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/AnnotationQueuesTab/AnnotationQueuesTab.tsx
@@ -29,7 +29,7 @@ import SearchInput from "@/components/shared/SearchInput/SearchInput";
 import FeedbackScoreListCell from "@/components/shared/DataTableCells/FeedbackScoreListCell";
 import IdCell from "@/components/shared/DataTableCells/IdCell";
 import ListCell from "@/components/shared/DataTableCells/ListCell";
-import ResourceCell from "@/components/shared/DataTableCells/ResourceCell";
+import TextCell from "@/components/shared/DataTableCells/TextCell";
 import TagCell from "@/components/shared/DataTableCells/TagCell";
 import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
 import PageBodyStickyTableWrapper from "@/components/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
@@ -42,7 +42,6 @@ import ExplainerCallout from "@/components/shared/ExplainerCallout/ExplainerCall
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
 import NoDataPage from "@/components/shared/NoDataPage/NoDataPage";
 import NoAnnotationQueuesPage from "@/components/pages-shared/annotation-queues/NoAnnotationQueuesPage";
-import { RESOURCE_TYPE } from "@/components/shared/ResourceLink/ResourceLink";
 
 import { convertColumnDataToColumn, migrateSelectedColumns } from "@/lib/table";
 import { formatDate } from "@/lib/date";
@@ -114,13 +113,8 @@ const DEFAULT_COLUMNS: ColumnData<AnnotationQueue>[] = [
     id: COLUMN_NAME_ID,
     label: "Name",
     type: COLUMN_TYPE.string,
-    cell: ResourceCell as never,
+    cell: TextCell as never,
     sortable: true,
-    customMeta: {
-      nameKey: "name",
-      idKey: "id",
-      resource: RESOURCE_TYPE.annotationQueue,
-    },
   },
   ...SHARED_COLUMNS,
   {

--- a/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsTab.tsx
@@ -53,7 +53,7 @@ import ColumnsButton from "@/components/shared/ColumnsButton/ColumnsButton";
 import DataTable from "@/components/shared/DataTable/DataTable";
 import DataTableNoData from "@/components/shared/DataTableNoData/DataTableNoData";
 import DataTablePagination from "@/components/shared/DataTablePagination/DataTablePagination";
-import LinkCell from "@/components/shared/DataTableCells/LinkCell";
+import IdCell from "@/components/shared/DataTableCells/IdCell";
 import DurationCell from "@/components/shared/DataTableCells/DurationCell";
 import PrettyCell from "@/components/shared/DataTableCells/PrettyCell";
 import CostCell from "@/components/shared/DataTableCells/CostCell";
@@ -166,10 +166,7 @@ const DEFAULT_COLUMNS: ColumnData<Thread>[] = [
     id: COLUMN_ID_ID,
     label: "ID",
     type: COLUMN_TYPE.string,
-    cell: LinkCell as never,
-    customMeta: {
-      asId: true,
-    },
+    cell: IdCell as never,
     sortable: true,
   },
   ...SHARED_COLUMNS,
@@ -251,6 +248,7 @@ const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
 
 const DEFAULT_SELECTED_COLUMNS: string[] = [
   COLUMN_ID_ID,
+  "start_time",
   "first_message",
   "last_message",
   "number_of_messages",
@@ -506,7 +504,7 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
       defaultValue: migrateSelectedColumns(
         SELECTED_COLUMNS_KEY,
         DEFAULT_SELECTED_COLUMNS,
-        [COLUMN_ID_ID],
+        [COLUMN_ID_ID, "start_time"],
       ),
     },
   );

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
@@ -71,6 +71,7 @@ import DataTablePagination from "@/components/shared/DataTablePagination/DataTab
 import LinkCell from "@/components/shared/DataTableCells/LinkCell";
 import ResourceCell from "@/components/shared/DataTableCells/ResourceCell";
 import { RESOURCE_TYPE } from "@/components/shared/ResourceLink/ResourceLink";
+import IdCell from "@/components/shared/DataTableCells/IdCell";
 import CodeCell from "@/components/shared/DataTableCells/CodeCell";
 import AutodetectCell from "@/components/shared/DataTableCells/AutodetectCell";
 import ListCell from "@/components/shared/DataTableCells/ListCell";
@@ -231,6 +232,7 @@ const DEFAULT_TRACES_COLUMN_PINNING: ColumnPinningState = {
 const DEFAULT_TRACES_PAGE_COLUMNS: string[] = [
   COLUMN_ID_ID,
   "name",
+  "start_time",
   "input",
   "output",
   "duration",
@@ -464,7 +466,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
       defaultValue: migrateSelectedColumns(
         SELECTED_COLUMNS_KEY,
         DEFAULT_TRACES_PAGE_COLUMNS,
-        [COLUMN_ID_ID],
+        [COLUMN_ID_ID, "start_time"],
       ),
     },
   );
@@ -851,11 +853,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
         id: COLUMN_ID_ID,
         label: "ID",
         type: COLUMN_TYPE.string,
-        cell: LinkCell as never,
-        customMeta: {
-          callback: handleRowClick,
-          asId: true,
-        },
+        cell: IdCell as never,
         sortable: true,
       },
       ...SHARED_COLUMNS,
@@ -946,7 +944,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
         : []),
       // Note: metadataColumnsData is NOT added here - it goes in columnSections instead
     ];
-  }, [type, handleRowClick, handleThreadIdClick, isGuardrailsEnabled]);
+  }, [type, handleThreadIdClick, isGuardrailsEnabled]);
 
   const filtersColumnData = useMemo(() => {
     return [


### PR DESCRIPTION
## Details

This PR removes redundant underline/bold links from ID/Name columns where the entire row is already clickable, improving UI consistency and reducing visual clutter.

### Changes Made

**Removed redundant underline/bold links from ID/Name columns** (duplicated row navigation):
- **Dashboards, Projects, Datasets, Prompts**: Name → plain text
- **Dataset items, Experiment items**: ID → plain text
- **Annotation queues** (2 locations), **Thread/Trace queue items**: Name/ID → plain text
- **Optimization trials**: Trial → plain text
- **Experiments** (grouped): Name column uses link
- **Optimizations**: Name column uses link for data rows

**Made rows clickable**:
- Prompt experiments table → navigate to experiment compare page
- Prompt commits table → navigate to prompt with selected version

**Fixed bugs**:
- Fixed `thread_id` link in trace queue items (was non-functional)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3718
- Depends on #4950 

## Testing
- Manually tested all affected tables to ensure:
  - Row click navigation works correctly
  - Plain text styling is applied to Name/ID columns
  - No broken links or navigation issues
  - Fixed thread_id link navigates correctly

## Documentation
No documentation updates required - UI-only change.