### PR TITLE
[NA] Fix MCP server configs: split commands, remove Atlassian

### DIFF
--- a/.agents/mcp.json
+++ b/.agents/mcp.json
@@ -32,25 +32,20 @@
         ],
         "envFile": "${workspaceFolder}/.env.local"
       },
-      "Atlassian": {
-        "command": "npx -y mcp-remote https://mcp.atlassian.com/v1/sse",
-        "env": {},
-        "args": []
-      },
       "Jira-Headless": {
         "command": "uvx",
         "args": ["mcp-atlassian"],
         "envFile": "${workspaceFolder}/.env.local"
       },
       "Notion": {
-        "command": "npx -y mcp-remote https://mcp.notion.com/mcp",
-        "env": {},
-        "args": []
+        "command": "npx",
+        "args": ["-y", "mcp-remote", "https://mcp.notion.com/mcp"],
+        "env": {}
       },
       "Playwright": {
-        "command": "npx @playwright/mcp@latest",
-        "env": {},
-        "args": []
+        "command": "npx",
+        "args": ["@playwright/mcp@latest"],
+        "env": {}
       },
       "chrome-devtools": {
         "command": "npx",


### PR DESCRIPTION
## Details
Split inline commands into proper `command` + `args` format so the executable is resolved correctly by Claude Code and other MCP clients. Remove Atlassian MCP server as it overlaps with Jira-Headless.

- Affected servers: Notion, Playwright

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## Testing
- Verified JSON syntax is valid. 
- Tested Notion MCP servers manually by connecting via Claude Code.

## Documentation
N/A