### PR TITLE
[OPIK-0000] [CI/CD] Increase be tests timeout to 45 min

### DIFF
--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -16,7 +16,7 @@ on:
 jobs:
     run-backend-tests:
         runs-on: ubuntu-latest
-        timeout-minutes: 40
+        timeout-minutes: 45
         defaults:
           run:
             working-directory: apps/opik-backend/


### PR DESCRIPTION
## Details
Increase be tests timeout to 45 min

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-0000

## Testing
NA

## Documentation
NA