### PR TITLE
[OPIK-4290] [BE] Fix SSE streaming format for OpenAI SDK compatibility

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ChatCompletionsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ChatCompletionsResource.java
@@ -74,7 +74,8 @@ public class ChatCompletionsResource {
             log.info("Creating and streaming chat completions, workspaceId '{}', model '{}', actualModel '{}'",
                     workspaceId, request.model(), resolvedModelInfo.actualModel());
             type = MediaType.SERVER_SENT_EVENTS;
-            var chunkedOutput = new ChunkedOutput<String>(String.class, "\r\n");
+            // Use "\n\n" separator for SSE format (each event ends with double newline)
+            var chunkedOutput = new ChunkedOutput<String>(String.class, "\n\n");
             chatCompletionService.createAndStreamResponse(request, workspaceId,
                     new ChunkedOutputHandlers(chunkedOutput));
             entity = chunkedOutput;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ChatCompletionsClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ChatCompletionsClient.java
@@ -133,7 +133,12 @@ public class ChatCompletionsClient {
         try (var inputStream = response.readEntity(CHUNKED_INPUT_STRING_GENERIC_TYPE)) {
             String chunk;
             while ((chunk = inputStream.read()) != null) {
-                entities.add(JsonUtils.readValue(chunk, CHAT_COMPLETION_RESPONSE_TYPE_REFERENCE));
+                // Strip "data: " prefix if present (SSE format)
+                String jsonChunk = chunk.startsWith("data: ") ? chunk.substring(6) : chunk;
+                // Skip [DONE] marker
+                if (!"[DONE]".equals(jsonChunk)) {
+                    entities.add(JsonUtils.readValue(jsonChunk, CHAT_COMPLETION_RESPONSE_TYPE_REFERENCE));
+                }
             }
         }
         return entities;
@@ -144,7 +149,12 @@ public class ChatCompletionsClient {
         try (var inputStream = response.readEntity(CHUNKED_INPUT_STRING_GENERIC_TYPE)) {
             String chunk;
             while ((chunk = inputStream.read()) != null) {
-                errorMessages.add(JsonUtils.readValue(chunk, ERROR_MESSAGE_TYPE_REFERENCE));
+                // Strip "data: " prefix if present (SSE format)
+                String jsonChunk = chunk.startsWith("data: ") ? chunk.substring(6) : chunk;
+                // Skip [DONE] marker
+                if (!"[DONE]".equals(jsonChunk)) {
+                    errorMessages.add(JsonUtils.readValue(jsonChunk, ERROR_MESSAGE_TYPE_REFERENCE));
+                }
             }
         }
         return errorMessages;


### PR DESCRIPTION
## Details

Fixes the SSE (Server-Sent Events) streaming format in the ChatCompletions proxy to be compatible with OpenAI SDK and LiteLLM clients.

The proxy was returning raw JSON chunks without the required `data: ` prefix and proper SSE separators, causing OpenAI Python client (used by LiteLLM) to parse zero events from the stream. This broke OpikAssist's streaming functionality when routing through the proxy.

**Changes:**
- Add `data: ` prefix to each streaming chunk in `ChunkedOutputHandlers`
- Change chunk separator to `\n\n` (double newline) per SSE specification
- Add `data: [DONE]` termination marker at stream end
- Update test client to handle new SSE format

This enables the AI backend to route LLM calls through the Opik proxy (using end-user configured API keys) instead of requiring server-side provider credentials.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-4290

## Testing

**Manual testing:**
1. Configure provider API key in workspace settings
2. Start OpikAssist conversation on a trace
3. Verify streaming response appears in UI
4. Check backend logs show `200 OK` responses from `/v1/private/chat/completions`

**Test script validation:**
Created standalone test (`test_proxy_streaming.py`) that verified:
- Raw httpx call shows proper SSE format with `data: ` prefix
- LiteLLM non-streaming works (200 OK with complete response)
- LiteLLM streaming now produces multiple chunks (previously 0)

## Documentation

No documentation changes needed - this is an internal API format fix for existing functionality.