### PR TITLE
[OPIK-5059] [FE] fix: update widget/section removal dialog text for auto-save

### DIFF
--- a/apps/opik-frontend/src/components/shared/Dashboard/DashboardSection/DashboardSectionHeader.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/DashboardSection/DashboardSectionHeader.tsx
@@ -175,7 +175,7 @@ const DashboardSectionHeader: React.FunctionComponent<
         setOpen={setShowDeleteDialog}
         onConfirm={onDeleteSection}
         title={`Delete ${title} section?`}
-        description={`This section will be removed from your dashboard. You can still undo this change before saving the dashboard.`}
+        description="Are you sure you want to delete this section? This action cannot be undone."
         confirmText={`Delete ${title}`}
         confirmButtonVariant="destructive"
       />

--- a/apps/opik-frontend/src/components/shared/Dashboard/DashboardWidget/DashboardWidgetActionsMenu.tsx
+++ b/apps/opik-frontend/src/components/shared/Dashboard/DashboardWidget/DashboardWidgetActionsMenu.tsx
@@ -172,7 +172,7 @@ const DashboardWidgetActionsMenu: React.FunctionComponent<
         setOpen={handleDeleteDialogOpenChange}
         onConfirm={handleConfirmDelete}
         title="Delete widget?"
-        description={`This widget will be removed from this dashboard. You can still undo this change before saving the dashboard.`}
+        description="Are you sure you want to delete this widget? This action cannot be undone."
         confirmText={`Delete ${widgetTitle}`}
         confirmButtonVariant="destructive"
       />


### PR DESCRIPTION
## Details

Updated the confirmation dialog text for widget and section removal in dashboards. Since dashboards now use auto-save, the old text ("You can still undo this change before saving the dashboard") was misleading. Replaced with the standard codebase pattern: "Are you sure you want to delete this X? This action cannot be undone."

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-5059

## Testing
- Open a dashboard, click delete on a widget → verify dialog says "Are you sure you want to delete this widget? This action cannot be undone."
- Click delete on a section → verify dialog says "Are you sure you want to delete this section? This action cannot be undone."

## Documentation
N/A