### PR TITLE
[SDK][Python] Add Chroma retrieval integration

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -655,6 +655,9 @@ navigation:
           - section: Other
             skip-slug: true
             contents:
+              - page: Chroma
+                path: docs/tracing/integrations/chroma.mdx
+                slug: chroma
               - page: Guardrails AI
                 path: docs/tracing/integrations/guardrails-ai.mdx
                 slug: guardrails-ai

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/chroma.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/chroma.mdx
@@ -1,0 +1,40 @@
+---
+title: Chroma
+description: Track Chroma retrieval operations in Opik.
+headline: Chroma | Opik Documentation
+---
+
+Opik can instrument Chroma collection retrieval calls and log them as tool spans.
+
+## Install
+
+```bash
+pip install opik chromadb
+```
+
+## Usage
+
+```python
+from chromadb import PersistentClient
+from opik.integrations.chroma import track_chroma
+
+client = PersistentClient(path="./chroma-db")
+collection = client.get_or_create_collection("docs")
+collection = track_chroma(collection, project_name="retrieval-demo")
+
+result = collection.query(
+    query_texts=["What is Opik?"],
+    n_results=3,
+)
+```
+
+## What gets logged
+
+- span `type`: `tool`
+- span name format: `chroma.<operation>`
+- metadata keys:
+- `opik.kind=retrieval`
+- `opik.provider=chroma`
+- `opik.operation=<operation>`
+
+Tracked operations include `query` and `get` when those methods are available.

--- a/sdks/python/src/opik/integrations/_retrieval_tracker.py
+++ b/sdks/python/src/opik/integrations/_retrieval_tracker.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+import opik
+
+Metadata = Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RetrievalTrackingConfig:
+    provider: str
+    operation_paths: Tuple[str, ...]
+    project_name: Optional[str] = None
+
+
+def _resolve_target_and_method(root: Any, path: str) -> Tuple[Optional[Any], Optional[str]]:
+    parts = path.split(".")
+    target = root
+    for part in parts[:-1]:
+        target = getattr(target, part, None)
+        if target is None:
+            return None, None
+    return target, parts[-1]
+
+
+def _build_metadata(provider: str, operation: str) -> Metadata:
+    return {
+        "created_from": provider,
+        "opik.kind": "retrieval",
+        "opik.provider": provider,
+        "opik.operation": operation,
+    }
+
+
+def _patch_operation(
+    target: Any,
+    method_name: str,
+    provider: str,
+    operation_name: str,
+    project_name: Optional[str],
+) -> bool:
+    method = getattr(target, method_name, None)
+    if method is None or not callable(method):
+        return False
+
+    if hasattr(method, "opik_tracked"):
+        return False
+
+    decorator = opik.track(
+        name=f"{provider}.{operation_name}",
+        type="tool",
+        tags=[provider, "retrieval"],
+        metadata=_build_metadata(provider, operation_name),
+        project_name=project_name,
+    )
+    setattr(target, method_name, decorator(method))
+    return True
+
+
+def patch_retrieval_client(target: Any, config: RetrievalTrackingConfig) -> Any:
+    if hasattr(target, "opik_tracked"):
+        return target
+
+    patched = False
+    for operation_path in config.operation_paths:
+        operation_target, method_name = _resolve_target_and_method(target, operation_path)
+        if operation_target is None or method_name is None:
+            continue
+
+        operation_name = operation_path.split(".")[-1]
+        patched = (
+            _patch_operation(
+                operation_target,
+                method_name,
+                provider=config.provider,
+                operation_name=operation_name,
+                project_name=config.project_name,
+            )
+            or patched
+        )
+
+    if patched:
+        target.opik_tracked = True
+
+    return target
+
+
+def as_tuple(paths: Iterable[str]) -> Tuple[str, ...]:
+    return tuple(paths)

--- a/sdks/python/src/opik/integrations/chroma/__init__.py
+++ b/sdks/python/src/opik/integrations/chroma/__init__.py
@@ -1,0 +1,3 @@
+from .opik_tracker import track_chroma
+
+__all__ = ["track_chroma"]

--- a/sdks/python/src/opik/integrations/chroma/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/chroma/opik_tracker.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from opik.integrations._retrieval_tracker import (
+    RetrievalTrackingConfig,
+    as_tuple,
+    patch_retrieval_client,
+)
+
+
+def track_chroma(chroma_client_or_collection: Any, project_name: Optional[str] = None) -> Any:
+    """Adds Opik tracking wrappers to a Chroma client or collection object."""
+    config = RetrievalTrackingConfig(
+        provider="chroma",
+        operation_paths=as_tuple(
+            [
+                "query",
+                "get",
+            ]
+        ),
+        project_name=project_name,
+    )
+    return patch_retrieval_client(chroma_client_or_collection, config)

--- a/sdks/python/tests/unit/integrations/test_chroma_tracker.py
+++ b/sdks/python/tests/unit/integrations/test_chroma_tracker.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from opik.integrations.chroma.opik_tracker import track_chroma
+
+
+@dataclass
+class _Calls:
+    values: List[Dict[str, Any]]
+
+
+class _TrackSpy:
+    def __init__(self) -> None:
+        self.calls = _Calls(values=[])
+
+    def __call__(self, **track_kwargs: Any):  # type: ignore[override]
+        self.calls.values.append(track_kwargs)
+
+        def decorator(func: Any) -> Any:
+            def wrapped(*args: Any, **kwargs: Any) -> Any:
+                return func(*args, **kwargs)
+
+            wrapped.opik_tracked = True
+            return wrapped
+
+        return decorator
+
+
+def _build_chroma_collection() -> Any:
+    class Collection:
+        def query(self) -> Dict[str, Any]:
+            return {"ok": True}
+
+        def get(self) -> Dict[str, Any]:
+            return {"ok": True}
+
+    return Collection()
+
+
+def test_track_chroma__patches_methods_with_retrieval_metadata(monkeypatch: Any) -> None:
+    import opik.integrations._retrieval_tracker as retrieval_tracker
+
+    track_spy = _TrackSpy()
+    monkeypatch.setattr(retrieval_tracker.opik, "track", track_spy)
+
+    collection = _build_chroma_collection()
+    tracked_collection = track_chroma(collection, project_name="proj")
+
+    assert tracked_collection is collection
+    assert tracked_collection.opik_tracked is True
+    assert len(track_spy.calls.values) == 2
+
+    operation_names = {call["name"] for call in track_spy.calls.values}
+    assert operation_names == {"chroma.query", "chroma.get"}
+
+    for call in track_spy.calls.values:
+        assert call["type"] == "tool"
+        assert call["metadata"]["opik.kind"] == "retrieval"
+        assert call["metadata"]["opik.provider"] == "chroma"
+        assert "opik.operation" in call["metadata"]
+
+
+def test_track_chroma__idempotent(monkeypatch: Any) -> None:
+    import opik.integrations._retrieval_tracker as retrieval_tracker
+
+    track_spy = _TrackSpy()
+    monkeypatch.setattr(retrieval_tracker.opik, "track", track_spy)
+
+    collection = _build_chroma_collection()
+    track_chroma(collection)
+    calls_after_first = len(track_spy.calls.values)
+    track_chroma(collection)
+
+    assert len(track_spy.calls.values) == calls_after_first


### PR DESCRIPTION
## Details
Adds first-pass Python retrieval integration wrapper for Chroma.

This PR includes:
- tracker function: `track_chroma`
- provider module export (`__init__.py`)
- shared retrieval tracking helper used by provider wrappers
- Chroma integration documentation page
- navigation update for the integration docs
- provider-specific unit tests for wrapper behavior and metadata contract

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-

## Testing
- `cd sdks/python && PYTHONPATH=src pytest tests/unit/integrations/test_chroma_tracker.py`
- Result: `2 passed`

## Documentation
- Added `docs/tracing/integrations/chroma.mdx`
- Updated docs navigation in `docs.yml`
