### PR TITLE
[OPIK-4728] [INFRA] Add explicit pagination requirement to address-github-pr-comments

### DIFF
--- a/.agents/commands/comet/address-github-pr-comments.md
+++ b/.agents/commands/comet/address-github-pr-comments.md
@@ -49,8 +49,19 @@ This workflow will:
 
 ### 3. Collect Pending Comments
 
-- **Fetch review comments**: Use GitHub MCP to retrieve PR review comments and/or discussion threads
-- **Fetch PR reviews**: Get all reviews to understand the review context
+- **Fetch review comments**: Use GitHub MCP to retrieve PR review comments and/or discussion threads. When using `gh api` for any list endpoint, **always** use `--paginate` to ensure all results are fetched:
+  ```bash
+  # Review comments (inline code comments)
+  gh api repos/comet-ml/opik/pulls/{pr_number}/comments --paginate
+
+  # Issue comments (general PR comments)
+  gh api repos/comet-ml/opik/issues/{pr_number}/comments --paginate
+
+  # PR reviews
+  gh api repos/comet-ml/opik/pulls/{pr_number}/reviews --paginate
+  ```
+  > **Why pagination is required**: GitHub API returns 30 items per page by default. Opik PRs regularly exceed this — 17 CI test group comments + deployment bot comments + reviewer comments can push past 30 total. Without `--paginate`, the agent silently gets only the first page and may miss real review feedback.
+- **Fetch PR reviews**: Get all reviews to understand the review context (use `--paginate` as shown above)
 - **Determine pending/unaddressed items**:
   - Prefer unresolved review threads when available
   - Otherwise, treat comments as pending if they are not from the latest code line (not "outdated") or explicitly unresolved, and have no author follow-up confirmation


### PR DESCRIPTION
## Details

<img width="1920" height="1522" alt="image" src="https://github.com/user-attachments/assets/8007b9bb-daed-4ecd-b114-e70737424445" />

Add explicit `--paginate` requirement to Step 3 of `/address-github-pr-comments` for all `gh api` list endpoints. GitHub API returns 30 items per page by default, and Opik PRs regularly exceed this (17 CI test group comments + deployment bot + reviewer comments). Without `--paginate`, the agent silently gets only the first page and may miss real review feedback.

Also audited other commands: `review-github-pr` already uses `--paginate`, and `create-pr` uses `gh pr list` (CLI handles pagination).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-4728

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review

## Testing
- Manual review of command spec changes
- No runtime code — spec-only change to `.agents/commands/comet/address-github-pr-comments.md`
- Audited `review-github-pr.md` and `create-pr.md` for the same gap

## Documentation
- Updated command spec Step 3 with `--paginate` examples and rationale note