### PR TITLE
[OPIK-5362] [BE] fix: scope dataset name uniqueness per project

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetDAO.java
@@ -201,12 +201,25 @@ public interface DatasetDAO {
             @Define("filters") String filters,
             @BindMap Map<String, Object> filterMapping);
 
+    /**
+     * @deprecated Use {@link #findByNameWorkspaceLevel} or {@link #findByNameProjectScoped} instead.
+     * This method is ambiguous when projectId is null: it matches datasets in any project.
+     */
+    @Deprecated
     @SqlQuery("SELECT * FROM datasets WHERE workspace_id = :workspace_id AND name = :name" +
             " <if(project_id)> AND project_id = :project_id <endif>")
     @UseStringTemplateEngine
     @AllowUnusedBindings
     Optional<Dataset> findByName(@Bind("workspace_id") String workspaceId, @Bind("name") String name,
             @Define("project_id") @Bind("project_id") UUID projectId);
+
+    @SqlQuery("SELECT * FROM datasets WHERE workspace_id = :workspace_id AND name = :name AND project_id IS NULL")
+    Optional<Dataset> findByNameWorkspaceLevel(@Bind("workspace_id") String workspaceId,
+            @Bind("name") String name);
+
+    @SqlQuery("SELECT * FROM datasets WHERE workspace_id = :workspace_id AND name = :name AND project_id = :project_id")
+    Optional<Dataset> findByNameProjectScoped(@Bind("workspace_id") String workspaceId,
+            @Bind("name") String name, @Bind("project_id") UUID projectId);
 
     @SqlQuery("SELECT id FROM datasets WHERE workspace_id = :workspace_id AND name LIKE CONCAT('%', :name, '%') ESCAPE '\\\\'")
     List<UUID> findIdsByPartialName(@Bind("workspace_id") String workspaceId, @Bind("name") String name);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetService.java
@@ -182,9 +182,18 @@ class DatasetServiceImpl implements DatasetService {
             UUID projectId) {
         var dataset = template.inTransaction(READ_ONLY, handle -> {
             var dao = handle.attach(DatasetDAO.class);
-            var result = dao.findByName(workspaceId, name, projectId);
-            if (result.isEmpty() && projectId != null) {
-                result = dao.findByName(workspaceId, name, null);
+            Optional<Dataset> result;
+            if (projectId != null) {
+                result = dao.findByNameProjectScoped(workspaceId, name, projectId);
+                if (result.isEmpty()) {
+                    // Backward compat: find workspace-level dataset (v1 created, no project_id)
+                    result = dao.findByNameWorkspaceLevel(workspaceId, name);
+                    result.ifPresent(d -> log.info(
+                            "Dataset '{}' not found in project '{}', using workspace-level dataset '{}'",
+                            name, projectId, d.id()));
+                }
+            } else {
+                result = dao.findByNameWorkspaceLevel(workspaceId, name);
             }
             return result;
         });
@@ -225,7 +234,7 @@ class DatasetServiceImpl implements DatasetService {
             return Mono.fromCallable(() -> getOrCreate(workspaceId, datasetName, userName, projectId))
                     .subscribeOn(Schedulers.boundedElastic());
         })
-                .onErrorResume(throwable -> handleDatasetCreationError(throwable, datasetName)
+                .onErrorResume(throwable -> handleDatasetCreationError(throwable, datasetName, projectId)
                         .map(Dataset::id));
     }
 
@@ -321,7 +330,8 @@ class DatasetServiceImpl implements DatasetService {
         Dataset dataset = template.inTransaction(READ_ONLY, handle -> {
             var dao = handle.attach(DatasetDAO.class);
 
-            Dataset d = dao.findByName(workspaceId, name, null).orElseThrow(this::newNotFoundException);
+            Dataset d = dao.findByNameWorkspaceLevel(workspaceId, name)
+                    .orElseThrow(this::newNotFoundException);
 
             log.info("Found dataset with name '{}', id '{}', workspaceId '{}'", name, d.id(), workspaceId);
             return d;
@@ -336,17 +346,21 @@ class DatasetServiceImpl implements DatasetService {
         Dataset dataset = template.inTransaction(READ_ONLY, handle -> {
             var dao = handle.attach(DatasetDAO.class);
 
-            return dao.findByName(workspaceId, name, projectId)
-                    .or(() -> {
-                        if (projectId == null) {
-                            return Optional.empty();
-                        }
-                        return dao.findByName(workspaceId, name, null).map(d -> {
-                            requestContext.get().setWorkspaceFallbackFor("Dataset", name);
-                            return d;
-                        });
-                    })
-                    .orElseThrow(this::newNotFoundException);
+            Optional<Dataset> result;
+            if (projectId != null) {
+                result = dao.findByNameProjectScoped(workspaceId, name, projectId);
+                if (result.isEmpty()) {
+                    // Backward compat: find workspace-level dataset (v1 created, no project_id)
+                    result = dao.findByNameWorkspaceLevel(workspaceId, name).map(d -> {
+                        requestContext.get().setWorkspaceFallbackFor("Dataset", name);
+                        return d;
+                    });
+                }
+            } else {
+                result = dao.findByNameWorkspaceLevel(workspaceId, name);
+            }
+
+            return result.orElseThrow(this::newNotFoundException);
         });
 
         log.info("Found dataset with name '{}', id '{}', workspaceId '{}', projectId '{}'",
@@ -397,13 +411,13 @@ class DatasetServiceImpl implements DatasetService {
     public void delete(@NonNull DatasetIdentifier identifier) {
         String workspaceId = requestContext.get().getWorkspaceId();
 
-        Dataset dataset = findByName(workspaceId, identifier.datasetName(), Visibility.PRIVATE);
+        Dataset dataset = findByName(workspaceId, identifier, Visibility.PRIVATE);
 
         template.inTransaction(WRITE, handle -> {
             deleteDatasetVersionData(handle, Set.of(dataset.id()), workspaceId);
 
             var datasetDao = handle.attach(DatasetDAO.class);
-            datasetDao.delete(workspaceId, identifier.datasetName());
+            datasetDao.delete(dataset.id(), workspaceId);
             return null;
         });
 
@@ -840,12 +854,12 @@ class DatasetServiceImpl implements DatasetService {
                 .orElseThrow(this::newNotFoundException);
     }
 
-    private Mono<Dataset> handleDatasetCreationError(Throwable throwable, String datasetName) {
+    private Mono<Dataset> handleDatasetCreationError(Throwable throwable, String datasetName, UUID projectId) {
         if (throwable instanceof EntityAlreadyExistsException) {
             return Mono.deferContextual(ctx -> {
                 String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
 
-                return Mono.fromCallable(() -> findByName(workspaceId, datasetName, Visibility.PRIVATE))
+                return Mono.fromCallable(() -> findByName(workspaceId, datasetName, projectId, Visibility.PRIVATE))
                         .subscribeOn(Schedulers.boundedElastic());
             });
         }

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000063_fix_dataset_name_uniqueness.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000063_fix_dataset_name_uniqueness.sql
@@ -1,0 +1,37 @@
+--liquibase formatted sql
+--changeset yboiko:000063_fix_dataset_name_uniqueness
+--comment: Fix dataset name uniqueness to be scoped per project, not just per workspace. Adds a generated column to normalize NULL project_id for unique constraint.
+
+-- 1. Add generated column that normalizes NULL project_id to empty string.
+--    MySQL treats NULL != NULL in unique constraints, so COALESCE ensures
+--    workspace-level datasets (project_id IS NULL) are still uniquely constrained.
+ALTER TABLE datasets
+    ADD COLUMN project_id_or_empty VARCHAR(36)
+    GENERATED ALWAYS AS (COALESCE(project_id, '')) STORED;
+
+-- 2. Rename any duplicate (workspace_id, coalesced project_id, name) rows
+--    so the new constraint can be added safely on existing data.
+--    Keeps the oldest row's name intact (ORDER BY created_at ASC, rn=1 is untouched).
+UPDATE datasets d
+INNER JOIN (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY workspace_id, COALESCE(project_id, ''), name
+               ORDER BY created_at ASC
+           ) AS rn,
+           name
+    FROM datasets
+) ranked ON d.id = ranked.id
+SET d.name = CONCAT(LEFT(ranked.name, 240), '_dup_', ranked.rn)
+WHERE ranked.rn > 1;
+
+-- 3. Drop old workspace-only constraint
+ALTER TABLE datasets DROP INDEX datasets_workspace_id_name_uk;
+
+-- 4. Add new project-scoped constraint
+ALTER TABLE datasets ADD CONSTRAINT datasets_workspace_project_name_uk
+    UNIQUE (workspace_id, project_id_or_empty, name);
+
+--rollback ALTER TABLE datasets DROP INDEX datasets_workspace_project_name_uk;
+--rollback ALTER TABLE datasets ADD CONSTRAINT datasets_workspace_id_name_uk UNIQUE (workspace_id, name);
+--rollback ALTER TABLE datasets DROP COLUMN project_id_or_empty;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceProjectScopedTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceProjectScopedTest.java
@@ -206,6 +206,134 @@ class DatasetsResourceProjectScopedTest {
     }
 
     @Test
+    @DisplayName("Create dataset with same name in different projects succeeds")
+    void createDataset__sameNameDifferentProjects__succeeds() {
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var projectIdA = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey, workspaceName);
+        var projectIdB = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey, workspaceName);
+
+        String sharedName = "shared-dataset-" + UUID.randomUUID();
+
+        var datasetA = buildDataset().toBuilder()
+                .id(null)
+                .name(sharedName)
+                .projectId(projectIdA)
+                .build();
+
+        var datasetB = buildDataset().toBuilder()
+                .id(null)
+                .name(sharedName)
+                .projectId(projectIdB)
+                .build();
+
+        var idA = datasetResourceClient.createDataset(datasetA, apiKey, workspaceName);
+        var idB = datasetResourceClient.createDataset(datasetB, apiKey, workspaceName);
+
+        assertThat(idA).isNotEqualTo(idB);
+
+        var fetchedA = datasetResourceClient.getDatasetById(idA, apiKey, workspaceName);
+        var fetchedB = datasetResourceClient.getDatasetById(idB, apiKey, workspaceName);
+        assertThat(fetchedA.name()).isEqualTo(sharedName);
+        assertThat(fetchedB.name()).isEqualTo(sharedName);
+        assertThat(fetchedA.projectId()).isEqualTo(projectIdA);
+        assertThat(fetchedB.projectId()).isEqualTo(projectIdB);
+    }
+
+    @Test
+    @DisplayName("Create dataset with same name in same project returns 409")
+    void createDataset__sameNameSameProject__returns409() {
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var projectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey, workspaceName);
+
+        String sharedName = "dup-dataset-" + UUID.randomUUID();
+
+        var dataset1 = buildDataset().toBuilder()
+                .id(null)
+                .name(sharedName)
+                .projectId(projectId)
+                .build();
+
+        datasetResourceClient.createDataset(dataset1, apiKey, workspaceName);
+
+        var dataset2 = buildDataset().toBuilder()
+                .id(null)
+                .name(sharedName)
+                .projectId(projectId)
+                .build();
+
+        try (var response = datasetResourceClient.callCreateDataset(dataset2, apiKey, workspaceName)) {
+            assertThat(response.getStatus()).isEqualTo(409);
+        }
+    }
+
+    @Test
+    @DisplayName("Create dataset with same name as workspace-level and project-scoped succeeds")
+    void createDataset__sameNameWorkspaceLevelAndProjectScoped__succeeds() {
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var projectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey, workspaceName);
+
+        String sharedName = "mixed-dataset-" + UUID.randomUUID();
+
+        var workspaceDataset = buildDataset().toBuilder()
+                .id(null)
+                .name(sharedName)
+                .projectId(null)
+                .build();
+
+        var projectDataset = buildDataset().toBuilder()
+                .id(null)
+                .name(sharedName)
+                .projectId(projectId)
+                .build();
+
+        var wsId = datasetResourceClient.createDataset(workspaceDataset, apiKey, workspaceName);
+        var projId = datasetResourceClient.createDataset(projectDataset, apiKey, workspaceName);
+
+        assertThat(wsId).isNotEqualTo(projId);
+    }
+
+    @Test
+    @DisplayName("Create two workspace-level datasets with same name returns 409")
+    void createDataset__sameNameBothWorkspaceLevel__returns409() {
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        String sharedName = "ws-dup-dataset-" + UUID.randomUUID();
+
+        var dataset1 = buildDataset().toBuilder()
+                .id(null)
+                .name(sharedName)
+                .projectId(null)
+                .build();
+
+        datasetResourceClient.createDataset(dataset1, apiKey, workspaceName);
+
+        var dataset2 = buildDataset().toBuilder()
+                .id(null)
+                .name(sharedName)
+                .projectId(null)
+                .build();
+
+        try (var response = datasetResourceClient.callCreateDataset(dataset2, apiKey, workspaceName)) {
+            assertThat(response.getStatus()).isEqualTo(409);
+        }
+    }
+
+    @Test
     @DisplayName("Put dataset items with project_name implicitly creates dataset scoped to that project")
     void putDatasetItemsWithProjectNameScopesDatasetToProject() {
         String apiKey = UUID.randomUUID().toString();


### PR DESCRIPTION
## Details

The `datasets` table had `UNIQUE(workspace_id, name)` which prevented creating same-named evaluation suites across different projects in the same workspace. Migration 000057 added `project_id` as a nullable column but never updated the constraint, causing cross-project uniqueness leakage.

This fix adds a stored generated column `COALESCE(project_id, '')` and replaces the constraint with `UNIQUE(workspace_id, project_id_or_empty, name)`. Also fixes the `getOrCreate`, `findByName`, `handleDatasetCreationError`, and `delete(DatasetIdentifier)` service methods to use explicit project-scoped DAO queries instead of the ambiguous template-based one.

- v1 backward compat preserved: workspace-level datasets (`project_id IS NULL`) still enforce uniqueness via the generated column normalizing NULL to `''`
- v2 project-scoped datasets can now share names across projects

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5362

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full implementation (migration, DAO, service, tests)
  - Human verification: Code review pending

## Testing

- Compiled main + test sources: `mvn compile test-compile` — passes cleanly
- Added 4 new integration test cases in `DatasetsResourceProjectScopedTest.java`:
  - Same name in different projects → succeeds (201)
  - Same name in same project → returns 409
  - Same name workspace-level + project-scoped → succeeds
  - Same name both workspace-level → returns 409
- Existing tests not yet run (require Docker containers for MySQL/ClickHouse):
  ```
  mvn test -pl apps/opik-backend -Dtest="DatasetsResourceProjectScopedTest"
  ```

## Documentation
N/A — no user-facing API changes, behavior fix only.