### PR TITLE
[OPIK-5239] [FE] fix: preserve query params in V1 compat redirect

### DIFF
--- a/apps/opik-frontend/src/v2/redirect/V1CompatRedirect.tsx
+++ b/apps/opik-frontend/src/v2/redirect/V1CompatRedirect.tsx
@@ -42,7 +42,14 @@ const V1CompatRedirect = ({ toPath }: V1CompatRedirectProps) => {
     }, FALLBACK_TIMEOUT_MS);
 
     return () => clearTimeout(timer);
-  }, [activeProjectId, workspaceName, toPath, splat, navigate, location.search]);
+  }, [
+    activeProjectId,
+    workspaceName,
+    toPath,
+    splat,
+    navigate,
+    location.search,
+  ]);
 
   return <Loader />;
 };


### PR DESCRIPTION
## Details

`V1CompatRedirect` was dropping query params (e.g. `?experiments=["..."]`) when redirecting from V1 workspace-scoped URLs to V2 project-scoped URLs. This caused evaluation suite experiment links from the SDK console to land on an empty compare page showing "Deleted evaluation suite", because `navigate()` only forwarded path segments via splat but discarded search params.

- Pass `location.search` through to `navigate()` so all query params are preserved during redirect.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5239

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: implementation and PR creation
  - Human verification: code review and manual testing

## Testing
Tested manually.
- Open an evaluation suite experiment link from the SDK console output (the V1 redirect URL)
- Verify the compare experiments page loads with the correct experiment data (not empty / "Deleted evaluation suite")
- Verify regular (non-eval-suite) experiment redirect links still work
- Verify other V1 redirects with query params still preserve their params

## Documentation
