### PR TITLE
[OPIK-4380] [BE] Add ClickHouse migration for experiment_aggregates and experiment_item_aggregates tables

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000060_create_experiment_stats_tables.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000060_create_experiment_stats_tables.sql
@@ -65,33 +65,33 @@ SETTINGS index_granularity = 8192;
 
 -- Speeds up queries filtering by project_id (multi-project experiment views)
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_aggregates ON CLUSTER '{cluster}'
-    ADD INDEX idx_experiment_aggregates_project_id project_id TYPE minmax GRANULARITY 4;
+    ADD INDEX idx_experiment_aggregates_project_id project_id TYPE minmax GRANULARITY 1;
 
 -- Speeds up queries filtering by optimization_id (optimizer experiment lookups)
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_aggregates ON CLUSTER '{cluster}'
-    ADD INDEX idx_experiment_aggregates_optimization_id optimization_id TYPE minmax GRANULARITY 4;
+    ADD INDEX idx_experiment_aggregates_optimization_id optimization_id TYPE minmax GRANULARITY 1;
 
 -- Speeds up queries filtering by dataset_version_id (version-scoped experiment views)
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_aggregates ON CLUSTER '{cluster}'
-    ADD INDEX idx_experiment_aggregates_dataset_version_id dataset_version_id TYPE minmax GRANULARITY 4;
+    ADD INDEX idx_experiment_aggregates_dataset_version_id dataset_version_id TYPE minmax GRANULARITY 1;
 
 -- Speeds up queries filtering by dataset_item_id (item-level experiment views)
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_item_aggregates ON CLUSTER '{cluster}'
-    ADD INDEX idx_experiment_item_aggregates_dataset_item_id dataset_item_id TYPE minmax GRANULARITY 4;
+    ADD INDEX idx_experiment_item_aggregates_dataset_item_id dataset_item_id TYPE minmax GRANULARITY 1;
 
 -- Speeds up queries filtering by trace_id (trace-linked experiment item lookups)
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_item_aggregates ON CLUSTER '{cluster}'
-    ADD INDEX idx_experiment_item_aggregates_trace_id trace_id TYPE minmax GRANULARITY 4;
+    ADD INDEX idx_experiment_item_aggregates_trace_id trace_id TYPE minmax GRANULARITY 1;
 
 -- Speeds up queries filtering by project_id on experiment items
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_item_aggregates ON CLUSTER '{cluster}'
-    ADD INDEX idx_experiment_item_aggregates_project_id project_id TYPE minmax GRANULARITY 4;
+    ADD INDEX idx_experiment_item_aggregates_project_id project_id TYPE minmax GRANULARITY 1;
 
---rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_aggregates ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_experiment_aggregates_project_id;
---rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_aggregates ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_experiment_aggregates_optimization_id;
---rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_aggregates ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_experiment_aggregates_dataset_version_id;
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_item_aggregates ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_experiment_item_aggregates_dataset_item_id;
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_item_aggregates ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_experiment_item_aggregates_trace_id;
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_item_aggregates ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_experiment_item_aggregates_project_id;
---rollback DROP TABLE IF EXISTS ${ANALYTICS_DB_DATABASE_NAME}.experiment_aggregates ON CLUSTER '{cluster}';
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_aggregates ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_experiment_aggregates_project_id;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_aggregates ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_experiment_aggregates_optimization_id;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_aggregates ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_experiment_aggregates_dataset_version_id;
 --rollback DROP TABLE IF EXISTS ${ANALYTICS_DB_DATABASE_NAME}.experiment_item_aggregates ON CLUSTER '{cluster}';
+--rollback DROP TABLE IF EXISTS ${ANALYTICS_DB_DATABASE_NAME}.experiment_aggregates ON CLUSTER '{cluster}';


### PR DESCRIPTION
## Details

Creates two new `ReplicatedReplacingMergeTree` ClickHouse tables to store pre-aggregated metrics at the experiment and experiment-item level:

**`experiment_aggregates`** — experiment-level rollups:
- Experiment metadata: `workspace_id`, `id`, `dataset_id`, `project_id`, `name`, `type`, `status`, `tags`, `optimization_id`, `dataset_version_id`, `prompt_versions`
- Aggregated metrics: `trace_count`, `experiment_items_count`, `experiment_scores`, `duration_percentiles`, `feedback_scores_percentiles`, `feedback_scores_avg`, `total_estimated_cost_sum/avg/percentiles`, `usage_avg`, `usage_total_tokens_percentiles`

**`experiment_item_aggregates`** — per-item rollups:
- Item metadata: `workspace_id`, `id`, `experiment_id`, `dataset_item_id`, `trace_id`, `project_id`, `visibility_mode`
- Aggregated metrics: `duration`, `total_estimated_cost`, `usage`, `feedback_scores`, `feedback_scores_array`, `input`/`output` (+ truncated variants)

Both tables use `ZSTD(3)` compression on all columns, `Delta` codec on timestamps, and include `minmax` skip indexes on the most common filter columns (`dataset_id`, `project_id`, `optimization_id`, `dataset_version_id`, `dataset_item_id`, `trace_id`).

This PR is related to: https://github.com/comet-ml/opik/pull/5338

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-4380

## Testing

Migration can be applied via:
```bash
java -jar target/opik-backend-*.jar dbAnalytics migrate config.yml
```

Rollback statements are included in the migration script.

## Documentation

No public documentation changes required. These are internal ClickHouse tables for storing pre-aggregated experiment metrics.
