### PR TITLE
[OPIK-5628] [FE] Clear stale job state on sandbox disconnect

### DIFF
--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
@@ -58,15 +58,15 @@ const AgentRunnerContent: React.FC<AgentRunnerContentProps> = ({
     jobId: activeJobId ?? "",
   });
 
-  // Clear the cached pair code as soon as the runner connects,
-  // since the backend has already consumed it. This way, if the runner
-  // later disconnects the empty state will fetch a fresh code on mount
-  // instead of displaying the stale one.
+  // On connect: drop the consumed pair code so a disconnect fetches a fresh one.
+  // On disconnect: clear job state so results/errors from the previous session don't persist.
   useEffect(() => {
     if (isConnected) {
       queryClient.removeQueries({
         queryKey: [AGENT_SANDBOX_KEY, "pair-code", { projectId }],
       });
+    } else {
+      setActiveJobId(null);
     }
   }, [isConnected, queryClient, projectId]);
 


### PR DESCRIPTION
## Details

When an SDK connection dropped and a new one was established in the Agent Sandbox, results/errors from the previous session were still displayed. This was because `activeJobId` was never cleared on disconnect. The fix resets it in the existing `isConnected` effect so each new session starts clean.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5628

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-opus-4-6
  - Scope: Implementation guided by human
  - Human verification: Yes — reviewed approach and code

## Testing

- `npx tsc --noEmit` — passes
- `npx eslint src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx` — passes
- Manual scenario: connect SDK → run job that fails → disconnect → reconnect → verify error is gone

## Documentation

N/A