### PR TITLE
[NA] [SDK] [DOCS] Pin Guardrails dependency to <0.9.0

### DIFF
--- a/apps/opik-documentation/documentation/docs/cookbook/guardrails-ai.ipynb
+++ b/apps/opik-documentation/documentation/docs/cookbook/guardrails-ai.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --upgrade opik guardrails-ai"
+    "%pip install --upgrade opik \"guardrails-ai<0.9.0\""
    ]
   },
   {

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/guardrails-ai.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/guardrails-ai.mdx
@@ -26,7 +26,7 @@ For this guide we will use a simple example that logs guardrails validation step
 First, ensure you have both `opik` and `guardrails-ai` installed:
 
 ```bash
-pip install opik guardrails-ai
+pip install opik "guardrails-ai<0.9.0"
 ```
 
 ### Configuring Opik

--- a/apps/opik-documentation/python-sdk-docs/requirements.txt
+++ b/apps/opik-documentation/python-sdk-docs/requirements.txt
@@ -11,7 +11,7 @@ crewai!=0.114.0 # https://github.com/crewAIInc/crewAI/issues/2575
 crewai-tools
 dspy-ai
 google-adk>=0.1.0
-guardrails-ai
+guardrails-ai<0.9.0
 haystack-ai
 langchain
 langchain_core

--- a/sdks/python/tests/library_integration/guardrails/requirements.txt
+++ b/sdks/python/tests/library_integration/guardrails/requirements.txt
@@ -1,2 +1,2 @@
 setuptools  # required by guardrails hub
-guardrails-ai<0.9.0  # 0.9.0 broke hub install API, causing PolitenessCheck import to fail
+guardrails-ai<0.9.0


### PR DESCRIPTION
## Details
This PR only applies dependency pinning to keep Guardrails integration using versions prior to 0.9.0, avoiding the breaking API changes introduced in 0.9.0.

Updated files:
- `sdks/python/tests/library_integration/guardrails/requirements.txt`
- `apps/opik-documentation/python-sdk-docs/requirements.txt`
- `apps/opik-documentation/documentation/fern/docs/tracing/integrations/guardrails-ai.mdx`
- `apps/opik-documentation/documentation/docs/cookbook/guardrails-ai.ipynb`

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- [NA] No issue link provided.

## Testing
- Not run locally in this pass.
- This change is intentionally minimal and targeted at dependency pinning for immediate CI unblock.

## Documentation
- Updated docs/examples/install instructions to align with pinned pre-0.9 Guardrails versions.
