### PR TITLE
[OPIK-3519] [INFRA] add automated provider model sync script

### DIFF
--- a/.github/workflows/sync_provider_models.yml
+++ b/.github/workflows/sync_provider_models.yml
@@ -54,6 +54,8 @@ jobs:
             echo "No new models found, skipping PR creation."
           fi
 
+          rm -f sync_summary.txt sync_stderr.txt
+
       - name: Print summary
         if: always() && steps.sync.outputs.summary != ''
         run: |

--- a/scripts/sync_provider_models.py
+++ b/scripts/sync_provider_models.py
@@ -576,10 +576,10 @@ def _format_java_entry_3arg(enum_name: str, qualified: str, value: str, flag: bo
 
 
 def _finalize_entries(lines: list[str]) -> str:
-    """Turn the last entry's trailing comma into a semicolon, add blank line."""
+    """Turn the last entry's trailing comma into a semicolon."""
     if not lines:
-        return "    ;\n\n"
-    lines[-1] = lines[-1].rstrip().rstrip(",") + ";\n"
+        return "    ;\n"
+    lines[-1] = lines[-1].rstrip().rstrip(",") + ";"
     return "\n".join(lines) + "\n"
 
 
@@ -669,7 +669,7 @@ def regenerate_providers_ts(
             lines.append(f'  {entry.enum_name} = "{entry.value}",')
         sections.append("\n".join(lines))
 
-    new_body = "\n\n".join(sections) + "\n"
+    new_body = "\n\n".join(sections)
     return content[:opik_free_end] + new_body + content[enum_close:]
 
 
@@ -707,7 +707,12 @@ def regenerate_models_data_ts(
         lines = ["["]
         for entry in entries:
             lines.append("    {")
-            lines.append(f"      value: PROVIDER_MODEL_TYPE.{entry.enum_name},")
+            value_line = f"      value: PROVIDER_MODEL_TYPE.{entry.enum_name},"
+            if len(value_line) > 80:
+                lines.append("      value:")
+                lines.append(f"        PROVIDER_MODEL_TYPE.{entry.enum_name},")
+            else:
+                lines.append(value_line)
             lines.append(f'      label: "{entry.label}",')
             lines.append("    },")
         lines.append("  ]")


### PR DESCRIPTION
## Details

Adds a Python script and GitHub Actions workflow to automatically sync LLM provider model definitions across 5 Java enum files and 2 TypeScript files. The script fetches models from provider APIs (OpenAI, Anthropic, Gemini) with fallback to the LiteLLM prices JSON, then updates backend enums and frontend dropdowns.

- **Add-only mode**: new models are added automatically; stale/deprecated models are reported in the PR summary for manual review, never auto-removed
- **Curated dropdown filtering**: frontend dropdowns show a filtered, sorted subset (excludes dated snapshots, deprecated models, Responses-API-only models)
- **Deprecation detection**: models with past `deprecation_date` are flagged and excluded from dropdown
- **Enum name preservation**: existing hand-crafted Java enum names are preserved; only new models get auto-generated names
- **CI-compatible formatting**: generated Java passes Spotless, generated TypeScript passes Prettier

### New files
- `scripts/sync_provider_models.py` — main sync script
- `.github/workflows/sync_provider_models.yml` — daily CI workflow (runs Mon–Fri, 30 min after model prices sync)

### Requires 3 GitHub secrets
- `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`
- Script works without them (falls back to prices JSON), so the workflow won't break if secrets aren't configured yet

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-3519

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Script implementation, workflow configuration, PR review fixes
  - Human verification: Requires manual review before merge

## Testing

- `python scripts/sync_provider_models.py --dry-run` — verified no files are written, summary output is correct
- Ran with all 3 provider API keys set — verified API fetching works for OpenAI, Anthropic, Gemini
- Ran without API keys — verified fallback to prices JSON works correctly
- Verified deprecated models are detected and excluded from dropdown
- Verified enum name preservation for existing models across all providers
- Verified idempotency: running twice produces no changes on second run
- Verified generated Java passes Spotless formatting check
- Verified generated TypeScript passes Prettier lint check

## Documentation

N/A — internal tooling script, no user-facing documentation changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)