### PR TITLE
feat: Add bulk annotation support for traces

### DIFF
--- a/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreBatchMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreBatchMutation.ts
@@ -1,0 +1,76 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import get from "lodash/get";
+import api, {
+  TRACES_KEY,
+  TRACES_REST_ENDPOINT,
+} from "@/api/api";
+import { AxiosError } from "axios";
+import { useToast } from "@/components/ui/use-toast";
+import { FEEDBACK_SCORE_TYPE } from "@/types/traces";
+
+export type FeedbackScoreBatchItem = {
+  id: string;
+  projectName?: string;
+  name: string;
+  value: number;
+  categoryName?: string;
+  reason?: string;
+  source: FEEDBACK_SCORE_TYPE;
+};
+
+type UseTraceFeedbackScoreBatchMutationParams = {
+  scores: FeedbackScoreBatchItem[];
+};
+
+const useTraceFeedbackScoreBatchMutation = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async ({
+      scores,
+    }: UseTraceFeedbackScoreBatchMutationParams) => {
+      const endpoint = `${TRACES_REST_ENDPOINT}feedback-scores`;
+
+      const { data } = await api.put(endpoint, {
+        scores: scores.map((score) => ({
+          id: score.id,
+          project_name: score.projectName,
+          name: score.name,
+          value: score.value,
+          category_name: score.categoryName,
+          reason: score.reason,
+          source: score.source,
+        })),
+      });
+
+      return data;
+    },
+    onSuccess: (_, variables) => {
+      toast({
+        title: "Scores applied",
+        description: `Successfully applied feedback scores to ${variables.scores.length} trace(s)`,
+      });
+    },
+    onError: (error: AxiosError) => {
+      const message = get(
+        error,
+        ["response", "data", "message"],
+        error.message,
+      );
+
+      toast({
+        title: "Error",
+        description: message,
+        variant: "destructive",
+      });
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: [TRACES_KEY] });
+      await queryClient.invalidateQueries({ queryKey: ["traces-columns"] });
+      await queryClient.invalidateQueries({ queryKey: ["traces-statistic"] });
+    },
+  });
+};
+
+export default useTraceFeedbackScoreBatchMutation;

--- a/apps/opik-frontend/src/components/pages-shared/traces/BulkAnnotateDialog/BulkAnnotateDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/BulkAnnotateDialog/BulkAnnotateDialog.tsx
@@ -1,0 +1,285 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { keepPreviousData } from "@tanstack/react-query";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Slider } from "@/components/ui/slider";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Span, Trace, FEEDBACK_SCORE_TYPE } from "@/types/traces";
+import {
+  FeedbackDefinition,
+  FEEDBACK_DEFINITION_TYPE,
+} from "@/types/feedback-definitions";
+import useFeedbackDefinitionsList from "@/api/feedback-definitions/useFeedbackDefinitionsList";
+import useTraceFeedbackScoreBatchMutation from "@/api/traces/useTraceFeedbackScoreBatchMutation";
+import useAppStore from "@/store/AppStore";
+
+type BulkAnnotateDialogProps = {
+  open: boolean;
+  setOpen: (open: boolean | number) => void;
+  selectedRows: Array<Trace | Span>;
+  projectName: string;
+};
+
+const BulkAnnotateDialog: React.FC<BulkAnnotateDialogProps> = ({
+  open,
+  setOpen,
+  selectedRows,
+  projectName,
+}) => {
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const [selectedDefinitionId, setSelectedDefinitionId] = useState<string>("");
+  const [scoreValue, setScoreValue] = useState<number | string>("");
+  const [reason, setReason] = useState<string>("");
+
+  const { data: definitionsData, isLoading: isLoadingDefinitions } =
+    useFeedbackDefinitionsList(
+      {
+        workspaceName,
+        page: 1,
+        size: 1000,
+      },
+      {
+        placeholderData: keepPreviousData,
+        enabled: open,
+      },
+    );
+
+  const definitions = useMemo(
+    () => definitionsData?.content ?? [],
+    [definitionsData],
+  );
+
+  const selectedDefinition = useMemo(
+    () => definitions.find((d) => d.id === selectedDefinitionId),
+    [definitions, selectedDefinitionId],
+  );
+
+  const { mutate: batchMutate, isPending } =
+    useTraceFeedbackScoreBatchMutation();
+
+  const handleDefinitionChange = useCallback((value: string) => {
+    setSelectedDefinitionId(value);
+    setScoreValue("");
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    if (!selectedDefinition || scoreValue === "") return;
+
+    const numericValue =
+      typeof scoreValue === "string" ? parseFloat(scoreValue) : scoreValue;
+
+    if (isNaN(numericValue)) return;
+
+    batchMutate(
+      {
+        scores: selectedRows.map((row) => ({
+          id: row.id,
+          projectName,
+          name: selectedDefinition.name,
+          value: numericValue,
+          categoryName:
+            selectedDefinition.type === FEEDBACK_DEFINITION_TYPE.categorical
+              ? getCategoryNameByValue(selectedDefinition, numericValue)
+              : undefined,
+          reason: reason || undefined,
+          source: FEEDBACK_SCORE_TYPE.ui,
+        })),
+      },
+      {
+        onSuccess: () => {
+          setOpen(false);
+          setSelectedDefinitionId("");
+          setScoreValue("");
+          setReason("");
+        },
+      },
+    );
+  }, [
+    selectedDefinition,
+    scoreValue,
+    selectedRows,
+    projectName,
+    reason,
+    batchMutate,
+    setOpen,
+  ]);
+
+  const renderValueInput = () => {
+    if (!selectedDefinition) return null;
+
+    switch (selectedDefinition.type) {
+      case FEEDBACK_DEFINITION_TYPE.numerical: {
+        const { min, max } = selectedDefinition.details;
+        const numValue =
+          typeof scoreValue === "number"
+            ? scoreValue
+            : scoreValue === ""
+              ? min
+              : parseFloat(scoreValue);
+        return (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label>Value</Label>
+              <span className="text-sm text-muted-foreground">
+                {numValue.toFixed(2)}
+              </span>
+            </div>
+            <Slider
+              value={[numValue]}
+              onValueChange={(values) => setScoreValue(values[0])}
+              min={min}
+              max={max}
+              step={(max - min) / 100}
+            />
+            <div className="flex justify-between text-xs text-muted-foreground">
+              <span>{min}</span>
+              <span>{max}</span>
+            </div>
+          </div>
+        );
+      }
+
+      case FEEDBACK_DEFINITION_TYPE.categorical: {
+        const categories = Object.entries(
+          selectedDefinition.details.categories,
+        );
+        return (
+          <div className="space-y-2">
+            <Label>Category</Label>
+            <Select
+              value={scoreValue.toString()}
+              onValueChange={(v) => setScoreValue(parseFloat(v))}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select a category" />
+              </SelectTrigger>
+              <SelectContent>
+                {categories.map(([name, value]) => (
+                  <SelectItem key={name} value={value.toString()}>
+                    {name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        );
+      }
+
+      case FEEDBACK_DEFINITION_TYPE.boolean: {
+        const { true_label, false_label } = selectedDefinition.details;
+        return (
+          <div className="space-y-2">
+            <Label>Value</Label>
+            <Select
+              value={scoreValue.toString()}
+              onValueChange={(v) => setScoreValue(parseFloat(v))}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select a value" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="1">{true_label || "True"}</SelectItem>
+                <SelectItem value="0">{false_label || "False"}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        );
+      }
+
+      default:
+        return null;
+    }
+  };
+
+  const isSubmitDisabled =
+    !selectedDefinition || scoreValue === "" || isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            Annotate {selectedRows.length} trace
+            {selectedRows.length !== 1 ? "s" : ""}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label>Feedback Score</Label>
+            <Select
+              value={selectedDefinitionId}
+              onValueChange={handleDefinitionChange}
+              disabled={isLoadingDefinitions}
+            >
+              <SelectTrigger>
+                <SelectValue
+                  placeholder={
+                    isLoadingDefinitions
+                      ? "Loading..."
+                      : "Select a feedback score"
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {definitions.map((def) => (
+                  <SelectItem key={def.id} value={def.id}>
+                    {def.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {renderValueInput()}
+
+          <div className="space-y-2">
+            <Label>Reason (optional)</Label>
+            <Input
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Add a reason for this annotation"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button onClick={handleSubmit} disabled={isSubmitDisabled}>
+            {isPending ? "Applying..." : "Apply to all"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+function getCategoryNameByValue(
+  definition: FeedbackDefinition,
+  value: number,
+): string | undefined {
+  if (definition.type !== FEEDBACK_DEFINITION_TYPE.categorical) return undefined;
+  const categories = definition.details.categories;
+  const entry = Object.entries(categories).find(([, v]) => v === value);
+  return entry ? entry[0] : undefined;
+}
+
+export default BulkAnnotateDialog;

--- a/apps/opik-frontend/src/components/pages-shared/traces/BulkAnnotateDialog/index.ts
+++ b/apps/opik-frontend/src/components/pages-shared/traces/BulkAnnotateDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./BulkAnnotateDialog";

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesActionsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useCallback } from "react";
-import { Tag, Trash, Brain } from "lucide-react";
+import { Tag, Trash, Brain, MessageSquarePlus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Span, Trace } from "@/types/traces";
@@ -10,6 +10,7 @@ import useTracesBatchDeleteMutation from "@/api/traces/useTraceBatchDeleteMutati
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import ExportToButton from "@/components/shared/ExportToButton/ExportToButton";
 import AddTagDialog from "@/components/pages-shared/traces/AddTagDialog/AddTagDialog";
+import BulkAnnotateDialog from "@/components/pages-shared/traces/BulkAnnotateDialog/BulkAnnotateDialog";
 import RunEvaluationDialog from "@/components/pages-shared/automations/RunEvaluationDialog/RunEvaluationDialog";
 import { useIsFeatureEnabled } from "@/components/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
@@ -81,6 +82,13 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
         projectId={projectId}
         type={type}
       />
+      <BulkAnnotateDialog
+        key={`annotate-${resetKeyRef.current}`}
+        open={open === 5}
+        setOpen={setOpen}
+        selectedRows={selectedRows}
+        projectName={projectName}
+      />
       {type === TRACE_DATA_TYPE.traces && (
         <RunEvaluationDialog
           key={`evaluation-${resetKeyRef.current}`}
@@ -107,6 +115,19 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
         disabled={disabled}
         dataType={type === TRACE_DATA_TYPE.traces ? "traces" : "spans"}
       />
+      <TooltipWrapper content="Annotate selected">
+        <Button
+          variant="outline"
+          size="icon-sm"
+          onClick={() => {
+            setOpen(5);
+            resetKeyRef.current = resetKeyRef.current + 1;
+          }}
+          disabled={disabled}
+        >
+          <MessageSquarePlus />
+        </Button>
+      </TooltipWrapper>
       <TooltipWrapper content="Add tags">
         <Button
           variant="outline"


### PR DESCRIPTION
## Summary

This PR adds the ability to select multiple traces and apply feedback scores to all of them at once, as requested in #1010.

## Changes

### New Files
- `useTraceFeedbackScoreBatchMutation.ts` - API hook for the batch feedback scores endpoint
- `BulkAnnotateDialog/` - Dialog component for bulk annotation

### Modified Files
- `TracesActionsPanel.tsx` - Added "Annotate selected" button

## Features

- Select multiple traces using checkboxes
- Click "Annotate selected" button to open bulk annotation dialog
- Choose from existing feedback score definitions:
  - **Numerical**: Slider input with min/max range
  - **Categorical**: Dropdown with category options
  - **Boolean**: True/False dropdown
- Add optional reason for the annotation
- Apply the same score to all selected traces in one operation

## Testing

1. Navigate to a project's Traces tab
2. Select multiple traces using checkboxes
3. Click the "Annotate selected" button (MessageSquarePlus icon)
4. Select a feedback score definition
5. Set the value and optionally add a reason
6. Click "Apply to all"
7. Verify scores are applied to all selected traces

## Screenshots

(Screenshots can be added after testing)

Resolves #1010