### PR TITLE
[OPIK-4387] [BE] Populate experiment items before experiment-level aggregates

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesService.java
@@ -69,18 +69,19 @@ public class ExperimentAggregatesService {
 
             String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
 
-            log.info("Starting aggregation population for experiment: '{}' in workspace: '{}', batchSize: '{}'",
+            log.info("Starting aggregation population for experiment: '{}' in workspaceId: '{}', batchSize: '{}'",
                     experimentId, workspaceId, batchSize);
 
             return populateExperimentItemsInBatches(experimentId, batchSize)
+                    .doOnSuccess(v -> log.info(
+                            "Experiment item aggregates populated for experiment: '{}' in workspaceId: '{}'",
+                            experimentId, workspaceId))
                     .then(Mono.defer(() -> experimentAggregatesDAO.populateExperimentAggregate(experimentId)))
                     .doOnSuccess(v -> log.info(
-                            "Experiment-level aggregates populated for experiment: '{}'", experimentId))
-                    .doOnSuccess(v -> log.info(
-                            "All aggregations populated successfully for experiment: '{}' in workspace: '{}'",
+                            "All aggregations populated successfully for experiment: '{}' in workspaceId: '{}'",
                             experimentId, workspaceId))
                     .doOnError(error -> log.error(
-                            "Failed to populate aggregations for experiment: '{}' in workspace: '{}'",
+                            "Failed to populate aggregations for experiment: '{}' in workspaceId: '{}'",
                             experimentId, workspaceId, error));
         });
     }


### PR DESCRIPTION
## Details
Reorder aggregation population in `ExperimentAggregatesService` so experiment items are processed first, then the experiment-level aggregate. This ensures aggregated data is only visible once all processing is complete. If experiment items fail, the experiment-level aggregate is skipped (error propagates), preventing inconsistent state.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-4387

## Testing
Existing experiment aggregation tests cover this change.

## Documentation
N/A