### PR TITLE
[OPIK-4688] [INFRA] Auto-trigger FERN update on BE merge and notify #code-review

### DIFF
--- a/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
+++ b/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
@@ -9,9 +9,6 @@ on:
       - 'apps/opik-backend/src/main/java/**/*.java'
       - 'apps/opik-backend/src/main/resources/openapi_template.yml'
       - 'apps/opik-backend/pom.xml'
-  pull_request:
-    paths:
-      - '.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml'
   workflow_dispatch: # Allows manual trigger
 
 concurrency:
@@ -164,7 +161,7 @@ jobs:
     needs: [update-open-api-spec-and-fern-code, resolve-trigger-context]
     if: >-
       !failure() &&
-      (github.event_name == 'push' || github.event_name == 'pull_request') &&
+      github.event_name == 'push' &&
       needs.update-open-api-spec-and-fern-code.outputs.pr_url != ''
 
     steps:
@@ -253,9 +250,6 @@ jobs:
               }]
             }
             ' > payload.json
-
-          # Skip actual Slack post during PR testing — will be removed in a follow-up commit
-          exit 0
 
           HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
             -X POST \


### PR DESCRIPTION
## Details

<img width="1920" height="3704" alt="image" src="https://github.com/user-attachments/assets/0c0fa2cb-3b49-4b52-985b-5c1ea19af69d" />

When a BE PR merges to main that changes API contracts (Java source, OpenAPI template, or pom.xml), this workflow now automatically triggers FERN SDK code regeneration and creates a PR with the updated SDK code. A Slack notification is sent to #code-review with the FERN PR link, originating BE PR, and an @mention of the merge author.

Changes to `sdks_generate_openapi_spec_and_fern_code.yml`:
- Add `push` trigger with path filters for BE files that affect OpenAPI spec
- Add concurrency group to prevent overlapping runs from rapid merges
- Capture merge author and originating BE PR for context
- Add Slack notification job (Block Kit message via webhook, author @mention via SLACK_USER_MAPPING)

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-4688

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (CLI)
- Model(s): Claude Opus 4.6
- Scope: Full implementation of workflow changes
- Human verification: Yes — iterative review and design decisions throughout

## Testing

- Workflow syntax validated
- FERN PR creation gated on `peter-evans/create-pull-request` output (no PR if zero file changes)
- Slack notification gated on `push` event + PR URL being non-empty
- Slack webhook secret check prevents failures in environments without the secret configured

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate