### PR TITLE
[NA] [FE] fix: bypass manifest fetch in dev mode for hot reload

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -281,7 +281,7 @@ function useAssistantMeta(backendUrl: string | null): AssistantMeta | null {
         version: manifest.ver,
       };
     },
-    enabled: !IS_DEV && !!manifestUrl,
+    enabled: !(IS_DEV && DEV_BASE_URL) && !!manifestUrl,
     staleTime: Infinity,
     retry: 1,
   });


### PR DESCRIPTION
## Details
In dev mode, skip the manifest fetch entirely and return a static `DEV_META` with hashless asset paths (`/assistant/assistant.js`, `/assistant/assistant.css`). This disables the react-query manifest fetch when `IS_DEV` is true and removes the dev-mode special case for `shellUrl` inside the query transform.

Unblocks Vite hot reload for the Ollie assistant sidebar during local development.

## Change checklist
- [x] Bypass manifest fetch in dev mode
- [x] Use static asset paths without content hashes
- [x] Clean up shellUrl dev-mode branching in prod path

## Issues
NA

## Testing
- Run Opik frontend in dev mode with Ollie assistant — sidebar loads without manifest fetch
- Change Ollie FE code — hot reload picks up the change without full page refresh
- Run in prod/staging mode — manifest fetch still works as before

## Documentation
No documentation changes needed.