### PR TITLE
[OPIK-2733] [FE] Expand feedback scores section by default in experiment items sidebar

### DIFF
--- a/apps/opik-frontend/src/components/shared/ExpandableSection/ExpandableSection.tsx
+++ b/apps/opik-frontend/src/components/shared/ExpandableSection/ExpandableSection.tsx
@@ -12,7 +12,7 @@ export type ExpandableSectionProps = {
   contentClassName?: string;
   sectionIdx: number;
   queryParamName: string;
-  expanded?: boolean;
+  defaultExpanded?: boolean;
 };
 
 const ExpandableSection: React.FC<ExpandableSectionProps> = ({
@@ -23,23 +23,16 @@ const ExpandableSection: React.FC<ExpandableSectionProps> = ({
   contentClassName,
   sectionIdx,
   queryParamName,
-  expanded = false,
+  defaultExpanded = false,
 }) => {
   const [sections, setSections] = useQueryParam(queryParamName, ArrayParam, {
     updateType: "replaceIn",
   });
 
   const currentSectionIdx = String(sectionIdx);
-  const hasUrlState = sections !== undefined && sections !== null;
-  const isInArray = sections?.includes(currentSectionIdx) ?? false;
+  const isInArray = sections?.includes(currentSectionIdx);
 
-  // When expanded=true, array tracks collapsed sections (inverted logic)
-  // When expanded=false, array tracks expanded sections (normal logic)
-  const isExpanded = hasUrlState
-    ? expanded
-      ? !isInArray
-      : isInArray
-    : expanded;
+  const isExpanded = defaultExpanded ? !isInArray : isInArray;
 
   const toggleIsExpanded = () => {
     const currentSections = sections?.filter((s) => s !== null) ?? [];

--- a/apps/opik-frontend/src/components/shared/ExperimentFeedbackScoresViewer/ExperimentFeedbackScoresViewer.tsx
+++ b/apps/opik-frontend/src/components/shared/ExperimentFeedbackScoresViewer/ExperimentFeedbackScoresViewer.tsx
@@ -49,7 +49,7 @@ const ExperimentFeedbackScoresViewer: React.FunctionComponent<
       queryParamName="expandedFeedbackScoresSections"
       sectionIdx={sectionIdx}
       count={feedbackScores.length}
-      expanded
+      defaultExpanded
     >
       <div className="px-2 pb-4">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">


### PR DESCRIPTION
## Details
Improves the UX of the experiment items sidebar by expanding feedback scores sections by default instead of requiring users to manually expand them.


https://github.com/user-attachments/assets/4856d35b-eb0d-479d-a678-5e99bcaea006



Changes:
- Added `expanded` prop to `ExpandableSection` component with inverted URL state logic - when `expanded=true`, the URL query param tracks collapsed sections instead of expanded ones
- Applied `expanded` prop to `ExperimentFeedbackScoresViewer` so feedback scores are visible immediately

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-2733

## Testing
1. Navigate to an experiment's items view
2. Open the sidebar for an experiment item with feedback scores
3. Verify feedback scores section is expanded by default
4. Collapse the section and verify URL state is preserved
5. Refresh and verify collapsed state persists

## Documentation
N/A
