### PR TITLE
[OPIK-5491] [BE] feat: make intervalEnd optional for KPI cards endpoint

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/metrics/KpiCardRequest.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/metrics/KpiCardRequest.java
@@ -22,11 +22,17 @@ public record KpiCardRequest(
         @NotNull EntityType entityType,
         String filters,
         @NotNull Instant intervalStart,
-        @NotNull Instant intervalEnd) {
+        Instant intervalEnd) {
 
     @JsonIgnore
-    @AssertTrue(message = "intervalStart must be before intervalEnd") public boolean isStartBeforeEnd() {
-        return intervalStart == null || intervalEnd == null || intervalStart.isBefore(intervalEnd);
+    @AssertTrue(message = "intervalStart must be before intervalEnd or current time") public boolean isStartBeforeEnd() {
+        if (intervalStart == null) {
+            return true;
+        }
+        if (intervalEnd != null) {
+            return intervalStart.isBefore(intervalEnd);
+        }
+        return intervalStart.isBefore(Instant.now());
     }
 
     @Getter

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
@@ -63,6 +63,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -288,7 +289,7 @@ public class ProjectsResource {
                 .entityType(request.entityType())
                 .filters(filters)
                 .intervalStart(request.intervalStart())
-                .intervalEnd(request.intervalEnd())
+                .intervalEnd(request.intervalEnd() != null ? request.intervalEnd() : Instant.now())
                 .build();
 
         KpiCardResponse response = kpiCardService.getKpiCards(criteria)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardCriteria.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardCriteria.java
@@ -15,5 +15,5 @@ public record KpiCardCriteria(
         @NonNull EntityType entityType,
         List<? extends Filter> filters,
         @NonNull Instant intervalStart,
-        @NonNull Instant intervalEnd) {
+        Instant intervalEnd) {
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/KpiCardsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/KpiCardsResourceTest.java
@@ -227,6 +227,39 @@ class KpiCardsResourceTest {
 
     @ParameterizedTest
     @EnumSource(EntityType.class)
+    @DisplayName("returns metrics when intervalEnd is null, defaulting to current time")
+    void nullIntervalEndDefaultsToNow(EntityType entityType) {
+        mockTargetWorkspace();
+        var projectName = RandomStringUtils.secure().nextAlphabetic(10);
+        var projectId = projectResourceClient.createProject(projectName, API_KEY, WORKSPACE_NAME);
+
+        Instant intervalStart = Instant.now();
+
+        createEntities(entityType, projectName,
+                List.of(DURATION_1, DURATION_2), List.of(true, false), List.of(COST_1, COST_2));
+
+        KpiCardResponse response = projectResourceClient.getKpiCards(projectId, KpiCardRequest.builder()
+                .entityType(entityType)
+                .intervalStart(intervalStart)
+                .intervalEnd(null)
+                .build(), API_KEY, WORKSPACE_NAME);
+
+        double expectedAvgDuration = (DURATION_1 + DURATION_2) / 2.0;
+        double expectedTotalCost = COST_1 + COST_2;
+
+        assertMetric(response, KpiMetricType.COUNT, 2.0, 0.0);
+        assertMetric(response, KpiMetricType.AVG_DURATION, expectedAvgDuration, null);
+        assertMetric(response, KpiMetricType.TOTAL_COST, expectedTotalCost, 0.0);
+
+        if (entityType != EntityType.THREADS) {
+            assertMetric(response, KpiMetricType.ERRORS, 1.0, 0.0);
+        } else {
+            assertNoMetric(response, KpiMetricType.ERRORS);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(EntityType.class)
     @DisplayName("returns metrics only for previous period when no current data exists")
     void previousPeriodOnly(EntityType entityType) {
         mockTargetWorkspace();
@@ -313,7 +346,7 @@ class KpiCardsResourceTest {
                                 .intervalStart(now.plus(1, ChronoUnit.HOURS))
                                 .intervalEnd(now)
                                 .build(),
-                        "intervalStart must be before intervalEnd"),
+                        "intervalStart must be before intervalEnd or current time"),
                 Arguments.of(
                         KpiCardRequest.builder()
                                 .entityType(null)
@@ -331,10 +364,10 @@ class KpiCardsResourceTest {
                 Arguments.of(
                         KpiCardRequest.builder()
                                 .entityType(EntityType.SPANS)
-                                .intervalStart(now)
+                                .intervalStart(now.plus(1, ChronoUnit.HOURS))
                                 .intervalEnd(null)
                                 .build(),
-                        "intervalEnd must not be null"));
+                        "intervalStart must be before intervalEnd or current time"));
     }
 
     // === Span Filter Tests ===


### PR DESCRIPTION
## Details
Make `intervalEnd` optional for the `getProjectKpiCards` endpoint. When not provided, the server defaults to the current timestamp (`Instant.now()`). This is consistent with how `getProjectMetrics` already handles an optional `intervalEnd`.

- Removed `@NotNull` from `KpiCardRequest.intervalEnd` and `@NonNull` from `KpiCardCriteria.intervalEnd`
- Updated `isStartBeforeEnd` validation to check against current time when `intervalEnd` is null
- Default `intervalEnd` to `Instant.now()` in `ProjectsResource` before building criteria
- Added happy path test for null `intervalEnd`; updated validation test expectations

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5491

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Implementation and test updates
  - Human verification: Yes, code reviewed during implementation

## Testing

- Updated `KpiCardsResourceTest`:
  - New `nullIntervalEndDefaultsToNow` test validates happy path with `intervalEnd = null` for all entity types (TRACES, SPANS, THREADS)
  - Updated `invalidRequestArguments` to test that `intervalStart` in the future with null `intervalEnd` returns 422
  - Updated error message assertions to match new validation message

## Documentation
N/A
