### PR TITLE
[NA] [FE] feat: pass organizationId through assistant bridge context

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -126,10 +126,13 @@ function useBridgeContext(assistantBackendUrl: string): BridgeContext {
   const projectName = project?.name ?? null;
   const resolvedProjectId = projectId ?? null;
 
+  const organizationId = workspace?.organizationId ?? null;
+
   return useMemo<BridgeContext>(
     () => ({
       workspaceId,
       workspaceName,
+      organizationId,
       projectId: resolvedProjectId,
       projectName,
       baseApiUrl: BASE_API_URL,
@@ -139,6 +142,7 @@ function useBridgeContext(assistantBackendUrl: string): BridgeContext {
     [
       workspaceId,
       workspaceName,
+      organizationId,
       resolvedProjectId,
       projectName,
       assistantBackendUrl,

--- a/apps/opik-frontend/src/types/assistant-sidebar.ts
+++ b/apps/opik-frontend/src/types/assistant-sidebar.ts
@@ -4,6 +4,7 @@ export type NotificationType = "success" | "error" | "info";
 export interface BridgeContext {
   workspaceId: string;
   workspaceName: string;
+  organizationId?: string | null;
   projectId: string | null;
   projectName: string | null;
   baseApiUrl: string;


### PR DESCRIPTION
## Details
Pass `organizationId` from the workspace object through the assistant sidebar bridge context. The Ollie console needs this to build billing links (e.g. `/organizations/{orgId}/ollie-credits`) when credit limits are hit.

Companion PRs:
- **comet-backend**: comet-ml/comet-backend#5506 — scopes Ollie pods per user+org, injects `ORGANIZATION_ID` env var
- **ollie-assist**: comet-ml/ollie-assist#89 — console shows "Manage credits" link on credit limit errors

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full implementation
  - Human verification: Reviewed diff and confirmed approach

## Testing

- Pre-commit hooks passed: lint, typecheck, dependency validation
- Bridge context verified to include `organizationId` from `workspace.organizationId`
- No runtime testing yet — requires Ollie sidebar integration (not available in local dev)

## Documentation

No documentation changes needed.