### PR TITLE
[OPIK-5407] [FE] fix: rename Assertions to Custom assertions in eval suite items

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsListTooltipContent.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsListTooltipContent.tsx
@@ -5,11 +5,12 @@ import { Separator } from "@/ui/separator";
 
 interface AssertionsListTooltipContentProps {
   assertions: string[];
+  title?: string;
 }
 
 export const AssertionsListTooltipContent: React.FC<
   AssertionsListTooltipContentProps
-> = ({ assertions }) => {
+> = ({ assertions, title = "Assertions" }) => {
   if (assertions.length === 0) {
     return null;
   }
@@ -20,9 +21,7 @@ export const AssertionsListTooltipContent: React.FC<
         <div className="flex size-4 items-center justify-center rounded bg-[#89DEFF]">
           <CheckCheck className="size-3 text-foreground" />
         </div>
-        <span className="comet-body-xs-accented text-foreground">
-          Assertions
-        </span>
+        <span className="comet-body-xs-accented text-foreground">{title}</span>
       </div>
       <Separator className="my-1" />
       {assertions.map((assertion, index) => (

--- a/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/EvaluationSuiteItemsTab/AssertionsCountCell.tsx
+++ b/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/EvaluationSuiteItemsTab/AssertionsCountCell.tsx
@@ -63,7 +63,10 @@ const AssertionsCountCellInner: React.FC<AssertionsCountCellInnerProps> = ({
             collisionPadding={16}
             className="max-w-fit p-0"
           >
-            <AssertionsListTooltipContent assertions={assertions} />
+            <AssertionsListTooltipContent
+              assertions={assertions}
+              title="Custom assertions"
+            />
           </TooltipContent>
         </TooltipPortal>
       </Tooltip>

--- a/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/EvaluationSuiteItemsTab/useEvaluationSuiteColumns.ts
+++ b/apps/opik-frontend/src/v2/pages/EvaluationSuiteItemsPage/EvaluationSuiteItemsTab/useEvaluationSuiteColumns.ts
@@ -58,7 +58,7 @@ export function useEvaluationSuiteColumns({
         },
         {
           id: "assertions",
-          label: "Assertions",
+          label: "Custom assertions",
           type: COLUMN_TYPE.string,
           iconType: "assertions",
           cell: AssertionsCountCell as never,


### PR DESCRIPTION
## Details
Rename the "Assertions" column header and tooltip to "Custom assertions" in the evaluation suite items table. This fixes confusion where an item shows "0" assertions but the suite badge says "1 global assertion" — now the column name clarifies it only counts per-item assertions.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5407

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-opus-4-6
  - Scope: full implementation
  - Human verification: reviewed diff and lint output

## Testing

- Ran `npm run lint` locally — passes with 0 warnings
- Scenarios: column header shows "Custom assertions"; tooltip on item assertion count says "Custom assertions"; global assertions badge tooltip still says "Assertions"

## Documentation

N/A — UI label change only