### PR TITLE
[OPIK-4517] [FE]: misplaced config button in opt studio is fixed;

### DIFF
--- a/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
+++ b/apps/opik-frontend/src/components/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
@@ -146,7 +146,7 @@ const OptimizationsNewPromptSection: React.FC<
               control={form.control}
               name="modelName"
               render={({ field }) => (
-                <FormItem className="flex flex-row h-full items-center gap-1">
+                <FormItem className="flex h-full flex-row items-center gap-1">
                   <FormControl>
                     <div className="h-full w-56">
                       <OptimizationModelSelect


### PR DESCRIPTION
## Details
Fixed the position for a temperature config button
<img width="1247" height="644" alt="image" src="https://github.com/user-attachments/assets/d0798616-9e42-4f2b-9600-30cf253aa9a6" />

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-4517

## Testing

## Documentation
