### PR TITLE
[NA] [BE] PAKE Opik Connect

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1044,6 +1044,16 @@ localRunner:
   # Description: How long the bridge nextCommands long-poll blocks before returning empty
   bridgePollTimeout: ${OPIK_RUNNER_BRIDGE_POLL_TIMEOUT:-30s}
   # Default: 30s
+  # Description: How long the PAKE pairing message long-poll blocks before returning empty.
+  # Clients should retry on empty responses; keeping this short limits the number of
+  # concurrently held HTTP connections and bounded-elastic threads under load.
+  pakePollTimeout: ${OPIK_RUNNER_PAKE_POLL_TIMEOUT:-30s}
+  # Default: 5s
+  # Description: Extra buffer added to async response timeout beyond pakePollTimeout.
+  # Lets the Redis-side poll fire and return cleanly before the JAX-RS container's
+  # AsyncResponse timeout fallback resumes with an empty page.
+  pakeAsyncTimeoutBuffer: ${OPIK_RUNNER_PAKE_ASYNC_TIMEOUT_BUFFER:-5s}
+  # Default: 30s
   # Description: Default timeout for bridge commands when not specified by caller
   bridgeDefaultCommandTimeout: ${OPIK_RUNNER_BRIDGE_DEFAULT_CMD_TIMEOUT:-30s}
   # Default: 120s

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResource.java
@@ -9,6 +9,7 @@ import com.comet.opik.api.runner.BridgeCommandResultRequest;
 import com.comet.opik.api.runner.BridgeCommandSubmitRequest;
 import com.comet.opik.api.runner.BridgeCommandSubmitResponse;
 import com.comet.opik.api.runner.CreateLocalRunnerJobRequest;
+import com.comet.opik.api.runner.DaemonPairRegisterRequest;
 import com.comet.opik.api.runner.LocalRunner;
 import com.comet.opik.api.runner.LocalRunnerConnectRequest;
 import com.comet.opik.api.runner.LocalRunnerConnectResponse;
@@ -20,10 +21,15 @@ import com.comet.opik.api.runner.LocalRunnerLogEntry;
 import com.comet.opik.api.runner.LocalRunnerPairRequest;
 import com.comet.opik.api.runner.LocalRunnerPairResponse;
 import com.comet.opik.api.runner.LocalRunnerStatus;
+import com.comet.opik.api.runner.PakeMessagePage;
+import com.comet.opik.api.runner.PakeMessageRequest;
+import com.comet.opik.api.runner.PakeRole;
+import com.comet.opik.api.runner.PakeStep;
 import com.comet.opik.domain.LocalRunnerService;
 import com.comet.opik.infrastructure.LocalRunnerConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.ratelimit.RateLimited;
+import com.comet.opik.infrastructure.web.AsyncResponseSupport;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -428,24 +434,98 @@ public class LocalRunnersResource {
         int maxTimeout = (int) runnerConfig.getBridgeMaxCommandTimeout().toSeconds();
         int clampedTimeout = Math.min(Math.max(timeout, 1), maxTimeout);
         long bufferSeconds = runnerConfig.getBridgeAsyncTimeoutBuffer().toSeconds();
-        asyncResponse.setTimeout(clampedTimeout + bufferSeconds, TimeUnit.SECONDS);
-        asyncResponse.setTimeoutHandler(
-                ar -> ar.resume(Response.status(Response.Status.REQUEST_TIMEOUT).build()));
 
-        runnerService.awaitBridgeCommand(runnerId, workspaceId, userName, commandId, clampedTimeout)
-                .map(cmd -> Response.ok(cmd).build())
-                .subscribe(
-                        asyncResponse::resume,
-                        error -> {
-                            if (error instanceof WebApplicationException wae) {
-                                asyncResponse.resume(wae);
-                            } else {
-                                log.error("Error awaiting bridge command='{}' runner='{}' workspace='{}'",
-                                        commandId,
-                                        runnerId, workspaceId, error);
-                                asyncResponse.resume(Response.serverError().build());
-                            }
-                        });
+        AsyncResponseSupport.resume(
+                asyncResponse,
+                runnerService.awaitBridgeCommand(runnerId, workspaceId, userName, commandId, clampedTimeout),
+                clampedTimeout + bufferSeconds,
+                cmd -> Response.ok(cmd).build(),
+                Response.status(Response.Status.REQUEST_TIMEOUT).build(),
+                "Error awaiting bridge command='{}' runner='{}' workspace='{}'",
+                commandId, runnerId, workspaceId);
+    }
+
+    // --- PAKE pairing relay endpoints ---
+
+    @POST
+    @Path("/daemon-pairs")
+    @RateLimited
+    @Operation(operationId = "registerDaemonPair", summary = "Register daemon pairing session", description = "Daemon registers a pairing session for a project. The pairing code is generated locally by the daemon and never sent to the backend. On success, the response has no body — the daemon parses the runnerId from the Location header and follows up with GET /local-runners/{runnerId} for details.", responses = {
+            @ApiResponse(responseCode = "201", description = "Pairing session registered", headers = @Header(name = "Location", description = "URI of the runner"))})
+    public Response registerDaemonPair(
+            @RequestBody(content = @Content(schema = @Schema(implementation = DaemonPairRegisterRequest.class))) @NotNull @Valid DaemonPairRegisterRequest request,
+            @Context UriInfo uriInfo) {
+        ensureEnabled();
+        String workspaceId = requestContext.get().getWorkspaceId();
+        String userName = requestContext.get().getUserName();
+        UUID runnerId = runnerService.registerDaemonPair(workspaceId, userName, request);
+        var uri = uriInfo.getBaseUriBuilder()
+                .path("v1/private/local-runners/{runnerId}")
+                .build(runnerId);
+        return Response.created(uri).build();
+    }
+
+    @POST
+    @Path("/pake/messages/{projectId}/{targetRole}")
+    @RateLimited
+    @Operation(operationId = "postPakeMessage", summary = "Post PAKE message", description = "Post a PAKE exchange message into the target inbox. target_role is the side that will read this message (daemon posts to BROWSER inbox; browser posts to DAEMON inbox). Session is resolved from auth context + projectId.", responses = {
+            @ApiResponse(responseCode = "204", description = "Message posted"),
+            @ApiResponse(responseCode = "404", description = "No pairing session found", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
+            @ApiResponse(responseCode = "429", description = "Too many attempts", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))})
+    public Response postPakeMessage(
+            @PathParam("projectId") UUID projectId,
+            @PathParam("targetRole") PakeRole targetRole,
+            @RequestBody(content = @Content(schema = @Schema(implementation = PakeMessageRequest.class))) @NotNull @Valid PakeMessageRequest request) {
+        ensureEnabled();
+        String workspaceId = requestContext.get().getWorkspaceId();
+        String userName = requestContext.get().getUserName();
+        runnerService.postPakeMessage(workspaceId, userName, projectId, targetRole, request);
+        return Response.noContent().build();
+    }
+
+    @GET
+    @Path("/pake/messages/{projectId}/{targetRole}")
+    @Operation(operationId = "getPakeMessages", summary = "Poll PAKE messages", description = "Long-poll the target inbox for the next PAKE exchange message at the specified step. Returns a PakeMessagePage envelope with zero or one messages.", responses = {
+            @ApiResponse(responseCode = "200", description = "Messages envelope", content = @Content(schema = @Schema(implementation = PakeMessagePage.class))),
+            @ApiResponse(responseCode = "404", description = "No pairing session found", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))})
+    public void getPakeMessages(
+            @PathParam("projectId") UUID projectId,
+            @PathParam("targetRole") PakeRole targetRole,
+            @QueryParam("target_step") @DefaultValue("spake2") PakeStep targetStep,
+            @Suspended AsyncResponse asyncResponse) {
+        ensureEnabled();
+        String workspaceId = requestContext.get().getWorkspaceId();
+        String userName = requestContext.get().getUserName();
+        long pollTimeoutSeconds = runnerConfig.getPakePollTimeout().toSeconds();
+        long bufferSeconds = runnerConfig.getPakeAsyncTimeoutBuffer().toSeconds();
+
+        AsyncResponseSupport.resume(
+                asyncResponse,
+                runnerService.getPakeMessages(workspaceId, userName, projectId, targetRole, targetStep),
+                pollTimeoutSeconds + bufferSeconds,
+                page -> Response.ok(page).build(),
+                Response.ok(PakeMessagePage.empty()).build(),
+                "Error polling PAKE messages for project='{}' workspace='{}' targetRole='{}' targetStep='{}'",
+                projectId, workspaceId, targetRole, targetStep);
+    }
+
+    @POST
+    @Path("/pake/complete/{projectId}")
+    @RateLimited
+    @Operation(operationId = "completePairing", summary = "Complete PAKE pairing", description = "Browser completes pairing after key confirmation, activating the runner. On success, the response has no body — the browser parses the runnerId from the Location header and follows up with GET /local-runners/{runnerId} for the project details.", responses = {
+            @ApiResponse(responseCode = "201", description = "Pairing completed", headers = @Header(name = "Location", description = "URI of the runner")),
+            @ApiResponse(responseCode = "404", description = "No pairing session found", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))})
+    public Response completePairing(
+            @PathParam("projectId") UUID projectId,
+            @Context UriInfo uriInfo) {
+        ensureEnabled();
+        String workspaceId = requestContext.get().getWorkspaceId();
+        String userName = requestContext.get().getUserName();
+        LocalRunnerConnectResponse response = runnerService.completePairing(workspaceId, userName, projectId);
+        var uri = uriInfo.getBaseUriBuilder()
+                .path("v1/private/local-runners/{runnerId}")
+                .build(response.runnerId());
+        return Response.created(uri).build();
     }
 
     private void ensureEnabled() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/runner/BridgeCommand.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/runner/BridgeCommand.java
@@ -24,5 +24,7 @@ public record BridgeCommand(
         Instant submittedAt,
         Instant pickedUpAt,
         Instant completedAt,
-        Long durationMs) {
+        Long durationMs,
+        String hmac,
+        Long sequence) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/runner/BridgeCommandBatchResponse.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/runner/BridgeCommandBatchResponse.java
@@ -24,6 +24,8 @@ public record BridgeCommandBatchResponse(
             BridgeCommandType type,
             JsonNode args,
             int timeoutSeconds,
-            Instant submittedAt) {
+            Instant submittedAt,
+            String hmac,
+            Long sequence) {
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/runner/DaemonPairRegisterRequest.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/runner/DaemonPairRegisterRequest.java
@@ -1,22 +1,22 @@
 package com.comet.opik.api.runner;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
+import java.util.UUID;
+
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record BridgeCommandResultRequest(
-        @NotNull BridgeCommandStatus status,
-        JsonNode result,
-        JsonNode error,
-        @Min(0) Long durationMs,
-        @Size(max = 512) String hmac,
-        @Min(0) Long sequence) {
+public record DaemonPairRegisterRequest(
+        @NotNull UUID projectId,
+        @NotBlank @Size(max = 128) String runnerName,
+        @NotNull @Min(1) @Max(86400) Long connectionTtlSeconds) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/runner/LocalRunnerConnectResponse.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/runner/LocalRunnerConnectResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 
+import java.time.Instant;
 import java.util.UUID;
 
 @Builder(toBuilder = true)
@@ -14,5 +15,6 @@ public record LocalRunnerConnectResponse(
         UUID runnerId,
         String workspaceId,
         UUID projectId,
-        String projectName) {
+        String projectName,
+        Instant expiresAt) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/runner/PakeMessagePage.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/runner/PakeMessagePage.java
@@ -1,22 +1,21 @@
 package com.comet.opik.api.runner;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
-import java.util.UUID;
+import java.util.List;
 
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record BridgeCommandSubmitRequest(
-        UUID commandId,
-        @NotNull BridgeCommandType type,
-        @NotNull JsonNode args,
-        Integer timeoutSeconds,
-        String hmac,
-        Long sequence) {
+public record PakeMessagePage(List<PakeMessageResponse> messages) {
+
+    private static final PakeMessagePage EMPTY = PakeMessagePage.builder().messages(List.of()).build();
+
+    /** Shared empty-page instance returned on long-poll timeouts. */
+    public static PakeMessagePage empty() {
+        return EMPTY;
+    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/runner/PakeMessageRequest.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/runner/PakeMessageRequest.java
@@ -1,10 +1,9 @@
 package com.comet.opik.api.runner;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -12,11 +11,7 @@ import lombok.Builder;
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record BridgeCommandResultRequest(
-        @NotNull BridgeCommandStatus status,
-        JsonNode result,
-        JsonNode error,
-        @Min(0) Long durationMs,
-        @Size(max = 512) String hmac,
-        @Min(0) Long sequence) {
+public record PakeMessageRequest(
+        @NotNull PakeStep step,
+        @NotBlank @Size(max = 4096) String payload) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/runner/PakeMessageResponse.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/runner/PakeMessageResponse.java
@@ -1,22 +1,14 @@
 package com.comet.opik.api.runner;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
-
-import java.util.UUID;
 
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record BridgeCommandSubmitRequest(
-        UUID commandId,
-        @NotNull BridgeCommandType type,
-        @NotNull JsonNode args,
-        Integer timeoutSeconds,
-        String hmac,
-        Long sequence) {
+public record PakeMessageResponse(
+        PakeStep step,
+        String payload) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/runner/PakeRole.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/runner/PakeRole.java
@@ -1,0 +1,32 @@
+package com.comet.opik.api.runner;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum PakeRole {
+
+    DAEMON("daemon"),
+    BROWSER("browser");
+
+    @JsonValue
+    private final String value;
+
+    /**
+     * Resolves a {@link PakeRole} from its wire value. Used by both Jackson
+     * body deserialization ({@link JsonCreator}) and JAX-RS path/query parameter
+     * conversion (via the standard {@code fromString} naming convention).
+     */
+    @JsonCreator
+    public static PakeRole fromString(String value) {
+        return Arrays.stream(values())
+                .filter(role -> role.value.equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown PakeRole: " + value));
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/runner/PakeStep.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/runner/PakeStep.java
@@ -1,0 +1,38 @@
+package com.comet.opik.api.runner;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum PakeStep {
+
+    SPAKE2("spake2"),
+    CONFIRMATION("confirmation"),
+    COMPLETION("completion");
+
+    @JsonValue
+    private final String value;
+
+    /**
+     * Resolves a {@link PakeStep} from its wire value. This is used by BOTH:
+     * <ul>
+     *   <li>Jackson body deserialization via {@link JsonCreator}</li>
+     *   <li>JAX-RS {@link jakarta.ws.rs.QueryParam} / {@link jakarta.ws.rs.PathParam}
+     *       conversion via the JAX-RS standard {@code fromString} naming convention</li>
+     * </ul>
+     * Throwing {@link IllegalArgumentException} on unknown values matches JAX-RS
+     * expectations and surfaces as a 404 at the resource layer.
+     */
+    @JsonCreator
+    public static PakeStep fromString(String value) {
+        return Arrays.stream(values())
+                .filter(step -> step.value.equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown PakeStep: " + value));
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DaemonPairPayload.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DaemonPairPayload.java
@@ -1,0 +1,28 @@
+package com.comet.opik.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+import java.util.UUID;
+
+/**
+ * Persisted PAKE pairing session payload stored in Redis for the duration of
+ * the handshake. Workspace/user identify the session owner; runnerId is the
+ * runner that will be activated on successful pairing; connectionTtlSeconds
+ * is the caller-supplied TTL used to compute the connection's {@code expiresAt}
+ * after completion (NOT the PAKE handshake TTL, which is a fixed 5 minutes).
+ */
+@Builder(toBuilder = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+record DaemonPairPayload(
+        UUID runnerId,
+        String workspaceId,
+        String userName,
+        String runnerName,
+        Long connectionTtlSeconds) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LocalRunnerService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LocalRunnerService.java
@@ -8,6 +8,7 @@ import com.comet.opik.api.runner.BridgeCommandStatus;
 import com.comet.opik.api.runner.BridgeCommandSubmitRequest;
 import com.comet.opik.api.runner.BridgeCommandType;
 import com.comet.opik.api.runner.CreateLocalRunnerJobRequest;
+import com.comet.opik.api.runner.DaemonPairRegisterRequest;
 import com.comet.opik.api.runner.LocalRunner;
 import com.comet.opik.api.runner.LocalRunnerConnectRequest;
 import com.comet.opik.api.runner.LocalRunnerConnectResponse;
@@ -19,6 +20,11 @@ import com.comet.opik.api.runner.LocalRunnerJobStatus;
 import com.comet.opik.api.runner.LocalRunnerLogEntry;
 import com.comet.opik.api.runner.LocalRunnerPairResponse;
 import com.comet.opik.api.runner.LocalRunnerStatus;
+import com.comet.opik.api.runner.PakeMessagePage;
+import com.comet.opik.api.runner.PakeMessageRequest;
+import com.comet.opik.api.runner.PakeMessageResponse;
+import com.comet.opik.api.runner.PakeRole;
+import com.comet.opik.api.runner.PakeStep;
 import com.comet.opik.infrastructure.LocalRunnerConfig;
 import com.comet.opik.infrastructure.redis.StringRedisClient;
 import com.comet.opik.utils.JsonUtils;
@@ -33,7 +39,6 @@ import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomUtils;
 import org.redisson.api.BatchResult;
@@ -114,11 +119,20 @@ public interface LocalRunnerService {
     void patchChecklist(UUID runnerId, String workspaceId, String userName, JsonNode updates);
 
     void reapDeadRunners();
+
+    UUID registerDaemonPair(String workspaceId, String userName, DaemonPairRegisterRequest request);
+
+    void postPakeMessage(String workspaceId, String userName, UUID projectId, PakeRole targetRole,
+            PakeMessageRequest request);
+
+    Mono<PakeMessagePage> getPakeMessages(String workspaceId, String userName, UUID projectId,
+            PakeRole targetRole, PakeStep targetStep);
+
+    LocalRunnerConnectResponse completePairing(String workspaceId, String userName, UUID projectId);
 }
 
 @Slf4j
 @Singleton
-@RequiredArgsConstructor(onConstructor_ = @Inject)
 class LocalRunnerServiceImpl implements LocalRunnerService {
 
     private static final String PAIRING_CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
@@ -255,16 +269,41 @@ class LocalRunnerServiceImpl implements LocalRunnerService {
     private static final String BRIDGE_FIELD_COMPLETED_AT = "completed_at";
     private static final String BRIDGE_FIELD_DURATION_MS = "duration_ms";
     private static final String BRIDGE_FIELD_WORKSPACE_ID = "workspace_id";
+    private static final String BRIDGE_FIELD_HMAC = "hmac";
+    private static final String BRIDGE_FIELD_SEQUENCE = "sequence";
 
     private static final List<String> DEFAULT_CAPABILITIES = List.of("jobs");
     private static final String BRIDGE_FIELD_COMPLETED_FLAG = "completed_flag";
     private static final String BRIDGE_DONE_SENTINEL = "done";
+
+    // Security-critical: these MUST NOT be made configurable. Changing them
+    // weakens brute-force resistance or widens the attack window.
+    private static final int MAX_PAKE_ATTEMPTS = 5;
+    private static final Duration PAKE_SESSION_TTL = Duration.ofMinutes(5);
+
+    // Bounds how long the completion marker (carrying the project name) survives in
+    // the daemon's inbox after completePairing. A daemon that misses this window
+    // recovers via the runner GET endpoint, which also returns project info.
+    private static final Duration COMPLETION_MARKER_TTL = Duration.ofMinutes(5);
 
     private final @NonNull StringRedisClient redisClient;
     private final @NonNull RedissonReactiveClient reactiveRedisClient;
     private final @NonNull LocalRunnerConfig runnerConfig;
     private final @NonNull IdGenerator idGenerator;
     private final @NonNull ProjectService projectService;
+
+    @Inject
+    LocalRunnerServiceImpl(StringRedisClient redisClient, RedissonReactiveClient reactiveRedisClient,
+            LocalRunnerConfig runnerConfig, IdGenerator idGenerator, ProjectService projectService) {
+        this.redisClient = redisClient;
+        this.reactiveRedisClient = reactiveRedisClient;
+        this.runnerConfig = runnerConfig;
+        this.idGenerator = idGenerator;
+        this.projectService = projectService;
+        this.pakeSession = new PakeSessionRedis(redisClient);
+    }
+
+    private final PakeSessionRedis pakeSession;
 
     @Override
     public LocalRunnerPairResponse generatePairingCode(@NonNull String workspaceId, @NonNull String userName,
@@ -339,12 +378,16 @@ class LocalRunnerServiceImpl implements LocalRunnerService {
             if (!projectIds.contains(runnerIdStr)) {
                 continue;
             }
+            UUID runnerId = UUID.fromString(runnerIdStr);
+            LocalRunnerStatus resolvedStatus = resolveStatus(runnerId);
             if (status != null) {
-                UUID runnerId = UUID.fromString(runnerIdStr);
-                LocalRunnerStatus resolvedStatus = resolveStatus(runnerId);
                 if (resolvedStatus != status) {
                     continue;
                 }
+            } else if (resolvedStatus == LocalRunnerStatus.PAIRING) {
+                // Hide half-paired runners from the default listing — they only show
+                // up when the caller explicitly asks for status=PAIRING.
+                continue;
             }
             matchedIds.add(runnerIdStr);
         }
@@ -1353,8 +1396,20 @@ class LocalRunnerServiceImpl implements LocalRunnerService {
         String argsJson = validateAndSerializePayload(request.args(), "args");
 
         int timeoutSeconds = resolveCommandTimeout(request.timeoutSeconds());
-        UUID commandId = idGenerator.generateId();
+        UUID commandId = request.commandId() != null ? request.commandId() : idGenerator.generateId();
+        Duration commandTtl = Duration.ofSeconds(timeoutSeconds * 2L + 60L);
+
         String now = Instant.now().toString();
+
+        // Reserve the command id atomically — collisions return 409 (no idempotent
+        // retries; see BridgeCommandSubmitRequest#commandId).
+        RMap<String, String> commandMap = redisClient.getMap(bridgeCommandKey(commandId));
+        if (!commandMap.fastPutIfAbsent(BRIDGE_FIELD_COMMAND_ID, commandId.toString())) {
+            throw new ClientErrorException(Response.status(Response.Status.CONFLICT)
+                    .entity(new ErrorMessage(List.of("Command ID already exists: " + commandId)))
+                    .build());
+        }
+        commandMap.expire(commandTtl);
 
         Map<String, String> commandFields = new HashMap<>();
         commandFields.put(BRIDGE_FIELD_COMMAND_ID, commandId.toString());
@@ -1365,12 +1420,13 @@ class LocalRunnerServiceImpl implements LocalRunnerService {
         commandFields.put(BRIDGE_FIELD_TIMEOUT_SECONDS, String.valueOf(timeoutSeconds));
         commandFields.put(BRIDGE_FIELD_SUBMITTED_AT, now);
         commandFields.put(BRIDGE_FIELD_WORKSPACE_ID, workspaceId);
+        putBridgeSignatureFields(commandFields, request.hmac(), request.sequence());
 
         RBatch batch = redisClient.createBatch();
         batch.<String, String>getMap(bridgeCommandKey(commandId), StringCodec.INSTANCE)
                 .putAllAsync(commandFields);
         batch.<String, String>getMap(bridgeCommandKey(commandId), StringCodec.INSTANCE)
-                .expireAsync(Duration.ofSeconds(timeoutSeconds * 2 + 60));
+                .expireAsync(commandTtl);
         batch.<String>getList(bridgePendingKey(runnerId), StringCodec.INSTANCE)
                 .addAsync(commandId.toString());
         batch.execute();
@@ -1506,6 +1562,7 @@ class LocalRunnerServiceImpl implements LocalRunnerService {
         if (request.durationMs() != null) {
             updates.put(BRIDGE_FIELD_DURATION_MS, request.durationMs().toString());
         }
+        putBridgeSignatureFields(updates, request.hmac(), request.sequence());
 
         RBatch resultBatch = redisClient.createBatch();
         resultBatch.<String, String>getMap(bridgeCommandKey(commandId), StringCodec.INSTANCE)
@@ -1755,6 +1812,8 @@ class LocalRunnerServiceImpl implements LocalRunnerService {
                 .args(parseJsonNode(fields.get(BRIDGE_FIELD_ARGS)))
                 .timeoutSeconds(parseIntValue(fields.get(BRIDGE_FIELD_TIMEOUT_SECONDS)))
                 .submittedAt(parseInstant(fields.get(BRIDGE_FIELD_SUBMITTED_AT)))
+                .hmac(fields.get(BRIDGE_FIELD_HMAC))
+                .sequence(parseLong(fields.get(BRIDGE_FIELD_SEQUENCE)))
                 .build();
     }
 
@@ -1772,6 +1831,8 @@ class LocalRunnerServiceImpl implements LocalRunnerService {
                 .pickedUpAt(parseInstant(fields.get(BRIDGE_FIELD_PICKED_UP_AT)))
                 .completedAt(parseInstant(fields.get(BRIDGE_FIELD_COMPLETED_AT)))
                 .durationMs(parseLong(fields.get(BRIDGE_FIELD_DURATION_MS)))
+                .hmac(fields.get(BRIDGE_FIELD_HMAC))
+                .sequence(parseLong(fields.get(BRIDGE_FIELD_SEQUENCE)))
                 .build();
     }
 
@@ -1808,6 +1869,155 @@ class LocalRunnerServiceImpl implements LocalRunnerService {
         } catch (NumberFormatException e) {
             return null;
         }
+    }
+
+    /**
+     * Writes the optional HMAC + sequence fields shared by bridge command submit and
+     * result requests into the given Redis field map. Null values are skipped so the
+     * BE stores absent fields as absent rather than the literal string "null".
+     */
+    private static void putBridgeSignatureFields(Map<String, String> target, String hmac, Long sequence) {
+        if (hmac != null) {
+            target.put(BRIDGE_FIELD_HMAC, hmac);
+        }
+        if (sequence != null) {
+            target.put(BRIDGE_FIELD_SEQUENCE, sequence.toString());
+        }
+    }
+
+    // --- PAKE relay methods ---
+
+    @Override
+    public UUID registerDaemonPair(@NonNull String workspaceId, @NonNull String userName,
+            @NonNull DaemonPairRegisterRequest request) {
+        UUID projectId = request.projectId();
+        UUID runnerId = idGenerator.generateId();
+        Duration ttl = PAKE_SESSION_TTL;
+
+        DaemonPairPayload payload = DaemonPairPayload.builder()
+                .runnerId(runnerId)
+                .workspaceId(workspaceId)
+                .userName(userName)
+                .runnerName(request.runnerName())
+                .connectionTtlSeconds(request.connectionTtlSeconds())
+                .build();
+
+        // Drop any prior runner row for this (workspace, project, user) so a re-pair
+        // doesn't leave the previous runnerId orphaned in the user's listing.
+        evictExistingRunner(workspaceId, projectId, userName, runnerId);
+        pakeSession.createSession(projectId, workspaceId, userName, payload, ttl);
+
+        RMap<String, String> runnerMap = redisClient.getMap(runnerKey(runnerId));
+        runnerMap.putAll(Map.of(
+                FIELD_NAME, request.runnerName(),
+                FIELD_STATUS, LocalRunnerStatus.PAIRING.getValue(),
+                FIELD_WORKSPACE_ID, workspaceId,
+                FIELD_USER_NAME, userName,
+                FIELD_PROJECT_ID, projectId.toString()));
+        runnerMap.expire(ttl.multipliedBy(2));
+
+        registerRunnerInSets(workspaceId, userName, projectId, runnerId);
+
+        return runnerId;
+    }
+
+    @Override
+    public void postPakeMessage(@NonNull String workspaceId, @NonNull String userName, @NonNull UUID projectId,
+            @NonNull PakeRole targetRole, @NonNull PakeMessageRequest request) {
+        PakeSessionRedis sessions = pakeSession;
+        if (!sessions.isSessionActive(projectId, workspaceId, userName)) {
+            throw new NotFoundException("No pairing session found for workspace='" + workspaceId
+                    + "' project='" + projectId + "'");
+        }
+
+        if (request.step() == PakeStep.SPAKE2) {
+            long count = sessions.incrementAttempts(projectId, workspaceId, userName, PAKE_SESSION_TTL);
+            if (count > MAX_PAKE_ATTEMPTS) {
+                sessions.deleteSession(projectId, workspaceId, userName);
+                throw new ClientErrorException(Response.status(Response.Status.TOO_MANY_REQUESTS)
+                        .entity(new ErrorMessage(List.of(
+                                "Too many pairing attempts for project='" + projectId
+                                        + "'. Session has been invalidated.")))
+                        .build());
+            }
+        }
+
+        boolean accepted = sessions.postMessageIfFirst(projectId, workspaceId, userName,
+                targetRole, request.step(), request.payload(), PAKE_SESSION_TTL);
+        if (!accepted) {
+            throw new ClientErrorException(Response.status(Response.Status.CONFLICT)
+                    .entity(new ErrorMessage(List.of(
+                            "PAKE message already posted for targetRole='" + targetRole
+                                    + "' step='" + request.step() + "' project='" + projectId + "'")))
+                    .build());
+        }
+    }
+
+    @Override
+    public Mono<PakeMessagePage> getPakeMessages(@NonNull String workspaceId, @NonNull String userName,
+            @NonNull UUID projectId, @NonNull PakeRole targetRole, @NonNull PakeStep targetStep) {
+        PakeSessionRedis sessions = pakeSession;
+        if (!sessions.sessionExists(projectId, workspaceId, userName)) {
+            throw new NotFoundException("No pairing session found for workspace='" + workspaceId
+                    + "' project='" + projectId + "'");
+        }
+
+        Duration pollTimeout = runnerConfig.getPakePollTimeout().toJavaDuration();
+
+        // Redisson's pollAsync returns a CompletionStage that the client fulfils when
+        // either a message arrives or the Redis-side timeout fires. Subscription
+        // cancellation (AsyncResponse timeout, client disconnect) propagates through
+        // the Mono chain, so an orphaned poll no longer blocks a boundedElastic thread
+        // or steals the next-arriving message from a retrying caller.
+        return sessions.awaitMessage(projectId, workspaceId, userName, targetRole, targetStep, pollTimeout)
+                .map(opt -> opt
+                        .map(payload -> PakeMessagePage.builder()
+                                .messages(List.of(PakeMessageResponse.builder()
+                                        .step(targetStep)
+                                        .payload(payload)
+                                        .build()))
+                                .build())
+                        .orElseGet(PakeMessagePage::empty));
+    }
+
+    @Override
+    public LocalRunnerConnectResponse completePairing(@NonNull String workspaceId, @NonNull String userName,
+            @NonNull UUID projectId) {
+        PakeSessionRedis sessions = pakeSession;
+        DaemonPairPayload payload = sessions.consumeSession(projectId, workspaceId, userName, COMPLETION_MARKER_TTL)
+                .orElseThrow(() -> new NotFoundException("No pairing session found for workspace='"
+                        + workspaceId + "' project='" + projectId + "'"));
+
+        UUID runnerId = payload.runnerId();
+        String projectName = projectService.get(projectId, workspaceId).name();
+
+        evictExistingRunner(workspaceId, projectId, userName, runnerId);
+        registerRunnerInSets(workspaceId, userName, projectId, runnerId);
+        setUserRunner(workspaceId, projectId, userName, runnerId);
+        activateRunner(runnerId, workspaceId, projectId, userName, payload.runnerName());
+
+        // Post the completion marker into the daemon's inbox so its final long-poll
+        // for target_step=COMPLETION returns the project name. takeSession above is
+        // atomic, so this method runs at most once per session — a duplicate here
+        // would mean an upstream invariant broke and we want it loud.
+        boolean accepted = sessions.postMessageIfFirst(projectId, workspaceId, userName,
+                PakeRole.DAEMON, PakeStep.COMPLETION, projectName, COMPLETION_MARKER_TTL);
+        if (!accepted) {
+            throw new IllegalStateException("Completion marker already posted for project='"
+                    + projectId + "' workspace='" + workspaceId + "'");
+        }
+
+        Instant expiresAt = payload.connectionTtlSeconds() != null
+                ? Instant.now().plusSeconds(payload.connectionTtlSeconds())
+                : null;
+
+        return LocalRunnerConnectResponse.builder()
+                .runnerId(runnerId)
+                .workspaceId(workspaceId)
+                .projectId(projectId)
+                .projectName(projectName)
+                .expiresAt(expiresAt)
+                .build();
     }
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PakeSessionRedis.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PakeSessionRedis.java
@@ -1,0 +1,196 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.runner.PakeRole;
+import com.comet.opik.api.runner.PakeStep;
+import com.comet.opik.infrastructure.redis.StringRedisClient;
+import com.comet.opik.utils.JsonUtils;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RBlockingDeque;
+import org.redisson.api.RBucket;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Encapsulates all Redis key construction and access for PAKE pairing sessions.
+ *
+ * <p>The PAKE handshake uses three kinds of Redis primitives per session:
+ * <ol>
+ *   <li>A bucket storing the {@link DaemonPairPayload} for the life of the handshake</li>
+ *   <li>Six {@link RBlockingDeque} inboxes, one per (target role, step) pair, that let
+ *       each side long-poll for the next expected message from its peer</li>
+ *   <li>An atomic counter tracking failed pairing attempts for rate limiting</li>
+ * </ol>
+ *
+ * <p>Key ordering deliberately puts {@code projectId} before {@code workspaceId:userName}
+ * so the higher-cardinality dimension comes first — this improves key dispersion in
+ * Redis cluster mode and matches the convention used elsewhere in this service.
+ *
+ * <p>The inbox-per-(role, step) split means a poller never scans or filters messages
+ * it doesn't want: {@code pollAsync} on the exact target queue either returns the
+ * next message from that side of the handshake or times out. No in-memory filtering,
+ * no {@code readAll} per poll cycle.
+ */
+@RequiredArgsConstructor
+class PakeSessionRedis {
+
+    private static final String KEY_PREFIX = "opik:runners:pake";
+
+    private final @NonNull StringRedisClient redisClient;
+
+    // ---- Key construction -------------------------------------------------
+
+    private static String sessionKey(UUID projectId, String workspaceId, String userName) {
+        return KEY_PREFIX + ":session:" + projectId + ":" + workspaceId + ":" + userName;
+    }
+
+    private static String consumedMarkerKey(UUID projectId, String workspaceId, String userName) {
+        return KEY_PREFIX + ":consumed:" + projectId + ":" + workspaceId + ":" + userName;
+    }
+
+    private static String inboxKey(UUID projectId, String workspaceId, String userName,
+            PakeRole targetRole, PakeStep step) {
+        return KEY_PREFIX + ":inbox:" + projectId + ":" + workspaceId + ":" + userName
+                + ":" + targetRole.getValue() + ":" + step.getValue();
+    }
+
+    /**
+     * Per (role, step) marker bucket used to detect and reject duplicate posts. A PAKE
+     * handshake expects exactly one message per {@code (targetRole, step)} combination
+     * within a session; a second post is either a client retry bug or a relay replay
+     * attempt and should be rejected with 409 rather than silently double-queued.
+     */
+    private static String postedMarkerKey(UUID projectId, String workspaceId, String userName,
+            PakeRole targetRole, PakeStep step) {
+        return KEY_PREFIX + ":posted:" + projectId + ":" + workspaceId + ":" + userName
+                + ":" + targetRole.getValue() + ":" + step.getValue();
+    }
+
+    private static String attemptsKey(UUID projectId, String workspaceId, String userName) {
+        return KEY_PREFIX + ":attempts:" + projectId + ":" + workspaceId + ":" + userName;
+    }
+
+    // ---- Session bucket ---------------------------------------------------
+
+    void createSession(UUID projectId, String workspaceId, String userName,
+            DaemonPairPayload payload, Duration ttl) {
+        // Clean up any stale session for this user+project (crash recovery).
+        deleteSession(projectId, workspaceId, userName);
+
+        RBucket<String> bucket = redisClient.getBucket(sessionKey(projectId, workspaceId, userName));
+        bucket.set(JsonUtils.writeValueAsString(payload), ttl);
+    }
+
+    /**
+     * Returns true if the session is reachable for any purpose — either still active
+     * or recently consumed (within the post-consume TTL set by {@link #consumeSession}).
+     * Used by long-pollers, which include the daemon's final COMPLETION poll after
+     * the active session has been consumed.
+     */
+    boolean sessionExists(UUID projectId, String workspaceId, String userName) {
+        return redisClient.getBucket(sessionKey(projectId, workspaceId, userName)).isExists()
+                || redisClient.getBucket(consumedMarkerKey(projectId, workspaceId, userName)).isExists();
+    }
+
+    /**
+     * Returns true only if the session is still in the active (pre-consume) state.
+     * Used by writers (handshake message posters) so a consumed session cannot
+     * accept new messages.
+     */
+    boolean isSessionActive(UUID projectId, String workspaceId, String userName) {
+        return redisClient.getBucket(sessionKey(projectId, workspaceId, userName)).isExists();
+    }
+
+    Optional<DaemonPairPayload> getSession(UUID projectId, String workspaceId, String userName) {
+        String json = redisClient.getBucket(sessionKey(projectId, workspaceId, userName)).get();
+        return json == null ? Optional.empty() : Optional.of(JsonUtils.readValue(json, DaemonPairPayload.class));
+    }
+
+    /**
+     * Atomically removes the active session and writes a short-lived consumed marker.
+     * The marker keeps {@link #sessionExists} true so the daemon's final COMPLETION
+     * poll still passes the auth check, while {@link #isSessionActive} immediately
+     * returns false so no further handshake messages can be posted.
+     */
+    Optional<DaemonPairPayload> consumeSession(UUID projectId, String workspaceId, String userName,
+            Duration postConsumeTtl) {
+        String json = redisClient.getBucket(sessionKey(projectId, workspaceId, userName)).getAndDelete();
+        if (json == null) {
+            return Optional.empty();
+        }
+        redisClient.getBucket(consumedMarkerKey(projectId, workspaceId, userName))
+                .set("1", postConsumeTtl);
+        return Optional.of(JsonUtils.readValue(json, DaemonPairPayload.class));
+    }
+
+    void deleteSession(UUID projectId, String workspaceId, String userName) {
+        redisClient.getBucket(sessionKey(projectId, workspaceId, userName)).delete();
+        redisClient.getBucket(consumedMarkerKey(projectId, workspaceId, userName)).delete();
+        for (PakeRole role : PakeRole.values()) {
+            for (PakeStep step : PakeStep.values()) {
+                redisClient.<String>getBlockingDeque(inboxKey(projectId, workspaceId, userName, role, step)).delete();
+                redisClient.getBucket(postedMarkerKey(projectId, workspaceId, userName, role, step)).delete();
+            }
+        }
+        redisClient.getAtomicLong(attemptsKey(projectId, workspaceId, userName)).delete();
+    }
+
+    // ---- Inboxes (one RBlockingDeque per (role, step)) --------------------
+
+    /**
+     * Posts a message into the target inbox. Returns {@code false} if a message
+     * for this {@code (targetRole, step)} pair has already been posted in this
+     * session — the caller should treat that as a 409 conflict and not append.
+     */
+    boolean postMessageIfFirst(UUID projectId, String workspaceId, String userName,
+            PakeRole targetRole, PakeStep step, String payload, Duration ttl) {
+        RBucket<String> marker = redisClient.getBucket(
+                postedMarkerKey(projectId, workspaceId, userName, targetRole, step));
+        if (!marker.trySet("1", ttl.toMillis(), TimeUnit.MILLISECONDS)) {
+            return false;
+        }
+        RBlockingDeque<String> deque = redisClient.<String>getBlockingDeque(
+                inboxKey(projectId, workspaceId, userName, targetRole, step));
+        deque.add(payload);
+        deque.expire(ttl);
+        return true;
+    }
+
+    /**
+     * Returns a {@link Mono} that emits the next message in the specified inbox
+     * or completes empty on timeout. Uses Redisson's async poll so a cancelled
+     * subscription (e.g. AsyncResponse timeout, client disconnect) releases the
+     * boundedElastic thread immediately rather than blocking until the Redis-side
+     * timeout expires — avoiding the orphaned-poll "message stealing" problem.
+     *
+     * <p>Mirrors the async pattern used by {@code awaitBridgeCommand} in
+     * {@link LocalRunnerService}, which drives the bridge long-poll.
+     */
+    Mono<Optional<String>> awaitMessage(UUID projectId, String workspaceId, String userName,
+            PakeRole targetRole, PakeStep step, Duration timeout) {
+        RBlockingDeque<String> deque = redisClient.<String>getBlockingDeque(
+                inboxKey(projectId, workspaceId, userName, targetRole, step));
+        return Mono.fromCompletionStage(() -> deque.pollAsync(timeout.toMillis(), TimeUnit.MILLISECONDS))
+                .map(Optional::ofNullable)
+                .defaultIfEmpty(Optional.empty());
+    }
+
+    // ---- Attempts counter -------------------------------------------------
+
+    /**
+     * Increments the attempts counter and refreshes its TTL. The two ops are not
+     * atomic — a crash between them leaves an un-TTL'd counter that gets wiped
+     * the next time {@link #createSession} runs for this (project, user).
+     */
+    long incrementAttempts(UUID projectId, String workspaceId, String userName, Duration ttl) {
+        RAtomicLong attempts = redisClient.getAtomicLong(attemptsKey(projectId, workspaceId, userName));
+        long count = attempts.incrementAndGet();
+        attempts.expire(ttl);
+        return count;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/LocalRunnerConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/LocalRunnerConfig.java
@@ -87,6 +87,14 @@ public class LocalRunnerConfig {
 
     @Valid @NotNull @JsonProperty
     @MinDuration(value = 1, unit = TimeUnit.SECONDS)
+    private Duration pakePollTimeout = Duration.seconds(30);
+
+    @Valid @NotNull @JsonProperty
+    @MinDuration(value = 1, unit = TimeUnit.SECONDS)
+    private Duration pakeAsyncTimeoutBuffer = Duration.seconds(5);
+
+    @Valid @NotNull @JsonProperty
+    @MinDuration(value = 1, unit = TimeUnit.SECONDS)
     private Duration bridgeDefaultCommandTimeout = Duration.seconds(30);
 
     @Valid @NotNull @JsonProperty

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/web/AsyncResponseSupport.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/web/AsyncResponseSupport.java
@@ -1,0 +1,67 @@
+package com.comet.opik.infrastructure.web;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.core.Response;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+/**
+ * Bridges Reactor {@link Mono} results to JAX-RS {@link AsyncResponse}, handling
+ * the timeout setup and error-path branching consistently.
+ *
+ * <p>Without this helper, each long-polling endpoint hand-rolls the same subscribe
+ * + timeout + WebApplicationException vs. generic error branch — which is easy to
+ * get slightly wrong in each copy. Centralizing it also means the context logging
+ * format for server errors is uniform across endpoints.
+ */
+@UtilityClass
+@Slf4j
+public class AsyncResponseSupport {
+
+    /**
+     * Resumes {@code asyncResponse} with the result of {@code mono}, mapping
+     * success through {@code onSuccess}. On timeout, resumes with {@code onTimeout}.
+     * On {@link WebApplicationException}, resumes the exception; on any other
+     * error, logs with the supplied context and resumes a 500.
+     *
+     * @param asyncResponse      the suspended response to resume
+     * @param mono               the reactive source
+     * @param timeoutSeconds     total timeout before {@code onTimeout} fires
+     * @param onSuccess          maps the emitted value to a Response
+     * @param onTimeout          built on timeout (e.g. 408 or 200 empty)
+     * @param errorContextFormat slf4j format string for the error log
+     * @param errorContextArgs   arguments for the format string (IDs only, no secrets)
+     */
+    public static <T> void resume(
+            AsyncResponse asyncResponse,
+            Mono<T> mono,
+            long timeoutSeconds,
+            Function<T, Response> onSuccess,
+            Response onTimeout,
+            String errorContextFormat,
+            Object... errorContextArgs) {
+
+        asyncResponse.setTimeout(timeoutSeconds, TimeUnit.SECONDS);
+        asyncResponse.setTimeoutHandler(ar -> ar.resume(onTimeout));
+
+        mono.map(onSuccess)
+                .subscribe(
+                        asyncResponse::resume,
+                        error -> {
+                            if (error instanceof WebApplicationException wae) {
+                                asyncResponse.resume(wae);
+                            } else {
+                                Object[] logArgs = new Object[errorContextArgs.length + 1];
+                                System.arraycopy(errorContextArgs, 0, logArgs, 0, errorContextArgs.length);
+                                logArgs[errorContextArgs.length] = error;
+                                log.error(errorContextFormat, logArgs);
+                                asyncResponse.resume(Response.serverError().build());
+                            }
+                        });
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/LocalRunnersResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/LocalRunnersResourceClient.java
@@ -7,17 +7,19 @@ import com.comet.opik.api.runner.BridgeCommandResultRequest;
 import com.comet.opik.api.runner.BridgeCommandSubmitRequest;
 import com.comet.opik.api.runner.BridgeCommandSubmitResponse;
 import com.comet.opik.api.runner.CreateLocalRunnerJobRequest;
+import com.comet.opik.api.runner.DaemonPairRegisterRequest;
 import com.comet.opik.api.runner.LocalRunner;
-import com.comet.opik.api.runner.LocalRunnerConnectRequest;
 import com.comet.opik.api.runner.LocalRunnerConnectResponse;
 import com.comet.opik.api.runner.LocalRunnerHeartbeatRequest;
 import com.comet.opik.api.runner.LocalRunnerHeartbeatResponse;
 import com.comet.opik.api.runner.LocalRunnerJob;
 import com.comet.opik.api.runner.LocalRunnerJobResultRequest;
 import com.comet.opik.api.runner.LocalRunnerLogEntry;
-import com.comet.opik.api.runner.LocalRunnerPairRequest;
-import com.comet.opik.api.runner.LocalRunnerPairResponse;
 import com.comet.opik.api.runner.LocalRunnerStatus;
+import com.comet.opik.api.runner.PakeMessagePage;
+import com.comet.opik.api.runner.PakeMessageRequest;
+import com.comet.opik.api.runner.PakeRole;
+import com.comet.opik.api.runner.PakeStep;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -41,30 +43,70 @@ public class LocalRunnersResourceClient {
     private final ClientSupport client;
     private final String baseURI;
 
-    public LocalRunnerPairResponse generatePairingCode(UUID projectId, String apiKey, String workspaceName) {
-        LocalRunnerPairRequest request = LocalRunnerPairRequest.builder().projectId(projectId).build();
-        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
-                .path("pairs")
-                .request()
-                .header(HttpHeaders.AUTHORIZATION, apiKey)
-                .header(WORKSPACE_HEADER, workspaceName)
-                .post(Entity.json(request))) {
+    private static final long DEFAULT_CONNECTION_TTL_SECONDS = 24 * 60 * 60L;
+
+    /**
+     * POST /daemon-pairs → 201 + Location (no entity). Parses the runnerId out
+     * of the Location header for convenience.
+     */
+    public UUID registerDaemonPair(UUID projectId, String runnerName, String apiKey, String workspaceName) {
+        try (var response = callRegisterDaemonPair(projectId, runnerName, DEFAULT_CONNECTION_TTL_SECONDS,
+                apiKey, workspaceName)) {
             assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CREATED);
-            return response.readEntity(LocalRunnerPairResponse.class);
+            assertThat(response.getLocation()).isNotNull();
+            return runnerIdFromLocation(response.getLocation().toString());
         }
     }
 
-    public LocalRunnerConnectResponse connect(LocalRunnerConnectRequest request, String apiKey,
-            String workspaceName) {
-        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
-                .path("connections")
+    /**
+     * Raw POST /daemon-pairs without status assertion. Useful for testing validation
+     * paths (e.g. asserting an over-large connection TTL is rejected with 422).
+     */
+    public Response callRegisterDaemonPair(UUID projectId, String runnerName, long connectionTtlSeconds,
+            String apiKey, String workspaceName) {
+        DaemonPairRegisterRequest request = DaemonPairRegisterRequest.builder()
+                .projectId(projectId)
+                .runnerName(runnerName)
+                .connectionTtlSeconds(connectionTtlSeconds)
+                .build();
+        return client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("daemon-pairs")
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, apiKey)
                 .header(WORKSPACE_HEADER, workspaceName)
-                .post(Entity.json(request))) {
+                .post(Entity.json(request));
+    }
+
+    /**
+     * POST /pake/complete/{projectId} → 201 + Location (no entity). Follows up with
+     * a GET /local-runners/{runnerId} to hydrate the response shape expected by
+     * existing tests. Real callers would do the follow-up GET themselves.
+     */
+    public LocalRunnerConnectResponse completePairing(UUID projectId, String apiKey, String workspaceName) {
+        UUID runnerId;
+        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("pake")
+                .path("complete")
+                .path(projectId.toString())
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(""))) {
             assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CREATED);
-            return response.readEntity(LocalRunnerConnectResponse.class);
+            assertThat(response.getLocation()).isNotNull();
+            runnerId = runnerIdFromLocation(response.getLocation().toString());
         }
+        LocalRunner runner = getRunner(runnerId, apiKey, workspaceName);
+        return LocalRunnerConnectResponse.builder()
+                .runnerId(runner.id())
+                .projectId(runner.projectId())
+                .build();
+    }
+
+    private static UUID runnerIdFromLocation(String location) {
+        int slash = location.lastIndexOf('/');
+        String id = slash >= 0 ? location.substring(slash + 1) : location;
+        return UUID.fromString(id);
     }
 
     public LocalRunner.LocalRunnerPage listRunners(UUID projectId, String apiKey, String workspaceName) {
@@ -231,15 +273,6 @@ public class LocalRunnersResourceClient {
                 .post(Entity.json(""))) {
             assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
         }
-    }
-
-    public Response callConnect(LocalRunnerConnectRequest request, String apiKey, String workspaceName) {
-        return client.target(RESOURCE_PATH.formatted(baseURI))
-                .path("connections")
-                .request()
-                .header(HttpHeaders.AUTHORIZATION, apiKey)
-                .header(WORKSPACE_HEADER, workspaceName)
-                .post(Entity.json(request));
     }
 
     public Response callGetRunner(UUID runnerId, String apiKey, String workspaceName) {
@@ -457,5 +490,55 @@ public class LocalRunnersResourceClient {
                 .header(HttpHeaders.AUTHORIZATION, apiKey)
                 .header(WORKSPACE_HEADER, workspaceName)
                 .get();
+    }
+
+    // --- PAKE message relay (new path-param API shape) ---
+
+    public Response callPostPakeMessage(UUID projectId, PakeRole targetRole, PakeStep step, String payload,
+            String apiKey, String workspaceName) {
+        PakeMessageRequest request = PakeMessageRequest.builder()
+                .step(step)
+                .payload(payload)
+                .build();
+        return client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("pake")
+                .path("messages")
+                .path(projectId.toString())
+                .path(targetRole.getValue())
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(request));
+    }
+
+    public void postPakeMessage(UUID projectId, PakeRole targetRole, PakeStep step, String payload,
+            String apiKey, String workspaceName) {
+        try (var response = callPostPakeMessage(projectId, targetRole, step, payload, apiKey, workspaceName)) {
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+        }
+    }
+
+    public Response callGetPakeMessages(UUID projectId, PakeRole targetRole, PakeStep targetStep,
+            String apiKey, String workspaceName) {
+        var target = client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("pake")
+                .path("messages")
+                .path(projectId.toString())
+                .path(targetRole.getValue());
+        if (targetStep != null) {
+            target = target.queryParam("target_step", targetStep.getValue());
+        }
+        return target.request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .get();
+    }
+
+    public PakeMessagePage getPakeMessages(UUID projectId, PakeRole targetRole, PakeStep targetStep,
+            String apiKey, String workspaceName) {
+        try (var response = callGetPakeMessages(projectId, targetRole, targetStep, apiKey, workspaceName)) {
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+            return response.readEntity(PakeMessagePage.class);
+        }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResourceTest.java
@@ -23,7 +23,6 @@ import com.comet.opik.api.runner.BridgeCommandSubmitResponse;
 import com.comet.opik.api.runner.BridgeCommandType;
 import com.comet.opik.api.runner.CreateLocalRunnerJobRequest;
 import com.comet.opik.api.runner.LocalRunner;
-import com.comet.opik.api.runner.LocalRunnerConnectRequest;
 import com.comet.opik.api.runner.LocalRunnerConnectResponse;
 import com.comet.opik.api.runner.LocalRunnerHeartbeatResponse;
 import com.comet.opik.api.runner.LocalRunnerJob;
@@ -31,8 +30,10 @@ import com.comet.opik.api.runner.LocalRunnerJobMetadata;
 import com.comet.opik.api.runner.LocalRunnerJobResultRequest;
 import com.comet.opik.api.runner.LocalRunnerJobStatus;
 import com.comet.opik.api.runner.LocalRunnerLogEntry;
-import com.comet.opik.api.runner.LocalRunnerPairResponse;
 import com.comet.opik.api.runner.LocalRunnerStatus;
+import com.comet.opik.api.runner.PakeMessagePage;
+import com.comet.opik.api.runner.PakeRole;
+import com.comet.opik.api.runner.PakeStep;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.podam.PodamFactoryUtils;
@@ -155,12 +156,8 @@ class LocalRunnersResourceTest {
     }
 
     private UUID connectRunnerWithPairing(String name, UUID projectId, String apiKey, String workspace) {
-        LocalRunnerPairResponse pair = runnersClient.generatePairingCode(projectId, apiKey, workspace);
-        LocalRunnerConnectRequest req = LocalRunnerConnectRequest.builder()
-                .pairingCode(pair.pairingCode())
-                .runnerName(name)
-                .build();
-        LocalRunnerConnectResponse resp = runnersClient.connect(req, apiKey, workspace);
+        runnersClient.registerDaemonPair(projectId, name, apiKey, workspace);
+        LocalRunnerConnectResponse resp = runnersClient.completePairing(projectId, apiKey, workspace);
         LocalRunner.Agent agent = LocalRunner.Agent.builder()
                 .name(AGENT_NAME)
                 .build();
@@ -190,18 +187,9 @@ class LocalRunnersResourceTest {
     void happyPath() {
         UUID projectId = createProject(API_KEY, TEST_WORKSPACE);
 
-        LocalRunnerPairResponse pairResponse = runnersClient.generatePairingCode(projectId, API_KEY, TEST_WORKSPACE);
-        assertThat(pairResponse.pairingCode()).isNotBlank();
-        assertThat(pairResponse.runnerId()).isNotNull();
-        assertThat(pairResponse.expiresInSeconds()).isPositive();
-
-        LocalRunnerConnectRequest connectRequest = LocalRunnerConnectRequest.builder()
-                .pairingCode(pairResponse.pairingCode())
-                .runnerName("test-runner")
-                .build();
-        LocalRunnerConnectResponse connectResp = runnersClient.connect(connectRequest, API_KEY, TEST_WORKSPACE);
+        runnersClient.registerDaemonPair(projectId, "test-runner", API_KEY, TEST_WORKSPACE);
+        LocalRunnerConnectResponse connectResp = runnersClient.completePairing(projectId, API_KEY, TEST_WORKSPACE);
         UUID runnerId = connectResp.runnerId();
-        assertThat(runnerId).isEqualTo(pairResponse.runnerId());
         assertThat(connectResp.projectId()).isEqualTo(projectId);
 
         LocalRunner.LocalRunnerPage runnerPage = runnersClient.listRunners(projectId, API_KEY, TEST_WORKSPACE);
@@ -309,65 +297,6 @@ class LocalRunnersResourceTest {
     }
 
     @Nested
-    @DisplayName("Generate Pairing Code")
-    class GeneratePairingCode {
-
-        @Test
-        void createsValidCode() {
-            UUID projectId = createProject(API_KEY, TEST_WORKSPACE);
-            LocalRunnerPairResponse resp = runnersClient.generatePairingCode(projectId, API_KEY, TEST_WORKSPACE);
-
-            assertThat(resp.pairingCode()).hasSize(6);
-            assertThat(resp.pairingCode()).matches("[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{6}");
-            assertThat(resp.runnerId()).isNotNull();
-            assertThat(resp.expiresInSeconds()).isEqualTo(3600);
-        }
-    }
-
-    @Nested
-    @DisplayName("Connect")
-    class Connect {
-
-        @Test
-        void withExpiredPairingCode_returns400() {
-            LocalRunnerConnectRequest req = LocalRunnerConnectRequest.builder()
-                    .pairingCode("ZZZZZZ")
-                    .runnerName("runner")
-                    .build();
-
-            try (var response = runnersClient.callConnect(req, API_KEY, TEST_WORKSPACE)) {
-                assertThat(response.getStatus()).isEqualTo(400);
-            }
-        }
-
-        @Test
-        void withPairingCodeFromDifferentWorkspace_returns400() {
-            UUID projectId = createProject(API_KEY, TEST_WORKSPACE);
-            LocalRunnerPairResponse pair = runnersClient.generatePairingCode(projectId, API_KEY, TEST_WORKSPACE);
-
-            LocalRunnerConnectRequest req = LocalRunnerConnectRequest.builder()
-                    .pairingCode(pair.pairingCode())
-                    .runnerName("runner")
-                    .build();
-
-            try (var response = runnersClient.callConnect(req, OTHER_API_KEY, OTHER_WORKSPACE)) {
-                assertThat(response.getStatus()).isEqualTo(400);
-            }
-        }
-
-        @Test
-        void withoutPairingCode_returns422() {
-            LocalRunnerConnectRequest req = LocalRunnerConnectRequest.builder()
-                    .runnerName("runner")
-                    .build();
-
-            try (var response = runnersClient.callConnect(req, API_KEY, TEST_WORKSPACE)) {
-                assertThat(response.getStatus()).isEqualTo(422);
-            }
-        }
-    }
-
-    @Nested
     @DisplayName("List Runners")
     class ListRunners {
 
@@ -467,8 +396,8 @@ class LocalRunnersResourceTest {
 
             UUID connectedRunner = connectRunnerWithPairing("connected-runner", projectId, ctx.apiKey, ctx.workspace);
 
-            LocalRunnerPairResponse pair = runnersClient.generatePairingCode(projectId, ctx.apiKey, ctx.workspace);
-            UUID pairingRunner = pair.runnerId();
+            UUID pairingRunner = runnersClient
+                    .registerDaemonPair(projectId, "pairing-runner", ctx.apiKey, ctx.workspace);
 
             LocalRunner.LocalRunnerPage pairingPage = runnersClient.listRunners(projectId,
                     LocalRunnerStatus.PAIRING, 0, 25, ctx.apiKey, ctx.workspace);
@@ -1426,6 +1355,36 @@ class LocalRunnersResourceTest {
                 assertThat(response.getStatus()).isEqualTo(404);
             }
         }
+
+        @Test
+        @DisplayName("Submitting twice with the same commandId returns 409 (no shadow, no double-queue)")
+        void duplicateCommandIdReturns409() {
+            var ctx = createIsolatedWorkspace();
+            UUID projectId = createProject(ctx.apiKey, ctx.workspace);
+            UUID runnerId = connectRunnerWithBridge("bridge-dup", projectId, ctx.apiKey, ctx.workspace);
+
+            UUID commandId = randomUUID();
+            BridgeCommandSubmitRequest req = BridgeCommandSubmitRequest.builder()
+                    .commandId(commandId)
+                    .type(BridgeCommandType.READ_FILE)
+                    .args(MAPPER.createObjectNode().put("path", "f.py"))
+                    .build();
+
+            BridgeCommandSubmitResponse first = runnersClient.createBridgeCommand(runnerId, req, ctx.apiKey,
+                    ctx.workspace);
+            assertThat(first.commandId()).isEqualTo(commandId);
+
+            try (var response = runnersClient.callSubmitBridgeCommand(runnerId, req, ctx.apiKey, ctx.workspace)) {
+                assertThat(response.getStatus()).isEqualTo(409);
+            }
+
+            // The pending queue should still have exactly one entry (the first submission).
+            // We assert this indirectly by polling once and checking we get a single command.
+            BridgeCommandBatchResponse batch = runnersClient.nextBridgeCommands(runnerId,
+                    BridgeCommandNextRequest.builder().maxCommands(10).build(), ctx.apiKey, ctx.workspace);
+            assertThat(batch.commands()).hasSize(1);
+            assertThat(batch.commands().getFirst().commandId()).isEqualTo(commandId);
+        }
     }
 
     @Nested
@@ -1524,6 +1483,239 @@ class LocalRunnersResourceTest {
 
             LocalRunner runner = runnersClient.getRunner(runnerId, ctx.apiKey, ctx.workspace);
             assertThat(runner.capabilities()).containsExactly("jobs");
+        }
+    }
+
+    @Nested
+    @DisplayName("PAKE Messaging")
+    class PakeMessaging {
+
+        // These tests target the Phase B redesigned API shape:
+        //   POST /v1/private/local-runners/pake/messages/{project_id}/{target_role}
+        //   GET  /v1/private/local-runners/pake/messages/{project_id}/{target_role}?target_step=SPAKE2
+        //
+        // Semantics:
+        //   target_role  = which inbox to read from / post into
+        //   target_step  = filter applied after dequeue
+        //
+        // Browser posts into DAEMON inbox (messages the daemon will poll for).
+        // Daemon posts into BROWSER inbox (messages the browser will poll for).
+        //
+        // Both sides use the same auth context in tests because the BE is a dumb relay —
+        // workspaceId+userName+projectId identifies the session, not the role.
+
+        @Test
+        @DisplayName("Post SPAKE2 into DAEMON inbox, poll from DAEMON inbox, round-trip payload")
+        void postThenPoll_roundTrip() {
+            var ctx = createIsolatedWorkspace();
+            UUID projectId = createProject(ctx.apiKey, ctx.workspace);
+            runnersClient.registerDaemonPair(projectId, "pake-roundtrip", ctx.apiKey, ctx.workspace);
+
+            runnersClient.postPakeMessage(projectId, PakeRole.DAEMON, PakeStep.SPAKE2,
+                    "browser-spake2-msg", ctx.apiKey, ctx.workspace);
+
+            PakeMessagePage page = runnersClient.getPakeMessages(projectId, PakeRole.DAEMON, PakeStep.SPAKE2,
+                    ctx.apiKey, ctx.workspace);
+
+            assertThat(page.messages()).hasSize(1);
+            assertThat(page.messages().getFirst().payload()).isEqualTo("browser-spake2-msg");
+            assertThat(page.messages().getFirst().step()).isEqualTo(PakeStep.SPAKE2);
+        }
+
+        @Test
+        @DisplayName("Two inboxes are independent — messages posted to DAEMON do not appear in BROWSER")
+        void inboxIsolation() {
+            var ctx = createIsolatedWorkspace();
+            UUID projectId = createProject(ctx.apiKey, ctx.workspace);
+            runnersClient.registerDaemonPair(projectId, "pake-isolation", ctx.apiKey, ctx.workspace);
+
+            runnersClient.postPakeMessage(projectId, PakeRole.DAEMON, PakeStep.SPAKE2,
+                    "msg-for-daemon", ctx.apiKey, ctx.workspace);
+
+            try (var resp = runnersClient.callGetPakeMessages(projectId, PakeRole.BROWSER, PakeStep.SPAKE2,
+                    ctx.apiKey, ctx.workspace)) {
+                assertThat(resp.getStatus()).isEqualTo(200);
+                PakeMessagePage browserInbox = resp.readEntity(PakeMessagePage.class);
+                assertThat(browserInbox.messages()).isEmpty();
+            }
+        }
+
+        @Test
+        @DisplayName("target_step filters messages by step within the inbox")
+        void targetStepFilter() {
+            var ctx = createIsolatedWorkspace();
+            UUID projectId = createProject(ctx.apiKey, ctx.workspace);
+            runnersClient.registerDaemonPair(projectId, "pake-filter", ctx.apiKey, ctx.workspace);
+
+            runnersClient.postPakeMessage(projectId, PakeRole.DAEMON, PakeStep.SPAKE2,
+                    "spake-blob", ctx.apiKey, ctx.workspace);
+            runnersClient.postPakeMessage(projectId, PakeRole.DAEMON, PakeStep.CONFIRMATION,
+                    "confirm-blob", ctx.apiKey, ctx.workspace);
+
+            PakeMessagePage spakePage = runnersClient.getPakeMessages(projectId, PakeRole.DAEMON,
+                    PakeStep.SPAKE2, ctx.apiKey, ctx.workspace);
+            assertThat(spakePage.messages()).hasSize(1);
+            assertThat(spakePage.messages().getFirst().payload()).isEqualTo("spake-blob");
+
+            PakeMessagePage confirmPage = runnersClient.getPakeMessages(projectId, PakeRole.DAEMON,
+                    PakeStep.CONFIRMATION, ctx.apiKey, ctx.workspace);
+            assertThat(confirmPage.messages()).hasSize(1);
+            assertThat(confirmPage.messages().getFirst().payload()).isEqualTo("confirm-blob");
+        }
+
+        @Test
+        @DisplayName("POST to a non-existent session returns 404")
+        void postToMissingSession_returns404() {
+            var ctx = createIsolatedWorkspace();
+            UUID projectId = createProject(ctx.apiKey, ctx.workspace);
+            // No registerDaemonPair — no session exists for this project
+
+            try (var resp = runnersClient.callPostPakeMessage(projectId, PakeRole.DAEMON, PakeStep.SPAKE2,
+                    "orphan", ctx.apiKey, ctx.workspace)) {
+                assertThat(resp.getStatus()).isEqualTo(404);
+            }
+        }
+
+        @Test
+        @DisplayName("GET on empty inbox long-polls until timeout, then returns empty page")
+        void getEmptyInbox_longPollsThenEmpty() {
+            var ctx = createIsolatedWorkspace();
+            UUID projectId = createProject(ctx.apiKey, ctx.workspace);
+            runnersClient.registerDaemonPair(projectId, "pake-timeout", ctx.apiKey, ctx.workspace);
+
+            long start = System.currentTimeMillis();
+            PakeMessagePage page = runnersClient.getPakeMessages(projectId, PakeRole.DAEMON, PakeStep.SPAKE2,
+                    ctx.apiKey, ctx.workspace);
+            long elapsed = System.currentTimeMillis() - start;
+
+            assertThat(page.messages()).isEmpty();
+            // config-test.yml sets pakePollTimeout: 2s — expect long-poll to hold for approximately that duration
+            assertThat(elapsed).isGreaterThanOrEqualTo(1500L);
+        }
+
+        @Test
+        @DisplayName("GET returns envelope (PakeMessagePage), not a bare array")
+        void responseIsEnvelope() {
+            var ctx = createIsolatedWorkspace();
+            UUID projectId = createProject(ctx.apiKey, ctx.workspace);
+            runnersClient.registerDaemonPair(projectId, "pake-envelope", ctx.apiKey, ctx.workspace);
+
+            runnersClient.postPakeMessage(projectId, PakeRole.DAEMON, PakeStep.SPAKE2,
+                    "payload", ctx.apiKey, ctx.workspace);
+
+            try (var resp = runnersClient.callGetPakeMessages(projectId, PakeRole.DAEMON, PakeStep.SPAKE2,
+                    ctx.apiKey, ctx.workspace)) {
+                assertThat(resp.getStatus()).isEqualTo(200);
+                // Envelope must deserialize cleanly — a bare array would fail here
+                PakeMessagePage page = resp.readEntity(PakeMessagePage.class);
+                assertThat(page).isNotNull();
+                assertThat(page.messages()).isNotNull();
+            }
+        }
+
+        @Test
+        @DisplayName("Cross-workspace isolation — another workspace cannot read this session's messages")
+        void crossWorkspaceIsolation() {
+            var ctxA = createIsolatedWorkspace();
+            var ctxB = createIsolatedWorkspace();
+            UUID projectA = createProject(ctxA.apiKey, ctxA.workspace);
+            runnersClient.registerDaemonPair(projectA, "iso-A", ctxA.apiKey, ctxA.workspace);
+
+            runnersClient.postPakeMessage(projectA, PakeRole.DAEMON, PakeStep.SPAKE2,
+                    "secret", ctxA.apiKey, ctxA.workspace);
+
+            // Workspace B tries to read workspace A's session for the same projectId — should 404
+            try (var resp = runnersClient.callGetPakeMessages(projectA, PakeRole.DAEMON, PakeStep.SPAKE2,
+                    ctxB.apiKey, ctxB.workspace)) {
+                assertThat(resp.getStatus()).isEqualTo(404);
+            }
+        }
+
+        @Test
+        @DisplayName("Same-userName isolation — different workspaceId still cannot read another's session")
+        void sameUserNameDifferentWorkspaceIsolation() {
+            // This test is the workspaceId-only counterpart to crossWorkspaceIsolation, which
+            // randomizes BOTH workspaceId AND userName. A bug where the BE keys only on userName
+            // would silently pass crossWorkspaceIsolation; this test catches that by reusing the
+            // same userName under two distinct workspaces.
+            String sharedUser = randomUUID().toString();
+            String wsAName = randomUUID().toString();
+            String wsAId = randomUUID().toString();
+            String wsAKey = randomUUID().toString();
+            String wsBName = randomUUID().toString();
+            String wsBId = randomUUID().toString();
+            String wsBKey = randomUUID().toString();
+            mockTargetWorkspace(wsAKey, wsAName, wsAId, sharedUser);
+            mockTargetWorkspace(wsBKey, wsBName, wsBId, sharedUser);
+
+            UUID projectA = createProject(wsAKey, wsAName);
+            runnersClient.registerDaemonPair(projectA, "iso-shared", wsAKey, wsAName);
+            runnersClient.postPakeMessage(projectA, PakeRole.DAEMON, PakeStep.SPAKE2,
+                    "wsA-secret", wsAKey, wsAName);
+
+            try (var resp = runnersClient.callGetPakeMessages(projectA, PakeRole.DAEMON, PakeStep.SPAKE2,
+                    wsBKey, wsBName)) {
+                assertThat(resp.getStatus()).isEqualTo(404);
+            }
+        }
+
+        @Test
+        @DisplayName("Duplicate (targetRole, step) post returns 409")
+        void duplicatePostReturns409() {
+            var ctx = createIsolatedWorkspace();
+            UUID projectId = createProject(ctx.apiKey, ctx.workspace);
+            runnersClient.registerDaemonPair(projectId, "pake-dup", ctx.apiKey, ctx.workspace);
+
+            runnersClient.postPakeMessage(projectId, PakeRole.DAEMON, PakeStep.SPAKE2,
+                    "first", ctx.apiKey, ctx.workspace);
+
+            try (var resp = runnersClient.callPostPakeMessage(projectId, PakeRole.DAEMON, PakeStep.SPAKE2,
+                    "second", ctx.apiKey, ctx.workspace)) {
+                assertThat(resp.getStatus()).isEqualTo(409);
+            }
+
+            // Different step in the same inbox is still accepted
+            runnersClient.postPakeMessage(projectId, PakeRole.DAEMON, PakeStep.CONFIRMATION,
+                    "confirm", ctx.apiKey, ctx.workspace);
+        }
+
+        @Test
+        @DisplayName("DaemonPairRegisterRequest connectionTtlSeconds upper bound is enforced")
+        void connectionTtlSecondsMaxEnforced() {
+            var ctx = createIsolatedWorkspace();
+            UUID projectId = createProject(ctx.apiKey, ctx.workspace);
+
+            try (var response = runnersClient.callRegisterDaemonPair(projectId, "oversized-ttl",
+                    86401L, ctx.apiKey, ctx.workspace)) {
+                assertThat(response.getStatus()).isEqualTo(422);
+            }
+        }
+
+        @Test
+        @DisplayName("Rate limit: >5 SPAKE2 attempts burns the session and subsequent posts 404")
+        void exceedingMaxAttemptsBurnsSession() {
+            var ctx = createIsolatedWorkspace();
+            UUID projectId = createProject(ctx.apiKey, ctx.workspace);
+            runnersClient.registerDaemonPair(projectId, "pake-rate", ctx.apiKey, ctx.workspace);
+
+            // First post is accepted; subsequent SPAKE2 posts to the same (role, step) are 409s
+            // (duplicate detection), but the attempts counter still increments. After
+            // MAX_PAKE_ATTEMPTS + 1 attempts the session is burned.
+            runnersClient.postPakeMessage(projectId, PakeRole.DAEMON, PakeStep.SPAKE2,
+                    "first", ctx.apiKey, ctx.workspace);
+            for (int i = 0; i < 5; i++) {
+                try (var resp = runnersClient.callPostPakeMessage(projectId, PakeRole.DAEMON, PakeStep.SPAKE2,
+                        "attempt-" + i, ctx.apiKey, ctx.workspace)) {
+                    // 409 (duplicate) until the 6th attempt burns the session and returns 429
+                    assertThat(resp.getStatus()).isIn(409, 429);
+                }
+            }
+
+            // After session burn, posts to ANY (role, step) return 404
+            try (var resp = runnersClient.callPostPakeMessage(projectId, PakeRole.BROWSER, PakeStep.SPAKE2,
+                    "post-burn", ctx.apiKey, ctx.workspace)) {
+                assertThat(resp.getStatus()).isEqualTo(404);
+            }
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/LocalRunnerReaperIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/LocalRunnerReaperIntegrationTest.java
@@ -3,12 +3,11 @@ package com.comet.opik.domain;
 import com.comet.opik.api.Project;
 import com.comet.opik.api.resources.utils.RedisContainerUtils;
 import com.comet.opik.api.runner.CreateLocalRunnerJobRequest;
+import com.comet.opik.api.runner.DaemonPairRegisterRequest;
 import com.comet.opik.api.runner.LocalRunner;
-import com.comet.opik.api.runner.LocalRunnerConnectRequest;
 import com.comet.opik.api.runner.LocalRunnerConnectResponse;
 import com.comet.opik.api.runner.LocalRunnerJobResultRequest;
 import com.comet.opik.api.runner.LocalRunnerJobStatus;
-import com.comet.opik.api.runner.LocalRunnerPairResponse;
 import com.comet.opik.infrastructure.LocalRunnerConfig;
 import com.comet.opik.infrastructure.redis.StringRedisClient;
 import com.redis.testcontainers.RedisContainer;
@@ -114,12 +113,13 @@ class LocalRunnerReaperIntegrationTest {
 
     private UUID pairAndConnect(String workspaceId, String userName, String runnerName) {
         stubNextId();
-        LocalRunnerPairResponse pair = runnerService.generatePairingCode(workspaceId, userName, PROJECT_ID);
-        LocalRunnerConnectRequest req = LocalRunnerConnectRequest.builder()
-                .pairingCode(pair.pairingCode())
-                .runnerName(runnerName)
-                .build();
-        LocalRunnerConnectResponse resp = runnerService.connect(workspaceId, userName, req);
+        runnerService.registerDaemonPair(workspaceId, userName,
+                DaemonPairRegisterRequest.builder()
+                        .projectId(PROJECT_ID)
+                        .runnerName(runnerName)
+                        .connectionTtlSeconds(86400L)
+                        .build());
+        LocalRunnerConnectResponse resp = runnerService.completePairing(workspaceId, userName, PROJECT_ID);
         LocalRunner.Agent agent = LocalRunner.Agent.builder()
                 .name(AGENT_NAME)
                 .build();

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/LocalRunnerServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/LocalRunnerServiceImplTest.java
@@ -9,15 +9,14 @@ import com.comet.opik.api.runner.BridgeCommandStatus;
 import com.comet.opik.api.runner.BridgeCommandSubmitRequest;
 import com.comet.opik.api.runner.BridgeCommandType;
 import com.comet.opik.api.runner.CreateLocalRunnerJobRequest;
+import com.comet.opik.api.runner.DaemonPairRegisterRequest;
 import com.comet.opik.api.runner.LocalRunner;
-import com.comet.opik.api.runner.LocalRunnerConnectRequest;
 import com.comet.opik.api.runner.LocalRunnerConnectResponse;
 import com.comet.opik.api.runner.LocalRunnerHeartbeatResponse;
 import com.comet.opik.api.runner.LocalRunnerJob;
 import com.comet.opik.api.runner.LocalRunnerJobResultRequest;
 import com.comet.opik.api.runner.LocalRunnerJobStatus;
 import com.comet.opik.api.runner.LocalRunnerLogEntry;
-import com.comet.opik.api.runner.LocalRunnerPairResponse;
 import com.comet.opik.infrastructure.LocalRunnerConfig;
 import com.comet.opik.infrastructure.redis.StringRedisClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -131,12 +130,13 @@ class LocalRunnerServiceImplTest {
 
     private UUID pairAndConnect(String workspaceId, String userName, String runnerName) {
         stubNextId();
-        LocalRunnerPairResponse pair = runnerService.generatePairingCode(workspaceId, userName, PROJECT_ID);
-        LocalRunnerConnectRequest req = LocalRunnerConnectRequest.builder()
-                .pairingCode(pair.pairingCode())
-                .runnerName(runnerName)
-                .build();
-        LocalRunnerConnectResponse resp = runnerService.connect(workspaceId, userName, req);
+        runnerService.registerDaemonPair(workspaceId, userName,
+                DaemonPairRegisterRequest.builder()
+                        .projectId(PROJECT_ID)
+                        .runnerName(runnerName)
+                        .connectionTtlSeconds(86400L)
+                        .build());
+        LocalRunnerConnectResponse resp = runnerService.completePairing(workspaceId, userName, PROJECT_ID);
         LocalRunner.Agent agent = LocalRunner.Agent.builder()
                 .name(AGENT_NAME)
                 .build();
@@ -158,135 +158,7 @@ class LocalRunnerServiceImplTest {
     }
 
     @Nested
-    class GeneratePairingCode {
-
-        @Test
-        void createsPairKeyInRedis() {
-            stubNextId();
-            LocalRunnerPairResponse resp = runnerService.generatePairingCode(WORKSPACE_ID, USER_NAME, PROJECT_ID);
-
-            RBucket<String> pairBucket = stringRedis.getBucket(
-                    "opik:runners:pair:" + resp.pairingCode());
-            assertThat(pairBucket.isExists()).isTrue();
-            String value = pairBucket.get();
-            assertThat(value).contains(resp.runnerId().toString());
-            assertThat(value).contains(WORKSPACE_ID);
-            assertThat(value).contains(PROJECT_ID.toString());
-            assertThat(pairBucket.remainTimeToLive()).isPositive();
-        }
-
-        @Test
-        void createsRunnerHash() {
-            stubNextId();
-            LocalRunnerPairResponse resp = runnerService.generatePairingCode(WORKSPACE_ID, USER_NAME, PROJECT_ID);
-
-            RMap<String, String> runnerMap = stringRedis.getMap(
-                    "opik:runners:runner:" + resp.runnerId());
-            assertThat(runnerMap.get("status")).isEqualTo("pairing");
-            assertThat(runnerMap.get("workspace_id")).isEqualTo(WORKSPACE_ID);
-            assertThat(runnerMap.get("user_name")).isEqualTo(USER_NAME);
-            assertThat(runnerMap.get("project_id")).isEqualTo(PROJECT_ID.toString());
-            assertThat(runnerMap.remainTimeToLive()).isPositive();
-        }
-
-        @Test
-        void addsToWorkspaceSets() {
-            stubNextId();
-            LocalRunnerPairResponse resp = runnerService.generatePairingCode(WORKSPACE_ID, USER_NAME, PROJECT_ID);
-
-            RScoredSortedSet<String> wsRunners = stringRedis.getScoredSortedSet(
-                    "opik:runners:workspace:" + WORKSPACE_ID + ":runners");
-            assertThat(wsRunners.contains(resp.runnerId().toString())).isTrue();
-
-            RSet<String> workspaces = stringRedis.getSet(
-                    "opik:runners:workspaces:with_runners");
-            assertThat(workspaces.contains(WORKSPACE_ID)).isTrue();
-        }
-
-        @Test
-        void doesNotSetUserRunnerMappingUntilConnect() {
-            stubNextId();
-            runnerService.generatePairingCode(WORKSPACE_ID, USER_NAME, PROJECT_ID);
-
-            RBucket<String> userRunner = stringRedis.getBucket(
-                    "opik:runners:workspace:" + WORKSPACE_ID + ":project:" + PROJECT_ID + ":user:" + USER_NAME
-                            + ":runner");
-            assertThat(userRunner.isExists()).isFalse();
-        }
-
-        @Test
-        void addsToProjectRunnersSet() {
-            stubNextId();
-            LocalRunnerPairResponse resp = runnerService.generatePairingCode(WORKSPACE_ID, USER_NAME, PROJECT_ID);
-
-            RSet<String> projectRunners = stringRedis.getSet(
-                    "opik:runners:workspace:" + WORKSPACE_ID + ":project:" + PROJECT_ID + ":runners");
-            assertThat(projectRunners.contains(resp.runnerId().toString())).isTrue();
-        }
-    }
-
-    @Nested
     class Connect {
-
-        @Test
-        void withPairingCode_claimsPairAndReturnsCredentials() {
-            stubNextId();
-            LocalRunnerPairResponse pair = runnerService.generatePairingCode(WORKSPACE_ID, USER_NAME, PROJECT_ID);
-
-            LocalRunnerConnectRequest req = LocalRunnerConnectRequest.builder()
-                    .pairingCode(pair.pairingCode())
-                    .runnerName(RUNNER_NAME)
-                    .build();
-            LocalRunnerConnectResponse resp = runnerService.connect(WORKSPACE_ID, USER_NAME, req);
-
-            assertThat(resp.runnerId()).isEqualTo(pair.runnerId());
-            assertThat(resp.projectId()).isEqualTo(PROJECT_ID);
-            assertThat(resp.projectName()).isEqualTo(PROJECT_NAME);
-
-            RBucket<String> pairBucket = stringRedis.getBucket(
-                    "opik:runners:pair:" + pair.pairingCode());
-            assertThat(pairBucket.isExists()).isFalse();
-
-            RMap<String, String> runnerMap = stringRedis.getMap(
-                    "opik:runners:runner:" + resp.runnerId());
-            assertThat(runnerMap.get("status")).isEqualTo("connected");
-            assertThat(runnerMap.get("name")).isEqualTo(RUNNER_NAME);
-            assertThat(runnerMap.get("connected_at")).isNotBlank();
-            assertThat(runnerMap.get("project_id")).isEqualTo(PROJECT_ID.toString());
-        }
-
-        @Test
-        void withPairingCode_removesRunnerTTL() {
-            stubNextId();
-            LocalRunnerPairResponse pair = runnerService.generatePairingCode(WORKSPACE_ID, USER_NAME, PROJECT_ID);
-
-            LocalRunnerConnectRequest req = LocalRunnerConnectRequest.builder()
-                    .pairingCode(pair.pairingCode())
-                    .runnerName(RUNNER_NAME)
-                    .build();
-            runnerService.connect(WORKSPACE_ID, USER_NAME, req);
-
-            RMap<String, String> runnerMap = stringRedis.getMap(
-                    "opik:runners:runner:" + pair.runnerId());
-            assertThat(runnerMap.remainTimeToLive()).isEqualTo(-1);
-        }
-
-        @Test
-        void withPairingCode_setsHeartbeat() {
-            stubNextId();
-            LocalRunnerPairResponse pair = runnerService.generatePairingCode(WORKSPACE_ID, USER_NAME, PROJECT_ID);
-
-            LocalRunnerConnectRequest req = LocalRunnerConnectRequest.builder()
-                    .pairingCode(pair.pairingCode())
-                    .runnerName(RUNNER_NAME)
-                    .build();
-            LocalRunnerConnectResponse resp = runnerService.connect(WORKSPACE_ID, USER_NAME, req);
-
-            RBucket<String> hb = stringRedis.getBucket(
-                    "opik:runners:runner:" + resp.runnerId() + ":heartbeat");
-            assertThat(hb.isExists()).isTrue();
-            assertThat(hb.remainTimeToLive()).isPositive();
-        }
 
         @Test
         void replacesExistingRunner() {
@@ -653,16 +525,14 @@ class LocalRunnerServiceImplTest {
     @Test
     void fullFlow_pairConnectCreateJobNextJobReportResult() {
         stubNextId();
-        LocalRunnerPairResponse pair = runnerService.generatePairingCode(WORKSPACE_ID, USER_NAME, PROJECT_ID);
-        assertThat(pair.pairingCode()).hasSize(6);
-
-        LocalRunnerConnectRequest connectReq = LocalRunnerConnectRequest.builder()
-                .pairingCode(pair.pairingCode())
-                .runnerName(RUNNER_NAME)
-                .build();
-        LocalRunnerConnectResponse connectResp = runnerService.connect(WORKSPACE_ID, USER_NAME, connectReq);
+        runnerService.registerDaemonPair(WORKSPACE_ID, USER_NAME,
+                DaemonPairRegisterRequest.builder()
+                        .projectId(PROJECT_ID)
+                        .runnerName(RUNNER_NAME)
+                        .connectionTtlSeconds(86400L)
+                        .build());
+        LocalRunnerConnectResponse connectResp = runnerService.completePairing(WORKSPACE_ID, USER_NAME, PROJECT_ID);
         UUID runnerId = connectResp.runnerId();
-        assertThat(runnerId).isEqualTo(pair.runnerId());
         assertThat(connectResp.projectId()).isEqualTo(PROJECT_ID);
         assertThat(connectResp.projectName()).isEqualTo(PROJECT_NAME);
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/web/AsyncResponseSupportTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/web/AsyncResponseSupportTest.java
@@ -1,0 +1,126 @@
+package com.comet.opik.infrastructure.web;
+
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.TimeoutHandler;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class AsyncResponseSupportTest {
+
+    private AsyncResponse asyncResponse;
+    private AtomicReference<TimeoutHandler> capturedTimeoutHandler;
+    private AtomicReference<Long> capturedTimeoutValue;
+
+    @BeforeEach
+    void setUp() {
+        asyncResponse = mock(AsyncResponse.class);
+        capturedTimeoutHandler = new AtomicReference<>();
+        capturedTimeoutValue = new AtomicReference<>();
+        doAnswer(inv -> {
+            capturedTimeoutValue.set(inv.getArgument(0));
+            return true;
+        }).when(asyncResponse).setTimeout(anyLong(), any(TimeUnit.class));
+        doAnswer(inv -> {
+            capturedTimeoutHandler.set(inv.getArgument(0));
+            return null;
+        }).when(asyncResponse).setTimeoutHandler(any(TimeoutHandler.class));
+    }
+
+    @Test
+    @DisplayName("Successful Mono resumes the AsyncResponse with the mapped Response")
+    void successResumesWithMappedResponse() {
+        AsyncResponseSupport.resume(
+                asyncResponse,
+                Mono.just("payload"),
+                30L,
+                value -> Response.ok(value).build(),
+                Response.noContent().build(),
+                "ctx={}", "test");
+
+        verify(asyncResponse).resume(any(Response.class));
+        assertThat(capturedTimeoutValue.get()).isEqualTo(30L);
+    }
+
+    @Test
+    @DisplayName("WebApplicationException from the Mono is resumed as the exception itself")
+    void webApplicationExceptionPropagates() {
+        var notFound = new NotFoundException("missing");
+
+        AsyncResponseSupport.resume(
+                asyncResponse,
+                Mono.error(notFound),
+                30L,
+                value -> Response.ok(value).build(),
+                Response.noContent().build(),
+                "ctx={}", "test");
+
+        verify(asyncResponse).resume(notFound);
+    }
+
+    @Test
+    @DisplayName("Generic exception from the Mono resumes a 500")
+    void genericExceptionResumesServerError() {
+        AsyncResponseSupport.resume(
+                asyncResponse,
+                Mono.error(new RuntimeException("boom")),
+                30L,
+                value -> Response.ok(value).build(),
+                Response.noContent().build(),
+                "ctx={}", "test");
+
+        var captor = org.mockito.ArgumentCaptor.forClass(Response.class);
+        verify(asyncResponse).resume(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(500);
+    }
+
+    @Test
+    @DisplayName("Timeout handler resumes with the configured fallback Response")
+    void timeoutHandlerInvocationFallsBack() {
+        Response onTimeout = Response.ok("timeout-fallback").build();
+
+        AsyncResponseSupport.resume(
+                asyncResponse,
+                Mono.never(),
+                5L,
+                value -> Response.ok(value).build(),
+                onTimeout,
+                "ctx={}", "test");
+
+        // Simulate the JAX-RS container firing the timeout handler
+        assertThat(capturedTimeoutHandler.get()).isNotNull();
+        capturedTimeoutHandler.get().handleTimeout(asyncResponse);
+
+        verify(asyncResponse).resume(onTimeout);
+    }
+
+    @Test
+    @DisplayName("Synchronously-resolving Mono still sets the timeout before resuming")
+    void synchronousMonoStillSetsTimeout() {
+        AsyncResponseSupport.resume(
+                asyncResponse,
+                Mono.just("immediate"),
+                15L,
+                value -> Response.ok(value).build(),
+                Response.noContent().build(),
+                "ctx={}", "test");
+
+        // Both setTimeout and resume should have been called; ordering matters because
+        // the JAX-RS container can race the resume vs. its own timer.
+        verify(asyncResponse).setTimeout(15L, TimeUnit.SECONDS);
+        verify(asyncResponse).resume(any(Response.class));
+    }
+}

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -563,6 +563,8 @@ localRunner:
   reaperLockDuration: 10s
   reaperLockWait: 2s
   nextJobAsyncTimeoutBuffer: 2s
+  pakePollTimeout: 2s
+  pakeAsyncTimeoutBuffer: 1s
 
 # Trace Thread configuration
 traceThreadConfig:


### PR DESCRIPTION
## Details
Adds SPAKE2-based PAKE pairing and HMAC-SHA256 command signing to the bridge between the CLI daemon (`opik connect`) and the browser (Ollie), with the Opik backend acting as an untrusted relay.

  ### What changed

  **Pairing (PAKE)**
  - CLI daemon generates a 6-char pairing code locally (never sent to backend or stored in Redis)
  - Daemon registers a pairing session via `POST /daemon-pairs` with `project_id` — backend keys the session in Redis by `workspace:user:project`
  - User types the code into Ollie, both sides perform a SPAKE2 exchange relayed through `POST /pake/messages` and `GET /pake/messages`
  - After key derivation, both sides exchange asymmetric confirmation values (`HMAC(K, "confirm-A")` / `HMAC(K, "confirm-B")`) to detect MITM
  - Ollie calls `POST /pake/complete` to activate the runner and bind it to the project
  - Backend is a dumb pipe throughout — it relays opaque base64 blobs without interpreting them

  **Command signing (HMAC)**
  - Every bridge command from Ollie carries an `hmac` field: `HMAC-SHA256(K, command_id | type | canonical_json(args))`
  - Daemon verifies HMAC before executing — failed verification silently drops the command (no report back to backend)
  - Daemon signs results back with HMAC so Ollie can verify them
  - Tamper burst detection warns in TUI when many commands fail verification

  **Session TTL**
  - `--ttl` flag on `opik connect` (default 24h) — daemon shuts down after expiration, checked every heartbeat cycle

  ### Security properties
  - Pairing code never touches Redis or any API request/response — only exists in the user's head and in memory on both SPAKE2 sessions
  - Compromised Redis/backend cannot derive the shared key or forge commands
  - Rate limiting burns the PAKE session after 5 failed attempts
  - Stale sessions cleaned on daemon re-register (crash recovery)
  - `completePairing` requires auth (workspace/user from RequestContext)
  - PAKE message `step` field validated to 0-2

  ### Flow

  1. User runs `opik connect --project my-project`
  2. CLI generates 6-char code, calls `POST /daemon-pairs` with `{project_id, runner_name}`
  3. CLI starts SPAKE2_A, posts daemon's message via `POST /pake/messages?project_id=X` `{role: "daemon", step: 0, payload: base64(msg_A)}`
  4. CLI displays pairing code in terminal, starts long-polling `GET /pake/messages`
  5. User enters code in Ollie
  6. Ollie starts SPAKE2_B, posts `{role: "browser", step: 0, payload: base64(msg_B)}`
  7. Both sides receive the other's SPAKE2 message and derive shared key K
  8. CLI posts `{role: "daemon", step: 1, payload: HMAC(K, "confirm-A")}`
  9. Ollie posts `{role: "browser", step: 1, payload: HMAC(K, "confirm-B")}`
  10. Both sides verify the other's confirmation — mismatched keys abort with MITM warning
  11. Ollie calls `POST /pake/complete` with `{project_id}` — backend activates runner, posts completion message
  12. CLI picks up completion, starts Supervisor with shared key K
  13. Bridge commands flow with HMAC signatures in both directions
  14. Session expires after `--ttl` (default 24h)

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues


## Testing
- Manually tested 
- BE Unit tests
- SDK Unit tests
- SDK e2e happy flow

## Documentation
