### PR TITLE
[OPIK-5488] [FE] Update onboarding prompt to use /instrument and include workspace

### DIFF
--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/InstallWithAITab.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/InstallWithAITab.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Check, LoaderCircle } from "lucide-react";
 import { useAgentOnboarding } from "./AgentOnboardingContext";
-import { useUserApiKey } from "@/store/AppStore";
+import { useUserApiKey, useActiveWorkspaceName } from "@/store/AppStore";
 import { buildDocsUrl, maskAPIKey } from "@/lib/utils";
 import CopyButton from "@/shared/CopyButton/CopyButton";
 import claudeCodeLogo from "/images/integrations/claude_code.svg";
@@ -70,9 +70,10 @@ const InstallWithAITab: React.FC<InstallWithAITabProps> = ({
 }) => {
   const { agentName } = useAgentOnboarding();
   const apiKey = useUserApiKey();
+  const workspaceName = useActiveWorkspaceName();
 
   const buildPrompt = (shouldMaskAPIKey: boolean) =>
-    `Instrument my agent with Opik, use project name "${agentName}"${
+    `Instrument my agent with Opik using the /instrument command. Make sure you use workspace "${workspaceName}", project name "${agentName}"${
       apiKey
         ? ` and API key "${shouldMaskAPIKey ? maskAPIKey(apiKey) : apiKey}"`
         : ""


### PR DESCRIPTION
## Summary
- Updated the "Install with AI" onboarding prompt (step 2 of Get Started) to reference the `/instrument` command
- Added the active workspace name to the prompt so users' coding agents configure the correct workspace

## Test plan
- [ ] Navigate to Get Started, enter an agent name, proceed to step 2
- [ ] Verify the prompt in the second code block includes `/instrument`, workspace name, project name, and API key
- [ ] Verify the copy button copies the full prompt with the real (unmasked) API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)