### PR TITLE
[OPIK-4449] [BE] Fix missing description in single-item GET endpoint

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
@@ -185,7 +185,7 @@ class DatasetItemResultMapper {
     private static final TypeReference<List<EvaluatorItem>> EVALUATOR_LIST_TYPE = new TypeReference<>() {
     };
 
-    private static List<EvaluatorItem> getEvaluators(Row row, RowMetadata rowMetadata) {
+    static List<EvaluatorItem> getEvaluators(Row row, RowMetadata rowMetadata) {
         if (!rowMetadata.contains("evaluators")) {
             return null;
         }
@@ -204,7 +204,7 @@ class DatasetItemResultMapper {
                 .orElse(null);
     }
 
-    private static ExecutionPolicy getExecutionPolicy(Row row, RowMetadata rowMetadata) {
+    static ExecutionPolicy getExecutionPolicy(Row row, RowMetadata rowMetadata) {
         if (!rowMetadata.contains("execution_policy")) {
             return null;
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -2973,11 +2973,12 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
 
             return makeFluxContextAware(bindWorkspaceIdToFlux(statement))
                     .doFinally(signalType -> endSegment(segment))
-                    .flatMap(result -> result.map((row, rowMetadata) -> mapVersionedItemToDatasetItem(row)));
+                    .flatMap(result -> result
+                            .map((row, rowMetadata) -> mapVersionedItemToDatasetItem(row, rowMetadata)));
         });
     }
 
-    private DatasetItem mapVersionedItemToDatasetItem(io.r2dbc.spi.Row row) {
+    private DatasetItem mapVersionedItemToDatasetItem(io.r2dbc.spi.Row row, io.r2dbc.spi.RowMetadata rowMetadata) {
         // Map data field - stored as Map<String, String> in ClickHouse
         Map<String, com.fasterxml.jackson.databind.JsonNode> data = Optional.ofNullable(row.get("data", Map.class))
                 .filter(m -> !m.isEmpty())
@@ -2994,7 +2995,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                 .datasetItemId(UUID.fromString(row.get("dataset_item_id", String.class)))
                 .datasetId(UUID.fromString(row.get("dataset_id", String.class)))
                 .data(data.isEmpty() ? null : data)
-                .description(DatasetItemResultMapper.getDescription(row, row.getMetadata()))
+                .description(DatasetItemResultMapper.getDescription(row, rowMetadata))
                 .source(Optional.ofNullable(row.get("source", String.class))
                         .map(com.comet.opik.api.DatasetItemSource::fromString)
                         .orElse(null))
@@ -3010,6 +3011,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                         .map(java.util.Arrays::asList)
                         .map(Set::copyOf)
                         .orElse(null))
+                .evaluators(DatasetItemResultMapper.getEvaluators(row, rowMetadata))
+                .executionPolicy(DatasetItemResultMapper.getExecutionPolicy(row, rowMetadata))
                 .createdAt(row.get("created_at", Instant.class))
                 .lastUpdatedAt(row.get("last_updated_at", Instant.class))
                 .createdBy(row.get("created_by", String.class))
@@ -3078,7 +3081,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                 statement.bind("workspace_id", workspaceId);
 
                 return Flux.from(statement.execute())
-                        .flatMap(result -> result.map((row, rowMetadata) -> mapVersionedItemToDatasetItem(row)))
+                        .flatMap(result -> result
+                                .map((row, rowMetadata) -> mapVersionedItemToDatasetItem(row, rowMetadata)))
                         .next()
                         .doOnSuccess(item -> {
                             if (item != null) {


### PR DESCRIPTION
## Details

`GET /v1/private/datasets/items/{id}` always returns `null` for the `description` field, even when the item has a description stored in ClickHouse. The list endpoint (`GET /datasets/{id}/items`) works correctly because it uses `DatasetItemResultMapper.mapItem()` which reads the column.

The root cause is that `mapVersionedItemToDatasetItem()` (used by the single-item and batch-by-ID queries) was never updated to read the `description` column from the result row.

### Changes
- **`DatasetItemVersionDAO`**: Add `.description()` to `mapVersionedItemToDatasetItem()` builder
- **`DatasetItemResultMapper`**: Widen `getDescription()` from `private` to package-private for reuse

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-4449

## Testing

- `GET /v1/private/datasets/items/{id}` returns `description` field when set
- List endpoint still returns `description` correctly (no regression)
- Items without a description still return `null`/omitted

## Documentation

N/A