### PR TITLE
Revert [OPIK-4871] [BE] Update feedback scores filter to support plural exclude categories

### DIFF
--- a/.agents/skills/opik-backend/SKILL.md
+++ b/.agents/skills/opik-backend/SKILL.md
@@ -156,9 +156,6 @@ Map.of("key", "value")
 Arrays.asList("A", "B", "C")
 ```
 
-## API Design
-- **Query parameters that accept lists**: Use plural names from the start (e.g., `exclude_category_names` not `exclude_category_name`). Starting with a singular name and later adding a plural variant results in two redundant query params on the same endpoint. Plural names are backward-compatible since they work for both single and multiple values.
-
 ## Error Handling
 
 ### Use Jakarta Exceptions

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -76,7 +76,6 @@ import jakarta.ws.rs.core.UriInfo;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.glassfish.jersey.server.ChunkedOutput;
 
 import java.util.Collections;
@@ -553,34 +552,23 @@ public class ExperimentsResource {
     @JsonView({FeedbackDefinition.View.Public.class})
     public Response findFeedbackScoreNames(
             @QueryParam("experiment_ids") String experimentIdsQueryParam,
-            @QueryParam("exclude_category_names") String excludeCategoryNamesQueryParam) {
+            @QueryParam("exclude_category_name") String excludeCategoryName) {
 
         var experimentIds = Optional.ofNullable(experimentIdsQueryParam)
                 .map(ParamsValidator::getIds)
                 .orElse(Collections.emptySet());
-
-        var resolvedExcludeCategories = resolveExcludeCategoryNames(excludeCategoryNamesQueryParam);
 
         String workspaceId = requestContext.get().getWorkspaceId();
 
         log.info("Find feedback score names by experiment_ids '{}', on workspaceId '{}'",
                 experimentIds, workspaceId);
         FeedbackScoreNames feedbackScoreNames = feedbackScoreService
-                .getExperimentsFeedbackScoreNames(experimentIds, resolvedExcludeCategories)
+                .getExperimentsFeedbackScoreNames(experimentIds, excludeCategoryName)
                 .contextWrite(ctx -> setRequestContext(ctx, requestContext))
                 .block();
         log.info("Found feedback score names '{}' by experiment_ids '{}', on workspaceId '{}'",
                 feedbackScoreNames.scores().size(), experimentIds, workspaceId);
 
         return Response.ok(feedbackScoreNames).build();
-    }
-
-    private static final Set<String> DEFAULT_EXCLUDE_CATEGORY_NAMES = Set.of("suite_assertion");
-
-    private Set<String> resolveExcludeCategoryNames(String excludeCategoryNamesQueryParam) {
-        if (StringUtils.isNotBlank(excludeCategoryNamesQueryParam)) {
-            return ParamsValidator.get(excludeCategoryNamesQueryParam, String.class, "exclude_category_names");
-        }
-        return DEFAULT_EXCLUDE_CATEGORY_NAMES;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
@@ -72,7 +72,6 @@ import org.glassfish.jersey.server.ChunkedOutput;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 import static com.comet.opik.api.FeedbackScoreBatchContainer.FeedbackScoreBatch;
@@ -399,20 +398,18 @@ public class SpansResource {
     @JsonView({FeedbackDefinition.View.Public.class})
     public Response findFeedbackScoreNames(@QueryParam("project_id") UUID projectId,
             @QueryParam("type") SpanType type,
-            @QueryParam("exclude_category_names") String excludeCategoryNamesQueryParam) {
+            @QueryParam("exclude_category_name") String excludeCategoryName) {
 
         if (projectId == null) {
             throw new BadRequestException("project_id must be provided");
         }
-
-        var resolvedExcludeCategories = resolveExcludeCategoryNames(excludeCategoryNamesQueryParam);
 
         String workspaceId = requestContext.get().getWorkspaceId();
 
         log.info("Find feedback score names by project_id '{}', on workspaceId '{}'",
                 projectId, workspaceId);
         FeedbackScoreNames feedbackScoreNames = feedbackScoreService
-                .getSpanFeedbackScoreNames(projectId, type, resolvedExcludeCategories)
+                .getSpanFeedbackScoreNames(projectId, type, excludeCategoryName)
                 .contextWrite(ctx -> setRequestContext(ctx, requestContext))
                 .block();
         log.info("Found feedback score names '{}' by project_id '{}', on workspaceId '{}'",
@@ -552,14 +549,5 @@ public class SpansResource {
         log.info("Deleted span comments with ids '{}' on workspaceId '{}'", batchDelete.ids(), workspaceId);
 
         return Response.noContent().build();
-    }
-
-    private static final Set<String> DEFAULT_EXCLUDE_CATEGORY_NAMES = Set.of("suite_assertion");
-
-    private Set<String> resolveExcludeCategoryNames(String excludeCategoryNamesQueryParam) {
-        if (StringUtils.isNotBlank(excludeCategoryNamesQueryParam)) {
-            return ParamsValidator.get(excludeCategoryNamesQueryParam, String.class, "exclude_category_names");
-        }
-        return DEFAULT_EXCLUDE_CATEGORY_NAMES;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -497,16 +497,14 @@ public class TracesResource {
     @JsonView({FeedbackDefinition.View.Public.class})
     public Response findFeedbackScoreNames(
             @QueryParam("project_id") UUID projectId,
-            @QueryParam("exclude_category_names") String excludeCategoryNamesQueryParam) {
-
-        var resolvedExcludeCategories = resolveExcludeCategoryNames(excludeCategoryNamesQueryParam);
+            @QueryParam("exclude_category_name") String excludeCategoryName) {
 
         String workspaceId = requestContext.get().getWorkspaceId();
 
         log.info("Find feedback score names by project_id '{}', on workspaceId '{}'",
                 projectId, workspaceId);
         FeedbackScoreNames feedbackScoreNames = feedbackScoreService
-                .getTraceFeedbackScoreNames(projectId, resolvedExcludeCategories)
+                .getTraceFeedbackScoreNames(projectId, excludeCategoryName)
                 .contextWrite(ctx -> setRequestContext(ctx, requestContext))
                 .block();
         log.info("Found feedback score names '{}' by project_id '{}', on workspaceId '{}'",
@@ -1059,14 +1057,5 @@ public class TracesResource {
         log.info("Deleted thread comments with ids '{}' on workspaceId '{}'", batchDelete.ids(), workspaceId);
 
         return Response.noContent().build();
-    }
-
-    private static final Set<String> DEFAULT_EXCLUDE_CATEGORY_NAMES = Set.of("suite_assertion");
-
-    private Set<String> resolveExcludeCategoryNames(String excludeCategoryNamesQueryParam) {
-        if (StringUtils.isNotBlank(excludeCategoryNamesQueryParam)) {
-            return ParamsValidator.get(excludeCategoryNamesQueryParam, String.class, "exclude_category_names");
-        }
-        return DEFAULT_EXCLUDE_CATEGORY_NAMES;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
@@ -52,13 +52,13 @@ public interface FeedbackScoreDAO {
 
     Mono<Long> scoreBatchOfThreads(List<FeedbackScoreBatchItemThread> scores, @Nullable String author);
 
-    Mono<List<String>> getTraceFeedbackScoreNames(UUID projectId, @NonNull Set<String> excludeCategoryNames);
+    Mono<List<String>> getTraceFeedbackScoreNames(UUID projectId, @Nullable String excludeCategoryName);
 
     Mono<List<String>> getSpanFeedbackScoreNames(@NonNull UUID projectId, SpanType type,
-            @NonNull Set<String> excludeCategoryNames);
+            @Nullable String excludeCategoryName);
 
     Mono<List<FeedbackScoreNames.ScoreName>> getExperimentsFeedbackScoreNames(Set<UUID> experimentIds,
-            @NonNull Set<String> excludeCategoryNames);
+            @Nullable String excludeCategoryName);
 
     Mono<List<String>> getProjectsFeedbackScoreNames(Set<UUID> projectIds);
 
@@ -173,8 +173,8 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
             <if(experiment_ids)>
             AND entity_id IN (SELECT trace_id FROM experiment_trace_ids)
             <endif>
-            <if(exclude_category_names)>
-            AND category_name NOT IN :exclude_category_names
+            <if(exclude_category_name)>
+            AND category_name != :exclude_category_name
             <endif>
             UNION DISTINCT
             SELECT DISTINCT
@@ -189,8 +189,8 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
             <if(experiment_ids)>
             AND entity_id IN (SELECT trace_id FROM experiment_trace_ids)
             <endif>
-            <if(exclude_category_names)>
-            AND category_name NOT IN :exclude_category_names
+            <if(exclude_category_name)>
+            AND category_name != :exclude_category_name
             <endif>
             <if(experiment_ids)>
             UNION DISTINCT
@@ -263,8 +263,8 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
                 )
                 <endif>
                 AND entity_type = 'span'
-                <if(exclude_category_names)>
-                AND category_name NOT IN :exclude_category_names
+                <if(exclude_category_name)>
+                AND category_name != :exclude_category_name
                 <endif>
                 ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
                 LIMIT 1 BY entity_id, name
@@ -287,8 +287,8 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
                 )
                 <endif>
                 AND entity_type = 'span'
-                <if(exclude_category_names)>
-                AND category_name NOT IN :exclude_category_names
+                <if(exclude_category_name)>
+                AND category_name != :exclude_category_name
                 <endif>
                 ORDER BY (workspace_id, project_id, entity_type, entity_id, author, name) DESC, last_updated_at DESC
                 LIMIT 1 BY entity_id, author, name
@@ -506,7 +506,7 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
 
     @Override
     @WithSpan
-    public Mono<List<String>> getTraceFeedbackScoreNames(UUID projectId, @NonNull Set<String> excludeCategoryNames) {
+    public Mono<List<String>> getTraceFeedbackScoreNames(UUID projectId, @Nullable String excludeCategoryName) {
         return asyncTemplate.nonTransaction(connection -> makeMonoContextAware((userName, workspaceId) -> {
 
             var template = getSTWithLogComment(SELECT_FEEDBACK_SCORE_NAMES, "get_trace_feedback_score_names",
@@ -515,13 +515,13 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
             List<UUID> projectIds = projectId == null ? List.of() : List.of(projectId);
 
             bindTemplateParam(projectIds, null, template);
-            bindExcludeCategoryNames(template, excludeCategoryNames);
+            bindExcludeCategoryName(template, excludeCategoryName);
 
             var statement = connection.createStatement(template.render())
                     .bind("workspace_id", workspaceId);
 
             bindStatementParam(projectIds, null, statement, EntityType.TRACE);
-            bindExcludeCategoryNames(statement, excludeCategoryNames);
+            bindExcludeCategoryName(statement, excludeCategoryName);
 
             return Flux.from(statement.execute())
                     .flatMap(result -> result.map((row, rowMetadata) -> row.get("name", String.class)))
@@ -532,17 +532,17 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
     @Override
     @WithSpan
     public Mono<List<FeedbackScoreNames.ScoreName>> getExperimentsFeedbackScoreNames(Set<UUID> experimentIds,
-            @NonNull Set<String> excludeCategoryNames) {
+            @Nullable String excludeCategoryName) {
         return asyncTemplate.nonTransaction(connection -> makeMonoContextAware((userName, workspaceId) -> {
             var template = getSTWithLogComment(SELECT_FEEDBACK_SCORE_NAMES, "get_experiments_feedback_score_names",
                     workspaceId, experimentIds.size());
             bindTemplateParam(null, experimentIds, template);
-            bindExcludeCategoryNames(template, excludeCategoryNames);
+            bindExcludeCategoryName(template, excludeCategoryName);
 
             var statement = connection.createStatement(template.render())
                     .bind("workspace_id", workspaceId);
             bindStatementParam(null, experimentIds, statement, EntityType.TRACE);
-            bindExcludeCategoryNames(statement, excludeCategoryNames);
+            bindExcludeCategoryName(statement, excludeCategoryName);
 
             return Flux.from(statement.execute())
                     .flatMap(result -> result.map((row, rowMetadata) -> FeedbackScoreNames.ScoreName.builder()
@@ -641,7 +641,7 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
     @Override
     @WithSpan
     public Mono<List<String>> getSpanFeedbackScoreNames(@NonNull UUID projectId, SpanType type,
-            @NonNull Set<String> excludeCategoryNames) {
+            @Nullable String excludeCategoryName) {
         return asyncTemplate.nonTransaction(connection -> makeMonoContextAware((userName, workspaceId) -> {
 
             var template = getSTWithLogComment(SELECT_SPAN_FEEDBACK_SCORE_NAMES, "get_span_feedback_score_names",
@@ -650,7 +650,7 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
             if (type != null) {
                 template.add("type", type.name());
             }
-            bindExcludeCategoryNames(template, excludeCategoryNames);
+            bindExcludeCategoryName(template, excludeCategoryName);
 
             var statement = connection.createStatement(template.render())
                     .bind("project_id", projectId)
@@ -659,7 +659,7 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
             if (type != null) {
                 statement.bind("type", type.name());
             }
-            bindExcludeCategoryNames(statement, excludeCategoryNames);
+            bindExcludeCategoryName(statement, excludeCategoryName);
 
             return Flux.from(statement.execute())
                     .flatMap(result -> result.map((row, rowMetadata) -> row.get("name", String.class)))
@@ -690,15 +690,15 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
         }
     }
 
-    private void bindExcludeCategoryNames(ST template, @NonNull Set<String> excludeCategoryNames) {
-        if (CollectionUtils.isNotEmpty(excludeCategoryNames)) {
-            template.add("exclude_category_names", excludeCategoryNames);
+    private void bindExcludeCategoryName(ST template, @Nullable String excludeCategoryName) {
+        if (StringUtils.isNotBlank(excludeCategoryName)) {
+            template.add("exclude_category_name", excludeCategoryName);
         }
     }
 
-    private void bindExcludeCategoryNames(Statement statement, @NonNull Set<String> excludeCategoryNames) {
-        if (CollectionUtils.isNotEmpty(excludeCategoryNames)) {
-            statement.bind("exclude_category_names", excludeCategoryNames);
+    private void bindExcludeCategoryName(Statement statement, @Nullable String excludeCategoryName) {
+        if (StringUtils.isNotBlank(excludeCategoryName)) {
+            statement.bind("exclude_category_name", excludeCategoryName);
         }
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
@@ -51,13 +51,13 @@ public interface FeedbackScoreService {
     Mono<Void> deleteSpanScore(UUID id, DeleteFeedbackScore score);
     Mono<Void> deleteTraceScore(UUID id, DeleteFeedbackScore score);
 
-    Mono<FeedbackScoreNames> getTraceFeedbackScoreNames(UUID projectId, @NonNull Set<String> excludeCategoryNames);
+    Mono<FeedbackScoreNames> getTraceFeedbackScoreNames(UUID projectId, @Nullable String excludeCategoryName);
 
     Mono<FeedbackScoreNames> getSpanFeedbackScoreNames(UUID projectId, SpanType type,
-            @NonNull Set<String> excludeCategoryNames);
+            @Nullable String excludeCategoryName);
 
     Mono<FeedbackScoreNames> getExperimentsFeedbackScoreNames(Set<UUID> experimentIds,
-            @NonNull Set<String> excludeCategoryNames);
+            @Nullable String excludeCategoryName);
 
     Mono<FeedbackScoreNames> getProjectsFeedbackScoreNames(Set<UUID> projectIds);
 
@@ -187,7 +187,7 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
 
     @Override
     public Mono<FeedbackScoreNames> getTraceFeedbackScoreNames(UUID projectId,
-            @NonNull Set<String> excludeCategoryNames) {
+            @Nullable String excludeCategoryName) {
         if (projectId == null) {
             // Allow only for private access
             boolean isPublic = Optional.ofNullable(requestContext.get().getVisibility())
@@ -203,7 +203,7 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
             projectService.get(projectId);
         }
 
-        return dao.getTraceFeedbackScoreNames(projectId, excludeCategoryNames)
+        return dao.getTraceFeedbackScoreNames(projectId, excludeCategoryName)
                 .map(names -> names.stream()
                         .map(name -> FeedbackScoreNames.ScoreName.builder().name(name).build())
                         .toList())
@@ -212,10 +212,10 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
 
     @Override
     public Mono<FeedbackScoreNames> getSpanFeedbackScoreNames(@NonNull UUID projectId, SpanType type,
-            @NonNull Set<String> excludeCategoryNames) {
+            @Nullable String excludeCategoryName) {
         // Will throw an error in case we try to get private project with public visibility
         projectService.get(projectId);
-        return dao.getSpanFeedbackScoreNames(projectId, type, excludeCategoryNames)
+        return dao.getSpanFeedbackScoreNames(projectId, type, excludeCategoryName)
                 .map(names -> names.stream()
                         .map(name -> FeedbackScoreNames.ScoreName.builder().name(name).build())
                         .toList())
@@ -224,8 +224,8 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
 
     @Override
     public Mono<FeedbackScoreNames> getExperimentsFeedbackScoreNames(Set<UUID> experimentIds,
-            @NonNull Set<String> excludeCategoryNames) {
-        return dao.getExperimentsFeedbackScoreNames(experimentIds, excludeCategoryNames)
+            @Nullable String excludeCategoryName) {
+        return dao.getExperimentsFeedbackScoreNames(experimentIds, excludeCategoryName)
                 .map(scores -> scores.stream()
                         .map(score -> FeedbackScoreNames.ScoreName.builder()
                                 .name(score.name())

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ExperimentResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ExperimentResourceClient.java
@@ -424,15 +424,14 @@ public class ExperimentResourceClient {
     }
 
     public FeedbackScoreNames getFeedbackScoreNames(List<UUID> experimentIds,
-            @Nullable Set<String> excludeCategoryNames, String apiKey, String workspaceName) {
+            @Nullable String excludeCategoryName, String apiKey, String workspaceName) {
         var ids = JsonUtils.writeValueAsString(experimentIds);
         WebTarget webTarget = client.target(RESOURCE_PATH.formatted(baseURI))
                 .path("feedback-scores")
                 .path("names")
                 .queryParam("experiment_ids", ids);
-        if (excludeCategoryNames != null) {
-            webTarget = webTarget.queryParam("exclude_category_names",
-                    JsonUtils.writeValueAsString(excludeCategoryNames));
+        if (excludeCategoryName != null) {
+            webTarget = webTarget.queryParam("exclude_category_name", excludeCategoryName);
         }
         try (var response = webTarget
                 .request()

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -5898,8 +5898,8 @@ class ExperimentsResourceTest {
         }
 
         @Test
-        @DisplayName("when no exclude param provided, then suite_assertion scores are excluded by default")
-        void getFeedbackScoreNames__noExcludeParam__thenSuiteAssertionExcludedByDefault() {
+        @DisplayName("when scores have mixed categories, then all score names returned without exclude param")
+        void getFeedbackScoreNames__mixedCategories__thenAllReturned() {
             var apiKey = "apiKey-" + UUID.randomUUID();
             var workspaceName = "workspace-" + UUID.randomUUID();
             var workspaceId = UUID.randomUUID().toString();
@@ -5951,12 +5951,13 @@ class ExperimentsResourceTest {
                     .filter(score -> "feedback_scores".equals(score.type()))
                     .map(FeedbackScoreNames.ScoreName::name)
                     .toList();
-            assertThat(feedbackNames).containsExactly("regular_score");
+            assertThat(feedbackNames).containsExactlyInAnyOrder(
+                    "regular_score", "suite_assertion_1", "suite_assertion_2");
         }
 
         @Test
-        @DisplayName("when exclude_category_names is provided, then exclude scores with those categories")
-        void getFeedbackScoreNames__excludeCategoryNames__thenExcludeMatchingScores() {
+        @DisplayName("when exclude_category_name is provided, then exclude scores with that category")
+        void getFeedbackScoreNames__excludeCategoryName__thenExcludeMatchingScores() {
             var apiKey = "apiKey-" + UUID.randomUUID();
             var workspaceName = "workspace-" + UUID.randomUUID();
             var workspaceId = UUID.randomUUID().toString();
@@ -6003,7 +6004,7 @@ class ExperimentsResourceTest {
             createScoreAndAssert(FeedbackScoreBatch.builder().scores(scores).build(), apiKey, workspaceName);
 
             var actualEntity = experimentResourceClient.getFeedbackScoreNames(
-                    List.of(experiment.id()), Set.of("suite_assertion"), apiKey, workspaceName);
+                    List.of(experiment.id()), "suite_assertion", apiKey, workspaceName);
             var feedbackNames = actualEntity.scores().stream()
                     .filter(score -> "feedback_scores".equals(score.type()))
                     .map(FeedbackScoreNames.ScoreName::name)


### PR DESCRIPTION
Reverts comet-ml/opik#5588

To implement the API contract right

## Details
Revert the feedback scores filter changes from #5588 to re-implement the API contract correctly.

## Issues
- https://comet-ml.atlassian.net/browse/OPIK-4871

## Testing
Revert PR — original tests are reverted as well.

## Documentation
N/A

## Change checklist
- [x] I have reviewed my own code
- [x] Existing tests pass