### PR TITLE
[OPIK-5274] [BE] feat: add source filter support to trace thread endpoints

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/filter/TraceThreadField.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/filter/TraceThreadField.java
@@ -1,7 +1,10 @@
 package com.comet.opik.api.filter;
 
+import com.comet.opik.api.Source;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Getter
@@ -19,6 +22,12 @@ public enum TraceThreadField implements Field {
     STATUS(STATUS_QUERY_PARAM, FieldType.ENUM),
     TAGS(TAGS_QUERY_PARAM, FieldType.LIST),
     ANNOTATION_QUEUE_IDS(ANNOTATION_QUEUE_IDS_QUERY_PARAM, FieldType.LIST),
+    SOURCE(SOURCE_QUERY_PARAM, FieldType.ENUM) {
+        @Override
+        public Optional<String> legacyFallbackDbValue(String filterValue) {
+            return Source.legacyFallbackDbValue(filterValue);
+        }
+    },
     ;
 
     private final String queryParamField;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
@@ -88,6 +88,7 @@ class ThreadDAOImpl implements ThreadDAO {
                   <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
                   <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
                   <if(search_text)> AND <search_text> <endif>
+                  <if(filters)> AND <filters> <endif>
             ), spans_agg AS (
                 SELECT
                     trace_id,
@@ -408,6 +409,7 @@ class ThreadDAOImpl implements ThreadDAO {
                   <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
                   <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
                   <if(search_text)> AND <search_text> <endif>
+                  <if(filters)> AND <filters> <endif>
             ), spans_agg AS (
                 SELECT
                     trace_id,
@@ -981,6 +983,7 @@ class ThreadDAOImpl implements ThreadDAO {
                     <if(search_text)> AND <search_text> <endif>
                     <if(uuid_from_time)>AND id >= :uuid_from_time<endif>
                     <if(uuid_to_time)>AND id \\<= :uuid_to_time<endif>
+                    <if(filters)> AND <filters> <endif>
                 ), spans_agg AS (
                     SELECT
                         trace_id,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -336,6 +336,7 @@ public class FilterQueryBuilder {
                     .put(TraceThreadField.STATUS, STATUS_DB)
                     .put(TraceThreadField.TAGS, TAGS_DB)
                     .put(TraceThreadField.ANNOTATION_QUEUE_IDS, THREAD_ANNOTATION_QUEUE_IDS_ANALYTICS_DB)
+                    .put(TraceThreadField.SOURCE, SOURCE_DB)
                     .build());
 
     private static final Map<SpanField, String> SPAN_FIELDS_MAP = new EnumMap<>(
@@ -540,7 +541,8 @@ public class FilterQueryBuilder {
                 TraceField.VISIBILITY_MODE,
                 TraceField.ERROR_INFO,
                 TraceField.ERROR_TYPE,
-                TraceField.SOURCE));
+                TraceField.SOURCE,
+                TraceThreadField.SOURCE));
 
         map.put(FilterStrategy.EXPERIMENT_AGGREGATION, Set.of(
                 TraceField.EXPERIMENT_ID));

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindTraceThreadsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindTraceThreadsResourceTest.java
@@ -5,6 +5,7 @@ import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.FeedbackScoreItem;
 import com.comet.opik.api.Project;
 import com.comet.opik.api.ProjectStats;
+import com.comet.opik.api.Source;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.TraceThread;
@@ -784,6 +785,69 @@ class FindTraceThreadsResourceTest {
             assertThreadPage(null, projectId, expectedThreads, List.of(statusFilter), Map.of(), apiKey,
                     workspaceName);
             assertTheadStream(null, projectId, apiKey, workspaceName, expectedThreads, List.of(statusFilter));
+        }
+
+        private Stream<Arguments> getSourceFilterTestArguments() {
+            return Stream.of(
+                    Arguments.of(false, Source.PLAYGROUND, Source.EXPERIMENT),
+                    Arguments.of(true, Source.PLAYGROUND, Source.EXPERIMENT),
+                    Arguments.of(false, Source.EXPERIMENT, Source.PLAYGROUND),
+                    Arguments.of(true, Source.EXPERIMENT, Source.PLAYGROUND));
+        }
+
+        @ParameterizedTest(name = "stream={0}, source={1}")
+        @MethodSource("getSourceFilterTestArguments")
+        @DisplayName("When filtering by source, should return only threads whose traces match the source")
+        void whenFilterBySource__thenReturnThreadsWithMatchingSource(boolean stream, Source filterSource,
+                Source otherSource) {
+
+            var projectName = RandomStringUtils.secure().nextAlphanumeric(10);
+            var threadId = UUID.randomUUID().toString();
+            var otherThreadId = UUID.randomUUID().toString();
+
+            var traces = IntStream.range(0, 3)
+                    .mapToObj(it -> {
+                        Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+                        return createTrace().toBuilder()
+                                .projectName(projectName)
+                                .usage(null)
+                                .threadId(threadId)
+                                .source(filterSource)
+                                .endTime(now.plus(it, ChronoUnit.MILLIS))
+                                .startTime(now)
+                                .build();
+                    })
+                    .toList();
+
+            var otherTraces = IntStream.range(0, 3)
+                    .mapToObj(it -> createTrace().toBuilder()
+                            .projectName(projectName)
+                            .usage(null)
+                            .threadId(otherThreadId)
+                            .source(otherSource)
+                            .build())
+                    .toList();
+
+            traceResourceClient.batchCreateTraces(traces, API_KEY, TEST_WORKSPACE);
+            traceResourceClient.batchCreateTraces(otherTraces, API_KEY, TEST_WORKSPACE);
+
+            var projectId = getProjectId(projectName, TEST_WORKSPACE, API_KEY);
+
+            List<TraceThread> expectedThreads = getExpectedThreads(traces, projectId, threadId, List.of(),
+                    TraceThreadStatus.ACTIVE);
+
+            var filter = TraceThreadFilter.builder()
+                    .field(TraceThreadField.SOURCE)
+                    .operator(Operator.EQUAL)
+                    .value(filterSource.getValue())
+                    .build();
+
+            if (!stream) {
+                assertThreadPage(projectName, null, expectedThreads, List.of(filter), Map.of(), API_KEY,
+                        TEST_WORKSPACE);
+            } else {
+                assertTheadStream(projectName, null, API_KEY, TEST_WORKSPACE, expectedThreads, List.of(filter));
+            }
         }
 
         @ParameterizedTest
@@ -2222,6 +2286,72 @@ class FindTraceThreadsResourceTest {
                     Map.of());
 
             assertThat(stats.stats()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("When filtering stats by source, should return stats only for threads with matching source")
+        void whenFilterBySource__thenReturnStatsForMatchingSource() {
+            var workspaceName = RandomStringUtils.secure().nextAlphanumeric(10);
+            var workspaceId = UUID.randomUUID().toString();
+            var apiKey = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var projectName = RandomStringUtils.secure().nextAlphanumeric(10);
+            projectResourceClient.createProject(
+                    factory.manufacturePojo(Project.class).toBuilder().name(projectName).build(),
+                    apiKey, workspaceName);
+
+            var thread1Id = UUID.randomUUID().toString();
+            var thread2Id = UUID.randomUUID().toString();
+
+            var thread1Traces = IntStream.range(0, 2)
+                    .mapToObj(it -> {
+                        Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+                        return createTrace().toBuilder()
+                                .projectName(projectName)
+                                .usage(null)
+                                .threadId(thread1Id)
+                                .source(Source.PLAYGROUND)
+                                .endTime(now.plus(it, ChronoUnit.MILLIS))
+                                .startTime(now)
+                                .build();
+                    })
+                    .toList();
+
+            var thread2Traces = IntStream.range(0, 3)
+                    .mapToObj(it -> {
+                        Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+                        return createTrace().toBuilder()
+                                .projectName(projectName)
+                                .usage(null)
+                                .threadId(thread2Id)
+                                .source(Source.EXPERIMENT)
+                                .endTime(now.plus(it + 100, ChronoUnit.MILLIS))
+                                .startTime(now)
+                                .build();
+                    })
+                    .toList();
+
+            traceResourceClient.batchCreateTraces(
+                    Stream.concat(thread1Traces.stream(), thread2Traces.stream()).toList(),
+                    apiKey, workspaceName);
+
+            Mono.delay(Duration.ofMillis(1000)).block();
+
+            var filter = TraceThreadFilter.builder()
+                    .field(TraceThreadField.SOURCE)
+                    .operator(Operator.EQUAL)
+                    .value(Source.PLAYGROUND.getValue())
+                    .build();
+
+            var stats = traceResourceClient.getTraceThreadStats(projectName, null, apiKey, workspaceName,
+                    List.of(filter), Map.of());
+
+            assertThat(getThreadCount(stats)).isEqualTo(1L);
+
+            var expectedStats = buildExpectedThreadStats(thread1Traces, List.of(), null);
+            TraceAssertions.assertStats(stats.stats(), expectedStats);
         }
     }
 


### PR DESCRIPTION
## Details

Adds `source` filter support to the trace thread endpoints (`GET /traces/threads` list, stream, and stats). Previously, the `source` field was not filterable on thread queries despite being a valid `TraceThreadField` entry — the filter was silently ignored.

Key changes:
- Added `SOURCE` field to `TraceThreadField` enum with `legacyFallbackDbValue` override (same pattern as `SpanField.SOURCE`, maps `sdk` to also match `unknown` rows from pre-tracking data)
- Routed `TraceThreadField.SOURCE` to `FilterStrategy.TRACE` in `FilterQueryBuilder` so it applies to the `traces_final` CTE where the `source` column lives (not the aggregated thread model)
- Added `<if(filters)> AND <filters> <endif>` to the `traces_final` CTE in all three affected SQL query templates: list/stream (`SELECT_TRACES_THREADS_BY_PROJECT_IDS`), stats (`SELECT_TRACE_THREADS_STATS`), and count (`SELECT_COUNT_TRACES_THREADS_BY_PROJECT_IDS`)
- Added integration tests covering source filtering for thread list (stream and non-stream) and thread stats endpoints

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5274

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: full implementation
- Human verification: code review + manual test run (all 4 new integration tests pass)

## Testing

- Ran new integration tests:
  ```
  mvn test -Dtest="FindTraceThreadsResourceTest\$FindTraceThreads#whenFilterBySource*+FindTraceThreadsResourceTest\$TraceThreadStats#whenFilterBySource*"
  ```
  All 4 tests pass (stream=true/false × PLAYGROUND/EXPERIMENT for list, plus stats test)
- Ran `mvn spotless:check` and `mvn compile -DskipTests` — both pass
- Scenarios validated:
  - Filter by `source = PLAYGROUND` returns only threads whose traces have `source = playground`
  - Filter by `source = EXPERIMENT` returns only threads whose traces have `source = experiment`
  - Non-stream list endpoint (`GET /traces/threads`) and stream endpoint both work
  - Stats endpoint returns correct count when filtered by source

## Documentation

N/A — no user-facing documentation changes required for filter field addition.