### PR TITLE
[issue-5106] [DOCS] Add docs for OpenAI-compatible providers with LLM-as-a-Judge metrics

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/custom_model.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/custom_model.mdx
@@ -39,6 +39,37 @@ hallucination_metric = Hallucination(
 )
 ```
 
+## Using OpenAI-compatible providers
+
+Many LLM providers (such as SiliconFlow, Together AI, Groq, and others) expose APIs that are compatible with the OpenAI API format. You can use these providers with Opik's LLM-as-a-Judge metrics by using LiteLLM's `openai/` prefix and setting the appropriate environment variables.
+
+Set `OPENAI_API_KEY` to your provider's API key and `OPENAI_BASE_URL` to the provider's API endpoint, then use the `openai/` prefix when specifying the model name:
+
+```python
+import os
+from opik.evaluation.metrics import Hallucination
+
+# Configure the OpenAI-compatible provider
+os.environ["OPENAI_API_KEY"] = "your-provider-api-key"
+os.environ["OPENAI_BASE_URL"] = "https://api.your-provider.com/v1"
+
+# Use the openai/ prefix with the provider's model name
+hallucination_metric = Hallucination(
+    model="openai/your-model-name"
+)
+
+score = hallucination_metric.score(
+    input="What is the capital of France?",
+    output="The capital of France is Paris, a city known for its iconic Eiffel Tower.",
+    context=["Paris is the capital and most populous city of France."]
+)
+print(f"Hallucination score: {score.value}")
+```
+
+The `openai/` prefix tells LiteLLM to use the OpenAI-compatible API format with the configured base URL. This approach works with any metric that accepts a `model` parameter, including `Hallucination`, `Moderation`, `AnswerRelevance`, and others.
+
+For more details on supported providers, see the [LiteLLM providers documentation](https://docs.litellm.ai/docs/providers).
+
 ## Creating Your Own Custom Model Class
 
 Opik's LLM-as-a-Judge metrics, such as [`Hallucination`](https://www.comet.com/docs/opik/python-sdk-reference/evaluation/metrics/Hallucination.html), are designed to work with various language models. While Opik supports many models out-of-the-box via LiteLLM, you can integrate any LLM by creating a custom model class. This involves subclassing [`opik.evaluation.models.OpikBaseModel`](https://www.comet.com/docs/opik/python-sdk-reference/Objects/OpikBaseModel.html#opik.evaluation.models.OpikBaseModel) and implementing its required methods.


### PR DESCRIPTION
## Details
Adds a new "Using OpenAI-compatible providers" section to the custom model documentation page. This explains how to use LiteLLM's `openai/` prefix with `OPENAI_API_KEY` and `OPENAI_BASE_URL` environment variables to connect to OpenAI-compatible API providers (SiliconFlow, Together AI, Groq, etc.).

This is a simpler alternative to creating a full custom model class for providers that support the OpenAI API format.

## Issues
Closes #5106

## Testing
- [ ] Verify the documentation renders correctly on the docs site
- [ ] Confirm the code example works with an OpenAI-compatible provider

## Change checklist
- [x] I have reviewed my own code
- [x] I have added/updated relevant documentation

## Documentation
- Updated `apps/opik-documentation/documentation/fern/docs/evaluation/metrics/custom_model.mdx` with a new section on OpenAI-compatible providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)