### PR TITLE
[OPIK-4476] [FE] Update Online Evaluation tables default columns

### DIFF
--- a/apps/opik-frontend/src/components/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
+++ b/apps/opik-frontend/src/components/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
@@ -63,12 +63,6 @@ const DEFAULT_COLUMNS: ColumnData<EvaluatorsRule>[] = [
     sortable: true,
   },
   {
-    id: COLUMN_ID_ID,
-    label: "ID",
-    type: COLUMN_TYPE.string,
-    cell: IdCell as never,
-  },
-  {
     id: "projects",
     label: "Projects",
     type: COLUMN_TYPE.string,
@@ -78,21 +72,10 @@ const DEFAULT_COLUMNS: ColumnData<EvaluatorsRule>[] = [
         : "N/A",
   },
   {
-    id: "last_updated_at",
-    label: "Last updated",
-    type: COLUMN_TYPE.time,
-    accessorFn: (row) => formatDate(row.last_updated_at),
-  },
-  {
-    id: "created_by",
-    label: "Created by",
+    id: "enabled",
+    label: "Status",
     type: COLUMN_TYPE.string,
-  },
-  {
-    id: "created_at",
-    label: "Created",
-    type: COLUMN_TYPE.time,
-    accessorFn: (row) => formatDate(row.created_at),
+    cell: StatusCell as never,
   },
   {
     id: "sampling_rate",
@@ -107,10 +90,27 @@ const DEFAULT_COLUMNS: ColumnData<EvaluatorsRule>[] = [
     accessorFn: (row) => capitalizeFirstLetter(getUIRuleScope(row.type)),
   },
   {
-    id: "enabled",
-    label: "Status",
+    id: "last_updated_at",
+    label: "Last updated",
+    type: COLUMN_TYPE.time,
+    accessorFn: (row) => formatDate(row.last_updated_at),
+  },
+  {
+    id: COLUMN_ID_ID,
+    label: "ID",
     type: COLUMN_TYPE.string,
-    cell: StatusCell as never,
+    cell: IdCell as never,
+  },
+  {
+    id: "created_at",
+    label: "Created",
+    type: COLUMN_TYPE.time,
+    accessorFn: (row) => formatDate(row.created_at),
+  },
+  {
+    id: "created_by",
+    label: "Created by",
+    type: COLUMN_TYPE.string,
   },
 ];
 

--- a/apps/opik-frontend/src/components/pages/TracesPage/RulesTab/RulesTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/RulesTab/RulesTab.tsx
@@ -56,29 +56,10 @@ const DEFAULT_COLUMNS: ColumnData<EvaluatorsRule>[] = [
     sortable: true,
   },
   {
-    id: COLUMN_ID_ID,
-    label: "ID",
+    id: "enabled",
+    label: "Status",
     type: COLUMN_TYPE.string,
-    cell: IdCell as never,
-  },
-  {
-    id: "last_updated_at",
-    label: "Last updated",
-    type: COLUMN_TYPE.time,
-    accessorFn: (row) => formatDate(row.last_updated_at),
-    sortable: true,
-  },
-  {
-    id: "created_at",
-    label: "Created",
-    type: COLUMN_TYPE.time,
-    accessorFn: (row) => formatDate(row.created_at),
-    sortable: true,
-  },
-  {
-    id: "created_by",
-    label: "Created by",
-    type: COLUMN_TYPE.string,
+    cell: StatusCell as never,
   },
   {
     id: "sampling_rate",
@@ -93,10 +74,29 @@ const DEFAULT_COLUMNS: ColumnData<EvaluatorsRule>[] = [
     accessorFn: (row) => capitalizeFirstLetter(getUIRuleScope(row.type)),
   },
   {
-    id: "enabled",
-    label: "Status",
+    id: "last_updated_at",
+    label: "Last updated",
+    type: COLUMN_TYPE.time,
+    accessorFn: (row) => formatDate(row.last_updated_at),
+    sortable: true,
+  },
+  {
+    id: COLUMN_ID_ID,
+    label: "ID",
     type: COLUMN_TYPE.string,
-    cell: StatusCell as never,
+    cell: IdCell as never,
+  },
+  {
+    id: "created_at",
+    label: "Created",
+    type: COLUMN_TYPE.time,
+    accessorFn: (row) => formatDate(row.created_at),
+    sortable: true,
+  },
+  {
+    id: "created_by",
+    label: "Created by",
+    type: COLUMN_TYPE.string,
   },
 ];
 


### PR DESCRIPTION
## Details

Update default visible columns for both Online Evaluation tables:

**Project rules tab** (`RulesTab.tsx`): Name, Status, Sampling rate, Scope, Last updated.
**Global online evaluations** (`OnlineEvaluationPage.tsx`): Name, Projects, Status, Sampling rate, Scope, Last updated.

Removed from both defaults: Created by, Created at. All removed columns remain available in the column selector. Existing users with saved preferences are not affected.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-4476

## Testing

- Clear localStorage (or use incognito)
- Navigate to a project's Online Evaluation Rules tab — verify defaults: Name, Status, Sampling rate, Scope, Last updated
- Navigate to the global Online Evaluations page — verify defaults: Name, Projects, Status, Sampling rate, Scope, Last updated
- Verify Created by and Created at are still available in the column selector

## Documentation

N/A