### PR TITLE
[NA] [SDK] Rename agent_config_decorator `project` param to `project_name`

### DIFF
--- a/sdks/python/src/opik/api_objects/agent_config/decorator.py
+++ b/sdks/python/src/opik/api_objects/agent_config/decorator.py
@@ -47,7 +47,7 @@ def agent_config_decorator(
     cls: typing.Optional[type] = None,
     *,
     name: typing.Optional[str] = None,
-    project: typing.Optional[str] = None,
+    project_name: typing.Optional[str] = None,
     workspace: typing.Optional[str] = None,
     env: typing.Optional[str] = None,
     mask_id: typing.Optional[str] = None,
@@ -72,7 +72,7 @@ def agent_config_decorator(
     Args:
         cls: The class being decorated (set automatically).
         name: Prefix used for backend field keys. Defaults to the class name.
-        project: Opik project name. Defaults to the client's default project.
+        project_name: Opik project name. Defaults to the client's default project.
         workspace: Opik workspace. Reserved for future use.
         env: Pin this config instance to a specific environment blueprint.
         mask_id: ID of a mask blueprint to overlay on every attribute read.
@@ -104,7 +104,7 @@ def agent_config_decorator(
 
             client = opik_client.get_client_cached()
 
-            resolved_project = project or client.project_name
+            resolved_project = project_name or client.project_name
             agent_config = config.AgentConfig(
                 project_name=resolved_project,
                 rest_client_=client.rest_client,

--- a/sdks/python/tests/e2e/test_agent_config.py
+++ b/sdks/python/tests/e2e/test_agent_config.py
@@ -43,7 +43,7 @@ def test_agent_config_decorator__all_primitive_and_collection_types__happyflow(
     opik_client: opik.Opik,
     project_name: str,
 ):
-    @opik.agent_config(project=project_name)
+    @opik.agent_config(project_name=project_name)
     class AllTypesConfig:
         temperature: float = 0.7
         max_tokens: Optional[int] = None
@@ -70,7 +70,7 @@ def test_agent_config_decorator__backend_overrides_local_defaults__happyflow(
     project_name: str,
 ):
     # First instantiation creates the blueprint with temperature=0.3
-    @opik.agent_config(project=project_name)
+    @opik.agent_config(project_name=project_name)
     class MyConfig:
         temperature: float = 0.3
         model: str = "gpt-3.5"
@@ -83,7 +83,7 @@ def test_agent_config_decorator__backend_overrides_local_defaults__happyflow(
     _registry.clear()
 
     # Second instantiation with different local defaults — backend values must win
-    @opik.agent_config(project=project_name)
+    @opik.agent_config(project_name=project_name)
     class MyConfig:  # type: ignore[no-redef]
         temperature: float = 0.99
         model: str = "gpt-4"
@@ -216,7 +216,7 @@ def test_agent_config__mask_id_pin__does_not_update_backend__happyflow(
     opik_client: opik.Opik,
     project_name: str,
 ):
-    @opik.agent_config(project=project_name)
+    @opik.agent_config(project_name=project_name)
     class BaseConfig:
         temperature: float = 0.5
 
@@ -234,7 +234,7 @@ def test_agent_config__mask_id_pin__does_not_update_backend__happyflow(
 
     _registry.clear()
 
-    @opik.agent_config(project=project_name, mask_id=mask_id)
+    @opik.agent_config(project_name=project_name, mask_id=mask_id)
     class BaseConfig:  # type: ignore[no-redef]
         temperature: float = 0.99
         name: str = "placeholder"
@@ -250,7 +250,7 @@ def test_agent_config__env_pin__does_not_update_backend__happyflow(
     opik_client: opik.Opik,
     project_name: str,
 ):
-    @opik.agent_config(project=project_name)
+    @opik.agent_config(project_name=project_name)
     class EnvConfig:
         temperature: float = 0.4
 
@@ -266,7 +266,7 @@ def test_agent_config__env_pin__does_not_update_backend__happyflow(
 
     _registry.clear()
 
-    @opik.agent_config(project=project_name, env="staging")
+    @opik.agent_config(project_name=project_name, env="staging")
     class EnvConfig:  # type: ignore[no-redef]
         temperature: float = 0.99
         name: str = "placeholder"
@@ -286,7 +286,7 @@ def test_agent_config__env_pin__second_instantiation_uses_backend_value__happyfl
     """Backend is source of truth: re-instantiating with a different constructor arg
     should return the value from the first registration, not the new arg."""
 
-    @opik.agent_config(project=project_name, env="prod")
+    @opik.agent_config(project_name=project_name, env="prod")
     class MyAgentConfig:
         my_param: int
         name: str
@@ -300,7 +300,7 @@ def test_agent_config__env_pin__second_instantiation_uses_backend_value__happyfl
     _registry.clear()
 
     # Second instantiation: backend is now source of truth, "Bob" should be ignored
-    @opik.agent_config(project=project_name, env="prod")
+    @opik.agent_config(project_name=project_name, env="prod")
     class MyAgentConfig:  # type: ignore[no-redef]
         my_param: int
         name: str
@@ -344,7 +344,7 @@ def test_agent_config_decorator__annotated_descriptions__sent_to_backend(
     opik_client: opik.Opik,
     project_name: str,
 ):
-    @opik.agent_config(project=project_name)
+    @opik.agent_config(project_name=project_name)
     class AnnotatedConfig:
         model: Annotated[str, "The LLM model identifier"] = "gpt-4o"
         temperature: Annotated[float, "Sampling temperature"] = 0.7
@@ -386,7 +386,7 @@ def test_agent_config_decorator__prompt_tracks_latest_version__prompt_version_st
     )
 
     # Register a config that holds both field types pinned to v1
-    @opik.agent_config(project=project_name)
+    @opik.agent_config(project_name=project_name)
     @dataclasses.dataclass
     class PromptConfig:
         system_prompt: Prompt = dataclasses.field(default_factory=lambda: prompt_v1)

--- a/sdks/python/tests/unit/api_objects/agent_config/test_decorator.py
+++ b/sdks/python/tests/unit/api_objects/agent_config/test_decorator.py
@@ -766,12 +766,12 @@ class TestConfigDecoratorMultiClass:
         assert p.template == "v2"
 
     def test_different_projects__separate_caches(self, mock_backend):
-        @agent_config_decorator(project="proj-a")
+        @agent_config_decorator(project_name="proj-a")
         @dataclasses.dataclass
         class ConfigA:
             val: int = 1
 
-        @agent_config_decorator(project="proj-b")
+        @agent_config_decorator(project_name="proj-b")
         @dataclasses.dataclass
         class ConfigB:
             val: int = 2


### PR DESCRIPTION
## Details

Renames the `project` parameter of `@agent_config` / `agent_config_decorator` to `project_name` to align with the naming convention used throughout the SDK (`@opik.track`, `opik_client.get_agent_config`, etc.).

- Updated `agent_config_decorator` signature and docstring in `decorator.py`
- Updated all call sites in e2e and unit tests

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: Full implementation
- Human verification: Reviewed

## Testing

- Unit tests in `tests/unit/api_objects/agent_config/test_decorator.py` cover the renamed parameter (`project_name="proj-a"`, `project_name="proj-b"`)
- E2e tests in `tests/e2e/test_agent_config.py` updated to use `project_name=` keyword

## Documentation

N/A — parameter rename only, no public docs affected.