### PR TITLE
[OPIK-5211] [BE] Add project_id filter field and minmax index for optimizations

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/filter/OptimizationField.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/filter/OptimizationField.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum OptimizationField implements Field {
     METADATA(METADATA_QUERY_PARAM, FieldType.DICTIONARY),
     DATASET_ID(DATASET_ID_QUERY_PARAM, FieldType.STRING_EXACT),
+    PROJECT_ID(PROJECT_ID_QUERY_PARAM, FieldType.STRING_EXACT),
     STATUS(STATUS_QUERY_PARAM, FieldType.ENUM),
     ;
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -378,6 +378,7 @@ public class FilterQueryBuilder {
             ImmutableMap.<OptimizationField, String>builder()
                     .put(OptimizationField.METADATA, METADATA_ANALYTICS_DB)
                     .put(OptimizationField.DATASET_ID, DATASET_ID_ANALYTICS_DB)
+                    .put(OptimizationField.PROJECT_ID, PROJECT_ID_DB)
                     .put(OptimizationField.STATUS, STATUS_DB)
                     .build());
 
@@ -712,6 +713,7 @@ public class FilterQueryBuilder {
         map.put(FilterStrategy.OPTIMIZATION, Set.of(
                 OptimizationField.METADATA,
                 OptimizationField.DATASET_ID,
+                OptimizationField.PROJECT_ID,
                 OptimizationField.STATUS));
 
         map.put(FilterStrategy.DASHBOARD, Set.of(

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000075_add_minmax_index_optimizations_project_id.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000075_add_minmax_index_optimizations_project_id.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+--changeset thiaghora:000075_add_minmax_index_optimizations_project_id
+--comment: Add minmax index on project_id in optimizations table for efficient granule skipping
+
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.optimizations ON CLUSTER '{cluster}'
+    ADD INDEX IF NOT EXISTS idx_optimizations_project_id project_id TYPE minmax GRANULARITY 1;
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.optimizations ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_optimizations_project_id;
+

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
@@ -1672,6 +1672,52 @@ class OptimizationsResourceTest {
             assertThat(afterCompletedCompletedPage.content().get(0).id()).isEqualTo(optId);
             assertThat(afterCompletedCompletedPage.content().get(0).status()).isEqualTo(OptimizationStatus.COMPLETED);
         }
+
+        @Test
+        @DisplayName("Filter optimizations by project_id")
+        void filterOptimizationsByProjectId() {
+            // Create isolated workspace for this test
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            // Create two projects
+            String project1Name = "project-" + UUID.randomUUID();
+            String project2Name = "project-" + UUID.randomUUID();
+            var project1Id = projectResourceClient.createProject(project1Name, apiKey, workspaceName);
+            var project2Id = projectResourceClient.createProject(project2Name, apiKey, workspaceName);
+
+            // Create one optimization per project using projectName
+            var opt1 = optimizationResourceClient.createPartialOptimization()
+                    .projectName(project1Name)
+                    .projectId(null)
+                    .build();
+            var opt2 = optimizationResourceClient.createPartialOptimization()
+                    .projectName(project2Name)
+                    .projectId(null)
+                    .build();
+
+            var opt1Id = optimizationResourceClient.create(opt1, apiKey, workspaceName);
+            var opt2Id = optimizationResourceClient.create(opt2, apiKey, workspaceName);
+
+            // Verify project_id was set on the stored optimization
+            var actualOpt1 = optimizationResourceClient.get(opt1Id, apiKey, workspaceName, 200);
+            assertThat(actualOpt1.projectId()).isEqualTo(project1Id);
+
+            // Filter by project1Id
+            var filter = OptimizationFilter.builder()
+                    .field(OptimizationField.PROJECT_ID)
+                    .operator(Operator.EQUAL)
+                    .value(project1Id.toString())
+                    .build();
+
+            var page = optimizationResourceClient.find(apiKey, workspaceName, 1, 10,
+                    null, null, null, List.of(filter), 200);
+
+            assertThat(page.content()).containsExactly(actualOpt1);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Details

Follow-up items for optimizations project scoping (OPIK-5211):

- **ClickHouse minmax index**: Added migration `000075_add_minmax_index_optimizations_project_id.sql` that adds a `minmax` index on `project_id` in the `optimizations` table, enabling efficient granule skipping for project-scoped queries
- **`PROJECT_ID` filter field**: Added `PROJECT_ID` to `OptimizationField` enum with `FieldType.STRING_EXACT` (case-sensitive, no unnecessary `lower()` wrapping). Wired it up in `FilterQueryBuilder` in both the `OPTIMIZATION_FIELDS_MAP` (column name mapping) and the `FilterStrategy.OPTIMIZATION` allowed-fields set so the filter is actually applied in ClickHouse queries
- **Integration test**: Added `filterOptimizationsByProjectId` test in `OptimizationsResourceTest` that verifies filtering works end-to-end, using whole-object comparison with `containsExactly`

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-5211

## Testing

Added integration test `filterOptimizationsByProjectId` in `OptimizationsResourceTest`:
1. Creates two projects and one optimization per project in an isolated workspace
2. Fetches the created optimization to get its full representation
3. Applies a `PROJECT_ID = <project1Id>` filter via the API
4. Asserts the response contains exactly the optimization from project1 (whole-object comparison)

All 44 tests in `OptimizationsResourceTest` passed.

## Documentation

No documentation changes required — this is a backend-only filter field addition and index optimization.