### PR TITLE
[NA] [INFRA] fix: persist-credentials: false for peter-evans workflows

### DIFF
--- a/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
+++ b/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
@@ -84,11 +84,6 @@ jobs:
         run: |
           echo "BRANCH_NAME=github-actions/NA-automatically-update-openapi-spec-and-fern-code-$(date +%Y-%m-%d-%H-%M-%S)" >> $GITHUB_ENV
 
-      - name: Create branch
-        uses: JosiahSiegel/remote-branch-action@v1.2.0
-        with:
-          branch: ${{ env.BRANCH_NAME }}
-
       - name: Run Generate OpenAPI spec and Fern code
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}

--- a/.github/workflows/span_cost_upload_daily.yml
+++ b/.github/workflows/span_cost_upload_daily.yml
@@ -22,11 +22,6 @@ jobs:
           curl -o apps/opik-backend/src/main/resources/model_prices_and_context_window.json https://raw.githubusercontent.com/BerriAI/litellm/refs/heads/main/model_prices_and_context_window.json
           cp apps/opik-backend/src/main/resources/model_prices_and_context_window.json apps/opik-frontend/src/data/model_prices_and_context_window.json
 
-      - name: Create branch
-        uses: JosiahSiegel/remote-branch-action@v1.2.0
-        with:
-          branch: ${{ env.BRANCH_NAME }}
-
       - name: Commit files
         run: |
           set -ex

--- a/.github/workflows/sync_provider_models.yml
+++ b/.github/workflows/sync_provider_models.yml
@@ -76,12 +76,6 @@ jobs:
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create branch
-        if: steps.check_changes.outputs.has_changes == 'true'
-        uses: JosiahSiegel/remote-branch-action@v1.2.0
-        with:
-          branch: ${{ env.BRANCH_NAME }}
-
       - name: Commit files
         if: steps.check_changes.outputs.has_changes == 'true'
         run: |


### PR DESCRIPTION
## Details

<img width="1920" height="2292" alt="image" src="https://github.com/user-attachments/assets/35981c5c-231b-4c1d-a8e9-fe33a9550d8e" />

Workflows using `peter-evans/create-pull-request` with a custom token (`COMET_ACTION_CREATE_PR`) fail with "Duplicate header: Authorization" because `actions/checkout@v6` persists its own GITHUB_TOKEN credentials, conflicting with the token set by `create-pull-request`.

- Added `persist-credentials: false` to checkout steps in all 3 affected workflows
- Removed redundant `JosiahSiegel/remote-branch-action` steps — `peter-evans/create-pull-request` already creates the branch via the GitHub API

**Affected workflows:** `sdks_generate_openapi_spec_and_fern_code.yml`, `sync_provider_models.yml`, `span_cost_upload_daily.yml`

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- N/A

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: CI workflow fix
  - Human verification: yes

## Testing

- Requires manual trigger of each workflow to verify PR creation succeeds without "Duplicate header" errors
- No unit tests applicable (CI workflow yaml changes)

## Documentation

N/A