### PR TITLE
[issue-5835] [BE] fix: add IF NOT EXISTS to non-idempotent ClickHouse migrations

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000001_init_script.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000001_init_script.sql
@@ -98,28 +98,28 @@ CREATE TABLE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME}.experiment_items
     ORDER BY (workspace_id, experiment_id, dataset_item_id, trace_id, id);
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_items
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.feedback_scores
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.dataset_items
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiments
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_items DROP COLUMN created_by, DROP COLUMN last_updated_by;
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans DROP COLUMN created_by, DROP COLUMN last_updated_by;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000003_add_metadata_to_experiments.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000003_add_metadata_to_experiments.sql
@@ -2,6 +2,6 @@
 --changeset andrescrz:add_metadata_to_experiments
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiments
-    ADD COLUMN metadata String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS metadata String DEFAULT '';
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiments DROP COLUMN metadata;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000014_add_thread_id_to_traces.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000014_add_thread_id_to_traces.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 --changeset thiagohora:add_thread_id_to_traces
 
-ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD COLUMN thread_id String;
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD COLUMN IF NOT EXISTS thread_id String;
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces DROP COLUMN IF EXISTS thread_id;


### PR DESCRIPTION
## Details

Add `IF NOT EXISTS` guards to `ADD COLUMN` statements in ClickHouse migrations
000001, 000003, and 000014 to ensure idempotent execution. These three early
migrations are the only ones missing this guard — all subsequent migrations
(000004+) already follow the `IF NOT EXISTS` convention.

## Change checklist

- [ ] User facing
- [ ] Documentation update

## Issues

Resolves #5835

<!-- AI-WATERMARK:START -->
AI-WATERMARK: yes
- **Tools**: Claude Code (CLI)
- **Model(s)**: Claude Opus 4.6
- **Scope**: Added `IF NOT EXISTS` to 14 `ADD COLUMN` statements across 3 migration files
- **Human verification**: All changes reviewed by human operator
<!-- AI-WATERMARK:END -->

## Testing

**Commands run:**
```bash
# Verify all ADD COLUMN now have IF NOT EXISTS
grep -n 'ADD COLUMN' apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000001_init_script.sql
grep -n 'ADD COLUMN' apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000003_add_metadata_to_experiments.sql
grep -n 'ADD COLUMN' apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000014_add_thread_id_to_traces.sql
```

**Scenarios validated:**
- Fresh migration run: all tables/columns created successfully
- Replayed migration on pre-existing schema: no errors (idempotent)

**Environment:** macOS, JDK 21, ClickHouse 24.8 (Alibaba Cloud managed)

## Documentation

No documentation update needed.