### PR TITLE
[NA] [DOCS] Add redirects for commonly guessed TS SDK and integration paths

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -1089,6 +1089,28 @@ redirects:
     permanent: true
   - source: "/docs/opik/prompt_engineering/prompt_optimization"
     destination: "/docs/opik/agent_optimization/best_practices/prompt_engineering"
+  # Common guessed paths for TypeScript SDK and integrations
+  - source: "/docs/opik/typescript-sdk"
+    destination: "/docs/opik/reference/typescript-sdk/overview"
+    permanent: true
+  - source: "/docs/opik/ts-sdk"
+    destination: "/docs/opik/reference/typescript-sdk/overview"
+    permanent: true
+  - source: "/docs/opik/ts-sdk/get-started"
+    destination: "/docs/opik/reference/typescript-sdk/overview"
+    permanent: true
+  - source: "/docs/opik/tracing/integrations/openai/nodejs"
+    destination: "/docs/opik/integrations/openai-typescript"
+    permanent: true
+  - source: "/docs/opik/tracing/integrations/openai/typescript"
+    destination: "/docs/opik/integrations/openai-typescript"
+    permanent: true
+  - source: "/docs/opik/integrations/openai/nodejs"
+    destination: "/docs/opik/integrations/openai-typescript"
+    permanent: true
+  - source: "/docs/opik/integrations/openai/typescript"
+    destination: "/docs/opik/integrations/openai-typescript"
+    permanent: true
   # TypeScript SDK integration redirects
   - source: "/docs/opik/reference/typescript-sdk/integrations/vercel-ai-sdk"
     destination: "/docs/opik/integrations/vercel-ai-sdk"


### PR DESCRIPTION
## Summary
- Add URL redirects for paths that agents and developers commonly guess when looking for TypeScript SDK docs
- Redirects `/typescript-sdk`, `/ts-sdk`, `/ts-sdk/get-started` to the TS SDK overview
- Redirects `/integrations/openai/nodejs`, `/integrations/openai/typescript`, and `/tracing/integrations/openai/nodejs` etc. to the OpenAI TypeScript integration page

## Test plan
- [ ] Verify redirects work on Fern preview
- [ ] Confirm existing redirects are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)