### PR TITLE
feat: add SecretStore support and upgrade ExternalSecret to v1 API

### DIFF
--- a/deployment/helm_chart/opik/templates/external-secret.yaml
+++ b/deployment/helm_chart/opik/templates/external-secret.yaml
@@ -1,6 +1,6 @@
 {{- range .Values.externalSecrets }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "opik.name" $ }}-{{ .name }}

--- a/deployment/helm_chart/opik/templates/secret-store.yaml
+++ b/deployment/helm_chart/opik/templates/secret-store.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.secretStore.enabled }}
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: {{ .Values.externalSecretsStoreRef.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opik.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: {{ .Values.secretStore.region }}
+      role: {{ .Values.secretStore.role }}
+{{- end }}

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -944,3 +944,27 @@ zookeeper:
     #     memory: 1500Mi
     #   limits:
     #     memory: 2Gi
+
+# External Secrets Operator integration
+secretStore:
+  enabled: false
+  region: us-east-1
+  role: ""
+
+externalSecretsStoreRef:
+  name: opik-secret-store
+  kind: SecretStore
+
+externalSecrets: []
+  # Example configuration:
+  # - name: clickhouse
+  #   refreshInterval: "2h"
+  #   data:
+  #     - secretKey: username
+  #       remoteRef:
+  #         key: dev/opik/config
+  #         property: CH_USERNAME
+  #     - secretKey: password
+  #       remoteRef:
+  #         key: dev/opik/config
+  #         property: CH_PASSWORD


### PR DESCRIPTION
  ## Description
  This PR adds support for External Secrets Operator SecretStore management and upgrades the ExternalSecret API to v1.

  ## Changes
  - **Upgrade ExternalSecret API**: `external-secrets.io/v1beta1` → `external-secrets.io/v1` (stable)
  - **Add SecretStore template**: New `templates/secret-store.yaml` for AWS Secrets Manager integration
  - **Add configuration**: New `secretStore` and `externalSecretsStoreRef` sections in values.yaml

  ## Benefits
  - Future-proof: Uses stable v1 API instead of deprecated v1beta1
  - Better UX: Users can manage SecretStore through Helm values
  - Backwards compatible: SecretStore disabled by default
  - Supports AWS Secrets Manager with IAM role authentication

  ## Testing
  Tested on AWS EKS cluster with External Secrets Operator and AWS Secrets Manager.

  ## Example Usage
  ```yaml
  secretStore:
    enabled: true
    region: us-west-2
    role: arn:aws:iam::123456789012:role/eks-secrets-role

  externalSecrets:
    - name: app-secrets
      refreshInterval: "2h"
      data:
        - secretKey: DATABASE_PASSWORD
          remoteRef:
            key: prod/app/config
            property: db_password