### PR TITLE
[OPIK-4355] [FE] Fix Experiment Leaderboard header row overlap after switching dashboards

### DIFF
--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/ExperimentsLeaderboardTableWrapper.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ExperimentsLeaderboardWidget/ExperimentsLeaderboardTableWrapper.tsx
@@ -7,7 +7,7 @@ const ExperimentsLeaderboardTableWrapper: React.FC<DataTableWrapperProps> = ({
 }) => {
   return (
     <div
-      className="comet-sticky-table relative h-full overflow-auto [&_thead[data-sticky-vertical]]:top-0"
+      className="comet-sticky-table relative h-full overflow-auto [&_thead[data-sticky-vertical]]:!top-0"
       {...{ [TABLE_WRAPPER_ATTRIBUTE]: "" }}
     >
       {children}


### PR DESCRIPTION
## Details

Fixes a bug where the Experiment Leaderboard widget's header row overlaps with data rows after switching dashboards.

**Root cause**: `PageBodyScrollContainer.calculateOffsets()` queries all `[data-sticky-vertical]` elements and sets inline `top` styles on them. The DataTable's `<thead>` inside the leaderboard widget also has this attribute (set when `stickyHeader` is true), so it gets an incorrect `top` offset — even though the widget has its own `overflow-auto` scroll container where `top: 0` is the correct value.

**Fix**: Use `!important` on the `top-0` Tailwind class in `ExperimentsLeaderboardTableWrapper` to override the inline style set by `calculateOffsets`. This is the same pattern used by `.comet-compare-optimizations-table` in `main.scss`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-4355

## Testing
- Open a dashboard with an Experiment Leaderboard widget
- Switch to a different dashboard (or navigate away and back)
- Verify the header row no longer overlaps with experiment data rows

## Documentation
N/A
