### PR TITLE
[NA][CI] Add concurrency groups to cancel redundant PR workflow runs

### DIFF
--- a/.github/workflows/backend_formatting_check.yml
+++ b/.github/workflows/backend_formatting_check.yml
@@ -13,6 +13,10 @@ on:
 
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   run-backend-formatting-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -17,6 +17,10 @@ on:
 
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
   checks: write

--- a/.github/workflows/clickhouse_migration_cluster_check.yml
+++ b/.github/workflows/clickhouse_migration_cluster_check.yml
@@ -15,6 +15,10 @@ on:
 
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   validate-clickhouse-migrations:
     runs-on: ubuntu-latest

--- a/.github/workflows/documentation_image_optimizer.yml
+++ b/.github/workflows/documentation_image_optimizer.yml
@@ -11,6 +11,10 @@ on:
         "apps/opik-documentation/documentation/fern/img/**.png",
         "apps/opik-documentation/documentation/fern/img/**.webp",
       ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
     # Only run on non-draft PRs within the same repository.

--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -5,6 +5,10 @@ on:
     paths:
         - 'apps/opik-documentation/documentation/**'
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
     run:
         runs-on: ubuntu-latest

--- a/.github/workflows/end2end_suites_typescript.yml
+++ b/.github/workflows/end2end_suites_typescript.yml
@@ -40,6 +40,10 @@ on:
         - 'sdks/code_generation/fern/openapi/openapi.yaml'
         - 'tests_end_to_end/**'
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 run-name: Application E2E Tests (TypeScript) - ${{ github.event.inputs.suite || 'fullregression' }}
 
 permissions:

--- a/.github/workflows/frontend_linter.yml
+++ b/.github/workflows/frontend_linter.yml
@@ -10,6 +10,10 @@ on:
     paths: 
       - "apps/opik-frontend/src/**"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend_unit_tests.yml
+++ b/.github/workflows/frontend_unit_tests.yml
@@ -13,6 +13,10 @@ on:
       - "apps/opik-frontend/**"
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   tests:
     name: Test on Node ${{ matrix.node-version }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   labeler:
     name: PR Labeler - Apply and Sync Labels

--- a/.github/workflows/lib-integration-tests-runner.yml
+++ b/.github/workflows/lib-integration-tests-runner.yml
@@ -51,6 +51,10 @@ on:
     paths:
       - 'sdks/python/**'
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   LIBS: ${{ github.event.inputs.libs != '' && github.event.inputs.libs  || 'all' }}

--- a/.github/workflows/lint_helm_chart.yaml
+++ b/.github/workflows/lint_helm_chart.yaml
@@ -12,6 +12,10 @@ on:
     paths: 
       - "deployment/helm_chart/opik/**"
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   
   lint-helm-chart:

--- a/.github/workflows/migration_prefix_check.yml
+++ b/.github/workflows/migration_prefix_check.yml
@@ -11,6 +11,10 @@ on:
       - "apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/**"
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   check-migration-prefix-conflicts:
     runs-on: ubuntu-latest

--- a/.github/workflows/opik-optimizer-linter.yaml
+++ b/.github/workflows/opik-optimizer-linter.yaml
@@ -6,6 +6,10 @@ on:
     pull_request:
         paths:
         - 'sdks/opik_optimizer/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
     lint:
         runs-on: ubuntu-latest

--- a/.github/workflows/opik-optimizer-unit-tests.yaml
+++ b/.github/workflows/opik-optimizer-unit-tests.yaml
@@ -6,6 +6,10 @@ on:
         paths:
           - 'sdks/opik_optimizer/**'
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 env:
   OPIK_ENABLE_LITELLM_MODELS_MONITORING: False
   OPIK_SENTRY_ENABLE: False

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   assign_pr_creator_or_pusher:
     name: Assign PR Creator or Pusher

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   lint-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/python_backend_tests.yml
+++ b/.github/workflows/python_backend_tests.yml
@@ -18,6 +18,10 @@ on:
       - ".github/workflows/python_backend_tests.yml"
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   run-python-backend-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
@@ -18,6 +18,10 @@ on:
           - 'sdks/python/**'
           - 'apps/opik-backend/**'
           - '.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 env:
   OPIK_ENABLE_LITELLM_MODELS_MONITORING: False
   OPIK_SENTRY_ENABLE: False

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -18,6 +18,10 @@ on:
           - 'sdks/python/**'
           - 'apps/opik-backend/**'
           - '.github/workflows/python_sdk_e2e_tests.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 env:
   OPIK_ENABLE_LITELLM_MODELS_MONITORING: False
   OPIK_SENTRY_ENABLE: False

--- a/.github/workflows/python_sdk_linter.yml
+++ b/.github/workflows/python_sdk_linter.yml
@@ -10,6 +10,10 @@ on:
       - 'main'
     paths:
       - 'sdks/python/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/python_sdk_unit_tests.yml
+++ b/.github/workflows/python_sdk_unit_tests.yml
@@ -15,6 +15,10 @@ on:
     paths:
       - 'sdks/python/**'
       - '.github/workflows/python_sdk_unit_tests.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 env:
   OPIK_ENABLE_LITELLM_MODELS_MONITORING: False
   OPIK_SENTRY_ENABLE: False

--- a/.github/workflows/sdk-e2e-library-tests.yaml
+++ b/.github/workflows/sdk-e2e-library-tests.yaml
@@ -27,6 +27,10 @@ on:
         paths:
           - 'sdks/python/**'
           - '.github/workflows/sdk-e2e-library-tests.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 env:
   OPIK_ENABLE_LITELLM_MODELS_MONITORING: True  # unlike other workflows, here we need it for tests
   OPIK_SENTRY_ENABLE: False

--- a/.github/workflows/trigger_test_env_on_label.yaml
+++ b/.github/workflows/trigger_test_env_on_label.yaml
@@ -6,6 +6,10 @@ on:
     types: [labeled]
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
@@ -18,6 +18,10 @@ on:
       - 'sdks/typescript/**'
       - 'apps/opik-backend/**'
       - '.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 env:
   OPIK_ENABLE_LITELLM_MODELS_MONITORING: False
   OPIK_SENTRY_ENABLE: False

--- a/.github/workflows/typescript_sdk_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_e2e_tests.yml
@@ -14,6 +14,10 @@ on:
       - 'sdks/typescript/**'
       - 'apps/opik-backend/**'
       - '.github/workflows/typescript_sdk_e2e_tests.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 env:
   OPIK_ENABLE_LITELLM_MODELS_MONITORING: False
   OPIK_SENTRY_ENABLE: False

--- a/.github/workflows/typescript_sdk_integration_publish.yml
+++ b/.github/workflows/typescript_sdk_integration_publish.yml
@@ -43,6 +43,10 @@ on:
         required: false
         default: false
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/typescript_sdk_linter.yml
+++ b/.github/workflows/typescript_sdk_linter.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - "sdks/typescript/**"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/typescript_sdk_publish.yml
+++ b/.github/workflows/typescript_sdk_publish.yml
@@ -45,6 +45,10 @@ on:
         required: false
         default: false
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/typescript_sdk_unit_tests.yml
+++ b/.github/workflows/typescript_sdk_unit_tests.yml
@@ -11,6 +11,10 @@ on:
       - "sdks/typescript/**"
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     name: Test on Node ${{ matrix.node-version }}

--- a/.github/workflows/update_helm_readme.yaml
+++ b/.github/workflows/update_helm_readme.yaml
@@ -6,6 +6,10 @@ on:
       - "deployment/helm_chart/opik/**"
     types: [opened, synchronize, reopened, labeled]
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   update-readme:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `concurrency` groups to all 30 PR-triggered workflows that were missing them (1 already had it)
- When a new commit is pushed to a PR, any in-progress or queued runs for the same PR are automatically cancelled
- Reduces runner queue pressure — especially for `ubuntu-latest-m` runners which have been backing up

## Details
Each workflow gets:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

This groups by workflow name + PR number (or branch ref for pushes to main), so:
- PR runs cancel previous runs for the same PR
- Main branch runs are grouped by ref and don't interfere with PR runs

## Test plan
- [ ] Verify workflows still trigger correctly on PRs
- [ ] Push two commits quickly to a PR and confirm the first run gets cancelled
- [ ] Verify main branch pushes still run independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)