### PR TITLE
[OPIK-4987] [FE] feat: add useProjectDatasetsList hook for project-scoped datasets endpoint

### DIFF
--- a/apps/opik-frontend/src/api/datasets/useAddSpansToDatasetMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useAddSpansToDatasetMutation.ts
@@ -62,6 +62,7 @@ const useAddSpansToDatasetMutation = () => {
       if (context) {
         queryClient.invalidateQueries({ queryKey: context.queryKey });
       }
+      queryClient.invalidateQueries({ queryKey: ["project-datasets"] });
       return queryClient.invalidateQueries({
         queryKey: ["datasets"],
       });

--- a/apps/opik-frontend/src/api/datasets/useAddTracesToDatasetMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useAddTracesToDatasetMutation.ts
@@ -63,6 +63,7 @@ const useAddTracesToDatasetMutation = () => {
       if (context) {
         queryClient.invalidateQueries({ queryKey: context.queryKey });
       }
+      queryClient.invalidateQueries({ queryKey: ["project-datasets"] });
       return queryClient.invalidateQueries({
         queryKey: ["datasets"],
       });

--- a/apps/opik-frontend/src/api/datasets/useDatasetBatchDeleteMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetBatchDeleteMutation.ts
@@ -32,6 +32,7 @@ const useDatasetBatchDeleteMutation = () => {
       });
     },
     onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["project-datasets"] });
       return queryClient.invalidateQueries({
         queryKey: ["datasets"],
       });

--- a/apps/opik-frontend/src/api/datasets/useDatasetCreateMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetCreateMutation.ts
@@ -56,6 +56,7 @@ const useDatasetCreateMutation = () => {
       });
     },
     onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["project-datasets"] });
       return queryClient.invalidateQueries({
         queryKey: ["datasets"],
       });

--- a/apps/opik-frontend/src/api/datasets/useDatasetDeleteMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetDeleteMutation.ts
@@ -30,6 +30,7 @@ const useDatasetDeleteMutation = () => {
       });
     },
     onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["project-datasets"] });
       return queryClient.invalidateQueries({ queryKey: ["datasets"] });
     },
   });

--- a/apps/opik-frontend/src/api/datasets/useDatasetItemBatchMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetItemBatchMutation.ts
@@ -63,6 +63,7 @@ const useDatasetItemBatchMutation = () => {
       queryClient.invalidateQueries({
         queryKey: ["dataset", { datasetId: variables.datasetId }],
       });
+      queryClient.invalidateQueries({ queryKey: ["project-datasets"] });
       return queryClient.invalidateQueries({
         queryKey: ["datasets"],
       });

--- a/apps/opik-frontend/src/api/datasets/useDatasetItemChangesMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetItemChangesMutation.ts
@@ -73,6 +73,7 @@ const useDatasetItemChangesMutation = (
       queryClient.invalidateQueries({
         queryKey: ["dataset-items", { datasetId: variables.datasetId }],
       });
+      queryClient.invalidateQueries({ queryKey: ["project-datasets"] });
       queryClient.invalidateQueries({
         queryKey: ["datasets"],
       });

--- a/apps/opik-frontend/src/api/datasets/useDatasetItemsFromCsvMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetItemsFromCsvMutation.ts
@@ -55,6 +55,7 @@ const useDatasetItemsFromCsvMutation = () => {
       if (context) {
         queryClient.invalidateQueries({ queryKey: context.queryKey });
       }
+      queryClient.invalidateQueries({ queryKey: ["project-datasets"] });
       return queryClient.invalidateQueries({
         queryKey: ["datasets"],
       });

--- a/apps/opik-frontend/src/api/datasets/useDatasetUpdateMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetUpdateMutation.ts
@@ -43,6 +43,7 @@ const useDatasetUpdateMutation = () => {
       queryClient.invalidateQueries({
         queryKey: ["dataset", { datasetId: variables.dataset.id }],
       });
+      queryClient.invalidateQueries({ queryKey: ["project-datasets"] });
       return queryClient.invalidateQueries({
         queryKey: ["datasets"],
       });

--- a/apps/opik-frontend/src/api/datasets/useExperimentBatchDeleteMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useExperimentBatchDeleteMutation.ts
@@ -32,6 +32,7 @@ const useExperimentBatchDeleteMutation = () => {
       });
     },
     onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["project-datasets"] });
       queryClient.invalidateQueries({ queryKey: ["datasets"] });
       return queryClient.invalidateQueries({
         queryKey: ["experiments"],

--- a/apps/opik-frontend/src/api/datasets/useGetOrCreateDemoDataset.ts
+++ b/apps/opik-frontend/src/api/datasets/useGetOrCreateDemoDataset.ts
@@ -61,6 +61,7 @@ const useGetOrCreateDemoDataset = () => {
             })),
           });
 
+          queryClient.invalidateQueries({ queryKey: ["project-datasets"] });
           queryClient.invalidateQueries({ queryKey: ["datasets"] });
         }
 

--- a/apps/opik-frontend/src/api/datasets/useProjectDatasetsList.ts
+++ b/apps/opik-frontend/src/api/datasets/useProjectDatasetsList.ts
@@ -1,0 +1,71 @@
+import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
+import api, { PROJECTS_REST_ENDPOINT, QueryConfig } from "@/api/api";
+import { Dataset } from "@/types/datasets";
+import { Filters } from "@/types/filters";
+import { processFilters } from "@/lib/filters";
+import { Sorting } from "@/types/sorting";
+import { processSorting } from "@/lib/sorting";
+
+type UseProjectDatasetsListParams = {
+  projectId: string;
+  withExperimentsOnly?: boolean;
+  withOptimizationsOnly?: boolean;
+  filters?: Filters;
+  sorting?: Sorting;
+  search?: string;
+  page: number;
+  size: number;
+};
+
+type UseProjectDatasetsListResponse = {
+  content: Dataset[];
+  sortable_by: string[];
+  total: number;
+};
+
+const getProjectDatasetsList = async (
+  { signal }: QueryFunctionContext,
+  {
+    projectId,
+    withExperimentsOnly,
+    withOptimizationsOnly,
+    filters,
+    sorting,
+    search,
+    size,
+    page,
+  }: UseProjectDatasetsListParams,
+) => {
+  const { data } = await api.get(
+    `${PROJECTS_REST_ENDPOINT}${projectId}/datasets`,
+    {
+      signal,
+      params: {
+        ...processFilters(filters),
+        ...processSorting(sorting),
+        ...(search && { name: search }),
+        ...(withExperimentsOnly && {
+          with_experiments_only: withExperimentsOnly,
+        }),
+        ...(withOptimizationsOnly && {
+          with_optimizations_only: withOptimizationsOnly,
+        }),
+        size,
+        page,
+      },
+    },
+  );
+
+  return data;
+};
+
+export default function useProjectDatasetsList(
+  params: UseProjectDatasetsListParams,
+  options?: QueryConfig<UseProjectDatasetsListResponse>,
+) {
+  return useQuery({
+    queryKey: ["project-datasets", params],
+    queryFn: (context) => getProjectDatasetsList(context, params),
+    ...options,
+  });
+}

--- a/apps/opik-frontend/src/api/optimizations/useOptimizationBatchDeleteMutation.ts
+++ b/apps/opik-frontend/src/api/optimizations/useOptimizationBatchDeleteMutation.ts
@@ -32,6 +32,7 @@ const useOptimizationBatchDeleteMutation = () => {
       });
     },
     onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["project-datasets"] });
       queryClient.invalidateQueries({ queryKey: ["datasets"] });
       return queryClient.invalidateQueries({
         queryKey: [OPTIMIZATIONS_KEY],

--- a/apps/opik-frontend/src/v2/pages-shared/DatasetVersionSelectBox/DatasetVersionSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/DatasetVersionSelectBox/DatasetVersionSelectBox.tsx
@@ -46,7 +46,7 @@ interface DatasetVersionSelectBoxProps {
   value: string | null; // "datasetId::versionId" format
   versionName?: string;
   onChange: (value: string | null) => void;
-  workspaceName: string;
+  projectId?: string | null;
   disabled?: boolean;
   showClearButton?: boolean;
   buttonClassName?: string;
@@ -69,7 +69,7 @@ function DatasetVersionSelectBox({
   value,
   versionName,
   onChange,
-  workspaceName,
+  projectId,
   disabled = false,
   showClearButton = true,
   buttonClassName,
@@ -101,7 +101,7 @@ function DatasetVersionSelectBox({
     loadMore,
     hasMore,
   } = useDatasetVersionSelect({
-    workspaceName,
+    projectId,
     search,
     openDatasetId,
   });

--- a/apps/opik-frontend/src/v2/pages-shared/DatasetVersionSelectBox/useDatasetVersionSelect.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/DatasetVersionSelectBox/useDatasetVersionSelect.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
-import useDatasetsList from "@/api/datasets/useDatasetsList";
+import useProjectDatasetsList from "@/api/datasets/useProjectDatasetsList";
 import useDatasetVersionsList from "@/api/datasets/useDatasetVersionsList";
 import { Dataset, DatasetVersion } from "@/types/datasets";
 import toLower from "lodash/toLower";
@@ -9,7 +9,6 @@ export const DEFAULT_LOADED_DATASETS = 1000;
 const MAX_LOADED_DATASETS = 10000;
 
 interface UseDatasetVersionSelectParams {
-  workspaceName: string;
   projectId?: string | null;
   search: string;
   openDatasetId: string | null;
@@ -27,23 +26,23 @@ export interface UseDatasetVersionSelectReturn {
 }
 
 export default function useDatasetVersionSelect({
-  workspaceName,
   projectId,
   search,
   openDatasetId,
 }: UseDatasetVersionSelectParams): UseDatasetVersionSelectReturn {
   const [isLoadedMore, setIsLoadedMore] = useState(false);
-  const { data: datasetsData, isLoading: isLoadingDatasets } = useDatasetsList(
-    {
-      workspaceName,
-      ...(projectId && { projectId }),
-      page: 1,
-      size: !isLoadedMore ? DEFAULT_LOADED_DATASETS : MAX_LOADED_DATASETS,
-    },
-    {
-      placeholderData: keepPreviousData,
-    },
-  );
+  const { data: datasetsData, isLoading: isLoadingDatasets } =
+    useProjectDatasetsList(
+      {
+        projectId: projectId!,
+        page: 1,
+        size: !isLoadedMore ? DEFAULT_LOADED_DATASETS : MAX_LOADED_DATASETS,
+      },
+      {
+        placeholderData: keepPreviousData,
+        enabled: !!projectId,
+      },
+    );
 
   const datasets = useMemo(
     () => datasetsData?.content || [],

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog.tsx
@@ -8,7 +8,7 @@ import CodeBlockWithHeader from "@/shared/CodeBlockWithHeader/CodeBlockWithHeade
 import CodeSectionTitle from "@/shared/CodeSectionTitle/CodeSectionTitle";
 import InstallOpikSection from "@/shared/InstallOpikSection/InstallOpikSection";
 import LoadableSelectBox from "@/shared/LoadableSelectBox/LoadableSelectBox";
-import useDatasetsList from "@/api/datasets/useDatasetsList";
+import useProjectDatasetsList from "@/api/datasets/useProjectDatasetsList";
 import { DATASET_TYPE } from "@/types/datasets";
 import SideDialog from "@/shared/SideDialog/SideDialog";
 import { SheetTitle } from "@/ui/sheet";
@@ -198,15 +198,15 @@ const AddExperimentDialog: React.FunctionComponent<
     LLM_JUDGES_MODELS_OPTIONS[0].value,
   ]); // Set the first LLM judge model as checked
 
-  const { data, isLoading } = useDatasetsList(
+  const { data, isLoading } = useProjectDatasetsList(
     {
-      workspaceName,
-      ...(projectId && { projectId }),
+      projectId: projectId!,
       page: 1,
       size: isLoadedMore ? 10000 : DEFAULT_LOADED_DATASET_ITEMS,
     },
     {
       placeholderData: keepPreviousData,
+      enabled: !!projectId,
     },
   );
 

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/DatasetSelectBox/DatasetSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/DatasetSelectBox/DatasetSelectBox.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
 
-import useAppStore from "@/store/AppStore";
-import useDatasetsList from "@/api/datasets/useDatasetsList";
+import useProjectDatasetsList from "@/api/datasets/useProjectDatasetsList";
 import LoadableSelectBox from "@/shared/LoadableSelectBox/LoadableSelectBox";
 import { DropdownOption } from "@/types/shared";
+import { usePermissions } from "@/contexts/PermissionsContext";
 
 const DEFAULT_LOADED_DATASET_ITEMS = 1000;
 
@@ -23,17 +23,19 @@ const DatasetSelectBox: React.FC<DatasetSelectBoxProps> = ({
   placeholder = "Select an evaluation suite",
   className,
 }) => {
-  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const {
+    permissions: { canViewDatasets },
+  } = usePermissions();
   const [isLoadedMore, setIsLoadedMore] = useState(false);
-  const { data, isLoading } = useDatasetsList(
+  const { data, isLoading } = useProjectDatasetsList(
     {
-      workspaceName,
-      ...(projectId && { projectId }),
+      projectId: projectId!,
       page: 1,
       size: isLoadedMore ? 10000 : DEFAULT_LOADED_DATASET_ITEMS,
     },
     {
       placeholderData: keepPreviousData,
+      enabled: canViewDatasets && !!projectId,
     },
   );
 

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx
@@ -12,7 +12,7 @@ const mockAddTracesToDataset = vi.fn();
 const mockAddSpansToDataset = vi.fn();
 
 // Mock the API hooks
-vi.mock("@/api/datasets/useDatasetsList", () => ({
+vi.mock("@/api/datasets/useProjectDatasetsList", () => ({
   default: vi.fn(() => ({
     data: {
       content: [

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
@@ -19,7 +19,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/ui/accordion";
-import useDatasetsList from "@/api/datasets/useDatasetsList";
+import useProjectDatasetsList from "@/api/datasets/useProjectDatasetsList";
 import Loader from "@/shared/Loader/Loader";
 import DataTablePagination from "@/shared/DataTablePagination/DataTablePagination";
 import SearchInput from "@/shared/SearchInput/SearchInput";
@@ -89,16 +89,16 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
   const { mutate: addTracesToDataset } = useAddTracesToDatasetMutation();
   const { mutate: addSpansToDataset } = useAddSpansToDatasetMutation();
 
-  const { data, isPending } = useDatasetsList(
+  const { data, isPending } = useProjectDatasetsList(
     {
-      workspaceName,
-      ...(activeProjectId && { projectId: activeProjectId }),
+      projectId: activeProjectId!,
       search,
       page,
       size,
     },
     {
       placeholderData: keepPreviousData,
+      enabled: !!activeProjectId,
     },
   );
 

--- a/apps/opik-frontend/src/v2/pages/EvaluationSuitesPage/EvaluationSuitesPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/EvaluationSuitesPage/EvaluationSuitesPage.tsx
@@ -12,7 +12,7 @@ import { JsonParam, StringParam, useQueryParam } from "use-query-params";
 import DataTable from "@/shared/DataTable/DataTable";
 import DataTablePagination from "@/shared/DataTablePagination/DataTablePagination";
 import DataTableNoData from "@/shared/DataTableNoData/DataTableNoData";
-import useDatasetsList from "@/api/datasets/useDatasetsList";
+import useProjectDatasetsList from "@/api/datasets/useProjectDatasetsList";
 import { Dataset } from "@/types/datasets";
 import Loader from "@/shared/Loader/Loader";
 import AddEditEvaluationSuiteDialog from "@/v2/pages-shared/datasets/AddEditEvaluationSuiteDialog/AddEditEvaluationSuiteDialog";
@@ -221,20 +221,21 @@ const EvaluationSuitesPage: React.FunctionComponent = () => {
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
-  const { data, isPending, isPlaceholderData, isFetching } = useDatasetsList(
-    {
-      workspaceName,
-      projectId: activeProjectId,
-      filters,
-      sorting: sortedColumns,
-      search: search!,
-      page,
-      size,
-    },
-    {
-      placeholderData: keepPreviousData,
-    },
-  );
+  const { data, isPending, isPlaceholderData, isFetching } =
+    useProjectDatasetsList(
+      {
+        projectId: activeProjectId!,
+        filters,
+        sorting: sortedColumns,
+        search: search!,
+        page,
+        size,
+      },
+      {
+        placeholderData: keepPreviousData,
+        enabled: !!activeProjectId,
+      },
+    );
 
   const datasets = useMemo(() => data?.content ?? [], [data?.content]);
   const sortableBy: string[] = useMemo(

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/AddOptimizationDialog/AddOptimizationDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/AddOptimizationDialog/AddOptimizationDialog.tsx
@@ -1,11 +1,10 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
-import useAppStore from "@/store/AppStore";
 import { DropdownOption } from "@/types/shared";
 import { Checkbox } from "@/ui/checkbox";
 import CodeHighlighter from "@/shared/CodeHighlighter/CodeHighlighter";
 import LoadableSelectBox from "@/shared/LoadableSelectBox/LoadableSelectBox";
-import useDatasetsList from "@/api/datasets/useDatasetsList";
+import useProjectDatasetsList from "@/api/datasets/useProjectDatasetsList";
 import SideDialog from "@/shared/SideDialog/SideDialog";
 import { SheetTitle } from "@/ui/sheet";
 import ApiKeyCard from "@/v2/pages-shared/onboarding/ApiKeyCard/ApiKeyCard";
@@ -269,8 +268,6 @@ type AddOptimizationDialogProps = {
 const AddOptimizationDialog: React.FunctionComponent<
   AddOptimizationDialogProps
 > = ({ open, setOpen, projectId }) => {
-  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
-
   const [isLoadedMore, setIsLoadedMore] = useState(false);
   const [datasetName, setDatasetName] = useState("");
   const [selectedModel, setSelectedModel] = useState<OPTIMIZATION_ALGORITHMS>(
@@ -289,16 +286,15 @@ const AddOptimizationDialog: React.FunctionComponent<
     datasetName || "your-dataset-name",
   );
 
-  const { data, isLoading } = useDatasetsList(
+  const { data, isLoading } = useProjectDatasetsList(
     {
-      workspaceName,
-      ...(projectId && { projectId }),
+      projectId: projectId!,
       page: 1,
       size: isLoadedMore ? 10000 : DEFAULT_LOADED_DATASET_ITEMS,
     },
     {
       placeholderData: keepPreviousData,
-      enabled: canViewDatasets,
+      enabled: canViewDatasets && !!projectId,
     },
   );
 

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
@@ -4,7 +4,7 @@ import { useFormContext } from "react-hook-form";
 
 import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import useBreadcrumbsStore from "@/store/BreadcrumbsStore";
-import useDatasetsList from "@/api/datasets/useDatasetsList";
+import useProjectDatasetsList from "@/api/datasets/useProjectDatasetsList";
 import useOptimizationCreateMutation from "@/api/optimizations/useOptimizationCreateMutation";
 import { OptimizationConfigFormType } from "@/v2/pages-shared/optimizations/OptimizationConfigForm/schema";
 import { convertFormDataToStudioConfig } from "@/v2/pages-shared/optimizations/OptimizationConfigForm/schema";
@@ -40,12 +40,16 @@ export const useOptimizationsNewFormHandlers = () => {
 
   const form = useFormContext<OptimizationConfigFormType>();
 
-  const { data: datasetsData } = useDatasetsList({
-    workspaceName,
-    ...(activeProjectId && { projectId: activeProjectId }),
-    page: 1,
-    size: 1000,
-  });
+  const { data: datasetsData } = useProjectDatasetsList(
+    {
+      projectId: activeProjectId!,
+      page: 1,
+      size: 1000,
+    },
+    {
+      enabled: !!activeProjectId,
+    },
+  );
 
   const datasets = useMemo(
     () => datasetsData?.content || [],

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -19,7 +19,8 @@ import PlaygroundHeader from "@/v2/pages/PlaygroundPage/PlaygroundHeader";
 import SetupProviderDialog from "@/v2/pages-shared/llm/SetupProviderDialog/SetupProviderDialog";
 import useActionButtonActions from "@/v2/pages/PlaygroundPage/useActionButtonActions";
 import useDatasetItemsList from "@/api/datasets/useDatasetItemsList";
-import useDatasetsList from "@/api/datasets/useDatasetsList";
+import useProjectDatasetsList from "@/api/datasets/useProjectDatasetsList";
+import useProjectByName from "@/api/projects/useProjectByName";
 import {
   useTriggerProviderValidation,
   useIsRunning,
@@ -36,6 +37,7 @@ import { usePermissions } from "@/contexts/PermissionsContext";
 import useNavigationBlocker from "@/hooks/useNavigationBlocker";
 
 import { DEFAULT_LOADED_DATASETS } from "@/v2/pages-shared/DatasetVersionSelectBox/useDatasetVersionSelect";
+import { PLAYGROUND_PROJECT_NAME } from "@/constants/shared";
 
 const EMPTY_ITEMS: DatasetItem[] = [];
 const EMPTY_DATASETS: Dataset[] = [];
@@ -119,9 +121,18 @@ const PlaygroundPage = () => {
   );
   const datasetItems = datasetItemsData?.content || EMPTY_ITEMS;
 
-  const { data: datasetsData } = useDatasetsList(
-    { workspaceName, page: 1, size: DEFAULT_LOADED_DATASETS },
-    { enabled: canViewDatasets && !!plainDatasetId },
+  const { data: playgroundProject } = useProjectByName(
+    { projectName: PLAYGROUND_PROJECT_NAME },
+    { enabled: !!workspaceName, retry: false },
+  );
+
+  const { data: datasetsData } = useProjectDatasetsList(
+    {
+      projectId: playgroundProject?.id ?? "",
+      page: 1,
+      size: DEFAULT_LOADED_DATASETS,
+    },
+    { enabled: canViewDatasets && !!playgroundProject?.id && !!plainDatasetId },
   );
   const datasetName =
     (datasetsData?.content || EMPTY_DATASETS).find(

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/RunOnDatasetDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/RunOnDatasetDialog.tsx
@@ -19,7 +19,7 @@ import MetricSelector from "@/v2/pages/PlaygroundPage/MetricSelector";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import AddEditRuleDialog from "@/v2/pages-shared/automations/AddEditRuleDialog/AddEditRuleDialog";
 
-import useDatasetsList from "@/api/datasets/useDatasetsList";
+import useProjectDatasetsList from "@/api/datasets/useProjectDatasetsList";
 import useDatasetItemsList from "@/api/datasets/useDatasetItemsList";
 import useDatasetVersionsList from "@/api/datasets/useDatasetVersionsList";
 import useProjectByName from "@/api/projects/useProjectByName";
@@ -96,14 +96,27 @@ const RunOnDatasetDialog: React.FC<RunOnDatasetDialogProps> = ({
     }
   }, [open, initialDatasetId, initialSelectedRuleIds, initialFilters]);
 
-  const { data: datasetsData } = useDatasetsList(
-    { workspaceName, page: 1, size: DEFAULT_LOADED_DATASETS },
-    { enabled: open },
+  const {
+    data: playgroundProject,
+    isError: isProjectError,
+    error: projectError,
+  } = useProjectByName(
+    { projectName: PLAYGROUND_PROJECT_NAME },
+    { enabled: !!workspaceName && open, retry: false },
   );
-  const datasets = datasetsData?.content || EMPTY_DATASETS;
 
   const parsedDatasetId = parseDatasetVersionKey(datasetId);
   const plainDatasetId = parsedDatasetId?.datasetId || datasetId;
+
+  const { data: datasetsData } = useProjectDatasetsList(
+    {
+      projectId: playgroundProject?.id ?? "",
+      page: 1,
+      size: DEFAULT_LOADED_DATASETS,
+    },
+    { enabled: open && !!playgroundProject?.id },
+  );
+  const datasets = datasetsData?.content || EMPTY_DATASETS;
   const datasetName =
     datasets.find((ds) => ds.id === plainDatasetId)?.name || null;
 
@@ -154,15 +167,6 @@ const RunOnDatasetDialog: React.FC<RunOnDatasetDialogProps> = ({
   const filtersColumnData = useMemo(
     () => buildDatasetFilterColumns(datasetColumns),
     [datasetColumns],
-  );
-
-  const {
-    data: playgroundProject,
-    isError: isProjectError,
-    error: projectError,
-  } = useProjectByName(
-    { projectName: PLAYGROUND_PROJECT_NAME },
-    { enabled: !!workspaceName && open, retry: false },
   );
 
   const isProjectNotFound =
@@ -271,7 +275,7 @@ const RunOnDatasetDialog: React.FC<RunOnDatasetDialogProps> = ({
                     value={datasetId}
                     versionName={versionName}
                     onChange={handleDatasetChange}
-                    workspaceName={workspaceName}
+                    projectId={playgroundProject?.id}
                     buttonClassName="w-full"
                   />
                 </div>


### PR DESCRIPTION
## Details

Switch EvaluationSuitesPage from the workspace-level `/v1/private/datasets/` endpoint (with `project_id` query param) to the dedicated project-scoped `GET /v1/private/projects/{projectId}/datasets` endpoint (`ProjectDatasetsResource`).
This aligns datasets with the pattern already used by prompts (`useProjectPromptsList`) and alerts (`useProjectAlertsList`) in the v2 IA revamp, and provides cache isolation via a separate `["project-datasets"]` query key.

- Created `useProjectDatasetsList` hook with `["project-datasets", params]` query key
- Added `["project-datasets"]` cache invalidation to all 11 dataset mutation hooks
- Updated `EvaluationSuitesPage` to use the new hook

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-4987

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: assisted implementation
- Human verification: code review + lint/typecheck verification

## Testing

- `npm run lint` — passed with 0 warnings
- `npx tsc --noEmit` — passed with no type errors
- Manual: navigate to v2 Evaluation Suites page, verify list loads, search/filter/sort work, create/delete mutations refresh the list

## Documentation

N/A