### PR TITLE
[OPIK-4354] Update Strands Integration Docs

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/strands-agents.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/strands-agents.mdx
@@ -155,7 +155,7 @@ results = agent("Hi, where can I eat in San Francisco?")
 ```
 
 <Warning>
-  Strands Agents does not configure OTLP by default. You must call `StrandsTelemetry().setup_otlp_exporter()` before creating your agent, otherwise traces will stay in-process and never be exported to Opik.
+  Strands Agents does not configure OTLP by default. Configure an OTLP exporter (for example via `StrandsTelemetry().setup_otlp_exporter()`) before you start operations that send traces, otherwise traces may remain in-process and not be exported.
 </Warning>
 
 


### PR DESCRIPTION
## Details
Updated Strands Agents integration documentation to include `StrandsTelemetry().setup_otlp_exporter()` for configuring OTLP export in Strands integration.

### The results in UI:
<img width="1257" height="1321" alt="Screenshot 2026-03-09 at 14 54 26" src="https://github.com/user-attachments/assets/db0c88cc-dc0f-48b1-b64b-6c77bc969ea2" />


## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-4354

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing

Manually tested

## Documentation

Updated the documentation in section: https://www.comet.com/docs/opik/integrations/strands-agents

Preview link: https://opik-preview-60f5382f-727e-4300-86cc-2c8f8e279c71.docs.buildwithfern.com/docs/opik/integrations/strands-agents