### PR TITLE
[OPIK-4928] [SDK] Include active mask_id in trace agent_configuration metadata

### DIFF
--- a/sdks/python/src/opik/api_objects/agent_config/decorator.py
+++ b/sdks/python/src/opik/api_objects/agent_config/decorator.py
@@ -394,7 +394,7 @@ def _inject_trace_metadata(
             "blueprint_id": resolved_cache.blueprint_id,
         }
         if mask_id is not None:
-            agent_config_metadata["mask_id"] = mask_id
+            agent_config_metadata["_mask_id"] = mask_id
         agent_config_metadata["values"] = values
 
         opik_context.update_current_trace(

--- a/sdks/python/tests/unit/api_objects/agent_config/test_decorator.py
+++ b/sdks/python/tests/unit/api_objects/agent_config/test_decorator.py
@@ -314,7 +314,7 @@ class TestConfigDecoratorMaskAndEnv:
 
         mock_backend.agent_configs.create_or_update_envs.assert_not_called()
         config = mock_update.call_args[1]["metadata"]["agent_configuration"]
-        assert config["mask_id"] == "mask-1"
+        assert config["_mask_id"] == "mask-1"
 
 
 class TestConfigDecoratorTraceMetadata:
@@ -344,7 +344,7 @@ class TestConfigDecoratorTraceMetadata:
             assert field_entry["value"] == 0.8
             assert field_entry["type"] == "float"
             assert "description" not in field_entry
-            assert "mask_id" not in config
+            assert "_mask_id" not in config
 
     def test_field_access_inside_trace__annotated_field__injects_description(
         self, mock_backend
@@ -1116,7 +1116,7 @@ class TestConfigDecoratorContextMask:
         call_kwargs = mock_backend.agent_configs.get_latest_blueprint.call_args[1]
         assert call_kwargs.get("mask_id") == "mask-ctx"
         config = mock_update.call_args[1]["metadata"]["agent_configuration"]
-        assert config["mask_id"] == "mask-ctx"
+        assert config["_mask_id"] == "mask-ctx"
 
     def test_context_mask__env_pinned_instance__calls_get_blueprint_by_env_with_mask_id(
         self, mock_backend
@@ -1163,8 +1163,15 @@ class TestConfigDecoratorContextMask:
         instance = MyConfig()
         assert instance.temp == 0.8
 
-        with agent_config_context("mask-ctx"):
-            assert instance.temp == 0.3
+        with mock.patch(
+            "opik.api_objects.agent_config.decorator.opik_context.update_current_trace"
+        ) as mock_update:
+            with agent_config_context("mask-ctx"):
+                assert instance.temp == 0.3
+
+        config = mock_update.call_args[1]["metadata"]["agent_configuration"]
+        assert config["_mask_id"] == "mask-ctx"
+        assert config["values"]["MyConfig.temp"]["value"] == 0.3
 
     def test_context_mask__no_env__does_not_call_get_blueprint_by_env(
         self, mock_backend


### PR DESCRIPTION
## Details

When a mask is active via `agent_config_context(mask_id=...)`, the trace's metadata now includes the `mask_id` in the agent_configuration so traces can be linked to the specific mask that produced their values.

The change updates `_inject_trace_metadata()` to include the active context mask ID when a mask is applied.

<img width="534" height="315" alt="image" src="https://github.com/user-attachments/assets/6d714aa4-d9a8-4490-9c96-609ea98c0c25" />

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-4928

## Testing

Unit tests verify that:
- Masked values are correctly injected into trace metadata
- The mask_id is included in agent_configuration metadata when a mask context is active
- Blueprint ID metadata is properly populated for both base and masked configs

## Documentation

N/A