### PR TITLE
feat: Support OpenAI TTS and audio transcriptions tracking

### DIFF
--- a/sdks/python/src/opik/integrations/openai/audio/__init__.py
+++ b/sdks/python/src/opik/integrations/openai/audio/__init__.py
@@ -1,0 +1,7 @@
+from .audio_speech_decorator import AudioSpeechTrackDecorator
+from .audio_transcriptions_decorator import AudioTranscriptionsTrackDecorator
+
+__all__ = [
+    "AudioSpeechTrackDecorator",
+    "AudioTranscriptionsTrackDecorator",
+]

--- a/sdks/python/src/opik/integrations/openai/audio/audio_speech_decorator.py
+++ b/sdks/python/src/opik/integrations/openai/audio/audio_speech_decorator.py
@@ -1,0 +1,155 @@
+"""
+Decorator for OpenAI audio speech (TTS) methods.
+
+Output type: openai._legacy_response.HttpxBinaryResponseContent
+
+This decorator tracks calls to audio.speech.create().
+"""
+
+import logging
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+
+from typing_extensions import override
+
+import opik.dict_utils as dict_utils
+from opik.api_objects import span
+from opik.decorator import arguments_helpers, base_track_decorator
+
+LOGGER = logging.getLogger(__name__)
+
+SPEECH_KWARGS_KEYS_TO_LOG_AS_INPUTS = [
+    "input",
+    "voice",
+    "response_format",
+    "speed",
+]
+
+SPEECH_KWARGS_KEYS_FOR_METADATA = [
+    "instructions",
+]
+
+
+class AudioSpeechTrackDecorator(base_track_decorator.BaseTrackDecorator):
+    """
+    Decorator for tracking OpenAI audio.speech.create() calls.
+
+    Tracks: model name, input text, voice, response format, speed,
+    input text length, and output audio size.
+    """
+
+    def __init__(self, provider: str) -> None:
+        super().__init__()
+        self.provider = provider
+
+    @override
+    def _start_span_inputs_preprocessor(
+        self,
+        func: Callable,
+        track_options: arguments_helpers.TrackOptions,
+        args: Tuple,
+        kwargs: Dict[str, Any],
+    ) -> arguments_helpers.StartSpanParameters:
+        assert kwargs is not None, (
+            "Expected kwargs to be not None in audio.speech.create() calls"
+        )
+
+        name = track_options.name if track_options.name is not None else func.__name__
+
+        metadata = track_options.metadata if track_options.metadata is not None else {}
+
+        input_data, new_metadata = dict_utils.split_dict_by_keys(
+            kwargs, keys=SPEECH_KWARGS_KEYS_TO_LOG_AS_INPUTS
+        )
+        metadata = dict_utils.deepmerge(metadata, new_metadata)
+
+        # Add extra metadata keys
+        extra_meta, _ = dict_utils.split_dict_by_keys(
+            kwargs, keys=SPEECH_KWARGS_KEYS_FOR_METADATA
+        )
+        metadata = dict_utils.deepmerge(metadata, extra_meta)
+
+        metadata.update(
+            {
+                "created_from": "openai",
+                "type": "openai_audio_speech",
+            }
+        )
+
+        # Track input text length for cost estimation
+        input_text = kwargs.get("input", "")
+        if isinstance(input_text, str):
+            metadata["input_text_length"] = len(input_text)
+
+        tags = ["openai", "audio", "tts"]
+        model = kwargs.get("model", None)
+
+        result = arguments_helpers.StartSpanParameters(
+            name=name,
+            input=input_data,
+            type=track_options.type,
+            tags=tags,
+            metadata=metadata,
+            project_name=track_options.project_name,
+            model=model,
+            provider=self.provider,
+        )
+
+        return result
+
+    @override
+    def _end_span_inputs_preprocessor(
+        self,
+        output: Any,
+        capture_output: bool,
+        current_span_data: span.SpanData,
+    ) -> arguments_helpers.EndSpanParameters:
+        metadata: Dict[str, Any] = {}
+        output_data: Dict[str, Any] = {}
+
+        if output is not None:
+            try:
+                # HttpxBinaryResponseContent - get response info
+                response = output.response
+                output_data["status_code"] = response.status_code
+                output_data["content_type"] = response.headers.get("content-type", "")
+
+                # Track output audio size
+                content_length = response.headers.get("content-length")
+                if content_length is not None:
+                    metadata["output_audio_bytes"] = int(content_length)
+                else:
+                    # Read content to get size (content is cached by httpx)
+                    try:
+                        content = output.content
+                        metadata["output_audio_bytes"] = len(content)
+                    except Exception:
+                        pass
+            except Exception as e:
+                LOGGER.debug(
+                    "Failed to extract audio speech response details: %s", e
+                )
+
+        return arguments_helpers.EndSpanParameters(
+            output=output_data,
+            usage=None,
+            metadata=metadata,
+            model=current_span_data.model,
+            provider=self.provider,
+        )
+
+    @override
+    def _streams_handler(
+        self,
+        output: Any,
+        capture_output: bool,
+        generations_aggregator: Optional[Callable[[List[Any]], Any]],
+    ) -> Optional[Any]:
+        NOT_A_STREAM = None
+        return NOT_A_STREAM

--- a/sdks/python/src/opik/integrations/openai/audio/audio_transcriptions_decorator.py
+++ b/sdks/python/src/opik/integrations/openai/audio/audio_transcriptions_decorator.py
@@ -1,0 +1,153 @@
+"""
+Decorator for OpenAI audio transcriptions methods.
+
+Output types:
+  - openai.types.audio.Transcription
+  - openai.types.audio.TranscriptionVerbose
+  - str (when response_format is text/srt/vtt)
+
+This decorator tracks calls to audio.transcriptions.create().
+"""
+
+import logging
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+
+from typing_extensions import override
+
+import opik.dict_utils as dict_utils
+from opik.api_objects import span
+from opik.decorator import arguments_helpers, base_track_decorator
+
+LOGGER = logging.getLogger(__name__)
+
+TRANSCRIPTION_KWARGS_KEYS_TO_LOG_AS_INPUTS = [
+    "language",
+    "prompt",
+    "response_format",
+    "temperature",
+    "timestamp_granularities",
+]
+
+
+class AudioTranscriptionsTrackDecorator(base_track_decorator.BaseTrackDecorator):
+    """
+    Decorator for tracking OpenAI audio.transcriptions.create() calls.
+
+    Tracks: model name, language, prompt, response format, temperature,
+    and the transcribed text output.
+    """
+
+    def __init__(self, provider: str) -> None:
+        super().__init__()
+        self.provider = provider
+
+    @override
+    def _start_span_inputs_preprocessor(
+        self,
+        func: Callable,
+        track_options: arguments_helpers.TrackOptions,
+        args: Tuple,
+        kwargs: Dict[str, Any],
+    ) -> arguments_helpers.StartSpanParameters:
+        assert kwargs is not None, (
+            "Expected kwargs to be not None in audio.transcriptions.create() calls"
+        )
+
+        name = track_options.name if track_options.name is not None else func.__name__
+
+        metadata = track_options.metadata if track_options.metadata is not None else {}
+
+        input_data, new_metadata = dict_utils.split_dict_by_keys(
+            kwargs, keys=TRANSCRIPTION_KWARGS_KEYS_TO_LOG_AS_INPUTS
+        )
+        metadata = dict_utils.deepmerge(metadata, new_metadata)
+
+        metadata.update(
+            {
+                "created_from": "openai",
+                "type": "openai_audio_transcription",
+            }
+        )
+
+        # Try to get file info for metadata
+        file_arg = kwargs.get("file")
+        if file_arg is not None:
+            if isinstance(file_arg, str):
+                input_data["file"] = file_arg
+            elif hasattr(file_arg, "name"):
+                input_data["file"] = getattr(file_arg, "name", "<file>")
+            else:
+                input_data["file"] = "<binary>"
+
+        tags = ["openai", "audio", "transcription"]
+        model = kwargs.get("model", None)
+
+        result = arguments_helpers.StartSpanParameters(
+            name=name,
+            input=input_data,
+            type=track_options.type,
+            tags=tags,
+            metadata=metadata,
+            project_name=track_options.project_name,
+            model=model,
+            provider=self.provider,
+        )
+
+        return result
+
+    @override
+    def _end_span_inputs_preprocessor(
+        self,
+        output: Any,
+        capture_output: bool,
+        current_span_data: span.SpanData,
+    ) -> arguments_helpers.EndSpanParameters:
+        metadata: Dict[str, Any] = {}
+        output_data: Dict[str, Any] = {}
+
+        if output is not None:
+            try:
+                if isinstance(output, str):
+                    output_data["text"] = output
+                elif hasattr(output, "model_dump"):
+                    # Transcription or TranscriptionVerbose
+                    result_dict = output.model_dump(mode="json")
+                    output_data["text"] = result_dict.get("text", "")
+                    # Extract duration if available (TranscriptionVerbose)
+                    if "duration" in result_dict:
+                        metadata["audio_duration"] = result_dict["duration"]
+                    if "language" in result_dict:
+                        metadata["detected_language"] = result_dict["language"]
+                    if "segments" in result_dict:
+                        metadata["segments_count"] = len(result_dict["segments"])
+                else:
+                    output_data["output"] = str(output)
+            except Exception as e:
+                LOGGER.debug(
+                    "Failed to extract transcription response details: %s", e
+                )
+
+        return arguments_helpers.EndSpanParameters(
+            output=output_data,
+            usage=None,
+            metadata=metadata,
+            model=current_span_data.model,
+            provider=self.provider,
+        )
+
+    @override
+    def _streams_handler(
+        self,
+        output: Any,
+        capture_output: bool,
+        generations_aggregator: Optional[Callable[[List[Any]], Any]],
+    ) -> Optional[Any]:
+        NOT_A_STREAM = None
+        return NOT_A_STREAM

--- a/sdks/python/tests/library_integration/openai/test_openai_audio.py
+++ b/sdks/python/tests/library_integration/openai/test_openai_audio.py
@@ -1,0 +1,166 @@
+"""Tests for OpenAI audio (TTS and transcriptions) tracking."""
+
+import io
+import os
+from unittest import mock
+
+import openai
+import pytest
+
+import opik
+from opik.config import OPIK_PROJECT_DEFAULT_NAME
+from opik.integrations.openai import track_openai
+from ...testlib import (
+    ANY_BUT_NONE,
+    ANY_DICT,
+    ANY_STRING,
+    SpanModel,
+    TraceModel,
+    assert_equal,
+)
+
+# Audio tests call the real API and cost money, skip unless explicitly enabled
+SKIP_EXPENSIVE_TESTS = os.environ.get("OPIK_TEST_EXPENSIVE", "").lower() not in (
+    "1",
+    "true",
+    "yes",
+)
+
+
+@pytest.fixture(autouse=True)
+def check_openai_configured(ensure_openai_configured):
+    pass
+
+
+@pytest.mark.skipif(
+    SKIP_EXPENSIVE_TESTS,
+    reason="Expensive tests disabled. Set OPIK_TEST_EXPENSIVE=1 to enable.",
+)
+class TestAudioSpeechTracking:
+    """Tests for audio.speech.create() (TTS) tracking."""
+
+    def test_audio_speech_create__happyflow(self, fake_backend):
+        client = openai.OpenAI()
+        wrapped_client = track_openai(openai_client=client)
+
+        response = wrapped_client.audio.speech.create(
+            model="tts-1",
+            voice="alloy",
+            input="Hello, this is a test of text to speech.",
+        )
+
+        # Response should be usable
+        assert response is not None
+        content = response.content
+        assert len(content) > 0
+
+        opik.flush_tracker()
+
+        assert len(fake_backend.trace_trees) == 1
+
+        trace = fake_backend.trace_trees[0]
+        assert trace.span_trees is not None
+        assert len(trace.span_trees) == 1
+
+        span = trace.span_trees[0]
+        assert span.name == "audio.speech.create"
+        assert span.model == "tts-1"
+        assert span.tags == ["openai", "audio", "tts"]
+
+        # Check input was logged
+        assert "input" in span.input
+        assert span.input["voice"] == "alloy"
+
+        # Check metadata
+        assert span.metadata["created_from"] == "openai"
+        assert span.metadata["type"] == "openai_audio_speech"
+        assert "input_text_length" in span.metadata
+        assert span.metadata["input_text_length"] == len(
+            "Hello, this is a test of text to speech."
+        )
+
+        # Check output has audio info
+        assert "status_code" in span.output
+        assert span.output["status_code"] == 200
+
+    def test_audio_speech_create__with_project_name(self, fake_backend):
+        client = openai.OpenAI()
+        wrapped_client = track_openai(
+            openai_client=client,
+            project_name="tts-test-project",
+        )
+
+        response = wrapped_client.audio.speech.create(
+            model="tts-1",
+            voice="nova",
+            input="Short test.",
+            response_format="mp3",
+            speed=1.0,
+        )
+
+        assert response is not None
+
+        opik.flush_tracker()
+
+        assert len(fake_backend.trace_trees) == 1
+        trace = fake_backend.trace_trees[0]
+        assert trace.span_trees[0].input.get("response_format") == "mp3"
+        assert trace.span_trees[0].input.get("speed") == 1.0
+
+
+@pytest.mark.skipif(
+    SKIP_EXPENSIVE_TESTS,
+    reason="Expensive tests disabled. Set OPIK_TEST_EXPENSIVE=1 to enable.",
+)
+class TestAudioTranscriptionsTracking:
+    """Tests for audio.transcriptions.create() tracking."""
+
+    def test_audio_transcriptions_create__happyflow(self, fake_backend):
+        client = openai.OpenAI()
+        wrapped_client = track_openai(openai_client=client)
+
+        # First generate some audio to transcribe
+        speech_response = wrapped_client.audio.speech.create(
+            model="tts-1",
+            voice="alloy",
+            input="Hello world, this is a transcription test.",
+        )
+
+        audio_content = speech_response.content
+
+        # Now transcribe it
+        audio_file = io.BytesIO(audio_content)
+        audio_file.name = "test_audio.mp3"
+
+        transcription = wrapped_client.audio.transcriptions.create(
+            model="whisper-1",
+            file=audio_file,
+        )
+
+        assert transcription is not None
+
+        opik.flush_tracker()
+
+        # Should have 2 traces: one for speech, one for transcription
+        assert len(fake_backend.trace_trees) == 2
+
+        # Find the transcription trace
+        transcription_trace = None
+        for trace in fake_backend.trace_trees:
+            if (
+                trace.span_trees
+                and trace.span_trees[0].name == "audio.transcriptions.create"
+            ):
+                transcription_trace = trace
+                break
+
+        assert transcription_trace is not None
+        span = transcription_trace.span_trees[0]
+        assert span.name == "audio.transcriptions.create"
+        assert span.model == "whisper-1"
+        assert span.tags == ["openai", "audio", "transcription"]
+        assert span.metadata["created_from"] == "openai"
+        assert span.metadata["type"] == "openai_audio_transcription"
+
+        # Output should contain transcribed text
+        assert "text" in span.output


### PR DESCRIPTION
## Summary

Adds tracking support for OpenAI audio APIs, addressing #2202.

### New tracked endpoints:
- **`audio.speech.create()`** (Text-to-Speech / TTS)
- **`audio.transcriptions.create()`**

### Tracked data:

**TTS (audio.speech.create):**
- Model name (`tts-1`, `tts-1-hd`)
- Input text, voice, response format, speed
- Input text length (for cost estimation — OpenAI charges per character)
- Output audio size in bytes
- Response status code and content type

**Transcriptions (audio.transcriptions.create):**
- Model name (`whisper-1`)
- File reference, language, prompt, response format, temperature
- Transcribed text output
- Audio duration (when available via verbose format)
- Detected language

### Implementation:
- New `audio/` subpackage following the same decorator pattern as `videos/`
- `AudioSpeechTrackDecorator` and `AudioTranscriptionsTrackDecorator` extending `BaseTrackDecorator`
- Patching wired in via `_patch_openai_audio()` in `opik_tracker.py`
- Integration tests in `test_openai_audio.py`

### Tags applied:
- TTS spans: `["openai", "audio", "tts"]`
- Transcription spans: `["openai", "audio", "transcription"]`

Closes #2202