### PR TITLE
[OPIK-5316] [INFRA] feat: add opt-in worktree support to work-on-jira-ticket skill

### DIFF
--- a/.agents/commands/comet/work-on-jira-ticket.md
+++ b/.agents/commands/comet/work-on-jira-ticket.md
@@ -19,6 +19,7 @@ This workflow will:
 ## Inputs
 
 - **Jira link (required)**: e.g., `https://comet-ml.atlassian.net/browse/OPIK-1234`
+- **Worktree (optional)**: Pass `worktree` to work in an isolated git worktree, or `no-worktree` to skip. If neither is specified, prompt the user when uncommitted changes are detected.
 
 ---
 
@@ -91,18 +92,38 @@ This workflow will:
 ### 6. Git & Branch Setup
 
 - Repo: Opik repository (current workspace)
-- **CRITICAL**: Handle working directory state BEFORE branching:
+- **NEVER commit directly to main** (following Opik git workflow)
+
+#### 6a. Worktree Decision
+
+Determine whether to use a git worktree for isolation:
+
+- **If `worktree` was passed as an argument**: Use a worktree (skip prompt).
+- **If `no-worktree` was passed as an argument**: Do not use a worktree (skip prompt).
+- **If neither was passed**: Check `git status` for uncommitted changes.
+  - If there are uncommitted changes, ask the user:
+    > "You have uncommitted changes on the current branch. Would you like to work in a worktree? This keeps your current branch untouched. (yes/no)"
+  - If no uncommitted changes, proceed without a worktree (no prompt needed).
+
+#### 6b. Worktree Path (if using worktree)
+
+1. Use the `EnterWorktree` tool with name `{USERNAME}-OPIK-{TICKET-NUMBER}-{TICKET-SUMMARY}` (replace `/` and `+` with `-` since worktree names only allow letters, digits, dots, underscores, and dashes).
+2. Inside the worktree, create the properly named branch:
+   ```bash
+   git checkout -b {USERNAME}/OPIK-{TICKET-NUMBER}-{TICKET-SUMMARY}
+   ```
+3. Continue with implementation in the worktree directory.
+
+#### 6c. Normal Path (if not using worktree)
+
+- **Handle working directory state BEFORE branching**:
   - If working directory has changes:
     - **Option 1**: Stash changes: `git stash push -m "WIP: before OPIK-{TICKET-NUMBER}"`
     - **Option 2**: Ask user what to do with uncommitted changes
-  - **NEVER commit directly to main** (following Opik git workflow)
 - If on `main`, create branch following Opik conventions:
   ```bash
-  # Ensure you're on main and pull latest
   git checkout main
   git pull origin main
-  
-  # Create task-specific branch
   git checkout -b {USERNAME}/OPIK-{TICKET-NUMBER}-{TICKET-SUMMARY}
   ```
 - **After branch creation**: Apply stashed changes if any: `git stash pop`

--- a/.agents/commands/comet/work-on-jira-ticket.md
+++ b/.agents/commands/comet/work-on-jira-ticket.md
@@ -101,7 +101,7 @@ Determine whether to use a git worktree for isolation:
 - **If `worktree` was passed as an argument**: Use a worktree (skip prompt).
 - **If `no-worktree` was passed as an argument**: Do not use a worktree (skip prompt).
 - **If neither was passed**: Use the `AskUserQuestion` tool to prompt the user with clickable options:
-    - **question**: "Would you like to work in a worktree? Tip: pass `worktree` or `no-worktree` to skip this prompt. Learn more: https://docs.anthropic.com/en/docs/claude-code/common-workflows"
+    - **question**: "Would you like to work in a worktree? Tip: pass `worktree` or `no-worktree` to skip this prompt. Learn more: https://code.claude.com/docs/en/common-workflows#run-parallel-claude-code-sessions-with-git-worktrees"
     - **header**: "Worktree"
     - **options**:
       1. **Yes** — "Create a separate copy of the repo so your current branch stays untouched (Recommended)"

--- a/.agents/commands/comet/work-on-jira-ticket.md
+++ b/.agents/commands/comet/work-on-jira-ticket.md
@@ -107,10 +107,10 @@ Determine whether to use a git worktree for isolation:
 
 #### 6b. Worktree Path (if using worktree)
 
-1. Use the `EnterWorktree` tool with name `{USERNAME}-OPIK-{TICKET-NUMBER}-{TICKET-SUMMARY}` (replace `/` and `+` with `-` since worktree names only allow letters, digits, dots, underscores, and dashes).
-2. Inside the worktree, create the properly named branch:
+1. Slugify `{TICKET-SUMMARY}` for the worktree name: replace any character not in `[A-Za-z0-9._-]` with `-`, collapse consecutive `-` into one, and trim leading/trailing `-`. Then call `EnterWorktree` with name `{USERNAME}-OPIK-{TICKET-NUMBER}-{SLUGIFIED-SUMMARY}`.
+2. Inside the worktree, create the properly named branch (using the same slugified summary):
    ```bash
-   git checkout -b {USERNAME}/OPIK-{TICKET-NUMBER}-{TICKET-SUMMARY}
+   git checkout -b {USERNAME}/OPIK-{TICKET-NUMBER}-{SLUGIFIED-SUMMARY}
    ```
 3. Continue with implementation in the worktree directory.
 

--- a/.agents/commands/comet/work-on-jira-ticket.md
+++ b/.agents/commands/comet/work-on-jira-ticket.md
@@ -100,16 +100,12 @@ Determine whether to use a git worktree for isolation:
 
 - **If `worktree` was passed as an argument**: Use a worktree (skip prompt).
 - **If `no-worktree` was passed as an argument**: Do not use a worktree (skip prompt).
-- **If neither was passed**: Always prompt the user:
-    > "Would you like to work in a **worktree**?
-    >
-    > A worktree creates a separate copy of the repo in its own folder so you can work on this ticket without touching your current branch or needing to stash anything. Your existing changes stay exactly as they are.
-    >
-    > Tip: pass `worktree` or `no-worktree` as an argument to skip this prompt next time.
-    >
-    > Learn more: https://docs.claude.ai/en/docs/worktrees
-    >
-    > Use worktree? (yes/no)"
+- **If neither was passed**: Use the `AskUserQuestion` tool to prompt the user with clickable options:
+    - **question**: "Would you like to work in a worktree? A worktree creates a separate copy of the repo in its own folder so you can work on this ticket without touching your current branch or needing to stash anything. Your existing changes stay exactly as they are. Tip: pass `worktree` or `no-worktree` as an argument to skip this prompt next time. Learn more: https://docs.claude.ai/en/docs/worktrees"
+    - **header**: "Worktree"
+    - **options**:
+      1. **Yes** — "Create an isolated worktree for this ticket (Recommended)"
+      2. **No** — "Use normal stash/branch flow on the current repo"
 
 #### 6b. Worktree Path (if using worktree)
 

--- a/.agents/commands/comet/work-on-jira-ticket.md
+++ b/.agents/commands/comet/work-on-jira-ticket.md
@@ -96,6 +96,8 @@ This workflow will:
 
 #### 6a. Worktree Decision
 
+If the `EnterWorktree` tool is not available (e.g., running in Cursor or another editor), skip steps 6a and 6b entirely and go straight to 6c (normal path).
+
 Determine whether to use a git worktree for isolation:
 
 - **If `worktree` was passed as an argument**: Use a worktree (skip prompt).

--- a/.agents/commands/comet/work-on-jira-ticket.md
+++ b/.agents/commands/comet/work-on-jira-ticket.md
@@ -124,11 +124,12 @@ Determine whether to use a git worktree for isolation:
   - If working directory has changes:
     - **Option 1**: Stash changes: `git stash push -m "WIP: before OPIK-{TICKET-NUMBER}"`
     - **Option 2**: Ask user what to do with uncommitted changes
+- Slugify `{TICKET-SUMMARY}` the same way as step 6b: replace any character not in `[A-Za-z0-9._-]` with `-`, collapse consecutive `-` into one, and trim leading/trailing `-`.
 - If on `main`, create branch following Opik conventions:
   ```bash
   git checkout main
   git pull origin main
-  git checkout -b {USERNAME}/OPIK-{TICKET-NUMBER}-{TICKET-SUMMARY}
+  git checkout -b {USERNAME}/OPIK-{TICKET-NUMBER}-{SLUGIFIED-SUMMARY}
   ```
 - **After branch creation**: Apply stashed changes if any: `git stash pop`
 - **Verify branch creation**: Confirm new branch is active and clean.

--- a/.agents/commands/comet/work-on-jira-ticket.md
+++ b/.agents/commands/comet/work-on-jira-ticket.md
@@ -102,7 +102,13 @@ Determine whether to use a git worktree for isolation:
 - **If `no-worktree` was passed as an argument**: Do not use a worktree (skip prompt).
 - **If neither was passed**: Check `git status` for uncommitted changes.
   - If there are uncommitted changes, ask the user:
-    > "You have uncommitted changes on the current branch. Would you like to work in a worktree? This keeps your current branch untouched. (yes/no)"
+    > "You have uncommitted changes on the current branch. Would you like to work in a **worktree**?
+    >
+    > A worktree creates a separate copy of the repo in its own folder so you can work on this ticket without touching your current branch or needing to stash anything. Your existing changes stay exactly as they are.
+    >
+    > Learn more: https://docs.claude.ai/en/docs/worktrees
+    >
+    > Use worktree? (yes/no)"
   - If no uncommitted changes, proceed without a worktree (no prompt needed).
 
 #### 6b. Worktree Path (if using worktree)

--- a/.agents/commands/comet/work-on-jira-ticket.md
+++ b/.agents/commands/comet/work-on-jira-ticket.md
@@ -101,10 +101,10 @@ Determine whether to use a git worktree for isolation:
 - **If `worktree` was passed as an argument**: Use a worktree (skip prompt).
 - **If `no-worktree` was passed as an argument**: Do not use a worktree (skip prompt).
 - **If neither was passed**: Use the `AskUserQuestion` tool to prompt the user with clickable options:
-    - **question**: "Would you like to work in a worktree? A worktree creates a separate copy of the repo in its own folder so you can work on this ticket without touching your current branch or needing to stash anything. Your existing changes stay exactly as they are. Tip: pass `worktree` or `no-worktree` as an argument to skip this prompt next time. Learn more: https://docs.claude.ai/en/docs/worktrees"
+    - **question**: "Would you like to work in a worktree? Tip: pass `worktree` or `no-worktree` to skip this prompt. Learn more: https://docs.claude.ai/en/docs/worktrees"
     - **header**: "Worktree"
     - **options**:
-      1. **Yes** — "Create an isolated worktree for this ticket (Recommended)"
+      1. **Yes** — "Create a separate copy of the repo so your current branch stays untouched (Recommended)"
       2. **No** — "Use normal stash/branch flow on the current repo"
 
 #### 6b. Worktree Path (if using worktree)

--- a/.agents/commands/comet/work-on-jira-ticket.md
+++ b/.agents/commands/comet/work-on-jira-ticket.md
@@ -100,16 +100,16 @@ Determine whether to use a git worktree for isolation:
 
 - **If `worktree` was passed as an argument**: Use a worktree (skip prompt).
 - **If `no-worktree` was passed as an argument**: Do not use a worktree (skip prompt).
-- **If neither was passed**: Check `git status` for uncommitted changes.
-  - If there are uncommitted changes, ask the user:
-    > "You have uncommitted changes on the current branch. Would you like to work in a **worktree**?
+- **If neither was passed**: Always prompt the user:
+    > "Would you like to work in a **worktree**?
     >
     > A worktree creates a separate copy of the repo in its own folder so you can work on this ticket without touching your current branch or needing to stash anything. Your existing changes stay exactly as they are.
+    >
+    > Tip: pass `worktree` or `no-worktree` as an argument to skip this prompt next time.
     >
     > Learn more: https://docs.claude.ai/en/docs/worktrees
     >
     > Use worktree? (yes/no)"
-  - If no uncommitted changes, proceed without a worktree (no prompt needed).
 
 #### 6b. Worktree Path (if using worktree)
 

--- a/.agents/commands/comet/work-on-jira-ticket.md
+++ b/.agents/commands/comet/work-on-jira-ticket.md
@@ -101,7 +101,7 @@ Determine whether to use a git worktree for isolation:
 - **If `worktree` was passed as an argument**: Use a worktree (skip prompt).
 - **If `no-worktree` was passed as an argument**: Do not use a worktree (skip prompt).
 - **If neither was passed**: Use the `AskUserQuestion` tool to prompt the user with clickable options:
-    - **question**: "Would you like to work in a worktree? Tip: pass `worktree` or `no-worktree` to skip this prompt. Learn more: https://docs.claude.ai/en/docs/worktrees"
+    - **question**: "Would you like to work in a worktree? Tip: pass `worktree` or `no-worktree` to skip this prompt. Learn more: https://docs.anthropic.com/en/docs/claude-code/common-workflows"
     - **header**: "Worktree"
     - **options**:
       1. **Yes** — "Create a separate copy of the repo so your current branch stays untouched (Recommended)"

--- a/.agents/commands/comet/work-on-jira-ticket.md
+++ b/.agents/commands/comet/work-on-jira-ticket.md
@@ -19,7 +19,7 @@ This workflow will:
 ## Inputs
 
 - **Jira link (required)**: e.g., `https://comet-ml.atlassian.net/browse/OPIK-1234`
-- **Worktree (optional)**: Pass `worktree` to work in an isolated git worktree, or `no-worktree` to skip. If neither is specified, prompt the user when uncommitted changes are detected.
+- **Worktree (optional)**: Pass `worktree` to work in an isolated git worktree. Defaults to no worktree when the argument is omitted — the command never prompts about worktrees.
 
 ---
 
@@ -96,18 +96,12 @@ This workflow will:
 
 #### 6a. Worktree Decision
 
-If the `EnterWorktree` tool is not available (e.g., running in Cursor or another editor), skip steps 6a and 6b entirely and go straight to 6c (normal path).
+Worktree usage is strictly opt-in:
 
-Determine whether to use a git worktree for isolation:
+- **If `worktree` was passed as an argument**: Use a worktree (continue to 6b).
+- **Otherwise (default)**: Skip 6b and go straight to 6c (normal path). Do not prompt the user.
 
-- **If `worktree` was passed as an argument**: Use a worktree (skip prompt).
-- **If `no-worktree` was passed as an argument**: Do not use a worktree (skip prompt).
-- **If neither was passed**: Use the `AskUserQuestion` tool to prompt the user with clickable options:
-    - **question**: "Would you like to work in a worktree? Tip: pass `worktree` or `no-worktree` to skip this prompt. Learn more: https://code.claude.com/docs/en/common-workflows#run-parallel-claude-code-sessions-with-git-worktrees"
-    - **header**: "Worktree"
-    - **options**:
-      1. **Yes** — "Create a separate copy of the repo so your current branch stays untouched (Recommended)"
-      2. **No** — "Use normal stash/branch flow on the current repo"
+If the `EnterWorktree` tool is not available (e.g., running in Cursor or another editor) even when `worktree` was passed, fall back to 6c without prompting.
 
 #### 6b. Worktree Path (if using worktree)
 


### PR DESCRIPTION
## Details

<img width="1920" height="1914" alt="image" src="https://github.com/user-attachments/assets/7c8ee46e-7b69-4c80-9e1e-bbbfd303a596" />

Adds **opt-in** worktree isolation to the `/comet:work-on-jira-ticket` skill. By default the command uses the normal stash/branch flow on the current repo — exactly the behaviour before this PR. Passing `worktree` as an argument switches to an isolated git worktree. The command never prompts about worktrees.

- Splits Step 6 (Git & Branch Setup) into 6a (worktree decision), 6b (worktree path), 6c (normal path)
- **No AskUserQuestion prompt** — absence of the `worktree` argument is treated as "no worktree"
- Worktree names are fully slugified to prevent `EnterWorktree` validation failures
- Graceful fallback: if `EnterWorktree` is unavailable (Cursor, etc.), falls back to the normal path without prompting

## Why opt-in (not default)

A worktree-by-default (or prompt-every-time) design adds a decision point to every ticket. For routine work the normal stash/branch flow is what we actually want — worktrees pay off when you're running parallel agents or want to keep the current branch untouched. Making it an explicit argument keeps the tool available without imposing friction on the common case.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-5316

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6, Claude Opus 4.7
  - Scope: Full implementation
  - Human verification: Reviewed diff and tested workflow

## Testing

- Run `/comet:work-on-jira-ticket OPIK-XXXX worktree` — should enter a worktree (no prompt)
- Run `/comet:work-on-jira-ticket OPIK-XXXX` with no argument — should use the normal stash/branch flow (no prompt)
- Run in an environment without `EnterWorktree` (e.g., Cursor) with `worktree` — should silently fall back to the normal path

## Documentation

N/A — internal skill change only.