### PR TITLE
[OPIK-5305] [FE] fix: show dashboard resize handle on hover only

### DIFF
--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -963,12 +963,16 @@ div.cm-theme div.cm-search.cm-panel {
   opacity: 0.2;
 }
 
-/* Dashboard widget resize handle styles */
-.react-grid-item > .react-resizable-handle::after {
-  border-color: hsl(var(--light-slate)) !important;
-  transition: border-color 0.2s ease-in-out;
+/* Dashboard widget resize handle styles — visible on hover only */
+.react-grid-item > .react-resizable-handle {
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
 }
 
-.react-grid-item:hover > .react-resizable-handle::after {
+.react-grid-item:hover > .react-resizable-handle {
+  opacity: 1;
+}
+
+.react-grid-item > .react-resizable-handle::after {
   border-color: hsl(var(--muted-slate)) !important;
 }


### PR DESCRIPTION
## Details

<img width="1657" height="929" alt="image" src="https://github.com/user-attachments/assets/7c248e9d-2df5-4cab-a41d-a5361fe1a261" />

<img width="1660" height="924" alt="image" src="https://github.com/user-attachments/assets/4785ef32-1fc7-4673-a523-aa2cba05197e" />


Hide the dashboard widget resize corner handle by default and only show it when hovering over the widget. Previously the resize grip (SVG icon from `react-grid-layout`) was always visible. Now it fades in with a 0.2s opacity transition on hover.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5305

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: full implementation
  - Human verification: code review + manual testing

## Testing

- Verified frontend lint, typecheck, and dependency validation pass (`scripts/dev-runner.sh --lint-fe`)
- Manual verification: navigate to a dashboard with widgets, confirm resize handle is hidden by default and appears on widget hover

## Documentation

N/A