### PR TITLE
[OPIK-4380] [BE] Fix dataset deadlock issue by wrapping version creation with reactive retry

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -9,6 +9,8 @@ import com.comet.opik.api.DatasetItemEdit;
 import com.comet.opik.api.DatasetItemSource;
 import com.comet.opik.api.DatasetItemStreamRequest;
 import com.comet.opik.api.DatasetVersion;
+import com.comet.opik.api.EvaluatorItem;
+import com.comet.opik.api.ExecutionPolicy;
 import com.comet.opik.api.PageColumns;
 import com.comet.opik.api.ProjectStats;
 import com.comet.opik.api.Visibility;
@@ -20,6 +22,7 @@ import com.comet.opik.api.sorting.SortingFactoryDatasets;
 import com.comet.opik.infrastructure.FeatureFlags;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.utils.RetryUtils;
 import com.google.inject.ImplementedBy;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.inject.Inject;
@@ -426,8 +429,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                             }))
                             .flatMap(existingItem -> {
                                 // Apply patch to the existing item
-                                DatasetItem patchedItem = applyPatchToItem(
-                                        existingItem, patchData, datasetId, userName);
+                                DatasetItem patchedItem = applyPatchToItem(existingItem, patchData, userName);
 
                                 log.info("Creating version with single item edit for dataset '{}', baseVersion='{}'",
                                         datasetId, baseVersionId);
@@ -449,12 +451,12 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                         Set.of(), // No deleted items
                                         unchangedUuids,
                                         Set.of())
-                                        .map(itemsTotal -> {
+                                        .flatMap(itemsTotal -> {
                                             log.info("Applied patch delta to dataset '{}': itemsTotal '{}'",
                                                     datasetId, itemsTotal);
 
                                             // Create version metadata
-                                            versionService.createVersionFromDelta(
+                                            return createVersionFromDelta(
                                                     datasetId,
                                                     newVersionId,
                                                     itemsTotal.intValue(),
@@ -466,11 +468,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                                     false, // Don't clear execution policy
                                                     null, // No batch group ID
                                                     workspaceId,
-                                                    userName);
-
-                                            log.info("Created version '{}' for dataset '{}' after patch",
-                                                    newVersionId, datasetId);
-                                            return itemsTotal;
+                                                    userName)
+                                                    .thenReturn(itemsTotal);
                                         });
                             });
                 });
@@ -491,8 +490,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
     /**
      * Applies patch data to an item, returning a new DatasetItem with the changes.
      */
-    private DatasetItem applyPatchToItem(DatasetItem existingItem, DatasetItem patchData,
-            UUID datasetId, String userName) {
+    private DatasetItem applyPatchToItem(DatasetItem existingItem, DatasetItem patchData, String userName) {
         var builder = existingItem.toBuilder()
                 .lastUpdatedAt(java.time.Instant.now())
                 .lastUpdatedBy(userName);
@@ -759,7 +757,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
         // Create version metadata
         String changeDescription = createChangeDescription(updatedCount, isFilterBased);
 
-        versionService.createVersionFromDelta(
+        return createVersionFromDelta(
                 datasetId,
                 newVersionId,
                 (int) itemsTotal,
@@ -771,10 +769,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 false, // Don't clear execution policy
                 null, // No batch group ID
                 workspaceId,
-                userName);
-
-        log.info("Created version '{}' for dataset '{}' after batch update", newVersionId, datasetId);
-        return Mono.empty();
+                userName)
+                .then();
     }
 
     /**
@@ -1106,7 +1102,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                         ? "Deleted 1 item"
                                         : "Deleted " + deletedCount + " items";
 
-                                versionService.createVersionFromDelta(
+                                return createVersionFromDelta(
                                         datasetId,
                                         newVersionId,
                                         newVersionItemCount.intValue(),
@@ -1119,8 +1115,6 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                         batchGroupId, // Pass batch group ID
                                         workspaceId,
                                         userName);
-
-                                return Mono.empty();
                             })
                             .then();
                 }));
@@ -1243,11 +1237,11 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 deletedIds,
                 unchangedUuids,
                 Set.of())
-                .map(itemsTotal -> {
+                .flatMap(itemsTotal -> {
                     log.info("Applied deletion delta to dataset '{}': itemsTotal '{}'", datasetId, itemsTotal);
 
                     // Create version metadata
-                    DatasetVersion version = versionService.createVersionFromDelta(
+                    return createVersionFromDelta(
                             datasetId,
                             newVersionId,
                             itemsTotal.intValue(),
@@ -1260,9 +1254,6 @@ class DatasetItemServiceImpl implements DatasetItemService {
                             batchGroupId, // Include batch group ID if provided
                             workspaceId,
                             userName);
-
-                    log.info("Created version '{}' for dataset '{}' after deletion", version.id(), datasetId);
-                    return version;
                 })
                 .then();
     }
@@ -1557,10 +1548,10 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                         addedItemsWithIds, List.of(), deletedIds, unchangedUuids,
                                         editedDatasetItemIds)
                                         .map(otherCount -> editedCount + otherCount))
-                                .map(itemsTotal -> {
+                                .flatMap(itemsTotal -> {
                                     log.info("Applied delta to dataset '{}': itemsTotal '{}'", datasetId, itemsTotal);
 
-                                    DatasetVersion version = versionService.createVersionFromDelta(
+                                    return createVersionFromDelta(
                                             datasetId,
                                             newVersionId,
                                             itemsTotal.intValue(),
@@ -1573,10 +1564,6 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                             null, // No batch group ID
                                             workspaceId,
                                             userName);
-
-                                    log.info("Created version '{}' for dataset '{}' with hash '{}'",
-                                            version.id(), datasetId, version.versionHash());
-                                    return version;
                                 });
                     });
         });
@@ -1928,7 +1915,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
         // Use applyDelta with no base version items (empty copy)
         // We need a special path since there's no base version
         return versionDao.insertItems(datasetId, newVersionId, addedItems, workspaceId, userName)
-                .map(itemsTotal -> {
+                .flatMap(itemsTotal -> {
                     log.info("Inserted '{}' items for first version of dataset '{}'", itemsTotal, datasetId);
 
                     // Determine change description based on whether this is a batch operation
@@ -1937,7 +1924,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                             : null;
 
                     // Create version metadata (first version - all items are "added")
-                    DatasetVersion version = versionService.createVersionFromDelta(
+                    return createVersionFromDelta(
                             datasetId,
                             newVersionId,
                             itemsTotal.intValue(),
@@ -1950,10 +1937,6 @@ class DatasetItemServiceImpl implements DatasetItemService {
                             batchGroupId, // Include batch group ID if provided
                             workspaceId,
                             userName);
-
-                    log.info("Created first version '{}' for dataset '{}' with hash '{}'",
-                            version.id(), datasetId, version.versionHash());
-                    return version;
                 });
     }
 
@@ -2017,7 +2000,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                     return versionDao.applyDelta(datasetId, baseVersionId, newVersionId,
                             addedItemsWithIds, editedItems, Set.of(), unchangedUuids,
                             Set.of())
-                            .map(itemsTotal -> {
+                            .flatMap(itemsTotal -> {
                                 log.info("Applied delta to dataset '{}': itemsTotal '{}'", datasetId, itemsTotal);
 
                                 // Determine change description based on whether this is a batch operation
@@ -2026,7 +2009,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                         : null;
 
                                 // Create version metadata
-                                DatasetVersion version = versionService.createVersionFromDelta(
+                                return createVersionFromDelta(
                                         datasetId,
                                         newVersionId,
                                         itemsTotal.intValue(),
@@ -2039,11 +2022,62 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                         batchGroupId, // Include batch group ID if provided
                                         workspaceId,
                                         userName);
-
-                                log.info("Created version '{}' for dataset '{}' with hash '{}'",
-                                        version.id(), datasetId, version.versionHash());
-                                return version;
                             });
+                });
+    }
+
+    /**
+    * Canonical method to create a dataset version from delta changes.
+    * All other createVersionFromDelta overloads delegate to this method.
+    *
+    * @param datasetId the dataset ID
+    * @param newVersionId the new version ID
+    * @param itemsTotal total number of items in the new version
+    * @param baseVersionId base version ID (null for first version)
+    * @param tags version tags (null if not specified)
+    * @param changeDescription description of changes (null for auto-generated)
+    * @param batchGroupId batch group ID (null if not a batch operation)
+    * @param workspaceId workspace ID
+    * @param userName user name
+    * @return Mono emitting the created DatasetVersion
+    */
+    private Mono<DatasetVersion> createVersionFromDelta(
+            UUID datasetId,
+            UUID newVersionId,
+            int itemsTotal,
+            UUID baseVersionId,
+            List<String> tags,
+            String changeDescription,
+            List<EvaluatorItem> evaluators,
+            ExecutionPolicy executionPolicy,
+            boolean clearExecutionPolicy,
+            UUID batchGroupId,
+            String workspaceId,
+            String userName) {
+
+        return Mono.fromCallable(() -> versionService.createVersionFromDelta(
+                datasetId,
+                newVersionId,
+                itemsTotal,
+                baseVersionId,
+                tags,
+                changeDescription,
+                evaluators,
+                executionPolicy,
+                clearExecutionPolicy,
+                batchGroupId,
+                workspaceId,
+                userName))
+                .retryWhen(RetryUtils.handleOnDeadLocks())
+                .subscribeOn(Schedulers.boundedElastic())
+                .doOnSuccess(version -> {
+                    if (baseVersionId == null) {
+                        log.info("Created first version '{}' for dataset '{}' with hash '{}'",
+                                version.id(), datasetId, version.versionHash());
+                    } else {
+                        log.info("Created version '{}' for dataset '{}' with hash '{}'",
+                                version.id(), datasetId, version.versionHash());
+                    }
                 });
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/RetryUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/RetryUtils.java
@@ -29,6 +29,20 @@ public class RetryUtils {
                 });
     }
 
+    public static RetryBackoffSpec handleOnDeadLocks() {
+        return Retry.backoff(5, Duration.ofMillis(250))
+                .maxBackoff(Duration.ofSeconds(2))
+                .jitter(0.5) // Add jitter to reduce thundering herd effect
+                .doBeforeRetry(retrySignal -> log.warn("Retrying due to: '{}'",
+                        retrySignal.failure().getMessage(), retrySignal.failure()))
+                .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> retrySignal.failure())
+                .filter(throwable -> {
+                    log.debug("Filtering for retry: '{}'", throwable.getMessage(), throwable);
+
+                    return isDatabaseDeadlock(throwable);
+                });
+    }
+
     @Getter
     public static class RetryableHttpException extends RuntimeException {
         private final int statusCode;
@@ -61,6 +75,22 @@ public class RetryUtils {
                     log.debug("Filtering for retry: {}", throwable.getMessage());
                     return isRetriableException(throwable);
                 });
+    }
+
+    private static boolean isDatabaseDeadlock(Throwable throwable) {
+        if (throwable == null) {
+            return false;
+        }
+
+        String className = throwable.getClass().getName();
+        String message = throwable.getMessage();
+
+        // Check for MySQL transaction rollback exception (deadlock)
+        boolean isMySQLDeadlock = "com.mysql.cj.jdbc.exceptions.MySQLTransactionRollbackException".equals(className)
+                && message != null && message.contains("Deadlock found");
+
+        // If not a direct match, check the cause recursively
+        return isMySQLDeadlock || (throwable.getCause() != null && isDatabaseDeadlock(throwable.getCause()));
     }
 
     private static boolean isRetriableException(Throwable throwable) {


### PR DESCRIPTION
## Details

`DatasetItemService` calls `versionService.createVersionFromDelta()` synchronously inside reactive pipelines (`.map()` operators on R2DBC `Mono`s). Because this method writes to MySQL inside an already-open ClickHouse reactive transaction, concurrent requests on the same dataset can produce MySQL deadlocks (`MySQLTransactionRollbackException: Deadlock found when trying to get lock; try restarting transaction`).

**Fix**:
- Introduced a private `createVersionFromDelta(...)` helper inside `DatasetItemServiceImpl` that wraps the blocking `versionService.createVersionFromDelta()` call in `Mono.fromCallable()` + `subscribeOn(Schedulers.boundedElastic())`, making it properly non-blocking.
- Applied `retryWhen(RetryUtils.handleOnDeadLocks())` to this helper so MySQL deadlocks are automatically retried with exponential backoff (up to 5 attempts, 250 ms base delay, 2 s max, 0.5 jitter) instead of propagating as errors.
- Changed all existing `.map(itemsTotal -> { versionService.createVersionFromDelta(...); return ...; })` call sites to `.flatMap(itemsTotal -> createVersionFromDelta(...))` so the Mono chain remains properly composed.
- Added `RetryUtils.handleOnDeadLocks()` — a reusable `RetryBackoffSpec` that matches `MySQLTransactionRollbackException` with "Deadlock found" in the message (checked recursively through exception causes).

This PR is related to: https://github.com/comet-ml/opik/pull/5338

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves # <!-- the GitHub issue this PR resolves (e.g. `#1234`) -->
- OPIK-4380
- NA <!-- If no ticket, such as hotfixes etc. -->

## Testing

- Compile passes (`mvn compile -DskipTests`).
- Spotless check passes (`mvn spotless:check`).
- The deadlock retry can be validated by running concurrent dataset item operations (batch upserts / deletes) against a single dataset under load and observing that requests no longer fail with `Deadlock found` — instead they are retried transparently and succeed.

## Documentation

No public documentation changes required. The retry is an internal infrastructure improvement with no user-facing API changes.
