### PR TITLE
[OPIK-4743] [BE] Add ClientErrorException as non-retryable in BaseRedisSubscriber

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
@@ -7,6 +7,7 @@ import io.opentelemetry.api.metrics.DoubleGauge;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.Meter;
+import jakarta.ws.rs.ClientErrorException;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
@@ -50,17 +51,18 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
     private static final String NOGROUP = "NOGROUP";
 
     /**
-     * Non-retryable: programming and validation exceptions that won't succeed on retry.
+     * Non-retryable exception types that won't succeed on retry. Checked via {@code instanceof} in
+     * {@link #isRetryableException(Throwable)}, so subclasses are automatically covered.
+     * These are usually programming, validation, client etc. exceptions.
      */
     private static final Set<Class<? extends RuntimeException>> NON_RETRYABLE_EXCEPTIONS = Set.of(
             ArithmeticException.class,
-            ArrayIndexOutOfBoundsException.class,
             ClassCastException.class,
+            ClientErrorException.class,
             IllegalArgumentException.class,
             IllegalStateException.class,
             IndexOutOfBoundsException.class,
             NullPointerException.class,
-            NumberFormatException.class,
             UnsupportedOperationException.class);
 
     /**
@@ -547,7 +549,8 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
     /**
      * Provide a particular implementation for processing the event.
      * <p>
-     * Exception handling: Exceptions in {@link #NON_RETRYABLE_EXCEPTIONS} are immediately removed from the stream.
+     * Exception handling: see {@link #isRetryableException(Throwable)} for the full non-retryable classification.
+     * Non-retryable exceptions are immediately removed from the stream.
      * All other exceptions are retried up to {@code maxRetries} times before being removed.
      *
      * @param message a Redis message
@@ -571,12 +574,15 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
     }
 
     /**
-     * Non-retryable exceptions are programming errors or validation failures that won't succeed on retry.
-     * All other exceptions are considered retryable (transient errors like network issues, timeouts, etc.)
+     * Non-retryable exceptions are checked via {@code instanceof} against {@link #NON_RETRYABLE_EXCEPTIONS},
+     * so both exact types and their subclasses are covered.
+     * Non-retryable exceptions are usually programming, validation, client errors that won't succeed on retry.
+     * All other exceptions are considered retryable (transient errors like network issues, timeouts, server errors, etc.)
      * Unknown exceptions default to retryable for safety.
      */
     private boolean isRetryableException(Throwable exception) {
-        return !NON_RETRYABLE_EXCEPTIONS.contains(exception.getClass());
+        return NON_RETRYABLE_EXCEPTIONS.stream()
+                .noneMatch(nonRetryable -> nonRetryable.isInstance(exception));
     }
 
     /**

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
@@ -4,12 +4,17 @@ import com.comet.opik.api.resources.utils.RedisContainerUtils;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.redis.testcontainers.RedisContainer;
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.NotFoundException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.redisson.Redisson;
 import org.redisson.api.RStreamReactive;
 import org.redisson.api.RedissonReactiveClient;
@@ -207,10 +212,24 @@ class BaseRedisSubscriberTest {
     @Nested
     class FailureTests {
 
-        @Test
-        void shouldAckAndRemoveNonRetryableFailures() {
+        static Stream<Arguments> nonRetryableExceptions() {
+            return Stream.of(
+                    Arguments.of("NullPointerException",
+                            new NullPointerException("Non-retryable")),
+                    Arguments.of("NumberFormatException (subclass of IllegalArgumentException)",
+                            new NumberFormatException("Non-retryable")),
+                    Arguments.of("ClientErrorException (4xx)",
+                            new ClientErrorException("Unauthorized", 401)),
+                    Arguments.of("NotFoundException (subclass of ClientErrorException)",
+                            new NotFoundException()));
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("nonRetryableExceptions")
+        void shouldAckAndRemoveNonRetryableFailures(String description, RuntimeException exception) {
             var messages = PodamFactoryUtils.manufacturePojoList(podamFactory, String.class);
-            var subscriber = trackSubscriber(TestRedisSubscriber.failingNoRetriesSubscriber(config, redissonClient));
+            var subscriber = trackSubscriber(TestRedisSubscriber.failingSubscriber(
+                    config, redissonClient, exception));
             subscriber.start();
 
             publishMessagesToStream(messages);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestRedisSubscriber.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestRedisSubscriber.java
@@ -55,14 +55,15 @@ public class TestRedisSubscriber extends BaseRedisSubscriber<String> {
     }
 
     /**
-     * Factory method for creating a subscriber that always fails with a non-retryable exception.
+     * Factory method for creating a subscriber that always fails.
      */
-    public static TestRedisSubscriber failingNoRetriesSubscriber(
+    public static TestRedisSubscriber failingSubscriber(
             StreamConfiguration config,
-            RedissonReactiveClient redisson) {
+            RedissonReactiveClient redisson,
+            Throwable throwable) {
         return createSubscriber(config, redisson, msg -> {
-            log.warn("Received message (will fail without retries): '{}'", msg);
-            return Mono.error(new NullPointerException("Test non-retryable failure for message '%s'".formatted(msg)));
+            log.warn("Received message (will fail): '{}'", msg);
+            return Mono.error(throwable);
         });
     }
 
@@ -72,10 +73,7 @@ public class TestRedisSubscriber extends BaseRedisSubscriber<String> {
     public static TestRedisSubscriber failingRetriesSubscriber(
             StreamConfiguration config,
             RedissonReactiveClient redisson) {
-        return createSubscriber(config, redisson, msg -> {
-            log.warn("Received message (will fail with retries): '{}'", msg);
-            return Mono.error(new RuntimeException("Test retryable failure for message '%s'".formatted(msg)));
-        });
+        return failingSubscriber(config, redisson, new RuntimeException("Test retryable failure"));
     }
 
     /**


### PR DESCRIPTION
## Details

When an LLM call fails with a 4xx HTTP error (e.g., `invalid_api_key` → `401`), `ChatCompletionService` throws `ClientErrorException`. This exception was not classified as non-retryable in `BaseRedisSubscriber`, causing messages to retry up to 3 times and growing the Redis stream unnecessarily until OOM.

- Added `ClientErrorException` to `NON_RETRYABLE_EXCEPTIONS` set, covering all `4xx` subclasses (`BadRequestException`, `NotFoundException`, `ForbiddenException`, etc.)
- Generalised `isRetryableException()` to use `instanceof` (via `Class.isInstance()`) instead of exact class matching, so subclasses are automatically covered
- Removed redundant entries from the set: `ArrayIndexOutOfBoundsException` (covered by `IndexOutOfBoundsException`), `NumberFormatException` (covered by `IllegalArgumentException`)

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- OPIK-4743

## Testing
- Parameterised existing test to cover all changes:
  - Previous non-retryable exception (`NullPointerException`).
  - New non-retryable exception (`ClientErrorException`).
  - Covering new functionality for subclasses of non-retryable exceptions `NumberFormatException` (subclass of `IllegalArgumentException` and `NotFoundException` (subclass of `ClientErrorException`).
- All existing subscriber tests continue to pass, both unit and integ.

## Documentation
- Updated javadocs with the complete details of the non-retryable policy. 