### PR TITLE
[NA] [CI] chore: downsize CI runners from ubuntu-latest-m to ubuntu-latest

### DIFF
--- a/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   run-compatibility-v1-e2e:
     name: TypeScript SDK Compatibility V1.x E2E Tests Node ${{matrix.node_version}}
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -52,7 +52,7 @@ jobs:
           COMPOSE_BAKE: false
         run: |
           cd ${{ github.workspace }}
-          ./opik.sh --backend --port-mapping --guardrails --build
+          ./opik.sh --backend --port-mapping --build
 
       - name: Check Opik server availability
         shell: bash
@@ -104,4 +104,4 @@ jobs:
         if: always()
         run: |
           cd ${{ github.workspace }}
-          ./opik.sh --stop --guardrails
+          ./opik.sh --stop

--- a/.github/workflows/typescript_sdk_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_e2e_tests.yml
@@ -33,7 +33,7 @@ jobs:
       contents: read
       checks: write
       pull-requests: write
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Details

Downsize TypeScript SDK E2E test runners from ubuntu-latest-m (larger instance) to ubuntu-latest (standard instance) to optimize CI resource usage and costs. Removed --guardrails flag from opik.sh commands as it's not needed for these E2E test workflows.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves NA
- NA

## AI-WATERMARK

AI-WATERMARK: no

## Testing

Pre-commit hooks passed. Workflow configuration validated.

## Documentation

N/A