### PR TITLE
[OPIK-4512] [FE] Fix section header labels hidden in dark mode

### DIFF
--- a/apps/opik-frontend/src/components/shared/DataTable/DataTable.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTable/DataTable.tsx
@@ -437,10 +437,11 @@ const DataTable = <TData, TValue>({
                         key={header.id}
                         data-header-id={header.id}
                         style={{
-                          zIndex: TABLE_HEADER_Z_INDEX,
+                          zIndex: TABLE_HEADER_Z_INDEX + (isLastRow ? 0 : 1),
                           ...getCommonPinningStyles({
                             column: header.column,
                             isHeader: true,
+                            isLastHeaderRow: isLastRow,
                             table,
                           }),
                         }}

--- a/apps/opik-frontend/src/components/shared/DataTable/utils.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTable/utils.tsx
@@ -49,6 +49,7 @@ export const calculateHeightStyle = (rowHeight: ROW_HEIGHT) => {
 export type GetCommonPinningStylesProps<TData> = {
   column: Column<TData>;
   isHeader?: boolean;
+  isLastHeaderRow?: boolean;
   applyStickyWorkaround?: boolean;
   forceGroup?: boolean;
   table: Table<TData>;
@@ -57,6 +58,7 @@ export type GetCommonPinningStylesProps<TData> = {
 export const getCommonPinningStyles = <TData,>({
   column,
   isHeader = false,
+  isLastHeaderRow = false,
   applyStickyWorkaround = false,
   forceGroup = false,
   table,
@@ -96,7 +98,11 @@ export const getCommonPinningStyles = <TData,>({
         : undefined,
     right: isPinned === "right" ? `${column.getAfter("right")}px` : undefined,
     position: applyStickyWorkaround ? "unset" : "sticky",
-    zIndex: isHeader ? TABLE_HEADER_Z_INDEX + 1 : TABLE_ROW_Z_INDEX + 1,
+    // +2 ensures pinned header cells always appear above non-pinned headers,
+    // which use TABLE_HEADER_Z_INDEX + (0 or 1) in DataTable.tsx
+    zIndex: isHeader
+      ? TABLE_HEADER_Z_INDEX + 2 + (isLastHeaderRow ? 0 : 1)
+      : TABLE_ROW_Z_INDEX + 1,
   };
 };
 


### PR DESCRIPTION
## Details

In the trial items table (and any table using grouped columns), section header labels like "Dataset", "Evaluation task", and "Optimizations scores" were invisible in dark mode.

The root cause: TanStack Table renders two `<tr>` rows inside `<thead>` — a group header row (with `SectionHeader`) and a column header row. The `SectionHeader` text intentionally overflows below its row boundary to visually sit above the column names. In dark mode, a global CSS rule (`.dark thead th { background-color: hsl(var(--accent-background)) }`) gives all `<th>` cells a solid dark background. Since the column header row comes later in document order, its cells are rasterized after the section header row, and their solid background covers the overflow text.

The fix gives group header row cells a higher `z-index` than column header row cells, so their overflow text is composited on top regardless of document order.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-4512

## Testing

Navigate to any trial comparison page with multiple columns (e.g. Optimization Studio → compare trials → Trial items tab). In dark mode, verify that section labels ("Dataset", "Evaluation task", "Optimizations scores") are visible above the column headers, matching the light mode appearance.

## Documentation

N/A

## Screenshots
Before:
<img width="547" height="302" alt="Screenshot 2026-02-19 at 19 43 16" src="https://github.com/user-attachments/assets/d79d6ccf-3d0b-464a-9a6b-cc914ce35c7c" />
After:
<img width="651" height="264" alt="Screenshot 2026-02-19 at 19 43 32" src="https://github.com/user-attachments/assets/6c6ddc73-9fc9-48b7-8528-caa12d6258fa" />
