### PR TITLE
[OPIK-5831] [FE] fix: import Opik logo asset in sandbox flow diagram

### DIFF
--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentSandboxFlowDiagram.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentSandboxFlowDiagram.tsx
@@ -15,6 +15,7 @@ import {
 import OllieOwl from "@/icons/ollie-owl.svg?react";
 import CurveRight from "@/icons/sandbox-curve-right.svg?react";
 import CurveLeft from "@/icons/sandbox-curve-left.svg?react";
+import opikLogoUrl from "/images/opik-logo.png";
 
 const Tag: React.FC<{
   icon: React.ReactNode;
@@ -55,7 +56,7 @@ const AgentSandboxFlowDiagram: React.FC = () => (
       }}
     >
       <img
-        src="/images/opik-logo.png"
+        src={opikLogoUrl}
         alt="Opik"
         className="mb-2 h-3 w-auto self-start"
       />


### PR DESCRIPTION
## Details

Fix broken Opik logo in the Agent Sandbox "Connect your agent" empty state. The image was referenced via a bare-string `src="/images/opik-logo.png"`, which bypasses Vite's base URL rewrite and 404s when the app is served under a subpath. Switched to a module import, matching the pattern used elsewhere in the codebase (`shared/Logo/Logo.tsx`, `constants/integrations.ts`).

<img width="1467" height="930" alt="image" src="https://github.com/user-attachments/assets/44beb588-d1c5-4d99-bdac-f5cea50925ed" />


## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-5831

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: full implementation
  - Human verification: code review + manual testing

## Testing

- `bash scripts/dev-runner.sh --lint-fe` → lint:fix, typecheck, deps:validate all pass
- Manual: navigated to v2 Agent Runner empty state (`/<workspace>/projects/<projectId>/agent-runner`) and verified the Opik logo renders correctly at the top of the illustrated flow diagram
- Regression check: no other call-sites use bare-string `/images/opik-logo.png`

## Documentation

N/A