### PR TITLE
[OPIK-5499] [SDK] `update_current_trace` not exported at top-level opik module

### DIFF
--- a/sdks/python/src/opik/__init__.py
+++ b/sdks/python/src/opik/__init__.py
@@ -41,6 +41,7 @@ from .decorator.context_manager.span_context_manager import start_as_current_spa
 from .decorator.context_manager.trace_context_manager import start_as_current_trace
 from .simulation import SimulatedUser, run_simulation
 from .api_objects.local_recording import record_traces_locally
+from .opik_context import update_current_trace, update_current_span
 
 
 _logging.setup()
@@ -85,6 +86,8 @@ __all__ = [
     "AgentConfigNotFound",
     "Blueprint",
     "agent_config_context",
+    "update_current_trace",
+    "update_current_span",
 ]
 
 sagemaker_auth.setup_aws_sagemaker_session_hook()


### PR DESCRIPTION
## Details

### Source: Claude session 1, issue #1

opik.track, opik.configure, opik.Opik, opik.AgentConfig, and opik.flush_tracker are all importable directly from opik. However, update_current_trace lives only in opik.opik_context. A user who follows the pattern of the other top-level APIs will naturally write opik.update_current_trace(...) and get an AttributeError.

This is the most common way to attach metadata inside a tracked function, so it should be a first-class top-level export.

### Steps to reproduce:

1. Decorate a function with @opik.track(...)
2. Inside it, call opik.update_current_trace(metadata={...})
3. Get AttributeError: module 'opik' has no attribute 'update_current_trace'

Additionally, Python's error suggestion says "Did you mean: 'start_as_current_trace'" which is a completely different function, sending users down the wrong path.

### Severity: 
Major


## Summary of changes

Added `update_current_trace` and `update_current_span` to SDK exports in `__init__.py`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-5499

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing

Manually checked

## Documentation

No changes