### PR TITLE
[OPIK-5760] [FE] feat: add assertion reasons and run-breakdown popover to experiment results

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
@@ -74,10 +74,17 @@ export const AssertionsBreakdownTooltip: React.FC<
         const firstFailed = runItem.querySelector(
           '[data-assertion-passed="false"]',
         ) as HTMLElement | null;
-        const target = firstFailed ?? runItem;
+        // When all assertions pass there is nothing to scroll to — leave the
+        // container at the top so Run 1 content is not clipped.
+        if (!firstFailed) return;
+        // Offset by the sticky header height so the failed assertion lands
+        // below the header rather than hidden behind it.
+        const headerHeight =
+          (runItem.firstElementChild as HTMLElement | null)?.getBoundingClientRect()
+            .height ?? 0;
         const containerTop = container.getBoundingClientRect().top;
-        const targetTop = target.getBoundingClientRect().top;
-        container.scrollTop += targetTop - containerTop;
+        const targetTop = firstFailed.getBoundingClientRect().top;
+        container.scrollTop += targetTop - containerTop - headerHeight;
       });
     });
   }, []);

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
@@ -1,14 +1,14 @@
-import React, { type ReactNode } from "react";
-import { CircleCheck, CircleX } from "lucide-react";
+import React, { type ReactNode, useCallback, useMemo, useRef } from "react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDown, CircleCheck, CircleX } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
 import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/ui/accordion";
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/ui/hover-card";
+import { Accordion, AccordionContent, AccordionItem } from "@/ui/accordion";
 import { AssertionResult } from "@/types/datasets";
 
 type AssertionsBreakdownTooltipProps = {
@@ -19,29 +19,70 @@ type AssertionsBreakdownTooltipProps = {
 export const AssertionsBreakdownTooltip: React.FC<
   AssertionsBreakdownTooltipProps
 > = ({ children, assertionsByRun }) => {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const scrollToRun = useCallback((idx: number) => {
+    requestAnimationFrame(() => {
+      const container = scrollContainerRef.current;
+      if (!container) return;
+      const item = container.querySelector(
+        `[data-run-idx="${idx}"]`,
+      ) as HTMLElement | null;
+      if (item) {
+        const containerTop = container.getBoundingClientRect().top;
+        const itemTop = item.getBoundingClientRect().top;
+        container.scrollTop += itemTop - containerTop;
+      }
+    });
+  }, []);
+
+  const defaultOpenIdx = useMemo(
+    () => assertionsByRun.findIndex((run) => run.some((a) => !a.passed)),
+    [assertionsByRun],
+  );
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) scrollToRun(defaultOpenIdx >= 0 ? defaultOpenIdx : 0);
+    },
+    [defaultOpenIdx, scrollToRun],
+  );
+
+  const handleValueChange = useCallback(
+    (value: string) => {
+      const idx = parseInt(value.replace("run-", ""), 10);
+      if (!isNaN(idx)) scrollToRun(idx);
+    },
+    [scrollToRun],
+  );
+
   if (assertionsByRun.length === 0 || assertionsByRun[0].length === 0) {
     return <>{children}</>;
   }
 
-  const defaultOpenIdx = assertionsByRun.findIndex((run) =>
-    run.some((a) => !a.passed),
-  );
   const defaultValue = `run-${defaultOpenIdx >= 0 ? defaultOpenIdx : 0}`;
 
   return (
-    <Popover>
-      <PopoverTrigger asChild onClick={(e) => e.stopPropagation()}>
-        {children}
-      </PopoverTrigger>
-      <PopoverContent
+    <HoverCard
+      openDelay={200}
+      closeDelay={500}
+      onOpenChange={handleOpenChange}
+    >
+      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+      <HoverCardContent
         side="bottom"
         align="start"
         collisionPadding={16}
         className="w-80 p-0"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="max-h-96 overflow-y-auto">
-          <Accordion type="single" defaultValue={defaultValue} collapsible>
+        <Accordion
+          type="single"
+          defaultValue={defaultValue}
+          collapsible
+          onValueChange={handleValueChange}
+        >
+          <div ref={scrollContainerRef} className="max-h-96 overflow-y-auto">
             {assertionsByRun.map((run, runIdx) => {
               const passedCount = run.filter((a) => a.passed).length;
               const allPassed = passedCount === run.length;
@@ -50,30 +91,34 @@ export const AssertionsBreakdownTooltip: React.FC<
                   key={runIdx}
                   value={`run-${runIdx}`}
                   className="last:border-b-0"
+                  data-run-idx={runIdx}
                 >
-                  <AccordionTrigger className="h-auto px-3 py-2">
-                    <div className="flex items-center gap-2">
-                      <span className="comet-body-xs-accented text-foreground">
-                        Run {runIdx + 1}
-                      </span>
-                      <div
-                        className={cn(
-                          "inline-flex items-center gap-1 rounded-full border border-transparent px-2 py-0.5 font-mono text-xs font-semibold",
-                          allPassed
-                            ? "bg-success/15 text-success"
-                            : "bg-destructive/15 text-destructive",
-                        )}
-                      >
-                        {allPassed ? (
-                          <CircleCheck className="size-3 shrink-0" />
-                        ) : (
-                          <CircleX className="size-3 shrink-0" />
-                        )}
-                        {passedCount}/{run.length} assertions passed
+                  <AccordionPrimitive.Header className="sticky top-0 z-10 flex bg-background">
+                    <AccordionPrimitive.Trigger className="flex flex-1 items-center justify-between px-3 py-2 outline-none focus-visible:ring-1 focus-visible:ring-ring [&[data-state=open]>svg:last-child]:rotate-180">
+                      <div className="flex items-center gap-2">
+                        <span className="comet-body-xs-accented text-foreground">
+                          Run {runIdx + 1}
+                        </span>
+                        <div
+                          className={cn(
+                            "inline-flex items-center gap-1 rounded-full border border-transparent px-2 py-0.5 font-mono text-xs font-normal",
+                            allPassed
+                              ? "bg-success/15 text-success"
+                              : "bg-destructive/15 text-destructive",
+                          )}
+                        >
+                          {allPassed ? (
+                            <CircleCheck className="size-3 shrink-0" />
+                          ) : (
+                            <CircleX className="size-3 shrink-0" />
+                          )}
+                          {passedCount}/{run.length} assertions passed
+                        </div>
                       </div>
-                    </div>
-                  </AccordionTrigger>
-                  <AccordionContent className="bg-muted/50 p-0">
+                      <ChevronDown className="size-4 shrink-0 transition-transform duration-200" />
+                    </AccordionPrimitive.Trigger>
+                  </AccordionPrimitive.Header>
+                  <AccordionContent className="p-0">
                     {run.map((assertion, aIdx) => (
                       <div key={aIdx} className="flex gap-2 px-3 py-2">
                         {assertion.passed ? (
@@ -97,10 +142,10 @@ export const AssertionsBreakdownTooltip: React.FC<
                 </AccordionItem>
               );
             })}
-          </Accordion>
-        </div>
-      </PopoverContent>
-    </Popover>
+          </div>
+        </Accordion>
+      </HoverCardContent>
+    </HoverCard>
   );
 };
 

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
@@ -156,8 +156,8 @@ export const AssertionsBreakdownTooltip: React.FC<
                           className={cn(
                             "inline-flex items-center gap-1 rounded-full border border-transparent px-2 py-0.5 font-mono text-xs font-normal",
                             allPassed
-                              ? "bg-success/15 text-success"
-                              : "bg-destructive/15 text-destructive",
+                              ? "bg-[var(--tag-green-bg)] text-[var(--tag-green-text)]"
+                              : "bg-[var(--tag-red-bg)] text-[var(--tag-red-text)]",
                           )}
                         >
                           {allPassed ? (

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
@@ -44,7 +44,9 @@ export const AssertionsBreakdownTooltip: React.FC<
   }, [preferredSide]);
 
   const scrollToRun = useCallback((idx: number) => {
-    requestAnimationFrame(() => {
+    // Wait for the 0.2s accordion animation to settle before measuring positions,
+    // otherwise the collapsing-run layout shift causes the scroll to land mid-content.
+    setTimeout(() => {
       const container = scrollContainerRef.current;
       if (!container) return;
       const item = container.querySelector(
@@ -55,7 +57,7 @@ export const AssertionsBreakdownTooltip: React.FC<
         const itemTop = item.getBoundingClientRect().top;
         container.scrollTop += itemTop - containerTop;
       }
-    });
+    }, 200);
   }, []);
 
   const scrollToFirstFailedAssertion = useCallback((runIdx: number) => {
@@ -96,9 +98,10 @@ export const AssertionsBreakdownTooltip: React.FC<
           );
         }
         scrollToFirstFailedAssertion(defaultOpenIdx >= 0 ? defaultOpenIdx : 0);
-      } else {
-        setPreferredSide("bottom");
       }
+      // No reset on close: resetting collisionPadding mid-animation causes Radix
+      // to re-evaluate position and flip the tooltip, producing a visible jump.
+      // preferredSide is always recomputed fresh on the next open.
     },
     [defaultOpenIdx, scrollToFirstFailedAssertion],
   );
@@ -126,7 +129,7 @@ export const AssertionsBreakdownTooltip: React.FC<
         side={preferredSide}
         align="start"
         collisionPadding={activeCollisionPadding}
-        className="w-80 p-0"
+        className="w-[30rem] overflow-hidden p-0"
         onClick={(e) => e.stopPropagation()}
       >
         <Accordion
@@ -154,7 +157,7 @@ export const AssertionsBreakdownTooltip: React.FC<
                         </span>
                         <div
                           className={cn(
-                            "inline-flex items-center gap-1 rounded-full border border-transparent px-2 py-0.5 font-mono text-xs font-normal",
+                            "inline-flex h-5 items-center gap-1 rounded-sm px-2 font-mono text-xs font-normal",
                             allPassed
                               ? "bg-[var(--tag-green-bg)] text-[var(--tag-green-text)]"
                               : "bg-[var(--tag-red-bg)] text-[var(--tag-red-text)]",
@@ -168,7 +171,7 @@ export const AssertionsBreakdownTooltip: React.FC<
                           {passedCount}/{run.length} assertions passed
                         </div>
                       </div>
-                      <ChevronDown className="size-4 shrink-0 transition-transform duration-200" />
+                      <ChevronDown className="size-3 shrink-0 transition-transform duration-200" />
                     </AccordionPrimitive.Trigger>
                   </AccordionPrimitive.Header>
                   <AccordionContent className="p-0">

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
@@ -3,11 +3,7 @@ import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import { ChevronDown, CircleCheck, CircleX } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/ui/hover-card";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/ui/hover-card";
 import { Accordion, AccordionContent, AccordionItem } from "@/ui/accordion";
 import { AssertionResult } from "@/types/datasets";
 
@@ -36,6 +32,28 @@ export const AssertionsBreakdownTooltip: React.FC<
     });
   }, []);
 
+  const scrollToFirstFailedAssertion = useCallback((runIdx: number) => {
+    // Double RAF: first positions the run, second targets the failed assertion
+    // after layout is stable (defaultValue means no animation delay needed)
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const container = scrollContainerRef.current;
+        if (!container) return;
+        const runItem = container.querySelector(
+          `[data-run-idx="${runIdx}"]`,
+        ) as HTMLElement | null;
+        if (!runItem) return;
+        const firstFailed = runItem.querySelector(
+          '[data-assertion-passed="false"]',
+        ) as HTMLElement | null;
+        const target = firstFailed ?? runItem;
+        const containerTop = container.getBoundingClientRect().top;
+        const targetTop = target.getBoundingClientRect().top;
+        container.scrollTop += targetTop - containerTop;
+      });
+    });
+  }, []);
+
   const defaultOpenIdx = useMemo(
     () => assertionsByRun.findIndex((run) => run.some((a) => !a.passed)),
     [assertionsByRun],
@@ -43,9 +61,10 @@ export const AssertionsBreakdownTooltip: React.FC<
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
-      if (open) scrollToRun(defaultOpenIdx >= 0 ? defaultOpenIdx : 0);
+      if (open)
+        scrollToFirstFailedAssertion(defaultOpenIdx >= 0 ? defaultOpenIdx : 0);
     },
-    [defaultOpenIdx, scrollToRun],
+    [defaultOpenIdx, scrollToFirstFailedAssertion],
   );
 
   const handleValueChange = useCallback(
@@ -63,11 +82,7 @@ export const AssertionsBreakdownTooltip: React.FC<
   const defaultValue = `run-${defaultOpenIdx >= 0 ? defaultOpenIdx : 0}`;
 
   return (
-    <HoverCard
-      openDelay={200}
-      closeDelay={500}
-      onOpenChange={handleOpenChange}
-    >
+    <HoverCard openDelay={200} closeDelay={500} onOpenChange={handleOpenChange}>
       <HoverCardTrigger asChild>{children}</HoverCardTrigger>
       <HoverCardContent
         side="bottom"
@@ -120,7 +135,11 @@ export const AssertionsBreakdownTooltip: React.FC<
                   </AccordionPrimitive.Header>
                   <AccordionContent className="p-0">
                     {run.map((assertion, aIdx) => (
-                      <div key={aIdx} className="flex gap-2 px-3 py-2">
+                      <div
+                        key={aIdx}
+                        className="flex gap-2 px-3 py-2"
+                        data-assertion-passed={String(assertion.passed)}
+                      >
                         {assertion.passed ? (
                           <CircleCheck className="mt-0.5 size-3.5 shrink-0 text-success" />
                         ) : (

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
@@ -1,4 +1,10 @@
-import React, { type ReactNode, useCallback, useMemo, useRef } from "react";
+import React, {
+  type ReactNode,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import { ChevronDown, CircleCheck, CircleX } from "lucide-react";
 
@@ -6,6 +12,11 @@ import { cn } from "@/lib/utils";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/ui/hover-card";
 import { Accordion, AccordionContent, AccordionItem } from "@/ui/accordion";
 import { AssertionResult } from "@/types/datasets";
+
+type Side = "top" | "bottom" | "left" | "right";
+
+// max-h-96 (384px) + sideOffset (4px) + collisionPadding (16px)
+const MAX_TOOLTIP_HEIGHT = 404;
 
 type AssertionsBreakdownTooltipProps = {
   children: ReactNode;
@@ -16,6 +27,21 @@ export const AssertionsBreakdownTooltip: React.FC<
   AssertionsBreakdownTooltipProps
 > = ({ children, assertionsByRun }) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const [preferredSide, setPreferredSide] = useState<Side>("bottom");
+
+  // Prevent side flipping while accordion items expand/collapse by making the opposite
+  // side appear to always overflow. Horizontal padding stays at 16 so the tooltip still
+  // nudges left/right to stay inside the viewport.
+  const activeCollisionPadding = useMemo(() => {
+    const LOCK_PADDING = 99999;
+    return {
+      top: preferredSide === "bottom" ? LOCK_PADDING : 16,
+      bottom: preferredSide === "top" ? LOCK_PADDING : 16,
+      left: preferredSide === "right" ? LOCK_PADDING : 16,
+      right: preferredSide === "left" ? LOCK_PADDING : 16,
+    };
+  }, [preferredSide]);
 
   const scrollToRun = useCallback((idx: number) => {
     requestAnimationFrame(() => {
@@ -61,8 +87,18 @@ export const AssertionsBreakdownTooltip: React.FC<
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
-      if (open)
+      if (open) {
+        // Compute side from trigger position — no async DOM sync needed
+        if (triggerRef.current) {
+          const { bottom } = triggerRef.current.getBoundingClientRect();
+          setPreferredSide(
+            window.innerHeight - bottom < MAX_TOOLTIP_HEIGHT ? "top" : "bottom",
+          );
+        }
         scrollToFirstFailedAssertion(defaultOpenIdx >= 0 ? defaultOpenIdx : 0);
+      } else {
+        setPreferredSide("bottom");
+      }
     },
     [defaultOpenIdx, scrollToFirstFailedAssertion],
   );
@@ -83,11 +119,13 @@ export const AssertionsBreakdownTooltip: React.FC<
 
   return (
     <HoverCard openDelay={200} closeDelay={500} onOpenChange={handleOpenChange}>
-      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+      <HoverCardTrigger asChild>
+        <span ref={triggerRef}>{children}</span>
+      </HoverCardTrigger>
       <HoverCardContent
-        side="bottom"
+        side={preferredSide}
         align="start"
-        collisionPadding={16}
+        collisionPadding={activeCollisionPadding}
         className="w-80 p-0"
         onClick={(e) => e.stopPropagation()}
       >

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
@@ -1,5 +1,5 @@
 import React, { type ReactNode } from "react";
-import { CheckCircle2, XCircle } from "lucide-react";
+import { CircleCheck, CircleX } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
@@ -58,16 +58,14 @@ export const AssertionsBreakdownTooltip: React.FC<
                       </span>
                       <div className="flex items-center gap-1">
                         {allPassed ? (
-                          <CheckCircle2 className="size-3.5 shrink-0 text-[var(--tag-green-text)]" />
+                          <CircleCheck className="size-3.5 shrink-0 text-success" />
                         ) : (
-                          <XCircle className="size-3.5 shrink-0 text-[var(--tag-red-text)]" />
+                          <CircleX className="size-3.5 shrink-0 text-destructive" />
                         )}
                         <span
                           className={cn(
                             "comet-body-xs",
-                            allPassed
-                              ? "text-[var(--tag-green-text)]"
-                              : "text-[var(--tag-red-text)]",
+                            allPassed ? "text-success" : "text-destructive",
                           )}
                         >
                           {passedCount}/{run.length} assertions passed
@@ -75,13 +73,13 @@ export const AssertionsBreakdownTooltip: React.FC<
                       </div>
                     </div>
                   </AccordionTrigger>
-                  <AccordionContent className="p-0">
+                  <AccordionContent className="bg-muted/50 p-0">
                     {run.map((assertion, aIdx) => (
                       <div key={aIdx} className="flex gap-2 px-3 py-2">
                         {assertion.passed ? (
-                          <CheckCircle2 className="mt-0.5 size-3.5 shrink-0 text-[var(--tag-green-text)]" />
+                          <CircleCheck className="mt-0.5 size-3.5 shrink-0 text-success" />
                         ) : (
-                          <XCircle className="mt-0.5 size-3.5 shrink-0 text-[var(--tag-red-text)]" />
+                          <CircleX className="mt-0.5 size-3.5 shrink-0 text-destructive" />
                         )}
                         <div className="flex flex-col gap-0.5">
                           <p className="comet-body-xs text-foreground">

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
@@ -1,14 +1,14 @@
-import React, { Fragment, type ReactNode } from "react";
-import { CheckCheck } from "lucide-react";
+import React, { type ReactNode } from "react";
+import { CheckCircle2, XCircle } from "lucide-react";
 
+import { cn } from "@/lib/utils";
+import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipPortal,
-  TooltipTrigger,
-} from "@/ui/tooltip";
-import { Separator } from "@/ui/separator";
-import { Tag } from "@/ui/tag";
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/ui/accordion";
 import { AssertionResult } from "@/types/datasets";
 
 type AssertionsBreakdownTooltipProps = {
@@ -23,77 +23,86 @@ export const AssertionsBreakdownTooltip: React.FC<
     return <>{children}</>;
   }
 
-  const isMultiRun = assertionsByRun.length > 1;
-  const assertionNames = assertionsByRun[0].map((a) => a.value);
-  const runCount = assertionsByRun.length;
-  const assertionMaps = assertionsByRun.map(
-    (run) => new Map(run.map((a) => [a.value, a])),
+  const defaultOpenIdx = assertionsByRun.findIndex((run) =>
+    run.some((a) => !a.passed),
   );
+  const defaultValue = `run-${defaultOpenIdx >= 0 ? defaultOpenIdx : 0}`;
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>{children}</TooltipTrigger>
-      <TooltipPortal>
-        <TooltipContent
-          side="bottom"
-          collisionPadding={16}
-          className="max-w-[600px] overflow-x-auto p-0"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <div
-            className="grid items-center gap-x-2 p-2"
-            style={{
-              gridTemplateColumns: `auto repeat(${runCount}, 64px)`,
-            }}
-          >
-            <div className="flex items-center gap-1.5 px-2 pb-0.5 pt-1">
-              <div className="flex size-4 items-center justify-center rounded bg-[#89DEFF]">
-                <CheckCheck className="size-3 text-foreground" />
-              </div>
-              <span className="comet-body-xs-accented text-foreground">
-                Assertions
-              </span>
-            </div>
-            {isMultiRun &&
-              assertionsByRun.map((_, runIdx) => (
-                <span
+    <Popover>
+      <PopoverTrigger asChild onClick={(e) => e.stopPropagation()}>
+        {children}
+      </PopoverTrigger>
+      <PopoverContent
+        side="bottom"
+        align="start"
+        collisionPadding={16}
+        className="w-80 p-0"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="max-h-96 overflow-y-auto">
+          <Accordion type="single" defaultValue={defaultValue} collapsible>
+            {assertionsByRun.map((run, runIdx) => {
+              const passedCount = run.filter((a) => a.passed).length;
+              const allPassed = passedCount === run.length;
+              return (
+                <AccordionItem
                   key={runIdx}
-                  className="comet-body-xs-accented pb-0.5 pt-1 text-center text-muted-slate"
+                  value={`run-${runIdx}`}
+                  className="last:border-b-0"
                 >
-                  Run {runIdx + 1}
-                </span>
-              ))}
-
-            <Separator className="col-span-full my-1" />
-
-            {assertionNames.map((name, aIdx) => (
-              <Fragment key={name}>
-                <div className="flex items-start gap-1.5 px-2 py-1">
-                  <div className="mt-[5px] size-[7px] shrink-0 rounded-[1.5px] bg-[#89DEFF]" />
-                  <span className="comet-body-xs whitespace-nowrap text-muted-slate">
-                    {name}
-                  </span>
-                </div>
-                {assertionsByRun.map((run, runIdx) => {
-                  const passed =
-                    assertionMaps[runIdx].get(name)?.passed ?? false;
-                  return (
-                    <div key={runIdx} className="flex justify-center py-1">
-                      <Tag variant={passed ? "green" : "red"} size="sm">
-                        {passed ? "Passed" : "Failed"}
-                      </Tag>
+                  <AccordionTrigger className="h-auto px-3 py-2">
+                    <div className="flex items-center gap-2">
+                      <span className="comet-body-xs-accented text-foreground">
+                        Run {runIdx + 1}
+                      </span>
+                      <div className="flex items-center gap-1">
+                        {allPassed ? (
+                          <CheckCircle2 className="size-3.5 shrink-0 text-[var(--tag-green-text)]" />
+                        ) : (
+                          <XCircle className="size-3.5 shrink-0 text-[var(--tag-red-text)]" />
+                        )}
+                        <span
+                          className={cn(
+                            "comet-body-xs",
+                            allPassed
+                              ? "text-[var(--tag-green-text)]"
+                              : "text-[var(--tag-red-text)]",
+                          )}
+                        >
+                          {passedCount}/{run.length} assertions passed
+                        </span>
+                      </div>
                     </div>
-                  );
-                })}
-                {aIdx < assertionNames.length - 1 && (
-                  <Separator className="col-span-full my-1 bg-[var(--separator-light)]" />
-                )}
-              </Fragment>
-            ))}
-          </div>
-        </TooltipContent>
-      </TooltipPortal>
-    </Tooltip>
+                  </AccordionTrigger>
+                  <AccordionContent className="p-0">
+                    {run.map((assertion, aIdx) => (
+                      <div key={aIdx} className="flex gap-2 px-3 py-2">
+                        {assertion.passed ? (
+                          <CheckCircle2 className="mt-0.5 size-3.5 shrink-0 text-[var(--tag-green-text)]" />
+                        ) : (
+                          <XCircle className="mt-0.5 size-3.5 shrink-0 text-[var(--tag-red-text)]" />
+                        )}
+                        <div className="flex flex-col gap-0.5">
+                          <p className="comet-body-xs text-foreground">
+                            {assertion.value}
+                          </p>
+                          {assertion.reason && (
+                            <p className="comet-body-xs text-muted-slate">
+                              {assertion.reason}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </AccordionContent>
+                </AccordionItem>
+              );
+            })}
+          </Accordion>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 };
 

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
@@ -56,20 +56,20 @@ export const AssertionsBreakdownTooltip: React.FC<
                       <span className="comet-body-xs-accented text-foreground">
                         Run {runIdx + 1}
                       </span>
-                      <div className="flex items-center gap-1">
-                        {allPassed ? (
-                          <CircleCheck className="size-3.5 shrink-0 text-success" />
-                        ) : (
-                          <CircleX className="size-3.5 shrink-0 text-destructive" />
+                      <div
+                        className={cn(
+                          "inline-flex items-center gap-1 rounded-full border border-transparent px-2 py-0.5 font-mono text-xs font-semibold",
+                          allPassed
+                            ? "bg-success/15 text-success"
+                            : "bg-destructive/15 text-destructive",
                         )}
-                        <span
-                          className={cn(
-                            "comet-body-xs",
-                            allPassed ? "text-success" : "text-destructive",
-                          )}
-                        >
-                          {passedCount}/{run.length} assertions passed
-                        </span>
+                      >
+                        {allPassed ? (
+                          <CircleCheck className="size-3 shrink-0" />
+                        ) : (
+                          <CircleX className="size-3 shrink-0" />
+                        )}
+                        {passedCount}/{run.length} assertions passed
                       </div>
                     </div>
                   </AccordionTrigger>
@@ -82,7 +82,7 @@ export const AssertionsBreakdownTooltip: React.FC<
                           <CircleX className="mt-0.5 size-3.5 shrink-0 text-destructive" />
                         )}
                         <div className="flex flex-col gap-0.5">
-                          <p className="comet-body-xs text-foreground">
+                          <p className="comet-body-xs-accented text-foreground">
                             {assertion.value}
                           </p>
                           {assertion.reason && (

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/AssertionsBreakdownTooltip.tsx
@@ -80,8 +80,9 @@ export const AssertionsBreakdownTooltip: React.FC<
         // Offset by the sticky header height so the failed assertion lands
         // below the header rather than hidden behind it.
         const headerHeight =
-          (runItem.firstElementChild as HTMLElement | null)?.getBoundingClientRect()
-            .height ?? 0;
+          (
+            runItem.firstElementChild as HTMLElement | null
+          )?.getBoundingClientRect().height ?? 0;
         const containerTop = container.getBoundingClientRect().top;
         const targetTop = firstFailed.getBoundingClientRect().top;
         container.scrollTop += targetTop - containerTop - headerHeight;

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.test.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.test.ts
@@ -220,7 +220,7 @@ describe("getStatusInfoForExperiment", () => {
   describe("aggregated item", () => {
     it("expands trialItems for passedCount and assertionsByRun", () => {
       const row = makeRow();
-      const aggregated: AggregatedExperimentItem = {
+      const aggregated = {
         ...makeItem({ id: "agg", status: ExperimentItemStatus.FAILED }),
         trialCount: 2,
         trialItems: [
@@ -235,7 +235,7 @@ describe("getStatusInfoForExperiment", () => {
             assertion_results: [{ value: "check", passed: false }],
           }),
         ],
-      };
+      } as AggregatedExperimentItem;
       const result = getStatusInfoForExperiment(row, "exp-1", aggregated);
       expect(result.passedCount).toBe(1);
       expect(result.assertionsByRun).toHaveLength(2);

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.test.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from "vitest";
+import {
+  getStatusFromExperimentItems,
+  getStatusInfoForExperiment,
+} from "./PassedCell";
+import {
+  ExperimentItem,
+  ExperimentsCompare,
+  DATASET_ITEM_SOURCE,
+} from "@/types/datasets";
+import { ExperimentItemStatus } from "@/types/evaluation-suites";
+import { AggregatedExperimentItem } from "@/lib/trials";
+
+const makeItem = (
+  overrides: Partial<ExperimentItem> & { id: string },
+): ExperimentItem => ({
+  experiment_id: "exp-1",
+  dataset_item_id: "di-1",
+  input: {},
+  output: {},
+  created_at: "2025-01-01T00:00:00Z",
+  last_updated_at: "2025-01-01T00:00:00Z",
+  ...overrides,
+});
+
+const makeRow = (
+  overrides: Partial<ExperimentsCompare> = {},
+): ExperimentsCompare => ({
+  id: "row-1",
+  data: {},
+  source: DATASET_ITEM_SOURCE.sdk,
+  created_at: "2025-01-01T00:00:00Z",
+  last_updated_at: "2025-01-01T00:00:00Z",
+  experiment_items: [],
+  ...overrides,
+});
+
+describe("getStatusFromExperimentItems", () => {
+  describe("no items", () => {
+    it("returns undefined status when experiment_items is empty", () => {
+      const result = getStatusFromExperimentItems(makeRow());
+      expect(result.status).toBeUndefined();
+      expect(result.totalCount).toBe(0);
+    });
+  });
+
+  describe("totalCount", () => {
+    it("uses items.length when no execution_policy is set", () => {
+      const row = makeRow({
+        experiment_items: [
+          makeItem({ id: "i1", status: ExperimentItemStatus.PASSED }),
+          makeItem({ id: "i2", status: ExperimentItemStatus.PASSED }),
+          makeItem({ id: "i3", status: ExperimentItemStatus.PASSED }),
+        ],
+      });
+      const result = getStatusFromExperimentItems(row);
+      expect(result.totalCount).toBe(3);
+    });
+
+    it("uses runs_per_item from execution_policy when set", () => {
+      const row = makeRow({
+        execution_policy: { runs_per_item: 5, pass_threshold: 3 },
+        experiment_items: [
+          makeItem({ id: "i1", status: ExperimentItemStatus.PASSED }),
+          makeItem({ id: "i2", status: ExperimentItemStatus.PASSED }),
+        ],
+      });
+      const result = getStatusFromExperimentItems(row);
+      // 5 from policy, not 2 from items array
+      expect(result.totalCount).toBe(5);
+    });
+  });
+
+  describe("status from run_summaries_by_experiment", () => {
+    it("returns PASSED when all summaries are PASSED", () => {
+      const row = makeRow({
+        experiment_items: [makeItem({ id: "i1" })],
+        run_summaries_by_experiment: {
+          "exp-1": {
+            passed_runs: 2,
+            total_runs: 2,
+            status: ExperimentItemStatus.PASSED,
+          },
+          "exp-2": {
+            passed_runs: 3,
+            total_runs: 3,
+            status: ExperimentItemStatus.PASSED,
+          },
+        },
+      });
+      expect(getStatusFromExperimentItems(row).status).toBe(
+        ExperimentItemStatus.PASSED,
+      );
+    });
+
+    it("returns FAILED when any summary is not PASSED", () => {
+      const row = makeRow({
+        experiment_items: [makeItem({ id: "i1" })],
+        run_summaries_by_experiment: {
+          "exp-1": {
+            passed_runs: 2,
+            total_runs: 3,
+            status: ExperimentItemStatus.FAILED,
+          },
+        },
+      });
+      expect(getStatusFromExperimentItems(row).status).toBe(
+        ExperimentItemStatus.FAILED,
+      );
+    });
+
+    it("falls back to first item status when no summaries", () => {
+      const row = makeRow({
+        experiment_items: [
+          makeItem({ id: "i1", status: ExperimentItemStatus.SKIPPED }),
+        ],
+      });
+      expect(getStatusFromExperimentItems(row).status).toBe(
+        ExperimentItemStatus.SKIPPED,
+      );
+    });
+  });
+});
+
+describe("getStatusInfoForExperiment", () => {
+  describe("no item", () => {
+    it("returns undefined status when item is undefined", () => {
+      const result = getStatusInfoForExperiment(makeRow(), "exp-1", undefined);
+      expect(result.status).toBeUndefined();
+      expect(result.passedCount).toBe(0);
+      expect(result.totalCount).toBe(0);
+    });
+  });
+
+  describe("totalCount without summary", () => {
+    it("returns 0 when no summary and no execution_policy", () => {
+      const row = makeRow();
+      const item = makeItem({ id: "i1", status: ExperimentItemStatus.PASSED });
+      const result = getStatusInfoForExperiment(row, "exp-1", item);
+      expect(result.totalCount).toBe(0);
+    });
+
+    it("uses runs_per_item when no summary but execution_policy is set", () => {
+      const row = makeRow({
+        execution_policy: { runs_per_item: 4, pass_threshold: 3 },
+      });
+      const item = makeItem({ id: "i1", status: ExperimentItemStatus.PASSED });
+      const result = getStatusInfoForExperiment(row, "exp-1", item);
+      expect(result.totalCount).toBe(4);
+    });
+  });
+
+  describe("with run summary", () => {
+    it("uses summary.passed_runs for passedCount", () => {
+      const row = makeRow({
+        run_summaries_by_experiment: {
+          "exp-1": {
+            passed_runs: 3,
+            total_runs: 5,
+            status: ExperimentItemStatus.PASSED,
+          },
+        },
+      });
+      const item = makeItem({ id: "i1", status: ExperimentItemStatus.FAILED });
+      const result = getStatusInfoForExperiment(row, "exp-1", item);
+      expect(result.passedCount).toBe(3);
+    });
+
+    it("uses summary.total_runs for totalCount", () => {
+      const row = makeRow({
+        run_summaries_by_experiment: {
+          "exp-1": {
+            passed_runs: 3,
+            total_runs: 5,
+            status: ExperimentItemStatus.PASSED,
+          },
+        },
+      });
+      const item = makeItem({ id: "i1", status: ExperimentItemStatus.PASSED });
+      const result = getStatusInfoForExperiment(row, "exp-1", item);
+      expect(result.totalCount).toBe(5);
+    });
+
+    it("summary.total_runs takes precedence over execution_policy.runs_per_item", () => {
+      const row = makeRow({
+        execution_policy: { runs_per_item: 10, pass_threshold: 5 },
+        run_summaries_by_experiment: {
+          "exp-1": {
+            passed_runs: 3,
+            total_runs: 5,
+            status: ExperimentItemStatus.PASSED,
+          },
+        },
+      });
+      const item = makeItem({ id: "i1", status: ExperimentItemStatus.PASSED });
+      const result = getStatusInfoForExperiment(row, "exp-1", item);
+      expect(result.totalCount).toBe(5);
+    });
+
+    it("uses local passedCount when no summary for that experimentId", () => {
+      const row = makeRow({
+        run_summaries_by_experiment: {
+          "exp-other": {
+            passed_runs: 99,
+            total_runs: 99,
+            status: ExperimentItemStatus.PASSED,
+          },
+        },
+        execution_policy: { runs_per_item: 3, pass_threshold: 2 },
+      });
+      const item = makeItem({ id: "i1", status: ExperimentItemStatus.PASSED });
+      const result = getStatusInfoForExperiment(row, "exp-1", item);
+      // No summary for exp-1, so passedCount comes from local items (1 PASSED item)
+      expect(result.passedCount).toBe(1);
+      // totalCount from execution_policy since no summary for exp-1
+      expect(result.totalCount).toBe(3);
+    });
+  });
+
+  describe("aggregated item", () => {
+    it("expands trialItems for passedCount and assertionsByRun", () => {
+      const row = makeRow();
+      const aggregated: AggregatedExperimentItem = {
+        ...makeItem({ id: "agg", status: ExperimentItemStatus.FAILED }),
+        trialCount: 2,
+        trialItems: [
+          makeItem({
+            id: "t1",
+            status: ExperimentItemStatus.PASSED,
+            assertion_results: [{ value: "check", passed: true }],
+          }),
+          makeItem({
+            id: "t2",
+            status: ExperimentItemStatus.FAILED,
+            assertion_results: [{ value: "check", passed: false }],
+          }),
+        ],
+      };
+      const result = getStatusInfoForExperiment(row, "exp-1", aggregated);
+      expect(result.passedCount).toBe(1);
+      expect(result.assertionsByRun).toHaveLength(2);
+      expect(result.assertionsByRun[0][0].passed).toBe(true);
+      expect(result.assertionsByRun[1][0].passed).toBe(false);
+    });
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { CheckCircle2, XCircle } from "lucide-react";
 import { CellContext } from "@tanstack/react-table";
 import CellWrapper from "@/shared/DataTableCells/CellWrapper";
 import VerticallySplitCellWrapper, {
@@ -21,7 +22,7 @@ const STATUS_DISPLAY: Record<
   { label: string; variant: TagProps["variant"] }
 > = {
   [ExperimentItemStatus.PASSED]: { label: "Passed", variant: "green" },
-  [ExperimentItemStatus.FAILED]: { label: "Failed", variant: "pink" },
+  [ExperimentItemStatus.FAILED]: { label: "Failed", variant: "red" },
   [ExperimentItemStatus.SKIPPED]: { label: "Skipped", variant: "gray" },
 };
 
@@ -124,21 +125,35 @@ export const StatusTag: React.FC<
   tagSize = "md",
   className,
 }) => {
-  const isMultiRun = totalCount > 1;
+  const hasAssertions =
+    assertionsByRun.length > 0 && assertionsByRun[0].length > 0;
 
   if (!status) {
     return <span className="text-muted-slate">{"\u2014"}</span>;
   }
+
+  const isSkipped = status === ExperimentItemStatus.SKIPPED;
+  const Icon = status === ExperimentItemStatus.PASSED ? CheckCircle2 : XCircle;
 
   return (
     <AssertionsBreakdownTooltip assertionsByRun={assertionsByRun}>
       <Tag
         variant={STATUS_DISPLAY[status].variant}
         size={tagSize}
-        className={cn("cursor-default", className)}
+        className={cn(
+          "inline-flex items-center gap-1",
+          hasAssertions ? "cursor-pointer" : "cursor-default",
+          className,
+        )}
       >
-        {STATUS_DISPLAY[status].label}
-        {isMultiRun && ` (${passedCount}/${totalCount})`}
+        {isSkipped ? (
+          STATUS_DISPLAY[status].label
+        ) : (
+          <>
+            <Icon className="size-3.5 shrink-0" />
+            {passedCount}/{totalCount}
+          </>
+        )}
       </Tag>
     </AssertionsBreakdownTooltip>
   );

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
@@ -58,11 +58,11 @@ export function getStatusFromExperimentItems(
     status,
     assertionsByRun,
     passedCount,
-    totalCount: items.length,
+    totalCount: row.execution_policy?.runs_per_item ?? items.length,
   };
 }
 
-function getStatusInfoForExperiment(
+export function getStatusInfoForExperiment(
   row: ExperimentsCompare,
   experimentId: string,
   item: ExperimentItem | undefined,
@@ -99,17 +99,15 @@ function getStatusInfoForExperiment(
   return {
     status,
     assertionsByRun,
-    passedCount,
-    totalCount: expItems.length,
+    passedCount: summary?.passed_runs ?? passedCount,
+    // Fall back to 0 when no summary and no policy — status will be SKIPPED so count isn't rendered
+    totalCount: summary?.total_runs ?? row.execution_policy?.runs_per_item ?? 0,
   };
 }
 
 export const StatusTag: React.FC<
   StatusInfo & { className?: string }
 > = ({ status, assertionsByRun, passedCount, totalCount, className }) => {
-  const hasAssertions =
-    assertionsByRun.length > 0 && assertionsByRun[0].length > 0;
-
   if (!status) {
     return <span className="text-muted-slate">{"\u2014"}</span>;
   }
@@ -128,7 +126,7 @@ export const StatusTag: React.FC<
             : isSkipped
               ? "bg-muted text-muted-foreground"
               : "bg-destructive/15 text-destructive",
-          hasAssertions ? "cursor-pointer" : "cursor-default",
+          "cursor-default",
           className,
         )}
       >

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
@@ -1,14 +1,12 @@
 import React from "react";
-import { CheckCircle2, XCircle } from "lucide-react";
+import { CircleCheck, CircleX } from "lucide-react";
 import { CellContext } from "@tanstack/react-table";
 import CellWrapper from "@/shared/DataTableCells/CellWrapper";
 import VerticallySplitCellWrapper, {
   CustomMeta,
 } from "@/shared/DataTableCells/VerticallySplitCellWrapper";
 import AssertionsBreakdownTooltip from "./AssertionsBreakdownTooltip";
-import { Tag, TagProps } from "@/ui/tag";
 import { cn } from "@/lib/utils";
-import { getCellTagSize, TAG_SIZE_MAP } from "@/constants/shared";
 import {
   AssertionResult,
   ExperimentItem,
@@ -16,15 +14,6 @@ import {
 } from "@/types/datasets";
 import { ExperimentItemStatus } from "@/types/evaluation-suites";
 import { isAggregatedItem } from "@/lib/trials";
-
-const STATUS_DISPLAY: Record<
-  ExperimentItemStatus,
-  { label: string; variant: TagProps["variant"] }
-> = {
-  [ExperimentItemStatus.PASSED]: { label: "Passed", variant: "green" },
-  [ExperimentItemStatus.FAILED]: { label: "Failed", variant: "red" },
-  [ExperimentItemStatus.SKIPPED]: { label: "Skipped", variant: "gray" },
-};
 
 type StatusInfo = {
   status: ExperimentItemStatus | undefined;
@@ -116,15 +105,8 @@ function getStatusInfoForExperiment(
 }
 
 export const StatusTag: React.FC<
-  StatusInfo & { tagSize?: TagProps["size"]; className?: string }
-> = ({
-  status,
-  assertionsByRun,
-  passedCount,
-  totalCount,
-  tagSize = "md",
-  className,
-}) => {
+  StatusInfo & { className?: string }
+> = ({ status, assertionsByRun, passedCount, totalCount, className }) => {
   const hasAssertions =
     assertionsByRun.length > 0 && assertionsByRun[0].length > 0;
 
@@ -133,28 +115,32 @@ export const StatusTag: React.FC<
   }
 
   const isSkipped = status === ExperimentItemStatus.SKIPPED;
-  const Icon = status === ExperimentItemStatus.PASSED ? CheckCircle2 : XCircle;
+  const isPassed = status === ExperimentItemStatus.PASSED;
+  const Icon = isPassed ? CircleCheck : CircleX;
 
   return (
     <AssertionsBreakdownTooltip assertionsByRun={assertionsByRun}>
-      <Tag
-        variant={STATUS_DISPLAY[status].variant}
-        size={tagSize}
+      <div
         className={cn(
-          "inline-flex items-center gap-1",
+          "inline-flex items-center gap-1 rounded-full border border-transparent px-2.5 py-0.5 font-mono text-xs font-semibold transition-colors",
+          isPassed
+            ? "bg-success/15 text-success"
+            : isSkipped
+              ? "bg-muted text-muted-foreground"
+              : "bg-destructive/15 text-destructive",
           hasAssertions ? "cursor-pointer" : "cursor-default",
           className,
         )}
       >
         {isSkipped ? (
-          STATUS_DISPLAY[status].label
+          "Skipped"
         ) : (
           <>
-            <Icon className="size-3.5 shrink-0" />
+            <Icon className="size-3 shrink-0" />
             {passedCount}/{totalCount}
           </>
         )}
-      </Tag>
+      </div>
     </AssertionsBreakdownTooltip>
   );
 };
@@ -165,15 +151,13 @@ const PassedCell: React.FC<CellContext<ExperimentsCompare, unknown>> = (
   const row = context.row.original;
   const { custom } = context.column.columnDef.meta ?? {};
   const { experimentsIds } = (custom ?? {}) as Partial<CustomMeta>;
-  const tagSize = getCellTagSize(context, TAG_SIZE_MAP);
-
   if (experimentsIds) {
     const renderContent = (
       item: ExperimentItem | undefined,
       experimentId: string,
     ) => {
       const statusInfo = getStatusInfoForExperiment(row, experimentId, item);
-      return <StatusTag {...statusInfo} tagSize={tagSize} />;
+      return <StatusTag {...statusInfo} />;
     };
 
     return (
@@ -194,7 +178,7 @@ const PassedCell: React.FC<CellContext<ExperimentsCompare, unknown>> = (
       metadata={context.column.columnDef.meta}
       tableMetadata={context.table.options.meta}
     >
-      <StatusTag {...statusInfo} tagSize={tagSize} />
+      <StatusTag {...statusInfo} />
     </CellWrapper>
   );
 };

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
@@ -124,7 +124,7 @@ export const StatusTag: React.FC<StatusInfo & { className?: string }> = ({
     <AssertionsBreakdownTooltip assertionsByRun={assertionsByRun}>
       <div
         className={cn(
-          "inline-flex h-5 items-center gap-1 rounded-sm border border-transparent px-2 font-mono text-xs font-semibold transition-colors",
+          "inline-flex h-5 items-center gap-1 rounded-md border border-transparent px-2 font-mono text-xs font-semibold transition-colors",
           isPassed
             ? "bg-[var(--tag-green-bg)] text-[var(--tag-green-text)]"
             : isSkipped

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
@@ -122,7 +122,7 @@ export const StatusTag: React.FC<StatusInfo & { className?: string }> = ({
 
   return (
     <AssertionsBreakdownTooltip assertionsByRun={assertionsByRun}>
-      <div
+      <span
         className={cn(
           "inline-flex h-5 items-center gap-1 rounded-md border border-transparent px-2 font-mono text-xs font-semibold transition-colors",
           isPassed
@@ -142,7 +142,7 @@ export const StatusTag: React.FC<StatusInfo & { className?: string }> = ({
             {passedCount}/{totalCount}
           </>
         )}
-      </div>
+      </span>
     </AssertionsBreakdownTooltip>
   );
 };

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
@@ -105,9 +105,13 @@ export function getStatusInfoForExperiment(
   };
 }
 
-export const StatusTag: React.FC<
-  StatusInfo & { className?: string }
-> = ({ status, assertionsByRun, passedCount, totalCount, className }) => {
+export const StatusTag: React.FC<StatusInfo & { className?: string }> = ({
+  status,
+  assertionsByRun,
+  passedCount,
+  totalCount,
+  className,
+}) => {
   if (!status) {
     return <span className="text-muted-slate">{"\u2014"}</span>;
   }

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
@@ -126,10 +126,10 @@ export const StatusTag: React.FC<StatusInfo & { className?: string }> = ({
         className={cn(
           "inline-flex items-center gap-1 rounded-full border border-transparent px-2.5 py-0.5 font-mono text-xs font-semibold transition-colors",
           isPassed
-            ? "bg-success/15 text-success"
+            ? "bg-[var(--tag-green-bg)] text-[var(--tag-green-text)]"
             : isSkipped
               ? "bg-muted text-muted-foreground"
-              : "bg-destructive/15 text-destructive",
+              : "bg-[var(--tag-red-bg)] text-[var(--tag-red-text)]",
           "cursor-default",
           className,
         )}

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/EvaluationSuiteExperiment/PassedCell.tsx
@@ -124,7 +124,7 @@ export const StatusTag: React.FC<StatusInfo & { className?: string }> = ({
     <AssertionsBreakdownTooltip assertionsByRun={assertionsByRun}>
       <div
         className={cn(
-          "inline-flex items-center gap-1 rounded-full border border-transparent px-2.5 py-0.5 font-mono text-xs font-semibold transition-colors",
+          "inline-flex h-5 items-center gap-1 rounded-sm border border-transparent px-2 font-mono text-xs font-semibold transition-colors",
           isPassed
             ? "bg-[var(--tag-green-bg)] text-[var(--tag-green-text)]"
             : isSkipped

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputScores/PlaygroundOutputAssertionStatus.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputScores/PlaygroundOutputAssertionStatus.tsx
@@ -115,10 +115,7 @@ const PlaygroundOutputAssertionStatus: React.FunctionComponent<
   }
 
   return (
-    <StatusTag
-      {...statusInfo}
-      className={stale ? "opacity-50" : undefined}
-    />
+    <StatusTag {...statusInfo} className={stale ? "opacity-50" : undefined} />
   );
 };
 

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputScores/PlaygroundOutputAssertionStatus.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputScores/PlaygroundOutputAssertionStatus.tsx
@@ -117,7 +117,6 @@ const PlaygroundOutputAssertionStatus: React.FunctionComponent<
   return (
     <StatusTag
       {...statusInfo}
-      tagSize="sm"
       className={stale ? "opacity-50" : undefined}
     />
   );


### PR DESCRIPTION
## Details

Redesigns the assertion status HoverCard for experiment results in v2. When hovering over a pass/fail status badge, a popover now shows a collapsible accordion with one section per run. Each run lists its assertions with pass/fail icons and, when available, the reason text below each criterion. The card auto-opens the first failing run and scrolls to its first failed assertion.

- Replaced the flat tooltip grid with a HoverCard + Radix Accordion (sticky run headers, scrollable body)
- StatusTag pill now shows `CircleCheck`/`CircleX` icon alongside `passed/total` count, using `bg-success/15` and `bg-destructive/15` colour tokens
- Added `scrollToFirstFailedAssertion` (double RAF) so the card scrolls to the first `data-assertion-passed="false"` element on open
- `passedCount`/`totalCount` now prefer `run_summaries_by_experiment` values for accuracy; `totalCount` falls back to `execution_policy.runs_per_item`
- Added 14 unit tests covering `getStatusFromExperimentItems` and `getStatusInfoForExperiment`

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5760

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: full implementation
- Human verification: code review + manual testing

## Testing

```
cd apps/opik-frontend
npm run lint && npm run typecheck
npm test -- PassedCell.test.ts
```

Scenarios validated:
- Hover over a pass badge: HoverCard opens, shows all runs as PASSED (no failed item auto-selected)
- Hover over a fail badge: HoverCard opens on the first failing run, scrolled to the first red assertion
- Multiple runs with mixed results: each run collapsible independently, sticky headers work with scroll
- Skipped status: renders "Skipped" pill, no tooltip breakdown
- No assertions: HoverCard is skipped entirely, children rendered directly
- Unit tests: 14 tests passing (status from summaries, counts, aggregated items)

## Documentation

N/A