### PR TITLE
[OPIK-3616] [FE] Fix "View in Prompt Library" link to show correct prompt version

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/PromptsTab.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/PromptsTab.tsx
@@ -159,6 +159,9 @@ const PromptsTab: React.FunctionComponent<PromptsTabProps> = ({
                     <Link
                       to="/$workspaceName/prompts/$promptId"
                       params={{ workspaceName, promptId }}
+                      search={{
+                        activeVersionId: rawPrompts[index]?.version?.id,
+                      }}
                       className="inline-flex items-center"
                     >
                       View in Prompt library


### PR DESCRIPTION
## Details

Fixes the "View in Prompt Library" link in the Trace Details panel to navigate to the correct prompt version that was used in the trace, instead of always showing the latest version.

The fix adds the `activeVersionId` search parameter to the link, using the version ID from the trace's prompt metadata.


https://github.com/user-attachments/assets/044545e7-abd0-40ec-84db-9d309926e9df



## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-3616

## Testing

1. Open a trace that used a specific prompt version
2. Navigate to the Prompts tab in the trace details panel
3. Click "View in Prompt library"
4. Verify the prompt page shows the exact version used in the trace, not the latest version

## Documentation

N/A - No documentation changes required.
