### PR TITLE
[OPIK-4428] [FE] Fix inconsistent number formatting across the UI

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
@@ -392,14 +392,13 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
             <TooltipWrapper
               content={`Estimated cost ${formatCost(
                 thread?.total_estimated_cost,
+                { modifier: "full" },
               )}`}
             >
               <div className="flex flex-nowrap items-center gap-x-1.5 px-1 text-muted-slate">
                 <Coins className="size-4 shrink-0" />
                 <span className="comet-body-s-accented truncate">
-                  {formatCost(thread?.total_estimated_cost, {
-                    modifier: "short",
-                  })}
+                  {formatCost(thread?.total_estimated_cost)}
                 </span>
               </div>
             </TooltipWrapper>

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -240,14 +240,16 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
             )}
             {!isUndefined(estimatedCost) && (
               <TooltipWrapper
-                content={`Estimated cost ${formatCost(estimatedCost)}`}
+                content={`Estimated cost ${formatCost(estimatedCost, {
+                  modifier: "full",
+                })}`}
               >
                 <div
                   className="comet-body-xs-accented flex items-center gap-1 text-muted-slate"
                   data-testid="data-viewer-cost"
                 >
                   <Coins className="size-3 shrink-0" />{" "}
-                  {formatCost(estimatedCost, { modifier: "short" })}
+                  {formatCost(estimatedCost)}
                 </div>
               </TooltipWrapper>
             )}

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceTreeViewer/VirtualizedTreeViewer.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceTreeViewer/VirtualizedTreeViewer.tsx
@@ -283,11 +283,13 @@ const VirtualizedTreeViewer: React.FC<VirtualizedTreeViewerProps> = ({
         {config[TREE_DATABLOCK_TYPE.ESTIMATED_COST] &&
           !isUndefined(estimatedCost) && (
             <TooltipWrapper
-              content={`Estimated cost ${formatCost(estimatedCost)}`}
+              content={`Estimated cost ${formatCost(estimatedCost, {
+                modifier: "full",
+              })}`}
             >
               <div className="comet-body-xs-accented flex items-center gap-1 text-muted-slate">
                 <Coins className="size-3 shrink-0" />{" "}
-                {formatCost(estimatedCost, { modifier: "short" })}
+                {formatCost(estimatedCost)}
               </div>
             </TooltipWrapper>
           )}

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
@@ -71,6 +71,7 @@ import QueueItemRowActionsCell from "@/components/pages/AnnotationQueuePage/Queu
 import NoQueueItemsPage from "@/components/pages/AnnotationQueuePage/QueueItemsTab/NoQueueItemsPage";
 import useTracesList from "@/api/traces/useTracesList";
 import { formatDate, formatDuration } from "@/lib/date";
+import { formatCost } from "@/lib/money";
 import { generateTracesURL } from "@/lib/annotation-queues";
 import useTracesStatistic from "@/api/traces/useTracesStatistic";
 import useAppStore from "@/store/AppStore";
@@ -132,6 +133,7 @@ const TRACE_COLUMNS: ColumnData<Trace>[] = [
     type: COLUMN_TYPE.duration,
     cell: DurationCell as never,
     statisticDataFormater: formatDuration,
+    statisticTooltipFormater: formatDuration,
   },
   {
     id: COLUMN_METADATA_ID,
@@ -183,6 +185,9 @@ const TRACE_COLUMNS: ColumnData<Trace>[] = [
     type: COLUMN_TYPE.cost,
     cell: CostCell as never,
     size: 160,
+    statisticDataFormater: formatCost,
+    statisticTooltipFormater: (value: number) =>
+      formatCost(value, { modifier: "full" }),
   },
   {
     id: "llm_span_count",

--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -86,6 +86,7 @@ import {
 } from "@/components/shared/DataTable/utils";
 import { calculateLineHeight } from "@/lib/experiments";
 import { formatDuration } from "@/lib/date";
+import { formatCost } from "@/lib/money";
 import SectionHeader from "@/components/shared/DataTableHeaders/SectionHeader";
 import CommentsCell from "@/components/shared/DataTableCells/CommentsCell";
 import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
@@ -460,6 +461,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         cell: DurationCell.Compare as never,
         statisticKey: "duration",
         statisticDataFormater: formatDuration,
+        statisticTooltipFormater: formatDuration,
         customMeta: {
           experimentsIds,
         },
@@ -483,6 +485,9 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         type: COLUMN_TYPE.cost,
         cell: CostCell.Compare as never,
         statisticKey: "total_estimated_cost",
+        statisticDataFormater: formatCost,
+        statisticTooltipFormater: (value: number) =>
+          formatCost(value, { modifier: "full" }),
         supportsPercentiles: true,
         customMeta: {
           experimentsIds,

--- a/apps/opik-frontend/src/components/pages/HomePage/CostOverview.tsx
+++ b/apps/opik-frontend/src/components/pages/HomePage/CostOverview.tsx
@@ -14,6 +14,7 @@ import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
 import ExplainerCallout from "@/components/shared/ExplainerCallout/ExplainerCallout";
 import PercentageTrend from "@/components/shared/PercentageTrend/PercentageTrend";
 import { formatCost } from "@/lib/money";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import { calculatePercentageChange } from "@/lib/utils";
 import {
   getChartData,
@@ -81,14 +82,18 @@ export const CostOverview: React.FC<CostOverviewProps> = ({
           <div>
             <div className="flex items-center gap-2">
               {!isPending && (
-                <div className="comet-title-l text-foreground-secondary">
-                  {isNumber(data?.current)
-                    ? formatCost(data?.current, {
-                        modifier: "kFormat",
-                        noValue: "$0",
-                      })
-                    : "$ -"}
-                </div>
+                <TooltipWrapper
+                  content={formatCost(data?.current, { modifier: "full" })}
+                >
+                  <div className="comet-title-l text-foreground-secondary">
+                    {isNumber(data?.current)
+                      ? formatCost(data?.current, {
+                          modifier: "kFormat",
+                          noValue: "$0",
+                        })
+                      : "$ -"}
+                  </div>
+                </TooltipWrapper>
               )}
               <PercentageTrend
                 percentage={calculatePercentageChange(

--- a/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/utils.ts
+++ b/apps/opik-frontend/src/components/pages/TracesPage/MetricsTab/utils.ts
@@ -57,7 +57,8 @@ export const durationYTickFormatter = (value: number) =>
  */
 export const renderCostTooltipValue = ({
   value,
-}: ChartTooltipRenderValueArguments) => formatCost(value as number);
+}: ChartTooltipRenderValueArguments) =>
+  formatCost(value as number, { modifier: "full" });
 
 /**
  * Formats Y-axis tick values for cost charts

--- a/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/ThreadsTab/ThreadsTab.tsx
@@ -61,6 +61,7 @@ import TraceDetailsPanel from "@/components/pages-shared/traces/TraceDetailsPane
 import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
 import PageBodyStickyTableWrapper from "@/components/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
 import { formatDate, formatDuration } from "@/lib/date";
+import { formatCost } from "@/lib/money";
 import ThreadsActionsPanel from "@/components/pages/TracesPage/ThreadsTab/ThreadsActionsPanel";
 import useThreadList from "@/api/traces/useThreadsList";
 import useThreadsStatistic from "@/api/traces/useThreadsStatistic";
@@ -131,7 +132,8 @@ const SHARED_COLUMNS: ColumnData<Thread>[] = [
     label: "Duration",
     type: COLUMN_TYPE.duration,
     cell: DurationCell as never,
-    statisticDataFormater: (value) => formatDuration(value),
+    statisticDataFormater: formatDuration,
+    statisticTooltipFormater: formatDuration,
     supportsPercentiles: true,
   },
   {
@@ -202,6 +204,9 @@ const DEFAULT_COLUMNS: ColumnData<Thread>[] = [
     explainer: EXPLAINERS_MAP[EXPLAINER_ID.hows_the_thread_cost_estimated],
     size: 160,
     statisticKey: "total_estimated_cost",
+    statisticDataFormater: formatCost,
+    statisticTooltipFormater: (value: number) =>
+      formatCost(value, { modifier: "full" }),
   },
   {
     id: "created_by",

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
@@ -91,6 +91,7 @@ import TracesOrSpansPathsAutocomplete from "@/components/pages-shared/traces/Tra
 import TracesOrSpansFeedbackScoresSelect from "@/components/pages-shared/traces/TracesOrSpansFeedbackScoresSelect/TracesOrSpansFeedbackScoresSelect";
 import ExperimentsSelectBox from "@/components/pages-shared/experiments/ExperimentsSelectBox/ExperimentsSelectBox";
 import { formatDate, formatDuration } from "@/lib/date";
+import { formatCost } from "@/lib/money";
 import useTracesOrSpansStatistic from "@/hooks/useTracesOrSpansStatistic";
 import { useDynamicColumnsCache } from "@/hooks/useDynamicColumnsCache";
 import { useIsFeatureEnabled } from "@/components/feature-toggles-provider";
@@ -181,6 +182,7 @@ const SHARED_COLUMNS: ColumnData<BaseTraceData>[] = [
     type: COLUMN_TYPE.duration,
     cell: DurationCell as never,
     statisticDataFormater: formatDuration,
+    statisticTooltipFormater: formatDuration,
   },
   {
     id: "tags",
@@ -223,6 +225,9 @@ const SHARED_COLUMNS: ColumnData<BaseTraceData>[] = [
     cell: CostCell as never,
     explainer: EXPLAINERS_MAP[EXPLAINER_ID.hows_the_cost_estimated],
     size: 160,
+    statisticDataFormater: formatCost,
+    statisticTooltipFormater: (value: number) =>
+      formatCost(value, { modifier: "full" }),
   },
 ];
 

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectStatsCardWidget/ProjectStatsCardWidget.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectStatsCardWidget/ProjectStatsCardWidget.tsx
@@ -17,20 +17,25 @@ import { TRACE_DATA_TYPE } from "@/constants/traces";
 import {
   getMetricDefinition,
   formatMetricValue,
+  formatMetricTooltipValue,
   isFeedbackScoreMetric,
   extractFeedbackScoreName,
 } from "./metrics";
 import { formatScoreDisplay } from "@/lib/feedback-scores";
 import { resolveProjectIdFromConfig } from "@/lib/dashboard/utils";
 
-const renderMetricDisplay = (label: string, value: string) => (
+const renderMetricDisplay = (
+  label: string,
+  value: string,
+  tooltipValue?: string,
+) => (
   <div className="flex h-full flex-col items-stretch justify-center">
     <TooltipWrapper content={label}>
       <div className="comet-body truncate text-center text-muted-foreground">
         {label}
       </div>
     </TooltipWrapper>
-    <TooltipWrapper content={value}>
+    <TooltipWrapper content={tooltipValue ?? value}>
       <div className="comet-title-xl mt-2 truncate text-center">{value}</div>
     </TooltipWrapper>
   </div>
@@ -232,6 +237,9 @@ const ProjectStatsCardWidget: React.FunctionComponent<
       selectedValue !== undefined
         ? formatMetricValue(selectedValue, metricDef)
         : "-",
+      selectedValue !== undefined
+        ? formatMetricTooltipValue(selectedValue, metricDef)
+        : undefined,
     );
   };
 

--- a/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectStatsCardWidget/metrics.ts
+++ b/apps/opik-frontend/src/components/shared/Dashboard/widgets/ProjectStatsCardWidget/metrics.ts
@@ -13,6 +13,7 @@ export type MetricDefinition = {
   type: STATISTIC_AGGREGATION_TYPE;
   statName: string;
   formatter: (value: number) => string;
+  tooltipFormatter?: (value: number) => string;
 };
 
 export type MetricOption = {
@@ -69,6 +70,7 @@ const SHARED_METRICS: MetricDefinition[] = [
     type: STATISTIC_AGGREGATION_TYPE.AVG,
     statName: "tags",
     formatter: formatNumericData,
+    tooltipFormatter: String,
   },
   {
     value: "total_estimated_cost_sum",
@@ -76,6 +78,8 @@ const SHARED_METRICS: MetricDefinition[] = [
     type: STATISTIC_AGGREGATION_TYPE.AVG,
     statName: "total_estimated_cost_sum",
     formatter: formatCost,
+    tooltipFormatter: (value: number) =>
+      formatCost(value, { modifier: "full" }),
   },
   {
     value: "usage.completion_tokens",
@@ -83,6 +87,7 @@ const SHARED_METRICS: MetricDefinition[] = [
     type: STATISTIC_AGGREGATION_TYPE.AVG,
     statName: "usage.completion_tokens",
     formatter: formatNumericData,
+    tooltipFormatter: String,
   },
   {
     value: "usage.prompt_tokens",
@@ -90,6 +95,7 @@ const SHARED_METRICS: MetricDefinition[] = [
     type: STATISTIC_AGGREGATION_TYPE.AVG,
     statName: "usage.prompt_tokens",
     formatter: formatNumericData,
+    tooltipFormatter: String,
   },
   {
     value: "usage.total_tokens",
@@ -97,6 +103,7 @@ const SHARED_METRICS: MetricDefinition[] = [
     type: STATISTIC_AGGREGATION_TYPE.AVG,
     statName: "usage.total_tokens",
     formatter: formatNumericData,
+    tooltipFormatter: String,
   },
   {
     value: "error_count",
@@ -128,6 +135,7 @@ const TRACE_SPECIFIC_METRICS: MetricDefinition[] = [
     type: STATISTIC_AGGREGATION_TYPE.AVG,
     statName: "llm_span_count",
     formatter: formatNumericData,
+    tooltipFormatter: String,
   },
   {
     value: "span_count",
@@ -135,6 +143,7 @@ const TRACE_SPECIFIC_METRICS: MetricDefinition[] = [
     type: STATISTIC_AGGREGATION_TYPE.AVG,
     statName: "span_count",
     formatter: formatNumericData,
+    tooltipFormatter: String,
   },
   {
     value: "total_estimated_cost",
@@ -142,6 +151,8 @@ const TRACE_SPECIFIC_METRICS: MetricDefinition[] = [
     type: STATISTIC_AGGREGATION_TYPE.AVG,
     statName: "total_estimated_cost",
     formatter: formatCost,
+    tooltipFormatter: (value: number) =>
+      formatCost(value, { modifier: "full" }),
   },
   {
     value: "guardrails_failed_count",
@@ -166,6 +177,8 @@ const SPAN_SPECIFIC_METRICS: MetricDefinition[] = [
     type: STATISTIC_AGGREGATION_TYPE.AVG,
     statName: "total_estimated_cost",
     formatter: formatCost,
+    tooltipFormatter: (value: number) =>
+      formatCost(value, { modifier: "full" }),
   },
 ];
 
@@ -210,11 +223,12 @@ export const getMetricDefinition = (
   return staticMetrics.find((m) => m.value === metricValue) || null;
 };
 
-export const formatMetricValue = (
+const formatWithFormatter = (
   value: number | string | object,
   metricDefinition: MetricDefinition,
+  formatter: (value: number) => string,
 ): string => {
-  const { type, formatter } = metricDefinition;
+  const { type } = metricDefinition;
 
   if (type === STATISTIC_AGGREGATION_TYPE.PERCENTAGE) {
     const percentageValue = value as {
@@ -238,6 +252,29 @@ export const formatMetricValue = (
 
   const numValue = Number(value);
   return formatter(numValue);
+};
+
+export const formatMetricValue = (
+  value: number | string | object,
+  metricDefinition: MetricDefinition,
+): string => {
+  return formatWithFormatter(
+    value,
+    metricDefinition,
+    metricDefinition.formatter,
+  );
+};
+
+export const formatMetricTooltipValue = (
+  value: number | string | object,
+  metricDefinition: MetricDefinition,
+): string | undefined => {
+  if (!metricDefinition.tooltipFormatter) return undefined;
+  return formatWithFormatter(
+    value,
+    metricDefinition,
+    metricDefinition.tooltipFormatter,
+  );
 };
 
 export const isFeedbackScoreMetric = (metricValue: string): boolean => {

--- a/apps/opik-frontend/src/components/shared/DataTableCells/CostCell.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableCells/CostCell.tsx
@@ -5,6 +5,7 @@ import isNumber from "lodash/isNumber";
 
 import { formatCost, FormatCostOptions } from "@/lib/money";
 import CellWrapper from "@/components/shared/DataTableCells/CellWrapper";
+import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import { ExperimentItem, ExperimentsCompare } from "@/types/datasets";
 import VerticallySplitCellWrapper, {
   SplitCellRenderContent,
@@ -18,7 +19,9 @@ const CostCell = <TData,>(context: CellContext<TData, string>) => {
       metadata={context.column.columnDef.meta}
       tableMetadata={context.table.options.meta}
     >
-      {formatCost(value, { modifier: "short" })}
+      <TooltipWrapper content={formatCost(value, { modifier: "full" })}>
+        <span>{formatCost(value)}</span>
+      </TooltipWrapper>
     </CellWrapper>
   );
 };
@@ -40,7 +43,7 @@ const CompareCostCell: React.FC<CellContext<ExperimentsCompare, unknown>> = (
     const value = get(item, accessor);
     if (!isNumber(value)) return "-";
 
-    return formatter(value, { modifier: "short" });
+    return formatter(value);
   };
 
   return (
@@ -74,7 +77,7 @@ const CostAggregationCell = <TData,>(context: CellContext<TData, string>) => {
   let value = "-";
 
   if (isNumber(rawValue)) {
-    value = dataFormatter(rawValue, { modifier: "short" });
+    value = dataFormatter(rawValue, {});
   }
 
   return (
@@ -82,7 +85,13 @@ const CostAggregationCell = <TData,>(context: CellContext<TData, string>) => {
       metadata={context.column.columnDef.meta}
       tableMetadata={context.table.options.meta}
     >
-      <span className="truncate text-light-slate">{value}</span>
+      {isNumber(rawValue) ? (
+        <TooltipWrapper content={formatCost(rawValue, { modifier: "full" })}>
+          <span className="truncate text-light-slate">{value}</span>
+        </TooltipWrapper>
+      ) : (
+        <span className="truncate text-light-slate">{value}</span>
+      )}
     </CellWrapper>
   );
 };

--- a/apps/opik-frontend/src/components/shared/DataTableHeaders/HeaderStatistic.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableHeaders/HeaderStatistic.tsx
@@ -63,6 +63,7 @@ type HeaderStatisticProps = {
   columnsStatistic?: ColumnsStatistic;
   statisticKey?: string;
   dataFormater?: (value: number) => string;
+  tooltipFormater?: (value: number) => string;
   supportsPercentiles?: boolean;
 };
 
@@ -70,8 +71,12 @@ const HeaderStatistic: React.FC<HeaderStatisticProps> = ({
   columnsStatistic,
   statisticKey,
   dataFormater = formatNumericData,
+  tooltipFormater,
   supportsPercentiles = false,
 }) => {
+  const formatTooltip = (value: number) =>
+    tooltipFormater ? tooltipFormater(value) : String(value);
+
   // Find all statistics matching the key (could have both AVG and PERCENTAGE)
   const matchingStatistics = React.useMemo(() => {
     if (!columnsStatistic || !statisticKey) return [];
@@ -188,7 +193,7 @@ const HeaderStatistic: React.FC<HeaderStatisticProps> = ({
               <div className="flex max-w-full">
                 <span className="comet-body-s truncate text-foreground">
                   <span>{selectedValue}</span>
-                  <TooltipWrapper content={String(displayValue)}>
+                  <TooltipWrapper content={formatTooltip(displayValue)}>
                     <span className="ml-1 font-semibold">
                       {dataFormater(displayValue)}
                     </span>
@@ -238,7 +243,7 @@ const HeaderStatistic: React.FC<HeaderStatisticProps> = ({
       return (
         <span className="comet-body-s truncate text-foreground">
           <span>{AGGREGATION_VALUE.AVG}</span>
-          <TooltipWrapper content={String(statistic.value)}>
+          <TooltipWrapper content={formatTooltip(statistic.value)}>
             <span className="ml-1 font-semibold">
               {dataFormater(statistic.value)}
             </span>
@@ -250,7 +255,7 @@ const HeaderStatistic: React.FC<HeaderStatisticProps> = ({
       return (
         <span className="comet-body-s truncate text-foreground">
           <span>{statistic.type.toLowerCase()}</span>
-          <TooltipWrapper content={String(statistic.value)}>
+          <TooltipWrapper content={formatTooltip(statistic.value)}>
             <span className="ml-1 font-semibold">
               {dataFormater(statistic.value)}
             </span>
@@ -265,7 +270,9 @@ const HeaderStatistic: React.FC<HeaderStatisticProps> = ({
               <span className="comet-body-s truncate text-foreground">
                 <span>{selectedValue}</span>
                 <TooltipWrapper
-                  content={String(get(statistic.value, selectedValue, 0))}
+                  content={formatTooltip(
+                    get(statistic.value, selectedValue, 0),
+                  )}
                 >
                   <span className="ml-1 font-semibold">
                     {dataFormater(get(statistic.value, selectedValue, 0))}

--- a/apps/opik-frontend/src/components/shared/DataTableHeaders/HeaderWrapper.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableHeaders/HeaderWrapper.tsx
@@ -9,6 +9,7 @@ type CustomColumnMeta = {
   type?: COLUMN_TYPE;
   statisticKey?: string;
   statisticDataFormater?: (value: number) => string;
+  statisticTooltipFormater?: (value: number) => string;
   supportsPercentiles?: boolean;
 };
 
@@ -33,6 +34,7 @@ const HeaderWrapper = <TData,>({
   const type = metaData?.type;
   const statisticKey = metaData?.statisticKey;
   const statisticDataFormater = metaData?.statisticDataFormater;
+  const statisticTooltipFormater = metaData?.statisticTooltipFormater;
   const supportsPercentiles = metaData?.supportsPercentiles;
   const { columnsStatistic } = tableMetadata || {};
 
@@ -67,6 +69,7 @@ const HeaderWrapper = <TData,>({
             columnsStatistic={columnsStatistic}
             statisticKey={statisticKey}
             dataFormater={statisticDataFormater}
+            tooltipFormater={statisticTooltipFormater}
             supportsPercentiles={supportsPercentiles}
           />
         </div>

--- a/apps/opik-frontend/src/lib/money.ts
+++ b/apps/opik-frontend/src/lib/money.ts
@@ -3,12 +3,12 @@ import floor from "lodash/floor";
 import isNull from "lodash/isNull";
 import { formatNumberInK } from "@/lib/utils";
 
-const MIN_DISPLAYED_COST = 0.001;
+const MIN_DISPLAYED_COST = 0.01;
 const CURRENCY = "$";
-const PRECISION = 3;
+const PRECISION = 2;
 
 export type FormatCostOptions = {
-  modifier?: "short" | "kFormat";
+  modifier?: "short" | "kFormat" | "full";
   noValue?: string;
   precision?: number;
 };
@@ -23,6 +23,10 @@ export const formatCost = (
 
   const numValue = Number(value);
 
+  if (modifier === "full") {
+    return `${CURRENCY}${value}`;
+  }
+
   if (numValue < MIN_DISPLAYED_COST) {
     return `<${CURRENCY}${MIN_DISPLAYED_COST}`;
   }
@@ -31,9 +35,5 @@ export const formatCost = (
     return `${CURRENCY}${formatNumberInK(numValue, precision)}`;
   }
 
-  if (modifier === "short") {
-    return `${CURRENCY}${floor(numValue, precision)}`;
-  }
-
-  return `${CURRENCY}${value}`;
+  return `${CURRENCY}${floor(numValue, precision)}`;
 };

--- a/apps/opik-frontend/src/lib/table.ts
+++ b/apps/opik-frontend/src/lib/table.ts
@@ -132,6 +132,9 @@ export const mapColumnDataFields = <TColumnData, TData>(
       ...(columnData.statisticDataFormater && {
         statisticDataFormater: columnData.statisticDataFormater,
       }),
+      ...(columnData.statisticTooltipFormater && {
+        statisticTooltipFormater: columnData.statisticTooltipFormater,
+      }),
       ...(columnData.supportsPercentiles !== undefined && {
         supportsPercentiles: columnData.supportsPercentiles,
       }),

--- a/apps/opik-frontend/src/lib/utils.ts
+++ b/apps/opik-frontend/src/lib/utils.ts
@@ -220,7 +220,7 @@ export const calculateWorkspaceName = (
 export const extractIdFromLocation = (location: string) =>
   last(location?.split("/"));
 
-export const formatNumericData = (value: number, precision = 3) =>
+export const formatNumericData = (value: number, precision = 2) =>
   String(round(value, precision));
 
 export const formatNumberInK = (value: number, precision = 1): string => {

--- a/apps/opik-frontend/src/types/shared.ts
+++ b/apps/opik-frontend/src/types/shared.ts
@@ -98,6 +98,7 @@ export type ColumnData<T> = {
   overrideRowHeight?: ROW_HEIGHT;
   statisticKey?: string;
   statisticDataFormater?: (value: number) => string;
+  statisticTooltipFormater?: (value: number) => string;
   supportsPercentiles?: boolean;
   sortable?: boolean;
   disposable?: boolean;


### PR DESCRIPTION
## Details


https://github.com/user-attachments/assets/7c0b2b61-7f73-4d15-9975-6ffe8e0ee4fb



Standardizes number formatting across the entire frontend to ensure consistent display of costs, durations, token counts, and other numeric values, with full precision available on hover.

### Key changes:

- **Cost formatting**: Standardized to 2 decimal places (`$1.23`) with `<$0.01` threshold. Full precision shown on hover via `formatCost(value, { modifier: "full" })` tooltip
- **Cost cells & tooltips**: All `CostCell` components and inline cost displays (thread/trace detail panels, cost overview) now show rounded values with full precision tooltips
- **Table header statistics**: Added `statisticTooltipFormater` support to `HeaderStatistic` and `HeaderWrapper`, applied to all 4 tables with `columnsStatistic` (TracesSpansTab, ThreadsTab, TraceQueueItemsTab, ExperimentItemsTab)
- **Dashboard stat cards**: Added `tooltipFormatter` to `MetricDefinition` type. Cost metrics show full precision on hover, token/avg metrics show raw unrounded values on hover via `String(value)` fallback (matching header statistic behavior)
- **Chart axis formatting**: Updated metrics chart utils to use consistent cost formatting

### Files changed (18):
- `lib/money.ts` — Cost precision 3→2dp, min $0.001→$0.01, added "full" modifier
- `lib/utils.ts` — `formatNumericData` default precision alignment
- `CostCell.tsx` — Full precision tooltip wrapper
- `HeaderStatistic.tsx` / `HeaderWrapper.tsx` / `types/shared.ts` / `table.ts` — Tooltip formatter plumbing
- `TracesSpansTab`, `ThreadsTab`, `TraceQueueItemsTab`, `ExperimentItemsTab` — Cost column formatters
- `ThreadDetailsPanel`, `TraceDataViewer`, `VirtualizedTreeViewer` — Inline cost tooltips
- `CostOverview`, `MetricsTab/utils` — Chart cost formatting
- `ProjectStatsCardWidget.tsx` / `metrics.ts` — Dashboard widget tooltip formatters

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-4428

## Testing

- Verified all cost values display `$X.XX` (2dp) with full precision on hover
- Verified token averages display rounded to 2dp with raw value on hover in dashboard widgets
- Verified table header statistics show correct tooltips for cost/token/duration columns
- Verified tables without `columnsStatistic` are unaffected
- TypeScript typecheck and ESLint pass cleanly

## Documentation

N/A — No documentation changes needed. This is an internal formatting consistency fix with no new configuration or APIs.