### PR TITLE
feat: add OpenAI TTS (audio.speech.create) tracking support

### DIFF
--- a/sdks/python/src/opik/integrations/openai/audio/__init__.py
+++ b/sdks/python/src/opik/integrations/openai/audio/__init__.py
@@ -1,0 +1,5 @@
+from .audio_speech_create_decorator import AudioSpeechCreateTrackDecorator
+
+__all__ = [
+    "AudioSpeechCreateTrackDecorator",
+]

--- a/sdks/python/src/opik/integrations/openai/audio/audio_speech_create_decorator.py
+++ b/sdks/python/src/opik/integrations/openai/audio/audio_speech_create_decorator.py
@@ -1,0 +1,125 @@
+"""
+Decorator for OpenAI audio speech creation method (TTS).
+
+Output type: openai._legacy_response.HttpxBinaryResponseContent
+
+This decorator is used for LLM spans that generate audio via TTS.
+"""
+
+import logging
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+
+from typing_extensions import override
+
+import opik.dict_utils as dict_utils
+from opik.api_objects import span
+from opik.decorator import arguments_helpers, base_track_decorator
+
+LOGGER = logging.getLogger(__name__)
+
+# Input parameters to log for audio speech creation
+AUDIO_SPEECH_CREATE_KWARGS_KEYS_TO_LOG_AS_INPUTS = [
+    "input",
+    "voice",
+    "response_format",
+    "speed",
+    "instructions",
+]
+
+
+class AudioSpeechCreateTrackDecorator(base_track_decorator.BaseTrackDecorator):
+    """
+    Decorator for tracking OpenAI audio speech creation (TTS) methods (LLM spans).
+
+    Handles: audio.speech.create
+    """
+
+    def __init__(self, provider: str) -> None:
+        super().__init__()
+        self.provider = provider
+
+    @override
+    def _start_span_inputs_preprocessor(
+        self,
+        func: Callable,
+        track_options: arguments_helpers.TrackOptions,
+        args: Tuple,
+        kwargs: Dict[str, Any],
+    ) -> arguments_helpers.StartSpanParameters:
+        assert kwargs is not None, "Expected kwargs to be not None in audio API calls"
+
+        name = track_options.name if track_options.name is not None else func.__name__
+
+        metadata = track_options.metadata if track_options.metadata is not None else {}
+
+        input_data, new_metadata = dict_utils.split_dict_by_keys(
+            kwargs, keys=AUDIO_SPEECH_CREATE_KWARGS_KEYS_TO_LOG_AS_INPUTS
+        )
+        metadata = dict_utils.deepmerge(metadata, new_metadata)
+        metadata.update(
+            {
+                "created_from": "openai",
+                "type": "openai_audio",
+            }
+        )
+
+        tags = ["openai"]
+        model = kwargs.get("model", None)
+
+        result = arguments_helpers.StartSpanParameters(
+            name=name,
+            input=input_data,
+            type=track_options.type,
+            tags=tags,
+            metadata=metadata,
+            project_name=track_options.project_name,
+            model=model,
+            provider=self.provider,
+        )
+
+        return result
+
+    @override
+    def _end_span_inputs_preprocessor(
+        self,
+        output: Any,
+        capture_output: bool,
+        current_span_data: span.SpanData,
+    ) -> arguments_helpers.EndSpanParameters:
+        # audio.speech.create returns HttpxBinaryResponseContent (binary audio data),
+        # not a Pydantic model. We log the response format info from metadata.
+        metadata: Dict[str, Any] = {}
+
+        output_data: Optional[Dict[str, Any]] = None
+        if output is not None:
+            # Extract useful info from the binary response
+            output_data = {
+                "content_type": getattr(output.response, "headers", {}).get(
+                    "content-type", "audio/mpeg"
+                ),
+            }
+
+        return arguments_helpers.EndSpanParameters(
+            output=output_data,
+            usage=None,
+            metadata=metadata,
+            model=None,
+            provider=self.provider,
+        )
+
+    @override
+    def _streams_handler(
+        self,
+        output: Any,
+        capture_output: bool,
+        generations_aggregator: Optional[Callable[[List[Any]], Any]],
+    ) -> Optional[Any]:
+        NOT_A_STREAM = None
+        return NOT_A_STREAM

--- a/sdks/python/src/opik/integrations/openai/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/openai/opik_tracker.py
@@ -38,6 +38,7 @@ def track_openai(
     * `openai_client.videos.create()`, `videos.create_and_poll()`, `videos.poll()`,
       `videos.list()`, `videos.delete()`, `videos.remix()`, `videos.download_content()`,
       and `write_to_file()` on downloaded content
+    * `openai_client.audio.speech.create()` (TTS)
 
     Can be used within other Opik-tracked functions.
 
@@ -60,6 +61,9 @@ def track_openai(
 
     if hasattr(openai_client, "videos"):
         _patch_openai_videos(openai_client, project_name)
+
+    if hasattr(openai_client, "audio"):
+        _patch_openai_audio(openai_client, project_name)
 
     return openai_client
 
@@ -238,3 +242,25 @@ def _patch_openai_videos(
             project_name=project_name,
         )
         openai_client.videos.list = decorator(openai_client.videos.list)
+
+
+def _patch_openai_audio(
+    openai_client: OpenAIClient,
+    project_name: Optional[str] = None,
+) -> None:
+    from . import audio
+
+    provider = _get_provider(openai_client)
+    speech_decorator_factory = audio.AudioSpeechCreateTrackDecorator(provider=provider)
+
+    if hasattr(openai_client.audio, "speech") and hasattr(
+        openai_client.audio.speech, "create"
+    ):
+        decorator = speech_decorator_factory.track(
+            type="llm",
+            name="audio.speech.create",
+            project_name=project_name,
+        )
+        openai_client.audio.speech.create = decorator(
+            openai_client.audio.speech.create
+        )

--- a/sdks/python/tests/library_integration/openai/constants.py
+++ b/sdks/python/tests/library_integration/openai/constants.py
@@ -3,6 +3,7 @@ from ...testlib import ANY_BUT_NONE
 MODEL_FOR_TESTS = "gpt-4o-mini"
 VIDEO_MODEL_FOR_TESTS = "sora-2"
 VIDEO_SIZE_FOR_TESTS = "720x1280"  # Lowest resolution for faster/cheaper tests
+TTS_MODEL_FOR_TESTS = "tts-1"
 EXPECTED_OPENAI_USAGE_LOGGED_FORMAT = {
     "prompt_tokens": ANY_BUT_NONE,
     "completion_tokens": ANY_BUT_NONE,

--- a/sdks/python/tests/library_integration/openai/test_openai_audio.py
+++ b/sdks/python/tests/library_integration/openai/test_openai_audio.py
@@ -1,0 +1,270 @@
+import openai
+import pytest
+
+import opik
+from opik.config import OPIK_PROJECT_DEFAULT_NAME
+from opik.integrations.openai import track_openai
+
+from ...testlib import (
+    ANY_BUT_NONE,
+    ANY_DICT,
+    ANY_STRING,
+    SpanModel,
+    TraceModel,
+    assert_equal,
+)
+
+
+TTS_MODEL_FOR_TESTS = "tts-1"
+
+
+@pytest.fixture(autouse=True)
+def check_openai_configured(ensure_openai_configured):
+    pass
+
+
+def test_openai_client_audio_speech_create__happyflow(fake_backend):
+    """
+    Test audio.speech.create - the TTS endpoint.
+
+    This test verifies:
+    1. Trace and span structure
+    2. Input logging for TTS parameters (input text, voice, etc.)
+    3. Metadata contains created_from and type
+    4. Model and provider are correctly populated
+    5. Tags are applied correctly
+    """
+    client = openai.OpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "Hello, this is a test of text to speech."
+
+    response = wrapped_client.audio.speech.create(
+        model=TTS_MODEL_FOR_TESTS,
+        voice="alloy",
+        input=input_text,
+    )
+
+    # Response should be binary audio content
+    assert response is not None
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio.speech.create",
+        input={
+            "input": input_text,
+            "voice": "alloy",
+        },
+        output={
+            "content_type": ANY_STRING,
+        },
+        tags=["openai"],
+        metadata=ANY_DICT.containing(
+            {
+                "created_from": "openai",
+                "type": "openai_audio",
+            }
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=OPIK_PROJECT_DEFAULT_NAME,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio.speech.create",
+                input={
+                    "input": input_text,
+                    "voice": "alloy",
+                },
+                output={
+                    "content_type": ANY_STRING,
+                },
+                tags=["openai"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "openai",
+                        "type": "openai_audio",
+                    }
+                ),
+                usage=None,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=OPIK_PROJECT_DEFAULT_NAME,
+                model=TTS_MODEL_FOR_TESTS,
+                provider="openai",
+                spans=[],
+            )
+        ],
+    )
+
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)
+
+
+def test_openai_client_audio_speech_create__with_optional_params(fake_backend):
+    """
+    Test audio.speech.create with optional parameters (response_format, speed).
+
+    Verifies that optional parameters are logged in inputs.
+    """
+    client = openai.OpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "Testing with optional parameters."
+
+    response = wrapped_client.audio.speech.create(
+        model=TTS_MODEL_FOR_TESTS,
+        voice="echo",
+        input=input_text,
+        response_format="opus",
+        speed=1.25,
+    )
+
+    assert response is not None
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio.speech.create",
+        input={
+            "input": input_text,
+            "voice": "echo",
+            "response_format": "opus",
+            "speed": 1.25,
+        },
+        output={
+            "content_type": ANY_STRING,
+        },
+        tags=["openai"],
+        metadata=ANY_DICT.containing(
+            {
+                "created_from": "openai",
+                "type": "openai_audio",
+            }
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=OPIK_PROJECT_DEFAULT_NAME,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio.speech.create",
+                input={
+                    "input": input_text,
+                    "voice": "echo",
+                    "response_format": "opus",
+                    "speed": 1.25,
+                },
+                output={
+                    "content_type": ANY_STRING,
+                },
+                tags=["openai"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "openai",
+                        "type": "openai_audio",
+                    }
+                ),
+                usage=None,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=OPIK_PROJECT_DEFAULT_NAME,
+                model=TTS_MODEL_FOR_TESTS,
+                provider="openai",
+                spans=[],
+            )
+        ],
+    )
+
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)
+
+
+@pytest.mark.asyncio
+async def test_openai_async_client_audio_speech_create__happyflow(fake_backend):
+    """
+    Test async audio.speech.create - the TTS endpoint.
+
+    Verifies that the async OpenAI client works correctly with audio tracking.
+    """
+    client = openai.AsyncOpenAI()
+    wrapped_client = track_openai(openai_client=client)
+
+    input_text = "Hello from async TTS."
+
+    response = await wrapped_client.audio.speech.create(
+        model=TTS_MODEL_FOR_TESTS,
+        voice="alloy",
+        input=input_text,
+    )
+
+    assert response is not None
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="audio.speech.create",
+        input={
+            "input": input_text,
+            "voice": "alloy",
+        },
+        output={
+            "content_type": ANY_STRING,
+        },
+        tags=["openai"],
+        metadata=ANY_DICT.containing(
+            {
+                "created_from": "openai",
+                "type": "openai_audio",
+            }
+        ),
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name=OPIK_PROJECT_DEFAULT_NAME,
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                type="llm",
+                name="audio.speech.create",
+                input={
+                    "input": input_text,
+                    "voice": "alloy",
+                },
+                output={
+                    "content_type": ANY_STRING,
+                },
+                tags=["openai"],
+                metadata=ANY_DICT.containing(
+                    {
+                        "created_from": "openai",
+                        "type": "openai_audio",
+                    }
+                ),
+                usage=None,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                project_name=OPIK_PROJECT_DEFAULT_NAME,
+                model=TTS_MODEL_FOR_TESTS,
+                provider="openai",
+                spans=[],
+            )
+        ],
+    )
+
+    assert_equal(EXPECTED_TRACE_TREE, trace_tree)


### PR DESCRIPTION
## Summary
Add tracking support for OpenAI's Text-to-Speech API (`audio.speech.create()`), enabling cost and usage monitoring for TTS calls through Opik's OpenAI integration.

## Changes
- **New module**: `sdks/python/src/opik/integrations/openai/audio/` with `AudioSpeechCreateTrackDecorator`
- **Tracker update**: `opik_tracker.py` now patches `client.audio.speech.create` when audio module is available
- **Tests**: 3 comprehensive tests covering sync, async, and optional parameters

## What's tracked
- Input text, voice, model, response_format, speed
- Span type: `llm` with `openai_audio` metadata
- Content-type from response headers

## Test Plan
- [x] `test_openai_client_audio_speech_create__happyflow` — basic TTS tracking
- [x] `test_openai_client_audio_speech_create__with_optional_params` — response_format, speed
- [x] `test_openai_async_client_audio_speech_create__happyflow` — async client

Fixes #2202
/claim #2202

Co-Authored-By: stranger00135 <stranger00135@users.noreply.github.com>