### PR TITLE
[NA] update Docker base images

### DIFF
--- a/apps/opik-frontend/Dockerfile
+++ b/apps/opik-frontend/Dockerfile
@@ -26,7 +26,7 @@ RUN printf '{"version": "%s"}\n' "$VITE_APP_VERSION" > dist/version.json
 
 # Production stage
 # Using nginx alpine image with OpenTelemetry support
-FROM nginx:1.29.5-alpine-otel AS nginx
+FROM nginx:1.29.8-alpine-otel AS nginx
 
 # Add label for later inspection
 ARG BUILD_MODE=production

--- a/apps/opik-sandbox-executor-python/Dockerfile
+++ b/apps/opik-sandbox-executor-python/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build: Build stage
-FROM python:3.12.12-slim AS builder
+FROM python:3.12.13-slim AS builder
 
 WORKDIR /build
 
@@ -38,7 +38,7 @@ RUN cp -r /usr/local/lib/python3.12/site-packages /runtime-python
 
 #######################################################################
 # Multi-stage build: Runtime stage
-FROM python:3.12.12-slim AS runtime
+FROM python:3.12.13-slim AS runtime
 
 WORKDIR /opt/opik-sandbox-executor-python
 


### PR DESCRIPTION
## Docker Base Image Updates

Automated update of Docker base images to latest patch versions to resolve known vulnerabilities.

### Changes Summary

| Dockerfile | Stage | Image | Current | Updated | Base Image Scan |
|---|---|---|---|---|---|
| `apps/opik-frontend/Dockerfile` | final | `nginx` | `1.29.5-alpine-otel` | `1.29.8-alpine-otel` | 3 HIGH/CRIT |
| `apps/opik-sandbox-executor-python/Dockerfile` | build (synced) | `python` | `3.12.12-slim` | `3.12.13-slim` | 9 HIGH/CRIT |
| `apps/opik-sandbox-executor-python/Dockerfile` | final | `python` | `3.12.12-slim` | `3.12.13-slim` | 9 HIGH/CRIT |

### Dockerfiles with no updates available

- `apps/opik-backend/Dockerfile` -- `amazoncorretto:21.0.10-al2023` is already latest
- `apps/opik-guardrails-backend/Dockerfile` -- `nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04` is already latest
- `apps/opik-python-backend/Dockerfile` -- `docker:29.2.1` is already latest

### Notes
- Trivy scans above are on the **base images only**, not the final built application images.
- The target repo's CI will build and test the full Docker images on this branch.
- Only patch versions were bumped (same major.minor line) to minimize breaking changes.

### Vulnerability Details

<details><summary>opik-frontend: 3 vulnerabilities</summary>

```
HIGH     CVE-2026-28390       libcrypto3 3.5.5-r0 -> 3.5.6-r0
HIGH     CVE-2026-28390       libssl3 3.5.5-r0 -> 3.5.6-r0
HIGH     CVE-2026-22184       zlib 1.3.1-r2 -> 1.3.2-r0
```
</details>

<details><summary>opik-sandbox-executor-python: 9 vulnerabilities</summary>

```
HIGH     CVE-2025-69720       libncursesw6 6.5+20250216-2 -> no fix
HIGH     CVE-2026-28390       libssl3t64 3.5.5-1~deb13u1 -> 3.5.5-1~deb13u2
HIGH     CVE-2026-29111       libsystemd0 257.9-1~deb13u1 -> no fix
HIGH     CVE-2025-69720       libtinfo6 6.5+20250216-2 -> no fix
HIGH     CVE-2026-29111       libudev1 257.9-1~deb13u1 -> no fix
HIGH     CVE-2025-69720       ncurses-base 6.5+20250216-2 -> no fix
HIGH     CVE-2025-69720       ncurses-bin 6.5+20250216-2 -> no fix
HIGH     CVE-2026-28390       openssl 3.5.5-1~deb13u1 -> 3.5.5-1~deb13u2
HIGH     CVE-2026-28390       openssl-provider-legacy 3.5.5-1~deb13u1 -> 3.5.5-1~deb13u2
```
</details>
