### PR TITLE
[OPIK-3101] [FE] Unify open in new tab icons

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/annotation-queues/AnnotateQueueCell.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/annotation-queues/AnnotateQueueCell.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { SquareArrowOutUpRight } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { CellContext } from "@tanstack/react-table";
 import { Link } from "@tanstack/react-router";
 
@@ -29,7 +29,7 @@ const AnnotateQueueCell = (context: CellContext<AnnotationQueue, string>) => {
       >
         <Button variant="tableLink" size="sm">
           Annotate queue
-          <SquareArrowOutUpRight className="ml-1.5 mt-1 size-3.5 shrink-0" />
+          <ExternalLink className="ml-1.5 mt-1 size-3.5 shrink-0" />
         </Button>
       </Link>
     </CellWrapper>

--- a/apps/opik-frontend/src/components/pages-shared/automations/RuleLogsCell.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/automations/RuleLogsCell.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { SquareArrowOutUpRight } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { CellContext } from "@tanstack/react-table";
 import { Link } from "@tanstack/react-router";
 
@@ -29,7 +29,7 @@ const RuleLogsCell = (context: CellContext<EvaluatorsRule, string>) => {
       >
         <Button variant="tableLink" size="sm">
           Show logs
-          <SquareArrowOutUpRight className="ml-1.5 mt-1 size-3.5 shrink-0" />
+          <ExternalLink className="ml-1.5 mt-1 size-3.5 shrink-0" />
         </Button>
       </Link>
     </CellWrapper>

--- a/apps/opik-frontend/src/components/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog.tsx
@@ -15,7 +15,7 @@ import ApiKeyCard from "@/components/pages-shared/onboarding/ApiKeyCard/ApiKeyCa
 import GoogleColabCard from "@/components/pages-shared/onboarding/GoogleColabCard/GoogleColabCard";
 import { putConfigInCode } from "@/lib/formatCodeSnippets";
 import { buildDocsUrl } from "@/lib/utils";
-import { SquareArrowOutUpRight } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import ExplainerDescription from "@/components/shared/ExplainerDescription/ExplainerDescription";
 import { useIsPhone } from "@/hooks/useIsPhone";
@@ -421,7 +421,7 @@ eval_results = evaluate(
           className="flex items-center"
         >
           Learn about custom metrics
-          <SquareArrowOutUpRight className="ml-1 size-4" />
+          <ExternalLink className="ml-1 size-4" />
         </a>
       </Button>
     </div>

--- a/apps/opik-frontend/src/components/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import CodeMirror from "@uiw/react-codemirror";
 import { jsonLanguage } from "@codemirror/lang-json";
 import { EditorView } from "@codemirror/view";
-import { SquareArrowOutUpRight } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 
 import useAppStore from "@/store/AppStore";
@@ -251,7 +251,7 @@ const AddNewPromptVersionDialog: React.FC<AddNewPromptVersionDialogProps> = ({
                 >
                   <Button variant="link" size="sm" className="px-1">
                     Prompt library
-                    <SquareArrowOutUpRight className="ml-1.5 mt-1 size-3.5 shrink-0" />
+                    <ExternalLink className="ml-1.5 mt-1 size-3.5 shrink-0" />
                   </Button>
                 </Link>
               </Description>
@@ -291,7 +291,7 @@ const AddNewPromptVersionDialog: React.FC<AddNewPromptVersionDialogProps> = ({
                   >
                     <Button variant="link" size="sm" className="px-1">
                       Prompt library
-                      <SquareArrowOutUpRight className="ml-1.5 mt-1 size-3.5 shrink-0" />
+                      <ExternalLink className="ml-1.5 mt-1 size-3.5 shrink-0" />
                     </Button>
                   </Link>
                 </Description>

--- a/apps/opik-frontend/src/components/pages-shared/onboarding/DocsLinkCard/DocsLinkCard.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/onboarding/DocsLinkCard/DocsLinkCard.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { SquareArrowOutUpRight } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 
 export type DocsLinkCardProps = {
   link: string;
@@ -23,7 +23,7 @@ const DocsLinkCard: React.FC<DocsLinkCardProps> = ({
           <a href={link} target="_blank" rel="noreferrer">
             <span className="flex items-center gap-1">
               {buttonText}
-              <SquareArrowOutUpRight className="ml-2 size-4 shrink-0" />
+              <ExternalLink className="ml-2 size-4 shrink-0" />
             </span>
           </a>
         </Button>

--- a/apps/opik-frontend/src/components/pages-shared/onboarding/FrameworkIntegrations/FrameworkIntegrations.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/onboarding/FrameworkIntegrations/FrameworkIntegrations.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { buildDocsUrl } from "@/lib/utils";
-import { SquareArrowOutUpRight } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { useTheme } from "@/components/theme-provider";
 import { THEME_MODE } from "@/constants/theme";
 import ApiKeyCard from "../ApiKeyCard/ApiKeyCard";
@@ -101,7 +101,7 @@ const FrameworkIntegrations: React.FC<FrameworkIntegrationsProps> = ({
           rel="noreferrer"
         >
           Explore all integrations
-          <SquareArrowOutUpRight className="ml-2 size-4 shrink-0" />
+          <ExternalLink className="ml-2 size-4 shrink-0" />
         </a>
       </Button>
     </>

--- a/apps/opik-frontend/src/components/pages-shared/onboarding/GoogleColabCard/GoogleColabCardCore.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/onboarding/GoogleColabCard/GoogleColabCardCore.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { SquareArrowOutUpRight } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import colabLogo from "/images/colab-logo.png";
 
 export type GoogleColabCardCoreProps = {
@@ -22,7 +22,7 @@ const GoogleColabCardCore: React.FC<GoogleColabCardCoreProps> = ({ link }) => {
               <img src={colabLogo} alt="colab logo" className="h-[27px] w-8" />
             </div>
 
-            <SquareArrowOutUpRight className="ml-2 size-4 shrink-0" />
+            <ExternalLink className="ml-2 size-4 shrink-0" />
           </a>
         </Button>
       </div>

--- a/apps/opik-frontend/src/components/pages/AnnotationQueuePage/OpenSMELinkButton.tsx
+++ b/apps/opik-frontend/src/components/pages/AnnotationQueuePage/OpenSMELinkButton.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { SquareArrowOutUpRight } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 
 import { AnnotationQueue } from "@/types/annotation-queues";
@@ -27,7 +27,7 @@ const OpenSMELinkButton: React.FunctionComponent<OpenSMELinkButtonProps> = ({
         target="_blank"
       >
         <Button size="sm">
-          <SquareArrowOutUpRight className="mr-1.5 size-3.5" />
+          <ExternalLink className="mr-1.5 size-3.5" />
           Annotate
         </Button>
       </Link>

--- a/apps/opik-frontend/src/components/pages/DatasetsPage/AddEditDatasetDialog.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetsPage/AddEditDatasetDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { SquareArrowOutUpRight } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { AxiosError, HttpStatusCode } from "axios";
 import get from "lodash/get";
 
@@ -456,7 +456,7 @@ const AddEditDatasetDialog: React.FunctionComponent<
                     rel="noopener noreferrer"
                   >
                     Learn more
-                    <SquareArrowOutUpRight className="ml-0.5 size-3 shrink-0" />
+                    <ExternalLink className="ml-0.5 size-3 shrink-0" />
                   </a>
                 </Button>
               </Description>

--- a/apps/opik-frontend/src/components/shared/ExplainerCallout/ExplainerCallout.tsx
+++ b/apps/opik-frontend/src/components/shared/ExplainerCallout/ExplainerCallout.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Info, SquareArrowOutUpRight, X } from "lucide-react";
+import { ExternalLink, Info, X } from "lucide-react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -50,7 +50,7 @@ const ExplainerCallout: React.FC<ExplainerCalloutProps> = ({
               rel="noreferrer"
             >
               Read more
-              <SquareArrowOutUpRight className="ml-0.5 size-3 shrink-0" />
+              <ExternalLink className="ml-0.5 size-3 shrink-0" />
             </a>
           </Button>
         )}

--- a/apps/opik-frontend/src/components/shared/ExplainerDescription/ExplainerDescription.tsx
+++ b/apps/opik-frontend/src/components/shared/ExplainerDescription/ExplainerDescription.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { SquareArrowOutUpRight } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { buildDocsUrl, cn } from "@/lib/utils";
@@ -48,7 +48,7 @@ const ExplainerDescription: React.FC<ExplainerDescriptionProps> = ({
             rel="noreferrer"
           >
             Read more
-            <SquareArrowOutUpRight className={cn("ml-1 shrink-0", iconSize)} />
+            <ExternalLink className={cn("ml-1 shrink-0", iconSize)} />
           </a>
         </Button>
       )}

--- a/apps/opik-frontend/src/components/shared/ExplainerIcon/ExplainerIcon.tsx
+++ b/apps/opik-frontend/src/components/shared/ExplainerIcon/ExplainerIcon.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CircleHelp, Info, SquareArrowOutUpRight } from "lucide-react";
+import { CircleHelp, ExternalLink, Info } from "lucide-react";
 
 import { buildDocsUrl, cn } from "@/lib/utils";
 import { Explainer } from "@/types/shared";
@@ -32,7 +32,7 @@ const ExplainerIcon: React.FC<ExplainerIconProps> = ({
                 rel="noreferrer"
               >
                 Read more
-                <SquareArrowOutUpRight className="ml-0.5 size-3 shrink-0" />
+                <ExternalLink className="ml-0.5 size-3 shrink-0" />
               </a>
             </Button>
           )}

--- a/apps/opik-frontend/src/components/shared/GitHubCallout/GitHubCallout.tsx
+++ b/apps/opik-frontend/src/components/shared/GitHubCallout/GitHubCallout.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Info, SquareArrowOutUpRight } from "lucide-react";
+import { ExternalLink, Info } from "lucide-react";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -23,7 +23,7 @@ const GitHubCallout: React.FunctionComponent<GitHubCalloutProps> = ({
             rel="noreferrer"
           >
             GitHub ticket
-            <SquareArrowOutUpRight className="ml-0.5 size-3 shrink-0" />
+            <ExternalLink className="ml-0.5 size-3 shrink-0" />
           </a>
         </Button>
         to let us know!


### PR DESCRIPTION
## Details
Replaces all `SquareArrowOutUpRight` Lucide icons with `ExternalLink` across the frontend to unify the "open in new tab" icon throughout the app. The codebase was using two different icons for the same action — this PR standardizes on `ExternalLink` only.

<img width="1593" height="932" alt="image" src="https://github.com/user-attachments/assets/6f06a86e-4bdd-4ddf-90ea-23414982045e" />


**13 files updated** across pages, shared components, and pages-shared:
- Annotation queue buttons (`OpenSMELinkButton`, `AnnotateQueueCell`)
- Explainer components (`ExplainerIcon`, `ExplainerCallout`, `ExplainerDescription`)
- Dataset dialog (`AddEditDatasetDialog`)
- GitHub callout (`GitHubCallout`)
- Automation logs (`RuleLogsCell`)
- Experiment dialog (`AddExperimentDialog`)
- Onboarding components (`FrameworkIntegrations`, `GoogleColabCardCore`, `DocsLinkCard`)
- Prompt version dialog (`AddNewPromptVersionDialog`)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-3101

## Testing
- Visual verification that all "open in new tab" buttons now show the `ExternalLink` icon consistently
- Lint, typecheck, and dependency validation all pass

## Documentation
N/A