### PR TITLE
[OPIK-4472] [FE] Fix metadata appearing in Feedback Scores section

### DIFF
--- a/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
@@ -1138,13 +1138,6 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
     [columnsWidth, setColumnsWidth],
   );
 
-  const handleMetadataOrderChange = useCallback(
-    (newOrder: string[]) => {
-      setMetadataOrder(newOrder);
-    },
-    [setMetadataOrder],
-  );
-
   const columnSections = useMemo(() => {
     const sections: {
       title: string;
@@ -1170,7 +1163,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
         title: "Metadata",
         columns: allMetadataColumns,
         order: metadataOrder,
-        onOrderChange: handleMetadataOrderChange,
+        onOrderChange: setMetadataOrder,
       });
     }
 
@@ -1182,7 +1175,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
     metadataMainColumnData,
     metadataColumnsData,
     metadataOrder,
-    handleMetadataOrderChange,
+    setMetadataOrder,
   ]);
 
   return (


### PR DESCRIPTION
## Details

Fix the column selector in the Traces/Spans table where the main "Metadata" column was incorrectly grouped inside the "Feedback scores" section. 

**Changes:**
- Separated the combined "Feedback scores + Metadata" section into two distinct sections: "Feedback scores" (scores only) and "Metadata" (main metadata column + individual metadata field columns)
- Replaced `handleCombinedOrderChange` with separate `handleMetadataOrderChange` callback
- Added explicit type annotation to the `sections` array to resolve TypeScript inference issue

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-4472

## Testing

- Open a project's Traces or Spans tab
- Click the columns selector button
- Verify "Feedback scores" section contains only score columns
- Verify "Metadata" section contains the main Metadata column and individual metadata field columns
- Verify column reordering within each section works correctly

## Documentation

N/A