### PR TITLE
[OPIK-4257] [BE] Upgrade org.assertj:assertj-core to version 3.27.7

### DIFF
--- a/apps/opik-backend/opik-telemetry-extension/pom.xml
+++ b/apps/opik-backend/opik-telemetry-extension/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.27.4</version>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/apps/opik-backend/pom.xml
+++ b/apps/opik-backend/pom.xml
@@ -84,6 +84,11 @@
                 <artifactId>json-smart</artifactId>
                 <version>2.6.0</version>
             </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.27.7</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Details
Fix vulnerability by upgrade org.assertj:assertj-core to version 3.27.7

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-4257

## Testing
NA

## Documentation
NA