### PR TITLE
[OPIK-5312] [FE] feat: add loading state to assistant sidebar

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -11,12 +11,95 @@ import { useActiveWorkspaceName } from "@/store/AppStore";
 import { useToast } from "@/ui/use-toast";
 import useWorkspace from "@/plugins/comet/useWorkspace";
 import useAssistantBackend from "@/plugins/comet/useAssistantBackend";
+import type { AssistantBackendPhase } from "@/plugins/comet/useAssistantBackend";
 import useProjectById from "@/api/projects/useProjectById";
 import { BASE_API_URL } from "@/api/api";
+import { Spinner } from "@/ui/spinner";
 
 const DEV_BASE_URL = import.meta.env.VITE_ASSISTANT_SIDEBAR_BASE_URL;
 const IS_DEV = import.meta.env.DEV;
 const BRIDGE_PROTOCOL_VERSION = 1;
+
+const LOADER_DEFAULT_WIDTH = 400;
+const LOADER_COLLAPSED_WIDTH = 33;
+
+function getStoredSidebarWidth(): number {
+  try {
+    const parsed = parseInt(
+      localStorage.getItem("assistant-sidebar-width") ?? "",
+      10,
+    );
+    if (parsed > 0) return parsed;
+  } catch {
+    /* localStorage unavailable */
+  }
+  return LOADER_DEFAULT_WIDTH;
+}
+
+function getStoredSidebarOpen(): boolean {
+  try {
+    const stored = localStorage.getItem("assistant-sidebar-open");
+    return stored === null ? true : stored === "true";
+  } catch {
+    return true;
+  }
+}
+
+const PHASE_MESSAGES: Partial<
+  Record<AssistantBackendPhase | "manifest", string>
+> = {
+  compute: "Starting assistant\u2026",
+  health: "Connecting\u2026",
+  manifest: "Loading interface\u2026",
+};
+
+interface AssistantSidebarLoaderProps {
+  phase: AssistantBackendPhase | "manifest";
+  error: string | null;
+  onWidthChange: (width: number) => void;
+}
+
+const AssistantSidebarLoader: React.FC<AssistantSidebarLoaderProps> = ({
+  phase,
+  error,
+  onWidthChange,
+}) => {
+  const isOpen = useRef(getStoredSidebarOpen());
+  const initialWidth = useRef(
+    isOpen.current ? getStoredSidebarWidth() : LOADER_COLLAPSED_WIDTH,
+  );
+
+  useEffect(() => {
+    onWidthChange(initialWidth.current);
+  }, [onWidthChange]);
+
+  const collapsed = !isOpen.current;
+
+  if (error) {
+    return (
+      <div className="flex size-full flex-col items-center justify-center gap-3 border-l bg-background px-6 text-center">
+        <div className="text-sm font-medium text-destructive">
+          Unable to load assistant
+        </div>
+        <p className="text-xs text-muted-foreground">{error}</p>
+      </div>
+    );
+  }
+
+  const message = PHASE_MESSAGES[phase] ?? "Loading\u2026";
+
+  return (
+    <div className="relative size-full border-l">
+      <div className="absolute inset-0 animate-pulse bg-muted" />
+      <div className="relative flex size-full items-center justify-center">
+        <Spinner size={collapsed ? "xs" : "small"} />
+        {!collapsed && (
+          <span className="ml-2 text-sm text-light-slate">{message}</span>
+        )}
+      </div>
+    </div>
+  );
+};
 
 const stopPropagation = (e: Event) => e.stopPropagation();
 
@@ -153,12 +236,14 @@ interface AssistantMeta {
   version: string;
 }
 
+function resolveManifestUrl(backendUrl: string | null): string | null {
+  if (DEV_BASE_URL) return `${DEV_BASE_URL}/manifest.json`;
+  if (backendUrl) return `${backendUrl}/console/manifest.json`;
+  return null;
+}
+
 function useAssistantMeta(backendUrl: string | null): AssistantMeta | null {
-  const manifestUrl = DEV_BASE_URL
-    ? `${DEV_BASE_URL}/manifest.json`
-    : backendUrl
-      ? `${backendUrl}/console/manifest.json`
-      : null;
+  const manifestUrl = resolveManifestUrl(backendUrl);
 
   const manifestBase = manifestUrl
     ? manifestUrl.substring(0, manifestUrl.lastIndexOf("/"))
@@ -194,7 +279,12 @@ interface AssistantSidebarProps {
 const AssistantSidebar: React.FC<AssistantSidebarProps> = ({
   onWidthChange,
 }) => {
-  const { backendUrl, isReady: isBackendReady } = useAssistantBackend();
+  const {
+    backendUrl,
+    isReady: isBackendReady,
+    error,
+    phase,
+  } = useAssistantBackend();
   const meta = useAssistantMeta(backendUrl);
   const context = useBridgeContext(backendUrl ?? "");
   const router = useRouter();
@@ -276,7 +366,17 @@ const AssistantSidebar: React.FC<AssistantSidebarProps> = ({
     }
   }, []);
 
-  if (!meta || !isBackendReady) return null;
+  if (!meta || !isBackendReady) {
+    if (phase === "disabled") return null;
+    const effectivePhase = isBackendReady && !meta ? "manifest" : phase;
+    return (
+      <AssistantSidebarLoader
+        phase={effectivePhase}
+        error={error}
+        onWidthChange={onWidthChange}
+      />
+    );
+  }
 
   return (
     <iframe

--- a/apps/opik-frontend/src/plugins/comet/useAssistantBackend.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAssistantBackend.ts
@@ -12,11 +12,20 @@ interface ComputeResult {
   enabled: boolean;
 }
 
+export type AssistantBackendPhase =
+  | "idle"
+  | "compute"
+  | "health"
+  | "ready"
+  | "error"
+  | "disabled";
+
 interface UseAssistantBackendResult {
   backendUrl: string | null;
   isReady: boolean;
   isLoading: boolean;
   error: string | null;
+  phase: AssistantBackendPhase;
 }
 
 const DEV_RESULT: UseAssistantBackendResult = {
@@ -24,13 +33,18 @@ const DEV_RESULT: UseAssistantBackendResult = {
   isReady: true,
   isLoading: false,
   error: null,
+  phase: "ready",
 };
 
-const notReadyResult = (error: string | null): UseAssistantBackendResult => ({
+const notReadyResult = (
+  error: string | null,
+  phase: AssistantBackendPhase,
+): UseAssistantBackendResult => ({
   backendUrl: null,
   isReady: false,
   isLoading: false,
   error,
+  phase,
 });
 
 interface UseAssistantBackendOptions {
@@ -136,18 +150,26 @@ export default function useAssistantBackend(
   // Dev mode — static URL, no network calls (queries are disabled via enabled: !IS_DEV)
   if (IS_DEV) return DEV_RESULT;
 
-  if (computeResult && !computeResult.enabled) return notReadyResult(null);
-  if (computeError) return notReadyResult((computeError as Error).message);
+  if (computeResult && !computeResult.enabled)
+    return notReadyResult(null, "disabled");
+  if (computeError)
+    return notReadyResult((computeError as Error).message, "error");
   if (isTimedOut && !healthResult?.ready) {
-    return notReadyResult("Assistant pod failed to become ready");
+    return notReadyResult("Assistant pod failed to become ready", "error");
   }
 
   const isReady = healthResult?.ready === true;
+
+  let phase: AssistantBackendPhase = "idle";
+  if (isReady) phase = "ready";
+  else if (isComputeLoading) phase = "compute";
+  else if (shouldPollHealth) phase = "health";
 
   return {
     backendUrl: isReady ? baseUrl : null,
     isReady,
     isLoading: isComputeLoading || (shouldPollHealth && !isReady),
     error: null,
+    phase,
   };
 }


### PR DESCRIPTION
## Details

Show a shimmer + spinner loader while the assistant backend pod starts up (5-30 seconds) instead of a blank empty space. Adds `phase` field to `useAssistantBackend` return type for contextual loading messages. Loader reads stored sidebar width from localStorage to match the iframe's eventual width, preventing layout jumps.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5312

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-6
- Scope: full implementation
- Human verification: code review

## Testing

- [ ] Verify loader appears during pod startup in staging/production
- [ ] Verify collapsed state shows shimmer + small spinner
- [ ] Verify expanded state shows shimmer + spinner + phase message
- [ ] Verify no width jump when iframe takes over after loading
- [ ] Verify error state renders when pod times out
- [ ] Verify dev mode still works (loader skipped, iframe loads immediately)

## Documentation

Nothing