### PR TITLE
[OPIK-4586] [FE] Fix dashboard selection shared across browser windows

### DIFF
--- a/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentsDashboardsTab/ExperimentsDashboardsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareExperimentsPage/ExperimentsDashboardsTab/ExperimentsDashboardsTab.tsx
@@ -26,6 +26,7 @@ import { EXPERIMENT_DATA_SOURCE } from "@/types/dashboard";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
 import CompareExperimentsButton from "@/components/pages/CompareExperimentsPage/CompareExperimentsButton/CompareExperimentsButton";
 import { Separator } from "@/components/ui/separator";
+import { useActiveWorkspaceName } from "@/store/AppStore";
 
 const DASHBOARD_QUERY_PARAM_KEY = "dashboardId";
 const DASHBOARD_LOCAL_STORAGE_KEY_PREFIX = "opik-experiments-dashboard";
@@ -37,12 +38,15 @@ interface ExperimentsDashboardsTabProps {
 const ExperimentsDashboardsTab: React.FunctionComponent<
   ExperimentsDashboardsTabProps
 > = ({ experimentsIds }) => {
+  const workspaceName = useActiveWorkspaceName();
+
   const [dashboardId, setDashboardId] = useQueryParamAndLocalStorageState({
-    localStorageKey: DASHBOARD_LOCAL_STORAGE_KEY_PREFIX,
+    localStorageKey: `${DASHBOARD_LOCAL_STORAGE_KEY_PREFIX}-${workspaceName}`,
     queryKey: DASHBOARD_QUERY_PARAM_KEY,
     defaultValue: null as string | null,
     queryParamConfig: StringParam,
     syncQueryWithLocalStorageOnInit: true,
+    syncLocalStorageAcrossTabs: false,
   });
 
   useEffect(() => {

--- a/apps/opik-frontend/src/components/pages/TracesPage/DashboardsTab/DashboardsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/TracesPage/DashboardsTab/DashboardsTab.tsx
@@ -24,6 +24,7 @@ import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer
 import { PROJECT_TEMPLATE_LIST } from "@/lib/dashboard/templates";
 import { Separator } from "@/components/ui/separator";
 import TooltipWrapper from "@/components/shared/TooltipWrapper/TooltipWrapper";
+import { useActiveWorkspaceName } from "@/store/AppStore";
 
 const DASHBOARD_QUERY_PARAM_KEY = "dashboardId";
 const DASHBOARD_LOCAL_STORAGE_KEY_PREFIX = "opik-project-dashboard";
@@ -35,12 +36,15 @@ interface DashboardsTabProps {
 const DashboardsTab: React.FunctionComponent<DashboardsTabProps> = ({
   projectId,
 }) => {
+  const workspaceName = useActiveWorkspaceName();
+
   const [dashboardId, setDashboardId] = useQueryParamAndLocalStorageState({
-    localStorageKey: DASHBOARD_LOCAL_STORAGE_KEY_PREFIX,
+    localStorageKey: `${DASHBOARD_LOCAL_STORAGE_KEY_PREFIX}-${workspaceName}`,
     queryKey: DASHBOARD_QUERY_PARAM_KEY,
     defaultValue: null as string | null,
     queryParamConfig: StringParam,
     syncQueryWithLocalStorageOnInit: true,
+    syncLocalStorageAcrossTabs: false,
   });
 
   useEffect(() => {

--- a/apps/opik-frontend/src/hooks/useQueryParamAndLocalStorageState.ts
+++ b/apps/opik-frontend/src/hooks/useQueryParamAndLocalStorageState.ts
@@ -21,6 +21,7 @@ type UseQueryParamAndLocalStorageStateParams<T> = {
   queryParamConfig: QueryParamConfig<T>;
   queryOptions?: QueryParamOptions;
   syncQueryWithLocalStorageOnInit?: boolean;
+  syncLocalStorageAcrossTabs?: boolean;
 };
 
 const useQueryParamAndLocalStorageState = <T>({
@@ -30,11 +31,13 @@ const useQueryParamAndLocalStorageState = <T>({
   queryParamConfig,
   queryOptions = QUERY_OPTIONS,
   syncQueryWithLocalStorageOnInit = false,
+  syncLocalStorageAcrossTabs = true,
 }: UseQueryParamAndLocalStorageStateParams<T>) => {
   const [localStorageValue, setLocalStorageValue] = useLocalStorageState<T>(
     localStorageKey,
     {
       defaultValue,
+      storageSync: syncLocalStorageAcrossTabs,
     },
   );
 


### PR DESCRIPTION
## Details
Dashboard selection was stored in localStorage with a global key, causing it to sync across all browser windows/tabs. Selecting a dashboard in one window would automatically change the dashboard in other windows, even across different projects or workspaces.

This fix:
- Scopes the localStorage key by workspace name so different workspaces maintain independent dashboard selections
- Disables cross-tab localStorage sync (`syncLocalStorageAcrossTabs: false`) so windows operate independently
- Adds `syncLocalStorageAcrossTabs` option to the shared `useQueryParamAndLocalStorageState` hook (defaults to `true` for backward compatibility)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-4586

## Testing
1. Open two browser windows viewing different projects (or same project in different workspaces)
2. Select a dashboard in Window A
3. Verify Window B's dashboard selection does not change
4. Refresh each window — verify last selected dashboard is remembered per workspace

## Documentation
N/A