### PR TITLE
[OPIK-4827] Show loading spinner in dataset items tab

### DIFF
--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsTab/DatasetItemsTab.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/DatasetItemsTab/DatasetItemsTab.tsx
@@ -54,6 +54,7 @@ import AutodetectCell from "@/components/shared/DataTableCells/AutodetectCell";
 import IdCell from "@/components/shared/DataTableCells/IdCell";
 import ListCell from "@/components/shared/DataTableCells/ListCell";
 import TimeCell from "@/components/shared/DataTableCells/TimeCell";
+import Loader from "@/components/shared/Loader/Loader";
 import { mapDynamicColumnTypesToColumnType } from "@/lib/filters";
 import {
   generateActionsColumDef,
@@ -526,7 +527,11 @@ const DatasetItemsTab: React.FC<DatasetItemsTabProps> = ({
     selectedRows.length < totalCount;
 
   if (isPending) {
-    return null;
+    return (
+      <div className="flex items-center justify-center pt-12">
+        <Loader />
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Details
Previously, the Dataset Items tab rendered nothing (`null`) while data was loading, causing a jarring blank screen. This change replaces that with a centered loading spinner so users get visual feedback that content is being fetched.

## Change checklist
- [x] Replace `return null` with a `<Loader />` spinner in the `isPending` branch of `DatasetItemsTab`
- [x] Import the shared `Loader` component

## Screenshots
<img width="1335" height="725" alt="Screenshot 2026-03-09 at 12 06 39" src="https://github.com/user-attachments/assets/eec7fb90-de89-486c-80d1-496e14f9f5c9" />

## Testing
- Open a dataset with items and verify a loading spinner is shown while the data is being fetched
- Confirm the spinner disappears once data loads and the table renders correctly

## Issues
OPIK-4827

## Documentation
No documentation changes needed.