### PR TITLE
[OPIK-5270] [E2E][T SDK] test: add exclude parameter tests for search traces

### DIFF
--- a/sdks/typescript/tests/unit/client/client-searchTraces.test.ts
+++ b/sdks/typescript/tests/unit/client/client-searchTraces.test.ts
@@ -68,12 +68,25 @@ describe("OpikClient searchTraces", () => {
         projectName: "custom-project",
         maxResults: 50,
         truncate: false,
+        exclude: ["feedback_scores"],
       });
 
       const callArgs = searchTracesWithFiltersSpy.mock.calls[0];
       expect(callArgs[1]).toBe("custom-project");
       expect(callArgs[3]).toBe(50);
       expect(callArgs[4]).toBe(false);
+      expect(callArgs[5]).toEqual(["feedback_scores"]);
+    });
+
+    it("should pass multiple exclude fields", async () => {
+      searchTracesWithFiltersSpy.mockResolvedValue([]);
+
+      await client.searchTraces({
+        exclude: ["feedback_scores", "input", "output"],
+      });
+
+      const callArgs = searchTracesWithFiltersSpy.mock.calls[0];
+      expect(callArgs[5]).toEqual(["feedback_scores", "input", "output"]);
     });
   });
 
@@ -204,6 +217,7 @@ describe("OpikClient searchTraces", () => {
         filterString: 'name = "test-trace" and duration > 100',
         maxResults: 50,
         truncate: false,
+        exclude: ["feedback_scores"],
         waitForAtLeast: 3,
         waitForTimeout: 10,
       });
@@ -215,6 +229,7 @@ describe("OpikClient searchTraces", () => {
       expect(callArgs[2]).toHaveLength(2);
       expect(callArgs[3]).toBe(50);
       expect(callArgs[4]).toBe(false);
+      expect(callArgs[5]).toEqual(["feedback_scores"]);
 
       expect(searchAndWaitForDoneSpy).toHaveBeenCalled();
     });

--- a/tests_end_to_end/test-helper-service/routes/traces.py
+++ b/tests_end_to_end/test-helper-service/routes/traces.py
@@ -308,6 +308,29 @@ def get_traces():
     return success_response({"traces": traces_response.dict()["content"]})
 
 
+@traces_bp.route("/search-traces", methods=["POST"])
+def search_traces():
+    data = request.get_json()
+    validate_required_fields(data, ["project_name"])
+
+    project_name = data["project_name"]
+    max_results = data.get("max_results", 1000)
+    truncate = data.get("truncate", True)
+    exclude = data.get("exclude", None)
+    filter_string = data.get("filter_string", None)
+    client = get_opik_client()
+
+    traces = client.search_traces(
+        project_name=project_name,
+        max_results=max_results,
+        truncate=truncate,
+        exclude=exclude,
+        filter_string=filter_string,
+    )
+
+    return success_response({"traces": [t.dict() for t in traces]})
+
+
 @traces_bp.route("/delete-traces", methods=["DELETE"])
 def delete_traces():
     data = request.get_json()

--- a/tests_end_to_end/typescript-tests/helpers/test-helper-client.ts
+++ b/tests_end_to_end/typescript-tests/helpers/test-helper-client.ts
@@ -542,6 +542,30 @@ export class TestHelperClient {
     }
   }
 
+  async searchTraces(
+    projectName: string,
+    options?: {
+      maxResults?: number;
+      truncate?: boolean;
+      exclude?: string[];
+      filterString?: string;
+    }
+  ): Promise<Record<string, any>[]> {
+    try {
+      const response = await this.client.post('/api/traces/search-traces', {
+        project_name: projectName,
+        max_results: options?.maxResults,
+        truncate: options?.truncate,
+        exclude: options?.exclude,
+        filter_string: options?.filterString,
+      });
+
+      return response.data.traces;
+    } catch (error) {
+      throw this.handleError(error, 'Failed to search traces');
+    }
+  }
+
   async getTraces(projectName: string, size: number = 10): Promise<Trace[]> {
     try {
       const response = await this.client.post('/api/traces/get-traces', {

--- a/tests_end_to_end/typescript-tests/tests/tracing/trace-search.spec.ts
+++ b/tests_end_to_end/typescript-tests/tests/tracing/trace-search.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '../../fixtures/tracing.fixture';
+
+test('Traces returned by search_traces contain expected fields and respect exclude option @fullregression @tracing', async ({
+  helperClient,
+  projectName,
+  createTracesWithSpansClient,
+}) => {
+  test.info().annotations.push({
+    type: 'description',
+    description: `Tests that traces returned by search_traces contain the expected fields from the fixture and that the exclude option removes specified fields.
+
+Steps:
+1. Create traces with tags, metadata, and feedback scores (handled by fixture)
+2. Search traces without exclude and verify all expected fields are returned
+3. Search traces with exclude=["feedback_scores"] and verify scores are absent while other fields remain`
+  });
+
+  const { traceConfig } = createTracesWithSpansClient;
+
+  await test.step('Search traces and verify all expected fields are returned', async () => {
+    const traces = await helperClient.searchTraces(projectName, {
+      maxResults: traceConfig.count,
+    });
+
+    expect(traces).toHaveLength(traceConfig.count);
+
+    for (let i = 0; i < traceConfig.count; i++) {
+      const trace = traces.find((t: Record<string, any>) => t.name === `${traceConfig.prefix}${i}`);
+      expect(trace).toBeDefined();
+      expect(trace!.id).toBeDefined();
+      expect(trace!.input).toMatchObject({ input: `input-${i}` });
+      expect(trace!.output).toMatchObject({ output: `output-${i}` });
+      expect(trace!.tags).toEqual(expect.arrayContaining(traceConfig.tags!));
+      expect(trace!.metadata).toMatchObject(traceConfig.metadata!);
+
+      const scores = trace!.feedback_scores;
+      expect(scores).toHaveLength(traceConfig.feedback_scores!.length);
+      for (const expectedScore of traceConfig.feedback_scores!) {
+        expect(scores).toEqual(
+          expect.arrayContaining([expect.objectContaining({ name: expectedScore.name, value: expectedScore.value, source: 'sdk' })])
+        );
+      }
+    }
+  });
+
+  await test.step('Search traces with exclude=["feedback_scores"] and verify scores are absent', async () => {
+    const traces = await helperClient.searchTraces(projectName, {
+      maxResults: traceConfig.count,
+      exclude: ['feedback_scores'],
+    });
+
+    expect(traces).toHaveLength(traceConfig.count);
+
+    for (let i = 0; i < traceConfig.count; i++) {
+      const trace = traces.find((t: Record<string, any>) => t.name === `${traceConfig.prefix}${i}`);
+      expect(trace).toBeDefined();
+      expect(trace!.id).toBeDefined();
+      expect(trace!.input).toMatchObject({ input: `input-${i}` });
+      expect(trace!.output).toMatchObject({ output: `output-${i}` });
+      expect(trace!.tags).toEqual(expect.arrayContaining(traceConfig.tags!));
+      expect(trace!.metadata).toMatchObject(traceConfig.metadata!);
+      expect(trace!.feedback_scores).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Details

Add test coverage for the `exclude` parameter on `search_traces`, as requested in PR #6098 review comments. This includes TypeScript SDK unit tests for the `exclude` option pass-through and E2E tests that verify the stream search endpoint correctly excludes feedback scores from the response while preserving all other trace fields.

Changes:
- **TS SDK unit tests**: Add `exclude` to existing option-override and integration tests, plus a standalone multi-field exclude test (3 modifications, 1 new test)
- **E2E infrastructure**: New `/search-traces` Flask endpoint wrapping `client.search_traces()` with exclude support, and corresponding `searchTraces` method on the TypeScript test helper client
- **E2E test**: New `trace-search.spec.ts` with control/treatment steps — verifies full trace payload (name, input, output, tags, metadata, feedback scores with values and source) then confirms `exclude=["feedback_scores"]` removes only scores

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5270

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review + iterative refinement of test assertions and conventions

## Testing

- **TS SDK unit tests**: `npx vitest run tests/unit/client/client-searchTraces.test.ts` — 16/16 pass
- **Pre-commit**: `pre-commit run --files <changed files>` — clean
- **E2E tests**: Require running local stack (`opik.sh` + Flask test helper). Not run locally — to be validated by CI (`@fullregression @tracing` suite)

## Documentation

N/A