### PR TITLE
[OPIK-5766] [BE] feat: V2 workspace allowlist for gradual rollout

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -967,6 +967,12 @@ serviceToggles:
   # Default: false
   # Description: Whether or not Collaborators tab feature is enabled
   collaboratorsTabEnabled: ${TOGGLE_COLLABORATORS_TAB_ENABLED:-"false"}
+  # Default: "" (empty) (no allowlisted workspaces)
+  # Description: Comma-separated list of workspace IDs that should always receive V2 navigation.
+  # Highest priority — overrides forceWorkspaceVersion and all other determination logic for listed workspaces.
+  # Non-allowlisted workspaces follow normal determination. Empty/missing means no allowlisting.
+  # Use case: gradual V2 rollout — set forceWorkspaceVersion to "version_1" and allowlist specific workspace IDs for V2.
+  v2WorkspaceAllowlist: ${TOGGLE_V2_WORKSPACE_ALLOWLIST:-""}
   # Default: version_1
   # Description: Forces ALL workspaces to a specific navigation version. Highest priority override.
   # Valid values: "disabled" (use version 1 entity check), "version_1" (force legacy), "version_2" (force project-first).

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -967,16 +967,19 @@ serviceToggles:
   # Default: false
   # Description: Whether or not Collaborators tab feature is enabled
   collaboratorsTabEnabled: ${TOGGLE_COLLABORATORS_TAB_ENABLED:-"false"}
-  # Default: "" (empty) (no allowlisted workspaces)
+  # Default: "" (empty, no allowlisted workspaces)
   # Description: Comma-separated list of workspace IDs that should always receive V2 navigation.
-  # Highest priority — overrides forceWorkspaceVersion and all other determination logic for listed workspaces.
-  # Non-allowlisted workspaces follow normal determination. Empty/missing means no allowlisting.
+  # Valid values: comma-separated workspace IDs (e.g. "ws-id-1,ws-id-2"), or "" (empty, disabled).
+  # Scope: Per-workspace — only listed workspace IDs are affected, all others follow normal determination.
+  # Priority: Highest — overrides forceWorkspaceVersion and all other determination logic for listed workspaces.
   # Use case: gradual V2 rollout — set forceWorkspaceVersion to "version_1" and allowlist specific workspace IDs for V2.
+  # Operational impact: empty/missing means no allowlisting. Non-allowlisted workspaces are unaffected.
   v2WorkspaceAllowlist: ${TOGGLE_V2_WORKSPACE_ALLOWLIST:-""}
   # Default: version_1
-  # Description: Forces ALL workspaces to a specific navigation version. Highest priority override.
+  # Description: Forces ALL workspaces to a specific navigation version.
   # Valid values: "disabled" (use version 1 entity check), "version_1" (force legacy), "version_2" (force project-first).
   # Scope: Global — applies to all workspaces regardless of their entity state.
+  # Priority: Second highest — overridden by v2WorkspaceAllowlist for listed workspaces.
   # Overrides: When not "disabled", overrides the version entity check and auth gate entirely.
   # Operational impact: Set to "version_1" until V2 is ready, then change to "disabled" to enable entity-based determination.
   forceWorkspaceVersion: ${TOGGLE_FORCE_WORKSPACE_VERSION:-"version_1"}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/WorkspacesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/WorkspacesResource.java
@@ -158,10 +158,11 @@ public class WorkspacesResource {
             determination, clients must never derive the version themselves.
 
             Determination logic (priority order):
-            1) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
-            2) Auth one-way V2 gate (authenticated mode only)
-            3) Version 1 entity check (entities without project_id)
-            4) Fallback on failure
+            1) V2 workspace allowlist (TOGGLE_V2_WORKSPACE_ALLOWLIST)
+            2) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
+            3) Auth one-way V2 gate (authenticated mode only)
+            4) Version 1 entity check (entities without project_id)
+            5) Fallback on failure
 
             In unauthenticated mode (authentication.enabled=false), auth steps are skipped.
             Called by the frontend on workspace load.""", responses = {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
@@ -36,9 +36,11 @@ import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONL
  *
  * <h3>Determination Logic (priority order):</h3>
  * <ol>
+ *   <li><b>V2 workspace allowlist</b> ({@code TOGGLE_V2_WORKSPACE_ALLOWLIST}) — comma-separated workspace IDs
+ *       that always receive {@code version_2}. Highest priority, all deployment modes.</li>
  *   <li><b>Feature flag override</b> ({@code TOGGLE_FORCE_WORKSPACE_VERSION}) — if set to a valid
  *       {@link OpikVersion} value ({@code "version_1"} or {@code "version_2"}), that version is returned
- *       unconditionally. Value {@code "disabled"} means no override. Highest priority, all deployment modes.</li>
+ *       unconditionally. Value {@code "disabled"} means no override.</li>
  *   <li><b>Auth one-way V2 gate</b> (authenticated mode only) — if auth metadata indicates the workspace
  *       was created post-launch ({@code version_2}), always return {@code version_2}.
  *       Prevents V2 to V1 demotion. Defensive: gracefully degrades when auth service doesn't

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
@@ -14,7 +14,7 @@ import com.comet.opik.infrastructure.CacheConfiguration;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.cache.CacheManager;
 import lombok.NonNull;
-import org.apache.tika.utils.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -117,6 +117,11 @@ abstract class AbstractWorkspaceVersionService implements WorkspaceVersionServic
 
     @Override
     public Mono<WorkspaceVersion> getWorkspaceVersion(@NonNull String workspaceId, OpikVersion authSuggestedVersion) {
+        var isWorkspaceInV2Allowlist = serviceTogglesConfig.getV2WorkspaceAllowlistIds().contains(workspaceId);
+        if (isWorkspaceInV2Allowlist) {
+            log.info("Workspace included in version_2 allowlist, workspaceId '{}'", workspaceId);
+            return Mono.just(buildResponse(OpikVersion.VERSION_2));
+        }
         var forcedVersion = getForcedVersion();
         if (forcedVersion.isPresent()) {
             log.info("Workspace version forced by feature flag, opikVersion '{}', workspaceId '{}'",

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
@@ -1,10 +1,17 @@
 package com.comet.opik.infrastructure;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Data
 public class ServiceTogglesConfig {
@@ -56,5 +63,19 @@ public class ServiceTogglesConfig {
     @NotNull boolean ollamaProviderEnabled;
     @JsonProperty
     @NotNull boolean collaboratorsTabEnabled;
+
+    @NotNull Set<@NotBlank String> v2WorkspaceAllowlistIds = Set.of();
+
+    @JsonSetter
+    public void setV2WorkspaceAllowlist(String v2WorkspaceAllowlist) {
+        this.v2WorkspaceAllowlistIds = Optional.ofNullable(v2WorkspaceAllowlist)
+                .filter(StringUtils::isNotBlank)
+                .map(commaSeparated -> Arrays.stream(commaSeparated.split(","))
+                        .map(String::strip)
+                        .filter(StringUtils::isNotBlank)
+                        .collect(Collectors.toUnmodifiableSet()))
+                .orElse(Set.of());
+    }
+
     @NotBlank String forceWorkspaceVersion = FORCE_WORKSPACE_VERSION_DISABLED;
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/WorkspaceVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/WorkspaceVersionResourceTest.java
@@ -35,6 +35,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -47,11 +50,13 @@ import uk.co.jemos.podam.api.PodamFactory;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
 import static com.comet.opik.api.resources.utils.TestUtils.waitForMillis;
 import static com.comet.opik.domain.ProjectService.DEFAULT_WORKSPACE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class WorkspaceVersionResourceTest {
@@ -66,6 +71,83 @@ class WorkspaceVersionResourceTest {
             .build();
 
     private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @ExtendWith(DropwizardAppExtensionProvider.class)
+    class V2WorkspaceAllowlistTest {
+
+        private static final String ALLOWLISTED_WORKSPACE_ID_1 = UUID.randomUUID().toString();
+        private static final String ALLOWLISTED_WORKSPACE_ID_2 = UUID.randomUUID().toString();
+        private static final String V2_WORKSPACE_ALLOWLIST = "%s, %s".formatted(
+                ALLOWLISTED_WORKSPACE_ID_1, ALLOWLISTED_WORKSPACE_ID_2);
+
+        private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+        private final Network NETWORK = Network.newNetwork();
+        private final GenericContainer<?> ZOOKEEPER = ClickHouseContainerUtils.newZookeeperContainer(false, NETWORK);
+        private final ClickHouseContainer CLICKHOUSE = ClickHouseContainerUtils.newClickHouseContainer(
+                false, NETWORK, ZOOKEEPER);
+        private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer(false);
+
+        @RegisterApp
+        private final TestDropwizardAppExtension app;
+
+        private final WireMockUtils.WireMockRuntime wireMock;
+
+        {
+            wireMock = WireMockUtils.startWireMock();
+
+            Startables.deepStart(REDIS, MYSQL, CLICKHOUSE).join();
+
+            MigrationUtils.runMysqlDbMigration(MYSQL);
+            MigrationUtils.runClickhouseDbMigration(CLICKHOUSE);
+
+            var databaseAnalyticsFactory = ClickHouseContainerUtils
+                    .newDatabaseAnalyticsFactory(CLICKHOUSE, DATABASE_NAME);
+
+            app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                    AppContextConfig.builder()
+                            .redisUrl(REDIS.getRedisURI())
+                            .jdbcUrl(MYSQL.getJdbcUrl())
+                            .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                            .runtimeInfo(wireMock.runtimeInfo())
+                            .customConfigs(List.of(
+                                    new CustomConfig("serviceToggles.v2WorkspaceAllowlist", V2_WORKSPACE_ALLOWLIST),
+                                    new CustomConfig("serviceToggles.forceWorkspaceVersion", "version_1")))
+                            .build());
+        }
+
+        private WorkspaceResourceClient workspaceClient;
+
+        @BeforeAll
+        void beforeAll(ClientSupport clientSupport) {
+            var baseUrl = TestUtils.getBaseUrl(clientSupport);
+            ClientSupportUtils.config(clientSupport);
+            workspaceClient = new WorkspaceResourceClient(clientSupport, baseUrl, podamFactory);
+        }
+
+        @AfterAll
+        void afterAll() {
+            wireMock.server().stop();
+        }
+
+        static Stream<Arguments> workspaceVersion__whenAllowlistAndForceV1__returnsExpectedVersion() {
+            return Stream.of(
+                    arguments(ALLOWLISTED_WORKSPACE_ID_1, V2_WORKSPACE_VERSION),
+                    arguments(ALLOWLISTED_WORKSPACE_ID_2, V2_WORKSPACE_VERSION),
+                    arguments(UUID.randomUUID().toString(), V1_WORKSPACE_VERSION));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void workspaceVersion__whenAllowlistAndForceV1__returnsExpectedVersion(
+                String workspaceId, WorkspaceVersion expectedVersion) {
+            var workspaceName = mockWorkspace(wireMock, workspaceId, null);
+
+            // If workspace ID in allow list will return V2, otherwise forcing to return V1
+            assertThat(workspaceClient.getWorkspaceVersion(API_KEY, workspaceName)).isEqualTo(expectedVersion);
+        }
+    }
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -241,22 +323,9 @@ class WorkspaceVersionResourceTest {
             wireMock.server().stop();
         }
 
-        private String mockWorkspace() {
-            return mockWorkspace(null);
-        }
-
-        private String mockWorkspace(OpikVersion opikVersion) {
-            var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
-            var workspaceId = UUID.randomUUID().toString();
-            var user = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
-            AuthTestUtils.mockTargetWorkspace(
-                    wireMock.server(), API_KEY, workspaceName, workspaceId, user, null, opikVersion);
-            return workspaceName;
-        }
-
         @Test
         void workspaceVersion__whenAuthSaysVersion2__locksToVersion2() {
-            var workspaceName = mockWorkspace(OpikVersion.VERSION_2);
+            var workspaceName = mockWorkspace(wireMock, OpikVersion.VERSION_2);
 
             // Creating a V1 entity
             datasetClient.createDataset(podamFactory.manufacturePojo(Dataset.class).toBuilder()
@@ -270,7 +339,7 @@ class WorkspaceVersionResourceTest {
         @Test
         void workspaceVersion__whenDatasetEntities__returnsExpectedVersion() {
             // When Auth says Version1 entity check still runs
-            var workspaceName = mockWorkspace(OpikVersion.VERSION_1);
+            var workspaceName = mockWorkspace(wireMock, OpikVersion.VERSION_1);
 
             // Demo-only datasets do not trigger version_1
             datasetClient.createDataset(podamFactory.manufacturePojo(Dataset.class).toBuilder()
@@ -298,7 +367,7 @@ class WorkspaceVersionResourceTest {
         @Test
         void workspaceVersion__whenPromptWithoutProject__returnsVersion1() {
             // Auth doesn't include opikVersion — defensive, entity check is primary signal
-            var workspaceName = mockWorkspace();
+            var workspaceName = mockWorkspace(wireMock);
 
             // Empty workspace returns version_2
             assertThat(workspaceClient.getWorkspaceVersion(API_KEY, workspaceName)).isEqualTo(V2_WORKSPACE_VERSION);
@@ -314,7 +383,7 @@ class WorkspaceVersionResourceTest {
 
         @Test
         void workspaceVersion__whenDashboardWithoutProject__returnsVersion1() {
-            var workspaceName = mockWorkspace();
+            var workspaceName = mockWorkspace(wireMock);
 
             // Empty workspace returns version_2
             assertThat(workspaceClient.getWorkspaceVersion(API_KEY, workspaceName)).isEqualTo(V2_WORKSPACE_VERSION);
@@ -326,7 +395,7 @@ class WorkspaceVersionResourceTest {
 
         @Test
         void workspaceVersion__whenMultiProjectRule__returnsVersion1() {
-            var workspaceName = mockWorkspace();
+            var workspaceName = mockWorkspace(wireMock);
 
             // Single-project rule does not trigger version_1
             evaluatorClient.createEvaluator(podamFactory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class)
@@ -347,7 +416,7 @@ class WorkspaceVersionResourceTest {
 
         @Test
         void workspaceVersion__whenExperimentWithoutProject__returnsVersion1() {
-            var workspaceName = mockWorkspace();
+            var workspaceName = mockWorkspace(wireMock);
 
             // Project-scoped dataset for the experiment does not trigger V1
             var dataset = podamFactory.manufacturePojo(Dataset.class).toBuilder()
@@ -372,7 +441,7 @@ class WorkspaceVersionResourceTest {
 
         @Test
         void workspaceVersion__whenOptimizationWithoutProject__returnsVersion1() {
-            var workspaceName = mockWorkspace();
+            var workspaceName = mockWorkspace(wireMock);
 
             // Project-scoped dataset for the optimization does not trigger V1
             var dataset = podamFactory.manufacturePojo(Dataset.class).toBuilder()
@@ -391,7 +460,7 @@ class WorkspaceVersionResourceTest {
 
         @Test
         void workspaceVersion__whenAlertWithoutProject__returnsVersion1() {
-            var workspaceName = mockWorkspace();
+            var workspaceName = mockWorkspace(wireMock);
 
             // Project-scoped alert (projectId column) does not trigger version_1
             alertClient.createAlert(
@@ -474,5 +543,23 @@ class WorkspaceVersionResourceTest {
             var response3 = workspaceClient.getWorkspaceVersion(DEFAULT_WORKSPACE_NAME);
             assertThat(response3.opikVersion()).isEqualTo(OpikVersion.VERSION_1);
         }
+    }
+
+    private static String mockWorkspace(WireMockUtils.WireMockRuntime wireMock) {
+        return mockWorkspace(wireMock, null);
+    }
+
+    private static String mockWorkspace(WireMockUtils.WireMockRuntime wireMock, OpikVersion opikVersion) {
+        var workspaceId = UUID.randomUUID().toString();
+        return mockWorkspace(wireMock, workspaceId, opikVersion);
+    }
+
+    private static String mockWorkspace(
+            WireMockUtils.WireMockRuntime wireMock, String workspaceId, OpikVersion opikVersion) {
+        var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        var user = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        AuthTestUtils.mockTargetWorkspace(
+                wireMock.server(), API_KEY, workspaceName, workspaceId, user, null, opikVersion);
+        return workspaceName;
     }
 }

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -533,16 +533,19 @@ serviceToggles:
   # Default: false
   # Description: Whether or not Collaborators tab feature is enabled
   collaboratorsTabEnabled: "false"
-  # Default: "" (empty) (no allowlisted workspaces)
+  # Default: "" (empty, no allowlisted workspaces)
   # Description: Comma-separated list of workspace IDs that should always receive V2 navigation.
-  # Highest priority — overrides forceWorkspaceVersion and all other determination logic for listed workspaces.
-  # Non-allowlisted workspaces follow normal determination. Empty/missing means no allowlisting.
+  # Valid values: comma-separated workspace IDs (e.g. "ws-id-1,ws-id-2"), or "" (empty, disabled).
+  # Scope: Per-workspace — only listed workspace IDs are affected, all others follow normal determination.
+  # Priority: Highest — overrides forceWorkspaceVersion and all other determination logic for listed workspaces.
   # Use case: gradual V2 rollout — set forceWorkspaceVersion to "version_1" and allowlist specific workspace IDs for V2.
+  # Operational impact: empty/missing means no allowlisting. Non-allowlisted workspaces are unaffected.
   v2WorkspaceAllowlist: ""
   # Default: version_1
-  # Description: Forces ALL workspaces to a specific navigation version. Highest priority override.
+  # Description: Forces ALL workspaces to a specific navigation version.
   # Valid values: "disabled" (use version 1 entity check), "version_1" (force legacy), "version_2" (force project-first).
   # Scope: Global — applies to all workspaces regardless of their entity state.
+  # Priority: Second highest — overridden by v2WorkspaceAllowlist for listed workspaces.
   # Overrides: When not "disabled", overrides the version entity check and auth gate entirely.
   # Operational impact: Set to "version_1" until V2 is ready, then change to "disabled" to enable entity-based determination.
   # For tests, changed to "disabled" as it will be the final state

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -533,6 +533,12 @@ serviceToggles:
   # Default: false
   # Description: Whether or not Collaborators tab feature is enabled
   collaboratorsTabEnabled: "false"
+  # Default: "" (empty) (no allowlisted workspaces)
+  # Description: Comma-separated list of workspace IDs that should always receive V2 navigation.
+  # Highest priority — overrides forceWorkspaceVersion and all other determination logic for listed workspaces.
+  # Non-allowlisted workspaces follow normal determination. Empty/missing means no allowlisting.
+  # Use case: gradual V2 rollout — set forceWorkspaceVersion to "version_1" and allowlist specific workspace IDs for V2.
+  v2WorkspaceAllowlist: ""
   # Default: version_1
   # Description: Forces ALL workspaces to a specific navigation version. Highest priority override.
   # Valid values: "disabled" (use version 1 entity check), "version_1" (force legacy), "version_2" (force project-first).


### PR DESCRIPTION
## Details

Add a configurable allowlist of workspace IDs that always receive V2 navigation, enabling gradual rollout before global release. The allowlist is the highest-priority check in the workspace version determination chain — overriding `forceWorkspaceVersion` and all other logic for listed workspaces.

- New config property `serviceToggles.v2WorkspaceAllowlist` (comma-separated workspace IDs, env var `TOGGLE_V2_WORKSPACE_ALLOWLIST`)
- Pre-parsed into `Set<String>` at config deserialization via `@JsonSetter` — no per-request parsing
- Allowlist check inserted before force flag in `WorkspaceVersionService.getWorkspaceVersion`
- Gradual rollout: `forceWorkspaceVersion="version_1"` + `v2WorkspaceAllowlist="ws-1,ws-2"` → only listed workspaces get V2

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5766

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Implementation, test coverage, PR description
  - Human verification: Yes — iterative code review, design decisions on priority chain and config approach

## Testing

Commands run:
- `mvn test -pl . -Dtest="WorkspaceVersionResourceTest$V2WorkspaceAllowlistTest"` — 3 tests pass
- `mvn test -pl . -Dtest="WorkspaceVersionResourceTest$EntityWorkspaceVersionTest"` — 8 tests pass
- `mvn test -pl . -Dtest="WorkspaceVersionResourceTest$ForceWorkspaceVersion1Test"` — 1 test passes
- `mvn test -pl . -Dtest="WorkspaceVersionResourceTest$ForceWorkspaceVersion2Test"` — 1 test passes

Scenarios validated:
- Allowlisted workspace ID 1 → V2 (even with forceWorkspaceVersion = "version_1")
- Allowlisted workspace ID 2 → V2 (tests comma-separated parsing with whitespace)
- Non-allowlisted random workspace → V1 (follows force flag)
- Empty/missing allowlist → no effect (existing tests pass unchanged)
- All pre-existing workspace version tests unaffected

## Documentation

N/A