### PR TITLE
fix(vercel): capture ai.response.object for generateObject output

### DIFF
--- a/sdks/typescript/src/opik/integrations/opik-vercel/src/exporter.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/src/exporter.ts
@@ -101,6 +101,10 @@ export class OpikExporter implements SpanExporter {
       return { text: attributes["ai.response.text"] };
     }
 
+    if (attributes["ai.response.object"]) {
+      return { object: safeParseJson(attributes["ai.response.object"]) };
+    }
+
     if (attributes["ai.toolCall.result"]) {
       return { result: attributes["ai.toolCall.result"] };
     }


### PR DESCRIPTION
## Summary

- Fix blank output (`{}`) when using AI SDK's `generateObject` with Opik tracing
- Add handling for `ai.response.object` telemetry attribute in `OpikExporter.getSpanOutput()`
- Add test for `generateObject` integration

## Problem

When using the Vercel AI SDK's `generateObject` function with Opik tracing, the output was always recorded as `{}`. This is because `getSpanOutput()` only checked for `ai.response.text`, `ai.toolCall.result`, and `ai.response.toolCalls` attributes, but `generateObject` stores its response in the `ai.response.object` attribute.

## Fix

Added a check for `ai.response.object` in `getSpanOutput()`, parsing the JSON string value with `safeParseJson` and returning it as `{ object: <parsed value> }`.

Fixes #3362

## Test plan

- [x] Added `generateObject` test case that verifies the output is correctly captured
- [x] All existing tests continue to pass (6/6)