### PR TITLE
[issue-5453] [TS SDK] Support @langchain/core v1 in opik-langchain

### DIFF
--- a/sdks/typescript/src/opik/integrations/opik-langchain/package.json
+++ b/sdks/typescript/src/opik/integrations/opik-langchain/package.json
@@ -57,7 +57,7 @@
     "README.md"
   ],
   "peerDependencies": {
-    "@langchain/core": "^0.3.78",
+    "@langchain/core": "^0.3.78 || ^1.0.0",
     "opik": "^1.8.75"
   },
   "devDependencies": {


### PR DESCRIPTION
## Details

The `opik-langchain` package previously declared `@langchain/core` as a peer dependency with the range `^0.3.78`, which resolves to `>=0.3.78 <1.0.0` — explicitly excluding v1.x.

This change widens the accepted range to `^0.3.78 || ^1.0.0`, allowing users with `@langchain/core` v1.x installed to use the integration without peer dependency conflicts.

All APIs imported from `@langchain/core` (`BaseCallbackHandler`, `Serialized`, `ChainValues`, `RunnableConfig`, `LLMResult`, `ChatResult`, `BaseMessage`, `ToolMessage`, `AgentAction`, `AgentFinish`) are stable types that remained compatible in v1.0.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves #5453

## Testing

Validated locally on March 2, 2026 with **LangChain v1-only** resolution:

```bash
cd sdks/typescript/src/opik/integrations/opik-langchain
npm ci
npm install --no-save --no-package-lock @langchain/core@^1.0.0
npm ls @langchain/core
# -> @langchain/core@1.1.29
npm run typecheck
npm run test
npm run build
```

Result:
- `typecheck` passed
- `vitest` passed: `3` files, `32` tests
- `build` (`tsup`) passed (CJS/ESM/DTS)

Consumer compatibility smoke (e2e-style) with only `@langchain/core@1`:

```bash
# packed opik-langchain and installed into a fresh temp app with:
# npm install @langchain/core@^1.0.0 opik <local opik-langchain tarball>
# then executed a runtime callback flow (OpikCallbackHandler start/end/flush)
```

Result:
- Runtime smoke passed (`smoke-pass`)
- Dependency tree resolved `@langchain/core@1.1.29` for both app and `opik-langchain`

## Documentation

No documentation changes required. The integration API is unchanged.
