### PR TITLE
[OPIK-3278] [FE] Hide pagination on empty tables

### DIFF
--- a/apps/opik-frontend/src/components/shared/DataTablePagination/DataTablePagination.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTablePagination/DataTablePagination.tsx
@@ -90,6 +90,10 @@ const DataTablePagination = ({
     }
   }, [total, page, size, pageChange]);
 
+  if (total === 0) {
+    return null;
+  }
+
   return (
     <div
       className={`flex flex-row justify-end ${isMinimal ? "gap-1" : "gap-4"} ${


### PR DESCRIPTION
## Details

Fix the DataTablePagination component to hide when there are no items (`total === 0`), resolving the "Showing 1-0 of 0" display issue on empty tables.

**Changes:**
- Add early return when `total === 0` to hide the pagination component
- Keep the page reset `useEffect` before the early return to ensure page resets to 1 when filters reduce results to zero

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-3278

## Testing

- TypeScript typecheck passes (`npm run typecheck`)
- All frontend unit tests pass (`npm test -- --run`)
- Manual verification scenarios:
  - Empty table: Pagination should not appear
  - Filter to empty: Apply filter that returns 0 results → pagination disappears
  - Page exceeds total: Go to page 5, apply filter reducing to <50 items → page resets to 1

## Documentation

N/A - Internal component behavior fix, no user-facing documentation changes required.

---
🤖 Generated with [Claude Code](https://claude.ai/code)