### PR TITLE
[NA] [DOCS] Update fern-api version in documentation deploy workflow

### DIFF
--- a/.github/workflows/documentation_deploy.yml
+++ b/.github/workflows/documentation_deploy.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0  # Fetch all history for git diff
 
       - name: Install Fern
-        run: npm install -g fern-api@0.64.26
+        run: npm install -g fern-api@4.3.0
 
       - name: Publish Docs
         env:


### PR DESCRIPTION
## Summary
- Update `fern-api` package from `0.64.26` to `4.3.0` in the documentation deploy GitHub Action

## Test plan
- [ ] Verify documentation deploy workflow runs successfully with the new Fern version

🤖 Generated with [Claude Code](https://claude.com/claude-code)