### PR TITLE
[OPIK-4573] [FE] fix: remove PageBodyScrollContainer and fill vertical space

### DIFF
--- a/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsMainContent.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsMainContent.tsx
@@ -53,7 +53,7 @@ const CompareOptimizationsMainContent: React.FC<
     isStudioOptimization && view === OPTIMIZATION_VIEW_TYPE.CONFIGURATION;
 
   return (
-    <div className="flex max-h-[500px] min-w-0 flex-1 overflow-auto">
+    <div className="flex min-w-0 flex-1 overflow-auto">
       {showLogsView && <OptimizationLogs optimization={optimization!} />}
       {showTrialsView && (
         <CompareOptimizationsTrialsTable

--- a/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsPage.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsPage.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
-import PageBodyScrollContainer from "@/components/layout/PageBodyScrollContainer/PageBodyScrollContainer";
-import PageBodyStickyContainer from "@/components/layout/PageBodyStickyContainer/PageBodyStickyContainer";
+
 import Loader from "@/components/shared/Loader/Loader";
 import OptimizationProgressChartContainer from "@/components/pages-shared/experiments/OptimizationProgressChart";
 import { OPTIMIZATION_VIEW_TYPE } from "@/components/pages/CompareOptimizationsPage/OptimizationViewSelector";
@@ -85,12 +84,8 @@ const CompareOptimizationsPage: React.FC = () => {
     !isStudioOptimization || view === OPTIMIZATION_VIEW_TYPE.TRIALS;
 
   return (
-    <PageBodyScrollContainer>
-      <PageBodyStickyContainer
-        className="pb-4 pt-6"
-        direction="horizontal"
-        limitWidth
-      >
+    <div className="flex h-full flex-col pt-6">
+      <div className="shrink-0 pb-4">
         <CompareOptimizationsHeader
           title={title}
           status={optimization?.status}
@@ -99,26 +94,18 @@ const CompareOptimizationsPage: React.FC = () => {
           canRerun={canRerun}
           bestExperiment={bestExperiment}
         />
-      </PageBodyStickyContainer>
+      </div>
 
-      <PageBodyStickyContainer
-        className="pb-6"
-        direction="horizontal"
-        limitWidth
-      >
+      <div className="shrink-0 pb-6">
         <OptimizationProgressChartContainer
           experiments={experiments}
           bestEntityId={bestExperiment?.id}
           objectiveName={optimization?.objective_name}
           status={optimization?.status}
         />
-      </PageBodyStickyContainer>
+      </div>
 
-      <PageBodyStickyContainer
-        className="-mt-4 flex flex-wrap items-center justify-between gap-x-8 gap-y-2 pb-6 pt-4"
-        direction="bidirectional"
-        limitWidth
-      >
+      <div className="-mt-4 flex shrink-0 flex-wrap items-center justify-between gap-x-8 gap-y-2 pb-6 pt-4">
         <div className="flex items-center gap-2">
           <CompareOptimizationsToolbar
             isStudioOptimization={isStudioOptimization}
@@ -140,13 +127,9 @@ const CompareOptimizationsPage: React.FC = () => {
             onColumnsOrderChange={setColumnsOrder}
           />
         )}
-      </PageBodyStickyContainer>
+      </div>
 
-      <PageBodyStickyContainer
-        className="flex flex-row gap-x-4 pb-6"
-        direction="horizontal"
-        limitWidth
-      >
+      <div className="flex min-h-[500px] flex-1 flex-row gap-x-4 pb-6">
         <CompareOptimizationsMainContent
           view={view}
           isStudioOptimization={isStudioOptimization}
@@ -173,14 +156,8 @@ const CompareOptimizationsPage: React.FC = () => {
           scoreMap={scoreMap}
           status={optimization?.status}
         />
-      </PageBodyStickyContainer>
-
-      <PageBodyStickyContainer
-        className="h-4"
-        direction="horizontal"
-        limitWidth
-      />
-    </PageBodyScrollContainer>
+      </div>
+    </div>
   );
 };
 

--- a/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsSidebar.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsSidebar.tsx
@@ -27,7 +27,7 @@ const CompareOptimizationsSidebar: React.FC<
   status,
 }) => {
   return (
-    <div className="max-h-[500px] w-2/5 shrink-0 overflow-auto">
+    <div className="w-2/5 shrink-0 overflow-auto">
       {bestExperiment && optimization ? (
         <BestPrompt
           experiment={bestExperiment}


### PR DESCRIPTION
## Details

https://github.com/user-attachments/assets/1f2cb607-2644-4e98-8d09-ea1d3d33c9a9

<img width="1592" height="927" alt="image" src="https://github.com/user-attachments/assets/c99230b1-cc57-4ad4-aa34-95c43e7197a9" />
<img width="1591" height="928" alt="image" src="https://github.com/user-attachments/assets/43cbe6a4-2bf0-49a8-9af5-a0ed5e45e4e5" />
<img width="1590" height="929" alt="image" src="https://github.com/user-attachments/assets/1dd76ec8-3cfc-4ae7-9ac6-f6f54e385fb2" />


Removes the dead `PageBodyScrollContainer` / `PageBodyStickyContainer` wrappers from the Compare Optimizations page and replaces them with a simple flex layout that fills the available vertical space.

### Behavior change

**Before:** The trials table and Best Prompt sidebar were capped at `max-h-[500px]`, wasting vertical space on larger screens. The page used `PageBodyScrollContainer` (originally introduced for virtualized table rows), which was left behind after virtualization was removed as buggy.

**After:** The content area (trials table + Best Prompt sidebar) now fills all remaining vertical space below the header, chart, and toolbar — with a `min-h-[500px]` floor so the area never becomes unusably small. Both the table and sidebar scroll internally when their content overflows, rather than capping at a fixed 500px height.

### What changed

- **CompareOptimizationsPage.tsx** — Replaced `PageBodyScrollContainer` / `PageBodyStickyContainer` with a `h-full flex-col` layout. Header, chart, and toolbar use `shrink-0`; the content row uses `flex-1 min-h-[500px]` to fill remaining space. Removed stray `123` debug artifact.
- **CompareOptimizationsMainContent.tsx** — Removed `max-h-[500px]` (parent now controls height via flex).
- **CompareOptimizationsSidebar.tsx** — Removed `max-h-[500px]` (same rationale).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-4573

## Testing
- Content area fills available vertical space on normal/large screens (no 500px cap)
- Trials table scrolls internally when many rows
- Sidebar (Best Prompt) scrolls internally when content is long
- All 3 views work: Trials, Logs, Configuration
- Chart stays at fixed height
- Lint, typecheck, and dependency validation pass

## Documentation
N/A — internal layout change, no new configuration or user-facing API changes.