### PR TITLE
Add OpenAI TTS model tracking support

### DIFF
--- a/sdks/python/src/opik/integrations/openai/tts/__init__.py
+++ b/sdks/python/src/opik/integrations/openai/tts/__init__.py
@@ -1,0 +1,5 @@
+from .tts_create_decorator import TTSCreateTrackDecorator
+
+__all__ = [
+    "TTSCreateTrackDecorator",
+]

--- a/sdks/python/src/opik/integrations/openai/tts/tts_create_decorator.py
+++ b/sdks/python/src/opik/integrations/openai/tts/tts_create_decorator.py
@@ -1,0 +1,156 @@
+"""
+Decorator for OpenAI Text-to-Speech (TTS) creation method.
+
+Output type: openai._legacy_response.HttpxBinaryResponseContent
+
+This decorator is used for LLM spans that generate speech audio from text.
+The TTS API (client.audio.speech.create) takes text input and returns binary
+audio content. Since the response is binary and not a Pydantic model, output
+logging captures the response format and content type rather than the raw bytes.
+"""
+
+import logging
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+
+from openai._legacy_response import HttpxBinaryResponseContent
+from typing_extensions import override
+
+import opik.dict_utils as dict_utils
+from opik.api_objects import span
+from opik.decorator import arguments_helpers, base_track_decorator
+
+LOGGER = logging.getLogger(__name__)
+
+# Input parameters to log for TTS generation
+TTS_CREATE_KWARGS_KEYS_TO_LOG_AS_INPUTS = [
+    "input",
+    "voice",
+    "response_format",
+    "speed",
+    "instructions",
+]
+
+
+class TTSCreateTrackDecorator(base_track_decorator.BaseTrackDecorator):
+    """
+    Decorator for tracking OpenAI audio.speech.create method (LLM spans).
+
+    Handles: audio.speech.create
+    """
+
+    def __init__(self, provider: str) -> None:
+        super().__init__()
+        self.provider = provider
+
+    @override
+    def _start_span_inputs_preprocessor(
+        self,
+        func: Callable,
+        track_options: arguments_helpers.TrackOptions,
+        args: Tuple,
+        kwargs: Dict[str, Any],
+    ) -> arguments_helpers.StartSpanParameters:
+        assert kwargs is not None, (
+            "Expected kwargs to be not None in audio.speech.create API calls"
+        )
+
+        name = track_options.name if track_options.name is not None else func.__name__
+
+        metadata = track_options.metadata if track_options.metadata is not None else {}
+
+        # Remove NOT_GIVEN sentinel values from kwargs before logging
+        cleaned_kwargs = _remove_not_given_sentinel_values(kwargs)
+
+        input_data, new_metadata = dict_utils.split_dict_by_keys(
+            cleaned_kwargs, keys=TTS_CREATE_KWARGS_KEYS_TO_LOG_AS_INPUTS
+        )
+        metadata = dict_utils.deepmerge(metadata, new_metadata)
+        metadata.update(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+            }
+        )
+
+        tags = ["openai"]
+        model = cleaned_kwargs.get("model", None)
+
+        result = arguments_helpers.StartSpanParameters(
+            name=name,
+            input=input_data,
+            type=track_options.type,
+            tags=tags,
+            metadata=metadata,
+            project_name=track_options.project_name,
+            model=model,
+            provider=self.provider,
+        )
+
+        return result
+
+    @override
+    def _end_span_inputs_preprocessor(
+        self,
+        output: Any,
+        capture_output: bool,
+        current_span_data: span.SpanData,
+    ) -> arguments_helpers.EndSpanParameters:
+        if output is None:
+            return arguments_helpers.EndSpanParameters(
+                output=None,
+                usage=None,
+                metadata={},
+                model=None,
+                provider=self.provider,
+            )
+
+        output_data: Dict[str, Any] = {}
+
+        if isinstance(output, HttpxBinaryResponseContent):
+            # Extract useful info from the binary response headers
+            try:
+                content_type = output.response.headers.get("content-type")
+                if content_type is not None:
+                    output_data["content_type"] = content_type
+            except Exception:
+                pass
+
+        return arguments_helpers.EndSpanParameters(
+            output=output_data,
+            usage=None,
+            metadata={},
+            model=None,
+            provider=self.provider,
+        )
+
+    @override
+    def _streams_handler(
+        self,
+        output: Any,
+        capture_output: bool,
+        generations_aggregator: Optional[Callable[[List[Any]], Any]],
+    ) -> Optional[Any]:
+        NOT_A_STREAM = None
+        return NOT_A_STREAM
+
+
+def _remove_not_given_sentinel_values(dict_: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    The OpenAI client may pass NOT_GIVEN and Omit sentinel values
+    for optional parameters that we don't want to track.
+    """
+    from openai import _types as _openai_types
+
+    return {
+        key: value
+        for key, value in dict_.items()
+        if value is not _openai_types.NOT_GIVEN
+        and not isinstance(value, _openai_types.Omit)
+    }

--- a/sdks/python/tests/library_integration/openai/constants.py
+++ b/sdks/python/tests/library_integration/openai/constants.py
@@ -1,6 +1,7 @@
 from ...testlib import ANY_BUT_NONE
 
 MODEL_FOR_TESTS = "gpt-4o-mini"
+TTS_MODEL_FOR_TESTS = "tts-1"
 VIDEO_MODEL_FOR_TESTS = "sora-2"
 VIDEO_SIZE_FOR_TESTS = "720x1280"  # Lowest resolution for faster/cheaper tests
 EXPECTED_OPENAI_USAGE_LOGGED_FORMAT = {

--- a/sdks/python/tests/library_integration/openai/test_openai_tts.py
+++ b/sdks/python/tests/library_integration/openai/test_openai_tts.py
@@ -1,0 +1,453 @@
+import os
+
+import openai
+import pytest
+
+import opik
+from opik.config import OPIK_PROJECT_DEFAULT_NAME
+from opik.integrations.openai import track_openai
+
+from .constants import TTS_MODEL_FOR_TESTS
+from ...testlib import (
+    ANY,
+    ANY_BUT_NONE,
+    ANY_DICT,
+    ANY_STRING,
+    SpanModel,
+    TraceModel,
+    assert_equal,
+)
+
+# TTS tests make real API calls, skip unless explicitly enabled
+SKIP_EXPENSIVE_TESTS = os.environ.get("OPIK_TEST_EXPENSIVE", "").lower() not in (
+    "1",
+    "true",
+    "yes",
+)
+
+
+@pytest.fixture(autouse=True)
+def check_openai_configured(ensure_openai_configured):
+    pass
+
+
+@pytest.mark.skipif(
+    SKIP_EXPENSIVE_TESTS,
+    reason="Expensive tests disabled. Set OPIK_TEST_EXPENSIVE=1 to enable.",
+)
+def test_openai_client_tts_create__happyflow(fake_backend):
+    """
+    Test audio.speech.create - the main TTS generation workflow.
+
+    This test verifies:
+    1. Trace and span structure
+    2. Input logging for TTS parameters (input text, voice, model)
+    3. Metadata contains created_from and type fields
+    4. Model and provider are correctly populated
+    5. Tags are applied correctly
+    """
+    client = openai.OpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "Hello, this is a test of text to speech."
+    voice = "alloy"
+
+    response = wrapped_client.audio.speech.create(
+        model=TTS_MODEL_FOR_TESTS,
+        voice=voice,
+        input=input_text,
+    )
+
+    # Verify we got audio content back
+    assert response is not None
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+
+    EXPECTED_TRACE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio.speech.create",
+        input={
+            "input": input_text,
+            "voice": voice,
+        },
+        output=ANY_DICT,
+        tags=["openai"],
+        metadata=ANY_DICT.containing(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+            }
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=OPIK_PROJECT_DEFAULT_NAME,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio.speech.create",
+                input={
+                    "input": input_text,
+                    "voice": voice,
+                },
+                output=ANY_DICT,
+                tags=["openai"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "openai",
+                        "type": "openai_tts",
+                    }
+                ),
+                usage=None,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=OPIK_PROJECT_DEFAULT_NAME,
+                model=TTS_MODEL_FOR_TESTS,
+                provider="openai",
+                spans=[],
+            ),
+        ],
+    )
+
+    assert_equal(EXPECTED_TRACE, fake_backend.trace_trees[0])
+
+
+@pytest.mark.skipif(
+    SKIP_EXPENSIVE_TESTS,
+    reason="Expensive tests disabled. Set OPIK_TEST_EXPENSIVE=1 to enable.",
+)
+def test_openai_client_tts_create_with_optional_params__happyflow(fake_backend):
+    """
+    Test audio.speech.create with optional parameters.
+
+    This test verifies:
+    1. Optional parameters (response_format, speed) are captured in input
+    2. All TTS-specific parameters are logged correctly
+    """
+    client = openai.OpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "Testing optional parameters."
+    voice = "echo"
+    response_format = "opus"
+    speed = 1.25
+
+    response = wrapped_client.audio.speech.create(
+        model=TTS_MODEL_FOR_TESTS,
+        voice=voice,
+        input=input_text,
+        response_format=response_format,
+        speed=speed,
+    )
+
+    assert response is not None
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+
+    EXPECTED_TRACE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio.speech.create",
+        input={
+            "input": input_text,
+            "voice": voice,
+            "response_format": response_format,
+            "speed": speed,
+        },
+        output=ANY_DICT,
+        tags=["openai"],
+        metadata=ANY_DICT.containing(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+            }
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=OPIK_PROJECT_DEFAULT_NAME,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio.speech.create",
+                input={
+                    "input": input_text,
+                    "voice": voice,
+                    "response_format": response_format,
+                    "speed": speed,
+                },
+                output=ANY_DICT,
+                tags=["openai"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "openai",
+                        "type": "openai_tts",
+                    }
+                ),
+                usage=None,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=OPIK_PROJECT_DEFAULT_NAME,
+                model=TTS_MODEL_FOR_TESTS,
+                provider="openai",
+                spans=[],
+            ),
+        ],
+    )
+
+    assert_equal(EXPECTED_TRACE, fake_backend.trace_trees[0])
+
+
+def test_openai_client_tts_create__error_handling(fake_backend):
+    """
+    Test error handling when TTS creation fails with invalid model.
+
+    This is a fast test (no actual TTS generation) that verifies:
+    1. Error info is logged on trace and span
+    2. Trace and span are finished gracefully despite the error
+    """
+    client = openai.OpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "Test speech"
+    voice = "alloy"
+
+    with pytest.raises(openai.OpenAIError):
+        _ = wrapped_client.audio.speech.create(
+            model="invalid-model-name",
+            voice=voice,
+            input=input_text,
+        )
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio.speech.create",
+        input={
+            "input": input_text,
+            "voice": voice,
+        },
+        output=None,
+        tags=["openai"],
+        metadata=ANY_DICT.containing(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+            }
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=OPIK_PROJECT_DEFAULT_NAME,
+        error_info={
+            "exception_type": ANY_STRING,
+            "message": ANY_STRING,
+            "traceback": ANY_STRING,
+        },
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio.speech.create",
+                input={
+                    "input": input_text,
+                    "voice": voice,
+                },
+                output=None,
+                tags=["openai"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "openai",
+                        "type": "openai_tts",
+                    }
+                ),
+                usage=None,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=OPIK_PROJECT_DEFAULT_NAME,
+                model="invalid-model-name",
+                provider="openai",
+                error_info={
+                    "exception_type": ANY_STRING,
+                    "message": ANY_STRING,
+                    "traceback": ANY_STRING,
+                },
+                spans=[],
+            ),
+        ],
+    )
+
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)
+
+
+@pytest.mark.skipif(
+    SKIP_EXPENSIVE_TESTS,
+    reason="Expensive tests disabled. Set OPIK_TEST_EXPENSIVE=1 to enable.",
+)
+@pytest.mark.asyncio
+async def test_openai_async_client_tts_create__happyflow(fake_backend):
+    """
+    Test async audio.speech.create workflow.
+
+    This test verifies that the async OpenAI client works correctly with TTS tracking.
+    """
+    client = openai.AsyncOpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "Hello, this is an async test of text to speech."
+    voice = "alloy"
+
+    response = await wrapped_client.audio.speech.create(
+        model=TTS_MODEL_FOR_TESTS,
+        voice=voice,
+        input=input_text,
+    )
+
+    assert response is not None
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+
+    EXPECTED_TRACE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio.speech.create",
+        input={
+            "input": input_text,
+            "voice": voice,
+        },
+        output=ANY_DICT,
+        tags=["openai"],
+        metadata=ANY_DICT.containing(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+            }
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=OPIK_PROJECT_DEFAULT_NAME,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio.speech.create",
+                input={
+                    "input": input_text,
+                    "voice": voice,
+                },
+                output=ANY_DICT,
+                tags=["openai"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "openai",
+                        "type": "openai_tts",
+                    }
+                ),
+                usage=None,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=OPIK_PROJECT_DEFAULT_NAME,
+                model=TTS_MODEL_FOR_TESTS,
+                provider="openai",
+                spans=[],
+            ),
+        ],
+    )
+
+    assert_equal(EXPECTED_TRACE, fake_backend.trace_trees[0])
+
+
+@pytest.mark.asyncio
+async def test_openai_async_client_tts_create__error_handling(fake_backend):
+    """
+    Test async error handling when TTS creation fails with invalid model.
+
+    This is a fast test (no actual TTS generation) that verifies async error handling.
+    """
+    client = openai.AsyncOpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "Test speech"
+    voice = "alloy"
+
+    with pytest.raises(openai.OpenAIError):
+        _ = await wrapped_client.audio.speech.create(
+            model="invalid-model-name",
+            voice=voice,
+            input=input_text,
+        )
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio.speech.create",
+        input={
+            "input": input_text,
+            "voice": voice,
+        },
+        output=None,
+        tags=["openai"],
+        metadata=ANY_DICT.containing(
+            {
+                "created_from": "openai",
+                "type": "openai_tts",
+            }
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=OPIK_PROJECT_DEFAULT_NAME,
+        error_info={
+            "exception_type": ANY_STRING,
+            "message": ANY_STRING,
+            "traceback": ANY_STRING,
+        },
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio.speech.create",
+                input={
+                    "input": input_text,
+                    "voice": voice,
+                },
+                output=None,
+                tags=["openai"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "openai",
+                        "type": "openai_tts",
+                    }
+                ),
+                usage=None,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=OPIK_PROJECT_DEFAULT_NAME,
+                model="invalid-model-name",
+                provider="openai",
+                error_info={
+                    "exception_type": ANY_STRING,
+                    "message": ANY_STRING,
+                    "traceback": ANY_STRING,
+                },
+                spans=[],
+            ),
+        ],
+    )
+
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)


### PR DESCRIPTION
## Summary
- Add tracking support for OpenAI Text-to-Speech API (`client.audio.speech.create()`) in the Python SDK
- Captures model name (tts-1, tts-1-hd), input text, voice, response format, speed, and instructions parameters
- Follows existing patterns established by the videos and chat completions integrations, using a dedicated `TTSCreateTrackDecorator` class
- Includes both sync and async test coverage with error handling tests

## Changes
- **New**: `sdks/python/src/opik/integrations/openai/tts/` module with `TTSCreateTrackDecorator`
- **Modified**: `sdks/python/src/opik/integrations/openai/opik_tracker.py` to patch `audio.speech.create` 
- **New**: `sdks/python/tests/library_integration/openai/test_openai_tts.py` with sync/async happy path and error handling tests

## Test plan
- [x] Error handling tests pass for both sync and async clients (verified locally)
- [x] Existing chat completion error handling tests still pass (no regression)
- [ ] Happy path tests require `OPIK_TEST_EXPENSIVE=1` and a valid OpenAI API key
- [ ] CI pipeline validation

/claim #2202

🤖 Generated with [Claude Code](https://claude.com/claude-code)