### PR TITLE
[OPIK-5270] [BE] [FE] fix: skip feedback score CTEs when excluded

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -866,7 +866,7 @@ class TraceDAOImpl implements TraceDAO {
                 <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
                 <if(filters)> AND <filters> <endif>
                 <if(search_text)> AND <search_text> <endif>
-            ), <endif>feedback_scores_combined_raw AS (
+            ), <endif><if(!exclude_feedback_scores)>feedback_scores_combined_raw AS (
                 SELECT workspace_id,
                        project_id,
                        entity_id,
@@ -1000,7 +1000,7 @@ class TraceDAOImpl implements TraceDAO {
                     )) AS feedback_scores_list
                 FROM feedback_scores_final
                 GROUP BY workspace_id, project_id, entity_id
-            ), guardrails_agg AS (
+            ),<endif> guardrails_agg AS (
                 SELECT
                     entity_id,
                     groupArray(tuple(
@@ -1027,7 +1027,7 @@ class TraceDAOImpl implements TraceDAO {
                     LIMIT 1 BY entity_id, id
                 )
                 GROUP BY workspace_id, project_id, entity_type, entity_id
-            ), target_spans AS (
+            ), <if(!exclude_feedback_scores)>target_spans AS (
                 SELECT DISTINCT id, trace_id
                 FROM spans
                 WHERE workspace_id = :workspace_id
@@ -1193,7 +1193,7 @@ class TraceDAOImpl implements TraceDAO {
                     )) AS span_feedback_scores_list
                 FROM span_feedback_scores_final
                 GROUP BY workspace_id, project_id, trace_id
-            ), spans_agg AS (
+            ),<endif> spans_agg AS (
                 SELECT
                     trace_id,
                     sumMap(usage) as usage,
@@ -1429,8 +1429,10 @@ class TraceDAOImpl implements TraceDAO {
                   , s.providers AS providers
                   <if(!exclude_experiment)>, eaag.experiment_id, eaag.experiment_name, eaag.experiment_dataset_id, eaag.experiment_dataset_item_id<endif>
              FROM traces_final t
+             <if(!exclude_feedback_scores)>
              LEFT JOIN feedback_scores_agg fsagg ON fsagg.entity_id = t.id
              LEFT JOIN span_feedback_scores_agg sfsagg ON sfsagg.trace_id = t.id
+             <endif>
              LEFT JOIN spans_agg s ON t.id = s.trace_id
              LEFT JOIN comments_agg c ON t.id = c.entity_id
              LEFT JOIN guardrails_agg gagg ON gagg.entity_id = t.id
@@ -3239,10 +3241,7 @@ class TraceDAOImpl implements TraceDAO {
      * CTE only queries the traces table, these references would fail. Guard against them.
      */
     private boolean shouldUseTraceIdPrefilter(TraceSearchCriteria criteria, ST template) {
-        boolean hasCteDependentFilters = template.getAttribute("feedback_scores_filters") != null
-                || template.getAttribute("feedback_scores_empty_filters") != null
-                || template.getAttribute("span_feedback_scores_filters") != null
-                || template.getAttribute("span_feedback_scores_empty_filters") != null
+        boolean hasCteDependentFilters = hasFeedbackScoreFilters(template)
                 || template.getAttribute("guardrails_filters") != null;
 
         boolean hasNarrowingFilters = criteria.searchText() != null
@@ -3334,9 +3333,12 @@ class TraceDAOImpl implements TraceDAO {
                             .filter(field -> !sortingFields.contains(field))
                             .collect(toSet());
 
-                    // check feedback_scores as well because it's a special case
+                    // check feedback_scores as well because it's a special case:
+                    // skip exclusion when sorting or filtering by feedback scores,
+                    // since the feedback score CTEs are needed for those operations
                     if (fields.contains(Trace.TraceField.FEEDBACK_SCORES.getValue())
-                            && sortingFields.stream().noneMatch(this::isFeedBackScoresField)) {
+                            && sortingFields.stream().noneMatch(this::isFeedBackScoresField)
+                            && !hasFeedbackScoreFilters(template)) {
 
                         template.add("exclude_feedback_scores", true);
                     }
@@ -3367,6 +3369,13 @@ class TraceDAOImpl implements TraceDAO {
     private boolean isFeedBackScoresField(String field) {
         return field
                 .startsWith(SortableFields.FEEDBACK_SCORES.substring(0, SortableFields.FEEDBACK_SCORES.length() - 1));
+    }
+
+    private boolean hasFeedbackScoreFilters(ST template) {
+        return template.getAttribute("feedback_scores_filters") != null
+                || template.getAttribute("feedback_scores_empty_filters") != null
+                || template.getAttribute("span_feedback_scores_filters") != null
+                || template.getAttribute("span_feedback_scores_empty_filters") != null;
     }
 
     private Mono<? extends Result> countTotal(TraceSearchCriteria traceSearchCriteria, Connection connection) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/GetTracesByProjectResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/GetTracesByProjectResourceTest.java
@@ -4850,6 +4850,56 @@ class GetTracesByProjectResourceTest {
         }
 
         @Test
+        void getTracesByProject__whenExcludeFeedbackScoresWithFilter__thenReturnTracesExcludingAndFilteringScores() {
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var workspaceId = UUID.randomUUID().toString();
+            var projectName = RandomStringUtils.secure().nextAlphanumeric(32);
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var traces = PodamFactoryUtils.manufacturePojoList(factory, Trace.class)
+                    .stream()
+                    .map(trace -> trace.toBuilder()
+                            .projectName(projectName)
+                            // We're creating feedback scores for these traces (by sending them in batch below)
+                            // but they should be excluded from the expected response by the "exclude" param,
+                            .feedbackScores(null)
+                            // Not logging any spans, so no expected usage
+                            .usage(null)
+                            .build())
+                    .toList();
+            traceResourceClient.batchCreateTraces(traces, apiKey, workspaceName);
+
+            // Creating multiple feedback scores for each trace
+            List<FeedbackScoreBatchItem> feedbackScores = traces.stream()
+                    .flatMap(trace -> PodamFactoryUtils.manufacturePojoList(factory, FeedbackScoreBatchItem.class)
+                            .stream()
+                            .map(feedbackScoreBatchItem -> feedbackScoreBatchItem.toBuilder()
+                                    .projectName(trace.projectName())
+                                    .id(trace.id())
+                                    .build()))
+                    .collect(Collectors.toList());
+            traceResourceClient.feedbackScores(feedbackScores, apiKey, workspaceName);
+
+            // Filter by the first trace's first feedback score
+            var filters = List.of(
+                    TraceFilter.builder()
+                            .field(TraceField.FEEDBACK_SCORES)
+                            .operator(Operator.EQUAL)
+                            .key(feedbackScores.getFirst().name())
+                            .value(feedbackScores.getFirst().value().toString())
+                            .build());
+
+            // The query still uses runs CTEs, joins etc. by enabling exclude_feedback_scores template
+            // because feedback_scores_filters is active.
+            // However, returned feedback scores are excluded (nulled) from the response
+            var expectedTraces = List.of(traces.getFirst());
+            var unexpectedTraces = traces.subList(1, traces.size());
+            getAndAssertPage(workspaceName, projectName, null, filters, traces, expectedTraces,
+                    unexpectedTraces, apiKey, List.of(), Set.of(Trace.TraceField.FEEDBACK_SCORES));
+        }
+
+        @Test
         @DisplayName("should handle filter with percent characters in value correctly")
         void shouldHandleTracesWithPercentCharactersInName() {
             var workspaceName = RandomStringUtils.secure().nextAlphanumeric(10);

--- a/apps/opik-frontend/src/v1/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v1/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
@@ -536,12 +536,20 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
   const excludeFields = useMemo(() => {
     const exclude: string[] = [];
 
-    // Only exclude experiment field for traces (not spans) when column is not visible
     if (
       type === TRACE_DATA_TYPE.traces &&
       !selectedColumns.includes(COLUMN_EXPERIMENT_ID)
     ) {
       exclude.push("experiment");
+    }
+
+    const hasFeedbackScoreColumn = selectedColumns.some(
+      (col) =>
+        col.startsWith(COLUMN_FEEDBACK_SCORES_ID) ||
+        col.startsWith(COLUMN_SPAN_FEEDBACK_SCORES_ID),
+    );
+    if (!hasFeedbackScoreColumn) {
+      exclude.push("feedback_scores");
     }
 
     return exclude;

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -535,12 +535,20 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
   const excludeFields = useMemo(() => {
     const exclude: string[] = [];
 
-    // Only exclude experiment field for traces (not spans) when column is not visible
     if (
       type === TRACE_DATA_TYPE.traces &&
       !selectedColumns.includes(COLUMN_EXPERIMENT_ID)
     ) {
       exclude.push("experiment");
+    }
+
+    const hasFeedbackScoreColumn = selectedColumns.some(
+      (col) =>
+        col.startsWith(COLUMN_FEEDBACK_SCORES_ID) ||
+        col.startsWith(COLUMN_SPAN_FEEDBACK_SCORES_ID),
+    );
+    if (!hasFeedbackScoreColumn) {
+      exclude.push("feedback_scores");
     }
 
     return exclude;


### PR DESCRIPTION
## Details

Skip the entire feedback score CTE chain (8 CTEs + 2 LEFT JOINs) when `exclude=feedback_scores` is set. The feedback score pipeline consumes ~12.7 GiB of ClickHouse pipeline overhead even when processing zero data rows, causing OOM on projects with high trace/span volume.

- **BE**: Wrap `feedback_scores_combined_raw` → `feedback_scores_agg` and `target_spans` → `span_feedback_scores_agg` CTE chains in `<if(!exclude_feedback_scores)>`. Guard against setting `exclude_feedback_scores` when feedback score filters or sorting are active (CTEs must remain). Extract `hasFeedbackScoreFilters(ST)` helper shared by `shouldUseTraceIdPrefilter` and `bindTemplateExcludeFieldVariables`.
- **FE**: Add `feedback_scores` to the `exclude` list when no feedback score columns are visible (v1 + v2 TracesSpansTab), matching the existing experiment column exclusion pattern.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5270

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Implementation, analysis, and query optimization
  - Human verification: Tested on customer ClickHouse instance — query drops from OOM (12.7 GiB pipeline overhead) to 68 MiB when feedback scores are excluded. Guard verified: exclude + filter returns 200 with guard, 500 without.

## Testing

- `mvn test-compile` passes
- New test: `getTracesByProject__whenExcludeFeedbackScoresWithFilter__thenReturnTracesExcludingAndFilteringScores` — creates traces with batch feedback scores, sends exclude + filter simultaneously, verifies:
  - With guard: returns 200 with correct filtered traces
  - Without guard: returns 500 (ClickHouse references non-existent CTEs)
- Existing parameterized test `getTracesByProject__whenExcludeParamIdDefined__thenReturnSpanExcludingFields` covers `FEEDBACK_SCORES` exclusion (iterates all `TraceField` enum values)
- Manually tested rendered SQL on customer ClickHouse instance:
  - Without feedback score CTEs: 68 MiB memory, completes in 80ms
  - With feedback score CTEs (zero data): 12.7 GiB memory, OOM at 13.97 GiB limit

## Documentation

N/A — internal query optimization, no user-facing API changes. The `exclude` parameter already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)