### PR TITLE
[OPIK-4755] [FE] Fix break-all CSS on links causing broken truncation in Firefox

### DIFF
--- a/apps/opik-frontend/src/components/shared/LinkifyText/LinkifyText.test.tsx
+++ b/apps/opik-frontend/src/components/shared/LinkifyText/LinkifyText.test.tsx
@@ -221,7 +221,6 @@ describe("LinkifyText", () => {
       const link = getLinks(container)[0];
       expect(link.className).toContain("text-blue-600");
       expect(link.className).toContain("underline");
-      expect(link.className).toContain("break-all");
     });
   });
 

--- a/apps/opik-frontend/src/components/shared/LinkifyText/LinkifyText.tsx
+++ b/apps/opik-frontend/src/components/shared/LinkifyText/LinkifyText.tsx
@@ -9,7 +9,7 @@ const LINKIFY_OPTIONS: Opts = {
   defaultProtocol: "https",
   target: "_blank",
   rel: "noopener noreferrer",
-  className: "break-all text-blue-600 underline hover:text-blue-800",
+  className: "text-blue-600 underline hover:text-blue-800",
   ignoreTags: ["script", "style"],
   validate: {
     url: (value: string) => URL_PATTERN.test(value),


### PR DESCRIPTION
## Details

Removes `word-break: break-all` from link className in the `LinkifyText` component. This CSS property on `<a>` elements interferes with Firefox inline layout inside `truncate` spans (`overflow: hidden; white-space: nowrap; text-overflow: ellipsis`), causing Input/Output cells in the traces table to render from the middle of the string instead of the beginning. Chrome is unaffected.

The parent containers already use `break-words` (`overflow-wrap: break-word`) in expanded row contexts, which is sufficient for URL wrapping.

**All LinkifyText consumer sites verified — no regressions:**
- `PrettyCell` (truncate + expanded) — fixed / parent handles wrapping
- `TextCell` (truncate + expanded) — fixed / parent handles wrapping
- `MarkdownHighlighter` — `whitespace-pre-wrap` handles wrapping
- `CompareExperimentsConfigCell` — parent has `break-words`
- `TextAndMediaContentRenderer` (truncate + expanded) — fixed / parent handles wrapping

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-4755

## Testing

- [x] Firefox renders truncated cells starting from the beginning of the content
- [x] Chrome behavior unchanged
- [x] All LinkifyText consumer sites verified
- [x] Unit test updated (removed `break-all` assertion)

## Documentation

N/A
