### PR TITLE
[NA] [SDK] Skip flaky OpenAI ADK test

### DIFF
--- a/sdks/python/tests/e2e_library_integration/adk/test_opik_tracer.py
+++ b/sdks/python/tests/e2e_library_integration/adk/test_opik_tracer.py
@@ -207,6 +207,9 @@ def test_opik_tracer_with_sample_agent_sse(
     )
 
 
+@pytest.mark.skip(
+    reason="Skipping due to flakiness with OpenAI API calls. Re-enable once https://github.com/google/adk-python/pull/4303 is merged."
+)
 @pytest.mark.parametrize("start_api_server", ["sample_agent_openai"], indirect=True)
 def test_opik_tracer_with_sample_agent__openai(
     opik_client_unique_project_name, start_api_server


### PR DESCRIPTION
## Details

Skip flaky test `test_opik_tracer_with_sample_agent__openai` in the ADK e2e integration tests due to flakiness with OpenAI API calls. The test will be re-enabled once the upstream fix in google/adk-python#4303 is merged.

## Change checklist
<!-- Please check the type of changes made -->
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## Testing

The test is temporarily skipped using `@pytest.mark.skip` decorator. Once the upstream ADK Python library fix (https://github.com/google/adk-python/pull/4303) is merged, this skip decorator should be removed to re-enable the test.

## Documentation

N/A