### PR TITLE
[OPIK-4325] [FE] Add missing data-testid to PromptTemplateView for E2E test compatibility

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/llm/PromptTemplateView/PromptTemplateView.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/llm/PromptTemplateView/PromptTemplateView.tsx
@@ -125,7 +125,10 @@ const PromptTemplateView: React.FC<PromptTemplateViewProps> = ({
 
     if (isTextPrompt) {
       return (
-        <div className="comet-body-s whitespace-pre-wrap break-words rounded-md border bg-primary-foreground p-3 text-foreground">
+        <div
+          className="comet-body-s whitespace-pre-wrap break-words rounded-md border bg-primary-foreground p-3 text-foreground"
+          data-testid="prompt-text-content"
+        >
           {textContent}
         </div>
       );


### PR DESCRIPTION
## Details
PR #5128 refactored `TextPromptView` to delegate to the new shared `PromptTemplateView` component, but the `data-testid="prompt-text-content"` attribute on the text prompt container was lost in the process. This caused two E2E tests to fail because they rely on that test ID to read the displayed prompt content.

This PR restores the `data-testid="prompt-text-content"` attribute on the text prompt `<div>` inside `PromptTemplateView`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-4325

## Testing
- `Prompts can be updated via SDK and version history is maintained` — passes
- `Prompts can be updated via UI and version history is maintained` — passes

Both tests verified locally with `npx playwright test tests/prompts/prompts.spec.ts -g "Prompts can be updated via"`.

## Documentation
No documentation changes required.