### PR TITLE
[OPIK-3382] [FE] Add loading overlay to tables during data fetching

### DIFF
--- a/apps/opik-frontend/src/components/pages/AlertsPage/AlertsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/AlertsPage/AlertsPage.tsx
@@ -211,7 +211,7 @@ const AlertsPage: React.FunctionComponent = () => {
     [],
   );
 
-  const { data, isPending } = useAlertsList(
+  const { data, isPending, isPlaceholderData, isFetching } = useAlertsList(
     {
       workspaceName,
       search: search!,
@@ -371,6 +371,7 @@ const AlertsPage: React.FunctionComponent = () => {
               )}
             </DataTableNoData>
           }
+          showLoadingOverlay={isPlaceholderData && isFetching}
         />
         <div className="py-4">
           <DataTablePagination

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
@@ -286,7 +286,7 @@ const ThreadQueueItemsTab: React.FunctionComponent<
     [annotationQueue.id, filters],
   );
 
-  const { data, isPending } = useThreadsList(
+  const { data, isPending, isPlaceholderData, isFetching } = useThreadsList(
     {
       projectId: annotationQueue.project_id,
       sorting: sortedColumns,
@@ -553,6 +553,7 @@ const ThreadQueueItemsTab: React.FunctionComponent<
         noData={<DataTableNoData title={noDataText} />}
         TableWrapper={PageBodyStickyTableWrapper}
         stickyHeader
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <PageBodyStickyContainer
         className="py-4"

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
@@ -342,7 +342,7 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
     [annotationQueue.id, filters],
   );
 
-  const { data, isPending } = useTracesList(
+  const { data, isPending, isPlaceholderData, isFetching } = useTracesList(
     {
       projectId: annotationQueue.project_id,
       sorting: sortedColumns,
@@ -624,6 +624,7 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
         noData={<DataTableNoData title={noDataText} />}
         TableWrapper={PageBodyStickyTableWrapper}
         stickyHeader
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <PageBodyStickyContainer
         className="py-4"

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuesPage/AnnotationQueuesPage.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuesPage/AnnotationQueuesPage.tsx
@@ -297,7 +297,12 @@ export const AnnotationQueuesPage: React.FC = () => {
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
-  const { data, isPending: isLoading } = useAnnotationQueuesList(
+  const {
+    data,
+    isPending: isLoading,
+    isPlaceholderData,
+    isFetching,
+  } = useAnnotationQueuesList(
     {
       workspaceName,
       search: search as string,
@@ -470,6 +475,7 @@ export const AnnotationQueuesPage: React.FC = () => {
         noData={<DataTableNoData title={noDataText} />}
         onRowClick={handleRowClick}
         stickyHeader
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <div className="py-4">
         <DataTablePagination

--- a/apps/opik-frontend/src/components/pages/AutomationLogsPage/AutomationLogsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/AutomationLogsPage/AutomationLogsPage.tsx
@@ -63,14 +63,15 @@ const AutomationLogsPage = () => {
     defaultValue: {},
   });
 
-  const { data, isPending, refetch } = useRulesLogsList(
-    {
-      ruleId: rule_id!,
-    },
-    {
-      enabled: Boolean(rule_id),
-    },
-  );
+  const { data, isPending, isPlaceholderData, isFetching, refetch } =
+    useRulesLogsList(
+      {
+        ruleId: rule_id!,
+      },
+      {
+        enabled: Boolean(rule_id),
+      },
+    );
 
   const { rows, markerKeys } = useMemo(() => {
     const rawRows =
@@ -209,6 +210,7 @@ const AutomationLogsPage = () => {
           getRowId={(row) => row.id}
           stickyHeader
           resizeConfig={resizeConfig}
+          showLoadingOverlay={isPlaceholderData && isFetching}
         />
       </PageBodyScrollContainer>
     </div>

--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -280,23 +280,24 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
 
   const truncationEnabled = useTruncationEnabled();
 
-  const { data, isPending } = useCompareExperimentsList(
-    {
-      workspaceName,
-      datasetId,
-      experimentsIds,
-      filters,
-      sorting,
-      search: search as string,
-      truncate: truncationEnabled,
-      page: page as number,
-      size: size as number,
-    },
-    {
-      placeholderData: keepPreviousData,
-      refetchInterval: REFETCH_INTERVAL,
-    },
-  );
+  const { data, isPending, isPlaceholderData, isFetching } =
+    useCompareExperimentsList(
+      {
+        workspaceName,
+        datasetId,
+        experimentsIds,
+        filters,
+        sorting,
+        search: search as string,
+        truncate: truncationEnabled,
+        page: page as number,
+        size: size as number,
+      },
+      {
+        placeholderData: keepPreviousData,
+        refetchInterval: REFETCH_INTERVAL,
+      },
+    );
 
   const { refetch: refetchExportData } = useCompareExperimentsList(
     {
@@ -884,6 +885,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         TableBody={DataTableVirtualBody}
         stickyHeader
         meta={meta}
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <PageBodyStickyContainer
         className="py-4"

--- a/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsMainContent.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsMainContent.tsx
@@ -23,6 +23,7 @@ type CompareOptimizationsMainContentProps = {
   onColumnsWidthChange: OnChangeFn<Record<string, number>>;
   highlightedTrialId?: string;
   bestExperiment?: Experiment;
+  showLoadingOverlay?: boolean;
 };
 
 const CompareOptimizationsMainContent: React.FC<
@@ -42,6 +43,7 @@ const CompareOptimizationsMainContent: React.FC<
   onColumnsWidthChange,
   highlightedTrialId,
   bestExperiment,
+  showLoadingOverlay,
 }) => {
   const showTrialsView =
     !isStudioOptimization || view === OPTIMIZATION_VIEW_TYPE.TRIALS;
@@ -65,6 +67,7 @@ const CompareOptimizationsMainContent: React.FC<
           columnsWidth={columnsWidth}
           onColumnsWidthChange={onColumnsWidthChange}
           highlightedTrialId={highlightedTrialId}
+          showLoadingOverlay={showLoadingOverlay}
         />
       )}
       {showConfigurationView && optimization?.studio_config && (

--- a/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsPage.tsx
@@ -31,6 +31,8 @@ const CompareOptimizationsPage: React.FC = () => {
     sortableBy,
     isOptimizationPending,
     isExperimentsPending,
+    isExperimentsPlaceholderData,
+    isExperimentsFetching,
     search,
     setSearch,
     sortedColumns,
@@ -160,6 +162,9 @@ const CompareOptimizationsPage: React.FC = () => {
           onColumnsWidthChange={setColumnsWidth}
           highlightedTrialId={bestExperiment?.id}
           bestExperiment={bestExperiment}
+          showLoadingOverlay={
+            isExperimentsPlaceholderData && isExperimentsFetching
+          }
         />
         <CompareOptimizationsSidebar
           optimization={optimization}

--- a/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsTrialsTable.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsTrialsTable.tsx
@@ -42,6 +42,7 @@ interface CompareOptimizationsTrialsTableProps {
   columnsWidth: Record<string, number>;
   onColumnsWidthChange: OnChangeFn<Record<string, number>>;
   highlightedTrialId?: string;
+  showLoadingOverlay?: boolean;
 }
 
 const CompareOptimizationsTrialsTable: React.FC<
@@ -57,6 +58,7 @@ const CompareOptimizationsTrialsTable: React.FC<
   columnsWidth,
   onColumnsWidthChange,
   highlightedTrialId,
+  showLoadingOverlay,
 }) => {
   const getRowClassName = useCallback(
     (row: Row<Experiment>) => {
@@ -91,6 +93,7 @@ const CompareOptimizationsTrialsTable: React.FC<
         noData={<DataTableNoData title={noDataText} />}
         TableWrapper={StickyTableWrapperWithBorder}
         stickyHeader
+        showLoadingOverlay={showLoadingOverlay}
       />
     </Card>
   );

--- a/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/useCompareOptimizationsData.ts
+++ b/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/useCompareOptimizationsData.ts
@@ -106,6 +106,8 @@ export const useCompareOptimizationsData = () => {
   const {
     data,
     isPending: isExperimentsPending,
+    isPlaceholderData: isExperimentsPlaceholderData,
+    isFetching: isExperimentsFetching,
     refetch: refetchExperiments,
   } = useExperimentsList(
     {
@@ -207,6 +209,8 @@ export const useCompareOptimizationsData = () => {
     // Loading states
     isOptimizationPending,
     isExperimentsPending,
+    isExperimentsPlaceholderData,
+    isExperimentsFetching,
     // Search
     search,
     setSearch,

--- a/apps/opik-frontend/src/components/pages/CompareTrialsPage/TrialsItemsTab/TrialItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareTrialsPage/TrialsItemsTab/TrialItemsTab.tsx
@@ -215,21 +215,22 @@ const TrialItemsTab: React.FC<TrialItemsTabProps> = ({
 
   const truncationEnabled = useTruncationEnabled();
 
-  const { data, isPending } = useCompareExperimentsList(
-    {
-      workspaceName,
-      datasetId,
-      experimentsIds,
-      filters,
-      truncate: truncationEnabled,
-      page: page as number,
-      size: size as number,
-    },
-    {
-      placeholderData: keepPreviousData,
-      refetchInterval: REFETCH_INTERVAL,
-    },
-  );
+  const { data, isPending, isPlaceholderData, isFetching } =
+    useCompareExperimentsList(
+      {
+        workspaceName,
+        datasetId,
+        experimentsIds,
+        filters,
+        truncate: truncationEnabled,
+        page: page as number,
+        size: size as number,
+      },
+      {
+        placeholderData: keepPreviousData,
+        refetchInterval: REFETCH_INTERVAL,
+      },
+    );
 
   const { data: experimentsOutputData, isPending: isExperimentsOutputPending } =
     useCompareExperimentsColumns(
@@ -610,6 +611,7 @@ const TrialItemsTab: React.FC<TrialItemsTabProps> = ({
         TableWrapper={PageBodyStickyTableWrapper}
         TableBody={DataTableVirtualBody}
         stickyHeader
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <PageBodyStickyContainer
         className="py-4"

--- a/apps/opik-frontend/src/components/pages/ConfigurationPage/FeedbackDefinitionsTab/FeedbackDefinitionsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/ConfigurationPage/FeedbackDefinitionsTab/FeedbackDefinitionsTab.tsx
@@ -115,18 +115,19 @@ const FeedbackDefinitionsTab: React.FunctionComponent = () => {
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
-  const { data, isPending } = useFeedbackDefinitionsList(
-    {
-      workspaceName,
-      search,
-      page,
-      size,
-    },
-    {
-      placeholderData: keepPreviousData,
-      refetchInterval: 30000,
-    },
-  );
+  const { data, isPending, isPlaceholderData, isFetching } =
+    useFeedbackDefinitionsList(
+      {
+        workspaceName,
+        search,
+        page,
+        size,
+      },
+      {
+        placeholderData: keepPreviousData,
+        refetchInterval: 30000,
+      },
+    );
 
   const feedbackDefinitions = useMemo(
     () => data?.content ?? [],
@@ -254,6 +255,7 @@ const FeedbackDefinitionsTab: React.FunctionComponent = () => {
             )}
           </DataTableNoData>
         }
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <div className="py-4">
         <DataTablePagination

--- a/apps/opik-frontend/src/components/pages/DashboardsPage/DashboardsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DashboardsPage/DashboardsPage.tsx
@@ -143,7 +143,7 @@ const DashboardsPage: React.FunctionComponent = () => {
     queryParamConfig: JsonParam,
   });
 
-  const { data, isPending } = useDashboardsList(
+  const { data, isPending, isPlaceholderData, isFetching } = useDashboardsList(
     {
       workspaceName,
       sorting: sortedColumns,
@@ -305,6 +305,7 @@ const DashboardsPage: React.FunctionComponent = () => {
             )}
           </DataTableNoData>
         }
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <div className="py-4">
         <DataTablePagination

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/VersionHistoryTab/VersionHistoryTab.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/VersionHistoryTab/VersionHistoryTab.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { ColumnPinningState } from "@tanstack/react-table";
+import { keepPreviousData } from "@tanstack/react-query";
 
 import DataTable from "@/components/shared/DataTable/DataTable";
 import DataTableNoData from "@/components/shared/DataTableNoData/DataTableNoData";
@@ -73,11 +74,21 @@ const VersionHistoryTab: React.FC<VersionHistoryTabProps> = ({ datasetId }) => {
   const [page, setPage] = useState(1);
   const [size, setSize] = useState(10);
 
-  const { data: versionsData, isLoading } = useDatasetVersionsList({
-    datasetId,
-    page,
-    size,
-  });
+  const {
+    data: versionsData,
+    isLoading,
+    isPlaceholderData,
+    isFetching,
+  } = useDatasetVersionsList(
+    {
+      datasetId,
+      page,
+      size,
+    },
+    {
+      placeholderData: keepPreviousData,
+    },
+  );
 
   const columns = useMemo(() => {
     const baseColumns = convertColumnDataToColumn<
@@ -119,6 +130,7 @@ const VersionHistoryTab: React.FC<VersionHistoryTabProps> = ({ datasetId }) => {
             </div>
           </DataTableNoData>
         }
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <DataTablePagination
         page={page}

--- a/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetsPage.tsx
@@ -197,7 +197,7 @@ const DatasetsPage: React.FunctionComponent = () => {
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
-  const { data, isPending } = useDatasetsList(
+  const { data, isPending, isPlaceholderData, isFetching } = useDatasetsList(
     {
       workspaceName,
       filters,
@@ -365,6 +365,7 @@ const DatasetsPage: React.FunctionComponent = () => {
             )}
           </DataTableNoData>
         }
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <div className="py-4">
         <DataTablePagination

--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentsPage.tsx
@@ -351,7 +351,7 @@ const ExperimentsPage: React.FC = () => {
     maxExpandedDeepestGroups: MAX_EXPANDED_DEEPEST_GROUPS,
   });
 
-  const { data, isPending, isPlaceholderData, refetch } =
+  const { data, isPending, isPlaceholderData, isFetching, refetch } =
     useGroupedExperimentsList({
       workspaceName,
       groupLimit,
@@ -753,6 +753,7 @@ const ExperimentsPage: React.FC = () => {
         TableWrapper={PageBodyStickyTableWrapper}
         TableBody={DataTableVirtualBody}
         stickyHeader
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <PageBodyStickyContainer
         className="py-4"

--- a/apps/opik-frontend/src/components/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
+++ b/apps/opik-frontend/src/components/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
@@ -186,7 +186,7 @@ export const OnlineEvaluationPage: React.FC = () => {
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
-  const { data, isPending } = useRulesList(
+  const { data, isPending, isPlaceholderData, isFetching } = useRulesList(
     {
       page: page as number,
       size: size as number,
@@ -422,6 +422,7 @@ export const OnlineEvaluationPage: React.FC = () => {
         getRowId={getRowId}
         columnPinning={DEFAULT_COLUMN_PINNING}
         noData={<DataTableNoData title={noDataText} />}
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <div className="py-4">
         <DataTablePagination

--- a/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -227,15 +227,16 @@ const OptimizationsPage: React.FunctionComponent = () => {
     [],
   );
 
-  const { data, isPending, refetch } = useGroupedOptimizationsList({
-    workspaceName,
-    groupLimit,
-    datasetId: datasetId!,
-    search: search!,
-    page: page!,
-    size: DEFAULT_GROUPS_PER_PAGE,
-    polling: true,
-  });
+  const { data, isPending, isPlaceholderData, isFetching, refetch } =
+    useGroupedOptimizationsList({
+      workspaceName,
+      groupLimit,
+      datasetId: datasetId!,
+      search: search!,
+      page: page!,
+      size: DEFAULT_GROUPS_PER_PAGE,
+      polling: true,
+    });
 
   const optimizations = useMemo(() => data?.content ?? [], [data?.content]);
 
@@ -464,6 +465,7 @@ const OptimizationsPage: React.FunctionComponent = () => {
               )}
             </DataTableNoData>
           }
+          showLoadingOverlay={isPlaceholderData && isFetching}
         />
         <div className="py-4">
           <DataTablePagination

--- a/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectsPage.tsx
@@ -292,26 +292,27 @@ const ProjectsPage: React.FunctionComponent = () => {
     },
   );
 
-  const { data, isPending } = useProjectWithStatisticsList(
-    {
-      workspaceName,
-      search: search!,
-      sorting: sortedColumns.map((column) => {
-        if (column.id === "last_updated_at") {
-          return {
-            ...column,
-            id: "last_updated_trace_at",
-          };
-        }
-        return column;
-      }),
-      page: page!,
-      size: size!,
-    },
-    {
-      placeholderData: keepPreviousData,
-    },
-  );
+  const { data, isPending, isPlaceholderData, isFetching } =
+    useProjectWithStatisticsList(
+      {
+        workspaceName,
+        search: search!,
+        sorting: sortedColumns.map((column) => {
+          if (column.id === "last_updated_at") {
+            return {
+              ...column,
+              id: "last_updated_trace_at",
+            };
+          }
+          return column;
+        }),
+        page: page!,
+        size: size!,
+      },
+      {
+        placeholderData: keepPreviousData,
+      },
+    );
 
   const projects = useMemo(() => data?.content ?? [], [data?.content]);
   const total = data?.total ?? 0;
@@ -450,6 +451,7 @@ const ProjectsPage: React.FunctionComponent = () => {
             )}
           </DataTableNoData>
         }
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <div className="py-4">
         <DataTablePagination

--- a/apps/opik-frontend/src/components/pages/PromptPage/CommitsTab/CommitsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/CommitsTab/CommitsTab.tsx
@@ -192,21 +192,22 @@ const CommitsTab = ({ prompt }: CommitsTabInterface) => {
 
   const navigate = useNavigate();
 
-  const { data, isPending } = usePromptVersionsById(
-    {
-      promptId: prompt?.id || "",
-      page,
-      size,
-      sorting: sortedColumns,
-      filters,
-      search: searchText || undefined,
-    },
-    {
-      enabled: !!prompt?.id,
-      placeholderData: keepPreviousData,
-      refetchInterval: 30000,
-    },
-  );
+  const { data, isPending, isPlaceholderData, isFetching } =
+    usePromptVersionsById(
+      {
+        promptId: prompt?.id || "",
+        page,
+        size,
+        sorting: sortedColumns,
+        filters,
+        search: searchText || undefined,
+      },
+      {
+        enabled: !!prompt?.id,
+        placeholderData: keepPreviousData,
+        refetchInterval: 30000,
+      },
+    );
 
   const versions = useMemo(() => data?.content ?? [], [data?.content]);
   const noDataText = "There are no commits yet";
@@ -356,6 +357,7 @@ const CommitsTab = ({ prompt }: CommitsTabInterface) => {
         TableBody={DataTableVirtualBody}
         TableWrapper={PageBodyStickyTableWrapper}
         stickyHeader
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <PageBodyStickyContainer
         className="py-4"

--- a/apps/opik-frontend/src/components/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
@@ -341,18 +341,19 @@ const ExperimentsTab: React.FC<ExperimentsTabProps> = ({ promptId }) => {
     maxExpandedDeepestGroups: MAX_EXPANDED_DEEPEST_GROUPS,
   });
 
-  const { data, isPending, isPlaceholderData } = useGroupedExperimentsList({
-    workspaceName,
-    groupLimit,
-    promptId,
-    filters,
-    sorting: sortedColumns,
-    groups,
-    search: search!,
-    page: page!,
-    size: size!,
-    expandedMap: expandingConfig.expanded as Record<string, boolean>,
-  });
+  const { data, isPending, isPlaceholderData, isFetching } =
+    useGroupedExperimentsList({
+      workspaceName,
+      groupLimit,
+      promptId,
+      filters,
+      sorting: sortedColumns,
+      groups,
+      search: search!,
+      page: page!,
+      size: size!,
+      expandedMap: expandingConfig.expanded as Record<string, boolean>,
+    });
 
   const experiments = useMemo(() => data?.content ?? [], [data?.content]);
 
@@ -502,6 +503,7 @@ const ExperimentsTab: React.FC<ExperimentsTabProps> = ({ promptId }) => {
         TableBody={DataTableVirtualBody}
         TableWrapper={PageBodyStickyTableWrapper}
         stickyHeader
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <PageBodyStickyContainer
         className="py-4"

--- a/apps/opik-frontend/src/components/pages/PromptsPage/PromptsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptsPage/PromptsPage.tsx
@@ -208,7 +208,7 @@ const PromptsPage: React.FunctionComponent = () => {
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
-  const { data, isPending } = usePromptsList(
+  const { data, isPending, isPlaceholderData, isFetching } = usePromptsList(
     {
       workspaceName,
       filters,
@@ -375,6 +375,7 @@ const PromptsPage: React.FunctionComponent = () => {
             )}
           </DataTableNoData>
         }
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <div className="py-4">
         <DataTablePagination

--- a/apps/opik-frontend/src/components/pages/TracesPage/AnnotationQueuesTab/AnnotationQueuesTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/AnnotationQueuesTab/AnnotationQueuesTab.tsx
@@ -270,7 +270,12 @@ const AnnotationQueuesTab: React.FC<AnnotationQueuesTabProps> = ({
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
-  const { data, isPending: isLoading } = useAnnotationQueuesList(
+  const {
+    data,
+    isPending: isLoading,
+    isPlaceholderData,
+    isFetching,
+  } = useAnnotationQueuesList(
     {
       search: search as string,
       page: page as number,
@@ -452,6 +457,7 @@ const AnnotationQueuesTab: React.FC<AnnotationQueuesTabProps> = ({
         onRowClick={handleRowClick}
         TableWrapper={PageBodyStickyTableWrapper}
         stickyHeader
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <PageBodyStickyContainer
         className="py-4"

--- a/apps/opik-frontend/src/components/pages/TracesPage/RulesTab/RulesTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/RulesTab/RulesTab.tsx
@@ -164,7 +164,7 @@ export const RulesTab: React.FC<RulesTabProps> = ({ projectId }) => {
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
-  const { data, isPending } = useRulesList(
+  const { data, isPending, isPlaceholderData, isFetching } = useRulesList(
     {
       projectId,
       page: page as number,
@@ -370,6 +370,7 @@ export const RulesTab: React.FC<RulesTabProps> = ({ projectId }) => {
         noData={<DataTableNoData title={noDataText} />}
         TableWrapper={PageBodyStickyTableWrapper}
         stickyHeader
+        showLoadingOverlay={isPlaceholderData && isFetching}
       />
       <PageBodyStickyContainer
         className="py-4"

--- a/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsTab.tsx
@@ -370,25 +370,26 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
     return () => clearTimeout(timer);
   }, []);
 
-  const { data, isPending, refetch } = useThreadList(
-    {
-      projectId,
-      sorting: sortedColumns,
-      filters,
-      page: page as number,
-      size: size as number,
-      search: search as string,
-      truncate: truncationEnabled,
-      fromTime: intervalStart,
-      toTime: intervalEnd,
-    },
-    {
-      enabled: isTableDataEnabled,
-      placeholderData: keepPreviousData,
-      refetchInterval: REFETCH_INTERVAL,
-      refetchOnMount: false,
-    },
-  );
+  const { data, isPending, isPlaceholderData, isFetching, refetch } =
+    useThreadList(
+      {
+        projectId,
+        sorting: sortedColumns,
+        filters,
+        page: page as number,
+        size: size as number,
+        search: search as string,
+        truncate: truncationEnabled,
+        fromTime: intervalStart,
+        toTime: intervalEnd,
+      },
+      {
+        enabled: isTableDataEnabled,
+        placeholderData: keepPreviousData,
+        refetchInterval: REFETCH_INTERVAL,
+        refetchOnMount: false,
+      },
+    );
 
   const { refetch: refetchExportData } = useThreadList(
     {
@@ -743,6 +744,7 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
             TableWrapper={PageBodyStickyTableWrapper}
             stickyHeader
             meta={meta}
+            showLoadingOverlay={isPlaceholderData && isFetching}
           />
           <PageBodyStickyContainer
             className="py-4"

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
@@ -494,26 +494,27 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
     return () => clearTimeout(timer);
   }, []);
 
-  const { data, isPending, refetch } = useTracesOrSpansList(
-    {
-      projectId,
-      type: type as TRACE_DATA_TYPE,
-      sorting: sortedColumns,
-      filters,
-      page: page as number,
-      size: size as number,
-      search: search as string,
-      truncate: truncationEnabled,
-      fromTime: intervalStart,
-      toTime: intervalEnd,
-      exclude: excludeFields,
-    },
-    {
-      enabled: isTableDataEnabled,
-      refetchInterval: REFETCH_INTERVAL,
-      refetchOnMount: false,
-    },
-  );
+  const { data, isPending, isPlaceholderData, isFetching, refetch } =
+    useTracesOrSpansList(
+      {
+        projectId,
+        type: type as TRACE_DATA_TYPE,
+        sorting: sortedColumns,
+        filters,
+        page: page as number,
+        size: size as number,
+        search: search as string,
+        truncate: truncationEnabled,
+        fromTime: intervalStart,
+        toTime: intervalEnd,
+        exclude: excludeFields,
+      },
+      {
+        enabled: isTableDataEnabled,
+        refetchInterval: REFETCH_INTERVAL,
+        refetchOnMount: false,
+      },
+    );
 
   const { refetch: refetchExportData } = useTracesOrSpansList(
     {
@@ -1295,6 +1296,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
             TableWrapper={PageBodyStickyTableWrapper}
             stickyHeader
             meta={meta}
+            showLoadingOverlay={isPlaceholderData && isFetching}
           />
           <PageBodyStickyContainer
             className="py-4"

--- a/apps/opik-frontend/src/components/shared/DataTable/DataTable.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTable/DataTable.tsx
@@ -400,7 +400,7 @@ const DataTable = <TData, TValue>({
   };
 
   return (
-    <TableWrapper showLoadingOverlay={showLoadingOverlay}>
+    <TableWrapper>
       <DataTableTooltipContext>
         <Table
           ref={tableRef}
@@ -470,6 +470,7 @@ const DataTable = <TData, TValue>({
             table={table}
             renderRow={renderRow}
             renderNoData={renderNoData}
+            showLoadingOverlay={showLoadingOverlay}
           />
         </Table>
       </DataTableTooltipContext>

--- a/apps/opik-frontend/src/components/shared/DataTable/DataTableBody.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTable/DataTableBody.tsx
@@ -1,22 +1,29 @@
 import React from "react";
 import { TableBody } from "@/components/ui/table";
 import { Row, Table } from "@tanstack/react-table";
+import { cn } from "@/lib/utils";
 
 export type DataTableBodyProps<TData> = {
   table: Table<TData>;
   renderRow: (row: Row<TData>) => React.ReactNode | null;
   renderNoData: () => React.ReactNode | null;
+  showLoadingOverlay?: boolean;
 };
 
 export const DataTableBody = <TData,>({
   table,
   renderRow,
   renderNoData,
+  showLoadingOverlay = false,
 }: DataTableBodyProps<TData>) => {
   const rows = table.getRowModel().rows;
 
   return (
-    <TableBody>{rows?.length ? rows.map(renderRow) : renderNoData()}</TableBody>
+    <TableBody
+      className={cn(showLoadingOverlay && "comet-table-body-loading-overlay")}
+    >
+      {rows?.length ? rows.map(renderRow) : renderNoData()}
+    </TableBody>
   );
 };
 

--- a/apps/opik-frontend/src/components/shared/DataTable/DataTableVirtualBody.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTable/DataTableVirtualBody.tsx
@@ -6,6 +6,7 @@ import last from "lodash/last";
 import { TableBody } from "@/components/ui/table";
 import { DataTableBodyProps } from "@/components/shared/DataTable/DataTableBody";
 import usePageBodyScrollContainer from "@/components/layout/PageBodyScrollContainer/usePageBodyScrollContainer";
+import { cn } from "@/lib/utils";
 
 const ROW_BORDER_SIZE = 1;
 const MIN_OVER_SCAN_ROWS = 2;
@@ -16,6 +17,7 @@ export const DataTableVirtualBody = <TData,>({
   table,
   renderRow,
   renderNoData,
+  showLoadingOverlay = false,
 }: DataTableBodyProps<TData>) => {
   const { scrollContainer, tableOffset } = usePageBodyScrollContainer();
   const { height } = table.options.meta?.rowHeightStyle ?? { height: "44" };
@@ -70,7 +72,11 @@ export const DataTableVirtualBody = <TData,>({
   };
 
   return (
-    <TableBody>{rows?.length ? renderVirtualRows() : renderNoData()}</TableBody>
+    <TableBody
+      className={cn(showLoadingOverlay && "comet-table-body-loading-overlay")}
+    >
+      {rows?.length ? renderVirtualRows() : renderNoData()}
+    </TableBody>
   );
 };
 

--- a/apps/opik-frontend/src/components/shared/DataTable/DataTableWrapper.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTable/DataTableWrapper.tsx
@@ -2,21 +2,12 @@ import React from "react";
 
 export type DataTableWrapperProps = {
   children: React.ReactNode;
-  showLoadingOverlay?: boolean;
 };
 
-const DataTableWrapper: React.FC<DataTableWrapperProps> = ({
-  children,
-  showLoadingOverlay = false,
-}) => {
+const DataTableWrapper: React.FC<DataTableWrapperProps> = ({ children }) => {
   return (
     <div className="overflow-x-auto overflow-y-hidden rounded-md border">
-      <div className="relative">
-        {children}
-        {showLoadingOverlay && (
-          <div className="duration-[1500ms] absolute inset-0 z-20 animate-pulse bg-background/70 ease-in-out" />
-        )}
-      </div>
+      {children}
     </div>
   );
 };

--- a/apps/opik-frontend/src/hooks/useGroupedOptimizationsList.ts
+++ b/apps/opik-frontend/src/hooks/useGroupedOptimizationsList.ts
@@ -50,6 +50,8 @@ type UseGroupedOptimizationsListResponse = {
     total: number;
   };
   isPending: boolean;
+  isPlaceholderData: boolean;
+  isFetching: boolean;
   refetch: (options?: RefetchOptions) => Promise<unknown>;
 };
 
@@ -122,6 +124,8 @@ export default function useGroupedOptimizationsList(
   const {
     data: datasetsRowData,
     isPending: isDatasetsPending,
+    isPlaceholderData: isDatasetsPlaceholderData,
+    isFetching: isDatasetsFetching,
     refetch: refetchDatasetsRowData,
   } = useDatasetsList(
     {
@@ -290,9 +294,16 @@ export default function useGroupedOptimizationsList(
     (optimizationsResponse.length > 0 &&
       optimizationsResponse.some((r) => r.isPending));
 
+  const isPlaceholderData = isFilteredByDataset
+    ? false
+    : isDatasetsPlaceholderData;
+  const isFetching = isFilteredByDataset ? false : isDatasetsFetching;
+
   return {
     data,
     isPending,
+    isPlaceholderData,
+    isFetching,
     refetch,
   } as UseGroupedOptimizationsListResponse;
 }

--- a/apps/opik-frontend/src/hooks/useProjectWithStatisticsList.ts
+++ b/apps/opik-frontend/src/hooks/useProjectWithStatisticsList.ts
@@ -19,13 +19,20 @@ type UseProjectWithStatisticsResponse = {
     total: number;
   };
   isPending: boolean;
+  isPlaceholderData: boolean;
+  isFetching: boolean;
 };
 
 export default function useProjectWithStatisticsList(
   params: UseProjectWithStatisticsParams,
   config: Omit<UseQueryOptions, "queryKey" | "queryFn">,
 ) {
-  const { data: projectsData, isPending } = useProjectsList(params, {
+  const {
+    data: projectsData,
+    isPending,
+    isPlaceholderData,
+    isFetching,
+  } = useProjectsList(params, {
     ...config,
     placeholderData: keepPreviousData,
   } as never);
@@ -73,5 +80,7 @@ export default function useProjectWithStatisticsList(
   return {
     data,
     isPending,
+    isPlaceholderData,
+    isFetching,
   } as UseProjectWithStatisticsResponse;
 }

--- a/apps/opik-frontend/src/hooks/useTracesOrSpansList.ts
+++ b/apps/opik-frontend/src/hooks/useTracesOrSpansList.ts
@@ -41,6 +41,8 @@ type UseTracesOrSpansListResponse = {
   isPending: boolean;
   isLoading: boolean;
   isError: boolean;
+  isPlaceholderData: boolean;
+  isFetching: boolean;
   refetch: (
     options?: RefetchOptions,
   ) => Promise<QueryObserverResult<TracesOrSpansListData, unknown>>;
@@ -58,6 +60,8 @@ export default function useTracesOrSpansList(
     isError: isTracesError,
     isPending: isTracesPending,
     isLoading: isTracesLoading,
+    isPlaceholderData: isTracesPlaceholderData,
+    isFetching: isTracesFetching,
     refetch: refetchTrace,
   } = useTracesList(params, {
     ...config,
@@ -70,6 +74,8 @@ export default function useTracesOrSpansList(
     isError: isSpansError,
     isPending: isSpansPending,
     isLoading: isSpansLoading,
+    isPlaceholderData: isSpansPlaceholderData,
+    isFetching: isSpansFetching,
     refetch: refetchSpan,
   } = useSpansList(
     {
@@ -87,6 +93,10 @@ export default function useTracesOrSpansList(
   const isError = !isTracesData ? isSpansError : isTracesError;
   const isPending = !isTracesData ? isSpansPending : isTracesPending;
   const isLoading = !isTracesData ? isSpansLoading : isTracesLoading;
+  const isPlaceholderData = !isTracesData
+    ? isSpansPlaceholderData
+    : isTracesPlaceholderData;
+  const isFetching = !isTracesData ? isSpansFetching : isTracesFetching;
   const refetch = !isTracesData ? refetchSpan : refetchTrace;
 
   return {
@@ -95,5 +105,7 @@ export default function useTracesOrSpansList(
     isError,
     isPending,
     isLoading,
+    isPlaceholderData,
+    isFetching,
   } as UseTracesOrSpansListResponse;
 }

--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -612,6 +612,29 @@
   }
 }
 
+.comet-table-body-loading-overlay {
+  position: relative;
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    background-color: hsl(var(--background) / 0.7);
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
 .comet-compare-optimizations-table {
   thead[data-sticky-vertical] {
     top: 0 !important;


### PR DESCRIPTION
## Details

This PR adds loading overlays to tables across the frontend application to provide visual feedback when data is being fetched after user interactions (filtering, sorting, pagination changes).


https://github.com/user-attachments/assets/5eb6d72d-f01a-4127-bc3e-d064580acb7b



**Key changes:**
- Added CSS-based loading overlay (`comet-loading-table-body-overlay`) that covers only the table body (not headers)
- Implemented `showLoadingOverlay` prop throughout the DataTable component hierarchy
- Uses React Query's `isPlaceholderData && isFetching` condition to show overlay only during parameter changes (not background polling)
- Fixed `isPlaceholderData` not working properly with `useQueries` in grouped tables by using entity-based cache as placeholder source

**Pages updated with loading overlay support:**
- Projects page
- Traces/Spans tabs
- Threads tab
- Experiments page (grouped mode)
- Optimizations page (grouped mode)
- Compare Experiments/Trials pages
- Compare Optimizations page
- Datasets page
- Prompts page (commits, experiments tabs)
- Alerts page
- Dashboards page
- Online Evaluation page
- Annotation Queues page
- Automation Logs page
- Feedback Definitions tab
- Rules tab

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3382

## Testing
- Apply filters, change sorting, or navigate pagination on any table page
- Observe loading overlay appears over table body while data is being fetched
- Verify overlay does not appear during background polling (30s refetch interval)
- Verify sticky headers remain visible above the overlay

## Documentation
N/A - No new configuration or API changes