### PR TITLE
[OPIK-4705] [INFRA] Fix create-pr command to read PR template from repo

### DIFF
--- a/.agents/commands/comet/create-pr.md
+++ b/.agents/commands/comet/create-pr.md
@@ -159,32 +159,19 @@ This workflow will:
 
 - **Title**: Format as `[{TICKET-NUMBER}] [{COMPONENT}] {TYPE}: {TASK-SUMMARY}` extracted from branch description and change analysis
   - Examples: `[OPIK-2180] [DOCS] docs: add cursor git workflow rule`, `[OPIK-1234] [BE] feat(api): add trace request validation endpoint`
-- **Description**: Fill using the Opik PR template format from `/.github/pull_request_template.md`. Unless specifically requested, **never** include customer names in the description of the PR as they should not be public:
-  ```markdown
-  ## Details
-  {implementation_summary_from_git_analysis}
-  
-  ## Change checklist
-  <!-- Please check the type of changes made -->
-  - [ ] User facing
-  - [ ] Documentation update
-  
-  ## Issues
-  - Resolves # <!-- the GitHub issue this PR resolves (e.g. `#1234`) -->
-  - OPIK-{ticket_number} <!-- The Jira ticket (e.g. `OPIK-1234`) -->
-  - NA <!-- If no ticket, such as hotfixes etc. -->
-  
-  ## Testing
-  {testing_scenarios_covered_by_tests_and_steps_to_reproduce}
-  
-  ## Documentation
-  {list_of_docs_updated_or_summary_of_new_configuration_introduced_or_links_to_web_documentation_reference_relevant_to_this_PR}
+- **Description**: Read the PR template from `.github/pull_request_template.md` at runtime and use it as the source of truth. Unless specifically requested, **never** include customer names in the description of the PR as they should not be public.
+  ```bash
+  # Read the actual PR template — do NOT hardcode it
+  cat .github/pull_request_template.md
   ```
-- **Template Fields**:
-  - **Details**: Implementation summary from git analysis
+  - **Fill every `##` section** in the template — the PR linter requires all sections to be present
+  - If a section is not applicable, write "N/A" rather than removing it
+- **Section guidance**:
+  - **Details**: Implementation summary from git analysis (replace the HTML comment placeholder)
   - **Change checklist**: Auto-check based on file types changed (user-facing for UI changes, documentation for docs)
-  - **Issues**: Link to Jira ticket (e.g., OPIK-2180) or GitHub issue, or "NA" for hotfixes
-  - **Testing**: Extract from commit messages or set based on test files changed
+  - **Issues**: Link to Jira ticket (e.g., `OPIK-2180`) or GitHub issue, or "NA" for hotfixes
+  - **AI-WATERMARK**: Fill with `AI-WATERMARK: yes`, then list: Tools (e.g., "Claude Code"), Model(s), Scope (e.g., "full implementation" or "assisted"), Human verification (e.g., "code review + manual testing")
+  - **Testing**: Extract from commit messages or set based on test files changed (replace the HTML comment placeholder)
   - **Documentation**: List docs updated or set "N/A" if no documentation changes
 
 ---


### PR DESCRIPTION
## Details

<img width="1920" height="1724" alt="image" src="https://github.com/user-attachments/assets/d2d098a1-66bb-4b89-910a-80266a24c508" />

Replace the hardcoded inline PR template in Step 7 of the `/create-pr` command with instructions to read `.github/pull_request_template.md` at runtime. The inline copy had drifted from the actual template (missing the `## AI-WATERMARK` section), and the agent treated it as a soft reference rather than a strict checklist. Now the command reads the real file and must fill every `##` section — preventing linter failures from template drift.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-4705

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review

## Testing
- Manual review of command spec changes
- No runtime code — spec-only change to `.agents/commands/comet/create-pr.md`
- Verified PR template sections match pr-lint.yml required headings (`## Details`, `## Change checklist`, `## Issues`, `## Testing`, `## Documentation`)

## Documentation
- Updated `.agents/commands/comet/create-pr.md` Step 7 with runtime template read instructions and per-section guidance