### PR TITLE
[OPIK-4508] [BE] Fix OTEL GenAI semantic conventions mapping gap

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingRuleFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingRuleFactory.java
@@ -3,6 +3,7 @@ package com.comet.opik.domain.mapping;
 import com.comet.opik.domain.mapping.otel.GenAIMappingRules;
 import com.comet.opik.domain.mapping.otel.GeneralMappingRules;
 import com.comet.opik.domain.mapping.otel.LangFuseMappingRules;
+import com.comet.opik.domain.mapping.otel.LiteLLMMappingRules;
 import com.comet.opik.domain.mapping.otel.LiveKitMappingRules;
 import com.comet.opik.domain.mapping.otel.LogfireMappingRules;
 import com.comet.opik.domain.mapping.otel.OpenInferenceMappingRules;
@@ -29,6 +30,7 @@ public class OpenTelemetryMappingRuleFactory {
             OpenInferenceMappingRules.getRules(),
             LiveKitMappingRules.getRules(),
             PydanticMappingRules.getRules(),
+            LiteLLMMappingRules.getRules(),
             GeneralMappingRules.getRules(),
             SmolagentsMappingRules.getRules(),
             LangFuseMappingRules.getRules())

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/GenAIMappingRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/GenAIMappingRules.java
@@ -49,6 +49,30 @@ public final class GenAIMappingRules {
                     .rule("gen_ai.usage.").isPrefix(true).source(SOURCE)
                     .outcome(OpenTelemetryMappingRule.Outcome.USAGE).spanType(SpanType.llm).build(),
             OpenTelemetryMappingRule.builder()
+                    .rule("gen_ai.input.").isPrefix(true).source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.INPUT).spanType(SpanType.llm).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("gen_ai.output.").isPrefix(true).source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.OUTPUT).spanType(SpanType.llm).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("gen_ai.system_instructions").source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.INPUT).spanType(SpanType.llm).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("gen_ai.cost.").isPrefix(true).source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).spanType(SpanType.llm).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("gen_ai.tool.").isPrefix(true).source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("gen_ai.agent.").isPrefix(true).source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("gen_ai.token.type").source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("gen_ai.framework").source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build(),
+            OpenTelemetryMappingRule.builder()
                     .rule("gen_ai.request.").isPrefix(true).source(SOURCE)
                     .outcome(OpenTelemetryMappingRule.Outcome.INPUT).build(),
             OpenTelemetryMappingRule.builder()

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/LiteLLMMappingRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/LiteLLMMappingRules.java
@@ -1,0 +1,40 @@
+package com.comet.opik.domain.mapping.otel;
+
+import com.comet.opik.domain.mapping.OpenTelemetryMappingRule;
+import lombok.experimental.UtilityClass;
+
+import java.util.List;
+
+/**
+ * Mapping rules for LiteLLM integration.
+ * LiteLLM uses non-standard {@code llm.*} namespace attributes.
+ */
+@UtilityClass
+public final class LiteLLMMappingRules {
+
+    public static final String SOURCE = "LiteLLM";
+
+    private static final List<OpenTelemetryMappingRule> RULES = List.of(
+            OpenTelemetryMappingRule.builder()
+                    .rule("llm.is_streaming").source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("llm.request.").isPrefix(true).source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("llm.response.").isPrefix(true).source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("llm.user").source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("metadata.").isPrefix(true).source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("hidden_params").source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build());
+
+    public static List<OpenTelemetryMappingRule> getRules() {
+        return RULES;
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -112,4 +112,332 @@ class OpenTelemetryMapperTest {
         assertThat(span.metadata().has("thread_id")).isTrue();
         assertThat(span.metadata().get("thread_id").asLong()).isEqualTo(12345L);
     }
+
+    @Test
+    void testGenAiOutputMessagesMapsToOutput() {
+        var attributes = List.of(
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.output.messages")
+                        .setValue(AnyValue.newBuilder()
+                                .setStringValue("[{\"role\":\"assistant\",\"content\":\"Hello\"}]"))
+                        .build());
+
+        var spanBuilder = Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
+
+        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
+
+        var span = spanBuilder.build();
+
+        assertThat(span.output().has("gen_ai.output.messages")).isTrue();
+        assertThat(span.input()).isNull();
+    }
+
+    @Test
+    void testGenAiInputMessagesMapsToInput() {
+        var attributes = List.of(
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.input.messages")
+                        .setValue(AnyValue.newBuilder().setStringValue("[{\"role\":\"user\",\"content\":\"Hi\"}]"))
+                        .build());
+
+        var spanBuilder = Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
+
+        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
+
+        var span = spanBuilder.build();
+
+        assertThat(span.input().has("gen_ai.input.messages")).isTrue();
+    }
+
+    @Test
+    void testGenAiSystemInstructionsMapsToInput() {
+        var attributes = List.of(
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.system_instructions")
+                        .setValue(AnyValue.newBuilder().setStringValue("You are a helpful assistant"))
+                        .build());
+
+        var spanBuilder = Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
+
+        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
+
+        var span = spanBuilder.build();
+
+        assertThat(span.input().has("gen_ai.system_instructions")).isTrue();
+    }
+
+    @Test
+    void testGenAiCostAttributesMapsToMetadata() {
+        var attributes = List.of(
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.cost.total_cost")
+                        .setValue(AnyValue.newBuilder().setDoubleValue(0.0035))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.cost.input_cost")
+                        .setValue(AnyValue.newBuilder().setDoubleValue(0.001))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.cost.output_cost")
+                        .setValue(AnyValue.newBuilder().setDoubleValue(0.0025))
+                        .build());
+
+        var spanBuilder = Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
+
+        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
+
+        var span = spanBuilder.build();
+
+        assertThat(span.metadata().has("gen_ai.cost.total_cost")).isTrue();
+        assertThat(span.metadata().has("gen_ai.cost.input_cost")).isTrue();
+        assertThat(span.metadata().has("gen_ai.cost.output_cost")).isTrue();
+        assertThat(span.input()).isNull();
+    }
+
+    @Test
+    void testOldAndNewGenAiAttributesCoexist() {
+        var attributes = List.of(
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.prompt")
+                        .setValue(AnyValue.newBuilder().setStringValue("old prompt"))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.input.messages")
+                        .setValue(AnyValue.newBuilder().setStringValue("[{\"role\":\"user\",\"content\":\"new\"}]"))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.completion")
+                        .setValue(AnyValue.newBuilder().setStringValue("old completion"))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.output.messages")
+                        .setValue(
+                                AnyValue.newBuilder().setStringValue("[{\"role\":\"assistant\",\"content\":\"new\"}]"))
+                        .build());
+
+        var spanBuilder = Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
+
+        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
+
+        var span = spanBuilder.build();
+
+        assertThat(span.input().has("gen_ai.prompt")).isTrue();
+        assertThat(span.input().has("gen_ai.input.messages")).isTrue();
+        assertThat(span.output().has("gen_ai.completion")).isTrue();
+        assertThat(span.output().has("gen_ai.output.messages")).isTrue();
+    }
+
+    @Test
+    void testGenAiToolAttributesMapsToMetadata() {
+        var attributes = List.of(
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.tool.name")
+                        .setValue(AnyValue.newBuilder().setStringValue("get_weather"))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.tool.call.id")
+                        .setValue(AnyValue.newBuilder().setStringValue("call_abc123"))
+                        .build());
+
+        var spanBuilder = Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
+
+        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
+
+        var span = spanBuilder.build();
+
+        assertThat(span.metadata().has("gen_ai.tool.name")).isTrue();
+        assertThat(span.metadata().has("gen_ai.tool.call.id")).isTrue();
+    }
+
+    @Test
+    void testLlmIsStreamingMapsToMetadata() {
+        var attributes = List.of(
+                KeyValue.newBuilder()
+                        .setKey("llm.is_streaming")
+                        .setValue(AnyValue.newBuilder().setBoolValue(true))
+                        .build());
+
+        var spanBuilder = Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
+
+        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
+
+        var span = spanBuilder.build();
+
+        assertThat(span.metadata().has("llm.is_streaming")).isTrue();
+    }
+
+    @Test
+    void testLlmResponseAttributesMapsToMetadata() {
+        var attributes = List.of(
+                KeyValue.newBuilder()
+                        .setKey("llm.response.finish_reason")
+                        .setValue(AnyValue.newBuilder().setStringValue("stop"))
+                        .build());
+
+        var spanBuilder = Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
+
+        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
+
+        var span = spanBuilder.build();
+
+        assertThat(span.metadata().has("llm.response.finish_reason")).isTrue();
+        assertThat(span.input()).isNull();
+    }
+
+    @Test
+    void testExistingGenAiRulesUnaffected() {
+        var attributes = List.of(
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.request.model")
+                        .setValue(AnyValue.newBuilder().setStringValue("gpt-4"))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.response.model")
+                        .setValue(AnyValue.newBuilder().setStringValue("gpt-4-0613"))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.usage.input_tokens")
+                        .setValue(AnyValue.newBuilder().setIntValue(100))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.usage.output_tokens")
+                        .setValue(AnyValue.newBuilder().setIntValue(50))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.system")
+                        .setValue(AnyValue.newBuilder().setStringValue("openai"))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.response.id")
+                        .setValue(AnyValue.newBuilder().setStringValue("chatcmpl-abc"))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.response.finish_reasons")
+                        .setValue(AnyValue.newBuilder().setStringValue("[\"stop\"]"))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.operation.name")
+                        .setValue(AnyValue.newBuilder().setStringValue("chat"))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.conversation.id")
+                        .setValue(AnyValue.newBuilder().setStringValue("conv-123"))
+                        .build());
+
+        var spanBuilder = Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
+
+        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
+
+        var span = spanBuilder.build();
+
+        // MODEL: response.model overwrites request.model (last-write-wins)
+        assertThat(span.model()).isEqualTo("gpt-4-0613");
+
+        // USAGE: input_tokens→prompt_tokens, output_tokens→completion_tokens (key mapping)
+        assertThat(span.usage().get("prompt_tokens")).isNotNull();
+        assertThat(span.usage().get("completion_tokens")).isNotNull();
+
+        // PROVIDER: gen_ai.system
+        assertThat(span.provider()).isEqualTo("openai");
+
+        // METADATA: response.id, response.finish_reasons, operation.name
+        assertThat(span.metadata().has("gen_ai.response.id")).isTrue();
+        assertThat(span.metadata().has("gen_ai.response.finish_reasons")).isTrue();
+        assertThat(span.metadata().has("gen_ai.operation.name")).isTrue();
+
+        // THREAD_ID: conversation.id
+        assertThat(span.metadata().has("thread_id")).isTrue();
+        assertThat(span.metadata().get("thread_id").asText()).isEqualTo("conv-123");
+    }
+
+    @Test
+    void testLiteLLMMetadataAttributesMapsToMetadata() {
+        var attributes = List.of(
+                KeyValue.newBuilder()
+                        .setKey("metadata.user_api_key_hash")
+                        .setValue(AnyValue.newBuilder().setStringValue("sk-hash-123"))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("metadata.user_api_key_team_id")
+                        .setValue(AnyValue.newBuilder().setStringValue("team-456"))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("metadata.requester_ip_address")
+                        .setValue(AnyValue.newBuilder().setStringValue("127.0.0.1"))
+                        .build());
+
+        var spanBuilder = Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
+
+        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
+
+        var span = spanBuilder.build();
+
+        assertThat(span.metadata().has("metadata.user_api_key_hash")).isTrue();
+        assertThat(span.metadata().has("metadata.user_api_key_team_id")).isTrue();
+        assertThat(span.metadata().has("metadata.requester_ip_address")).isTrue();
+        assertThat(span.input()).isNull();
+    }
+
+    @Test
+    void testLiteLLMHiddenParamsMapsToMetadata() {
+        var attributes = List.of(
+                KeyValue.newBuilder()
+                        .setKey("hidden_params")
+                        .setValue(AnyValue.newBuilder().setStringValue(
+                                "{\"api_base\":\"https://api.openai.com\",\"response_cost\":0.005}"))
+                        .build());
+
+        var spanBuilder = Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
+
+        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
+
+        var span = spanBuilder.build();
+
+        assertThat(span.metadata().has("hidden_params")).isTrue();
+        assertThat(span.input()).isNull();
+    }
 }


### PR DESCRIPTION
## Details

Fix OTEL GenAI semantic conventions mapping gaps in the backend. The OTEL GenAI spec evolved in v1.37.0+ with new attribute namespaces (`gen_ai.input.*`, `gen_ai.output.*`, `gen_ai.cost.*`, etc.) that Opik's mapper didn't handle.

**Critical bug fixed:** `gen_ai.output.messages` had no matching rule and fell through to the INPUT fallback — response messages ended up in `span.input` instead of `span.output`.

**Additional fixes:**
- `gen_ai.input.*` → explicit INPUT rule (was correct by accident via fallback)
- `gen_ai.output.*` → OUTPUT (was wrongly routed to INPUT)
- `gen_ai.system_instructions` → INPUT
- `gen_ai.cost.*` (11 cost fields) → METADATA (was wrongly in INPUT)
- `gen_ai.tool.*`, `gen_ai.agent.*` → METADATA
- `gen_ai.token.type`, `gen_ai.framework` → METADATA
- LiteLLM-specific `llm.*` namespace → new `LiteLLMMappingRules.java`
- LiteLLM `metadata.*` and `hidden_params` → METADATA (were wrongly in INPUT)

**Files changed:**
- `GenAIMappingRules.java` — 8 new mapping rules for GenAI v1.37.0+ namespaces
- `LiteLLMMappingRules.java` — New file: 6 rules for LiteLLM-specific `llm.*`, `metadata.*`, `hidden_params` attributes
- `OpenTelemetryMappingRuleFactory.java` — Register `LiteLLMMappingRules`
- `OpenTelemetryMapperTest.java` — 11 new test methods (output mapping, input mapping, cost routing, coexistence, LiteLLM metadata, regression)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-4508

## Testing

- 15 unit tests pass (4 existing + 11 new) in `OpenTelemetryMapperTest`
- Tested end-to-end with LiteLLM proxy → Opik local dev environment:
  - `gen_ai.output.messages` correctly appears in span OUTPUT
  - `gen_ai.input.messages` correctly appears in span INPUT
  - `gen_ai.cost.*` (10 fields) correctly appear in span METADATA
  - `metadata.*` (24 keys) correctly appear in span METADATA (previously in INPUT)
  - `hidden_params` correctly appears in span METADATA
  - All existing mappings (model, provider, usage, thread_id) unaffected

## Documentation

N/A — Internal mapping logic, no user-facing configuration changes.