### PR TITLE
[NA] [CI] chore: remove daily cron schedule from Fern/OpenAPI workflow

### DIFF
--- a/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
+++ b/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
@@ -1,8 +1,6 @@
 name: SDKs Generate OpenAPI spec and Fern code
 
 on:
-  schedule:
-    - cron: '0 0 * * 1-5' # Runs at midnight UTC, Monday to Friday
   push:
     branches: ['main']
     paths:


### PR DESCRIPTION
## Details
Remove the daily cron schedule (`0 0 * * 1-5`) from the Fern/OpenAPI generation workflow. The push-to-main and manual dispatch triggers are kept — only the redundant nightly run is removed since we now generate immediately after backend changes are merged.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- N/A

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full PR
  - Human verification: Reviewed by author

## Testing
- CI-only change; no runtime impact

## Documentation
N/A