### PR TITLE
feat(ui): batch annotate multiple traces at once

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/BatchAnnotateDialog/BatchAnnotateDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/BatchAnnotateDialog/BatchAnnotateDialog.tsx
@@ -1,0 +1,395 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { sortBy } from "lodash";
+import isNumber from "lodash/isNumber";
+import { X } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+import { Trace, Span } from "@/types/traces";
+import {
+  FEEDBACK_DEFINITION_TYPE,
+  FeedbackDefinition,
+} from "@/types/feedback-definitions";
+import useFeedbackDefinitionsList from "@/api/feedback-definitions/useFeedbackDefinitionsList";
+import useAppStore from "@/store/AppStore";
+import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
+import useTraceFeedbackScoreSetMutation from "@/api/traces/useTraceFeedbackScoreSetMutation";
+import ColoredTagNew from "@/components/shared/ColoredTag/ColoredTagNew";
+import DebounceInput from "@/components/shared/DebounceInput/DebounceInput";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import SelectBox from "@/components/shared/SelectBox/SelectBox";
+import { SelectItem } from "@/components/ui/select";
+import { DropdownOption } from "@/types/shared";
+import { isNumericFeedbackScoreValid } from "@/lib/traces";
+import { categoryOptionLabelRenderer } from "@/lib/feedback-scores";
+
+type ScoreEntry = {
+  name: string;
+  value: number;
+  categoryName?: string;
+};
+
+type BatchAnnotateDialogProps = {
+  rows: Array<Trace | Span>;
+  open: boolean | number;
+  setOpen: (open: boolean | number) => void;
+  type: TRACE_DATA_TYPE;
+};
+
+const BatchAnnotateDialog: React.FunctionComponent<
+  BatchAnnotateDialogProps
+> = ({ rows, open, setOpen, type }) => {
+  const { toast } = useToast();
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const [scores, setScores] = useState<Map<string, ScoreEntry>>(new Map());
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const { mutateAsync: setFeedbackScore } = useTraceFeedbackScoreSetMutation();
+
+  const { data: feedbackDefinitionsData } = useFeedbackDefinitionsList({
+    workspaceName,
+    page: 1,
+    size: 1000,
+  });
+
+  const feedbackDefinitions: FeedbackDefinition[] = useMemo(() => {
+    return sortBy(feedbackDefinitionsData?.content || [], "name");
+  }, [feedbackDefinitionsData?.content]);
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+    setScores(new Map());
+    setIsSubmitting(false);
+  }, [setOpen]);
+
+  const handleScoreChange = useCallback(
+    (name: string, value: number, categoryName?: string) => {
+      setScores((prev) => {
+        const next = new Map(prev);
+        next.set(name, { name, value, categoryName });
+        return next;
+      });
+    },
+    [],
+  );
+
+  const handleScoreRemove = useCallback((name: string) => {
+    setScores((prev) => {
+      const next = new Map(prev);
+      next.delete(name);
+      return next;
+    });
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    if (scores.size === 0) return;
+
+    setIsSubmitting(true);
+    const scoreEntries = Array.from(scores.values());
+    const isTrace = type === TRACE_DATA_TYPE.traces;
+
+    try {
+      const promises = rows.flatMap((row) =>
+        scoreEntries.map((score) =>
+          setFeedbackScore({
+            name: score.name,
+            value: score.value,
+            categoryName: score.categoryName,
+            traceId: isTrace ? row.id : (row as Span).trace_id,
+            spanId: isTrace ? undefined : row.id,
+          }),
+        ),
+      );
+
+      await Promise.all(promises);
+
+      const entityName = isTrace ? "traces" : "spans";
+      toast({
+        title: "Success",
+        description: `Applied ${scoreEntries.length} score${
+          scoreEntries.length > 1 ? "s" : ""
+        } to ${rows.length} ${entityName}`,
+      });
+
+      handleClose();
+    } catch {
+      toast({
+        title: "Error",
+        description: "Failed to apply some feedback scores. Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [scores, rows, type, setFeedbackScore, toast, handleClose]);
+
+  const entityName = type === TRACE_DATA_TYPE.traces ? "traces" : "spans";
+
+  return (
+    <Dialog open={Boolean(open)} onOpenChange={handleClose}>
+      <DialogContent className="max-h-[80vh] sm:max-w-[550px]">
+        <DialogHeader>
+          <DialogTitle>
+            Annotate {rows.length} {entityName}
+          </DialogTitle>
+          <DialogDescription>
+            Set feedback scores that will be applied to all {rows.length}{" "}
+            selected {entityName}.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="max-h-[50vh] overflow-y-auto py-2">
+          {feedbackDefinitions.length === 0 ? (
+            <div className="comet-body-s px-2 py-4 text-muted-slate">
+              No feedback definitions configured. Please set up feedback
+              definitions in the Configuration page first.
+            </div>
+          ) : (
+            <div className="grid max-w-full grid-cols-[minmax(0,5fr)_minmax(0,5fr)_30px] border-b border-border empty:border-transparent">
+              {feedbackDefinitions.map((definition) => (
+                <BatchAnnotateRow
+                  key={definition.name}
+                  feedbackDefinition={definition}
+                  scoreEntry={scores.get(definition.name)}
+                  onScoreChange={handleScoreChange}
+                  onScoreRemove={handleScoreRemove}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={scores.size === 0 || isSubmitting}
+          >
+            {isSubmitting
+              ? "Applying..."
+              : `Apply to ${rows.length} ${entityName}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+type BatchAnnotateRowProps = {
+  feedbackDefinition: FeedbackDefinition;
+  scoreEntry?: ScoreEntry;
+  onScoreChange: (name: string, value: number, categoryName?: string) => void;
+  onScoreRemove: (name: string) => void;
+};
+
+const BatchAnnotateRow: React.FunctionComponent<BatchAnnotateRowProps> = ({
+  feedbackDefinition,
+  scoreEntry,
+  onScoreChange,
+  onScoreRemove,
+}) => {
+  const name = feedbackDefinition.name;
+  const value = scoreEntry ? scoreEntry.value : ("" as const);
+  const categoryName = scoreEntry?.categoryName ?? "";
+
+  const renderOptions = () => {
+    if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.numerical) {
+      return (
+        <DebounceInput
+          className="my-0.5 h-7 min-w-[100px] py-1"
+          max={feedbackDefinition.details.max}
+          min={feedbackDefinition.details.min}
+          step="any"
+          dimension="sm"
+          delay={300}
+          onValueChange={(val) => {
+            const newValue = val === "" ? "" : Number(val);
+
+            if (newValue === "") {
+              onScoreRemove(name);
+              return;
+            }
+
+            if (
+              isNumericFeedbackScoreValid(feedbackDefinition.details, newValue)
+            ) {
+              onScoreChange(name, newValue);
+            }
+          }}
+          placeholder="Score"
+          type="number"
+          value={value}
+        />
+      );
+    }
+
+    if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.boolean) {
+      const onBooleanValueChange = (val?: string) => {
+        if (!val) {
+          onScoreRemove(name);
+          return;
+        }
+        const boolValue = val === feedbackDefinition.details.true_label ? 1 : 0;
+        onScoreChange(name, boolValue, val);
+      };
+
+      return (
+        <ToggleGroup
+          className="min-w-fit p-0.5"
+          onValueChange={onBooleanValueChange}
+          variant="outline"
+          type="single"
+          size="md"
+          value={categoryName}
+        >
+          <ToggleGroupItem
+            className="w-full"
+            key="true"
+            value={feedbackDefinition.details.true_label}
+          >
+            <div className="text-nowrap">
+              {feedbackDefinition.details.true_label}
+            </div>
+          </ToggleGroupItem>
+          <ToggleGroupItem
+            className="w-full"
+            key="false"
+            value={feedbackDefinition.details.false_label}
+          >
+            <div className="text-nowrap">
+              {feedbackDefinition.details.false_label}
+            </div>
+          </ToggleGroupItem>
+        </ToggleGroup>
+      );
+    }
+
+    if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.categorical) {
+      const onCategoricalValueChange = (val?: string) => {
+        if (val === "") {
+          onScoreRemove(name);
+          return;
+        }
+
+        const categoryEntry = Object.entries(
+          feedbackDefinition.details.categories,
+        ).find(([catName]) => catName === val);
+
+        if (categoryEntry) {
+          onScoreChange(name, categoryEntry[1], val);
+        }
+      };
+
+      const categoricalOptionList = sortBy(
+        Object.entries(feedbackDefinition.details.categories).map(
+          ([catName, catValue]) => ({
+            name: catName,
+            value: catValue,
+          }),
+        ),
+        "value",
+      );
+
+      const hasLongNames = categoricalOptionList.some((item) => {
+        const label = categoryOptionLabelRenderer(item.name, item.value);
+        return label.length > 10;
+      });
+      const hasMultipleOptions = categoricalOptionList.length > 2;
+
+      if (hasLongNames || hasMultipleOptions) {
+        const categoricalSelectOptionList = categoricalOptionList.map(
+          (item) => ({
+            label: item.name,
+            value: item.name,
+            description: String(item.value),
+          }),
+        );
+        return (
+          <SelectBox
+            value={categoryName || ""}
+            options={categoricalSelectOptionList}
+            onChange={onCategoricalValueChange}
+            className="my-0.5 h-7 min-w-[100px] py-1"
+            renderTrigger={(val) => {
+              const selectedOption = categoricalOptionList.find(
+                (item) => item.name.trim() === val.trim(),
+              );
+
+              if (!selectedOption) {
+                return <div className="truncate">Select a category</div>;
+              }
+
+              return (
+                <span className="text-nowrap">
+                  {categoryOptionLabelRenderer(val, selectedOption.value)}
+                </span>
+              );
+            }}
+            renderOption={(option: DropdownOption<string>) => (
+              <SelectItem key={option.value} value={option.value}>
+                {categoryOptionLabelRenderer(option.value, option.description)}
+              </SelectItem>
+            )}
+          />
+        );
+      }
+
+      return (
+        <ToggleGroup
+          className="min-w-fit p-0.5"
+          onValueChange={onCategoricalValueChange}
+          variant="outline"
+          type="single"
+          size="md"
+          value={String(categoryName)}
+        >
+          {categoricalOptionList.map(({ name: catName, value: catValue }) => {
+            return (
+              <ToggleGroupItem className="w-full" key={catName} value={catName}>
+                <div className="text-nowrap">
+                  {catName} ({catValue})
+                </div>
+              </ToggleGroupItem>
+            );
+          })}
+        </ToggleGroup>
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <>
+      <div className="flex items-center overflow-hidden border-t border-border p-1 pl-0">
+        <ColoredTagNew label={name} />
+      </div>
+      <div
+        className="flex items-center overflow-hidden border-t border-border p-1"
+        data-test-value={name}
+      >
+        <div className="min-w-0 flex-1 overflow-auto">{renderOptions()}</div>
+      </div>
+      <div className="flex items-center overflow-hidden border-t border-border px-0.5">
+        {isNumber(value) && (
+          <Button
+            variant="minimal"
+            size="icon-xs"
+            onClick={() => onScoreRemove(name)}
+          >
+            <X />
+          </Button>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default BatchAnnotateDialog;

--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesActionsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useCallback } from "react";
-import { Tag, Trash, Brain } from "lucide-react";
+import { Tag, Trash, Brain, PenLine } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Span, Trace } from "@/types/traces";
@@ -10,6 +10,7 @@ import useTracesBatchDeleteMutation from "@/api/traces/useTraceBatchDeleteMutati
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import ExportToButton from "@/components/shared/ExportToButton/ExportToButton";
 import AddTagDialog from "@/components/pages-shared/traces/AddTagDialog/AddTagDialog";
+import BatchAnnotateDialog from "@/components/pages-shared/traces/BatchAnnotateDialog/BatchAnnotateDialog";
 import RunEvaluationDialog from "@/components/pages-shared/automations/RunEvaluationDialog/RunEvaluationDialog";
 import { useIsFeatureEnabled } from "@/components/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
@@ -81,6 +82,13 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
         projectId={projectId}
         type={type}
       />
+      <BatchAnnotateDialog
+        key={`annotate-${resetKeyRef.current}`}
+        rows={selectedRows}
+        open={open === 5}
+        setOpen={setOpen}
+        type={type}
+      />
       {type === TRACE_DATA_TYPE.traces && (
         <RunEvaluationDialog
           key={`evaluation-${resetKeyRef.current}`}
@@ -118,6 +126,19 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
           disabled={disabled}
         >
           <Tag />
+        </Button>
+      </TooltipWrapper>
+      <TooltipWrapper content="Annotate">
+        <Button
+          variant="outline"
+          size="icon-sm"
+          onClick={() => {
+            setOpen(5);
+            resetKeyRef.current = resetKeyRef.current + 1;
+          }}
+          disabled={disabled}
+        >
+          <PenLine />
         </Button>
       </TooltipWrapper>
       {(type === TRACE_DATA_TYPE.traces || type === TRACE_DATA_TYPE.spans) && (


### PR DESCRIPTION
## Summary
- Adds the ability to select multiple traces/spans in a project and annotate them all at once with feedback scores
- New **BatchAnnotateDialog** component shows all configured feedback definitions (numerical, boolean, categorical) and lets users set scores to apply to all selected items
- New **Annotate** button (PenLine icon) in the traces action toolbar, enabled when rows are selected
- Scores are applied in parallel using the existing per-trace feedback score API

This addresses the feature request for production LLM-based app workflows where users apply filters and then want to annotate many traces at once instead of going one by one.

### Files Changed
- `apps/opik-frontend/src/components/pages-shared/traces/BatchAnnotateDialog/BatchAnnotateDialog.tsx` (new) - Dialog component with inline score editors for each feedback definition
- `apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesActionsPanel.tsx` (modified) - Added Annotate button and BatchAnnotateDialog integration

### How It Works
1. User selects one or more traces/spans using the checkbox column
2. The Annotate button (pen icon) becomes enabled in the toolbar
3. Clicking it opens a dialog listing all feedback definitions with score inputs
4. User sets values for one or more feedback scores
5. Clicking "Apply" sends the scores to all selected traces/spans in parallel
6. A success toast confirms the operation

## Test plan
- [ ] Select multiple traces in a project, click Annotate button, verify dialog opens with feedback definitions
- [ ] Set numerical, boolean, and categorical scores in the dialog
- [ ] Click Apply and verify scores are applied to all selected traces
- [ ] Verify the button is disabled when no rows are selected
- [ ] Verify the dialog shows an appropriate message when no feedback definitions exist
- [ ] Verify it works for both traces and spans tabs

/claim #1010

🤖 Generated with [Claude Code](https://claude.com/claude-code)