### PR TITLE
[NA] [DOCS] Improve multi-turn agents evaluation docs for new users

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_multi_turn_agents.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_multi_turn_agents.mdx
@@ -73,9 +73,9 @@ turn evaluate.
     </Step>
     <Step title="2. Create our agent app">
         The `run_simulation` function expects an `app` callable with the following contract: it
-        receives a `user_message` string and a `thread_id` keyword argument, and returns the
-        assistant's response as a string. The app is responsible for managing its own conversation
-        history using the `thread_id`.
+        receives a `user_message` string and a `thread_id` keyword argument, and returns a message
+        dict `{"role": "assistant", "content": "..."}`. The app is responsible for managing its own
+        conversation history using the `thread_id`.
 
         Here is an example using LangChain:
 
@@ -93,17 +93,17 @@ turn evaluate.
 
         agent_history = {}
 
-        def run_agent(user_message: str, *, thread_id: str, **kwargs) -> str:
+        def run_agent(user_message: str, *, thread_id: str, **kwargs) -> dict[str, str]:
             if thread_id not in agent_history:
                 agent_history[thread_id] = []
-            
+
             agent_history[thread_id].append({"role": "user", "content": user_message})
             messages = agent_history[thread_id]
 
             response = agent.invoke({"messages": messages}, config={"callbacks": [opik_tracer]})
             agent_history[thread_id] = response["messages"]
 
-            return response["messages"][-1].content
+            return {"role": "assistant", "content": response["messages"][-1].content}
         ```
     </Step>
     <Step title="3. Run the simulations">


### PR DESCRIPTION
## Details

Improves the multi-turn agents evaluation docs page for clarity and new-user readability:

- **Tightened intro**: Removed repetitive "based on the previous turns" phrasing (appeared 3 times)
- **Clarified Step 2**: Replaced misleading "signature" description with a clear explanation of the `run_simulation` app callable contract, and relabeled the code block as a LangChain example
- **Fixed duplicate titles**: Three code blocks all titled "Running simulations" now have distinct, descriptive titles
- **Documented return value**: Added explanation of the `run_simulation` return dict (`thread_id`, `conversation_history`) before it's used in the scoring section
- **Fixed minor issues**: Updated `UserSimulator` → `SimulatedUser` references, fixed return type annotation, added missing `import opik` in evaluate_threads example

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- NA

## Testing

- Ran `npx fern check` — 0 errors

## Documentation

- Updated `apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_multi_turn_agents.mdx`