### PR TITLE
[OPIK-5177] [FE] fix: minor UI fixes and copy changes

### DIFF
--- a/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
@@ -42,8 +42,8 @@ const CompareExperimentsDetails: React.FunctionComponent<
     : `Compare (${experimentsIds.length})`;
 
   useEffect(() => {
-    title && setBreadcrumbParam("compare", "compare", title);
-    return () => setBreadcrumbParam("compare", "compare", "");
+    title && setBreadcrumbParam("compare", "Compare", title);
+    return () => setBreadcrumbParam("compare", "Compare", "");
   }, [title, setBreadcrumbParam]);
 
   const experimentTracesSearch = useMemo(

--- a/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -398,16 +398,6 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
       generateSelectColumDef<ExperimentsCompare>({
         verticalAlignment: calculateVerticalAlignment(experimentsCount),
       }),
-      mapColumnDataFields<ExperimentsCompare, ExperimentsCompare>({
-        id: COLUMN_ID_ID,
-        label: isEvalSuite ? "ID (Evaluation suite item)" : "Dataset item ID",
-        type: COLUMN_TYPE.string,
-        cell: IdCell as never,
-        verticalAlignment: calculateVerticalAlignment(experimentsCount),
-        size: 180,
-        sortable: isColumnSortable(COLUMN_ID_ID, sortableColumns),
-        explainer: EXPLAINERS_MAP[EXPLAINER_ID.whats_the_evaluation_suite_item],
-      }),
     ];
 
     if (hasAnyVisibleColumns(datasetColumnsData, selectedColumns)) {

--- a/apps/opik-frontend/src/v1/pages/EvaluationSuiteItemsPage/EvaluationSuiteItemsPage.tsx
+++ b/apps/opik-frontend/src/v1/pages/EvaluationSuiteItemsPage/EvaluationSuiteItemsPage.tsx
@@ -362,7 +362,10 @@ function EvaluationSuiteItemsPage(): React.ReactElement {
           {isEvaluationSuite && effectiveAssertions.length > 0 && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <div className="flex shrink-0 cursor-pointer items-center gap-1 rounded bg-thread-active px-1.5 py-0.5">
+                <div
+                  className="flex shrink-0 cursor-pointer items-center gap-1 rounded bg-thread-active px-1.5 py-0.5"
+                  onClick={() => setSettingsDialogOpen(true)}
+                >
                   <CheckCheck className="size-3 text-muted-foreground" />
                   <span className="comet-body-s-accented text-muted-foreground">
                     {effectiveAssertions.length} global assertion

--- a/apps/opik-frontend/src/v1/pages/EvaluationSuitesPage/DatasetTypeCell.tsx
+++ b/apps/opik-frontend/src/v1/pages/EvaluationSuitesPage/DatasetTypeCell.tsx
@@ -15,7 +15,7 @@ const DatasetTypeCell = (context: CellContext<unknown, unknown>) => {
   const value = (context.getValue() as string) ?? DATASET_TYPE.DATASET;
 
   const variant = VARIANT_MAP[value] ?? "yellow";
-  const label = TYPE_LABELS[value] ?? "Legacy dataset";
+  const label = TYPE_LABELS[value] ?? "Dataset";
 
   return (
     <CellWrapper

--- a/apps/opik-frontend/src/v1/pages/EvaluationSuitesPage/columns.tsx
+++ b/apps/opik-frontend/src/v1/pages/EvaluationSuitesPage/columns.tsx
@@ -3,7 +3,7 @@ import { COLUMN_NAME_ID } from "@/types/shared";
 
 export const TYPE_LABELS: Record<string, string> = {
   [DATASET_TYPE.EVALUATION_SUITE]: "Evaluation suite",
-  [DATASET_TYPE.DATASET]: "Legacy dataset",
+  [DATASET_TYPE.DATASET]: "Dataset",
 };
 
 export const DEFAULT_SELECTED_COLUMNS: string[] = [

--- a/apps/opik-frontend/src/v1/router.tsx
+++ b/apps/opik-frontend/src/v1/router.tsx
@@ -227,9 +227,8 @@ const compareExperimentsRoute = createRoute({
   getParentRoute: () => experimentsRoute,
   component: CompareExperimentsPage,
   staticData: {
-    title: "Compare",
     param: "compare",
-    paramValue: "compare",
+    paramValue: "Compare",
   },
 });
 


### PR DESCRIPTION
## Details

Minor UI fixes and copy changes across evaluation suites and experiment comparison views:

- **Breadcrumb fix**: Show experiment name instead of static "Compare" when viewing a single experiment
- **Label rename**: "Legacy dataset" → "Dataset" in evaluation suites type column
- **Hide ID column**: Remove always-visible item ID column from compare experiments table (still available via column selector)
- **Global assertions click**: Open settings dialog when clicking the global assertions tag in evaluation suite header

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5177

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review + manual testing

## Testing

Manually

## Documentation

N/A