### PR TITLE
fix anthropic cache_creation_input_tokens miscategorized as completion tokens

### DIFF
--- a/sdks/python/src/opik/llm_usage/opik_usage.py
+++ b/sdks/python/src/opik/llm_usage/opik_usage.py
@@ -120,16 +120,20 @@ class OpikUsage(pydantic.BaseModel):
     def from_anthropic_dict(cls, usage: Dict[str, Any]) -> "OpikUsage":
         provider_usage = anthropic_usage.AnthropicUsage.from_original_usage_dict(usage)
 
-        prompt_tokens = provider_usage.input_tokens + (
-            provider_usage.cache_read_input_tokens
-            if provider_usage.cache_read_input_tokens is not None
-            else 0
+        prompt_tokens = (
+            provider_usage.input_tokens
+            + (
+                provider_usage.cache_read_input_tokens
+                if provider_usage.cache_read_input_tokens is not None
+                else 0
+            )
+            + (
+                provider_usage.cache_creation_input_tokens
+                if provider_usage.cache_creation_input_tokens is not None
+                else 0
+            )
         )
-        completion_tokens = provider_usage.output_tokens + (
-            provider_usage.cache_creation_input_tokens
-            if provider_usage.cache_creation_input_tokens is not None
-            else 0
-        )
+        completion_tokens = provider_usage.output_tokens
         total_tokens = prompt_tokens + completion_tokens
 
         return cls(

--- a/sdks/python/tests/unit/llm_usage/test_opik_usage.py
+++ b/sdks/python/tests/unit/llm_usage/test_opik_usage.py
@@ -104,8 +104,8 @@ def test_opik_usage__to_backend_compatible_full_usage_dict__anthropic_source():
     usage = OpikUsage.from_anthropic_dict(usage_data)
     full_dict = usage.to_backend_compatible_full_usage_dict()
     assert full_dict == {
-        "completion_tokens": 150,
-        "prompt_tokens": 230,
+        "completion_tokens": 100,
+        "prompt_tokens": 280,
         "total_tokens": 380,
         "original_usage.input_tokens": 200,
         "original_usage.output_tokens": 100,


### PR DESCRIPTION
`cache_creation_input_tokens` from Anthropic's API represents input tokens used to create a cache entry, but it was being added to `completion_tokens` instead of `prompt_tokens`. Per Anthropic's docs, the total input token count is `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` — all three are input tokens.

The old code was:
- `prompt_tokens = input_tokens + cache_read_input_tokens`
- `completion_tokens = output_tokens + cache_creation_input_tokens`

This meant `prompt_tokens` was too low and `completion_tokens` was inflated whenever prompt caching was used. The total happened to be correct since the error canceled out, but the per-category breakdown was wrong — which matters for cost calculations since prompt and completion tokens are priced differently.

Fixed by moving `cache_creation_input_tokens` into the `prompt_tokens` sum where it belongs. Updated the unit test to match.