### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -15946,6 +15946,9 @@ components:
         mask_id:
           type: string
           format: uuid
+        blueprint_name:
+          pattern: (?s)^\s*(\S.*\S|\S)\s*$
+          type: string
         metadata:
           $ref: "#/components/schemas/LocalRunnerJobMetadata"
     LocalRunnerJobMetadata:
@@ -16063,6 +16066,9 @@ components:
         mask_id:
           type: string
           format: uuid
+        blueprint_name:
+          pattern: (?s)^\s*(\S.*\S|\S)\s*$
+          type: string
         metadata:
           $ref: "#/components/schemas/LocalRunnerJobMetadata"
         timeout:

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -15946,6 +15946,9 @@ components:
         mask_id:
           type: string
           format: uuid
+        blueprint_name:
+          pattern: (?s)^\s*(\S.*\S|\S)\s*$
+          type: string
         metadata:
           $ref: "#/components/schemas/LocalRunnerJobMetadata"
     LocalRunnerJobMetadata:
@@ -16063,6 +16066,9 @@ components:
         mask_id:
           type: string
           format: uuid
+        blueprint_name:
+          pattern: (?s)^\s*(\S.*\S|\S)\s*$
+          type: string
         metadata:
           $ref: "#/components/schemas/LocalRunnerJobMetadata"
         timeout:

--- a/sdks/python/src/opik/rest_api/runners/client.py
+++ b/sdks/python/src/opik/rest_api/runners/client.py
@@ -212,6 +212,7 @@ class RunnersClient:
         project_id: str,
         inputs: typing.Optional[JsonNode] = OMIT,
         mask_id: typing.Optional[str] = OMIT,
+        blueprint_name: typing.Optional[str] = OMIT,
         metadata: typing.Optional[LocalRunnerJobMetadata] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
@@ -227,6 +228,8 @@ class RunnersClient:
         inputs : typing.Optional[JsonNode]
 
         mask_id : typing.Optional[str]
+
+        blueprint_name : typing.Optional[str]
 
         metadata : typing.Optional[LocalRunnerJobMetadata]
 
@@ -248,6 +251,7 @@ class RunnersClient:
             project_id=project_id,
             inputs=inputs,
             mask_id=mask_id,
+            blueprint_name=blueprint_name,
             metadata=metadata,
             request_options=request_options,
         )
@@ -910,6 +914,7 @@ class AsyncRunnersClient:
         project_id: str,
         inputs: typing.Optional[JsonNode] = OMIT,
         mask_id: typing.Optional[str] = OMIT,
+        blueprint_name: typing.Optional[str] = OMIT,
         metadata: typing.Optional[LocalRunnerJobMetadata] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
@@ -925,6 +930,8 @@ class AsyncRunnersClient:
         inputs : typing.Optional[JsonNode]
 
         mask_id : typing.Optional[str]
+
+        blueprint_name : typing.Optional[str]
 
         metadata : typing.Optional[LocalRunnerJobMetadata]
 
@@ -949,6 +956,7 @@ class AsyncRunnersClient:
             project_id=project_id,
             inputs=inputs,
             mask_id=mask_id,
+            blueprint_name=blueprint_name,
             metadata=metadata,
             request_options=request_options,
         )

--- a/sdks/python/src/opik/rest_api/runners/raw_client.py
+++ b/sdks/python/src/opik/rest_api/runners/raw_client.py
@@ -373,6 +373,7 @@ class RawRunnersClient:
         project_id: str,
         inputs: typing.Optional[JsonNode] = OMIT,
         mask_id: typing.Optional[str] = OMIT,
+        blueprint_name: typing.Optional[str] = OMIT,
         metadata: typing.Optional[LocalRunnerJobMetadata] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[None]:
@@ -388,6 +389,8 @@ class RawRunnersClient:
         inputs : typing.Optional[JsonNode]
 
         mask_id : typing.Optional[str]
+
+        blueprint_name : typing.Optional[str]
 
         metadata : typing.Optional[LocalRunnerJobMetadata]
 
@@ -406,6 +409,7 @@ class RawRunnersClient:
                 "inputs": inputs,
                 "project_id": project_id,
                 "mask_id": mask_id,
+                "blueprint_name": blueprint_name,
                 "metadata": convert_and_respect_annotation_metadata(
                     object_=metadata, annotation=LocalRunnerJobMetadata, direction="write"
                 ),
@@ -1592,6 +1596,7 @@ class AsyncRawRunnersClient:
         project_id: str,
         inputs: typing.Optional[JsonNode] = OMIT,
         mask_id: typing.Optional[str] = OMIT,
+        blueprint_name: typing.Optional[str] = OMIT,
         metadata: typing.Optional[LocalRunnerJobMetadata] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[None]:
@@ -1607,6 +1612,8 @@ class AsyncRawRunnersClient:
         inputs : typing.Optional[JsonNode]
 
         mask_id : typing.Optional[str]
+
+        blueprint_name : typing.Optional[str]
 
         metadata : typing.Optional[LocalRunnerJobMetadata]
 
@@ -1625,6 +1632,7 @@ class AsyncRawRunnersClient:
                 "inputs": inputs,
                 "project_id": project_id,
                 "mask_id": mask_id,
+                "blueprint_name": blueprint_name,
                 "metadata": convert_and_respect_annotation_metadata(
                     object_=metadata, annotation=LocalRunnerJobMetadata, direction="write"
                 ),


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

**Triggered by BE merge:** https://github.com/comet-ml/opik/pull/6166

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate