### PR TITLE
[OPIK-4680] [FE] fix: preserve column types when adding/editing dataset items

### DIFF
--- a/apps/opik-frontend/src/api/datasets/useDatasetItemBatchMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetItemBatchMutation.ts
@@ -58,6 +58,11 @@ const useDatasetItemBatchMutation = () => {
       if (context) {
         queryClient.invalidateQueries({ queryKey: context.queryKey });
       }
+      // Inserting items may create the first dataset version (latest_version),
+      // which the POST /changes flow needs as base_version.
+      queryClient.invalidateQueries({
+        queryKey: ["dataset", { datasetId: variables.datasetId }],
+      });
       return queryClient.invalidateQueries({
         queryKey: ["datasets"],
       });

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/AddDatasetItemSidebar.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/AddDatasetItemSidebar.tsx
@@ -7,6 +7,7 @@ import ConfirmDialog from "@/components/shared/ConfirmDialog/ConfirmDialog";
 import { DATASET_ITEM_SOURCE, DatasetItemColumn } from "@/types/datasets";
 import { useDatasetItemData } from "./DatasetItemEditor/hooks/useDatasetItemData";
 import { useDatasetItemFormState } from "./DatasetItemEditor/hooks/useDatasetItemFormState";
+import { prepareFormDataForSave } from "./DatasetItemEditor/hooks/useDatasetItemFormHelpers";
 import DatasetItemEditorForm from "./DatasetItemEditor/DatasetItemEditorForm";
 import { useAddItem } from "@/store/DatasetDraftStore";
 
@@ -46,8 +47,9 @@ const AddDatasetItemSidebar: React.FC<AddDatasetItemSidebarProps> = ({
 
   const handleSave = useCallback(
     (data: Record<string, unknown>) => {
+      const preparedData = prepareFormDataForSave(data, columns);
       addItem({
-        data,
+        data: preparedData,
         source: DATASET_ITEM_SOURCE.manual,
         tags: [],
         created_at: new Date().toISOString(),
@@ -56,7 +58,7 @@ const AddDatasetItemSidebar: React.FC<AddDatasetItemSidebarProps> = ({
       setHasUnsavedChanges(false);
       handleClose();
     },
-    [addItem, handleClose, setHasUnsavedChanges],
+    [addItem, handleClose, setHasUnsavedChanges, columns],
   );
 
   const handleDiscard = useCallback(() => {

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemEditor/DatasetItemEditorAutosaveContext.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemEditor/DatasetItemEditorAutosaveContext.tsx
@@ -111,10 +111,10 @@ export const DatasetItemEditorAutosaveProvider: React.FC<
   const handleFieldChange = useCallback(
     (data: Record<string, unknown>) => {
       if (!datasetItemId) return;
-      const preparedData = prepareFormDataForSave(data, fields);
+      const preparedData = prepareFormDataForSave(data, columns);
       editItem(datasetItemId, { data: preparedData });
     },
-    [editItem, datasetItemId, fields],
+    [editItem, datasetItemId, columns],
   );
 
   const handleDelete = useCallback(

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemEditor/hooks/useDatasetItemFormHelpers.test.ts
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemEditor/hooks/useDatasetItemFormHelpers.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import { prepareFormDataForSave } from "./useDatasetItemFormHelpers";
+import { DYNAMIC_COLUMN_TYPE } from "@/types/shared";
+import { DatasetItemColumn } from "@/types/datasets";
+
+const col = (
+  name: string,
+  ...types: DYNAMIC_COLUMN_TYPE[]
+): DatasetItemColumn => ({
+  name,
+  types,
+});
+
+describe("prepareFormDataForSave", () => {
+  describe("JSON object/array always wins", () => {
+    it("parses a JSON object even if column says string", () => {
+      const result = prepareFormDataForSave({ input: '{"key": "value"}' }, [
+        col("input", DYNAMIC_COLUMN_TYPE.string),
+      ]);
+      expect(result.input).toEqual({ key: "value" });
+    });
+
+    it("parses a JSON array even if column says number", () => {
+      const result = prepareFormDataForSave({ data: "[1, 2, 3]" }, [
+        col("data", DYNAMIC_COLUMN_TYPE.number),
+      ]);
+      expect(result.data).toEqual([1, 2, 3]);
+    });
+
+    it("parses nested JSON objects", () => {
+      const result = prepareFormDataForSave({ input: '{"a": {"b": [1, 2]}}' }, [
+        col("input", DYNAMIC_COLUMN_TYPE.object),
+      ]);
+      expect(result.input).toEqual({ a: { b: [1, 2] } });
+    });
+  });
+
+  describe("number coercion", () => {
+    it("coerces string to number when column type is number", () => {
+      const result = prepareFormDataForSave({ score: "42" }, [
+        col("score", DYNAMIC_COLUMN_TYPE.number),
+      ]);
+      expect(result.score).toBe(42);
+    });
+
+    it("coerces float strings", () => {
+      const result = prepareFormDataForSave({ score: "3.14" }, [
+        col("score", DYNAMIC_COLUMN_TYPE.number),
+      ]);
+      expect(result.score).toBe(3.14);
+    });
+
+    it("coerces negative numbers", () => {
+      const result = prepareFormDataForSave({ score: "-7" }, [
+        col("score", DYNAMIC_COLUMN_TYPE.number),
+      ]);
+      expect(result.score).toBe(-7);
+    });
+
+    it("falls back to string if not a valid number", () => {
+      const result = prepareFormDataForSave({ score: "foobar" }, [
+        col("score", DYNAMIC_COLUMN_TYPE.number),
+      ]);
+      expect(result.score).toBe("foobar");
+    });
+
+    it("does not coerce empty string to number", () => {
+      const result = prepareFormDataForSave({ score: "" }, [
+        col("score", DYNAMIC_COLUMN_TYPE.number),
+      ]);
+      expect(result.score).toBe("");
+    });
+  });
+
+  describe("boolean coercion", () => {
+    it("coerces 'true' to boolean", () => {
+      const result = prepareFormDataForSave({ flag: "true" }, [
+        col("flag", DYNAMIC_COLUMN_TYPE.boolean),
+      ]);
+      expect(result.flag).toBe(true);
+    });
+
+    it("coerces 'false' to boolean", () => {
+      const result = prepareFormDataForSave({ flag: "false" }, [
+        col("flag", DYNAMIC_COLUMN_TYPE.boolean),
+      ]);
+      expect(result.flag).toBe(false);
+    });
+
+    it("is case-insensitive", () => {
+      const result = prepareFormDataForSave(
+        { a: "True", b: "FALSE", c: "tRuE" },
+        [
+          col("a", DYNAMIC_COLUMN_TYPE.boolean),
+          col("b", DYNAMIC_COLUMN_TYPE.boolean),
+          col("c", DYNAMIC_COLUMN_TYPE.boolean),
+        ],
+      );
+      expect(result.a).toBe(true);
+      expect(result.b).toBe(false);
+      expect(result.c).toBe(true);
+    });
+
+    it("falls back to string for non-boolean values", () => {
+      const result = prepareFormDataForSave({ flag: "yes" }, [
+        col("flag", DYNAMIC_COLUMN_TYPE.boolean),
+      ]);
+      expect(result.flag).toBe("yes");
+    });
+  });
+
+  describe("object/array column coercion", () => {
+    it("parses JSON when column type is object", () => {
+      const result = prepareFormDataForSave({ config: '{"a": 1}' }, [
+        col("config", DYNAMIC_COLUMN_TYPE.object),
+      ]);
+      expect(result.config).toEqual({ a: 1 });
+    });
+
+    it("parses JSON when column type is array", () => {
+      const result = prepareFormDataForSave({ items: '["a", "b"]' }, [
+        col("items", DYNAMIC_COLUMN_TYPE.array),
+      ]);
+      expect(result.items).toEqual(["a", "b"]);
+    });
+
+    it("falls back to string for invalid JSON in object column", () => {
+      const result = prepareFormDataForSave({ config: "not json" }, [
+        col("config", DYNAMIC_COLUMN_TYPE.object),
+      ]);
+      expect(result.config).toBe("not json");
+    });
+  });
+
+  describe("multi-type columns", () => {
+    it("tries non-string types first", () => {
+      const result = prepareFormDataForSave({ value: "42" }, [
+        col("value", DYNAMIC_COLUMN_TYPE.string, DYNAMIC_COLUMN_TYPE.number),
+      ]);
+      expect(result.value).toBe(42);
+    });
+
+    it("falls back to string when non-string coercion fails", () => {
+      const result = prepareFormDataForSave({ value: "hello" }, [
+        col("value", DYNAMIC_COLUMN_TYPE.number, DYNAMIC_COLUMN_TYPE.string),
+      ]);
+      expect(result.value).toBe("hello");
+    });
+  });
+
+  describe("string fallback", () => {
+    it("keeps plain strings as-is for string columns", () => {
+      const result = prepareFormDataForSave({ name: "hello world" }, [
+        col("name", DYNAMIC_COLUMN_TYPE.string),
+      ]);
+      expect(result.name).toBe("hello world");
+    });
+
+    it("keeps value as-is when no column metadata matches", () => {
+      const result = prepareFormDataForSave({ unknown_field: "some value" }, [
+        col("other_field", DYNAMIC_COLUMN_TYPE.string),
+      ]);
+      expect(result.unknown_field).toBe("some value");
+    });
+  });
+
+  describe("non-string values pass through", () => {
+    it("does not re-coerce numbers", () => {
+      const result = prepareFormDataForSave({ score: 42 }, [
+        col("score", DYNAMIC_COLUMN_TYPE.number),
+      ]);
+      expect(result.score).toBe(42);
+    });
+
+    it("does not re-coerce booleans", () => {
+      const result = prepareFormDataForSave({ flag: true }, [
+        col("flag", DYNAMIC_COLUMN_TYPE.boolean),
+      ]);
+      expect(result.flag).toBe(true);
+    });
+  });
+});

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemEditor/hooks/useDatasetItemFormHelpers.ts
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemEditor/hooks/useDatasetItemFormHelpers.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 import { FIELD_TYPE, DatasetField } from "./useDatasetItemData";
+import { DatasetItemColumn } from "@/types/datasets";
+import { DYNAMIC_COLUMN_TYPE } from "@/types/shared";
 
 export const getFieldType = (
   value: unknown,
@@ -86,41 +88,95 @@ export const createDynamicSchema = (fields: DatasetField[]) => {
   return z.object(schemaShape);
 };
 
+const tryParseJsonStructure = (
+  value: string,
+): { parsed: unknown; isStructure: boolean } => {
+  try {
+    const parsed = JSON.parse(value);
+    if (typeof parsed === "object" && parsed !== null) {
+      return { parsed, isStructure: true };
+    }
+  } catch {
+    // not valid JSON
+  }
+  return { parsed: undefined, isStructure: false };
+};
+
+const coerceToColumnType = (
+  value: unknown,
+  columnTypes: DYNAMIC_COLUMN_TYPE[],
+): unknown => {
+  if (typeof value !== "string") return value;
+
+  const str = value as string;
+
+  for (const colType of columnTypes) {
+    if (colType === DYNAMIC_COLUMN_TYPE.string) continue;
+
+    if (
+      colType === DYNAMIC_COLUMN_TYPE.object ||
+      colType === DYNAMIC_COLUMN_TYPE.array
+    ) {
+      const { parsed, isStructure } = tryParseJsonStructure(str);
+      if (isStructure) return parsed;
+    }
+
+    if (
+      colType === DYNAMIC_COLUMN_TYPE.number &&
+      str.trim() !== "" &&
+      !isNaN(Number(str))
+    ) {
+      return Number(str);
+    }
+
+    if (colType === DYNAMIC_COLUMN_TYPE.boolean) {
+      const lower = str.toLowerCase();
+      if (lower === "true") return true;
+      if (lower === "false") return false;
+    }
+  }
+
+  return str;
+};
+
 /**
- * Transforms form data before saving by parsing JSON strings back to objects/arrays.
- * This is necessary because COMPLEX fields are stringified for display in CodeMirror,
- * but need to be saved as proper JSON objects/arrays.
- * Only parses fields explicitly marked as COMPLEX to avoid accidentally converting
- * plain text strings that happen to be valid JSON.
+ * Transforms form data before saving, using column type metadata to preserve
+ * the correct JSON types in the API payload.
+ *
+ * Priority:
+ * 1. If the user typed a valid JSON object/array, always use that (user intent).
+ * 2. Try to coerce the value to the column's known non-string type (number, boolean).
+ * 3. Fall back to string.
  */
 export const prepareFormDataForSave = (
   formData: Record<string, unknown>,
-  fields: DatasetField[],
+  columns: DatasetItemColumn[],
 ): Record<string, unknown> => {
   const result: Record<string, unknown> = {};
 
-  // Create a map of field keys to their types for quick lookup
-  const fieldTypeMap = new Map<string, FIELD_TYPE>();
-  fields.forEach((field) => {
-    fieldTypeMap.set(field.key, field.type);
+  const columnTypeMap = new Map<string, DYNAMIC_COLUMN_TYPE[]>();
+  columns.forEach((col) => {
+    columnTypeMap.set(col.name, col.types);
   });
 
   for (const [key, value] of Object.entries(formData)) {
-    const fieldType = fieldTypeMap.get(key);
-
-    // Only parse JSON strings for fields explicitly marked as COMPLEX
-    if (fieldType === FIELD_TYPE.COMPLEX && typeof value === "string") {
-      try {
-        const parsed = JSON.parse(value);
-        // Only use parsed value if it's an object or array
-        if (typeof parsed === "object" && parsed !== null) {
-          result[key] = parsed;
-          continue;
-        }
-      } catch {
-        // Not valid JSON, keep as string
+    // 1. If the user typed a valid JSON object/array, always use that
+    if (typeof value === "string") {
+      const { parsed, isStructure } = tryParseJsonStructure(value);
+      if (isStructure) {
+        result[key] = parsed;
+        continue;
       }
     }
+
+    // 2. Try to coerce based on column metadata
+    const colTypes = columnTypeMap.get(key);
+    if (colTypes && colTypes.length > 0) {
+      result[key] = coerceToColumnType(value, colTypes);
+      continue;
+    }
+
+    // 3. Fall back to value as-is
     result[key] = value;
   }
 


### PR DESCRIPTION
## Details

When dataset items were added or edited through the versioned flow (POST /changes),
all values were stored as strings in ClickHouse — losing numbers, booleans, objects,
and arrays. The root cause was the frontend's `prepareFormDataForSave` function, which
only restored JSON types for fields already tagged as `COMPLEX`, missing every new item
and any field whose type wasn't inferred at render time.

This PR rewrites the save-time data transformation to use the API's column type metadata:
- Always parse valid JSON objects/arrays (respecting explicit user input)
- Coerce values to number/boolean when the column metadata indicates a non-string type
- Gracefully fall back to string when coercion fails
- Also fixes a race where `latest_version` was stale after the initial PUT /items,
  causing `baseVersion is required` errors on subsequent POST /changes calls

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-4680
- OPIK-4740

## Testing

- **Unit tests**: `cd apps/opik-frontend && npm run test -- --run useDatasetItemFormHelpers` — 21 tests covering `prepareFormDataForSave` and `coerceToColumnType` for all type coercions, JSON parsing, multi-type columns, and string fallbacks.
- **Linting**: `cd apps/opik-frontend && npx eslint` on all changed files — no errors.
- **Manual testing**: Verified locally (via `scripts/dev-runner.sh`) that:
  - Adding a new dataset item preserves numbers (42), booleans (true/false/True/False), objects, and arrays as their correct ClickHouse types.
  - Editing an existing item also preserves types correctly.
  - The `baseVersion is required` error no longer occurs after the first item is inserted.
- **Scenarios validated**: Happy path (all types), edge cases (empty strings, invalid JSON, case-insensitive booleans, mixed-type columns), and regressions (existing string-only items).

## Documentation

No documentation changes required.