### PR TITLE
[OPIK-4962] [M2] Python SDK: Implement deprecation warning on workspace fallback

### DIFF
--- a/sdks/python/src/opik/httpx_client.py
+++ b/sdks/python/src/opik/httpx_client.py
@@ -140,10 +140,11 @@ class OpikHttpxClient(httpx.Client):
         deprecation_message = response.headers.get(DEPRECATION_HEADER)
         if deprecation_message:
             message = "Deprecation warning for %s %s: %s"
-            if request.url.path not in self.warnings:
-                self.warnings[request.url.path] = True
+            request_key = f"{request.method}:{request.url.path}"
+            if request_key not in self.warnings:
+                self.warnings[request_key] = True
                 LOGGER.warning(
-                    message, request.method, request.url.path, deprecation_message
+                    message, request.method, request.url, deprecation_message
                 )
 
         return response

--- a/sdks/python/tests/unit/test_httpx_client.py
+++ b/sdks/python/tests/unit/test_httpx_client.py
@@ -129,6 +129,10 @@ class TestOpikHttpxClientDeprecationHeader:
             None, None, check_tls_certificate=False, compress_json_requests=False
         )
 
+        yield
+
+        self.client.close()
+
     @respx.mock
     def test_deprecation_header_present__logged_only_once_for_same_path(
         self, capture_log
@@ -144,7 +148,7 @@ class TestOpikHttpxClientDeprecationHeader:
         assert capture_log.records[0].levelname == "WARNING"
         assert (
             capture_log.records[0].message
-            == "Deprecation warning for GET /api/v1/deprecated: deprecated"
+            == f"Deprecation warning for GET {rx_url}: deprecated"
         )
 
     @respx.mock
@@ -174,7 +178,7 @@ class TestOpikHttpxClientDeprecationHeader:
         assert capture_log.records[0].levelname == "WARNING"
         assert (
             capture_log.records[0].message
-            == "Deprecation warning for GET /api/v2/deprecated: deprecated"
+            == f"Deprecation warning for GET {rx_url}: deprecated"
         )
 
         assert response.status_code == 200


### PR DESCRIPTION
## Details
Surface a deprecation warning in the Python SDK when the backend resolves an entity via workspace-wide fallback, so that users know to update their code to use project-scoped calls.

## Summary

This branch adds server-side deprecation header handling to the Python SDK's HTTPX client.

---

## Changes

### `sdks/python/src/opik/httpx_client.py`

**New constants:**
- `DEPRECATION_HEADER = "X-Opik-Deprecation"` — the response header name to watch for.
- `LOGGER` — module-level logger (`opik.httpx_client`).

**`OpikHttpxClient` changes:**
- Added `warnings: Dict[str, bool]` instance attribute to track which URL paths have already produced a deprecation log entry (per client instance).
- Added `send()` override that inspects every response for the `X-Opik-Deprecation` header. When present, logs a `WARNING` once per unique URL path in the format:
  ```
  Deprecation warning for {METHOD} {path}: {header value}
  ```
  The response is always returned unchanged regardless of the header.

### `sdks/python/tests/unit/test_httpx_client.py`

**New test class `TestOpikHttpxClientDeprecationHeader`** with three test cases:

| Test | Verifies |
|------|----------|
| `test_deprecation_header_present__logged_only_once_for_same_path` | Warning is emitted exactly once even when the same deprecated endpoint is called multiple times |
| `test_deprecation_header_absent__no_warning_logged_and_response_still_returned` | No warning is logged for normal responses; response object is returned correctly |
| `test_deprecation_header_present__warning_logged_and_response_still_returned` | Warning contains the correct HTTP method and URL path; response object is returned correctly |

---

## Design decisions

- **Once-per-path semantics** are enforced at the `OpikHttpxClient` instance level via the `warnings` dict, keyed on `request.url.path`. This avoids log spam when a deprecated endpoint is called in a loop.
- The `send()` override is non-intrusive: it calls `super().send()` first, reads the header, logs if needed, and returns the original response — no change to request building or response content.
- The warning message includes both the HTTP method and the URL path so that callers can identify which specific operation is deprecated.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-4962

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code v2.1.76
  - Model(s): Sonnet 4.6
  - Scope: tests implementation
  - Human verification: Done

## Testing
Implemented unit tests

## Documentation
Nothing changed