### PR TITLE
[OPIK-5154] [BE] Remove lower() from string equality/inequality filters

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -184,8 +184,8 @@ public class FilterQueryBuilder {
                             FieldType.DICTIONARY_STATE_DB,
                             "JSON_VALUE(%1$s, :filterKey%2$d) LIKE CONCAT('%%', :filter%2$d)")))
                     .put(Operator.EQUAL, new EnumMap<>(Map.ofEntries(
-                            Map.entry(FieldType.STRING, "lower(%1$s) = lower(:filter%2$d)"),
-                            Map.entry(FieldType.STRING_STATE_DB, "lower(%1$s) = lower(:filter%2$d)"),
+                            Map.entry(FieldType.STRING, "%1$s = :filter%2$d"),
+                            Map.entry(FieldType.STRING_STATE_DB, "%1$s = :filter%2$d"),
                             Map.entry(FieldType.DATE_TIME, "%1$s = parseDateTime64BestEffort(:filter%2$d, 9)"),
                             Map.entry(FieldType.DATE_TIME_STATE_DB, "%1$s = :filter%2$d"),
                             Map.entry(FieldType.NUMBER, "%1$s = :filter%2$d"),
@@ -203,8 +203,8 @@ public class FilterQueryBuilder {
                                     "lower(trimBoth(replaceAll(arrayElement(mapValues(%1$s),indexOf(mapKeys(%1$s), :filterKey%2$d)), '\\\\\"', ''), '\"')) = lower(:filter%2$d)"),
                             Map.entry(FieldType.ENUM, "%1$s = :filter%2$d"))))
                     .put(Operator.NOT_EQUAL, new EnumMap<>(Map.ofEntries(
-                            Map.entry(FieldType.STRING, "lower(%1$s) != lower(:filter%2$d)"),
-                            Map.entry(FieldType.STRING_STATE_DB, "lower(%1$s) != lower(:filter%2$d)"),
+                            Map.entry(FieldType.STRING, "%1$s != :filter%2$d"),
+                            Map.entry(FieldType.STRING_STATE_DB, "%1$s != :filter%2$d"),
                             Map.entry(FieldType.DATE_TIME, "%1$s != parseDateTime64BestEffort(:filter%2$d, 9)"),
                             Map.entry(FieldType.DATE_TIME_STATE_DB, "%1$s != :filter%2$d"),
                             Map.entry(FieldType.NUMBER, "%1$s != :filter%2$d"),


### PR DESCRIPTION
## Details
Remove `lower()` wrapping from STRING and STRING_STATE_DB field types for EQUAL and NOT_EQUAL operators in `FilterQueryBuilder`.
This fixes incorrect case-insensitive matching on ID fields where case-sensitive comparison is required.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5154

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Commit, PR creation
  - Human verification: yes

## Testing

- Scenarios validated: string equality/inequality filters now perform case-sensitive matching on STRING and STRING_STATE_DB field types
- ID field filtering should return exact matches only

## Documentation
N/A