### PR TITLE
[NA] [SDK] Fix flaky PromptVersion test for month-ago date assertion

### DIFF
--- a/sdks/typescript/tests/unit/prompt/PromptVersion.test.ts
+++ b/sdks/typescript/tests/unit/prompt/PromptVersion.test.ts
@@ -177,7 +177,7 @@ describe("PromptVersion", () => {
 
     it("should return age for old dates", () => {
       const oneMonthAgo = new Date();
-      oneMonthAgo.setDate(oneMonthAgo.getDate() - 31);
+      oneMonthAgo.setDate(oneMonthAgo.getDate() - 45);
 
       const version = new PromptVersion({
         versionId: "version-123",
@@ -200,7 +200,7 @@ describe("PromptVersion", () => {
         { daysAgo: 1, expectedPattern: /1 day ago/ },
         { daysAgo: 7, expectedPattern: /7 days ago/ },
         { daysAgo: 14, expectedPattern: /14 days ago|2 weeks ago/ },
-        { daysAgo: 30, expectedPattern: /month|about/ },
+        { daysAgo: 45, expectedPattern: /month|about/ },
       ];
 
       testCases.forEach(({ daysAgo, expectedPattern }) => {


### PR DESCRIPTION
## Details
Fix flaky `PromptVersion.getVersionAge` test that fails during short months (e.g. February).
The test used a 31-day offset to test "about 1 month ago" output from `date-fns`, but `formatDistanceToNow` bases month calculations on actual calendar days. During March, subtracting 31 days lands in early February, and the short month causes `date-fns` to return "28 days ago" instead of "about 1 month ago". Changed the offset to 45 days to reliably cross the month threshold year-round.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full implementation
  - Human verification: Test execution verified fix

## Testing

- `npx vitest run tests/unit/prompt/PromptVersion.test.ts` — all 39 tests pass
- Validated the "should return age for old dates" test case and the "should return age for various date ranges" parameterized test case both pass with 45-day offset

## Documentation

N/A