### PR TITLE
[NA] [Helm] fix: add frontend egress rule to python-backend network policy

### DIFF
--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Comet Opik
 
-![Version: 1.10.58](https://img.shields.io/badge/Version-1.10.58-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.58](https://img.shields.io/badge/AppVersion-1.10.58-informational?style=flat-square)
+![Version: 1.11.2](https://img.shields.io/badge/Version-1.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.2](https://img.shields.io/badge/AppVersion-1.11.2-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opik)](https://artifacthub.io/packages/search?repo=opik)
 
 # Run Comet Opik with Helm

--- a/deployment/helm_chart/opik/templates/networkpolicies.yaml
+++ b/deployment/helm_chart/opik/templates/networkpolicies.yaml
@@ -37,6 +37,14 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
+    # Allow traffic to frontend reverse proxy (used by post_user_signup demo data creation)
+    - to:
+      - podSelector:
+          matchLabels:
+            component: {{ include "opik.name" $ }}-frontend
+      ports:
+        - protocol: TCP
+          port: 5173
     {{- if index .Values "component" "python-backend" "networkPolicy" "engineEgress" }}
     # Legacy engineEgress support (deprecated, use additionalRules instead)
     - to:


### PR DESCRIPTION
## Details

The network policy for `opik-python-backend` only allowed egress to `opik-backend:8080` and DNS. However, the demo data creation at signup (`post_user_signup.py`) reaches the Java backend through the frontend reverse proxy at `opik-frontend:5173/api` (via `OPIK_REVERSE_PROXY_URL`), causing requests to time out when the network policy is enabled.

Added an egress rule allowing `opik-python-backend` to reach `opik-frontend` on port 5173.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5241

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-6
- Scope: Network policy egress rule addition
- Human verification: yes

## Testing

- Verified the Helm template renders correctly with the new egress rule
- The fix needs to be validated in a cluster environment where the network policy is enabled:
  1. Deploy the updated Helm chart
  2. Restart `opik-python-backend` pods
  3. Trigger a new user signup and verify demo data creation succeeds without `[Errno 110] Operation timed out`
  4. Confirm `opik-python-backend` can reach `opik-frontend:5173/api`

## Documentation

No documentation changes required — this is an infrastructure-level fix to the Kubernetes network policy.
