### PR TITLE
[NA] [DOCS] Remove GitHub MCP and add gh CLI PATH instructions

### DIFF
--- a/.agents/agents/meta-auditor.md
+++ b/.agents/agents/meta-auditor.md
@@ -41,7 +41,7 @@ description: |
 
   <example>
   Context: User enabling MCPs
-  user: "Enable the GitHub MCP"
+  user: "Enable the Slack MCP"
   assistant: "I'll use the config-auditor agent to check current MCP usage before adding another."
   <commentary>
   MCP change. Trigger config-auditor to check for overlap and context impact.

--- a/.agents/commands/comet/address-github-pr-comments.md
+++ b/.agents/commands/comet/address-github-pr-comments.md
@@ -6,12 +6,12 @@
 
 Given the current working branch (which must include an Opik ticket number), fetch the open GitHub PR for this branch in `comet-ml/opik`, collect comments/discussions that are not addressed yet, list them clearly, and propose how to address each one (or suggest closing when appropriate). Provide options to proceed with fixes or mark items as not needed.
 
-- **Execution model**: Always runs from scratch. Each invocation re-checks MCP availability, re-validates the branch, re-detects the PR, and re-collects pending comments.
+- **Execution model**: Always runs from scratch. Each invocation re-validates the branch, re-detects the PR, and re-collects pending comments.
 
 This workflow will:
 
 - Validate branch name and extract the Opik ticket number
-- Verify GitHub MCP availability (stop if not available)
+- Verify `gh` CLI is authenticated and working (stop if not available)
 - Find the existing open PR for the branch (stop if none)
 - Fetch pending/unaddressed comments or review threads
 - Summarize findings and propose solutions or next actions
@@ -29,8 +29,9 @@ This workflow will:
 
 ### 1. Preflight & Environment Check
 
-- **Check GitHub MCP**: Test availability by attempting to fetch basic repository information for `comet-ml/opik`
-  > If unavailable, respond with: "This command needs the GitHub MCP server. Please enable it, then run: `npm run install-mcp`."  
+- **Check `gh` CLI**: Test availability by running `gh auth status`
+  > If unavailable or not authenticated, respond with: "This command needs the GitHub CLI (`gh`). Please install it (`brew install gh` on macOS) and authenticate with `gh auth login`."
+  > If installed via Homebrew but not found, add `/opt/homebrew/bin` to PATH in `~/.zshenv`: `echo 'export PATH="/opt/homebrew/bin:$PATH"' >> ~/.zshenv` and restart Claude Code/Cursor.
   > Stop here.
 - **Check Git repository**: Verify we're in a Git repository
 - **Check current branch**: Ensure we're not on `main`
@@ -40,7 +41,7 @@ This workflow will:
 
 ### 2. Locate Existing PR
 
-- **Search PRs**: Use GitHub MCP to find an open PR for the current branch in `comet-ml/opik`
+- **Search PRs**: Use `gh pr list --head <branch-name> --state open --json number,url,title` to find an open PR for the current branch
 - **If no PR exists**: Print: "No open PR found for this branch." and stop
 - **If PR exists**: Capture PR number, URL, and title for later use
 
@@ -48,8 +49,9 @@ This workflow will:
 
 ### 3. Collect Pending Comments
 
-- **Fetch review comments**: Use GitHub MCP to retrieve PR review comments and/or discussion threads
-- **Fetch PR reviews**: Get all reviews to understand the review context
+- **Fetch review comments**: Use `gh api repos/comet-ml/opik/pulls/<PR_NUMBER>/comments` to retrieve PR review comments
+- **Fetch PR reviews**: Use `gh api repos/comet-ml/opik/pulls/<PR_NUMBER>/reviews` to get all reviews and understand the review context
+- **Fetch review threads**: Use `gh pr view <PR_NUMBER> --json reviewThreads` to get review thread information including resolved status
 - **Determine pending/unaddressed items**:
   - Prefer unresolved review threads when available
   - Otherwise, treat comments as pending if they are not from the latest code line (not "outdated") or explicitly unresolved, and have no author follow-up confirmation
@@ -82,10 +84,10 @@ This workflow will:
 
 ## Error Handling
 
-### **MCP Availability Errors**
+### **CLI Availability Errors**
 
-- **GitHub MCP unavailable**: Stop immediately after testing and provide setup instructions
-- **Connection failures**: Stop and request to verify MCP server status
+- **`gh` CLI unavailable**: Stop immediately after testing and provide setup instructions (`gh auth login`)
+- **Authentication failures**: Stop and request to run `gh auth login`
 
 ### **Branch Validation Errors**
 
@@ -103,7 +105,7 @@ This workflow will:
 
 The command is successful when:
 
-1. ✅ GitHub MCP is available and accessible
+1. ✅ `gh` CLI is available and authenticated
 2. ✅ Feature branch is validated with Opik ticket number
 3. ✅ An open PR for the branch is found (or we clearly stop if not)
 4. ✅ Pending/unaddressed comments are listed (or we clearly state none)
@@ -116,8 +118,8 @@ The command is successful when:
 
 - **Repository**: Always targets `comet-ml/opik`
 - **Comment Context**: This command focuses on analyzing and proposing fixes rather than replying to comments
-- **Reply Limitation**: GitHub MCP doesn't support proper replies to existing comment threads, so this option is not provided
-- **Heuristics**: If unresolved review thread flags are not available via MCP, use best-effort heuristics (latest commit context, lack of author confirmation, not marked as outdated) and clearly label them
+- **Reply Limitation**: Adding replies to comment threads requires additional API calls; this command focuses on analysis
+- **Heuristics**: If unresolved review thread flags are not available, use best-effort heuristics (latest commit context, lack of author confirmation, not marked as outdated) and clearly label them
 - **User control**: Ask before proceeding with any fixes or marking items as not needed
 - **Stateless**: Re-runs discovery and analysis on every invocation
 - **No Delete Operations**: This command only creates and updates content; it never deletes files, comments, or other content

--- a/.agents/commands/comet/generate-code-review-slack-command.md
+++ b/.agents/commands/comet/generate-code-review-slack-command.md
@@ -37,7 +37,7 @@ This workflow will:
 
 ### Configuration
 - **No Slack MCP required**: This command does not send messages, so Slack MCP configuration is not needed
-- **GitHub MCP**: Required for extracting PR information
+- **`gh` CLI**: Required for extracting PR information
 
 ---
 
@@ -45,8 +45,9 @@ This workflow will:
 
 ### 1. Preflight & Environment Check
 
-- **Check GitHub MCP**: Test GitHub MCP availability by attempting to fetch repository info using `get_file_contents` for `comet-ml/opik`
-  > If unavailable, respond with: "This command needs the GitHub MCP server. Please enable it, then run: `npm run install-mcp`."  
+- **Check `gh` CLI**: Test availability by running `gh auth status`
+  > If unavailable or not authenticated, respond with: "This command needs the GitHub CLI (`gh`). Please install it (`brew install gh` on macOS) and authenticate with `gh auth login`."
+  > If installed via Homebrew but not found, add `/opt/homebrew/bin` to PATH in `~/.zshenv`: `echo 'export PATH="/opt/homebrew/bin:$PATH"' >> ~/.zshenv` and restart Claude Code/Cursor.
   > Stop here.
 - **Check Git repository**: Verify we're in a Git repository
 - **Check current branch**: Get current branch name
@@ -55,14 +56,14 @@ This workflow will:
 
 ### 2. Find GitHub PR for Current Branch
 
-- **Search for PR**: Use GitHub MCP to find an open PR for the current branch in `comet-ml/opik`
-- **If PR found**: 
+- **Search for PR**: Use `gh pr list --head <branch-name> --state open --json number,url,title,body` to find an open PR for the current branch
+- **If PR found**:
   - Extract PR number, URL, title, and description
   - Store PR information for extraction steps
-- **If no PR found**: 
+- **If no PR found**:
   > "No open PR found for this branch. Please provide the PR link manually:"
   - Prompt for PR link and validate URL format
-  - If provided, fetch PR details using GitHub MCP
+  - If provided, fetch PR details using `gh pr view <PR_NUMBER> --json number,url,title,body`
   - If PR cannot be fetched, stop with error message
   - **After successfully fetching PR by manual link**: Extract PR number, URL, title, and description and store PR information for extraction steps (same as "PR found" branch)
 
@@ -79,13 +80,13 @@ This workflow will:
   - **Build Jira URL**: Construct Jira link as `https://comet-ml.atlassian.net/browse/{TICKET}` (e.g., `https://comet-ml.atlassian.net/browse/OPIK-1234`)
 
 - **Extract Baz approved status (optional)**:
-  - Try to fetch PR status checks using GitHub MCP
+  - Try to fetch PR status checks using `gh pr checks <PR_NUMBER>`
   - Look for status checks or CI checks that might indicate "Baz approved" or similar approval status
   - If found, store the status (e.g., "Baz approved: ✅" or "Baz status: pending")
   - If not found or unavailable, skip this field (it's optional)
 
 - **Extract test environment link from PR description and comments**:
-  - First, search PR comments for test environment deployment messages (look for "Test environment is now available!" or similar)
+  - First, search PR comments using `gh pr view <PR_NUMBER> --json comments` for test environment deployment messages (look for "Test environment is now available!" or similar)
   - Extract URL from comment body (typically in format `https://pr-XXXX.dev.comet.com` or `https://test.opik.com`)
   - If not found in comments, search PR description for URLs in "## Testing" section
   - Look for common test environment patterns: `https://pr-*.dev.comet.com`, `https://test.opik.com`, `https://*.opik.com`, or any `https://` URL
@@ -95,17 +96,17 @@ This workflow will:
   - Validate URL format and store
 
 - **Extract component summaries from PR description**:
-  - **FE summary**: 
+  - **FE summary**:
     - Look for mentions of "frontend", "FE", "React", "UI", or `[FE]` tag in PR description
     - Extract relevant one-line summary from "## Details" section or component-specific mentions
     - If not found, prompt: "Frontend summary not found in PR. Enter frontend summary (one line, optional - press Enter to skip):"
-  
-  - **BE summary**: 
+
+  - **BE summary**:
     - Look for mentions of "backend", "BE", "Java", "API", or `[BE]` tag in PR description
     - Extract relevant one-line summary from "## Details" section or component-specific mentions
     - If not found, prompt: "Backend summary not found in PR. Enter backend summary (one line, optional - press Enter to skip):"
-  
-  - **Python summary**: 
+
+  - **Python summary**:
     - Look for mentions of "Python", "Python SDK", "SDK", or Python-related changes in PR description
     - Extract relevant one-line summary from "## Details" section or component-specific mentions
     - If not found, prompt: "Python summary not found in PR. Enter Python summary (one line, optional - press Enter to skip):"
@@ -133,9 +134,9 @@ This workflow will:
   Hi team,
 
   Please review the following PR:
-  
+
   {{user_customization_text_if_provided}}
-  
+
   :jira_epic: jira link: {{Jira_URL}}
   :github: pr link: {{PR_link}}
   :test_tube: test env link: {{test_env}}
@@ -159,7 +160,7 @@ This workflow will:
   Hi team,
 
   Please review the following PR:
-  
+
   :jira_epic: jira link: https://comet-ml.atlassian.net/browse/OPIK-1234
   :github: pr link: https://github.com/comet-ml/opik/pull/1234
   :test_tube: test env link: https://test.opik.com
@@ -193,9 +194,9 @@ This workflow will:
 
 ## Error Handling
 
-### **GitHub MCP Errors**
+### **CLI Errors**
 
-- **GitHub MCP unavailable**: Stop immediately after testing and provide setup instructions
+- **`gh` CLI unavailable**: Stop immediately after testing and provide setup instructions (`gh auth login`)
 - **PR not found**: Prompt for manual PR link or stop if user cancels
 - **PR fetch failure**: Show error details and suggest manual input
 
@@ -217,7 +218,7 @@ This workflow will:
 
 The command is successful when:
 
-1. ✅ GitHub MCP is available and accessible
+1. ✅ `gh` CLI is available and authenticated
 2. ✅ PR is found for current branch (or manually provided)
 3. ✅ Jira ticket is extracted from PR or provided manually
 4. ✅ Test environment link is extracted from PR or provided manually
@@ -230,7 +231,7 @@ The command is successful when:
 
 ## Notes
 
-- **GitHub MCP Required**: Uses GitHub MCP to fetch PR information automatically
+- **`gh` CLI Required**: Uses `gh` CLI to fetch PR information automatically
 - **No Slack MCP Required**: This command does not send messages, so Slack MCP configuration is not needed
 - **Message format**: Follows the exact template provided with emoji prefixes, includes greeting and Jira link
 - **Automatic extraction**: Extracts information from PR title and description to minimize manual input
@@ -254,7 +255,8 @@ The command is successful when:
 ### Setup and Usage
 
 ```bash
-# 1. Ensure GitHub MCP is configured (no Slack MCP needed)
+# 1. Ensure gh CLI is installed and authenticated
+gh auth status
 
 # 2. Run command (on a branch with an open PR)
 cursor generate-code-review-slack-command
@@ -274,27 +276,27 @@ cursor generate-code-review-slack-command
 
 # Output:
 # 📋 **Copiable Slack Command Generated**
-# 
+#
 # Copy the command below and paste it into the #code-review channel in Slack.
-# 
+#
 # You can edit it before sending to:
 # - Add @ mentions for specific reviewers
 # - Add media links or video links
 # - Make final proof edits
 # - Add any additional context
-# 
+#
 # ```
 # Hi team,
-# 
+#
 # Please review the following PR:
-# 
+#
 # :jira_epic: jira link: https://comet-ml.atlassian.net/browse/OPIK-1234
 # :github: pr link: https://github.com/comet-ml/opik/pull/1234
 # :test_tube: test env link: https://test.opik.com
 # :react: fe summary (optional): Added new metrics dashboard UI
 # :java: be summary (optional): Implemented metrics aggregation endpoint
 # ```
-# 
+#
 # **To send in Slack:**
 # 1. Open Slack and navigate to #code-review channel
 # 2. Paste the command above
@@ -324,14 +326,14 @@ cursor generate-code-review-slack-command
 
 # ... extraction steps ...
 # Would you like to customize the message? (Enter any additional text to prepend/append, or press Enter to use default message): This PR includes important security updates, please review carefully.
-# 
+#
 # Generated command includes the customization:
 # Hi team,
-# 
+#
 # Please review the following PR:
-# 
+#
 # This PR includes important security updates, please review carefully.
-# 
+#
 # :jira_epic: jira link: https://comet-ml.atlassian.net/browse/OPIK-1234
 # ...
 ```

--- a/.agents/commands/comet/work-on-github-issue.md
+++ b/.agents/commands/comet/work-on-github-issue.md
@@ -4,10 +4,10 @@
 
 ## Overview
 
-Fetch a GitHub issue by link, build full context (title, description, comments, labels, assignees, milestone), and generate an actionable implementation plan.  
+Fetch a GitHub issue by link, build full context (title, description, comments, labels, assignees, milestone), and generate an actionable implementation plan.
 This workflow will:
 
-- Verify GitHub MCP availability (or instruct how to install it).
+- Verify `gh` CLI availability (or instruct how to install it).
 - Fetch and parse the issue details.
 - If not found, list your assigned **open** issues.
 - Check local git status in the Opik repository and propose a branch if on `main`.
@@ -26,8 +26,9 @@ This workflow will:
 
 ### 1. Preflight & Environment Check
 
-- **Check GitHub MCP**: If unavailable, respond with:
-  > "This command needs the GitHub MCP server. Please enable it, then run: `npm run install-mcp`."  
+- **Check `gh` CLI**: Test availability by running `gh auth status`
+  > If unavailable or not authenticated, respond with: "This command needs the GitHub CLI (`gh`). Please install it (`brew install gh` on macOS) and authenticate with `gh auth login`."
+  > If installed via Homebrew but not found, add `/opt/homebrew/bin` to PATH in `~/.zshenv`: `echo 'export PATH="/opt/homebrew/bin:$PATH"' >> ~/.zshenv` and restart Claude Code/Cursor.
   > Stop here.
 - **Check development environment**: Verify project dependencies, build tools, and project structure are ready.
 - **Check local git branch** in the Opik repository:
@@ -45,9 +46,9 @@ This workflow will:
 ### 2. Fetch Issue
 
 - Extract issue number from link.
-- Fetch with GitHub MCP: title, body, state, labels, assignees, milestone, comments, created_at, updated_at.
+- Fetch with `gh` CLI: `gh issue view <ISSUE_NUMBER> --json number,title,body,state,labels,assignees,milestone,comments,createdAt,updatedAt`
 - **If fetch fails**: Show error message and suggest troubleshooting steps.
-- **If not found**: Search for open issues assigned to current user: `is:open assignee:@me` (max 10).
+- **If not found**: Search for open issues assigned to current user: `gh issue list --assignee @me --state open --limit 10`
 - **Show list**: `#1234 — Title (State)` and stop if issue not found.
 
 ---
@@ -58,7 +59,7 @@ This workflow will:
 - **Description**: verbatim if short, otherwise concise summary + key quotes.
 - **If no description**: Note this and suggest adding context for better implementation planning.
 - **Comments**: newest → oldest, `[author @ date] summary` with important snippets.
-- **Linked PRs**: Include any linked pull requests if available.
+- **Linked PRs**: Use `gh pr list --search "issue:<ISSUE_NUMBER>"` to find linked pull requests if available.
 - **Project context**: Include project board information if available.
 
 ---
@@ -102,7 +103,7 @@ This workflow will:
   # Ensure you're on main and pull latest
   git checkout main
   git pull origin main
-  
+
   # Create task-specific branch
   git checkout -b {USERNAME}/issue-{ISSUE-NUMBER}-{ISSUE-SUMMARY}
   ```
@@ -114,7 +115,7 @@ This workflow will:
 ### 7. Status Management (Optional)
 
 - **Move issue to "In Progress"** if currently **open**:
-  - Use GitHub MCP to add appropriate labels (e.g., "in-progress")
+  - Use `gh` CLI to add appropriate labels: `gh issue edit <ISSUE_NUMBER> --add-label "in-progress"`
   - **Verify label addition**: Confirm labels were added successfully
   - **Handle label failures**: Provide error details and retry options
 
@@ -187,7 +188,7 @@ This workflow will:
 ### 11. Completion Summary & Validation
 
 - **Confirm all steps completed**:
-  - ✅ GitHub MCP available and working
+  - ✅ `gh` CLI available and working
   - ✅ Issue fetched and analyzed successfully
   - ✅ Labels updated (if applicable)
   - ✅ Feature branch created and active following Opik naming convention
@@ -200,9 +201,10 @@ This workflow will:
 
 ## Error Handling
 
-### **GitHub MCP Failures**
+### **CLI Failures**
 
-- Connection issues: Check network and authentication
+- **`gh` CLI unavailable**: Stop immediately and provide installation instructions (`gh auth login`)
+- Connection issues: Check network and authentication with `gh auth status`
 - Permission errors: Verify user access to the repository
 - Rate limiting: Wait and retry
 - API errors: Check GitHub API status and retry
@@ -217,7 +219,7 @@ This workflow will:
 
 ### **Label Management Failures**
 
-- Invalid label: Check available labels in the repository
+- Invalid label: Check available labels in the repository with `gh label list`
 - Permission denied: Verify user can modify issue labels
 - Label doesn't exist: Create the label or use existing ones
 
@@ -242,7 +244,13 @@ The command is successful when:
 
 ### **Common Issues**
 
-- **GitHub MCP not available**: Run `npm run install-mcp`
+- **`gh` CLI not available**: Install with `brew install gh` (macOS) or see https://cli.github.com/
+- **`gh` CLI installed but not found**: If installed via Homebrew on macOS but not found in non-interactive shells (like Claude Code), add to `~/.zshenv`:
+  ```bash
+  echo 'export PATH="/opt/homebrew/bin:$PATH"' >> ~/.zshenv
+  ```
+  Then restart Claude Code/Cursor.
+- **`gh` CLI not authenticated**: Run `gh auth login`
 - **Git branch conflicts**: Resolve conflicts before proceeding
 - **Permission errors**: Check user access and repository settings
 - **Network issues**: Verify connectivity to GitHub services

--- a/.agents/mcp.json
+++ b/.agents/mcp.json
@@ -1,19 +1,5 @@
 {
     "mcpServers": {
-      "GitHub": {
-        "command": "docker",
-        "args": [
-          "run",
-          "-i",
-          "--rm",
-          "-e",
-          "GITHUB_PERSONAL_ACCESS_TOKEN",
-          "-e",
-          "GITHUB_TOOLSETS=repos,pull_requests,issues",
-          "ghcr.io/github/github-mcp-server"
-        ],
-        "envFile": "${workspaceFolder}/.env.local"
-      },
       "slack": {
         "command": "docker",
         "args": [

--- a/.env.template
+++ b/.env.template
@@ -2,11 +2,6 @@
 # Copy this file to .env.local and fill in your actual values
 # DO NOT COMMIT .env.local to version control
 
-# GitHub Personal Access Token
-# Get from: https://github.com/settings/tokens
-GITHUB_PERSONAL_ACCESS_TOKEN=your_github_token_here
-
-
 # Jira Headless MCP Configuration
 # Get API token from: https://id.atlassian.com/manage-profile/security/api-tokens
 JIRA_URL=https://comet-ml.atlassian.net


### PR DESCRIPTION
## Summary
- Remove GitHub MCP configuration from `mcp.json` (use `gh` CLI directly instead)
- Remove `GITHUB_PERSONAL_ACCESS_TOKEN` from `.env.template`
- Update meta-auditor example from "GitHub MCP" to "Slack MCP"
- Add PATH configuration instructions for Homebrew-installed `gh` CLI in non-interactive shells (Claude Code/Cursor)

## Test plan
- [ ] Verify `gh` CLI works in Claude Code after adding PATH to `~/.zshenv`
- [ ] Verify skills correctly display PATH instructions when `gh` is not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)