### PR TITLE
[NA] [E2E] fix: increase online scoring test timeouts for GitHub-hosted runners

### DIFF
--- a/tests_end_to_end/typescript-tests/tests/online-scoring/online-scoring.spec.ts
+++ b/tests_end_to_end/typescript-tests/tests/online-scoring/online-scoring.spec.ts
@@ -7,7 +7,7 @@ import { modelConfigLoader } from '../../helpers/model-config-loader';
 
 // Timeout constants
 const RULE_ACTIVATION_TIMEOUT = 10000; // 10 seconds for rule to fully activate in backend
-const PAGE_REFRESH_TIMEOUT = 2000; // 2 seconds wait after page refresh
+const PAGE_REFRESH_TIMEOUT = 3000; // 3 seconds wait after page refresh
 const POST_RELOAD_TIMEOUT = 1000; // 1 second wait after page reload
 
 const enabledModels = modelConfigLoader.getEnabledModelsForOnlineScoring();
@@ -62,6 +62,7 @@ test.describe('Online Scoring Tests', () => {
       helperClient,
       createProjectApi,
     }) => {
+      test.setTimeout(120_000);
       const providerSetupHelper = new AIProviderSetupHelper(page);
       const rulesPage = new RulesPage(page);
       const tracesPage = new TracesPage(page);
@@ -106,7 +107,7 @@ test.describe('Online Scoring Tests', () => {
 
         // Retry loop: wait for Moderation column header in the table, then check score value.
         // Scoring is async and Anthropic models can take longer, so we allow generous retries.
-        const maxAttempts = 15;
+        const maxAttempts = 25;
         let moderationColumnIndex = -1;
         let moderationValue = '';
 


### PR DESCRIPTION
## Details

Online scoring E2E tests were consistently timing out (60s) on GitHub-hosted runners in post-merge CI while passing on self-hosted runners. Investigation via Allure TestOps showed the scoring pipeline (rule activation → LLM API call → score storage) takes longer on resource-constrained `ubuntu-latest` runners compared to self-hosted `automation-q5pjv-*` pods.

- Test timeout increased from 60s to 120s
- Polling attempts increased from 15 to 25
- Page refresh wait increased from 2s to 3s

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA — flaky test fix for post-merge CI

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: investigation + fix
- Human verification: code review, will verify in next post-merge run

## Testing

Verified by analyzing Allure TestOps data:
- Post-merge #804 (launch 53489): 6/8 online scoring tests timed out at ~62s
- Post-merge #805 (launch 53491): 2/8 timed out at ~63s
- Local Happy Paths (launch 53456): all passed in 28-51s
- New timeout budget: ~15s setup + 25 retries × ~3.5s ≈ 102s, within 120s limit

## Documentation

N/A