### PR TITLE
[NA] [SDK] Fix mask_id not applied in InProcessRunnerLoop job execution

### DIFF
--- a/sdks/python/src/opik/runner/in_process_loop.py
+++ b/sdks/python/src/opik/runner/in_process_loop.py
@@ -182,6 +182,7 @@ class InProcessRunnerLoop:
                     else:
                         result = await coro
             else:
+
                 def _run_with_mask() -> object:
                     with agent_config_context(mask_id):
                         return func(**inputs)


### PR DESCRIPTION
## Details

- The `InProcessRunnerLoop` was not wrapping function calls with `agent_config_context(mask_id)`, so `@agent_config` decorated classes could not see the mask and always used base blueprint values
- Sync functions are wrapped via a `_run_with_mask()` closure that sets the context var in the executor thread
- Async functions are wrapped directly since the context manager applies to the current coroutine
## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

## Testing

- [ ] Manually verified: created a blueprint + mask with overridden `prompt_template`, submitted a job via `create_job` with `mask_id`, confirmed the agent received the masked config values
- [ ] Ran evaluation suite with mask — assertions checking for masked behavior now pass

## Documentation
