### PR TITLE
[OPIK-5187] [BE] Extend per-endpoint throttling to span/trace query endpoints

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -357,6 +357,84 @@ rateLimit:
       userFacingBucketName: ollie_state_upload
       # Description: Rate limit error message
       errorMessage: "You have exceeded the rate limit for ollie state uploads. Please try again later."
+    getSpans:
+      # Default: 30
+      # Description: how many getSpansByProject queries are allowed per workspace in the specified time bucket
+      limit: ${RATE_LIMIT_GET_SPANS_EVENTS_PER_WORKSPACE_LIMIT:-30}
+      # Default: 60
+      # Description: Time bucket size in seconds
+      durationInSeconds: ${RATE_LIMIT_WORKSPACE_EVENTS_DURATION_IN_SEC:-60}
+      # Description: Header name to use for rate limiting
+      headerName: Get-Spans
+      # Description: User facing bucket name
+      userFacingBucketName: get_spans
+      # Description: Rate limit error message
+      errorMessage: "You have exceeded the rate limit for this operation. Please try again later."
+    search_spans:
+      # Default: 30
+      # Description: how many searchSpans queries are allowed per workspace in the specified time bucket
+      limit: ${RATE_LIMIT_SEARCH_SPANS_EVENTS_PER_WORKSPACE_LIMIT:-30}
+      # Default: 60
+      # Description: Time bucket size in seconds
+      durationInSeconds: ${RATE_LIMIT_WORKSPACE_EVENTS_DURATION_IN_SEC:-60}
+      # Description: Header name to use for rate limiting
+      headerName: Search-Spans
+      # Description: User facing bucket name
+      userFacingBucketName: search_spans
+      # Description: Rate limit error message
+      errorMessage: "You have exceeded the rate limit for this operation. Please try again later."
+    getSpanStats:
+      # Default: 30
+      # Description: how many getSpanStats queries are allowed per workspace in the specified time bucket
+      limit: ${RATE_LIMIT_GET_SPAN_STATS_EVENTS_PER_WORKSPACE_LIMIT:-30}
+      # Default: 60
+      # Description: Time bucket size in seconds
+      durationInSeconds: ${RATE_LIMIT_WORKSPACE_EVENTS_DURATION_IN_SEC:-60}
+      # Description: Header name to use for rate limiting
+      headerName: Get-Span-Stats
+      # Description: User facing bucket name
+      userFacingBucketName: get_span_stats
+      # Description: Rate limit error message
+      errorMessage: "You have exceeded the rate limit for this operation. Please try again later."
+    getTraces:
+      # Default: 30
+      # Description: how many getTracesByProject queries are allowed per workspace in the specified time bucket
+      limit: ${RATE_LIMIT_GET_TRACES_EVENTS_PER_WORKSPACE_LIMIT:-30}
+      # Default: 60
+      # Description: Time bucket size in seconds
+      durationInSeconds: ${RATE_LIMIT_WORKSPACE_EVENTS_DURATION_IN_SEC:-60}
+      # Description: Header name to use for rate limiting
+      headerName: Get-Traces
+      # Description: User facing bucket name
+      userFacingBucketName: get_traces
+      # Description: Rate limit error message
+      errorMessage: "You have exceeded the rate limit for this operation. Please try again later."
+    searchTraces:
+      # Default: 30
+      # Description: how many searchTraces queries are allowed per workspace in the specified time bucket
+      limit: ${RATE_LIMIT_SEARCH_TRACES_EVENTS_PER_WORKSPACE_LIMIT:-30}
+      # Default: 60
+      # Description: Time bucket size in seconds
+      durationInSeconds: ${RATE_LIMIT_WORKSPACE_EVENTS_DURATION_IN_SEC:-60}
+      # Description: Header name to use for rate limiting
+      headerName: Search-Traces
+      # Description: User facing bucket name
+      userFacingBucketName: search_traces
+      # Description: Rate limit error message
+      errorMessage: "You have exceeded the rate limit for this operation. Please try again later."
+    getTraceStats:
+      # Default: 30
+      # Description: how many getTraceStats queries are allowed per workspace in the specified time bucket
+      limit: ${RATE_LIMIT_GET_TRACE_STATS_EVENTS_PER_WORKSPACE_LIMIT:-30}
+      # Default: 60
+      # Description: Time bucket size in seconds
+      durationInSeconds: ${RATE_LIMIT_WORKSPACE_EVENTS_DURATION_IN_SEC:-60}
+      # Description: Header name to use for rate limiting
+      headerName: Get-Trace-Stats
+      # Description: User facing bucket name
+      userFacingBucketName: get_trace_stats
+      # Description: Rate limit error message
+      errorMessage: "You have exceeded the rate limit for this operation. Please try again later."
 
 # Configuration for usage limit. This is not enabled by default for open source installations.
 # In order to support that, the remote authentication server must contain a `quotas` object in its authentication

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
@@ -358,6 +358,7 @@ public class SpansResource {
             @ApiResponse(responseCode = "200", description = "Span stats resource", content = @Content(schema = @Schema(implementation = ProjectStats.class)))
     })
     @JsonView({ProjectStats.ProjectStatItem.View.Public.class})
+    @RateLimited(value = "getSpanStats:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     public Response getStats(@QueryParam("project_id") UUID projectId,
             @QueryParam("project_name") String projectName,
             @QueryParam("trace_id") UUID traceId,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -126,6 +126,7 @@ public class TracesResource {
     @Operation(operationId = "getTracesByProject", summary = "Get traces by project_name or project_id", description = "Get traces by project_name or project_id", responses = {
             @ApiResponse(responseCode = "200", description = "Trace resource", content = @Content(schema = @Schema(implementation = TracePage.class)))})
     @JsonView(Trace.View.Public.class)
+    @RateLimited(value = "getTraces:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     public Response getTracesByProject(
             @QueryParam("page") @Min(1) @DefaultValue("1") int page,
             @QueryParam("size") @Min(1) @DefaultValue("10") int size,
@@ -201,6 +202,7 @@ public class TracesResource {
             @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
     })
     @JsonView(Trace.View.Public.class)
+    @RateLimited(value = "searchTraces:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     public ChunkedOutput<JsonNode> searchTraces(
             @RequestBody(content = @Content(schema = @Schema(implementation = TraceSearchStreamRequest.class))) @NotNull @Valid TraceSearchStreamRequest request) {
 
@@ -400,6 +402,7 @@ public class TracesResource {
             @ApiResponse(responseCode = "200", description = "Trace stats resource", content = @Content(schema = @Schema(implementation = ProjectStats.class)))
     })
     @JsonView({ProjectStats.ProjectStatItem.View.Public.class})
+    @RateLimited(value = "getTraceStats:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     public Response getStats(@QueryParam("project_id") UUID projectId,
             @QueryParam("project_name") String projectName,
             @QueryParam("filters") String filters,


### PR DESCRIPTION
## Details

On 2026-03-20, a single user caused platform-wide Opik slowness by firing ~108 queries/min against a 300M span project via SDK (22,025 queries over 3 hours, 3.2 TB rows read, 4.4 TB ClickHouse memory). The abused endpoints had no effective rate limiting.

This PR adds per-workspace rate limiting (30 req/min) to 6 heavy read endpoints:

- **Fixed silent no-ops** (annotation existed but config was missing):
  - `getSpansByProject` (`getSpans` bucket)
  - `searchSpans` (`search_spans` bucket)
- **Added new rate limiting** (no annotation or config existed):
  - `getSpanStats` (`getSpanStats` bucket)
  - `getTracesByProject` (`getTraces` bucket)
  - `searchTraces` (`searchTraces` bucket)
  - `getTraceStats` (`getTraceStats` bucket)

Root cause: `RateLimitInterceptor` silently skips enforcement when a custom bucket config is missing (logs a warning). Two endpoints had `@RateLimited` annotations but no matching `customLimits` entry in `config.yml`.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-5187

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full implementation - config entries, annotations, testing
  - Human verification: Code reviewed, manually tested all 6 endpoints with rate limit headers and burst test (429 at request #30)

## Testing

Tested locally with `RATE_LIMIT_ENABLED=true` and `dev-runner.sh --quick-restart`:

1. **Rate limit headers verified** on all 6 endpoints:
```bash
curl -sS -D /dev/stderr -o /dev/null "http://localhost:8080/v1/private/spans?project_id=00000000-0000-0000-0000-000000000000"
# Returns: Opik-Get-Spans-Limit: get_spans, Opik-Get-Spans-Remaining-Limit: 29

curl -sS -D /dev/stderr -o /dev/null "http://localhost:8080/v1/private/spans/stats?project_id=00000000-0000-0000-0000-000000000000"
# Returns: Opik-Get-Span-Stats-Limit: get_span_stats, Opik-Get-Span-Stats-Remaining-Limit: 29

curl -sS -D /dev/stderr -o /dev/null "http://localhost:8080/v1/private/traces?project_id=00000000-0000-0000-0000-000000000000"
# Returns: Opik-Get-Traces-Limit: get_traces, Opik-Get-Traces-Remaining-Limit: 29

# Same for searchSpans, searchTraces, getTraceStats
```

2. **Burst test** — 35 rapid requests against `getSpansByProject`:
```
Got 429 Too Many Requests on request #30 - Rate limiting is working!
```

3. **UI impact analysis** — normal UI usage is ~2 req/min per endpoint (30s refetch interval). Even aggressive page navigation stays well under 30/min.

- Tests not run: `RateLimitE2ETest` — rate limiting is disabled in test config (`config-test.yml`), existing tests unaffected.

## Documentation

No external documentation changes needed. Rate limiting is an internal infrastructure concern. Config entries are self-documented with comments and env var overrides.