### PR TITLE
[OPIK-5707] [BE] Fix eval suite dataset storing empty data for non-object trace input

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -275,12 +275,18 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
         // For evaluation suites, use only the input value as top-level data
         var inputNode = data.get("input");
-        if (inputNode == null || !inputNode.isObject()) {
+        if (inputNode == null || inputNode.isNull()) {
             return Map.of();
         }
 
-        return JsonUtils.convertValue(inputNode, new TypeReference<Map<String, JsonNode>>() {
-        });
+        // Object inputs: unwrap fields as top-level keys (existing behavior)
+        if (inputNode.isObject()) {
+            return JsonUtils.convertValue(inputNode, new TypeReference<Map<String, JsonNode>>() {
+            });
+        }
+
+        // Non-object inputs (array, string, number, boolean): wrap under "input" key
+        return Map.of("input", inputNode);
     }
 
     private Mono<UUID> resolveProjectId(DatasetItemBatch batch) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemServiceFilterDataTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemServiceFilterDataTest.java
@@ -64,9 +64,30 @@ class DatasetItemServiceFilterDataTest {
                                 JsonUtils.getJsonNodeFromString("{\"answer\":\"F1 is a sport\"}")),
                         Map.<String, JsonNode>of()),
                 Arguments.of(
-                        "EVALUATION_SUITE with non-object input returns empty map",
+                        "EVALUATION_SUITE with string input wraps under input key",
                         DatasetType.EVALUATION_SUITE,
                         Map.of("input", JsonUtils.getJsonNodeFromString("\"just a string\"")),
+                        Map.of("input", JsonUtils.getJsonNodeFromString("\"just a string\""))),
+                Arguments.of(
+                        "EVALUATION_SUITE with array input wraps under input key",
+                        DatasetType.EVALUATION_SUITE,
+                        Map.of("input", JsonUtils.getJsonNodeFromString("[{\"role\":\"user\",\"content\":\"hello\"}]")),
+                        Map.of("input",
+                                JsonUtils.getJsonNodeFromString("[{\"role\":\"user\",\"content\":\"hello\"}]"))),
+                Arguments.of(
+                        "EVALUATION_SUITE with numeric input wraps under input key",
+                        DatasetType.EVALUATION_SUITE,
+                        Map.of("input", JsonUtils.getJsonNodeFromString("42")),
+                        Map.of("input", JsonUtils.getJsonNodeFromString("42"))),
+                Arguments.of(
+                        "EVALUATION_SUITE with boolean input wraps under input key",
+                        DatasetType.EVALUATION_SUITE,
+                        Map.of("input", JsonUtils.getJsonNodeFromString("true")),
+                        Map.of("input", JsonUtils.getJsonNodeFromString("true"))),
+                Arguments.of(
+                        "EVALUATION_SUITE with null input returns empty map",
+                        DatasetType.EVALUATION_SUITE,
+                        Map.of("input", JsonUtils.getJsonNodeFromString("null")),
                         Map.<String, JsonNode>of()));
     }
 


### PR DESCRIPTION
## Details

When adding a trace to an evaluation suite dataset, if the trace input is a JSON array (e.g. chat messages `[{"role":"user","content":"hello"}]`) or a scalar value, `filterDataForDatasetType()` discards the input entirely and stores `{}` as the dataset item data.

The fix adds a third branch: non-object inputs (array, string, number, boolean) are now wrapped under an `"input"` key, preserving the data while maintaining the `Map<String, JsonNode>` type constraint. Object inputs continue to be unwrapped as top-level keys (no regression).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5707

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Implementation of fix and tests
  - Human verification: Code reviewed, unit tests pass, bug reproduced and fix verified locally

## Testing

- `mvn test -Dtest=DatasetItemServiceFilterDataTest` — all 9 parameterized tests pass
- Reproduced bug locally: created trace with array input, added to eval suite dataset, confirmed `"data":{}` before fix
- Verified fix locally: same flow now produces `"data":{"input":[{"role":"user","content":"hello"}]}`
- Test cases cover: object input (unchanged), array input, string input, numeric input, boolean input, null input, missing input

## Documentation

N/A