### PR TITLE
[OPIK-4498] [INFRA] Disable Buildx Bake in remaining CI e2e workflows

### DIFF
--- a/.github/workflows/end2end_suites_typescript.yml
+++ b/.github/workflows/end2end_suites_typescript.yml
@@ -86,6 +86,8 @@ jobs:
             - name: Install Opik (Local)
               env:
                 OPIK_USAGE_REPORT_ENABLED: false
+                # Avoid Buildx Bake concurrent image export collisions in CI.
+                COMPOSE_BAKE: false
               run: |
                 cd ${{ github.workspace }}
                 TOGGLE_WELCOME_WIZARD_ENABLED="false" ./opik.sh --build

--- a/.github/workflows/sdk-e2e-tests.yaml
+++ b/.github/workflows/sdk-e2e-tests.yaml
@@ -47,6 +47,8 @@ jobs:
         - name: Run latest Opik server
           env:
             OPIK_USAGE_REPORT_ENABLED: false
+            # Avoid Buildx Bake concurrent image export collisions in CI.
+            COMPOSE_BAKE: false
           run: |
             cd ${{ github.workspace }}
             ./opik.sh --build --guardrails

--- a/.github/workflows/typescript_sdk_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_e2e_tests.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Run latest Opik server
         env:
           OPIK_USAGE_REPORT_ENABLED: false
+          # Avoid Buildx Bake concurrent image export collisions in CI.
+          COMPOSE_BAKE: false
         run: |
           cd ${{ github.workspace }}
           ./opik.sh --build --guardrails


### PR DESCRIPTION
## Details

Extends the `COMPOSE_BAKE=false` fix from PR #5293 to all remaining CI workflows that call `./opik.sh --build`.

The Buildx Bake concurrent image export collision (`image "ghcr.io/comet-ml/opik/opik-python-backend:latest": already exists`) was only addressed in `sdk-e2e-library-tests.yaml` and `e2e_tests_post_merge.yml`. The same race condition affects three other workflows that were still using Bake-enabled builds:

- `sdk-e2e-tests.yaml` — SDK E2E Tests
- `typescript_sdk_e2e_tests.yml` — TypeScript SDK E2E Tests
- `end2end_suites_typescript.yml` — E2E Suites TypeScript

Each workflow's "Run latest Opik server" / "Install Opik" step now sets `COMPOSE_BAKE: false` in its `env` block, matching the pattern already established in `sdk-e2e-library-tests.yaml`.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- OPIK-4498

## Testing
- Verified that the only 5 workflows calling `./opik.sh --build` are now all covered with `COMPOSE_BAKE: false`
- No functional changes — only CI environment variable additions

## Documentation
N/A