### PR TITLE
[OPIK-5159] [FE] feat: v2 Insights page

### DIFF
--- a/apps/opik-frontend/src/v2/pages/InsightsPage/InsightsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/InsightsPage/InsightsPage.tsx
@@ -64,6 +64,12 @@ const InsightsPage: React.FunctionComponent = () => {
     scope: DASHBOARD_SCOPE.INSIGHTS,
   });
 
+  useEffect(() => {
+    if (!isPending && dashboardId && !dashboard) {
+      setDashboardId(DEFAULT_TEMPLATE_ID);
+    }
+  }, [isPending, dashboardId, dashboard, setDashboardId]);
+
   const setRuntimeConfig = useDashboardStore(selectSetRuntimeConfig);
 
   const { dateRange, handleDateRangeChange, minDate, maxDate, dateRangeValue } =
@@ -129,24 +135,6 @@ const InsightsPage: React.FunctionComponent = () => {
 
       <div className="px-6 pb-4 pt-1">
         {isPending && <Loader />}
-
-        {!isPending && !dashboardId && (
-          <div className="flex h-full items-center justify-center">
-            <p className="text-muted-foreground">
-              No view selected. Please select or create a view.
-            </p>
-          </div>
-        )}
-
-        {!isPending && dashboardId && !dashboard && (
-          <div className="flex h-full items-center justify-center">
-            <p className="text-muted-foreground">
-              View could not be loaded. Please select another view from the
-              dropdown.
-            </p>
-          </div>
-        )}
-
         {!isPending && dashboard && <DashboardContent />}
       </div>
     </PageBodyScrollContainer>


### PR DESCRIPTION
## Details
When an insights view cannot be loaded (e.g., stale ID in localStorage, deleted view, 404 from API), the page showed a dead-end error: "View could not be loaded. Please select another view from the dropdown." This change auto-falls back to the default template instead, removing error states from the UI.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5159

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: assisted
- Human verification: code review + manual testing

## Testing
- Open Insights page with a valid view — renders normally
- Set an invalid `dashboardId` in localStorage/query param — auto-resets to default template
- Delete a custom view while it's selected — falls back to default template

## Documentation
N/A