### PR TITLE
[NA] [FE] Fix color update failing when workspace has no configuration

### DIFF
--- a/apps/opik-frontend/src/api/workspaces/useWorkspaceConfig.ts
+++ b/apps/opik-frontend/src/api/workspaces/useWorkspaceConfig.ts
@@ -6,17 +6,28 @@ import api, {
 } from "@/api/api";
 import { WorkspaceConfig } from "@/types/workspaces";
 
+const DEFAULT_CONFIG: WorkspaceConfig = {
+  timeout_to_mark_thread_as_inactive: null,
+  truncation_on_tables: null,
+  color_map: null,
+};
+
 type UseWorkspaceConfigResponse = WorkspaceConfig;
 type UseWorkspaceConfigParams = {
   workspaceName: string;
 };
 
-const getWorkspaceConfig = async ({ signal }: QueryFunctionContext) => {
-  const { data } = await api.get(WORKSPACE_CONFIG_REST_ENDPOINT, {
+const getWorkspaceConfig = async ({
+  signal,
+}: QueryFunctionContext): Promise<WorkspaceConfig> => {
+  // 404 means the workspace has no configuration yet, which is valid —
+  // accept it so react-query treats it as success rather than error
+  const { data, status } = await api.get(WORKSPACE_CONFIG_REST_ENDPOINT, {
     signal,
+    validateStatus: (s) => (s >= 200 && s < 300) || s === 404,
   });
 
-  return data;
+  return status === 404 ? DEFAULT_CONFIG : data;
 };
 
 export default function useWorkspaceConfig(

--- a/apps/opik-frontend/src/hooks/useUpdateColorMapping.ts
+++ b/apps/opik-frontend/src/hooks/useUpdateColorMapping.ts
@@ -23,7 +23,7 @@ const useUpdateColorMapping = () => {
           variant: "destructive",
         });
 
-      const currentMap = { ...(config.color_map ?? {}) };
+      const currentMap = { ...(config?.color_map ?? {}) };
       const isDefault =
         hexColor.toLowerCase() ===
         resolveHexColor(resolveColor(colorKey)).toLowerCase();
@@ -51,8 +51,8 @@ const useUpdateColorMapping = () => {
       updateWorkspaceConfig({
         config: {
           timeout_to_mark_thread_as_inactive:
-            config.timeout_to_mark_thread_as_inactive,
-          truncation_on_tables: config.truncation_on_tables,
+            config?.timeout_to_mark_thread_as_inactive ?? null,
+          truncation_on_tables: config?.truncation_on_tables ?? null,
           color_map: Object.keys(currentMap).length > 0 ? currentMap : null,
         },
       });


### PR DESCRIPTION
## Details

When a workspace has no configuration yet (new workspace or config was never set), the backend returns a `404` for the `GET /v1/private/workspaces/configurations/` endpoint. Previously, axios treated this 404 as an error, which caused react-query to mark the query as failed (`isSuccess: false`, `data: undefined`).

This meant the `ServerSyncProvider` would expose `config: null`, and `useUpdateColorMapping` couldn't distinguish between:
- **Config is still loading** (query in progress) — user should wait
- **Config fetch failed** (network error, server down) — user should retry
- **No config exists yet** (404) — this is a valid state, user should be able to proceed

As a result, users in workspaces without a configuration would see a "Workspace configuration is not loaded yet. Please try again" error toast every time they tried to update a color, with no way to resolve it.

### Fix

- **`useWorkspaceConfig.ts`**: Accept 404 as a valid response using axios `validateStatus`, and return a `DEFAULT_CONFIG` (all null fields) instead of letting it throw. This way react-query treats 404 as a successful query, and consumers always get a valid `WorkspaceConfig` object after the fetch completes.
- **`useUpdateColorMapping.ts`**: Use optional chaining with null fallbacks for config fields, so it works correctly whether the config came from the server or from the default.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- NA

## Testing
- Delete workspace config from ClickHouse, verify color picker works without error toast
- Verify existing workspaces with config continue to work normally
- Verify the "not loaded yet" toast still shows during initial loading

## Documentation
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)