### PR TITLE
[NA] [BE] fix: add IF NOT EXISTS to non-idempotent ClickHouse migrations

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000001_init_script.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000001_init_script.sql
@@ -98,28 +98,28 @@ CREATE TABLE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME}.experiment_items
     ORDER BY (workspace_id, experiment_id, dataset_item_id, trace_id, id);
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_items
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.feedback_scores
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.dataset_items
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiments
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_items DROP COLUMN created_by, DROP COLUMN last_updated_by;
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans DROP COLUMN created_by, DROP COLUMN last_updated_by;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000003_add_metadata_to_experiments.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000003_add_metadata_to_experiments.sql
@@ -2,6 +2,6 @@
 --changeset andrescrz:add_metadata_to_experiments
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiments
-    ADD COLUMN metadata String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS metadata String DEFAULT '';
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiments DROP COLUMN metadata;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000014_add_thread_id_to_traces.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000014_add_thread_id_to_traces.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 --changeset thiagohora:add_thread_id_to_traces
 
-ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD COLUMN thread_id String;
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD COLUMN IF NOT EXISTS thread_id String;
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces DROP COLUMN IF EXISTS thread_id;


### PR DESCRIPTION
## Summary

- Add `IF NOT EXISTS` guards to `ADD COLUMN` statements in migrations `000001`, `000003`, and `000014`
- Aligns these early migrations with the convention used consistently in all subsequent migration files (`000004`+)

## Motivation

Three early ClickHouse migration files use `ADD COLUMN` without `IF NOT EXISTS`:

| Migration | Statement | Risk |
|-----------|-----------|------|
| `000001_init_script.sql` | 12x `ADD COLUMN` (created_by, last_updated_by on 6 tables) | Fails if columns exist |
| `000003_add_metadata_to_experiments.sql` | `ADD COLUMN metadata` | Fails if column exists |
| `000014_add_thread_id_to_traces.sql` | `ADD COLUMN thread_id` | Fails if column exists |

While Liquibase normally prevents re-execution via `DATABASECHANGELOG` tracking, these non-idempotent statements cause failures when:

- `DATABASECHANGELOG` table is lost or recreated (e.g., disaster recovery)
- Migrations are replayed manually on a pre-existing schema
- Schema is pre-created on managed ClickHouse services before Liquibase runs

All other migration files in the project (`000004`+) already follow the `IF NOT EXISTS` / `IF EXISTS` convention.

## Test plan

- [ ] Verify migrations run successfully on a fresh ClickHouse instance
- [ ] Verify migrations run successfully when replayed on an existing schema (idempotency)
- [ ] Run backend unit tests

## Breaking changes

None. Adding `IF NOT EXISTS` is purely additive — it makes previously failing re-runs succeed without affecting first-run behavior.