### PR TITLE
[NA][CI]Update AWS keys for tests

### DIFF
--- a/.github/workflows/lib-bedrock-tests.yml
+++ b/.github/workflows/lib-bedrock-tests.yml
@@ -54,8 +54,8 @@ jobs:
       - name: change aws role
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.BEDROCK_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.BEDROCK_AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ vars.BEDROCK_ROLE }}
           aws-region: us-east-1
           role-chaining: true

--- a/.github/workflows/lib-crewai-v0-tests.yml
+++ b/.github/workflows/lib-crewai-v0-tests.yml
@@ -11,8 +11,8 @@ env:
   OPENAI_ORG_ID:  ${{ secrets.OPENAI_ORG_ID }}
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   AWS_DEFAULT_REGION: us-east-1
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.BEDROCK_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.BEDROCK_AWS_SECRET_ACCESS_KEY }}
   GCP_CREDENTIALS_JSON: ${{ secrets.GCP_CREDENTIALS_JSON }}
   GOOGLE_CLOUD_LOCATION: us-east1
   GOOGLE_CLOUD_PROJECT: opik-sdk-tests
@@ -62,8 +62,8 @@ jobs:
       - name: Configure AWS credentials for Bedrock
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.BEDROCK_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.BEDROCK_AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ vars.BEDROCK_ROLE }}
           aws-region: us-east-1
           role-chaining: true

--- a/.github/workflows/lib-crewai-v1-tests.yml
+++ b/.github/workflows/lib-crewai-v1-tests.yml
@@ -11,8 +11,8 @@ env:
   OPENAI_ORG_ID:  ${{ secrets.OPENAI_ORG_ID }}
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   AWS_DEFAULT_REGION: us-east-1
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.BEDROCK_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.BEDROCK_AWS_SECRET_ACCESS_KEY }}
   GCP_CREDENTIALS_JSON: ${{ secrets.GCP_CREDENTIALS_JSON }}
   GOOGLE_CLOUD_LOCATION: us-east1
   GOOGLE_CLOUD_PROJECT: opik-sdk-tests
@@ -62,8 +62,8 @@ jobs:
       - name: Configure AWS credentials for Bedrock
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.BEDROCK_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.BEDROCK_AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ vars.BEDROCK_ROLE }}
           aws-region: us-east-1
           role-chaining: true

--- a/.github/workflows/lib-langchain-legacy-tests.yml
+++ b/.github/workflows/lib-langchain-legacy-tests.yml
@@ -15,8 +15,8 @@ env:
   GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   AWS_DEFAULT_REGION: us-east-1
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.BEDROCK_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.BEDROCK_AWS_SECRET_ACCESS_KEY }}
   OPIK_ENABLE_LITELLM_MODELS_MONITORING: False
   OPIK_SENTRY_ENABLE: False
   GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
@@ -63,8 +63,8 @@ jobs:
       - name: change aws role
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.BEDROCK_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.BEDROCK_AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ vars.BEDROCK_ROLE }}
           aws-region: us-east-1
           role-chaining: true

--- a/.github/workflows/lib-langchain-tests.yml
+++ b/.github/workflows/lib-langchain-tests.yml
@@ -15,8 +15,8 @@ env:
   GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   AWS_DEFAULT_REGION: us-east-1
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.BEDROCK_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.BEDROCK_AWS_SECRET_ACCESS_KEY }}
   OPIK_ENABLE_LITELLM_MODELS_MONITORING: False
   OPIK_SENTRY_ENABLE: False
   GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
@@ -62,8 +62,8 @@ jobs:
       - name: change aws role
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.BEDROCK_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.BEDROCK_AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ vars.BEDROCK_ROLE }}
           aws-region: us-east-1
           role-chaining: true

--- a/.github/workflows/quickstart_guide_snippets_test.yml
+++ b/.github/workflows/quickstart_guide_snippets_test.yml
@@ -56,8 +56,8 @@ jobs:
                 OPIK_TEST_WORKSPACE: default
                 OPIK_TEST_PROJECT_NAME: Quickstart
                 OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-                AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                AWS_ACCESS_KEY_ID: ${{ secrets.BEDROCK_AWS_ACCESS_KEY_ID }}
+                AWS_SECRET_ACCESS_KEY: ${{ secrets.BEDROCK_AWS_SECRET_ACCESS_KEY }}
                 ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
               run: |
                 cd ${{ github.workspace }}/tests_end_to_end


### PR DESCRIPTION
## Details
This pull request updates the GitHub Actions workflow configurations to consistently use Bedrock-specific AWS credentials and secrets across all test workflows. It also updates the version of the `actions/checkout` action. These changes help standardize the CI environment and improve security by ensuring that only the intended AWS credentials are used for Bedrock-related tests.

**Credential and Secret Updates:**

* All references to `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` have been replaced with `BEDROCK_AWS_ACCESS_KEY_ID` and `BEDROCK_AWS_SECRET_ACCESS_KEY` in the environment variables and AWS credential configuration steps for the following workflows:
  - `lib-langchain-tests.yml`
  - `lib-langchain-legacy-tests.yml` 
  - `lib-crewai-v0-tests.yml` 
  - `lib-crewai-v1-tests.yml` 
  - `lib-bedrock-tests.yml`
  - `quickstart_guide_snippets_test.yml` 

**Dependency Update:**

* The `actions/checkout` action has been updated from version 4 to version 6 in the `lib-bedrock-tests.yml` workflow for improved security and latest features.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #


## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
<!--
REPLACE ME WITH:

How you tested

Include:
- Exact commands run (for example: `mvn test`, `npm run lint && npm run test`, `pytest ...`)
- Scenarios validated (happy path, edge cases, regressions)
- Environment/context used (local process mode vs Docker, OS/browser when relevant)
- Any tests not run, with reason
- Relevant logs/artifacts links if available

Video evidence:
- External contributors: include a short recording for all contributions where possible.
- Internal contributors: include a short recording for complex changes where possible.
-->

## Documentation
