### PR TITLE
[OPIK-4292] [DOCS] Document OpikAssist for self-hosted deployments

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/administration/workspace-settings/ai_providers.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/workspace-settings/ai_providers.mdx
@@ -8,14 +8,15 @@ og:title: Configure AI Providers in Opik
 title: AI Providers
 ---
 
-AI Providers let you connect LLMs for use in the Playground and Online Evaluation.
+AI Providers let you connect LLMs for use in the Playground, Online Evaluation, and Opik Assist.
 
 ## Using AI Providers
 
-Once configured, providers appear in two places:
+Once configured, providers appear in three places:
 
 1. **Playground** — Test prompts interactively with different models.
 2. **Online Evaluation** — Run LLM-as-a-judge scoring on your traces.
+3. **Opik Assist** — AI-powered trace analysis and debugging (requires OpenAI).
 
 ## Adding a Provider
 

--- a/apps/opik-documentation/documentation/fern/docs/self-host/architecture.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/architecture.mdx
@@ -12,6 +12,7 @@ Opik's architecture consists of multiple services that each handle a specific ro
 
 - **A backend service**: Java + Dropwizard.
 - **A frontend application**: TypeScript + React, served by Nginx.
+- **An AI backend service** (optional): Python + FastAPI service that powers Opik Assist, the AI-powered trace analysis feature.
 - **Data stores**:
   - ClickHouse for large-scale data ingestion and fast queries (e.g., for traces or experiments).
     - With Zookeeper to coordinate the cluster.
@@ -40,6 +41,24 @@ interacting with the backend services. The frontend is built using a modular app
 encapsulating a specific feature or functionality.
 
 _You can find the full frontend codebase in Github under the [`apps/opik-frontend`](https://github.com/comet-ml/opik/tree/main/apps/opik-frontend) folder._
+
+## AI Backend Service (Optional)
+
+Opik Assist is an optional AI-powered trace analysis service built with Python 3.13, FastAPI, and Google's Agent Development Kit (ADK). It enables conversational debugging of traces through an AI agent that can:
+
+- Analyze trace and span data to identify performance bottlenecks, errors, and anomalies
+- Answer natural language questions about trace behavior
+- Provide debugging recommendations and optimization suggestions
+
+**Key characteristics:**
+- **LLM Integration**: Routes all LLM calls through the Opik backend's `/v1/private/chat/completions` proxy, using the end-user's configured AI provider API key
+- **Session Storage**: Uses MySQL (same database as the main backend) to store conversation history via Google ADK's DatabaseSessionService
+- **Streaming**: Delivers responses via Server-Sent Events (SSE) for real-time interaction
+- **Dependencies**: Requires the Opik backend (for data retrieval and LLM proxy) and MySQL (for session storage)
+
+This service is disabled by default and can be enabled in Docker Compose via the `--opik-ai` flag or in Kubernetes by setting `component.ai-backend.enabled: true` in Helm values.
+
+_You can find the full AI backend codebase in Github under the [`apps/opik-ai-backend`](https://github.com/comet-ml/opik/tree/main/apps/opik-ai-backend) folder._
 
 ## SDK's
 

--- a/apps/opik-documentation/documentation/fern/docs/self-host/kubernetes.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/kubernetes.mdx
@@ -147,6 +147,28 @@ component:
         eks.amazonaws.com/role-arn: <your IAM Role arn>
 ```
 
+## Enable Opik Assist (AI Trace Analyzer)
+
+Opik Assist is an optional AI-powered trace analysis feature that helps you debug and optimize your traces conversationally.
+
+To enable Opik Assist, add the following to your Helm values file:
+
+```yaml
+component:
+  ai-backend:
+    enabled: true
+```
+
+Then upgrade your deployment:
+
+```bash
+helm upgrade opik opik/opik -f values.yaml
+```
+
+<Note>
+**Prerequisites**: Before using Opik Assist, you must configure an OpenAI provider in Workspace Settings → AI Providers after deployment. See the [AI Providers documentation](/administration/workspace-settings/ai_providers) for setup instructions.
+</Note>
+
 ## Use external Clickhouse installation
 
 Supported from Opik chart version 1.4.2

--- a/apps/opik-documentation/documentation/fern/docs/self-host/local_deployment.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/local_deployment.mdx
@@ -208,6 +208,40 @@ cd opik
 
 This will build the Frontend and Backend Docker images and start the Opik platform.
 
+### Enabling Opik Assist (AI Trace Analyzer)
+
+Opik Assist is an optional AI-powered trace analysis feature that helps you debug and optimize your traces conversationally.
+
+#### Using the opik.sh script
+
+To start Opik with Opik Assist enabled:
+
+```bash
+./opik.sh --opik-ai
+```
+
+#### Manual Docker Compose configuration
+
+Alternatively, you can enable Opik Assist manually:
+
+```bash
+cd deployment/docker-compose
+
+# Start Opik with the opik-ai-backend profile
+docker compose --profile opik-ai-backend up --detach
+```
+
+You'll also need to set the following environment variables:
+
+```bash
+export TOGGLE_OPIK_AI_ENABLED=true
+export OPIK_FRONTEND_FLAVOR=opik-ai-backend
+```
+
+<Note>
+**Prerequisites**: Before using Opik Assist, you must configure an OpenAI provider in Workspace Settings → AI Providers. See the [AI Providers documentation](/administration/workspace-settings/ai_providers) for setup instructions.
+</Note>
+
 ## Troubleshooting
 
 If you get this error when running `docker compose`

--- a/apps/opik-documentation/documentation/fern/docs/tracing/opik_assist.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/opik_assist.mdx
@@ -11,10 +11,10 @@ title: ✨ Opik Assist (Beta)
 <img src="/img/tracing/trace_inspector_with_response.png" alt="Opik Assist AI response with recommendations" />
 
 <Warning>
-**Beta Feature**: Opik Assist is currently in beta and available exclusively on Opik Cloud (www.comet.com). Features and functionality may change as we continue to improve the experience.
+**Beta Feature**: Opik Assist is currently in beta. Features and functionality may change as we continue to improve the experience.
 </Warning>
 
-Opik Assist is an AI-powered assistant that helps you quickly analyze, debug, and optimize your LLM application traces. By conversing with the AI agent, you can:
+Opik Assist is an AI-powered assistant that helps you quickly analyze, debug, and optimize your LLM application traces. Available in both Opik Cloud and self-hosted deployments, you can converse with the AI agent to:
 
 - **Ask natural language questions** about your current trace and its spans
 - **Identify performance issues** and bottlenecks automatically  
@@ -22,9 +22,17 @@ Opik Assist is an AI-powered assistant that helps you quickly analyze, debug, an
 - **Analyze patterns** within the selected trace
 - **Understand cost implications** of your LLM calls
 
+## Prerequisites
+
+Before using Opik Assist, you need to configure an OpenAI provider in your workspace:
+
+1. **Navigate to Workspace Settings** → **[AI Providers](/administration/workspace-settings/ai_providers)**
+2. **Add an OpenAI provider** with your API key
+3. Opik Assist uses OpenAI's GPT-4.1 model
+
 ## How to Use Opik Assist
 
-1. **Navigate to your project** in Opik Cloud
+1. **Navigate to your project** in Opik
 2. **Open any trace** you want to analyze
 3. **Click the "Debug with AI" button** (marked with a Beta badge)
 4. **Use the chat interface** on the right panel to ask questions
@@ -32,17 +40,59 @@ Opik Assist is an AI-powered assistant that helps you quickly analyze, debug, an
 
 <img src="/img/tracing/trace_inspector_initial_view.png" alt="Opik Assist interface" />
 
+## Self-Hosted Setup
+
+Opik Assist is available for self-hosted deployments and can be enabled as follows:
+
+### Docker Compose
+
+To enable Opik Assist when using the `opik.sh` script:
+
+```bash
+./opik.sh --opik-ai
+```
+
+For manual Docker Compose configuration:
+
+```bash
+cd deployment/docker-compose
+docker compose --profile opik-ai-backend \
+  -e TOGGLE_OPIK_AI_ENABLED=true \
+  -e OPIK_FRONTEND_FLAVOR=opik-ai-backend \
+  up --detach
+```
+
+### Kubernetes (Helm)
+
+Add the following to your Helm values file:
+
+```yaml
+component:
+  ai-backend:
+    enabled: true
+```
+
+Then upgrade your deployment:
+
+```bash
+helm upgrade opik opik/opik -f values.yaml
+```
+
+<Tip>
+After enabling Opik Assist, remember to configure an OpenAI provider in Workspace Settings → AI Providers before using the feature.
+</Tip>
+
 ## Data Privacy & Security
 
 Your trace data security and privacy are our top priorities. Here's exactly how your data is handled:
 
-### Privacy Guarantees
+### Privacy Guarantees (Opik Cloud)
 - **No Training**: Your trace data is **never used** to train AI models
 - **Quality Assurance Only**: Comet retains logs of prompts and responses solely for internal quality assurance and debugging
 - **No Third-Party Training**: These logs are not used for training third-party models
 
 ### What Data is Shared with OpenAI
-To provide intelligent analysis, Opik Assist sends the following to OpenAI's AI models:
+To provide intelligent analysis, Opik Assist sends the following to OpenAI:
 - **Trace and span metadata**: Names, timestamps, latency information
 - **Input/output content**: The actual prompts, responses, and tool outputs from your trace
 - **Performance metrics**: Token counts, costs, and timing data
@@ -54,16 +104,15 @@ To provide intelligent analysis, Opik Assist sends the following to OpenAI's AI 
 - **Historical data**: Only the current trace being analyzed
 
 <Warning>
-**Important**: While Opik doesn't send system identifiers, your trace data (inputs/outputs) may contain personal or sensitive information that you've included in prompts or responses. This content will be sent to OpenAI as part of the trace analysis.
+**Important**: Your trace data (inputs/outputs) may contain personal or sensitive information that you've included in prompts or responses. This content will be sent to OpenAI as part of the trace analysis.
 </Warning>
 
 ## Current Limitations (Beta)
 
 As a beta feature, Opik Assist currently has some limitations:
 
-- **Cloud Only**: Available exclusively on Opik Cloud, not in self-hosted deployments
 - **Single Trace Analysis**: Can only analyze one trace at a time, no cross-trace comparisons or aggregations
-- **Rate Limits**: Usage may be subject to rate limiting during peak times
+- **Rate Limits**: Usage may be subject to rate limiting during peak times (Opik Cloud only)
 
 ## Feedback & Support
 
@@ -71,9 +120,3 @@ Since this is a beta feature, we'd love to hear your feedback:
 
 - Report issues via [GitHub Issues](https://github.com/comet-ml/opik/issues)
 - Join our [Slack community](http://chat.comet.com/) for real-time support
-
----
-
-<Info>
-**Coming Soon**: We're working on expanding Opik Assist to self-hosted deployments and adding support for advanced analysis capabilities.
-</Info>


### PR DESCRIPTION
Update documentation to reflect that OpikAssist (AI trace analyzer) is now available for self-hosted deployments via Docker Compose and Kubernetes.

Changes:
- Remove "Cloud Only" restriction from OpikAssist documentation
- Add self-hosted setup instructions for Docker Compose (--opik-ai flag)
- Add Kubernetes/Helm configuration (component.ai-backend.enabled)
- Document AI provider prerequisite (OpenAI by default)
- Add OpikAssist to platform architecture documentation
- Update AI Providers page to include OpikAssist usage

OpikAssist routes LLM calls through the backend's /v1/private/chat/completions proxy, using the end-user's configured AI provider API key from workspace settings. Session storage uses MySQL via Google ADK's DatabaseSessionService.

## Details

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing

## Documentation
