### PR TITLE
[OPIK-5270] [BE] perf: skip feedback score CTEs in SpanDAO when excluded

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -825,7 +825,7 @@ public class SpanDAO {
                 LIMIT 1 BY id
               )
               GROUP BY workspace_id, project_id, entity_id
-            ), feedback_scores_deduped AS (
+            )<if(!exclude_feedback_scores)>, feedback_scores_deduped AS (
                 SELECT workspace_id,
                        project_id,
                        entity_id,
@@ -945,7 +945,7 @@ public class SpanDAO {
                  HAVING <feedback_scores_empty_filters>
             )
             <endif>
-            , spans_deduped AS (
+            <endif>, spans_deduped AS (
                 SELECT
                       s.* <if(exclude_fields)>EXCEPT (<exclude_fields>) <endif>,
                       truncated_input,
@@ -1008,7 +1008,7 @@ public class SpanDAO {
                 <if(!exclude_comments)>, c.comments AS comments <endif>
             FROM spans_final s
             LEFT JOIN comments_final c ON s.id = c.entity_id
-            LEFT JOIN feedback_scores_agg fsa ON fsa.entity_id = s.id
+            <if(!exclude_feedback_scores)>LEFT JOIN feedback_scores_agg fsa ON fsa.entity_id = s.id<endif>
             <if(stream)>
             ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
             <else>
@@ -2272,9 +2272,12 @@ public class SpanDAO {
                             .filter(field -> !sortingFields.contains(field))
                             .collect(Collectors.toSet());
 
-                    // check feedback_scores as well because it's a special case
+                    // check feedback_scores as well because it's a special case:
+                    // skip exclusion when sorting or filtering by feedback scores,
+                    // since the feedback score CTEs are needed for those operations
                     if (fields.contains(SpanField.FEEDBACK_SCORES.getValue())
-                            && sortingFields.stream().noneMatch(this::isFeedBackScoresField)) {
+                            && sortingFields.stream().noneMatch(this::isFeedBackScoresField)
+                            && !hasFeedbackScoreFilters(template)) {
 
                         template.add("exclude_feedback_scores", true);
                     }
@@ -2360,8 +2363,7 @@ public class SpanDAO {
      * not a semantic filter.
      */
     private boolean shouldUseSpanIdPrefilter(SpanSearchCriteria criteria, ST template) {
-        boolean hasFeedbackScoreFilters = template.getAttribute("feedback_scores_filters") != null
-                || template.getAttribute("feedback_scores_empty_filters") != null;
+        boolean hasFeedbackScoreFilters = hasFeedbackScoreFilters(template);
 
         boolean hasNarrowingFilters = criteria.traceId() != null
                 || criteria.type() != null
@@ -2369,6 +2371,11 @@ public class SpanDAO {
                 || template.getAttribute("filters") != null;
 
         return !hasFeedbackScoreFilters && hasNarrowingFilters;
+    }
+
+    private boolean hasFeedbackScoreFilters(ST template) {
+        return template.getAttribute("feedback_scores_filters") != null
+                || template.getAttribute("feedback_scores_empty_filters") != null;
     }
 
     private void bindSearchCriteria(Statement statement, SpanSearchCriteria spanSearchCriteria) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindSpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindSpansResourceTest.java
@@ -4263,6 +4263,51 @@ class FindSpansResourceTest {
                     List.of(), exclude);
         }
 
+        @Test
+        void findSpans__whenExcludeFeedbackScoresWithFilter__thenReturnSpansExcludingAndFilteringScores() {
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var workspaceId = UUID.randomUUID().toString();
+            var projectName = RandomStringUtils.secure().nextAlphanumeric(32);
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var spans = PodamFactoryUtils.manufacturePojoList(podamFactory, Span.class)
+                    .stream()
+                    .map(span -> span.toBuilder()
+                            .projectName(projectName)
+                            .feedbackScores(null)
+                            .build())
+                    .toList();
+            spanResourceClient.batchCreateSpans(spans, apiKey, workspaceName);
+
+            List<FeedbackScoreItem.FeedbackScoreBatchItem> feedbackScores = spans.stream()
+                    .flatMap(span -> PodamFactoryUtils
+                            .manufacturePojoList(podamFactory, FeedbackScoreItem.FeedbackScoreBatchItem.class)
+                            .stream()
+                            .map(score -> score.toBuilder()
+                                    .projectName(span.projectName())
+                                    .id(span.id())
+                                    .build()))
+                    .collect(Collectors.toList());
+            spanResourceClient.feedbackScores(feedbackScores, apiKey, workspaceName);
+
+            var filters = List.of(
+                    SpanFilter.builder()
+                            .field(SpanField.FEEDBACK_SCORES)
+                            .operator(Operator.EQUAL)
+                            .key(feedbackScores.getFirst().name())
+                            .value(feedbackScores.getFirst().value().toString())
+                            .build());
+
+            // The query still runs feedback score CTEs because feedback_scores_filters is active,
+            // even though exclude_feedback_scores is requested.
+            // However, returned feedback scores are excluded (nulled) from the response.
+            var expectedSpans = List.of(spans.getFirst());
+            var unexpectedSpans = spans.subList(1, spans.size());
+            getAndAssertPage(workspaceName, projectName, filters, spans, expectedSpans,
+                    unexpectedSpans, apiKey, List.of(), List.of(Span.SpanField.FEEDBACK_SCORES));
+        }
+
         @ParameterizedTest
         @MethodSource("getFilterTestArguments")
         void whenFilterErrorIsNotEmpty__thenReturnSpansFiltered(String endpoint, SpanPageTestAssertion testAssertion) {


### PR DESCRIPTION
## Details

Propagate the `exclude_feedback_scores` optimization from TraceDAO (PR #6012) to SpanDAO's `SELECT_BY_PROJECT_ID` template. Previously, setting `exclude=feedback_scores` on the spans endpoint only hid the SELECT columns, but all 4 feedback score CTEs (`feedback_scores_deduped` → `feedback_scores_grouped` → `feedback_scores_final` → `feedback_scores_agg`) and the final `LEFT JOIN` still executed and scanned data.

- Wrap the entire feedback score CTE chain and LEFT JOIN in `<if(!exclude_feedback_scores)>` guards
- Add `hasFeedbackScoreFilters` guard to prevent CTE skipping when feedback score filters are active (matching TraceDAO behavior)
- Extract `hasFeedbackScoreFilters()` into a reusable method, called from both the exclude binding and `shouldUseSpanIdPrefilter`
- No FE changes needed — the frontend already sends `exclude=["feedback_scores"]` to the spans endpoint via `useTracesOrSpansList`

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- OPIK-5270

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review + ST4 comma placement verified across all 3 render paths

## Testing

- **Compilation**: `mvn compile -DskipTests` — clean
- **Spotless**: `mvn spotless:check` — clean
- **ST4 if/endif balance**: 134/134 verified
- **New test**: `findSpans__whenExcludeFeedbackScoresWithFilter__thenReturnSpansExcludingAndFilteringScores` — creates spans with feedback scores, applies `exclude=feedback_scores` AND a feedback score filter simultaneously, verifies the filter works while feedback scores are excluded from the response (validates the `hasFeedbackScoreFilters` guard)
- **Pre-existing coverage**: `findSpans__whenExcludeParamIdDefined__thenReturnSpanExcludingFields(FEEDBACK_SCORES)` — parameterized test covering the pure exclude path (CTEs skipped, scores null)
- **Tests not run locally**: Full `mvn test` suite requires Docker infrastructure. To be validated by CI.

## Documentation

N/A