### PR TITLE
[NA] [BE][FE] chore: sync provider model definitions

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
@@ -50,6 +50,7 @@ public enum OpenRouterModelName implements StructuredOutputSupported {
     ANTHROPIC_CLAUDE_OPUS_4_1("anthropic/claude-opus-4.1"),
     ANTHROPIC_CLAUDE_OPUS_4_5("anthropic/claude-opus-4.5"),
     ANTHROPIC_CLAUDE_OPUS_4_6("anthropic/claude-opus-4.6"),
+    ANTHROPIC_CLAUDE_OPUS_4_6_FAST("anthropic/claude-opus-4.6-fast"),
     ANTHROPIC_CLAUDE_SONNET_4("anthropic/claude-sonnet-4"),
     ANTHROPIC_CLAUDE_SONNET_4_5("anthropic/claude-sonnet-4.5"),
     ANTHROPIC_CLAUDE_SONNET_4_6("anthropic/claude-sonnet-4.6"),
@@ -138,7 +139,9 @@ public enum OpenRouterModelName implements StructuredOutputSupported {
     GOOGLE_GEMMA_3N_E4B_IT("google/gemma-3n-e4b-it"),
     GOOGLE_GEMMA_3N_E4B_IT_FREE("google/gemma-3n-e4b-it:free"),
     GOOGLE_GEMMA_4_26B_A4B_IT("google/gemma-4-26b-a4b-it"),
+    GOOGLE_GEMMA_4_26B_A4B_IT_FREE("google/gemma-4-26b-a4b-it:free"),
     GOOGLE_GEMMA_4_31B_IT("google/gemma-4-31b-it"),
+    GOOGLE_GEMMA_4_31B_IT_FREE("google/gemma-4-31b-it:free"),
     GOOGLE_LYRIA_3_CLIP_PREVIEW("google/lyria-3-clip-preview"),
     GOOGLE_LYRIA_3_PRO_PREVIEW("google/lyria-3-pro-preview"),
     GRYPHE_MYTHOMAX_L2_13B("gryphe/mythomax-l2-13b"),
@@ -403,6 +406,7 @@ public enum OpenRouterModelName implements StructuredOutputSupported {
     QWEN_QWEN3_5_9B("qwen/qwen3.5-9b"),
     QWEN_QWEN3_5_FLASH_02_23("qwen/qwen3.5-flash-02-23"),
     QWEN_QWEN3_5_PLUS_02_15("qwen/qwen3.5-plus-02-15"),
+    QWEN_QWEN3_6_PLUS("qwen/qwen3.6-plus"),
     QWEN_QWEN3_6_PLUS_PREVIEW_FREE("qwen/qwen3.6-plus-preview:free"),
     QWEN_QWEN3_6_PLUS_FREE("qwen/qwen3.6-plus:free"),
     QWEN_QWQ_32B("qwen/qwq-32b"),
@@ -463,6 +467,7 @@ public enum OpenRouterModelName implements StructuredOutputSupported {
     Z_AI_GLM_4_7_FLASH("z-ai/glm-4.7-flash"),
     Z_AI_GLM_5("z-ai/glm-5"),
     Z_AI_GLM_5_TURBO("z-ai/glm-5-turbo"),
+    Z_AI_GLM_5_1("z-ai/glm-5.1"),
     Z_AI_GLM_5V_TURBO("z-ai/glm-5v-turbo");
 
     private static final String WARNING_UNKNOWN_MODEL = "could not find OpenRouterModelName with value '{}'";

--- a/apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts
+++ b/apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts
@@ -276,6 +276,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       label: "anthropic/claude-opus-4.6",
     },
     {
+      value: PROVIDER_MODEL_TYPE.ANTHROPIC_CLAUDE_OPUS_4_6_FAST,
+      label: "anthropic/claude-opus-4.6-fast",
+    },
+    {
       value: PROVIDER_MODEL_TYPE.ANTHROPIC_CLAUDE_SONNET_4,
       label: "anthropic/claude-sonnet-4",
     },
@@ -625,8 +629,16 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       label: "google/gemma-4-26b-a4b-it",
     },
     {
+      value: PROVIDER_MODEL_TYPE.GOOGLE_GEMMA_4_26B_A4B_IT_FREE,
+      label: "google/gemma-4-26b-a4b-it:free",
+    },
+    {
       value: PROVIDER_MODEL_TYPE.GOOGLE_GEMMA_4_31B_IT,
       label: "google/gemma-4-31b-it",
+    },
+    {
+      value: PROVIDER_MODEL_TYPE.GOOGLE_GEMMA_4_31B_IT_FREE,
+      label: "google/gemma-4-31b-it:free",
     },
     {
       value: PROVIDER_MODEL_TYPE.GOOGLE_LYRIA_3_CLIP_PREVIEW,
@@ -1685,6 +1697,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       label: "qwen/qwen3.5-plus-02-15",
     },
     {
+      value: PROVIDER_MODEL_TYPE.QWEN_QWEN3_6_PLUS,
+      label: "qwen/qwen3.6-plus",
+    },
+    {
       value: PROVIDER_MODEL_TYPE.QWEN_QWEN3_6_PLUS_PREVIEW_FREE,
       label: "qwen/qwen3.6-plus-preview:free",
     },
@@ -1923,6 +1939,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
     {
       value: PROVIDER_MODEL_TYPE.Z_AI_GLM_5_TURBO,
       label: "z-ai/glm-5-turbo",
+    },
+    {
+      value: PROVIDER_MODEL_TYPE.Z_AI_GLM_5_1,
+      label: "z-ai/glm-5.1",
     },
     {
       value: PROVIDER_MODEL_TYPE.Z_AI_GLM_5V_TURBO,

--- a/apps/opik-frontend/src/types/providers.ts
+++ b/apps/opik-frontend/src/types/providers.ts
@@ -137,6 +137,7 @@ export enum PROVIDER_MODEL_TYPE {
   ANTHROPIC_CLAUDE_OPUS_4_1 = "anthropic/claude-opus-4.1",
   ANTHROPIC_CLAUDE_OPUS_4_5 = "anthropic/claude-opus-4.5",
   ANTHROPIC_CLAUDE_OPUS_4_6 = "anthropic/claude-opus-4.6",
+  ANTHROPIC_CLAUDE_OPUS_4_6_FAST = "anthropic/claude-opus-4.6-fast",
   ANTHROPIC_CLAUDE_SONNET_4 = "anthropic/claude-sonnet-4",
   ANTHROPIC_CLAUDE_SONNET_4_5 = "anthropic/claude-sonnet-4.5",
   ANTHROPIC_CLAUDE_SONNET_4_6 = "anthropic/claude-sonnet-4.6",
@@ -224,7 +225,9 @@ export enum PROVIDER_MODEL_TYPE {
   GOOGLE_GEMMA_3N_E4B_IT = "google/gemma-3n-e4b-it",
   GOOGLE_GEMMA_3N_E4B_IT_FREE = "google/gemma-3n-e4b-it:free",
   GOOGLE_GEMMA_4_26B_A4B_IT = "google/gemma-4-26b-a4b-it",
+  GOOGLE_GEMMA_4_26B_A4B_IT_FREE = "google/gemma-4-26b-a4b-it:free",
   GOOGLE_GEMMA_4_31B_IT = "google/gemma-4-31b-it",
+  GOOGLE_GEMMA_4_31B_IT_FREE = "google/gemma-4-31b-it:free",
   GOOGLE_LYRIA_3_CLIP_PREVIEW = "google/lyria-3-clip-preview",
   GOOGLE_LYRIA_3_PRO_PREVIEW = "google/lyria-3-pro-preview",
   GRYPHE_MYTHOMAX_L2_13B = "gryphe/mythomax-l2-13b",
@@ -489,6 +492,7 @@ export enum PROVIDER_MODEL_TYPE {
   QWEN_QWEN3_5_9B = "qwen/qwen3.5-9b",
   QWEN_QWEN3_5_FLASH_02_23 = "qwen/qwen3.5-flash-02-23",
   QWEN_QWEN3_5_PLUS_02_15 = "qwen/qwen3.5-plus-02-15",
+  QWEN_QWEN3_6_PLUS = "qwen/qwen3.6-plus",
   QWEN_QWEN3_6_PLUS_PREVIEW_FREE = "qwen/qwen3.6-plus-preview:free",
   QWEN_QWEN3_6_PLUS_FREE = "qwen/qwen3.6-plus:free",
   QWEN_QWQ_32B = "qwen/qwq-32b",
@@ -549,6 +553,7 @@ export enum PROVIDER_MODEL_TYPE {
   Z_AI_GLM_4_7_FLASH = "z-ai/glm-4.7-flash",
   Z_AI_GLM_5 = "z-ai/glm-5",
   Z_AI_GLM_5_TURBO = "z-ai/glm-5-turbo",
+  Z_AI_GLM_5_1 = "z-ai/glm-5.1",
   Z_AI_GLM_5V_TURBO = "z-ai/glm-5v-turbo",
 
   //   <----- gemini


### PR DESCRIPTION
## Details

Automated sync of LLM provider model definitions from source APIs and prices JSON.

**Sync summary:**
```
## Provider Model Sync

### Openrouter
- Added 5 model(s):
  + anthropic/claude-opus-4.6-fast
  + google/gemma-4-26b-a4b-it:free
  + google/gemma-4-31b-it:free
  + qwen/qwen3.6-plus
  + z-ai/glm-5.1
- Stale 99 model(s) (not in source, manual review needed):
  ? ai21/jamba-mini-1.7
  ? alibaba/tongyi-deepresearch-30b-a3b:free
  ? allenai/molmo-2-8b
  ? allenai/olmo-3-7b-instruct
  ? allenai/olmo-3-7b-think
  ? allenai/olmo-3.1-32b-think
  ? anthropic/claude-3.5-sonnet
  ? arcee-ai/afm-4.5b
  ? arliai/qwq-32b-arliai-rpr-v1
  ? arliai/qwq-32b-arliai-rpr-v1:free
  ? deepcogito/cogito-v2-preview-deepseek-671b
  ? deepcogito/cogito-v2-preview-llama-109b-moe
  ? deepcogito/cogito-v2-preview-llama-405b
  ? deepcogito/cogito-v2-preview-llama-70b
  ? deepseek/deepseek-chat-v3-0324:free
  ? deepseek/deepseek-prover-v2
  ? deepseek/deepseek-r1-0528-qwen3-8b
  ? deepseek/deepseek-r1-0528-qwen3-8b:free
  ? deepseek/deepseek-r1-0528:free
  ? deepseek/deepseek-r1-distill-llama-70b:free
  ? deepseek/deepseek-r1-distill-qwen-14b
  ? deepseek/deepseek-r1:free
  ? deepseek/deepseek-v3.1-terminus:exacto
  ? google/gemini-2.0-flash-exp:free
  ? google/gemini-2.5-flash-image-preview
  ? google/gemini-2.5-flash-preview-09-2025
  ? google/gemini-3-pro-preview
  ? kwaipilot/kat-coder-pro
  ? kwaipilot/kat-coder-pro:free
  ? liquid/lfm-2.2-6b
  ? liquid/lfm2-8b-a1b
  ? meituan/longcat-flash-chat:free
  ? meta-llama/llama-3.1-405b
  ? meta-llama/llama-3.1-405b-instruct
  ? meta-llama/llama-3.2-90b-vision-instruct
  ? meta-llama/llama-guard-2-8b
  ? microsoft/mai-ds-r1
  ? microsoft/mai-ds-r1:free
  ? microsoft/phi-3-medium-128k-instruct
  ? microsoft/phi-3-mini-128k-instruct
  ? microsoft/phi-3.5-mini-128k-instruct
  ? microsoft/phi-4-multimodal-instruct
  ? microsoft/phi-4-reasoning-plus
  ? mistralai/codestral-2501
  ? mistralai/devstral-small-2505
  ? mistralai/magistral-medium-2506
  ? mistralai/magistral-medium-2506:thinking
  ? mistralai/magistral-small-2506
  ? mistralai/ministral-3b
  ? mistralai/ministral-8b
  ? mistralai/mistral-7b-instruct
  ? mistralai/mistral-7b-instruct-v0.2
  ? mistralai/mistral-7b-instruct-v0.3
  ? mistralai/mistral-7b-instruct:free
  ? mistralai/mistral-nemo:free
  ? mistralai/mistral-small
  ? mistralai/mistral-small-24b-instruct-2501:free
  ? mistralai/mistral-small-3.1-24b-instruct:free
  ? mistralai/mistral-small-3.2-24b-instruct:free
  ? mistralai/mistral-tiny
  ? mistralai/pixtral-12b
  ? moonshotai/kimi-dev-72b
  ? moonshotai/kimi-k2-0905:exacto
  ? moonshotai/kimi-k2:free
  ? moonshotai/kimi-linear-48b-a3b-instruct
  ? neversleep/llama-3.1-lumimaid-8b
  ? neversleep/noromaid-20b
  ? nousresearch/deephermes-3-mistral-24b-preview
  ? openai/chatgpt-4o-latest
  ? openai/codex-mini
  ? openai/gpt-5.2-chat-latest
  ? openai/gpt-oss-120b:exacto
  ? opengvlab/internvl3-78b
  ? openrouter/healer-alpha
  ? openrouter/hunter-alpha
  ? perplexity/sonar-reasoning
  ? qwen/qwen-2.5-72b-instruct:free
  ? qwen/qwen-2.5-coder-32b-instruct:free
  ? qwen/qwen-2.5-vl-7b-instruct
  ? qwen/qwen2.5-vl-32b-instruct:free
  ? qwen/qwen3-14b:free
  ? qwen/qwen3-235b-a22b:free
  ? qwen/qwen3-30b-a3b:free
  ? qwen/qwen3-4b:free
  ? qwen/qwen3-coder:exacto
  ? qwen/qwen3.6-plus-preview:free
  ? qwen/qwen3.6-plus:free
  ? raifle/sorcererlm-8x22b
  ? reka/reka-edge
  ? stepfun-ai/step3
  ? thedrummer/anubis-70b-v1.1
  ? thudm/glm-4.1v-9b-thinking
  ? tngtech/deepseek-r1t-chimera
  ? tngtech/deepseek-r1t-chimera:free
  ? tngtech/deepseek-r1t2-chimera:free
  ? x-ai/grok-4.1-fast:free
  ? x-ai/grok-4.20-beta
  ? x-ai/grok-4.20-multi-agent-beta
  ? z-ai/glm-4.6:exacto
- Total models: 451 (dropdown: 451)

### Openai
- Stale 15 model(s) (not in source, manual review needed):
  ? chatgpt-4o-latest
  ? gpt-4-0125-preview
  ? gpt-4-0314
  ? gpt-4-1106-preview
  ? gpt-4-turbo-2024-04-09
  ? gpt-4-turbo-preview
  ? gpt-4o-2024-05-13
  ? gpt-4o-2024-08-06
  ? gpt-4o-2024-11-20
  ? gpt-4o-mini-2024-07-18
  ? o1-2024-12-17
  ? o1-mini
  ? o1-mini-2024-09-12
  ? o1-preview
  ? o1-preview-2024-09-12
- Deprecated 4 model(s) (past deprecation_date, excluded from dropdown):
  ✗ gpt-4-0125-preview
  ✗ gpt-4-0314
  ✗ gpt-4-0613
  ✗ gpt-4-1106-preview
- Total models: 62 (dropdown: 19)

### Anthropic
- Stale 2 model(s) (not in source, manual review needed):
  ? claude-3-7-sonnet-20250219
  ? claude-sonnet-4-5
- Deprecated 1 model(s) (past deprecation_date, excluded from dropdown):
  ✗ claude-3-7-sonnet-20250219
- Total models: 10 (dropdown: 8)

### Gemini
- Stale 6 model(s) (not in source, manual review needed):
  ? aqa
  ? gemini-1.0-pro
  ? gemini-1.5-flash-latest
  ? gemini-1.5-pro-latest
  ? gemini-pro-vision
  ? text-embedding-004
- Deprecated 2 model(s) (past deprecation_date, excluded from dropdown):
  ✗ gemini-3-pro-preview
  ✗ text-embedding-004
- Total models: 21 (dropdown: 10)

### Vertexai
- Stale 9 model(s) (not in source, manual review needed):
  ? vertex_ai/gemini-2.0-flash-001
  ? vertex_ai/gemini-2.0-flash-lite-001
  ? vertex_ai/gemini-2.5-flash
  ? vertex_ai/gemini-2.5-flash-lite-preview-06-17
  ? vertex_ai/gemini-2.5-flash-preview-04-17
  ? vertex_ai/gemini-2.5-pro
  ? vertex_ai/gemini-2.5-pro-exp-03-25
  ? vertex_ai/gemini-2.5-pro-preview-03-25
  ? vertex_ai/gemini-2.5-pro-preview-05-06
- Total models: 12 (dropdown: 7)

```

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: GitHub Actions (`sync_provider_models.yml`)
  - Model(s): N/A (scripted automation)
  - Scope: Automated model list sync
  - Human verification: Requires manual review before merge

## Testing

- Script dry-run passed in CI
- Changes are add-only; stale/deprecated models flagged for manual review

## Documentation

N/A