### PR TITLE
[NA] [E2E] fix SDK terminal link test

### DIFF
--- a/tests_end_to_end/test-helper-service/routes/traces.py
+++ b/tests_end_to_end/test-helper-service/routes/traces.py
@@ -124,7 +124,7 @@ def create_traces_and_get_url():
     # Parse the URL from the SDK's terminal log message:
     # 'Started logging traces to the "project_name" project at {url}.'
     url_match = re.search(
-        r'Started logging traces.*? at (https?://\S+?)\.',
+        r'Started logging traces.*? at (https?://\S+)\.',
         terminal_output
     )
     if not url_match:


### PR DESCRIPTION
## Details
Fixes broken SDK terminal URL test test by fixing a regex. Now properly sees both localhost and cloud environment URLs

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
NA

## AI-WATERMARK

AI-WATERMARK: no

## Testing
works against prod

## Documentation
