### PR TITLE
[OPIK-4743] [BE] Add NOGROUP recovery to Redis stream consumers

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
@@ -47,6 +47,7 @@ import java.util.stream.Stream;
 public abstract class BaseRedisSubscriber<M> implements Managed {
 
     private static final String BUSYGROUP = "BUSYGROUP";
+    private static final String NOGROUP = "NOGROUP";
 
     /**
      * Non-retryable: programming and validation exceptions that won't succeed on retry.
@@ -302,10 +303,15 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
      * Propagates errors except BUSYGROUP and makes start fail in that case.
      */
     private void enforceConsumerGroup() {
+        createConsumerGroup()
+                .block(config.getLongPollingDuration().toJavaDuration());
+    }
+
+    private Mono<Void> createConsumerGroup() {
         var streamCreateGroupArgs = StreamCreateGroupArgs
                 .name(config.getConsumerGroupName())
                 .makeStream();
-        stream.createGroup(streamCreateGroupArgs)
+        return stream.createGroup(streamCreateGroupArgs)
                 .subscribeOn(consumerScheduler)
                 .onErrorResume(throwable -> {
                     if (Objects.toString(throwable.getMessage(), "").contains(BUSYGROUP)) {
@@ -316,8 +322,7 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
                     log.error("Failed to create consumer group '{}' for stream '{}'",
                             config.getConsumerGroupName(), config.getStreamName(), throwable);
                     return Mono.error(throwable);
-                })
-                .block(config.getLongPollingDuration().toJavaDuration());
+                });
     }
 
     private Disposable setupStreamListener() {
@@ -377,6 +382,9 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
                 .onErrorResume(throwable -> {
                     claimErrors.add(1);
                     log.error("Error claiming pending messages", throwable);
+                    if (isNoGroupError(throwable)) {
+                        return recoverFromNoGroup();
+                    }
                     return Mono.just(Map.of());
                 })
                 .doFinally(signalType -> claimTime.record(System.currentTimeMillis() - startMillis));
@@ -397,9 +405,28 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
                 .onErrorResume(throwable -> {
                     readErrors.add(1);
                     log.error("Error reading from Redis stream", throwable);
+                    if (isNoGroupError(throwable)) {
+                        return recoverFromNoGroup();
+                    }
                     return Mono.just(Map.of());
                 })
                 .doFinally(signalType -> readTime.record(System.currentTimeMillis() - startMillis));
+    }
+
+    private boolean isNoGroupError(Throwable throwable) {
+        return Objects.toString(throwable.getMessage(), "").contains(NOGROUP);
+    }
+
+    private Mono<Map<StreamMessageId, Map<String, M>>> recoverFromNoGroup() {
+        log.warn("Recreating not found consumer group '{}' for stream '{}'",
+                config.getConsumerGroupName(), config.getStreamName());
+        return createConsumerGroup()
+                .onErrorResume(throwable -> {
+                    log.error("Failed to recreate consumer group '{}' for stream '{}'",
+                            config.getConsumerGroupName(), config.getStreamName(), throwable);
+                    return Mono.empty();
+                })
+                .thenReturn(Map.of());
     }
 
     private Mono<ProcessingResult> processMessage(Map.Entry<StreamMessageId, Map<String, M>> entry) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
@@ -244,6 +244,36 @@ class BaseRedisSubscriberTest {
             waitForMessagesAckedAndRemoved();
             assertThat(subscriber.getFailedMessageCount().get()).isEqualTo(otherPayloadMessages.size());
         }
+
+        @Test
+        void shouldRecoverFromNoGroupOnReadAndContinueProcessing() {
+            var messages = PodamFactoryUtils.manufacturePojoList(podamFactory, String.class);
+            var subscriber = trackSubscriber(TestRedisSubscriber.createSubscriber(config, redissonClient));
+            subscriber.start();
+
+            // Process initial messages to confirm subscriber works
+            publishMessagesToStream(messages);
+            waitForMessagesProcessed(subscriber, messages.size());
+            waitForMessagesAckedAndRemoved();
+            assertThat(subscriber.getFailedMessageCount().get()).isZero();
+            var countAfterFirstBatch = subscriber.getSuccessMessageCount().get();
+
+            // Delete the stream (which destroys the consumer group)
+            stream.delete().block();
+
+            waitForStreamRecovery();
+
+            // Publish new messages after group deletion
+            var newMessages = PodamFactoryUtils.manufacturePojoList(podamFactory, String.class);
+            publishMessagesToStream(newMessages);
+
+            // Subscriber should recover and process new messages
+            await().atMost(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertThat(subscriber.getSuccessMessageCount().get())
+                            .isEqualTo(countAfterFirstBatch + newMessages.size()));
+            waitForMessagesAckedAndRemoved();
+            assertThat(subscriber.getFailedMessageCount().get()).isZero();
+        }
     }
 
     @Nested
@@ -414,5 +444,10 @@ class BaseRedisSubscriberTest {
         await().atMost(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 // Verify messages were removed from stream
                 .untilAsserted(() -> assertThat(stream.size().block()).isEqualTo(pendingMessages));
+    }
+
+    private void waitForStreamRecovery() {
+        await().atMost(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(stream.isExists().block()).isTrue());
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberUnitTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberUnitTest.java
@@ -433,6 +433,98 @@ class BaseRedisSubscriberUnitTest {
     }
 
     @Nested
+    class NoGroupErrorTests {
+
+        @Test
+        void shouldRecoverOnClaimAndNotDie() {
+            whenCreateGroupReturnEmpty();
+            whenRemoveConsumerReturn();
+            var fastConfig = CONFIG.toBuilder()
+                    .claimIntervalRatio(3)
+                    .build();
+            var claimCount = new AtomicInteger();
+            var subscriber = trackSubscriber(TestRedisSubscriber.createSubscriber(fastConfig, redissonClient));
+            // autoClaim fails with NOGROUP on first attempt, then succeeds
+            when(stream.autoClaim(
+                    fastConfig.getConsumerGroupName(),
+                    subscriber.getConsumerId(),
+                    fastConfig.getPendingMessageDuration().toJavaDuration().toMillis(),
+                    TimeUnit.MILLISECONDS,
+                    StreamMessageId.MIN,
+                    fastConfig.getConsumerBatchSize()))
+                    .thenAnswer(invocation -> {
+                        int count = claimCount.incrementAndGet();
+                        if (count == 1) {
+                            return Mono.error(
+                                    new RuntimeException("NOGROUP No such key stream or consumer group"));
+                        }
+                        var result = new AutoClaimResult<>(null, Map.of(), List.of());
+                        return Mono.just(result);
+                    });
+            // readGroup works fine, isolating NOGROUP to claim path only
+            whenReadGroupReturnMessages();
+            whenAckReturn();
+            whenRemoveReturn();
+
+            subscriber.start();
+
+            await().atMost(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        assertThat(claimCount.get()).isGreaterThan(1);
+                        assertThat(subscriber.getSuccessMessageCount().get()).isGreaterThan(2);
+                        assertThat(subscriber.getFailedMessageCount().get()).isEqualTo(0);
+                        // createGroup called at start + once for NOGROUP recovery on claim
+                        verify(stream, times(2)).createGroup(any(StreamCreateGroupArgs.class));
+                    });
+        }
+
+        @Test
+        void shouldNotDieOnRecreatingGroup() {
+            whenRemoveConsumerReturn();
+            var readCount = new AtomicInteger();
+            var createGroupCount = new AtomicInteger();
+
+            // First createGroup succeeds (startup), second fails (NOGROUP recovery)
+            when(stream.createGroup(any(StreamCreateGroupArgs.class)))
+                    .thenAnswer(invocation -> {
+                        int count = createGroupCount.incrementAndGet();
+                        if (count == 2) {
+                            return Mono.error(new RuntimeException("Redis connection error"));
+                        }
+                        return Mono.empty();
+                    });
+
+            var subscriber = trackSubscriber(TestRedisSubscriber.createSubscriber(CONFIG, redissonClient));
+            whenAutoClaimReturnEmpty(subscriber.getConsumerId());
+
+            when(stream.readGroup(eq(CONFIG.getConsumerGroupName()), anyString(), any(StreamReadGroupArgs.class)))
+                    .thenAnswer(invocation -> {
+                        int count = readCount.incrementAndGet();
+                        if (count == 1) {
+                            return Mono.error(
+                                    new RuntimeException("NOGROUP No such key stream or consumer group"));
+                        }
+                        return Mono.just(Map.of(new StreamMessageId(System.currentTimeMillis(), 0),
+                                Map.of(TestStreamConfiguration.PAYLOAD_FIELD,
+                                        podamFactory.manufacturePojo(String.class))));
+                    });
+            whenAckReturn();
+            whenRemoveReturn();
+
+            subscriber.start();
+
+            // Should continue processing even after recovery failure
+            await().atMost(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        assertThat(readCount.get()).isGreaterThan(2);
+                        assertThat(subscriber.getSuccessMessageCount().get()).isGreaterThan(2);
+                        assertThat(subscriber.getFailedMessageCount().get()).isEqualTo(0);
+                        assertThat(createGroupCount.get()).isEqualTo(2);
+                    });
+        }
+    }
+
+    @Nested
     class LifecycleErrorTests {
 
         @Test


### PR DESCRIPTION
## Details

When Redis restarts or streams are recreated, consumer groups are lost. This causes NOGROUP errors on `readGroup` and `autoClaim` operations, which previously were only logged but never recovered from. The subscriber would keep failing on every poll cycle indefinitely.

Now `BaseRedisSubscriber` detects NOGROUP errors and automatically recreates the consumer group, allowing the subscriber to resume processing new messages.

Added NOGROUP detection and recovery in both `readMessages` and `claimPendingMessages` error handlers

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- OPIK-4743

## Testing
Added integration and unit test coverage covering all paths:
- Integration tests:
  - Recovery from NOGROUP on read.
- Unit tests for situations can't be simulated:
  - Recovery from NOGROUP on claim.
  - Not dying from group recreation.
- Existing tests continue to pass

## Documentation

No documentation changes needed - this is an internal resilience fix.