### PR TITLE
[OPIK-4560] [BE] Fix @ApiResponse annotations for feedback score names endpoints

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -543,7 +543,7 @@ public class ExperimentsResource {
     @GET
     @Path("/feedback-scores/names")
     @Operation(operationId = "findFeedbackScoreNames", summary = "Find Feedback Score names", description = "Find Feedback Score names", responses = {
-            @ApiResponse(responseCode = "200", description = "Feedback Scores resource", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class))))
+            @ApiResponse(responseCode = "200", description = "Feedback Scores resource", content = @Content(schema = @Schema(implementation = FeedbackScoreNames.class)))
     })
     @JsonView({FeedbackDefinition.View.Public.class})
     public Response findFeedbackScoreNames(@QueryParam("experiment_ids") String experimentIdsQueryParam) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
@@ -388,7 +388,7 @@ public class SpansResource {
     @GET
     @Path("/feedback-scores/names")
     @Operation(operationId = "findFeedbackScoreNames", summary = "Find Feedback Score names", description = "Find Feedback Score names", responses = {
-            @ApiResponse(responseCode = "200", description = "Feedback Scores resource", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class))))
+            @ApiResponse(responseCode = "200", description = "Feedback Scores resource", content = @Content(schema = @Schema(implementation = FeedbackScoreNames.class)))
     })
     @JsonView({FeedbackDefinition.View.Public.class})
     public Response findFeedbackScoreNames(@QueryParam("project_id") UUID projectId,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -487,7 +487,7 @@ public class TracesResource {
     @GET
     @Path("/feedback-scores/names")
     @Operation(operationId = "findFeedbackScoreNames", summary = "Find Feedback Score names", description = "Find Feedback Score names", responses = {
-            @ApiResponse(responseCode = "200", description = "Feedback Scores resource", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class))))
+            @ApiResponse(responseCode = "200", description = "Feedback Scores resource", content = @Content(schema = @Schema(implementation = FeedbackScoreNames.class)))
     })
     @JsonView({FeedbackDefinition.View.Public.class})
     public Response findFeedbackScoreNames(@QueryParam("project_id") UUID projectId) {
@@ -940,7 +940,7 @@ public class TracesResource {
     @GET
     @Path("/threads/feedback-scores/names")
     @Operation(operationId = "findTraceThreadsFeedbackScoreNames", summary = "Find Trace Threads Feedback Score names", description = "Find Trace Threads Feedback Score names", responses = {
-            @ApiResponse(responseCode = "200", description = "Find Trace Threads Feedback Score names", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class))))
+            @ApiResponse(responseCode = "200", description = "Find Trace Threads Feedback Score names", content = @Content(schema = @Schema(implementation = FeedbackScoreNames.class)))
     })
     @JsonView({FeedbackDefinition.View.Public.class})
     public Response findTraceThreadsFeedbackScoreNames(@QueryParam("project_id") UUID projectId) {


### PR DESCRIPTION
## Details

<img width="1920" height="4372" alt="image" src="https://github.com/user-attachments/assets/4fac5211-aa62-46bd-82b2-4ddd77329655" />

Fixed 4 incorrect Swagger `@ApiResponse` annotations that declared the response type as `array of String` when the backend actually returns a `FeedbackScoreNames` object (`{"scores": [{"name": "...", "type": "..."}]}`).

This mismatch caused the auto-generated Python/TypeScript SDKs to fail with a Pydantic `ValidationError` when calling these endpoints, because the SDK tried to parse the response as `List[str]` instead of the actual `FeedbackScoreNames` structure.

**Affected endpoints (4):**
- `GET /v1/private/traces/feedback-scores/names` — `TracesResource.java`
- `GET /v1/private/traces/threads/feedback-scores/names` — `TracesResource.java`
- `GET /v1/private/spans/feedback-scores/names` — `SpansResource.java`
- `GET /v1/private/experiments/feedback-scores/names` — `ExperimentsResource.java`

**Fix:** Changed `@Content(array = @ArraySchema(schema = @Schema(implementation = String.class)))` to `@Content(schema = @Schema(implementation = FeedbackScoreNames.class))` — aligning with the correct pattern already used by `ProjectsResource.java`.

**No frontend changes needed** — the FE makes direct HTTP calls with its own type definitions and already correctly handles the `{"scores": [...]}` response format.

Once merged, the CI pipeline will auto-regenerate the OpenAPI spec and SDK code with the correct types.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- OPIK-4560

## Testing

- Annotation-only change — no runtime behavior change, only Swagger metadata correction
- Maven compile passes successfully
- Spotless check passes
- The correct pattern (`FeedbackScoreNames.class`) is already proven by `ProjectsResource.findFeedbackScoreNames`

## Documentation

N/A — SDK documentation will be auto-updated when the CI regenerates the OpenAPI spec and SDK code.