### PR TITLE
[OPIK-4524] [BE] Refactor and skills update

### DIFF
--- a/.agents/skills/opik-backend/SKILL.md
+++ b/.agents/skills/opik-backend/SKILL.md
@@ -46,6 +46,68 @@ public class TracesDAO { }
 public class TracesService { }
 ```
 
+## Lombok Conventions
+
+### Records and DTOs
+- Always annotate records/DTOs with `@Builder(toBuilder = true)`
+- Add `@NonNull` on all non-optional fields
+- Use builders (not constructors) when instantiating records
+
+```java
+// ✅ GOOD
+@Builder(toBuilder = true)
+record MyData(@NonNull UUID id, @NonNull String name, String description) {}
+
+MyData data = MyData.builder()
+        .id(id)
+        .name(name)
+        .build();
+
+// ❌ BAD - plain constructor (positional mistakes, less readable)
+new MyData(id, name, null);
+
+// ❌ BAD - @Builder without toBuilder
+@Builder
+record MyData(UUID id, String name) {}
+```
+
+### Dependency Injection
+- Use `@RequiredArgsConstructor(onConstructor_ = @Inject)` instead of manual constructors
+
+```java
+// ✅ GOOD
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class MyService {
+    private final @NonNull DependencyA depA;
+    private final @NonNull DependencyB depB;
+}
+
+// ❌ BAD - boilerplate constructor
+public class MyService {
+    private final DependencyA depA;
+    @Inject
+    public MyService(DependencyA depA) {
+        this.depA = depA;
+    }
+}
+```
+
+### Interfaces
+- Don't put validation annotations (`@NonNull`) on interface method parameters
+- Keep interfaces free of implementation details
+
+```java
+// ✅ GOOD
+interface MyService {
+    void process(String workspaceId, UUID promptId);
+}
+
+// ❌ BAD - validation on interface
+interface MyService {
+    void process(@NonNull String workspaceId, @NonNull UUID promptId);
+}
+```
+
 ## Critical Gotchas
 
 ### StringTemplate Memory Leak

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
@@ -473,18 +473,29 @@ class AgentConfigServiceImpl implements AgentConfigService {
                 UUID configId = refs.getFirst().configId();
                 UUID blueprintId = idGenerator.generateId();
 
-                blueprintInserts.add(new AgentConfigDAO.BlueprintInsertData(
-                        blueprintId, entry.getKey(), configId,
-                        AgentBlueprint.BlueprintType.BLUEPRINT, null));
+                blueprintInserts.add(AgentConfigDAO.BlueprintInsertData.builder()
+                        .id(blueprintId)
+                        .projectId(entry.getKey())
+                        .configId(configId)
+                        .type(AgentBlueprint.BlueprintType.BLUEPRINT)
+                        .build());
 
                 for (var ref : refs) {
-                    valueCloses.add(new AgentConfigDAO.ValueCloseRef(
-                            ref.projectId(), blueprintId, ref.configKey()));
+                    valueCloses.add(AgentConfigDAO.ValueCloseRef.builder()
+                            .projectId(ref.projectId())
+                            .validToBlueprintId(blueprintId)
+                            .key(ref.configKey())
+                            .build());
 
-                    valueInserts.add(new AgentConfigDAO.ValueInsertData(
-                            idGenerator.generateId(), ref.projectId(), configId,
-                            ref.configKey(), newCommit, AgentConfigValue.ValueType.PROMPT,
-                            null, blueprintId));
+                    valueInserts.add(AgentConfigDAO.ValueInsertData.builder()
+                            .id(idGenerator.generateId())
+                            .projectId(ref.projectId())
+                            .configId(configId)
+                            .key(ref.configKey())
+                            .value(newCommit)
+                            .type(AgentConfigValue.ValueType.PROMPT)
+                            .validFromBlueprintId(blueprintId)
+                            .build());
                 }
             }
 


### PR DESCRIPTION
## Details
Refactored `AgentConfigService` to use Lombok builder pattern instead of positional constructors for `BlueprintInsertData`, `ValueCloseRef`, and `ValueInsertData` records. This improves readability and reduces risk of positional parameter mistakes.

Also added Lombok conventions documentation to the backend skill covering records/DTOs, dependency injection, and interface best practices.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-4524

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-opus-4-6
  - Scope: record instantiation refactor and skill documentation
  - Human verification: yes

## Testing

- Existing tests cover the `AgentConfigService` logic; no behavioral changes were made (pure refactor from constructors to builders)
- `mvn compile -DskipTests` to verify compilation

## Documentation

- Updated `.agents/skills/opik-backend/SKILL.md` with Lombok conventions (builder usage, DI patterns, interface guidelines)
