### PR TITLE
[OPIK-4481] [FE] Update Optimization Studio table default columns

### DIFF
--- a/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -90,10 +90,24 @@ export const GROUPING_CONFIG = {
 
 export const DEFAULT_COLUMNS: ColumnData<GroupedOptimization>[] = [
   {
-    id: COLUMN_ID_ID,
-    label: "ID",
+    id: "status",
+    label: "Status",
     type: COLUMN_TYPE.string,
-    cell: IdCell as never,
+    cell: OptimizationStatusCell as never,
+  },
+  {
+    id: "num_trials",
+    label: "Trial count",
+    type: COLUMN_TYPE.number,
+  },
+  {
+    id: "objective_name",
+    label: "Best score",
+    type: COLUMN_TYPE.numberDictionary,
+    accessorFn: (row) =>
+      getFeedbackScore(row.feedback_scores ?? [], row.objective_name),
+    cell: FeedbackScoreTagCell as never,
+    explainer: EXPLAINERS_MAP[EXPLAINER_ID.whats_the_best_score],
   },
   {
     id: "created_at",
@@ -102,14 +116,15 @@ export const DEFAULT_COLUMNS: ColumnData<GroupedOptimization>[] = [
     accessorFn: (row) => formatDate(row.created_at),
   },
   {
+    id: COLUMN_ID_ID,
+    label: "ID",
+    type: COLUMN_TYPE.string,
+    cell: IdCell as never,
+  },
+  {
     id: "created_by",
     label: "Created by",
     type: COLUMN_TYPE.string,
-  },
-  {
-    id: "num_trials",
-    label: "Trial count",
-    type: COLUMN_TYPE.number,
   },
   {
     id: "optimizer",
@@ -129,21 +144,6 @@ export const DEFAULT_COLUMNS: ColumnData<GroupedOptimization>[] = [
     },
     explainer: EXPLAINERS_MAP[EXPLAINER_ID.whats_the_optimizer],
   },
-  {
-    id: "objective_name",
-    label: "Best score",
-    type: COLUMN_TYPE.numberDictionary,
-    accessorFn: (row) =>
-      getFeedbackScore(row.feedback_scores ?? [], row.objective_name),
-    cell: FeedbackScoreTagCell as never,
-    explainer: EXPLAINERS_MAP[EXPLAINER_ID.whats_the_best_score],
-  },
-  {
-    id: "status",
-    label: "Status",
-    type: COLUMN_TYPE.string,
-    cell: OptimizationStatusCell as never,
-  },
 ];
 
 export const FILTER_COLUMNS: ColumnData<GroupedOptimization>[] = [
@@ -161,11 +161,10 @@ export const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
 };
 
 export const DEFAULT_SELECTED_COLUMNS: string[] = [
-  "created_at",
-  "num_trials",
-  "optimizer",
-  "objective_name",
   "status",
+  "num_trials",
+  "objective_name",
+  "created_at",
 ];
 
 const OptimizationsPage: React.FunctionComponent = () => {


### PR DESCRIPTION
## Details
Update default column order and visibility for the Optimization Studio table. Reordered DEFAULT_COLUMNS to: Status, Trial count, Best score, Created, ID, Created by, Optimizer. Updated DEFAULT_SELECTED_COLUMNS to show: Status, Trial count, Best score, Created (removed Optimizer).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-4481

## Testing
- Verify new users see columns in order: Status, Trial count, Best score, Created
- Verify existing users retain their saved column preferences

## Documentation
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)