### PR TITLE
[OPIK-4127] [SDK] Add dataset_filter_string parameter to evaluate functions

### DIFF
--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -89,6 +89,7 @@ def evaluate(
     trial_count: int = 1,
     experiment_scoring_functions: Optional[List[ExperimentScoreFunction]] = None,
     experiment_tags: Optional[List[str]] = None,
+    dataset_filter_string: Optional[str] = None,
 ) -> evaluation_result.EvaluationResult:
     """
     Performs task evaluation on a given dataset. You can use either `scoring_metrics` or `scorer_functions` to calculate
@@ -159,6 +160,21 @@ def evaluate(
             metrics across the entire experiment.
 
         experiment_tags: Optional list of tags to associate with the experiment.
+
+        dataset_filter_string: Optional OQL filter string to filter dataset items.
+            Supports filtering by tags, data fields, metadata, etc.
+
+            Supported columns include:
+            - `id`, `source`, `trace_id`, `span_id`: String fields
+            - `data`: Dictionary field (use dot notation, e.g., "data.category")
+            - `tags`: List field (use "contains" operator)
+            - `created_at`, `last_updated_at`: DateTime fields (ISO 8601 format)
+            - `created_by`, `last_updated_by`: String fields
+
+            Examples:
+            - `tags contains "failed"` - Items with 'failed' tag
+            - `data.category = "test"` - Items with specific data field value
+            - `created_at >= "2024-01-01T00:00:00Z"` - Items created after date
     """
     experiment_scoring_functions = (
         [] if experiment_scoring_functions is None else experiment_scoring_functions
@@ -206,6 +222,7 @@ def evaluate(
         dataset_sampler=dataset_sampler,
         trial_count=trial_count,
         experiment_scoring_functions=experiment_scoring_functions,
+        dataset_filter_string=dataset_filter_string,
     )
 
 
@@ -225,6 +242,7 @@ def _evaluate_task(
     dataset_sampler: Optional[samplers.BaseDatasetSampler],
     trial_count: int,
     experiment_scoring_functions: List[ExperimentScoreFunction],
+    dataset_filter_string: Optional[str] = None,
 ) -> evaluation_result.EvaluationResult:
     start_time = time.time()
 
@@ -245,6 +263,7 @@ def _evaluate_task(
             dataset_sampler=dataset_sampler,
             trial_count=trial_count,
             experiment_=experiment,
+            dataset_filter_string=dataset_filter_string,
         )
 
     total_time = time.time() - start_time
@@ -717,6 +736,7 @@ def evaluate_optimization_trial(
     trial_count: int = 1,
     experiment_scoring_functions: Optional[List[ExperimentScoreFunction]] = None,
     experiment_tags: Optional[List[str]] = None,
+    dataset_filter_string: Optional[str] = None,
 ) -> evaluation_result.EvaluationResult:
     """
     Performs task evaluation on a given dataset.
@@ -786,6 +806,21 @@ def evaluate_optimization_trial(
             metrics across the entire experiment.
 
         experiment_tags: A list of tags to associate with the experiment.
+
+        dataset_filter_string: Optional OQL filter string to filter dataset items.
+            Supports filtering by tags, data fields, metadata, etc.
+
+            Supported columns include:
+            - `id`, `source`, `trace_id`, `span_id`: String fields
+            - `data`: Dictionary field (use dot notation, e.g., "data.category")
+            - `tags`: List field (use "contains" operator)
+            - `created_at`, `last_updated_at`: DateTime fields (ISO 8601 format)
+            - `created_by`, `last_updated_by`: String fields
+
+            Examples:
+            - `tags contains "failed"` - Items with 'failed' tag
+            - `data.category = "test"` - Items with specific data field value
+            - `created_at >= "2024-01-01T00:00:00Z"` - Items created after date
     """
     experiment_scoring_functions = (
         [] if experiment_scoring_functions is None else experiment_scoring_functions
@@ -838,6 +873,7 @@ def evaluate_optimization_trial(
         dataset_sampler=dataset_sampler,
         trial_count=trial_count,
         experiment_scoring_functions=experiment_scoring_functions,
+        dataset_filter_string=dataset_filter_string,
     )
 
 

--- a/sdks/python/tests/e2e/evaluation/test_evaluate_filter_string.py
+++ b/sdks/python/tests/e2e/evaluation/test_evaluate_filter_string.py
@@ -1,0 +1,133 @@
+from typing import Dict, Any
+
+import opik
+from opik import id_helpers
+from opik.evaluation import metrics
+from opik.evaluation import evaluator as evaluator_module
+
+
+def test_evaluate__with_filter_string__filters_dataset_items(
+    opik_client: opik.Opik, dataset_name: str, experiment_name: str
+):
+    """Test that evaluate correctly filters dataset items using filter_string."""
+    dataset = opik_client.create_dataset(dataset_name)
+
+    dataset_items = [
+        {
+            "id": id_helpers.generate_id(),
+            "input": {"question": "What is the capital of France?"},
+            "expected_model_output": {"output": "Paris"},
+            "category": "geography",
+        },
+        {
+            "id": id_helpers.generate_id(),
+            "input": {"question": "What is 2+2?"},
+            "expected_model_output": {"output": "4"},
+            "category": "math",
+        },
+        {
+            "id": id_helpers.generate_id(),
+            "input": {"question": "What is the capital of Germany?"},
+            "expected_model_output": {"output": "Berlin"},
+            "category": "geography",
+        },
+    ]
+
+    dataset.insert(dataset_items)
+
+    def task(item: Dict[str, Any]):
+        if item["input"] == {"question": "What is the capital of France?"}:
+            return {"output": "Paris"}
+        if item["input"] == {"question": "What is the capital of Germany?"}:
+            return {"output": "Berlin"}
+        if item["input"] == {"question": "What is 2+2?"}:
+            return {"output": "4"}
+
+        raise AssertionError(
+            f"Task received dataset item with an unexpected input: {item['input']}"
+        )
+
+    equals_metric = metrics.Equals()
+    opik.evaluate(
+        dataset=dataset,
+        task=task,
+        scoring_metrics=[equals_metric],
+        experiment_name=experiment_name,
+        scoring_key_mapping={
+            "reference": lambda x: x["expected_model_output"]["output"],
+        },
+        dataset_filter_string='data.category = "geography"',
+    )
+
+    opik.flush_tracker()
+
+    retrieved_experiment = opik_client.get_experiment_by_name(experiment_name)
+    experiment_items_contents = retrieved_experiment.get_items()
+    assert len(experiment_items_contents) == 2, (
+        f"Expected 2 experiment items (filtered by geography category), but got {len(experiment_items_contents)}. "
+        f"Experiment items: {experiment_items_contents}"
+    )
+
+
+def test_evaluate_optimization_trial__with_filter_string__filters_dataset_items(
+    opik_client: opik.Opik, dataset_name: str, experiment_name: str
+):
+    """Test that evaluate_optimization_trial correctly filters dataset items using filter_string."""
+    dataset = opik_client.create_dataset(dataset_name)
+
+    dataset_items = [
+        {
+            "id": id_helpers.generate_id(),
+            "input": {"question": "What is the capital of France?"},
+            "expected_model_output": {"output": "Paris"},
+            "category": "geography",
+        },
+        {
+            "id": id_helpers.generate_id(),
+            "input": {"question": "What is 2+2?"},
+            "expected_model_output": {"output": "4"},
+            "category": "math",
+        },
+        {
+            "id": id_helpers.generate_id(),
+            "input": {"question": "What is the capital of Germany?"},
+            "expected_model_output": {"output": "Berlin"},
+            "category": "geography",
+        },
+    ]
+
+    dataset.insert(dataset_items)
+
+    def task(item: Dict[str, Any]):
+        if item["input"] == {"question": "What is the capital of France?"}:
+            return {"output": "Paris"}
+        if item["input"] == {"question": "What is the capital of Germany?"}:
+            return {"output": "Berlin"}
+        if item["input"] == {"question": "What is 2+2?"}:
+            return {"output": "4"}
+
+        raise AssertionError(
+            f"Task received dataset item with an unexpected input: {item['input']}"
+        )
+
+    equals_metric = metrics.Equals()
+    evaluator_module.evaluate_optimization_trial(
+        optimization_id=id_helpers.generate_id(),
+        dataset=dataset,
+        task=task,
+        scoring_metrics=[equals_metric],
+        experiment_name=experiment_name,
+        scoring_key_mapping={
+            "reference": lambda x: x["expected_model_output"]["output"],
+        },
+        dataset_filter_string='data.category = "math"',
+    )
+
+    opik.flush_tracker()
+
+    retrieved_experiment = opik_client.get_experiment_by_name(experiment_name)
+    experiment_items_contents = retrieved_experiment.get_items()
+    assert len(experiment_items_contents) == 1, (
+        f"Expected 1 experiment item (filtered by math category), but got {len(experiment_items_contents)}. "
+        f"Experiment items: {experiment_items_contents}"
+    )

--- a/sdks/python/tests/unit/evaluation/test_evaluate.py
+++ b/sdks/python/tests/unit/evaluation/test_evaluate.py
@@ -2938,3 +2938,201 @@ def test_evaluate_prompt__with_filter_string_and_dataset_sampler__passes_filter_
         batch_size=engine.EVALUATION_STREAM_DATASET_BATCH_SIZE,
         filter_string=filter_string,
     )
+
+
+def test_evaluate__with_filter_string__passes_to_streaming(fake_backend):
+    """Test that evaluate correctly passes filter_string to streaming method."""
+    filter_string = 'tags contains "important"'
+
+    mock_dataset = create_mock_dataset(
+        items=[
+            dataset_item.DatasetItem(
+                id="dataset-item-id-1",
+                question="Hello, world!",
+                reference="Hello, world!",
+            ),
+            dataset_item.DatasetItem(
+                id="dataset-item-id-2",
+                question="What is the capital of France?",
+                reference="Paris",
+            ),
+        ]
+    )
+
+    def say_task(dataset_item: Dict[str, Any]):
+        return {"output": "hello"}
+
+    mock_experiment, mock_create_experiment, mock_get_experiment_url_by_id = (
+        create_mock_experiment()
+    )
+
+    with patch_evaluation_dependencies(
+        mock_create_experiment,
+        mock_get_experiment_url_by_id,
+    ):
+        evaluation.evaluate(
+            dataset=mock_dataset,
+            task=say_task,
+            experiment_name="the-experiment-name",
+            scoring_metrics=[metrics.Equals()],
+            task_threads=1,
+            dataset_filter_string=filter_string,
+        )
+
+    mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
+        nb_samples=None,
+        dataset_item_ids=None,
+        batch_size=engine.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        filter_string=filter_string,
+    )
+
+
+def test_evaluate__with_filter_string_and_nb_samples__passes_both_parameters(
+    fake_backend,
+):
+    """Test that evaluate correctly passes both filter_string and nb_samples to streaming method."""
+    filter_string = 'data.category = "test"'
+
+    mock_dataset = create_mock_dataset(
+        items=[
+            dataset_item.DatasetItem(
+                id="dataset-item-id-1",
+                question="Hello, world!",
+                reference="Hello, world!",
+            ),
+            dataset_item.DatasetItem(
+                id="dataset-item-id-2",
+                question="What is the capital of France?",
+                reference="Paris",
+            ),
+        ]
+    )
+
+    def say_task(dataset_item: Dict[str, Any]):
+        return {"output": "hello"}
+
+    mock_experiment, mock_create_experiment, mock_get_experiment_url_by_id = (
+        create_mock_experiment()
+    )
+
+    with patch_evaluation_dependencies(
+        mock_create_experiment,
+        mock_get_experiment_url_by_id,
+    ):
+        evaluation.evaluate(
+            dataset=mock_dataset,
+            task=say_task,
+            experiment_name="the-experiment-name",
+            scoring_metrics=[metrics.Equals()],
+            task_threads=1,
+            nb_samples=2,
+            dataset_filter_string=filter_string,
+        )
+
+    mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
+        nb_samples=2,
+        dataset_item_ids=None,
+        batch_size=engine.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        filter_string=filter_string,
+    )
+
+
+def test_evaluate__with_filter_string_and_dataset_sampler__passes_filter_string(
+    fake_backend,
+):
+    """Test that evaluate passes filter_string even when dataset_sampler is used."""
+    sampler = samplers.RandomDatasetSampler(max_samples=1)
+    filter_string = 'created_at >= "2024-01-01T00:00:00Z"'
+
+    mock_dataset = create_mock_dataset(
+        items=[
+            dataset_item.DatasetItem(
+                id="dataset-item-id-1",
+                question="Hello, world!",
+                reference="Hello, world!",
+            ),
+            dataset_item.DatasetItem(
+                id="dataset-item-id-2",
+                question="What is the capital of France?",
+                reference="Paris",
+            ),
+        ]
+    )
+
+    def say_task(dataset_item: Dict[str, Any]):
+        return {"output": "hello"}
+
+    mock_experiment, mock_create_experiment, mock_get_experiment_url_by_id = (
+        create_mock_experiment()
+    )
+
+    with patch_evaluation_dependencies(
+        mock_create_experiment,
+        mock_get_experiment_url_by_id,
+    ):
+        evaluation.evaluate(
+            dataset=mock_dataset,
+            task=say_task,
+            experiment_name="the-experiment-name",
+            scoring_metrics=[metrics.Equals()],
+            task_threads=1,
+            dataset_sampler=sampler,
+            dataset_filter_string=filter_string,
+        )
+
+    mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
+        nb_samples=None,
+        dataset_item_ids=None,
+        batch_size=engine.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        filter_string=filter_string,
+    )
+
+
+def test_evaluate_optimization_trial__with_filter_string__passes_to_streaming(
+    fake_backend,
+):
+    """Test that evaluate_optimization_trial correctly passes filter_string to streaming method."""
+    filter_string = 'tags contains "test"'
+
+    mock_dataset = create_mock_dataset(
+        items=[
+            dataset_item.DatasetItem(
+                id="dataset-item-id-1",
+                question="Hello, world!",
+                reference="Hello, world!",
+            ),
+            dataset_item.DatasetItem(
+                id="dataset-item-id-2",
+                question="What is the capital of France?",
+                reference="Paris",
+            ),
+        ]
+    )
+
+    def say_task(dataset_item: Dict[str, Any]):
+        return {"output": "hello"}
+
+    mock_experiment, mock_create_experiment, mock_get_experiment_url_by_id = (
+        create_mock_experiment()
+    )
+
+    with patch_evaluation_dependencies(
+        mock_create_experiment,
+        mock_get_experiment_url_by_id,
+    ):
+        evaluator_module.evaluate_optimization_trial(
+            optimization_id="opt-123",
+            dataset=mock_dataset,
+            task=say_task,
+            experiment_name="the-experiment-name",
+            scoring_metrics=[metrics.Equals()],
+            task_threads=1,
+            dataset_filter_string=filter_string,
+        )
+
+    mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
+        nb_samples=None,
+        dataset_item_ids=None,
+        batch_size=engine.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        filter_string=filter_string,
+    )


### PR DESCRIPTION
## Details

This PR adds `dataset_filter_string` parameter support to both `evaluate()` and `evaluate_optimization_trial()` functions in the Python SDK. This allows users to filter dataset items using OQL filter strings before evaluation, enabling more flexible evaluation workflows.

**Changes:**
- Added `dataset_filter_string` parameter to `evaluate()` function
- Added `dataset_filter_string` parameter to `evaluate_optimization_trial()` function
- Added comprehensive documentation for filter string syntax and supported columns
- Added 4 unit tests verifying filter string parameter passing
- Added 2 e2e tests verifying actual dataset filtering functionality

The filter string supports filtering by:
- Tags (e.g., `tags contains "failed"`)
- Data fields using dot notation (e.g., `data.category = "test"`)
- Metadata fields (id, source, trace_id, span_id)
- DateTime fields (created_at, last_updated_at)
- User fields (created_by, last_updated_by)

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-4127
- #4978 

## Testing

**Unit Tests:**
- `test_evaluate__with_filter_string__passes_to_streaming` - Verifies filter_string is passed to streaming method
- `test_evaluate__with_filter_string_and_nb_samples__passes_both_parameters` - Verifies filter_string works with nb_samples
- `test_evaluate__with_filter_string_and_dataset_sampler__passes_filter_string` - Verifies filter_string works with dataset_sampler
- `test_evaluate_optimization_trial__with_filter_string__passes_to_streaming` - Verifies filter_string works in optimization trials

**E2E Tests:**
- `test_evaluate__with_filter_string__filters_dataset_items` - Tests actual filtering by data.category field
- `test_evaluate_optimization_trial__with_filter_string__filters_dataset_items` - Tests filtering in optimization trials

All tests pass and verify that:
1. Filter string is correctly passed through the evaluation pipeline
2. Dataset items are actually filtered before evaluation
3. Filter string works in combination with other parameters (nb_samples, dataset_sampler)

## Documentation

Added comprehensive docstring documentation for the `dataset_filter_string` parameter in both functions, including:
- Description of supported filter operations
- List of supported columns and their types
- Examples of common filter string patterns
- Reference to OQL filter string semantics