### PR TITLE
[OPIK-5427] [FE] Prettify agent sandbox output with SyntaxHighlighter

### DIFF
--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerResult.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerResult.tsx
@@ -10,9 +10,11 @@ type AgentRunnerResultProps = {
 };
 
 const AgentRunnerResult: React.FC<AgentRunnerResultProps> = ({ job }) => {
-  const resultData = useMemo((): object | null => {
-    if (job?.result == null) return null;
-    if (typeof job.result === "object") return job.result as object;
+  const resultData = useMemo((): object | undefined => {
+    if (job?.result === undefined) return undefined;
+    if (typeof job.result === "object" && job.result !== null) {
+      return job.result as object;
+    }
     return { output: job.result };
   }, [job?.result]);
 
@@ -49,14 +51,15 @@ const AgentRunnerResult: React.FC<AgentRunnerResultProps> = ({ job }) => {
         </div>
       )}
 
-      {job?.status === SandboxJobStatus.COMPLETED && resultData && (
-        <div className="py-2">
-          <SyntaxHighlighter
-            data={resultData}
-            prettifyConfig={{ fieldType: "output" }}
-          />
-        </div>
-      )}
+      {job?.status === SandboxJobStatus.COMPLETED &&
+        resultData !== undefined && (
+          <div className="py-2">
+            <SyntaxHighlighter
+              data={resultData}
+              prettifyConfig={{ fieldType: "output" }}
+            />
+          </div>
+        )}
 
       {job &&
         [SandboxJobStatus.FAILED, SandboxJobStatus.CANCELLED].includes(


### PR DESCRIPTION
## Details

The agent sandbox result was rendered as raw `JSON.stringify` in a plain `<pre>` tag, showing literal `\n` characters and no formatting for markdown content. This replaces it with the existing `SyntaxHighlighter` component, which provides:

- **Pretty mode** (default) — renders markdown content with proper headings, bold, lists, etc.
- **JSON mode** — syntax-highlighted JSON view
- **YAML mode** — YAML-formatted view
- Mode switcher dropdown, copy button, and search support — all from the reused component

The `prettifyMessage` chain (OpenAI, LangGraph, LangChain, ADK, generic patterns) is applied automatically, so results from any agent framework are handled gracefully. Non-prettifiable results fall back to structured YAML/JSON view.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5427

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-opus-4-6
  - Scope: Full implementation
  - Human verification: Code reviewed and tested by developer

## Testing

- `npx tsc --noEmit` — no type errors
- `npx eslint src/v2/pages/AgentRunnerPage/AgentRunnerResult.tsx` — no lint errors
- Manual verification: navigate to Agent Sandbox page, run an agent, observe formatted output with mode switcher

## Documentation

N/A

## Screenshots

<img width="1816" height="1231" alt="Screenshot 2026-03-31 at 18 49 11" src="https://github.com/user-attachments/assets/d5b3ff86-fb4e-4e71-8ccf-c2ab0a261a9c" />

