### PR TITLE
[OPIK-4675] [BE] fix: remove maxCompletionTokens from dataset expansion to support reasoning models

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetExpansionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetExpansionService.java
@@ -180,7 +180,6 @@ public class DatasetExpansionService {
                     .model(request.model())
                     .addUserMessage(prompt)
                     .temperature(1.0) // Set temperature to 1.0 for consistent output
-                    .maxCompletionTokens(4000)
                     .stream(false) // Non-streaming request for dataset expansion
                     .build();
 


### PR DESCRIPTION
## Details

Removes the hardcoded `maxCompletionTokens(4000)` from `DatasetExpansionService.generateSamples()`. Reasoning models (e.g. `gpt-5-nano`) consume this limit on internal reasoning tokens, leaving zero tokens for output and causing silent empty responses. Non-reasoning models are unaffected — they stop generating naturally when the JSON array is complete.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-4675

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Sonnet 4.6
  - Scope: investigation, fix implementation, local testing
  - Human verification: manually tested with gpt-5-nano and gpt-4.1-nano locally

## Testing

- Reproduced failure locally with `gpt-5-nano` before fix: UI showed "empty or very short response" error
- Verified `gpt-5-nano` expansion succeeds post-fix (~46s response time, consistent with reasoning model behaviour)
- Verified `gpt-4.1-nano` continues to work as before
- No unit tests exist for `DatasetExpansionService`; no tests to update

## Documentation

N/A