### PR TITLE
[OPIK-5360] [FE] fix: collapse ResizableSidePanel width when closed to prevent scroll overflow

### DIFF
--- a/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanel.tsx
+++ b/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanel.tsx
@@ -281,7 +281,10 @@ const ResizableSidePanel: React.FunctionComponent<ResizableSidePanelProps> = ({
 
   return createPortal(
     <div
-      className={cn("absolute inset-0 z-10", !open && "pointer-events-none")}
+      className={cn(
+        "absolute inset-0 z-10",
+        !open && "pointer-events-none w-0",
+      )}
     >
       {open && closeOnClickOutside && (
         <div className="absolute inset-0 bg-black/10" onClick={onClose} />


### PR DESCRIPTION
## Details

Fix horizontal scroll showing a blank page when scrolling all the way to the right on any page with a table (Projects, Experiments, Datasets).

The `ResizableSidePanel` portal wrapper uses `absolute inset-0`, giving it full viewport width even when closed. While `pointer-events-none` blocked interactions, the element still contributed to the document's scrollable width. Adding `w-0` when the panel is closed collapses the wrapper so it no longer extends the scroll area.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5360

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: assisted (validation of user's fix)
- Human verification: code review + manual testing

## Testing

- Go to any page with a scrollable table (Projects, Experiments, Datasets)
- Scroll all the way to the right — verify no blank page appears
- Open a side panel (e.g. click a trace row) — verify it opens and renders correctly
- Resize the side panel — verify drag handle works
- Close the side panel — verify it closes with smooth animation
- Verify arrow key navigation still works within the side panel

## Documentation

N/A