### PR TITLE
[OPIK-5020] [FE] fix: Comet plugin GetStartedPage respects v2 workspace version

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/GetStartedPage.tsx
+++ b/apps/opik-frontend/src/plugins/comet/GetStartedPage.tsx
@@ -1,12 +1,15 @@
-import NewQuickstart from "@/v1/pages/GetStartedPage/NewQuickstart";
+import V1NewQuickstart from "@/v1/pages/GetStartedPage/NewQuickstart";
+import V2NewQuickstart from "@/v2/pages/GetStartedPage/NewQuickstart";
 import useUser from "./useUser";
 import useOrganizations from "@/plugins/comet/useOrganizations";
 import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
 import { ORGANIZATION_PLAN_ENTERPRISE } from "./types";
 import useAppStore from "@/store/AppStore";
+import { useWorkspaceVersion } from "@/store/AppStore";
 
 const GetStartedPage = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const workspaceVersion = useWorkspaceVersion();
 
   const { data: user } = useUser();
   const { data: organizations } = useOrganizations({
@@ -17,6 +20,10 @@ const GetStartedPage = () => {
   });
 
   if (!user) return;
+
+  if (workspaceVersion === "v2") {
+    return <V2NewQuickstart />;
+  }
 
   const currentWorkspace = allWorkspaces?.find(
     (workspace) => workspace.workspaceName === workspaceName,
@@ -29,7 +36,7 @@ const GetStartedPage = () => {
   const isEnterpriseCustomer =
     currentOrganization?.paymentPlan === ORGANIZATION_PLAN_ENTERPRISE;
 
-  return <NewQuickstart shouldSkipQuestions={isEnterpriseCustomer} />;
+  return <V1NewQuickstart shouldSkipQuestions={isEnterpriseCustomer} />;
 };
 
 export default GetStartedPage;


### PR DESCRIPTION
## Details
The Comet plugin's `GetStartedPage` was hardcoded to always render the v1 `NewQuickstart` component, which meant the v2 agent onboarding flow was never shown in the full Comet environment (e.g., test.dev). This worked in opik-only PR test environments because the Comet plugin isn't loaded there.

This fix makes the Comet plugin version-aware: when `workspaceVersion` is `"v2"`, it renders the v2 `NewQuickstart` (agent onboarding); otherwise it falls back to v1 with the existing enterprise customer logic.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5020

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: assisted (diagnosis and implementation)
- Human verification: code review + manual testing on test.dev

## Testing
- `cd apps/opik-frontend && npm run lint` — passes
- `cd apps/opik-frontend && npm run typecheck` — pre-existing unrelated errors only (`react-h5-audio-player` types)
- Manual verification: set `localStorage.setItem("opik-version-override", "v2")` in full Comet environment and confirm v2 agent onboarding flow renders

## Documentation
N/A