### PR TITLE
[OPIK-5613] [BE] fix: preserve experiment item aggregates when trace is deleted

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
@@ -2050,13 +2050,22 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
         Map<UUID, AssertionData> assertionsMap = assertionsData.stream()
                 .collect(Collectors.toMap(AssertionData::traceId, Function.identity()));
 
+        // Skip items whose traces were deleted to preserve existing aggregate data
+        List<ExperimentItemData> itemsWithTraces = items.stream()
+                .filter(item -> tracesMap.containsKey(item.traceId()))
+                .toList();
+
+        if (itemsWithTraces.isEmpty()) {
+            return Mono.just(0L);
+        }
+
         return asyncTemplate.nonTransaction(connection -> {
             return makeMonoContextAware((userName, workspaceId) -> {
 
-                List<TemplateUtils.QueryItem> queryItems = getQueryItemPlaceHolder(items.size());
+                List<TemplateUtils.QueryItem> queryItems = getQueryItemPlaceHolder(itemsWithTraces.size());
 
                 var template = getSTWithLogComment(INSERT_EXPERIMENT_ITEM_AGGREGATE,
-                        "insertExperimentItemAggregate", workspaceId, userName, items.size())
+                        "insertExperimentItemAggregate", workspaceId, userName, itemsWithTraces.size())
                         .add("items", queryItems);
 
                 var statement = connection.createStatement(template.render())
@@ -2064,7 +2073,8 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                         .bind("project_id", projectId);
 
                 // Bind item parameters in batch
-                bindItemsParameters(statement, items, tracesMap, spansMap, feedbackMap, commentsMap, assertionsMap);
+                bindItemsParameters(statement, itemsWithTraces, tracesMap, spansMap, feedbackMap, commentsMap,
+                        assertionsMap);
 
                 return Mono.from(statement.execute())
                         .flatMapMany(Result::getRowsUpdated)

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
@@ -2267,6 +2267,73 @@ class ExperimentAggregatesIntegrationTest {
     }
 
     @Test
+    @DisplayName("Experiment item aggregates are preserved when trace is deleted after aggregation")
+    void experimentItemAggregatesPreservedAfterTraceDeletion() {
+        var project = createProject(API_KEY, TEST_WORKSPACE);
+        var dataset = createDataset(API_KEY, TEST_WORKSPACE);
+
+        var experiment = experimentResourceClient.createPartialExperiment()
+                .datasetId(dataset.id())
+                .datasetName(dataset.name())
+                .evaluationMethod(EvaluationMethod.EVALUATION_SUITE)
+                .build();
+        experimentResourceClient.create(experiment, API_KEY, TEST_WORKSPACE);
+
+        List<String> feedbackScoreNames = PodamFactoryUtils.manufacturePojoList(factory, String.class);
+        var experimentItems = createExperimentItemWithData(
+                experiment.id(), dataset.id(), project.name(),
+                feedbackScoreNames, API_KEY, TEST_WORKSPACE);
+
+        var traceId = experimentItems.getFirst().traceId();
+
+        // Populate aggregates (copies trace data to experiment_item_aggregates)
+        experimentAggregatesService.populateAggregations(experiment.id())
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, WORKSPACE_ID))
+                .block();
+
+        // Query BEFORE trace deletion to capture expected data
+        var streamRequest = ExperimentItemStreamRequest.builder()
+                .experimentName(experiment.name())
+                .build();
+        var beforeDeletion = experimentResourceClient.streamExperimentItems(streamRequest, API_KEY, TEST_WORKSPACE);
+        assertThat(beforeDeletion).isNotEmpty();
+        var beforeItem = beforeDeletion.stream()
+                .filter(i -> traceId.equals(i.traceId()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(beforeItem.input()).isNotNull();
+        assertThat(beforeItem.output()).isNotNull();
+
+        // Delete the trace
+        traceResourceClient.deleteTrace(traceId, TEST_WORKSPACE, API_KEY);
+
+        // Re-aggregate (this would overwrite good data with empty data before the fix)
+        experimentAggregatesService.populateAggregations(experiment.id())
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, WORKSPACE_ID))
+                .block();
+
+        // Query AFTER trace deletion + re-aggregation: data must still be present
+        var afterDeletion = experimentResourceClient.streamExperimentItems(streamRequest, API_KEY, TEST_WORKSPACE);
+        assertThat(afterDeletion).isNotEmpty();
+        var afterItem = afterDeletion.stream()
+                .filter(i -> traceId.equals(i.traceId()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(afterItem)
+                .as("experiment item data must be preserved after trace deletion and re-aggregation")
+                .usingRecursiveComparison()
+                .ignoringFields(IGNORED_FIELDS_EXPERIMENT_ITEM)
+                .ignoringCollectionOrderInFields("feedbackScores", "assertionResults")
+                .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
+                .isEqualTo(beforeItem);
+    }
+
+    @Test
     @DisplayName("DatasetItemVersionDAO has_aggregated branch: assertionResults in dataset items view are preserved after aggregation")
     void assertionResultsInDatasetItemsArePreservedAfterAggregation() {
         var project = createProject(API_KEY, TEST_WORKSPACE);


### PR DESCRIPTION
## Details

<img width="1920" height="1764" alt="image" src="https://github.com/user-attachments/assets/cf80f36d-e37d-4e5b-a78b-92d85dc2a03b" />

When a trace referenced by an experiment item was deleted, the async re-aggregation process would read trace data from the `traces` table (returning empty), then overwrite the existing good data in `experiment_item_aggregates` with empty values via ClickHouse's ReplacingMergeTree.

This fix filters out experiment items whose traces were deleted during re-aggregation, preserving the previously aggregated data (input, output, duration, feedback scores, etc.).

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-5613

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review + integration test

## Testing

- Ran `mvn test -Dtest="ExperimentAggregatesIntegrationTest#experimentItemAggregatesPreservedAfterTraceDeletion"` — test passed (30s)
- Test creates experiment items with trace data, aggregates, deletes the trace, re-aggregates, and verifies all fields are preserved
- Backend compiles cleanly (`mvn compile`)
- Spotless formatting check passed via pre-commit hook

## Documentation
N/A