### PR TITLE
Revert: Allow experiments with null dataset_name to be listed

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Experiment.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Experiment.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 public record Experiment(
         @JsonView( {
                 Experiment.View.Public.class, Experiment.View.Write.class}) UUID id,
-        @JsonView({Experiment.View.Public.class, Experiment.View.Write.class}) String datasetName,
+        @JsonView({Experiment.View.Public.class, Experiment.View.Write.class}) @NotBlank String datasetName,
         @JsonView({Experiment.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) UUID datasetId,
         @JsonView({Experiment.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) UUID projectId,
         @JsonView({Experiment.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String projectName,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -57,7 +57,6 @@ import jakarta.inject.Provider;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
@@ -75,7 +74,6 @@ import jakarta.ws.rs.core.UriInfo;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.glassfish.jersey.server.ChunkedOutput;
 
 import java.util.Collections;
@@ -289,9 +287,6 @@ public class ExperimentsResource {
     public Response create(
             @RequestBody(content = @Content(schema = @Schema(implementation = Experiment.class))) @JsonView(Experiment.View.Write.class) @NotNull @Valid Experiment experiment,
             @Context UriInfo uriInfo) {
-        if (StringUtils.isBlank(experiment.datasetName())) {
-            throw new BadRequestException("dataset_name must not be blank");
-        }
         var workspaceId = requestContext.get().getWorkspaceId();
         log.info("Creating experiment with id '{}', name '{}', datasetName '{}', workspaceId '{}'",
                 experiment.id(), experiment.name(), experiment.datasetName(), workspaceId);

--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -10593,12 +10593,15 @@ components:
           items:
             $ref: "#/components/schemas/ExperimentScore"
     Experiment:
+      required:
+      - dataset_name
       type: object
       properties:
         id:
           type: string
           format: uuid
         dataset_name:
+          minLength: 1
           type: string
         dataset_id:
           type: string
@@ -11470,12 +11473,15 @@ components:
         value:
           type: number
     Experiment_Public:
+      required:
+      - dataset_name
       type: object
       properties:
         id:
           type: string
           format: uuid
         dataset_name:
+          minLength: 1
           type: string
         dataset_id:
           type: string

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -10593,12 +10593,15 @@ components:
           items:
             $ref: "#/components/schemas/ExperimentScore"
     Experiment:
+      required:
+      - dataset_name
       type: object
       properties:
         id:
           type: string
           format: uuid
         dataset_name:
+          minLength: 1
           type: string
         dataset_id:
           type: string
@@ -11470,12 +11473,15 @@ components:
         value:
           type: number
     Experiment_Public:
+      required:
+      - dataset_name
       type: object
       properties:
         id:
           type: string
           format: uuid
         dataset_name:
+          minLength: 1
           type: string
         dataset_id:
           type: string

--- a/sdks/python/src/opik/rest_api/types/experiment.py
+++ b/sdks/python/src/opik/rest_api/types/experiment.py
@@ -18,7 +18,7 @@ from .prompt_version_link import PromptVersionLink
 
 class Experiment(UniversalBaseModel):
     id: typing.Optional[str] = None
-    dataset_name: typing.Optional[str] = None
+    dataset_name: str
     dataset_id: typing.Optional[str] = None
     project_id: typing.Optional[str] = None
     project_name: typing.Optional[str] = None

--- a/sdks/python/src/opik/rest_api/types/experiment_public.py
+++ b/sdks/python/src/opik/rest_api/types/experiment_public.py
@@ -18,7 +18,7 @@ from .prompt_version_link_public import PromptVersionLinkPublic
 
 class ExperimentPublic(UniversalBaseModel):
     id: typing.Optional[str] = None
-    dataset_name: typing.Optional[str] = None
+    dataset_name: str
     dataset_id: typing.Optional[str] = None
     project_id: typing.Optional[str] = None
     project_name: typing.Optional[str] = None

--- a/sdks/typescript/src/opik/experiment/Experiment.ts
+++ b/sdks/typescript/src/opik/experiment/Experiment.ts
@@ -16,7 +16,7 @@ import type { Prompt } from "@/prompt/Prompt";
 export interface ExperimentData {
   id?: string;
   name?: string;
-  datasetName?: string;
+  datasetName: string;
   prompts?: Prompt[];
 }
 
@@ -26,7 +26,7 @@ export interface ExperimentData {
 export class Experiment {
   public readonly id: string;
   private _name?: string;
-  public readonly datasetName?: string;
+  public readonly datasetName: string;
   public readonly prompts?: Prompt[];
 
   /**
@@ -199,9 +199,6 @@ export class Experiment {
   }
 
   async getUrl(): Promise<string> {
-    if (!this.datasetName) {
-      throw new Error("Cannot get URL for experiment without a dataset name");
-    }
     const dataset = await this.opik.getDataset(this.datasetName);
     const baseUrl = this.opik.config.apiUrl || DEFAULT_CONFIG.apiUrl;
 

--- a/sdks/typescript/src/opik/rest_api/api/types/Experiment.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/Experiment.ts
@@ -4,7 +4,7 @@ import type * as OpikApi from "../index.js";
 
 export interface Experiment {
     id?: string;
-    datasetName?: string;
+    datasetName: string;
     datasetId?: string;
     projectId?: string;
     projectName?: string;

--- a/sdks/typescript/src/opik/rest_api/api/types/ExperimentPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/ExperimentPublic.ts
@@ -4,7 +4,7 @@ import type * as OpikApi from "../index.js";
 
 export interface ExperimentPublic {
     id?: string;
-    datasetName?: string;
+    datasetName: string;
     datasetId?: string;
     projectId?: string;
     projectName?: string;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/Experiment.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/Experiment.ts
@@ -16,7 +16,7 @@ import { PromptVersionLink } from "./PromptVersionLink.js";
 export const Experiment: core.serialization.ObjectSchema<serializers.Experiment.Raw, OpikApi.Experiment> =
     core.serialization.object({
         id: core.serialization.string().optional(),
-        datasetName: core.serialization.property("dataset_name", core.serialization.string().optional()),
+        datasetName: core.serialization.property("dataset_name", core.serialization.string()),
         datasetId: core.serialization.property("dataset_id", core.serialization.string().optional()),
         projectId: core.serialization.property("project_id", core.serialization.string().optional()),
         projectName: core.serialization.property("project_name", core.serialization.string().optional()),
@@ -59,7 +59,7 @@ export const Experiment: core.serialization.ObjectSchema<serializers.Experiment.
 export declare namespace Experiment {
     export interface Raw {
         id?: string | null;
-        dataset_name?: string | null;
+        dataset_name: string;
         dataset_id?: string | null;
         project_id?: string | null;
         project_name?: string | null;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/ExperimentPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/ExperimentPublic.ts
@@ -18,7 +18,7 @@ export const ExperimentPublic: core.serialization.ObjectSchema<
     OpikApi.ExperimentPublic
 > = core.serialization.object({
     id: core.serialization.string().optional(),
-    datasetName: core.serialization.property("dataset_name", core.serialization.string().optional()),
+    datasetName: core.serialization.property("dataset_name", core.serialization.string()),
     datasetId: core.serialization.property("dataset_id", core.serialization.string().optional()),
     projectId: core.serialization.property("project_id", core.serialization.string().optional()),
     projectName: core.serialization.property("project_name", core.serialization.string().optional()),
@@ -64,7 +64,7 @@ export const ExperimentPublic: core.serialization.ObjectSchema<
 export declare namespace ExperimentPublic {
     export interface Raw {
         id?: string | null;
-        dataset_name?: string | null;
+        dataset_name: string;
         dataset_id?: string | null;
         project_id?: string | null;
         project_name?: string | null;


### PR DESCRIPTION
## Summary
- Reverts #5209 ([CUST-5054] [BE/P SDK/ TS] Allow experiments with null dataset_name to be listed)

## Test plan
- [ ] Verify backend compiles and existing tests pass
- [ ] Verify SDK types are restored to their previous state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CUST-5054]: https://comet-ml.atlassian.net/browse/CUST-5054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ