### PR TITLE
[NA] add multi-tenant isolation check to code-reviewer

### DIFF
--- a/.agents/agents/code-reviewer.md
+++ b/.agents/agents/code-reviewer.md
@@ -43,7 +43,8 @@ You are a senior code reviewer with deep expertise in the Opik codebase. Your ro
 2. **Assess code quality** - Check for clarity, maintainability, and adherence to patterns
 3. **Identify security issues** - Flag vulnerabilities, hardcoded secrets, injection risks
 4. **Verify correctness** - Look for logic errors, edge cases, null safety
-5. **Provide actionable feedback** - Give specific, prioritized recommendations
+5. **Check multi-tenant isolation** - Verify user data cannot leak across tenant boundaries
+6. **Provide actionable feedback** - Give specific, prioritized recommendations
 
 ## Review Process
 
@@ -59,6 +60,7 @@ git status               # Modified files
 **Critical (must fix before merge)**
 - Security: hardcoded secrets, SQL injection, XSS, auth bypasses
 - Data integrity: race conditions, missing transactions, data loss risks
+- Tenant isolation: identifiers that could collide across users/tenants
 - Breaking changes: API contract violations, removed public methods
 
 **High (should fix)**
@@ -82,6 +84,7 @@ git status               # Modified files
 - ClickHouse queries use LIMIT 1 BY for deduplication
 - Proper error mapping to API responses
 - No StringTemplate memory leaks
+- **Multi-tenant isolation**: For changes involving data storage, retrieval, auth, or request context, check if identifiers (cache keys, session IDs, file paths, lookup keys) could collide across users. Verify: (1) Can two users generate the same identifier? (2) If data is stored in multiple places, do ALL use consistent isolation? (3) Is retrieved data validated before use? (4) Are there tests with multiple users accessing same-named resources?
 
 **Frontend (React/TypeScript)**
 - TanStack Query for data fetching (not useEffect)


### PR DESCRIPTION
## Details
Triggered by production escalation related to users' data (threads, traces, spans, datasets, experiments) landed in workspaces the users don't have access to.
Validated the ai code-review updated by following algorithm:
1. Switch on Opik version preceeding the bug merge
2. Ask Cursor to review the changes of PR https://github.com/comet-ml/opik/pull/5207 to see if it is able to identify the issue - No multi-tenant isolation issue detected.
3. Apply ai code-review updates
4. With clean context re-validate PR applying updated review rules - Issue identified 

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
<!--
REPLACE ME WITH:

How you tested

Include:
- Exact commands run (for example: `mvn test`, `npm run lint && npm run test`, `pytest ...`)
- Scenarios validated (happy path, edge cases, regressions)
- Environment/context used (local process mode vs Docker, OS/browser when relevant)
- Any tests not run, with reason
- Relevant logs/artifacts links if available

Video evidence:
- External contributors: include a short recording for all contributions where possible.
- Internal contributors: include a short recording for complex changes where possible.
-->

## Documentation
