### PR TITLE
[OPIK-4604] [P SDK] Add backwards compatibility logic for evaluation suite and legacy evaluate func

### DIFF
--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -10,6 +10,7 @@ from ..api_objects.experiment import helpers as experiment_helpers
 from ..api_objects.dataset import execution_policy as dataset_execution_policy
 from ..api_objects.prompt.chat import chat_prompt_template
 from ..api_objects.prompt import types as prompt_types
+from ..api_objects.dataset import evaluation_suite
 from . import (
     asyncio_support,
     engine,
@@ -133,7 +134,9 @@ def _compute_experiment_scores(
 
 
 def evaluate(
-    dataset: Union[dataset.Dataset, dataset.DatasetVersion],
+    dataset: Union[
+        dataset.Dataset, dataset.DatasetVersion, evaluation_suite.EvaluationSuite
+    ],
     task: LLMTask,
     scoring_metrics: Optional[List[base_metric.BaseMetric]] = None,
     scoring_functions: Optional[List[scorer_function.ScorerFunction]] = None,
@@ -239,6 +242,10 @@ def evaluate(
             - `data.category = "test"` - Items with specific data field value
             - `created_at >= "2024-01-01T00:00:00Z"` - Items created after date
     """
+    if isinstance(dataset, evaluation_suite.EvaluationSuite):
+        # backwards compatibility for transition period
+        dataset = dataset.dataset
+
     experiment_scoring_functions = (
         [] if experiment_scoring_functions is None else experiment_scoring_functions
     )
@@ -748,7 +755,9 @@ def _build_prompt_evaluation_task(
 
 
 def evaluate_prompt(
-    dataset: Union[dataset.Dataset, dataset.DatasetVersion],
+    dataset: Union[
+        dataset.Dataset, dataset.DatasetVersion, evaluation_suite.EvaluationSuite
+    ],
     messages: List[Dict[str, Any]],
     model: Optional[Union[str, base_model.OpikBaseModel]] = None,
     scoring_metrics: Optional[List[base_metric.BaseMetric]] = None,
@@ -835,6 +844,10 @@ def evaluate_prompt(
             - `data.category = "test"` - Items with specific data field value
             - `created_at >= "2024-01-01T00:00:00Z"` - Items created after date
     """
+    if isinstance(dataset, evaluation_suite.EvaluationSuite):
+        # backwards compatibility for transition period
+        dataset = dataset.dataset
+
     experiment_scoring_functions = (
         [] if experiment_scoring_functions is None else experiment_scoring_functions
     )
@@ -964,7 +977,9 @@ def evaluate_prompt(
 
 def evaluate_optimization_trial(
     optimization_id: str,
-    dataset: Union[dataset.Dataset, dataset.DatasetVersion],
+    dataset: Union[
+        dataset.Dataset, dataset.DatasetVersion, evaluation_suite.EvaluationSuite
+    ],
     task: LLMTask,
     scoring_metrics: Optional[List[base_metric.BaseMetric]] = None,
     scoring_functions: Optional[List[scorer_function.ScorerFunction]] = None,
@@ -1069,6 +1084,10 @@ def evaluate_optimization_trial(
             - `data.category = "test"` - Items with specific data field value
             - `created_at >= "2024-01-01T00:00:00Z"` - Items created after date
     """
+    if isinstance(dataset, evaluation_suite.EvaluationSuite):
+        # backwards compatibility for transition period
+        dataset = dataset.dataset
+
     experiment_scoring_functions = (
         [] if experiment_scoring_functions is None else experiment_scoring_functions
     )


### PR DESCRIPTION

## Details
Added logic for compatibility between EvaluationSuite and Dataset (to reduce the chance of old dataset users confusion when FE starts supporting only the evaluation suite functions)

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-4604

## Testing
Tested manually.

## Documentation
-