### PR TITLE
[OPIK-000] [BE] fix: use tolerant double comparison in findWithImageTruncation test

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/GetTracesByProjectResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/GetTracesByProjectResourceTest.java
@@ -28,6 +28,7 @@ import com.comet.opik.api.resources.utils.MigrationUtils;
 import com.comet.opik.api.resources.utils.MinIOContainerUtils;
 import com.comet.opik.api.resources.utils.MySQLContainerUtils;
 import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.StatsUtils;
 import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
 import com.comet.opik.api.resources.utils.TestUtils;
 import com.comet.opik.api.resources.utils.TestWorkspace;
@@ -4142,8 +4143,10 @@ class GetTracesByProjectResourceTest {
                     .toList();
 
             assertThat(actualTraces)
-                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS_TRACES)
-                    .containsExactlyElementsOf(expectedTraces);
+                    .usingRecursiveComparison()
+                    .withComparatorForType(StatsUtils::compareDoubles, Double.class)
+                    .ignoringFields(IGNORED_FIELDS_TRACES)
+                    .isEqualTo(expectedTraces);
         }
 
         @ParameterizedTest


### PR DESCRIPTION
## Details
Fix flaky `findWithImageTruncation` test in `GetTracesByProjectResourceTest`. The `ttft` (Double) field
loses precision during the ClickHouse round-trip (`8.507032352557604E8` vs `8.507032352557603E8`), causing
intermittent assertion failures. Switched to `usingRecursiveComparison()` with `StatsUtils::compareDoubles`
(1e-6 tolerance), matching how all other trace assertions already handle double comparisons.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-0000

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Test fix
  - Human verification: yes

## Testing

- Scenario: `findWithImageTruncation` was failing intermittently due to floating-point precision loss on the `ttft` field after ClickHouse storage round-trip.
- Fix verified by inspection: the new assertion uses the same `StatsUtils::compareDoubles` comparator (tolerance 1e-6) already used by `TraceAssertions.assertTraces()` and `SpanAssertions`.

## Documentation

N/A
