### PR TITLE
[NA] [E2E] test: reorder experiment items test steps for better flow

### DIFF
--- a/tests_end_to_end/typescript-tests/tests/experiments/experiment-items.spec.ts
+++ b/tests_end_to_end/typescript-tests/tests/experiments/experiment-items.spec.ts
@@ -19,9 +19,10 @@ Steps:
 4. Verify the trace count matches via backend
 5. Retrieve all item IDs from both UI and backend
 6. Verify that item IDs match between UI and backend
-7. Verify "Go to traces" button navigates to experiment traces
-8. Click an experiment item and verify trace details panel opens
-9. Verify trace information is displayed correctly
+7. Click an experiment item and verify trace details panel opens
+8. Click Trace button and verify trace panel opens
+9. Verify trace details match experiment item content
+10. Verify "Go to traces" button navigates to experiment traces
 
 This test ensures proper synchronization of experiment items between UI and backend, and validates trace navigation.`
     });
@@ -63,38 +64,6 @@ This test ensures proper synchronization of experiment items between UI and back
       const sortedBackendIds = idsOnBackend.sort();
 
       expect(sortedFrontendIds).toEqual(sortedBackendIds);
-    });
-
-    await test.step('Verify "Go to traces" button navigates to experiment traces', async () => {
-      const experimentItems = await helperClient.getExperimentItems(experiment.name);
-      const firstItem = experimentItems[0];
-
-      const goToTracesButton = page.getByRole('link', { name: /Go to traces/i });
-      await expect(goToTracesButton).toBeVisible();
-
-      await goToTracesButton.click();
-      await expect(page).toHaveURL(/\/traces/, { timeout: 10000 });
-      
-      const currentUrl = page.url();
-      expect(currentUrl).toContain('experiment_id');
-
-      const firstTraceRow = page.locator('table tbody tr').first();
-      await expect(firstTraceRow).toBeVisible({ timeout: 10000 });
-
-      const inputValue = firstItem.input?.input || firstItem.data?.input;
-      if (inputValue) {
-        const inputText = typeof inputValue === 'string' ? inputValue : JSON.stringify(inputValue);
-        await expect(page.locator('table')).toContainText(inputText);
-      }
-
-      const outputValue = firstItem.output?.output || firstItem.output;
-      if (outputValue) {
-        const outputText = typeof outputValue === 'string' ? outputValue : JSON.stringify(outputValue);
-        await expect(page.locator('table')).toContainText(outputText);
-      }
-
-      await page.goBack();
-      await page.waitForLoadState('networkidle');
     });
 
     await test.step('Click experiment item and verify detail panel opens', async () => {
@@ -165,6 +134,39 @@ This test ensures proper synchronization of experiment items between UI and back
 
       const feedbackScoresTab = page.getByRole('tab', { name: 'Feedback scores' }).first();
       await expect(feedbackScoresTab).toBeVisible();
+    });
+
+    await test.step('Verify "Go to traces" button navigates to experiment traces', async () => {
+      const experimentsPage = new ExperimentsPage(page);
+      await experimentsPage.goto();
+      await experimentsPage.clickExperiment(experiment.name);
+
+      const experimentItems = await helperClient.getExperimentItems(experiment.name);
+      const firstItem = experimentItems[0];
+
+      const goToTracesButton = page.getByRole('link', { name: /Go to traces/i });
+      await expect(goToTracesButton).toBeVisible();
+
+      await goToTracesButton.click();
+      await expect(page).toHaveURL(/\/traces/, { timeout: 10000 });
+      
+      const currentUrl = page.url();
+      expect(currentUrl).toContain('experiment_id');
+
+      const firstTraceRow = page.locator('table tbody tr').first();
+      await expect(firstTraceRow).toBeVisible({ timeout: 10000 });
+
+      const inputValue = firstItem.input?.input || firstItem.data?.input;
+      if (inputValue) {
+        const inputText = typeof inputValue === 'string' ? inputValue : JSON.stringify(inputValue);
+        await expect(page.locator('table')).toContainText(inputText);
+      }
+
+      const outputValue = firstItem.output?.output || firstItem.output;
+      if (outputValue) {
+        const outputText = typeof outputValue === 'string' ? outputValue : JSON.stringify(outputValue);
+        await expect(page.locator('table')).toContainText(outputText);
+      }
     });
   });
 


### PR DESCRIPTION
## Details

This PR reorders test steps in the experiment items E2E test to improve test flow and reliability. The "Go to traces" button verification step has been moved to the end of the test sequence, after the trace detail panel interactions are complete.

**Changes:**
- Moved "Go to traces" button verification from step 7 to step 10
- Added navigation back to experiments page before "Go to traces" verification
- Updated test description to reflect new step order
- Ensures trace detail panel is closed before navigating to traces page

This reordering prevents potential state conflicts where the detail panel might interfere with the "Go to traces" navigation flow.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- NA

## Testing

**Test coverage:**
- ✅ TypeScript type checking passes
- ✅ Existing test structure maintained
- ✅ All test steps remain functionally identical

**Steps to reproduce:**
1. Run the experiment items test suite: `cd tests_end_to_end/typescript-tests && TEST_SUITE=experiments npm test`
2. Verify the "Experiment items are created and visible" test passes
3. Confirm the "Go to traces" step executes after trace panel interactions

## Documentation

N/A - Test-only change with no user-facing impact.