### PR TITLE
[OPIK-5270] [BE] fix: add trace_id_prefilter to scope trace query CTEs

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -3224,17 +3224,22 @@ class TraceDAOImpl implements TraceDAO {
      * uuidFromTime/uuidToTime are excluded because the if/else fallback applies them directly
      * to each CTE; lastReceivedId is excluded because it's a pagination cursor, not a
      * semantic filter.
+     *
+     * <p>Guardrails filters inject {@code gagg.guardrails_result} into the {@code <filters>}
+     * template variable, which references the guardrails_agg CTE alias. Since the prefilter
+     * CTE only queries the traces table, these references would fail. Guard against them.
      */
     private boolean shouldUseTraceIdPrefilter(TraceSearchCriteria criteria, ST template) {
-        boolean hasFeedbackScoreFilters = template.getAttribute("feedback_scores_filters") != null
+        boolean hasCteDependentFilters = template.getAttribute("feedback_scores_filters") != null
                 || template.getAttribute("feedback_scores_empty_filters") != null
                 || template.getAttribute("span_feedback_scores_filters") != null
-                || template.getAttribute("span_feedback_scores_empty_filters") != null;
+                || template.getAttribute("span_feedback_scores_empty_filters") != null
+                || template.getAttribute("guardrails_filters") != null;
 
         boolean hasNarrowingFilters = criteria.searchText() != null
                 || template.getAttribute("filters") != null;
 
-        return !hasFeedbackScoreFilters && hasNarrowingFilters;
+        return !hasCteDependentFilters && hasNarrowingFilters;
     }
 
     private Mono<? extends Result> getTracesByProjectId(


### PR DESCRIPTION
## Details

Adds a conditional `trace_id_prefilter` CTE to the `SELECT_BY_PROJECT_ID` trace query, matching the `span_id_prefilter` pattern from PRs #5625 and #5599. When trace-level filters (tags, search text) or search text are active, the prefilter narrows all enrichment CTEs (feedback scores, spans, guardrails, comments, annotations, experiments) to only process data for matching traces instead of scanning the entire project.

This prevents OOM kills caused by the `arrayMap` in `feedback_scores_final` attempting to allocate multi-GiB chunks when processing unscoped feedback scores for large projects.

- Prefilter CTE: `SELECT DISTINCT id FROM traces WHERE <filters>`
- 9 CTEs scoped via `IN (SELECT id FROM trace_id_prefilter)` with if/else fallback to uuid-range
- Decision logic in `shouldUseTraceIdPrefilter()`: activates when narrowing filters exist, guards against feedback score filters and sort-by-feedback-scores
- Both `findTraceStream` (streaming) and `getTracesByProjectId` (paginated) paths covered

## Performance (measured on affected customer instance)

| Metric | Before (killed) | After (prefilter) |
|--------|-----|------|
| Rows read | 34,995,469 | 273,092 |
| Bytes read | 6.26 GiB | 33.21 MiB |
| Duration | killed / 11s+ | 4.8s |
| Memory | 21+ GiB (OOM at 13.97 GiB limit) | 12.35 GiB |

The remaining 12 GiB memory is inherent to the project's data volume (confirmed by a real application query without prefilter hitting 13.01 GiB and being killed with the same `arrayMap` OOM). The prefilter eliminates the 4-8 GiB `arrayMap` chunk allocation that pushes memory past the limit.

Without narrowing filters active, the query is unchanged (zero overhead).

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- OPIK-5270

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Implementation, analysis, and query optimization
  - Human verification: Tested directly against customer ClickHouse instance with before/after measurements

## Testing

- `mvn compile` passes
- Manually tested the rendered SQL query directly against the affected ClickHouse instance:
  - Ran original killed query and prefiltered variant side by side
  - Verified identical result sets (6 rows)
  - Measured rows read, bytes read, memory, and duration via `system.query_log`
  - Confirmed the query no longer exceeds the 13.97 GiB memory limit
  - Verified the prefilter does not activate when no narrowing filters are present (no regression for default page loads)

## Documentation
N/A — internal query optimization, no user-facing API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)