### PR TITLE
[OPIK-4574] [FE] feat: make configuration/initial-prompt separator resizable

### DIFF
--- a/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsConfiguration.tsx
+++ b/apps/opik-frontend/src/components/pages/CompareOptimizationsPage/CompareOptimizationsConfiguration.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Link } from "@tanstack/react-router";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
 import { OptimizationStudioConfig } from "@/types/optimizations";
 import { Experiment } from "@/types/datasets";
 import { MessagesList } from "@/components/pages-shared/prompts/PromptMessageDisplay";
@@ -9,6 +8,7 @@ import { OPTIMIZATION_METRIC_OPTIONS } from "@/constants/optimizations";
 import { getOptimizerLabel } from "@/lib/optimizations";
 import { extractDisplayMessages } from "@/lib/llm";
 import useAppStore from "@/store/AppStore";
+import ResizableSection from "@/components/shared/ResizableSection/ResizableSection";
 
 interface CompareOptimizationsConfigurationProps {
   studioConfig: OptimizationStudioConfig;
@@ -48,82 +48,90 @@ const CompareOptimizationsConfiguration: React.FC<
   const messages = extractDisplayMessages(prompt?.messages);
 
   return (
-    <Card className="flex size-full flex-col">
-      <CardHeader className="shrink-0 pb-2">
-        <CardTitle className="text-sm">Configuration</CardTitle>
-      </CardHeader>
-      <CardContent className="flex shrink-0 flex-col gap-1">
-        <ConfigItem
-          label="Dataset"
-          value={
-            <Link
-              to="/$workspaceName/datasets/$datasetId"
-              params={{ workspaceName, datasetId }}
-              className="text-primary hover:underline"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {dataset_name}
-            </Link>
-          }
-        />
-        <ConfigItem label="Model" value={llm_model?.model || "-"} />
-        <ConfigItem
-          label="Algorithm"
-          value={optimizer?.type ? getOptimizerLabel(optimizer.type) : "-"}
-        />
-        <ConfigItem
-          label="Metric"
-          value={metric?.type ? getMetricLabel(metric.type) : "-"}
-        />
-        {metric?.parameters && Object.keys(metric.parameters).length > 0 && (
-          <div className="ml-4 flex flex-col gap-1">
-            {Object.entries(metric.parameters).map(([key, value]) => (
+    <Card className="flex size-full flex-col overflow-hidden">
+      <ResizableSection
+        storageKey={`optimization-configuration-height-${optimizationId}`}
+        className="border-b"
+      >
+        <div className="flex h-full flex-col overflow-auto">
+          <CardHeader className="shrink-0 pb-2">
+            <CardTitle className="text-sm">Configuration</CardTitle>
+          </CardHeader>
+          <CardContent className="flex shrink-0 flex-col gap-1">
+            <ConfigItem
+              label="Dataset"
+              value={
+                <Link
+                  to="/$workspaceName/datasets/$datasetId"
+                  params={{ workspaceName, datasetId }}
+                  className="text-primary hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {dataset_name}
+                </Link>
+              }
+            />
+            <ConfigItem label="Model" value={llm_model?.model || "-"} />
+            <ConfigItem
+              label="Algorithm"
+              value={optimizer?.type ? getOptimizerLabel(optimizer.type) : "-"}
+            />
+            <ConfigItem
+              label="Metric"
+              value={metric?.type ? getMetricLabel(metric.type) : "-"}
+            />
+            {metric?.parameters &&
+              Object.keys(metric.parameters).length > 0 && (
+                <div className="ml-4 flex flex-col gap-1">
+                  {Object.entries(metric.parameters).map(([key, value]) => (
+                    <ConfigItem
+                      key={key}
+                      label={formatParamName(key)}
+                      value={String(value)}
+                    />
+                  ))}
+                </div>
+              )}
+            {bestExperiment && (
               <ConfigItem
-                key={key}
-                label={formatParamName(key)}
-                value={String(value)}
+                label="Best trial configuration"
+                value={
+                  <Link
+                    to="/$workspaceName/optimizations/$datasetId/$optimizationId/compare"
+                    params={{
+                      workspaceName,
+                      datasetId,
+                      optimizationId,
+                    }}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    search={{ trials: [bestExperiment.id], tab: "config" }}
+                    className="text-primary hover:underline"
+                  >
+                    {bestExperiment.name}
+                  </Link>
+                }
               />
-            ))}
-          </div>
-        )}
-        {bestExperiment && (
-          <ConfigItem
-            label="Best trial configuration"
-            value={
-              <Link
-                to="/$workspaceName/optimizations/$datasetId/$optimizationId/compare"
-                params={{
-                  workspaceName,
-                  datasetId,
-                  optimizationId,
-                }}
-                target="_blank"
-                rel="noopener noreferrer"
-                search={{ trials: [bestExperiment.id], tab: "config" }}
-                className="text-primary hover:underline"
-              >
-                {bestExperiment.name}
-              </Link>
-            }
-          />
-        )}
-      </CardContent>
+            )}
+          </CardContent>
+        </div>
+      </ResizableSection>
 
-      <Separator className="my-2 shrink-0" />
-
-      <CardHeader className="shrink-0 px-6 py-1.5">
-        <CardTitle className="text-sm">Initial prompt</CardTitle>
-      </CardHeader>
-      <CardContent className="min-h-0 flex-1 overflow-auto">
-        {messages && messages.length > 0 ? (
-          <MessagesList messages={messages} />
-        ) : (
-          <span className="comet-body-s text-muted-slate">
-            No prompt messages
-          </span>
-        )}
-      </CardContent>
+      <div className="flex min-h-0 flex-1 flex-col overflow-auto">
+        <CardHeader className="shrink-0 px-6 py-1.5">
+          <CardTitle className="text-sm">Initial prompt</CardTitle>
+        </CardHeader>
+        <CardContent className="min-h-0 flex-1">
+          {messages && messages.length > 0 ? (
+            <MessagesList messages={messages} />
+          ) : (
+            <span className="comet-body-s text-muted-slate">
+              No prompt messages
+            </span>
+          )}
+        </CardContent>
+      </div>
     </Card>
   );
 };

--- a/apps/opik-frontend/src/components/shared/ResizableSection/ResizableSection.tsx
+++ b/apps/opik-frontend/src/components/shared/ResizableSection/ResizableSection.tsx
@@ -1,0 +1,64 @@
+import React, { useCallback } from "react";
+import { Resizable, ResizeCallback } from "re-resizable";
+import useLocalStorageState from "use-local-storage-state";
+
+interface ResizableSectionProps {
+  storageKey: string;
+  children: React.ReactNode;
+  className?: string;
+  minHeight?: number;
+  minPercentage?: number;
+  maxPercentage?: number;
+}
+
+const ResizableSection: React.FC<ResizableSectionProps> = ({
+  storageKey,
+  children,
+  className,
+  minHeight = 60,
+  minPercentage = 10,
+  maxPercentage = 90,
+}) => {
+  const [savedHeight, setSavedHeight] = useLocalStorageState<number | null>(
+    storageKey,
+    { defaultValue: null },
+  );
+
+  const onResizeStop: ResizeCallback = useCallback(
+    (_e, _direction, ref) => {
+      const parent = ref.parentElement;
+      if (!parent) return;
+
+      const parentHeight = parent.clientHeight;
+      if (parentHeight === 0) return;
+
+      const percentage = Math.min(
+        Math.max((ref.clientHeight / parentHeight) * 100, minPercentage),
+        maxPercentage,
+      );
+      setSavedHeight(percentage);
+    },
+    [setSavedHeight, minPercentage, maxPercentage],
+  );
+
+  const sizeProps =
+    savedHeight !== null
+      ? { size: { height: `${savedHeight}%` } }
+      : { defaultSize: { height: "auto" } };
+
+  return (
+    <Resizable
+      {...sizeProps}
+      className={className}
+      enable={{ bottom: true }}
+      minHeight={minHeight}
+      maxHeight={`${maxPercentage}%`}
+      bounds="parent"
+      onResizeStop={onResizeStop}
+    >
+      {children}
+    </Resizable>
+  );
+};
+
+export default ResizableSection;


### PR DESCRIPTION
## Details
Makes the separator between "Configuration" and "Initial Prompt" sections resizable in the Optimization Studio single run Configuration tab.

https://github.com/user-attachments/assets/d1bd584b-1b84-41e4-9c4d-7ad98bbdf34c

- Replaces the static `Separator` with a draggable resize handle using `re-resizable`
- Default behavior preserved: Configuration section auto-sizes to its content, Initial Prompt fills the remaining space
- User can drag to resize; the height is saved as a percentage to localStorage, keyed per optimization ID
- Extracted resize logic into a reusable `ResizableSection` shared component with configurable `minHeight`, `minPercentage` (default 10%), and `maxPercentage` (default 90%) boundaries

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-4574

## Testing
- Navigate to an optimization's single run Configuration tab
- Verify the Configuration section auto-sizes to its content on first load
- Drag the bottom edge of the Configuration section to resize
- Refresh the page — the resized height should persist
- Navigate to a different optimization — it should have its own independent sizing
- Verify the resize is clamped between 10% and 90% of the card height

## Documentation
N/A