### PR TITLE
[OPIK-3519] [INFRA] add automated provider model sync script

### DIFF
--- a/.github/workflows/sync_provider_models.yml
+++ b/.github/workflows/sync_provider_models.yml
@@ -37,9 +37,9 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
-          set +e
+          set +e -o pipefail
           python scripts/sync_provider_models.py 2>sync_stderr.txt | tee sync_summary.txt
-          EXIT_CODE=$?
+          EXIT_CODE=${PIPESTATUS[0]}
           set -e
           echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
 

--- a/scripts/sync_provider_models.py
+++ b/scripts/sync_provider_models.py
@@ -245,7 +245,7 @@ def build_deprecated_set(prices: dict) -> set[str]:
         try:
             if date.fromisoformat(dep) <= today:
                 deprecated.add(key)
-                for prefix in ("gemini/", "anthropic/", "openai/", "vertex_ai/"):
+                for prefix in ("gemini/", "anthropic/", "openai/", "vertex_ai/", "openrouter/"):
                     if key.startswith(prefix):
                         deprecated.add(key.removeprefix(prefix))
         except ValueError:


### PR DESCRIPTION
## Details

Adds a Python script and GitHub Actions workflow to automatically sync LLM provider model definitions across 5 Java enum files and 2 TypeScript files. The script fetches models from provider APIs (OpenAI, Anthropic, Gemini) with fallback to the LiteLLM prices JSON, then updates backend enums and frontend dropdowns.

- **Add-only mode**: new models are added automatically; stale/deprecated models are reported in the PR summary for manual review, never auto-removed
- **Curated dropdown filtering**: frontend dropdowns show a filtered, sorted subset (excludes dated snapshots, deprecated models, Responses-API-only models like `gpt-5.2-pro`)
- **Deprecation detection**: models with past `deprecation_date` are flagged and excluded from dropdown
- **Enum name preservation**: existing hand-crafted Java enum names are preserved; only new models get auto-generated names

### New files
- `scripts/sync_provider_models.py` — main sync script
- `.github/workflows/sync_provider_models.yml` — daily CI workflow (runs Mon–Fri, 30 min after model prices sync)

### Requires 3 GitHub secrets
- `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` - ALL OK
- Script works without them (falls back to prices JSON), so the workflow won't break if secrets aren't configured yet

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-3519


## Testing

- `python scripts/sync_provider_models.py --dry-run` — verified no files are written, summary output is correct
- Ran with all 3 provider API keys set — verified API fetching works for OpenAI (46 models), Anthropic (8 models), Gemini (13 models)
- Ran without API keys — verified fallback to prices JSON works correctly
- Verified deprecated models (e.g. `gemini-1.5-flash`, `gemini-1.5-pro`) are detected and excluded from dropdown
- Verified Responses-API-only models (`-pro$` pattern) are excluded from dropdown
- Verified enum name preservation for existing models across all providers
- Verified idempotency: running twice produces no changes on second run

## Documentation

N/A — internal tooling script, no user-facing documentation changes needed.