### PR TITLE
[NA] [FE] Fix infinite request loop on annotation queue pages

### DIFF
--- a/apps/opik-frontend/src/lib/filters.ts
+++ b/apps/opik-frontend/src/lib/filters.ts
@@ -121,6 +121,7 @@ export const generateAnnotationQueueIdFilter = (annotationQueueId?: string) => {
 
   return [
     createFilter({
+      id: `annotation-queue-filter-${annotationQueueId}`,
       field: "annotation_queue_ids",
       type: COLUMN_TYPE.list,
       operator: "contains",


### PR DESCRIPTION
## Details

Fix an infinite request loop on annotation queue pages caused by filter IDs being regenerated on each render.

**Root cause:** `generateAnnotationQueueIdFilter()` uses `createFilter()` which calls `uniqid()` to generate a new filter ID on each call. When used in query hook params, React Query sees different query keys and triggers new requests, causing an infinite loop.

**Fix:** Add a deterministic ID based on the annotation queue ID to the filter, so the filter object remains stable across renders.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- NA

## Testing
1. Start local dev: `scripts/dev-runner.sh --fe-only`
2. Navigate to annotation queue page (e.g., `/default/annotation-queues/{id}`)
3. Open DevTools Network tab
4. Verify: Only initial requests are made, no infinite loop
5. Test SME flow page works without infinite requests

## Documentation
N/A

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)