### PR TITLE
[OPIK-4756] [FE] Add overflow-hidden to CellWrapper to prevent row content bleeding

### DIFF
--- a/apps/opik-frontend/src/components/shared/DataTableCells/CellWrapper.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableCells/CellWrapper.tsx
@@ -40,7 +40,7 @@ const CellWrapper = <TData,>({
   return (
     <div
       className={cn(
-        "flex size-full py-2 px-3",
+        "flex size-full overflow-hidden py-2 px-3",
         stopClickPropagation && "cursor-auto",
         verticalAlignClass,
         horizontalAlignClass,


### PR DESCRIPTION
## Details
Adds `overflow-hidden` to CellWrapper's className as a defense-in-depth fix to prevent any cell content from visually overflowing into adjacent table rows. This ensures no cell renderer can accidentally cause visual overflow across row boundaries, regardless of its own internal overflow handling.

## Change checklist
- [x] Add `overflow-hidden` to CellWrapper flex container

## Issues
OPIK-4756

## Testing
- Verified cell content doesn't bleed into adjacent rows in Firefox and Chrome
- Verified scrolling in medium/large row heights still works correctly
- Visual check across table views (traces, spans, experiments, datasets)

## Documentation
No documentation changes needed.