### PR TITLE
[issue-5621] [BE] fix: strip provider prefix in findModelPrice() for LiteLLM OTel

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -74,7 +74,10 @@ public class CostService {
      * Fixes issue #5018: Handles model names with date suffixes like "gpt-5.2-2025-12-17"
      * by stripping the date suffix and falling back to the base model name.
      *
-     * @param modelName The model name (may contain dots, e.g., "claude-3.5-sonnet")
+     * Fixes issue #5621: Handles model names with provider prefix like "openai/gpt-4o"
+     * sent by LiteLLM via gen_ai.request.model, by stripping the prefix before lookup.
+     *
+     * @param modelName The model name (may contain dots or provider prefix, e.g., "openai/gpt-4o")
      * @param provider The provider name (e.g., "anthropic")
      * @return ModelPrice for the model, or DEFAULT_COST if not found
      */
@@ -83,8 +86,12 @@ public class CostService {
             return DEFAULT_COST;
         }
 
-        // Strip provider prefix if present (e.g. "openai/gpt-4o" -> "gpt-4o")
-        // LiteLLM sends model names with provider prefix via gen_ai.request.model
+        // Strip provider prefix if present (e.g. "openai/gpt-4o" -> "gpt-4o").
+        // LiteLLM sends model names with provider prefix via gen_ai.request.model.
+        // This is safe because parseModelPrices() also calls parseModelName() when building
+        // the price map, so stored keys never contain a provider prefix. All subsequent
+        // normalization steps (dot→hyphen, date suffix stripping) are therefore applied to
+        // the same prefix-free name that was used as the key when the map was populated.
         modelName = parseModelName(modelName);
 
         // Try exact match first (backwards compatibility)

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -120,6 +120,13 @@ class CostServiceTest {
                 Arguments.of("claude-haiku-4-5", "anthropic", true),
                 Arguments.of("claude-sonnet-4-5", "anthropic", true),
 
+                // Provider prefix + dot notation should work (prefix stripped, then dots normalized)
+                Arguments.of("anthropic/claude-3.5-sonnet-20241022", "anthropic", true),
+                Arguments.of("anthropic/claude-sonnet-4.5", "anthropic", true),
+
+                // Provider prefix + case variation should work
+                Arguments.of("anthropic/Claude-3.5-Sonnet-20241022", "anthropic", true),
+
                 // Unknown models should gracefully return zero
                 Arguments.of("claude-3.5.1", "anthropic", false),
                 Arguments.of("unknown-model-with-dots.1.2.3", "unknown", false));
@@ -183,6 +190,9 @@ class CostServiceTest {
                 Arguments.of("claude-sonnet-4.5-2025-12-17", "anthropic"),
                 // 3. Base models without date suffix should still work
                 Arguments.of("gpt-5.2", "openai"),
-                Arguments.of("claude-sonnet-4.5", "anthropic"));
+                Arguments.of("claude-sonnet-4.5", "anthropic"),
+                // 4. Provider prefix + date suffix: prefix stripped first, then date suffix removed
+                Arguments.of("anthropic/claude-sonnet-4.5-2025-12-17", "anthropic"),
+                Arguments.of("openai/gpt-5.2-2025-12-17", "openai"));
     }
 }


### PR DESCRIPTION
## Details

LiteLLM sends model names with a provider prefix via `gen_ai.request.model` (e.g. `openai/gpt-4o`, `anthropic/claude-3-5-sonnet-20241022`). The pricing map is built by `parseModelPrices()` which already strips this prefix via `parseModelName()`, storing keys like `gpt-4o/openai`. However, `findModelPrice()` was not stripping the prefix at lookup time, so all four fallback attempts would fail and return `DEFAULT_COST = 0`.

Fix: call `parseModelName(modelName)` at the top of `findModelPrice()`, immediately after the blank-check guard, before any lookup attempts. This reuses the existing helper and is backwards-compatible — models without a `/` are returned unchanged.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves #5621

## Testing

New parameterized test `calculateCost_shouldStripProviderPrefix_issue5621` in `CostServiceTest` covers:
- `openai/gpt-4o` with provider `openai`
- `openai/gpt-4o-mini` with provider `openai`
- `anthropic/claude-3-5-sonnet-20241022` with provider `anthropic`
- `anthropic/claude-3-5-haiku-20241022` with provider `anthropic`

All 27 `CostServiceTest` tests pass, including pre-existing backwards-compatibility cases for exact match, dot normalization (#4114), and date-suffix stripping (#5018).

```
mvn test -Dtest="CostServiceTest" -pl apps/opik-backend
```

## Documentation

No documentation update needed.