### PR TITLE
[OPIK-5278] [BE] fix: correct blueprint name auto-increment for prompt version updates

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigDAO.java
@@ -54,7 +54,7 @@ interface AgentConfigDAO {
 
     @Builder(toBuilder = true)
     record BlueprintValueReference(@NonNull UUID blueprintId, @NonNull UUID projectId, @NonNull UUID configId,
-            @NonNull String configKey, String oldValue, @NonNull String latestBlueprintName) {
+            @NonNull String configKey, String oldValue, long blueprintCount) {
     }
 
     @Builder(toBuilder = true)
@@ -309,6 +309,12 @@ interface AgentConfigDAO {
                 WHERE pv.workspace_id = :workspace_id
                     AND pv.prompt_id = :prompt_id
                     AND pv.commit != :new_commit
+            ),
+            blueprint_counts AS (
+                SELECT workspace_id, project_id, COUNT(*) AS blueprint_count
+                FROM agent_blueprints
+                WHERE workspace_id = :workspace_id AND type = 'blueprint'
+                GROUP BY workspace_id, project_id
             )
             SELECT DISTINCT
                 ab.id as blueprint_id,
@@ -316,12 +322,15 @@ interface AgentConfigDAO {
                 ab.config_id,
                 acv.key as config_key,
                 acv.value as old_value,
-                ab.name as latest_blueprint_name
+                COALESCE(bc.blueprint_count, 0) as blueprint_count
             FROM agent_blueprints ab
             JOIN agent_config_values acv
                 ON acv.valid_from_blueprint_id = ab.id
                 AND acv.workspace_id = ab.workspace_id
                 AND acv.project_id = ab.project_id
+            LEFT JOIN blueprint_counts bc
+                ON bc.workspace_id = ab.workspace_id
+                AND bc.project_id = ab.project_id
             WHERE ab.workspace_id = :workspace_id
                 AND ab.type = 'blueprint'
                 AND acv.type = 'prompt'

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
@@ -180,7 +180,9 @@ class AgentConfigServiceImpl implements AgentConfigService {
                 .lastUpdatedBy(userName)
                 .build();
 
-        String name = generateNextBlueprintName(dao, workspaceId, projectId);
+        String name = blueprint.type() == AgentBlueprint.BlueprintType.MASK
+                ? ""
+                : generateNextBlueprintName(dao, workspaceId, projectId);
         UUID blueprintId = createBlueprintSnapshot(dao, workspaceId, projectId, configId, name, blueprint);
 
         return blueprint.toBuilder()
@@ -228,11 +230,6 @@ class AgentConfigServiceImpl implements AgentConfigService {
     private String generateNextBlueprintName(AgentConfigDAO dao, String workspaceId, UUID projectId) {
         long count = dao.countBlueprints(workspaceId, projectId);
         return "v" + (count + 1);
-    }
-
-    static String incrementBlueprintName(String name) {
-        int version = Integer.parseInt(name.substring(1));
-        return "v" + (version + 1);
     }
 
     private void insertValues(
@@ -632,7 +629,7 @@ class AgentConfigServiceImpl implements AgentConfigService {
                     for (var entry : referencesByProject.entrySet()) {
                         List<AgentConfigDAO.BlueprintValueReference> refs = entry.getValue();
                         UUID configId = refs.getFirst().configId();
-                        String name = incrementBlueprintName(refs.getFirst().latestBlueprintName());
+                        String name = "v" + (refs.getFirst().blueprintCount() + 1);
                         UUID blueprintId = idGenerator.generateId();
 
                         blueprintInserts.add(AgentConfigDAO.BlueprintInsertData.builder()

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResourceTest.java
@@ -1654,6 +1654,69 @@ class AgentConfigsResourceTest {
 
             assertConfigValues(expectedValues, latestBlueprint.values());
         }
+
+        @Test
+        @DisplayName("Success: auto-created blueprint gets correct name when intermediate blueprints exist")
+        void createPromptVersion__whenIntermediateBlueprintsExist__thenAutoUpdateUsesCorrectName() {
+            var projectName = UUID.randomUUID().toString();
+            var projectId = projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
+
+            var promptName = "test-prompt-" + UUID.randomUUID();
+            var prompt = com.comet.opik.api.Prompt.builder()
+                    .name(promptName)
+                    .build();
+
+            promptResourceClient.createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            var promptVersion1 = promptResourceClient.createPromptVersion(prompt, API_KEY, TEST_WORKSPACE);
+            var commit1 = promptVersion1.commit();
+
+            // v1: blueprint with prompt reference
+            agentConfigsResourceClient.createAgentConfig(
+                    AgentConfigCreate.builder()
+                            .projectId(projectId)
+                            .blueprint(AgentBlueprint.builder()
+                                    .type(BlueprintType.BLUEPRINT)
+                                    .description("Initial config with prompt")
+                                    .values(List.of(
+                                            AgentConfigValue.builder().key("system_prompt").value(commit1)
+                                                    .type(ValueType.PROMPT).build()))
+                                    .build())
+                            .build(),
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+
+            // v2: blueprint that adds a different parameter (prompt reference stays from v1)
+            agentConfigsResourceClient.updateAgentConfig(
+                    AgentConfigCreate.builder()
+                            .projectId(projectId)
+                            .blueprint(AgentBlueprint.builder()
+                                    .type(BlueprintType.BLUEPRINT)
+                                    .description("Second blueprint with other param")
+                                    .values(List.of(
+                                            AgentConfigValue.builder().key("temperature").value("0.7")
+                                                    .type(ValueType.FLOAT).build()))
+                                    .build())
+                            .build(),
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_NO_CONTENT);
+
+            // create new prompt version -> triggers auto blueprint creation
+            var promptVersion2 = promptResourceClient.createPromptVersion(prompt, API_KEY, TEST_WORKSPACE);
+            var commit2 = promptVersion2.commit();
+
+            Awaitility.await().untilAsserted(() -> {
+                var latestBlueprint = agentConfigsResourceClient.getLatestBlueprint(projectId, null, API_KEY,
+                        TEST_WORKSPACE, HttpStatus.SC_OK);
+
+                assertThat(latestBlueprint).isNotNull();
+                assertThat(latestBlueprint.name()).isEqualTo("v3");
+
+                var promptValue = latestBlueprint.values().stream()
+                        .filter(v -> v.key().equals("system_prompt"))
+                        .findFirst()
+                        .orElseThrow();
+                assertThat(promptValue.value()).isEqualTo(commit2);
+            });
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Details
Fixed blueprint name auto-increment logic when new prompt versions trigger automatic blueprint creation. Previously, the name was derived by parsing and incrementing the latest blueprint's name (e.g., "v2" → "v3"), which produced incorrect results when intermediate blueprints existed (e.g., skipping from "v2" to "v3" when there were already 3 blueprints). Now the name is based on the total count of blueprints in the project, ensuring correct sequential naming regardless of intermediate snapshots.

Key changes:
- Replaced `latestBlueprintName`-based increment with a `blueprint_count` CTE query in `AgentConfigDAO`
- Removed unused `incrementBlueprintName` helper method
- Skip name generation for MASK-type blueprints (they don't need names)
- Added test covering the intermediate-blueprint scenario

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5278

## AI-WATERMARK

AI-WATERMARK: yes
- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: PR description generation
- Human verification: yes

## Testing
- `cd apps/opik-backend && mvn test` — new test `createPromptVersion__whenIntermediateBlueprintsExist__thenAutoUpdateUsesCorrectName` validates that auto-created blueprints get the correct name (v3) when intermediate blueprints exist between the original and the auto-created one.

## Documentation
N/A
