### PR TITLE
[issue-5081] [FE] Expose metadata in Python online evaluation rules

### DIFF
--- a/apps/opik-frontend/src/constants/llm.ts
+++ b/apps/opik-frontend/src/constants/llm.ts
@@ -771,7 +771,7 @@ export const DEFAULT_PYTHON_CODE_TRACE_DATA: PythonCodeDetailsTraceForm = {
     '    def __init__(self, name: str = "my_custom_metric"):\n' +
     "        self.name = name\n" +
     "\n" +
-    "    def score(self, input: str, output: str, **ignored_kwargs: Any):\n" +
+    "    def score(self, input: str, output: str, metadata: dict, **ignored_kwargs: Any):\n" +
     "        # Add you logic here\n" +
     "\n" +
     "        return score_result.ScoreResult(\n" +
@@ -782,6 +782,7 @@ export const DEFAULT_PYTHON_CODE_TRACE_DATA: PythonCodeDetailsTraceForm = {
   arguments: {
     input: "input",
     output: "output",
+    metadata: "metadata",
   },
 };
 
@@ -824,7 +825,7 @@ export const DEFAULT_PYTHON_CODE_SPAN_DATA: PythonCodeDetailsSpanForm = {
     '    def __init__(self, name: str = "my_custom_metric"):\n' +
     "        self.name = name\n" +
     "\n" +
-    "    def score(self, input: str, output: str, **ignored_kwargs: Any):\n" +
+    "    def score(self, input: str, output: str, metadata: dict, **ignored_kwargs: Any):\n" +
     "        # Add you logic here\n" +
     "\n" +
     "        return score_result.ScoreResult(\n" +
@@ -835,5 +836,6 @@ export const DEFAULT_PYTHON_CODE_SPAN_DATA: PythonCodeDetailsSpanForm = {
   arguments: {
     input: "input",
     output: "output",
+    metadata: "metadata",
   },
 };


### PR DESCRIPTION
## Details

Added metadata parameter to default Python code templates for both trace and span evaluation rules. This allows users to access trace metadata (e.g., token counts) directly in their custom metrics.

Changes:
- Updated DEFAULT_PYTHON_CODE_TRACE_DATA to include metadata parameter
- Updated DEFAULT_PYTHON_CODE_SPAN_DATA to include metadata parameter
- Added metadata to default arguments mapping for both templates

The backend infrastructure already supports metadata extraction via TraceSection.METADATA, but it wasn't exposed in the default templates. This change makes metadata immediately discoverable to users.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #5081 

## Testing

Not yet.

## Documentation

Not yet.