### PR TITLE
[NA] [FE] fix: deduplicate eval suite input columns in experiment items table

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/experiments/useExperimentItemsData.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/useExperimentItemsData.ts
@@ -146,18 +146,14 @@ const useExperimentItemsData = ({
   }, [data]);
 
   const dynamicOutputColumns = useMemo(() => {
-    const datasetColumnNames = new Set(
-      dynamicDatasetColumns.map((c) => c.label),
-    );
     return (experimentsOutputData?.columns ?? [])
-      .filter((c) => !datasetColumnNames.has(c.name))
       .sort((c1, c2) => c1.name.localeCompare(c2.name))
       .map<DynamicColumn>((c) => ({
         id: `${EXPERIMENT_ITEM_OUTPUT_PREFIX}.${c.name}`,
         label: c.name,
         columnType: mapDynamicColumnTypesToColumnType(c.types),
       }));
-  }, [experimentsOutputData, dynamicDatasetColumns]);
+  }, [experimentsOutputData]);
 
   const dynamicScoresColumns = useMemo(() => {
     return (feedbackScoresData?.scores ?? [])

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/useExperimentItemsData.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/useExperimentItemsData.ts
@@ -146,14 +146,18 @@ const useExperimentItemsData = ({
   }, [data]);
 
   const dynamicOutputColumns = useMemo(() => {
+    const datasetColumnNames = new Set(
+      dynamicDatasetColumns.map((c) => c.label),
+    );
     return (experimentsOutputData?.columns ?? [])
+      .filter((c) => !datasetColumnNames.has(c.name))
       .sort((c1, c2) => c1.name.localeCompare(c2.name))
       .map<DynamicColumn>((c) => ({
         id: `${EXPERIMENT_ITEM_OUTPUT_PREFIX}.${c.name}`,
         label: c.name,
         columnType: mapDynamicColumnTypesToColumnType(c.types),
       }));
-  }, [experimentsOutputData]);
+  }, [experimentsOutputData, dynamicDatasetColumns]);
 
   const dynamicScoresColumns = useMemo(() => {
     return (feedbackScoresData?.scores ?? [])

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -273,16 +273,18 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
     ];
   }, [dynamicDatasetColumns, experimentsCount, sortableColumns]);
 
-  const datasetColumnLabels = useMemo(
-    () => new Set(dynamicDatasetColumns.map((c) => c.label)),
-    [dynamicDatasetColumns],
-  );
+  const visibleOutputColumns = useMemo(() => {
+    const datasetColumnLabels = new Set(
+      dynamicDatasetColumns.map((c) => c.label),
+    );
+    return dynamicOutputColumns.filter(
+      (c) => !datasetColumnLabels.has(c.label),
+    );
+  }, [dynamicOutputColumns, dynamicDatasetColumns]);
 
   const outputColumnsData = useMemo(() => {
     return [
-      ...dynamicOutputColumns
-        .filter((c) => !datasetColumnLabels.has(c.label))
-        .map(
+      ...visibleOutputColumns.map(
           ({ label, id, columnType }) =>
             ({
               id,
@@ -350,8 +352,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
       } as ColumnData<ExperimentsCompare>,
     ];
   }, [
-    datasetColumnLabels,
-    dynamicOutputColumns,
+    visibleOutputColumns,
     experiments,
     experimentsIds,
     setTraceId,
@@ -556,14 +557,14 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
           type: columnType,
         }),
       ),
-      ...sortBy(dynamicOutputColumns, "label").map(({ id, label }) => ({
+      ...sortBy(visibleOutputColumns, "label").map(({ id, label }) => ({
         id,
         label: `${label} (Output)`,
         type: COLUMN_TYPE.string,
       })),
       ...getFilterColumns(!!isEvalSuite),
     ];
-  }, [dynamicDatasetColumns, dynamicOutputColumns, isEvalSuite]);
+  }, [dynamicDatasetColumns, visibleOutputColumns, isEvalSuite]);
 
   const resizeConfig = useMemo(
     () => ({

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -273,24 +273,31 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
     ];
   }, [dynamicDatasetColumns, experimentsCount, sortableColumns]);
 
+  const datasetColumnLabels = useMemo(
+    () => new Set(dynamicDatasetColumns.map((c) => c.label)),
+    [dynamicDatasetColumns],
+  );
+
   const outputColumnsData = useMemo(() => {
     return [
-      ...dynamicOutputColumns.map(
-        ({ label, id, columnType }) =>
-          ({
-            id,
-            label,
-            type: columnType,
-            cell: CompareExperimentsOutputCell as never,
-            customMeta: {
-              experiments,
-              experimentsIds,
-              outputKey: label,
-              openTrace: setTraceId,
-            },
-            ...(columnType === COLUMN_TYPE.dictionary && { size: 400 }),
-          }) as ColumnData<ExperimentsCompare>,
-      ),
+      ...dynamicOutputColumns
+        .filter((c) => !datasetColumnLabels.has(c.label))
+        .map(
+          ({ label, id, columnType }) =>
+            ({
+              id,
+              label,
+              type: columnType,
+              cell: CompareExperimentsOutputCell as never,
+              customMeta: {
+                experiments,
+                experimentsIds,
+                outputKey: label,
+                openTrace: setTraceId,
+              },
+              ...(columnType === COLUMN_TYPE.dictionary && { size: 400 }),
+            }) as ColumnData<ExperimentsCompare>,
+        ),
       {
         id: COLUMN_DURATION_ID,
         label: "Duration",
@@ -343,6 +350,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
       } as ColumnData<ExperimentsCompare>,
     ];
   }, [
+    datasetColumnLabels,
     dynamicOutputColumns,
     experiments,
     experimentsIds,

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -18,6 +18,7 @@ import {
   COLUMN_TYPE,
   COLUMN_USAGE_ID,
   ColumnData,
+  DynamicColumn,
   OnChangeFn,
   ROW_HEIGHT,
 } from "@/types/shared";
@@ -85,6 +86,7 @@ const COLUMN_EXPERIMENT_NAME_ID = "experiment_name";
 const COLUMN_PASSED_ID = "passed";
 const STORAGE_PREFIX = "compare-experiments";
 const DYNAMIC_COLUMNS_KEY = "compare-experiments-dynamic-columns";
+const EVAL_SUITE_ECHOED_OUTPUT_KEY = "input";
 
 function getFilterColumns(
   isEvalSuite: boolean,
@@ -273,14 +275,13 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
     ];
   }, [dynamicDatasetColumns, experimentsCount, sortableColumns]);
 
-  const visibleOutputColumns = useMemo(() => {
-    const datasetColumnLabels = new Set(
-      dynamicDatasetColumns.map((c) => c.label),
-    );
-    return dynamicOutputColumns.filter(
-      (c) => !datasetColumnLabels.has(c.label),
-    );
-  }, [dynamicOutputColumns, dynamicDatasetColumns]);
+  const visibleOutputColumns = useMemo(
+    () =>
+      isEvalSuite
+        ? dynamicOutputColumns.filter((c: DynamicColumn) => c.label !== EVAL_SUITE_ECHOED_OUTPUT_KEY)
+        : dynamicOutputColumns,
+    [dynamicOutputColumns, isEvalSuite],
+  );
 
   const outputColumnsData = useMemo(() => {
     return [

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -278,7 +278,9 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
   const visibleOutputColumns = useMemo(
     () =>
       isEvalSuite
-        ? dynamicOutputColumns.filter((c: DynamicColumn) => c.label !== EVAL_SUITE_ECHOED_OUTPUT_KEY)
+        ? dynamicOutputColumns.filter(
+            (c: DynamicColumn) => c.label !== EVAL_SUITE_ECHOED_OUTPUT_KEY,
+          )
         : dynamicOutputColumns,
     [dynamicOutputColumns, isEvalSuite],
   );
@@ -286,21 +288,21 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
   const outputColumnsData = useMemo(() => {
     return [
       ...visibleOutputColumns.map(
-          ({ label, id, columnType }) =>
-            ({
-              id,
-              label,
-              type: columnType,
-              cell: CompareExperimentsOutputCell as never,
-              customMeta: {
-                experiments,
-                experimentsIds,
-                outputKey: label,
-                openTrace: setTraceId,
-              },
-              ...(columnType === COLUMN_TYPE.dictionary && { size: 400 }),
-            }) as ColumnData<ExperimentsCompare>,
-        ),
+        ({ label, id, columnType }: DynamicColumn) =>
+          ({
+            id,
+            label,
+            type: columnType,
+            cell: CompareExperimentsOutputCell as never,
+            customMeta: {
+              experiments,
+              experimentsIds,
+              outputKey: label,
+              openTrace: setTraceId,
+            },
+            ...(columnType === COLUMN_TYPE.dictionary && { size: 400 }),
+          }) as ColumnData<ExperimentsCompare>,
+      ),
       {
         id: COLUMN_DURATION_ID,
         label: "Duration",


### PR DESCRIPTION
## Details

When viewing evaluation suite experiments, the "input" column appeared twice — once under "Evaluation suite" (from dataset item data) and again under "Evaluation task (last trial)" (from experiment item output). This happened because the SDK always produces `{"input": ..., "output": ...}` as the task result, so the "input" key in the output always overlaps with the dataset's "input" key.

This fix filters `dynamicOutputColumns` to exclude the second "input" column when displaying the experiment item for evaluation suites.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Implementation and PR creation
  - Human verification: Visual verification via UI screenshots

## Testing

- TypeScript type check (`npx tsc --noEmit`) — passes
- ESLint on changed file — no errors
- Manually verified via UI that duplicated "input" column no longer appears under "Evaluation task (last trial)" section

## Documentation

N/A