### PR TITLE
[OPIK-1959] [FE] Fix markdown code block indentation and restyle per Figma

### DIFF
--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -752,9 +752,20 @@
   overflow-wrap: break-word;
   word-break: break-word;
 
+  pre {
+    color: hsl(var(--foreground));
+    background-color: hsl(var(--muted));
+    border: 1px solid hsl(var(--border));
+    border-radius: 0.375rem;
+    padding: 0.75rem;
+    overflow-x: auto;
+  }
+
   pre code {
-    font-size: 0.875rem !important;
-    white-space: preserve-breaks;
+    @apply comet-code;
+    font-size: 0.9375rem !important;
+    line-height: 1.2;
+    white-space: pre-wrap;
     overflow-wrap: break-word;
     word-break: break-word;
   }


### PR DESCRIPTION
## Details



https://github.com/user-attachments/assets/ba7b4e1b-1abc-4402-bbbd-2288253a234d




Fixes broken markdown code blocks across the Opik UI. The previous `white-space: preserve-breaks` CSS rule collapsed spaces, destroying all code indentation (especially Python). This PR:

- **Fixes indentation bug**: Changed `white-space: preserve-breaks` to `pre-wrap` so spaces are preserved in code blocks
- **Fixes text visibility**: Added explicit `color: hsl(var(--foreground))` to `pre` blocks to override Tailwind Typography's `prose` class, which sets light text color (`slate-200`) designed for dark backgrounds — our light `hsl(var(--muted))` background made text nearly invisible
- **Restyles code blocks per Figma**: Added `hsl(var(--muted))` background, `hsl(var(--border))` border, `0.375rem` border radius, and `0.75rem` padding
- **Updates code font**: Uses existing `.comet-code` class (Ubuntu Mono font stack) at 15px / line-height 1.2, matching Figma's `Code/Small` text style

CSS-only change in `.comet-markdown` — applies globally to all 10+ screens that render markdown (traces, spans, threads, playground, experiments, prompts, annotations, dashboards).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-1959

## Testing

- Lint, typecheck, and all 769 unit tests pass
- Manual verification: paste Python code with indentation into a trace, confirm indentation is preserved and code block has muted background with border in both light/dark mode
- Verify text is readable (dark text on light background in light mode, light text on dark background in dark mode)

## Documentation

N/A