### PR TITLE
[OPIK-3501] [FE] Unify destructive menu options with red text and separators

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/annotation-queues/AnnotationQueueRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/annotation-queues/AnnotationQueueRowActionsCell.tsx
@@ -98,7 +98,7 @@ const AnnotationQueueRowActionsCell: React.FunctionComponent<
               setOpen(1);
               resetKeyRef.current = resetKeyRef.current + 1;
             }}
-            className="text-destructive focus:text-destructive"
+            variant="destructive"
           >
             <Trash className="mr-2 size-4" />
             Delete

--- a/apps/opik-frontend/src/components/pages-shared/automations/RuleRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/automations/RuleRowActionsCell.tsx
@@ -75,7 +75,7 @@ Tip: To pause scoring without deleting, disable the rule.`}
               setOpen(1);
               resetKeyRef.current = resetKeyRef.current + 1;
             }}
-            className="text-destructive focus:text-destructive"
+            variant="destructive"
           >
             <Trash className="mr-2 size-4" />
             Delete

--- a/apps/opik-frontend/src/components/pages-shared/dashboards/DashboardSelectBox/SelectItem.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/dashboards/DashboardSelectBox/SelectItem.tsx
@@ -5,7 +5,7 @@ import {
   Copy,
   MoreVertical,
   Pencil,
-  Trash2,
+  Trash,
 } from "lucide-react";
 
 import {
@@ -160,9 +160,9 @@ export const SelectItem: React.FC<SelectItemProps> = ({
                 e.stopPropagation();
                 onDelete?.(dashboard);
               }}
-              className="text-destructive focus:bg-transparent focus:text-destructive"
+              variant="destructive"
             >
-              <Trash2 className="mr-2 size-4" />
+              <Trash className="mr-2 size-4" />
               Delete
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/apps/opik-frontend/src/components/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
@@ -664,7 +664,7 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={() => setPopupOpen(true)}
-                className="text-destructive focus:text-destructive"
+                variant="destructive"
               >
                 <Trash className="mr-2 size-4" />
                 Delete

--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsActionsPanel.tsx
@@ -611,7 +611,7 @@ const TraceDetailsActionsPanel: React.FunctionComponent<
             <DropdownMenuSeparator />
             <DropdownMenuItem
               onClick={() => setPopupOpen(true)}
-              className="text-destructive focus:text-destructive"
+              variant="destructive"
             >
               <Trash className="mr-2 size-4" />
               Delete trace

--- a/apps/opik-frontend/src/components/pages/AlertsPage/AlertsRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/AlertsPage/AlertsRowActionsCell.tsx
@@ -79,7 +79,7 @@ const AlertsRowActionsCell: React.FunctionComponent<
               setOpen(1);
               resetKeyRef.current = resetKeyRef.current + 1;
             }}
-            className="text-destructive focus:text-destructive"
+            variant="destructive"
           >
             <Trash className="mr-2 size-4" />
             Delete

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/QueueItemRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/QueueItemsTab/QueueItemRowActionsCell.tsx
@@ -69,7 +69,7 @@ const QueueItemRowActionsCell: React.FC<
               setOpen(1);
               resetKeyRef.current = resetKeyRef.current + 1;
             }}
-            className="text-destructive focus:text-destructive"
+            variant="destructive"
           >
             <Trash className="mr-2 size-4" />
             Remove from queue

--- a/apps/opik-frontend/src/components/pages/ConfigurationPage/AIProvidersTab/AIProvidersRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/ConfigurationPage/AIProvidersTab/AIProvidersRowActionsCell.tsx
@@ -96,7 +96,7 @@ const AIProvidersRowActionsCell: React.FunctionComponent<
               setOpen(1);
               resetKeyRef.current = resetKeyRef.current + 1;
             }}
-            className="text-destructive focus:text-destructive"
+            variant="destructive"
           >
             <Trash className="mr-2 size-4" />
             Delete

--- a/apps/opik-frontend/src/components/pages/ConfigurationPage/FeedbackDefinitionsTab/FeedbackDefinitionsRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/ConfigurationPage/FeedbackDefinitionsTab/FeedbackDefinitionsRowActionsCell.tsx
@@ -89,7 +89,7 @@ const FeedbackDefinitionsRowActionsCell: React.FunctionComponent<
               setOpen(1);
               resetKeyRef.current = resetKeyRef.current + 1;
             }}
-            className="text-destructive focus:text-destructive"
+            variant="destructive"
           >
             <Trash className="mr-2 size-4" />
             Delete

--- a/apps/opik-frontend/src/components/pages/DashboardsPage/DashboardRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/DashboardsPage/DashboardRowActionsCell.tsx
@@ -73,10 +73,7 @@ export const DashboardRowActionsCell: React.FunctionComponent<
             Clone
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onClick={handleDelete}
-            className="text-destructive focus:text-destructive"
-          >
+          <DropdownMenuItem onClick={handleDelete} variant="destructive">
             <Trash className="mr-2 size-4" />
             Delete
           </DropdownMenuItem>

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemRowActionsCell.tsx
@@ -39,10 +39,7 @@ export const DatasetItemRowActionsCell: React.FunctionComponent<
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-52">
-          <DropdownMenuItem
-            onClick={deleteDataset}
-            className="text-destructive focus:text-destructive"
-          >
+          <DropdownMenuItem onClick={deleteDataset} variant="destructive">
             <Trash className="mr-2 size-4" />
             Delete
           </DropdownMenuItem>

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/Legacy/DatasetItemRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/Legacy/DatasetItemRowActionsCell.tsx
@@ -66,7 +66,7 @@ export const DatasetItemRowActionsCell: React.FunctionComponent<
               setOpen(1);
               resetKeyRef.current = resetKeyRef.current + 1;
             }}
-            className="text-destructive focus:text-destructive"
+            variant="destructive"
           >
             <Trash className="mr-2 size-4" />
             Delete

--- a/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetsPage/DatasetRowActionsCell.tsx
@@ -127,7 +127,7 @@ export const DatasetRowActionsCell: React.FunctionComponent<
               setOpen(1);
               resetKeyRef.current = resetKeyRef.current + 1;
             }}
-            className="text-destructive focus:text-destructive"
+            variant="destructive"
           >
             <Trash className="mr-2 size-4" />
             Delete

--- a/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/ExperimentsPage/ExperimentRowActionsCell.tsx
@@ -94,7 +94,7 @@ const ExperimentRowActionsCell: React.FunctionComponent<
               setOpen(1);
               resetKeyRef.current = resetKeyRef.current + 1;
             }}
-            className="text-destructive focus:text-destructive"
+            variant="destructive"
           >
             <Trash className="mr-2 size-4" />
             Delete

--- a/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationRowActionsCell.tsx
@@ -58,7 +58,7 @@ const OptimizationRowActionsCell: React.FunctionComponent<
               setOpen(true);
               resetKeyRef.current = resetKeyRef.current + 1;
             }}
-            className="text-destructive focus:text-destructive"
+            variant="destructive"
           >
             <Trash className="mr-2 size-4" />
             Delete

--- a/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/ProjectsPage/ProjectRowActionsCell.tsx
@@ -76,7 +76,7 @@ export const ProjectRowActionsCell: React.FC<CellContext<Project, unknown>> = (
               setOpen(1);
               resetKeyRef.current = resetKeyRef.current + 1;
             }}
-            className="text-destructive focus:text-destructive"
+            variant="destructive"
           >
             <Trash className="mr-2 size-4" />
             Delete

--- a/apps/opik-frontend/src/components/pages/PromptsPage/PromptRowActionsCell.tsx
+++ b/apps/opik-frontend/src/components/pages/PromptsPage/PromptRowActionsCell.tsx
@@ -82,7 +82,7 @@ export const PromptRowActionsCell: React.FunctionComponent<
               setOpen(DELETE_KEY);
               resetKeyRef.current = resetKeyRef.current + 1;
             }}
-            className="text-destructive focus:text-destructive"
+            variant="destructive"
           >
             <Trash className="mr-2 size-4" />
             Delete

--- a/apps/opik-frontend/src/components/shared/Dashboard/DashboardSection/DashboardSectionHeader.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/DashboardSection/DashboardSectionHeader.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from "react";
 import {
   GripHorizontal,
   MoreHorizontal,
-  Trash2,
+  Trash,
   ArrowUp,
   ArrowDown,
   ChevronDown,
@@ -137,9 +137,9 @@ const DashboardSectionHeader: React.FunctionComponent<
             <DropdownMenuItem
               onClick={handleDeleteClick}
               disabled={isLastSection}
-              className="text-destructive focus:text-destructive disabled:cursor-not-allowed disabled:opacity-50"
+              variant="destructive"
             >
-              <Trash2 className="mr-2 size-4" />
+              <Trash className="mr-2 size-4" />
               Delete section
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/apps/opik-frontend/src/components/shared/Dashboard/DashboardWidget/DashboardWidgetActionsMenu.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/DashboardWidget/DashboardWidgetActionsMenu.tsx
@@ -1,11 +1,5 @@
 import React, { useState, useCallback } from "react";
-import {
-  MoreHorizontal,
-  Pencil,
-  Copy,
-  ArrowUpDown,
-  Trash2,
-} from "lucide-react";
+import { MoreHorizontal, Pencil, Copy, ArrowUpDown, Trash } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 
 import { Button } from "@/components/ui/button";
@@ -165,11 +159,8 @@ const DashboardWidgetActionsMenu: React.FunctionComponent<
           )}
           {showSeparator && <DropdownMenuSeparator />}
           {!hideDelete && (
-            <DropdownMenuItem
-              onClick={handleDeleteClick}
-              className="text-destructive focus:text-destructive"
-            >
-              <Trash2 className="mr-2 size-4" />
+            <DropdownMenuItem onClick={handleDeleteClick} variant="destructive">
+              <Trash className="mr-2 size-4" />
               Delete widget
             </DropdownMenuItem>
           )}

--- a/apps/opik-frontend/src/components/ui/dropdown-menu.tsx
+++ b/apps/opik-frontend/src/components/ui/dropdown-menu.tsx
@@ -77,12 +77,16 @@ const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
     inset?: boolean;
+    variant?: "default" | "destructive";
   }
->(({ className, inset, ...props }, ref) => (
+>(({ className, inset, variant = "default", ...props }, ref) => (
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "comet-body-s relative flex cursor-pointer select-none items-center rounded-sm px-4 py-2 outline-none transition-colors focus:bg-primary-foreground focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:bg-muted-disabled data-[disabled]:text-muted-gray",
+      "comet-body-s relative flex cursor-pointer select-none items-center rounded-sm px-4 py-2 outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:bg-muted-disabled data-[disabled]:text-muted-gray",
+      variant === "destructive"
+        ? "text-destructive focus:bg-destructive/10 focus:text-destructive"
+        : "focus:bg-primary-foreground focus:text-foreground",
       inset && "pl-8",
       className,
     )}

--- a/apps/opik-frontend/src/plugins/comet/WorkspaceMemberActionsCell.tsx
+++ b/apps/opik-frontend/src/plugins/comet/WorkspaceMemberActionsCell.tsx
@@ -55,7 +55,7 @@ const WorkspaceMemberActionsCell = (
     <DropdownMenuItem
       onClick={handleDeleteClick}
       disabled={isInvitedByEmail}
-      className="text-destructive focus:text-destructive"
+      variant="destructive"
     >
       <Trash className="mr-2 size-4" />
       Delete


### PR DESCRIPTION
## Details


https://github.com/user-attachments/assets/3e3fa2a4-8be8-4b16-a76f-9143cfd6e2ef


Unify the styling of destructive (Delete/Remove) dropdown menu items across the entire app for visual consistency. The dashboards feature previously introduced a pattern where destructive options are styled with red text (`text-destructive`) and separated from other items by a horizontal line (`DropdownMenuSeparator`). This PR applies that pattern to all remaining action menus.

**Changes across 17 files:**
- **10 multi-item menus** (Group A): Added `DropdownMenuSeparator` before the destructive item + added `text-destructive focus:text-destructive` className
- **5 single-item menus** (Group B): Added `text-destructive focus:text-destructive` className only (no separator needed when Delete is the only option)
- **2 existing separator menus** (Group C): Added `text-destructive focus:text-destructive` className to items that already had separators
- **Bonus fix**: Added missing `confirmButtonVariant="destructive"` to the DashboardRowActionsCell ConfirmDialog

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-3501

## Testing

- Lint, typecheck, and dependency validation all pass (`scripts/dev-runner.sh --lint-fe`)
- Visual verification: navigate to each page with action menus (Projects, Datasets, Dataset Items, Prompts, Experiments, Dashboards, Alerts, Annotation Queues, Queue Items, Feedback Definitions, AI Providers, Automations/Rules, Optimizations, Trace Details Panel, Thread Details Panel) and confirm:
  - Delete/Remove items appear in red text
  - A horizontal separator appears before the destructive item (when other items exist)
  - Hover/focus state also shows red text
  - Disabled state (WorkspaceMemberActionsCell) still works correctly

## Documentation

N/A