### PR TITLE
[OPIK-4802] [SDK] Fix agent_config to avoid API calls during import and remove unused defaults

### DIFF
--- a/sdks/python/src/opik/api_objects/agent_config/decorator.py
+++ b/sdks/python/src/opik/api_objects/agent_config/decorator.py
@@ -83,23 +83,24 @@ def agent_config_decorator(
         if not dataclasses.is_dataclass(cls):
             cls = dataclasses.dataclass(cls)
 
-        supported_fields = type_helpers.extract_dataclass_fields(cls)
         class_prefix = name or cls.__name__
-
-        fields: typing.Dict[str, ConfigField] = {
-            f_name: ConfigField(
-                prefixed_key=f"{class_prefix}.{f_name}",
-                py_type=f_type,
-                description=desc,
-            )
-            for f_name, f_type, _, desc in supported_fields
-        }
-        prefixed_field_types = {cf.prefixed_key: cf.py_type for cf in fields.values()}
 
         original_init = cls.__init__
 
         def new_init(self: typing.Any, *args: typing.Any, **kwargs: typing.Any) -> None:
             original_init(self, *args, **kwargs)
+
+            fields: typing.Dict[str, ConfigField] = {
+                f_name: ConfigField(
+                    prefixed_key=f"{class_prefix}.{f_name}",
+                    py_type=f_type,
+                    description=desc,
+                )
+                for f_name, f_type, desc in type_helpers.extract_dataclass_fields(cls)
+            }
+            prefixed_field_types = {
+                cf.prefixed_key: cf.py_type for cf in fields.values()
+            }
 
             client = opik_client.get_client_cached()
 
@@ -129,10 +130,11 @@ def agent_config_decorator(
         original_getattribute = cls.__getattribute__
 
         def new_getattribute(self: typing.Any, attr: str) -> typing.Any:
-            if attr.startswith("_") or attr not in fields:
+            instance: AgentConfigInstance = self
+
+            if attr.startswith("_") or attr not in instance.__opik_fields__:
                 return original_getattribute(self, attr)
 
-            instance: AgentConfigInstance = self
             masked = _get_masked_value(instance, attr)
             if masked is not _MISSING:
                 _inject_trace_metadata(instance, attr, value=masked)

--- a/sdks/python/src/opik/api_objects/agent_config/type_helpers.py
+++ b/sdks/python/src/opik/api_objects/agent_config/type_helpers.py
@@ -134,8 +134,8 @@ def backend_value_to_python_value(
 
 def extract_dataclass_fields(
     cls: type,
-) -> typing.List[typing.Tuple[str, typing.Any, typing.Any, typing.Optional[str]]]:
-    """Returns (field_name, field_type, default_or_MISSING, description) for supported fields."""
+) -> typing.List[typing.Tuple[str, typing.Any, typing.Optional[str]]]:
+    """Returns (field_name, field_type, description) for supported fields."""
     if not dataclasses.is_dataclass(cls):
         raise TypeError(f"{cls} is not a dataclass")
 
@@ -155,11 +155,5 @@ def extract_dataclass_fields(
             py_type = inner
         if not is_supported_type(py_type):
             continue
-        if f.default is not dataclasses.MISSING:
-            default = f.default
-        elif f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
-            default = f.default_factory()
-        else:
-            default = dataclasses.MISSING
-        result.append((f.name, py_type, default, description))
+        result.append((f.name, py_type, description))
     return result

--- a/sdks/python/tests/unit/api_objects/agent_config/test_decorator.py
+++ b/sdks/python/tests/unit/api_objects/agent_config/test_decorator.py
@@ -1014,6 +1014,31 @@ class TestConfigDecoratorContextMask:
         mock_backend.agent_configs.get_blueprint_by_env.assert_not_called()
 
 
+class TestConfigDecoratorDefaultFactory:
+    def test_default_factory_prompt__instantiated_exactly_once(self, mock_backend):
+        factory_call_count = 0
+
+        def counting_factory():
+            nonlocal factory_call_count
+            factory_call_count += 1
+            p = mock.Mock(spec=Prompt)
+            p.commit = "abc123"
+            return p
+
+        @agent_config_decorator
+        @dataclasses.dataclass
+        class MyConfig:
+            system_prompt: Prompt = dataclasses.field(default_factory=counting_factory)
+
+        assert factory_call_count == 0, "factory must not be called at decoration time"
+        config = MyConfig()
+        assert factory_call_count == 1, (
+            "factory must be called exactly once on instantiation"
+        )
+        config.system_prompt
+        assert factory_call_count == 1, "factory must not be called on attribute access"
+
+
 class TestConfigDecoratorAnnotatedDescriptions:
     def test_annotated_field__description_sent_to_backend(self, mock_backend):
         @agent_config_decorator

--- a/sdks/python/tests/unit/api_objects/agent_config/test_type_helpers.py
+++ b/sdks/python/tests/unit/api_objects/agent_config/test_type_helpers.py
@@ -431,24 +431,24 @@ class TestExtractDataclassFields:
         with pytest.raises(TypeError):
             type_helpers.extract_dataclass_fields(NotADataclass)
 
-    def test_fields_with_defaults__defaults_extracted(self):
+    def test_fields_with_defaults__names_and_types_extracted(self):
         @dataclasses.dataclass
         class WithDefaults:
             temp: float = 0.8
             name: str = "default"
 
         fields = type_helpers.extract_dataclass_fields(WithDefaults)
-        defaults = {f[0]: f[2] for f in fields}
-        assert defaults["temp"] == 0.8
-        assert defaults["name"] == "default"
+        by_name = {f[0]: f[1] for f in fields}
+        assert by_name["temp"] is float
+        assert by_name["name"] is str
 
-    def test_field_without_default__returns_missing_sentinel(self):
+    def test_field_without_default__included_in_results(self):
         @dataclasses.dataclass
         class NoDefault:
             temp: float
 
         fields = type_helpers.extract_dataclass_fields(NoDefault)
-        assert fields[0][2] is dataclasses.MISSING
+        assert fields[0][0] == "temp"
 
     def test_prompt_field__included_in_extracted_fields(self):
         @dataclasses.dataclass
@@ -478,10 +478,9 @@ class TestExtractDataclassFieldsAnnotated:
 
         fields = type_helpers.extract_dataclass_fields(Cfg)
         assert len(fields) == 1
-        name, py_type, default, desc = fields[0]
+        name, py_type, desc = fields[0]
         assert name == "model"
         assert py_type is str
-        assert default == "gpt-4o"
         assert desc == "The LLM model name"
 
     def test_annotated_float__description_extracted(self):
@@ -490,7 +489,7 @@ class TestExtractDataclassFieldsAnnotated:
             temperature: Annotated[float, "Sampling temperature"] = 0.7
 
         fields = type_helpers.extract_dataclass_fields(Cfg)
-        name, py_type, default, desc = fields[0]
+        name, py_type, desc = fields[0]
         assert py_type is float
         assert desc == "Sampling temperature"
 
@@ -500,7 +499,7 @@ class TestExtractDataclassFieldsAnnotated:
             tokens: Annotated[int, 42, "Max tokens to generate"] = 512
 
         fields = type_helpers.extract_dataclass_fields(Cfg)
-        _, _, _, desc = fields[0]
+        _, _, desc = fields[0]
         assert desc == "Max tokens to generate"
 
     def test_annotated_no_str_metadata__description_is_none(self):
@@ -509,7 +508,7 @@ class TestExtractDataclassFieldsAnnotated:
             tokens: Annotated[int, 42] = 512
 
         fields = type_helpers.extract_dataclass_fields(Cfg)
-        _, _, _, desc = fields[0]
+        _, _, desc = fields[0]
         assert desc is None
 
     def test_plain_type__description_is_none(self):
@@ -518,7 +517,7 @@ class TestExtractDataclassFieldsAnnotated:
             tokens: int = 512
 
         fields = type_helpers.extract_dataclass_fields(Cfg)
-        _, _, _, desc = fields[0]
+        _, _, desc = fields[0]
         assert desc is None
 
     def test_mixed_annotated_and_plain__descriptions_per_field(self):
@@ -528,7 +527,7 @@ class TestExtractDataclassFieldsAnnotated:
             temperature: float = 0.7
 
         fields = type_helpers.extract_dataclass_fields(Cfg)
-        by_name = {f[0]: f[3] for f in fields}
+        by_name = {f[0]: f[2] for f in fields}
         assert by_name["model"] == "Model name"
         assert by_name["temperature"] is None
 
@@ -614,7 +613,7 @@ class TestExtractDataclassFieldsOptional:
 
         fields = type_helpers.extract_dataclass_fields(Cfg)
         assert len(fields) == 1
-        _, py_type, _, _ = fields[0]
+        _, py_type, _ = fields[0]
         assert py_type is str
 
     def test_optional_and_plain_field__both_included(self):


### PR DESCRIPTION
## Details

Fixes the agent_config decorator to prevent API calls during module import time and removes unused default value extraction.

**Key changes:**
- Move field initialization from class decoration time to instance instantiation time to prevent API calls when the module is imported
- Remove default value extraction from `extract_dataclass_fields()` function - this avoids calling default_factory functions at decoration time
- Delay `client.get_client_cached()` call to instance initialization instead of class decoration
- Updated tests to verify factory functions are called only at instantiation, not at decoration time

This ensures that importing a module with @agent_config decorated classes doesn't trigger API calls or execute factory functions prematurely.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-4802

## Testing

- Added test case `TestConfigDecoratorDefaultFactory.test_default_factory_prompt__instantiated_exactly_once` to verify:
  - Factory is not called during class decoration
  - Factory is called exactly once on instance initialization
  - Factory is not called again on attribute access
- Updated existing tests in `test_type_helpers.py` to verify field extraction returns only name, type, and description

## Documentation

N/A