### PR TITLE
[OPIK-4862] [INFRA] Add explicit pagination to code review Slack commands

### DIFF
--- a/.agents/commands/comet/generate-code-review-slack-command.md
+++ b/.agents/commands/comet/generate-code-review-slack-command.md
@@ -87,6 +87,15 @@ This workflow will:
 
 - **Extract test environment link from PR description and comments**:
   - First, search PR comments for test environment deployment messages (look for "Test environment is now available!" or similar)
+  - When fetching PR comments via `gh api`, **always** use `--paginate` to ensure all results are fetched:
+    ```bash
+    # Issue comments (general PR comments, including deployment bot messages)
+    gh api repos/comet-ml/opik/issues/{pr_number}/comments --paginate
+
+    # Review comments (inline code comments)
+    gh api repos/comet-ml/opik/pulls/{pr_number}/comments --paginate
+    ```
+    > **Why pagination is required**: GitHub API returns 30 items per page by default. Opik PRs regularly exceed this — 17 CI test group comments + deployment bot comments + reviewer comments can push past 30 total. Without `--paginate`, the deployment bot comment with the test environment link may end up on page 2 and get silently missed.
   - Extract URL from comment body (typically in format `https://pr-XXXX.dev.comet.com` or `https://test.opik.com`)
   - If not found in comments, search PR description for URLs in "## Testing" section
   - Look for common test environment patterns: `https://pr-*.dev.comet.com`, `https://test.opik.com`, `https://*.opik.com`, or any `https://` URL

--- a/.agents/commands/comet/send-code-review-slack.md
+++ b/.agents/commands/comet/send-code-review-slack.md
@@ -98,6 +98,15 @@ This workflow will:
 
 - **Extract test environment link from PR description and comments**:
   - First, search PR comments for test environment deployment messages (look for "Test environment is now available!" or similar)
+  - When fetching PR comments via `gh api`, **always** use `--paginate` to ensure all results are fetched:
+    ```bash
+    # Issue comments (general PR comments, including deployment bot messages)
+    gh api repos/comet-ml/opik/issues/{pr_number}/comments --paginate
+
+    # Review comments (inline code comments)
+    gh api repos/comet-ml/opik/pulls/{pr_number}/comments --paginate
+    ```
+    > **Why pagination is required**: GitHub API returns 30 items per page by default. Opik PRs regularly exceed this — 17 CI test group comments + deployment bot comments + reviewer comments can push past 30 total. Without `--paginate`, the deployment bot comment with the test environment link may end up on page 2 and get silently missed.
   - Extract URL from comment body (typically in format `https://pr-XXXX.dev.comet.com` or `https://test.opik.com`)
   - If not found in comments, search PR description for URLs in "## Testing" section
   - Look for common test environment patterns: `https://pr-*.dev.comet.com`, `https://test.opik.com`, `https://*.opik.com`, or any `https://` URL


### PR DESCRIPTION
## Details

<img width="1920" height="2194" alt="image" src="https://github.com/user-attachments/assets/80edebfd-31a4-4699-b9c9-b5c7e0aa8d09" />

Add explicit `gh api --paginate` requirement to `/generate-code-review-slack-command` and `/send-code-review-slack` command specs when fetching PR comments to find test environment links.

GitHub API returns 30 items per page by default. Opik PRs regularly exceed this — 17 CI test group comments + deployment bot comments + reviewer comments push past 30 total. Without `--paginate`, the deployment bot comment with the test env link ends up on page 2 and gets silently missed.

Follows the same pagination pattern established in OPIK-4728 for `/address-github-pr-comments`.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-4862

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full implementation
  - Human verification: Reviewed all changes

## Testing

- Verified all 4 command spec files (2 tracked in git, 2 in .claude/ gitignored) contain the `--paginate` requirement
- Grep confirmed `--paginate` is present in the test env link extraction section of both `generate-code-review-slack-command.md` and `send-code-review-slack.md`
- The fix is a documentation/spec change — runtime testing will happen when the commands are next used on a PR with 30+ comments

## Documentation

N/A — changes are to internal command spec files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)