### PR TITLE
[OPIK-5321] [FE] Fix incorrect sizing in playground prompt header section

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSelect/PromptModelSelect.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSelect/PromptModelSelect.tsx
@@ -286,7 +286,7 @@ const PromptModelSelect = ({
           className={cn(
             "size-full data-[placeholder]:text-light-slate",
             compact &&
-              "w-auto min-w-0 gap-1 border-0 bg-transparent px-0 text-left hover:shadow-none hover:text-primary-hover [&>span]:truncate [&>svg]:text-current [&>svg]:opacity-100",
+              "w-auto min-w-0 gap-1 border-0 bg-transparent px-0 text-left text-xs hover:shadow-none hover:text-primary-hover [&>span]:truncate [&>svg]:text-current [&>svg]:opacity-100",
             hasError && (compact ? "text-destructive" : "border-destructive"),
           )}
         >

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -283,9 +283,9 @@ const PlaygroundPrompt = ({
       <div className="flex h-10 items-center justify-between overflow-hidden border-b px-4">
         <div className="flex min-w-0 items-center gap-1">
           <div className="flex shrink-0 items-center gap-1 pr-2">
-            <p className="comet-body-s-accented whitespace-nowrap">{name}</p>
+            <p className="comet-body-xs-accented whitespace-nowrap">{name}</p>
             <span
-              className="comet-body-s flex size-6 items-center justify-center rounded-md"
+              className="comet-body-xs flex size-5 items-center justify-center rounded-md"
               style={{
                 backgroundColor: promptColor.bg,
                 color: promptColor.text,


### PR DESCRIPTION
## Details

Fixes incorrect sizing in the v2 Playground prompt header section to match design specs:

- **Prompt label**: Changed from Body Small (14px) to Body XSmall (12px) — `comet-body-s-accented` → `comet-body-xs-accented`
- **Letter container ("A")**: Changed from 24x24px to 20x20px — `size-6` → `size-5`, `comet-body-s` → `comet-body-xs`
- **Model selector text**: Added explicit `text-xs` (12px) to compact trigger to override inherited `text-sm` (14px)

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5321

## Testing

- Open the v2 Playground page
- Verify the "Prompt" label renders at 12px (Body XSmall)
- Verify the colored letter container is 20x20px
- Verify the model selector text is 12px
- Verify the config gear button remains unchanged at icon-xs size

## Documentation

N/A