### PR TITLE
[OPIK-4446] [BE] Use pull_request_target for auto-labeling external PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: 🗂️ Auto Label PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:


### PR DESCRIPTION
## Details

Switches the auto-labeler workflow trigger from `pull_request` to `pull_request_target` so that PRs from forks (external contributors) also get labeled automatically.

`pull_request` events from forks run with read-only permissions and cannot write labels. `pull_request_target` runs in the context of the base branch with write access, which is safe here since the labeler action only reads changed file paths — it doesn't checkout or execute PR code.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-4446

## Testing

Verified that the workflow file is valid YAML. The change will be validated by observing auto-labeling on the next external PR.

## Documentation

N/A