### PR TITLE
[OPIK-5371] [FE] feat: wire up mask_id in Agent Sandbox run request

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
@@ -19,7 +19,7 @@ type AgentConfigurationEditViewProps = {
   item: ConfigHistoryItem;
   projectId: string;
   onCancel: () => void;
-  onSaved: () => void;
+  onSaved: (maskId: string) => void;
 };
 
 const AgentConfigurationEditView: React.FC<AgentConfigurationEditViewProps> = ({

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
@@ -39,7 +39,7 @@ type UseAgentConfigurationSaveParams = {
   originalValues: React.RefObject<Record<string, string>>;
   description: string;
   projectId: string;
-  onSaved: () => void;
+  onSaved: (maskId: string) => void;
 };
 
 export const useAgentConfigurationSave = ({
@@ -150,12 +150,16 @@ export const useAgentConfigurationSave = ({
           project_id: projectId,
           blueprint: {
             description: description || undefined,
-            type: BlueprintType.BLUEPRINT,
+            type: BlueprintType.MASK,
             values,
           },
         },
       },
-      { onSuccess: onSaved },
+      {
+        onSuccess: (data) => {
+          if (data.id) onSaved(data.id);
+        },
+      },
     );
   }, [
     agentConfig,

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerConfigEditor.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerConfigEditor.tsx
@@ -9,12 +9,14 @@ type AgentRunnerConfigEditorProps = {
   item: ConfigHistoryItem;
   projectId: string;
   onClose: () => void;
+  onMaskSaved: (maskId: string) => void;
 };
 
 const AgentRunnerConfigEditor: React.FC<AgentRunnerConfigEditorProps> = ({
   item,
   projectId,
   onClose,
+  onMaskSaved,
 }) => {
   return (
     <div>
@@ -27,7 +29,10 @@ const AgentRunnerConfigEditor: React.FC<AgentRunnerConfigEditorProps> = ({
         item={item}
         projectId={projectId}
         onCancel={onClose}
-        onSaved={onClose}
+        onSaved={(maskId) => {
+          onMaskSaved(maskId);
+          onClose();
+        }}
       />
     </div>
   );

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerConnectedState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerConnectedState.tsx
@@ -22,6 +22,7 @@ const AgentRunnerConnectedState: React.FC<AgentRunnerConnectedStateProps> = ({
   result,
 }) => {
   const [activeTab, setActiveTab] = useState("input");
+  const [maskId, setMaskId] = useState<string | undefined>();
 
   const { data: configData } = useConfigHistoryListInfinite({ projectId });
   const latestConfig = configData?.pages?.[0]?.content?.[0];
@@ -49,6 +50,7 @@ const AgentRunnerConnectedState: React.FC<AgentRunnerConnectedStateProps> = ({
             fields={inputFields}
             onSubmit={onRun}
             isRunning={isRunning}
+            maskId={maskId}
           />
         </TabsContent>
 
@@ -64,6 +66,7 @@ const AgentRunnerConnectedState: React.FC<AgentRunnerConnectedStateProps> = ({
                 item={latestConfig}
                 projectId={projectId}
                 onClose={() => setActiveTab("input")}
+                onMaskSaved={setMaskId}
               />
             </div>
           ) : (

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerInputForm.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerInputForm.tsx
@@ -53,12 +53,14 @@ type AgentRunnerInputFormProps = {
   fields: AgentParam[];
   onSubmit: (inputs: Record<string, unknown>, maskId?: string) => void;
   isRunning: boolean;
+  maskId?: string;
 };
 
 const AgentRunnerInputForm: React.FC<AgentRunnerInputFormProps> = ({
   fields,
   onSubmit,
   isRunning,
+  maskId,
 }) => {
   const { register, handleSubmit, setValue, watch } = useForm({
     defaultValues: fields.reduce(
@@ -76,7 +78,7 @@ const AgentRunnerInputForm: React.FC<AgentRunnerInputFormProps> = ({
       const value = data[field.name];
       inputs[field.name] = coerceValue(value, field.type);
     }
-    onSubmit(inputs);
+    onSubmit(inputs, maskId);
   });
 
   return (


### PR DESCRIPTION
## Details

<img width="1920" height="2310" alt="image" src="https://github.com/user-attachments/assets/e9351551-4bf1-474f-8d5a-ee7f1de68e03" />

Wire up `mask_id` from the sandbox config editor through to the Agent Sandbox run request.

When a user edits configuration values in the sandbox and saves, the editor now creates a **mask** (config override) instead of a full blueprint. The resulting mask ID flows through the component chain to be included in the `POST /v1/private/local-runners/jobs` payload. When no mask is saved, the field is omitted (backward compatible).

**Data flow:** ConfigEditor saves as MASK → returns mask ID → stored in ConnectedState → passed to InputForm → included in `onSubmit(inputs, maskId)` → `handleRun` → mutation payload.

**Files changed:**
- `useAgentConfigurationSave.ts` (pages-shared) — save as `MASK` type, `onSaved` receives mask ID
- `AgentConfigurationEditView.tsx` (pages-shared) — updated `onSaved` prop type
- `AgentRunnerConfigEditor.tsx` — added `onMaskSaved` prop, forwards mask ID before closing
- `AgentRunnerConnectedState.tsx` — added `maskId` state, wired to form and editor
- `AgentRunnerInputForm.tsx` — accepts `maskId` prop, passes to `onSubmit`

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5371

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review + manual testing

## Testing

- `npx tsc --noEmit` — passes with no errors
- `npx eslint` on all 5 changed files — passes with no warnings
- Pre-commit hooks (lint, typecheck, dep validation) — all passed

Manual verification needed:
1. Open Agent Sandbox, connect an agent
2. Go to Configuration tab, edit values, save as new version
3. Switch to Input tab, fill inputs, click Run
4. Verify via network inspector that `mask_id` appears in the POST payload
5. Verify that running without saving config changes still works (no `mask_id` in payload)

## Documentation

N/A