### PR TITLE
[OPIK-4631] [BE] perf: optimize trace get-by-id query to prevent memory amplification

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -634,19 +634,10 @@ class TraceDAOImpl implements TraceDAO {
                     toInt64(countIf(type = 'llm')) AS llm_span_count,
                     countIf(type = 'tool') > 0 AS has_tool_spans,
                     arraySort(groupUniqArrayIf(provider, provider != '')) as providers
-                FROM (
-                    SELECT
-                        trace_id,
-                        usage,
-                        total_estimated_cost,
-                        id,
-                        type,
-                        provider
-                    FROM spans FINAL
-                    WHERE workspace_id = :workspace_id
-                    <if(has_target_projects)>AND project_id IN :target_project_ids<endif>
-                    AND trace_id IN :ids
-                )
+                FROM spans FINAL
+                WHERE workspace_id = :workspace_id
+                <if(has_target_projects)>AND project_id IN :target_project_ids<endif>
+                AND trace_id IN :ids
                 GROUP BY trace_id
             ), experiments_agg AS (
                 SELECT DISTINCT


### PR DESCRIPTION
## Details

Optimizes the critical `SELECT_BY_IDS` query in `TraceDAO` that was causing `SocketTimeoutException` (in production) and `MEMORY_LIMIT_EXCEEDED` (running via SQL Editor) errors when fetching traces with large payloads and many spans.

The root cause was a fan-out LEFT JOIN: a single trace row (e.g. 18MB payload) was being duplicated for each span (e.g. 2550 spans), creating ~45 GiB of intermediate data during `JoiningTransform`. The fix pre-aggregates spans before joining, turning the N:1 fan-out into a 1:1 join.

Additionally, redundant `FINAL` modifiers are removed from feedback score CTEs across all trace queries since the downstream `ROW_NUMBER()` already handles deduplication. This is expected to reduce a lot of extra work.

Changes:
- **SELECT_BY_IDS**: Pre-aggregate spans in `spans_agg` CTE, use `DISTINCT` instead of `FINAL` for `target_spans`, remove final `GROUP BY t.*`
- **SELECT_BY_IDS**: Join span feedback scores with `target_spans` early in the CTE pipeline (inside `span_feedback_scores_combined_raw`) instead of fetching all workspace/project span feedback scores first and filtering later — drastically reduces the amount of data scanned
- **SELECT_BY_IDS**: Add missing `project_id` filter to trace feedback score CTEs (`feedback_scores_combined_raw`) and authored feedback score CTEs, which were previously only filtering by `workspace_id` and `entity_id`
- **SELECT_BY_PROJECT_ID, COUNT_BY_PROJECT_ID, SELECT_TRACES_STATS**: Remove `FINAL` from `feedback_scores` and `authored_feedback_scores` (16 occurrences total) where `ROW_NUMBER()` dedup is already applied

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-4631

## Testing

- Ran `mvn spotless:apply` — no formatting issues
- Ran `mvn test -Dtest="TracesResourceTest"` — all tests pass (BUILD SUCCESS, ~4m42s)
- Ran `mvn compile` — compiles cleanly
- Manually tested the optimized `SELECT_BY_IDS` query against production ClickHouse with a problematic trace (18MB payload, 2550 spans):
  - Before: `MEMORY_LIMIT_EXCEEDED` (25 GiB attempted, 9.31 GiB limit) or 31s timeout
  - After: Completes in ~2 seconds

## Documentation

NA
