### PR TITLE
[NA] [TS SDK] Fix handling of datasetName for deleted datasets

### DIFF
--- a/sdks/typescript/src/opik/experiment/Experiment.ts
+++ b/sdks/typescript/src/opik/experiment/Experiment.ts
@@ -203,6 +203,12 @@ export class Experiment {
   }
 
   async getUrl(): Promise<string> {
+    if (!this.datasetName) {
+      throw new Error(
+        "Cannot get URL: the associated dataset has been deleted or is unavailable"
+      );
+    }
+
     const dataset = await this.opik.getDataset(this.datasetName);
     const baseUrl = this.opik.config.apiUrl || DEFAULT_CONFIG.apiUrl;
 


### PR DESCRIPTION
## Details
When dataset is deleted the `datasetName` returned by BE is `null`. The TS Experiment class defined `datasetName` as not nullable that caused an issues with retrieval of experiments associated with deleted datasets.

----
A summary of the TypeScript SDK changes on this branch:

Experiment.ts — 2 changes                                                                                                                                                       
                                                                                                                                                                                  
1.  datasetName made optional (string → string | undefined). The datasetName field on the Experiment class was changed from a required string to an optional string?. This aligns with the backend behavior where experiments can exist after their associated dataset has been deleted — in that case the API returns a null datasetName.                                                                                   
2.  getUrl() guard for missing datasetName. Added a null/undefined check at the top of getUrl(). If datasetName is not set (deleted dataset scenario), the method now throws a descriptive error ("Cannot get URL: the associated dataset has been deleted or is unavailable") instead of passing undefined to getDataset() and failing with a cryptic type or API error downstream.  

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-NA

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing


## Documentation
No changes