### PR TITLE
[OPIK-5764] [SDK] CrewAI integration broken with crewai >= 1.13.0 (LLM client attribute renamed)

### DIFF
--- a/sdks/python/src/opik/integrations/crewai/patchers/llm_client.py
+++ b/sdks/python/src/opik/integrations/crewai/patchers/llm_client.py
@@ -6,7 +6,7 @@ Each provider has its own patching function that handles missing dependencies gr
 """
 
 import logging
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING, Protocol
 
 import crewai
 
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
     import crewai.llms.providers.bedrock.completion as bedrock_completion
 
 LOGGER = logging.getLogger(__name__)
+
+
+class LLMPatcher(Protocol):
+    def __call__(self, client: Any, /, project_name: Optional[str] = None) -> Any: ...
 
 
 def patch_llm_client(crew: crewai.Crew, project_name: Optional[str]) -> None:
@@ -140,8 +144,10 @@ def _patch_openai_client(
     try:
         import opik.integrations.openai
 
-        llm.client = opik.integrations.openai.track_openai(
-            llm.client, project_name=project_name
+        _patch_client_attribute(
+            llm=llm,
+            project_name=project_name,
+            patcher=opik.integrations.openai.track_openai,
         )
     except Exception:
         LOGGER.warning("Failed to track OpenAI client for LLM", exc_info=True)
@@ -160,8 +166,10 @@ def _patch_anthropic_client(
     try:
         import opik.integrations.anthropic
 
-        llm.client = opik.integrations.anthropic.track_anthropic(
-            llm.client, project_name=project_name
+        _patch_client_attribute(
+            llm=llm,
+            project_name=project_name,
+            patcher=opik.integrations.anthropic.track_anthropic,
         )
     except Exception:
         LOGGER.warning("Failed to track Anthropic client for LLM", exc_info=True)
@@ -180,8 +188,10 @@ def _patch_gemini_client(
     try:
         import opik.integrations.genai
 
-        llm.client = opik.integrations.genai.track_genai(
-            llm.client, project_name=project_name
+        _patch_client_attribute(
+            llm=llm,
+            project_name=project_name,
+            patcher=opik.integrations.genai.track_genai,
         )
     except Exception:
         LOGGER.warning("Failed to track Gemini client for LLM", exc_info=True)
@@ -200,8 +210,26 @@ def _patch_bedrock_client(
     try:
         import opik.integrations.bedrock
 
-        llm.client = opik.integrations.bedrock.track_bedrock(
-            llm.client, project_name=project_name
+        _patch_client_attribute(
+            llm=llm,
+            project_name=project_name,
+            patcher=opik.integrations.bedrock.track_bedrock,
         )
     except Exception:
         LOGGER.warning("Failed to track Bedrock client for LLM", exc_info=True)
+
+
+def _get_client_attribute_name(llm: Any) -> str:
+    # CrewAI >= 1.13.0 converted LLM classes to Pydantic BaseModel,
+    # moving the SDK client from a public `client` attribute to a
+    # Pydantic PrivateAttr `_client`.
+    return "_client" if hasattr(llm, "_client") else "client"
+
+
+def _patch_client_attribute(
+    llm: Any, project_name: Optional[str], patcher: LLMPatcher
+) -> None:
+    client_attribute = _get_client_attribute_name(llm)
+    client = getattr(llm, client_attribute)
+    patched_client = patcher(client, project_name=project_name)
+    setattr(llm, client_attribute, patched_client)

--- a/sdks/python/tests/library_integration/crewai/requirements_v1.txt
+++ b/sdks/python/tests/library_integration/crewai/requirements_v1.txt
@@ -1,2 +1,1 @@
-anthropic>=0.88.0  # AttributeError: 'OpenAICompletion' object has no attribute 'client'
 crewai[anthropic, bedrock, google-genai]>=1.0.0

--- a/sdks/python/tests/library_integration/crewai/test_crewai.py
+++ b/sdks/python/tests/library_integration/crewai/test_crewai.py
@@ -1,7 +1,10 @@
-import opik
-from opik.integrations.crewai import track_crewai
-from opik.integrations.crewai import opik_tracker
+import pytest
 from crewai import Agent, Crew, Process, Task
+
+import opik
+from opik.integrations.crewai import opik_tracker
+from opik.integrations.crewai import track_crewai
+from . import constants
 from ...testlib import (
     ANY,
     ANY_BUT_NONE,
@@ -11,10 +14,6 @@ from ...testlib import (
     TraceModel,
     assert_equal,
 )
-from . import constants
-
-import pytest
-
 
 pytestmark = [
     pytest.mark.usefixtures("ensure_openai_configured"),


### PR DESCRIPTION
## Details
The CrewAI integration's LLM client patching is broken with CrewAI >= 1.13.0. CrewAI v1.13.0 refactored LLM provider classes from plain ABCs to Pydantic BaseModel, renaming the underlying SDK client attribute from the public self.client to a Pydantic PrivateAttr self._client. Our patching code in llm_client.py accesses llm.client, which raises AttributeError on the new versions.
The error is silently swallowed by the except Exception handler, so crews still run — but LLM-level tracing is completely lost (no type="llm" spans for individual OpenAI/Anthropic/Gemini/Bedrock calls).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-5764

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
No changes

## Documentation
No changes