### PR TITLE
[OPIK-4759] [BE] feat: add maskId to local runner job

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/runner/CreateLocalRunnerJobRequest.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/runner/CreateLocalRunnerJobRequest.java
@@ -16,5 +16,6 @@ public record CreateLocalRunnerJobRequest(
         @NotBlank String agentName,
         JsonNode inputs,
         String project,
-        UUID runnerId) {
+        UUID runnerId,
+        UUID maskId) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/runner/LocalRunnerJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/runner/LocalRunnerJob.java
@@ -24,6 +24,7 @@ public record LocalRunnerJob(
         String error,
         String project,
         UUID traceId,
+        UUID maskId,
         int timeout,
         Instant createdAt,
         Instant startedAt,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LocalRunnerService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LocalRunnerService.java
@@ -163,6 +163,7 @@ class LocalRunnerServiceImpl implements LocalRunnerService {
     private static final String FIELD_ERROR = "error";
     private static final String FIELD_TRACE_ID = "trace_id";
     private static final String FIELD_TIMEOUT = "timeout";
+    private static final String FIELD_MASK_ID = "mask_id";
 
     private final @NonNull RedissonClient redisClient;
     private final @NonNull LocalRunnerConfig runnerConfig;
@@ -379,6 +380,9 @@ class LocalRunnerServiceImpl implements LocalRunnerService {
         jobFields.put(FIELD_MAX_RETRIES, "1");
         if (request.inputs() != null) {
             jobFields.put(FIELD_INPUTS, JsonUtils.writeValueAsString(request.inputs()));
+        }
+        if (request.maskId() != null) {
+            jobFields.put(FIELD_MASK_ID, request.maskId().toString());
         }
 
         int timeout = resolveAgentTimeout(runnerId, request.agentName());
@@ -951,6 +955,7 @@ class LocalRunnerServiceImpl implements LocalRunnerService {
                 .error(fields.get(FIELD_ERROR))
                 .project(fields.get(FIELD_PROJECT))
                 .traceId(parseUUID(fields.get(FIELD_TRACE_ID)))
+                .maskId(parseUUID(fields.get(FIELD_MASK_ID)))
                 .timeout(parseIntValue(fields.get(FIELD_TIMEOUT)))
                 .createdAt(parseInstant(fields.get(FIELD_CREATED_AT)))
                 .startedAt(parseInstant(fields.get(FIELD_STARTED_AT)))

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/LocalRunnersResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/LocalRunnersResourceClient.java
@@ -317,6 +317,20 @@ public class LocalRunnersResourceClient {
                 .post(Entity.json(""));
     }
 
+    public LocalRunnerJob nextJob(UUID runnerId, String apiKey, String workspaceName) {
+        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
+                .path(runnerId.toString())
+                .path("jobs")
+                .path("next")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(""))) {
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+            return response.readEntity(LocalRunnerJob.class);
+        }
+    }
+
     public Response callNextJob(UUID runnerId, String apiKey, String workspaceName) {
         return client.target(RESOURCE_PATH.formatted(baseURI))
                 .path(runnerId.toString())

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResourceTest.java
@@ -748,6 +748,33 @@ class LocalRunnersResourceTest {
         }
 
         @Test
+        void storesMaskId() {
+            var ctx = createIsolatedWorkspace();
+            UUID runnerId = connectRunner("cj-mask-id", ctx.apiKey, ctx.workspace);
+            UUID maskId = randomUUID();
+
+            UUID jobId = runnersClient.createJob(CreateLocalRunnerJobRequest.builder()
+                    .agentName(AGENT_NAME).runnerId(runnerId).maskId(maskId).build(),
+                    ctx.apiKey, ctx.workspace);
+
+            LocalRunnerJob job = runnersClient.getJob(jobId, ctx.apiKey, ctx.workspace);
+            assertThat(job.maskId()).isEqualTo(maskId);
+        }
+
+        @Test
+        void storesMaskIdNullWhenNotProvided() {
+            var ctx = createIsolatedWorkspace();
+            UUID runnerId = connectRunner("cj-no-mask-id", ctx.apiKey, ctx.workspace);
+
+            UUID jobId = runnersClient.createJob(CreateLocalRunnerJobRequest.builder()
+                    .agentName(AGENT_NAME).runnerId(runnerId).build(),
+                    ctx.apiKey, ctx.workspace);
+
+            LocalRunnerJob job = runnersClient.getJob(jobId, ctx.apiKey, ctx.workspace);
+            assertThat(job.maskId()).isNull();
+        }
+
+        @Test
         void fallsBackToConfigTimeoutWhenNoAgentsRegistered() {
             var ctx = createIsolatedWorkspace();
             UUID runnerId = connectRunner("cj-no-agents", ctx.apiKey, ctx.workspace);
@@ -779,6 +806,20 @@ class LocalRunnersResourceTest {
                 assertThat(claimed.status().getValue()).isEqualTo("running");
                 assertThat(claimed.startedAt()).isNotNull();
             }
+        }
+
+        @Test
+        void returnsMaskIdWhenClaimed() {
+            var ctx = createIsolatedWorkspace();
+            UUID runnerId = connectRunner("nj-mask-id", ctx.apiKey, ctx.workspace);
+            UUID maskId = randomUUID();
+
+            runnersClient.createJob(CreateLocalRunnerJobRequest.builder()
+                    .agentName(AGENT_NAME).runnerId(runnerId).maskId(maskId).build(),
+                    ctx.apiKey, ctx.workspace);
+
+            LocalRunnerJob claimed = runnersClient.nextJob(runnerId, ctx.apiKey, ctx.workspace);
+            assertThat(claimed.maskId()).isEqualTo(maskId);
         }
 
         @Test
@@ -822,6 +863,22 @@ class LocalRunnersResourceTest {
                     ctx.apiKey, ctx.workspace);
             assertThat(page.content()).hasSize(2);
             assertThat(page.total()).isEqualTo(2);
+        }
+
+        @Test
+        void returnsMaskIdInList() {
+            var ctx = createIsolatedWorkspace();
+            UUID runnerId = connectRunner("lj-mask-id", ctx.apiKey, ctx.workspace);
+            UUID maskId = randomUUID();
+
+            runnersClient.createJob(CreateLocalRunnerJobRequest.builder()
+                    .agentName(AGENT_NAME).runnerId(runnerId).maskId(maskId).build(),
+                    ctx.apiKey, ctx.workspace);
+
+            LocalRunnerJob.LocalRunnerJobPage page = runnersClient.listJobs(runnerId, null, 0, 10,
+                    ctx.apiKey, ctx.workspace);
+            assertThat(page.content()).hasSize(1);
+            assertThat(page.content().getFirst().maskId()).isEqualTo(maskId);
         }
 
         @Test


### PR DESCRIPTION
## Details
Add `maskId` field to the local runner job model and creation request. When a job is created with a `maskId`, it is stored in Redis and returned through all job retrieval endpoints (get, next, list).

- Added `maskId` (optional UUID) to `CreateLocalRunnerJobRequest` and `LocalRunnerJob`
- Updated `LocalRunnerService` to persist and retrieve `maskId` from Redis
- Added `nextJob` helper to `LocalRunnersResourceClient` for tests
- Added tests covering: maskId stored on create, null when not provided, returned when claimed via next, and returned in list

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-4759

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-opus-4-6
  - Scope: full implementation
  - Human verification: code review

## Testing
- Unit tests added in `LocalRunnersResourceTest`:
  - `storesMaskId` — verifies maskId is persisted and returned via getJob
  - `storesMaskIdNullWhenNotProvided` — verifies maskId is null when omitted
  - `returnsMaskIdWhenClaimed` — verifies maskId is returned via nextJob
  - `returnsMaskIdInList` — verifies maskId is returned in job list
- Commands: `cd apps/opik-backend && mvn test`

## Documentation
N/A
