### PR TITLE
[NA][CI] Update official actions versions

### DIFF
--- a/.github/workflows/backend_formatting_check.yml
+++ b/.github/workflows/backend_formatting_check.yml
@@ -22,7 +22,7 @@ jobs:
         working-directory: apps/opik-backend/
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -32,7 +32,7 @@ jobs:
           matrix: ${{ steps.split.outputs.matrix }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4.1.1
+              uses: actions/checkout@v6
               with:
                 fetch-depth: 1
                 sparse-checkout: |
@@ -57,7 +57,7 @@ jobs:
           matrix: ${{ fromJSON(needs.discover-tests.outputs.matrix) }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4.1.1
+              uses: actions/checkout@v6
               with:
                 fetch-depth: 1
 

--- a/.github/workflows/build_and_publish_sdk.yaml
+++ b/.github/workflows/build_and_publish_sdk.yaml
@@ -45,7 +45,7 @@ jobs:
               echo "build_from=${{inputs.version}}" | tee -a $GITHUB_OUTPUT
             fi
         - name: Checkout
-          uses: actions/checkout@v4.1.1
+          uses: actions/checkout@v6
           with:
             ref: ${{steps.setup.outputs.build_from}}
             fetch-tags: true

--- a/.github/workflows/build_and_push_docker.yaml
+++ b/.github/workflows/build_and_push_docker.yaml
@@ -106,7 +106,7 @@ jobs:
           echo "image_name=$IMAGE_NAME" >> $GITHUB_OUTPUT
 
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.build_from }}
 
@@ -171,7 +171,7 @@ jobs:
           echo "$HASH" > "/tmp/digests/${{ steps.set_vars.outputs.image_name }}/${{ matrix.platform }}.digest"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ github.run_id }}-${{ steps.set_vars.outputs.image_name }}-digest-${{ matrix.platform }}
           path: /tmp/digests/${{ steps.set_vars.outputs.image_name }}/${{ matrix.platform }}.digest

--- a/.github/workflows/build_apps.yml
+++ b/.github/workflows/build_apps.yml
@@ -69,7 +69,7 @@ jobs:
         build_from: ${{ steps.version.outputs.build_from }}
     steps:
         - name: Checkout
-          uses: actions/checkout@v4.1.1
+          uses: actions/checkout@v6
           with:
             ref: ${{ inputs.ref || github.ref }}
 
@@ -201,7 +201,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create git tag
         run: |

--- a/.github/workflows/clickhouse_migration_cluster_check.yml
+++ b/.github/workflows/clickhouse_migration_cluster_check.yml
@@ -22,7 +22,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy_python_sdk_docs.yml
+++ b/.github/workflows/deploy_python_sdk_docs.yml
@@ -18,7 +18,7 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:      
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Build Python SDK docs
         run: |

--- a/.github/workflows/documentation_cookbook_tests.yml
+++ b/.github/workflows/documentation_cookbook_tests.yml
@@ -38,7 +38,7 @@ jobs:
       NOTEBOOK_TO_TEST: ${{ matrix.notebooks }}
       OPIK_SENTRY_ENABLE: False
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/documentation_deploy.yml
+++ b/.github/workflows/documentation_deploy.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history for git diff
 

--- a/.github/workflows/documentation_image_optimizer.yml
+++ b/.github/workflows/documentation_image_optimizer.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.2.2
           
       - name: Compress Images
         uses: calibreapp/image-actions@1.1.0

--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -12,7 +12,7 @@ jobs:
         permissions: write-all
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
                 
             - name: Install Fern
               run: npm install -g fern-api@0.64.26

--- a/.github/workflows/e2e_tests_post_merge.yml
+++ b/.github/workflows/e2e_tests_post_merge.yml
@@ -73,7 +73,7 @@ jobs:
       # PHASE 1: Checkout & Environment Setup
       # ========================================
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "🔍 Get PR/commit information"
         id: get-pr-info
@@ -345,7 +345,7 @@ jobs:
       # ========================================
       - name: "📤 Upload Allure results"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: allure-results
           path: tests_end_to_end/typescript-tests/allure-results
@@ -353,7 +353,7 @@ jobs:
 
       - name: "📤 Upload Playwright report"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: tests_end_to_end/typescript-tests/playwright-report
@@ -361,7 +361,7 @@ jobs:
 
       - name: "📤 Upload test results JSON"
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-json
           path: tests_end_to_end/typescript-tests/test-results/results.json

--- a/.github/workflows/end2end_suites_typescript.yml
+++ b/.github/workflows/end2end_suites_typescript.yml
@@ -53,7 +53,7 @@ jobs:
 
         steps:
             - name: Checkout repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -132,7 +132,7 @@ jobs:
 
             - name: Upload Allure Results
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                 name: allure-results
                 path: tests_end_to_end/typescript-tests/allure-results
@@ -140,7 +140,7 @@ jobs:
 
             - name: Upload Playwright Report
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                 name: playwright-report
                 path: tests_end_to_end/typescript-tests/playwright-report

--- a/.github/workflows/frontend_linter.yml
+++ b/.github/workflows/frontend_linter.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: apps/opik-frontend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/frontend_unit_tests.yml
+++ b/.github/workflows/frontend_unit_tests.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.2.2
 
       - name: Set up Node.js
         uses: actions/setup-node@v4.2.0

--- a/.github/workflows/installation_tests.yml
+++ b/.github/workflows/installation_tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 
@@ -110,7 +110,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 
@@ -164,7 +164,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 
@@ -219,7 +219,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/lib-adk-legacy-1-3-0-tests.yml
+++ b/.github/workflows/lib-adk-legacy-1-3-0-tests.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-adk-tests.yml
+++ b/.github/workflows/lib-adk-tests.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-aisuite-tests.yml
+++ b/.github/workflows/lib-aisuite-tests.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-anthropic-tests.yml
+++ b/.github/workflows/lib-anthropic-tests.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-bedrock-tests.yml
+++ b/.github/workflows/lib-bedrock-tests.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-crewai-v0-tests.yml
+++ b/.github/workflows/lib-crewai-v0-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-crewai-v1-tests.yml
+++ b/.github/workflows/lib-crewai-v1-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-dspy-tests.yml
+++ b/.github/workflows/lib-dspy-tests.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-genai-tests.yml
+++ b/.github/workflows/lib-genai-tests.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-guardrails-tests.yml
+++ b/.github/workflows/lib-guardrails-tests.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-harbor-tests.yml
+++ b/.github/workflows/lib-harbor-tests.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-haystack-tests.yml
+++ b/.github/workflows/lib-haystack-tests.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-langchain-legacy-tests.yml
+++ b/.github/workflows/lib-langchain-legacy-tests.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-langchain-tests.yml
+++ b/.github/workflows/lib-langchain-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-litellm-tests.yml
+++ b/.github/workflows/lib-litellm-tests.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-llama-index-tests.yml
+++ b/.github/workflows/lib-llama-index-tests.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-metrics-with-llm-judge-tests.yml
+++ b/.github/workflows/lib-metrics-with-llm-judge-tests.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-openai-tests.yml
+++ b/.github/workflows/lib-openai-tests.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
         uses: actions/setup-python@v5

--- a/.github/workflows/lint_helm_chart.yaml
+++ b/.github/workflows/lint_helm_chart.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
         - name: Checkout
-          uses: actions/checkout@v4.1.1
+          uses: actions/checkout@v6
 
         - name: Run lint on Helm chart
           run: |

--- a/.github/workflows/migration_prefix_check.yml
+++ b/.github/workflows/migration_prefix_check.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch full history to compare with main
       

--- a/.github/workflows/opik-optimizer-e2e-tests.yaml
+++ b/.github/workflows/opik-optimizer-e2e-tests.yaml
@@ -41,7 +41,7 @@ jobs:
                 
         steps:
         - name: Check out code
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
             
         - name: Setup Python ${{matrix.python_version}}
           uses: actions/setup-python@v5
@@ -92,7 +92,7 @@ jobs:
 
         - name: Upload test artifacts on failure
           if: failure()
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           with:
               name: opik-optimizer-e2e-logs-p${{matrix.python_version}}
               path: |
@@ -114,7 +114,7 @@ jobs:
 
         steps:
         - name: Check out code
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
 
         - name: Setup Python 3.12
           uses: actions/setup-python@v5

--- a/.github/workflows/opik-optimizer-linter.yaml
+++ b/.github/workflows/opik-optimizer-linter.yaml
@@ -14,7 +14,7 @@ jobs:
             run:
                 working-directory: sdks/opik_optimizer
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: install pre-commit
               run: pip install pre-commit

--- a/.github/workflows/opik-optimizer-publish.yml
+++ b/.github/workflows/opik-optimizer-publish.yml
@@ -17,7 +17,7 @@ jobs:
           HF_HUB_DISABLE_TELEMETRY: "1"
         steps:
         - name: Checkout
-          uses: actions/checkout@v4.1.1
+          uses: actions/checkout@v6
 
         - name: Set up Python 3.9
           uses: actions/setup-python@v3

--- a/.github/workflows/opik-optimizer-unit-tests.yaml
+++ b/.github/workflows/opik-optimizer-unit-tests.yaml
@@ -39,7 +39,7 @@ jobs:
 
         steps:
         - name: Check out code
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
             
         - name: Setup Python ${{matrix.python_version}}
           uses: actions/setup-python@v5

--- a/.github/workflows/opik_wizard_publish.yml
+++ b/.github/workflows/opik_wizard_publish.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: sdks/typescript/src/opik/configure
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate PR Title, Description, and Commits
         uses: actions/github-script@v7

--- a/.github/workflows/publish_helm_chart.yaml
+++ b/.github/workflows/publish_helm_chart.yaml
@@ -48,7 +48,7 @@ jobs:
             echo "Version validated: $VERSION"
 
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
           with:
             ref: ${{inputs.version}}
             fetch-tags: true
@@ -56,7 +56,7 @@ jobs:
             fetch-depth: 0
 
         - name: Checkout GH Pages branch
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
           with:
             path: 'dest'
             ref: 'gh-pages'

--- a/.github/workflows/python_backend_tests.yml
+++ b/.github/workflows/python_backend_tests.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: apps/opik-python-backend/
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -44,7 +44,7 @@ jobs:
 
         steps:
         - name: Checkout
-          uses: actions/checkout@v4.1.1
+          uses: actions/checkout@v6
             
         - name: Setup Python ${{matrix.python_version}}
           uses: actions/setup-python@v5
@@ -109,7 +109,7 @@ jobs:
 
         - name: Attach BE log
           if: failure()
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           with:
               name: opik-backend-log-p${{matrix.python_version}}
               path: ${{ github.workspace }}/opik-backend_p${{matrix.python_version}}.log

--- a/.github/workflows/python_sdk_linter.yml
+++ b/.github/workflows/python_sdk_linter.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         working-directory: sdks/python
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: install pre-commit
         run: pip install pre-commit
       - name: linting

--- a/.github/workflows/python_sdk_unit_tests.yml
+++ b/.github/workflows/python_sdk_unit_tests.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Print environment variables
         run: env

--- a/.github/workflows/quickstart_guide_snippets_test.yml
+++ b/.github/workflows/quickstart_guide_snippets_test.yml
@@ -21,7 +21,7 @@ jobs:
 
         steps:
             - name: Checkout repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                 ref: ${{ github.ref }}
             

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6
 
       - name: Set version
         id: version
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6
 
       - name: Create git tag
         run: |
@@ -126,7 +126,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/sdk-e2e-library-tests.yaml
+++ b/.github/workflows/sdk-e2e-library-tests.yaml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6
           
       - name: Install uv and set the Python version ${{ matrix.python_version }}
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
+++ b/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/span_cost_upload_daily.yml
+++ b/.github/workflows/span_cost_upload_daily.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set branch name and update the file
         run: |

--- a/.github/workflows/sync_provider_models.yml
+++ b/.github/workflows/sync_provider_models.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test_docs_links.yml
+++ b/.github/workflows/test_docs_links.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/trigger_test_env_on_label.yaml
+++ b/.github/workflows/trigger_test_env_on_label.yaml
@@ -28,7 +28,7 @@ jobs:
       version: ${{ steps.get-tag.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/typescript_sdk_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_e2e_tests.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.2.2
 
       - name: Set up Node.js ${{matrix.node_version}}
         uses: actions/setup-node@v4.2.0
@@ -95,7 +95,7 @@ jobs:
 
       - name: Attach BE log
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: opik-backend-log-node${{matrix.node_version}}
           path: ${{ github.workspace }}/opik-backend_node${{matrix.node_version}}.log

--- a/.github/workflows/typescript_sdk_integration_publish.yml
+++ b/.github/workflows/typescript_sdk_integration_publish.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0

--- a/.github/workflows/typescript_sdk_linter.yml
+++ b/.github/workflows/typescript_sdk_linter.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: sdks/typescript
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.2.2
 
       - name: Set up Node.js
         uses: actions/setup-node@v4.2.0

--- a/.github/workflows/typescript_sdk_publish.yml
+++ b/.github/workflows/typescript_sdk_publish.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0

--- a/.github/workflows/typescript_sdk_unit_tests.yml
+++ b/.github/workflows/typescript_sdk_unit_tests.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.2.2
 
       - name: Set up Node.js
         uses: actions/setup-node@v4.2.0

--- a/.github/workflows/update_helm_readme.yaml
+++ b/.github/workflows/update_helm_readme.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.ref }}
 


### PR DESCRIPTION
## Details
This pull request updates several GitHub Actions workflows to use the latest major versions of key GitHub Actions, primarily upgrading from version 4 to version 6 (or 6.x.x) for `actions/checkout` and from version 4 to version 7 for `actions/upload-artifact`. These updates help ensure better security, performance, and compatibility with the latest features and bug fixes.

**GitHub Actions version upgrades:**

* Upgraded `actions/checkout` from v4 (or v4.x.x) to v6 (or v6.x.x) across all workflow files, including backend, frontend, SDK, documentation, end-to-end, and library test workflows. 

* Upgraded `actions/upload-artifact` from v4 to v7 in workflows that handle artifact uploads, such as Docker builds, end-to-end tests, and documentation. 

These changes are focused on keeping CI/CD infrastructure up-to-date and do not alter application logic or test coverage.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #


## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
<!--
REPLACE ME WITH:

How you tested

Include:
- Exact commands run (for example: `mvn test`, `npm run lint && npm run test`, `pytest ...`)
- Scenarios validated (happy path, edge cases, regressions)
- Environment/context used (local process mode vs Docker, OS/browser when relevant)
- Any tests not run, with reason
- Relevant logs/artifacts links if available

Video evidence:
- External contributors: include a short recording for all contributions where possible.
- Internal contributors: include a short recording for complex changes where possible.
-->

## Documentation
