### PR TITLE
[OPIK-4133] [DOCS] Fix import order rule to match actual codebase conventions

### DIFF
--- a/.agents/skills/opik-frontend/code-quality.md
+++ b/.agents/skills/opik-frontend/code-quality.md
@@ -67,28 +67,24 @@ const handleClick = () => {};  // Too vague
 ## Import Order
 
 ```typescript
-// 1. React and external libraries
+// 1. React
 import React, { useState, useCallback } from "react";
+
+// 2. External libraries (tanstack, zod, axios, lucide-react, etc.)
 import { useQuery } from "@tanstack/react-query";
+import { SquareArrowOutUpRight } from "lucide-react";
+import get from "lodash/get";
 
-// 2. UI components
+// 3. Internal imports (@/) — no strict ordering required
 import { Button } from "@/components/ui/button";
-import { Dialog } from "@/components/ui/dialog";
-
-// 3. Shared components
 import DataTable from "@/components/shared/DataTable/DataTable";
-
-// 4. Hooks and utilities
+import useAppStore from "@/store/AppStore";
+import useDatasetCreateMutation from "@/api/datasets/useDatasetCreateMutation";
 import { cn } from "@/lib/utils";
-import useEntityStore from "@/store/EntityStore";
-
-// 5. Lodash utilities (grouped)
-import isString from "lodash/isString";
-import isEmpty from "lodash/isEmpty";
-
-// 6. Types and constants
 import { COLUMN_TYPE } from "@/types/shared";
 ```
+
+Internal `@/` imports have no strict order. Do not reorder existing imports for style.
 
 ## Dependency Architecture
 


### PR DESCRIPTION
## Details

The import ordering rule in `.agents/skills/opik-frontend/code-quality.md` prescribed a strict 6-group ordering (React → UI → shared → hooks/utils → lodash → types) that doesn't match actual codebase conventions. The codebase uses a simpler pattern: React first, external libraries second, then internal `@/` imports in no strict order.

Updated the rule to reflect reality: 3 groups instead of 6, with a note that internal imports have no enforced order.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues
- OPIK-4133

## Testing
N/A — documentation-only change.

## Documentation
Updated `.agents/skills/opik-frontend/code-quality.md` import order section.