### PR TITLE
[NA] fix: restore migration 000061 and split index change into 000062

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000061_add_catch_up_columns_to_retention_rules.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000061_add_catch_up_columns_to_retention_rules.sql
@@ -1,5 +1,5 @@
 --liquibase formatted sql
---changeset daniela:000062_add_catch_up_columns_to_retention_rules
+--changeset daniela:000061_add_catch_up_columns_to_retention_rules
 --comment: Add catch-up tracking columns for progressive historical data deletion
 
 ALTER TABLE retention_rules
@@ -7,12 +7,9 @@ ALTER TABLE retention_rules
     ADD COLUMN catch_up_cursor      CHAR(36)        NULL COMMENT 'UUID v7 catch-up cursor: data before this point has been deleted. Advances oldest to newest. NULL when catch-up is complete.',
     ADD COLUMN catch_up_done        BOOLEAN         NOT NULL DEFAULT TRUE COMMENT 'TRUE when historical catch-up is complete. Only FALSE for apply_to_past rules with pending backfill.';
 
--- Covers catch-up finder queries: equality columns first, then cursor for ORDER BY.
--- catch_up_velocity is intentionally excluded — it's a range predicate in all queries,
--- and a B-tree range break prevents subsequent columns from being used for ordering.
--- Velocity filtering happens post-index with negligible cost (small table).
+-- catch_up_done=false implies enabled=true and apply_to_past=true, so only (done, velocity) needed
 CREATE INDEX idx_catch_up_pending
-    ON retention_rules (catch_up_done, enabled, apply_to_past, catch_up_cursor);
+    ON retention_rules (catch_up_done, catch_up_velocity);
 
 --rollback DROP INDEX idx_catch_up_pending ON retention_rules;
 --rollback ALTER TABLE retention_rules DROP COLUMN catch_up_done;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000062_fix_catch_up_pending_index.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000062_fix_catch_up_pending_index.sql
@@ -1,0 +1,15 @@
+--liquibase formatted sql
+--changeset daniela:000062_fix_catch_up_pending_index
+--comment: Recreate idx_catch_up_pending with equality-first column order for catch-up finder queries
+
+DROP INDEX idx_catch_up_pending ON retention_rules;
+
+-- Covers catch-up finder queries: equality columns first, then cursor for ORDER BY.
+-- catch_up_velocity is intentionally excluded — it's a range predicate in all queries,
+-- and a B-tree range break prevents subsequent columns from being used for ordering.
+-- Velocity filtering happens post-index with negligible cost (small table).
+CREATE INDEX idx_catch_up_pending
+    ON retention_rules (catch_up_done, enabled, apply_to_past, catch_up_cursor);
+
+--rollback DROP INDEX idx_catch_up_pending ON retention_rules;
+--rollback CREATE INDEX idx_catch_up_pending ON retention_rules (catch_up_done, catch_up_velocity);


### PR DESCRIPTION
## Details
Migration 000061_add_catch_up_columns_to_retention_rules was already executed in staging/prod. It was mistakenly renamed to 000062 with an in-place index change, which would break Liquibase checksum validation.

This restores 000061 to its original form and creates a new 000062 that drops the old index `(catch_up_done, catch_up_velocity)` and recreates it as `(catch_up_done, enabled, apply_to_past, catch_up_cursor)`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-4842

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-opus-4-6
  - Scope: migration file creation
  - Human verification: reviewed diff and migration logic

## Testing

- Verify Liquibase runs cleanly on a fresh database (both 000061 migrations + 000062 applied)
- Verify Liquibase runs cleanly on staging/prod (000061s already applied, only 000062 is new)

## Documentation