### PR TITLE
feat: add tracking support for OpenAI TTS models

### DIFF
--- a/sdks/python/src/opik/integrations/openai/tts/__init__.py
+++ b/sdks/python/src/opik/integrations/openai/tts/__init__.py
@@ -1,0 +1,5 @@
+from .tts_create_decorator import TtsCreateTrackDecorator
+
+__all__ = [
+    "TtsCreateTrackDecorator",
+]

--- a/sdks/python/src/opik/integrations/openai/tts/tts_create_decorator.py
+++ b/sdks/python/src/opik/integrations/openai/tts/tts_create_decorator.py
@@ -1,0 +1,162 @@
+"""
+Decorator for OpenAI TTS (Text-To-Speech) audio.speech.create method.
+
+Output type: openai._legacy_response.HttpxBinaryResponseContent
+         or openai._response.StreamedBinaryAPIResponse (via with_streaming_response)
+
+This decorator is used for LLM spans that generate speech audio.
+"""
+
+import logging
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+
+from typing_extensions import override
+
+import opik.dict_utils as dict_utils
+from opik.api_objects import span
+from opik.decorator import arguments_helpers, base_track_decorator
+
+LOGGER = logging.getLogger(__name__)
+
+# Input parameters to log for TTS generation
+TTS_KWARGS_KEYS_TO_LOG_AS_INPUTS = [
+    "input",
+    "voice",
+    "instructions",
+]
+
+
+def _remove_not_given_sentinel_values(dict_: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove OpenAI NOT_GIVEN sentinel values from a dictionary."""
+    from openai._types import NOT_GIVEN, Omit
+
+    return {
+        key: value
+        for key, value in dict_.items()
+        if value is not NOT_GIVEN and not isinstance(value, Omit)
+    }
+
+
+class TtsCreateTrackDecorator(base_track_decorator.BaseTrackDecorator):
+    """
+    Decorator for tracking OpenAI TTS audio.speech.create method (LLM spans).
+
+    Handles: audio.speech.create, audio.speech.with_streaming_response.create
+    """
+
+    def __init__(self, provider: str) -> None:
+        super().__init__()
+        self.provider = provider
+
+    @override
+    def _start_span_inputs_preprocessor(
+        self,
+        func: Callable,
+        track_options: arguments_helpers.TrackOptions,
+        args: Tuple,
+        kwargs: Dict[str, Any],
+    ) -> arguments_helpers.StartSpanParameters:
+        assert kwargs is not None, (
+            "Expected kwargs to be not None in audio.speech.create(**kwargs)"
+        )
+
+        kwargs = _remove_not_given_sentinel_values(kwargs)
+
+        name = track_options.name if track_options.name is not None else func.__name__
+
+        metadata = track_options.metadata if track_options.metadata is not None else {}
+
+        input_data, new_metadata = dict_utils.split_dict_by_keys(
+            kwargs, keys=TTS_KWARGS_KEYS_TO_LOG_AS_INPUTS
+        )
+        metadata = dict_utils.deepmerge(metadata, new_metadata)
+        metadata.update(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+            }
+        )
+
+        tags = ["openai"]
+        model = kwargs.get("model", None)
+
+        result = arguments_helpers.StartSpanParameters(
+            name=name,
+            input=input_data,
+            type=track_options.type,
+            tags=tags,
+            metadata=metadata,
+            project_name=track_options.project_name,
+            model=model,
+            provider=self.provider,
+        )
+
+        return result
+
+    @override
+    def _end_span_inputs_preprocessor(
+        self,
+        output: Any,
+        capture_output: bool,
+        current_span_data: span.SpanData,
+    ) -> arguments_helpers.EndSpanParameters:
+        if output is None:
+            return arguments_helpers.EndSpanParameters(
+                output=None,
+                usage=None,
+                metadata={},
+                model=None,
+                provider=self.provider,
+            )
+
+        # The output is HttpxBinaryResponseContent or StreamedBinaryAPIResponse
+        # (binary audio data). We don't log the binary content itself, but log
+        # metadata about the response.
+        output_data: Dict[str, Any] = {
+            "content_type": "audio",
+        }
+
+        metadata: Dict[str, Any] = {}
+
+        try:
+            from openai._legacy_response import HttpxBinaryResponseContent
+
+            if isinstance(output, HttpxBinaryResponseContent):
+                response = output.response
+                if hasattr(response, "headers"):
+                    content_type = response.headers.get("content-type")
+                    if content_type:
+                        output_data["content_type"] = content_type
+                    content_length = response.headers.get("content-length")
+                    if content_length:
+                        metadata["audio_content_length"] = int(content_length)
+        except Exception:
+            LOGGER.debug(
+                "Failed to extract response metadata from TTS output",
+                exc_info=True,
+            )
+
+        return arguments_helpers.EndSpanParameters(
+            output=output_data,
+            usage=None,
+            metadata=metadata,
+            model=None,
+            provider=self.provider,
+        )
+
+    @override
+    def _streams_handler(
+        self,
+        output: Any,
+        capture_output: bool,
+        generations_aggregator: Optional[Callable[[List[Any]], Any]],
+    ) -> Optional[Any]:
+        NOT_A_STREAM = None
+        return NOT_A_STREAM

--- a/sdks/python/tests/library_integration/openai/test_openai_tts.py
+++ b/sdks/python/tests/library_integration/openai/test_openai_tts.py
@@ -1,0 +1,444 @@
+import os
+from unittest import mock
+
+import openai
+import pytest
+
+import opik
+from opik.config import OPIK_PROJECT_DEFAULT_NAME
+from opik.integrations.openai import track_openai
+
+from ...testlib import (
+    ANY,
+    ANY_BUT_NONE,
+    ANY_DICT,
+    ANY_STRING,
+    SpanModel,
+    TraceModel,
+    assert_equal,
+)
+
+
+# TTS tests that call the real API are slow, skip unless explicitly enabled
+SKIP_EXPENSIVE_TESTS = os.environ.get("OPIK_TEST_EXPENSIVE", "").lower() not in (
+    "1",
+    "true",
+    "yes",
+)
+
+
+@pytest.fixture(autouse=True)
+def check_openai_configured(ensure_openai_configured):
+    pass
+
+
+def test_openai_client_tts_create__error_handling(fake_backend):
+    """
+    Test error handling when TTS creation fails with invalid parameters.
+
+    This is a fast test (no actual audio generation) that verifies:
+    1. Error info is logged on both trace and span
+    2. Trace and spans are finished gracefully despite the error
+    3. Input parameters are correctly captured
+    """
+    client = openai.OpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    with pytest.raises(openai.OpenAIError):
+        _ = wrapped_client.audio.speech.create(
+            model="invalid-tts-model",
+            input="Hello, this is a test.",
+            voice="alloy",
+        )
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio.speech.create",
+        input={
+            "input": "Hello, this is a test.",
+            "voice": "alloy",
+        },
+        output=None,
+        tags=["openai"],
+        metadata=ANY_DICT.containing(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+            }
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=OPIK_PROJECT_DEFAULT_NAME,
+        error_info={
+            "exception_type": ANY_STRING,
+            "message": ANY_STRING,
+            "traceback": ANY_STRING,
+        },
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio.speech.create",
+                input={
+                    "input": "Hello, this is a test.",
+                    "voice": "alloy",
+                },
+                output=None,
+                tags=["openai"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "openai",
+                        "type": "openai_tts",
+                    }
+                ),
+                usage=None,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=OPIK_PROJECT_DEFAULT_NAME,
+                model="invalid-tts-model",
+                provider="openai",
+                error_info={
+                    "exception_type": ANY_STRING,
+                    "message": ANY_STRING,
+                    "traceback": ANY_STRING,
+                },
+                spans=[],
+            ),
+        ],
+    )
+
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)
+
+
+@pytest.mark.asyncio
+async def test_openai_async_client_tts_create__error_handling(fake_backend):
+    """
+    Test async error handling when TTS creation fails with invalid parameters.
+
+    This is a fast test (no actual audio generation) that verifies async error handling.
+    """
+    client = openai.AsyncOpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    with pytest.raises(openai.OpenAIError):
+        _ = await wrapped_client.audio.speech.create(
+            model="invalid-tts-model",
+            input="Hello, this is a test.",
+            voice="alloy",
+        )
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio.speech.create",
+        input={
+            "input": "Hello, this is a test.",
+            "voice": "alloy",
+        },
+        output=None,
+        tags=["openai"],
+        metadata=ANY_DICT.containing(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+            }
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=OPIK_PROJECT_DEFAULT_NAME,
+        error_info={
+            "exception_type": ANY_STRING,
+            "message": ANY_STRING,
+            "traceback": ANY_STRING,
+        },
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio.speech.create",
+                input={
+                    "input": "Hello, this is a test.",
+                    "voice": "alloy",
+                },
+                output=None,
+                tags=["openai"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "openai",
+                        "type": "openai_tts",
+                    }
+                ),
+                usage=None,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=OPIK_PROJECT_DEFAULT_NAME,
+                model="invalid-tts-model",
+                provider="openai",
+                error_info={
+                    "exception_type": ANY_STRING,
+                    "message": ANY_STRING,
+                    "traceback": ANY_STRING,
+                },
+                spans=[],
+            ),
+        ],
+    )
+
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)
+
+
+@pytest.mark.skipif(
+    SKIP_EXPENSIVE_TESTS,
+    reason="Expensive tests disabled. Set OPIK_TEST_EXPENSIVE=1 to enable.",
+)
+def test_openai_client_tts_create__happyflow(fake_backend):
+    """
+    Test TTS audio.speech.create - the standard TTS workflow.
+
+    This test verifies:
+    1. Trace and span structure
+    2. Input logging for TTS parameters (input text, voice, model)
+    3. Metadata contains openai_tts type
+    4. Model and provider are correctly populated
+    5. Tags are applied correctly
+    6. Output contains content_type info
+    """
+    client = openai.OpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "Hello, this is a text-to-speech test."
+
+    response = wrapped_client.audio.speech.create(
+        model="tts-1",
+        input=input_text,
+        voice="alloy",
+        response_format="mp3",
+        speed=1.0,
+    )
+
+    # Verify we got audio content back
+    assert response is not None
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio.speech.create",
+        input={
+            "input": input_text,
+            "voice": "alloy",
+        },
+        output=ANY_DICT.containing({"content_type": ANY_BUT_NONE}),
+        tags=["openai"],
+        metadata=ANY_DICT.containing(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+            }
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=OPIK_PROJECT_DEFAULT_NAME,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio.speech.create",
+                input={
+                    "input": input_text,
+                    "voice": "alloy",
+                },
+                output=ANY_DICT.containing({"content_type": ANY_BUT_NONE}),
+                tags=["openai"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "openai",
+                        "type": "openai_tts",
+                        "response_format": "mp3",
+                        "speed": 1.0,
+                    }
+                ),
+                usage=None,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=OPIK_PROJECT_DEFAULT_NAME,
+                model="tts-1",
+                provider="openai",
+                spans=[],
+            ),
+        ],
+    )
+
+    trace_tree = fake_backend.trace_trees[0]
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)
+
+
+@pytest.mark.skipif(
+    SKIP_EXPENSIVE_TESTS,
+    reason="Expensive tests disabled. Set OPIK_TEST_EXPENSIVE=1 to enable.",
+)
+def test_openai_client_tts_with_streaming_response_create__happyflow(fake_backend):
+    """
+    Test TTS audio.speech.with_streaming_response.create workflow.
+
+    This test verifies that the with_streaming_response pattern is tracked
+    correctly. The with_streaming_response.create internally calls
+    audio.speech.create, so our decorator on create fires.
+    """
+    client = openai.OpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "Hello, streaming TTS test."
+
+    with wrapped_client.audio.speech.with_streaming_response.create(
+        model="tts-1",
+        input=input_text,
+        voice="alloy",
+    ) as response:
+        # Read the stream to complete the request
+        _ = response.read()
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio.speech.create",
+        input={
+            "input": input_text,
+            "voice": "alloy",
+        },
+        output=ANY_DICT.containing({"content_type": ANY_BUT_NONE}),
+        tags=["openai"],
+        metadata=ANY_DICT.containing(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+            }
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=OPIK_PROJECT_DEFAULT_NAME,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio.speech.create",
+                input={
+                    "input": input_text,
+                    "voice": "alloy",
+                },
+                output=ANY_DICT.containing({"content_type": ANY_BUT_NONE}),
+                tags=["openai"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "openai",
+                        "type": "openai_tts",
+                    }
+                ),
+                usage=None,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=OPIK_PROJECT_DEFAULT_NAME,
+                model="tts-1",
+                provider="openai",
+                spans=[],
+            ),
+        ],
+    )
+
+    trace_tree = fake_backend.trace_trees[0]
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)
+
+
+@pytest.mark.skipif(
+    SKIP_EXPENSIVE_TESTS,
+    reason="Expensive tests disabled. Set OPIK_TEST_EXPENSIVE=1 to enable.",
+)
+@pytest.mark.asyncio
+async def test_openai_async_client_tts_create__happyflow(fake_backend):
+    """
+    Test async TTS audio.speech.create workflow.
+    """
+    client = openai.AsyncOpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "Hello, async TTS test."
+
+    response = await wrapped_client.audio.speech.create(
+        model="tts-1",
+        input=input_text,
+        voice="alloy",
+    )
+
+    assert response is not None
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio.speech.create",
+        input={
+            "input": input_text,
+            "voice": "alloy",
+        },
+        output=ANY_DICT.containing({"content_type": ANY_BUT_NONE}),
+        tags=["openai"],
+        metadata=ANY_DICT.containing(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+            }
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=OPIK_PROJECT_DEFAULT_NAME,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio.speech.create",
+                input={
+                    "input": input_text,
+                    "voice": "alloy",
+                },
+                output=ANY_DICT.containing({"content_type": ANY_BUT_NONE}),
+                tags=["openai"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "openai",
+                        "type": "openai_tts",
+                    }
+                ),
+                usage=None,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=OPIK_PROJECT_DEFAULT_NAME,
+                model="tts-1",
+                provider="openai",
+                spans=[],
+            ),
+        ],
+    )
+
+    trace_tree = fake_backend.trace_trees[0]
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)


### PR DESCRIPTION
## Summary
- Adds tracing/tracking support for OpenAI Text-To-Speech (TTS) models in the Python SDK
- Tracks `audio.speech.create` and `audio.speech.with_streaming_response.create` calls
- Captures model name, input text, voice, response format, speed, and instructions
- Follows the existing OpenAI integration patterns (videos, chat completions, responses)

Closes #2202

## Changes

### New files
- `sdks/python/src/opik/integrations/openai/tts/__init__.py` - TTS module init
- `sdks/python/src/opik/integrations/openai/tts/tts_create_decorator.py` - `TtsCreateTrackDecorator` extending `BaseTrackDecorator`, handling input/output preprocessing for TTS calls
- `sdks/python/tests/library_integration/openai/test_openai_tts.py` - Tests for sync/async error handling, happy-path sync/async create, and streaming response create

### Modified files
- `sdks/python/src/opik/integrations/openai/opik_tracker.py` - Added `_patch_openai_tts()` to wire TTS tracking into `track_openai()`, including invalidation of the `with_streaming_response` cached property so it picks up the patched `create` method

## Design decisions

1. **Input tracking**: `input`, `voice`, and `instructions` are logged as span inputs. Other parameters like `model`, `response_format`, `speed`, and `stream_format` are logged as metadata (following the same pattern as chat completions where `messages` are input and other params go to metadata).

2. **Output tracking**: Since TTS returns binary audio data (`HttpxBinaryResponseContent`), we don't log the audio content. Instead, we log the content type and content length from response headers as output/metadata.

3. **`with_streaming_response` support**: The `with_streaming_response.create` method internally calls `speech.create` through a wrapper. By patching `speech.create` and invalidating the `cached_property` for `with_streaming_response`, the streaming response path automatically goes through our tracked version.

4. **Span type**: TTS spans use type `"llm"` since they represent an LLM API call, consistent with how chat completions and video generation are tracked.

## Test plan
- [x] Sync error handling test (no API call needed) - passes
- [x] Async error handling test (no API call needed) - passes
- [x] Existing chat completions error test - passes (no regression)
- [ ] Sync `audio.speech.create` happy-flow test (requires `OPIK_TEST_EXPENSIVE=1`)
- [ ] Async `audio.speech.create` happy-flow test (requires `OPIK_TEST_EXPENSIVE=1`)
- [ ] `audio.speech.with_streaming_response.create` test (requires `OPIK_TEST_EXPENSIVE=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)