### PR TITLE
[OPIK-4365] [DOCS] docs: remove opik-ai-backend reference from contributing overview

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/contributing/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/contributing/overview.mdx
@@ -91,7 +91,7 @@ Opik is a monorepo with multiple services and SDKs. Common contributor entry poi
 - `apps/opik-backend`: Core Java backend API/services
 - `apps/opik-frontend`: React frontend application
 - `apps/opik-documentation`: Documentation website and docs source
-- `apps/opik-ai-backend`, `apps/opik-guardrails-backend`, `apps/opik-python-backend`, `apps/opik-sandbox-executor-python`: supporting backends and runtime services
+- `apps/opik-guardrails-backend`, `apps/opik-python-backend`, `apps/opik-sandbox-executor-python`: supporting backends and runtime services
 - `sdks/python`, `sdks/typescript`, `sdks/opik_optimizer`: SDKs and optimizer tooling
 - `tests_end_to_end`: E2E suites and helper services
 


### PR DESCRIPTION
## Details
Follow-up to #5602 — removes `apps/opik-ai-backend` from the contributor documentation project directory listing, since the AI backend was removed from the OSS repo.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-4365

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Identified and applied documentation cleanup
  - Human verification: Yes, reviewed the change

## Testing

- Verified the diff only removes `apps/opik-ai-backend` from the directory listing on line 94 of `contributing/overview.mdx`
- No other documentation references to `opik-ai-backend` found
- No code changes, documentation-only update

## Documentation

This PR *is* the documentation cleanup.