### PR TITLE
[OPIK-5206] [FE] feat: enable workspace version endpoint integration

### DIFF
--- a/apps/opik-frontend/src/api/workspaces/useWorkspaceVersion.ts
+++ b/apps/opik-frontend/src/api/workspaces/useWorkspaceVersion.ts
@@ -4,24 +4,21 @@ import { WorkspaceVersion, useActiveWorkspaceName } from "@/store/AppStore";
 import { DEFAULT_WORKSPACE_VERSION } from "@/lib/workspaceVersion";
 
 type WorkspaceVersionResponse = {
-  opikVersion: "opik1" | "opik2";
+  opik_version: "version_1" | "version_2";
 };
 
 const VERSION_MAP: Record<
-  WorkspaceVersionResponse["opikVersion"],
+  WorkspaceVersionResponse["opik_version"],
   WorkspaceVersion
 > = {
-  opik1: "v1",
-  opik2: "v2",
+  version_1: "v1",
+  version_2: "v2",
 };
 
 export async function fetchWorkspaceVersion(opts?: {
   workspaceName?: string;
   signal?: AbortSignal;
 }): Promise<WorkspaceVersion> {
-  // TODO: remove early return when BE endpoint (OPIK-5171) is implemented
-  return DEFAULT_WORKSPACE_VERSION;
-
   try {
     const { workspaceName, signal } = opts ?? {};
     const config = {
@@ -31,10 +28,10 @@ export async function fetchWorkspaceVersion(opts?: {
       }),
     };
     const { data } = await api.get<WorkspaceVersionResponse>(
-      WORKSPACES_REST_ENDPOINT + "version",
+      WORKSPACES_REST_ENDPOINT + "versions",
       config,
     );
-    return VERSION_MAP[data.opikVersion] ?? DEFAULT_WORKSPACE_VERSION;
+    return VERSION_MAP[data.opik_version] ?? DEFAULT_WORKSPACE_VERSION;
   } catch {
     return DEFAULT_WORKSPACE_VERSION;
   }


### PR DESCRIPTION
## Details

Enable the previously scaffolded workspace version API call (`fetchWorkspaceVersion`) that was disabled with a TODO placeholder pending the BE endpoint (OPIK-5171/OPIK-5206). The BE endpoint is now implemented.

- Remove the early return that bypassed the API call and always returned `"v1"`
- Fix endpoint path from `"version"` to `"versions"` to match BE `@Path("/versions")`
- Fix response type from `{ opikVersion: "opik1" | "opik2" }` to `{ opik_version: "version_1" | "version_2" }` to match BE snake_case contract

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5206

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Implementation, PR description
  - Human verification: Yes — tested locally with dev-runner.sh and forceWorkspaceVersion config toggle

## Testing

- Tested locally with `dev-runner.sh`
- Toggled `forceWorkspaceVersion` in `config.yml` between `version_1`, and `version_2`
- Verified workspace version correctly switches between V1 and V2 navigation modes
- Verified V1 is the current default.

## Documentation

No documentation updates required.