### PR TITLE
[OPIK-4253] resolve axios CVE-2025-58754 by upgrading to v1.13.4

### DIFF
--- a/apps/opik-frontend/package-lock.json
+++ b/apps/opik-frontend/package-lock.json
@@ -51,7 +51,7 @@
         "@uiw/react-codemirror": "^4.23.10",
         "ansi-to-html": "^0.7.2",
         "async": "^3.2.6",
-        "axios": "^1.8.2",
+        "axios": "^1.13.4",
         "class-variance-authority": "^0.7.0",
         "clipboard-copy": "^4.0.1",
         "clsx": "^2.1.1",
@@ -7850,13 +7850,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
-      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
-      "license": "MIT",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
+      "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/apps/opik-frontend/package.json
+++ b/apps/opik-frontend/package.json
@@ -71,7 +71,7 @@
     "@uiw/react-codemirror": "^4.23.10",
     "ansi-to-html": "^0.7.2",
     "async": "^3.2.6",
-    "axios": "^1.8.2",
+    "axios": "^1.13.4",
     "class-variance-authority": "^0.7.0",
     "clipboard-copy": "^4.0.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Details
- Upgrade axios from 1.8.2 to 1.13.4
- Fixes HIGH severity DoS vulnerability via data size
- Enforces maxContentLength for data: URLs
- Resolves Dependabot alert #122
- No breaking changes, fully backward compatible

Refs: OPIK-4253
## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-4253

## Testing

## Documentation
