### PR TITLE
[OPIK-4009] [FE] Center checkboxes in select column

### DIFF
--- a/apps/opik-frontend/src/components/shared/DataTable/utils.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTable/utils.tsx
@@ -189,7 +189,7 @@ export const generateSelectColumDef = <TData,>(meta?: {
         metadata={context.column.columnDef.meta}
         tableMetadata={context.table.options.meta}
         supportStatistic={false}
-        className="ml-[calc(var(--cell-left-padding)/-4)] justify-center"
+        className="justify-center !px-0"
       >
         <Checkbox
           onClick={(event) => event.stopPropagation()}
@@ -214,10 +214,7 @@ export const generateSelectColumDef = <TData,>(meta?: {
         <CellWrapper
           metadata={context.column.columnDef.meta}
           tableMetadata={context.table.options.meta}
-          className={cn(
-            "ml-[calc(var(--cell-left-padding)/-4)] justify-center py-3.5",
-            additionalClassName,
-          )}
+          className={cn("justify-center py-3.5 !px-0", additionalClassName)}
           stopClickPropagation
         >
           <Checkbox

--- a/apps/opik-frontend/src/components/ui/table.tsx
+++ b/apps/opik-frontend/src/components/ui/table.tsx
@@ -76,7 +76,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "relative p-0 text-left align-middle font-medium text-light-slate [&:has([role=checkbox])]:pr-0 [&:last-child_[data-header-wrapper=true]]:pr-5",
+      "relative p-0 text-left align-middle font-medium text-light-slate [&:has([role=checkbox])]:pr-0 [&:first-child_[data-header-wrapper=true]]:pl-5 [&:last-child_[data-header-wrapper=true]]:pr-5",
       className,
     )}
     {...props}
@@ -91,7 +91,7 @@ const TableCell = React.forwardRef<
   <td
     ref={ref}
     className={cn(
-      "comet-fix-cell-height relative p-0 align-middle [&:has([role=checkbox])]:pr-0 [&:last-child_[data-cell-wrapper=true]]:pr-5 group-hover/row:bg-primary-foreground",
+      "comet-fix-cell-height relative p-0 align-middle [&:has([role=checkbox])]:pr-0 [&:first-child_[data-cell-wrapper=true]]:pl-5 [&:last-child_[data-cell-wrapper=true]]:pr-5 group-hover/row:bg-primary-foreground",
       className,
     )}
     {...props}

--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -577,12 +577,6 @@
   }
 }
 
-td:first-child [data-cell-wrapper="true"],
-th:first-child [data-header-wrapper="true"] {
-  --cell-left-padding: 20px;
-  padding-left: var(--cell-left-padding);
-}
-
 // rewrite padding for first cell for tables that takes full width with sticky behaviour
 .comet-sticky-table {
   thead:before {
@@ -609,12 +603,12 @@ th:first-child [data-header-wrapper="true"] {
 
   td:first-child [data-cell-wrapper="true"],
   th:first-child [data-header-wrapper="true"] {
-    padding-left: 24px !important;
+    padding-left: 24px;
   }
 
   td:last-child [data-cell-wrapper="true"],
   th:last-child [data-header-wrapper="true"] {
-    padding-right: 24px !important;
+    padding-right: 24px;
   }
 }
 


### PR DESCRIPTION
## Details

This PR centers the checkboxes in the select column across all tables for better visual alignment and consistency.

### Changes Made

- Centered checkbox alignment in select column header and cells
- Updated table cell styling to properly center checkbox content
- Applied consistent styling across all data tables

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-4009
- Depends on #5020 (OPIK-3718)

## Testing
- Manually verified checkbox alignment in:
  - Experiments tables
  - Optimizations tables
  - All other tables with selectable rows
- Tested checkbox selection functionality remains unchanged

## Documentation
No documentation updates required - UI-only styling change.