### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -7859,10 +7859,11 @@ paths:
         determination, clients must never derive the version themselves.
 
         Determination logic (priority order):
-        1) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
-        2) Auth one-way V2 gate (authenticated mode only)
-        3) Version 1 entity check (entities without project_id)
-        4) Fallback on failure
+        1) V2 workspace allowlist (TOGGLE_V2_WORKSPACE_ALLOWLIST)
+        2) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
+        3) Auth one-way V2 gate (authenticated mode only)
+        4) Version 1 entity check (entities without project_id)
+        5) Fallback on failure
 
         In unauthenticated mode (authentication.enabled=false), auth steps are skipped.
         Called by the frontend on workspace load.
@@ -18139,6 +18140,7 @@ components:
       - spanLlmAsJudgeEnabled
       - spanUserDefinedMetricPythonEnabled
       - traceThreadPythonEvaluatorEnabled
+      - v2WorkspaceAllowlistIds
       - vertexaiProviderEnabled
       - welcomeWizardEnabled
       type: object
@@ -18187,9 +18189,18 @@ components:
           type: boolean
         collaboratorsTabEnabled:
           type: boolean
+        v2WorkspaceAllowlistIds:
+          uniqueItems: true
+          type: array
+          items:
+            minLength: 1
+            type: string
         forceWorkspaceVersion:
           minLength: 1
           type: string
+        v2WorkspaceAllowlist:
+          type: string
+          writeOnly: true
     SpanBatchUpdate:
       required:
       - ids

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -7859,10 +7859,11 @@ paths:
         determination, clients must never derive the version themselves.
 
         Determination logic (priority order):
-        1) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
-        2) Auth one-way V2 gate (authenticated mode only)
-        3) Version 1 entity check (entities without project_id)
-        4) Fallback on failure
+        1) V2 workspace allowlist (TOGGLE_V2_WORKSPACE_ALLOWLIST)
+        2) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
+        3) Auth one-way V2 gate (authenticated mode only)
+        4) Version 1 entity check (entities without project_id)
+        5) Fallback on failure
 
         In unauthenticated mode (authentication.enabled=false), auth steps are skipped.
         Called by the frontend on workspace load.
@@ -18139,6 +18140,7 @@ components:
       - spanLlmAsJudgeEnabled
       - spanUserDefinedMetricPythonEnabled
       - traceThreadPythonEvaluatorEnabled
+      - v2WorkspaceAllowlistIds
       - vertexaiProviderEnabled
       - welcomeWizardEnabled
       type: object
@@ -18187,9 +18189,18 @@ components:
           type: boolean
         collaboratorsTabEnabled:
           type: boolean
+        v2WorkspaceAllowlistIds:
+          uniqueItems: true
+          type: array
+          items:
+            minLength: 1
+            type: string
         forceWorkspaceVersion:
           minLength: 1
           type: string
+        v2WorkspaceAllowlist:
+          type: string
+          writeOnly: true
     SpanBatchUpdate:
       required:
       - ids

--- a/sdks/python/src/opik/rest_api/types/service_toggles_config.py
+++ b/sdks/python/src/opik/rest_api/types/service_toggles_config.py
@@ -35,7 +35,13 @@ class ServiceTogglesConfig(UniversalBaseModel):
     customllm_provider_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="customllmProviderEnabled")]
     ollama_provider_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="ollamaProviderEnabled")]
     collaborators_tab_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="collaboratorsTabEnabled")]
+    v2workspace_allowlist_ids: typing_extensions.Annotated[
+        typing.List[str], FieldMetadata(alias="v2WorkspaceAllowlistIds")
+    ]
     force_workspace_version: typing_extensions.Annotated[str, FieldMetadata(alias="forceWorkspaceVersion")]
+    v2workspace_allowlist: typing_extensions.Annotated[
+        typing.Optional[str], FieldMetadata(alias="v2WorkspaceAllowlist")
+    ] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/workspaces/client.py
+++ b/sdks/python/src/opik/rest_api/workspaces/client.py
@@ -267,10 +267,11 @@ class WorkspacesClient:
         determination, clients must never derive the version themselves.
 
         Determination logic (priority order):
-        1) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
-        2) Auth one-way V2 gate (authenticated mode only)
-        3) Version 1 entity check (entities without project_id)
-        4) Fallback on failure
+        1) V2 workspace allowlist (TOGGLE_V2_WORKSPACE_ALLOWLIST)
+        2) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
+        3) Auth one-way V2 gate (authenticated mode only)
+        4) Version 1 entity check (entities without project_id)
+        5) Fallback on failure
 
         In unauthenticated mode (authentication.enabled=false), auth steps are skipped.
         Called by the frontend on workspace load.
@@ -612,10 +613,11 @@ class AsyncWorkspacesClient:
         determination, clients must never derive the version themselves.
 
         Determination logic (priority order):
-        1) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
-        2) Auth one-way V2 gate (authenticated mode only)
-        3) Version 1 entity check (entities without project_id)
-        4) Fallback on failure
+        1) V2 workspace allowlist (TOGGLE_V2_WORKSPACE_ALLOWLIST)
+        2) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
+        3) Auth one-way V2 gate (authenticated mode only)
+        4) Version 1 entity check (entities without project_id)
+        5) Fallback on failure
 
         In unauthenticated mode (authentication.enabled=false), auth steps are skipped.
         Called by the frontend on workspace load.

--- a/sdks/python/src/opik/rest_api/workspaces/raw_client.py
+++ b/sdks/python/src/opik/rest_api/workspaces/raw_client.py
@@ -415,10 +415,11 @@ class RawWorkspacesClient:
         determination, clients must never derive the version themselves.
 
         Determination logic (priority order):
-        1) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
-        2) Auth one-way V2 gate (authenticated mode only)
-        3) Version 1 entity check (entities without project_id)
-        4) Fallback on failure
+        1) V2 workspace allowlist (TOGGLE_V2_WORKSPACE_ALLOWLIST)
+        2) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
+        3) Auth one-way V2 gate (authenticated mode only)
+        4) Version 1 entity check (entities without project_id)
+        5) Fallback on failure
 
         In unauthenticated mode (authentication.enabled=false), auth steps are skipped.
         Called by the frontend on workspace load.
@@ -918,10 +919,11 @@ class AsyncRawWorkspacesClient:
         determination, clients must never derive the version themselves.
 
         Determination logic (priority order):
-        1) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
-        2) Auth one-way V2 gate (authenticated mode only)
-        3) Version 1 entity check (entities without project_id)
-        4) Fallback on failure
+        1) V2 workspace allowlist (TOGGLE_V2_WORKSPACE_ALLOWLIST)
+        2) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
+        3) Auth one-way V2 gate (authenticated mode only)
+        4) Version 1 entity check (entities without project_id)
+        5) Fallback on failure
 
         In unauthenticated mode (authentication.enabled=false), auth steps are skipped.
         Called by the frontend on workspace load.

--- a/sdks/typescript/src/opik/rest_api/api/resources/workspaces/client/Client.ts
+++ b/sdks/typescript/src/opik/rest_api/api/resources/workspaces/client/Client.ts
@@ -528,10 +528,11 @@ export class WorkspacesClient {
      * determination, clients must never derive the version themselves.
      *
      * Determination logic (priority order):
-     * 1) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
-     * 2) Auth one-way V2 gate (authenticated mode only)
-     * 3) Version 1 entity check (entities without project_id)
-     * 4) Fallback on failure
+     * 1) V2 workspace allowlist (TOGGLE_V2_WORKSPACE_ALLOWLIST)
+     * 2) Feature flag override (TOGGLE_FORCE_WORKSPACE_VERSION)
+     * 3) Auth one-way V2 gate (authenticated mode only)
+     * 4) Version 1 entity check (entities without project_id)
+     * 5) Fallback on failure
      *
      * In unauthenticated mode (authentication.enabled=false), auth steps are skipped.
      * Called by the frontend on workspace load.

--- a/sdks/typescript/src/opik/rest_api/api/types/ServiceTogglesConfig.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/ServiceTogglesConfig.ts
@@ -23,5 +23,7 @@ export interface ServiceTogglesConfig {
     customllmProviderEnabled: boolean;
     ollamaProviderEnabled: boolean;
     collaboratorsTabEnabled: boolean;
+    v2WorkspaceAllowlistIds: string[];
     forceWorkspaceVersion: string;
+    v2WorkspaceAllowlist?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/ServiceTogglesConfig.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/ServiceTogglesConfig.ts
@@ -30,7 +30,9 @@ export const ServiceTogglesConfig: core.serialization.ObjectSchema<
     customllmProviderEnabled: core.serialization.boolean(),
     ollamaProviderEnabled: core.serialization.boolean(),
     collaboratorsTabEnabled: core.serialization.boolean(),
+    v2WorkspaceAllowlistIds: core.serialization.list(core.serialization.string()),
     forceWorkspaceVersion: core.serialization.string(),
+    v2WorkspaceAllowlist: core.serialization.string().optional(),
 });
 
 export declare namespace ServiceTogglesConfig {
@@ -57,6 +59,8 @@ export declare namespace ServiceTogglesConfig {
         customllmProviderEnabled: boolean;
         ollamaProviderEnabled: boolean;
         collaboratorsTabEnabled: boolean;
+        v2WorkspaceAllowlistIds: string[];
         forceWorkspaceVersion: string;
+        v2WorkspaceAllowlist?: string | null;
     }
 }


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

**Triggered by commit:** https://github.com/comet-ml/opik/commit/1fb52a114c82a4d157f1617096dcbca7e50270ec

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate