### PR TITLE
[OPIK-4371][DOCKER] Update base images to latest to resolve vulnerabilities

### DIFF
--- a/apps/opik-ai-backend/Dockerfile
+++ b/apps/opik-ai-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13.12-slim
 
 COPY --from=ghcr.io/astral-sh/uv:0.8 /uv /uvx /bin/
 

--- a/apps/opik-backend/Dockerfile
+++ b/apps/opik-backend/Dockerfile
@@ -24,7 +24,7 @@ RUN mvn versions:set -DnewVersion=${OPIK_VERSION} && \
     mvn clean package -DskipTests
 
 ###############################
-FROM amazoncorretto:21.0.8-al2023
+FROM amazoncorretto:21.0.10-al2023
 
 # Add metadata labels
 LABEL org.opencontainers.image.title="Opik Backend"

--- a/apps/opik-frontend/Dockerfile
+++ b/apps/opik-frontend/Dockerfile
@@ -26,7 +26,7 @@ RUN printf '{"version": "%s"}\n' "$VITE_APP_VERSION" > dist/version.json
 
 # Production stage
 # Using nginx alpine image with OpenTelemetry support
-FROM nginx:1.29.4-alpine-otel AS nginx
+FROM nginx:1.29.5-alpine-otel AS nginx
 
 # Add label for later inspection
 ARG BUILD_MODE=production

--- a/apps/opik-guardrails-backend/Dockerfile
+++ b/apps/opik-guardrails-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/apps/opik-python-backend/Dockerfile
+++ b/apps/opik-python-backend/Dockerfile
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 ##############################################################
 # Runtime stage - minimal packages only
-FROM docker:28.4.0
+FROM docker:29.2.1
 
 # First upgrading to latest available versions to mitigate CVEs
 RUN apk add --no-cache --upgrade libexpat

--- a/apps/opik-sandbox-executor-python/Dockerfile
+++ b/apps/opik-sandbox-executor-python/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build: Build stage
-FROM python:3.12.11-slim AS builder
+FROM python:3.12.12-slim AS builder
 
 WORKDIR /build
 
@@ -38,7 +38,7 @@ RUN cp -r /usr/local/lib/python3.12/site-packages /runtime-python
 
 #######################################################################
 # Multi-stage build: Runtime stage
-FROM python:3.12.11-slim AS runtime
+FROM python:3.12.12-slim AS runtime
 
 WORKDIR /opt/opik-sandbox-executor-python
 


### PR DESCRIPTION
## Details
Updated base Docker images across Opik project to their latest versions to resolve known vulnerabilities

## Base Image Updates
| Dockerfile | Old | New |
|---|---|---|
| opik-guardrails-backend | `nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04` | `nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04` |
| opik-python-backend | `docker:28.4.0` | `docker:29.2.1` |
| opik-sandbox-executor-python | `python:3.12.11-slim` | `python:3.12.12-slim` |
| opik-backend | `amazoncorretto:21.0.8-al2023` | `amazoncorretto:21.0.10-al2023` |
| opik-frontend | `nginx:1.29.4-alpine-otel` | `nginx:1.29.5-alpine-otel` |
| opik-ai-backend | `python:3.13-slim` | `python:3.13.12-slim` |


## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-4371

## Testing
- [x] All images built locally
- [x] Trivy scan passed with 0 HIGH/CRITICAL vulnerabilities on all images
- [x] Built and run on Test Environment 

## Documentation
