### PR TITLE
[OPIK-5150] [BE] perf: replace FINAL with ORDER BY/LIMIT 1 BY in optimization studio queries

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -240,21 +240,25 @@ class ExperimentDAO {
             WITH experiments_resolved AS (
                 SELECT
                     *, arrayConcat([prompt_id], mapKeys(prompt_versions)) AS prompt_ids
-                FROM experiments
-                WHERE workspace_id = :workspace_id
-                <if(dataset_id)> AND dataset_id = :dataset_id <endif>
+                FROM (
+                    SELECT *
+                    FROM experiments
+                    WHERE workspace_id = :workspace_id
+                    <if(dataset_id)> AND dataset_id = :dataset_id <endif>
+                    <if(dataset_ids)> AND dataset_id IN :dataset_ids <endif>
+                    <if(id)> AND id = :id <endif>
+                    <if(ids_list)> AND id IN :ids_list <endif>
+                    <if(experiment_ids)> AND id IN :experiment_ids <endif>
+                    <if(lastRetrievedId)> AND id \\< :lastRetrievedId <endif>
+                    ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
+                    LIMIT 1 BY workspace_id, dataset_id, id
+                )
+                WHERE 1=1
                 <if(optimization_id)> AND optimization_id = :optimization_id <endif>
                 <if(types)> AND type IN :types <endif>
                 <if(name)> AND ilike(name, CONCAT('%', :name, '%')) <endif>
-                <if(dataset_ids)> AND dataset_id IN :dataset_ids <endif>
-                <if(id)> AND id = :id <endif>
-                <if(ids_list)> AND id IN :ids_list <endif>
-                <if(experiment_ids)> AND id IN :experiment_ids <endif>
-                <if(lastRetrievedId)> AND id \\< :lastRetrievedId <endif>
-                <if(prompt_ids)>AND hasAny(prompt_ids, :prompt_ids)<endif>
+                <if(prompt_ids)>AND hasAny(arrayConcat([prompt_id], mapKeys(prompt_versions)), :prompt_ids)<endif>
                 <if(filters)> AND <filters> <endif>
-                ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
-                LIMIT 1 BY workspace_id, dataset_id, id
                 <if(limit &&
                 !feedback_scores_filters &&
                 !feedback_scores_empty_filters &&
@@ -353,7 +357,7 @@ class ExperimentDAO {
                         sumMap(usage) as usage,
                         sum(total_estimated_cost) as total_estimated_cost
                     FROM (
-                        SELECT *
+                        SELECT workspace_id, project_id, trace_id, parent_span_id, id, usage, total_estimated_cost, last_updated_at
                         FROM spans
                         WHERE workspace_id = :workspace_id
                         <if(has_target_projects)>
@@ -738,18 +742,22 @@ class ExperimentDAO {
     private static final String FIND_COUNT = """
             WITH experiments_initial AS (
                 SELECT id, arrayConcat([prompt_id], mapKeys(prompt_versions)) AS prompt_ids, experiment_scores, project_id
-                FROM experiments
-                WHERE workspace_id = :workspace_id
-                <if(dataset_id)> AND dataset_id = :dataset_id <endif>
+                FROM (
+                    SELECT *
+                    FROM experiments
+                    WHERE workspace_id = :workspace_id
+                    <if(dataset_id)> AND dataset_id = :dataset_id <endif>
+                    <if(dataset_ids)> AND dataset_id IN :dataset_ids <endif>
+                    <if(experiment_ids)> AND id IN :experiment_ids <endif>
+                    ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
+                    LIMIT 1 BY workspace_id, dataset_id, id
+                )
+                WHERE 1=1
                 <if(optimization_id)> AND optimization_id = :optimization_id <endif>
                 <if(types)> AND type IN :types <endif>
                 <if(name)> AND ilike(name, CONCAT('%', :name, '%')) <endif>
-                <if(dataset_ids)> AND dataset_id IN :dataset_ids <endif>
-                <if(experiment_ids)> AND id IN :experiment_ids <endif>
-                <if(prompt_ids)>AND hasAny(prompt_ids, :prompt_ids)<endif>
+                <if(prompt_ids)>AND hasAny(arrayConcat([prompt_id], mapKeys(prompt_versions)), :prompt_ids)<endif>
                 <if(filters)> AND <filters> <endif>
-                ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
-                LIMIT 1 BY id
             ), experiments_from_aggregates AS (
                 SELECT id
                 FROM experiment_aggregates
@@ -988,13 +996,17 @@ class ExperimentDAO {
                     arrayConcat([prompt_id], mapKeys(prompt_versions)) AS prompt_ids,
                     created_at,
                     project_id AS experiment_project_id
-                FROM experiments
-                WHERE workspace_id = :workspace_id
+                FROM (
+                    SELECT *
+                    FROM experiments
+                    WHERE workspace_id = :workspace_id
+                    ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
+                    LIMIT 1 BY workspace_id, dataset_id, id
+                )
+                WHERE 1=1
                 <if(types)> AND type IN :types <endif>
                 <if(name)> AND ilike(name, CONCAT('%', :name, '%')) <endif>
                 <if(filters)> AND <filters> <endif>
-                ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
-                LIMIT 1 BY workspace_id, dataset_id, id
             ), experiments_from_aggregates AS (
                 SELECT id
                 FROM experiment_aggregates
@@ -1010,7 +1022,7 @@ class ExperimentDAO {
                     if(ea.project_id = :zero_uuid, cast([] AS Array(String)), cast([ea.project_id] AS Array(String))) AS project_ids
                 FROM experiments_filtered ef
                 INNER JOIN (
-                    SELECT *
+                    SELECT id, project_id, workspace_id
                     FROM experiment_aggregates
                     WHERE workspace_id = :workspace_id
                     ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
@@ -1103,18 +1115,22 @@ class ExperimentDAO {
             WITH experiments_final AS (
                 SELECT
                     id, arrayConcat([prompt_id], mapKeys(prompt_versions)) AS prompt_ids
-                FROM experiments
-                WHERE workspace_id = :workspace_id
-                <if(dataset_id)> AND dataset_id = :dataset_id <endif>
+                FROM (
+                    SELECT *
+                    FROM experiments
+                    WHERE workspace_id = :workspace_id
+                    <if(dataset_id)> AND dataset_id = :dataset_id <endif>
+                    <if(dataset_ids)> AND dataset_id IN :dataset_ids <endif>
+                    <if(experiment_ids)> AND id IN :experiment_ids <endif>
+                    ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
+                    LIMIT 1 BY workspace_id, dataset_id, id
+                )
+                WHERE 1=1
                 <if(optimization_id)> AND optimization_id = :optimization_id <endif>
                 <if(types)> AND type IN :types <endif>
                 <if(name)> AND ilike(name, CONCAT('%', :name, '%')) <endif>
-                <if(dataset_ids)> AND dataset_id IN :dataset_ids <endif>
-                <if(experiment_ids)> AND id IN :experiment_ids <endif>
-                <if(prompt_ids)>AND hasAny(prompt_ids, :prompt_ids)<endif>
+                <if(prompt_ids)>AND hasAny(arrayConcat([prompt_id], mapKeys(prompt_versions)), :prompt_ids)<endif>
                 <if(filters)> AND <filters> <endif>
-                ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
-                LIMIT 1 BY workspace_id, dataset_id, id
             ), experiment_items_trace_scope AS (
                 SELECT DISTINCT ei.trace_id
                 FROM experiment_items ei
@@ -1133,13 +1149,17 @@ class ExperimentDAO {
             WITH experiments_resolved AS (
                 SELECT
                     id, dataset_id, dataset_version_id, metadata, tags, experiment_scores, evaluation_method, execution_policy, arrayConcat([prompt_id], mapKeys(prompt_versions)) AS prompt_ids, project_id AS experiment_project_id
-                FROM experiments
-                WHERE workspace_id = :workspace_id
+                FROM (
+                    SELECT *
+                    FROM experiments
+                    WHERE workspace_id = :workspace_id
+                    ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
+                    LIMIT 1 BY workspace_id, dataset_id, id
+                )
+                WHERE 1=1
                 <if(types)> AND type IN :types <endif>
                 <if(name)> AND ilike(name, CONCAT('%', :name, '%')) <endif>
                 <if(filters)> AND <filters> <endif>
-                ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
-                LIMIT 1 BY workspace_id, dataset_id, id
             ), experiments_from_aggregates AS (
                 SELECT id
                 FROM experiment_aggregates
@@ -1218,7 +1238,7 @@ class ExperimentDAO {
                         trace_id,
                         sum(total_estimated_cost) as total_estimated_cost
                     FROM (
-                        SELECT *
+                        SELECT workspace_id, project_id, trace_id, parent_span_id, id, total_estimated_cost, last_updated_at
                         FROM spans
                         WHERE workspace_id = :workspace_id
                         <if(has_target_projects)>

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
@@ -110,17 +110,21 @@ class OptimizationDAOImpl implements OptimizationDAO {
             WITH optimization_final AS (
                 SELECT
                     *
-                FROM optimizations
-                WHERE workspace_id = :workspace_id
-                <if(id)>AND id = :id <endif>
+                FROM (
+                    SELECT *
+                    FROM optimizations
+                    WHERE workspace_id = :workspace_id
+                    <if(dataset_id)>AND dataset_id = :dataset_id <endif>
+                    <if(dataset_ids)>AND dataset_id IN :dataset_ids <endif>
+                    <if(id)>AND id = :id <endif>
+                    ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
+                    LIMIT 1 BY workspace_id, dataset_id, id
+                )
+                WHERE 1=1
                 <if(name)>AND ilike(name, CONCAT('%%', :name ,'%%'))<endif>
-                <if(dataset_id)>AND dataset_id = :dataset_id <endif>
-                <if(dataset_ids)>AND dataset_id IN :dataset_ids <endif>
                 <if(dataset_deleted)>AND dataset_deleted = :dataset_deleted<endif>
                 <if(studio_only)>AND studio_config != ''<endif>
                 <if(filters)>AND <filters><endif>
-                ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
-                LIMIT 1 BY workspace_id, dataset_id, id
             ), experiments_final AS (
                 SELECT
                     id,
@@ -156,8 +160,6 @@ class OptimizationDAOImpl implements OptimizationDAO {
                 WHERE entity_type = :entity_type
                   AND workspace_id = :workspace_id
                   AND entity_id IN (SELECT trace_id FROM experiment_items_final)
-                ORDER BY (workspace_id, project_id, entity_type, entity_id, name) DESC, last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_type, entity_id, name
                 UNION ALL
                 SELECT workspace_id,
                        project_id,
@@ -170,8 +172,6 @@ class OptimizationDAOImpl implements OptimizationDAO {
                 WHERE entity_type = :entity_type
                   AND workspace_id = :workspace_id
                   AND entity_id IN (SELECT trace_id FROM experiment_items_final)
-                ORDER BY (workspace_id, project_id, entity_type, entity_id, author, name) DESC, last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_type, entity_id, author, name
             ), feedback_scores_with_ranking AS (
                 SELECT workspace_id,
                        project_id,
@@ -272,7 +272,7 @@ class OptimizationDAOImpl implements OptimizationDAO {
                 LEFT JOIN (
                     SELECT trace_id, sum(total_estimated_cost) AS total_estimated_cost
                     FROM (
-                        SELECT *
+                        SELECT workspace_id, project_id, trace_id, parent_span_id, id, total_estimated_cost, last_updated_at
                         FROM spans
                         WHERE workspace_id = :workspace_id
                         AND trace_id IN (SELECT trace_id FROM experiment_items_final)
@@ -380,17 +380,21 @@ class OptimizationDAOImpl implements OptimizationDAO {
             FROM (
                 SELECT
                     id
-                FROM optimizations
-                WHERE workspace_id = :workspace_id
-                <if(id)>AND id = :id <endif>
+                FROM (
+                    SELECT *
+                    FROM optimizations
+                    WHERE workspace_id = :workspace_id
+                    <if(dataset_id)>AND dataset_id = :dataset_id <endif>
+                    <if(dataset_ids)>AND dataset_id IN :dataset_ids <endif>
+                    <if(id)>AND id = :id <endif>
+                    ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
+                    LIMIT 1 BY workspace_id, dataset_id, id
+                )
+                WHERE 1=1
                 <if(name)>AND ilike(name, CONCAT('%%', :name ,'%%'))<endif>
-                <if(dataset_id)>AND dataset_id = :dataset_id <endif>
-                <if(dataset_ids)>AND dataset_id IN :dataset_ids <endif>
                 <if(dataset_deleted)>AND dataset_deleted = :dataset_deleted<endif>
                 <if(studio_only)>AND studio_config != ''<endif>
                 <if(filters)>AND <filters><endif>
-                ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
-                LIMIT 1 BY workspace_id, dataset_id, id
             )
             ;
             """;


### PR DESCRIPTION
## Details

Replace ClickHouse `FINAL` modifier with explicit `ORDER BY ... DESC, last_updated_at DESC` + `LIMIT 1 BY` pattern in `ExperimentDAO` and `OptimizationDAO`.

The `FINAL` modifier on ReplacingMergeTree tables defeats primary key index pruning, causing full table scans (reading 1.6M+ rows to return a few hundred). The new pattern allows ClickHouse to prune by primary key first, then deduplicate only the relevant rows.

**Key changes:**
- Two-layer dedup-then-filter subquery pattern: inner query deduplicates with immutable sort-key filters only, outer query applies mutable column filters (name, type, optimization_id, etc.) to prevent phantom/stale rows
- Remove redundant `LIMIT 1 BY` from feedback_scores/authored_feedback_scores CTEs (downstream `ROW_NUMBER()` already handles dedup, and missing `author` key would drop authored scores)
- Narrow `SELECT *` to specific columns in spans and experiment_aggregates helper CTEs

**Production performance (tested on multiple workspaces):**
- Query time: 31-54s → 0.3-1.1s
- Memory: 500MB-3.5GB → 12-75MB
- Results verified identical between old (FINAL) and new (LIMIT 1 BY) queries

## Change checklist

- [x] ExperimentDAO.java - FIND, FIND_COUNT, FIND_GROUPS, SELECT_TARGET_PROJECTS, FIND_GROUPS_AGGREGATIONS
- [x] OptimizationDAO.java - FIND, COUNT
- [x] Production A/B testing with hash comparison across 6 test cases
- [x] Two-layer dedup pattern for correctness with mutable column filters

## Issues

OPIK-5150

## Testing

Tested against production ClickHouse with multiple workspaces:
- Large workspace (118K experiments): count and hash match ✅
- Medium workspace (6.7K experiments): count match ✅
- Small workspace (561 experiments): count match ✅
- Optimization+experiments join: count match ✅
- Mutable column filters (name, optimization_id, type): count match ✅

## Documentation

No documentation changes needed - internal query optimization only.