### PR TITLE
[OPIK-5158] [FE] feat: add hidden source filter to v2 project pages

### DIFF
--- a/apps/opik-frontend/src/api/projects/useProjectMetric.ts
+++ b/apps/opik-frontend/src/api/projects/useProjectMetric.ts
@@ -2,7 +2,8 @@ import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import api, { PROJECTS_REST_ENDPOINT, QueryConfig } from "@/api/api";
 import { ProjectMetricTrace } from "@/types/projects";
 import { Filter } from "@/types/filters";
-import { processFiltersArray } from "@/lib/filters";
+import { generateLogsSourceFilter, processFiltersArray } from "@/lib/filters";
+import { LOGS_SOURCE } from "@/types/traces";
 import { BreakdownConfig, BREAKDOWN_FIELD } from "@/types/dashboard";
 
 export enum METRIC_NAME_TYPE {
@@ -38,6 +39,7 @@ type UseProjectMetricsParams = {
   threadFilters?: Filter[];
   spanFilters?: Filter[];
   breakdown?: BreakdownConfig;
+  logsSource?: LOGS_SOURCE;
 };
 
 export interface ProjectMetricResult {
@@ -79,8 +81,11 @@ const getProjectMetric = async (
     threadFilters,
     spanFilters,
     breakdown,
+    logsSource,
   }: UseProjectMetricsParams,
 ) => {
+  const sourceFilter = logsSource ? generateLogsSourceFilter(logsSource) : [];
+
   const { data } = await api.post<ProjectMetricsResponse>(
     `${PROJECTS_REST_ENDPOINT}${projectId}/metrics`,
     {
@@ -88,13 +93,18 @@ const getProjectMetric = async (
       interval,
       ...(intervalStart && { interval_start: intervalStart }),
       ...(intervalEnd && { interval_end: intervalEnd }),
-      trace_filters: traceFilters
-        ? processFiltersArray(traceFilters)
-        : undefined,
-      thread_filters: threadFilters
-        ? processFiltersArray(threadFilters)
-        : undefined,
-      span_filters: spanFilters ? processFiltersArray(spanFilters) : undefined,
+      trace_filters: processFiltersArray([
+        ...(traceFilters ?? []),
+        ...sourceFilter,
+      ]),
+      thread_filters: processFiltersArray([
+        ...(threadFilters ?? []),
+        ...sourceFilter,
+      ]),
+      span_filters: processFiltersArray([
+        ...(spanFilters ?? []),
+        ...sourceFilter,
+      ]),
       breakdown: processBreakdownConfig(breakdown),
     },
     {

--- a/apps/opik-frontend/src/api/traces/useSpansList.ts
+++ b/apps/opik-frontend/src/api/traces/useSpansList.ts
@@ -2,7 +2,8 @@ import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import api, { QueryConfig, SPANS_KEY, SPANS_REST_ENDPOINT } from "@/api/api";
 import { Span, SPAN_TYPE } from "@/types/traces";
 import { Filters } from "@/types/filters";
-import { processFilters } from "@/lib/filters";
+import { generateLogsSourceFilter, processFilters } from "@/lib/filters";
+import { LOGS_SOURCE } from "@/types/traces";
 import { Sorting } from "@/types/sorting";
 import { processSorting } from "@/lib/sorting";
 
@@ -20,6 +21,7 @@ export type UseSpansListParams = {
   exclude?: string[];
   fromTime?: string;
   toTime?: string;
+  logsSource?: LOGS_SOURCE;
 };
 
 export type UseSpansListResponse = {
@@ -44,6 +46,7 @@ const getSpansList = async (
     exclude,
     fromTime,
     toTime,
+    logsSource,
   }: UseSpansListParams,
 ) => {
   const { data } = await api.get(SPANS_REST_ENDPOINT, {
@@ -52,7 +55,10 @@ const getSpansList = async (
       project_id: projectId,
       ...(traceId && { trace_id: traceId }),
       ...(type && { type }),
-      ...processFilters(filters),
+      ...processFilters(
+        filters,
+        logsSource ? generateLogsSourceFilter(logsSource) : undefined,
+      ),
       ...processSorting(sorting),
       ...(search && { search }),
       ...(exclude && { exclude: JSON.stringify(exclude) }),

--- a/apps/opik-frontend/src/api/traces/useSpansStatistic.ts
+++ b/apps/opik-frontend/src/api/traces/useSpansStatistic.ts
@@ -3,7 +3,8 @@ import api, { QueryConfig, SPANS_REST_ENDPOINT } from "@/api/api";
 import { SPAN_TYPE } from "@/types/traces";
 import { ColumnsStatistic } from "@/types/shared";
 import { Filters } from "@/types/filters";
-import { processFilters } from "@/lib/filters";
+import { generateLogsSourceFilter, processFilters } from "@/lib/filters";
+import { LOGS_SOURCE } from "@/types/traces";
 
 type UseSpansStatisticParams = {
   projectId: string;
@@ -13,6 +14,7 @@ type UseSpansStatisticParams = {
   search?: string;
   fromTime?: string;
   toTime?: string;
+  logsSource?: LOGS_SOURCE;
 };
 
 export type UseSpansStatisticResponse = {
@@ -29,6 +31,7 @@ const getSpansStatistic = async (
     search,
     fromTime,
     toTime,
+    logsSource,
   }: UseSpansStatisticParams,
 ) => {
   const { data } = await api.get(`${SPANS_REST_ENDPOINT}stats`, {
@@ -37,7 +40,10 @@ const getSpansStatistic = async (
       project_id: projectId,
       ...(traceId && { trace_id: traceId }),
       ...(type && { type }),
-      ...processFilters(filters),
+      ...processFilters(
+        filters,
+        logsSource ? generateLogsSourceFilter(logsSource) : undefined,
+      ),
       ...(search && { search }),
       ...(fromTime && { from_time: fromTime }),
       ...(toTime && { to_time: toTime }),

--- a/apps/opik-frontend/src/api/traces/useThreadsList.ts
+++ b/apps/opik-frontend/src/api/traces/useThreadsList.ts
@@ -1,6 +1,7 @@
 import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import api, { QueryConfig, THREADS_KEY, TRACES_REST_ENDPOINT } from "@/api/api";
-import { processFilters } from "@/lib/filters";
+import { generateLogsSourceFilter, processFilters } from "@/lib/filters";
+import { LOGS_SOURCE } from "@/types/traces";
 import { Thread } from "@/types/traces";
 import { Filters } from "@/types/filters";
 import { Sorting } from "@/types/sorting";
@@ -16,6 +17,7 @@ type UseThreadListParams = {
   truncate?: boolean;
   fromTime?: string;
   toTime?: string;
+  logsSource?: LOGS_SOURCE;
 };
 
 export type UseThreadListResponse = {
@@ -36,6 +38,7 @@ const getThreadList = async (
     truncate,
     fromTime,
     toTime,
+    logsSource,
   }: UseThreadListParams,
 ) => {
   const { data } = await api.get<UseThreadListResponse>(
@@ -44,7 +47,10 @@ const getThreadList = async (
       signal,
       params: {
         project_id: projectId,
-        ...processFilters(filters),
+        ...processFilters(
+          filters,
+          logsSource ? generateLogsSourceFilter(logsSource) : undefined,
+        ),
         ...processSorting(sorting),
         ...(search && { search }),
         size,

--- a/apps/opik-frontend/src/api/traces/useThreadsStatistic.ts
+++ b/apps/opik-frontend/src/api/traces/useThreadsStatistic.ts
@@ -2,7 +2,8 @@ import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import api, { QueryConfig, TRACES_REST_ENDPOINT } from "@/api/api";
 import { ColumnsStatistic } from "@/types/shared";
 import { Filters } from "@/types/filters";
-import { processFilters } from "@/lib/filters";
+import { generateLogsSourceFilter, processFilters } from "@/lib/filters";
+import { LOGS_SOURCE } from "@/types/traces";
 
 type UseThreadsStatisticParams = {
   projectId: string;
@@ -10,6 +11,7 @@ type UseThreadsStatisticParams = {
   search?: string;
   fromTime?: string;
   toTime?: string;
+  logsSource?: LOGS_SOURCE;
 };
 
 export type UseThreadsStatisticResponse = {
@@ -18,7 +20,14 @@ export type UseThreadsStatisticResponse = {
 
 const getThreadsStatistic = async (
   { signal }: QueryFunctionContext,
-  { projectId, filters, search, fromTime, toTime }: UseThreadsStatisticParams,
+  {
+    projectId,
+    filters,
+    search,
+    fromTime,
+    toTime,
+    logsSource,
+  }: UseThreadsStatisticParams,
 ) => {
   const { data } = await api.get<UseThreadsStatisticResponse>(
     `${TRACES_REST_ENDPOINT}threads/stats`,
@@ -26,7 +35,10 @@ const getThreadsStatistic = async (
       signal,
       params: {
         project_id: projectId,
-        ...processFilters(filters),
+        ...processFilters(
+          filters,
+          logsSource ? generateLogsSourceFilter(logsSource) : undefined,
+        ),
         ...(search && { search }),
         ...(fromTime && { from_time: fromTime }),
         ...(toTime && { to_time: toTime }),

--- a/apps/opik-frontend/src/api/traces/useTracesList.ts
+++ b/apps/opik-frontend/src/api/traces/useTracesList.ts
@@ -2,7 +2,12 @@ import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import api, { QueryConfig, TRACES_KEY, TRACES_REST_ENDPOINT } from "@/api/api";
 import { Trace } from "@/types/traces";
 import { Filters } from "@/types/filters";
-import { generateVisibilityFilters, processFilters } from "@/lib/filters";
+import {
+  generateLogsSourceFilter,
+  generateVisibilityFilters,
+  processFilters,
+} from "@/lib/filters";
+import { LOGS_SOURCE } from "@/types/traces";
 import { Sorting } from "@/types/sorting";
 import { processSorting } from "@/lib/sorting";
 
@@ -17,6 +22,7 @@ type UseTracesListParams = {
   fromTime?: string;
   toTime?: string;
   exclude?: string[];
+  logsSource?: LOGS_SOURCE;
 };
 
 export type UseTracesListResponse = {
@@ -38,13 +44,19 @@ const getTracesList = async (
     fromTime,
     toTime,
     exclude,
+    logsSource,
   }: UseTracesListParams,
 ) => {
+  const additionalFilters = [
+    ...generateVisibilityFilters(),
+    ...(logsSource ? generateLogsSourceFilter(logsSource) : []),
+  ];
+
   const { data } = await api.get<UseTracesListResponse>(TRACES_REST_ENDPOINT, {
     signal,
     params: {
       project_id: projectId,
-      ...processFilters(filters, generateVisibilityFilters()),
+      ...processFilters(filters, additionalFilters),
       ...processSorting(sorting),
       ...(search && { search }),
       size,

--- a/apps/opik-frontend/src/api/traces/useTracesStatistic.ts
+++ b/apps/opik-frontend/src/api/traces/useTracesStatistic.ts
@@ -2,7 +2,8 @@ import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import api, { QueryConfig, TRACES_REST_ENDPOINT } from "@/api/api";
 import { ColumnsStatistic } from "@/types/shared";
 import { Filters } from "@/types/filters";
-import { processFilters } from "@/lib/filters";
+import { generateLogsSourceFilter, processFilters } from "@/lib/filters";
+import { LOGS_SOURCE } from "@/types/traces";
 
 type UseTracesStatisticParams = {
   projectId: string;
@@ -10,6 +11,7 @@ type UseTracesStatisticParams = {
   search?: string;
   fromTime?: string;
   toTime?: string;
+  logsSource?: LOGS_SOURCE;
 };
 
 export type UseTracesStatisticResponse = {
@@ -18,7 +20,14 @@ export type UseTracesStatisticResponse = {
 
 const getTracesStatistic = async (
   { signal }: QueryFunctionContext,
-  { projectId, filters, search, fromTime, toTime }: UseTracesStatisticParams,
+  {
+    projectId,
+    filters,
+    search,
+    fromTime,
+    toTime,
+    logsSource,
+  }: UseTracesStatisticParams,
 ) => {
   const { data } = await api.get<UseTracesStatisticResponse>(
     `${TRACES_REST_ENDPOINT}stats`,
@@ -26,7 +35,10 @@ const getTracesStatistic = async (
       signal,
       params: {
         project_id: projectId,
-        ...processFilters(filters),
+        ...processFilters(
+          filters,
+          logsSource ? generateLogsSourceFilter(logsSource) : undefined,
+        ),
         ...(search && { search }),
         ...(fromTime && { from_time: fromTime }),
         ...(toTime && { to_time: toTime }),

--- a/apps/opik-frontend/src/hooks/useTracesOrSpansList.ts
+++ b/apps/opik-frontend/src/hooks/useTracesOrSpansList.ts
@@ -9,7 +9,7 @@ import isBoolean from "lodash/isBoolean";
 
 import useTracesList from "@/api/traces/useTracesList";
 import useSpansList from "@/api/traces/useSpansList";
-import { Span, Trace } from "@/types/traces";
+import { Span, Trace, LOGS_SOURCE } from "@/types/traces";
 import { Filters } from "@/types/filters";
 import { Sorting } from "@/types/sorting";
 import { TRACE_DATA_TYPE } from "@/constants/traces";
@@ -28,6 +28,7 @@ type UseTracesOrSpansListParams = {
   fromTime?: string;
   toTime?: string;
   exclude?: string[];
+  logsSource?: LOGS_SOURCE;
 };
 
 export type TracesOrSpansListData = {

--- a/apps/opik-frontend/src/hooks/useTracesOrSpansStatistic.ts
+++ b/apps/opik-frontend/src/hooks/useTracesOrSpansStatistic.ts
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-query";
 import { Filters } from "@/types/filters";
 import { ColumnsStatistic } from "@/types/shared";
+import { LOGS_SOURCE } from "@/types/traces";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 import useTracesStatistic from "@/api/traces/useTracesStatistic";
 import useSpansStatistic from "@/api/traces/useSpansStatistic";
@@ -17,6 +18,7 @@ type UseTracesOrSpansStatisticParams = {
   search?: string;
   fromTime?: string;
   toTime?: string;
+  logsSource?: LOGS_SOURCE;
 };
 
 type UseTracesOrSpansStatisticResponse = {

--- a/apps/opik-frontend/src/lib/filters.ts
+++ b/apps/opik-frontend/src/lib/filters.ts
@@ -2,7 +2,7 @@ import uniqid from "uniqid";
 import flatten from "lodash/flatten";
 import { Filter, Filters } from "@/types/filters";
 import { COLUMN_TYPE, DYNAMIC_COLUMN_TYPE } from "@/types/shared";
-import { TRACE_VISIBILITY_MODE } from "@/types/traces";
+import { LOGS_SOURCE, TRACE_VISIBILITY_MODE } from "@/types/traces";
 import {
   makeEndOfMinute,
   makeStartOfMinute,
@@ -69,6 +69,19 @@ export const generateVisibilityFilters = () => {
       operator: "=",
       key: "",
       value: TRACE_VISIBILITY_MODE.default,
+    },
+  ] as Filter[];
+};
+
+export const generateLogsSourceFilter = (source: LOGS_SOURCE) => {
+  return [
+    {
+      id: "logs_source_filter",
+      field: "source",
+      type: COLUMN_TYPE.string,
+      operator: "=",
+      key: "",
+      value: source,
     },
   ] as Filter[];
 };

--- a/apps/opik-frontend/src/types/traces.ts
+++ b/apps/opik-frontend/src/types/traces.ts
@@ -19,6 +19,13 @@ export enum TRACE_VISIBILITY_MODE {
   hidden = "hidden",
 }
 
+export enum LOGS_SOURCE {
+  sdk = "sdk",
+  experiment = "experiment",
+  playground = "playground",
+  optimization = "optimization",
+}
+
 export type FeedbackScoreValueByAuthorMap = Record<
   string,
   {

--- a/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/MetricChart/MetricChartContainer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/MetricChart/MetricChartContainer.tsx
@@ -21,6 +21,7 @@ import NoData from "@/shared/NoData/NoData";
 import { ValueType } from "recharts/types/component/DefaultTooltipContent";
 import { COLOR_VARIANTS_MAP } from "@/constants/colorVariants";
 import { Filter } from "@/types/filters";
+import { LOGS_SOURCE } from "@/types/traces";
 import { CHART_TYPE } from "@/constants/chart";
 import MetricLineChart from "./MetricLineChart";
 import MetricBarChart from "./MetricBarChart";
@@ -57,6 +58,7 @@ interface MetricContainerChartProps {
   getLabelAction?: (label: string) => LegendLabelAction | undefined;
   isAggregateTotal?: boolean;
   customEmptyState?: React.ReactNode;
+  logsSource?: LOGS_SOURCE;
 }
 
 const customColorMap = {
@@ -98,6 +100,7 @@ const MetricContainerChart = ({
   getLabelAction,
   isAggregateTotal = false,
   customEmptyState,
+  logsSource,
 }: MetricContainerChartProps) => {
   const { data: response, isPending } = useProjectMetric(
     {
@@ -110,6 +113,7 @@ const MetricContainerChart = ({
       threadFilters,
       spanFilters,
       breakdown,
+      logsSource,
     },
     {
       enabled: !!projectId,

--- a/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/ProjectMetricsWidget.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/ProjectMetricsWidget.tsx
@@ -20,6 +20,7 @@ import { Filter } from "@/types/filters";
 import { isFilterValid, createFilter } from "@/lib/filters";
 import MetricContainerChart from "./MetricChart/MetricChartContainer";
 import { LOGS_TYPE } from "@/constants/traces";
+import { LOGS_SOURCE } from "@/types/traces";
 import useAppStore from "@/store/AppStore";
 import { CHART_TYPE } from "@/constants/chart";
 import {
@@ -448,6 +449,7 @@ const ProjectMetricsWidget: React.FunctionComponent<
           traceFilters={validTraceFilters}
           threadFilters={validThreadFilters}
           spanFilters={validSpanFilters}
+          logsSource={LOGS_SOURCE.sdk}
           filterLineCallback={filterLineCallback}
           breakdown={effectiveBreakdown}
           getLabelAction={effectiveBreakdown ? getLabelAction : undefined}

--- a/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectStatsCardWidget/ProjectStatsCardWidget.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectStatsCardWidget/ProjectStatsCardWidget.tsx
@@ -18,6 +18,7 @@ import useSpansStatistic from "@/api/traces/useSpansStatistic";
 import { ColumnStatistic } from "@/types/shared";
 import { Skeleton } from "@/ui/skeleton";
 import { TRACE_DATA_TYPE } from "@/constants/traces";
+import { LOGS_SOURCE } from "@/types/traces";
 import {
   getMetricDefinition,
   formatMetricValue,
@@ -116,6 +117,7 @@ const ProjectStatsCardWidget: React.FunctionComponent<
       filters: validTraceFilters,
       fromTime: intervalStart,
       toTime: intervalEnd,
+      logsSource: LOGS_SOURCE.sdk,
     },
     { enabled: source === TRACE_DATA_TYPE.traces && !!projectId },
   );
@@ -126,6 +128,7 @@ const ProjectStatsCardWidget: React.FunctionComponent<
       filters: validSpanFilters,
       fromTime: intervalStart,
       toTime: intervalEnd,
+      logsSource: LOGS_SOURCE.sdk,
     },
     { enabled: source === TRACE_DATA_TYPE.spans && !!projectId },
   );

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
@@ -21,7 +21,7 @@ import {
   ANNOTATION_QUEUE_SCOPE,
   AnnotationQueue,
 } from "@/types/annotation-queues";
-import { Trace, Thread } from "@/types/traces";
+import { Trace, Thread, LOGS_SOURCE } from "@/types/traces";
 import {
   getFeedbackScoresByUser,
   getCommentsByUser,
@@ -93,6 +93,7 @@ const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
       filters: annotationQueueFilter,
       search: "",
       truncate: false,
+      logsSource: LOGS_SOURCE.sdk,
     },
     {
       enabled: false,
@@ -108,6 +109,7 @@ const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
       filters: annotationQueueFilter,
       search: "",
       truncate: false,
+      logsSource: LOGS_SOURCE.sdk,
     },
     {
       enabled: false,

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
@@ -26,7 +26,7 @@ import {
   DynamicColumn,
   ROW_HEIGHT,
 } from "@/types/shared";
-import { Thread } from "@/types/traces";
+import { Thread, LOGS_SOURCE } from "@/types/traces";
 import { AnnotationQueue } from "@/types/annotation-queues";
 import { convertColumnDataToColumn, migrateSelectedColumns } from "@/lib/table";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
@@ -309,6 +309,7 @@ const ThreadQueueItemsTab: React.FunctionComponent<
       size: size as number,
       search: search as string,
       truncate: truncationEnabled,
+      logsSource: LOGS_SOURCE.sdk,
     },
     {
       placeholderData: keepPreviousData,

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
@@ -29,7 +29,7 @@ import {
   DynamicColumn,
   ROW_HEIGHT,
 } from "@/types/shared";
-import { Trace } from "@/types/traces";
+import { Trace, LOGS_SOURCE } from "@/types/traces";
 import { AnnotationQueue } from "@/types/annotation-queues";
 import {
   convertColumnDataToColumn,
@@ -382,6 +382,7 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
       size: size as number,
       search: search as string,
       truncate: truncationEnabled,
+      logsSource: LOGS_SOURCE.sdk,
     },
     {
       placeholderData: keepPreviousData,
@@ -393,6 +394,7 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
       projectId: annotationQueue.project_id,
       filters,
       search: search as string,
+      logsSource: LOGS_SOURCE.sdk,
     },
     {
       placeholderData: keepPreviousData,

--- a/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
@@ -33,7 +33,7 @@ import {
   DynamicColumn,
   ROW_HEIGHT,
 } from "@/types/shared";
-import { Thread } from "@/types/traces";
+import { Thread, LOGS_SOURCE } from "@/types/traces";
 import {
   convertColumnDataToColumn,
   injectColumnCallback,
@@ -391,6 +391,7 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
         truncate: truncationEnabled,
         fromTime: intervalStart,
         toTime: intervalEnd,
+        logsSource: LOGS_SOURCE.sdk,
       },
       {
         enabled: isTableDataEnabled,
@@ -411,6 +412,7 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
       truncate: false,
       fromTime: intervalStart,
       toTime: intervalEnd,
+      logsSource: LOGS_SOURCE.sdk,
     },
     {
       enabled: false,
@@ -425,6 +427,7 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
       search: search as string,
       fromTime: intervalStart,
       toTime: intervalEnd,
+      logsSource: LOGS_SOURCE.sdk,
     },
     {
       refetchInterval: REFETCH_INTERVAL,

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -50,7 +50,7 @@ import {
   normalizeMetadataPaths,
   buildDynamicMetadataColumns,
 } from "@/lib/metadata";
-import { BaseTraceData, Span, Trace } from "@/types/traces";
+import { BaseTraceData, Span, Trace, LOGS_SOURCE } from "@/types/traces";
 import { convertColumnDataToColumn, migrateSelectedColumns } from "@/lib/table";
 import { getJSONPaths } from "@/lib/utils";
 import { generateSelectColumDef } from "@/shared/DataTable/utils";
@@ -578,6 +578,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
         fromTime: intervalStart,
         toTime: intervalEnd,
         exclude: excludeFields,
+        logsSource: LOGS_SOURCE.sdk,
       },
       {
         enabled: isTableDataEnabled,
@@ -599,6 +600,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
       fromTime: intervalStart,
       toTime: intervalEnd,
       exclude: excludeFields,
+      logsSource: LOGS_SOURCE.sdk,
     },
     {
       enabled: false,
@@ -615,6 +617,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
         search: trimmedSearch,
         fromTime: intervalStart,
         toTime: intervalEnd,
+        logsSource: LOGS_SOURCE.sdk,
       },
       {
         refetchInterval: REFETCH_INTERVAL,

--- a/apps/opik-frontend/src/v2/pages/LogsPage/useLogsType.ts
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/useLogsType.ts
@@ -4,6 +4,7 @@ import useLocalStorageState from "use-local-storage-state";
 import useThreadsStatistic from "@/api/traces/useThreadsStatistic";
 import { useMetricDateRangeWithQueryAndStorage } from "@/v2/pages-shared/traces/MetricDateRangeSelect";
 import { LOGS_TYPE } from "@/constants/traces";
+import { LOGS_SOURCE } from "@/types/traces";
 import { STATISTIC_AGGREGATION_TYPE } from "@/types/shared";
 
 const isLogsType = (value: string | null | undefined): value is LOGS_TYPE =>
@@ -30,6 +31,7 @@ const useLogsType = (options: UseLogsTypeOptions) => {
       projectId,
       fromTime: intervalStart,
       toTime: intervalEnd,
+      logsSource: LOGS_SOURCE.sdk,
     },
     {
       enabled: !!projectId,


### PR DESCRIPTION
## Details

Per OPIK-4617 Addendum A, all v2 project pages must show only application traces (`sdk`/`unknown` source), excluding experiment, playground, and optimization traces. This PR adds a hidden `source = sdk` filter to every v2 page that displays trace/span/thread data or their statistics.

### Changes:
- Added `LOGS_SOURCE` enum to `types/traces.ts` (reusable: `sdk`, `experiment`, `playground`, `optimization`)
- Added `generateLogsSourceFilter()` utility to `lib/filters.ts` with hardcoded filter ID
- Added optional `logsSource` param to all trace/span/thread API hooks (`useTracesList`, `useSpansList`, `useThreadsList`, `useTracesStatistic`, `useSpansStatistic`, `useThreadsStatistic`, `useTracesOrSpansList`, `useTracesOrSpansStatistic`, `useProjectMetric`)
- V2 pages pass `logsSource: LOGS_SOURCE.sdk`: LogsPage (TracesSpansTab, ThreadsTab, useLogsType), AnnotationQueuePage (TraceQueueItemsTab, ThreadQueueItemsTab, ExportAnnotatedDataButton), ProjectMetricsWidget, ProjectStatsCardWidget
- V1 pages remain untouched — no `logsSource` passed, all traces shown as before

### How it works:
When `logsSource` is provided, the hook generates a source filter and merges it into `additionalFilters` alongside existing ones (e.g. `generateVisibilityFilters()`). The BE `legacyFallbackDbValue("sdk")` automatically expands `source = sdk` to `source IN ('sdk', 'unknown')`, capturing legacy traces.

### Known gaps (blocked on BE):
- `GET /projects/stats` (Manage Projects page) — no source filtering support in endpoint
- Feedback score names endpoints — no source filtering support

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5158

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: full implementation
  - Human verification: code review + manual testing

## Testing

- `scripts/dev-runner.sh --lint-fe` — lint, typecheck, dependency validation all pass
- Manual verification:
  - V2 Logs page: only `sdk`/`unknown` traces appear in traces, spans, and threads tabs
  - V2 Insights page: charts filtered to sdk/unknown data
  - V2 Annotation queue: trace/thread lists source-filtered
  - V1 Traces page: ALL traces still appear (backward compatible)

## Documentation

N/A — internal filtering change, no user-facing documentation needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)