### PR TITLE
[OPIK-3225] [FE] Fix drag-and-drop horizontal overflow in reordering

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/llm/LLMPromptMessages/LLMPromptMessage.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/llm/LLMPromptMessages/LLMPromptMessage.tsx
@@ -122,7 +122,7 @@ const LLMPromptMessage = forwardRef<
 
     const editorViewRef = useRef<EditorView | null>(null);
     const style = {
-      transform: CSS.Transform.toString(transform),
+      transform: CSS.Translate.toString(transform),
       transition,
     };
 

--- a/apps/opik-frontend/src/components/pages-shared/llm/LLMPromptMessages/LLMPromptMessages.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/llm/LLMPromptMessages/LLMPromptMessages.tsx
@@ -10,6 +10,7 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { SortableContext } from "@dnd-kit/sortable";
 
 import {
@@ -188,6 +189,7 @@ const LLMPromptMessages = ({
     <DndContext
       sensors={sensors}
       collisionDetection={closestCenter}
+      modifiers={[restrictToVerticalAxis]}
       onDragEnd={handleDragEnd}
     >
       <div className="comet-no-scrollbar h-[calc(100%-30px)] overflow-y-auto">

--- a/apps/opik-frontend/src/components/shared/ColumnsButton/SortableMenuSection.tsx
+++ b/apps/opik-frontend/src/components/shared/ColumnsButton/SortableMenuSection.tsx
@@ -6,6 +6,7 @@ import {
   useSensors,
   MouseSensor,
 } from "@dnd-kit/core";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import {
   arrayMove,
   SortableContext,
@@ -81,6 +82,7 @@ const SortableMenuSection = <TColumnData,>({
     <DndContext
       sensors={sensors}
       collisionDetection={closestCenter}
+      modifiers={[restrictToVerticalAxis]}
       onDragEnd={handleDragEnd}
     >
       <SortableContext

--- a/apps/opik-frontend/src/components/shared/GroupsButton/GroupsButton.tsx
+++ b/apps/opik-frontend/src/components/shared/GroupsButton/GroupsButton.tsx
@@ -10,6 +10,7 @@ import {
   useSensors,
   MouseSensor,
 } from "@dnd-kit/core";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import {
   arrayMove,
   SortableContext,
@@ -219,6 +220,7 @@ const GroupsButton = <TColumnData,>({
             <DndContext
               sensors={sensors}
               collisionDetection={closestCenter}
+              modifiers={[restrictToVerticalAxis]}
               onDragEnd={handleDragEnd}
             >
               <SortableContext

--- a/apps/opik-frontend/src/components/shared/GroupsContent/GroupsContent.tsx
+++ b/apps/opik-frontend/src/components/shared/GroupsContent/GroupsContent.tsx
@@ -8,6 +8,7 @@ import {
   useSensors,
   MouseSensor,
 } from "@dnd-kit/core";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import {
   arrayMove,
   SortableContext,
@@ -120,6 +121,7 @@ const GroupsContent = <TColumnData,>({
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
+        modifiers={[restrictToVerticalAxis]}
         onDragEnd={handleDragEnd}
       >
         <SortableContext items={groups} strategy={verticalListSortingStrategy}>


### PR DESCRIPTION
## Details

Fix drag-and-drop reordering issues where items could be dragged horizontally outside the container, creating unwanted horizontal scrolling.

**Changes:**
- Add `restrictToVerticalAxis` modifier from `@dnd-kit/modifiers` to all `DndContext` components that use vertical list sorting. This constrains the drag transform to vertical movement only.
- Fix height distortion in Playground messages by using `CSS.Translate.toString()` instead of `CSS.Transform.toString()` to avoid scale transformations during drag.

**Affected components:**
- `LLMPromptMessages` - Playground message reordering
- `LLMPromptMessage` - Height distortion fix
- `SortableMenuSection` - Columns menu reordering
- `GroupsButton` - Groups popover reordering
- `GroupsContent` - Groups panel reordering

## Change checklist
- [x] User facing

## Issues
- OPIK-3225

## Testing
1. Open Playground and add multiple messages with different heights
2. Drag to reorder messages - verify they can only move vertically and maintain their height
3. Open Columns menu and drag to reorder - verify items stay within bounds
4. Open Groups popover and drag to reorder - verify items stay within bounds

## Documentation
N/A - Bug fix only