### PR TITLE
[OPIK-4739] [SDK] Migrate prompts in blueprints to use commit references

### DIFF
--- a/sdks/python/src/opik/api_objects/agent_config/blueprint.py
+++ b/sdks/python/src/opik/api_objects/agent_config/blueprint.py
@@ -10,12 +10,11 @@ from opik.rest_api.types.prompt_version_detail import PromptVersionDetail
 from . import type_helpers
 
 
-def _resolve_prompt_from_version_id(
-    rest_client_: rest_client.OpikApi, version_id: str
+def _resolve_prompt_from_commit(
+    rest_client_: rest_client.OpikApi, commit: str
 ) -> typing.Any:
-    version_detail = rest_client_.prompts.get_prompt_version_by_id(version_id)
-    prompt_detail = rest_client_.prompts.get_prompt_by_id(version_detail.prompt_id)
-
+    prompt_detail = rest_client_.prompts.get_prompt_by_commit(commit)
+    version_detail = prompt_detail.requested_version
     if version_detail.template_structure == "chat":
         return ChatPrompt.from_fern_prompt_version(
             name=prompt_detail.name, prompt_version=version_detail
@@ -25,10 +24,11 @@ def _resolve_prompt_from_version_id(
     )
 
 
-def _resolve_prompt_version_from_version_id(
-    rest_client_: rest_client.OpikApi, version_id: str
+def _resolve_prompt_version_from_commit(
+    rest_client_: rest_client.OpikApi, commit: str
 ) -> PromptVersionDetail:
-    return rest_client_.prompts.get_prompt_version_by_id(version_id)
+    prompt_detail = rest_client_.prompts.get_prompt_by_commit(commit)
+    return prompt_detail.requested_version
 
 
 def _convert_primitives(
@@ -83,9 +83,9 @@ def _resolve_prompts(
             continue
 
         if _is_prompt_field(param.key, param.type, field_types):
-            values[param.key] = _resolve_prompt_from_version_id(rest_client_, raw_value)
+            values[param.key] = _resolve_prompt_from_commit(rest_client_, raw_value)
         elif _is_prompt_version_field(param.key, param.type, field_types):
-            values[param.key] = _resolve_prompt_version_from_version_id(
+            values[param.key] = _resolve_prompt_version_from_commit(
                 rest_client_, raw_value
             )
 

--- a/sdks/python/src/opik/api_objects/agent_config/type_helpers.py
+++ b/sdks/python/src/opik/api_objects/agent_config/type_helpers.py
@@ -86,9 +86,9 @@ def python_value_to_backend_value(value: typing.Any, py_type: typing.Any) -> str
     if py_type is str:
         return value
     if is_prompt_type(py_type):
-        return value.__internal_api__version_id__
+        return value.commit
     if is_prompt_version_type(py_type):
-        return value.id
+        return value.commit
     origin = typing.get_origin(py_type)
     if origin in (list, dict):
         return json.dumps(value)

--- a/sdks/python/tests/e2e/test_agent_config.py
+++ b/sdks/python/tests/e2e/test_agent_config.py
@@ -410,11 +410,8 @@ def test_agent_config_decorator__prompt_tracks_latest_version__prompt_version_st
 
     instance2 = PromptConfig()
 
-    # TODO: Once the backend supports resolving a Prompt field to the latest version of
-    # the prompt by prompt_id (rather than the specific version_id stored in the
-    # blueprint), this assert should change to version_id_v2. For now the blueprint still
-    # holds version_id_v1 so the Prompt field resolves to that same version.
-    assert instance2.system_prompt.version_id == version_id_v1
+    # We've received a new version
+    assert instance2.system_prompt.version_id != version_id_v1
 
     # PromptVersionDetail field stays pinned to the specific commit it was registered with
     assert instance2.pinned_version.id == version_id_v1

--- a/sdks/python/tests/unit/api_objects/agent_config/test_blueprint.py
+++ b/sdks/python/tests/unit/api_objects/agent_config/test_blueprint.py
@@ -135,20 +135,18 @@ class TestBlueprintPromptResolution:
         raw = _make_raw_blueprint(
             values=[
                 AgentConfigValuePublic(
-                    key="system_prompt", type="prompt", value="ver-111"
+                    key="system_prompt", type="prompt", value="abc12345"
                 ),
             ]
         )
 
         mock_rest = mock.Mock()
         version_detail = mock.Mock()
-        version_detail.prompt_id = "prompt-1"
         version_detail.template_structure = "text"
-        mock_rest.prompts.get_prompt_version_by_id.return_value = version_detail
-
         prompt_detail = mock.Mock()
         prompt_detail.name = "my-prompt"
-        mock_rest.prompts.get_prompt_by_id.return_value = prompt_detail
+        prompt_detail.requested_version = version_detail
+        mock_rest.prompts.get_prompt_by_commit.return_value = prompt_detail
 
         fake_prompt = mock.Mock(spec=Prompt)
         with mock.patch(
@@ -162,25 +160,22 @@ class TestBlueprintPromptResolution:
             )
 
         assert bp["system_prompt"] is fake_prompt
-        mock_rest.prompts.get_prompt_version_by_id.assert_called_once_with("ver-111")
-        mock_rest.prompts.get_prompt_by_id.assert_called_once_with("prompt-1")
+        mock_rest.prompts.get_prompt_by_commit.assert_called_once_with("abc12345")
 
     def test_chat_prompt_field__resolves_to_chat_prompt_object(self):
         raw = _make_raw_blueprint(
             values=[
-                AgentConfigValuePublic(key="messages", type="prompt", value="ver-222"),
+                AgentConfigValuePublic(key="messages", type="prompt", value="bcd23456"),
             ]
         )
 
         mock_rest = mock.Mock()
         version_detail = mock.Mock()
-        version_detail.prompt_id = "prompt-2"
         version_detail.template_structure = "chat"
-        mock_rest.prompts.get_prompt_version_by_id.return_value = version_detail
-
         prompt_detail = mock.Mock()
         prompt_detail.name = "chat-prompt"
-        mock_rest.prompts.get_prompt_by_id.return_value = prompt_detail
+        prompt_detail.requested_version = version_detail
+        mock_rest.prompts.get_prompt_by_commit.return_value = prompt_detail
 
         fake_chat_prompt = mock.Mock(spec=ChatPrompt)
         with mock.patch(
@@ -198,19 +193,17 @@ class TestBlueprintPromptResolution:
     def test_base_prompt_annotation__chat_structure__resolves_to_chat_prompt(self):
         raw = _make_raw_blueprint(
             values=[
-                AgentConfigValuePublic(key="p", type="prompt", value="ver-333"),
+                AgentConfigValuePublic(key="p", type="prompt", value="cde34567"),
             ]
         )
 
         mock_rest = mock.Mock()
         version_detail = mock.Mock()
-        version_detail.prompt_id = "prompt-3"
         version_detail.template_structure = "chat"
-        mock_rest.prompts.get_prompt_version_by_id.return_value = version_detail
-
         prompt_detail = mock.Mock()
         prompt_detail.name = "any-prompt"
-        mock_rest.prompts.get_prompt_by_id.return_value = prompt_detail
+        prompt_detail.requested_version = version_detail
+        mock_rest.prompts.get_prompt_by_commit.return_value = prompt_detail
 
         fake_chat_prompt = mock.Mock(spec=ChatPrompt)
         with mock.patch(
@@ -228,19 +221,17 @@ class TestBlueprintPromptResolution:
     def test_base_prompt_annotation__text_structure__resolves_to_prompt(self):
         raw = _make_raw_blueprint(
             values=[
-                AgentConfigValuePublic(key="p", type="prompt", value="ver-444"),
+                AgentConfigValuePublic(key="p", type="prompt", value="def45678"),
             ]
         )
 
         mock_rest = mock.Mock()
         version_detail = mock.Mock()
-        version_detail.prompt_id = "prompt-4"
         version_detail.template_structure = "text"
-        mock_rest.prompts.get_prompt_version_by_id.return_value = version_detail
-
         prompt_detail = mock.Mock()
         prompt_detail.name = "any-prompt"
-        mock_rest.prompts.get_prompt_by_id.return_value = prompt_detail
+        prompt_detail.requested_version = version_detail
+        mock_rest.prompts.get_prompt_by_commit.return_value = prompt_detail
 
         fake_prompt = mock.Mock(spec=Prompt)
         with mock.patch(
@@ -259,15 +250,13 @@ class TestBlueprintPromptResolution:
         raw = _make_raw_blueprint(
             values=[
                 AgentConfigValuePublic(
-                    key="system_prompt", type="prompt", value="ver-bad"
+                    key="system_prompt", type="prompt", value="badbad00"
                 ),
             ]
         )
 
         mock_rest = mock.Mock()
-        mock_rest.prompts.get_prompt_version_by_id.side_effect = Exception(
-            "network error"
-        )
+        mock_rest.prompts.get_prompt_by_commit.side_effect = Exception("network error")
 
         with pytest.raises(Exception, match="network error"):
             Blueprint(
@@ -280,14 +269,16 @@ class TestBlueprintPromptResolution:
         raw = _make_raw_blueprint(
             values=[
                 AgentConfigValuePublic(
-                    key="version", type="prompt_commit", value="ver-pv-111"
+                    key="version", type="prompt_commit", value="pv111111"
                 ),
             ]
         )
 
         mock_rest = mock.Mock()
         fake_version_detail = mock.Mock(spec=PromptVersionDetail)
-        mock_rest.prompts.get_prompt_version_by_id.return_value = fake_version_detail
+        prompt_detail = mock.Mock()
+        prompt_detail.requested_version = fake_version_detail
+        mock_rest.prompts.get_prompt_by_commit.return_value = prompt_detail
 
         bp = Blueprint(
             raw,
@@ -296,20 +287,19 @@ class TestBlueprintPromptResolution:
         )
 
         assert bp["version"] is fake_version_detail
-        mock_rest.prompts.get_prompt_version_by_id.assert_called_once_with("ver-pv-111")
-        mock_rest.prompts.get_prompt_by_id.assert_not_called()
+        mock_rest.prompts.get_prompt_by_commit.assert_called_once_with("pv111111")
 
     def test_prompt_version_field__resolution_fails__raises(self):
         raw = _make_raw_blueprint(
             values=[
                 AgentConfigValuePublic(
-                    key="version", type="prompt_commit", value="ver-pv-bad"
+                    key="version", type="prompt_commit", value="badbad00"
                 ),
             ]
         )
 
         mock_rest = mock.Mock()
-        mock_rest.prompts.get_prompt_version_by_id.side_effect = Exception("not found")
+        mock_rest.prompts.get_prompt_by_commit.side_effect = Exception("not found")
 
         with pytest.raises(Exception, match="not found"):
             Blueprint(
@@ -318,30 +308,25 @@ class TestBlueprintPromptResolution:
                 rest_client_=mock_rest,
             )
 
-    def test_two_prompt_fields__makes_exactly_two_api_calls_per_prompt(self):
+    def test_two_prompt_fields__makes_exactly_one_api_call_per_prompt(self):
         raw = _make_raw_blueprint(
             values=[
-                AgentConfigValuePublic(key="p1", type="prompt", value="ver-1"),
-                AgentConfigValuePublic(key="p2", type="prompt", value="ver-2"),
+                AgentConfigValuePublic(key="p1", type="prompt", value="aaaaaaaa"),
+                AgentConfigValuePublic(key="p2", type="prompt", value="bbbbbbbb"),
             ]
         )
 
         mock_rest = mock.Mock()
 
-        def _version_side_effect(vid):
+        def _commit_side_effect(commit):
             v = mock.Mock()
-            v.prompt_id = f"prompt-{vid}"
             v.template_structure = "text"
-            return v
-
-        mock_rest.prompts.get_prompt_version_by_id.side_effect = _version_side_effect
-
-        def _detail_side_effect(pid):
             d = mock.Mock()
-            d.name = f"name-{pid}"
+            d.name = f"name-{commit}"
+            d.requested_version = v
             return d
 
-        mock_rest.prompts.get_prompt_by_id.side_effect = _detail_side_effect
+        mock_rest.prompts.get_prompt_by_commit.side_effect = _commit_side_effect
 
         with mock.patch(
             "opik.api_objects.prompt.text.prompt.Prompt.from_fern_prompt_version",
@@ -353,8 +338,7 @@ class TestBlueprintPromptResolution:
                 rest_client_=mock_rest,
             )
 
-        assert mock_rest.prompts.get_prompt_version_by_id.call_count == 2
-        assert mock_rest.prompts.get_prompt_by_id.call_count == 2
+        assert mock_rest.prompts.get_prompt_by_commit.call_count == 2
 
 
 class TestBlueprintPromptResolutionWithoutFieldTypes:
@@ -362,20 +346,18 @@ class TestBlueprintPromptResolutionWithoutFieldTypes:
         raw = _make_raw_blueprint(
             values=[
                 AgentConfigValuePublic(
-                    key="system_prompt", type="prompt", value="ver-111"
+                    key="system_prompt", type="prompt", value="abc12345"
                 ),
             ]
         )
 
         mock_rest = mock.Mock()
         version_detail = mock.Mock()
-        version_detail.prompt_id = "prompt-1"
         version_detail.template_structure = "text"
-        mock_rest.prompts.get_prompt_version_by_id.return_value = version_detail
-
         prompt_detail = mock.Mock()
         prompt_detail.name = "my-prompt"
-        mock_rest.prompts.get_prompt_by_id.return_value = prompt_detail
+        prompt_detail.requested_version = version_detail
+        mock_rest.prompts.get_prompt_by_commit.return_value = prompt_detail
 
         fake_prompt = mock.Mock(spec=Prompt)
         with mock.patch(
@@ -389,19 +371,17 @@ class TestBlueprintPromptResolutionWithoutFieldTypes:
     def test_chat_prompt_type__resolves_to_chat_prompt_object(self):
         raw = _make_raw_blueprint(
             values=[
-                AgentConfigValuePublic(key="messages", type="prompt", value="ver-222"),
+                AgentConfigValuePublic(key="messages", type="prompt", value="bcd23456"),
             ]
         )
 
         mock_rest = mock.Mock()
         version_detail = mock.Mock()
-        version_detail.prompt_id = "prompt-2"
         version_detail.template_structure = "chat"
-        mock_rest.prompts.get_prompt_version_by_id.return_value = version_detail
-
         prompt_detail = mock.Mock()
         prompt_detail.name = "chat-prompt"
-        mock_rest.prompts.get_prompt_by_id.return_value = prompt_detail
+        prompt_detail.requested_version = version_detail
+        mock_rest.prompts.get_prompt_by_commit.return_value = prompt_detail
 
         fake_chat_prompt = mock.Mock(spec=ChatPrompt)
         with mock.patch(
@@ -416,34 +396,33 @@ class TestBlueprintPromptResolutionWithoutFieldTypes:
         raw = _make_raw_blueprint(
             values=[
                 AgentConfigValuePublic(
-                    key="version", type="prompt_commit", value="ver-pv-111"
+                    key="version", type="prompt_commit", value="pv111111"
                 ),
             ]
         )
 
         mock_rest = mock.Mock()
         fake_version_detail = mock.Mock(spec=PromptVersionDetail)
-        mock_rest.prompts.get_prompt_version_by_id.return_value = fake_version_detail
+        prompt_detail = mock.Mock()
+        prompt_detail.requested_version = fake_version_detail
+        mock_rest.prompts.get_prompt_by_commit.return_value = prompt_detail
 
         bp = Blueprint(raw, rest_client_=mock_rest)
 
         assert bp["version"] is fake_version_detail
-        mock_rest.prompts.get_prompt_version_by_id.assert_called_once_with("ver-pv-111")
-        mock_rest.prompts.get_prompt_by_id.assert_not_called()
+        mock_rest.prompts.get_prompt_by_commit.assert_called_once_with("pv111111")
 
     def test_prompt_resolution_fails__raises(self):
         raw = _make_raw_blueprint(
             values=[
                 AgentConfigValuePublic(
-                    key="system_prompt", type="prompt", value="ver-bad"
+                    key="system_prompt", type="prompt", value="badbad00"
                 ),
             ]
         )
 
         mock_rest = mock.Mock()
-        mock_rest.prompts.get_prompt_version_by_id.side_effect = Exception(
-            "network error"
-        )
+        mock_rest.prompts.get_prompt_by_commit.side_effect = Exception("network error")
 
         with pytest.raises(Exception, match="network error"):
             Blueprint(raw, rest_client_=mock_rest)

--- a/sdks/python/tests/unit/api_objects/agent_config/test_decorator.py
+++ b/sdks/python/tests/unit/api_objects/agent_config/test_decorator.py
@@ -666,9 +666,9 @@ class TestConfigDecoratorTTLEnvVar:
 
 
 class TestConfigDecoratorPromptFields:
-    def test_prompt_field__sent_to_backend_as_version_id(self, mock_backend):
+    def test_prompt_field__sent_to_backend_as_commit(self, mock_backend):
         fake_prompt = mock.Mock(spec=Prompt)
-        fake_prompt.__internal_api__version_id__ = "ver-abc"
+        fake_prompt.commit = "abc12345"
 
         @agent_config_decorator
         @dataclasses.dataclass
@@ -685,11 +685,11 @@ class TestConfigDecoratorPromptFields:
             v for v in blueprint.values if v.key == "MyConfig.system_prompt"
         )
         assert prompt_param.type == "prompt"
-        assert prompt_param.value == "ver-abc"
+        assert prompt_param.value == "abc12345"
 
-    def test_chat_prompt_field__sent_to_backend_as_version_id(self, mock_backend):
+    def test_chat_prompt_field__sent_to_backend_as_commit(self, mock_backend):
         fake_prompt = mock.Mock(spec=ChatPrompt)
-        fake_prompt.__internal_api__version_id__ = "ver-chat-1"
+        fake_prompt.commit = "bcd23456"
 
         @agent_config_decorator
         @dataclasses.dataclass
@@ -703,27 +703,21 @@ class TestConfigDecoratorPromptFields:
         call_kwargs = mock_backend.agent_configs.create_agent_config.call_args[1]
         blueprint = call_kwargs["blueprint"]
         param = next(v for v in blueprint.values if v.key == "MyConfig.messages")
-        assert param.value == "ver-chat-1"
+        assert param.value == "bcd23456"
 
     def test_existing_blueprint_prompt_field__resolves_and_applied_to_instance(
         self, mock_backend
     ):
         mock_backend.set_blueprint_values(
-            [
-                mock.Mock(
-                    key="MyConfig.system_prompt", type="string", value="ver-backend"
-                )
-            ]
+            [mock.Mock(key="MyConfig.system_prompt", type="string", value="abc12345")]
         )
 
         version_detail = mock.Mock()
-        version_detail.prompt_id = "prompt-id-1"
         version_detail.template_structure = "text"
-        mock_backend.client.rest_client.prompts.get_prompt_version_by_id.return_value = version_detail
-
         prompt_detail = mock.Mock()
         prompt_detail.name = "my-prompt"
-        mock_backend.client.rest_client.prompts.get_prompt_by_id.return_value = (
+        prompt_detail.requested_version = version_detail
+        mock_backend.client.rest_client.prompts.get_prompt_by_commit.return_value = (
             prompt_detail
         )
 
@@ -747,17 +741,15 @@ class TestConfigDecoratorPromptFields:
         self, mock_backend
     ):
         mock_backend.set_blueprint_values(
-            [mock.Mock(key="MyConfig.messages", type="string", value="ver-chat")]
+            [mock.Mock(key="MyConfig.messages", type="string", value="bcd23456")]
         )
 
         version_detail = mock.Mock()
-        version_detail.prompt_id = "prompt-id-2"
         version_detail.template_structure = "chat"
-        mock_backend.client.rest_client.prompts.get_prompt_version_by_id.return_value = version_detail
-
         prompt_detail = mock.Mock()
         prompt_detail.name = "chat-prompt"
-        mock_backend.client.rest_client.prompts.get_prompt_by_id.return_value = (
+        prompt_detail.requested_version = version_detail
+        mock_backend.client.rest_client.prompts.get_prompt_by_commit.return_value = (
             prompt_detail
         )
 
@@ -781,17 +773,15 @@ class TestConfigDecoratorPromptFields:
         self, mock_backend
     ):
         mock_backend.set_blueprint_values(
-            [mock.Mock(key="MyConfig.p", type="prompt", value="ver-base")]
+            [mock.Mock(key="MyConfig.p", type="prompt", value="cde34567")]
         )
 
         version_detail = mock.Mock()
-        version_detail.prompt_id = "prompt-base"
         version_detail.template_structure = "chat"
-        mock_backend.client.rest_client.prompts.get_prompt_version_by_id.return_value = version_detail
-
         prompt_detail = mock.Mock()
         prompt_detail.name = "base-prompt"
-        mock_backend.client.rest_client.prompts.get_prompt_by_id.return_value = (
+        prompt_detail.requested_version = version_detail
+        mock_backend.client.rest_client.prompts.get_prompt_by_commit.return_value = (
             prompt_detail
         )
 
@@ -811,9 +801,9 @@ class TestConfigDecoratorPromptFields:
 
         assert instance.p is fake_chat_prompt
 
-    def test_prompt_version_field__sent_to_backend_as_version_id(self, mock_backend):
+    def test_prompt_version_field__sent_to_backend_as_commit(self, mock_backend):
         fake_version = mock.Mock(spec=PromptVersionDetail)
-        fake_version.id = "ver-pv-abc"
+        fake_version.commit = "pv123456"
 
         @agent_config_decorator
         @dataclasses.dataclass
@@ -828,7 +818,7 @@ class TestConfigDecoratorPromptFields:
         blueprint = call_kwargs["blueprint"]
         param = next(v for v in blueprint.values if v.key == "MyConfig.version")
         assert param.type == "prompt_commit"
-        assert param.value == "ver-pv-abc"
+        assert param.value == "pv123456"
 
     def test_existing_blueprint_prompt_version_field__resolves_to_prompt_version_detail(
         self, mock_backend
@@ -838,13 +828,17 @@ class TestConfigDecoratorPromptFields:
                 mock.Mock(
                     key="MyConfig.version",
                     type="prompt_commit",
-                    value="ver-pv-backend",
+                    value="pv111111",
                 )
             ]
         )
 
         fake_version_detail = mock.Mock(spec=PromptVersionDetail)
-        mock_backend.client.rest_client.prompts.get_prompt_version_by_id.return_value = fake_version_detail
+        prompt_detail = mock.Mock()
+        prompt_detail.requested_version = fake_version_detail
+        mock_backend.client.rest_client.prompts.get_prompt_by_commit.return_value = (
+            prompt_detail
+        )
 
         @agent_config_decorator
         @dataclasses.dataclass
@@ -854,10 +848,9 @@ class TestConfigDecoratorPromptFields:
         instance = MyConfig()
 
         assert instance.version is fake_version_detail
-        mock_backend.client.rest_client.prompts.get_prompt_version_by_id.assert_called_with(
-            "ver-pv-backend"
+        mock_backend.client.rest_client.prompts.get_prompt_by_commit.assert_called_with(
+            "pv111111"
         )
-        mock_backend.client.rest_client.prompts.get_prompt_by_id.assert_not_called()
 
     def test_existing_blueprint_prompt_version_field__resolution_fails__raises(
         self, mock_backend
@@ -867,11 +860,11 @@ class TestConfigDecoratorPromptFields:
                 mock.Mock(
                     key="MyConfig.version",
                     type="prompt_commit",
-                    value="ver-pv-bad",
+                    value="badbad00",
                 )
             ]
         )
-        mock_backend.client.rest_client.prompts.get_prompt_version_by_id.side_effect = (
+        mock_backend.client.rest_client.prompts.get_prompt_by_commit.side_effect = (
             Exception("not found")
         )
 

--- a/sdks/python/tests/unit/api_objects/agent_config/test_type_helpers.py
+++ b/sdks/python/tests/unit/api_objects/agent_config/test_type_helpers.py
@@ -252,17 +252,17 @@ class TestPythonValueToBackendValue:
         [Prompt, ChatPrompt, BasePrompt],
         ids=["Prompt", "ChatPrompt", "BasePrompt"],
     )
-    def test_prompt_value__returns_version_id(self, py_type):
+    def test_prompt_value__returns_commit(self, py_type):
         prompt = mock.Mock()
-        prompt.__internal_api__version_id__ = "ver-abc"
-        assert type_helpers.python_value_to_backend_value(prompt, py_type) == "ver-abc"
+        prompt.commit = "abc12345"
+        assert type_helpers.python_value_to_backend_value(prompt, py_type) == "abc12345"
 
-    def test_prompt_version_value__returns_id(self):
+    def test_prompt_version_value__returns_commit(self):
         version = mock.Mock(spec=PromptVersionDetail)
-        version.id = "ver-pv-123"
+        version.commit = "pv123456"
         assert (
             type_helpers.python_value_to_backend_value(version, PromptVersionDetail)
-            == "ver-pv-123"
+            == "pv123456"
         )
 
 


### PR DESCRIPTION
## Details

Migrates prompt serialization and resolution in blueprints from version ID to commit-based references. This provides a more stable and consistent mechanism for prompt versioning across the SDK and aligns blueprints with the backend's shift toward commit-based prompt references.

**Changes:**
- Updated prompt resolution functions to use commit identifiers
- Modified type helpers to serialize/deserialize prompts using commits
- Support for both Prompt and ChatPrompt types with commit-based lookup
- PromptVersionDetail resolution now uses commit-based mechanism
- Simplified type conversion logic with proper commit handling

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-4739

## Testing

- E2E tests for agent config with prompt resolution updated
- Unit tests for blueprint and type helpers updated to verify commit-based behavior
- Type conversion and serialization/deserialization tested across all prompt types

## Documentation

N/A