### PR TITLE
[NA] [DOCS] Mark OPIK_WORKSPACE as optional across docs and TS SDK

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/faq.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/faq.mdx
@@ -218,7 +218,7 @@ Otherwise, please double-check your existing configuration:
 For Opik Cloud by Comet:
 
 - `api_key` (required): Verify your API key is correct and active
-- `workspace` (required): Confirm you have access to the specified workspace
+- `workspace` (optional): If specified, confirm you have access to the specified workspace
 - `project_name` (optional): If specified, ensure the project name is valid
 - `url_override`: Should be set to `https://www.comet.com/opik/api` (this is the default)
 

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/kong-ai-gateway.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/kong-ai-gateway.mdx
@@ -58,7 +58,7 @@ curl -is -X POST http://localhost:8001/services/{serviceName|Id}/plugins \
 The Opik Kong plugin accepts the following configuration parameters:
 
 - **`opik_api_key`**: Your Opik API key (required)
-- **`opik_workspace`**: Your Opik workspace name (required)
+- **`opik_workspace`**: Your Opik workspace name (optional)
 
 ### Viewing Traces in Opik
 

--- a/apps/opik-documentation/documentation/fern/docs/tracing/log_chat_conversations.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/log_chat_conversations.mdx
@@ -37,7 +37,7 @@ You can log chat conversations by specifying the `thread_id` parameter when usin
     apiUrl: "https://www.comet.com/opik/api", // Only required if you are using Opik Cloud
     apiKey: "your-api-key",
     projectName: "your-project-name",
-    workspaceName: "your-workspace-name", // Only required if you are using Opik Cloud
+    workspaceName: "your-workspace-name", // Optional
     });
 
     const threadId = "your-thread-id"; // any unique string per conversation

--- a/apps/opik-documentation/documentation/fern/docs/tracing/log_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/log_traces.mdx
@@ -588,7 +588,7 @@ If you need full control over the logging process, you can use the low-level SDK
             apiUrl: "https://www.comet.com/opik/api",
             apiKey: "your-api-key", // Only required if you are using Opik Cloud
             projectName: "your-project-name",
-            workspaceName: "your-workspace-name", // Only required if you are using Opik Cloud
+            workspaceName: "your-workspace-name", // Optional
         });
 
         // Log a trace with an LLM span

--- a/apps/opik-documentation/documentation/fern/docs/tracing/sdk_configuration.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/sdk_configuration.mdx
@@ -432,7 +432,7 @@ await flushAll();
 | -------------------------- | ---------------------------- | ------------------------------------------------------------------------- |
 | url_override               | `OPIK_URL_OVERRIDE`          | The URL of the Opik server - Defaults to `https://www.comet.com/opik/api` |
 | api_key                    | `OPIK_API_KEY`               | The API key - Only required for Opik Cloud                                |
-| workspace                  | `OPIK_WORKSPACE`             | The workspace name - Only required for Opik Cloud                         |
+| workspace                  | `OPIK_WORKSPACE`             | The workspace name - Optional                                             |
 | project_name               | `OPIK_PROJECT_NAME`          | The project name to use                                                   |
 | N/A                        | `OPIK_DEFAULT_LLM`           | Default LLM used by Python evaluation/simulation helpers - Defaults to `openai/gpt-5-nano` |
 | opik_track_disable         | `OPIK_TRACK_DISABLE`         | Disable tracking of traces and spans - Defaults to `false`                |
@@ -448,7 +448,7 @@ await flushAll();
 | ------------------ | ----------------------- | -------------------------------------------------------------------- |
 | apiUrl             | `OPIK_URL_OVERRIDE`     | The URL of the Opik server - Defaults to `http://localhost:5173/api` |
 | apiKey             | `OPIK_API_KEY`          | The API key - Required for Opik Cloud                                |
-| workspaceName      | `OPIK_WORKSPACE`        | The workspace name - Required for Opik Cloud                         |
+| workspaceName      | `OPIK_WORKSPACE`        | The workspace name - Optional                                        |
 | projectName        | `OPIK_PROJECT_NAME`     | The project name - Defaults to `Default Project`                     |
 | batchDelayMs       | `OPIK_BATCH_DELAY_MS`   | Batching delay in milliseconds - Defaults to `300`                   |
 | holdUntilFlush     | `OPIK_HOLD_UNTIL_FLUSH` | Hold data until manual flush - Defaults to `false`                   |
@@ -496,7 +496,7 @@ The TypeScript SDK validates configuration at startup. Common errors:
 
 - **"OPIK_URL_OVERRIDE is not set"**: Set the `OPIK_URL_OVERRIDE` environment variable
 - **"OPIK_API_KEY is not set"**: Required for Opik Cloud deployments
-- **"OPIK_WORKSPACE is not set"**: Required for Opik Cloud deployments
+- **"OPIK_WORKSPACE is not set"**: Optional, but can be set for Opik Cloud deployments
 
 #### Debug Logging
 

--- a/sdks/typescript/src/opik/configure/src/nodejs/docs.ts
+++ b/sdks/typescript/src/opik/configure/src/nodejs/docs.ts
@@ -64,7 +64,7 @@ import { Opik } from 'opik';
 const opik = new Opik({
   apiKey: ${apiKeyText},                    // Required
   apiUrl: ${hostText},                      // Required (Cloud or Local URL)
-  workspaceName: 'my-workspace',                   // Required
+  workspaceName: 'my-workspace',                   // Optional
   projectName: 'my-project',                       // Optional (defaults to "Default")
   batchDelayMs: 100,                               // Optional: Default 100ms
   holdUntilFlush: false,                           // Optional: Default false
@@ -641,7 +641,7 @@ Configuration:
   }="https://www.comet.com/opik/api" # Required (Cloud or Local)
   export ${
     OPIK_ENV_VARS.WORKSPACE
-  }="your-workspace-name"                # Required
+  }="your-workspace-name"                # Optional
   export ${
     OPIK_ENV_VARS.PROJECT_NAME
   }="your-project-name"               # Optional (defaults to "Default")


### PR DESCRIPTION
## Summary
- `OPIK_WORKSPACE` defaults to `"default"` in both Python and TypeScript SDKs, so it should not be documented as required
- Updated 6 files across docs and TS SDK configure tool to mark workspace as optional instead of required

## Test plan
- [ ] Verify docs render correctly on Fern preview
- [ ] Confirm no other references to workspace being "required" remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)