### PR TITLE
[NA] [CI] fix: use unique concurrency groups in TS SDK reusable workflows

### DIFF
--- a/.github/workflows/typescript_sdk_integration_publish.yml
+++ b/.github/workflows/typescript_sdk_integration_publish.yml
@@ -45,7 +45,7 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ts-sdk-integration-publish-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   build-and-publish:

--- a/.github/workflows/typescript_sdk_publish.yml
+++ b/.github/workflows/typescript_sdk_publish.yml
@@ -47,7 +47,7 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ts-sdk-publish-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   build-and-publish:


### PR DESCRIPTION
## Details
Fix release workflow failures caused by TS SDK reusable workflows sharing the same concurrency group. `github.workflow` resolves to the **caller's** name during `workflow_call`, so both TS SDK workflows ended up in concurrency group `Release with Release-n-Deploy-Agent-refs/heads/main` and `cancel-in-progress: true` made them cancel each other.

- Replace `${{ github.workflow }}` with hardcoded workflow-specific prefixes (`ts-sdk-publish-`, `ts-sdk-integration-publish-`) in concurrency groups

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Failing run: https://github.com/comet-ml/opik/actions/runs/23641640111
- Root cause: commit 1ba14260d7

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full PR (investigation + fix)
  - Human verification: Reviewed diff and root cause analysis

## Testing

- Verified that no other reusable workflows in the release chain are affected
- PR-triggered runs will still cancel redundant jobs within each workflow (group key includes PR number)
- Full validation requires a release run after merge

## Documentation
N/A