### PR TITLE
[OPIK-4272] [EXT] Bump cursor extension version to 0.3.4

### DIFF
--- a/extensions/cursor/package-lock.json
+++ b/extensions/cursor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opik",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opik",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@sentry/node": "^10.38.0",
         "glob": "^11.1.0",

--- a/extensions/cursor/package.json
+++ b/extensions/cursor/package.json
@@ -4,7 +4,7 @@
   "description": "Export your chat history from Cursor to Opik.",
   "repository": "https://github.com/comet-ml/opik",
   "publisher": "opik",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "preview": false,
   "engines": {
     "vscode": "^1.90.0"


### PR DESCRIPTION
## Details

Bumped cursor extension version from 0.3.3 to 0.3.4.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-4272

## Testing

Version bump only - no functional changes. Verified package.json and package-lock.json are updated correctly.

## Documentation

N/A - Version bump only.