### PR TITLE
[OPIK-4479] [FE] Update Experiment Items table default columns

### DIFF
--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -153,8 +153,9 @@ export const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
 };
 
 export const DEFAULT_SELECTED_COLUMNS: string[] = [
-  COLUMN_ID_ID,
-  COLUMN_COMMENTS_ID,
+  COLUMN_DURATION_ID,
+  `${COLUMN_USAGE_ID}.total_tokens`,
+  "total_estimated_cost",
   USER_FEEDBACK_COLUMN_ID,
 ];
 


### PR DESCRIPTION
## Details
Update default selected columns for the Experiment Items (Compare Experiments) table to show: Duration, Total tokens, Estimated cost, User feedback.

Removed ID and Comments from default visible columns. Dynamic columns (dataset input/output, evaluation task output, scores) are auto-managed by `useDynamicColumnsCache`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-4479

## Testing
- Verify new users see Duration, Total tokens, Estimated cost, and User feedback columns by default
- Verify existing users retain their saved column preferences
- Verify dynamic columns still auto-appear when data is loaded

## Documentation
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)