### PR TITLE
[OPIK-5217] [BE] Follow-up: address review comments on project-scoped alerts

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Alert.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Alert.java
@@ -54,10 +54,12 @@ public record Alert(
         @JsonView({
                 Alert.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy,
         @JsonView({Alert.View.Public.class,
-                Alert.View.Write.class}) @Schema(description = "Optional project scope for this alert. "
-                        + "When set, the alert is scoped to the specified project. "
-                        + "Do NOT also provide a 'scope:project' trigger config — the system will create it automatically from this field. "
-                        + "Sending both project_id and a scope:project trigger config will result in an error.") UUID projectId,
+                Alert.View.Write.class}) @Schema(description = """
+                        Optional project scope for this alert. \
+                        When set, the alert is scoped to the specified project. \
+                        Do NOT also provide a 'scope:project' trigger config — the system will create it automatically from this field. \
+                        Sending both project_id and a scope:project trigger config will result in an error.\
+                        """) UUID projectId,
         @JsonIgnore String workspaceId){
 
     public static class View {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/alerts/AlertScopeUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/alerts/AlertScopeUtils.java
@@ -3,6 +3,7 @@ package com.comet.opik.domain.alerts;
 import com.comet.opik.api.AlertTriggerConfig;
 import com.comet.opik.api.AlertTriggerConfigType;
 import com.comet.opik.utils.JsonUtils;
+import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
@@ -12,10 +13,8 @@ import java.util.UUID;
 
 import static com.comet.opik.api.AlertTriggerConfig.PROJECT_IDS_CONFIG_KEY;
 
-public final class AlertScopeUtils {
-
-    private AlertScopeUtils() {
-    }
+@UtilityClass
+public class AlertScopeUtils {
 
     /**
      * Returns the project IDs that define the scope of an alert trigger.

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/MaskedSecretTokenSerializer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/MaskedSecretTokenSerializer.java
@@ -7,12 +7,15 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.util.Objects;
 
 @Slf4j
 public class MaskedSecretTokenSerializer extends JsonSerializer<String> {
 
     @Override
     public void serialize(String value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        Objects.requireNonNull(gen, "gen must not be null");
+
         if (value == null) {
             gen.writeNull();
             return;
@@ -20,8 +23,8 @@ public class MaskedSecretTokenSerializer extends JsonSerializer<String> {
 
         try {
             gen.writeString(EncryptionUtils.maskApiKey(EncryptionUtils.decrypt(value)));
-        } catch (Exception e) {
-            log.debug("Failed to decrypt secret token, falling back to masked raw value", e);
+        } catch (SecurityException e) {
+            log.debug("Failed to decrypt API key for masking, returning masked value directly.", e);
             gen.writeString(EncryptionUtils.maskApiKey(value));
         }
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AlertResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AlertResourceClient.java
@@ -51,7 +51,7 @@ public class AlertResourceClient {
      * so Jersey serializes the ObjectNode directly (not as a quoted JSON string).
      */
     private ObjectNode toRequestNode(Alert alert) {
-        var node = (ObjectNode) JsonUtils.getMapper().valueToTree(alert);
+        var node = (ObjectNode) JsonUtils.valueToTree(alert);
         if (alert.webhook() != null && alert.webhook().secretToken() != null) {
             var webhookNode = node.get("webhook");
             if (webhookNode instanceof ObjectNode webhookObjectNode) {


### PR DESCRIPTION
## Details

Follow-up to #5825. Addresses review comments from andrescrz:

- **Alert.java**: Use text block for `@Schema` description instead of string concatenation
- **AlertScopeUtils.java**: Use `@UtilityClass` instead of manual `final` class + private constructor
- **MaskedSecretTokenSerializer.java**: Add null guard on `gen` parameter; narrow exception catch from `Exception` to `SecurityException`
- **AlertResourceClient.java**: Use `JsonUtils.valueToTree` instead of `JsonUtils.getMapper().valueToTree`

## Change checklist

- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5217

## Testing

No functional changes — existing test suite covers all affected paths.

## Documentation

N/A