### PR TITLE
[OPIK-5708] [FE] feat: add New project button to project selector

### DIFF
--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
@@ -5,6 +5,7 @@ import {
   ChevronUp,
   MoreHorizontal,
   Pencil,
+  Plus,
   Trash,
 } from "lucide-react";
 import { Link, useNavigate } from "@tanstack/react-router";
@@ -49,9 +50,14 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
 }) => {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const [openCreateDialog, setOpenCreateDialog] = useState(false);
   const activeProjectId = useActiveProjectId();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const navigate = useNavigate();
+
+  const {
+    permissions: { canCreateProjects },
+  } = usePermissions();
 
   const { data: activeProject, isPending: isProjectPending } = useProjectById(
     { projectId: activeProjectId! },
@@ -85,6 +91,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   );
 
   return (
+    <>
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverAnchor asChild>
         <PopoverTrigger asChild>
@@ -202,8 +209,30 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
             />
           ))}
         </div>
+        {canCreateProjects && (
+          <>
+            <Separator className="my-1" />
+            <button
+              className="flex w-full items-center gap-2 rounded-md px-3 py-2 hover:bg-primary-foreground"
+              onClick={() => {
+                setOpen(false);
+                setOpenCreateDialog(true);
+              }}
+            >
+              <Plus className="size-3.5 shrink-0 text-foreground" />
+              <span className="comet-body-s text-foreground">
+                Create new project
+              </span>
+            </button>
+          </>
+        )}
       </PopoverContent>
     </Popover>
+    <AddEditProjectDialog
+      open={openCreateDialog}
+      setOpen={setOpenCreateDialog}
+    />
+    </>
   );
 };
 

--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
@@ -168,8 +168,11 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
       <PopoverContent
         align="start"
         side="bottom"
-        className="w-[320px] p-1"
+        className="flex w-[320px] flex-col overflow-hidden p-1"
         sideOffset={4}
+        style={{
+          maxHeight: "var(--radix-popover-content-available-height)",
+        }}
       >
         <div className="px-3 py-2">
           <span className="comet-body-s-accented text-foreground">
@@ -186,7 +189,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
           />
         </div>
         <Separator className="my-1" />
-        <div className="max-h-[300px] overflow-auto">
+        <div className="min-h-0 flex-1 overflow-auto">
           {projectsData?.content?.map((project) => (
             <ProjectItem
               key={project.id}

--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
@@ -221,7 +221,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
             >
               <Plus className="size-3.5 shrink-0 text-foreground" />
               <span className="comet-body-s text-foreground">
-                Create new project
+                New project
               </span>
             </button>
           </>

--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
@@ -92,149 +92,151 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
 
   return (
     <>
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverAnchor asChild>
-        <PopoverTrigger asChild>
-          {expanded ? (
-            <button
-              className={cn(
-                "flex w-full items-center gap-2 rounded-md px-2 py-1.5",
-                open && "bg-primary-foreground",
-              )}
-            >
-              {isLoading ? (
-                <>
-                  <Spinner size="xs" />
-                  <span className="comet-body-s flex-1 text-left text-muted-slate">
-                    Loading…
-                  </span>
-                </>
-              ) : (
-                <>
-                  <ProjectIcon
-                    index={
-                      activeProjectId
-                        ? iconIndices.get(activeProjectId) ?? 0
-                        : 0
-                    }
-                    variant="owl"
-                  />
-                  <div className="flex min-w-0 flex-1 flex-col items-start">
-                    <div className="flex w-full items-center gap-0.5">
-                      <span className="comet-body-s text-light-slate">
-                        Project
-                      </span>
-                      <span className="shrink-0 text-light-slate">
-                        {open ? (
-                          <ChevronUp className="size-3.5" />
-                        ) : (
-                          <ChevronDown className="size-3.5" />
-                        )}
-                      </span>
-                    </div>
-                    {activeProject ? (
-                      <TooltipWrapper content={activeProject.name}>
-                        <span className="comet-body-s-accented w-full truncate text-left text-foreground hover:underline hover:underline-offset-4">
-                          {activeProject.name}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverAnchor asChild>
+          <PopoverTrigger asChild>
+            {expanded ? (
+              <button
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-md px-2 py-1.5",
+                  open && "bg-primary-foreground",
+                )}
+              >
+                {isLoading ? (
+                  <>
+                    <Spinner size="xs" />
+                    <span className="comet-body-s flex-1 text-left text-muted-slate">
+                      Loading…
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <ProjectIcon
+                      index={
+                        activeProjectId
+                          ? iconIndices.get(activeProjectId) ?? 0
+                          : 0
+                      }
+                      variant="owl"
+                    />
+                    <div className="flex min-w-0 flex-1 flex-col items-start">
+                      <div className="flex w-full items-center gap-0.5">
+                        <span className="comet-body-s text-light-slate">
+                          Project
                         </span>
-                      </TooltipWrapper>
-                    ) : (
-                      <span className="comet-body-s-accented truncate text-left text-muted-slate">
-                        Select project
-                      </span>
-                    )}
-                  </div>
-                </>
-              )}
-            </button>
-          ) : (
-            <button
-              className={cn(
-                "flex size-7 items-center justify-center rounded-md py-1",
-                open ? "bg-primary-foreground" : "hover:bg-primary-foreground",
-              )}
-            >
-              {isLoading ? (
-                <Spinner size="xs" />
-              ) : open ? (
-                <ChevronUp className="size-3.5 text-foreground" />
-              ) : (
-                <ChevronDown className="size-3.5 text-foreground" />
-              )}
-            </button>
-          )}
-        </PopoverTrigger>
-      </PopoverAnchor>
-      <PopoverContent
-        align="start"
-        side="bottom"
-        className="flex w-[320px] flex-col overflow-hidden p-1"
-        sideOffset={4}
-        style={{
-          maxHeight: "var(--radix-popover-content-available-height)",
-        }}
-      >
-        <div className="px-3 py-2">
-          <span className="comet-body-s-accented text-foreground">
-            Projects
-          </span>
-        </div>
-        <Separator className="my-1" />
-        <div className="px-1">
-          <SearchInput
-            searchText={search}
-            setSearchText={setSearch}
-            variant="ghost"
-            size="sm"
-          />
-        </div>
-        <Separator className="my-1" />
-        <div className="min-h-0 flex-1 overflow-auto">
-          {projectsData?.content?.map((project) => (
-            <ProjectItem
-              key={project.id}
-              project={project}
-              iconIndex={iconIndices.get(project.id) ?? 0}
-              isSelected={project.id === activeProjectId}
-              workspaceName={workspaceName}
-              onSelect={handleSelect}
-              onDelete={
-                project.id === activeProjectId
-                  ? () => {
-                      setActiveProject(workspaceName, null);
-                      navigate({
-                        to: "/$workspaceName/projects",
-                        params: { workspaceName },
-                      });
-                    }
-                  : undefined
-              }
+                        <span className="shrink-0 text-light-slate">
+                          {open ? (
+                            <ChevronUp className="size-3.5" />
+                          ) : (
+                            <ChevronDown className="size-3.5" />
+                          )}
+                        </span>
+                      </div>
+                      {activeProject ? (
+                        <TooltipWrapper content={activeProject.name}>
+                          <span className="comet-body-s-accented w-full truncate text-left text-foreground hover:underline hover:underline-offset-4">
+                            {activeProject.name}
+                          </span>
+                        </TooltipWrapper>
+                      ) : (
+                        <span className="comet-body-s-accented truncate text-left text-muted-slate">
+                          Select project
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+              </button>
+            ) : (
+              <button
+                className={cn(
+                  "flex size-7 items-center justify-center rounded-md py-1",
+                  open
+                    ? "bg-primary-foreground"
+                    : "hover:bg-primary-foreground",
+                )}
+              >
+                {isLoading ? (
+                  <Spinner size="xs" />
+                ) : open ? (
+                  <ChevronUp className="size-3.5 text-foreground" />
+                ) : (
+                  <ChevronDown className="size-3.5 text-foreground" />
+                )}
+              </button>
+            )}
+          </PopoverTrigger>
+        </PopoverAnchor>
+        <PopoverContent
+          align="start"
+          side="bottom"
+          className="flex w-[320px] flex-col overflow-hidden p-1"
+          sideOffset={4}
+          style={{
+            maxHeight: "var(--radix-popover-content-available-height)",
+          }}
+        >
+          <div className="px-3 py-2">
+            <span className="comet-body-s-accented text-foreground">
+              Projects
+            </span>
+          </div>
+          <Separator className="my-1" />
+          <div className="px-1">
+            <SearchInput
+              searchText={search}
+              setSearchText={setSearch}
+              variant="ghost"
+              size="sm"
             />
-          ))}
-        </div>
-        {canCreateProjects && (
-          <>
-            <Separator className="my-1" />
-            <button
-              className="flex w-full items-center gap-2 rounded-md px-3 py-2 hover:bg-primary-foreground"
-              onClick={() => {
-                setOpen(false);
-                setOpenCreateDialog(true);
-              }}
-            >
-              <Plus className="size-3.5 shrink-0 text-foreground" />
-              <span className="comet-body-s text-foreground">
-                New project
-              </span>
-            </button>
-          </>
-        )}
-      </PopoverContent>
-    </Popover>
-    <AddEditProjectDialog
-      open={openCreateDialog}
-      setOpen={setOpenCreateDialog}
-    />
+          </div>
+          <Separator className="my-1" />
+          <div className="min-h-0 flex-1 overflow-auto">
+            {projectsData?.content?.map((project) => (
+              <ProjectItem
+                key={project.id}
+                project={project}
+                iconIndex={iconIndices.get(project.id) ?? 0}
+                isSelected={project.id === activeProjectId}
+                workspaceName={workspaceName}
+                onSelect={handleSelect}
+                onDelete={
+                  project.id === activeProjectId
+                    ? () => {
+                        setActiveProject(workspaceName, null);
+                        navigate({
+                          to: "/$workspaceName/projects",
+                          params: { workspaceName },
+                        });
+                      }
+                    : undefined
+                }
+              />
+            ))}
+          </div>
+          {canCreateProjects && (
+            <>
+              <Separator className="my-1" />
+              <button
+                className="flex w-full items-center gap-2 rounded-md px-3 py-2 hover:bg-primary-foreground"
+                onClick={() => {
+                  setOpen(false);
+                  setOpenCreateDialog(true);
+                }}
+              >
+                <Plus className="size-3.5 shrink-0 text-foreground" />
+                <span className="comet-body-s text-foreground">
+                  New project
+                </span>
+              </button>
+            </>
+          )}
+        </PopoverContent>
+      </Popover>
+      <AddEditProjectDialog
+        open={openCreateDialog}
+        setOpen={setOpenCreateDialog}
+      />
     </>
   );
 };


### PR DESCRIPTION
## Details

Adds a **\"+ New project\"** button to the project selector popover in the v2 sidebar, allowing users to create a project directly from wherever they are in the app — without having to navigate to the workspace Projects page.

**Changes:**
- Added \"New project\" button at the bottom of the project selector popover, separated by a divider
- Button is gated behind `canCreateProjects` permission (consistent with existing patterns)
- Reuses `AddEditProjectDialog` in create mode (no `project` prop), so all create logic, validation, toasts, and post-creation navigation are handled by the existing dialog
- `AddEditProjectDialog` is rendered outside `<Popover>` (wrapped in a React fragment) to prevent it from unmounting when the popover closes
- Fixed `PopoverContent` layout to use `flex flex-col` + `maxHeight: var(--radix-popover-content-available-height)` so the button stays visible even when the project list is long and the popover is near the bottom of the viewport

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-5708

## Testing

Manually validated end-to-end:
1. Open project selector from the sidebar
2. \"+ New project\" button appears at the bottom of the popover
3. Clicking it closes the popover and opens the \"Create a new project\" dialog
4. Fill in a name and click \"Create project\"
5. App navigates to the new project's home page with a success toast
6. Verified button is visible with 8+ projects in the list (viewport overflow fix works)

## Documentation

No documentation changes required.