### PR TITLE
[OPIK-5874] [Optimizer SDK] fix: handle empty GEPA candidates gracefully

### DIFF
--- a/sdks/opik_optimizer/src/opik_optimizer/agents/litellm_agent.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/agents/litellm_agent.py
@@ -578,8 +578,7 @@ class LiteLLMAgent(optimizable_agent.OptimizableAgent):
         ]
         if not outputs:
             logger.warning(
-                "LiteLLMAgent: all candidate responses were empty; "
-                "returning empty list"
+                "LiteLLMAgent: all candidate responses were empty; returning empty list"
             )
         return outputs
 

--- a/sdks/opik_optimizer/src/opik_optimizer/agents/litellm_agent.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/agents/litellm_agent.py
@@ -576,7 +576,12 @@ class LiteLLMAgent(optimizable_agent.OptimizableAgent):
             for ch in choices
             if hasattr(ch, "message") and getattr(ch, "message").content
         ]
-        return outputs if outputs else [""]
+        if not outputs:
+            logger.warning(
+                "LiteLLMAgent: all candidate responses were empty; "
+                "returning empty list"
+            )
+        return outputs
 
     def _prepare_messages(
         self, messages: list[dict[str, Any]], dataset_item: dict[str, Any] | None

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/adapter.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/adapter.py
@@ -350,7 +350,11 @@ class OpikGEPAAdapter(GEPAAdapter[OpikDataInst, dict[str, Any], dict[str, Any]])
             # Choose the best candidate output before passing into Opik evaluation.
             candidates = self._collect_candidates(prompt_variants, dataset_item)
             if not candidates:
-                raise RuntimeError("No candidates produced by agent")
+                logger.warning(
+                    "No candidates produced by agent for dataset item; "
+                    "scoring as empty output (0 score)"
+                )
+                return {"llm_output": ""}
 
             best_output = candidates[0]
             best_score = float("-inf")

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/adapter.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/adapter.py
@@ -346,14 +346,18 @@ class OpikGEPAAdapter(GEPAAdapter[OpikDataInst, dict[str, Any], dict[str, Any]])
             )
             return _local_evaluation()
 
+        _failed_items: set[str] = set()
+
         def llm_task(dataset_item: dict[str, Any]) -> dict[str, str]:
             # Choose the best candidate output before passing into Opik evaluation.
             candidates = self._collect_candidates(prompt_variants, dataset_item)
             if not candidates:
                 logger.warning(
                     "No candidates produced by agent for dataset item; "
-                    "scoring as empty output (0 score)"
+                    "forcing score to 0"
                 )
+                nonlocal _failed_items
+                _failed_items.add(dataset_item.get("id", ""))
                 return {"llm_output": ""}
 
             best_output = candidates[0]
@@ -419,7 +423,10 @@ class OpikGEPAAdapter(GEPAAdapter[OpikDataInst, dict[str, Any], dict[str, Any]])
 
             output_text = ""
             score_value = 0.0
-            if test_result is not None:
+            if dataset_item_id in _failed_items:
+                # Agent produced no candidates — force score to 0
+                pass
+            elif test_result is not None:
                 output_text = str(
                     test_result.test_case.task_output.get("llm_output", "")
                 ).strip()

--- a/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_optimizer.py
+++ b/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_optimizer.py
@@ -389,3 +389,85 @@ def test_gepa_adapter_falls_back_for_legacy_agent_signature() -> None:
 
     result = adapter._collect_candidates(context.prompts, STANDARD_DATASET_ITEMS[0])
     assert result == ["legacy"]
+
+
+def test_gepa_adapter_empty_candidates_returns_empty_output() -> None:
+    """When the agent produces no candidates, llm_task should return empty output instead of crashing."""
+    dataset = make_mock_dataset(
+        STANDARD_DATASET_ITEMS[:1], name="test-dataset", dataset_id="dataset-123"
+    )
+    prompt = make_baseline_prompt()
+
+    def metric_fn(dataset_item: dict[str, Any], llm_output: str) -> float:
+        _ = dataset_item, llm_output
+        return 0.0
+
+    metric_fn.__name__ = "metric_fn"
+
+    class EmptyAgent:
+        def invoke_agent_candidates(
+            self,
+            prompts: dict[str, ChatPrompt],
+            dataset_item: dict[str, Any],
+            allow_tool_use: bool = False,
+        ) -> list[str]:
+            _ = prompts, dataset_item, allow_tool_use
+            return []
+
+    context = make_optimization_context(
+        prompt, dataset=dataset, metric=metric_fn, allow_tool_use=False
+    )
+    optimizer = GepaOptimizer(model="gpt-4o-mini", verbose=0, seed=42)
+    adapter = OpikGEPAAdapter(
+        base_prompts=context.prompts,
+        agent=EmptyAgent(),  # type: ignore[arg-type]
+        optimizer=optimizer,
+        context=context,
+        metric=metric_fn,
+        dataset=dataset,
+        experiment_config=None,
+    )
+
+    result = adapter._collect_candidates(context.prompts, STANDARD_DATASET_ITEMS[0])
+    assert result == []
+
+
+def test_gepa_adapter_whitespace_only_candidates_filtered() -> None:
+    """When the agent produces only whitespace candidates, they should be filtered out."""
+    dataset = make_mock_dataset(
+        STANDARD_DATASET_ITEMS[:1], name="test-dataset", dataset_id="dataset-123"
+    )
+    prompt = make_baseline_prompt()
+
+    def metric_fn(dataset_item: dict[str, Any], llm_output: str) -> float:
+        _ = dataset_item, llm_output
+        return 0.0
+
+    metric_fn.__name__ = "metric_fn"
+
+    class WhitespaceAgent:
+        def invoke_agent_candidates(
+            self,
+            prompts: dict[str, ChatPrompt],
+            dataset_item: dict[str, Any],
+            allow_tool_use: bool = False,
+        ) -> list[str]:
+            _ = prompts, dataset_item, allow_tool_use
+            return ["", "   ", "\n"]
+
+    context = make_optimization_context(
+        prompt, dataset=dataset, metric=metric_fn, allow_tool_use=False
+    )
+    optimizer = GepaOptimizer(model="gpt-4o-mini", verbose=0, seed=42)
+    adapter = OpikGEPAAdapter(
+        base_prompts=context.prompts,
+        agent=WhitespaceAgent(),  # type: ignore[arg-type]
+        optimizer=optimizer,
+        context=context,
+        metric=metric_fn,
+        dataset=dataset,
+        experiment_config=None,
+    )
+
+    result = adapter._collect_candidates(context.prompts, STANDARD_DATASET_ITEMS[0])
+    assert result == []


### PR DESCRIPTION
## Details

GEPA optimizations in production were crashing at trial 4 with `RuntimeError: No candidates produced by agent`. This happened because GEPA's reflection loop evolved a prompt variant that caused the LLM to return empty responses. The hard crash killed the entire optimization instead of letting GEPA score the bad variant poorly and evolve away from it.

- GEPA adapter now returns empty output and forces score to 0 instead of raising `RuntimeError` when the agent produces no candidates, allowing the trial to continue
- `LiteLLMAgent.invoke_agent_candidates` no longer returns `[""]` as fallback (which was filtered to empty list anyway), returns `[]` with a warning log
- Failed items are tracked in a `_failed_items` set and explicitly scored 0 in the results loop, bypassing the metric

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5874

## Testing

**Unit tests:**
- `python3 -m pytest tests/unit/algorithms/gepa_optimizer/test_gepa_optimizer.py -v` — 13 passed, 1 pre-existing failure (unrelated `test_gepa_adapter_passes_allow_tool_use_to_candidate_agent`)
- `test_gepa_adapter_empty_candidates_returns_empty_output` — verifies `_collect_candidates` returns `[]` when agent returns no candidates
- `test_gepa_adapter_whitespace_only_candidates_filtered` — verifies whitespace-only candidates are filtered out

**Local integration test:**
Patched the container to force empty candidates on every 3rd dataset item, ran a GEPA optimization, and confirmed:
- All three warning messages fired in Redis logs:
  - `[TEST] Forcing empty candidates for testing`
  - `No candidates produced by agent for dataset item; forcing score to 0`
  - `LiteLLMAgent: all candidate responses were empty; returning empty list`
- Optimization continued through forced failures instead of crashing
- Trials completed with degraded scores (as expected) rather than `RuntimeError`

## Documentation