### PR TITLE
[NA] [INFRA] ci: Disable bake for sdk e2e library build path

### DIFF
--- a/.github/workflows/sdk-e2e-library-tests.yaml
+++ b/.github/workflows/sdk-e2e-library-tests.yaml
@@ -87,6 +87,8 @@ jobs:
       - name: Run latest Opik server
         env:
           OPIK_USAGE_REPORT_ENABLED: false
+          # Avoid Buildx Bake concurrent image export collisions in CI.
+          COMPOSE_BAKE: false
         shell: bash
         run: |
           cd ${{ github.workspace }}

--- a/opik.sh
+++ b/opik.sh
@@ -125,6 +125,11 @@ log_worktree_config() {
 
 setup_buildx_bake() {
   if [[ "${BUILD_MODE}" = "true" ]]; then
+    if [[ "${COMPOSE_BAKE:-}" = "false" ]]; then
+      echo "ℹ️ COMPOSE_BAKE is explicitly disabled. Skipping Bake-enabled builds"
+      return
+    fi
+
     if docker buildx bake --help >/dev/null 2>&1; then
       echo "ℹ️ Bake is available on Docker Buildx. Exporting COMPOSE_BAKE=true"
       export COMPOSE_BAKE=true


### PR DESCRIPTION
## Details
This PR disables Docker Buildx Bake for the `SDK E2E Libraries Integration Tests` build path to prevent intermittent CI failures during `./opik.sh --build`.

The failing jobs were erroring at image export time with:
`image "ghcr.io/comet-ml/opik/opik-python-backend:latest": already exists`.
In this workflow, both `python-backend` and `demo-data-generator` reference the same image tag, and Bake-enabled parallel export can race on that shared tag.

Changes:
- In `opik.sh`, `setup_buildx_bake()` now respects an explicit `COMPOSE_BAKE=false` override.
- In `.github/workflows/sdk-e2e-library-tests.yaml`, the “Run latest Opik server” step sets `COMPOSE_BAKE: false`.

This keeps the fix scoped to CI for that workflow and does not change local defaults.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing
- Verified on PR #5216 that, with this change, `E2E Lib Integration Python 3.10/3.11/3.12/3.13/3.14` completed successfully in the follow-up run. (https://github.com/comet-ml/opik/actions/runs/22020786775) i subsequently reverted the commit once validated.
- Confirmed this addresses the previously observed Docker export collision failure in `Run latest Opik server`.

## Documentation
N/A
