### PR TITLE
Make early ClickHouse migrations idempotent (ADD COLUMN IF NOT EXISTS)

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000001_init_script.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000001_init_script.sql
@@ -98,28 +98,28 @@ CREATE TABLE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME}.experiment_items
     ORDER BY (workspace_id, experiment_id, dataset_item_id, trace_id, id);
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_items
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.feedback_scores
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.dataset_items
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiments
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_items DROP COLUMN created_by, DROP COLUMN last_updated_by;
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans DROP COLUMN created_by, DROP COLUMN last_updated_by;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000003_add_metadata_to_experiments.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000003_add_metadata_to_experiments.sql
@@ -2,6 +2,6 @@
 --changeset andrescrz:add_metadata_to_experiments
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiments
-    ADD COLUMN metadata String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS metadata String DEFAULT '';
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiments DROP COLUMN metadata;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000014_add_thread_id_to_traces.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000014_add_thread_id_to_traces.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 --changeset thiagohora:add_thread_id_to_traces
 
-ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD COLUMN thread_id String;
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD COLUMN IF NOT EXISTS thread_id String;
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces DROP COLUMN IF EXISTS thread_id;


### PR DESCRIPTION
## Summary

Fixes #5835

Migrations `000001_init_script.sql`, `000003_add_metadata_to_experiments.sql`, and `000014_add_thread_id_to_traces.sql` use bare `ADD COLUMN`, which causes ClickHouse to error with "duplicate column" on re-run. All migrations from `000004` onward already use `ADD COLUMN IF NOT EXISTS`.

This PR aligns those three early migrations with the existing convention. Minimal change — just adding `IF NOT EXISTS` to each `ADD COLUMN` clause.

A prior PR for this issue was closed; this takes a simpler, more focused approach limited strictly to the `ADD COLUMN` statements.

## Changes

- **000001_init_script.sql**: 12 `ADD COLUMN` → `ADD COLUMN IF NOT EXISTS` across 6 ALTER TABLE statements
- **000003_add_metadata_to_experiments.sql**: 1 `ADD COLUMN` → `ADD COLUMN IF NOT EXISTS`
- **000014_add_thread_id_to_traces.sql**: 1 `ADD COLUMN` → `ADD COLUMN IF NOT EXISTS`

## Test plan

- Verified the three files compile with correct ClickHouse SQL syntax
- No behavioral change on first run; only affects re-run idempotency