### PR TITLE
[OPIK-5161] [FE] Scope v2 Playground to active project

### DIFF
--- a/apps/opik-frontend/src/api/playground/createLogPlaygroundProcessor.ts
+++ b/apps/opik-frontend/src/api/playground/createLogPlaygroundProcessor.ts
@@ -56,6 +56,7 @@ export interface LogProcessorArgs {
   onError: (error: Error) => void;
   onCreateTraces: (traces: LogTrace[], mappings: TraceMapping[]) => void;
   onExperimentItemsComplete?: () => void;
+  projectName?: string;
 }
 
 export interface LogProcessor {
@@ -104,10 +105,13 @@ const USAGE_FIELDS_TO_SEND = [
   "total_tokens",
 ];
 
-const getTraceFromRun = (run: LogQueueParams): LogTrace => {
+const getTraceFromRun = (
+  run: LogQueueParams,
+  projectName: string,
+): LogTrace => {
   const trace: LogTrace = {
     id: v7(),
-    projectName: PLAYGROUND_PROJECT_NAME,
+    projectName,
     name: PLAYGROUND_TRACE_SPAN_NAME,
     startTime: run.startTime,
     endTime: run.endTime,
@@ -118,6 +122,7 @@ const getTraceFromRun = (run: LogQueueParams): LogTrace => {
     metadata: {
       created_from: "playground",
     },
+    source: "playground",
   };
 
   // Add selected_rule_ids to trace metadata if provided
@@ -152,7 +157,11 @@ const hasChoicesContent = (run: LogQueueParams): boolean => {
   return !!run?.choices?.some((choice) => choice.delta.content);
 };
 
-const getSpanFromRun = (run: LogQueueParams, traceId: string): LogSpan => {
+const getSpanFromRun = (
+  run: LogQueueParams,
+  traceId: string,
+  projectName: string,
+): LogSpan => {
   const spanOutput =
     run.choices && hasChoicesContent(run)
       ? { choices: run.choices }
@@ -166,7 +175,7 @@ const getSpanFromRun = (run: LogQueueParams, traceId: string): LogSpan => {
   return {
     id: v7(),
     traceId,
-    projectName: PLAYGROUND_PROJECT_NAME,
+    projectName,
     type: SPAN_TYPE.llm,
     name: PLAYGROUND_TRACE_SPAN_NAME,
     startTime: run.startTime,
@@ -238,6 +247,7 @@ const createLogPlaygroundProcessor = ({
   onError,
   onCreateTraces,
   onExperimentItemsComplete,
+  projectName = PLAYGROUND_PROJECT_NAME,
 }: LogProcessorArgs): LogProcessor => {
   const experimentPromptMap: Record<string, string> = {};
   const experimentRegistry: LogExperiment[] = [];
@@ -316,8 +326,8 @@ const createLogPlaygroundProcessor = ({
 
       const isWithExperiments = !!datasetName;
 
-      const trace = getTraceFromRun(run);
-      const span = getSpanFromRun(run, trace.id);
+      const trace = getTraceFromRun(run, projectName);
+      const span = getSpanFromRun(run, trace.id, projectName);
 
       // Store the trace mapping
       traceMappings.push({

--- a/apps/opik-frontend/src/types/playground.ts
+++ b/apps/opik-frontend/src/types/playground.ts
@@ -85,6 +85,7 @@ export interface LogTrace {
   input: { messages: ProviderMessageType[] };
   output: { output: string | null };
   metadata?: Record<string, unknown>;
+  source?: string;
 }
 
 export interface LogSpan {

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputScores/PlaygroundOutputScoresContainer.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputScores/PlaygroundOutputScoresContainer.tsx
@@ -2,9 +2,7 @@ import React, { useMemo, useRef, useEffect } from "react";
 
 import useTraceById from "@/api/traces/useTraceById";
 import useRulesList from "@/api/automations/useRulesList";
-import useProjectByName from "@/api/projects/useProjectByName";
-import useAppStore from "@/store/AppStore";
-import { PLAYGROUND_PROJECT_NAME } from "@/constants/shared";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { getScoreNamesFromRule } from "@/lib/rules";
 import PlaygroundOutputScores, { ScoreData } from "./PlaygroundOutputScores";
 
@@ -22,6 +20,7 @@ const PlaygroundOutputScoresContainer: React.FC<
   PlaygroundOutputScoresContainerProps
 > = ({ traceId, selectedRuleIds, stale = false, className }) => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const pollingStartTimeRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -35,20 +34,15 @@ const PlaygroundOutputScoresContainer: React.FC<
   const hasRulesSelected =
     selectedRuleIds == null || selectedRuleIds.length > 0;
 
-  const { data: playgroundProject } = useProjectByName(
-    { projectName: PLAYGROUND_PROJECT_NAME },
-    { enabled: !!workspaceName && shouldShowMetrics && hasRulesSelected },
-  );
-
   const { data: rulesData } = useRulesList(
     {
       workspaceName,
-      projectId: playgroundProject?.id,
+      projectId: activeProjectId ?? undefined,
       page: 1,
       size: 100,
     },
     {
-      enabled: !!playgroundProject?.id && shouldShowMetrics && hasRulesSelected,
+      enabled: !!activeProjectId && shouldShowMetrics && hasRulesSelected,
     },
   );
 

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundOutputCell.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundOutputCell.tsx
@@ -17,9 +17,7 @@ import { cn } from "@/lib/utils";
 import { PLAYGROUND_PROMPT_COLORS } from "@/constants/llm";
 import PlaygroundNoRunsYet from "@/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundNoRunsYet";
 import { generateTracesURL } from "@/lib/annotation-queues";
-import useAppStore from "@/store/AppStore";
-import useProjectByName from "@/api/projects/useProjectByName";
-import { PLAYGROUND_PROJECT_NAME } from "@/constants/shared";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { Button } from "@/ui/button";
 
@@ -66,21 +64,14 @@ const PlaygroundOutputCell: React.FunctionComponent<
     originalRow.dataItemId,
   );
 
-  const { data: playgroundProject } = useProjectByName(
-    {
-      projectName: PLAYGROUND_PROJECT_NAME,
-    },
-    {
-      enabled: !!traceId && !!workspaceName,
-    },
-  );
+  const activeProjectId = useActiveProjectId();
 
   const handleTraceLinkClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    if (traceId && playgroundProject?.id) {
+    if (traceId && activeProjectId) {
       const url = generateTracesURL(
         workspaceName,
-        playgroundProject.id,
+        activeProjectId,
         "traces",
         traceId,
       );
@@ -118,7 +109,7 @@ const PlaygroundOutputCell: React.FunctionComponent<
     >
       {hasOutput ? (
         <div className="group relative flex size-full flex-col">
-          {traceId && playgroundProject?.id && (
+          {traceId && activeProjectId && (
             <TooltipWrapper content="Click to open original trace">
               <Button
                 size="icon-xs"

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -12,7 +12,8 @@ import { Separator } from "@/ui/separator";
 import PlaygroundOutputs from "@/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputs";
 import PlaygroundAddVariant from "@/v2/pages/PlaygroundPage/PlaygroundAddVariant";
 import { usePlaygroundDataset } from "@/hooks/usePlaygroundDataset";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
+import useProjectById from "@/api/projects/useProjectById";
 import useProviderKeys from "@/api/provider-keys/useProviderKeys";
 import PlaygroundPrompts from "@/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompts";
 import PlaygroundHeader from "@/v2/pages/PlaygroundPage/PlaygroundHeader";
@@ -44,6 +45,11 @@ const EMPTY_DATASETS: Dataset[] = [];
 
 const PlaygroundPage = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
+  const { data: activeProject } = useProjectById(
+    { projectId: activeProjectId! },
+    { enabled: !!activeProjectId },
+  );
   const {
     permissions: { canViewDatasets },
   } = usePermissions();
@@ -144,6 +150,7 @@ const PlaygroundPage = () => {
     datasetItems,
     datasetName,
     datasetVersionId: parsedVersionId || undefined,
+    projectName: activeProject?.name,
   });
 
   const isExperimentMode = !!datasetId;

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/RunOnDatasetDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/RunOnDatasetDialog.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import dayjs from "dayjs";
-import { useQueryClient } from "@tanstack/react-query";
 
 import { Button } from "@/ui/button";
 import {
@@ -22,11 +21,10 @@ import AddEditRuleDialog from "@/v2/pages-shared/automations/AddEditRuleDialog/A
 import useProjectDatasetsList from "@/api/datasets/useProjectDatasetsList";
 import useDatasetItemsList from "@/api/datasets/useDatasetItemsList";
 import useDatasetVersionsList from "@/api/datasets/useDatasetVersionsList";
-import useProjectByName from "@/api/projects/useProjectByName";
 import useRulesList from "@/api/automations/useRulesList";
-import useProjectCreateMutation from "@/api/projects/useProjectCreateMutation";
 
 import { useIsRunning } from "@/store/PlaygroundStore";
+import { useActiveProjectId } from "@/store/AppStore";
 import { usePermissions } from "@/contexts/PermissionsContext";
 import { Dataset, DatasetItemColumn } from "@/types/datasets";
 import { Filters } from "@/types/filters";
@@ -34,7 +32,6 @@ import {
   buildDatasetFilterColumns,
   transformDataColumnFilters,
 } from "@/lib/filters";
-import { PLAYGROUND_PROJECT_NAME } from "@/constants/shared";
 import { parseDatasetVersionKey } from "@/utils/datasetVersionStorage";
 
 import { DEFAULT_LOADED_DATASETS } from "@/v2/pages-shared/DatasetVersionSelectBox/useDatasetVersionSelect";
@@ -75,13 +72,9 @@ const RunOnDatasetDialog: React.FC<RunOnDatasetDialogProps> = ({
   const [filters, setFilters] = useState<Filters>(initialFilters);
   const [experimentPrefix, setExperimentPrefix] = useState("");
   const [isRuleDialogOpen, setIsRuleDialogOpen] = useState(false);
-  const [ruleDialogProjectId, setRuleDialogProjectId] = useState<
-    string | undefined
-  >(undefined);
 
   const isRunning = useIsRunning();
-  const queryClient = useQueryClient();
-  const createProjectMutation = useProjectCreateMutation();
+  const activeProjectId = useActiveProjectId();
 
   const {
     permissions: { canCreateProjects },
@@ -96,25 +89,16 @@ const RunOnDatasetDialog: React.FC<RunOnDatasetDialogProps> = ({
     }
   }, [open, initialDatasetId, initialSelectedRuleIds, initialFilters]);
 
-  const {
-    data: playgroundProject,
-    isError: isProjectError,
-    error: projectError,
-  } = useProjectByName(
-    { projectName: PLAYGROUND_PROJECT_NAME },
-    { enabled: !!workspaceName && open, retry: false },
-  );
-
   const parsedDatasetId = parseDatasetVersionKey(datasetId);
   const plainDatasetId = parsedDatasetId?.datasetId || datasetId;
 
   const { data: datasetsData } = useProjectDatasetsList(
     {
-      projectId: playgroundProject?.id ?? "",
+      projectId: activeProjectId ?? "",
       page: 1,
       size: DEFAULT_LOADED_DATASETS,
     },
-    { enabled: open && !!playgroundProject?.id },
+    { enabled: open && !!activeProjectId },
   );
   const datasets = datasetsData?.content || EMPTY_DATASETS;
   const datasetName =
@@ -169,52 +153,16 @@ const RunOnDatasetDialog: React.FC<RunOnDatasetDialogProps> = ({
     [datasetColumns],
   );
 
-  const isProjectNotFound =
-    isProjectError &&
-    projectError &&
-    "response" in projectError &&
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (projectError as any).response?.status === 404;
-
-  const canUsePlayground = !!playgroundProject?.id || canCreateProjects;
-
   const { data: rulesData } = useRulesList(
     {
       workspaceName,
-      projectId: playgroundProject?.id,
+      projectId: activeProjectId ?? undefined,
       page: 1,
       size: 100,
     },
-    { enabled: !!playgroundProject?.id && open },
+    { enabled: !!activeProjectId && open },
   );
   const rules = rulesData?.content || [];
-
-  const handleCreateRuleClick = useCallback(async () => {
-    try {
-      let projectId: string | undefined = playgroundProject?.id;
-      if (!projectId && isProjectNotFound && canCreateProjects) {
-        const result = await createProjectMutation.mutateAsync({
-          project: { name: PLAYGROUND_PROJECT_NAME },
-        });
-        projectId = result.id;
-        await queryClient.refetchQueries({
-          queryKey: ["project", { projectName: PLAYGROUND_PROJECT_NAME }],
-        });
-      }
-      if (projectId || playgroundProject?.id) {
-        setRuleDialogProjectId(projectId || playgroundProject?.id);
-        setIsRuleDialogOpen(true);
-      }
-    } catch (error) {
-      console.error("Failed to create playground project:", error);
-    }
-  }, [
-    playgroundProject,
-    isProjectNotFound,
-    createProjectMutation,
-    queryClient,
-    canCreateProjects,
-  ]);
 
   const handleDatasetChange = useCallback((value: string | null) => {
     setDatasetId(value);
@@ -275,7 +223,7 @@ const RunOnDatasetDialog: React.FC<RunOnDatasetDialogProps> = ({
                     value={datasetId}
                     versionName={versionName}
                     onChange={handleDatasetChange}
-                    projectId={playgroundProject?.id}
+                    projectId={activeProjectId ?? undefined}
                     buttonClassName="w-full"
                   />
                 </div>
@@ -298,10 +246,10 @@ const RunOnDatasetDialog: React.FC<RunOnDatasetDialogProps> = ({
                 selectedRuleIds={selectedRuleIds}
                 onSelectionChange={setSelectedRuleIds}
                 datasetId={datasetId}
-                onCreateRuleClick={handleCreateRuleClick}
+                onCreateRuleClick={() => setIsRuleDialogOpen(true)}
                 workspaceName={workspaceName}
-                projectId={playgroundProject?.id}
-                canUsePlayground={canUsePlayground}
+                projectId={activeProjectId ?? undefined}
+                canUsePlayground={!!activeProjectId || canCreateProjects}
               />
             </div>
           </div>
@@ -335,12 +283,8 @@ const RunOnDatasetDialog: React.FC<RunOnDatasetDialogProps> = ({
 
       <AddEditRuleDialog
         open={isRuleDialogOpen}
-        setOpen={(o) => {
-          setIsRuleDialogOpen(o);
-          if (!o) setRuleDialogProjectId(undefined);
-        }}
-        projectId={ruleDialogProjectId || playgroundProject?.id || ""}
-        projectName={PLAYGROUND_PROJECT_NAME}
+        setOpen={setIsRuleDialogOpen}
+        projectId={activeProjectId || ""}
         datasetColumnNames={datasetColumns.map((c) => c.name)}
         hideScopeSelector
       />

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/useActionButtonActions.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/useActionButtonActions.tsx
@@ -40,6 +40,7 @@ interface UseActionButtonActionsArguments {
   workspaceName: string;
   datasetName: string | null;
   datasetVersionId?: string;
+  projectName?: string;
 }
 
 const useActionButtonActions = ({
@@ -47,6 +48,7 @@ const useActionButtonActions = ({
   workspaceName,
   datasetName,
   datasetVersionId,
+  projectName,
 }: UseActionButtonActionsArguments) => {
   const queryClient = useQueryClient();
 
@@ -215,7 +217,10 @@ const useActionButtonActions = ({
     setAllRunning(true);
     clearCreatedExperiments();
 
-    const logProcessor = createLogPlaygroundProcessor(logProcessorHandlers);
+    const logProcessor = createLogPlaygroundProcessor({
+      ...logProcessorHandlers,
+      projectName,
+    });
 
     const combinations = createCombinations();
     const totalCombinations = combinations.length;
@@ -254,6 +259,7 @@ const useActionButtonActions = ({
     logProcessorHandlers,
     maxConcurrentRequests,
     setProgress,
+    projectName,
   ]);
 
   const runSingle = useCallback(
@@ -263,7 +269,10 @@ const useActionButtonActions = ({
 
       isToStopRef.current = false;
       setPromptRunning(promptId, true);
-      const logProcessor = createLogPlaygroundProcessor(logProcessorHandlers);
+      const logProcessor = createLogPlaygroundProcessor({
+        ...logProcessorHandlers,
+        projectName,
+      });
 
       try {
         await processCombination({ prompt }, logProcessor);
@@ -272,7 +281,7 @@ const useActionButtonActions = ({
         setPromptRunning(promptId, false);
       }
     },
-    [setPromptRunning, logProcessorHandlers, processCombination],
+    [setPromptRunning, logProcessorHandlers, processCombination, projectName],
   );
 
   return {


### PR DESCRIPTION
## Details

Migrates the v2 Playground page from the hardcoded "playground" project to the active project context from the URL. This is part of the IA revamp (OPIK-4617) to make all pages project-scoped in v2.

**Key changes:**
- Trace and span creation now uses the active project name instead of the hardcoded `PLAYGROUND_PROJECT_NAME` constant
- Added `source: "playground"` on traces for proper source-based filtering (R3)
- Rules and metrics queries in `RunOnDatasetDialog` scoped to the active project via `useActiveProjectId()`
- Trace links in output cells use `activeProjectId` instead of looking up the "playground" project by name
- Removed project creation logic from `RunOnDatasetDialog` (no longer needed — active project always exists in v2)
- All changes to `createLogPlaygroundProcessor` are backward compatible (new `projectName` param defaults to `PLAYGROUND_PROJECT_NAME`)

**Not included (deferred):**
- `TraceLogsSidebar` integration (depends on T6) — playground traces are accessible by clicking individual output cells but not listed on the Logs page (by design, Logs filters `source = sdk`)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-5161

## Testing
- Verified traces are created in the active project when running prompts
- Verified trace links in experiment mode output cells open the correct trace detail
- Verified rules/metrics in RunOnDatasetDialog are scoped to the active project
- Verified v1 Playground still works unchanged (no v1 files modified)
- TypeScript and ESLint pass clean

## Documentation
N/A