### PR TITLE
docs: migrate python sdk reference to fern generation

### DIFF
--- a/.github/workflows/documentation_deploy.yml
+++ b/.github/workflows/documentation_deploy.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0  # Fetch all history for git diff
 
       - name: Install Fern
-        run: npm install -g fern-api@0.64.26
+        run: npm install -g fern-api@4.0.1
 
       - name: Publish Docs
         env:
@@ -28,5 +28,7 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_API_HOST: ${{ secrets.POSTHOG_API_HOST }}
         run: |
-          cd apps/opik-documentation/documentation
+          cd apps/opik-documentation/documentation/fern
+          fern docs md generate
+          cd ..
           fern generate --docs

--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -15,7 +15,7 @@ jobs:
               uses: actions/checkout@v4
                 
             - name: Install Fern
-              run: npm install -g fern-api@0.64.26
+              run: npm install -g fern-api@4.0.1
 
             - name: Generate preview URL
               id: generate-docs
@@ -23,6 +23,8 @@ jobs:
               env:
                   FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
               run: |
+                  cd fern
+                  fern docs md generate
                   OUTPUT=$(fern generate --docs --preview 2>&1) || true
                   echo "$OUTPUT"
                   URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')

--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -84,6 +84,15 @@ tabs:
     display-name: Opik University
     icon: fa-regular fa-graduation-cap
     slug: /opik-university
+libraries:
+  opik-python-core:
+    input:
+      git: https://github.com/vincentkoc/opik-python-sdk-fern-source
+      subpath: sdks/python/src/opik
+    output:
+      path: docs/reference/python-sdk/core-api-generated
+    lang: python
+
 navigation:
   - tab: documentation
     layout:
@@ -920,8 +929,9 @@ navigation:
       - section: Python SDK
         slug: python-sdk
         contents:
-          - link: Reference
-            href: https://www.comet.com/docs/opik/python-sdk-reference/
+          - library: opik-python-core
+            title: Core API
+            slug: core-api
           - page: REST API Client
             path: docs/reference/python-sdk/rest-api.mdx
             slug: rest-api
@@ -1041,6 +1051,24 @@ navigation:
             path: docs/opik-university/6_production-monitoring/6.1-production-monitoring-online-evaluation-rules.mdx
             slug: online-evaluation-rules
 redirects:
+  - source: "/docs/opik/python-sdk-reference"
+    destination: "/docs/opik/reference/python-sdk/core-api"
+    permanent: true
+  - source: "/docs/opik/python-sdk-reference/:slug"
+    destination: "/docs/opik/reference/python-sdk/core-api"
+    permanent: true
+  - source: "/docs/opik/python-sdk-reference/:slug/:slug"
+    destination: "/docs/opik/reference/python-sdk/core-api"
+    permanent: true
+  - source: "/docs/opik/python-sdk-reference/:slug/:slug/:slug"
+    destination: "/docs/opik/reference/python-sdk/core-api"
+    permanent: true
+  - source: "/docs/opik/python-sdk-reference/rest_api/:slug"
+    destination: "/docs/opik/reference/python-sdk/rest-api"
+    permanent: true
+  - source: "/docs/opik/python-sdk-reference/rest_api/:slug/:slug"
+    destination: "/docs/opik/reference/python-sdk/rest-api"
+    permanent: true
   - source: "/docs/opik/playground"
     destination: "/docs/opik/prompt_engineering/playground"
     permanent: true

--- a/apps/opik-documentation/documentation/fern/docs/contributing/documentation.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/contributing/documentation.mdx
@@ -18,7 +18,7 @@ This guide will help you get started with contributing to Opik's documentation.
 
 ## Documentation Structure
 
-This guide covers how to contribute to the two main parts of Opik's documentation: **This Documentation Website**: Built with [Fern](https://www.buildwithfern.com/) and **Python SDK Reference Documentation**: Built with [Sphinx](https://www.sphinx-doc.org/en/master/).
+This guide covers how to contribute to the two main parts of Opik's documentation: **This Documentation Website**: Built with [Fern](https://www.buildwithfern.com/) and **Python SDK Reference Documentation**: Built with [Fern](https://www.buildwithfern.com/).
 
 Here's how you can work with either one:
 
@@ -59,30 +59,33 @@ Here's how you can work with either one:
     </Steps>
 
   </Accordion>
-  <Accordion title="Contributing to the Python SDK Reference Documentation (Sphinx)">
-    The Python SDK reference docs (source in `apps/opik-documentation/python-sdk-docs`) are generated from docstrings in the Python codebase using [Sphinx](https://www.sphinx-doc.org/en/master/).
+  <Accordion title="Contributing to the Python SDK Reference Documentation (Fern)">
+    The Python SDK reference docs (source in `apps/opik-documentation/documentation/fern/docs/reference/python-sdk`) are generated from docstrings in the Python codebase using [Fern](https://www.buildwithfern.com/) via `fern docs md generate`.
     <Steps>
       ### 1. Install Prerequisites
-      Ensure you have Python and pip installed. A virtual environment is highly recommended.
+      Ensure you have Node.js, npm, Python, and Fern CLI available.
 
       ### 2. Set up Locally
       ```bash
-      cd apps/opik-documentation/python-sdk-docs
-      # Install dependencies - Only needs to be run once
-      pip install -r requirements.txt
-      # Run the python sdk reference documentation locally
-      make dev
+      cd apps/opik-documentation/documentation
+
+      # Install dependencies - only needs to be run once
+      npm install
+
+      # Generate Fern library markdown
+      cd fern
+      fern docs md generate
       ```
-      Access the local site at `http://127.0.0.1:8000`. Changes will update in real-time as you modify docstrings in the SDK (`sdks/python`) and rebuild.
+      Access the local site at `http://localhost:3000` after returning to `documentation` and running `npm run dev`.
 
       ### 3. Making Changes
       Improvements to the SDK reference usually involve updating the Python docstrings directly in the SDK source files located in the `sdks/python` directory.
 
       ### 4. Building and Previewing
-      After editing docstrings, run `make dev` (or `make html` for a one-time build) in the `apps/opik-documentation/python-sdk-docs` directory to regenerate the HTML and preview your changes.
+      After editing docstrings, run `fern docs md generate` in `apps/opik-documentation/documentation/fern` and then run `npm run dev` from `apps/opik-documentation/documentation`.
 
       ### 5. Submitting Changes
-      Commit your changes to both the Python SDK source files and any necessary updates in the `python-sdk-docs` directory. Open a Pull Request against the `main` branch.
+      Commit your changes to both the Python SDK source files and any necessary generated markdown in `docs/reference/python-sdk/core-api-generated`. Open a Pull Request against the `main` branch.
     </Steps>
 
   </Accordion>

--- a/apps/opik-documentation/documentation/fern/docs/reference/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/overview.mdx
@@ -11,8 +11,8 @@ Opik provides in-depth reference documentation for all its SDKs. If you are look
 guides on how to use Opik, check out our [cookbook](/integrations/overview) instead.
 
 <CardGroup cols={2}>
-    <Card title="Python SDK docs" icon="fa-brands fa-python" href="https://www.comet.com/docs/opik/python-sdk-reference/">
-    Python SDK reference documentation for all SDK methods
+    <Card title="Python SDK docs" icon="fa-brands fa-python" href="/reference/python-sdk/core-api">
+    Fern-native generated Core API reference from Python docstrings
     </Card>
 
     <Card title="Typescript SDK docs" icon="fa-brands fa-js" href="/reference/typescript-sdk/overview">

--- a/apps/opik-documentation/documentation/fern/docs/reference/python-sdk/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/python-sdk/overview.mdx
@@ -6,3 +6,13 @@ og:site_name: Opik Documentation
 og:title: Opik Python SDK - Simplify Your Python Development
 title: Overview
 ---
+
+This section is the primary reference for the Opik Python SDK.
+
+- Use [Core API](/reference/python-sdk/core-api) for the generated symbol-level documentation from docstrings.
+- Use [REST API Client](/reference/python-sdk/rest-api) for low-level REST client guidance and examples.
+
+<Tip>
+  Legacy links under `/docs/opik/python-sdk-reference/*` are redirected to the Fern
+  Python SDK reference section.
+</Tip>

--- a/apps/opik-documentation/documentation/fern/fern.config.json
+++ b/apps/opik-documentation/documentation/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "opik",
-  "version": "0.99.1"
+  "version": "4.0.1"
 }


### PR DESCRIPTION
## Summary
- Replace python sdk docs references with Fern API library generation
- Remove old Sphinx references from docs navigation and contribution docs
- Update docs deploy/preview workflows to Fern 4.0.1 and include Directory "fern" not found.
- Add redirects from legacy  paths to Fern reference pages

## Testing
- fern docs md generate
- fern generate --docs --preview (blocked locally by missing Fern auth)

## Notes
This change updates the preview/docs pipeline to consume Fern-generated Python SDK markdown from  instead of Sphinx.