### PR TITLE
[Python SDK][Integrations] Add Exa integration

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -667,6 +667,9 @@ navigation:
           - section: Other
             skip-slug: true
             contents:
+              - page: Exa
+                path: docs/tracing/integrations/exa.mdx
+                slug: exa
               - page: Guardrails AI
                 path: docs/tracing/integrations/guardrails-ai.mdx
                 slug: guardrails-ai

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/exa.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/exa.mdx
@@ -1,0 +1,41 @@
+---
+title: Observability for Exa (Python) with Opik
+description: Trace Exa search operations with Opik using the Python SDK.
+headline: Exa | Opik Documentation
+---
+
+This guide explains how to integrate Opik with the Exa Python SDK.
+
+## Python
+
+Install:
+
+```bash
+pip install opik exa-py
+```
+
+Usage:
+
+```python
+from exa_py import Exa
+from opik.integrations.exa import track_exa
+
+exa = Exa()
+tracked_exa = track_exa(exa, project_name="exa-search")
+
+result = tracked_exa.search("latest ai eval benchmarks")
+```
+
+Supported wrapped methods (when present on the client):
+
+- `search`
+- `search_and_contents`
+- `find_similar`
+- `get_contents`
+- `answer`
+
+All wrapped operations are logged as `tool` spans with:
+
+- `opik.kind=search`
+- `opik.provider=exa`
+- `opik.operation=<method_name>`

--- a/sdks/python/src/opik/integrations/exa/__init__.py
+++ b/sdks/python/src/opik/integrations/exa/__init__.py
@@ -1,0 +1,3 @@
+from .opik_tracker import track_exa
+
+__all__ = ["track_exa"]

--- a/sdks/python/src/opik/integrations/exa/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/exa/opik_tracker.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any, Optional, TypeVar
+
+import opik
+
+ExaClient = TypeVar("ExaClient", bound=object)
+
+_EXA_SEARCH_METHODS = (
+    "search",
+    "search_and_contents",
+    "searchAndContents",
+    "find_similar",
+    "findSimilar",
+    "answer",
+    "get_contents",
+    "getContents",
+)
+
+
+def _build_metadata(operation: str) -> dict[str, Any]:
+    return {
+        "created_from": "exa",
+        "opik.kind": "search",
+        "opik.provider": "exa",
+        "opik.operation": operation,
+    }
+
+
+def _patch_method(
+    exa_client: ExaClient,
+    method_name: str,
+    project_name: Optional[str],
+) -> None:
+    method = getattr(exa_client, method_name, None)
+    if not callable(method):
+        return
+
+    decorator = opik.track(
+        type="tool",
+        name=f"exa.{method_name}",
+        metadata=_build_metadata(method_name),
+        project_name=project_name,
+    )
+    setattr(exa_client, method_name, decorator(method))
+
+
+def track_exa(
+    exa_client: ExaClient,
+    project_name: Optional[str] = None,
+) -> ExaClient:
+    """Adds Opik tracking wrappers to an Exa client.
+
+    Supported methods (patched when available):
+    * `search()`
+    * `search_and_contents()`
+    * `find_similar()`
+    * `answer()`
+
+    Each patched call emits a `tool` span with metadata:
+    * `opik.kind=search`
+    * `opik.provider=exa`
+    * `opik.operation=<method_name>`
+    """
+    if hasattr(exa_client, "opik_tracked"):
+        return exa_client
+
+    setattr(exa_client, "opik_tracked", True)
+
+    for method_name in _EXA_SEARCH_METHODS:
+        _patch_method(exa_client, method_name, project_name)
+
+    return exa_client

--- a/sdks/python/tests/unit/test_exa_integration.py
+++ b/sdks/python/tests/unit/test_exa_integration.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import opik
+
+from opik.integrations.exa import track_exa
+
+
+class _DummyExaClient:
+    def search(self, query: str) -> dict[str, Any]:
+        return {"results": [{"title": query}]}
+
+    def search_and_contents(self, query: str) -> dict[str, Any]:
+        return {"results": [{"text": query}]}
+
+    def find_similar(self, url: str) -> dict[str, Any]:
+        return {"results": [{"url": url}]}
+
+    def answer(self, question: str) -> dict[str, Any]:
+        return {"answer": question}
+
+    def not_tracked(self) -> str:
+        return "ok"
+
+
+def test_track_exa__patches_supported_methods_with_search_metadata(monkeypatch: Any) -> None:
+    tracked_calls: list[dict[str, Any]] = []
+
+    def fake_track(**track_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            def wrapped(*args: Any, **kwargs: Any) -> Any:
+                tracked_calls.append(track_kwargs)
+                return func(*args, **kwargs)
+
+            return wrapped
+
+        return decorator
+
+    monkeypatch.setattr(opik, "track", fake_track)
+
+    client = _DummyExaClient()
+    tracked_client = track_exa(client, project_name="exa-test-project")
+
+    assert tracked_client is client
+
+    assert tracked_client.search("latest ai")["results"][0]["title"] == "latest ai"
+    assert tracked_client.search_and_contents("agents")["results"][0]["text"] == "agents"
+    assert tracked_client.find_similar("https://exa.ai")["results"][0]["url"] == "https://exa.ai"
+    assert tracked_client.answer("what is exa?")["answer"] == "what is exa?"
+    assert tracked_client.not_tracked() == "ok"
+
+    assert len(tracked_calls) == 4
+    for call in tracked_calls:
+        assert call["type"] == "tool"
+        assert call["project_name"] == "exa-test-project"
+        assert call["metadata"]["opik.kind"] == "search"
+        assert call["metadata"]["opik.provider"] == "exa"
+        assert call["metadata"]["opik.operation"] in {
+            "search",
+            "search_and_contents",
+            "find_similar",
+            "answer",
+        }
+
+
+def test_track_exa__second_patch_is_noop(monkeypatch: Any) -> None:
+    decorated_method_ids: list[int] = []
+
+    def fake_track(**_track_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            def wrapped(*args: Any, **kwargs: Any) -> Any:
+                return func(*args, **kwargs)
+
+            return wrapped
+
+        return decorator
+
+    monkeypatch.setattr(opik, "track", fake_track)
+
+    client = _DummyExaClient()
+    track_exa(client)
+    decorated_method_ids.append(id(client.search))
+
+    track_exa(client)
+    decorated_method_ids.append(id(client.search))
+
+    assert decorated_method_ids[0] == decorated_method_ids[1]


### PR DESCRIPTION
## Details
Add Exa integration for the Opik Python SDK.

### Included
- `track_exa(...)` integration wrapper
- Search metadata contract on tool spans:
  - `opik.kind=search`
  - `opik.provider=exa`
  - `opik.operation=<method>`
- Offline unit tests for wrapper patching behavior
- Python Exa integration docs page and nav entry

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing
- `PYTHONPATH=sdks/python/src pytest sdks/python/tests/unit/test_exa_integration.py`

## Documentation
- Added `docs/tracing/integrations/exa.mdx`
- Updated `docs.yml` navigation
