### PR TITLE
[OPIK-4436] [FE] Fix feedback score tag trimming value instead of only the label

### DIFF
--- a/apps/opik-frontend/src/components/shared/FeedbackScoreTag/FeedbackScoreTag.tsx
+++ b/apps/opik-frontend/src/components/shared/FeedbackScoreTag/FeedbackScoreTag.tsx
@@ -121,7 +121,7 @@ const FeedbackScoreTag: React.FunctionComponent<FeedbackScoreTagProps> = ({
       >
         <span
           data-testid="feedback-score-tag-value"
-          className="comet-body-s-accented min-w-0 truncate"
+          className="comet-body-s-accented shrink-0"
         >
           {displayValue}
         </span>


### PR DESCRIPTION
## Details

The `FeedbackScoreTag` component was truncating both the score name and score value when space was limited (e.g. `AnswerRelevance (a... 0....`). This fix ensures only the score name truncates while the value always remains fully visible (e.g. `AnswerRelevance (a... 0.73`).

**Change:** In `FeedbackScoreTag.tsx`, replaced `min-w-0 truncate` with `shrink-0` on the value `<span>`, preventing it from shrinking in the flex container. The label div keeps its existing `min-w-0 truncate` classes to absorb all truncation.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-4436

## Testing
- Verified lint, typecheck, and dependency validation all pass
- Visual verification: feedback score tags in any table (Projects → Traces, Experiments) should show the full numeric value while only truncating the score name

## Documentation
N/A