### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -15486,6 +15486,14 @@ components:
             \ the frontend will limit pagination to prevent performance issues. Default:\
             \ true (truncation enabled)."
           example: true
+        color_map:
+          type: object
+          additionalProperties:
+            type: string
+            description: "Workspace-level color map. Maps label names to hex color\
+              \ values (e.g. #FF0000). Max 10000 entries."
+          description: "Workspace-level color map. Maps label names to hex color values\
+            \ (e.g. #FF0000). Max 10000 entries."
     WorkspaceMetricsSummaryResponse:
       type: object
       properties:

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -15486,6 +15486,14 @@ components:
             \ the frontend will limit pagination to prevent performance issues. Default:\
             \ true (truncation enabled)."
           example: true
+        color_map:
+          type: object
+          additionalProperties:
+            type: string
+            description: "Workspace-level color map. Maps label names to hex color\
+              \ values (e.g. #FF0000). Max 10000 entries."
+          description: "Workspace-level color map. Maps label names to hex color values\
+            \ (e.g. #FF0000). Max 10000 entries."
     WorkspaceMetricsSummaryResponse:
       type: object
       properties:

--- a/sdks/python/src/opik/rest_api/types/workspace_configuration.py
+++ b/sdks/python/src/opik/rest_api/types/workspace_configuration.py
@@ -17,6 +17,11 @@ class WorkspaceConfiguration(UniversalBaseModel):
     Enable or disable data truncation in table views. When disabled, the frontend will limit pagination to prevent performance issues. Default: true (truncation enabled).
     """
 
+    color_map: typing.Optional[typing.Dict[str, str]] = pydantic.Field(default=None)
+    """
+    Workspace-level color map. Maps label names to hex color values (e.g. #FF0000). Max 10000 entries.
+    """
+
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
     else:

--- a/sdks/python/src/opik/rest_api/workspaces/client.py
+++ b/sdks/python/src/opik/rest_api/workspaces/client.py
@@ -106,6 +106,7 @@ class WorkspacesClient:
         *,
         timeout_to_mark_thread_as_inactive: typing.Optional[str] = OMIT,
         truncation_on_tables: typing.Optional[bool] = OMIT,
+        color_map: typing.Optional[typing.Dict[str, str]] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> WorkspaceConfiguration:
         """
@@ -118,6 +119,9 @@ class WorkspacesClient:
 
         truncation_on_tables : typing.Optional[bool]
             Enable or disable data truncation in table views. When disabled, the frontend will limit pagination to prevent performance issues. Default: true (truncation enabled).
+
+        color_map : typing.Optional[typing.Dict[str, str]]
+            Workspace-level color map. Maps label names to hex color values (e.g. #FF0000). Max 10000 entries.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -136,6 +140,7 @@ class WorkspacesClient:
         _response = self._raw_client.upsert_workspace_configuration(
             timeout_to_mark_thread_as_inactive=timeout_to_mark_thread_as_inactive,
             truncation_on_tables=truncation_on_tables,
+            color_map=color_map,
             request_options=request_options,
         )
         return _response.data
@@ -398,6 +403,7 @@ class AsyncWorkspacesClient:
         *,
         timeout_to_mark_thread_as_inactive: typing.Optional[str] = OMIT,
         truncation_on_tables: typing.Optional[bool] = OMIT,
+        color_map: typing.Optional[typing.Dict[str, str]] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> WorkspaceConfiguration:
         """
@@ -410,6 +416,9 @@ class AsyncWorkspacesClient:
 
         truncation_on_tables : typing.Optional[bool]
             Enable or disable data truncation in table views. When disabled, the frontend will limit pagination to prevent performance issues. Default: true (truncation enabled).
+
+        color_map : typing.Optional[typing.Dict[str, str]]
+            Workspace-level color map. Maps label names to hex color values (e.g. #FF0000). Max 10000 entries.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -431,6 +440,7 @@ class AsyncWorkspacesClient:
         _response = await self._raw_client.upsert_workspace_configuration(
             timeout_to_mark_thread_as_inactive=timeout_to_mark_thread_as_inactive,
             truncation_on_tables=truncation_on_tables,
+            color_map=color_map,
             request_options=request_options,
         )
         return _response.data

--- a/sdks/python/src/opik/rest_api/workspaces/raw_client.py
+++ b/sdks/python/src/opik/rest_api/workspaces/raw_client.py
@@ -148,6 +148,7 @@ class RawWorkspacesClient:
         *,
         timeout_to_mark_thread_as_inactive: typing.Optional[str] = OMIT,
         truncation_on_tables: typing.Optional[bool] = OMIT,
+        color_map: typing.Optional[typing.Dict[str, str]] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[WorkspaceConfiguration]:
         """
@@ -160,6 +161,9 @@ class RawWorkspacesClient:
 
         truncation_on_tables : typing.Optional[bool]
             Enable or disable data truncation in table views. When disabled, the frontend will limit pagination to prevent performance issues. Default: true (truncation enabled).
+
+        color_map : typing.Optional[typing.Dict[str, str]]
+            Workspace-level color map. Maps label names to hex color values (e.g. #FF0000). Max 10000 entries.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -175,6 +179,7 @@ class RawWorkspacesClient:
             json={
                 "timeout_to_mark_thread_as_inactive": timeout_to_mark_thread_as_inactive,
                 "truncation_on_tables": truncation_on_tables,
+                "color_map": color_map,
             },
             headers={
                 "content-type": "application/json",
@@ -599,6 +604,7 @@ class AsyncRawWorkspacesClient:
         *,
         timeout_to_mark_thread_as_inactive: typing.Optional[str] = OMIT,
         truncation_on_tables: typing.Optional[bool] = OMIT,
+        color_map: typing.Optional[typing.Dict[str, str]] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[WorkspaceConfiguration]:
         """
@@ -611,6 +617,9 @@ class AsyncRawWorkspacesClient:
 
         truncation_on_tables : typing.Optional[bool]
             Enable or disable data truncation in table views. When disabled, the frontend will limit pagination to prevent performance issues. Default: true (truncation enabled).
+
+        color_map : typing.Optional[typing.Dict[str, str]]
+            Workspace-level color map. Maps label names to hex color values (e.g. #FF0000). Max 10000 entries.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -626,6 +635,7 @@ class AsyncRawWorkspacesClient:
             json={
                 "timeout_to_mark_thread_as_inactive": timeout_to_mark_thread_as_inactive,
                 "truncation_on_tables": truncation_on_tables,
+                "color_map": color_map,
             },
             headers={
                 "content-type": "application/json",

--- a/sdks/typescript/src/opik/rest_api/api/types/WorkspaceConfiguration.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/WorkspaceConfiguration.ts
@@ -5,4 +5,6 @@ export interface WorkspaceConfiguration {
     timeoutToMarkThreadAsInactive?: string;
     /** Enable or disable data truncation in table views. When disabled, the frontend will limit pagination to prevent performance issues. Default: true (truncation enabled). */
     truncationOnTables?: boolean;
+    /** Workspace-level color map. Maps label names to hex color values (e.g. #FF0000). Max 10000 entries. */
+    colorMap?: Record<string, string>;
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/WorkspaceConfiguration.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/WorkspaceConfiguration.ts
@@ -13,11 +13,16 @@ export const WorkspaceConfiguration: core.serialization.ObjectSchema<
         core.serialization.string().optional(),
     ),
     truncationOnTables: core.serialization.property("truncation_on_tables", core.serialization.boolean().optional()),
+    colorMap: core.serialization.property(
+        "color_map",
+        core.serialization.record(core.serialization.string(), core.serialization.string()).optional(),
+    ),
 });
 
 export declare namespace WorkspaceConfiguration {
     export interface Raw {
         timeout_to_mark_thread_as_inactive?: string | null;
         truncation_on_tables?: boolean | null;
+        color_map?: Record<string, string> | null;
     }
 }


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate