### PR TITLE
[OPIK-4905] [FE] Hide experiment CTAs if no permission

### DIFF
--- a/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsActionsPanel.tsx
+++ b/apps/opik-frontend/src/components/pages-shared/traces/TraceDetailsPanel/TraceDetailsActionsPanel.tsx
@@ -118,7 +118,7 @@ const TraceDetailsActionsPanel: React.FunctionComponent<
   const isExportEnabled = useIsFeatureEnabled(FeatureToggleKeys.EXPORT_ENABLED);
 
   const {
-    permissions: { canDeleteTraces },
+    permissions: { canDeleteTraces, canViewExperiments },
   } = usePermissions();
 
   const { toast } = useToast();
@@ -128,6 +128,8 @@ const TraceDetailsActionsPanel: React.FunctionComponent<
   const hasThread = Boolean(setThreadId && threadId);
   const experiment: ExperimentItemReference | undefined = (treeData[0] as Trace)
     ?.experiment;
+
+  const showExperimentButton = !!experiment && canViewExperiments;
 
   const minPanelWidth = useMemo(() => {
     const elements = [
@@ -384,10 +386,10 @@ const TraceDetailsActionsPanel: React.FunctionComponent<
 
   return (
     <div ref={ref} className="flex flex-auto items-center justify-between">
-      {hasThread || experiment ? (
+      {hasThread || showExperimentButton ? (
         <div className="flex items-center">
           <Separator orientation="vertical" className="mx-3 h-4" />
-          {experiment && (
+          {showExperimentButton && (
             <NavigationTag
               id={experiment.dataset_id}
               name="View in experiment"

--- a/apps/opik-frontend/src/components/pages/DatasetItemsPage/UseDatasetDropdown.tsx
+++ b/apps/opik-frontend/src/components/pages/DatasetItemsPage/UseDatasetDropdown.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useRef, useState } from "react";
 import { Blocks, ChevronDown, Code2 } from "lucide-react";
-
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -11,6 +10,7 @@ import {
 import AddExperimentDialog from "@/components/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog";
 import ConfirmDialog from "@/components/shared/ConfirmDialog/ConfirmDialog";
 import useLoadPlayground from "@/hooks/useLoadPlayground";
+import { usePermissions } from "@/contexts/PermissionsContext";
 
 export type UseDatasetDropdownProps = {
   datasetName?: string;
@@ -28,6 +28,10 @@ const UseDatasetDropdown: React.FunctionComponent<UseDatasetDropdownProps> = ({
   const resetKeyRef = useRef(0);
   const [openExperimentDialog, setOpenExperimentDialog] = useState(false);
   const [openConfirmDialog, setOpenConfirmDialog] = useState(false);
+
+  const {
+    permissions: { canViewExperiments },
+  } = usePermissions();
 
   const { loadPlayground, isPlaygroundEmpty, isPendingProviderKeys } =
     useLoadPlayground();
@@ -54,11 +58,13 @@ const UseDatasetDropdown: React.FunctionComponent<UseDatasetDropdownProps> = ({
 
   return (
     <>
-      <AddExperimentDialog
-        open={openExperimentDialog}
-        setOpen={setOpenExperimentDialog}
-        datasetName={datasetName}
-      />
+      {canViewExperiments && (
+        <AddExperimentDialog
+          open={openExperimentDialog}
+          setOpen={setOpenExperimentDialog}
+          datasetName={datasetName}
+        />
+      )}
       <ConfirmDialog
         key={resetKeyRef.current}
         open={openConfirmDialog}
@@ -88,18 +94,20 @@ const UseDatasetDropdown: React.FunctionComponent<UseDatasetDropdownProps> = ({
               </span>
             </div>
           </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={handleRunExperimentClick}
-            disabled={disabled}
-          >
-            <Code2 className="mr-2 mt-0.5 size-4 shrink-0 self-start" />
-            <div className="comet-body-s flex flex-col">
-              <span>Run an experiment</span>
-              <span className="text-light-slate">
-                Use this dataset to run an experiment using the Python SDK
-              </span>
-            </div>
-          </DropdownMenuItem>
+          {canViewExperiments && (
+            <DropdownMenuItem
+              onClick={handleRunExperimentClick}
+              disabled={disabled}
+            >
+              <Code2 className="mr-2 mt-0.5 size-4 shrink-0 self-start" />
+              <div className="comet-body-s flex flex-col">
+                <span>Run an experiment</span>
+                <span className="text-light-slate">
+                  Use this dataset to run an experiment using the Python SDK
+                </span>
+              </div>
+            </DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </>


### PR DESCRIPTION
## Details
Hide experiment-related CTAs from users who lack `canViewExperiments` permission:

- **TraceDetailsActionsPanel**: The "View in experiment" navigation tag is now conditionally rendered based on `canViewExperiments`, preventing unauthorized users from seeing the experiment link in trace details.
- **UseDatasetDropdown**: The "Run an experiment" dropdown menu item and the `AddExperimentDialog` are gated behind `canViewExperiments`, so users without experiment access no longer see these options on the dataset items page.

## Change checklist
- [x] Consumed `canViewExperiments` from `usePermissions()` in `TraceDetailsActionsPanel`
- [x] Conditionally render experiment navigation tag based on permission
- [x] Consumed `canViewExperiments` from `usePermissions()` in `UseDatasetDropdown`
- [x] Conditionally render "Run an experiment" menu item and `AddExperimentDialog`

## Screenshots
<img width="965" height="294" alt="Screenshot 2026-03-12 at 11 00 57" src="https://github.com/user-attachments/assets/f00b6ea0-d7a6-4fa0-83d8-ff57e9d36cff" />
<img width="1101" height="534" alt="Screenshot 2026-03-12 at 11 01 51" src="https://github.com/user-attachments/assets/8632ef37-f651-48d9-b513-e5607bdb46fe" />

## Testing
- [ ] Verify that users **with** `canViewExperiments` permission still see experiment CTAs as before
- [ ] Verify that users **without** `canViewExperiments` permission no longer see:
  - "View in experiment" tag in trace details panel
  - "Run an experiment" option in the dataset "Use dataset" dropdown
  - `AddExperimentDialog` on the dataset items page

## Issues
- [OPIK-4905]

## Documentation
No documentation changes required.

[OPIK-4905]: https://comet-ml.atlassian.net/browse/OPIK-4905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ