### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -11058,6 +11058,10 @@ components:
             precision
           format: double
           readOnly: true
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
     Trace:
       required:
       - start_time
@@ -11150,6 +11154,10 @@ components:
             precision
           format: double
           readOnly: true
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
         thread_id:
           type: string
         visibility_mode:
@@ -11351,6 +11359,10 @@ components:
           type: number
         total_estimated_cost_version:
           type: string
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
     Trace_ExperimentItemBulkWriteView:
       required:
       - start_time
@@ -11387,6 +11399,10 @@ components:
         last_updated_at:
           type: string
           format: date-time
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
         thread_id:
           type: string
       description: "Please provide either none, only one of evaluate_task_result or\
@@ -14332,6 +14348,9 @@ components:
           type: number
         error_info:
           $ref: "#/components/schemas/ErrorInfo"
+        ttft:
+          type: number
+          format: double
     ErrorInfo_Write:
       required:
       - exception_type
@@ -14410,6 +14429,10 @@ components:
           type: number
         total_estimated_cost_version:
           type: string
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
     SpanBatch:
       required:
       - spans
@@ -14598,6 +14621,10 @@ components:
             precision
           format: double
           readOnly: true
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
     ValueEntry_Public:
       type: object
       properties:
@@ -14791,6 +14818,9 @@ components:
           $ref: "#/components/schemas/ErrorInfo"
         thread_id:
           type: string
+        ttft:
+          type: number
+          format: double
     TraceThreadBatchUpdate:
       required:
       - ids
@@ -14876,6 +14906,10 @@ components:
         last_updated_at:
           type: string
           format: date-time
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
         thread_id:
           type: string
     TraceBatch:
@@ -15097,6 +15131,10 @@ components:
             precision
           format: double
           readOnly: true
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
         thread_id:
           type: string
         visibility_mode:

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -11058,6 +11058,10 @@ components:
             precision
           format: double
           readOnly: true
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
     Trace:
       required:
       - start_time
@@ -11150,6 +11154,10 @@ components:
             precision
           format: double
           readOnly: true
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
         thread_id:
           type: string
         visibility_mode:
@@ -11351,6 +11359,10 @@ components:
           type: number
         total_estimated_cost_version:
           type: string
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
     Trace_ExperimentItemBulkWriteView:
       required:
       - start_time
@@ -11387,6 +11399,10 @@ components:
         last_updated_at:
           type: string
           format: date-time
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
         thread_id:
           type: string
       description: "Please provide either none, only one of evaluate_task_result or\
@@ -14332,6 +14348,9 @@ components:
           type: number
         error_info:
           $ref: "#/components/schemas/ErrorInfo"
+        ttft:
+          type: number
+          format: double
     ErrorInfo_Write:
       required:
       - exception_type
@@ -14410,6 +14429,10 @@ components:
           type: number
         total_estimated_cost_version:
           type: string
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
     SpanBatch:
       required:
       - spans
@@ -14598,6 +14621,10 @@ components:
             precision
           format: double
           readOnly: true
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
     ValueEntry_Public:
       type: object
       properties:
@@ -14791,6 +14818,9 @@ components:
           $ref: "#/components/schemas/ErrorInfo"
         thread_id:
           type: string
+        ttft:
+          type: number
+          format: double
     TraceThreadBatchUpdate:
       required:
       - ids
@@ -14876,6 +14906,10 @@ components:
         last_updated_at:
           type: string
           format: date-time
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
         thread_id:
           type: string
     TraceBatch:
@@ -15097,6 +15131,10 @@ components:
             precision
           format: double
           readOnly: true
+        ttft:
+          type: number
+          description: Time to first token in milliseconds
+          format: double
         thread_id:
           type: string
         visibility_mode:

--- a/sdks/python/src/opik/rest_api/spans/client.py
+++ b/sdks/python/src/opik/rest_api/spans/client.py
@@ -345,6 +345,7 @@ class SpansClient:
         last_updated_at: typing.Optional[dt.datetime] = OMIT,
         total_estimated_cost: typing.Optional[float] = OMIT,
         total_estimated_cost_version: typing.Optional[str] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -391,6 +392,9 @@ class SpansClient:
 
         total_estimated_cost_version : typing.Optional[str]
 
+        ttft : typing.Optional[float]
+            Time to first token in milliseconds
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -425,6 +429,7 @@ class SpansClient:
             last_updated_at=last_updated_at,
             total_estimated_cost=total_estimated_cost,
             total_estimated_cost_version=total_estimated_cost_version,
+            ttft=ttft,
             request_options=request_options,
         )
         return _response.data
@@ -508,6 +513,7 @@ class SpansClient:
         usage: typing.Optional[typing.Dict[str, int]] = OMIT,
         total_estimated_cost: typing.Optional[float] = OMIT,
         error_info: typing.Optional[ErrorInfo] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -551,6 +557,8 @@ class SpansClient:
 
         error_info : typing.Optional[ErrorInfo]
 
+        ttft : typing.Optional[float]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -582,6 +590,7 @@ class SpansClient:
             usage=usage,
             total_estimated_cost=total_estimated_cost,
             error_info=error_info,
+            ttft=ttft,
             request_options=request_options,
         )
         return _response.data
@@ -1259,6 +1268,7 @@ class AsyncSpansClient:
         last_updated_at: typing.Optional[dt.datetime] = OMIT,
         total_estimated_cost: typing.Optional[float] = OMIT,
         total_estimated_cost_version: typing.Optional[str] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -1305,6 +1315,9 @@ class AsyncSpansClient:
 
         total_estimated_cost_version : typing.Optional[str]
 
+        ttft : typing.Optional[float]
+            Time to first token in milliseconds
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -1342,6 +1355,7 @@ class AsyncSpansClient:
             last_updated_at=last_updated_at,
             total_estimated_cost=total_estimated_cost,
             total_estimated_cost_version=total_estimated_cost_version,
+            ttft=ttft,
             request_options=request_options,
         )
         return _response.data
@@ -1431,6 +1445,7 @@ class AsyncSpansClient:
         usage: typing.Optional[typing.Dict[str, int]] = OMIT,
         total_estimated_cost: typing.Optional[float] = OMIT,
         error_info: typing.Optional[ErrorInfo] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -1474,6 +1489,8 @@ class AsyncSpansClient:
 
         error_info : typing.Optional[ErrorInfo]
 
+        ttft : typing.Optional[float]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -1508,6 +1525,7 @@ class AsyncSpansClient:
             usage=usage,
             total_estimated_cost=total_estimated_cost,
             error_info=error_info,
+            ttft=ttft,
             request_options=request_options,
         )
         return _response.data

--- a/sdks/python/src/opik/rest_api/spans/raw_client.py
+++ b/sdks/python/src/opik/rest_api/spans/raw_client.py
@@ -406,6 +406,7 @@ class RawSpansClient:
         last_updated_at: typing.Optional[dt.datetime] = OMIT,
         total_estimated_cost: typing.Optional[float] = OMIT,
         total_estimated_cost_version: typing.Optional[str] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[None]:
         """
@@ -452,6 +453,9 @@ class RawSpansClient:
 
         total_estimated_cost_version : typing.Optional[str]
 
+        ttft : typing.Optional[float]
+            Time to first token in milliseconds
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -490,6 +494,7 @@ class RawSpansClient:
                 "last_updated_at": last_updated_at,
                 "total_estimated_cost": total_estimated_cost,
                 "total_estimated_cost_version": total_estimated_cost_version,
+                "ttft": ttft,
             },
             headers={
                 "content-type": "application/json",
@@ -635,6 +640,7 @@ class RawSpansClient:
         usage: typing.Optional[typing.Dict[str, int]] = OMIT,
         total_estimated_cost: typing.Optional[float] = OMIT,
         error_info: typing.Optional[ErrorInfo] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[None]:
         """
@@ -678,6 +684,8 @@ class RawSpansClient:
 
         error_info : typing.Optional[ErrorInfo]
 
+        ttft : typing.Optional[float]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -713,6 +721,7 @@ class RawSpansClient:
                 "error_info": convert_and_respect_annotation_metadata(
                     object_=error_info, annotation=ErrorInfo, direction="write"
                 ),
+                "ttft": ttft,
             },
             headers={
                 "content-type": "application/json",
@@ -1576,6 +1585,7 @@ class AsyncRawSpansClient:
         last_updated_at: typing.Optional[dt.datetime] = OMIT,
         total_estimated_cost: typing.Optional[float] = OMIT,
         total_estimated_cost_version: typing.Optional[str] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[None]:
         """
@@ -1622,6 +1632,9 @@ class AsyncRawSpansClient:
 
         total_estimated_cost_version : typing.Optional[str]
 
+        ttft : typing.Optional[float]
+            Time to first token in milliseconds
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -1660,6 +1673,7 @@ class AsyncRawSpansClient:
                 "last_updated_at": last_updated_at,
                 "total_estimated_cost": total_estimated_cost,
                 "total_estimated_cost_version": total_estimated_cost_version,
+                "ttft": ttft,
             },
             headers={
                 "content-type": "application/json",
@@ -1805,6 +1819,7 @@ class AsyncRawSpansClient:
         usage: typing.Optional[typing.Dict[str, int]] = OMIT,
         total_estimated_cost: typing.Optional[float] = OMIT,
         error_info: typing.Optional[ErrorInfo] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[None]:
         """
@@ -1848,6 +1863,8 @@ class AsyncRawSpansClient:
 
         error_info : typing.Optional[ErrorInfo]
 
+        ttft : typing.Optional[float]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -1883,6 +1900,7 @@ class AsyncRawSpansClient:
                 "error_info": convert_and_respect_annotation_metadata(
                     object_=error_info, annotation=ErrorInfo, direction="write"
                 ),
+                "ttft": ttft,
             },
             headers={
                 "content-type": "application/json",

--- a/sdks/python/src/opik/rest_api/traces/client.py
+++ b/sdks/python/src/opik/rest_api/traces/client.py
@@ -468,6 +468,7 @@ class TracesClient:
         tags: typing.Optional[typing.Sequence[str]] = OMIT,
         error_info: typing.Optional[ErrorInfoWrite] = OMIT,
         last_updated_at: typing.Optional[dt.datetime] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         thread_id: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
@@ -499,6 +500,9 @@ class TracesClient:
 
         last_updated_at : typing.Optional[dt.datetime]
 
+        ttft : typing.Optional[float]
+            Time to first token in milliseconds
+
         thread_id : typing.Optional[str]
 
         request_options : typing.Optional[RequestOptions]
@@ -527,6 +531,7 @@ class TracesClient:
             tags=tags,
             error_info=error_info,
             last_updated_at=last_updated_at,
+            ttft=ttft,
             thread_id=thread_id,
             request_options=request_options,
         )
@@ -605,6 +610,7 @@ class TracesClient:
         tags: typing.Optional[typing.Sequence[str]] = OMIT,
         error_info: typing.Optional[ErrorInfo] = OMIT,
         thread_id: typing.Optional[str] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -636,6 +642,8 @@ class TracesClient:
 
         thread_id : typing.Optional[str]
 
+        ttft : typing.Optional[float]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -661,6 +669,7 @@ class TracesClient:
             tags=tags,
             error_info=error_info,
             thread_id=thread_id,
+            ttft=ttft,
             request_options=request_options,
         )
         return _response.data
@@ -2036,6 +2045,7 @@ class AsyncTracesClient:
         tags: typing.Optional[typing.Sequence[str]] = OMIT,
         error_info: typing.Optional[ErrorInfoWrite] = OMIT,
         last_updated_at: typing.Optional[dt.datetime] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         thread_id: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
@@ -2066,6 +2076,9 @@ class AsyncTracesClient:
         error_info : typing.Optional[ErrorInfoWrite]
 
         last_updated_at : typing.Optional[dt.datetime]
+
+        ttft : typing.Optional[float]
+            Time to first token in milliseconds
 
         thread_id : typing.Optional[str]
 
@@ -2098,6 +2111,7 @@ class AsyncTracesClient:
             tags=tags,
             error_info=error_info,
             last_updated_at=last_updated_at,
+            ttft=ttft,
             thread_id=thread_id,
             request_options=request_options,
         )
@@ -2182,6 +2196,7 @@ class AsyncTracesClient:
         tags: typing.Optional[typing.Sequence[str]] = OMIT,
         error_info: typing.Optional[ErrorInfo] = OMIT,
         thread_id: typing.Optional[str] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -2213,6 +2228,8 @@ class AsyncTracesClient:
 
         thread_id : typing.Optional[str]
 
+        ttft : typing.Optional[float]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -2241,6 +2258,7 @@ class AsyncTracesClient:
             tags=tags,
             error_info=error_info,
             thread_id=thread_id,
+            ttft=ttft,
             request_options=request_options,
         )
         return _response.data

--- a/sdks/python/src/opik/rest_api/traces/raw_client.py
+++ b/sdks/python/src/opik/rest_api/traces/raw_client.py
@@ -577,6 +577,7 @@ class RawTracesClient:
         tags: typing.Optional[typing.Sequence[str]] = OMIT,
         error_info: typing.Optional[ErrorInfoWrite] = OMIT,
         last_updated_at: typing.Optional[dt.datetime] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         thread_id: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[None]:
@@ -607,6 +608,9 @@ class RawTracesClient:
         error_info : typing.Optional[ErrorInfoWrite]
 
         last_updated_at : typing.Optional[dt.datetime]
+
+        ttft : typing.Optional[float]
+            Time to first token in milliseconds
 
         thread_id : typing.Optional[str]
 
@@ -640,6 +644,7 @@ class RawTracesClient:
                     object_=error_info, annotation=ErrorInfoWrite, direction="write"
                 ),
                 "last_updated_at": last_updated_at,
+                "ttft": ttft,
                 "thread_id": thread_id,
             },
             headers={
@@ -747,6 +752,7 @@ class RawTracesClient:
         tags: typing.Optional[typing.Sequence[str]] = OMIT,
         error_info: typing.Optional[ErrorInfo] = OMIT,
         thread_id: typing.Optional[str] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[None]:
         """
@@ -778,6 +784,8 @@ class RawTracesClient:
 
         thread_id : typing.Optional[str]
 
+        ttft : typing.Optional[float]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -807,6 +815,7 @@ class RawTracesClient:
                     object_=error_info, annotation=ErrorInfo, direction="write"
                 ),
                 "thread_id": thread_id,
+                "ttft": ttft,
             },
             headers={
                 "content-type": "application/json",
@@ -2628,6 +2637,7 @@ class AsyncRawTracesClient:
         tags: typing.Optional[typing.Sequence[str]] = OMIT,
         error_info: typing.Optional[ErrorInfoWrite] = OMIT,
         last_updated_at: typing.Optional[dt.datetime] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         thread_id: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[None]:
@@ -2658,6 +2668,9 @@ class AsyncRawTracesClient:
         error_info : typing.Optional[ErrorInfoWrite]
 
         last_updated_at : typing.Optional[dt.datetime]
+
+        ttft : typing.Optional[float]
+            Time to first token in milliseconds
 
         thread_id : typing.Optional[str]
 
@@ -2691,6 +2704,7 @@ class AsyncRawTracesClient:
                     object_=error_info, annotation=ErrorInfoWrite, direction="write"
                 ),
                 "last_updated_at": last_updated_at,
+                "ttft": ttft,
                 "thread_id": thread_id,
             },
             headers={
@@ -2798,6 +2812,7 @@ class AsyncRawTracesClient:
         tags: typing.Optional[typing.Sequence[str]] = OMIT,
         error_info: typing.Optional[ErrorInfo] = OMIT,
         thread_id: typing.Optional[str] = OMIT,
+        ttft: typing.Optional[float] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[None]:
         """
@@ -2829,6 +2844,8 @@ class AsyncRawTracesClient:
 
         thread_id : typing.Optional[str]
 
+        ttft : typing.Optional[float]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -2858,6 +2875,7 @@ class AsyncRawTracesClient:
                     object_=error_info, annotation=ErrorInfo, direction="write"
                 ),
                 "thread_id": thread_id,
+                "ttft": ttft,
             },
             headers={
                 "content-type": "application/json",

--- a/sdks/python/src/opik/rest_api/types/span.py
+++ b/sdks/python/src/opik/rest_api/types/span.py
@@ -47,6 +47,11 @@ class Span(UniversalBaseModel):
     Duration in milliseconds as a decimal number to support sub-millisecond precision
     """
 
+    ttft: typing.Optional[float] = pydantic.Field(default=None)
+    """
+    Time to first token in milliseconds
+    """
+
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
     else:

--- a/sdks/python/src/opik/rest_api/types/span_experiment_item_bulk_write_view.py
+++ b/sdks/python/src/opik/rest_api/types/span_experiment_item_bulk_write_view.py
@@ -28,6 +28,10 @@ class SpanExperimentItemBulkWriteView(UniversalBaseModel):
     last_updated_at: typing.Optional[dt.datetime] = None
     total_estimated_cost: typing.Optional[float] = None
     total_estimated_cost_version: typing.Optional[str] = None
+    ttft: typing.Optional[float] = pydantic.Field(default=None)
+    """
+    Time to first token in milliseconds
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/span_public.py
+++ b/sdks/python/src/opik/rest_api/types/span_public.py
@@ -47,6 +47,11 @@ class SpanPublic(UniversalBaseModel):
     Duration in milliseconds as a decimal number to support sub-millisecond precision
     """
 
+    ttft: typing.Optional[float] = pydantic.Field(default=None)
+    """
+    Time to first token in milliseconds
+    """
+
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
     else:

--- a/sdks/python/src/opik/rest_api/types/span_update.py
+++ b/sdks/python/src/opik/rest_api/types/span_update.py
@@ -35,6 +35,7 @@ class SpanUpdate(UniversalBaseModel):
     usage: typing.Optional[typing.Dict[str, int]] = None
     total_estimated_cost: typing.Optional[float] = None
     error_info: typing.Optional[ErrorInfo] = None
+    ttft: typing.Optional[float] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/span_write.py
+++ b/sdks/python/src/opik/rest_api/types/span_write.py
@@ -34,6 +34,10 @@ class SpanWrite(UniversalBaseModel):
     last_updated_at: typing.Optional[dt.datetime] = None
     total_estimated_cost: typing.Optional[float] = None
     total_estimated_cost_version: typing.Optional[str] = None
+    ttft: typing.Optional[float] = pydantic.Field(default=None)
+    """
+    Time to first token in milliseconds
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/trace.py
+++ b/sdks/python/src/opik/rest_api/types/trace.py
@@ -50,6 +50,11 @@ class Trace(UniversalBaseModel):
     Duration in milliseconds as a decimal number to support sub-millisecond precision
     """
 
+    ttft: typing.Optional[float] = pydantic.Field(default=None)
+    """
+    Time to first token in milliseconds
+    """
+
     thread_id: typing.Optional[str] = None
     visibility_mode: typing.Optional[TraceVisibilityMode] = None
     llm_span_count: typing.Optional[int] = None

--- a/sdks/python/src/opik/rest_api/types/trace_experiment_item_bulk_write_view.py
+++ b/sdks/python/src/opik/rest_api/types/trace_experiment_item_bulk_write_view.py
@@ -29,6 +29,11 @@ class TraceExperimentItemBulkWriteView(UniversalBaseModel):
     tags: typing.Optional[typing.List[str]] = None
     error_info: typing.Optional[ErrorInfoExperimentItemBulkWriteView] = None
     last_updated_at: typing.Optional[dt.datetime] = None
+    ttft: typing.Optional[float] = pydantic.Field(default=None)
+    """
+    Time to first token in milliseconds
+    """
+
     thread_id: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/sdks/python/src/opik/rest_api/types/trace_public.py
+++ b/sdks/python/src/opik/rest_api/types/trace_public.py
@@ -45,6 +45,11 @@ class TracePublic(UniversalBaseModel):
     Duration in milliseconds as a decimal number to support sub-millisecond precision
     """
 
+    ttft: typing.Optional[float] = pydantic.Field(default=None)
+    """
+    Time to first token in milliseconds
+    """
+
     thread_id: typing.Optional[str] = None
     visibility_mode: typing.Optional[TracePublicVisibilityMode] = None
     llm_span_count: typing.Optional[int] = None

--- a/sdks/python/src/opik/rest_api/types/trace_update.py
+++ b/sdks/python/src/opik/rest_api/types/trace_update.py
@@ -28,6 +28,7 @@ class TraceUpdate(UniversalBaseModel):
     tags: typing.Optional[typing.List[str]] = None
     error_info: typing.Optional[ErrorInfo] = None
     thread_id: typing.Optional[str] = None
+    ttft: typing.Optional[float] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/trace_write.py
+++ b/sdks/python/src/opik/rest_api/types/trace_write.py
@@ -25,6 +25,11 @@ class TraceWrite(UniversalBaseModel):
     tags: typing.Optional[typing.List[str]] = None
     error_info: typing.Optional[ErrorInfoWrite] = None
     last_updated_at: typing.Optional[dt.datetime] = None
+    ttft: typing.Optional[float] = pydantic.Field(default=None)
+    """
+    Time to first token in milliseconds
+    """
+
     thread_id: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/sdks/typescript/src/opik/rest_api/api/types/Span.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/Span.ts
@@ -31,4 +31,6 @@ export interface Span {
     totalEstimatedCostVersion?: string;
     /** Duration in milliseconds as a decimal number to support sub-millisecond precision */
     duration?: number;
+    /** Time to first token in milliseconds */
+    ttft?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/SpanExperimentItemBulkWriteView.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/SpanExperimentItemBulkWriteView.ts
@@ -20,4 +20,6 @@ export interface SpanExperimentItemBulkWriteView {
     lastUpdatedAt?: Date;
     totalEstimatedCost?: number;
     totalEstimatedCostVersion?: string;
+    /** Time to first token in milliseconds */
+    ttft?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/SpanPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/SpanPublic.ts
@@ -31,4 +31,6 @@ export interface SpanPublic {
     totalEstimatedCostVersion?: string;
     /** Duration in milliseconds as a decimal number to support sub-millisecond precision */
     duration?: number;
+    /** Time to first token in milliseconds */
+    ttft?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/SpanUpdate.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/SpanUpdate.ts
@@ -21,4 +21,5 @@ export interface SpanUpdate {
     usage?: Record<string, number>;
     totalEstimatedCost?: number;
     errorInfo?: OpikApi.ErrorInfo;
+    ttft?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/SpanWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/SpanWrite.ts
@@ -23,4 +23,6 @@ export interface SpanWrite {
     lastUpdatedAt?: Date;
     totalEstimatedCost?: number;
     totalEstimatedCostVersion?: string;
+    /** Time to first token in milliseconds */
+    ttft?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/Trace.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/Trace.ts
@@ -29,6 +29,8 @@ export interface Trace {
     spanCount?: number;
     /** Duration in milliseconds as a decimal number to support sub-millisecond precision */
     duration?: number;
+    /** Time to first token in milliseconds */
+    ttft?: number;
     threadId?: string;
     visibilityMode?: OpikApi.TraceVisibilityMode;
     llmSpanCount?: number;

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceExperimentItemBulkWriteView.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceExperimentItemBulkWriteView.ts
@@ -18,5 +18,7 @@ export interface TraceExperimentItemBulkWriteView {
     tags?: string[];
     errorInfo?: OpikApi.ErrorInfoExperimentItemBulkWriteView;
     lastUpdatedAt?: Date;
+    /** Time to first token in milliseconds */
+    ttft?: number;
     threadId?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/TracePublic.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TracePublic.ts
@@ -27,6 +27,8 @@ export interface TracePublic {
     spanCount?: number;
     /** Duration in milliseconds as a decimal number to support sub-millisecond precision */
     duration?: number;
+    /** Time to first token in milliseconds */
+    ttft?: number;
     threadId?: string;
     visibilityMode?: OpikApi.TracePublicVisibilityMode;
     llmSpanCount?: number;

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceUpdate.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceUpdate.ts
@@ -15,4 +15,5 @@ export interface TraceUpdate {
     tags?: string[];
     errorInfo?: OpikApi.ErrorInfo;
     threadId?: string;
+    ttft?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceWrite.ts
@@ -15,5 +15,7 @@ export interface TraceWrite {
     tags?: string[];
     errorInfo?: OpikApi.ErrorInfoWrite;
     lastUpdatedAt?: Date;
+    /** Time to first token in milliseconds */
+    ttft?: number;
     threadId?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/Span.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/Span.ts
@@ -39,6 +39,7 @@ export const Span: core.serialization.ObjectSchema<serializers.Span.Raw, OpikApi
         core.serialization.string().optional(),
     ),
     duration: core.serialization.number().optional(),
+    ttft: core.serialization.number().optional(),
 });
 
 export declare namespace Span {
@@ -69,5 +70,6 @@ export declare namespace Span {
         total_estimated_cost?: number | null;
         total_estimated_cost_version?: string | null;
         duration?: number | null;
+        ttft?: number | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/SpanExperimentItemBulkWriteView.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/SpanExperimentItemBulkWriteView.ts
@@ -31,6 +31,7 @@ export const SpanExperimentItemBulkWriteView: core.serialization.ObjectSchema<
         "total_estimated_cost_version",
         core.serialization.string().optional(),
     ),
+    ttft: core.serialization.number().optional(),
 });
 
 export declare namespace SpanExperimentItemBulkWriteView {
@@ -52,5 +53,6 @@ export declare namespace SpanExperimentItemBulkWriteView {
         last_updated_at?: string | null;
         total_estimated_cost?: number | null;
         total_estimated_cost_version?: string | null;
+        ttft?: number | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/SpanPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/SpanPublic.ts
@@ -43,6 +43,7 @@ export const SpanPublic: core.serialization.ObjectSchema<serializers.SpanPublic.
             core.serialization.string().optional(),
         ),
         duration: core.serialization.number().optional(),
+        ttft: core.serialization.number().optional(),
     });
 
 export declare namespace SpanPublic {
@@ -73,5 +74,6 @@ export declare namespace SpanPublic {
         total_estimated_cost?: number | null;
         total_estimated_cost_version?: string | null;
         duration?: number | null;
+        ttft?: number | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/SpanUpdate.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/SpanUpdate.ts
@@ -25,6 +25,7 @@ export const SpanUpdate: core.serialization.ObjectSchema<serializers.SpanUpdate.
         usage: core.serialization.record(core.serialization.string(), core.serialization.number()).optional(),
         totalEstimatedCost: core.serialization.property("total_estimated_cost", core.serialization.number().optional()),
         errorInfo: core.serialization.property("error_info", ErrorInfo.optional()),
+        ttft: core.serialization.number().optional(),
     });
 
 export declare namespace SpanUpdate {
@@ -45,5 +46,6 @@ export declare namespace SpanUpdate {
         usage?: Record<string, number> | null;
         total_estimated_cost?: number | null;
         error_info?: ErrorInfo.Raw | null;
+        ttft?: number | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/SpanWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/SpanWrite.ts
@@ -31,6 +31,7 @@ export const SpanWrite: core.serialization.ObjectSchema<serializers.SpanWrite.Ra
             "total_estimated_cost_version",
             core.serialization.string().optional(),
         ),
+        ttft: core.serialization.number().optional(),
     });
 
 export declare namespace SpanWrite {
@@ -54,5 +55,6 @@ export declare namespace SpanWrite {
         last_updated_at?: string | null;
         total_estimated_cost?: number | null;
         total_estimated_cost_version?: string | null;
+        ttft?: number | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/Trace.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/Trace.ts
@@ -41,6 +41,7 @@ export const Trace: core.serialization.ObjectSchema<serializers.Trace.Raw, OpikA
     totalEstimatedCost: core.serialization.property("total_estimated_cost", core.serialization.number().optional()),
     spanCount: core.serialization.property("span_count", core.serialization.number().optional()),
     duration: core.serialization.number().optional(),
+    ttft: core.serialization.number().optional(),
     threadId: core.serialization.property("thread_id", core.serialization.string().optional()),
     visibilityMode: core.serialization.property("visibility_mode", TraceVisibilityMode.optional()),
     llmSpanCount: core.serialization.property("llm_span_count", core.serialization.number().optional()),
@@ -74,6 +75,7 @@ export declare namespace Trace {
         total_estimated_cost?: number | null;
         span_count?: number | null;
         duration?: number | null;
+        ttft?: number | null;
         thread_id?: string | null;
         visibility_mode?: TraceVisibilityMode.Raw | null;
         llm_span_count?: number | null;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceExperimentItemBulkWriteView.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceExperimentItemBulkWriteView.ts
@@ -21,6 +21,7 @@ export const TraceExperimentItemBulkWriteView: core.serialization.ObjectSchema<
     tags: core.serialization.list(core.serialization.string()).optional(),
     errorInfo: core.serialization.property("error_info", ErrorInfoExperimentItemBulkWriteView.optional()),
     lastUpdatedAt: core.serialization.property("last_updated_at", core.serialization.date().optional()),
+    ttft: core.serialization.number().optional(),
     threadId: core.serialization.property("thread_id", core.serialization.string().optional()),
 });
 
@@ -37,6 +38,7 @@ export declare namespace TraceExperimentItemBulkWriteView {
         tags?: string[] | null;
         error_info?: ErrorInfoExperimentItemBulkWriteView.Raw | null;
         last_updated_at?: string | null;
+        ttft?: number | null;
         thread_id?: string | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TracePublic.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TracePublic.ts
@@ -44,6 +44,7 @@ export const TracePublic: core.serialization.ObjectSchema<serializers.TracePubli
         totalEstimatedCost: core.serialization.property("total_estimated_cost", core.serialization.number().optional()),
         spanCount: core.serialization.property("span_count", core.serialization.number().optional()),
         duration: core.serialization.number().optional(),
+        ttft: core.serialization.number().optional(),
         threadId: core.serialization.property("thread_id", core.serialization.string().optional()),
         visibilityMode: core.serialization.property("visibility_mode", TracePublicVisibilityMode.optional()),
         llmSpanCount: core.serialization.property("llm_span_count", core.serialization.number().optional()),
@@ -76,6 +77,7 @@ export declare namespace TracePublic {
         total_estimated_cost?: number | null;
         span_count?: number | null;
         duration?: number | null;
+        ttft?: number | null;
         thread_id?: string | null;
         visibility_mode?: TracePublicVisibilityMode.Raw | null;
         llm_span_count?: number | null;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceUpdate.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceUpdate.ts
@@ -18,6 +18,7 @@ export const TraceUpdate: core.serialization.ObjectSchema<serializers.TraceUpdat
         tags: core.serialization.list(core.serialization.string()).optional(),
         errorInfo: core.serialization.property("error_info", ErrorInfo.optional()),
         threadId: core.serialization.property("thread_id", core.serialization.string().optional()),
+        ttft: core.serialization.number().optional(),
     });
 
 export declare namespace TraceUpdate {
@@ -32,5 +33,6 @@ export declare namespace TraceUpdate {
         tags?: string[] | null;
         error_info?: ErrorInfo.Raw | null;
         thread_id?: string | null;
+        ttft?: number | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceWrite.ts
@@ -19,6 +19,7 @@ export const TraceWrite: core.serialization.ObjectSchema<serializers.TraceWrite.
         tags: core.serialization.list(core.serialization.string()).optional(),
         errorInfo: core.serialization.property("error_info", ErrorInfoWrite.optional()),
         lastUpdatedAt: core.serialization.property("last_updated_at", core.serialization.date().optional()),
+        ttft: core.serialization.number().optional(),
         threadId: core.serialization.property("thread_id", core.serialization.string().optional()),
     });
 
@@ -35,6 +36,7 @@ export declare namespace TraceWrite {
         tags?: string[] | null;
         error_info?: ErrorInfoWrite.Raw | null;
         last_updated_at?: string | null;
+        ttft?: number | null;
         thread_id?: string | null;
     }
 }


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate