### PR TITLE
[NA] [DOCS] fix: align TS SDK docs with current SDK behavior

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/opik-ts.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/opik-ts.mdx
@@ -37,7 +37,7 @@ The CLI will guide you through:
 
 ### Requirements
 
-- **Node.js**: Version 18 or higher
+- **Node.js**: Version 18.17.0 or higher
 - **Package Manager**: npm, yarn, pnpm, or bun
 - **Supported Project Types**:
   - Node.js applications
@@ -101,7 +101,7 @@ The CLI automatically creates or updates your `.env` file with the necessary con
 OPIK_API_KEY=your-api-key-here
 OPIK_URL_OVERRIDE=https://www.comet.com/opik/api
 OPIK_PROJECT_NAME=default
-OPIK_WORKSPACE_NAME=default
+OPIK_WORKSPACE=default
 ```
 
 <Tip>

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/overview.mdx
@@ -68,7 +68,7 @@ export OPIK_URL_OVERRIDE="https://www.comet.com/opik/api"
 export OPIK_URL_OVERRIDE="http://localhost:5173/api"
 
 export OPIK_PROJECT_NAME="your-project-name"
-export OPIK_WORKSPACE_NAME="your-workspace-name"
+export OPIK_WORKSPACE="your-workspace-name"
 ```
 
 Or you can pass the configuration to the Opik client constructor.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/langchainjs.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/langchainjs.mdx
@@ -36,8 +36,8 @@ yarn add opik-langchain
 ### Requirements
 
 - Node.js ≥ 18
-- LangChain (`@langchain/core` ≥ 0.3.42)
-- Opik SDK (automatically installed as a dependency)
+- LangChain (`@langchain/core` ≥ 0.3.78)
+- Opik SDK (`opik` peer dependency)
 
 ## Basic Usage
 

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openai-typescript.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openai-typescript.mdx
@@ -37,8 +37,8 @@ yarn add opik-openai openai
 ### Requirements
 
 - Node.js ≥ 18
-- OpenAI SDK (`openai` ≥ 4.0.0)
-- Opik SDK (automatically installed as a dependency)
+- OpenAI SDK (`openai` ≥ 6.0.1)
+- Opik SDK (`opik` peer dependency)
 
 ## Basic Usage
 

--- a/apps/opik-documentation/documentation/fern/docs/tracing/log_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/log_traces.mdx
@@ -50,7 +50,7 @@ Opik SDK.
     You can then set the Opik environment variables in your `.env` file:
 
     ```bash
-    # Set OPIK_API_KEY and OPIK_WORKSPACE_NAME in your .env file
+    # Set OPIK_API_KEY and OPIK_WORKSPACE in your .env file
     OPIK_API_KEY=your_api_key_here
     OPIK_WORKSPACE=your_workspace_name
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -39,7 +39,7 @@ You can configure the Opik client using environment variables.
 OPIK_API_KEY="your-api-key"
 OPIK_URL_OVERRIDE="https://www.comet.com/opik/api"
 OPIK_PROJECT_NAME="your-project-name"
-OPIK_WORKSPACE_NAME="your-workspace-name"
+OPIK_WORKSPACE="your-workspace-name"
 ```
 
 Or you can pass the configuration to the Opik client constructor.

--- a/sdks/typescript/src/opik/integrations/opik-langchain/README.md
+++ b/sdks/typescript/src/opik/integrations/opik-langchain/README.md
@@ -29,8 +29,8 @@ pnpm add opik-langchain
 ### Requirements
 
 - Node.js ≥ 18
-- LangChain (`@langchain/core` ≥ 0.3.42)
-- Opik SDK (automatically installed as a dependency)
+- LangChain (`@langchain/core` ≥ 0.3.78)
+- Opik SDK (`opik` peer dependency)
 
 ## Quick Start
 

--- a/sdks/typescript/src/opik/integrations/opik-openai/README.md
+++ b/sdks/typescript/src/opik/integrations/opik-openai/README.md
@@ -30,8 +30,8 @@ pnpm add opik-openai
 ### Requirements
 
 - Node.js ≥ 18
-- OpenAI SDK (`openai` ≥ 4.0.0)
-- Opik SDK (automatically installed as a dependency)
+- OpenAI SDK (`openai` ≥ 6.0.1)
+- Opik SDK (`opik` peer dependency)
 
 ## Usage
 


### PR DESCRIPTION
## Details
This PR aligns TypeScript SDK documentation with current TypeScript SDK behavior and package metadata.

Changes made:
- Corrected workspace env var from `OPIK_WORKSPACE_NAME` to `OPIK_WORKSPACE` in TS SDK docs.
- Updated OpenAI integration requirements to match current peer dependency constraints.
- Updated LangChain integration requirements to match current peer dependency constraints.
- Clarified `opik-ts` minimum Node.js requirement (`18.17.0+`) to match CLI runtime guard.
- Fixed a mismatched comment in tracing docs (`OPIK_WORKSPACE_NAME` -> `OPIK_WORKSPACE`).

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #N/A
- OPIK-NA

## Testing
- Docs-only change.
- Validation performed by cross-checking docs content against:
  - `sdks/typescript/src/opik/config/Config.ts`
  - `sdks/typescript/src/opik/configure/bin.ts`
  - integration `package.json` peerDependencies for `opik-openai` and `opik-langchain`.

## Documentation
- Updated:
  - `sdks/typescript/README.md`
  - `apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/overview.mdx`
  - `apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/opik-ts.mdx`
  - `apps/opik-documentation/documentation/fern/docs/tracing/log_traces.mdx`
  - `sdks/typescript/src/opik/integrations/opik-openai/README.md`
  - `apps/opik-documentation/documentation/fern/docs/tracing/integrations/openai-typescript.mdx`
  - `sdks/typescript/src/opik/integrations/opik-langchain/README.md`
  - `apps/opik-documentation/documentation/fern/docs/tracing/integrations/langchainjs.mdx`

## AI Assistance
- AI-WATERMARK: no
- Tool(s): n/a
- Model(s): n/a
- Scope: n/a
- Human verification: yes (manual review of docs against source files)
