### PR TITLE
[OPIK-3226] [FE] Fix wrong icon on filled prompt select

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { Database, Plus } from "lucide-react";
+import { FileTerminal, Plus } from "lucide-react";
 import isFunction from "lodash/isFunction";
 
 import useAppStore from "@/store/AppStore";
@@ -93,7 +93,7 @@ const PromptsSelectBox: React.FC<PromptsSelectBoxProps> = ({
         </div>
       ) : (
         <div className="flex w-full items-center text-light-slate">
-          <Database className="mr-2 size-4" />
+          <FileTerminal className="mr-2 size-4" />
           <span className="truncate font-normal">
             {filterByTemplateStructure === PROMPT_TEMPLATE_STRUCTURE.CHAT
               ? "Load chat prompt"
@@ -159,7 +159,7 @@ const PromptsSelectBox: React.FC<PromptsSelectBoxProps> = ({
         renderTitle={(option) => {
           return (
             <div className="flex w-full min-w-1 flex-nowrap items-center text-foreground">
-              <Database className="mr-2 size-4 shrink-0" />
+              <FileTerminal className="mr-2 size-4 shrink-0" />
               <span className="truncate">{option.label}</span>
             </div>
           );


### PR DESCRIPTION
## Details
Replace `Database` icon with `FileTerminal` icon in the `PromptsSelectBox` component to match the icon used for prompts in the sidebar navigation.

**Before:** The "Load a prompt" / "Load chat prompt" select was using the `Database` icon
**After:** Now uses `FileTerminal` icon, consistent with the Prompt Library sidebar icon

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3226

## Testing
1. Go to Playground page
2. Look at the "Load chat prompt" dropdown
3. Verify the icon is now `FileTerminal` (matches sidebar) instead of `Database`
4. Select a prompt and verify the icon remains consistent

## Documentation
N/A - No documentation changes required