### PR TITLE
[NA] [SDK] fix: skip call_llm wrapper spans from ADK 1.29.0

### DIFF
--- a/sdks/python/src/opik/integrations/adk/patchers/adk_otel_tracer/opik_adk_otel_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/patchers/adk_otel_tracer/opik_adk_otel_tracer.py
@@ -49,6 +49,7 @@ class OpikADKOtelTracer(opentelemetry.trace.NoOpTracer):
 
     _ADK_INTERNAL_SPAN_NAME_SKIP_LIST = [
         "invocation",  # This is the span that is created by ADK when the invocation is started.
+        "call_llm",  # Wrapper span around LLM calls, added in ADK 1.29.0.
     ]
 
     def __init__(


### PR DESCRIPTION
## Details

ADK 1.29.0 introduced a new OTel wrapper span `"call_llm"` around LLM calls. This caused extra empty spans (type `"general"`, no data) to appear in Opik traces, breaking the expected flat span structure.

Fix: add `"call_llm"` to the existing `_ADK_INTERNAL_SPAN_NAME_SKIP_LIST` so the wrapper is ignored, matching the existing pattern for `"invocation"`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- N/A — compatibility fix for upstream ADK 1.29.0
## Testing

- All 36 ADK integration tests pass on ADK 1.29.0
- Backwards compatible — `"call_llm"` span doesn't exist in older ADK versions, so the skip is a no-op

## Documentation

N/A

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code (Claude Opus 4.6)
  - Model(s): claude-opus-4-6
  - Scope: Investigation and one-line fix
  - Human verification: Yes — tested full ADK test suite locally