### PR TITLE
[OPIK-5430] [FE] fix: grouping experiments by tags shows experiments from other projects

### DIFF
--- a/apps/opik-frontend/src/hooks/useGroupedExperimentsList.ts
+++ b/apps/opik-frontend/src/hooks/useGroupedExperimentsList.ts
@@ -547,7 +547,10 @@ export default function useGroupedExperimentsList(
         promptId: params.promptId,
         types: params.types,
         // Don't send projectId if it's an orphan project, use projectDeleted flag instead
-        projectId: isOrphanProject ? undefined : projectIdValue,
+        // Fall back to params.projectId (page context) when no project filter or group metadata
+        projectId: isOrphanProject
+          ? undefined
+          : projectIdValue ?? params.projectId,
         projectDeleted: isOrphanProject || undefined,
         page: 1,
         size: extractPageSize(id, params.groupLimit),


### PR DESCRIPTION
## Details

When a user is on a project's Experiments page and groups by tags, expanding a tag group fetches experiments using the general `/v1/private/experiments/` endpoint without a `project_id` filter — returning experiments from **all projects** in the workspace instead of only the current one.

The root cause was in `useGroupedExperimentsList.ts`: the per-group query derived `projectId` only from explicit user-applied filters or group metadata (both absent when grouping by tags). The `params.projectId` passed in from the page context was never used as a fallback.

Fix: fall back to `params.projectId` when neither a project filter nor project group metadata is present.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-5430

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: Root cause analysis and fix
- Human verification: Fix verified by reproducing the issue in the network tab (missing `project_id` on the experiments request)

## Testing

- Reproduced via browser network tab: `/v1/private/experiments/` was called without `project_id` when expanding a tag group on a project page
- After fix: the scoped endpoint `/v1/private/projects/{projectId}/experiments` is used, returning only experiments belonging to the current project
- Both v1 and v2 `GeneralDatasetsTab` use this shared hook, so both are fixed

## Documentation

N/A — internal implementation fix, no API or user-facing documentation changes required.
