### PR TITLE
[OPIK-4964] [FE] feat: v2 sidebar navigation with project-scoped routing

### DIFF
--- a/apps/opik-frontend/src/hooks/useActiveProject.ts
+++ b/apps/opik-frontend/src/hooks/useActiveProject.ts
@@ -1,0 +1,54 @@
+import { useEffect, useCallback } from "react";
+import useLocalStorageState from "use-local-storage-state";
+import useAppStore, { useActiveWorkspaceName } from "@/store/AppStore";
+import useProjectsList from "@/api/projects/useProjectsList";
+
+const ACTIVE_PROJECT_KEY_PREFIX = "opik-active-project-";
+const LATEST_PROJECT_SORTING = [{ id: "last_updated_at", desc: true }];
+
+/**
+ * Syncs activeProjectId between localStorage and AppStore.
+ * Mount once in the sidebar — all other components read from the store
+ * via useActiveProjectId().
+ */
+export default function useActiveProject() {
+  const workspaceName = useActiveWorkspaceName();
+
+  const [storedProjectId, setStoredProjectId] = useLocalStorageState<
+    string | null
+  >(ACTIVE_PROJECT_KEY_PREFIX + workspaceName, {
+    defaultValue: null,
+  });
+
+  const { data: latestProjectData } = useProjectsList(
+    {
+      workspaceName,
+      page: 1,
+      size: 1,
+      sorting: LATEST_PROJECT_SORTING,
+    },
+    {
+      enabled: !storedProjectId && !!workspaceName,
+      staleTime: 30_000,
+    },
+  );
+
+  const latestProjectId = latestProjectData?.content?.[0]?.id ?? null;
+  const resolvedProjectId = storedProjectId ?? latestProjectId;
+
+  useEffect(() => {
+    if (useAppStore.getState().activeProjectId !== resolvedProjectId) {
+      useAppStore.getState().setActiveProjectId(resolvedProjectId);
+    }
+  }, [resolvedProjectId]);
+
+  const setActiveProjectId = useCallback(
+    (projectId: string | null) => {
+      setStoredProjectId(projectId);
+      useAppStore.getState().setActiveProjectId(projectId);
+    },
+    [setStoredProjectId],
+  );
+
+  return { setActiveProjectId };
+}

--- a/apps/opik-frontend/src/shared/ResourceLink/ResourceLink.tsx
+++ b/apps/opik-frontend/src/shared/ResourceLink/ResourceLink.tsx
@@ -15,7 +15,7 @@ import isUndefined from "lodash/isUndefined";
 
 import { cn } from "@/lib/utils";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { Tag, TagProps } from "@/ui/tag";
 import { Button } from "@/ui/button";
 import { Filter } from "@/types/filters";
@@ -48,6 +48,8 @@ export const RESOURCE_MAP = {
   },
   [RESOURCE_TYPE.dataset]: {
     url: "/$workspaceName/evaluation-suites/$suiteId/items",
+    projectUrl:
+      "/$workspaceName/projects/$projectId/evaluation-suites/$suiteId/items",
     icon: Database,
     param: "suiteId",
     deleted: "Deleted evaluation suite",
@@ -56,6 +58,8 @@ export const RESOURCE_MAP = {
   },
   [RESOURCE_TYPE.datasetItem]: {
     url: "/$workspaceName/evaluation-suites/$suiteId/items",
+    projectUrl:
+      "/$workspaceName/projects/$projectId/evaluation-suites/$suiteId/items",
     icon: Database,
     param: "suiteId",
     deleted: "Deleted evaluation suite item",
@@ -64,6 +68,7 @@ export const RESOURCE_MAP = {
   },
   [RESOURCE_TYPE.prompt]: {
     url: "/$workspaceName/prompts/$promptId",
+    projectUrl: "/$workspaceName/projects/$projectId/prompts/$promptId",
     icon: FileTerminal,
     param: "promptId",
     deleted: "Deleted prompt",
@@ -72,6 +77,8 @@ export const RESOURCE_MAP = {
   },
   [RESOURCE_TYPE.experiment]: {
     url: "/$workspaceName/experiments/$datasetId/compare",
+    projectUrl:
+      "/$workspaceName/projects/$projectId/experiments/$datasetId/compare",
     icon: FlaskConical,
     param: "datasetId",
     deleted: "Deleted experiment",
@@ -80,6 +87,8 @@ export const RESOURCE_MAP = {
   },
   [RESOURCE_TYPE.experimentItem]: {
     url: "/$workspaceName/experiments/$datasetId/compare",
+    projectUrl:
+      "/$workspaceName/projects/$projectId/experiments/$datasetId/compare",
     icon: FlaskConical,
     param: "datasetId",
     deleted: "Deleted experiment item",
@@ -88,6 +97,8 @@ export const RESOURCE_MAP = {
   },
   [RESOURCE_TYPE.optimization]: {
     url: "/$workspaceName/optimizations/$optimizationId",
+    projectUrl:
+      "/$workspaceName/projects/$projectId/optimizations/$optimizationId",
     icon: SparklesIcon,
     param: "optimizationId",
     deleted: "Deleted optimization",
@@ -96,6 +107,8 @@ export const RESOURCE_MAP = {
   },
   [RESOURCE_TYPE.trial]: {
     url: "/$workspaceName/optimizations/$optimizationId/trials",
+    projectUrl:
+      "/$workspaceName/projects/$projectId/optimizations/$optimizationId/trials",
     icon: SparklesIcon,
     param: "optimizationId",
     deleted: "Deleted optimization",
@@ -104,6 +117,8 @@ export const RESOURCE_MAP = {
   },
   [RESOURCE_TYPE.annotationQueue]: {
     url: "/$workspaceName/annotation-queues/$annotationQueueId",
+    projectUrl:
+      "/$workspaceName/projects/$projectId/annotation-queues/$annotationQueueId",
     icon: UserPen,
     param: "annotationQueueId",
     deleted: "Deleted annotation queue",
@@ -129,6 +144,8 @@ export const RESOURCE_MAP = {
   },
   [RESOURCE_TYPE.evaluationSuite]: {
     url: "/$workspaceName/evaluation-suites/$suiteId/items",
+    projectUrl:
+      "/$workspaceName/projects/$projectId/evaluation-suites/$suiteId/items",
     icon: Database,
     param: "suiteId",
     deleted: "Deleted evaluation suite",
@@ -180,11 +197,20 @@ function ResourceLink({
   className,
 }: ResourceLinkProps): React.ReactElement {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const props = RESOURCE_MAP[resource];
+
+  const useProjectUrl =
+    activeProjectId && "projectUrl" in props && props.projectUrl;
+  const url = useProjectUrl ? props.projectUrl : props.url;
+
   const linkParams: Record<string, string> = {
     workspaceName,
     ...params,
   };
+  if (useProjectUrl) {
+    linkParams.projectId = activeProjectId;
+  }
   linkParams[props.param] = id;
 
   const deleted = isUndefined(name) || isDeleted;
@@ -192,7 +218,7 @@ function ResourceLink({
 
   return (
     <Link
-      to={props.url}
+      to={url}
       params={linkParams}
       search={{ ...("search" in props ? props.search : {}), ...search }}
       onClick={(event) => event.stopPropagation()}

--- a/apps/opik-frontend/src/store/AppStore.ts
+++ b/apps/opik-frontend/src/store/AppStore.ts
@@ -13,6 +13,8 @@ type AppStore = {
   setUser: (user: AppUser) => void;
   activeWorkspaceName: string;
   setActiveWorkspaceName: (workspaceName: string) => void;
+  activeProjectId: string | null;
+  setActiveProjectId: (projectId: string | null) => void;
   workspaceVersion: WorkspaceVersion | null;
   setWorkspaceVersion: (version: WorkspaceVersion) => void;
 };
@@ -31,6 +33,9 @@ const useAppStore = create<AppStore>((set) => ({
       activeWorkspaceName: workspaceName,
     }));
   },
+  activeProjectId: null,
+  setActiveProjectId: (projectId: string | null) =>
+    set({ activeProjectId: projectId }),
   workspaceVersion: null,
   setWorkspaceVersion: (version: WorkspaceVersion) =>
     set({ workspaceVersion: version }),
@@ -38,6 +43,9 @@ const useAppStore = create<AppStore>((set) => ({
 
 export const useActiveWorkspaceName = () =>
   useAppStore((state) => state.activeWorkspaceName);
+
+export const useActiveProjectId = () =>
+  useAppStore((state) => state.activeProjectId);
 
 export const useWorkspaceVersion = () =>
   useAppStore((state) => state.workspaceVersion);

--- a/apps/opik-frontend/src/v2/layout/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/opik-frontend/src/v2/layout/Breadcrumbs/Breadcrumbs.tsx
@@ -10,7 +10,6 @@ import {
   BreadcrumbSeparator,
 } from "@/ui/breadcrumb";
 import useBreadcrumbsStore from "@/store/BreadcrumbsStore";
-import usePluginsStore from "@/store/PluginsStore";
 import useAppStore from "@/store/AppStore";
 import { calculateWorkspaceName } from "@/lib/utils";
 
@@ -22,9 +21,6 @@ type CustomRouteStaticData = {
 
 const Breadcrumbs = () => {
   const params = useBreadcrumbsStore((state) => state.params);
-  const WorkspaceSelectorComponent = usePluginsStore(
-    (state) => state.WorkspaceSelector,
-  );
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
 
   const breadcrumbs = useRouterState({
@@ -84,10 +80,6 @@ const Breadcrumbs = () => {
   };
 
   const renderWorkspaceItem = () => {
-    if (WorkspaceSelectorComponent) {
-      return <WorkspaceSelectorComponent />;
-    }
-
     return (
       <BreadcrumbLink asChild>
         <Link

--- a/apps/opik-frontend/src/v2/layout/SideBar/GitHubStarListItem/GitHubStarListItem.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/GitHubStarListItem/GitHubStarListItem.tsx
@@ -22,7 +22,7 @@ const GitHubStarListItem: React.FC<GitHubStarListItemProps> = ({
   }, [data?.stargazers_count]);
 
   const itemElement = (
-    <li className="mb-2">
+    <li>
       <Button
         variant="outline"
         size="sm"

--- a/apps/opik-frontend/src/v2/layout/SideBar/MenuItem/SidebarMenuItem.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/MenuItem/SidebarMenuItem.tsx
@@ -1,11 +1,10 @@
 import React, { MouseEventHandler } from "react";
-import isNumber from "lodash/isNumber";
 import { Link } from "@tanstack/react-router";
 import { LucideIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import useAppStore from "@/store/AppStore";
+import { useActiveWorkspaceName, useActiveProjectId } from "@/store/AppStore";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
 
@@ -21,8 +20,7 @@ export type MenuItem = {
   type: MENU_ITEM_TYPE;
   icon: LucideIcon;
   label: string;
-  count?: string;
-  showIndicator?: string;
+  disabled?: boolean;
   featureFlag?: FeatureToggleKeys;
   onClick?: MouseEventHandler<HTMLButtonElement>;
 };
@@ -36,37 +34,77 @@ export type MenuItemGroup = {
 interface SidebarMenuItemProps {
   item: MenuItem;
   expanded: boolean;
-  count?: number;
-  hasIndicator?: boolean;
-  compact?: boolean;
 }
 
-interface GetItemElementProps {
-  item: MenuItem;
-  content: React.ReactElement;
-  workspaceName: string;
-  linkClasses: string;
-}
-
-const getItemElementByType = ({
+const SidebarMenuItem: React.FunctionComponent<SidebarMenuItemProps> = ({
   item,
-  content,
-  workspaceName,
-  linkClasses,
-}: GetItemElementProps): React.ReactElement | null => {
-  if (item.type === MENU_ITEM_TYPE.router) {
-    return (
-      <li key={item.id} className="flex">
-        <Link to={item.path} params={{ workspaceName }} className={linkClasses}>
+  expanded,
+}) => {
+  const workspaceName = useActiveWorkspaceName();
+  const activeProjectId = useActiveProjectId();
+  const isFeatureEnabled = useIsFeatureEnabled(item.featureFlag!);
+
+  if (item.featureFlag && !isFeatureEnabled) {
+    return null;
+  }
+
+  const content = (
+    <>
+      <item.icon className="size-3.5 shrink-0" />
+      {expanded && <div className="grow truncate">{item.label}</div>}
+    </>
+  );
+
+  const baseClasses = cn(
+    "comet-body-s relative flex w-full items-center gap-2 rounded-md",
+    expanded ? "px-2 py-1" : "w-9 justify-center py-1",
+  );
+
+  if (item.disabled) {
+    const disabledElement = (
+      <li className="flex">
+        <span
+          className={cn(baseClasses, "cursor-not-allowed opacity-50")}
+          aria-disabled="true"
+        >
+          {content}
+        </span>
+      </li>
+    );
+
+    if (!expanded) {
+      return (
+        <TooltipWrapper content={item.label} side="right">
+          {disabledElement}
+        </TooltipWrapper>
+      );
+    }
+
+    return disabledElement;
+  }
+
+  const linkClasses = cn(
+    baseClasses,
+    "hover:bg-primary-foreground data-[status=active]:bg-muted data-[status=active]:font-medium",
+  );
+
+  let itemElement: React.ReactElement | null = null;
+
+  if (item.type === MENU_ITEM_TYPE.router && item.path) {
+    const params: Record<string, string> = { workspaceName };
+    if (activeProjectId) {
+      params.projectId = activeProjectId;
+    }
+    itemElement = (
+      <li className="flex">
+        <Link to={item.path} params={params} className={linkClasses}>
           {content}
         </Link>
       </li>
     );
-  }
-
-  if (item.type === MENU_ITEM_TYPE.link) {
-    return (
-      <li key={item.id} className="flex">
+  } else if (item.type === MENU_ITEM_TYPE.link && item.path) {
+    itemElement = (
+      <li className="flex">
         <a
           href={item.path}
           target="_blank"
@@ -77,11 +115,9 @@ const getItemElementByType = ({
         </a>
       </li>
     );
-  }
-
-  if (item.type === MENU_ITEM_TYPE.button) {
-    return (
-      <li key={item.id} className="flex">
+  } else if (item.type === MENU_ITEM_TYPE.button) {
+    itemElement = (
+      <li className="flex">
         <button onClick={item.onClick} className={cn(linkClasses, "text-left")}>
           {content}
         </button>
@@ -89,74 +125,17 @@ const getItemElementByType = ({
     );
   }
 
-  return null;
-};
+  if (!itemElement) return null;
 
-const SidebarMenuItem: React.FunctionComponent<SidebarMenuItemProps> = ({
-  item,
-  expanded,
-  count,
-  hasIndicator,
-  compact = false,
-}) => {
-  const { activeWorkspaceName: workspaceName } = useAppStore();
-  const hasCount = item.count && isNumber(count);
-  const showIndicatorBadge = item.showIndicator && hasIndicator;
-  const isFeatureEnabled = useIsFeatureEnabled(item.featureFlag!);
-
-  if (item.featureFlag && !isFeatureEnabled) {
-    return null;
+  if (!expanded) {
+    return (
+      <TooltipWrapper content={item.label} side="right">
+        {itemElement}
+      </TooltipWrapper>
+    );
   }
 
-  const content = (
-    <>
-      <item.icon className="size-4 shrink-0" />
-      {expanded && (
-        <>
-          <div className="grow truncate">{item.label}</div>
-          {showIndicatorBadge ? (
-            <div className="size-2 shrink-0 rounded-full bg-[var(--color-green)]" />
-          ) : (
-            hasCount && <div className="h-6 shrink-0 leading-6">{count}</div>
-          )}
-        </>
-      )}
-      {!expanded && showIndicatorBadge && (
-        <div className="absolute right-1 top-1 size-2 rounded-full bg-[var(--color-green)]" />
-      )}
-    </>
-  );
-
-  const linkClasses = cn(
-    "comet-body-s relative flex w-full items-center gap-2 rounded-md hover:bg-primary-foreground data-[status=active]:bg-primary-100 data-[status=active]:text-primary",
-    compact
-      ? "h-8 text-muted-slate data-[status=active]:text-muted-slate data-[status=active]:bg-muted"
-      : "h-9 text-foreground",
-    compact
-      ? expanded
-        ? "px-2.5"
-        : "w-8 justify-center"
-      : expanded
-        ? "pl-[10px] pr-3"
-        : "w-9 justify-center",
-  );
-
-  const itemElement = getItemElementByType({
-    item,
-    content,
-    workspaceName,
-    linkClasses,
-  });
-
-  if (expanded || !itemElement) {
-    return itemElement;
-  }
-
-  return (
-    <TooltipWrapper content={item.label} side="right">
-      {itemElement}
-    </TooltipWrapper>
-  );
+  return itemElement;
 };
 
 export default SidebarMenuItem;

--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
@@ -1,0 +1,252 @@
+import React, { useCallback, useRef, useState } from "react";
+import {
+  Check,
+  ChevronDown,
+  MoreHorizontal,
+  Pencil,
+  Trash,
+} from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+
+import { cn } from "@/lib/utils";
+import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
+import { Separator } from "@/ui/separator";
+import { Button } from "@/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/ui/dropdown-menu";
+import { SearchInput } from "@/shared/SearchInput/SearchInput";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import useActiveProject from "@/hooks/useActiveProject";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
+import useProjectsList from "@/api/projects/useProjectsList";
+import useProjectById from "@/api/projects/useProjectById";
+import useProjectDeleteMutation from "@/api/projects/useProjectDeleteMutation";
+import { usePermissions } from "@/contexts/PermissionsContext";
+import { Project } from "@/types/projects";
+import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
+import AddEditProjectDialog from "@/v2/pages/ProjectsPage/AddEditProjectDialog";
+
+interface ProjectSelectorProps {
+  expanded: boolean;
+}
+
+const ProjectSelector: React.FC<ProjectSelectorProps> = ({ expanded }) => {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const { setActiveProjectId } = useActiveProject();
+  const activeProjectId = useActiveProjectId();
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const navigate = useNavigate();
+
+  const { data: activeProject } = useProjectById(
+    { projectId: activeProjectId! },
+    { enabled: !!activeProjectId },
+  );
+
+  const { data: projectsData } = useProjectsList(
+    {
+      workspaceName,
+      search,
+      page: 1,
+      size: 50,
+    },
+    { enabled: open },
+  );
+
+  const handleSelect = useCallback(
+    (projectId: string) => {
+      setActiveProjectId(projectId);
+      setOpen(false);
+      setSearch("");
+      navigate({
+        to: "/$workspaceName/projects/$projectId/traces",
+        params: { workspaceName, projectId },
+      });
+    },
+    [setActiveProjectId, navigate, workspaceName],
+  );
+
+  const projectName = activeProject?.name ?? "Select project";
+
+  const trigger = expanded ? (
+    <PopoverTrigger asChild>
+      <button className="flex w-full items-center gap-1 rounded-md bg-muted px-2 py-1">
+        <span className="comet-body-s-accented flex-1 truncate text-left text-foreground">
+          {projectName}
+        </span>
+        <ChevronDown className="size-3.5 shrink-0 text-muted-slate" />
+      </button>
+    </PopoverTrigger>
+  ) : (
+    <TooltipWrapper content={projectName} side="right">
+      <PopoverTrigger asChild>
+        <button className="flex w-9 items-center justify-center rounded-md bg-muted py-1">
+          <ChevronDown className="size-3.5 text-muted-slate" />
+        </button>
+      </PopoverTrigger>
+    </TooltipWrapper>
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      {trigger}
+      <PopoverContent
+        align="start"
+        side="bottom"
+        className="w-[216px] p-1"
+        sideOffset={4}
+      >
+        <div className="px-3 py-2">
+          <span className="comet-body-s-accented text-foreground">
+            Projects
+          </span>
+        </div>
+        <div className="px-1">
+          <SearchInput
+            searchText={search}
+            setSearchText={setSearch}
+            variant="ghost"
+            size="sm"
+          />
+        </div>
+        <Separator className="my-1" />
+        <div className="max-h-[300px] overflow-auto">
+          {projectsData?.content?.map((project) => (
+            <ProjectItem
+              key={project.id}
+              project={project}
+              isSelected={project.id === activeProjectId}
+              onSelect={handleSelect}
+            />
+          ))}
+        </div>
+        <Separator className="my-1" />
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full justify-start text-primary"
+          onClick={() => {
+            setOpen(false);
+            navigate({
+              to: "/$workspaceName/projects",
+              params: { workspaceName },
+            });
+          }}
+        >
+          Manage projects
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+interface ProjectItemProps {
+  project: Project;
+  isSelected: boolean;
+  onSelect: (projectId: string) => void;
+}
+
+const ProjectItem: React.FC<ProjectItemProps> = ({
+  project,
+  isSelected,
+  onSelect,
+}) => {
+  const resetKeyRef = useRef(0);
+  const [openDialog, setOpenDialog] = useState<boolean | number>(false);
+
+  const {
+    permissions: { canCreateProjects, canDeleteProjects },
+  } = usePermissions();
+
+  const { mutate: deleteProject } = useProjectDeleteMutation();
+
+  const handleDelete = useCallback(() => {
+    deleteProject({ projectId: project.id });
+  }, [project.id, deleteProject]);
+
+  const hasActions = canCreateProjects || canDeleteProjects;
+
+  return (
+    <>
+      <AddEditProjectDialog
+        key={`edit-${resetKeyRef.current}`}
+        project={project}
+        open={openDialog === 2}
+        setOpen={setOpenDialog}
+      />
+      <ConfirmDialog
+        key={`delete-${resetKeyRef.current}`}
+        open={openDialog === 1}
+        setOpen={setOpenDialog}
+        onConfirm={handleDelete}
+        title="Delete project"
+        description="Deleting a project will also remove all the traces and their data. This action can't be undone. Are you sure you want to continue?"
+        confirmText="Delete project"
+        confirmButtonVariant="destructive"
+      />
+      <div
+        className={cn(
+          "group flex cursor-pointer items-center gap-2 rounded-md px-3 py-1.5 hover:bg-primary-foreground",
+          isSelected && "bg-muted",
+        )}
+        onClick={() => onSelect(project.id)}
+      >
+        <Check
+          className={cn(
+            "size-3.5 shrink-0",
+            isSelected ? "text-foreground" : "invisible",
+          )}
+        />
+        <span className="comet-body-s flex-1 truncate text-foreground">
+          {project.name}
+        </span>
+        {hasActions && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+              <Button
+                variant="minimal"
+                size="icon-2xs"
+                className="invisible shrink-0 group-hover:visible"
+              >
+                <MoreHorizontal className="size-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-40">
+              {canCreateProjects && (
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setOpenDialog(2);
+                    resetKeyRef.current += 1;
+                  }}
+                >
+                  <Pencil className="mr-2 size-3.5" />
+                  Edit
+                </DropdownMenuItem>
+              )}
+              {canDeleteProjects && (
+                <DropdownMenuItem
+                  variant="destructive"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setOpenDialog(1);
+                    resetKeyRef.current += 1;
+                  }}
+                >
+                  <Trash className="mr-2 size-3.5" />
+                  Delete
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default ProjectSelector;

--- a/apps/opik-frontend/src/v2/layout/SideBar/SideBar.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/SideBar.tsx
@@ -1,32 +1,19 @@
-import React, { useState } from "react";
+import React from "react";
 import { Link } from "@tanstack/react-router";
-import { Bolt, ChevronLeft, ChevronRight } from "lucide-react";
-import useAppStore from "@/store/AppStore";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useActiveWorkspaceName } from "@/store/AppStore";
 import { OnChangeFn } from "@/types/shared";
 import { Button } from "@/ui/button";
 import { Separator } from "@/ui/separator";
 import { cn } from "@/lib/utils";
 import Logo from "@/v2/layout/Logo/Logo";
 import usePluginsStore from "@/store/PluginsStore";
-import ProvideFeedbackDialog from "@/v2/layout/SideBar/FeedbackDialog/ProvideFeedbackDialog";
-import { useOpenQuickStartDialog } from "@/v2/pages-shared/onboarding/QuickstartDialog/QuickstartDialog";
 import GitHubStarListItem from "@/v2/layout/SideBar/GitHubStarListItem/GitHubStarListItem";
-import SupportHubDropdown from "@/v2/layout/SideBar/SupportHubDropdown/SupportHubDropdown";
-import SidebarMenuItem, {
-  MENU_ITEM_TYPE,
-  MenuItem,
-} from "@/v2/layout/SideBar/MenuItem/SidebarMenuItem";
-import SideBarMenuItems from "./SideBarMenuItems";
+import SideBarMenuItems from "@/v2/layout/SideBar/SideBarMenuItems";
+import ProjectSelector from "@/v2/layout/SideBar/ProjectSelector/ProjectSelector";
+import WorkspaceSection from "@/v2/layout/SideBar/WorkspaceSection/WorkspaceSection";
 
 const HOME_PATH = "/$workspaceName/home";
-
-const CONFIGURATION_ITEM: MenuItem = {
-  id: "configuration",
-  path: "/$workspaceName/configuration",
-  type: MENU_ITEM_TYPE.router,
-  icon: Bolt,
-  label: "Configuration",
-};
 
 type SideBarProps = {
   expanded: boolean;
@@ -37,14 +24,8 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
   expanded,
   setExpanded,
 }) => {
-  const [openProvideFeedback, setOpenProvideFeedback] = useState(false);
-  const { open: openQuickstart } = useOpenQuickStartDialog();
-
-  const { activeWorkspaceName: workspaceName } = useAppStore();
+  const workspaceName = useActiveWorkspaceName();
   const LogoComponent = usePluginsStore((state) => state.Logo);
-  const SidebarInviteDevButton = usePluginsStore(
-    (state) => state.SidebarInviteDevButton,
-  );
 
   const logo = LogoComponent ? (
     <LogoComponent expanded={expanded} />
@@ -52,80 +33,47 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
     <Logo expanded={expanded} />
   );
 
-  const renderBottomItems = () => {
-    const bottomItems = [
-      <SidebarMenuItem
-        key="configuration"
-        item={CONFIGURATION_ITEM}
-        expanded={expanded}
-        compact
-      />,
-      <SupportHubDropdown
-        key="support-hub"
-        expanded={expanded}
-        openQuickstart={openQuickstart}
-        openProvideFeedback={() => setOpenProvideFeedback(true)}
-      />,
-    ];
-
-    if (SidebarInviteDevButton) {
-      bottomItems.push(
-        <SidebarInviteDevButton key="inviteDevButton" expanded={expanded} />,
-      );
-    }
-
-    return bottomItems;
-  };
-
-  const renderExpandCollapseButton = () => {
-    return (
-      <Button
-        variant="outline"
-        size="icon-2xs"
-        onClick={() => setExpanded((s) => !s)}
-        className={cn(
-          "absolute -right-3 top-2 hidden rounded-full z-50 lg:group-hover:flex",
-        )}
-      >
-        {expanded ? <ChevronLeft /> : <ChevronRight />}
-      </Button>
-    );
-  };
-
   return (
-    <>
-      <aside className="comet-sidebar-width group h-[calc(100vh-var(--banner-height))] border-r transition-all">
-        <div className="comet-header-height relative flex w-full items-center justify-between gap-6 border-b">
-          <Link
-            to={HOME_PATH}
-            className="absolute left-[18px] z-10 block"
-            params={{ workspaceName }}
-          >
-            {logo}
-          </Link>
+    <aside className="comet-sidebar-width group h-[calc(100vh-var(--banner-height))] border-r transition-all">
+      <div className="comet-header-height relative flex w-full items-center justify-between gap-6 border-b">
+        <Link
+          to={HOME_PATH}
+          className="absolute left-[18px] z-10 block"
+          params={{ workspaceName }}
+        >
+          {logo}
+        </Link>
+      </div>
+
+      <div className="relative flex h-[calc(100%-var(--header-height))] flex-col">
+        <Button
+          variant="outline"
+          size="icon-2xs"
+          onClick={() => setExpanded((s) => !s)}
+          className={cn(
+            "absolute -right-3 top-2 z-50 hidden rounded-full lg:group-hover:flex",
+          )}
+        >
+          {expanded ? <ChevronLeft /> : <ChevronRight />}
+        </Button>
+
+        <div className="flex min-h-0 flex-1 flex-col overflow-auto px-3 py-4">
+          <ProjectSelector expanded={expanded} />
+          <ul className="mt-2 flex flex-col">
+            <SideBarMenuItems expanded={expanded} />
+          </ul>
         </div>
-        <div className="relative flex h-[calc(100%-var(--header-height))]">
-          {renderExpandCollapseButton()}
-          <div className="flex min-h-0 grow flex-col justify-between overflow-auto px-3 py-4">
-            <ul className="flex flex-col gap-1 pb-2">
-              <SideBarMenuItems expanded={expanded} />
-            </ul>
-            <div className="flex flex-col gap-3">
-              <Separator />
-              <ul className="flex flex-col">
-                <GitHubStarListItem expanded={expanded} />
-                {renderBottomItems()}
-              </ul>
-            </div>
+
+        <div className="shrink-0 px-3 pb-4">
+          <Separator />
+          <WorkspaceSection expanded={expanded} />
+          <Separator />
+          <div className="pt-2">
+            <GitHubStarListItem expanded={expanded} />
           </div>
         </div>
-      </aside>
-
-      <ProvideFeedbackDialog
-        open={openProvideFeedback}
-        setOpen={setOpenProvideFeedback}
-      />
-    </>
+      </div>
+    </aside>
   );
 };
 

--- a/apps/opik-frontend/src/v2/layout/SideBar/SideBarMenuItems.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/SideBarMenuItems.tsx
@@ -1,216 +1,55 @@
 import React from "react";
-import { keepPreviousData } from "@tanstack/react-query";
 import { cn } from "@/lib/utils";
-import useAppStore from "@/store/AppStore";
+import { useActiveProjectId } from "@/store/AppStore";
 import SidebarMenuItem, {
   MenuItem,
 } from "@/v2/layout/SideBar/MenuItem/SidebarMenuItem";
-import useDashboardsList from "@/api/dashboards/useDashboardsList";
-import useAlertsList from "@/api/alerts/useAlertsList";
-import useAnnotationQueuesList from "@/api/annotation-queues/useAnnotationQueuesList";
-import useOptimizationsList from "@/api/optimizations/useOptimizationsList";
-import useExperimentsList from "@/api/datasets/useExperimentsList";
-import usePromptsList from "@/api/prompts/usePromptsList";
-import useRulesList from "@/api/automations/useRulesList";
-import useProjectsList from "@/api/projects/useProjectsList";
-import useDatasetsList from "@/api/datasets/useDatasetsList";
-import { ACTIVE_OPTIMIZATION_FILTER } from "@/lib/optimizations";
-import { generateDashboardScopeFilter } from "@/lib/filters";
-import { DASHBOARD_SCOPE } from "@/types/dashboard";
 import getMenuItems from "@/v2/layout/SideBar/helpers/getMenuItems";
 import { usePermissions } from "@/contexts/PermissionsContext";
-
-const RUNNING_OPTIMIZATION_REFETCH_INTERVAL = 5000;
-const DASHBOARD_FILTERS = generateDashboardScopeFilter(
-  DASHBOARD_SCOPE.WORKSPACE,
-);
+import { Separator } from "@/ui/separator";
 
 interface SideBarMenuItemsProps {
   expanded: boolean;
 }
 
 const SideBarMenuItems: React.FC<SideBarMenuItemsProps> = ({ expanded }) => {
-  const { activeWorkspaceName: workspaceName } = useAppStore();
+  const activeProjectId = useActiveProjectId();
   const {
-    permissions: { canViewExperiments, canViewDashboards, canViewDatasets },
+    permissions: { canViewExperiments, canViewDatasets },
   } = usePermissions();
 
   const menuItems = getMenuItems({
+    projectId: activeProjectId,
     canViewExperiments,
-    canViewDashboards,
     canViewDatasets,
   });
 
-  const { data: projectData } = useProjectsList(
-    {
-      workspaceName,
-      page: 1,
-      size: 1,
-    },
-    {
-      placeholderData: keepPreviousData,
-      enabled: expanded,
-    },
-  );
-
-  const { data: datasetsData } = useDatasetsList(
-    {
-      workspaceName,
-      page: 1,
-      size: 1,
-    },
-    {
-      placeholderData: keepPreviousData,
-      enabled: expanded && canViewDatasets,
-    },
-  );
-
-  const { data: experimentsData } = useExperimentsList(
-    {
-      workspaceName,
-      page: 1,
-      size: 1,
-    },
-    {
-      placeholderData: keepPreviousData,
-      enabled: expanded && canViewExperiments,
-    },
-  );
-
-  const { data: promptsData } = usePromptsList(
-    {
-      workspaceName,
-      page: 1,
-      size: 1,
-    },
-    {
-      placeholderData: keepPreviousData,
-      enabled: expanded,
-    },
-  );
-
-  const { data: rulesData } = useRulesList(
-    {
-      workspaceName,
-      page: 1,
-      size: 1,
-    },
-    {
-      placeholderData: keepPreviousData,
-      enabled: expanded,
-    },
-  );
-
-  const { data: optimizationsData } = useOptimizationsList(
-    {
-      workspaceName,
-      page: 1,
-      size: 1,
-    },
-    {
-      placeholderData: keepPreviousData,
-      enabled: expanded,
-    },
-  );
-
-  const { data: runningOptimizationsData } = useOptimizationsList(
-    {
-      workspaceName,
-      filters: ACTIVE_OPTIMIZATION_FILTER,
-      page: 1,
-      size: 1,
-    },
-    {
-      placeholderData: keepPreviousData,
-      refetchInterval: RUNNING_OPTIMIZATION_REFETCH_INTERVAL,
-      enabled: !!workspaceName,
-    },
-  );
-
-  const { data: annotationQueuesData } = useAnnotationQueuesList(
-    {
-      workspaceName,
-      page: 1,
-      size: 1,
-    },
-    {
-      placeholderData: keepPreviousData,
-      enabled: expanded,
-    },
-  );
-
-  const { data: dashboardsData } = useDashboardsList(
-    {
-      workspaceName,
-      page: 1,
-      size: 1,
-      filters: DASHBOARD_FILTERS,
-    },
-    {
-      placeholderData: keepPreviousData,
-      enabled: expanded && canViewDashboards,
-    },
-  );
-
-  const { data: alertsData } = useAlertsList(
-    {
-      workspaceName,
-      page: 1,
-      size: 1,
-    },
-    {
-      placeholderData: keepPreviousData,
-      enabled: expanded,
-    },
-  );
-
-  const countDataMap: Record<string, number | undefined> = {
-    projects: projectData?.total,
-    evaluation_suites: datasetsData?.total,
-    experiments: experimentsData?.total,
-    prompts: promptsData?.total,
-    rules: rulesData?.total,
-    optimizations: optimizationsData?.total,
-    annotation_queues: annotationQueuesData?.total,
-    alerts: alertsData?.total,
-    dashboards: dashboardsData?.total,
-  };
-
-  const hasActiveOptimizations = (runningOptimizationsData?.total ?? 0) > 0;
-
-  const indicatorDataMap: Record<string, boolean> = {
-    optimizations_running: hasActiveOptimizations,
-  };
-
   const renderItems = (items: MenuItem[]) => {
     return items.map((item) => (
-      <SidebarMenuItem
-        key={item.id}
-        item={item}
-        expanded={expanded}
-        count={countDataMap[item.count!]}
-        hasIndicator={indicatorDataMap[item.showIndicator!]}
-      />
+      <SidebarMenuItem key={item.id} item={item} expanded={expanded} />
     ));
   };
 
   return (
     <>
-      {menuItems.map((menuGroup) => {
-        return (
-          <li key={menuGroup.id} className={cn(expanded && "mb-1")}>
-            <div>
-              {menuGroup.label && expanded && (
-                <div className="comet-body-s truncate pb-1 pl-2.5 pr-3 pt-3 text-light-slate">
-                  {menuGroup.label}
-                </div>
-              )}
-
-              <ul>{renderItems(menuGroup.items)}</ul>
+      {menuItems.map((menuGroup, index) => (
+        <li key={menuGroup.id}>
+          {index > 0 && <Separator className="my-2" />}
+          {menuGroup.label && expanded && (
+            <div className="comet-body-s-accented truncate px-2 py-1 text-light-slate">
+              {menuGroup.label}
             </div>
-          </li>
-        );
-      })}
+          )}
+          <ul
+            className={cn(
+              "flex flex-col text-foreground",
+              !expanded && "items-center",
+            )}
+          >
+            {renderItems(menuGroup.items)}
+          </ul>
+        </li>
+      ))}
     </>
   );
 };

--- a/apps/opik-frontend/src/v2/layout/SideBar/WorkspaceSection/WorkspaceSection.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/WorkspaceSection/WorkspaceSection.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+import useAppStore from "@/store/AppStore";
+import usePluginsStore from "@/store/PluginsStore";
+import SidebarMenuItem from "@/v2/layout/SideBar/MenuItem/SidebarMenuItem";
+import { getWorkspaceMenuItems } from "@/v2/layout/SideBar/helpers/getMenuItems";
+import { usePermissions } from "@/contexts/PermissionsContext";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import { calculateWorkspaceName } from "@/lib/utils";
+
+interface WorkspaceSectionProps {
+  expanded: boolean;
+}
+
+const WorkspaceSection: React.FC<WorkspaceSectionProps> = ({ expanded }) => {
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const WorkspaceSelectorComponent = usePluginsStore(
+    (state) => state.WorkspaceSelector,
+  );
+  const {
+    permissions: { canViewDashboards },
+  } = usePermissions();
+
+  const menuGroups = getWorkspaceMenuItems({ canViewDashboards });
+  const displayName = calculateWorkspaceName(workspaceName);
+
+  const renderWorkspaceSelector = () => {
+    if (WorkspaceSelectorComponent) {
+      return <WorkspaceSelectorComponent />;
+    }
+
+    if (!expanded) {
+      return (
+        <TooltipWrapper content={displayName} side="right">
+          <div className="comet-body-s-accented flex w-9 items-center justify-center truncate rounded-md py-1 text-foreground">
+            {displayName.charAt(0).toUpperCase()}
+          </div>
+        </TooltipWrapper>
+      );
+    }
+
+    return (
+      <div className="comet-body-s-accented truncate rounded-md px-2 py-1 text-foreground">
+        {displayName}
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex flex-col px-3 py-2">
+      {expanded && (
+        <div className="comet-body-s-accented truncate px-2 py-1 text-light-slate">
+          Workspace
+        </div>
+      )}
+
+      {renderWorkspaceSelector()}
+
+      <ul
+        className={cn(
+          "flex flex-col text-muted-slate",
+          !expanded && "items-center",
+        )}
+      >
+        {menuGroups.flatMap((group) =>
+          group.items.map((item) => (
+            <SidebarMenuItem key={item.id} item={item} expanded={expanded} />
+          )),
+        )}
+      </ul>
+    </div>
+  );
+};
+
+export default WorkspaceSection;

--- a/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
+++ b/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
@@ -1,15 +1,16 @@
 import {
   Bell,
-  FlaskConical,
-  LayoutGrid,
-  FileTerminal,
-  ListChecks,
-  LucideHome,
   Blocks,
-  Brain,
   ChartLine,
-  SparklesIcon,
+  FileTerminal,
+  FlaskConical,
+  ListChecks,
+  Rows3,
+  Settings2,
+  Sparkles,
   UserPen,
+  Brain,
+  Workflow,
 } from "lucide-react";
 import {
   MENU_ITEM_TYPE,
@@ -18,50 +19,40 @@ import {
 import { FeatureToggleKeys } from "@/types/feature-toggles";
 
 const getMenuItems = ({
+  projectId,
   canViewExperiments,
-  canViewDashboards,
   canViewDatasets,
 }: {
+  projectId: string | null;
   canViewExperiments: boolean;
-  canViewDashboards: boolean;
   canViewDatasets: boolean;
 }): MenuItemGroup[] => {
+  const projectPrefix = projectId
+    ? "/$workspaceName/projects/$projectId"
+    : null;
+
+  const projectPath = (suffix: string) =>
+    projectPrefix ? `${projectPrefix}${suffix}` : undefined;
+
   return [
-    {
-      id: "home",
-      items: [
-        {
-          id: "home",
-          path: "/$workspaceName/home",
-          type: MENU_ITEM_TYPE.router,
-          icon: LucideHome,
-          label: "Home",
-        },
-        ...(canViewDashboards
-          ? [
-              {
-                id: "dashboards",
-                path: "/$workspaceName/dashboards",
-                type: MENU_ITEM_TYPE.router,
-                icon: ChartLine,
-                label: "Dashboards",
-                count: "dashboards",
-              },
-            ]
-          : []),
-      ],
-    },
     {
       id: "observability",
       label: "Observability",
       items: [
         {
-          id: "projects",
-          path: "/$workspaceName/projects",
+          id: "logs",
+          path: projectPath("/traces"),
           type: MENU_ITEM_TYPE.router,
-          icon: LayoutGrid,
-          label: "Projects",
-          count: "projects",
+          icon: Rows3,
+          label: "Logs",
+          disabled: !projectPrefix,
+        },
+        {
+          id: "insights",
+          type: MENU_ITEM_TYPE.router,
+          icon: ChartLine,
+          label: "Insights",
+          disabled: true,
         },
       ],
     },
@@ -72,12 +63,12 @@ const getMenuItems = ({
         ...(canViewExperiments
           ? [
               {
-                id: "experiments" as const,
-                path: "/$workspaceName/experiments" as const,
-                type: MENU_ITEM_TYPE.router,
+                id: "experiments",
+                path: projectPath("/experiments"),
+                type: MENU_ITEM_TYPE.router as const,
                 icon: FlaskConical,
-                label: "Experiments" as const,
-                count: "experiments" as const,
+                label: "Experiments",
+                disabled: !projectPrefix,
               },
             ]
           : []),
@@ -85,21 +76,21 @@ const getMenuItems = ({
           ? [
               {
                 id: "evaluation_suites",
-                path: "/$workspaceName/evaluation-suites",
-                type: MENU_ITEM_TYPE.router,
+                path: projectPath("/evaluation-suites"),
+                type: MENU_ITEM_TYPE.router as const,
                 icon: ListChecks,
-                label: "Datasets",
-                count: "evaluation_suites",
+                label: "Evaluation suites",
+                disabled: !projectPrefix,
               },
             ]
           : []),
         {
           id: "annotation_queues",
-          path: "/$workspaceName/annotation-queues",
+          path: projectPath("/annotation-queues"),
           type: MENU_ITEM_TYPE.router,
           icon: UserPen,
           label: "Annotation queues",
-          count: "annotation_queues",
+          disabled: !projectPrefix,
         },
       ],
     },
@@ -109,18 +100,19 @@ const getMenuItems = ({
       items: [
         {
           id: "prompts",
-          path: "/$workspaceName/prompts",
+          path: projectPath("/prompts"),
           type: MENU_ITEM_TYPE.router,
           icon: FileTerminal,
           label: "Prompt library",
-          count: "prompts",
+          disabled: !projectPrefix,
         },
         {
           id: "playground",
-          path: "/$workspaceName/playground",
+          path: projectPath("/playground"),
           type: MENU_ITEM_TYPE.router,
           icon: Blocks,
           label: "Playground",
+          disabled: !projectPrefix,
         },
       ],
     },
@@ -130,12 +122,18 @@ const getMenuItems = ({
       items: [
         {
           id: "optimizations",
-          path: "/$workspaceName/optimizations",
+          path: projectPath("/optimizations"),
           type: MENU_ITEM_TYPE.router,
-          icon: SparklesIcon,
+          icon: Sparkles,
           label: "Optimization studio",
-          count: "optimizations",
-          showIndicator: "optimizations_running",
+          disabled: !projectPrefix,
+        },
+        {
+          id: "agent_configuration",
+          type: MENU_ITEM_TYPE.router,
+          icon: Workflow,
+          label: "Agent configuration",
+          disabled: true,
         },
       ],
     },
@@ -145,20 +143,53 @@ const getMenuItems = ({
       items: [
         {
           id: "online_evaluation",
-          path: "/$workspaceName/online-evaluation",
+          path: projectPath("/online-evaluation"),
           type: MENU_ITEM_TYPE.router,
           icon: Brain,
           label: "Online evaluation",
-          count: "rules",
+          disabled: !projectPrefix,
         },
         {
           id: "alerts",
-          path: "/$workspaceName/alerts",
+          path: projectPath("/alerts"),
           type: MENU_ITEM_TYPE.router,
           icon: Bell,
           label: "Alerts",
-          count: "alerts",
+          disabled: !projectPrefix,
           featureFlag: FeatureToggleKeys.TOGGLE_ALERTS_ENABLED,
+        },
+      ],
+    },
+  ];
+};
+
+export const getWorkspaceMenuItems = ({
+  canViewDashboards,
+}: {
+  canViewDashboards: boolean;
+}): MenuItemGroup[] => {
+  return [
+    {
+      id: "workspace",
+      label: "Workspace",
+      items: [
+        ...(canViewDashboards
+          ? [
+              {
+                id: "dashboards",
+                path: "/$workspaceName/dashboards",
+                type: MENU_ITEM_TYPE.router as const,
+                icon: ChartLine,
+                label: "Dashboards",
+              },
+            ]
+          : []),
+        {
+          id: "configuration",
+          path: "/$workspaceName/configuration",
+          type: MENU_ITEM_TYPE.router,
+          icon: Settings2,
+          label: "Configuration",
         },
       ],
     },

--- a/apps/opik-frontend/src/v2/layout/SupportHub/SupportHub.tsx
+++ b/apps/opik-frontend/src/v2/layout/SupportHub/SupportHub.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import {
+  Book,
+  GraduationCap,
+  LifeBuoy,
+  MessageCircleQuestion,
+} from "lucide-react";
+import SlackIcon from "@/icons/slack.svg?react";
+import { Button } from "@/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/ui/dropdown-menu";
+import { buildDocsUrl } from "@/lib/utils";
+import { SLACK_LINK } from "@/v2/pages-shared/onboarding/IntegrationExplorer/components/HelpLinks";
+import { useOpenQuickStartDialog } from "@/v2/pages-shared/onboarding/QuickstartDialog/QuickstartDialog";
+import ProvideFeedbackDialog from "@/v2/layout/SideBar/FeedbackDialog/ProvideFeedbackDialog";
+
+const SupportHub = () => {
+  const [openProvideFeedback, setOpenProvideFeedback] = useState(false);
+  const { open: openQuickstart } = useOpenQuickStartDialog();
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon-sm">
+            <LifeBuoy className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-56">
+          <DropdownMenuItem asChild>
+            <a
+              href={buildDocsUrl()}
+              target="_blank"
+              rel="noreferrer"
+              className="flex cursor-pointer items-center gap-2"
+            >
+              <Book className="size-4" />
+              <span>Documentation</span>
+            </a>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={openQuickstart}
+            className="flex cursor-pointer items-center gap-2"
+          >
+            <GraduationCap className="size-4" />
+            <span>Quickstart guide</span>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={() => setOpenProvideFeedback(true)}
+            className="flex cursor-pointer items-center gap-2"
+          >
+            <MessageCircleQuestion className="size-4" />
+            <span>Provide feedback</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <a
+              href={SLACK_LINK}
+              target="_blank"
+              rel="noreferrer"
+              className="flex cursor-pointer items-center gap-2"
+            >
+              <SlackIcon className="size-4" />
+              <span>Get help in Slack</span>
+            </a>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <ProvideFeedbackDialog
+        open={openProvideFeedback}
+        setOpen={setOpenProvideFeedback}
+      />
+    </>
+  );
+};
+
+export default SupportHub;

--- a/apps/opik-frontend/src/v2/layout/TopBar/TopBar.tsx
+++ b/apps/opik-frontend/src/v2/layout/TopBar/TopBar.tsx
@@ -2,6 +2,7 @@ import Breadcrumbs from "@/v2/layout/Breadcrumbs/Breadcrumbs";
 import usePluginsStore from "@/store/PluginsStore";
 import AppDebugInfo from "@/v2/layout/AppDebugInfo/AppDebugInfo";
 import SettingsMenu from "../SettingsMenu/SettingsMenu";
+import SupportHub from "@/v2/layout/SupportHub/SupportHub";
 
 const TopBar = () => {
   const UserMenu = usePluginsStore((state) => state.UserMenu);
@@ -12,8 +13,11 @@ const TopBar = () => {
         <Breadcrumbs />
       </div>
 
-      <AppDebugInfo />
-      {UserMenu ? <UserMenu /> : <SettingsMenu />}
+      <div className="flex items-center gap-2">
+        <AppDebugInfo />
+        <SupportHub />
+        {UserMenu ? <UserMenu /> : <SettingsMenu />}
+      </div>
     </nav>
   );
 };

--- a/apps/opik-frontend/src/v2/pages-shared/OnboardingOverlay/steps/StartPreference.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/OnboardingOverlay/steps/StartPreference.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "@tanstack/react-router";
 import { useFeatureFlagVariantKey } from "posthog-js/react";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import OnboardingStep from "@/v2/pages-shared/OnboardingOverlay/OnboardingStep";
 import { usePermissions } from "@/contexts/PermissionsContext";
 
@@ -17,6 +17,7 @@ const FEATURE_FLAG_KEY = "onboarding-start-exploring-test";
 
 const StartPreference: React.FC = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const variant = useFeatureFlagVariantKey(FEATURE_FLAG_KEY);
 
   const {
@@ -47,8 +48,8 @@ const StartPreference: React.FC = () => {
         )}
 
         <Link
-          to="/$workspaceName/playground"
-          params={{ workspaceName }}
+          to="/$workspaceName/projects/$projectId/playground"
+          params={{ workspaceName, projectId: activeProjectId! }}
           className="w-full"
         >
           <OnboardingStep.AnswerCard option={OPTIONS.TEST_PROMPTS} />
@@ -56,8 +57,8 @@ const StartPreference: React.FC = () => {
 
         {canViewExperiments && (
           <Link
-            to="/$workspaceName/experiments"
-            params={{ workspaceName }}
+            to="/$workspaceName/projects/$projectId/experiments"
+            params={{ workspaceName, projectId: activeProjectId! }}
             search={
               showEnhancedOnboarding
                 ? {

--- a/apps/opik-frontend/src/v2/pages-shared/evaluation-suites/useSuiteIdFromURL.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/evaluation-suites/useSuiteIdFromURL.ts
@@ -1,0 +1,8 @@
+import { useParams } from "@tanstack/react-router";
+
+export const useSuiteIdFromURL = () => {
+  return useParams({
+    select: (params) => params["suiteId"],
+    from: "/workspaceGuard/$workspaceName/projects/$projectId/evaluation-suites/$suiteId",
+  });
+};

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/BestPromptCard/BestPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/BestPromptCard/BestPrompt.tsx
@@ -6,7 +6,7 @@ import isObject from "lodash/isObject";
 import get from "lodash/get";
 
 import { OPTIMIZATION_PROMPT_KEY } from "@/constants/experiments";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { Experiment } from "@/types/datasets";
 import { Optimization, OPTIMIZATION_STATUS } from "@/types/optimizations";
 import { IN_PROGRESS_OPTIMIZATION_STATUSES } from "@/lib/optimizations";
@@ -57,6 +57,7 @@ export const BestPrompt: React.FC<BestPromptProps> = ({
   status,
 }) => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const navigate = useNavigate();
   const { toast } = useToast();
   const [diffOpen, setDiffOpen] = useState(false);
@@ -181,8 +182,12 @@ export const BestPrompt: React.FC<BestPromptProps> = ({
               className="px-0"
               onClick={() =>
                 navigate({
-                  to: "/$workspaceName/prompts/$promptId",
-                  params: { workspaceName, promptId },
+                  to: "/$workspaceName/projects/$projectId/prompts/$promptId",
+                  params: {
+                    workspaceName,
+                    projectId: activeProjectId!,
+                    promptId,
+                  },
                 })
               }
             >
@@ -192,7 +197,14 @@ export const BestPrompt: React.FC<BestPromptProps> = ({
         });
       }
     },
-    [closeSaveDialog, toast, workspaceName, navigate, existingPrompt?.id],
+    [
+      closeSaveDialog,
+      toast,
+      workspaceName,
+      navigate,
+      existingPrompt?.id,
+      activeProjectId,
+    ],
   );
 
   return (
@@ -272,9 +284,10 @@ export const BestPrompt: React.FC<BestPromptProps> = ({
       <CardContent className="flex min-h-0 flex-1 flex-col px-5 pb-4">
         <div className="flex shrink-0 items-center justify-between">
           <Link
-            to="/$workspaceName/optimizations/$optimizationId/trials"
+            to="/$workspaceName/projects/$projectId/optimizations/$optimizationId/trials"
             params={{
               workspaceName,
+              projectId: activeProjectId!,
               optimizationId: optimization.id,
             }}
             search={{ trials: [experiment.id] }}

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/ExperimentItemSidebar/ExperimentItemContent.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/ExperimentItemSidebar/ExperimentItemContent.tsx
@@ -22,7 +22,7 @@ import {
 import { ExperimentItemStatus } from "@/types/evaluation-suites";
 import { OnChangeFn } from "@/types/shared";
 import { traceExist, traceVisible } from "@/lib/traces";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
 import PassFailBadge from "./PassFailBadge";
 import AssertionResultsTable from "./AssertionResultsTable";
@@ -161,6 +161,7 @@ export const ExperimentItemContent: React.FC<ExperimentItemContentProps> = ({
   runSummariesByExperiment,
 }) => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
 
   const itemsByExperiment = useMemo(
     () => groupBy(experimentItems, "experiment_id"),
@@ -180,8 +181,12 @@ export const ExperimentItemContent: React.FC<ExperimentItemContentProps> = ({
           <h4 className="comet-body-accented">Item context</h4>
           {datasetId && (
             <Link
-              to="/$workspaceName/evaluation-suites/$suiteId/items"
-              params={{ workspaceName, suiteId: datasetId }}
+              to="/$workspaceName/projects/$projectId/evaluation-suites/$suiteId/items"
+              params={{
+                workspaceName,
+                projectId: activeProjectId!,
+                suiteId: datasetId,
+              }}
               search={datasetItemId ? { row: datasetItemId } : {}}
               onClick={(e) => e.stopPropagation()}
             >

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/ExperimentsActionsPanel/ExperimentsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/ExperimentsActionsPanel/ExperimentsActionsPanel.tsx
@@ -4,7 +4,7 @@ import { Split, Trash, Tag } from "lucide-react";
 import { Button } from "@/ui/button";
 import { Experiment } from "@/types/datasets";
 import { useNavigate } from "@tanstack/react-router";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import FilterExperimentsToCompareDialog from "@/v2/pages-shared/experiments/ExperimentsActionsPanel/FilterExperimentsToCompareDialog";
 import useExperimentBatchDeleteMutation from "@/api/datasets/useExperimentBatchDeleteMutation";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
@@ -26,6 +26,7 @@ const ExperimentsActionsPanel: React.FunctionComponent<
   const [open, setOpen] = useState<boolean | number>(false);
   const navigate = useNavigate();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const disabled = !experiments?.length;
 
   const handleCompareClick = () => {
@@ -37,10 +38,11 @@ const ExperimentsActionsPanel: React.FunctionComponent<
 
     if (hasTheSameDataset) {
       navigate({
-        to: "/$workspaceName/experiments/$datasetId/compare",
+        to: "/$workspaceName/projects/$projectId/experiments/$datasetId/compare",
         params: {
           datasetId: experiments[0].dataset_id,
           workspaceName,
+          projectId: activeProjectId!,
         },
         search: {
           experiments: experiments.map((e) => e.id),

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/ExperimentsActionsPanel/FilterExperimentsToCompareDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/ExperimentsActionsPanel/FilterExperimentsToCompareDialog.tsx
@@ -9,7 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/ui/dialog";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { Experiment } from "@/types/datasets";
 import { Button } from "@/ui/button";
 import { useNavigate } from "@tanstack/react-router";
@@ -27,6 +27,7 @@ const FilterExperimentsToCompareDialog: React.FunctionComponent<
 > = ({ experiments, open, setOpen }) => {
   const navigate = useNavigate();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const [selectedExperiments, setSelectedExperiments] = useState(experiments);
   const isValid = selectedExperiments.every(
     (e) => e.dataset_id === selectedExperiments[0].dataset_id,
@@ -36,10 +37,11 @@ const FilterExperimentsToCompareDialog: React.FunctionComponent<
     if (!isValid) return;
 
     navigate({
-      to: "/$workspaceName/experiments/$datasetId/compare",
+      to: "/$workspaceName/projects/$projectId/experiments/$datasetId/compare",
       params: {
         datasetId: selectedExperiments[0].dataset_id,
         workspaceName,
+        projectId: activeProjectId!,
       },
       search: {
         experiments: selectedExperiments.map((e) => e.id),

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/useNavigateToExperiment.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/useNavigateToExperiment.ts
@@ -1,0 +1,52 @@
+import { useNavigate } from "@tanstack/react-router";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
+
+type UseNavigateToExperimentParams = {
+  experimentIds?: string[];
+  datasetId?: string;
+  newExperiment?: boolean;
+  datasetName?: string;
+};
+
+export const useNavigateToExperiment = () => {
+  const navigate = useNavigate();
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
+
+  return {
+    navigate: ({
+      experimentIds,
+      datasetId,
+      newExperiment,
+      datasetName,
+    }: UseNavigateToExperimentParams) => {
+      if (experimentIds?.length && datasetId) {
+        navigate({
+          to: "/$workspaceName/projects/$projectId/experiments/$datasetId/compare",
+          params: {
+            workspaceName,
+            projectId: activeProjectId!,
+            datasetId,
+          },
+          search: {
+            experiments: experimentIds,
+          },
+        });
+      } else {
+        navigate({
+          to: "/$workspaceName/projects/$projectId/experiments",
+          params: {
+            workspaceName,
+            projectId: activeProjectId!,
+          },
+          search: {
+            new: {
+              experiment: newExperiment,
+              datasetName,
+            },
+          },
+        });
+      }
+    },
+  };
+};

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog.tsx
@@ -5,7 +5,7 @@ import { EditorView } from "@codemirror/view";
 import { ExternalLink } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import {
   Dialog,
   DialogAutoScrollBody,
@@ -84,6 +84,7 @@ const AddNewPromptVersionDialog: React.FC<AddNewPromptVersionDialogProps> = ({
   onSave,
 }) => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const [promptId, setPromptId] = useState<string | undefined>(prompt?.id);
   const [saveMode, setSaveMode] = useState<SaveMode>(
     prompt?.id ? "update" : "new",
@@ -245,8 +246,12 @@ const AddNewPromptVersionDialog: React.FC<AddNewPromptVersionDialogProps> = ({
                 Selected prompt will be updated. You can view versions in the
                 <Link
                   onClick={(event) => event.stopPropagation()}
-                  to="/$workspaceName/prompts/$promptId"
-                  params={{ workspaceName, promptId: promptId! }}
+                  to="/$workspaceName/projects/$projectId/prompts/$promptId"
+                  params={{
+                    workspaceName,
+                    projectId: activeProjectId!,
+                    promptId: promptId!,
+                  }}
                   target="_blank"
                 >
                   <Button variant="link" size="sm" className="px-1">
@@ -285,8 +290,8 @@ const AddNewPromptVersionDialog: React.FC<AddNewPromptVersionDialogProps> = ({
                   A new prompt will be created in the
                   <Link
                     onClick={(event) => event.stopPropagation()}
-                    to="/$workspaceName/prompts"
-                    params={{ workspaceName }}
+                    to="/$workspaceName/projects/$projectId/prompts"
+                    params={{ workspaceName, projectId: activeProjectId! }}
                     target="_blank"
                   >
                     <Button variant="link" size="sm" className="px-1">

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/EvaluationExamples/UsingPlaygroundTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/EvaluationExamples/UsingPlaygroundTab.tsx
@@ -1,12 +1,13 @@
 import { Button } from "@/ui/button";
 import { SheetClose } from "@/ui/sheet";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { Link } from "@tanstack/react-router";
 import evaluationGifUrl from "/images/playground_evaluation.gif";
 import { buildDocsUrl } from "@/lib/utils";
 
 const UsingPlaygroundTab = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
 
   return (
     <div className="flex flex-col gap-6 rounded-md border bg-background p-6">
@@ -47,7 +48,10 @@ const UsingPlaygroundTab = () => {
               className="inline-flex h-auto px-0"
               asChild
             >
-              <Link to="/$workspaceName/playground" params={{ workspaceName }}>
+              <Link
+                to="/$workspaceName/projects/$projectId/playground"
+                params={{ workspaceName, projectId: activeProjectId! }}
+              >
                 Playground.
               </Link>
             </Button>

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationExplorer/components/HelpLinks.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationExplorer/components/HelpLinks.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext } from "react";
 import { Button } from "@/ui/button";
 import { cn } from "@/lib/utils";
 import { Blocks, MonitorPlay, MousePointerClick } from "lucide-react";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import Slack from "@/icons/slack.svg?react";
 import { Link } from "@tanstack/react-router";
 import usePluginsStore from "@/store/PluginsStore";
@@ -107,6 +107,7 @@ SlackButton.displayName = "HelpLinks.Slack";
 
 const PlaygroundButton: React.FC = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
 
   return (
     <Button
@@ -116,7 +117,10 @@ const PlaygroundButton: React.FC = () => {
       id="help-links-playground"
       data-fs-element="HelpLinksPlayground"
     >
-      <Link to={"/$workspaceName/playground"} params={{ workspaceName }}>
+      <Link
+        to={"/$workspaceName/projects/$projectId/playground"}
+        params={{ workspaceName, projectId: activeProjectId! }}
+      >
         <Blocks className="mr-2 size-4" />
         Try our Playground
       </Link>

--- a/apps/opik-frontend/src/v2/pages-shared/optimizations/StudioTemplates/StudioTemplates.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/optimizations/StudioTemplates/StudioTemplates.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { SquareDashedMousePointer, MessageSquare } from "lucide-react";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { OPTIMIZATION_DEMO_TEMPLATES } from "@/constants/optimizations";
 import OptimizationTemplateCard from "./OptimizationTemplateCard";
 
@@ -17,12 +17,13 @@ const TEMPLATE_ICONS: Record<
 
 const StudioTemplates: React.FC = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const navigate = useNavigate();
 
   const handleTemplateClick = (templateId?: string) => {
     navigate({
-      to: "/$workspaceName/optimizations/new",
-      params: { workspaceName },
+      to: "/$workspaceName/projects/$projectId/optimizations/new",
+      params: { workspaceName, projectId: activeProjectId! },
       search: templateId ? { template: templateId } : undefined,
     });
   };

--- a/apps/opik-frontend/src/v2/pages-shared/playground/useLoadPlayground.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/playground/useLoadPlayground.ts
@@ -1,0 +1,236 @@
+import { useCallback, useMemo } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import useLocalStorageState from "use-local-storage-state";
+
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
+import { usePromptMap, useSetPromptMap } from "@/store/PlaygroundStore";
+import { generateDefaultPrompt } from "@/lib/playground";
+import {
+  generateDefaultLLMPromptMessage,
+  getTextFromMessageContent,
+  parseChatTemplateToLLMMessages,
+} from "@/lib/llm";
+import {
+  PLAYGROUND_LAST_PICKED_MODEL,
+  PLAYGROUND_SELECTED_DATASET_VERSION_KEY,
+} from "@/constants/llm";
+import useLastPickedModel from "@/hooks/useLastPickedModel";
+import useLLMProviderModelsData from "@/hooks/useLLMProviderModelsData";
+import useProviderKeys from "@/api/provider-keys/useProviderKeys";
+import { MessageContent } from "@/types/llm";
+import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
+import { formatDatasetVersionKey } from "@/utils/datasetVersionStorage";
+
+interface NamedPromptContent {
+  name: string;
+  content: MessageContent;
+}
+
+interface LoadPlaygroundOptions {
+  promptContent?: MessageContent;
+  promptId?: string;
+  promptVersionId?: string;
+  autoImprove?: boolean;
+  datasetId?: string;
+  datasetVersionId?: string;
+  templateStructure?: PROMPT_TEMPLATE_STRUCTURE;
+  namedPrompts?: NamedPromptContent[];
+}
+
+function useLoadPlayground() {
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
+  const navigate = useNavigate();
+
+  const promptMap = usePromptMap();
+  const setPromptMap = useSetPromptMap();
+
+  const [lastPickedModel] = useLastPickedModel({
+    key: PLAYGROUND_LAST_PICKED_MODEL,
+  });
+  const { calculateModelProvider, calculateDefaultModel } =
+    useLLMProviderModelsData();
+
+  const { data: providerKeysData, isPending: isPendingProviderKeys } =
+    useProviderKeys({
+      workspaceName,
+    });
+
+  const [, setDatasetVersionKey] = useLocalStorageState<string | null>(
+    PLAYGROUND_SELECTED_DATASET_VERSION_KEY,
+    {
+      defaultValue: null,
+    },
+  );
+
+  const isPlaygroundEmpty = useMemo(() => {
+    const keys = Object.keys(promptMap);
+
+    return (
+      keys.length === 1 &&
+      promptMap[keys[0]]?.messages?.length === 1 &&
+      promptMap[keys[0]]?.messages[0]?.content === ""
+    );
+  }, [promptMap]);
+
+  const providerKeys = useMemo(() => {
+    return providerKeysData?.content?.map((c) => c.ui_composed_provider) || [];
+  }, [providerKeysData]);
+
+  const createPromptFromContent = useCallback(
+    (
+      content: MessageContent,
+      options: {
+        promptId?: string;
+        promptVersionId?: string;
+        autoImprove?: boolean;
+        templateStructure?: PROMPT_TEMPLATE_STRUCTURE;
+        initPrompt?: Partial<ReturnType<typeof generateDefaultPrompt>>;
+      } = {},
+    ) => {
+      const {
+        promptId,
+        promptVersionId,
+        autoImprove = false,
+        templateStructure,
+        initPrompt,
+      } = options;
+
+      const newPrompt = generateDefaultPrompt({
+        initPrompt,
+        setupProviders: providerKeys,
+        lastPickedModel,
+        providerResolver: calculateModelProvider,
+        modelResolver: calculateDefaultModel,
+      });
+
+      if (templateStructure === PROMPT_TEMPLATE_STRUCTURE.CHAT) {
+        if (promptId) {
+          newPrompt.loadedChatPromptId = promptId;
+        }
+
+        try {
+          const contentString = getTextFromMessageContent(content);
+          const parsedMessages = parseChatTemplateToLLMMessages(contentString, {
+            promptId,
+            promptVersionId,
+            useTimestamp: true,
+          });
+
+          if (parsedMessages.length > 0) {
+            newPrompt.messages = parsedMessages;
+          } else {
+            newPrompt.messages = [
+              generateDefaultLLMPromptMessage({
+                content,
+                promptId,
+                promptVersionId,
+                autoImprove,
+              }),
+            ];
+          }
+        } catch (error) {
+          console.error("Failed to parse chat prompt:", error);
+          newPrompt.messages = [
+            generateDefaultLLMPromptMessage({
+              content,
+              promptId,
+              promptVersionId,
+              autoImprove,
+            }),
+          ];
+        }
+      } else {
+        newPrompt.messages = [
+          generateDefaultLLMPromptMessage({
+            content,
+            promptId,
+            promptVersionId,
+            autoImprove,
+          }),
+        ];
+      }
+
+      return newPrompt;
+    },
+    [
+      calculateDefaultModel,
+      calculateModelProvider,
+      lastPickedModel,
+      providerKeys,
+    ],
+  );
+
+  const loadPlayground = useCallback(
+    (options: LoadPlaygroundOptions = {}) => {
+      const {
+        promptContent = "",
+        promptId,
+        promptVersionId,
+        autoImprove = false,
+        datasetId,
+        datasetVersionId,
+        templateStructure,
+        namedPrompts,
+      } = options;
+
+      let promptIds: string[];
+      let promptMap: Record<string, ReturnType<typeof generateDefaultPrompt>>;
+
+      if (namedPrompts && namedPrompts.length > 0) {
+        const prompts = namedPrompts.map((np) =>
+          createPromptFromContent(np.content, {
+            templateStructure: PROMPT_TEMPLATE_STRUCTURE.CHAT,
+            initPrompt: { name: np.name },
+          }),
+        );
+        promptIds = prompts.map((p) => p.id);
+        promptMap = Object.fromEntries(prompts.map((p) => [p.id, p]));
+      } else {
+        const newPrompt = createPromptFromContent(promptContent, {
+          promptId,
+          promptVersionId,
+          autoImprove,
+          templateStructure,
+        });
+        promptIds = [newPrompt.id];
+        promptMap = { [newPrompt.id]: newPrompt };
+      }
+
+      setPromptMap(promptIds, promptMap);
+
+      if (datasetId && datasetVersionId) {
+        const versionKey = formatDatasetVersionKey(datasetId, datasetVersionId);
+        setDatasetVersionKey(versionKey);
+      } else if (datasetId) {
+        console.warn(
+          "useLoadPlayground: datasetId provided without datasetVersionId — dataset context will not be set",
+        );
+      }
+
+      navigate({
+        to: "/$workspaceName/projects/$projectId/playground",
+        params: {
+          workspaceName,
+          projectId: activeProjectId!,
+        },
+      });
+    },
+    [
+      createPromptFromContent,
+      navigate,
+      setPromptMap,
+      setDatasetVersionKey,
+      workspaceName,
+      activeProjectId,
+    ],
+  );
+
+  return {
+    loadPlayground,
+    isPlaygroundEmpty,
+    isPendingProviderKeys,
+  };
+}
+
+export default useLoadPlayground;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx
@@ -48,8 +48,10 @@ vi.mock("@/store/AppStore", () => ({
   default: vi.fn((selector) =>
     selector({
       activeWorkspaceName: "test-workspace",
+      activeProjectId: "test-project-id",
     }),
   ),
+  useActiveProjectId: () => "test-project-id",
 }));
 
 // Mock the toast hook
@@ -60,7 +62,7 @@ vi.mock("@/ui/use-toast", () => ({
 }));
 
 // Mock the navigate hook
-vi.mock("@/hooks/useNavigateToExperiment", () => ({
+vi.mock("@/v2/pages-shared/experiments/useNavigateToExperiment", () => ({
   useNavigateToExperiment: () => ({
     navigate: vi.fn(),
   }),

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
@@ -37,7 +37,7 @@ import AddEditEvaluationSuiteDialog from "@/v2/pages-shared/datasets/AddEditEval
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
 import { ToastAction } from "@/ui/toast";
-import { useNavigateToExperiment } from "@/hooks/useNavigateToExperiment";
+import { useNavigateToExperiment } from "@/v2/pages-shared/experiments/useNavigateToExperiment";
 
 const DEFAULT_SIZE = 100;
 

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToQueueDialog/AddToQueueDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToQueueDialog/AddToQueueDialog.tsx
@@ -4,7 +4,7 @@ import { keepPreviousData } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 
 import { Thread, Trace } from "@/types/traces";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/ui/dialog";
 import { useToast } from "@/ui/use-toast";
 import { ToastAction } from "@/ui/toast";
@@ -46,6 +46,7 @@ const AddToQueueDialog: React.FunctionComponent<AddToQueueDialogProps> = ({
   } = usePermissions();
 
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const { toast } = useToast();
   const navigate = useNavigate();
   const [search, setSearch] = useState("");
@@ -110,9 +111,10 @@ const AddToQueueDialog: React.FunctionComponent<AddToQueueDialogProps> = ({
             key="Go to annotation queue"
             onClick={() =>
               navigate({
-                to: "/$workspaceName/annotation-queues/$annotationQueueId",
+                to: "/$workspaceName/projects/$projectId/annotation-queues/$annotationQueueId",
                 params: {
                   workspaceName,
+                  projectId: activeProjectId!,
                   annotationQueueId: queue.id,
                 },
               })
@@ -123,7 +125,7 @@ const AddToQueueDialog: React.FunctionComponent<AddToQueueDialogProps> = ({
         ],
       });
     },
-    [toast, navigate, workspaceName],
+    [toast, navigate, workspaceName, activeProjectId],
   );
 
   const addToQueueHandler = useCallback(

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/PromptContentView.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/PromptContentView.tsx
@@ -4,6 +4,7 @@ import { Link } from "@tanstack/react-router";
 import { Button } from "@/ui/button";
 import PromptTemplateView from "@/v2/pages-shared/llm/PromptTemplateView/PromptTemplateView";
 import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
+import { useActiveProjectId } from "@/store/AppStore";
 
 export const CustomUseInPlaygroundButton: React.FC<{
   variant?: string;
@@ -48,6 +49,8 @@ const PromptContentView: React.FC<PromptContentViewProps> = ({
   templateStructure,
   playgroundButton,
 }) => {
+  const activeProjectId = useActiveProjectId();
+
   return (
     <PromptTemplateView
       template={template}
@@ -58,8 +61,8 @@ const PromptContentView: React.FC<PromptContentViewProps> = ({
         {promptId && (
           <Button variant="ghost" size="sm" asChild>
             <Link
-              to="/$workspaceName/prompts/$promptId"
-              params={{ workspaceName, promptId }}
+              to="/$workspaceName/projects/$projectId/prompts/$promptId"
+              params={{ workspaceName, projectId: activeProjectId!, promptId }}
               search={{ activeVersionId }}
               className="inline-flex items-center"
             >

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/AlertForm.tsx
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/AlertForm.tsx
@@ -17,7 +17,7 @@ import Loader from "@/shared/Loader/Loader";
 import { Alert, ALERT_TYPE } from "@/types/alerts";
 import useAlertCreateMutation from "@/api/alerts/useAlertCreateMutation";
 import useAlertUpdateMutation from "@/api/alerts/useAlertUpdateMutation";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import useNavigationBlocker from "@/hooks/useNavigationBlocker";
 
 import { AlertFormType, AlertFormSchema } from "./schema";
@@ -40,6 +40,7 @@ const AlertForm: React.FunctionComponent<AlertFormProps> = ({
 }) => {
   const navigate = useNavigate();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const alertCreateMutation = useAlertCreateMutation();
   const alertUpdateMutation = useAlertUpdateMutation();
 
@@ -104,10 +105,10 @@ const AlertForm: React.FunctionComponent<AlertFormProps> = ({
 
   const handleNavigateBack = useCallback(() => {
     navigate({
-      to: "/$workspaceName/alerts",
-      params: { workspaceName },
+      to: "/$workspaceName/projects/$projectId/alerts",
+      params: { workspaceName, projectId: activeProjectId! },
     });
-  }, [navigate, workspaceName]);
+  }, [navigate, workspaceName, activeProjectId]);
 
   const canLeavePage = form.formState.isSubmitted || !form.formState.isDirty;
 

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/AlertNestedRoute.tsx
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/AlertNestedRoute.tsx
@@ -6,7 +6,7 @@ const AlertNestedRoute: React.FunctionComponent = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const matchRoute = useMatchRoute();
   const isAlertsRootRoute = matchRoute({
-    to: "/$workspaceName/alerts",
+    to: "/$workspaceName/projects/$projectId/alerts",
   });
 
   if (isAlertsRootRoute) {

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AlertsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AlertsPage.tsx
@@ -18,7 +18,7 @@ import Loader from "@/shared/Loader/Loader";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";
 import { Button } from "@/ui/button";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { Alert, ALERT_TYPE } from "@/types/alerts";
 import {
   COLUMN_ID_ID,
@@ -177,6 +177,7 @@ const DEFAULT_COLUMNS_ORDER: string[] = [
 
 const AlertsPage: React.FunctionComponent = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const navigate = useNavigate();
 
   const [search = "", setSearch] = useQueryParam("alerts_search", StringParam, {
@@ -316,11 +317,11 @@ const AlertsPage: React.FunctionComponent = () => {
 
   const handleNewAlertClick = useCallback(() => {
     navigate({
-      to: "/$workspaceName/alerts/new",
-      params: { workspaceName },
+      to: "/$workspaceName/projects/$projectId/alerts/new",
+      params: { workspaceName, projectId: activeProjectId! },
       search: (prev: Record<string, unknown>) => prev,
     });
-  }, [navigate, workspaceName]);
+  }, [navigate, workspaceName, activeProjectId]);
 
   if (isPending) {
     return <Loader />;

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AlertsRouteWrapper.tsx
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AlertsRouteWrapper.tsx
@@ -5,7 +5,7 @@ import AlertsPage from "@/v2/pages/AlertsPage/AlertsPage";
 const AlertsRouteWrapper: React.FunctionComponent = () => {
   const matchRoute = useMatchRoute();
   const isAlertsRootRoute = matchRoute({
-    to: "/$workspaceName/alerts",
+    to: "/$workspaceName/projects/$projectId/alerts",
   });
 
   if (isAlertsRootRoute) {

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AlertsRowActionsCell.tsx
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AlertsRowActionsCell.tsx
@@ -15,7 +15,7 @@ import { Alert } from "@/types/alerts";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
 import CellWrapper from "@/shared/DataTableCells/CellWrapper";
 import useAlertsBatchDeleteMutation from "@/api/alerts/useAlertsBatchDeleteMutation";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 
 const AlertsRowActionsCell: React.FunctionComponent<
   CellContext<Alert, unknown>
@@ -25,6 +25,7 @@ const AlertsRowActionsCell: React.FunctionComponent<
   const [open, setOpen] = useState<boolean | number>(false);
   const navigate = useNavigate();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
 
   const { mutate } = useAlertsBatchDeleteMutation();
 
@@ -38,11 +39,11 @@ const AlertsRowActionsCell: React.FunctionComponent<
     if (!alert.id) return;
 
     navigate({
-      to: "/$workspaceName/alerts/$alertId",
-      params: { workspaceName, alertId: alert.id },
+      to: "/$workspaceName/projects/$projectId/alerts/$alertId",
+      params: { workspaceName, projectId: activeProjectId!, alertId: alert.id },
       search: (prev: Record<string, unknown>) => prev,
     });
-  }, [navigate, workspaceName, alert.id]);
+  }, [navigate, workspaceName, activeProjectId, alert.id]);
 
   return (
     <CellWrapper

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
@@ -5,7 +5,7 @@ import sortBy from "lodash/sortBy";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/ui/tabs";
 import useAnnotationQueueById from "@/api/annotation-queues/useAnnotationQueueById";
 import useBreadcrumbsStore from "@/store/BreadcrumbsStore";
-import { useAnnotationQueueIdFromURL } from "@/hooks/useAnnotationQueueIdFromURL";
+import { useAnnotationQueueIdFromURL } from "@/v2/pages/AnnotationQueuePage/useAnnotationQueueIdFromURL";
 import DateTag from "@/shared/DateTag/DateTag";
 import { RESOURCE_TYPE } from "@/shared/ResourceLink/ResourceLink";
 import NavigationTag from "@/shared/NavigationTag";

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/useAnnotationQueueIdFromURL.ts
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/useAnnotationQueueIdFromURL.ts
@@ -1,0 +1,8 @@
+import { useParams } from "@tanstack/react-router";
+
+export const useAnnotationQueueIdFromURL = () => {
+  return useParams({
+    select: (params) => params["annotationQueueId"],
+    from: "/workspaceGuard/$workspaceName/projects/$projectId/annotation-queues/$annotationQueueId",
+  });
+};

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuesPage/AnnotationQueuesPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuesPage/AnnotationQueuesPage.tsx
@@ -52,7 +52,7 @@ import {
   getRowId,
 } from "@/shared/DataTable/utils";
 import useAnnotationQueuesList from "@/api/annotation-queues/useAnnotationQueuesList";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { usePermissions } from "@/contexts/PermissionsContext";
 
 import {
@@ -240,6 +240,7 @@ const FILTERS_CONFIG = {
 
 export const AnnotationQueuesPage: React.FC = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const navigate = useNavigate();
   const resetDialogKeyRef = useRef(0);
   const [openDialog, setOpenDialog] = useState<boolean>(false);
@@ -349,14 +350,15 @@ export const AnnotationQueuesPage: React.FC = () => {
   const handleRowClick = useCallback(
     (queue: AnnotationQueue) => {
       navigate({
-        to: "/$workspaceName/annotation-queues/$annotationQueueId",
+        to: "/$workspaceName/projects/$projectId/annotation-queues/$annotationQueueId",
         params: {
           workspaceName,
+          projectId: activeProjectId!,
           annotationQueueId: queue.id,
         },
       });
     },
-    [navigate, workspaceName],
+    [navigate, workspaceName, activeProjectId],
   );
 
   const columns = useMemo(() => {

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDialog.tsx
@@ -11,7 +11,7 @@ import {
   DialogTitle,
 } from "@/ui/dialog";
 import useExperimentsList from "@/api/datasets/useExperimentsList";
-import { useDatasetIdFromCompareExperimentsURL } from "@/hooks/useDatasetIdFromCompareExperimentsURL";
+import { useDatasetIdFromCompareExperimentsURL } from "@/v2/pages/CompareExperimentsPage/useDatasetIdFromCompareExperimentsURL";
 import Loader from "@/shared/Loader/Loader";
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
 import DataTablePagination from "@/shared/DataTablePagination/DataTablePagination";

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/CompareExperimentsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/CompareExperimentsPanel.tsx
@@ -17,7 +17,7 @@ import { COLUMN_TYPE, OnChangeFn } from "@/types/shared";
 import useDatasetItemById from "@/api/datasets/useDatasetItemById";
 import useCompareExperimentsList from "@/api/datasets/useCompareExperimentsList";
 import useAppStore from "@/store/AppStore";
-import { useDatasetIdFromCompareExperimentsURL } from "@/hooks/useDatasetIdFromCompareExperimentsURL";
+import { useDatasetIdFromCompareExperimentsURL } from "@/v2/pages/CompareExperimentsPage/useDatasetIdFromCompareExperimentsURL";
 import DataTab from "@/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/DataTab";
 
 type CompareExperimentsPanelProps = {

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/ExperimentDataset.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/ExperimentDataset.tsx
@@ -18,7 +18,7 @@ import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
 import NavigationTag from "@/shared/NavigationTag/NavigationTag";
 import { RESOURCE_TYPE } from "@/shared/ResourceLink/ResourceLink";
-import { useDatasetIdFromCompareExperimentsURL } from "@/hooks/useDatasetIdFromCompareExperimentsURL";
+import { useDatasetIdFromCompareExperimentsURL } from "@/v2/pages/CompareExperimentsPage/useDatasetIdFromCompareExperimentsURL";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
 

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -42,7 +42,7 @@ import Loader from "@/shared/Loader/Loader";
 import ExplainerCallout from "@/shared/ExplainerCallout/ExplainerCallout";
 import useAppStore from "@/store/AppStore";
 import { Experiment, ExperimentsCompare } from "@/types/datasets";
-import { useDatasetIdFromCompareExperimentsURL } from "@/hooks/useDatasetIdFromCompareExperimentsURL";
+import { useDatasetIdFromCompareExperimentsURL } from "@/v2/pages/CompareExperimentsPage/useDatasetIdFromCompareExperimentsURL";
 import { useTruncationEnabled } from "@/contexts/server-sync-provider";
 import {
   convertColumnDataToColumn,

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/useDatasetIdFromCompareExperimentsURL.ts
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/useDatasetIdFromCompareExperimentsURL.ts
@@ -1,0 +1,8 @@
+import { useParams } from "@tanstack/react-router";
+
+export const useDatasetIdFromCompareExperimentsURL = () => {
+  return useParams({
+    select: (params) => params["datasetId"],
+    from: "/workspaceGuard/$workspaceName/projects/$projectId/experiments/$datasetId/compare",
+  });
+};

--- a/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/EditEvaluationSuiteSettingsDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/EditEvaluationSuiteSettingsDialog.tsx
@@ -24,7 +24,7 @@ import { Separator } from "@/ui/separator";
 import useDatasetById from "@/api/datasets/useDatasetById";
 import useDatasetUpdateMutation from "@/api/datasets/useDatasetUpdateMutation";
 import useDatasetVersionsList from "@/api/datasets/useDatasetVersionsList";
-import { useSuiteIdFromURL } from "@/hooks/useSuiteIdFromURL";
+import { useSuiteIdFromURL } from "@/v2/pages-shared/evaluation-suites/useSuiteIdFromURL";
 import { useClampedIntegerInput } from "@/hooks/useClampedIntegerInput";
 import {
   useSuiteAssertions,

--- a/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/EvaluationSuiteItemPanel/AddEvaluationSuiteItemPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/EvaluationSuiteItemPanel/AddEvaluationSuiteItemPanel.tsx
@@ -11,7 +11,7 @@ import useEvaluationSuiteDraftStore, {
 } from "@/store/EvaluationSuiteDraftStore";
 import { useEffectiveSuiteAssertions } from "@/hooks/useEffectiveSuiteAssertions";
 import { useEffectiveExecutionPolicy } from "@/hooks/useEffectiveExecutionPolicy";
-import { useSuiteIdFromURL } from "@/hooks/useSuiteIdFromURL";
+import { useSuiteIdFromURL } from "@/v2/pages-shared/evaluation-suites/useSuiteIdFromURL";
 import EvaluationSuiteItemFormContainer from "./EvaluationSuiteItemFormContainer";
 import {
   EvaluationSuiteItemFormValues,

--- a/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/EvaluationSuiteItemPanel/EvaluationSuiteItemPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/EvaluationSuiteItemPanel/EvaluationSuiteItemPanel.tsx
@@ -36,7 +36,7 @@ import { useEffectiveSuiteAssertions } from "@/hooks/useEffectiveSuiteAssertions
 import { useEffectiveExecutionPolicy } from "@/hooks/useEffectiveExecutionPolicy";
 import { useEffectiveItemAssertions } from "@/hooks/useEffectiveItemAssertions";
 import { useEffectiveItemExecutionPolicy } from "@/hooks/useEffectiveItemExecutionPolicy";
-import { useSuiteIdFromURL } from "@/hooks/useSuiteIdFromURL";
+import { useSuiteIdFromURL } from "@/v2/pages-shared/evaluation-suites/useSuiteIdFromURL";
 import {
   EvaluationSuiteItemFormValues,
   toFormValues,

--- a/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/EvaluationSuiteItemsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/EvaluationSuiteItemsPage.tsx
@@ -40,11 +40,11 @@ import {
 } from "@/ui/tooltip";
 import { ToastAction } from "@/ui/toast";
 import { useToast } from "@/ui/use-toast";
-import useLoadPlayground from "@/hooks/useLoadPlayground";
+import useLoadPlayground from "@/v2/pages-shared/playground/useLoadPlayground";
 import useNavigationBlocker from "@/hooks/useNavigationBlocker";
-import { useNavigateToExperiment } from "@/hooks/useNavigateToExperiment";
+import { useNavigateToExperiment } from "@/v2/pages-shared/experiments/useNavigateToExperiment";
 import { useEvaluationSuiteSavePayload } from "@/hooks/useEvaluationSuiteSavePayload";
-import { useSuiteIdFromURL } from "@/hooks/useSuiteIdFromURL";
+import { useSuiteIdFromURL } from "@/v2/pages-shared/evaluation-suites/useSuiteIdFromURL";
 import { useClearDraft, useHasDraft } from "@/store/EvaluationSuiteDraftStore";
 import { DATASET_STATUS, DATASET_TYPE } from "@/types/datasets";
 import { useEffectiveSuiteAssertions } from "@/hooks/useEffectiveSuiteAssertions";

--- a/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/EvaluationSuiteItemsTab/ExecutionPolicyCell.tsx
+++ b/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/EvaluationSuiteItemsTab/ExecutionPolicyCell.tsx
@@ -3,7 +3,7 @@ import { CellContext, ColumnMeta, TableMeta } from "@tanstack/react-table";
 import { DatasetItem } from "@/types/datasets";
 import { useEffectiveItemExecutionPolicy } from "@/hooks/useEffectiveItemExecutionPolicy";
 import { useEffectiveExecutionPolicy } from "@/hooks/useEffectiveExecutionPolicy";
-import { useSuiteIdFromURL } from "@/hooks/useSuiteIdFromURL";
+import { useSuiteIdFromURL } from "@/v2/pages-shared/evaluation-suites/useSuiteIdFromURL";
 import CellWrapper from "@/shared/DataTableCells/CellWrapper";
 
 interface ExecutionPolicyCellInnerProps {

--- a/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/UseEvaluationSuiteDropdown.tsx
+++ b/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/UseEvaluationSuiteDropdown.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/ui/dropdown-menu";
 import AddExperimentDialog from "@/v2/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
-import useLoadPlayground from "@/hooks/useLoadPlayground";
+import useLoadPlayground from "@/v2/pages-shared/playground/useLoadPlayground";
 import { usePermissions } from "@/contexts/PermissionsContext";
 
 export interface UseEvaluationSuiteDropdownProps {

--- a/apps/opik-frontend/src/v2/pages/EvaluationSuitePage/EvaluationSuitePage.tsx
+++ b/apps/opik-frontend/src/v2/pages/EvaluationSuitePage/EvaluationSuitePage.tsx
@@ -7,7 +7,7 @@ import {
 } from "@tanstack/react-router";
 import useDatasetById from "@/api/datasets/useDatasetById";
 import useBreadcrumbsStore from "@/store/BreadcrumbsStore";
-import { useSuiteIdFromURL } from "@/hooks/useSuiteIdFromURL";
+import { useSuiteIdFromURL } from "@/v2/pages-shared/evaluation-suites/useSuiteIdFromURL";
 
 const EvaluationSuitePage = () => {
   const setBreadcrumbParam = useBreadcrumbsStore((state) => state.setParam);
@@ -21,7 +21,7 @@ const EvaluationSuitePage = () => {
   });
 
   const isSuiteRoot = matchRoute({
-    to: "/$workspaceName/evaluation-suites/$suiteId",
+    to: "/$workspaceName/projects/$projectId/evaluation-suites/$suiteId",
   });
 
   // Evaluation suites are datasets under the hood — reuse the existing hook

--- a/apps/opik-frontend/src/v2/pages/EvaluationSuitesPage/EvaluationSuitesPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/EvaluationSuitesPage/EvaluationSuitesPage.tsx
@@ -21,7 +21,7 @@ import { createDatasetRowActionsCell } from "@/v2/pages-shared/datasets/DatasetR
 import { Button } from "@/ui/button";
 import { Separator } from "@/ui/separator";
 import { buildDocsUrl } from "@/lib/utils";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import TimeCell from "@/shared/DataTableCells/TimeCell";
 import {
@@ -183,6 +183,7 @@ export const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
 
 const EvaluationSuitesPage: React.FunctionComponent = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const navigate = useNavigate();
 
   const isDatasetExportEnabled = useIsFeatureEnabled(
@@ -336,14 +337,15 @@ const EvaluationSuitesPage: React.FunctionComponent = () => {
       if (!row.id) return;
 
       navigate({
-        to: "/$workspaceName/evaluation-suites/$suiteId",
+        to: "/$workspaceName/projects/$projectId/evaluation-suites/$suiteId",
         params: {
           suiteId: row.id,
           workspaceName,
+          projectId: activeProjectId!,
         },
       });
     },
-    [workspaceName, navigate],
+    [workspaceName, activeProjectId, navigate],
   );
 
   if (isPending) {

--- a/apps/opik-frontend/src/v2/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
@@ -28,7 +28,7 @@ import TraceCountCell from "@/v2/pages-shared/traces/TraceCountCell/TraceCountCe
 import ListCell from "@/shared/DataTableCells/ListCell";
 import { RESOURCE_TYPE } from "@/shared/ResourceLink/ResourceLink";
 import Loader from "@/shared/Loader/Loader";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { formatDate } from "@/lib/date";
 import { isEvalSuiteExperiment } from "@/lib/experiments";
 import {
@@ -128,6 +128,7 @@ export const MAX_EXPANDED_DEEPEST_GROUPS = 5;
 
 const GeneralDatasetsTab: React.FC = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const navigate = useNavigate();
   const resetDialogKeyRef = useRef(0);
   const [query] = useQueryParam("new", JsonParam);
@@ -460,17 +461,18 @@ const GeneralDatasetsTab: React.FC = () => {
   const handleRowClick = useCallback(
     (row: GroupedExperiment) => {
       navigate({
-        to: "/$workspaceName/experiments/$datasetId/compare",
+        to: "/$workspaceName/projects/$projectId/experiments/$datasetId/compare",
         params: {
           datasetId: row.dataset_id,
           workspaceName,
+          projectId: activeProjectId!,
         },
         search: {
           experiments: [row.id],
         },
       });
     },
-    [navigate, workspaceName],
+    [navigate, workspaceName, activeProjectId],
   );
 
   const hasGroups = Boolean(groups.length);

--- a/apps/opik-frontend/src/v2/pages/HomePage/EvaluationSection.tsx
+++ b/apps/opik-frontend/src/v2/pages/HomePage/EvaluationSection.tsx
@@ -12,7 +12,7 @@ import useExperimentsList from "@/api/datasets/useExperimentsList";
 import Loader from "@/shared/Loader/Loader";
 import AddExperimentDialog from "@/v2/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog";
 import { Button } from "@/ui/button";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import {
   COLUMN_FEEDBACK_SCORES_ID,
   COLUMN_NAME_ID,
@@ -101,6 +101,7 @@ export const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
 const EvaluationSection: React.FC = () => {
   const navigate = useNavigate();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const {
     permissions: { canViewExperiments, canCreateExperiments },
   } = usePermissions();
@@ -131,17 +132,18 @@ const EvaluationSection: React.FC = () => {
   const handleRowClick = useCallback(
     (row: Experiment) => {
       navigate({
-        to: "/$workspaceName/experiments/$datasetId/compare",
+        to: "/$workspaceName/projects/$projectId/experiments/$datasetId/compare",
         params: {
           datasetId: row.dataset_id,
           workspaceName,
+          projectId: activeProjectId!,
         },
         search: {
           experiments: [row.id],
         },
       });
     },
-    [navigate, workspaceName],
+    [navigate, workspaceName, activeProjectId],
   );
 
   const resizeConfig = useMemo(
@@ -188,7 +190,10 @@ const EvaluationSection: React.FC = () => {
         }
       />
       <div className="flex justify-end pt-1">
-        <Link to="/$workspaceName/experiments" params={{ workspaceName }}>
+        <Link
+          to="/$workspaceName/projects/$projectId/experiments"
+          params={{ workspaceName, projectId: activeProjectId! }}
+        >
           <Button variant="ghost" className="flex items-center gap-1 pr-0">
             All experiments <ArrowRight className="size-4" />
           </Button>

--- a/apps/opik-frontend/src/v2/pages/HomePage/GetStartedSection.tsx
+++ b/apps/opik-frontend/src/v2/pages/HomePage/GetStartedSection.tsx
@@ -6,7 +6,7 @@ import {
   MousePointer,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import SideDialog from "@/shared/SideDialog/SideDialog";
 import FrameworkIntegrations from "@/v2/pages-shared/onboarding/FrameworkIntegrations/FrameworkIntegrations";
 import AddExperimentDialog from "@/v2/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog";
@@ -18,6 +18,7 @@ import SetGuardrailDialog from "../HomePageShared/SetGuardrailDialog";
 
 const GetStartedSection = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const [isNewExperimentDialogOpened, setIsNewExperimentDialogOpened] =
     useState<boolean>(false);
   const [isGuardrailsDialogOpened, setIsGuardrailsDialogOpened] =
@@ -74,8 +75,8 @@ const GetStartedSection = () => {
         )}
         <Link
           className="flex w-full max-w-[300px] cursor-pointer items-center gap-3 rounded-md border bg-background p-4 transition-shadow hover:shadow-action-card dark:hover:bg-primary-foreground dark:hover:shadow-none"
-          to={"/$workspaceName/playground"}
-          params={{ workspaceName }}
+          to={"/$workspaceName/projects/$projectId/playground"}
+          params={{ workspaceName, projectId: activeProjectId! }}
         >
           <div className="flex size-[24px] items-center justify-center rounded bg-action-playground-background">
             <FlaskConical className="size-3.5 text-action-playground-text" />

--- a/apps/opik-frontend/src/v2/pages/HomePage/OptimizationRunsSection.tsx
+++ b/apps/opik-frontend/src/v2/pages/HomePage/OptimizationRunsSection.tsx
@@ -16,7 +16,7 @@ import useOptimizationsList from "@/api/optimizations/useOptimizationsList";
 import Loader from "@/shared/Loader/Loader";
 import AddOptimizationDialog from "@/v2/pages/OptimizationsPage/AddOptimizationDialog/AddOptimizationDialog";
 import { Button } from "@/ui/button";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { COLUMN_NAME_ID, COLUMN_SELECT_ID, COLUMN_TYPE } from "@/types/shared";
 import { RESOURCE_TYPE } from "@/shared/ResourceLink/ResourceLink";
 import { Optimization } from "@/types/optimizations";
@@ -114,6 +114,7 @@ export const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
 const OptimizationRunsSection: React.FunctionComponent = () => {
   const navigate = useNavigate();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
 
   const resetDialogKeyRef = useRef(0);
   const [openDialog, setOpenDialog] = useState<boolean>(false);
@@ -141,14 +142,15 @@ const OptimizationRunsSection: React.FunctionComponent = () => {
   const handleRowClick = useCallback(
     (row: Optimization) => {
       navigate({
-        to: "/$workspaceName/optimizations/$optimizationId",
+        to: "/$workspaceName/projects/$projectId/optimizations/$optimizationId",
         params: {
           optimizationId: row.id,
           workspaceName,
+          projectId: activeProjectId!,
         },
       });
     },
-    [navigate, workspaceName],
+    [navigate, workspaceName, activeProjectId],
   );
 
   const resizeConfig = useMemo(
@@ -189,7 +191,10 @@ const OptimizationRunsSection: React.FunctionComponent = () => {
         }
       />
       <div className="flex justify-end pt-1">
-        <Link to="/$workspaceName/optimizations" params={{ workspaceName }}>
+        <Link
+          to="/$workspaceName/projects/$projectId/optimizations"
+          params={{ workspaceName, projectId: activeProjectId! }}
+        >
           <Button variant="ghost" className="flex items-center gap-1 pr-0">
             All optimization runs <ArrowRight className="size-4" />
           </Button>

--- a/apps/opik-frontend/src/v2/pages/HomePage/WorkspaceStatisticSection.tsx
+++ b/apps/opik-frontend/src/v2/pages/HomePage/WorkspaceStatisticSection.tsx
@@ -5,7 +5,7 @@ import { keepPreviousData } from "@tanstack/react-query";
 import useProjectsList from "@/api/projects/useProjectsList";
 import useExperimentsList from "@/api/datasets/useExperimentsList";
 import usePromptsList from "@/api/prompts/usePromptsList";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { formatNumberInK } from "@/lib/utils";
 import { Card, CardContent, CardHeader } from "@/ui/card";
 import { FileTerminal, FlaskConical, LayoutGrid } from "lucide-react";
@@ -15,6 +15,7 @@ import { usePermissions } from "@/contexts/PermissionsContext";
 
 const WorkspaceStatisticSection = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const navigate = useNavigate();
 
   const {
@@ -89,9 +90,10 @@ const WorkspaceStatisticSection = () => {
           className="min-w-52 flex-1 cursor-pointer hover:shadow-md"
           onClick={() =>
             navigate({
-              to: "/$workspaceName/experiments",
+              to: "/$workspaceName/projects/$projectId/experiments",
               params: {
                 workspaceName,
+                projectId: activeProjectId!,
               },
             })
           }
@@ -118,9 +120,10 @@ const WorkspaceStatisticSection = () => {
         className="min-w-52 flex-1 cursor-pointer hover:shadow-md"
         onClick={() =>
           navigate({
-            to: "/$workspaceName/prompts",
+            to: "/$workspaceName/projects/$projectId/prompts",
             params: {
               workspaceName,
+              projectId: activeProjectId!,
             },
           })
         }

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationCompareRedirect.test.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationCompareRedirect.test.tsx
@@ -17,8 +17,9 @@ vi.mock("@tanstack/react-router", () => ({
 
 vi.mock("@/store/AppStore", () => ({
   default: vi.fn((selector: (state: Record<string, unknown>) => unknown) =>
-    selector({ activeWorkspaceName: "default" }),
+    selector({ activeWorkspaceName: "default", activeProjectId: "proj-123" }),
   ),
+  useActiveProjectId: () => "proj-123",
 }));
 
 describe("OptimizationCompareRedirect", () => {
@@ -35,8 +36,12 @@ describe("OptimizationCompareRedirect", () => {
     render(<OptimizationCompareRedirect />);
 
     expect(mockNavigate).toHaveBeenCalledWith({
-      to: "/$workspaceName/optimizations/$optimizationId",
-      params: { workspaceName: "default", optimizationId: "opt-123-abc" },
+      to: "/$workspaceName/projects/$projectId/optimizations/$optimizationId",
+      params: {
+        workspaceName: "default",
+        projectId: "proj-123",
+        optimizationId: "opt-123-abc",
+      },
       replace: true,
     });
   });
@@ -61,8 +66,8 @@ describe("OptimizationCompareRedirect", () => {
     render(<OptimizationCompareRedirect />);
 
     expect(mockNavigate).toHaveBeenCalledWith({
-      to: "/$workspaceName/optimizations",
-      params: { workspaceName: "default" },
+      to: "/$workspaceName/projects/$projectId/optimizations",
+      params: { workspaceName: "default", projectId: "proj-123" },
       replace: true,
     });
   });
@@ -73,8 +78,8 @@ describe("OptimizationCompareRedirect", () => {
     render(<OptimizationCompareRedirect />);
 
     expect(mockNavigate).toHaveBeenCalledWith({
-      to: "/$workspaceName/optimizations",
-      params: { workspaceName: "default" },
+      to: "/$workspaceName/projects/$projectId/optimizations",
+      params: { workspaceName: "default", projectId: "proj-123" },
       replace: true,
     });
   });

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationCompareRedirect.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationCompareRedirect.tsx
@@ -1,5 +1,5 @@
 import { Navigate, useRouterState } from "@tanstack/react-router";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 
 /**
  * Redirect from the legacy `/$datasetId/compare?optimizations=[id]` URL
@@ -7,6 +7,7 @@ import useAppStore from "@/store/AppStore";
  */
 const OptimizationCompareRedirect = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const searchStr = useRouterState({ select: (s) => s.location.searchStr });
 
   const searchParams = new URLSearchParams(searchStr);
@@ -25,8 +26,8 @@ const OptimizationCompareRedirect = () => {
   if (!optimizationId) {
     return (
       <Navigate
-        to="/$workspaceName/optimizations"
-        params={{ workspaceName }}
+        to="/$workspaceName/projects/$projectId/optimizations"
+        params={{ workspaceName, projectId: activeProjectId! }}
         replace
       />
     );
@@ -34,8 +35,8 @@ const OptimizationCompareRedirect = () => {
 
   return (
     <Navigate
-      to="/$workspaceName/optimizations/$optimizationId"
-      params={{ workspaceName, optimizationId }}
+      to="/$workspaceName/projects/$projectId/optimizations/$optimizationId"
+      params={{ workspaceName, projectId: activeProjectId!, optimizationId }}
       replace
     />
   );

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationConfiguration.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationConfiguration.tsx
@@ -7,7 +7,7 @@ import { MessagesList } from "@/v2/pages-shared/prompts/PromptMessageDisplay";
 import { OPTIMIZATION_METRIC_OPTIONS } from "@/constants/optimizations";
 import { getOptimizerLabel } from "@/lib/optimizations";
 import { extractDisplayMessages } from "@/lib/llm";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import ResizableSection from "@/shared/ResizableSection/ResizableSection";
 
 interface OptimizationConfigurationProps {
@@ -44,6 +44,7 @@ const OptimizationConfiguration: React.FC<OptimizationConfigurationProps> = ({
   bestExperiment,
 }) => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const { prompt, optimizer, evaluation, dataset_name, llm_model } =
     studioConfig;
   const metric = evaluation?.metrics?.[0];
@@ -65,8 +66,12 @@ const OptimizationConfiguration: React.FC<OptimizationConfigurationProps> = ({
               label="Evaluation suite"
               value={
                 <Link
-                  to="/$workspaceName/evaluation-suites/$suiteId"
-                  params={{ workspaceName, suiteId: datasetId }}
+                  to="/$workspaceName/projects/$projectId/evaluation-suites/$suiteId"
+                  params={{
+                    workspaceName,
+                    projectId: activeProjectId!,
+                    suiteId: datasetId,
+                  }}
                   className="text-primary hover:underline"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -101,9 +106,10 @@ const OptimizationConfiguration: React.FC<OptimizationConfigurationProps> = ({
                 label="Best trial configuration"
                 value={
                   <Link
-                    to="/$workspaceName/optimizations/$optimizationId/trials"
+                    to="/$workspaceName/projects/$projectId/optimizations/$optimizationId/trials"
                     params={{
                       workspaceName,
+                      projectId: activeProjectId!,
                       optimizationId,
                     }}
                     target="_blank"

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationHeader.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationHeader.tsx
@@ -7,7 +7,7 @@ import { OPTIMIZATION_STATUS, Optimization } from "@/types/optimizations";
 import { STATUS_TO_VARIANT_MAP } from "@/constants/experiments";
 import { IN_PROGRESS_OPTIMIZATION_STATUSES } from "@/lib/optimizations";
 import useOptimizationStopMutation from "@/api/optimizations/useOptimizationStopMutation";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import NavigationTag from "@/shared/NavigationTag/NavigationTag";
 import { RESOURCE_TYPE } from "@/shared/ResourceLink/ResourceLink";
 import { formatDate } from "@/lib/date";
@@ -28,6 +28,7 @@ const OptimizationHeader: React.FC<OptimizationHeaderProps> = ({
   canRerun,
 }) => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const navigate = useNavigate();
   const { mutate: stopOptimization, isPending: isStoppingOptimization } =
     useOptimizationStopMutation();
@@ -45,8 +46,8 @@ const OptimizationHeader: React.FC<OptimizationHeaderProps> = ({
   const handleRerun = () => {
     if (!optimizationId) return;
     navigate({
-      to: "/$workspaceName/optimizations/new",
-      params: { workspaceName },
+      to: "/$workspaceName/projects/$projectId/optimizations/new",
+      params: { workspaceName, projectId: activeProjectId! },
       search: { rerun: optimizationId },
     });
   };

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationPage.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { useActiveProjectId } from "@/store/AppStore";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/ui/tabs";
 import Loader from "@/shared/Loader/Loader";
@@ -22,6 +23,7 @@ enum OPTIMIZATION_TAB {
 
 const OptimizationPage: React.FC = () => {
   const navigate = useNavigate();
+  const activeProjectId = useActiveProjectId();
 
   const {
     workspaceName,
@@ -90,10 +92,11 @@ const OptimizationPage: React.FC = () => {
       const candidate = candidates.find((c) => c.candidateId === candidateId);
       if (!candidate) return;
       navigate({
-        to: "/$workspaceName/optimizations/$optimizationId/trials",
+        to: "/$workspaceName/projects/$projectId/optimizations/$optimizationId/trials",
         params: {
           optimizationId,
           workspaceName,
+          projectId: activeProjectId!,
         },
         search: {
           trials: candidate.experimentIds,
@@ -101,7 +104,7 @@ const OptimizationPage: React.FC = () => {
         },
       });
     },
-    [candidates, navigate, optimizationId, workspaceName],
+    [candidates, navigate, optimizationId, workspaceName, activeProjectId],
   );
 
   const isInProgress =

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/useOptimizationExperiments.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/useOptimizationExperiments.ts
@@ -25,7 +25,7 @@ export const useOptimizationExperiments = () => {
 
   const { optimizationId } = useParams({
     select: (params) => params,
-    from: "/workspaceGuard/$workspaceName/optimizations/$optimizationId",
+    from: "/workspaceGuard/$workspaceName/projects/$projectId/optimizations/$optimizationId",
   });
 
   const {

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/useOptimizationTableState.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/useOptimizationTableState.ts
@@ -5,6 +5,7 @@ import useLocalStorageState from "use-local-storage-state";
 import { StringParam, useQueryParam } from "use-query-params";
 
 import { COLUMN_ID_ID, COLUMN_NAME_ID, ROW_HEIGHT } from "@/types/shared";
+import { useActiveProjectId } from "@/store/AppStore";
 import { AggregatedCandidate } from "@/types/optimizations";
 import { sortCandidates } from "@/lib/optimizations";
 
@@ -51,6 +52,7 @@ export const useOptimizationTableState = ({
   optimizationId,
 }: UseOptimizationTableStateParams) => {
   const navigate = useNavigate();
+  const activeProjectId = useActiveProjectId();
 
   const [search = "", setSearch] = useQueryParam("search", StringParam, {
     updateType: "replaceIn",
@@ -100,10 +102,11 @@ export const useOptimizationTableState = ({
   const handleRowClick = useCallback(
     (row: AggregatedCandidate) => {
       navigate({
-        to: "/$workspaceName/optimizations/$optimizationId/trials",
+        to: "/$workspaceName/projects/$projectId/optimizations/$optimizationId/trials",
         params: {
           optimizationId,
           workspaceName,
+          projectId: activeProjectId!,
         },
         search: {
           trials: row.experimentIds,
@@ -111,7 +114,7 @@ export const useOptimizationTableState = ({
         },
       });
     },
-    [navigate, workspaceName, optimizationId],
+    [navigate, workspaceName, activeProjectId, optimizationId],
   );
 
   return {

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/DatasetNameCell.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/DatasetNameCell.tsx
@@ -7,10 +7,11 @@ import CellWrapper from "@/shared/DataTableCells/CellWrapper";
 import { Button } from "@/ui/button";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { Optimization } from "@/types/optimizations";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 
 const DatasetNameCell = (context: CellContext<unknown, unknown>) => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const row = context.row.original as Optimization;
   const name = row.dataset_name ?? "-";
 
@@ -26,8 +27,12 @@ const DatasetNameCell = (context: CellContext<unknown, unknown>) => {
 
       {row.dataset_id && (
         <Link
-          to="/$workspaceName/datasets/$datasetId/items"
-          params={{ workspaceName, datasetId: row.dataset_id }}
+          to="/$workspaceName/projects/$projectId/evaluation-suites/$datasetId/items"
+          params={{
+            workspaceName,
+            projectId: activeProjectId!,
+            datasetId: row.dataset_id,
+          }}
           onClick={(e) => e.stopPropagation()}
         >
           <Button

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useFormContext } from "react-hook-form";
 
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import useBreadcrumbsStore from "@/store/BreadcrumbsStore";
 import useDatasetsList from "@/api/datasets/useDatasetsList";
 import useOptimizationCreateMutation from "@/api/optimizations/useOptimizationCreateMutation";
@@ -31,6 +31,7 @@ const getBreadcrumbTitle = (name: string) =>
 
 export const useOptimizationsNewFormHandlers = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const navigate = useNavigate();
   const { setLastSessionRunId } = useLastOptimizationRun();
   const { mutateAsync: createOptimization } = useOptimizationCreateMutation();
@@ -224,9 +225,10 @@ export const useOptimizationsNewFormHandlers = () => {
       if (result?.id) {
         setLastSessionRunId(result.id);
         navigate({
-          to: "/$workspaceName/optimizations/$optimizationId",
+          to: "/$workspaceName/projects/$projectId/optimizations/$optimizationId",
           params: {
             workspaceName,
+            projectId: activeProjectId!,
             optimizationId: result.id,
           },
         });
@@ -240,15 +242,16 @@ export const useOptimizationsNewFormHandlers = () => {
     createOptimization,
     navigate,
     workspaceName,
+    activeProjectId,
     setLastSessionRunId,
   ]);
 
   const handleCancel = useCallback(() => {
     navigate({
-      to: "/$workspaceName/optimizations",
-      params: { workspaceName },
+      to: "/$workspaceName/projects/$projectId/optimizations",
+      params: { workspaceName, projectId: activeProjectId! },
     });
-  }, [navigate, workspaceName]);
+  }, [navigate, workspaceName, activeProjectId]);
 
   const handleNameChange = useCallback(
     (value: string) => {

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -22,7 +22,7 @@ import {
   OptimizationTotalCostCell,
 } from "@/v2/pages/OptimizationsPage/OptimizationMetricCells";
 import Loader from "@/shared/Loader/Loader";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import TimeCell from "@/shared/DataTableCells/TimeCell";
 import { COLUMN_DATASET_ID, COLUMN_TYPE, ColumnData } from "@/types/shared";
 import { Filter } from "@/types/filters";
@@ -161,6 +161,7 @@ const actionsColumn = generateActionsColumDef({
 
 const OptimizationsPage: React.FunctionComponent = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const navigate = useNavigate();
   const resetDialogKeyRef = useRef(0);
   const [openDialog, setOpenDialog] = useState<boolean>(false);
@@ -295,14 +296,15 @@ const OptimizationsPage: React.FunctionComponent = () => {
   const handleRowClick = useCallback(
     (row: Optimization) => {
       navigate({
-        to: "/$workspaceName/optimizations/$optimizationId",
+        to: "/$workspaceName/projects/$projectId/optimizations/$optimizationId",
         params: {
           optimizationId: row.id,
           workspaceName,
+          projectId: activeProjectId!,
         },
       });
     },
-    [navigate, workspaceName],
+    [navigate, workspaceName, activeProjectId],
   );
 
   const handleNewOptimizationClick = useCallback(() => {

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/useActionButtonActions.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/useActionButtonActions.tsx
@@ -25,7 +25,7 @@ import createLogPlaygroundProcessor, {
   TraceMapping,
 } from "@/api/playground/createLogPlaygroundProcessor";
 import usePromptDatasetItemCombination from "@/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/usePromptDatasetItemCombination";
-import { useNavigateToExperiment } from "@/hooks/useNavigateToExperiment";
+import { useNavigateToExperiment } from "@/v2/pages-shared/experiments/useNavigateToExperiment";
 import { useUpdateOutputTraceId } from "@/store/PlaygroundStore";
 
 const DEFAULT_MAX_CONCURRENT_REQUESTS = 5;

--- a/apps/opik-frontend/src/v2/pages/ProjectPage/ProjectPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectPage/ProjectPage.tsx
@@ -3,11 +3,18 @@ import last from "lodash/last";
 import { Navigate, Outlet, useLocation } from "@tanstack/react-router";
 import useProjectById from "@/api/projects/useProjectById";
 import useBreadcrumbsStore from "@/store/BreadcrumbsStore";
+import useAppStore from "@/store/AppStore";
 import { useProjectIdFromURL } from "@/hooks/useProjectIdFromURL";
 
 const ProjectPage = () => {
   const setBreadcrumbParam = useBreadcrumbsStore((state) => state.setParam);
   const projectId = useProjectIdFromURL();
+
+  useEffect(() => {
+    if (useAppStore.getState().activeProjectId !== projectId) {
+      useAppStore.getState().setActiveProjectId(projectId);
+    }
+  }, [projectId]);
 
   const { data } = useProjectById({
     projectId,

--- a/apps/opik-frontend/src/v2/pages/PromptPage/ImproveInPlaygroundButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/ImproveInPlaygroundButton.tsx
@@ -5,7 +5,7 @@ import { PromptWithLatestVersion, PromptVersion } from "@/types/prompts";
 import { Button } from "@/ui/button";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import useLoadPlayground from "@/hooks/useLoadPlayground";
+import useLoadPlayground from "@/v2/pages-shared/playground/useLoadPlayground";
 import { parsePromptVersionContent } from "@/lib/llm";
 
 type ImproveInPlaygroundButtonProps = {

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptPage.tsx
@@ -3,7 +3,7 @@ import { StringParam, useQueryParam } from "use-query-params";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/ui/tabs";
 import useBreadcrumbsStore from "@/store/BreadcrumbsStore";
-import { usePromptIdFromURL } from "@/hooks/usePromptIdFromURL";
+import { usePromptIdFromURL } from "@/v2/pages/PromptPage/usePromptIdFromURL";
 import usePromptById from "@/api/prompts/usePromptById";
 import DateTag from "@/shared/DateTag/DateTag";
 import PromptTab from "@/v2/pages/PromptPage/PromptTab/PromptTab";

--- a/apps/opik-frontend/src/v2/pages/PromptPage/TryInPlaygroundButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/TryInPlaygroundButton.tsx
@@ -4,7 +4,7 @@ import { Play } from "lucide-react";
 import { PromptWithLatestVersion, PromptVersion } from "@/types/prompts";
 import { Button } from "@/ui/button";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
-import useLoadPlayground from "@/hooks/useLoadPlayground";
+import useLoadPlayground from "@/v2/pages-shared/playground/useLoadPlayground";
 import { parsePromptVersionContent } from "@/lib/llm";
 
 type TryInPlaygroundButtonProps = {

--- a/apps/opik-frontend/src/v2/pages/PromptPage/usePromptIdFromURL.ts
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/usePromptIdFromURL.ts
@@ -1,0 +1,8 @@
+import { useParams } from "@tanstack/react-router";
+
+export const usePromptIdFromURL = () => {
+  return useParams({
+    select: (params) => params["promptId"],
+    from: "/workspaceGuard/$workspaceName/projects/$projectId/prompts/$promptId",
+  });
+};

--- a/apps/opik-frontend/src/v2/pages/PromptsPage/AddEditPromptDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptsPage/AddEditPromptDialog.tsx
@@ -36,7 +36,7 @@ import usePromptUpdateMutation from "@/api/prompts/usePromptUpdateMutation";
 import { isValidJsonObject, safelyParseJSON } from "@/lib/utils";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
 import { useBooleanTimeoutState } from "@/hooks/useBooleanTimeoutState";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
 import { useMessageContent } from "@/hooks/useMessageContent";
@@ -55,6 +55,7 @@ const AddEditPromptDialog: React.FC<AddPromptDialogProps> = ({
   prompt: defaultPrompt,
 }) => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const navigate = useNavigate();
   const [name, setName] = useState(defaultPrompt?.name || "");
   const [template, setTemplate] = useState("");
@@ -111,14 +112,15 @@ const AddEditPromptDialog: React.FC<AddPromptDialogProps> = ({
       if (!prompt.id) return;
 
       navigate({
-        to: "/$workspaceName/prompts/$promptId",
+        to: "/$workspaceName/projects/$projectId/prompts/$promptId",
         params: {
           promptId: prompt.id,
           workspaceName,
+          projectId: activeProjectId!,
         },
       });
     },
-    [workspaceName, navigate],
+    [workspaceName, activeProjectId, navigate],
   );
 
   const createPrompt = () => {

--- a/apps/opik-frontend/src/v2/pages/PromptsPage/PromptsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptsPage/PromptsPage.tsx
@@ -12,7 +12,7 @@ import ListCell from "@/shared/DataTableCells/ListCell";
 import Loader from "@/shared/Loader/Loader";
 import { Button } from "@/ui/button";
 import { Separator } from "@/ui/separator";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import TimeCell from "@/shared/DataTableCells/TimeCell";
 import {
@@ -196,6 +196,7 @@ const DEFAULT_COLUMNS_ORDER: string[] = [
 const PromptsPage: React.FunctionComponent = () => {
   const navigate = useNavigate();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
 
   const resetDialogKeyRef = useRef(0);
   const [openDialog, setOpenDialog] = useState<boolean>(false);
@@ -315,14 +316,15 @@ const PromptsPage: React.FunctionComponent = () => {
   const handleRowClick = useCallback(
     (row: Prompt) => {
       navigate({
-        to: "/$workspaceName/prompts/$promptId",
+        to: "/$workspaceName/projects/$projectId/prompts/$promptId",
         params: {
           promptId: row.id,
           workspaceName,
+          projectId: activeProjectId!,
         },
       });
     },
-    [navigate, workspaceName],
+    [navigate, workspaceName, activeProjectId],
   );
 
   const handleNewPromptClick = useCallback(() => {

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/ReturnToAnnotationQueueButton.test.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/ReturnToAnnotationQueueButton.test.tsx
@@ -26,11 +26,16 @@ vi.mock("@/hooks/useNavigationBlocker", () => ({
 
 interface AppStoreState {
   activeWorkspaceName: string;
+  activeProjectId: string;
 }
 
 vi.mock("@/store/AppStore", () => ({
   default: (selector: (state: AppStoreState) => string) =>
-    selector({ activeWorkspaceName: "test-workspace" }),
+    selector({
+      activeWorkspaceName: "test-workspace",
+      activeProjectId: "test-project-id",
+    }),
+  useActiveProjectId: () => "test-project-id",
 }));
 
 interface MockLinkProps {
@@ -72,9 +77,10 @@ describe("ReturnToAnnotationQueueButton", () => {
 
     expect(mockLink).toHaveBeenCalledWith(
       expect.objectContaining({
-        to: "/$workspaceName/annotation-queues/$annotationQueueId",
+        to: "/$workspaceName/projects/$projectId/annotation-queues/$annotationQueueId",
         params: {
           workspaceName: "test-workspace",
+          projectId: "test-project-id",
           annotationQueueId: "queue-123",
         },
       }),

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/ReturnToAnnotationQueueButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/ReturnToAnnotationQueueButton.tsx
@@ -2,12 +2,13 @@ import React, { useMemo } from "react";
 import { ArrowLeft } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { Button } from "@/ui/button";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { useSMEFlow } from "./SMEFlowContext";
 import useNavigationBlocker from "@/hooks/useNavigationBlocker";
 
 const ReturnToAnnotationQueueButton: React.FC = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const { annotationQueue, hasAnyUnsavedChanges } = useSMEFlow();
 
   const queueId = annotationQueue?.id || "";
@@ -29,8 +30,12 @@ const ReturnToAnnotationQueueButton: React.FC = () => {
   return (
     <>
       <Link
-        to="/$workspaceName/annotation-queues/$annotationQueueId"
-        params={{ workspaceName, annotationQueueId: queueId }}
+        to="/$workspaceName/projects/$projectId/annotation-queues/$annotationQueueId"
+        params={{
+          workspaceName,
+          projectId: activeProjectId!,
+          annotationQueueId: queueId,
+        }}
       >
         <Button variant="ghost" aria-label="Return to annotation queue">
           <ArrowLeft className="mr-2 size-4" />

--- a/apps/opik-frontend/src/v2/pages/TracesPage/AnnotationQueuesTab/AnnotationQueuesTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/TracesPage/AnnotationQueuesTab/AnnotationQueuesTab.tsx
@@ -49,7 +49,7 @@ import {
   getRowId,
 } from "@/shared/DataTable/utils";
 import useAnnotationQueuesList from "@/api/annotation-queues/useAnnotationQueuesList";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { usePermissions } from "@/contexts/PermissionsContext";
 
 import {
@@ -217,6 +217,7 @@ const AnnotationQueuesTab: React.FC<AnnotationQueuesTabProps> = ({
   projectId,
 }) => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const navigate = useNavigate();
   const resetDialogKeyRef = useRef(0);
   const [openDialog, setOpenDialog] = useState<boolean>(false);
@@ -316,14 +317,15 @@ const AnnotationQueuesTab: React.FC<AnnotationQueuesTabProps> = ({
   const handleRowClick = useCallback(
     (queue: AnnotationQueue) => {
       navigate({
-        to: "/$workspaceName/annotation-queues/$annotationQueueId",
+        to: "/$workspaceName/projects/$projectId/annotation-queues/$annotationQueueId",
         params: {
           workspaceName,
+          projectId: activeProjectId!,
           annotationQueueId: queue.id,
         },
       });
     },
-    [navigate, workspaceName],
+    [navigate, workspaceName, activeProjectId],
   );
 
   const columns = useMemo(() => {

--- a/apps/opik-frontend/src/v2/pages/TrialPage/TrialPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/TrialPage/TrialPage.tsx
@@ -37,7 +37,7 @@ const TrialPage: React.FunctionComponent = () => {
 
   const { optimizationId } = useParams({
     select: (params) => params,
-    from: "/workspaceGuard/$workspaceName/optimizations/$optimizationId/trials",
+    from: "/workspaceGuard/$workspaceName/projects/$projectId/optimizations/$optimizationId/trials",
   });
 
   const response = useExperimentsByIds({

--- a/apps/opik-frontend/src/v2/redirect/V1CompatRedirect.tsx
+++ b/apps/opik-frontend/src/v2/redirect/V1CompatRedirect.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from "react";
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { useActiveWorkspaceName, useActiveProjectId } from "@/store/AppStore";
+import Loader from "@/shared/Loader/Loader";
+
+const FALLBACK_TIMEOUT_MS = 3000;
+
+type V1CompatRedirectProps = {
+  toPath: string;
+};
+
+const V1CompatRedirect = ({ toPath }: V1CompatRedirectProps) => {
+  const workspaceName = useActiveWorkspaceName();
+  const activeProjectId = useActiveProjectId();
+  const navigate = useNavigate();
+  const params = useParams({ strict: false });
+  const splat = (params as Record<string, string>)["_splat"] ?? "";
+  const fallbackFired = useRef(false);
+
+  useEffect(() => {
+    if (activeProjectId) {
+      const suffix = splat ? `/${splat}` : "";
+      const target = `/${workspaceName}/projects/${activeProjectId}${toPath}${suffix}`;
+      navigate({ to: target, replace: true });
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (!fallbackFired.current) {
+        fallbackFired.current = true;
+        navigate({
+          to: "/$workspaceName/projects",
+          params: { workspaceName },
+          replace: true,
+        });
+      }
+    }, FALLBACK_TIMEOUT_MS);
+
+    return () => clearTimeout(timer);
+  }, [activeProjectId, workspaceName, toPath, splat, navigate]);
+
+  return <Loader />;
+};
+
+export default V1CompatRedirect;

--- a/apps/opik-frontend/src/v2/redirect/v1RedirectConfig.tsx
+++ b/apps/opik-frontend/src/v2/redirect/v1RedirectConfig.tsx
@@ -1,0 +1,61 @@
+// TODO: These splat-based redirects only handle URL navigation (bookmarks, external links).
+// Additional migration is still needed:
+//
+//    Traces page tab→route redirects: v1 used query params for tabs on the traces page
+//    (e.g. /$ws/projects/$pid/traces?tab=annotation-queues). In v2, those tabs became
+//    separate routes (/$ws/projects/$pid/annotation-queues). Old bookmarked URLs with
+//    ?tab= params need to redirect to the corresponding project-scoped routes.
+
+import { createRoute, type AnyRoute } from "@tanstack/react-router";
+import V1CompatRedirect from "@/v2/redirect/V1CompatRedirect";
+
+type V1RedirectEntry = {
+  from: string;
+  to: string;
+  catchAll?: boolean;
+};
+
+const V1_REDIRECT_PATHS: V1RedirectEntry[] = [
+  { from: "/experiments", to: "/experiments", catchAll: true },
+  { from: "/evaluation-suites", to: "/evaluation-suites", catchAll: true },
+  { from: "/datasets", to: "/evaluation-suites", catchAll: true },
+  { from: "/prompts", to: "/prompts", catchAll: true },
+  { from: "/playground", to: "/playground" },
+  { from: "/optimizations", to: "/optimizations", catchAll: true },
+  { from: "/online-evaluation", to: "/online-evaluation" },
+  { from: "/annotation-queues", to: "/annotation-queues", catchAll: true },
+  { from: "/alerts", to: "/alerts", catchAll: true },
+];
+
+export function createV1RedirectRoutes(parentRoute: AnyRoute) {
+  return V1_REDIRECT_PATHS.map(({ from, to, catchAll }) => {
+    const component = () => <V1CompatRedirect toPath={to} />;
+
+    if (!catchAll) {
+      return createRoute({
+        path: from,
+        getParentRoute: () => parentRoute,
+        component,
+      });
+    }
+
+    const base = createRoute({
+      path: from,
+      getParentRoute: () => parentRoute,
+    });
+
+    const indexRoute = createRoute({
+      path: "/",
+      getParentRoute: () => base,
+      component,
+    });
+
+    const splatRoute = createRoute({
+      path: "$",
+      getParentRoute: () => base,
+      component,
+    });
+
+    return base.addChildren([indexRoute, splatRoute]);
+  });
+}

--- a/apps/opik-frontend/src/v2/router.tsx
+++ b/apps/opik-frontend/src/v2/router.tsx
@@ -10,7 +10,6 @@ import {
 
 import WorkspaceGuard from "@/v2/layout/WorkspaceGuard/WorkspaceGuard";
 import ExperimentsPageGuard from "@/v2/layout/ExperimentsPageGuard";
-import DatasetsPageGuard from "@/v2/layout/DatasetsPageGuard";
 import DashboardsPageGuard from "@/v2/layout/DashboardsPageGuard";
 import SMEPageLayout from "@/v2/layout/SMEPageLayout/SMEPageLayout";
 import ExperimentsPage from "@/v2/pages/ExperimentsPage/ExperimentsPage";
@@ -27,6 +26,7 @@ import PromptsPage from "@/v2/pages/PromptsPage/PromptsPage";
 import PromptPage from "@/v2/pages/PromptPage/PromptPage";
 import RedirectProjects from "@/v2/redirect/RedirectProjects";
 import RedirectDatasets from "@/v2/redirect/RedirectDatasets";
+import { createV1RedirectRoutes } from "@/v2/redirect/v1RedirectConfig";
 import PlaygroundPage from "@/v2/pages/PlaygroundPage/PlaygroundPage";
 import useAppStore from "@/store/AppStore";
 import ConfigurationPage from "@/v2/pages/ConfigurationPage/ConfigurationPage";
@@ -92,6 +92,7 @@ const workspaceGuardEmptyLayoutRoute = createRoute({
   component: () => <WorkspaceGuard Layout={EmptyPageLayout} />,
 });
 
+// ----------- base redirect
 const baseRoute = createRoute({
   path: "/",
   getParentRoute: () => workspaceGuardRoute,
@@ -101,6 +102,25 @@ const baseRoute = createRoute({
       params={{ workspaceName: useAppStore.getState().activeWorkspaceName }}
     />
   ),
+});
+
+// ----------- home
+const homeRoute = createRoute({
+  path: "/$workspaceName/home",
+  getParentRoute: () => workspaceGuardRoute,
+  component: OldHomePage,
+  staticData: {
+    title: "Home",
+  },
+});
+
+const homeRouteNew = createRoute({
+  path: "/$workspaceName/home-new",
+  getParentRoute: () => workspaceGuardRoute,
+  component: HomePage,
+  staticData: {
+    title: "Home",
+  },
 });
 
 const workspaceRoute = createRoute({
@@ -131,52 +151,11 @@ const getStartedRoute = createRoute({
   },
 });
 
-// ----------- home
-// TODO temporary revert of old implementation, should be removed in the future
-const homeRoute = createRoute({
-  path: "/$workspaceName/home",
-  getParentRoute: () => workspaceGuardRoute,
-  component: OldHomePage,
-  staticData: {
-    title: "Home",
-  },
-});
+// ═══════════════════════════════════════════════════════════════
+// PROJECTS (workspace-level management + project-scoped routes)
+// /$workspaceName/projects/...
+// ═══════════════════════════════════════════════════════════════
 
-const homeRouteNew = createRoute({
-  path: "/$workspaceName/home-new",
-  getParentRoute: () => workspaceGuardRoute,
-  component: HomePage,
-  staticData: {
-    title: "Home",
-  },
-});
-
-// ----------- dashboards
-const dashboardsRoute = createRoute({
-  path: "/dashboards",
-  getParentRoute: () => workspaceRoute,
-  component: DashboardsPageGuard,
-  staticData: {
-    title: "Dashboards",
-  },
-});
-
-const dashboardsPageRoute = createRoute({
-  path: "/",
-  getParentRoute: () => dashboardsRoute,
-  component: DashboardsPage,
-});
-
-const dashboardDetailRoute = createRoute({
-  path: "/$dashboardId",
-  getParentRoute: () => dashboardsRoute,
-  component: DashboardPage,
-  staticData: {
-    param: "dashboardId",
-  },
-});
-
-// ----------- projects
 const projectsRoute = createRoute({
   path: "/projects",
   getParentRoute: () => workspaceRoute,
@@ -191,7 +170,7 @@ const projectsListRoute = createRoute({
   component: ProjectsPage,
 });
 
-const projectRoute = createRoute({
+const projectScopedRoute = createRoute({
   path: "/$projectId",
   getParentRoute: () => projectsRoute,
   component: ProjectPage,
@@ -200,16 +179,17 @@ const projectRoute = createRoute({
   },
 });
 
+// ----------- traces (project-scoped)
 const tracesRoute = createRoute({
   path: "/traces",
-  getParentRoute: () => projectRoute,
+  getParentRoute: () => projectScopedRoute,
   component: TracesPage,
 });
 
-// ----------- experiments
+// ----------- experiments (project-scoped)
 const experimentsRoute = createRoute({
   path: "/experiments",
-  getParentRoute: () => workspaceRoute,
+  getParentRoute: () => projectScopedRoute,
   component: ExperimentsPageGuard,
   staticData: {
     title: "Experiments",
@@ -232,10 +212,74 @@ const compareExperimentsRoute = createRoute({
   },
 });
 
-// Optimization studio
+// ----------- evaluation suites (project-scoped)
+const evaluationSuitesRoute = createRoute({
+  path: "/evaluation-suites",
+  getParentRoute: () => projectScopedRoute,
+  staticData: {
+    title: "Datasets",
+  },
+});
+
+const evaluationSuitesListRoute = createRoute({
+  path: "/",
+  getParentRoute: () => evaluationSuitesRoute,
+  component: EvaluationSuitesPage,
+});
+
+const evaluationSuiteRoute = createRoute({
+  path: "/$suiteId",
+  getParentRoute: () => evaluationSuitesRoute,
+  component: EvaluationSuitePage,
+  staticData: {
+    param: "suiteId",
+  },
+});
+
+const evaluationSuiteItemsRoute = createRoute({
+  path: "/items",
+  getParentRoute: () => evaluationSuiteRoute,
+  component: EvaluationSuiteItemsPage,
+});
+
+// ----------- prompts (project-scoped)
+const promptsRoute = createRoute({
+  path: "/prompts",
+  getParentRoute: () => projectScopedRoute,
+  staticData: {
+    title: "Prompt library",
+  },
+});
+
+const promptsListRoute = createRoute({
+  path: "/",
+  getParentRoute: () => promptsRoute,
+  component: PromptsPage,
+});
+
+const promptRoute = createRoute({
+  path: "/$promptId",
+  getParentRoute: () => promptsRoute,
+  component: PromptPage,
+  staticData: {
+    param: "promptId",
+  },
+});
+
+// ----------- playground (project-scoped)
+const playgroundRoute = createRoute({
+  path: "/playground",
+  getParentRoute: () => projectScopedRoute,
+  staticData: {
+    title: "Playground",
+  },
+  component: PlaygroundPage,
+});
+
+// ----------- optimizations (project-scoped)
 const optimizationsRoute = createRoute({
   path: "/optimizations",
-  getParentRoute: () => workspaceRoute,
+  getParentRoute: () => projectScopedRoute,
   staticData: {
     title: "Optimization studio",
   },
@@ -287,118 +331,111 @@ const trialRoute = createRoute({
   },
 });
 
-// ----------- evaluation suites
-const evaluationSuitesRoute = createRoute({
-  path: "/evaluation-suites",
+// ----------- online evaluation (project-scoped)
+const onlineEvaluationRoute = createRoute({
+  path: "/online-evaluation",
+  getParentRoute: () => projectScopedRoute,
+  staticData: {
+    title: "Online evaluation",
+  },
+  component: OnlineEvaluationPage,
+});
+
+// ----------- annotation queues (project-scoped)
+const annotationQueuesRoute = createRoute({
+  path: "/annotation-queues",
+  getParentRoute: () => projectScopedRoute,
+  staticData: {
+    title: "Annotation queues",
+  },
+});
+
+const annotationQueuesListRoute = createRoute({
+  path: "/",
+  getParentRoute: () => annotationQueuesRoute,
+  component: AnnotationQueuesPage,
+});
+
+const annotationQueueDetailsRoute = createRoute({
+  path: "/$annotationQueueId",
+  getParentRoute: () => annotationQueuesRoute,
+  component: AnnotationQueuePage,
+  staticData: {
+    param: "annotationQueueId",
+  },
+});
+
+// ----------- alerts (project-scoped)
+const alertsRoute = createRoute({
+  path: "/alerts",
+  getParentRoute: () => projectScopedRoute,
+  staticData: {
+    title: "Alerts",
+  },
+  component: AlertsRouteWrapper,
+});
+
+const alertNewRoute = createRoute({
+  path: "/new",
+  getParentRoute: () => alertsRoute,
+  staticData: {
+    title: "New alert",
+  },
+  component: AlertEditPageGuard,
+});
+
+const alertEditRoute = createRoute({
+  path: "/$alertId",
+  getParentRoute: () => alertsRoute,
+  staticData: {
+    param: "alertId",
+  },
+  component: AlertEditPageGuard,
+});
+
+// ═══════════════════════════════════════════════════════════════
+// WORKSPACE-LEVEL ROUTES (stay at workspace level)
+// ═══════════════════════════════════════════════════════════════
+
+// ----------- dashboards (workspace-level)
+const dashboardsRoute = createRoute({
+  path: "/dashboards",
+  getParentRoute: () => workspaceRoute,
+  component: DashboardsPageGuard,
+  staticData: {
+    title: "Dashboards",
+  },
+});
+
+const dashboardsPageRoute = createRoute({
+  path: "/",
+  getParentRoute: () => dashboardsRoute,
+  component: DashboardsPage,
+});
+
+const dashboardDetailRoute = createRoute({
+  path: "/$dashboardId",
+  getParentRoute: () => dashboardsRoute,
+  component: DashboardPage,
+  staticData: {
+    param: "dashboardId",
+  },
+});
+
+// ----------- configuration (workspace-level)
+const configurationRoute = createRoute({
+  path: "/configuration",
   getParentRoute: () => workspaceRoute,
   staticData: {
-    title: "Datasets",
+    title: "Configuration",
   },
+  component: ConfigurationPage,
 });
 
-const evaluationSuitesListRoute = createRoute({
-  path: "/",
-  getParentRoute: () => evaluationSuitesRoute,
-  component: EvaluationSuitesPage,
-});
+// ═══════════════════════════════════════════════════════════════
+// SDK REDIRECT ROUTES
+// ═══════════════════════════════════════════════════════════════
 
-const evaluationSuiteRoute = createRoute({
-  path: "/$suiteId",
-  getParentRoute: () => evaluationSuitesRoute,
-  component: EvaluationSuitePage,
-  staticData: {
-    param: "suiteId",
-  },
-});
-
-const evaluationSuiteItemsRoute = createRoute({
-  path: "/items",
-  getParentRoute: () => evaluationSuiteRoute,
-  component: EvaluationSuiteItemsPage,
-});
-
-// ----------- datasets (legacy redirects)
-const datasetsRoute = createRoute({
-  path: "/datasets",
-  component: DatasetsPageGuard,
-  getParentRoute: () => workspaceRoute,
-});
-
-const datasetsListRoute = createRoute({
-  path: "/",
-  getParentRoute: () => datasetsRoute,
-  component: () => (
-    <Navigate
-      to="/$workspaceName/evaluation-suites"
-      params={{ workspaceName: useAppStore.getState().activeWorkspaceName }}
-    />
-  ),
-});
-
-const datasetRoute = createRoute({
-  path: "/$datasetId",
-  getParentRoute: () => datasetsRoute,
-});
-
-const datasetRedirectRoute = createRoute({
-  path: "/",
-  getParentRoute: () => datasetRoute,
-  component: () => {
-    const { datasetId } = datasetRoute.useParams();
-    return (
-      <Navigate
-        to="/$workspaceName/evaluation-suites/$suiteId"
-        params={{
-          workspaceName: useAppStore.getState().activeWorkspaceName,
-          suiteId: datasetId,
-        }}
-      />
-    );
-  },
-});
-
-const datasetItemsRoute = createRoute({
-  path: "/items",
-  getParentRoute: () => datasetRoute,
-  component: () => {
-    const { datasetId } = datasetRoute.useParams();
-    return (
-      <Navigate
-        to="/$workspaceName/evaluation-suites/$suiteId/items"
-        params={{
-          workspaceName: useAppStore.getState().activeWorkspaceName,
-          suiteId: datasetId,
-        }}
-      />
-    );
-  },
-});
-
-// ----------- prompts
-const promptsRoute = createRoute({
-  path: "/prompts",
-  getParentRoute: () => workspaceRoute,
-  staticData: {
-    title: "Prompt library",
-  },
-});
-
-const promptsListRoute = createRoute({
-  path: "/",
-  getParentRoute: () => promptsRoute,
-  component: PromptsPage,
-});
-
-const promptRoute = createRoute({
-  path: "/$promptId",
-  getParentRoute: () => promptsRoute,
-  component: PromptPage,
-  staticData: {
-    param: "promptId",
-  },
-});
-
-// ----------- redirect
 const redirectRoute = createRoute({
   path: "/redirect",
   getParentRoute: () => workspaceRoute,
@@ -429,96 +466,22 @@ const homeSMERoute = createRoute({
   component: lazy(() => import("@/v2/pages/SMEFlowPage/SMEFlowPage")),
 });
 
-// --------- playground
-
-const playgroundRoute = createRoute({
-  path: "/playground",
-  getParentRoute: () => workspaceRoute,
-  staticData: {
-    title: "Playground",
-  },
-  component: PlaygroundPage,
-});
-
-// --------- configuration
-
-const configurationRoute = createRoute({
-  path: "/configuration",
-  getParentRoute: () => workspaceRoute,
-  staticData: {
-    title: "Configuration",
-  },
-  component: ConfigurationPage,
-});
-
-const alertsRoute = createRoute({
-  path: "/alerts",
-  getParentRoute: () => workspaceRoute,
-  staticData: {
-    title: "Alerts",
-  },
-  component: AlertsRouteWrapper,
-});
-
-const alertNewRoute = createRoute({
-  path: "/new",
-  getParentRoute: () => alertsRoute,
-  staticData: {
-    title: "New alert",
-  },
-  component: AlertEditPageGuard,
-});
-
-const alertEditRoute = createRoute({
-  path: "/$alertId",
-  getParentRoute: () => alertsRoute,
-  staticData: {
-    param: "alertId",
-  },
-  component: AlertEditPageGuard,
-});
-
-// --------- production
-
-const onlineEvaluationRoute = createRoute({
-  path: "/online-evaluation",
-  getParentRoute: () => workspaceRoute,
-  staticData: {
-    title: "Online evaluation",
-  },
-  component: OnlineEvaluationPage,
-});
-
-const annotationQueuesRoute = createRoute({
-  path: "/annotation-queues",
-  getParentRoute: () => workspaceRoute,
-  staticData: {
-    title: "Annotation queues",
-  },
-});
-
-const annotationQueuesListRoute = createRoute({
-  path: "/",
-  getParentRoute: () => annotationQueuesRoute,
-  component: AnnotationQueuesPage,
-});
-
-const annotationQueueDetailsRoute = createRoute({
-  path: "/$annotationQueueId",
-  getParentRoute: () => annotationQueuesRoute,
-  component: AnnotationQueuePage,
-  staticData: {
-    param: "annotationQueueId",
-  },
-});
-
 // ----------- Automation logs
-
 const automationLogsRoute = createRoute({
   path: "/$workspaceName/automation-logs",
   getParentRoute: () => workspaceGuardEmptyLayoutRoute,
   component: AutomationLogsPage,
 });
+
+// ═══════════════════════════════════════════════════════════════
+// V1 COMPAT REDIRECTS
+// ═══════════════════════════════════════════════════════════════
+
+const v1RedirectRoutes = createV1RedirectRoutes(workspaceRoute);
+
+// ═══════════════════════════════════════════════════════════════
+// ROUTE TREE
+// ═══════════════════════════════════════════════════════════════
 
 const routeTree = rootRoute.addChildren([
   workspaceGuardEmptyLayoutRoute.addChildren([automationLogsRoute]),
@@ -532,43 +495,49 @@ const routeTree = rootRoute.addChildren([
     homeRoute,
     homeRouteNew,
     workspaceRoute.addChildren([
-      dashboardsRoute.addChildren([dashboardsPageRoute, dashboardDetailRoute]),
+      // Projects: workspace-level list + project-scoped routes
       projectsRoute.addChildren([
         projectsListRoute,
-        projectRoute.addChildren([tracesRoute]),
+        projectScopedRoute.addChildren([
+          tracesRoute,
+          experimentsRoute.addChildren([
+            experimentsListRoute,
+            compareExperimentsRoute,
+          ]),
+          evaluationSuitesRoute.addChildren([
+            evaluationSuitesListRoute,
+            evaluationSuiteRoute.addChildren([evaluationSuiteItemsRoute]),
+          ]),
+          promptsRoute.addChildren([promptsListRoute, promptRoute]),
+          playgroundRoute,
+          optimizationsRoute.addChildren([
+            optimizationsListRoute,
+            optimizationsNewRoute,
+            optimizationCompareRedirectRoute,
+            optimizationBaseRoute.addChildren([optimizationRoute, trialRoute]),
+          ]),
+          onlineEvaluationRoute,
+          annotationQueuesRoute.addChildren([
+            annotationQueuesListRoute,
+            annotationQueueDetailsRoute,
+          ]),
+          alertsRoute.addChildren([alertNewRoute, alertEditRoute]),
+        ]),
       ]),
-      experimentsRoute.addChildren([
-        experimentsListRoute,
-        compareExperimentsRoute,
-      ]),
-      evaluationSuitesRoute.addChildren([
-        evaluationSuitesListRoute,
-        evaluationSuiteRoute.addChildren([evaluationSuiteItemsRoute]),
-      ]),
-      optimizationsRoute.addChildren([
-        optimizationsListRoute,
-        optimizationsNewRoute,
-        optimizationCompareRedirectRoute,
-        optimizationBaseRoute.addChildren([optimizationRoute, trialRoute]),
-      ]),
-      datasetsRoute.addChildren([
-        datasetsListRoute,
-        datasetRoute.addChildren([datasetRedirectRoute, datasetItemsRoute]),
-      ]),
-      promptsRoute.addChildren([promptsListRoute, promptRoute]),
+
+      // Workspace-level routes
+      dashboardsRoute.addChildren([dashboardsPageRoute, dashboardDetailRoute]),
+      configurationRoute,
+
+      // SDK redirects
       redirectRoute.addChildren([
         homeRedirectRoute,
         redirectProjectsRoute,
         redirectDatasetsRoute,
       ]),
-      playgroundRoute,
-      configurationRoute,
-      alertsRoute.addChildren([alertNewRoute, alertEditRoute]),
-      onlineEvaluationRoute,
-      annotationQueuesRoute.addChildren([
-        annotationQueuesListRoute,
-        annotationQueueDetailsRoute,
-      ]),
+
+      // V1 compat redirects (workspace-level → project-scoped)
+      ...v1RedirectRoutes,
     ]),
   ]),
 ]);


### PR DESCRIPTION
## Details

Implements the v2 sidebar with project-first navigation as part of the IA Revamp (OPIK-4617). This PR restructures the v2 route tree to be project-scoped, adds a project selector to the sidebar, and updates all internal navigation to use project-scoped paths.

Key changes:
- **Route tree**: All feature routes moved under `/$ws/projects/$projectId/...` (experiments, prompts, optimizations, etc.)
- **Active project**: `activeProjectId` stored in AppStore, synced from URL in ProjectPage and from localStorage fallback
- **Sidebar**: New layout with project selector dropdown, grouped menu sections (Observability, Evaluation, Prompt engineering, Optimization, Production), workspace section at bottom
- **V1 compat redirects**: Splat-based redirects catch old workspace-level URLs and redirect to project-scoped equivalents
- **Internal links**: ~40 navigate()/Link references updated to project-scoped paths, shared hooks duplicated for v2 with correct route patterns
- **ResourceLink**: Added `projectUrl` field for version-aware URL resolution (v1 uses `url`, v2 uses `projectUrl` when activeProjectId exists)
- **SupportHub**: Moved from sidebar to TopBar

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-4964

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: Full implementation
- Human verification: Code review + manual testing of all navigation paths

## Testing

- `scripts/dev-runner.sh --lint-fe` — lint, typecheck, and dependency validation all pass with zero new violations
- Manual testing: sidebar navigation, project selector, route redirects, internal link navigation
- Verified v1 routes remain unaffected (shared ResourceLink falls back to workspace-level URLs when no activeProjectId)

## Documentation

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)