### PR TITLE
[OPIK-4258] [BE] Bump urllib3 version to 2.6.3 for python-backend

### DIFF
--- a/apps/opik-python-backend/requirements.txt
+++ b/apps/opik-python-backend/requirements.txt
@@ -14,7 +14,7 @@ MarkupSafe==3.0.2
 packaging==24.2
 pydantic-settings>=2.0.0,<3.0.0,!=2.9.0
 requests==2.32.3
-urllib3==2.3.0
+urllib3==2.6.3
 Werkzeug==3.1.3
 opentelemetry-api==1.36.0
 opentelemetry-sdk==1.36.0


### PR DESCRIPTION
## Details
Bump urllib3 version to 2.6.0 for python-backend

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-4258

## Testing
NA

## Documentation
NA