### PR TITLE
[OPIK-000] [BE] Fix GeneratePairingCode.createsValidCode test

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResourceTest.java
@@ -310,7 +310,7 @@ class LocalRunnersResourceTest {
             assertThat(resp.pairingCode()).hasSize(6);
             assertThat(resp.pairingCode()).matches("[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{6}");
             assertThat(resp.runnerId()).isNotNull();
-            assertThat(resp.expiresInSeconds()).isEqualTo(300);
+            assertThat(resp.expiresInSeconds()).isEqualTo(3600);
         }
     }
 


### PR DESCRIPTION
## Details
Fix GeneratePairingCode.createsValidCode test
Caused by https://github.com/comet-ml/opik/pull/6016

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-000

## AI-WATERMARK

AI-WATERMARK: no

## Testing
<!--
REPLACE ME WITH:

How you tested
NA

## Documentation
NA