### PR TITLE
[OPIK-5323] [FE] fix: guard DatasetExportPanel query on workspace readiness

### DIFF
--- a/apps/opik-frontend/src/v1/pages-shared/datasets/DatasetExportPanel/DatasetExportPanel.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/datasets/DatasetExportPanel/DatasetExportPanel.tsx
@@ -11,6 +11,7 @@ import {
   useHydrateFromApi,
   useIsHydrated,
 } from "@/store/DatasetExportStore";
+import { useActiveWorkspaceName } from "@/store/AppStore";
 import useDatasetExportJobs from "@/api/datasets/useDatasetExportJobs";
 import { DATASET_EXPORT_STATUS } from "@/types/datasets";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
@@ -25,11 +26,14 @@ const DatasetExportPanel: React.FC = () => {
   const removeJob = useRemoveExportJob();
   const hydrateFromApi = useHydrateFromApi();
   const isHydrated = useIsHydrated();
+  const workspaceName = useActiveWorkspaceName();
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
 
-  // Fetch all export jobs on mount to restore state after page refresh
+  // Fetch all export jobs on mount to restore state after page refresh.
+  // Guard on workspaceName because this component renders at the App root,
+  // before WorkspacePreloader sets the Comet-Workspace header on axios.
   const { data: apiJobs } = useDatasetExportJobs({
-    enabled: !isHydrated,
+    enabled: !isHydrated && !!workspaceName,
   });
 
   // Hydrate store from API data

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetExportPanel/DatasetExportPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetExportPanel/DatasetExportPanel.tsx
@@ -11,6 +11,7 @@ import {
   useHydrateFromApi,
   useIsHydrated,
 } from "@/store/DatasetExportStore";
+import { useActiveWorkspaceName } from "@/store/AppStore";
 import useDatasetExportJobs from "@/api/datasets/useDatasetExportJobs";
 import { DATASET_EXPORT_STATUS } from "@/types/datasets";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
@@ -25,11 +26,14 @@ const DatasetExportPanel: React.FC = () => {
   const removeJob = useRemoveExportJob();
   const hydrateFromApi = useHydrateFromApi();
   const isHydrated = useIsHydrated();
+  const workspaceName = useActiveWorkspaceName();
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
 
-  // Fetch all export jobs on mount to restore state after page refresh
+  // Fetch all export jobs on mount to restore state after page refresh.
+  // Guard on workspaceName because this component renders at the App root,
+  // before WorkspacePreloader sets the Comet-Workspace header on axios.
   const { data: apiJobs } = useDatasetExportJobs({
-    enabled: !isHydrated,
+    enabled: !isHydrated && !!workspaceName,
   });
 
   // Hydrate store from API data


### PR DESCRIPTION
## Summary
- `DatasetExportPanel` renders at the App root level (outside the router) and fires `useDatasetExportJobs` before `WorkspacePreloader` has called `setActiveWorkspaceName`, so the `Comet-Workspace` header isn't set on the axios instance yet
- The backend's `RemoteAuthService` rejects requests without workspace name with 403
- Fix: add `!!workspaceName` guard to the `enabled` condition in both v1 and v2 `DatasetExportPanel`

## Root cause
The opik-backend logs `WARN: Workspace name is missing` for every 403. The `DatasetExportPanel` component is a sibling of `RouterProvider` in `App.tsx`, so it mounts and fires queries before the router's `WorkspacePreloader` sets the workspace header on the shared axios instance.

## Test plan
- [ ] Load opik frontend in cloud (comet) mode — verify no 403 errors for `/v1/private/datasets/export-jobs` in the network tab
- [ ] Verify export panel still appears and functions when a dataset export is triggered
- [ ] Check backend logs for absence of "Workspace name is missing" warnings on export-jobs endpoint

Jira: https://comet-ml.atlassian.net/browse/OPIK-5323

🤖 Generated with [Claude Code](https://claude.com/claude-code)