### PR TITLE
[NA] [CI] chore: add comment_mode: failures to test reporters

### DIFF
--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -82,5 +82,6 @@ jobs:
               if: always()
               with:
                 action_fail: true
+                comment_mode: failures
                 check_name: "Backend Tests - ${{ matrix.name }}"
                 files: '**/target/surefire-reports/TEST-*.xml'

--- a/.github/workflows/python_backend_tests.yml
+++ b/.github/workflows/python_backend_tests.yml
@@ -55,5 +55,6 @@ jobs:
         if: always()
         with:
           action_fail: true
+          comment_mode: failures
           check_name: Python Backend Tests Results
           files: apps/opik-python-backend/test-results.xml

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -98,6 +98,7 @@ jobs:
           if: always()
           with:
             action_fail: true
+            comment_mode: failures
             check_name: Python SDK E2E Tests Results (Python ${{matrix.python_version}})
             files: ${{ github.workspace }}/test_results_${{matrix.python_version}}.xml
 

--- a/.github/workflows/python_sdk_unit_tests.yml
+++ b/.github/workflows/python_sdk_unit_tests.yml
@@ -76,5 +76,6 @@ jobs:
         if: always()
         with:
           action_fail: true
+          comment_mode: failures
           check_name: Python SDK Unit Tests Results (Python ${{matrix.python_version}})
           files: ${{ github.workspace }}/test_results.xml

--- a/.github/workflows/typescript_sdk_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_e2e_tests.yml
@@ -82,6 +82,7 @@ jobs:
         if: always()
         with:
           action_fail: true
+          comment_mode: failures
           check_name: "TS SDK E2E Tests - Node ${{matrix.node_version}}"
           files: ${{ github.workspace }}/test_results_node${{matrix.node_version}}.xml
 


### PR DESCRIPTION
## Details

Add `comment_mode: failures` to the `dorny/test-reporter` action across all CI test workflows. This ensures PR comments are only posted when tests fail, reducing noise on passing runs.

Affected workflows: backend tests, Python backend tests, Python SDK E2E tests, Python SDK unit tests, TypeScript SDK E2E tests.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-sonnet-4-6
  - Scope: PR creation
  - Human verification: code review

## Testing

No tests required — CI configuration change only. The `comment_mode: failures` parameter is a standard option of the `dorny/test-reporter` action and does not affect test execution or reporting logic beyond suppressing comments on passing runs.

## Documentation

N/A