### PR TITLE
[OPIK-3519] [INFRA] fix: formatting issues in sync provider models script

### DIFF
--- a/.github/workflows/sync_provider_models.yml
+++ b/.github/workflows/sync_provider_models.yml
@@ -54,6 +54,8 @@ jobs:
             echo "No new models found, skipping PR creation."
           fi
 
+          rm -f sync_summary.txt sync_stderr.txt
+
       - name: Print summary
         if: always() && steps.sync.outputs.summary != ''
         run: |

--- a/scripts/sync_provider_models.py
+++ b/scripts/sync_provider_models.py
@@ -576,10 +576,10 @@ def _format_java_entry_3arg(enum_name: str, qualified: str, value: str, flag: bo
 
 
 def _finalize_entries(lines: list[str]) -> str:
-    """Turn the last entry's trailing comma into a semicolon, add blank line."""
+    """Turn the last entry's trailing comma into a semicolon."""
     if not lines:
-        return "    ;\n\n"
-    lines[-1] = lines[-1].rstrip().rstrip(",") + ";\n"
+        return "    ;\n"
+    lines[-1] = lines[-1].rstrip().rstrip(",") + ";"
     return "\n".join(lines) + "\n"
 
 
@@ -669,7 +669,7 @@ def regenerate_providers_ts(
             lines.append(f'  {entry.enum_name} = "{entry.value}",')
         sections.append("\n".join(lines))
 
-    new_body = "\n\n".join(sections) + "\n"
+    new_body = "\n\n".join(sections)
     return content[:opik_free_end] + new_body + content[enum_close:]
 
 
@@ -707,7 +707,12 @@ def regenerate_models_data_ts(
         lines = ["["]
         for entry in entries:
             lines.append("    {")
-            lines.append(f"      value: PROVIDER_MODEL_TYPE.{entry.enum_name},")
+            value_line = f"      value: PROVIDER_MODEL_TYPE.{entry.enum_name},"
+            if len(value_line) > 80:
+                lines.append("      value:")
+                lines.append(f"        PROVIDER_MODEL_TYPE.{entry.enum_name},")
+            else:
+                lines.append(value_line)
             lines.append(f'      label: "{entry.label}",')
             lines.append("    },")
         lines.append("  ]")


### PR DESCRIPTION
## Details

Fixes formatting issues in the `sync_provider_models.py` script that caused CI failures ([PR #5636](https://github.com/comet-ml/opik/pull/5636)) on the generated Java and TypeScript files.

**Java (Spotless):** `_finalize_entries` produced an extra blank line between the last enum entry (`;`) and `private` field declarations across all 5 provider enum files.

**TypeScript (Prettier):**
- `useLLMProviderModelsData.ts` — long `value:` lines (>80 chars) weren't wrapped, violating Prettier's `printWidth`
- `providers.ts` — trailing newline before closing `}` of the enum block

**Workflow:** `sync_stderr.txt` and `sync_summary.txt` were left in the working directory, causing `peter-evans/create-pull-request` to include them in commits.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-3519

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Bug fixes in code generation formatting
  - Human verification: Requires manual review before merge

## Testing

- Verified generated Java passes `mvn spotless:check` locally
- Verified generated TypeScript passes `npx prettier --check` locally
- Verified `python scripts/sync_provider_models.py --dry-run` still runs correctly

## Documentation

N/A