### PR TITLE
[OPIK-5233] [DOCS] Update Permissions by role table

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/administration/roles_and_permissions.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/roles_and_permissions.mdx
@@ -54,15 +54,28 @@ These roles are available in all Opik organizations and serve as the basis for c
 
 The table below shows the default permissions for each role. Custom roles can combine these permissions differently.
 
-| Group | Permission | Manage | Write | Annotate | Read |
-| --- | --- | --- | --- | --- | --- |
-| Admin | Invite users to workspace | Yes | Yes | No | No |
-| Admin | Update user role | Yes | No | No | No |
-| Admin | Delete workspaces | Yes | No | No | No |
-| Experiment management | Change project settings | Yes | No | No | No |
-| Experiment management | Approve and manage models | Yes | No | No | No |
-| Observability | View project data | Yes | Yes | Yes | Yes |
-| Observability | Log trace, span, or thread | Yes | Yes | No | No |
+| Group                 | Permission                      | Manage | Write | Annotate | Read |
+| --------------------- | ------------------------------- | ------ | ----- | -------- | ---- |
+| Admin                 | Invite users to workspace       | Yes    | Yes   | No       | No   |
+| Admin                 | Configure workspace settings    | Yes    | No    | No       | No   |
+| Admin                 | Delete workspaces               | Yes    | No    | No       | No   |
+| Admin                 | Define AI providers             | Yes    | Yes   | No       | No   |
+| Experiment management | Change project settings         | Yes    | No    | No       | No   |
+| Experiment management | Approve and manage models       | Yes    | No    | No       | No   |
+| Observability         | View project data               | Yes    | Yes   | Yes      | Yes  |
+| Observability         | Log trace, span, or thread      | Yes    | Yes   | No       | No   |
+| Observability         | Delete trace                    | Yes    | Yes   | No       | No   |
+| Observability         | Write comments                  | Yes    | Yes   | Yes      | No   |
+| Observability         | Annotate trace, span, or thread | Yes    | Yes   | Yes      | No   |
+| Observability         | Tag trace                       | Yes    | Yes   | Yes      | No   |
+| Observability         | Define online evaluation rule   | Yes    | Yes   | No       | No   |
+| Observability         | Define alert                    | Yes    | Yes   | No       | No   |
+| Observability         | Create annotation queue         | Yes    | Yes   | No       | No   |
+| Dashboards            | View dashboard                  | Yes    | Yes   | No       | Yes  |
+| Experiments           | View experiments                | Yes    | Yes   | No       | Yes  |
+| Datasets              | View datasets                   | Yes    | Yes   | No       | Yes  |
+| Annotation queues     | View annotation queues          | Yes    | Yes   | Yes      | Yes  |
+| Annotation queues     | Annotate trace, span, or thread | Yes    | Yes   | Yes      | Yes  |
 
 ### Custom roles
 


### PR DESCRIPTION
## Details
Updates the roles and permissions documentation table to be more comprehensive and better formatted:
- Added new permissions of P0-P3 phases
- Improved table alignment for readability

## Change checklist
- [x] Updated permissions table in `roles_and_permissions.mdx`
- [x] No code changes — documentation only

## Screenshots
<img width="512" height="660" alt="Screenshot 2026-03-25 at 15 25 59" src="https://github.com/user-attachments/assets/ff7ce4c8-4929-449b-83d9-a3f173156b57" />


## Testing
- [ ] Verify the documentation page renders correctly in Fern

## Issues
[OPIK-5233]

## Documentation
This PR **is** the documentation update.

[OPIK-5233]: https://comet-ml.atlassian.net/browse/OPIK-5233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ