### PR TITLE
[OPIK-5784] [FE] Forward structured search to router.navigate

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -154,7 +154,7 @@ function createHostListeners(): HostListeners {
 
 interface BridgeRefs {
   navigate: React.MutableRefObject<
-    (path: string, search?: Record<string, string>) => void
+    (path: string, search?: Record<string, unknown>) => void
   >;
   onWidthChange: React.MutableRefObject<(width: number) => void>;
   onNotification: React.MutableRefObject<
@@ -381,8 +381,16 @@ const AssistantSidebar: React.FC<AssistantSidebarProps> = ({
     emitHostEvent(listenersRef, "visibility:changed", { isOpen: open });
   });
 
+  /**
+   * Forwards a sidebar navigation request to TanStack Router. `search` is
+   * typed `Record<string, unknown>` because the bridge is route-agnostic and
+   * no runtime narrowing is possible here — the producer (ollie-assist) is
+   * responsible for supplying values that match the destination route's
+   * search schema. Structured values are single-stringified by the router so
+   * `use-query-params`' `JsonParam` round-trips correctly.
+   */
   const navigateRef = useLatestRef(
-    (path: string, search?: Record<string, string>) => {
+    (path: string, search?: Record<string, unknown>) => {
       const ws = contextRef.current.workspaceName;
       const fullPath = ws ? `/${ws}${path}` : path;
       router.navigate({ to: fullPath, search });

--- a/apps/opik-frontend/src/types/assistant-sidebar.ts
+++ b/apps/opik-frontend/src/types/assistant-sidebar.ts
@@ -39,7 +39,11 @@ export interface HostEventMap {
 
 /** Sidebar → Host events */
 export interface SidebarEventMap {
-  navigate: { path: string; search?: Record<string, string> };
+  // `search` values are `unknown` so structured data (filter arrays, sort
+  // specs) can flow through to TanStack Router as real objects. Passing
+  // them as pre-serialized JSON strings triggers TanStack's double-encode
+  // path in stringifySearchWith and breaks use-query-params readers.
+  navigate: { path: string; search?: Record<string, unknown> };
   notification: { message: string; type: NotificationType };
   "sidebar:resized": { width: number };
   "sidebar:request-close": Record<string, never>;


### PR DESCRIPTION
## Details

Frontend half of OPIK-5784. The sidebar bridge was typing `navigate.search` as `Record<string, string>`, which forced ollie-assist to pre-serialize filter arrays as JSON strings. TanStack Router's `stringifySearchWith` then double-encoded those strings (its deliberate round-trip path for JSON-looking strings), but the logs page reads filters via `use-query-params` + `JsonParam` which does a single `JSON.parse` — so `setFilters` ended up with the string `"[{...}]"` instead of the filter array, and the table stayed unfiltered even though the URL visibly changed. This PR widens the bridge type so structured values flow through as real objects, hitting TanStack's object branch (single stringify) which round-trips correctly.

- `types/assistant-sidebar.ts`: `SidebarEventMap.navigate.search` is `Record<string, unknown>` with a rationale comment pointing at the TanStack Router quirk.
- `plugins/comet/AssistantSidebar.tsx`: `BridgeRefs.navigate` and `navigateRef` match the new type. A JSDoc on `navigateRef` documents that the bridge is route-agnostic, so the producer (ollie-assist) owns validating that `search` matches the destination route's search schema — no runtime narrowing is possible at this layer.
- No behavior change for scalars (`page=2`, `time_range=alltime`); those still flow through as strings for `NumberParam`/`StringParam`.

**Why `Record<string, unknown>` and not a narrower union**: the bridge accepts navigation for any page in the app, so no single union can cover every route's search schema. Narrowing to `string | number | boolean | unknown[] | Record<string, unknown>` would add noise without adding any real safety — the router still has to accept the same shape. The JSDoc calls out where responsibility for validation lives.

Full root-cause analysis and backend fix are in the companion PR below.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-5784
- Requires companion backend PR: comet-ml/ollie-assist#174 (both must ship together)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-6 (1M context)
- Scope: root-cause investigation of the filter-serialization bug, implementation of the `Record<string, unknown>` bridge type change and the JSDoc, verification via `tsc --noEmit` and `eslint --max-warnings=0`
- Human verification: author reviewed every change, confirmed tsc/eslint pass locally, and will run the E2E scenarios listed under Testing before merging

## Testing

Commands run locally in the worktree against `origin/main`:

```
cd apps/opik-frontend
npx tsc --project tsconfig.json --noEmit
npx eslint src/plugins/comet/AssistantSidebar.tsx src/types/assistant-sidebar.ts --max-warnings=0
```

Both pass with zero warnings/errors.

### Scenarios still to validate (needs both PRs deployed together)

- [ ] Ask Ollie "show me only traces with errors in project X"
  - Filter chip UI above the traces table shows the active errors-only filter
  - Table rows are filtered, not the full set
  - URL `traces_filters` is URL-encoded JSON with a single layer of quoting (no `%22[%7B` wrapping)
  - Copying the URL into a new tab reproduces the filtered view
- [ ] Regression: manual filter-panel clicks still work (sanity check — the call path is unchanged)
- [ ] Regression: "show traces for project X, page 2, size 50" paginates correctly (scalar params stay as strings)
- [ ] Regression: thread filter via `ThreadDetailsPanel` "View all traces" button still works (internal navigation passes real arrays, unaffected by this change)

No unit tests added on the opik-frontend side — the change is a pure type widening on a bridge that has no existing component tests, and the behavior is covered by the companion backend PR's unit tests plus the E2E scenarios above.

## Documentation

No user-facing documentation changes. This is an internal bridge-contract fix; the user-visible behavior is "filters Ollie applies now actually apply" — which matches what the UI already claimed was happening.
