### PR TITLE
[issue-5106] [DOCS] Add intent note and canonical source links for OpenAI-compatible provider docs

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/custom_model.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/custom_model.mdx
@@ -41,9 +41,14 @@ hallucination_metric = Hallucination(
 
 ## Using OpenAI-compatible providers
 
-Many LLM providers (such as SiliconFlow, Together AI, Groq, and others) expose APIs that are compatible with the OpenAI API format. You can use these providers with Opik's LLM-as-a-Judge metrics by using LiteLLM's `openai/` prefix and setting the appropriate environment variables.
+Many LLM providers (such as SiliconFlow, Together AI, Groq, and others) expose APIs that are compatible with the OpenAI API format. You can use these providers with Opik's LLM-as-a-Judge metrics by using LiteLLM's [`openai/` provider prefix](https://docs.litellm.ai/docs/providers/openai_compatible) and setting the appropriate environment variables.
+
+This is a simpler alternative to [creating a custom model class](#creating-your-own-custom-model-class) when your provider already supports the OpenAI API format.
 
 Set `OPENAI_API_KEY` to your provider's API key and `OPENAI_BASE_URL` to the provider's API endpoint, then use the `openai/` prefix when specifying the model name:
+
+{/* Example based on LiteLLM's OpenAI-compatible provider pattern.
+    See: https://docs.litellm.ai/docs/providers/openai_compatible */}
 
 ```python
 import os
@@ -68,7 +73,7 @@ print(f"Hallucination score: {score.value}")
 
 The `openai/` prefix tells LiteLLM to use the OpenAI-compatible API format with the configured base URL. This approach works with any metric that accepts a `model` parameter, including `Hallucination`, `Moderation`, `AnswerRelevance`, and others.
 
-For more details on supported providers, see the [LiteLLM providers documentation](https://docs.litellm.ai/docs/providers).
+For the full list of supported providers and configuration options, see the [LiteLLM OpenAI-compatible providers documentation](https://docs.litellm.ai/docs/providers/openai_compatible).
 
 ## Creating Your Own Custom Model Class
 


### PR DESCRIPTION
## Details
Follow-up to #5317 which was merged before review fixes could land. This addresses the Baz reviewer feedback by:

- Linking the `openai/` prefix text to the canonical [LiteLLM OpenAI-compatible providers docs](https://docs.litellm.ai/docs/providers/openai_compatible)
- Adding an intent line explaining this is a simpler alternative to creating a custom model class
- Adding an MDX comment noting the example's canonical source for maintainability
- Updating the bottom link to point specifically to the OpenAI-compatible providers page rather than the generic providers page

## Issues
Closes #5106

## Testing
- [ ] Verify the documentation renders correctly on the docs site

## Change checklist
- [x] I have reviewed my own code
- [x] I have added/updated relevant documentation

## Documentation
- Updated `apps/opik-documentation/documentation/fern/docs/evaluation/metrics/custom_model.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)