### PR TITLE
[OPIK-5164] [OPIK-5160] [FE] feat: v2 online evaluation & annotation queues — project scoping

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
@@ -27,7 +27,6 @@ import {
 import { Input } from "@/ui/input";
 import { Textarea } from "@/ui/textarea";
 import SelectBox from "@/shared/SelectBox/SelectBox";
-import ProjectsSelectBox from "@/v2/pages-shared/automations/ProjectsSelectBox";
 import FeedbackDefinitionsSelectBox from "@/v2/pages-shared/annotation-queues/FeedbackDefinitionsSelectBox";
 
 import {
@@ -72,7 +71,7 @@ type AddEditAnnotationQueueDialogProps = {
   open: boolean;
   setOpen: (open: boolean) => void;
   onQueueCreated?: (queue: Partial<AnnotationQueue>) => void;
-  projectId?: string;
+  projectId: string;
   scope?: ANNOTATION_QUEUE_SCOPE;
   queue?: AnnotationQueue;
 };
@@ -201,35 +200,6 @@ const AddEditAnnotationQueueDialog: React.FunctionComponent<
                 }}
               />
               <div className="flex gap-4">
-                <FormField
-                  control={form.control}
-                  name="project_id"
-                  render={({ field, formState }) => {
-                    const validationErrors = get(formState.errors, [
-                      "project_id",
-                    ]);
-
-                    return (
-                      <FormItem className="flex-1">
-                        <FormLabel>Project</FormLabel>
-                        <FormControl>
-                          <ProjectsSelectBox
-                            value={field.value}
-                            onValueChange={field.onChange}
-                            className={cn({
-                              "border-destructive": Boolean(
-                                validationErrors?.message,
-                              ),
-                            })}
-                            disabled={Boolean(projectId)}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    );
-                  }}
-                />
-
                 <FormField
                   control={form.control}
                   name="scope"

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/AddEditRuleDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/AddEditRuleDialog.tsx
@@ -47,7 +47,6 @@ import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import ExplainerCallout from "@/shared/ExplainerCallout/ExplainerCallout";
 import PythonCodeRuleDetails from "@/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails";
 import LLMJudgeRuleDetails from "@/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails";
-import ProjectsSelectBox from "@/v2/pages-shared/automations/ProjectsSelectBox";
 import RuleFilteringSection, {
   TRACE_FILTER_COLUMNS,
   THREAD_FILTER_COLUMNS,
@@ -138,7 +137,7 @@ const DEFAULT_PYTHON_CODE_DATA: Record<
 type AddEditRuleDialogProps = {
   open: boolean;
   setOpen: (open: boolean) => void;
-  projectId?: string;
+  projectId: string;
   rule?: EvaluatorsRule;
   projectName?: string; // Optional: project name for pre-selected projects
   datasetColumnNames?: string[]; // Optional: dataset column names from playground
@@ -264,9 +263,7 @@ const AddEditRuleDialog: React.FC<AddEditRuleDialogProps> = ({
       // For clone mode, reset the form with cloned rule data and append " (Copy)" to name
       const cloneFormData = {
         ruleName: `${defaultRule.name} (Copy)`,
-        projectIds:
-          defaultRule.projects?.map((p) => p.project_id) ||
-          (projectId ? [projectId] : []),
+        projectIds: projectId ? [projectId] : [],
         samplingRate: defaultRule.sampling_rate ?? 1,
         uiType: formUIRuleType,
         scope: formScope,
@@ -527,37 +524,6 @@ const AddEditRuleDialog: React.FC<AddEditRuleDialogProps> = ({
                   }}
                 />
                 <div className="flex gap-4">
-                  <FormField
-                    control={form.control}
-                    name="projectIds"
-                    render={({ field, formState }) => {
-                      const validationErrors = get(formState.errors, [
-                        "projectIds",
-                      ]);
-
-                      return (
-                        <FormItem className="min-w-0 flex-1">
-                          <Label>Projects</Label>
-                          <FormControl>
-                            <ProjectsSelectBox
-                              align="start"
-                              value={field.value}
-                              onValueChange={field.onChange}
-                              className={cn({
-                                "border-destructive": Boolean(
-                                  validationErrors?.message,
-                                ),
-                              })}
-                              multiselect
-                              showSelectAll
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      );
-                    }}
-                  />
-
                   {!hideScopeSelector && (
                     <FormField
                       control={form.control}

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationPage.tsx
@@ -1,9 +1,9 @@
-import { useProjectIdFromURL } from "@/hooks/useProjectIdFromURL";
+import { useActiveProjectId } from "@/store/AppStore";
 import PageBodyScrollContainer from "@/v2/layout/PageBodyScrollContainer/PageBodyScrollContainer";
 import AgentConfigurationTab from "@/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationTab";
 
 const AgentConfigurationPage = () => {
-  const projectId = useProjectIdFromURL();
+  const projectId = useActiveProjectId()!;
 
   return (
     <PageBodyScrollContainer>

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuesPage/AnnotationQueuesPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuesPage/AnnotationQueuesPage.tsx
@@ -50,7 +50,7 @@ import {
 } from "@/shared/DataTable/utils";
 import useAnnotationQueuesList from "@/api/annotation-queues/useAnnotationQueuesList";
 import useAppStore from "@/store/AppStore";
-import { useProjectIdFromURL } from "@/hooks/useProjectIdFromURL";
+import { useActiveProjectId } from "@/store/AppStore";
 import { usePermissions } from "@/contexts/PermissionsContext";
 
 import {
@@ -215,7 +215,7 @@ const FILTERS_CONFIG = {
 
 export const AnnotationQueuesPage: React.FC = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
-  const projectId = useProjectIdFromURL();
+  const projectId = useActiveProjectId()!;
   const navigate = useNavigate();
   const resetDialogKeyRef = useRef(0);
   const [openDialog, setOpenDialog] = useState<boolean>(false);
@@ -396,6 +396,7 @@ export const AnnotationQueuesPage: React.FC = () => {
           key={resetDialogKeyRef.current}
           open={openDialog}
           setOpen={setOpenDialog}
+          projectId={projectId}
         />
       </>
     );

--- a/apps/opik-frontend/src/v2/pages/InsightsPage/InsightsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/InsightsPage/InsightsPage.tsx
@@ -26,7 +26,7 @@ import {
 } from "@/lib/dashboard/templates";
 import { Separator } from "@/ui/separator";
 import { useActiveWorkspaceName } from "@/store/AppStore";
-import { useProjectIdFromURL } from "@/hooks/useProjectIdFromURL";
+import { useActiveProjectId } from "@/store/AppStore";
 
 const DASHBOARD_QUERY_PARAM_KEY = "dashboardId";
 const DASHBOARD_LOCAL_STORAGE_KEY_PREFIX = "opik-project-dashboard";
@@ -35,7 +35,7 @@ const DEFAULT_TEMPLATE = PROJECT_TEMPLATE_LIST[0];
 const DEFAULT_TEMPLATE_ID = DEFAULT_TEMPLATE.id;
 
 const InsightsPage: React.FunctionComponent = () => {
-  const projectId = useProjectIdFromURL();
+  const projectId = useActiveProjectId()!;
   const workspaceName = useActiveWorkspaceName();
 
   const [dashboardId, setDashboardId] = useQueryParamAndLocalStorageState({

--- a/apps/opik-frontend/src/v2/pages/LogsPage/LogsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/LogsPage.tsx
@@ -1,4 +1,4 @@
-import { useProjectIdFromURL } from "@/hooks/useProjectIdFromURL";
+import { useActiveProjectId } from "@/store/AppStore";
 import useProjectById from "@/api/projects/useProjectById";
 import PageBodyScrollContainer from "@/v2/layout/PageBodyScrollContainer/PageBodyScrollContainer";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
@@ -13,7 +13,7 @@ import { FeatureToggleKeys } from "@/types/feature-toggles";
 import useLogsType from "@/v2/pages/LogsPage/useLogsType";
 
 const LogsPage = () => {
-  const projectId = useProjectIdFromURL();
+  const projectId = useActiveProjectId()!;
   const [isGuardrailsDialogOpened, setIsGuardrailsDialogOpened] =
     useState<boolean>(false);
   const isGuardrailsEnabled = useIsFeatureEnabled(

--- a/apps/opik-frontend/src/v2/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
@@ -55,7 +55,7 @@ import { capitalizeFirstLetter } from "@/lib/utils";
 import { getUIRuleScope } from "@/v2/pages-shared/automations/AddEditRuleDialog/helpers";
 import { usePermissions } from "@/contexts/PermissionsContext";
 
-import { useProjectIdFromURL } from "@/hooks/useProjectIdFromURL";
+import { useActiveProjectId } from "@/store/AppStore";
 
 const getRowId = (d: EvaluatorsRule) => d.id;
 
@@ -148,7 +148,7 @@ const COLUMNS_SORT_KEY = "workspace-rules-columns-sort";
 const PAGINATION_SIZE_KEY = "workspace-rules-pagination-size";
 
 export const OnlineEvaluationPage: React.FC = () => {
-  const projectId = useProjectIdFromURL();
+  const projectId = useActiveProjectId()!;
   const {
     permissions: { canUpdateOnlineEvaluationRules },
   } = usePermissions();

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/PlaygroundOutputActions.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputActions/PlaygroundOutputActions.tsx
@@ -531,6 +531,9 @@ const PlaygroundOutputActions = ({
           {renderActionButton()}
         </div>
       </div>
+      {/* TODO: When Playground is integrated into project scope (OPIK-5161),
+          use useActiveProjectId() instead of playgroundProject and remove
+          project creation logic from handleCreateRuleClick */}
       <AddEditRuleDialog
         open={isRuleDialogOpen}
         setOpen={(open) => {
@@ -540,7 +543,7 @@ const PlaygroundOutputActions = ({
             setRuleDialogProjectId(undefined);
           }
         }}
-        projectId={ruleDialogProjectId || playgroundProject?.id}
+        projectId={ruleDialogProjectId || playgroundProject?.id || ""}
         projectName={PLAYGROUND_PROJECT_NAME}
         datasetColumnNames={datasetColumns.map((c) => c.name)}
         hideScopeSelector

--- a/apps/opik-frontend/src/v2/pages/ProjectPage/ProjectPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectPage/ProjectPage.tsx
@@ -3,7 +3,7 @@ import last from "lodash/last";
 import { Link, Navigate, Outlet, useLocation } from "@tanstack/react-router";
 import useProjectById from "@/api/projects/useProjectById";
 import useBreadcrumbsStore from "@/store/BreadcrumbsStore";
-import { useActiveWorkspaceName } from "@/store/AppStore";
+import { useActiveProjectId, useActiveWorkspaceName } from "@/store/AppStore";
 import { useProjectIdFromURL } from "@/hooks/useProjectIdFromURL";
 import { setActiveProject } from "@/hooks/useActiveProjectInitializer";
 import Loader from "@/shared/Loader/Loader";
@@ -14,6 +14,8 @@ const ProjectPage = () => {
   const setBreadcrumbParam = useBreadcrumbsStore((state) => state.setParam);
   const projectId = useProjectIdFromURL();
   const workspaceName = useActiveWorkspaceName();
+
+  const activeProjectId = useActiveProjectId();
 
   useEffect(() => {
     setActiveProject(workspaceName, projectId);
@@ -33,7 +35,7 @@ const ProjectPage = () => {
     select: (location) => location.pathname,
   });
 
-  if (isPending) {
+  if (isPending || activeProjectId !== projectId) {
     return <Loader />;
   }
 


### PR DESCRIPTION
## Details

Project-scoping the v2 Online Evaluation and Annotation Queues pages as part of the IA revamp (OPIK-4617). All v2 pages now read `projectId` from the AppStore instead of URL params, and project selectors are removed from create/edit dialogs since the project is always the active sidebar project.

- Switch all v2 project-scoped pages from `useProjectIdFromURL()` to `useActiveProjectId()` (AppStore)
- Add guard in `ProjectPage`: don't render children (`<Outlet />`) until the store's `activeProjectId` matches the URL — prevents race condition where child pages see `null`
- Remove `ProjectsSelectBox` from v2 `AddEditRuleDialog` (online evaluation rules always belong to active project)
- Remove `ProjectsSelectBox` from v2 `AddEditAnnotationQueueDialog` (annotation queues always belong to active project)
- Make `projectId` prop required (not optional) in both v2 dialogs — TypeScript enforces all callers supply it
- Force active project on rule clone instead of preserving original rule's projects
- Fix missing `projectId` on empty-state annotation queue dialog
- Add TODO for Playground project scoping (deferred to OPIK-5161)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5164
- OPIK-5160

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review + manual testing

## Testing

- `scripts/dev-runner.sh --lint-fe` — lint, typecheck, dependency validation all pass
- Manual verification:
  - Online evaluation page: rules list filtered by active project, create/edit/clone dialogs have no project selector
  - Annotation queues page: queues list filtered by active project, create/edit dialogs have no project selector
  - Switching projects in sidebar updates both lists
  - Direct URL navigation (browser refresh) works — ProjectPage guard ensures store is synced before children render
  - Logs, Insights, Agent configuration pages still work correctly
  - V1 regression: project selectors still present in v1 dialogs

## Documentation

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)