### PR TITLE
[OPIK-4159] [FE] Fix feedback definition dialog scroll issue

### DIFF
--- a/apps/opik-frontend/src/components/shared/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.tsx
+++ b/apps/opik-frontend/src/components/shared/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.tsx
@@ -7,6 +7,7 @@ import SelectBox from "@/components/shared/SelectBox/SelectBox";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogAutoScrollBody,
   DialogClose,
   DialogContent,
   DialogFooter,
@@ -149,55 +150,57 @@ const AddEditFeedbackDefinitionDialog: React.FunctionComponent<
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
-        {isEdit && (
-          <ExplainerCallout
-            Icon={MessageCircleWarning}
-            className="mb-2"
-            isDismissable={false}
-            {...EXPLAINERS_MAP[
-              EXPLAINER_ID.what_happens_if_i_edit_a_feedback_definition
-            ]}
-          />
-        )}
-        <div className="flex flex-col gap-2 pb-4">
-          <Label htmlFor="feedbackDefinitionName">Name</Label>
-          <Input
-            id="feedbackDefinitionName"
-            placeholder="Feedback definition name"
-            value={name}
-            onChange={(event) => setName(event.target.value)}
-          />
-        </div>
-        <div className="flex flex-col gap-2 pb-4">
-          <Label htmlFor="feedbackDefinitionDescription">Description</Label>
-          <Textarea
-            id="feedbackDefinitionDescription"
-            placeholder="Feedback definition description"
-            className="min-h-20"
-            value={description}
-            onChange={(event) => setDescription(event.target.value)}
-            maxLength={255}
-          />
-        </div>
-        <div className="flex flex-col gap-2 pb-4">
-          <Label htmlFor="feedbackDefinitionType">Type</Label>
-          <SelectBox
-            id="feedbackDefinitionType"
-            value={type}
-            onChange={(type) => {
-              setDetails(undefined);
-              setType(type as CreateFeedbackDefinition["type"]);
-            }}
-            options={TYPE_OPTIONS}
-          />
-        </div>
-        <div className="flex max-h-[400px] flex-col gap-4 overflow-y-auto">
-          <FeedbackDefinitionDetails
-            onChange={setDetails}
-            type={type}
-            details={details}
-          />
-        </div>
+        <DialogAutoScrollBody>
+          {isEdit && (
+            <ExplainerCallout
+              Icon={MessageCircleWarning}
+              className="mb-2"
+              isDismissable={false}
+              {...EXPLAINERS_MAP[
+                EXPLAINER_ID.what_happens_if_i_edit_a_feedback_definition
+              ]}
+            />
+          )}
+          <div className="flex flex-col gap-2 pb-4">
+            <Label htmlFor="feedbackDefinitionName">Name</Label>
+            <Input
+              id="feedbackDefinitionName"
+              placeholder="Feedback definition name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+            />
+          </div>
+          <div className="flex flex-col gap-2 pb-4">
+            <Label htmlFor="feedbackDefinitionDescription">Description</Label>
+            <Textarea
+              id="feedbackDefinitionDescription"
+              placeholder="Feedback definition description"
+              className="min-h-20"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              maxLength={255}
+            />
+          </div>
+          <div className="flex flex-col gap-2 pb-4">
+            <Label htmlFor="feedbackDefinitionType">Type</Label>
+            <SelectBox
+              id="feedbackDefinitionType"
+              value={type}
+              onChange={(type) => {
+                setDetails(undefined);
+                setType(type as CreateFeedbackDefinition["type"]);
+              }}
+              options={TYPE_OPTIONS}
+            />
+          </div>
+          <div className="flex flex-col gap-4">
+            <FeedbackDefinitionDetails
+              onChange={setDetails}
+              type={type}
+              details={details}
+            />
+          </div>
+        </DialogAutoScrollBody>
         <DialogFooter>
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>


### PR DESCRIPTION
## Details

Fixed the scroll issue in the feedback definition dialog where users couldn't scroll to the bottom buttons when adding many categories.

**Root cause:** The dialog used a hardcoded `max-h-[400px] overflow-y-auto` wrapper that didn't properly handle scrolling when content exceeded viewport height.

**Solution:** Replaced the hardcoded scroll container with `DialogAutoScrollBody`, which:
- Dynamically calculates available height based on viewport, header, and footer
- Ensures footer buttons always remain visible
- Adds visual indicators (borders) when scrolling is active
- Follows the established pattern used in other dialogs (AddEditAnnotationQueueDialog, SetupProviderDialog, etc.)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-4159

## Testing

1. Navigate to Configuration > Feedback Definitions
2. Click "Create new feedback definition"
3. Select "Categorical" type
4. Add 10+ categories using "Add category" button
5. Verify you can scroll the dialog content
6. Verify the Cancel/Create buttons remain accessible at all times

## Documentation

N/A - No documentation changes required