### PR TITLE
[NA] [SDK] fix flakey tests tolerate feline variants in multimodal image tests

### DIFF
--- a/sdks/python/tests/e2e/evaluation/test_multimodal.py
+++ b/sdks/python/tests/e2e/evaluation/test_multimodal.py
@@ -72,6 +72,9 @@ def _normalize_output(output: Any) -> str:
             if isinstance(text_value, str):
                 collected_parts.append(text_value)
 
+            if isinstance(text_value, list):
+                collect_values(text_value)
+
             content_value = value.get("content")
             if isinstance(content_value, str):
                 collected_parts.append(content_value)
@@ -83,6 +86,13 @@ def _normalize_output(output: Any) -> str:
                 collected_parts.append(output_value)
             elif isinstance(output_value, list):
                 collect_values(output_value)
+            elif isinstance(output_value, dict):
+                collect_values(output_value)
+
+            for key, item in value.items():
+                if key in {"text", "content", "output"}:
+                    continue
+                collect_values(item)
 
     collect_values(output)
     return " ".join(part.strip() for part in collected_parts).strip().lower()
@@ -150,9 +160,12 @@ def test_evaluate_prompt_supports_multimodal_images(
         reference = str(item.dataset_item_data.get("reference", "")).strip().lower()
         results[reference] = _normalize_output(item.evaluation_task_output["output"])
 
-    assert (
-        results["cat"].strip() in ["cat", "kitten", "kitty", "feline"]
-    )  # relaxed to avoid flakiness
+    assert results["cat"].strip() in [
+        "cat",
+        "kitten",
+        "kitty",
+        "feline",
+    ]  # relaxed to avoid flakiness
     assert results["dog"].strip() == "dog"
     assert results["fox"].strip() == "fox"
 

--- a/sdks/typescript/tests/integration/evaluation/evaluateImage.test.ts
+++ b/sdks/typescript/tests/integration/evaluation/evaluateImage.test.ts
@@ -120,9 +120,23 @@ function validateImageOutput(
         return normalized.content.flatMap((item) => collectText(item));
       }
 
-      if (Array.isArray(normalized.output)) {
-        return normalized.output.flatMap((item) => collectText(item));
+      if ("output" in normalized) {
+        if (Array.isArray(normalized.output)) {
+          return normalized.output.flatMap((item) => collectText(item));
+        }
+
+        if (typeof normalized.output === "object" && normalized.output !== null) {
+          return collectText(normalized.output);
+        }
+
+        if (typeof normalized.output === "string") {
+          return [normalized.output];
+        }
       }
+
+      return Object.entries(normalized)
+        .filter(([key]) => key !== "text" && key !== "content" && key !== "output")
+        .flatMap(([, value]) => collectText(value));
     }
 
     return [];


### PR DESCRIPTION
## Details

- Relaxed image integration assertions to accept `kitten`, `kitty`, and `feline` variants in addition to `cat`.
- Updated the TS image-output normalizer to recursively extract text from structured outputs.
- Updated Python e2e multimodal test and feline alias assertions for parity with TypeScript expectations.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing
See live test results from Github Actions

## Documentation
n.a.
