### PR TITLE
[NA] [FE] Fix AccordionItem missing Accordion wrapper in ThreadDetailsPanel

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
@@ -70,6 +70,7 @@ import {
 } from "@/components/ui/resizable";
 import ThreadComments from "./ThreadComments";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Accordion } from "@/components/ui/accordion";
 import { JsonParam, StringParam, useQueryParam } from "use-query-params";
 import ThreadAnnotations from "./ThreadAnnotations";
 import useThreadFeedbackScoreDeleteMutation from "@/api/traces/useThreadFeedbackScoreDeleteMutation";
@@ -440,7 +441,9 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
           <MediaProvider media={media}>
             {media.length > 0 && (
               <div className="mb-4 px-6">
-                <AttachmentsList media={media} />
+                <Accordion type="multiple" defaultValue={["attachments"]}>
+                  <AttachmentsList media={media} />
+                </Accordion>
               </div>
             )}
             <div style={bodyStyle}>


### PR DESCRIPTION
## Details

`AttachmentsList` renders `AccordionItem` which requires an `Accordion` ancestor via Radix UI context. In `ThreadDetailsPanel`, it was rendered without the required `Accordion` wrapper, causing a runtime crash (`AccordionItem must be used within Accordion`) when opening a thread that has attachments.

The fix wraps `AttachmentsList` in an `<Accordion>` component, consistent with how it's used in `DetailsTab` and `SMEFlowPage/TraceDataViewer`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- NA

## Testing
- Open a thread that contains traces with attachments
- Verify the thread details panel opens without crash
- Verify attachments accordion section renders correctly and is expandable

## Documentation
N/A