### PR TITLE
[NA] [DOCS] Add TypeScript SDK section to code review Slack commands

### DIFF
--- a/.agents/commands/comet/generate-code-review-slack-command.md
+++ b/.agents/commands/comet/generate-code-review-slack-command.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Generate a formatted, copiable Slack command for the #code-review channel with PR information, Jira ticket, test environment link, and optional component summaries (FE, BE, Python). Automatically extracts information from the GitHub PR for the current branch and outputs a command that can be copied, edited (to add @ mentions, media links, etc.), and pasted into Slack.
+Generate a formatted, copiable Slack command for the #code-review channel with PR information, Jira ticket, test environment link, and optional component summaries (FE, BE, Python, TypeScript). Automatically extracts information from the GitHub PR for the current branch and outputs a command that can be copied, edited (to add @ mentions, media links, etc.), and pasted into Slack.
 
 - **Execution model**: Automatically extracts information from GitHub PR, prompts only for missing information, formats the message according to the template, and outputs a copiable Slack command (does NOT send automatically).
 
@@ -13,7 +13,7 @@ This workflow will:
 - Find the GitHub PR for the current branch
 - Extract Jira ticket from PR title
 - Extract test environment link from PR description
-- Extract component summaries (FE, BE, Python) from PR description
+- Extract component summaries (FE, BE, Python, TypeScript) from PR description
 - Prompt only for missing information
 - Allow user to customize the message slightly
 - Format the message according to the code review template
@@ -33,6 +33,7 @@ This workflow will:
 - **FE summary**: Extracted from PR description (looks for frontend/React/FE mentions) or prompted if not found
 - **BE summary**: Extracted from PR description (looks for backend/Java/BE mentions) or prompted if not found
 - **Python summary**: Extracted from PR description (looks for Python/Python SDK mentions) or prompted if not found
+- **TypeScript summary**: Extracted from PR description (looks for TypeScript/TypeScript SDK/TS mentions) or prompted if not found
 - **Baz approved status**: Extracted from PR status checks (optional, may not be available)
 
 ### Configuration
@@ -105,10 +106,15 @@ This workflow will:
     - Extract relevant one-line summary from "## Details" section or component-specific mentions
     - If not found, prompt: "Backend summary not found in PR. Enter backend summary (one line, optional - press Enter to skip):"
   
-  - **Python summary**: 
+  - **Python summary**:
     - Look for mentions of "Python", "Python SDK", "SDK", or Python-related changes in PR description
     - Extract relevant one-line summary from "## Details" section or component-specific mentions
     - If not found, prompt: "Python summary not found in PR. Enter Python summary (one line, optional - press Enter to skip):"
+
+  - **TypeScript summary**:
+    - Look for mentions of "TypeScript", "TypeScript SDK", "TS", "TS SDK", or `[TS]` tag in PR description
+    - Extract relevant one-line summary from "## Details" section or component-specific mentions
+    - If not found, prompt: "TypeScript summary not found in PR. Enter TypeScript summary (one line, optional - press Enter to skip):"
 
 - **Store extracted information**: Keep all extracted and prompted values for message formatting
 
@@ -143,6 +149,7 @@ This workflow will:
   :react: fe summary (optional): {{description_in_one_line}}
   :java: be summary (optional): {{description_in_one_line}}
   :python: python summary (optional): {{description_in_one_line}}
+  :typescript: typescript summary (optional): {{description_in_one_line}}
   ```
 
 - **Message structure**:
@@ -165,6 +172,7 @@ This workflow will:
   :test_tube: test env link: https://test.opik.com
   :react: fe summary (optional): Added new metrics dashboard UI
   :java: be summary (optional): Implemented metrics aggregation endpoint
+  :typescript: typescript summary (optional): Added TypeScript SDK support for metrics
   ```
 
 ---
@@ -268,6 +276,7 @@ cursor generate-code-review-slack-command
 #    - FE: Added new metrics dashboard UI (from Details section)
 #    - BE: Implemented metrics aggregation endpoint (from Details section)
 #    - Python: (not found, prompts user)
+#    - TypeScript: (not found, prompts user)
 # 5. Prompt for message customization (optional)
 # 6. Format message according to template (with greeting and Jira link)
 # 7. Generate and display copiable Slack command
@@ -293,6 +302,7 @@ cursor generate-code-review-slack-command
 # :test_tube: test env link: https://test.opik.com
 # :react: fe summary (optional): Added new metrics dashboard UI
 # :java: be summary (optional): Implemented metrics aggregation endpoint
+# :typescript: typescript summary (optional): Added TypeScript SDK support for metrics
 # ```
 # 
 # **To send in Slack:**
@@ -314,6 +324,7 @@ cursor generate-code-review-slack-command
 # Frontend summary not found in PR. Enter frontend summary (one line, optional - press Enter to skip): [Enter pressed - skipped]
 # Backend summary not found in PR. Enter backend summary (one line, optional - press Enter to skip): Implemented metrics endpoint
 # Python summary not found in PR. Enter Python summary (one line, optional - press Enter to skip): [Enter pressed - skipped]
+# TypeScript summary not found in PR. Enter TypeScript summary (one line, optional - press Enter to skip): [Enter pressed - skipped]
 # Would you like to customize the message? (Enter any additional text to prepend/append, or press Enter to use default message): [Enter pressed - using default]
 ```
 

--- a/.agents/commands/comet/send-code-review-slack.md
+++ b/.agents/commands/comet/send-code-review-slack.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Send a formatted Slack message to the #code-review channel with PR information, Jira ticket, test environment link, and optional component summaries (FE, BE, Python). Automatically extracts information from the GitHub PR for the current branch.
+Send a formatted Slack message to the #code-review channel with PR information, Jira ticket, test environment link, and optional component summaries (FE, BE, Python, TypeScript). Automatically extracts information from the GitHub PR for the current branch.
 
 - **Execution model**: Automatically extracts information from GitHub PR, prompts only for missing information, formats the message according to the template, and sends it via Slack MCP.
 
@@ -13,7 +13,7 @@ This workflow will:
 - Find the GitHub PR for the current branch
 - Extract Jira ticket from PR title
 - Extract test environment link from PR description
-- Extract component summaries (FE, BE, Python) from PR description
+- Extract component summaries (FE, BE, Python, TypeScript) from PR description
 - Prompt only for missing information
 - Allow user to customize the message slightly
 - Format the message according to the code review template
@@ -33,6 +33,7 @@ This workflow will:
 - **FE summary**: Extracted from PR description (looks for frontend/React/FE mentions) or prompted if not found
 - **BE summary**: Extracted from PR description (looks for backend/Java/BE mentions) or prompted if not found
 - **Python summary**: Extracted from PR description (looks for Python/Python SDK mentions) or prompted if not found
+- **TypeScript summary**: Extracted from PR description (looks for TypeScript/TypeScript SDK/TS mentions) or prompted if not found
 - **Baz approved status**: Extracted from PR status checks (optional, may not be available)
 
 ### Configuration
@@ -116,10 +117,15 @@ This workflow will:
     - Extract relevant one-line summary from "## Details" section or component-specific mentions
     - If not found, prompt: "Backend summary not found in PR. Enter backend summary (one line, optional - press Enter to skip):"
   
-  - **Python summary**: 
+  - **Python summary**:
     - Look for mentions of "Python", "Python SDK", "SDK", or Python-related changes in PR description
     - Extract relevant one-line summary from "## Details" section or component-specific mentions
     - If not found, prompt: "Python summary not found in PR. Enter Python summary (one line, optional - press Enter to skip):"
+
+  - **TypeScript summary**:
+    - Look for mentions of "TypeScript", "TypeScript SDK", "TS", "TS SDK", or `[TS]` tag in PR description
+    - Extract relevant one-line summary from "## Details" section or component-specific mentions
+    - If not found, prompt: "TypeScript summary not found in PR. Enter TypeScript summary (one line, optional - press Enter to skip):"
 
 - **Store extracted information**: Keep all extracted and prompted values for message formatting
 
@@ -154,6 +160,7 @@ This workflow will:
   :react: fe summary (optional): {{description_in_one_line}}
   :java: be summary (optional): {{description_in_one_line}}
   :python: python summary (optional): {{description_in_one_line}}
+  :typescript: typescript summary (optional): {{description_in_one_line}}
   ```
 
 - **Message structure**:
@@ -177,6 +184,7 @@ This workflow will:
   :test_tube: test env link: https://test.opik.com
   :react: fe summary (optional): Added new metrics dashboard UI
   :java: be summary (optional): Implemented metrics aggregation endpoint
+  :typescript: typescript summary (optional): Added TypeScript SDK support for metrics
   ```
 
 - **Note about videos**: Slack has limitations on sending videos directly. Videos should be added to the PR description, and the link can be shared in Slack. For easier communication with the product team, consider using the `cursor generate-code-review-slack-command` command to generate a copiable Slack command that you can edit before sending (allowing you to add @ mentions, media links, and final proof editing).
@@ -336,6 +344,7 @@ cursor send-code-review-slack
 #    - FE: Added new metrics dashboard UI (from Details section)
 #    - BE: Implemented metrics aggregation endpoint (from Details section)
 #    - Python: (not found, prompts user)
+#    - TypeScript: (not found, prompts user)
 # 5. Prompt for message customization (optional)
 # 6. Format message according to template (with greeting and Jira link)
 # 7. Send formatted message to Slack via conversations_add_message MCP tool (posts as user account)
@@ -349,6 +358,7 @@ cursor send-code-review-slack
 # :test_tube: test env link: https://test.opik.com
 # :react: fe summary (optional): Added new metrics dashboard UI
 # :java: be summary (optional): Implemented metrics aggregation endpoint
+# :typescript: typescript summary (optional): Added TypeScript SDK support for metrics
 ```
 
 ### Example with Missing Information
@@ -364,6 +374,7 @@ cursor send-code-review-slack
 # Frontend summary not found in PR. Enter frontend summary (one line, optional - press Enter to skip): [Enter pressed - skipped]
 # Backend summary not found in PR. Enter backend summary (one line, optional - press Enter to skip): Implemented metrics endpoint
 # Python summary not found in PR. Enter Python summary (one line, optional - press Enter to skip): [Enter pressed - skipped]
+# TypeScript summary not found in PR. Enter TypeScript summary (one line, optional - press Enter to skip): [Enter pressed - skipped]
 # Would you like to customize the message? (Enter any additional text to prepend/append, or press Enter to use default message): [Enter pressed - using default]
 ```
 


### PR DESCRIPTION
## Details

Added TypeScript SDK summary field to both `send-code-review-slack` and `generate-code-review-slack-command` workflows to ensure TypeScript SDK changes are properly documented in code review messages.

**Before this change**: TypeScript SDK changes were not mentioned in code review Slack messages and had to be added manually to notifications.

**After this change**: TypeScript SDK changes are automatically extracted from PR descriptions and included in code review messages with the `:typescript:` emoji.

Changes include:
- Added TypeScript summary extraction logic in Step 3 (Extract Information from PR)
- Added `:typescript: typescript summary (optional): {{description_in_one_line}}` field to message templates
- Updated extraction patterns to look for "TypeScript", "TypeScript SDK", "TS", "TS SDK", or `[TS]` tags
- Added TypeScript prompt if summary not found in PR description
- Updated all examples and documentation to include TypeScript SDK field
- Follows same format and structure as Python SDK section

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- NA

## Testing
- Verified both command files have consistent TypeScript SDK sections
- Confirmed extraction logic follows same pattern as Python/BE/FE sections
- Validated message template includes TypeScript field in correct order

## Documentation
Updated documentation files:
- `.agents/commands/comet/send-code-review-slack.md`
- `.agents/commands/comet/generate-code-review-slack-command.md`