### PR TITLE
[OPIK-4201] [FE] Improve Add to action style

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/AddToDropdown/AddToDropdown.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/AddToDropdown/AddToDropdown.tsx
@@ -50,7 +50,12 @@ const AddToDropdown: React.FunctionComponent<AddToDropdownProps> = (props) => {
       )}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="sm" disabled={disabled}>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={disabled}
+            className="font-normal"
+          >
             Add to
             <ChevronDown className="ml-2 size-4" />
           </Button>


### PR DESCRIPTION
## Details

Changed the "Add to" button on trace/span/thread lists to use regular text style instead of accented (bold) text. This makes it consistent with other filter components like the time period filter ("Past 30 days").

The fix applies `font-normal` class to override the default `font-medium` from `comet-body-s-accented` that all buttons inherit.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-4201

## Testing
- Navigate to Traces/Spans/Threads list page
- Verify the "Add to" button text matches the style of the time period filter (regular weight, not bold)

## Documentation
N/A