### PR TITLE
[OPIK-4428] [FE] Add full precision tooltip to CompareCostCell

### DIFF
--- a/apps/opik-frontend/src/components/shared/DataTableCells/CostCell.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableCells/CostCell.tsx
@@ -43,7 +43,11 @@ const CompareCostCell: React.FC<CellContext<ExperimentsCompare, unknown>> = (
     const value = get(item, accessor);
     if (!isNumber(value)) return "-";
 
-    return formatter(value);
+    return (
+      <TooltipWrapper content={formatCost(value, { modifier: "full" })}>
+        <span>{formatter(value)}</span>
+      </TooltipWrapper>
+    );
   };
 
   return (


### PR DESCRIPTION
## Details

The `CompareCostCell` in the experiment compare page was missing the full precision cost tooltip that was already present in the other cost cell variants (`CostCell` and `CostAggregationCell`). This wraps the formatted cost value in a `TooltipWrapper` showing the untruncated value on hover, matching the existing pattern.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-4428

## Testing

- Navigate to the experiment compare page
- Hover over a cost cell value — a tooltip should appear showing the full precision cost (e.g. `$0.00456789` instead of the displayed `$0.00`)

## Documentation

N/A