### PR TITLE
[NA] [CI] Remove daily cron schedule from cookbook tests

### DIFF
--- a/.github/workflows/documentation_cookbook_tests.yml
+++ b/.github/workflows/documentation_cookbook_tests.yml
@@ -10,8 +10,6 @@ on:
         options:
           - 'false'
           - 'true'
-  schedule:
-    - cron: '0 0 * * *'  # Run once a day at midnight UTC
 jobs:
   test-notebooks:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- Removes the daily midnight UTC cron schedule from the `documentation_cookbook_tests` workflow
- The workflow can still be triggered manually via `workflow_dispatch`

## Test plan
- [ ] Verify the workflow no longer runs on a schedule
- [ ] Verify the workflow can still be triggered manually from the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)