### PR TITLE
[NA][TS SDK] Make `datasetName` in `ExperimentData` interface optional

### DIFF
--- a/sdks/typescript/src/opik/experiment/Experiment.ts
+++ b/sdks/typescript/src/opik/experiment/Experiment.ts
@@ -16,7 +16,7 @@ import type { Prompt } from "@/prompt/Prompt";
 export interface ExperimentData {
   id?: string;
   name?: string;
-  datasetName: string;
+  datasetName?: string;
   prompts?: Prompt[];
   tags?: string[];
 }


### PR DESCRIPTION
## Details
Make `datasetName` in `ExperimentData` interface optional to handle cases where associated datasets may be deleted.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-NA

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
Nothing changed

## Documentation
Nothing changed