### PR TITLE
[OPIK-5361] [INFRA] feat: enhance create-jira-ticket skill with story points, sprint, due date, and epic selection

### DIFF
--- a/.agents/commands/comet/create-jira-ticket.md
+++ b/.agents/commands/comet/create-jira-ticket.md
@@ -135,7 +135,7 @@ mcp_Jira_home_jira_create_issue(
 
 After creating the ticket:
 1. Wait briefly, then use `mcp_Jira_home_jira_get_issue` to check the ticket's status. A Jira automation will move it to **BACKLOG** status automatically.
-2. Once the status is confirmed as **BACKLOG**, use `AskUserQuestion` to ask: "The ticket is now in Backlog. Would you like me to move it to **TO DO**?"
+2. Once the status is confirmed as **BACKLOG**, **you MUST use the `AskUserQuestion` tool** (not inline text) to prompt: "The ticket is now in Backlog. Would you like me to move it to **TO DO**?"
 3. If the user confirms, use `mcp_Jira_home_jira_transition_issue` to move it to "TO DO".
 
 ## Title Prefixes


### PR DESCRIPTION
## Details

<img width="1920" height="2214" alt="image" src="https://github.com/user-attachments/assets/c2c3a828-4fd2-4ea8-9ce5-4bfb7dc45572" />

Enhance the `/create-jira-ticket` Claude Code skill to gather additional fields during ticket creation. Adds story points (Fibonacci 1–13, with guesstimation and 21+ split guard), sprint assignment (active/next from board 524), due date selection, automatic tech debt parenting under OPIK-670, parent epic picker for Task/Story tickets, and post-creation Backlog→TO DO status transition prompt.

Also fixes `customfield_10028` usage (the `story_points` alias silently fails at creation) and `parent` field format (plain string, not object).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5361

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: iterative review during conversation

## Testing

Manual testing during development:
- Created OPIK-5361 using the updated skill, verified story points (`customfield_10028`), sprint (`customfield_10020`), due date, and parent epic fields were set correctly
- Confirmed `story_points` alias does NOT work at creation time — must use `customfield_10028` directly
- Confirmed `parent` must be a plain string (`"OPIK-670"`), not an object (`{"key": "OPIK-670"}`)
- Verified post-creation status transition from Backlog → TO DO

## Documentation

N/A — internal skill file only