### PR TITLE
[NA] [SDK] fix: normalize assertion_results to dicts to prevent TypeError after Fern regeneration

### DIFF
--- a/sdks/python/src/opik/api_objects/experiment/experiment_item.py
+++ b/sdks/python/src/opik/api_objects/experiment/experiment_item.py
@@ -46,9 +46,15 @@ class ExperimentItemContent:
             ]
 
         raw_assertions = _extract_extra_field(value, "assertion_results")
-        assertion_results: List[AssertionResultDict] = (
-            raw_assertions if raw_assertions else []
-        )
+        if raw_assertions is None:
+            assertion_results: List[AssertionResultDict] = []
+        else:
+            assertion_results = [
+                ar
+                if isinstance(ar, dict)
+                else {"value": ar.value, "passed": ar.passed, "reason": ar.reason}
+                for ar in raw_assertions
+            ]
 
         return ExperimentItemContent(
             id=value.id,


### PR DESCRIPTION
## Details

<img width="1920" height="2306" alt="image" src="https://github.com/user-attachments/assets/f78e47a2-86a3-4595-81b6-7534f26dcb44" />

`AssertionResultDict` is typed as `Dict[str, Any]`, but the extraction code was passing `raw_assertions` through as-is. Currently `assertion_results` lands in `model_extra` as plain Python dicts (since it's not yet a typed field on `ExperimentItemCompare`), so `ar["value"]` works. After Fern SDK regeneration adds `assertion_results: List[AssertionResultCompare]` as a typed field, `_extract_extra_field` will fall back to `getattr()` and return Pydantic objects — causing `TypeError: 'AssertionResultCompare' object is not subscriptable` in all callers.

Fix mirrors the `feedback_scores` pattern: iterate and explicitly convert each item to a dict, with an `isinstance(ar, dict)` guard to handle both the current state (raw dicts from `model_extra`) and the post-Fern state (Pydantic objects).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: Fix implementation
- Human verification: Yes

## Testing

- Existing e2e tests in `tests/e2e/evaluation/test_evaluation_suite.py` cover the `assertion_results` access patterns (`ar["value"]`, `assertion["passed"]`)
- Fix is defensive and backwards-compatible: no behaviour change in the current state (raw dicts pass through unchanged via `isinstance(ar, dict)`)

## Documentation

N/A — internal SDK fix, no public API change.
