### PR TITLE
[OPIK-5320] [CI] Add pr-lint validation step to create-pr skill

### DIFF
--- a/.agents/commands/comet/create-pr.md
+++ b/.agents/commands/comet/create-pr.md
@@ -196,7 +196,7 @@ Before creating the PR, validate the generated title and body against the same r
   - `## Testing`
   - `## Documentation`
 
-- **Details section non-empty**: Extract content between `## Details` and the next `##` heading. Verify it is not empty after stripping HTML comments (`<!-- ... -->`).
+- **Details section non-empty**: Extract content between `## Details` and the next `##` heading. Verify it is not empty after trimming whitespace (matching CI's `getSectionContent` which only calls `.trim()`). Note: HTML comment placeholders are handled separately in the template placeholder cleanup step below — do not strip them during this validation check.
 
 - **Issues section ticket reference**: Extract content of `## Issues`. Unless the PR title starts with `[NA]`, verify it references at least one ticket matching: `#\d+`, `OPIK-\d+`, `DND-\d+`, `DEV-\d+`, or `CUST-\d+`.
 


### PR DESCRIPTION
## Details

<img width="1920" height="3424" alt="image" src="https://github.com/user-attachments/assets/7f6cfd5c-fc3b-4b1f-899b-06ba60a3beaa" />

Add a pr-lint validation step (Step 8) to the `/comet:create-pr` skill that validates the generated PR title and body against the same rules enforced by `.github/workflows/pr-lint.yml` **before** calling `gh pr create`.

Previously, the skill would generate PR titles and descriptions without checking them against CI rules, causing PRs to immediately fail the PR Linter workflow and require manual edits.

The new validation step checks:
- PR title matches the required regex (ticket prefix + valid component tags)
- All required `##` sections are present (`Details`, `Change checklist`, `Issues`, `Testing`, `Documentation`)
- `Details` section is not empty (after stripping HTML comment placeholders)
- `Issues` section references at least one ticket (unless title starts with `[NA]`)
- No leftover template placeholder comments remain in the body

On failure, errors are shown and auto-fixed before retrying. Steps 8-10 were renumbered to 9-11 accordingly.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-5320

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: full implementation
  - Human verification: code review

## Testing

Verified the updated skill file:
- All step numbering is correct and sequential (1-11)
- Cross-references between steps are updated (Step 4 now references Steps 5-11)
- New Step 8 validation rules match `pr-lint.yml` exactly (title regex, required sections, details non-empty, issues reference)
- Error handling section includes new "PR Lint Validation Failures" subsection
- Success criteria updated with new item #9
- Completion summary includes pr-lint validation checkbox

## Documentation

N/A - the skill file itself is the documentation