### PR TITLE
[OPIK-4969] [FE] feat: v2 prompt library — project-scoped API integration

### DIFF
--- a/apps/opik-frontend/src/api/prompts/useCreatePromptVersionMutation.ts
+++ b/apps/opik-frontend/src/api/prompts/useCreatePromptVersionMutation.ts
@@ -18,6 +18,7 @@ type UseCreatePromptVersionMutationParams = {
   templateStructure?: PROMPT_TEMPLATE_STRUCTURE;
   type?: PROMPT_TYPE;
   excludeBlueprintUpdateForProjects?: string[];
+  projectId?: string;
   onSuccess: (promptVersion: PromptVersion) => void;
 };
 
@@ -34,6 +35,7 @@ const useCreatePromptVersionMutation = () => {
       templateStructure,
       type,
       excludeBlueprintUpdateForProjects,
+      projectId,
     }: UseCreatePromptVersionMutationParams) => {
       const { data } = await api.post(`${PROMPTS_REST_ENDPOINT}versions`, {
         name,
@@ -48,6 +50,7 @@ const useCreatePromptVersionMutation = () => {
           exclude_blueprint_update_for_projects:
             excludeBlueprintUpdateForProjects,
         }),
+        ...(projectId && { project_id: projectId }),
       });
 
       return data;
@@ -84,6 +87,10 @@ const useCreatePromptVersionMutation = () => {
           "promptId" in query.queryKey[1] &&
           query.queryKey[1].promptId === data.prompt_id,
       });
+
+      // Invalidate prompt list queries so version_count and last_updated_at refresh
+      queryClient.invalidateQueries({ queryKey: ["project-prompts"] });
+      queryClient.invalidateQueries({ queryKey: ["prompts"] });
     },
   });
 };

--- a/apps/opik-frontend/src/api/prompts/useProjectPromptsList.ts
+++ b/apps/opik-frontend/src/api/prompts/useProjectPromptsList.ts
@@ -1,0 +1,61 @@
+import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
+import api, { PROJECTS_REST_ENDPOINT, QueryConfig } from "@/api/api";
+import { Prompt } from "@/types/prompts";
+import { Filters } from "@/types/filters";
+import { processFilters } from "@/lib/filters";
+import { Sorting } from "@/types/sorting";
+import { processSorting } from "@/lib/sorting";
+
+type UseProjectPromptsListParams = {
+  projectId: string;
+  filters?: Filters;
+  sorting?: Sorting;
+  search?: string;
+  page: number;
+  size: number;
+};
+
+type UseProjectPromptsListResponse = {
+  content: Prompt[];
+  sortable_by: string[];
+  total: number;
+};
+
+const getProjectPromptsList = async (
+  { signal }: QueryFunctionContext,
+  {
+    projectId,
+    filters,
+    sorting,
+    search,
+    size,
+    page,
+  }: UseProjectPromptsListParams,
+) => {
+  const { data } = await api.get(
+    `${PROJECTS_REST_ENDPOINT}${projectId}/prompts`,
+    {
+      signal,
+      params: {
+        ...processFilters(filters),
+        ...processSorting(sorting),
+        ...(search && { name: search }),
+        size,
+        page,
+      },
+    },
+  );
+
+  return data;
+};
+
+export default function useProjectPromptsList(
+  params: UseProjectPromptsListParams,
+  options?: QueryConfig<UseProjectPromptsListResponse>,
+) {
+  return useQuery({
+    queryKey: ["project-prompts", params],
+    queryFn: (context) => getProjectPromptsList(context, params),
+    ...options,
+  });
+}

--- a/apps/opik-frontend/src/api/prompts/usePromptBatchDeleteMutation.ts
+++ b/apps/opik-frontend/src/api/prompts/usePromptBatchDeleteMutation.ts
@@ -32,6 +32,7 @@ const usePromptBatchDeleteMutation = () => {
       });
     },
     onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["project-prompts"] });
       return queryClient.invalidateQueries({
         queryKey: ["prompts"],
       });

--- a/apps/opik-frontend/src/api/prompts/usePromptCreateMutation.ts
+++ b/apps/opik-frontend/src/api/prompts/usePromptCreateMutation.ts
@@ -15,7 +15,7 @@ interface CreatePromptTemplate {
 }
 
 type UsePromptCreateMutationParams = {
-  prompt: Partial<Prompt> & CreatePromptTemplate;
+  prompt: Partial<Prompt> & CreatePromptTemplate & { project_id?: string };
   withResponse?: boolean;
 };
 
@@ -86,6 +86,7 @@ const usePromptCreateMutation = () => {
       }
     },
     onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["project-prompts"] });
       return queryClient.invalidateQueries({ queryKey: ["prompts"] });
     },
   });

--- a/apps/opik-frontend/src/api/prompts/usePromptDeleteMutation.ts
+++ b/apps/opik-frontend/src/api/prompts/usePromptDeleteMutation.ts
@@ -30,6 +30,7 @@ const usePromptDeleteMutation = () => {
       });
     },
     onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["project-prompts"] });
       return queryClient.invalidateQueries({ queryKey: ["prompts"] });
     },
   });

--- a/apps/opik-frontend/src/api/prompts/usePromptUpdateMutation.ts
+++ b/apps/opik-frontend/src/api/prompts/usePromptUpdateMutation.ts
@@ -43,6 +43,7 @@ const usePromptUpdateMutation = () => {
       queryClient.invalidateQueries({
         queryKey: ["prompt", { promptId: variables.prompt.id }],
       });
+      queryClient.invalidateQueries({ queryKey: ["project-prompts"] });
       return queryClient.invalidateQueries({ queryKey: ["prompts"] });
     },
   });

--- a/apps/opik-frontend/src/api/prompts/useRestorePromptVersionMutation.ts
+++ b/apps/opik-frontend/src/api/prompts/useRestorePromptVersionMutation.ts
@@ -46,6 +46,7 @@ const useRestorePromptVersionMutation = () => {
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["prompt-versions"] });
       queryClient.invalidateQueries({ queryKey: ["prompt"] });
+      queryClient.invalidateQueries({ queryKey: ["project-prompts"] });
       return queryClient.invalidateQueries({ queryKey: ["prompts"] });
     },
   });

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/BestPromptCard/BestPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/BestPromptCard/BestPrompt.tsx
@@ -146,6 +146,7 @@ export const BestPrompt: React.FC<BestPromptProps> = ({
     saveTemplate,
     saveMetadata,
   } = useSaveToPromptLibrary({
+    projectId: activeProjectId!,
     promptName: optimization.name,
     extractedPrompt,
     optimizationId: optimization.id,

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog.tsx
@@ -177,6 +177,7 @@ const AddNewPromptVersionDialog: React.FC<AddNewPromptVersionDialogProps> = ({
           ...(finalMetadata && { metadata: finalMetadata }),
           ...(templateStructure && { templateStructure }),
           ...(promptType && { type: promptType }),
+          projectId: activeProjectId ?? undefined,
           onSuccess: (data) =>
             onSave(data, selectedPrompt?.name, selectedPrompt?.id),
         });
@@ -192,6 +193,7 @@ const AddNewPromptVersionDialog: React.FC<AddNewPromptVersionDialogProps> = ({
             template_structure: templateStructure,
             ...(finalMetadata && { metadata: finalMetadata }),
             ...(description && { description }),
+            project_id: activeProjectId,
           },
           withResponse: true,
         },
@@ -236,6 +238,7 @@ const AddNewPromptVersionDialog: React.FC<AddNewPromptVersionDialogProps> = ({
             <div className="flex flex-col gap-2 pb-4">
               <Label>Prompt</Label>
               <PromptsSelectBox
+                projectId={activeProjectId!}
                 onValueChange={setPromptId}
                 value={promptId}
                 clearable={false}

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
@@ -18,6 +18,7 @@ import { Separator } from "@/ui/separator";
 import { Button } from "@/ui/button";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import usePromptById from "@/api/prompts/usePromptById";
+import { useActiveProjectId } from "@/store/AppStore";
 import PromptsSelectBox from "@/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
 import AddNewPromptVersionDialog from "@/v2/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog";
@@ -69,6 +70,7 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
   improvePromptConfig,
   disabled = false,
 }) => {
+  const activeProjectId = useActiveProjectId();
   const resetKeyRef = useRef(0);
   const [open, setOpen] = useState<boolean | ConfirmType>(false);
   const selectedPromptIdRef = useRef<string | undefined>();
@@ -344,6 +346,7 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
         )}
         <div className="flex h-full min-w-40 max-w-60 flex-auto flex-nowrap">
           <PromptsSelectBox
+            projectId={activeProjectId!}
             value={promptId}
             onValueChange={(id) => {
               if (id !== promptId) {

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
@@ -2,13 +2,12 @@ import React, { useCallback, useMemo, useState } from "react";
 import { FileTerminal, Plus } from "lucide-react";
 import isFunction from "lodash/isFunction";
 
-import useAppStore from "@/store/AppStore";
 import { cn } from "@/lib/utils";
 import { ListAction } from "@/ui/list-action";
 import { Separator } from "@/ui/separator";
 import LoadableSelectBox from "@/shared/LoadableSelectBox/LoadableSelectBox";
 import SelectBoxClearWrapper from "@/shared/SelectBoxClearWrapper/SelectBoxClearWrapper";
-import usePromptsList from "@/api/prompts/usePromptsList";
+import useProjectPromptsList from "@/api/prompts/useProjectPromptsList";
 import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
 import useDeepMemo from "@/hooks/useDeepMemo";
 
@@ -17,6 +16,7 @@ const MAX_LOADED_PROMPTS = 10000;
 const NEW_PROMPT_VALUE = "new-prompt";
 
 interface PromptsSelectBoxProps {
+  projectId: string;
   value?: string;
   onValueChange: (value?: string) => void;
   onOpenChange?: (value: boolean) => void;
@@ -28,6 +28,7 @@ interface PromptsSelectBoxProps {
 }
 
 const PromptsSelectBox: React.FC<PromptsSelectBoxProps> = ({
+  projectId,
   value,
   onValueChange,
   onOpenChange,
@@ -38,20 +39,20 @@ const PromptsSelectBox: React.FC<PromptsSelectBoxProps> = ({
   disabled = false,
 }) => {
   const [open, setOpen] = useState(false);
-  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const [isLoadedMore, setIsLoadedMore] = useState(false);
   const isClearable = clearable && Boolean(value);
 
-  const { data: promptsData, isLoading: isLoadingPrompts } = usePromptsList(
-    {
-      workspaceName,
-      page: 1,
-      size: !isLoadedMore ? DEFAULT_LOADED_PROMPTS : MAX_LOADED_PROMPTS,
-    },
-    {
-      refetchOnMount,
-    },
-  );
+  const { data: promptsData, isLoading: isLoadingPrompts } =
+    useProjectPromptsList(
+      {
+        projectId,
+        page: 1,
+        size: !isLoadedMore ? DEFAULT_LOADED_PROMPTS : MAX_LOADED_PROMPTS,
+      },
+      {
+        refetchOnMount,
+      },
+    );
 
   const prompts = useDeepMemo(
     () => promptsData?.content ?? [],

--- a/apps/opik-frontend/src/v2/pages-shared/shared/useSaveToPromptLibrary.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/shared/useSaveToPromptLibrary.ts
@@ -1,6 +1,5 @@
 import { useMemo, useRef, useState } from "react";
-import useAppStore from "@/store/AppStore";
-import usePromptsList from "@/api/prompts/usePromptsList";
+import useProjectPromptsList from "@/api/prompts/useProjectPromptsList";
 import { ExtractedPromptData, OpenAIMessage } from "@/lib/prompt";
 import { convertOptimizationVariableFormat } from "@/lib/optimizations";
 import { PromptWithLatestVersion } from "@/types/prompts";
@@ -12,6 +11,7 @@ export const convertMessages = (messages: OpenAIMessage[]) =>
   }));
 
 interface UseSaveToPromptLibraryOptions {
+  projectId: string;
   promptName: string;
   extractedPrompt: ExtractedPromptData | null;
   optimizationId: string;
@@ -37,19 +37,19 @@ interface UseSaveToPromptLibraryReturn {
 }
 
 export const useSaveToPromptLibrary = ({
+  projectId,
   promptName,
   extractedPrompt,
   optimizationId,
   optimizationName,
   experimentId,
 }: UseSaveToPromptLibraryOptions): UseSaveToPromptLibraryReturn => {
-  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const dialogKeyRef = useRef(0);
 
-  const { data: promptsData } = usePromptsList(
+  const { data: promptsData } = useProjectPromptsList(
     {
-      workspaceName,
+      projectId,
       search: promptName,
       page: 1,
       size: 1,

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ConfigurationTab/BlueprintValuePrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ConfigurationTab/BlueprintValuePrompt.tsx
@@ -142,6 +142,7 @@ const BlueprintValuePrompt = forwardRef<
           template: currentTemplate,
           type: promptVersion?.type,
           templateStructure: prompt.template_structure,
+          projectId,
           ...(projectId && {
             excludeBlueprintUpdateForProjects: [projectId],
           }),

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
@@ -20,6 +20,7 @@ import LLMPromptMessages from "@/v2/pages-shared/llm/LLMPromptMessages/LLMPrompt
 import OptimizationModelSelect from "@/v2/pages-shared/optimizations/OptimizationModelSelect/OptimizationModelSelect";
 import OptimizationTemperatureConfig from "@/v2/pages-shared/optimizations/OptimizationConfigForm/OptimizationTemperatureConfig";
 import { OPTIMIZATION_MESSAGE_TYPE_OPTIONS } from "@/constants/optimizations";
+import { useActiveProjectId } from "@/store/AppStore";
 import PromptsSelectBox from "@/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox";
 import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
@@ -47,6 +48,7 @@ const OptimizationsNewPromptSection: React.FC<
   onModelChange,
   onModelConfigChange,
 }) => {
+  const activeProjectId = useActiveProjectId();
   const [selectedChatPromptId, setSelectedChatPromptId] = useState<
     string | undefined
   >(undefined);
@@ -115,6 +117,7 @@ const OptimizationsNewPromptSection: React.FC<
             >
               <div className="flex h-full min-w-40 max-w-60 flex-auto flex-nowrap">
                 <PromptsSelectBox
+                  projectId={activeProjectId!}
                   value={selectedChatPromptId}
                   onValueChange={(value) =>
                     value && handleImportChatPrompt(value)

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -44,6 +44,7 @@ import {
   ModelResolver,
   ProviderResolver,
 } from "@/hooks/useLLMProviderModelsData";
+import { useActiveProjectId } from "@/store/AppStore";
 import PromptsSelectBox from "@/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox";
 import AddNewPromptVersionDialog from "@/v2/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog";
 import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
@@ -72,6 +73,7 @@ const PlaygroundPrompt = ({
 }: PlaygroundPromptProps) => {
   const checkedIfModelIsValidRef = useRef(false);
   const queryClient = useQueryClient();
+  const activeProjectId = useActiveProjectId();
 
   const prompt = usePromptById(promptId);
   const datasetVariables = useDatasetVariables();
@@ -298,6 +300,7 @@ const PlaygroundPrompt = ({
           <TooltipWrapper content={chatPromptData?.name || "Load chat prompt"}>
             <div className="flex h-full min-w-40 max-w-60 flex-auto flex-nowrap">
               <PromptsSelectBox
+                projectId={activeProjectId!}
                 value={selectedChatPromptId}
                 onValueChange={(value) =>
                   value && handleImportChatPrompt(value)

--- a/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/CommitsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/CommitsTab.tsx
@@ -224,11 +224,13 @@ const CommitsTab = ({ prompt }: CommitsTabInterface) => {
     (row: PromptVersion) => {
       const promptResource = RESOURCE_MAP[RESOURCE_TYPE.prompt];
       const workspaceName = useAppStore.getState().activeWorkspaceName;
+      const projectId = useAppStore.getState().activeProjectId;
       navigate({
-        to: promptResource.url,
+        to: promptResource.projectUrl,
         params: {
           [promptResource.param]: row.prompt_id,
           workspaceName,
+          projectId: projectId!,
         },
         search: {
           activeVersionId: row.id,

--- a/apps/opik-frontend/src/v2/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
@@ -32,7 +32,7 @@ import TextCell from "@/shared/DataTableCells/TextCell";
 import TraceCountCell from "@/v2/pages-shared/traces/TraceCountCell/TraceCountCell";
 import DatasetVersionCell from "@/shared/DataTableCells/DatasetVersionCell";
 import ListCell from "@/shared/DataTableCells/ListCell";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { transformExperimentScores } from "@/lib/feedback-scores";
 import useGroupedExperimentsList, {
   GroupedExperiment,
@@ -114,6 +114,7 @@ interface ExperimentsTabProps {
 
 const ExperimentsTab: React.FC<ExperimentsTabProps> = ({ promptId }) => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const [search = "", setSearch] = useQueryParam("search", StringParam, {
     updateType: "replaceIn",
   });
@@ -159,17 +160,18 @@ const ExperimentsTab: React.FC<ExperimentsTabProps> = ({ promptId }) => {
     (row: GroupedExperiment) => {
       const experimentResource = RESOURCE_MAP[RESOURCE_TYPE.experiment];
       navigate({
-        to: experimentResource.url,
+        to: experimentResource.projectUrl,
         params: {
           [experimentResource.param]: row.dataset_id,
           workspaceName,
+          projectId: activeProjectId!,
         },
         search: {
           experiments: [row.id],
         },
       });
     },
-    [navigate, workspaceName],
+    [navigate, workspaceName, activeProjectId],
   );
 
   const columnsDef: ColumnData<GroupedExperiment>[] = useMemo(() => {
@@ -351,9 +353,11 @@ const ExperimentsTab: React.FC<ExperimentsTabProps> = ({ promptId }) => {
     ];
   }, []);
 
+  // TODO: Need project scoping in V2 (OPIK-4968)
   const { isFeedbackScoresPending, dynamicScoresColumns } =
     useExperimentsFeedbackScores();
 
+  // TODO: Need project scoping in V2 (OPIK-4968) — DatasetSelectBox, ExperimentsPathsAutocomplete
   const { groups, setGroups, filtersAndGroupsConfig } =
     useExperimentsGroupsAndFilters({
       storageKeyPrefix: STORAGE_KEY_PREFIX,
@@ -367,6 +371,7 @@ const ExperimentsTab: React.FC<ExperimentsTabProps> = ({ promptId }) => {
     maxExpandedDeepestGroups: MAX_EXPANDED_DEEPEST_GROUPS,
   });
 
+  // TODO: Need project scoping in V2 (OPIK-4968) — useDatasetsList, useProjectsList inside
   const { data, isPending, isPlaceholderData, isFetching } =
     useGroupedExperimentsList({
       workspaceName,

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/EditPromptVersionDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/EditPromptVersionDialog.tsx
@@ -28,6 +28,7 @@ import {
 import TextDiff from "@/shared/CodeDiff/TextDiff";
 import MediaTagsList from "@/v2/pages-shared/llm/PromptMessageMediaTags/MediaTagsList";
 import MarkdownPreview from "@/shared/MarkdownPreview/MarkdownPreview";
+import { useActiveProjectId } from "@/store/AppStore";
 import useCreatePromptVersionMutation from "@/api/prompts/useCreatePromptVersionMutation";
 import { useBooleanTimeoutState } from "@/hooks/useBooleanTimeoutState";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
@@ -75,6 +76,7 @@ const EditPromptVersionDialog: React.FC<EditPromptVersionDialogProps> = ({
   type: promptType,
   onSetActiveVersionId,
 }) => {
+  const activeProjectId = useActiveProjectId();
   const isChatPrompt = templateStructure === PROMPT_TEMPLATE_STRUCTURE.CHAT;
 
   const [previewMode, setPreviewMode] = useState<PROMPT_PREVIEW_MODE>(
@@ -150,6 +152,7 @@ const EditPromptVersionDialog: React.FC<EditPromptVersionDialogProps> = ({
       ...(metadata && { metadata: safelyParseJSON(metadata) }),
       ...(templateStructure && { templateStructure }),
       ...(promptType && { type: promptType }),
+      projectId: activeProjectId ?? undefined,
       onSuccess: (data) => {
         onSetActiveVersionId(data.id);
       },

--- a/apps/opik-frontend/src/v2/pages/PromptsPage/AddEditPromptDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptsPage/AddEditPromptDialog.tsx
@@ -150,6 +150,7 @@ const AddEditPromptDialog: React.FC<AddPromptDialogProps> = ({
           template_structure: templateStructure,
           ...(metadata && { metadata: safelyParseJSON(metadata) }),
           ...(description && { description }),
+          project_id: activeProjectId ?? undefined,
         },
       },
       { onSuccess: onPromptCreated },

--- a/apps/opik-frontend/src/v2/pages/PromptsPage/PromptsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptsPage/PromptsPage.tsx
@@ -26,7 +26,7 @@ import useLocalStorageState from "use-local-storage-state";
 import { convertColumnDataToColumn, migrateSelectedColumns } from "@/lib/table";
 import ColumnsButton from "@/shared/ColumnsButton/ColumnsButton";
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";
-import usePromptsList from "@/api/prompts/usePromptsList";
+import useProjectPromptsList from "@/api/prompts/useProjectPromptsList";
 import { Prompt, PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
 import { PromptRowActionsCell } from "@/v2/pages/PromptsPage/PromptRowActionsCell";
 import AddEditPromptDialog from "@/v2/pages/PromptsPage/AddEditPromptDialog";
@@ -229,20 +229,21 @@ const PromptsPage: React.FunctionComponent = () => {
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
-  const { data, isPending, isPlaceholderData, isFetching } = usePromptsList(
-    {
-      workspaceName,
-      filters,
-      sorting: sortedColumns,
-      search: search!,
-      page,
-      size,
-    },
-    {
-      placeholderData: keepPreviousData,
-      refetchInterval: 30000,
-    },
-  );
+  const { data, isPending, isPlaceholderData, isFetching } =
+    useProjectPromptsList(
+      {
+        projectId: activeProjectId!,
+        filters,
+        sorting: sortedColumns,
+        search: search!,
+        page,
+        size,
+      },
+      {
+        placeholderData: keepPreviousData,
+        refetchInterval: 30000,
+      },
+    );
 
   const prompts = useMemo(() => data?.content ?? [], [data?.content]);
   const sortableBy: string[] = useMemo(


### PR DESCRIPTION
## Details

Integrates the v2 Prompt library pages with project-scoped BE endpoints (OPIK-4617 IA revamp). All prompt CRUD operations now pass `project_id` context, and the list page uses the new `GET /v1/private/projects/{projectId}/prompts` endpoint. Navigation links in prompt sub-pages (ExperimentsTab, CommitsTab) updated to use v2 project-scoped URLs.

- New `useProjectPromptsList` hook for project-scoped prompt listing
- `PromptsSelectBox` (v2) requires `projectId`, uses project-scoped endpoint
- `useSaveToPromptLibrary` (v2) requires `projectId`, uses project-scoped endpoint
- Cache invalidation for `["project-prompts"]` added to all prompt mutation hooks
- `project_id` passed on prompt creation and version creation (where BE resolves by name)
- ExperimentsTab and CommitsTab navigation fixed to use `projectUrl` instead of v1 `url`

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-4969

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review + manual testing

## Testing

- `scripts/dev-runner.sh --lint-fe` — lint, typecheck, dependency validation all pass
- Manual verification:
  - V2 PromptsPage shows only active project's prompts (network: project-scoped endpoint)
  - Create prompt → `project_id` in request body, prompt appears in project list only
  - PromptsSelectBox in Playground/Optimization Studio shows project-scoped prompts
  - Save to prompt library dialog uses project-scoped endpoint
  - ExperimentsTab row click navigates to v2 URL (`/projects/$pid/experiments/...`)
  - CommitsTab row click navigates to v2 URL (`/projects/$pid/prompts/...`)
  - V1 regression: workspace-wide prompt listing still works

## Documentation

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)