### PR TITLE
[OPIK-5368] [INFRA] chore: add figma_screenshots/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ response.txt
 
 # Generated diagrams (local artifacts from /share-diagram command)
 /diagrams/
+
+# Figma screenshots (local reference images)
+/figma_screenshots/


### PR DESCRIPTION
## Details

<img width="1920" height="1210" alt="image" src="https://github.com/user-attachments/assets/43e5ca71-cf80-464b-9ea0-fe3bc6dd1126" />

Added `/figma_screenshots/` to `.gitignore` to prevent local Figma reference PNGs from being accidentally committed to the repository.
Verified no files from the directory are currently tracked in the git index — no cleanup needed.

<img width="488" height="195" alt="image" src="https://github.com/user-attachments/assets/5adbb88c-f782-4b99-9fca-00410356f41e" />

Figma MCP related


## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-5368

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code (CLI)
  - Model(s): Claude Opus 4.6
  - Scope: full implementation
  - Human verification: reviewed diff

## Testing

- Confirmed `figma_screenshots/` does not appear in `git status` after the change
- Confirmed no files from `figma_screenshots/` were tracked (`git ls-files --cached figma_screenshots/` returned empty)

## Documentation

N/A