### PR TITLE
[OPIK-3617] [FE/SDK] Fix prompt version metadata for traces

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/PromptsTab.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/PromptsTab.tsx
@@ -40,12 +40,10 @@ const convertRawPromptToPromptWithLatestVersion = (
 ): PromptWithLatestVersion => {
   const date = new Date().toISOString();
 
-  // Use existing metadata or create default metadata for messages_json format
-  // This ensures parsePromptVersionContent knows how to parse the template correctly
-  const metadata = rawPrompt.version.metadata ?? {
-    created_from: "opik_ui",
-    type: "messages_json",
-  };
+  // Use existing metadata if available, otherwise use empty object
+  // Empty object causes isMessagesJsonFormat() to return false, so the template
+  // is treated as plain text (correct for SDK text prompts without metadata)
+  const metadata = rawPrompt.version.metadata ?? {};
 
   const promptVersion: PromptVersion = {
     id: rawPrompt.version.id,

--- a/sdks/python/src/opik/api_objects/prompt/chat/chat_prompt.py
+++ b/sdks/python/src/opik/api_objects/prompt/chat/chat_prompt.py
@@ -221,6 +221,9 @@ class ChatPrompt(base_prompt.BasePrompt):
         if self.__internal_api__version_id__ is not None:
             info_dict["version"]["id"] = self.__internal_api__version_id__
 
+        if self._metadata is not None:
+            info_dict["version"]["metadata"] = self._metadata
+
         return info_dict
 
     @classmethod

--- a/sdks/python/src/opik/api_objects/prompt/text/prompt.py
+++ b/sdks/python/src/opik/api_objects/prompt/text/prompt.py
@@ -192,6 +192,9 @@ class Prompt(base_prompt.BasePrompt):
         if self.__internal_api__version_id__ is not None:
             info_dict["version"]["id"] = self.__internal_api__version_id__
 
+        if self._metadata is not None:
+            info_dict["version"]["metadata"] = self._metadata
+
         return info_dict
 
     @classmethod


### PR DESCRIPTION
## Details

Fixes the "Use in playground" button showing empty prompts for SDK-created text prompts.

https://github.com/user-attachments/assets/fe7879be-81d1-4394-a288-0e99ef05a22b

**Root cause:** When prompts created via the Python SDK (text prompts without metadata) were loaded in the trace details panel, the frontend incorrectly assumed they were in `messages_json` format by adding default metadata. This caused `isMessagesJsonFormat()` to return true, and the parser failed to display the content correctly in the playground.

**Changes:**
- **Python SDK**: Include prompt version metadata in `_get_info_dict()` for both `Prompt` and `ChatPrompt` classes, ensuring trace metadata accurately reflects the prompt type
- **Frontend**: When no metadata exists on a prompt version, use an empty object instead of defaulting to `messages_json` format. This allows `isMessagesJsonFormat()` to correctly return false, treating the template as plain text

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3617

## Testing
- Create a text prompt via Python SDK
- Use the prompt in a trace
- Open trace details and click "Use in playground" button
- Verify the prompt content is displayed correctly (not empty)

## Documentation
N/A - Bug fix with no configuration changes
