### PR TITLE
[OPIK-5319] [INFRA] Make ticket number a clickable Jira link in create-jira-ticket output

### DIFF
--- a/.agents/commands/comet/create-jira-ticket.md
+++ b/.agents/commands/comet/create-jira-ticket.md
@@ -108,6 +108,21 @@ Use these prefixes in the summary based on the work area:
 - `[DOCS]` - Documentation updates
 - `[INFRA]` - Infrastructure/DevOps changes
 
+## Confirmation Output
+
+After successfully creating a ticket, always display the ticket key as a **clickable markdown link** in the confirmation message:
+
+```
+[OPIK-{number}](https://comet-ml.atlassian.net/browse/OPIK-{number})
+```
+
+For example, if the created ticket key is `OPIK-5316`, display:
+```
+[OPIK-5316](https://comet-ml.atlassian.net/browse/OPIK-5316)
+```
+
+Never display the ticket key as plain text — always wrap it in a markdown link to the Jira ticket URL.
+
 ## Notes
 
 - The project key is always `OPIK`


### PR DESCRIPTION
## Details
Add a "Confirmation Output" section to the `/comet:create-jira-ticket` skill so that after creating a ticket, the ticket key is rendered as a clickable markdown link (e.g., `[OPIK-5316](https://comet-ml.atlassian.net/browse/OPIK-5316)`) instead of plain text.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5319

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: full implementation
  - Human verification: code review

## Testing
- Run `/comet:create-jira-ticket` and verify the created ticket key appears as a clickable link
- Verify the link URL correctly points to the Jira ticket at `https://comet-ml.atlassian.net/browse/OPIK-{number}`

## Documentation
N/A

[OPIK-5316]: https://comet-ml.atlassian.net/browse/OPIK-5316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ