### PR TITLE
[OPIK-4757] [FE] Fix PrettyCell showing literal \n instead of rendering newlines

### DIFF
--- a/apps/opik-frontend/src/components/shared/DataTableCells/PrettyCell.tsx
+++ b/apps/opik-frontend/src/components/shared/DataTableCells/PrettyCell.tsx
@@ -25,39 +25,24 @@ const PrettyCell = <TData,>(context: CellContext<TData, string | object>) => {
   const { fieldType = "input" } = (custom ?? {}) as CustomMeta;
   const value = context.getValue() as string | object | undefined | null;
 
-  const rawValue = useMemo(() => {
-    let text = "";
-    if (isObject(value)) {
-      text = JSON.stringify(value, null, 2);
-    } else {
-      text = value ?? "-";
-    }
-
-    return text;
-  }, [value]);
-
-  const hasExceededLimit = useMemo(
-    () => truncationEnabled && rawValue.length > maxDataLength,
-    [rawValue, maxDataLength, truncationEnabled],
-  );
-
   const displayMessage = useMemo(() => {
-    if (!value || hasExceededLimit) {
-      return hasExceededLimit
-        ? rawValue.slice(0, maxDataLength) + " [truncated]"
-        : "-";
+    if (!value) return "-";
+
+    const pretty = prettifyMessage(value, { type: fieldType });
+
+    let message: string;
+    if (isObject(pretty.message)) {
+      message = JSON.stringify(value, null, 2);
+    } else {
+      message = pretty.message || "";
     }
 
-    const pretty = prettifyMessage(value, {
-      type: fieldType,
-    });
-
-    const message = isObject(pretty.message)
-      ? JSON.stringify(value, null, 2)
-      : pretty.message || "";
+    if (truncationEnabled && message.length > maxDataLength) {
+      return message.slice(0, maxDataLength) + " [truncated]";
+    }
 
     return message;
-  }, [value, hasExceededLimit, fieldType, rawValue, maxDataLength]);
+  }, [value, fieldType, truncationEnabled, maxDataLength]);
 
   const rowHeight =
     context.column.columnDef.meta?.overrideRowHeight ??

--- a/apps/opik-frontend/src/lib/traces.test.ts
+++ b/apps/opik-frontend/src/lib/traces.test.ts
@@ -432,6 +432,25 @@ describe("prettifyMessage", () => {
     expect(result.message).toBeDefined();
   });
 
+  it("parses JSON string and extracts text field", () => {
+    const message = JSON.stringify({
+      prompt: "Hello\nWorld",
+      systemPrompt: "You are a helpful assistant.",
+    });
+    const result = prettifyMessage(message, { type: "input" });
+    expect(result).toEqual({ message: "Hello\nWorld", prettified: true });
+  });
+
+  it("extracts text field from backend-truncated JSON string", () => {
+    const fullJson = JSON.stringify({
+      prompt: "Hello\nWorld",
+      systemPrompt: "A".repeat(11000),
+    });
+    const truncated = fullJson.slice(0, 10000);
+    const result = prettifyMessage(truncated, { type: "input" });
+    expect(result).toEqual({ message: "Hello\nWorld", prettified: true });
+  });
+
   it("handles OpenAI input with mixed roles and returns last user message", () => {
     const message = {
       messages: [

--- a/apps/opik-frontend/src/lib/traces.ts
+++ b/apps/opik-frontend/src/lib/traces.ts
@@ -527,15 +527,60 @@ const prettifyGenericLogic = (
   }
 };
 
+// Workaround: when the backend truncates large input/output JSON (truncate=true),
+// it cuts the serialized string at ~10k chars, producing invalid JSON that can't
+// be parsed. This extracts known text field values directly from the broken string.
+// Can be removed if we instead truncate individual field values in the backend.
+const KNOWN_TEXT_FIELDS: Record<string, string[]> = {
+  input: ["question", "message", "query", "prompt", "input", "text", "content"],
+  output: ["answer", "output", "response", "reply"],
+};
+
+const extractTextFieldFromTruncatedJson = (
+  jsonString: string,
+  config: PrettifyMessageConfig,
+): string | undefined => {
+  const fields = KNOWN_TEXT_FIELDS[config.type];
+  if (!fields) return undefined;
+
+  for (const field of fields) {
+    const needle = `"${field}":"`;
+    const idx = jsonString.indexOf(needle);
+    if (idx === -1) continue;
+
+    const valueStart = idx + needle.length;
+    let i = valueStart;
+    while (i < jsonString.length) {
+      if (jsonString[i] === "\\") {
+        i += 2;
+      } else if (jsonString[i] === '"') {
+        break;
+      } else {
+        i++;
+      }
+    }
+
+    if (i <= valueStart || i >= jsonString.length) continue;
+
+    try {
+      return JSON.parse(`"${jsonString.slice(valueStart, i)}"`);
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+};
+
 export const prettifyMessage = (
   message: object | string | undefined,
   config: PrettifyMessageConfig = {
     type: "input",
   },
-) => {
+): PrettifyMessageResponse => {
   if (isString(message)) {
+    const extracted = extractTextFieldFromTruncatedJson(message, config);
     return {
-      message,
+      message: extracted || message,
       prettified: true,
     } as PrettifyMessageResponse;
   }


### PR DESCRIPTION
## Details
When the backend truncates large input/output JSON (`truncate=true`), it produces an invalid JSON string that arrives as a raw string in the frontend. `prettifyMessage` returned these strings as-is, showing literal `\n` escape sequences instead of rendered newlines.

- Added `extractTextFieldFromTruncatedJson` to scan truncated JSON strings for known text field values (e.g., `prompt`, `query`, `response`) and extract them with proper unescaping
- Simplified `PrettyCell` memo to prettify first then truncate, removing unnecessary duplicate `JSON.stringify` calls

## Change checklist
- [x] Added `extractTextFieldFromTruncatedJson` in `traces.ts`
- [x] Simplified `PrettyCell` display memo
- [x] Added unit tests for valid and truncated JSON string extraction

## Issues
OPIK-4757

## Testing
- [x] All 34 existing `prettifyMessage` unit tests pass
- [ ] Manual verification with large trace data containing newlines

## Documentation
No documentation changes needed.

## Screenshots
Before:
<img width="949" height="297" alt="Screenshot 2026-03-05 at 19 05 11" src="https://github.com/user-attachments/assets/0c33ce2b-615c-4af0-aeb5-c025c9eef075" />
After:
<img width="956" height="298" alt="Screenshot 2026-03-05 at 19 04 45" src="https://github.com/user-attachments/assets/d2bb845b-0f24-47b0-85c1-938dcde0c40c" />
