### PR TITLE
[OPIK-4743] [BE] Add configurable MAXLEN trimming and trim limit to Redis stream producers

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -354,6 +354,12 @@ onlineScoring:
   # Default: 3
   # Description: Maximum number of retry attempts for failed messages (1-10, global default)
   maxRetries: ${REDIS_SCORING_MAX_RETRIES:-3}
+  # Default: 10000
+  # Description: Max number of entries (approx) when publishing to the Redis stream. Oldest are evicted if exceeded
+  streamMaxLen: ${REDIS_SCORING_STREAM_MAX_LEN:-10000}
+  # Default: 100
+  # Description: Max number of entries to evict when publishing to the Redis stream (0 = no limit) if over max length
+  streamTrimLimit: ${REDIS_SCORING_STREAM_TRIM_LIMIT:-100}
   ## scorer: options from AutomationRuleEvaluatorType
   ## streamName: the name of the stream in redis
   ## codec: 'json' when there are non-java consumers, 'java' for java consumers only
@@ -363,6 +369,8 @@ onlineScoring:
   ## claimIntervalRatio: (optional) per stream claim interval ratio, overrides global value
   ## pendingMessageDuration: (optional) per stream pending message duration, overrides global value
   ## maxRetries: (optional) per stream max retries, overrides global value
+  ## streamMaxLen: (optional) per stream max length, overrides global streamMaxLen value
+  ## streamTrimLimit: (optional) per stream trim limit, overrides global streamTrimLimit value
   streams:
     - scorer: llm_as_judge
       streamName: stream_scoring_llm_as_judge
@@ -374,6 +382,8 @@ onlineScoring:
       claimIntervalRatio: ${REDIS_SCORING_LLM_AS_JUDGE_CLAIM_INTERVAL_RATIO:-}
       pendingMessageDuration: ${REDIS_SCORING_LLM_AS_JUDGE_PENDING_MESSAGE_DURATION:-}
       maxRetries: ${REDIS_SCORING_LLM_AS_JUDGE_MAX_RETRIES:-}
+      streamMaxLen: ${REDIS_SCORING_LLM_AS_JUDGE_STREAM_MAX_LEN:-}
+      streamTrimLimit: ${REDIS_SCORING_LLM_AS_JUDGE_STREAM_TRIM_LIMIT:-}
     - scorer: user_defined_metric_python
       streamName: stream_scoring_user_defined_metric_python
       codec: java
@@ -384,6 +394,8 @@ onlineScoring:
       claimIntervalRatio: ${REDIS_SCORING_USER_DEFINED_METRIC_PYTHON_CLAIM_INTERVAL_RATIO:-}
       pendingMessageDuration: ${REDIS_SCORING_USER_DEFINED_METRIC_PYTHON_PENDING_MESSAGE_DURATION:-}
       maxRetries: ${REDIS_SCORING_USER_DEFINED_METRIC_PYTHON_MAX_RETRIES:-}
+      streamMaxLen: ${REDIS_SCORING_USER_DEFINED_METRIC_PYTHON_STREAM_MAX_LEN:-}
+      streamTrimLimit: ${REDIS_SCORING_USER_DEFINED_METRIC_PYTHON_STREAM_TRIM_LIMIT:-}
     - scorer: trace_thread_llm_as_judge
       streamName: stream_scoring_trace_thread_llm_as_judge
       codec: java
@@ -394,6 +406,8 @@ onlineScoring:
       claimIntervalRatio: ${REDIS_SCORING_TRACE_THREAD_LLM_AS_JUDGE_CLAIM_INTERVAL_RATIO:-}
       pendingMessageDuration: ${REDIS_SCORING_TRACE_THREAD_LLM_AS_JUDGE_PENDING_MESSAGE_DURATION:-}
       maxRetries: ${REDIS_SCORING_TRACE_THREAD_LLM_AS_JUDGE_MAX_RETRIES:-}
+      streamMaxLen: ${REDIS_SCORING_TRACE_THREAD_LLM_AS_JUDGE_STREAM_MAX_LEN:-}
+      streamTrimLimit: ${REDIS_SCORING_TRACE_THREAD_LLM_AS_JUDGE_STREAM_TRIM_LIMIT:-}
     - scorer: trace_thread_user_defined_metric_python
       streamName: stream_scoring_trace_thread_user_defined_metric_python
       codec: java
@@ -404,6 +418,8 @@ onlineScoring:
       claimIntervalRatio: ${REDIS_SCORING_TRACE_THREAD_USER_DEFINED_METRIC_PYTHON_CLAIM_INTERVAL_RATIO:-}
       pendingMessageDuration: ${REDIS_SCORING_TRACE_THREAD_USER_DEFINED_METRIC_PYTHON_PENDING_MESSAGE_DURATION:-}
       maxRetries: ${REDIS_SCORING_TRACE_THREAD_USER_DEFINED_METRIC_PYTHON_MAX_RETRIES:-}
+      streamMaxLen: ${REDIS_SCORING_TRACE_THREAD_USER_DEFINED_METRIC_PYTHON_STREAM_MAX_LEN:-}
+      streamTrimLimit: ${REDIS_SCORING_TRACE_THREAD_USER_DEFINED_METRIC_PYTHON_STREAM_TRIM_LIMIT:-}
     - scorer: span_llm_as_judge
       streamName: stream_scoring_span_llm_as_judge
       codec: java
@@ -414,6 +430,8 @@ onlineScoring:
       claimIntervalRatio: ${REDIS_SCORING_SPAN_LLM_AS_JUDGE_CLAIM_INTERVAL_RATIO:-}
       pendingMessageDuration: ${REDIS_SCORING_SPAN_LLM_AS_JUDGE_PENDING_MESSAGE_DURATION:-}
       maxRetries: ${REDIS_SCORING_SPAN_LLM_AS_JUDGE_MAX_RETRIES:-}
+      streamMaxLen: ${REDIS_SCORING_SPAN_LLM_AS_JUDGE_STREAM_MAX_LEN:-}
+      streamTrimLimit: ${REDIS_SCORING_SPAN_LLM_AS_JUDGE_STREAM_TRIM_LIMIT:-}
     - scorer: span_user_defined_metric_python
       streamName: stream_scoring_span_user_defined_metric_python
       codec: java
@@ -424,6 +442,8 @@ onlineScoring:
       claimIntervalRatio: ${REDIS_SCORING_SPAN_USER_DEFINED_METRIC_PYTHON_CLAIM_INTERVAL_RATIO:-}
       pendingMessageDuration: ${REDIS_SCORING_SPAN_USER_DEFINED_METRIC_PYTHON_PENDING_MESSAGE_DURATION:-}
       maxRetries: ${REDIS_SCORING_SPAN_USER_DEFINED_METRIC_PYTHON_MAX_RETRIES:-}
+      streamMaxLen: ${REDIS_SCORING_SPAN_USER_DEFINED_METRIC_PYTHON_STREAM_MAX_LEN:-}
+      streamTrimLimit: ${REDIS_SCORING_SPAN_USER_DEFINED_METRIC_PYTHON_STREAM_TRIM_LIMIT:-}
 
 # Configuration for Dataset Export
 datasetExport:
@@ -454,6 +474,12 @@ datasetExport:
   # Default: 5m
   # Description: Time before export job message considered orphaned and eligible for claiming
   pendingMessageDuration: ${DATASET_EXPORT_PENDING_MESSAGE_DURATION:-5m}
+  # Default: 10000
+  # Description: Max number of entries (approx) when publishing to the Redis stream. Oldest are evicted if exceeded
+  streamMaxLen: ${DATASET_EXPORT_STREAM_MAX_LEN:-10000}
+  # Default: 100
+  # Description: Max number of entries to evict when publishing to the Redis stream (0 = no limit) if over max length
+  streamTrimLimit: ${DATASET_EXPORT_STREAM_TRIM_LIMIT:-100}
   # Default: 24h
   # Description: Default time-to-live for exported CSV files before automatic cleanup
   defaultTtl: ${DATASET_EXPORT_DEFAULT_TTL:-24h}
@@ -748,6 +774,12 @@ traceThreadConfig:
   # Default: 3
   # Description: Maximum number of retry attempts for failed messages (1-10)
   maxRetries: ${OPIK_REDIS_TRACE_THREAD_MAX_RETRIES:-3}
+  # Default: 100000
+  # Description: Max number of entries (approx) when publishing to the Redis stream. Oldest are evicted if exceeded
+  streamMaxLen: ${OPIK_REDIS_TRACE_THREAD_STREAM_MAX_LEN:-100000}
+  # Default: 100
+  # Description: Max number of entries to evict when publishing to the Redis stream (0 = no limit) if over max length
+  streamTrimLimit: ${OPIK_REDIS_TRACE_THREAD_STREAM_TRIM_LIMIT:-100}
 
 # Job timeout configuration
 jobTimeout:
@@ -820,6 +852,12 @@ webhook:
   # Default: 10m
   # Description: Time before message considered orphaned and eligible for claiming
   pendingMessageDuration: ${WEBHOOK_PENDING_MESSAGE_DURATION:-10m}
+  # Default: 10000
+  # Description: Max number of entries (approx) when publishing to the Redis stream. Oldest are evicted if exceeded
+  streamMaxLen: ${WEBHOOK_STREAM_MAX_LEN:-10000}
+  # Default: 100
+  # Description: Max number of entries to evict when publishing to the Redis stream (0 = no limit) if over max length
+  streamTrimLimit: ${WEBHOOK_STREAM_TRIM_LIMIT:-100}
   debouncing:
     # Default: true
     # Description: Whether or not webhook event debouncing is enabled

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/webhooks/WebhookPublisher.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/webhooks/WebhookPublisher.java
@@ -38,12 +38,10 @@ public class WebhookPublisher {
      * Publishes a webhook event to the Redis stream for processing with custom retry count.
      *
      * @param eventType    The type of event
-     * @param alertId      The alert ID
+     * @param alert      The alert payload containing webhook configuration
      * @param workspaceId  The workspace ID associated with the event
      * @param workspaceName The workspace name associated with the event
-     * @param webhookUrl   The URL to send the webhook to
      * @param payload      The payload to include in the webhook
-     * @param headers      Optional custom headers to include in the HTTP request
      * @param maxRetries   Maximum number of retry attempts for this specific event
      * @return A Mono that completes when the event is published to the stream
      */
@@ -87,16 +85,19 @@ public class WebhookPublisher {
                     webhookConfig.getStreamName(),
                     webhookConfig.getCodec());
 
-            return stream.add(StreamAddArgs.entry(WebhookConfig.PAYLOAD_FIELD, webhookEvent))
+            var streamAddArgs = StreamAddArgs
+                    .<String, WebhookEvent<?>>entry(WebhookConfig.PAYLOAD_FIELD, webhookEvent)
+                    .trimNonStrict()
+                    .maxLen(webhookConfig.getStreamMaxLen())
+                    .limit(webhookConfig.getStreamTrimLimit());
+            return stream.add(streamAddArgs)
                     .map(streamMessageId -> {
                         log.debug("Webhook event published successfully: id='{}', streamMessageId='{}'",
                                 eventId, streamMessageId);
                         return eventId;
                     })
-                    .doOnError(throwable -> {
-                        log.error("Failed to publish webhook event: id='{}', type='{}', error='{}'",
-                                eventId, eventType, throwable.getMessage(), throwable);
-                    });
+                    .doOnError(throwable -> log.error("Failed to publish webhook event: id='{}', type='{}', error='{}'",
+                            eventId, eventType, throwable.getMessage(), throwable));
         })
                 .subscribeOn(Schedulers.boundedElastic());
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/TraceThreadsClosingJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/TraceThreadsClosingJob.java
@@ -130,7 +130,12 @@ public class TraceThreadsClosingJob extends Job implements InterruptableJob {
                     return traceThreadService.addToPendingQueue(message.projectId())
                             .flatMap(pending -> {
                                 if (Boolean.TRUE.equals(pending)) {
-                                    return stream.add(StreamAddArgs.entry(TraceThreadConfig.PAYLOAD_FIELD, message));
+                                    var streamAddArgs = StreamAddArgs
+                                            .<Object, Object>entry(TraceThreadConfig.PAYLOAD_FIELD, message)
+                                            .trimNonStrict()
+                                            .maxLen(traceThreadConfig.getStreamMaxLen())
+                                            .limit(traceThreadConfig.getStreamTrimLimit());
+                                    return stream.add(streamAddArgs);
                                 } else {
                                     log.info("Project {} is already in the pending closure list, skipping enqueue",
                                             message.projectId());

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CsvDatasetExportService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CsvDatasetExportService.java
@@ -164,7 +164,12 @@ class CsvDatasetExportServiceImpl implements CsvDatasetExportService {
                 exportConfig.getStreamName(),
                 exportConfig.getCodec());
 
-        return stream.add(StreamAddArgs.entry(DatasetExportConfig.PAYLOAD_FIELD, message))
+        var streamAddArgs = StreamAddArgs
+                .entry(DatasetExportConfig.PAYLOAD_FIELD, message)
+                .trimNonStrict()
+                .maxLen(exportConfig.getStreamMaxLen())
+                .limit(exportConfig.getStreamTrimLimit());
+        return stream.add(streamAddArgs)
                 .doOnNext(messageId -> log.info(
                         "Export job published to Redis stream: jobId='{}', messageId='{}'",
                         job.id(), messageId))

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java
@@ -7,8 +7,8 @@ import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
 import com.comet.opik.api.events.TraceThreadToScoreLlmAsJudge;
 import com.comet.opik.api.events.TraceThreadToScoreUserDefinedMetricPython;
 import com.comet.opik.infrastructure.OnlineScoringConfig;
+import com.comet.opik.infrastructure.OnlineScoringStreamConfigurationAdapter;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
-import com.comet.opik.infrastructure.redis.RedisStreamCodec;
 import com.google.inject.ImplementedBy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -22,7 +22,6 @@ import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -59,7 +58,7 @@ class OnlineScorePublisherImpl implements OnlineScorePublisher {
 
     private final RedissonReactiveClient redisClient;
     private final AutomationRuleEvaluatorService automationRuleEvaluatorService;
-    private final Map<AutomationRuleEvaluatorType, OnlineScoringConfig.StreamConfiguration> streamConfigurations;
+    private final Map<AutomationRuleEvaluatorType, OnlineScoringStreamConfigurationAdapter> streamConfigurations;
     private final ServiceTogglesConfig serviceTogglesConfig;
 
     @Inject
@@ -73,30 +72,31 @@ class OnlineScorePublisherImpl implements OnlineScorePublisher {
         this.streamConfigurations = config.getStreams().stream()
                 .map(streamConfiguration -> {
                     var evaluatorType = AutomationRuleEvaluatorType.fromString(streamConfiguration.getScorer());
-                    if (evaluatorType != null) {
-                        log.info(
-                                "Online Score publisher for evaluatorType: '{}' with configuration: streamName='{}', codec='{}'",
-                                evaluatorType, streamConfiguration.getStreamName(), streamConfiguration.getCodec());
-                        return Map.entry(evaluatorType, streamConfiguration);
-                    } else {
-                        log.warn("No Online Score publisher for evaluatorType: '{}'", streamConfiguration.getScorer());
-                        return null;
-                    }
+                    var adapter = OnlineScoringStreamConfigurationAdapter.create(config, evaluatorType);
+                    log.info(
+                            "Online Score publisher for evaluatorType: '{}' with configuration: streamName='{}', codec='{}'",
+                            evaluatorType, adapter.getStreamName(), adapter.getCodec());
+                    return Map.entry(evaluatorType, adapter);
                 })
-                .filter(Objects::nonNull)
                 .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     public void enqueueMessage(List<?> messages, AutomationRuleEvaluatorType type) {
         var config = streamConfigurations.get(type);
-        var codec = RedisStreamCodec.fromString(config.getCodec()).getCodec();
-        var llmAsJudgeStream = redisClient.getStream(config.getStreamName(), codec);
+        var codec = config.getCodec();
+        var stream = redisClient.getStream(config.getStreamName(), codec);
         Flux.fromIterable(messages)
-                .flatMap(message -> llmAsJudgeStream
-                        .add(StreamAddArgs.entry(OnlineScoringConfig.PAYLOAD_FIELD, message))
-                        .doOnNext(id -> log.debug("Message sent with ID: '{}' into stream '{}'",
-                                id, config.getStreamName()))
-                        .doOnError(throwable -> log.error("Error sending message", throwable)))
+                .flatMap(message -> {
+                    var streamAddArgs = StreamAddArgs
+                            .<Object, Object>entry(OnlineScoringConfig.PAYLOAD_FIELD, message)
+                            .trimNonStrict()
+                            .maxLen(config.getStreamMaxLen())
+                            .limit(config.getStreamTrimLimit());
+                    return stream.add(streamAddArgs)
+                            .doOnNext(id -> log.debug("Message sent with ID: '{}' into stream '{}'",
+                                    id, config.getStreamName()))
+                            .doOnError(throwable -> log.error("Error sending message", throwable));
+                })
                 .subscribe(id -> {
                     // noop
                 }, throwable -> log.error("Unexpected error when enqueueing messages into redis", throwable));

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatasetExportConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatasetExportConfig.java
@@ -52,6 +52,12 @@ public class DatasetExportConfig implements StreamConfiguration {
     @NotNull @MinDuration(value = 1, unit = TimeUnit.MINUTES)
     private Duration pendingMessageDuration = Duration.minutes(5);
 
+    @JsonProperty
+    @Min(1000) @Max(10_000_000) private int streamMaxLen = 10000;
+
+    @JsonProperty
+    @Min(0) @Max(10_000) private int streamTrimLimit = 100;
+
     @Valid @JsonProperty
     @NotNull @MinDuration(value = 1, unit = TimeUnit.HOURS)
     @MaxDuration(value = 7, unit = TimeUnit.DAYS)

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/JobTimeoutConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/JobTimeoutConfig.java
@@ -2,9 +2,15 @@ package com.comet.opik.infrastructure;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
 public class JobTimeoutConfig {
 
     @Valid @JsonProperty

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OnlineScoringConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OnlineScoringConfig.java
@@ -10,12 +10,18 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
 public class OnlineScoringConfig {
 
     public static final String PAYLOAD_FIELD = "message";
@@ -45,10 +51,19 @@ public class OnlineScoringConfig {
     @JsonProperty
     @Min(1) @Max(10) private int maxRetries;
 
+    @JsonProperty
+    @Min(1000) @Max(10_000_000) private int streamMaxLen;
+
+    @JsonProperty
+    @Min(0) @Max(10_000) private int streamTrimLimit;
+
     @Valid @JsonProperty
     @NotEmpty private List<@NotNull @Valid StreamConfiguration> streams;
 
     @Data
+    @Builder(toBuilder = true)
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class StreamConfiguration {
         @JsonProperty
         @NotBlank private String scorer;
@@ -80,5 +95,11 @@ public class OnlineScoringConfig {
 
         @JsonProperty
         @Min(1) @Max(10) private Integer maxRetries;
+
+        @JsonProperty
+        @Min(1000) @Max(10_000_000) private Integer streamMaxLen;
+
+        @JsonProperty
+        @Min(0) @Max(10_000) private Integer streamTrimLimit;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OnlineScoringStreamConfigurationAdapter.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OnlineScoringStreamConfigurationAdapter.java
@@ -96,4 +96,18 @@ public class OnlineScoringStreamConfigurationAdapter implements StreamConfigurat
                 ? streamConfig.getMaxRetries()
                 : onlineScoringConfig.getMaxRetries();
     }
+
+    @Override
+    public int getStreamMaxLen() {
+        return streamConfig.getStreamMaxLen() != null
+                ? streamConfig.getStreamMaxLen()
+                : onlineScoringConfig.getStreamMaxLen();
+    }
+
+    @Override
+    public int getStreamTrimLimit() {
+        return streamConfig.getStreamTrimLimit() != null
+                ? streamConfig.getStreamTrimLimit()
+                : onlineScoringConfig.getStreamTrimLimit();
+    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/StreamConfiguration.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/StreamConfiguration.java
@@ -24,4 +24,8 @@ public interface StreamConfiguration {
     Duration getPendingMessageDuration();
 
     int getMaxRetries();
+
+    int getStreamMaxLen();
+
+    int getStreamTrimLimit();
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/TraceThreadConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/TraceThreadConfig.java
@@ -11,12 +11,18 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.redisson.client.codec.Codec;
 
 import java.util.concurrent.TimeUnit;
 
 @Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
 public class TraceThreadConfig implements StreamConfiguration {
 
     public static final String PAYLOAD_FIELD = "message";
@@ -61,6 +67,12 @@ public class TraceThreadConfig implements StreamConfiguration {
 
     @Valid @JsonProperty
     @Min(1) @Max(10_000) private int closeTraceThreadMaxItemPerRun;
+
+    @JsonProperty
+    @Min(1000) @Max(10_000_000) private int streamMaxLen;
+
+    @JsonProperty
+    @Min(0) @Max(10_000) private int streamTrimLimit;
 
     @JsonProperty
     @Min(2) private int claimIntervalRatio;

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/WebhookConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/WebhookConfig.java
@@ -11,12 +11,18 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.redisson.client.codec.Codec;
 
 import java.util.concurrent.TimeUnit;
 
 @Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
 public class WebhookConfig implements StreamConfiguration {
 
     public static final String PAYLOAD_FIELD = "message";
@@ -77,6 +83,12 @@ public class WebhookConfig implements StreamConfiguration {
     @Valid @JsonProperty
     @NotNull @MinDuration(value = 1, unit = TimeUnit.MINUTES)
     private Duration pendingMessageDuration;
+
+    @JsonProperty
+    @Min(1000) @Max(10_000_000) private int streamMaxLen = 10000;
+
+    @JsonProperty
+    @Min(0) @Max(10_000) private int streamTrimLimit = 100;
 
     // lazy codec creation to ensure it picks up the configured JsonUtils mapper
     @Override

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestStreamConfiguration.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestStreamConfiguration.java
@@ -45,6 +45,12 @@ public class TestStreamConfiguration implements StreamConfiguration {
     private int maxRetries = 3;
 
     @Builder.Default
+    private int streamMaxLen = 10000;
+
+    @Builder.Default
+    private int streamTrimLimit = 100;
+
+    @Builder.Default
     private Codec codec = RedisStreamCodec.JAVA.getCodec();
 
     public static TestStreamConfiguration create() {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/webhooks/WebhookPublisherTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/webhooks/WebhookPublisherTest.java
@@ -1,0 +1,78 @@
+package com.comet.opik.api.resources.v1.events.webhooks;
+
+import com.comet.opik.api.Alert;
+import com.comet.opik.api.AlertEventType;
+import com.comet.opik.infrastructure.WebhookConfig;
+import com.comet.opik.infrastructure.db.IdGeneratorImpl;
+import com.comet.opik.podam.PodamFactoryUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RStreamReactive;
+import org.redisson.api.RedissonReactiveClient;
+import org.redisson.api.StreamMessageId;
+import org.redisson.api.stream.StreamAddParams;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WebhookPublisherTest {
+
+    private static final int STREAM_MAX_LEN = 10000;
+    private static final int STREAM_TRIM_LIMIT = 100;
+
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+
+    private final WebhookConfig webhookConfig = WebhookConfig.builder()
+            .enabled(true)
+            .streamName("test-webhook-stream-%s".formatted(
+                    RandomStringUtils.secure().nextAlphanumeric(10).toLowerCase()))
+            .streamMaxLen(STREAM_MAX_LEN)
+            .streamTrimLimit(STREAM_TRIM_LIMIT)
+            .build();
+
+    private final IdGeneratorImpl idGenerator = new IdGeneratorImpl();
+
+    @Mock
+    private RedissonReactiveClient redisClient;
+
+    @Mock
+    private RStreamReactive<Object, Object> stream;
+
+    @Test
+    void shouldUseConfiguredStreamAddParams() {
+        when(redisClient.getStream(anyString(), any())).thenReturn(stream);
+        when(stream.add(any())).thenReturn(Mono.just(new StreamMessageId(System.currentTimeMillis(), 0)));
+        var publisher = new WebhookPublisher(redisClient, webhookConfig, idGenerator);
+
+        var alert = podamFactory.manufacturePojo(Alert.class);
+        var workspaceName = "workspace-%s".formatted(
+                RandomStringUtils.secure().nextAlphanumeric(32).toLowerCase());
+        var payload = "test-payload-%s".formatted(
+                RandomStringUtils.secure().nextAlphanumeric(10).toLowerCase());
+        StepVerifier.create(publisher.publishWebhookEvent(
+                AlertEventType.TRACE_ERRORS, alert, UUID.randomUUID().toString(), workspaceName, payload, 3))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        ArgumentCaptor<StreamAddParams<Object, Object>> captor = ArgumentCaptor.forClass(StreamAddParams.class);
+        verify(stream, atLeastOnce()).add(captor.capture());
+        var streamAddParams = captor.getValue();
+        assertThat(streamAddParams.getMaxLen()).isEqualTo(STREAM_MAX_LEN);
+        assertThat(streamAddParams.getLimit()).isEqualTo(STREAM_TRIM_LIMIT);
+        assertThat(streamAddParams.isTrimStrict()).isFalse();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/TraceThreadsClosingJobStreamAddParamsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/TraceThreadsClosingJobStreamAddParamsTest.java
@@ -1,0 +1,95 @@
+package com.comet.opik.api.resources.v1.jobs;
+
+import com.comet.opik.api.events.ProjectWithPendingClosureTraceThreads;
+import com.comet.opik.domain.threads.TraceThreadService;
+import com.comet.opik.infrastructure.JobTimeoutConfig;
+import com.comet.opik.infrastructure.TraceThreadConfig;
+import com.comet.opik.infrastructure.lock.LockService;
+import com.comet.opik.podam.PodamFactoryUtils;
+import io.dropwizard.util.Duration;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobExecutionContext;
+import org.redisson.api.RStreamReactive;
+import org.redisson.api.RedissonReactiveClient;
+import org.redisson.api.StreamMessageId;
+import org.redisson.api.stream.StreamAddParams;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TraceThreadsClosingJobStreamAddParamsTest {
+
+    private static final int STREAM_MAX_LEN = 10000;
+    private static final int STREAM_TRIM_LIMIT = 100;
+
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+
+    private final TraceThreadConfig traceThreadConfig = TraceThreadConfig.builder()
+            .streamName("test-trace-thread-stream-%s".formatted(
+                    RandomStringUtils.secure().nextAlphanumeric(10).toLowerCase()))
+            .streamMaxLen(STREAM_MAX_LEN)
+            .streamTrimLimit(STREAM_TRIM_LIMIT)
+            .timeoutToMarkThreadAsInactive(Duration.seconds(30))
+            .closeTraceThreadJobLockTime(Duration.seconds(4))
+            .closeTraceThreadJobLockWaitTime(Duration.milliseconds(300))
+            .build();
+
+    private final JobTimeoutConfig jobTimeoutConfig = JobTimeoutConfig.builder()
+            .traceThreadsClosingJobTimeout(30)
+            .build();
+
+    @Mock
+    private TraceThreadService traceThreadService;
+
+    @Mock
+    private LockService lockService;
+
+    @Mock
+    private RedissonReactiveClient redisClient;
+
+    @Mock
+    private RStreamReactive<Object, Object> stream;
+
+    @Mock
+    private JobExecutionContext jobExecutionContext;
+
+    @Test
+    void shouldUseConfiguredStreamAddParams() {
+        var message = podamFactory.manufacturePojo(ProjectWithPendingClosureTraceThreads.class);
+        when(redisClient.getStream(anyString(), any())).thenReturn(stream);
+        when(stream.add(any())).thenReturn(Mono.just(new StreamMessageId(System.currentTimeMillis(), 0)));
+        when(traceThreadService.getProjectsWithPendingClosureThreads(any(), any(), anyInt()))
+                .thenReturn(Flux.just(message));
+        when(traceThreadService.addToPendingQueue(any())).thenReturn(Mono.just(true));
+        when(lockService.bestEffortLock(any(), any(), any(), any(), any()))
+                .thenAnswer(invocation -> invocation.<Mono<?>>getArgument(1));
+
+        var job = new TraceThreadsClosingJob(
+                traceThreadService, lockService, traceThreadConfig, redisClient, jobTimeoutConfig);
+        job.doJob(jobExecutionContext);
+
+        await().untilAsserted(() -> {
+            ArgumentCaptor<StreamAddParams<Object, Object>> captor = ArgumentCaptor.forClass(StreamAddParams.class);
+            verify(stream, atLeastOnce()).add(captor.capture());
+            var streamAddParams = captor.getValue();
+            assertThat(streamAddParams.getMaxLen()).isEqualTo(STREAM_MAX_LEN);
+            assertThat(streamAddParams.getLimit()).isEqualTo(STREAM_TRIM_LIMIT);
+            assertThat(streamAddParams.isTrimStrict()).isFalse();
+        });
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/CsvDatasetExportServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/CsvDatasetExportServiceImplTest.java
@@ -12,12 +12,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.redisson.api.RStreamReactive;
 import org.redisson.api.RedissonReactiveClient;
 import org.redisson.api.StreamMessageId;
 import org.redisson.api.stream.StreamAddArgs;
+import org.redisson.api.stream.StreamAddParams;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -80,10 +82,7 @@ class CsvDatasetExportServiceImplTest {
 
         // Mock: lock service executes the action
         when(lockService.executeWithLock(any(LockService.Lock.class), any(Mono.class)))
-                .thenAnswer(invocation -> {
-                    Mono<DatasetExportJob> action = invocation.getArgument(1);
-                    return action;
-                });
+                .thenAnswer(invocation -> invocation.getArgument(1));
 
         // Mock: config returns default TTL
         when(exportConfig.getDefaultTtl()).thenReturn(DEFAULT_TTL);
@@ -100,6 +99,8 @@ class CsvDatasetExportServiceImplTest {
         StreamMessageId mockMessageId = new StreamMessageId(UUID.randomUUID().getMostSignificantBits());
         when(mockStream.add(any(StreamAddArgs.class))).thenReturn(Mono.just(mockMessageId));
         when(exportConfig.getStreamName()).thenReturn("dataset-export-events");
+        when(exportConfig.getStreamMaxLen()).thenReturn(10000);
+        when(exportConfig.getStreamTrimLimit()).thenReturn(100);
 
         // When
         Mono<DatasetExportJob> result = service.startExport(DATASET_ID)
@@ -120,8 +121,14 @@ class CsvDatasetExportServiceImplTest {
         verify(jobService, times(2)).findInProgressJobs(eq(DATASET_ID)); // Initial check + double-check in lock
         verify(jobService, times(1)).createJob(eq(DATASET_ID), eq(DEFAULT_TTL.toJavaDuration()));
 
-        // Verify stream.add was called with correct message
-        verify(mockStream, times(1)).add(any(StreamAddArgs.class));
+        // Verify stream.add was called with correct params
+        ArgumentCaptor<StreamAddParams<String, DatasetExportMessage>> captor = ArgumentCaptor
+                .forClass(StreamAddParams.class);
+        verify(mockStream, times(1)).add(captor.capture());
+        var streamAddParams = captor.getValue();
+        assertThat(streamAddParams.getMaxLen()).isEqualTo(10000);
+        assertThat(streamAddParams.getLimit()).isEqualTo(100);
+        assertThat(streamAddParams.isTrimStrict()).isFalse();
     }
 
     @ParameterizedTest

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/OnlineScorePublisherTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/OnlineScorePublisherTest.java
@@ -1,0 +1,114 @@
+package com.comet.opik.domain.evaluators;
+
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
+import com.comet.opik.infrastructure.OnlineScoringConfig;
+import com.comet.opik.infrastructure.ServiceTogglesConfig;
+import com.comet.opik.infrastructure.redis.RedisStreamCodec;
+import com.comet.opik.podam.PodamFactoryUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RStreamReactive;
+import org.redisson.api.RedissonReactiveClient;
+import org.redisson.api.StreamMessageId;
+import org.redisson.api.stream.StreamAddParams;
+import reactor.core.publisher.Mono;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OnlineScorePublisherTest {
+
+    private static final int GLOBAL_MAX_LEN = 10000;
+    private static final int GLOBAL_TRIM_LIMIT = 100;
+
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+
+    private final ServiceTogglesConfig serviceTogglesConfig = new ServiceTogglesConfig();
+
+    @Mock
+    private RedissonReactiveClient redisClient;
+
+    @Mock
+    private AutomationRuleEvaluatorService automationRuleEvaluatorService;
+
+    @Mock
+    private RStreamReactive<Object, Object> stream;
+
+    @Test
+    void shouldUseGlobalStreamAddParams() {
+        var config = createConfig();
+        var publisher = createPublisher(config);
+
+        var message = podamFactory.manufacturePojo(String.class);
+        publisher.enqueueMessage(List.of(message), AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+
+        await().untilAsserted(() -> {
+            var streamAddParams = captureStreamAddParams();
+            assertThat(streamAddParams.getMaxLen()).isEqualTo(GLOBAL_MAX_LEN);
+            assertThat(streamAddParams.getLimit()).isEqualTo(GLOBAL_TRIM_LIMIT);
+            assertThat(streamAddParams.isTrimStrict()).isFalse();
+        });
+    }
+
+    @Test
+    void shouldUsePerStreamStreamAddParams() {
+        var config = createConfig(5000, 500);
+        var publisher = createPublisher(config);
+
+        var messages = PodamFactoryUtils.manufacturePojoList(podamFactory, String.class);
+        publisher.enqueueMessage(messages, AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+
+        await().untilAsserted(() -> {
+            var streamAddParams = captureStreamAddParams();
+            assertThat(streamAddParams.getMaxLen()).isEqualTo(5000);
+            assertThat(streamAddParams.getLimit()).isEqualTo(500);
+            assertThat(streamAddParams.isTrimStrict()).isFalse();
+        });
+    }
+
+    private OnlineScorePublisher createPublisher(OnlineScoringConfig onlineScoringConfig) {
+        when(redisClient.getStream(anyString(), any())).thenReturn(stream);
+        when(stream.add(any())).thenReturn(Mono.just(new StreamMessageId(System.currentTimeMillis(), 0)));
+        return new OnlineScorePublisherImpl(
+                onlineScoringConfig, serviceTogglesConfig, redisClient, automationRuleEvaluatorService);
+    }
+
+    private StreamAddParams<Object, Object> captureStreamAddParams() {
+        ArgumentCaptor<StreamAddParams<Object, Object>> captor = ArgumentCaptor.forClass(StreamAddParams.class);
+        verify(stream, atLeastOnce()).add(captor.capture());
+        return captor.getValue();
+    }
+
+    private OnlineScoringConfig createConfig() {
+        return createConfig(null, null);
+    }
+
+    private OnlineScoringConfig createConfig(Integer perStreamMaxLen, Integer perStreamTrimLimit) {
+        var streamConfiguration = OnlineScoringConfig.StreamConfiguration.builder()
+                .scorer(AutomationRuleEvaluatorType.LLM_AS_JUDGE.getType())
+                .streamName("test-stream-%s".formatted(
+                        RandomStringUtils.secure().nextAlphanumeric(10).toLowerCase()))
+                .codec(RedisStreamCodec.JAVA.getName())
+                .streamMaxLen(perStreamMaxLen)
+                .streamTrimLimit(perStreamTrimLimit)
+                .build();
+        return OnlineScoringConfig.builder()
+                .streamMaxLen(GLOBAL_MAX_LEN)
+                .streamTrimLimit(GLOBAL_TRIM_LIMIT)
+                .streams(List.of(streamConfiguration))
+                .build();
+    }
+}

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -165,11 +165,11 @@ server:
 # Controls limits for JSON deserialization to prevent memory exhaustion
 jacksonConfig:
   # Default: 104857600 (100MB)
-  # Description: Maximum size for individual string values during JSON deserialization. 
+  # Description: Maximum size for individual string values during JSON deserialization.
   #   A JSON with 3 fields up to this size will work, but a single larger string will fail.
   #   This configuration is used by both HTTP layer and internal JSON processing for consistency,
   #   preventing memory exhaustion from extremely large base64-encoded attachments before they can be stripped
-  maxStringLength: 262144000 
+  maxStringLength: 262144000
 
 # Configuration for batch operations
 batchOperations:
@@ -247,6 +247,12 @@ onlineScoring:
   # Default: 3
   # Description: Maximum number of retry attempts for failed messages (1-10, global default)
   maxRetries: 3
+  # Default: 10000
+  # Description: Max number of entries (approx) when publishing to the Redis stream. Oldest are evicted if exceeded
+  streamMaxLen: 10000
+  # Default: 100
+  # Description: Max number of entries to evict when publishing to the Redis stream (0 = no limit) if over max length
+  streamTrimLimit: 100
   ## scorer: options from AutomationRuleEvaluatorType
   ## streamName: the name of the stream in redis
   ## codec: 'json' when there are non-java consumers, 'java' for java consumers only
@@ -328,6 +334,12 @@ datasetExport:
   maxRetries: 3
   claimIntervalRatio: 10
   pendingMessageDuration: 5m
+  # Default: 10000
+  # Description: Max number of entries (approx) when publishing to the Redis stream. Oldest are evicted if exceeded
+  streamMaxLen: 10000
+  # Default: 100
+  # Description: Max number of entries to evict when publishing to the Redis stream (0 = no limit) if over max length
+  streamTrimLimit: 100
   defaultTtl: 24h
   minPartSize: 5242880  # 5MB - S3 minimum
   maxPartSize: 10485760  # 10MB
@@ -555,6 +567,12 @@ traceThreadConfig:
   # Default: 3
   # Description: Maximum number of retry attempts for failed messages (1-10)
   maxRetries: 3
+  # Default: 100000
+  # Description: Max number of entries (approx) when publishing to the Redis stream. Oldest are evicted if exceeded
+  streamMaxLen: 100000
+  # Default: 100
+  # Description: Max number of entries to evict when publishing to the Redis stream (0 = no limit) if over max length
+  streamTrimLimit: 100
 
 # Dataset Versioning Migration configuration
 # Includes both lazy migration (on-demand) and items_total migration (startup)
@@ -657,6 +675,12 @@ webhook:
   # Default: 10m
   # Description: Time before message considered orphaned and eligible for claiming
   pendingMessageDuration: 10m
+  # Default: 10000
+  # Description: Max number of entries (approx) when publishing to the Redis stream. Oldest are evicted if exceeded
+  streamMaxLen: 10000
+  # Default: 100
+  # Description: Max number of entries to evict when publishing to the Redis stream (0 = no limit) if over max length
+  streamTrimLimit: 100
   debouncing:
     # Default: {}
     # Description: Period for events aggregation before sending to webhook endpoint


### PR DESCRIPTION
## Details

Adds `XADD MAXLEN ~ <maxLen> LIMIT <trimLimit>` (approximate trimming) to **all 4 Redis stream producers** in the service to prevent streams from growing unboundedly and causing Redis OOM crashes.                                                  

Updated publishers:
- `OnlineScorePublisher` — with per-stream override support via `OnlineScoringStreamConfigurationAdapter`
- `TraceThreadsClosingJob`
- `CsvDatasetExportService`
- `WebhookPublisher`

Changes:
 - `MAXLEN ~` (approximate trimming): Caps the stream at roughly streamMaxLen entries. When a new message is added via `XADD`, Redis evicts the oldest entries if the stream exceeds this threshold. 
   - The `~` means approximate:  Redis trims in bulk (per radix tree node) rather than entry-by-entry, making it much faster with negligible over-count.
  - `streamMaxLen`: The target maximum number of entries in the stream. Not a hard cap due to approximate trimming, but the stream will stay close to this value.                                                  
  - `streamTrimLimit` (`LIMIT` parameter): Controls how many entries Redis examines for eviction per `XADD` call. 
    - Prevents a single XADD from doing a massive trim if the stream has grown far beyond `streamMaxLen`
  (e.g., after a consumer outage). 
    - Set to `0` to disable the limit and trim everything in one shot.          
- Add configurable `streamMaxLen` and `streamTrimLimit` fields with `@Min/@Max` validation to all stream config classes. Validation bounds: 
    - `streamMaxLen` - `@Min(1000) @Max(10_000_000)`
    - `streamTrimLimit` - `@Min(0) @Max(10_000)`
- For online scoring streams, support per-stream overrides (nullable per-stream values fall back to global defaults)

Default values:

| Config | streamMaxLen | streamTrimLimit |
|---|---|---|
| onlineScoring (global) | 10000 | 100 |
| traceThreadConfig | 100000 (higher volume) | 100 |
| datasetExport | 10000 | 100 |
| webhook | 10000 | 100 |


## Change checklist
- [x] User facing change
- [ ] Documentation update

## Issues

- OPIK-4743

## Testing
- Added unit test coverage verifying the three new params (non strict trimming, max len and trim limit) for the 4 existing publishers in the system.
- Tested locally manually.

## Documentation

N/A

