### PR TITLE
[OPIK-5829] [BE] refactor: use Podam, builders, and whole-object assertions in from-traces/from-spans tests

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceCreateFromSpansTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceCreateFromSpansTest.java
@@ -6,7 +6,6 @@ import com.comet.opik.api.Dataset;
 import com.comet.opik.api.DatasetItemSource;
 import com.comet.opik.api.DatasetType;
 import com.comet.opik.api.EvaluatorItem;
-import com.comet.opik.api.EvaluatorType;
 import com.comet.opik.api.ExecutionPolicy;
 import com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
 import com.comet.opik.api.ScoreSource;
@@ -407,7 +406,8 @@ class DatasetsResourceCreateFromSpansTest {
 
     static Stream<Arguments> evaluatorsWithExecutionPolicyProvider() {
         return Stream.of(
-                Arguments.of(new ExecutionPolicy(3, 2), "with execution policy"),
+                Arguments.of(ExecutionPolicy.builder().runsPerItem(3).passThreshold(2).build(),
+                        "with execution policy"),
                 Arguments.of(null, "without execution policy"));
     }
 
@@ -437,13 +437,7 @@ class DatasetsResourceCreateFromSpansTest {
                 .build();
         spanResourceClient.createSpan(span, apiKey, workspaceName);
 
-        var evaluatorConfig = JsonUtils.getJsonNodeFromString(
-                "{\"version\":\"1\",\"name\":\"llm_judge\",\"schema\":[{\"name\":\"is_correct\",\"type\":\"BOOLEAN\",\"description\":\"is_correct\"}]}");
-        var evaluator = EvaluatorItem.builder()
-                .name("llm_judge")
-                .type(EvaluatorType.LLM_JUDGE)
-                .config(evaluatorConfig)
-                .build();
+        var evaluator = factory.manufacturePojo(EvaluatorItem.class);
 
         var request = CreateDatasetItemsFromSpansRequest.builder()
                 .spanIds(Set.of(span.id()))
@@ -460,9 +454,7 @@ class DatasetsResourceCreateFromSpansTest {
 
         var item = actualEntity.content().getFirst();
         assertThat(item.source()).isEqualTo(DatasetItemSource.SPAN);
-        assertThat(item.evaluators()).hasSize(1);
-        assertThat(item.evaluators().getFirst().name()).isEqualTo("llm_judge");
-        assertThat(item.evaluators().getFirst().type()).isEqualTo(EvaluatorType.LLM_JUDGE);
+        assertThat(item.evaluators()).containsExactly(evaluator);
 
         assertThat(item.executionPolicy()).isEqualTo(executionPolicy);
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceCreateFromTracesTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceCreateFromTracesTest.java
@@ -5,7 +5,6 @@ import com.comet.opik.api.CreateDatasetItemsFromTracesRequest;
 import com.comet.opik.api.Dataset;
 import com.comet.opik.api.DatasetItemSource;
 import com.comet.opik.api.EvaluatorItem;
-import com.comet.opik.api.EvaluatorType;
 import com.comet.opik.api.ExecutionPolicy;
 import com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
 import com.comet.opik.api.ScoreSource;
@@ -387,7 +386,8 @@ class DatasetsResourceCreateFromTracesTest {
 
     static Stream<Arguments> evaluatorsWithExecutionPolicyProvider() {
         return Stream.of(
-                Arguments.of(new ExecutionPolicy(3, 2), "with execution policy"),
+                Arguments.of(ExecutionPolicy.builder().runsPerItem(3).passThreshold(2).build(),
+                        "with execution policy"),
                 Arguments.of(null, "without execution policy"));
     }
 
@@ -412,13 +412,7 @@ class DatasetsResourceCreateFromTracesTest {
 
         traceResourceClient.createTrace(trace, apiKey, workspaceName);
 
-        var evaluatorConfig = JsonUtils.getJsonNodeFromString(
-                "{\"version\":\"1\",\"name\":\"llm_judge\",\"schema\":[{\"name\":\"is_correct\",\"type\":\"BOOLEAN\",\"description\":\"is_correct\"}]}");
-        var evaluator = EvaluatorItem.builder()
-                .name("llm_judge")
-                .type(EvaluatorType.LLM_JUDGE)
-                .config(evaluatorConfig)
-                .build();
+        var evaluator = factory.manufacturePojo(EvaluatorItem.class);
 
         var request = CreateDatasetItemsFromTracesRequest.builder()
                 .traceIds(Set.of(trace.id()))
@@ -435,9 +429,7 @@ class DatasetsResourceCreateFromTracesTest {
 
         var item = actualEntity.content().getFirst();
         assertThat(item.source()).isEqualTo(DatasetItemSource.TRACE);
-        assertThat(item.evaluators()).hasSize(1);
-        assertThat(item.evaluators().getFirst().name()).isEqualTo("llm_judge");
-        assertThat(item.evaluators().getFirst().type()).isEqualTo(EvaluatorType.LLM_JUDGE);
+        assertThat(item.evaluators()).containsExactly(evaluator);
 
         assertThat(item.executionPolicy()).isEqualTo(executionPolicy);
     }


### PR DESCRIPTION
## Details

<img width="1920" height="2174" alt="image" src="https://github.com/user-attachments/assets/d76422c9-f96e-489c-8317-12f3f3993266" />

Improve test quality in `DatasetsResourceCreateFromTracesTest` and `DatasetsResourceCreateFromSpansTest` based on PR review notes from #6150 (@andrescrz  & @BorisTkachenko  ):

- Use `PodamFactory.manufacturePojo(EvaluatorItem.class)` instead of manual builder with hardcoded values
- Use `ExecutionPolicy.builder()` instead of constructor (`new ExecutionPolicy(3, 2)`)
- Replace field-by-field evaluator assertions with whole-object `containsExactly(evaluator)`
- Remove unused `EvaluatorType` import from both files

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-5829

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review

## Testing

- Backend compilation: `cd apps/opik-backend && mvn compile -pl . -q` — passes
- Pre-commit hooks (Spotless): pass on both changed files
- No behavioral changes — same test coverage, only assertion style and data generation improved

## Documentation

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)