### PR TITLE
[OPIK-5429] [FE] fix: set source=experiment for playground-initiated experiment traces

### DIFF
--- a/apps/opik-frontend/src/api/playground/createLogPlaygroundProcessor.ts
+++ b/apps/opik-frontend/src/api/playground/createLogPlaygroundProcessor.ts
@@ -11,7 +11,7 @@ import {
   PromptLibraryMetadata,
 } from "@/types/playground";
 
-import { SPAN_TYPE } from "@/types/traces";
+import { LOGS_SOURCE, SPAN_TYPE } from "@/types/traces";
 import api, {
   EXPERIMENTS_REST_ENDPOINT,
   SPANS_REST_ENDPOINT,
@@ -108,6 +108,7 @@ const USAGE_FIELDS_TO_SEND = [
 const getTraceFromRun = (
   run: LogQueueParams,
   projectName: string,
+  source: LOGS_SOURCE,
 ): LogTrace => {
   const trace: LogTrace = {
     id: v7(),
@@ -122,7 +123,7 @@ const getTraceFromRun = (
     metadata: {
       created_from: "playground",
     },
-    source: "playground",
+    source,
   };
 
   // Add selected_rule_ids to trace metadata if provided
@@ -161,6 +162,7 @@ const getSpanFromRun = (
   run: LogQueueParams,
   traceId: string,
   projectName: string,
+  source: LOGS_SOURCE,
 ): LogSpan => {
   const spanOutput =
     run.choices && hasChoicesContent(run)
@@ -187,6 +189,7 @@ const getSpanFromRun = (
     usage: !run.usage ? undefined : pick(run.usage, USAGE_FIELDS_TO_SEND),
     model: spanModel,
     provider: spanProvider,
+    source,
     metadata: {
       created_from: spanProvider,
       usage: run.usage,
@@ -325,9 +328,12 @@ const createLogPlaygroundProcessor = ({
       const { promptId, datasetName, datasetItemId } = run;
 
       const isWithExperiments = !!datasetName;
+      const source = isWithExperiments
+        ? LOGS_SOURCE.experiment
+        : LOGS_SOURCE.playground;
 
-      const trace = getTraceFromRun(run, projectName);
-      const span = getSpanFromRun(run, trace.id, projectName);
+      const trace = getTraceFromRun(run, projectName, source);
+      const span = getSpanFromRun(run, trace.id, projectName, source);
 
       // Store the trace mapping
       traceMappings.push({

--- a/apps/opik-frontend/src/types/playground.ts
+++ b/apps/opik-frontend/src/types/playground.ts
@@ -97,6 +97,7 @@ export interface LogSpan {
   startTime: string;
   endTime: string;
   input: { messages: ProviderMessageType[] };
+  source?: string;
   output:
     | { choices: ChatCompletionMessageChoiceType[] }
     | { output: string | null };


### PR DESCRIPTION
## Details

When running an experiment from the Playground, traces and spans were created with `source=playground`. The experiment page logs sidebar filters by `source=experiment`, making these traces invisible in the experiment context.

**Fix:** The playground log processor now sets `source=experiment` on both traces and spans when running on a dataset (experiment mode). Ad-hoc playground runs keep `source=playground`.

**Trade-off:** Playground-initiated experiment traces won't appear in the Playground logs sidebar, but will correctly appear in the experiment logs. This is the right behavior — the experiment is the user's intent, and playground logs should show only ad-hoc prompt iterations.

**Changes:**
- `createLogPlaygroundProcessor.ts` — `getTraceFromRun` and `getSpanFromRun` accept `source: LOGS_SOURCE` param instead of hardcoded `"playground"`
- `playground.ts` — added `source?: string` to `LogSpan` interface
- Source computed once at call site: `isWithExperiments ? LOGS_SOURCE.experiment : LOGS_SOURCE.playground`

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5429

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review + manual testing

## Testing

- `npx tsc --noEmit` — compiles clean
- Manual: run experiment from Playground → traces have `source=experiment` in the API response
- Manual: ad-hoc playground run → traces still have `source=playground`
- Manual: experiment logs sidebar shows playground-initiated experiment traces

## Documentation

N/A