### PR TITLE
[OPIK-5374] [GHA] fix: skip empty PRs in peter-evans/create-pull-request workflows

### DIFF
--- a/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
+++ b/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
@@ -110,7 +110,17 @@ jobs:
             echo "trigger_info=" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Commit files
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           set -ex
           git config --local user.email "github-actions@comet.com"
@@ -120,9 +130,10 @@ jobs:
           git add sdks/code_generation/fern/openapi/openapi.yaml
           git add apps/opik-documentation/documentation/fern/openapi/opik.yaml
           git add apps/opik-documentation/documentation/fern/docs/agent_optimization/opik_optimizer/reference.mdx
-          git commit --allow-empty -m "[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code"
+          git commit -m "[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code"
 
       - name: Create Pull Request
+        if: steps.check_changes.outputs.has_changes == 'true'
         id: create-pr
         uses: peter-evans/create-pull-request@v6
         with:

--- a/.github/workflows/span_cost_upload_daily.yml
+++ b/.github/workflows/span_cost_upload_daily.yml
@@ -22,16 +22,27 @@ jobs:
           curl -o apps/opik-backend/src/main/resources/model_prices_and_context_window.json https://raw.githubusercontent.com/BerriAI/litellm/refs/heads/main/model_prices_and_context_window.json
           cp apps/opik-backend/src/main/resources/model_prices_and_context_window.json apps/opik-frontend/src/data/model_prices_and_context_window.json
 
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Commit files
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           set -ex
           git config --local user.email "github-actions@comet.com"
           git config --local user.name "Github Actions (${{ github.actor }})"
           git add apps/opik-backend/src/main/resources/model_prices_and_context_window.json
           git add apps/opik-frontend/src/data/model_prices_and_context_window.json
-          git commit --allow-empty -m "[NA] [BE] Update model prices file"
+          git commit -m "[NA] [BE] Update model prices file"
 
       - name: Create Pull Request
+        if: steps.check_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.COMET_ACTION_CREATE_PR }}


### PR DESCRIPTION
## Details

<img width="1920" height="1720" alt="image" src="https://github.com/user-attachments/assets/0060fe91-6409-432c-83be-821dbf31fee8" />

Two GitHub Actions workflows (`span_cost_upload_daily.yml` and `sdks_generate_openapi_spec_and_fern_code.yml`) used `git commit --allow-empty` and unconditionally ran `peter-evans/create-pull-request`, creating empty PRs (no diff) when upstream data hadn't changed. This adds a `git diff --quiet` guard — matching the pattern already used in `sync_provider_models.yml` — to skip commit and PR creation when there are no actual changes.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-5374

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full implementation
  - Human verification: Code review

## Testing

- Manual review of workflow YAML diffs
- Verified `sync_provider_models.yml` (already guarded) was left unchanged
- Verified both modified workflows now gate commit + PR steps on `has_changes == 'true'`
- Verified downstream Slack notification in OpenAPI workflow already checks `pr_url != ''`

## Documentation

N/A