### PR TITLE
[OPIK-5247] [BE] fix: preserve assertion results and status after experiment item aggregation

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -1116,7 +1116,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                         ei.metadata,
                         di.description,
                         ei.execution_policy,
-                        arp.assertions_array
+                        ei.assertions_array
                     )) AS experiment_items_array
                 FROM (
                     SELECT
@@ -1141,7 +1141,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                         eia.metadata,
                         eia.feedback_scores,
                         eia.comments_array_agg,
-                        eia.execution_policy
+                        eia.execution_policy,
+                        eia.assertions_array
                     FROM experiment_item_aggregates AS eia FINAL
                     WHERE eia.workspace_id = :workspace_id
                     AND eia.experiment_id IN (SELECT id FROM experiment_aggregated_scope_ids)
@@ -1156,7 +1157,6 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                 INNER JOIN experiment_aggregated_scope_ids eas ON eas.id = ei.experiment_id
                 LEFT JOIN dataset_items_aggr_resolved AS di ON (di.id = ei.dataset_item_id OR di.row_id = ei.dataset_item_id)
                     AND di.dataset_version_id = eas.resolved_dataset_version_id
-                LEFT JOIN assertion_results_per_trace AS arp ON ei.trace_id = arp.entity_id
                 GROUP BY
                     ei.dataset_item_id,
                     :datasetId,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
@@ -408,7 +408,7 @@ class ExperimentItemDAO {
                       ei.last_updated_by AS last_updated_by,
                       ei.visibility_mode AS trace_visibility_mode,
                       ei.execution_policy,
-                      '' AS assertions_array
+                      ei.assertions_array AS assertions_array
                   FROM experiment_item_aggregates_final AS ei
                   <endif>
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
@@ -77,6 +77,7 @@ import static com.comet.opik.domain.experiments.aggregations.ExperimentAggregate
 import static com.comet.opik.domain.experiments.aggregations.ExperimentAggregatesModel.TraceAggregations;
 import static com.comet.opik.domain.experiments.aggregations.ExperimentAggregatesUtils.BatchResult;
 import static com.comet.opik.domain.experiments.aggregations.ExperimentEntityData.ExperimentData;
+import static com.comet.opik.domain.experiments.aggregations.ExperimentSourceData.AssertionData;
 import static com.comet.opik.domain.experiments.aggregations.ExperimentSourceData.CommentsData;
 import static com.comet.opik.domain.experiments.aggregations.ExperimentSourceData.FeedbackScoreData;
 import static com.comet.opik.infrastructure.DatabaseUtils.getSTWithLogComment;
@@ -87,7 +88,7 @@ import static com.comet.opik.utils.template.TemplateUtils.getQueryItemPlaceHolde
 @ImplementedBy(ExperimentAggregatesDAOImpl.class)
 public interface ExperimentAggregatesDAO {
 
-    Mono<Void> populateExperimentAggregate(@NonNull UUID experimentId);
+    Mono<Void> populateExperimentAggregate(UUID experimentId);
 
     Mono<BatchResult> populateExperimentItemAggregates(UUID experimentId, UUID cursor, int limit);
 
@@ -99,19 +100,15 @@ public interface ExperimentAggregatesDAO {
 
     Flux<ExperimentGroupAggregationItem> findGroupsAggregations(ExperimentGroupCriteria criteria);
 
-    Mono<Long> countDatasetItemsWithExperimentItemsFromAggregates(@NonNull DatasetItemSearchCriteria criteria,
-            @NonNull UUID versionId);
+    Mono<Long> countDatasetItemsWithExperimentItemsFromAggregates(DatasetItemSearchCriteria criteria, UUID versionId);
 
-    Mono<DatasetItemPage> getDatasetItemsWithExperimentItemsFromAggregates(
-            @NonNull DatasetItemSearchCriteria criteria,
-            @NonNull UUID versionId, int page, int size);
+    Mono<DatasetItemPage> getDatasetItemsWithExperimentItemsFromAggregates(DatasetItemSearchCriteria criteria,
+            UUID versionId, int page, int size);
 
-    Mono<ProjectStats> getExperimentItemsStatsFromAggregates(@NonNull UUID datasetId,
-            @NonNull UUID versionId, @NonNull Set<UUID> experimentIds,
+    Mono<ProjectStats> getExperimentItemsStatsFromAggregates(UUID datasetId, UUID versionId, Set<UUID> experimentIds,
             List<ExperimentsComparisonFilter> filters);
 
-    Mono<AggregatedExperimentCounts> getAggregationBranchCounts(
-            @NonNull AggregationBranchCountsCriteria criteria);
+    Mono<AggregatedExperimentCounts> getAggregationBranchCounts(AggregationBranchCountsCriteria criteria);
 }
 
 @Singleton
@@ -902,6 +899,39 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
             """;
 
     /**
+     * Get assertions data per trace for experiment items (paginated)
+     */
+    private static final String GET_ASSERTIONS_DATA = """
+            WITH experiment_items AS (
+                SELECT DISTINCT trace_id
+                FROM experiment_items FINAL
+                WHERE workspace_id = :workspace_id
+                AND experiment_id = :experiment_id
+                <if(cursor)>AND id > :cursor<endif>
+                ORDER BY id ASC
+                LIMIT :limit
+            )
+            SELECT
+                entity_id AS trace_id,
+                toJSONString(
+                    groupArray(
+                        CAST(
+                            (name, toString(passed), reason),
+                            'Tuple(value String, passed String, reason String)'
+                        )
+                    )
+                ) AS assertions_array
+            FROM assertion_results FINAL
+            WHERE entity_type = 'trace'
+              AND workspace_id = :workspace_id
+              AND project_id = :project_id
+              AND entity_id IN (SELECT trace_id FROM experiment_items)
+            GROUP BY entity_id
+            SETTINGS log_comment = '<log_comment>'
+            ;
+            """;
+
+    /**
      * Get comments aggregated at experiment level
      */
     private static final String GET_COMMENTS_AGGREGATION = """
@@ -984,7 +1014,8 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                 last_updated_at,
                 created_by,
                 last_updated_by,
-                execution_policy
+                execution_policy,
+                assertions_array
             )
             SETTINGS log_comment = '<log_comment>'
             FORMAT Values
@@ -1012,7 +1043,8 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                     parseDateTime64BestEffort(:last_updated_at<item.index>, 9),
                     :created_by<item.index>,
                     :last_updated_by<item.index>,
-                    :execution_policy<item.index>
+                    :execution_policy<item.index>,
+                    :assertions_array<item.index>
                 )
                 <if(item.hasNext)>,<endif>
             }>
@@ -1545,12 +1577,15 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                                         getFeedbackScoresData(workspaceId, experimentId, projectId, cursorId, limit)
                                                 .collectList(),
                                         getCommentsData(workspaceId, experimentId, projectId, cursorId, limit)
+                                                .collectList(),
+                                        getAssertionsData(workspaceId, experimentId, projectId, cursorId, limit)
                                                 .collectList())
                                         .flatMap(tuple -> {
                                             var tracesData = tuple.getT1();
                                             var spansData = tuple.getT2();
                                             var feedbackData = tuple.getT3();
                                             var commentsData = tuple.getT4();
+                                            var assertionsData = tuple.getT5();
 
                                             return insertExperimentItemAggregates(
                                                     projectId,
@@ -1558,7 +1593,8 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                                                     tracesData,
                                                     spansData,
                                                     feedbackData,
-                                                    commentsData).map(count -> new BatchResult(count, lastCursor));
+                                                    commentsData,
+                                                    assertionsData).map(count -> new BatchResult(count, lastCursor));
                                         }));
                     });
         });
@@ -1871,6 +1907,19 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                 this::mapCommentsData);
     }
 
+    private Flux<AssertionData> getAssertionsData(String workspaceId, UUID experimentId, UUID projectId,
+            UUID cursor, int limit) {
+        return streamWithExperimentPagination(
+                GET_ASSERTIONS_DATA,
+                "getAssertionsData",
+                workspaceId,
+                experimentId,
+                projectId,
+                cursor,
+                limit,
+                this::mapAssertionData);
+    }
+
     private Mono<String> getCommentsAggregation(UUID experimentId, UUID projectId) {
         return queryExperimentAggregation(
                 GET_COMMENTS_AGGREGATION, "getCommentsAggregation", experimentId, projectId,
@@ -1910,7 +1959,8 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
             Map<UUID, TraceData> tracesMap,
             Map<UUID, SpanData> spansMap,
             Map<UUID, FeedbackScoreData> feedbackMap,
-            Map<UUID, CommentsData> commentsMap) {
+            Map<UUID, CommentsData> commentsMap,
+            Map<UUID, AssertionData> assertionsMap) {
 
         for (int i = 0; i < items.size(); i++) {
             var item = items.get(i);
@@ -1960,7 +2010,11 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                     .bind("execution_policy" + i,
                             Optional.ofNullable(item.executionPolicy())
                                     .filter(StringUtils::isNotBlank)
-                                    .orElse(""));
+                                    .orElse(""))
+                    .bind("assertions_array" + i,
+                            Optional.ofNullable(assertionsMap.get(item.traceId()))
+                                    .map(AssertionData::assertionsArray)
+                                    .orElse(EMPTY_ARRAY_STR));
 
             // Bind array parameters only if maps are not empty
             var usageArrays = mapToArrays(usageMap, String[]::new, Long[]::new, Long::longValue);
@@ -1981,17 +2035,20 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
             List<TraceData> tracesData,
             List<SpanData> spansData,
             List<FeedbackScoreData> feedbackData,
-            List<CommentsData> commentsData) {
+            List<CommentsData> commentsData,
+            List<AssertionData> assertionsData) {
 
         // Create lookup maps
         Map<UUID, TraceData> tracesMap = tracesData.stream()
-                .collect(Collectors.toMap(TraceData::traceId, t -> t));
+                .collect(Collectors.toMap(TraceData::traceId, Function.identity()));
         Map<UUID, SpanData> spansMap = spansData.stream()
-                .collect(Collectors.toMap(SpanData::traceId, s -> s));
+                .collect(Collectors.toMap(SpanData::traceId, Function.identity()));
         Map<UUID, FeedbackScoreData> feedbackMap = feedbackData.stream()
-                .collect(Collectors.toMap(FeedbackScoreData::traceId, f -> f));
+                .collect(Collectors.toMap(FeedbackScoreData::traceId, Function.identity()));
         Map<UUID, CommentsData> commentsMap = commentsData.stream()
-                .collect(Collectors.toMap(CommentsData::traceId, c -> c));
+                .collect(Collectors.toMap(CommentsData::traceId, Function.identity()));
+        Map<UUID, AssertionData> assertionsMap = assertionsData.stream()
+                .collect(Collectors.toMap(AssertionData::traceId, Function.identity()));
 
         return asyncTemplate.nonTransaction(connection -> {
             return makeMonoContextAware((userName, workspaceId) -> {
@@ -2007,7 +2064,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                         .bind("project_id", projectId);
 
                 // Bind item parameters in batch
-                bindItemsParameters(statement, items, tracesMap, spansMap, feedbackMap, commentsMap);
+                bindItemsParameters(statement, items, tracesMap, spansMap, feedbackMap, commentsMap, assertionsMap);
 
                 return Mono.from(statement.execute())
                         .flatMapMany(Result::getRowsUpdated)
@@ -2389,6 +2446,14 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
         return CommentsData.builder()
                 .traceId(getUUID(row, "trace_id"))
                 .commentsArrayAgg(StringUtils.isNotBlank(commentsArrayAgg) ? commentsArrayAgg : EMPTY_ARRAY_STR)
+                .build();
+    }
+
+    private AssertionData mapAssertionData(Row row) {
+        var assertionsArray = row.get("assertions_array", String.class);
+        return AssertionData.builder()
+                .traceId(getUUID(row, "trace_id"))
+                .assertionsArray(StringUtils.isNotBlank(assertionsArray) ? assertionsArray : EMPTY_ARRAY_STR)
                 .build();
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentSourceData.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentSourceData.java
@@ -78,4 +78,16 @@ public class ExperimentSourceData {
             UUID traceId,
             String commentsArrayAgg) {
     }
+
+    /**
+     * Raw assertion data for aggregation.
+     *
+     * @param traceId          The trace ID
+     * @param assertionsArray  JSON string of assertions array for this trace
+     */
+    @Builder
+    public record AssertionData(
+            UUID traceId,
+            String assertionsArray) {
+    }
 }

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000076_add_assertions_array_to_experiment_item_aggregates.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000076_add_assertions_array_to_experiment_item_aggregates.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+--changeset thiaghora:000076_add_assertions_array_to_experiment_item_aggregates
+--comment: Add assertions_array to experiment_item_aggregates for pre-aggregated assertion data
+
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_item_aggregates ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS assertions_array String DEFAULT '[]' CODEC(ZSTD(3));
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_item_aggregates ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS assertions_array;

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.comet.opik.domain;
 
+import com.comet.opik.api.AssertionResult;
 import com.comet.opik.api.Dataset;
 import com.comet.opik.api.DatasetItem;
 import com.comet.opik.api.DatasetItemBatch;
@@ -10,10 +11,12 @@ import com.comet.opik.api.ExperimentGroupAggregationsResponse;
 import com.comet.opik.api.ExperimentGroupCriteria;
 import com.comet.opik.api.ExperimentGroupResponse;
 import com.comet.opik.api.ExperimentItem;
+import com.comet.opik.api.ExperimentItemStreamRequest;
 import com.comet.opik.api.ExperimentSearchCriteria;
 import com.comet.opik.api.ExperimentType;
 import com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
 import com.comet.opik.api.Project;
+import com.comet.opik.api.RunStatus;
 import com.comet.opik.api.ScoreSource;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
@@ -113,7 +116,7 @@ class ExperimentAggregatesIntegrationTest {
             "createdBy", "lastUpdatedBy", "datasetId", "tags", "datasetItemId"};
 
     public static final String[] IGNORED_FIELDS_EXPERIMENT_ITEM = {"createdAt", "lastUpdatedAt", "createdBy",
-            "lastUpdatedBy", "comments", "projectName", "executionPolicy", "assertionResults", "status"};
+            "lastUpdatedBy", "comments", "projectName", "executionPolicy"};
 
     @RegisterApp
     private final TestDropwizardAppExtension APP;
@@ -1310,7 +1313,7 @@ class ExperimentAggregatesIntegrationTest {
                     .usingRecursiveComparison()
                     .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
                     .withComparatorForFields(StatsUtils::closeToEpsilonComparator, "duration")
-                    .ignoringCollectionOrderInFields("feedbackScores")
+                    .ignoringCollectionOrderInFields("feedbackScores", "assertionResults")
                     .ignoringFields(IGNORED_FIELDS_EXPERIMENT_ITEM)
                     .isEqualTo(expectedExperiments);
         }
@@ -2172,6 +2175,159 @@ class ExperimentAggregatesIntegrationTest {
                 Arguments.of("usage.completion_tokens", com.comet.opik.api.sorting.Direction.DESC),
                 Arguments.of("output.result", com.comet.opik.api.sorting.Direction.ASC),
                 Arguments.of("output.result", com.comet.opik.api.sorting.Direction.DESC));
+    }
+
+    @Test
+    @DisplayName("ExperimentItemDAO has_aggregated branch: assertionResults and status are preserved in stream after aggregation")
+    void assertionResultsArePreservedAfterExperimentItemAggregation() {
+        var project = createProject(API_KEY, TEST_WORKSPACE);
+        var dataset = createDataset(API_KEY, TEST_WORKSPACE);
+
+        var experiment = experimentResourceClient.createPartialExperiment()
+                .datasetId(dataset.id())
+                .datasetName(dataset.name())
+                .evaluationMethod(EvaluationMethod.EVALUATION_SUITE)
+                .build();
+        experimentResourceClient.create(experiment, API_KEY, TEST_WORKSPACE);
+
+        List<String> feedbackScoreNames = PodamFactoryUtils.manufacturePojoList(factory, String.class);
+        var experimentItems = createExperimentItemWithData(
+                experiment.id(), dataset.id(), project.name(),
+                feedbackScoreNames, API_KEY, TEST_WORKSPACE);
+
+        var traceId = experimentItems.getFirst().traceId();
+        var assertionScores = List.of(
+                (FeedbackScoreBatchItem) factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
+                        .id(traceId)
+                        .projectName(project.name())
+                        .name("assertion-grounded")
+                        .categoryName("suite_assertion")
+                        .value(BigDecimal.ONE)
+                        .reason("Grounded in context")
+                        .source(ScoreSource.SDK)
+                        .build(),
+                (FeedbackScoreBatchItem) factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
+                        .id(traceId)
+                        .projectName(project.name())
+                        .name("assertion-concise")
+                        .categoryName("suite_assertion")
+                        .value(BigDecimal.ONE)
+                        .reason("Under 200 words")
+                        .source(ScoreSource.SDK)
+                        .build());
+
+        traceResourceClient.feedbackScores(assertionScores, API_KEY, TEST_WORKSPACE);
+
+        var streamRequest = ExperimentItemStreamRequest.builder()
+                .experimentName(experiment.name())
+                .build();
+
+        // Query BEFORE aggregation (has_raw branch)
+        var beforeItems = experimentResourceClient.streamExperimentItems(streamRequest, API_KEY, TEST_WORKSPACE);
+
+        var expectedAssertionResults = List.of(
+                AssertionResult.builder().value("assertion-grounded").passed(true).reason("Grounded in context")
+                        .build(),
+                AssertionResult.builder().value("assertion-concise").passed(true).reason("Under 200 words").build());
+
+        assertThat(beforeItems).isNotEmpty();
+        var beforeItem = beforeItems.stream()
+                .filter(i -> traceId.equals(i.traceId()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(beforeItem.assertionResults())
+                .as("assertionResults must be populated from raw path before aggregation")
+                .containsExactlyInAnyOrderElementsOf(expectedAssertionResults);
+        assertThat(beforeItem.status())
+                .as("status must be PASSED before aggregation (all assertions pass)")
+                .isEqualTo(RunStatus.PASSED);
+
+        // Populate aggregates
+        experimentAggregatesService.populateAggregations(experiment.id())
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, WORKSPACE_ID))
+                .block();
+
+        // Query AFTER aggregation (has_aggregated branch): assertionResults must still be present
+        var afterItems = experimentResourceClient.streamExperimentItems(streamRequest, API_KEY, TEST_WORKSPACE);
+
+        assertThat(afterItems).isNotEmpty();
+        var afterItem = afterItems.stream()
+                .filter(i -> traceId.equals(i.traceId()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(afterItem)
+                .as("experiment item must be identical before and after aggregation")
+                .usingRecursiveComparison()
+                .ignoringFields(IGNORED_FIELDS_EXPERIMENT_ITEM)
+                .ignoringCollectionOrderInFields("feedbackScores", "assertionResults")
+                .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
+                .isEqualTo(beforeItem);
+    }
+
+    @Test
+    @DisplayName("DatasetItemVersionDAO has_aggregated branch: assertionResults in dataset items view are preserved after aggregation")
+    void assertionResultsInDatasetItemsArePreservedAfterAggregation() {
+        var project = createProject(API_KEY, TEST_WORKSPACE);
+        var dataset = createDataset(API_KEY, TEST_WORKSPACE);
+
+        var experiment = experimentResourceClient.createPartialExperiment()
+                .datasetId(dataset.id())
+                .datasetName(dataset.name())
+                .evaluationMethod(EvaluationMethod.EVALUATION_SUITE)
+                .build();
+        experimentResourceClient.create(experiment, API_KEY, TEST_WORKSPACE);
+
+        List<String> feedbackScoreNames = PodamFactoryUtils.manufacturePojoList(factory, String.class);
+        var experimentItems = createExperimentItemWithData(
+                experiment.id(), dataset.id(), project.name(),
+                feedbackScoreNames, API_KEY, TEST_WORKSPACE);
+
+        var traceId = experimentItems.getFirst().traceId();
+        var assertionScores = List.of(
+                (FeedbackScoreBatchItem) factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
+                        .id(traceId)
+                        .projectName(project.name())
+                        .name("assertion-grounded")
+                        .categoryName("suite_assertion")
+                        .value(BigDecimal.ONE)
+                        .reason("Grounded in context")
+                        .source(ScoreSource.SDK)
+                        .build(),
+                (FeedbackScoreBatchItem) factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
+                        .id(traceId)
+                        .projectName(project.name())
+                        .name("assertion-concise")
+                        .categoryName("suite_assertion")
+                        .value(BigDecimal.ZERO)
+                        .reason("Too long")
+                        .source(ScoreSource.SDK)
+                        .build());
+
+        traceResourceClient.feedbackScores(assertionScores, API_KEY, TEST_WORKSPACE);
+
+        var experimentIds = List.of(experiment.id());
+
+        // Query BEFORE aggregation (has_raw branch)
+        var beforeAggregation = datasetResourceClient.getDatasetItemsWithExperimentItems(
+                dataset.id(), experimentIds, null, null, API_KEY, TEST_WORKSPACE);
+
+        assertPageNotEmpty(beforeAggregation);
+
+        // Populate aggregates
+        experimentAggregatesService.populateAggregations(experiment.id())
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, WORKSPACE_ID))
+                .block();
+
+        // Query AFTER aggregation (has_aggregated branch)
+        var afterAggregation = datasetResourceClient.getDatasetItemsWithExperimentItems(
+                dataset.id(), experimentIds, null, null, API_KEY, TEST_WORKSPACE);
+
+        assertPageNotEmpty(afterAggregation);
+        assertDatasetItemsWithExperimentItems(beforeAggregation.content(), afterAggregation.content());
     }
 
 }


### PR DESCRIPTION
## Details

After experiment items are aggregated into `experiment_item_aggregates`, two DAO branches responsible for reading pre-computed data were silently discarding `assertionResults` and `status`:

- **`ExperimentItemDAO` (`has_aggregated` branch)**: was returning `'' AS assertions_array` (hardcoded empty string) instead of reading `ei.assertions_array` from the aggregates table.
- **`DatasetItemVersionDAO` (`has_aggregated` branch)**: was live-joining `assertion_results` at query time instead of reading the already-aggregated `eia.assertions_array` column.

This caused `assertionResults` and `status` to disappear from experiment items after aggregation runs.

**Fix:**
- `ExperimentItemDAO`: read `ei.assertions_array` from `experiment_item_aggregates`
- `DatasetItemVersionDAO`: read `eia.assertions_array` from `experiment_item_aggregates` instead of joining `assertion_results`
- `ExperimentAggregatesDAO`: added `GET_ASSERTIONS_ARRAY` aggregation step that serializes assertion results (name, passed, reason) into a JSON array and stores it in `assertions_array`
- `ExperimentSourceData`: added `assertionsArray` field to carry the aggregated data through the pipeline
- Migration `000076`: adds `assertions_array String DEFAULT '[]'` column to `experiment_item_aggregates`
- `ExperimentAggregatesIntegrationTest`: two new integration tests covering both the stream endpoint and dataset items view, verifying that `assertionResults` and `status` are identical before and after aggregation

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-5247

## Testing

Two new integration tests added to `ExperimentAggregatesIntegrationTest`:

1. **`assertionResultsArePreservedAfterExperimentItemAggregation`** — creates an evaluation suite experiment with assertion scores on one trace, verifies `assertionResults` and `status` are present in the raw path, runs aggregation, then verifies the aggregated path returns identical data via whole-object recursive comparison.

2. **`assertionResultsInDatasetItemsArePreservedAfterAggregation`** — same scenario via the dataset items endpoint, verifies before/after parity using `assertDatasetItemsWithExperimentItems` (which now includes order-insensitive `assertionResults` comparison).

## Documentation

No documentation changes required. Internal fix to aggregation pipeline.