### PR TITLE
[OPIK-4729] [INFRA] Add resolve-thread step to address-github-pr-comments command

### DIFF
--- a/.agents/commands/comet/address-github-pr-comments.md
+++ b/.agents/commands/comet/address-github-pr-comments.md
@@ -133,6 +133,68 @@ If the user declines to push immediately, remind them which comments still need 
 
 ---
 
+### 7. Resolve Addressed Review Threads (Optional)
+
+After all replies are posted, offer to resolve the GitHub review threads that were addressed in this run.
+
+- **Ask**: "Would you like to resolve all addressed review threads?"
+- **If no**: Skip and finish
+- **If yes**: Proceed with thread resolution
+
+#### Fetch Review Threads
+
+Use the GitHub GraphQL API to fetch review threads for the PR:
+
+```bash
+gh api graphql -f query='
+  query {
+    repository(owner: "comet-ml", name: "opik") {
+      pullRequest(number: PR_NUMBER) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            comments(first: 1) {
+              nodes {
+                databaseId
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+'
+```
+
+#### Match Threads to Addressed Comments
+
+- Filter to unresolved threads only (`isResolved: false`)
+- Match each thread to comments addressed in this run by comparing `databaseId` from the thread's first comment against the comment IDs that received "Fixed" or "Skipping" replies
+- Only resolve threads that were actually addressed — never resolve unrelated threads
+
+#### Resolve Threads
+
+For each matched thread, resolve via GraphQL mutation:
+
+```bash
+gh api graphql -f query='
+  mutation {
+    resolveReviewThread(input: {threadId: "THREAD_NODE_ID"}) {
+      thread { isResolved }
+    }
+  }
+'
+```
+
+#### Report Results
+
+- Report success/failure count (e.g., "Resolved 7/8 threads")
+- If a resolution fails, log the error and continue with remaining threads (non-blocking)
+- Gracefully handle permission errors without failing the whole command
+
+---
+
 ## Error Handling
 
 ### **MCP Availability Errors**
@@ -164,6 +226,7 @@ The command is successful when:
 6. ✅ User can choose actions (fix, skip, reply) per comment
 7. ✅ "Skipping" replies posted immediately with AI marker
 8. ✅ "Fixed" replies posted after push with commit SHA and AI marker
+9. ✅ Addressed review threads resolved (if user opted in)
 
 ---
 


### PR DESCRIPTION
## Details

<img width="1920" height="1722" alt="image" src="https://github.com/user-attachments/assets/45957a1c-5f53-4eaf-a045-8eed434f0948" />

Add new Step 7 to the `/address-github-pr-comments` command that offers to resolve GitHub review threads via GraphQL `resolveReviewThread` mutation after all replies are posted. Threads are matched to addressed comments by `databaseId`, and errors are handled gracefully (non-blocking).

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- OPIK-4729

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review

## Testing
- Manual review of command spec changes
- No runtime code — spec-only change to `.agents/commands/comet/address-github-pr-comments.md`

## Documentation
- Updated command spec with new Step 7, GraphQL query/mutation examples, and updated success criteria