### PR TITLE
[OPIK-5378] [CI] chore: downsize Python SDK E2E test runners from ubuntu-latest-m to ubuntu-latest

### DIFF
--- a/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
@@ -33,7 +33,7 @@ env:
 jobs:
     run-compatibility-v1-e2e:
         name: Python SDK Compatibility V1.x E2E Tests ${{matrix.python_version}}
-        runs-on: ubuntu-latest-m
+        runs-on: ubuntu-latest
         timeout-minutes: 30
         strategy:
             fail-fast: false

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -33,7 +33,7 @@ env:
 jobs:
     run-e2e:
         name: Python SDK E2E Tests ${{matrix.python_version}}
-        runs-on: ubuntu-latest-m
+        runs-on: ubuntu-latest
         timeout-minutes: 30   
         strategy:
             fail-fast: false


### PR DESCRIPTION
## Details

Downsize Python SDK E2E test runners from ubuntu-latest-m (larger instance) to ubuntu-latest (standard instance) to optimize CI resource usage and costs. Matches the configuration changes made to TypeScript SDK E2E tests.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-5378
- OPIK-5378

## AI-WATERMARK

AI-WATERMARK: no

## Testing

Pre-commit checks passed. Workflow configuration validated.

## Documentation

N/A