### PR TITLE
[NA] [HELM] Add suspend option to clickhouse backup cronjob

### DIFF
--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Comet Opik
 
-![Version: 1.10.58](https://img.shields.io/badge/Version-1.10.58-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.58](https://img.shields.io/badge/AppVersion-1.10.58-informational?style=flat-square)
+![Version: 1.11.2](https://img.shields.io/badge/Version-1.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.2](https://img.shields.io/badge/AppVersion-1.11.2-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opik)](https://artifacthub.io/packages/search?repo=opik)
 
 # Run Comet Opik with Helm

--- a/deployment/helm_chart/opik/templates/clickhouse-backup-cronjob.yaml
+++ b/deployment/helm_chart/opik/templates/clickhouse-backup-cronjob.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "opik.labels" $  | nindent 4 }}
 spec:
+  suspend: {{ .Values.clickhouse.backup.suspend | default false }}
   schedule: "{{ .Values.clickhouse.backup.schedule }}"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: {{ .Values.clickhouse.backup.successfulJobsHistoryLimit }}


### PR DESCRIPTION
## Details

Add `suspend` field to the ClickHouse backup CronJob template, allowing the backup job to be paused via Helm values (`clickhouse.backup.suspend: true`) without removing the resource. Defaults to `false` to maintain existing behavior.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full implementation
  - Human verification: Reviewed

## Testing

- Verified the template renders correctly with `suspend: false` (default) and `suspend: true` by inspecting the generated YAML.
- Confirmed no other CronJob templates or values files required changes.

## Documentation

No documentation update needed — this is an internal Helm chart configuration option.
