### PR TITLE
[NA] [DOCS] docs: refine OpenClaw integration setup flow

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openclaw.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openclaw.mdx
@@ -21,26 +21,28 @@ This integration captures:
 - [OpenClaw](https://github.com/openclaw/openclaw) version `2026.3.2` or newer.
 - Opik project/workspace details (for cloud or enterprise deployments).
 
-## Step 1: Install the plugin
+## Setup
 
-```bash
-openclaw plugins install @opik/opik-openclaw
-```
+<Steps>
+  <Step title="1. Install the plugin">
+    ```bash
+    openclaw plugins install @opik/opik-openclaw
+    ```
+  </Step>
+  <Step title="2. Configure the plugin">
+    ```bash
+    openclaw opik configure
+    ```
 
-## Step 2: Configure the plugin
-
-```bash
-openclaw opik configure
-```
-
-This command validates your Opik URL, validates API key access (when required), enables the plugin, and writes plugin-scoped config.
-
-## Step 3: Check status and restart the OpenClaw gateway
-
-```bash
-openclaw opik status
-openclaw gateway restart
-```
+    This command validates your Opik URL, validates API key access (when required), enables the plugin, and writes plugin-scoped config.
+  </Step>
+  <Step title="3. Check status and restart the OpenClaw gateway">
+    ```bash
+    openclaw opik status
+    openclaw gateway restart
+    ```
+  </Step>
+</Steps>
 
 ## Advanced configuration (manual JSON)
 
@@ -78,13 +80,16 @@ Environment variable fallbacks are also supported:
 
 ## Validate setup
 
-1. Check plugin status:
-
-```bash
-openclaw opik status
-```
-
-2. Send a message through OpenClaw and verify traces appear in the configured Opik project dashboard.
+<Steps>
+  <Step title="1. Check plugin status">
+    ```bash
+    openclaw opik status
+    ```
+  </Step>
+  <Step title="2. Send a message and verify traces in Opik">
+    Send a message through OpenClaw and verify traces appear in the configured Opik project dashboard.
+  </Step>
+</Steps>
 
 ## Known limitation
 


### PR DESCRIPTION
## Details
Add and refine the OpenClaw integration documentation in Fern. The setup flow is now concise and explicit, uses native Fern `Steps`, keeps gateway restart in setup, and retains manual JSON as an advanced configuration path.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: no

## Testing
No runtime tests were run for this docs-only change.

Validated by checking the rendered structure in source for:
- Fern `Steps` usage consistency with existing docs patterns
- Updated prerequisite (`OpenClaw >= 2026.3.2`)
- Setup flow clarity (`install`, `configure`, `status + restart`)
- Validation flow simplification

## Documentation
Updated:
- `apps/opik-documentation/documentation/fern/docs/tracing/integrations/openclaw.mdx`
