### PR TITLE
[OPIK-5768] [BE] fix: restrict online evaluation rules to SDK source traces/spans

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Source.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Source.java
@@ -53,4 +53,12 @@ public enum Source {
         }
         return Optional.empty();
     }
+
+    /**
+     * Returns true for sources originating from SDK logging, i.e. {@link #SDK} or {@code null}
+     * for legacy rows that predate source tracking.
+     */
+    public static boolean isLoggingSource(Source source) {
+        return source == null || source == SDK;
+    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
@@ -151,7 +151,7 @@ public class OnlineScoringSampler {
             var scorableTraces = new ArrayList<Trace>();
             var selectedRuleIdsByTrace = new HashMap<UUID, Set<UUID>>();
             for (var trace : projectTraces) {
-                if (isLoggingSource(trace)) {
+                if (Source.isLoggingSource(trace.source())) {
                     // For SDK traces all evaluators apply
                     scorableTraces.add(trace);
                 } else {
@@ -214,13 +214,6 @@ public class OnlineScoringSampler {
                 }
             });
         });
-    }
-
-    /**
-     * Returns true for traces originating from SDK logging (source == SDK or null for legacy rows).
-     */
-    private boolean isLoggingSource(Trace trace) {
-        return trace.source() == null || trace.source() == Source.SDK;
     }
 
     private boolean shouldSampleTrace(AutomationRuleEvaluator<?, ?> evaluator, String workspaceId, Trace trace) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
@@ -33,6 +33,7 @@ import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -148,15 +149,16 @@ public class OnlineScoringSampler {
             // Non-SDK traces (playground, experiment, optimization) are only scored when
             // they carry selected_rule_ids metadata (explicit user selection from the playground).
             var scorableTraces = new ArrayList<Trace>();
-            var selectedRuleIds = new HashSet<UUID>();
+            var selectedRuleIdsByTrace = new HashMap<UUID, Set<UUID>>();
             for (var trace : projectTraces) {
                 if (isLoggingSource(trace)) {
+                    // For SDK traces all evaluators apply
                     scorableTraces.add(trace);
                 } else {
                     var ruleIds = extractSelectedRuleIds(trace);
                     if (!ruleIds.isEmpty()) {
                         scorableTraces.add(trace);
-                        selectedRuleIds.addAll(ruleIds);
+                        selectedRuleIdsByTrace.put(trace.id(), ruleIds);
                     }
                 }
             }
@@ -173,14 +175,13 @@ public class OnlineScoringSampler {
             List<? extends AutomationRuleEvaluator<?, ?>> evaluators = ruleEvaluatorService.findAll(
                     projectId, workspaceId);
 
-            // If any trace carries explicit rule selections, narrow evaluators to that set.
-            // If no selection found, use all evaluators (default behavior for backward compatibility).
-            evaluators = filterEvaluatorsBySelectedRuleIds(evaluators, selectedRuleIds);
-
             //When using the MDC with multiple threads, we must ensure that the context is propagated. For this reason, we must use the wrapWithMdc method.
             evaluators.parallelStream().forEach(evaluator -> {
-                // samples traces for this rule
+                // Samples traces for this rule.
+                // If any trace carries explicit rule selections, filter evaluators to that set.
+                // If no selection found, use all evaluators (default behavior for backward compatibility).
                 var samples = scorableTraces.stream()
+                        .filter(trace -> isEvaluatorSelectedForTrace(evaluator, trace, selectedRuleIdsByTrace))
                         .filter(trace -> shouldSampleTrace(evaluator, workspaceId, trace));
                 switch (evaluator.getType()) {
                     case LLM_AS_JUDGE -> {
@@ -307,29 +308,23 @@ public class OnlineScoringSampler {
     }
 
     /**
-     * Filters evaluators to only those whose ID is in the given selected set.
-     * If the selection is empty, all evaluators are returned (default behavior for backward compatibility).
+     * Decides whether the given evaluator applies to the given trace based on per-trace rule selection.
+     * <ul>
+     *   <li>SDK traces (and legacy null-source traces) are absent from {@code selectedRuleIdsByTrace}
+     *       and always run against every evaluator.</li>
+     *   <li>Non-SDK traces (e.g., Playground) that carry {@code selected_rule_ids} metadata are
+     *       present in the map and only run against evaluators whose ID is in their own selection.</li>
+     * </ul>
      *
-     * @param evaluators the list of all evaluators for the project
-     * @param ruleIdsToApply the rule IDs for filtering; empty means no filtering
-     * @return filtered list of evaluators matching the selection, or all evaluators if selection is empty
+     * @param evaluator              the evaluator being considered
+     * @param trace                  the trace being sampled
+     * @param selectedRuleIdsByTrace trace-id to selected rule IDs, populated only for non-SDK traces
+     * @return true if the evaluator applies to the trace
      */
-    private List<? extends AutomationRuleEvaluator<?, ?>> filterEvaluatorsBySelectedRuleIds(
-            List<? extends AutomationRuleEvaluator<?, ?>> evaluators, Set<UUID> ruleIdsToApply) {
-
-        if (ruleIdsToApply.isEmpty()) {
-            return evaluators;
-        }
-
-        log.info("Filtering evaluators based on trace metadata. Selected rule IDs: '{}'", ruleIdsToApply);
-
-        // Filter evaluators to only include those in the selected list
-        List<? extends AutomationRuleEvaluator<?, ?>> filtered = evaluators.stream()
-                .filter(evaluator -> ruleIdsToApply.contains(evaluator.getId()))
-                .toList();
-
-        log.info("Filtered '{}' evaluators out of '{}' based on trace metadata", filtered.size(), evaluators.size());
-        return filtered;
+    private boolean isEvaluatorSelectedForTrace(AutomationRuleEvaluator<?, ?> evaluator, Trace trace,
+            Map<UUID, Set<UUID>> selectedRuleIdsByTrace) {
+        var selectedRuleIds = selectedRuleIdsByTrace.get(trace.id());
+        return selectedRuleIds == null || selectedRuleIds.contains(evaluator.getId());
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
@@ -1,6 +1,7 @@
 package com.comet.opik.api.resources.v1.events;
 
 import com.comet.opik.api.PromptType;
+import com.comet.opik.api.Source;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluator;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorLlmAsJudge;
@@ -15,7 +16,6 @@ import com.comet.opik.domain.evaluators.AutomationRuleEvaluatorService;
 import com.comet.opik.domain.evaluators.OnlineScorePublisher;
 import com.comet.opik.domain.evaluators.TraceFilterEvaluationService;
 import com.comet.opik.domain.evaluators.UserLog;
-import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.log.LogContextAware;
@@ -33,9 +33,11 @@ import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -60,8 +62,7 @@ public class OnlineScoringSampler {
     private final OnlineScorePublisher onlineScorePublisher;
 
     @Inject
-    public OnlineScoringSampler(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
-            @NonNull @Config("serviceToggles") ServiceTogglesConfig serviceTogglesConfig,
+    public OnlineScoringSampler(@NonNull @Config("serviceToggles") ServiceTogglesConfig serviceTogglesConfig,
             @NonNull AutomationRuleEvaluatorService ruleEvaluatorService,
             @NonNull TraceFilterEvaluationService filterEvaluationService,
             @NonNull OnlineScorePublisher onlineScorePublisher,
@@ -142,19 +143,44 @@ public class OnlineScoringSampler {
 
         // fetch automation rules per project
         tracesByProject.forEach((projectId, projectTraces) -> {
+            // Only score traces from SDK logging source, by all applicable evaluators.
+            // We deliberately do not read selected_rule_ids from SDK traces.
+            // Non-SDK traces (playground, experiment, optimization) are only scored when
+            // they carry selected_rule_ids metadata (explicit user selection from the playground).
+            var scorableTraces = new ArrayList<Trace>();
+            var selectedRuleIds = new HashSet<UUID>();
+            for (var trace : projectTraces) {
+                if (isLoggingSource(trace)) {
+                    scorableTraces.add(trace);
+                } else {
+                    var ruleIds = extractSelectedRuleIds(trace);
+                    if (!ruleIds.isEmpty()) {
+                        scorableTraces.add(trace);
+                        selectedRuleIds.addAll(ruleIds);
+                    }
+                }
+            }
+            if (scorableTraces.isEmpty()) {
+                log.info(
+                        "No scorable traces: source is not SDK and no selected_rule_ids, projectId '{}', workspaceId '{}'",
+                        projectId, workspaceId);
+                return;
+            }
+
             log.info("Fetching evaluators, traces '{}', project '{}', workspace '{}'",
-                    projectTraces.size(), projectId, workspaceId);
+                    scorableTraces.size(), projectId, workspaceId);
 
             List<? extends AutomationRuleEvaluator<?, ?>> evaluators = ruleEvaluatorService.findAll(
                     projectId, workspaceId);
 
-            // Filter evaluators based on trace metadata if selected_rule_ids is present
-            evaluators = filterEvaluatorsByTraceMetadata(evaluators, projectTraces);
+            // If any trace carries explicit rule selections, narrow evaluators to that set.
+            // If no selection found, use all evaluators (default behavior for backward compatibility).
+            evaluators = filterEvaluatorsBySelectedRuleIds(evaluators, selectedRuleIds);
 
             //When using the MDC with multiple threads, we must ensure that the context is propagated. For this reason, we must use the wrapWithMdc method.
             evaluators.parallelStream().forEach(evaluator -> {
                 // samples traces for this rule
-                var samples = projectTraces.stream()
+                var samples = scorableTraces.stream()
                         .filter(trace -> shouldSampleTrace(evaluator, workspaceId, trace));
                 switch (evaluator.getType()) {
                     case LLM_AS_JUDGE -> {
@@ -162,8 +188,10 @@ public class OnlineScoringSampler {
                                 .map(trace -> toLlmAsJudgeMessage(workspaceId, userName,
                                         (AutomationRuleEvaluatorLlmAsJudge) evaluator, trace))
                                 .toList();
-                        logSampledTrace(evaluator, messages, projectTraces.size());
-                        onlineScorePublisher.enqueueMessage(messages, AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+                        logSampledTrace(evaluator, messages, scorableTraces.size());
+                        if (!messages.isEmpty()) {
+                            onlineScorePublisher.enqueueMessage(messages, AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+                        }
                     }
                     case USER_DEFINED_METRIC_PYTHON -> {
                         if (serviceTogglesConfig.isPythonEvaluatorEnabled()) {
@@ -171,9 +199,11 @@ public class OnlineScoringSampler {
                                     .map(trace -> toScoreUserDefinedMetricPython(workspaceId, userName,
                                             (AutomationRuleEvaluatorUserDefinedMetricPython) evaluator, trace))
                                     .toList();
-                            logSampledTrace(evaluator, messages, projectTraces.size());
-                            onlineScorePublisher.enqueueMessage(messages,
-                                    AutomationRuleEvaluatorType.USER_DEFINED_METRIC_PYTHON);
+                            logSampledTrace(evaluator, messages, scorableTraces.size());
+                            if (!messages.isEmpty()) {
+                                onlineScorePublisher.enqueueMessage(messages,
+                                        AutomationRuleEvaluatorType.USER_DEFINED_METRIC_PYTHON);
+                            }
                         } else {
                             log.warn("Python evaluator is disabled. Skipping sampling for evaluator type '{}'",
                                     evaluator.getType());
@@ -183,6 +213,13 @@ public class OnlineScoringSampler {
                 }
             });
         });
+    }
+
+    /**
+     * Returns true for traces originating from SDK logging (source == SDK or null for legacy rows).
+     */
+    private boolean isLoggingSource(Trace trace) {
+        return trace.source() == null || trace.source() == Source.SDK;
     }
 
     private boolean shouldSampleTrace(AutomationRuleEvaluator<?, ?> evaluator, String workspaceId, Trace trace) {
@@ -270,35 +307,20 @@ public class OnlineScoringSampler {
     }
 
     /**
-     * Filters evaluators based on trace metadata. If the first trace in the batch contains
-     * "selected_rule_ids" in its metadata, only evaluators with IDs in that list will be returned.
-     * Otherwise, all evaluators are returned (default behavior for backward compatibility).
-     *
-     * Note: All traces in a batch from the same source (e.g., Playground) will have the same metadata,
-     * so checking only the first trace is sufficient.
+     * Filters evaluators to only those whose ID is in the given selected set.
+     * If the selection is empty, all evaluators are returned (default behavior for backward compatibility).
      *
      * @param evaluators the list of all evaluators for the project
-     * @param traces the traces batch to check for metadata
-     * @return filtered list of evaluators, or all evaluators if no selection metadata is present
+     * @param ruleIdsToApply the rule IDs for filtering; empty means no filtering
+     * @return filtered list of evaluators matching the selection, or all evaluators if selection is empty
      */
-    private List<? extends AutomationRuleEvaluator<?, ?>> filterEvaluatorsByTraceMetadata(
-            List<? extends AutomationRuleEvaluator<?, ?>> evaluators, List<Trace> traces) {
+    private List<? extends AutomationRuleEvaluator<?, ?>> filterEvaluatorsBySelectedRuleIds(
+            List<? extends AutomationRuleEvaluator<?, ?>> evaluators, Set<UUID> ruleIdsToApply) {
 
-        // Check if batch is empty
-        if (traces.isEmpty()) {
+        if (ruleIdsToApply.isEmpty()) {
             return evaluators;
         }
 
-        // Check the first trace for selected_rule_ids metadata
-        // All traces in the same batch will have identical metadata
-        Optional<List<UUID>> selectedRuleIds = extractSelectedRuleIds(traces.getFirst());
-
-        // If no selection found, return all evaluators (default behavior)
-        if (selectedRuleIds.isEmpty()) {
-            return evaluators;
-        }
-
-        List<UUID> ruleIdsToApply = selectedRuleIds.get();
         log.info("Filtering evaluators based on trace metadata. Selected rule IDs: '{}'", ruleIdsToApply);
 
         // Filter evaluators to only include those in the selected list
@@ -311,33 +333,33 @@ public class OnlineScoringSampler {
     }
 
     /**
-     * Extracts selected_rule_ids from trace metadata if present.
+     * Extracts selected_rule_ids from trace metadata.
      *
      * @param trace the trace to check
-     * @return Optional containing list of rule UUIDs if present, empty otherwise
+     * @return set of rule UUIDs found in metadata, or empty set if absent/invalid
      */
-    private Optional<List<UUID>> extractSelectedRuleIds(Trace trace) {
+    private Set<UUID> extractSelectedRuleIds(Trace trace) {
         return Optional.ofNullable(trace.metadata())
                 .map(metadata -> metadata.get("selected_rule_ids"))
                 .filter(JsonNode::isArray)
                 .map(ruleIdsNode -> {
+                    Set<UUID> ruleIds = new HashSet<>();
                     try {
-                        List<UUID> ruleIds = new ArrayList<>();
                         ruleIdsNode.forEach(idNode -> {
                             if (idNode.isTextual()) {
                                 try {
                                     ruleIds.add(UUID.fromString(idNode.asText()));
-                                } catch (IllegalArgumentException e) {
+                                } catch (IllegalArgumentException exception) {
                                     log.warn("Invalid UUID format in selected_rule_ids metadata for trace: '{}'",
-                                            trace.id(), e);
+                                            trace.id(), exception);
                                 }
                             }
                         });
-                        return ruleIds.isEmpty() ? null : ruleIds;
-                    } catch (Exception e) {
-                        log.warn("Error parsing selected_rule_ids metadata for trace: '{}'", trace.id(), e);
-                        return null;
+                    } catch (RuntimeException exception) {
+                        log.warn("Error parsing selected_rule_ids metadata for trace: '{}'", trace.id(), exception);
                     }
-                });
+                    return ruleIds;
+                })
+                .orElse(Set.of());
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSampler.java
@@ -90,7 +90,7 @@ public class OnlineScoringSpanSampler {
         spansByProject.forEach((projectId, spans) -> {
             // Only score spans from SDK logging source. Non-SDK spans (playground, experiment,
             // optimization) are skipped from online evaluation.
-            var scorableSpans = spans.stream().filter(this::isLoggingSource).toList();
+            var scorableSpans = spans.stream().filter(span -> Source.isLoggingSource(span.source())).toList();
             if (scorableSpans.isEmpty()) {
                 log.info("No scorable spans: source is not SDK, projectId '{}', workspaceId '{}'",
                         projectId, spansBatch.workspaceId());
@@ -172,13 +172,6 @@ public class OnlineScoringSpanSampler {
                 }
             });
         });
-    }
-
-    /**
-     * Returns true for spans originating from SDK logging (source == SDK or null for legacy rows).
-     */
-    private boolean isLoggingSource(Span span) {
-        return span.source() == null || span.source() == Source.SDK;
     }
 
     private void logUnsupportedEvaluatorType(AutomationRuleEvaluator<?, ?> evaluator) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSampler.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api.resources.v1.events;
 
+import com.comet.opik.api.Source;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluator;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorLlmAsJudge;
@@ -76,7 +77,6 @@ public class OnlineScoringSpanSampler {
     @Subscribe
     public void onSpansCreated(SpansCreated spansBatch) {
         // Check if feature is enabled before processing spans
-
         var spansByProject = spansBatch.spans().stream().collect(Collectors.groupingBy(Span::projectId));
 
         var countMap = spansByProject.entrySet().stream()
@@ -88,8 +88,17 @@ public class OnlineScoringSpanSampler {
 
         // fetch automation rules per project
         spansByProject.forEach((projectId, spans) -> {
+            // Only score spans from SDK logging source. Non-SDK spans (playground, experiment,
+            // optimization) are skipped from online evaluation.
+            var scorableSpans = spans.stream().filter(this::isLoggingSource).toList();
+            if (scorableSpans.isEmpty()) {
+                log.info("No scorable spans: source is not SDK, projectId '{}', workspaceId '{}'",
+                        projectId, spansBatch.workspaceId());
+                return;
+            }
+
             log.info("Fetching evaluators for '{}' spans, project '{}' on workspace '{}'",
-                    spans.size(), projectId, spansBatch.workspaceId());
+                    scorableSpans.size(), projectId, spansBatch.workspaceId());
 
             // Fetch all span-level evaluators by filtering at database level
             // Only fetch evaluators if their respective feature toggles are enabled
@@ -122,16 +131,15 @@ public class OnlineScoringSpanSampler {
                             return;
                         }
                         // samples spans for this rule
-                        var samples = spans.stream()
+                        var samples = scorableSpans.stream()
                                 .filter(span -> shouldSampleSpan(rule, spansBatch.workspaceId(), span))
                                 .toList();
 
                         var messages = samples.stream()
                                 .map(span -> toLlmAsJudgeMessage(spansBatch, rule, span))
                                 .toList();
-
+                        logSampledSpan(evaluator, messages, scorableSpans.size());
                         if (!messages.isEmpty()) {
-                            logSampledSpan(spansBatch, evaluator, messages);
                             onlineScorePublisher.enqueueMessage(messages,
                                     AutomationRuleEvaluatorType.SPAN_LLM_AS_JUDGE);
                         }
@@ -149,14 +157,14 @@ public class OnlineScoringSpanSampler {
                                     "Span Python evaluator is disabled. This should not happen as evaluators are filtered before fetching.");
                             return;
                         }
-                        var samples = spans.stream()
+                        var samples = scorableSpans.stream()
                                 .filter(span -> shouldSampleSpan(rule, spansBatch.workspaceId(), span))
                                 .toList();
                         var messages = samples.stream()
                                 .map(span -> toUserDefinedMetricPythonMessage(spansBatch, rule, span))
                                 .toList();
+                        logSampledSpan(evaluator, messages, scorableSpans.size());
                         if (!messages.isEmpty()) {
-                            logSampledSpan(spansBatch, evaluator, messages);
                             onlineScorePublisher.enqueueMessage(messages,
                                     AutomationRuleEvaluatorType.SPAN_USER_DEFINED_METRIC_PYTHON);
                         }
@@ -164,6 +172,13 @@ public class OnlineScoringSpanSampler {
                 }
             });
         });
+    }
+
+    /**
+     * Returns true for spans originating from SDK logging (source == SDK or null for legacy rows).
+     */
+    private boolean isLoggingSource(Span span) {
+        return span.source() == null || span.source() == Source.SDK;
     }
 
     private void logUnsupportedEvaluatorType(AutomationRuleEvaluator<?, ?> evaluator) {
@@ -234,12 +249,12 @@ public class OnlineScoringSpanSampler {
                 .build();
     }
 
-    private void logSampledSpan(SpansCreated spansBatch, AutomationRuleEvaluator<?, ?> evaluator, List<?> messages) {
+    private void logSampledSpan(AutomationRuleEvaluator<?, ?> evaluator, List<?> messages, int totalSpans) {
         log.info("[AutomationRule '{}', type '{}'] Sampled '{}/{}' from span batch (expected rate: '{}')",
                 evaluator.getName(),
                 evaluator.getType(),
                 messages.size(),
-                spansBatch.spans().size(),
+                totalSpans,
                 evaluator.getSamplingRate());
     }
 
@@ -252,5 +267,4 @@ public class OnlineScoringSpanSampler {
                 UserLog.RULE_ID, evaluator.getId().toString(),
                 UserLog.SPAN_ID, span.id().toString()));
     }
-
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
@@ -4,10 +4,13 @@ import com.comet.opik.api.FeedbackScoreItem;
 import com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
 import com.comet.opik.api.LogItem.LogLevel;
 import com.comet.opik.api.ScoreSource;
+import com.comet.opik.api.Source;
+import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.TraceUpdate;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorLlmAsJudge;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeCode;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorSpanLlmAsJudge;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadLlmAsJudge.TraceThreadLlmAsJudgeCode;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
 import com.comet.opik.api.evaluators.LlmAsJudgeMessage;
@@ -29,7 +32,6 @@ import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
 import com.comet.opik.domain.FeedbackScoreService;
 import com.comet.opik.domain.llm.ChatCompletionService;
-import com.comet.opik.domain.llm.MessageContentNormalizer;
 import com.comet.opik.domain.llm.structuredoutput.InstructionStrategy;
 import com.comet.opik.domain.llm.structuredoutput.ToolCallingStrategy;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
@@ -37,7 +39,6 @@ import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.JsonUtils;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.uuid.Generators;
 import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 import com.github.dockerjava.api.exception.InternalServerErrorException;
@@ -67,7 +68,9 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -156,9 +159,6 @@ class OnlineScoringEngineTest {
 
             {{context}}
             """;
-
-    private static final String IMAGE_PLACEHOLDER = MessageContentNormalizer.IMAGE_PLACEHOLDER_START + "%s"
-            + MessageContentNormalizer.IMAGE_PLACEHOLDER_END;
 
     private final String unquoted;
 
@@ -299,10 +299,15 @@ class OnlineScoringEngineTest {
         Mockito.reset(aiProxyService, feedbackScoreService, eventBus);
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(value = Source.class, names = {"SDK"})
+    @NullSource
     @DisplayName("test Redis producer and consumer base flow")
-    void testRedisProducerAndConsumerBaseFlow(OnlineScoringSampler onlineScoringSampler) throws Exception {
-        var projectId = projectResourceClient.createProject(PROJECT_NAME, API_KEY, WORKSPACE_NAME);
+    void testRedisProducerAndConsumerBaseFlow(Source source, OnlineScoringSampler onlineScoringSampler) {
+        Mockito.reset(feedbackScoreService, aiProxyService, eventBus);
+
+        var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        var projectId = projectResourceClient.createProject(projectName, API_KEY, WORKSPACE_NAME);
 
         var evaluatorCode = JsonUtils.readValue(TEST_EVALUATOR, LlmAsJudgeCode.class);
 
@@ -311,7 +316,7 @@ class OnlineScoringEngineTest {
         evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
 
         var traceId = generator.generate();
-        var trace = createTrace(traceId, projectId);
+        var trace = createTrace(traceId, projectId, source);
         var event = new TracesCreated(List.of(trace), WORKSPACE_ID, USER_NAME);
 
         Mockito.doNothing().when(eventBus).register(Mockito.any());
@@ -349,7 +354,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("test filtering evaluators by trace metadata")
-    void testFilteringEvaluatorsByTraceMetadata(OnlineScoringSampler onlineScoringSampler) throws Exception {
+    void testFilteringEvaluatorsByTraceMetadata(OnlineScoringSampler onlineScoringSampler) {
         Mockito.reset(feedbackScoreService, aiProxyService, eventBus);
 
         var projectName = "project" + RandomStringUtils.secure().nextAlphanumeric(36);
@@ -373,7 +378,9 @@ class OnlineScoringEngineTest {
                 .add(evaluatorId1.toString())
                 .add(evaluatorId2.toString());
 
-        var trace = createTrace(traceId, projectId).toBuilder()
+        // non-SDK traces, such as playground with "selected_rule_ids" must still be scored
+        // by the explicitly selected evaluators.
+        var trace = createTrace(traceId, projectId, Source.PLAYGROUND).toBuilder()
                 .metadata(metadata)
                 .build();
 
@@ -419,7 +426,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("test User Facing log error when AI provider fails")
-    void testUserFacingLogErrorWhenAIProviderFails(OnlineScoringSampler onlineScoringSampler) throws Exception {
+    void testUserFacingLogErrorWhenAIProviderFails(OnlineScoringSampler onlineScoringSampler) {
         Mockito.reset(feedbackScoreService, aiProxyService, eventBus);
 
         var projectName = "project" + RandomStringUtils.secure().nextAlphanumeric(36);
@@ -465,7 +472,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("test partial trace without end_time is skipped, complete trace is scored once")
-    void testPartialTraceThenCompleteTraceScoresOnlyOnce(OnlineScoringSampler onlineScoringSampler) throws Exception {
+    void testPartialTraceThenCompleteTraceScoresOnlyOnce(OnlineScoringSampler onlineScoringSampler) {
         Mockito.reset(feedbackScoreService, aiProxyService, eventBus);
 
         var projectName = "project" + RandomStringUtils.secure().nextAlphanumeric(36);
@@ -524,7 +531,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("onTracesUpdated when endTime is set triggers scoring")
-    void onTracesUpdatedWhenEndTimeSetTriggersScoring(OnlineScoringSampler onlineScoringSampler) throws Exception {
+    void onTracesUpdatedWhenEndTimeSetTriggersScoring(OnlineScoringSampler onlineScoringSampler) {
         Mockito.reset(feedbackScoreService, aiProxyService, eventBus);
 
         var projectName = "project" + RandomStringUtils.secure().nextAlphanumeric(36);
@@ -546,6 +553,7 @@ class OnlineScoringEngineTest {
                 .input(JsonUtils.getJsonNodeFromString(INPUT))
                 .output(JsonUtils.getJsonNodeFromString(OUTPUT))
                 .endTime(java.time.Instant.now())
+                .source(null)
                 .feedbackScores(null)
                 .build();
         traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
@@ -582,8 +590,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("onTracesUpdated when endTime is null does NOT trigger scoring")
-    void onTracesUpdatedWithoutEndTimeDoesNotTriggerScoring(OnlineScoringSampler onlineScoringSampler)
-            throws Exception {
+    void onTracesUpdatedWithoutEndTimeDoesNotTriggerScoring(OnlineScoringSampler onlineScoringSampler) {
         Mockito.reset(feedbackScoreService, aiProxyService, eventBus);
 
         var projectName = "project" + RandomStringUtils.secure().nextAlphanumeric(36);
@@ -608,7 +615,11 @@ class OnlineScoringEngineTest {
         Mockito.verify(feedbackScoreService, Mockito.never()).scoreBatchOfTraces(Mockito.any());
     }
 
-    private Trace createTrace(UUID traceId, UUID projectId) throws JsonProcessingException {
+    private Trace createTrace(UUID traceId, UUID projectId) {
+        return createTrace(traceId, projectId, null);
+    }
+
+    private Trace createTrace(UUID traceId, UUID projectId, Source source) {
         return Trace.builder()
                 .id(traceId)
                 .projectName(PROJECT_NAME)
@@ -617,6 +628,7 @@ class OnlineScoringEngineTest {
                 .input(JsonUtils.getJsonNodeFromString(INPUT))
                 .output(JsonUtils.getJsonNodeFromString(OUTPUT))
                 .endTime(java.time.Instant.now())
+                .source(source)
                 .build();
     }
 
@@ -633,7 +645,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("parse variable mapping into a usable one")
-    void testVariableMapping() throws JsonProcessingException {
+    void testVariableMapping() {
         var evaluatorCode = JsonUtils.readValue(TEST_EVALUATOR, LlmAsJudgeCode.class);
         var variableMappings = OnlineScoringEngine.toVariableMapping(evaluatorCode.variables());
 
@@ -730,7 +742,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("toReplacements should produce valid JSON for complex objects (Python evaluator path)")
-    void testToReplacementsProducesValidJsonForComplexObjects() throws JsonProcessingException {
+    void testToReplacementsProducesValidJsonForComplexObjects() {
         // Given - a trace with a complex nested object in output (similar to the customer's sql_template case)
         var complexOutput = """
                 {
@@ -789,7 +801,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("render message templates with root object variables")
-    void testRenderTemplateWithRootObjects() throws JsonProcessingException {
+    void testRenderTemplateWithRootObjects() {
         // Given
         var messageTemplate = "Full input: {{full_input}}\\nNested field: {{nested_field}}";
         var evaluatorJson = """
@@ -834,7 +846,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("render message templates with output root object")
-    void testRenderTemplateWithOutputRootObject() throws JsonProcessingException {
+    void testRenderTemplateWithOutputRootObject() {
         // Given
         var messageTemplate = "Full output: {{full_output}}";
         var evaluatorJson = """
@@ -874,7 +886,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("render span message templates with root object variables")
-    void testRenderSpanTemplateWithRootObjects() throws JsonProcessingException {
+    void testRenderSpanTemplateWithRootObjects() {
         // Given
         var messageTemplate = "Full input: {{full_input}}\\nNested field: {{nested_field}}";
         var evaluatorJson = """
@@ -894,7 +906,7 @@ class OnlineScoringEngineTest {
                 """.formatted(messageTemplate).trim();
 
         var evaluatorCode = JsonUtils.readValue(evaluatorJson,
-                com.comet.opik.api.evaluators.AutomationRuleEvaluatorSpanLlmAsJudge.SpanLlmAsJudgeCode.class);
+                AutomationRuleEvaluatorSpanLlmAsJudge.SpanLlmAsJudgeCode.class);
         var spanId = generator.generate();
         var projectId = generator.generate();
         var span = createSpan(spanId, projectId);
@@ -923,7 +935,7 @@ class OnlineScoringEngineTest {
     @ParameterizedTest
     @MethodSource
     @DisplayName("render message templates with a trace")
-    void testRenderTemplate(String evaluator) throws JsonProcessingException {
+    void testRenderTemplate(String evaluator) {
         var evaluatorCode = JsonUtils.readValue(evaluator, LlmAsJudgeCode.class);
         var traceId = generator.generate();
         var projectId = generator.generate();
@@ -946,7 +958,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("render message templates with a trace thread")
-    void testRenderTemplateWithTraceThread() throws JsonProcessingException {
+    void testRenderTemplateWithTraceThread() {
         var evaluatorCode = JsonUtils.readValue(TEST_TRACE_THREAD_EVALUATOR, TraceThreadLlmAsJudgeCode.class);
         var traceId = generator.generate();
         var projectId = generator.generate();
@@ -970,7 +982,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("prepare trace thread LLM request with tool-calling strategy")
-    void testPrepareTraceThreadLlmRequestWithToolCallingStrategy() throws JsonProcessingException {
+    void testPrepareTraceThreadLlmRequestWithToolCallingStrategy() {
         var evaluatorCode = JsonUtils.readValue(TEST_TRACE_THREAD_EVALUATOR, TraceThreadLlmAsJudgeCode.class);
         var trace = createTrace(generator.generate(), generator.generate()).toBuilder()
                 .threadId("thread-" + RandomStringUtils.secure().nextAlphanumeric(36))
@@ -986,7 +998,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("prepare LLM request with tool-calling strategy")
-    void testPrepareLlmRequestWithToolCallingStrategy() throws JsonProcessingException {
+    void testPrepareLlmRequestWithToolCallingStrategy() {
         var evaluatorCode = JsonUtils.readValue(TEST_EVALUATOR, LlmAsJudgeCode.class);
         var trace = createTrace(generator.generate(), generator.generate());
 
@@ -999,7 +1011,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("prepare LLM request with instruction strategy")
-    void testPrepareLlmRequestWithInstructionStrategy() throws JsonProcessingException {
+    void testPrepareLlmRequestWithInstructionStrategy() {
         var evaluatorCode = JsonUtils.readValue(TEST_EVALUATOR, LlmAsJudgeCode.class);
         var trace = createTrace(generator.generate(), generator.generate());
 
@@ -1107,7 +1119,7 @@ class OnlineScoringEngineTest {
     @ParameterizedTest
     @MethodSource
     @DisplayName("renderMessages should support keys with dots in their names")
-    void testExtractFromJsonWithDotKey(String key, String jsonBody) throws Exception {
+    void testExtractFromJsonWithDotKey(String key, String jsonBody) {
         // variable mapping: variable 'testVar' maps to 'input.' + key
         var variables = Map.of("testVar", "input." + key);
         var trace = Trace.builder()
@@ -1383,8 +1395,8 @@ class OnlineScoringEngineTest {
         assertThat(isString).isFalse();
         assertThat(isArray).isTrue();
         assertThat(message.asContentList()).hasSize(1);
-        assertThat(message.asContentList().get(0).type()).isEqualTo("text");
-        assertThat(message.asContentList().get(0).text()).isEqualTo("Analyze this video");
+        assertThat(message.asContentList().getFirst().type()).isEqualTo("text");
+        assertThat(message.asContentList().getFirst().text()).isEqualTo("Analyze this video");
     }
 
     @Test
@@ -1443,7 +1455,7 @@ class OnlineScoringEngineTest {
 
         // When & Then
         assertThat(message.isStructuredContent()).isTrue();
-        var videoPart = message.asContentList().get(0);
+        var videoPart = message.asContentList().getFirst();
         assertThat(videoPart.videoUrl().url()).startsWith("data:video/mp4;base64,");
     }
 
@@ -1485,7 +1497,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("should render template variables in array content with video URL from input")
-    void shouldRenderTemplateVariables_whenVideoUrlFromInput() throws JsonProcessingException {
+    void shouldRenderTemplateVariables_whenVideoUrlFromInput() {
         // Given
         var trace = Trace.builder()
                 .id(UUID.randomUUID())
@@ -1522,7 +1534,7 @@ class OnlineScoringEngineTest {
 
         // Then
         assertThat(renderedMessages).hasSize(1);
-        var userMessage = (UserMessage) renderedMessages.get(0);
+        var userMessage = (UserMessage) renderedMessages.getFirst();
         assertThat(userMessage.contents()).hasSize(2);
 
         var textContent = (TextContent) userMessage.contents().get(0);
@@ -1535,7 +1547,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("should render template variables with base64 video from input")
-    void shouldRenderTemplateVariables_whenBase64VideoFromInput() throws JsonProcessingException {
+    void shouldRenderTemplateVariables_whenBase64VideoFromInput() {
         // Given
         var trace = Trace.builder()
                 .id(UUID.randomUUID())
@@ -1572,7 +1584,7 @@ class OnlineScoringEngineTest {
 
         // Then
         assertThat(renderedMessages).hasSize(1);
-        var userMessage = (UserMessage) renderedMessages.get(0);
+        var userMessage = (UserMessage) renderedMessages.getFirst();
         assertThat(userMessage.contents()).hasSize(2);
 
         var videoContent = (VideoContent) userMessage.contents().get(1);
@@ -1581,7 +1593,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("should render mixed media with template variables")
-    void shouldRenderTemplateVariables_whenMixedMedia() throws JsonProcessingException {
+    void shouldRenderTemplateVariables_whenMixedMedia() {
         // Given
         var trace = Trace.builder()
                 .id(UUID.randomUUID())
@@ -1625,7 +1637,7 @@ class OnlineScoringEngineTest {
 
         // Then
         assertThat(renderedMessages).hasSize(1);
-        var userMessage = (UserMessage) renderedMessages.get(0);
+        var userMessage = (UserMessage) renderedMessages.getFirst();
         assertThat(userMessage.contents()).hasSize(3);
 
         var textContent = (TextContent) userMessage.contents().get(0);
@@ -1640,7 +1652,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("should render template variables in multimodal content with video URL")
-    void shouldRenderTemplateVariables_whenMultimodalContentWithVideoUrl() throws JsonProcessingException {
+    void shouldRenderTemplateVariables_whenMultimodalContentWithVideoUrl() {
         // Given
         var trace = Trace.builder()
                 .id(UUID.randomUUID())
@@ -1678,7 +1690,7 @@ class OnlineScoringEngineTest {
 
         // Then
         assertThat(renderedMessages).hasSize(1);
-        var userMessage = (UserMessage) renderedMessages.get(0);
+        var userMessage = (UserMessage) renderedMessages.getFirst();
         assertThat(userMessage.contents()).hasSize(2);
 
         var textContent = (TextContent) userMessage.contents().get(0);
@@ -1708,7 +1720,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("should render video URL from output field")
-    void shouldRenderTemplateVariables_whenVideoUrlFromOutput() throws JsonProcessingException {
+    void shouldRenderTemplateVariables_whenVideoUrlFromOutput() {
         // Given
         var outputWithVideo = """
                 {
@@ -1751,7 +1763,7 @@ class OnlineScoringEngineTest {
 
         // Then
         assertThat(renderedMessages).hasSize(1);
-        var userMessage = (UserMessage) renderedMessages.get(0);
+        var userMessage = (UserMessage) renderedMessages.getFirst();
         assertThat(userMessage.contents()).hasSize(2);
 
         var videoContent = (VideoContent) userMessage.contents().get(1);
@@ -1760,9 +1772,9 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("render span message templates")
-    void testRenderSpanTemplate() throws JsonProcessingException {
+    void testRenderSpanTemplate() {
         var evaluatorCode = JsonUtils.readValue(TEST_EVALUATOR,
-                com.comet.opik.api.evaluators.AutomationRuleEvaluatorSpanLlmAsJudge.SpanLlmAsJudgeCode.class);
+                AutomationRuleEvaluatorSpanLlmAsJudge.SpanLlmAsJudgeCode.class);
         var spanId = generator.generate();
         var projectId = generator.generate();
         var span = createSpan(spanId, projectId);
@@ -1784,9 +1796,9 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("prepare span LLM request with tool-calling strategy")
-    void testPrepareSpanLlmRequestWithToolCallingStrategy() throws JsonProcessingException {
+    void testPrepareSpanLlmRequestWithToolCallingStrategy() {
         var evaluatorCode = JsonUtils.readValue(TEST_EVALUATOR,
-                com.comet.opik.api.evaluators.AutomationRuleEvaluatorSpanLlmAsJudge.SpanLlmAsJudgeCode.class);
+                AutomationRuleEvaluatorSpanLlmAsJudge.SpanLlmAsJudgeCode.class);
         var span = createSpan(generator.generate(), generator.generate());
 
         var request = OnlineScoringEngine.prepareSpanLlmRequest(evaluatorCode, span, new ToolCallingStrategy());
@@ -1798,9 +1810,9 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("prepare span LLM request with instruction strategy")
-    void testPrepareSpanLlmRequestWithInstructionStrategy() throws JsonProcessingException {
+    void testPrepareSpanLlmRequestWithInstructionStrategy() {
         var evaluatorCode = JsonUtils.readValue(TEST_EVALUATOR,
-                com.comet.opik.api.evaluators.AutomationRuleEvaluatorSpanLlmAsJudge.SpanLlmAsJudgeCode.class);
+                AutomationRuleEvaluatorSpanLlmAsJudge.SpanLlmAsJudgeCode.class);
         var span = createSpan(generator.generate(), generator.generate());
 
         var request = OnlineScoringEngine.prepareSpanLlmRequest(evaluatorCode, span, new InstructionStrategy());
@@ -1823,8 +1835,8 @@ class OnlineScoringEngineTest {
         assertThat(userMessage.singleText()).contains("Literal: some literal value");
     }
 
-    private com.comet.opik.api.Span createSpan(UUID spanId, UUID projectId) throws JsonProcessingException {
-        return com.comet.opik.api.Span.builder()
+    private Span createSpan(UUID spanId, UUID projectId) {
+        return Span.builder()
                 .id(spanId)
                 .projectName(PROJECT_NAME)
                 .projectId(projectId)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerTest.java
@@ -1,0 +1,592 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.PromptType;
+import com.comet.opik.api.Source;
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.TraceUpdate;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorLlmAsJudge;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeCode;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorUserDefinedMetricPython;
+import com.comet.opik.api.events.TraceToScoreLlmAsJudge;
+import com.comet.opik.api.events.TraceToScoreUserDefinedMetricPython;
+import com.comet.opik.api.events.TracesCreated;
+import com.comet.opik.api.events.TracesUpdated;
+import com.comet.opik.api.filter.Operator;
+import com.comet.opik.api.filter.TraceField;
+import com.comet.opik.api.filter.TraceFilter;
+import com.comet.opik.domain.TraceService;
+import com.comet.opik.domain.evaluators.AutomationRuleEvaluatorService;
+import com.comet.opik.domain.evaluators.OnlineScorePublisher;
+import com.comet.opik.domain.evaluators.TraceFilterEvaluationService;
+import com.comet.opik.infrastructure.ServiceTogglesConfig;
+import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import reactor.core.publisher.Flux;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.comet.opik.api.resources.utils.AutomationRuleEvaluatorTestUtils.toProjects;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OnlineScoringSamplerTest {
+
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+
+    @Mock
+    private ServiceTogglesConfig serviceTogglesConfig;
+
+    @Mock
+    private AutomationRuleEvaluatorService ruleEvaluatorService;
+
+    @Mock
+    private OnlineScorePublisher onlineScorePublisher;
+
+    @Mock
+    private TraceService traceService;
+
+    private OnlineScoringSampler onlineScoringSampler;
+    private MockedStatic<UserFacingLoggingFactory> mockedFactory;
+
+    private UUID projectId;
+    private String workspaceId;
+    private String userName;
+
+    @BeforeEach
+    void setUp() throws NoSuchAlgorithmException {
+        mockedFactory = mockStatic(UserFacingLoggingFactory.class);
+        mockedFactory.when(() -> UserFacingLoggingFactory.getLogger(any(Class.class)))
+                .thenReturn(mock(Logger.class));
+
+        onlineScoringSampler = new OnlineScoringSampler(
+                serviceTogglesConfig,
+                ruleEvaluatorService,
+                new TraceFilterEvaluationService(),
+                onlineScorePublisher,
+                traceService);
+
+        projectId = UUID.randomUUID();
+        workspaceId = UUID.randomUUID().toString();
+        userName = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (mockedFactory != null) {
+            mockedFactory.close();
+        }
+    }
+
+    @Nested
+    class ServiceToggleTests {
+
+        @Test
+        void processesPythonEvaluatorWhenToggleEnabled() {
+            when(serviceTogglesConfig.isPythonEvaluatorEnabled()).thenReturn(true);
+            var trace = createTrace(Source.SDK);
+            var evaluator = createPythonEvaluator(1.0f);
+            whenFindAllPythonEvaluators(evaluator);
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            var expectedMessage = TraceToScoreUserDefinedMetricPython.builder()
+                    .trace(trace)
+                    .ruleId(evaluator.getId())
+                    .ruleName(evaluator.getName())
+                    .code(evaluator.getCode())
+                    .workspaceId(workspaceId)
+                    .userName(userName)
+                    .build();
+            verify(onlineScorePublisher).enqueueMessage(List.of(expectedMessage),
+                    AutomationRuleEvaluatorType.USER_DEFINED_METRIC_PYTHON);
+        }
+
+        @Test
+        void skipsPythonEvaluatorWhenToggleDisabled() {
+            when(serviceTogglesConfig.isPythonEvaluatorEnabled()).thenReturn(false);
+            var trace = createTrace(Source.SDK);
+            var evaluator = createPythonEvaluator(1.0f);
+            whenFindAllPythonEvaluators(evaluator);
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verifyNoInteractions(onlineScorePublisher);
+        }
+    }
+
+    @Nested
+    class SourceFilteringTests {
+
+        @ParameterizedTest
+        @EnumSource(value = Source.class, names = {"SDK"})
+        @NullSource
+        void scoresTracesWithSdkOrNullSource(Source source) {
+            var trace = createTrace(source);
+            var evaluator = createLlmEvaluator(true, 1.0f, List.of());
+            whenFindAllLlmEvaluators(evaluator);
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verify(onlineScorePublisher).enqueueMessage(List.of(toLlmMessage(evaluator, trace)),
+                    AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Source.class, mode = EnumSource.Mode.EXCLUDE, names = {"SDK"})
+        void skipsNonSdkTracesWithoutSelectedRuleIds(Source source) {
+            var trace = createTrace(source);
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verifyNoInteractions(ruleEvaluatorService);
+            verifyNoInteractions(onlineScorePublisher);
+        }
+    }
+
+    @Nested
+    class SelectedRuleIdsTests {
+
+        @ParameterizedTest
+        @EnumSource(value = Source.class, mode = EnumSource.Mode.EXCLUDE, names = {"SDK"})
+        void scoresNonSdkTracesCarryingSelectedRuleIds(Source source) {
+            var evaluator = createLlmEvaluator(true, 1.0f, List.of());
+            var trace = createTrace(source).toBuilder()
+                    .metadata(metadataWithRuleIds(evaluator.getId()))
+                    .build();
+            whenFindAllLlmEvaluators(evaluator);
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verify(onlineScorePublisher).enqueueMessage(List.of(toLlmMessage(evaluator, trace)),
+                    AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+        }
+
+        @Test
+        void narrowsEvaluatorsToSelectedRuleIdsSet() {
+            var selected = createLlmEvaluator(true, 1.0f, List.of());
+            var other = createLlmEvaluator(true, 1.0f, List.of());
+            var trace = createTrace(Source.PLAYGROUND).toBuilder()
+                    .metadata(metadataWithRuleIds(selected.getId()))
+                    .build();
+            whenFindAllLlmEvaluators(selected, other);
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verify(onlineScorePublisher).enqueueMessage(List.of(toLlmMessage(selected, trace)),
+                    AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+        }
+
+        @Test
+        void unionsSelectedRuleIdsAcrossMultipleNonSdkTraces() {
+            var evalA = createLlmEvaluator(true, 1.0f, List.of());
+            var evalB = createLlmEvaluator(true, 1.0f, List.of());
+            var unrelated = createLlmEvaluator(true, 1.0f, List.of());
+
+            var traceA = createTrace(Source.PLAYGROUND).toBuilder()
+                    .metadata(metadataWithRuleIds(evalA.getId()))
+                    .build();
+            var traceB = createTrace(Source.PLAYGROUND).toBuilder()
+                    .metadata(metadataWithRuleIds(evalB.getId()))
+                    .build();
+
+            whenFindAllLlmEvaluators(evalA, evalB, unrelated);
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(traceA, traceB), workspaceId, userName));
+
+            // evalA and evalB each enqueue once with both traces; unrelated never enqueues
+            ArgumentCaptor<List<TraceToScoreLlmAsJudge>> captor = ArgumentCaptor.forClass(List.class);
+            verify(onlineScorePublisher, times(2)).enqueueMessage(captor.capture(),
+                    eq(AutomationRuleEvaluatorType.LLM_AS_JUDGE));
+
+            assertThat(captor.getAllValues()).containsExactlyInAnyOrder(
+                    List.of(toLlmMessage(evalA, traceA), toLlmMessage(evalA, traceB)),
+                    List.of(toLlmMessage(evalB, traceA), toLlmMessage(evalB, traceB)));
+        }
+
+        @Test
+        void scoresMixedBatchAndNarrowsEvaluators() {
+            var selected = createLlmEvaluator(true, 1.0f, List.of());
+            var other = createLlmEvaluator(true, 1.0f, List.of());
+            var sdkTrace = createTrace(Source.SDK);
+            var playgroundTrace = createTrace(Source.PLAYGROUND).toBuilder()
+                    .metadata(metadataWithRuleIds(selected.getId()))
+                    .build();
+            whenFindAllLlmEvaluators(selected, other);
+
+            onlineScoringSampler
+                    .onTracesCreated(new TracesCreated(List.of(sdkTrace, playgroundTrace), workspaceId, userName));
+
+            verify(onlineScorePublisher).enqueueMessage(
+                    List.of(toLlmMessage(selected, sdkTrace), toLlmMessage(selected, playgroundTrace)),
+                    AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+        }
+
+        @Test
+        void skipsMalformedUuidsButKeepsValidOnesInSelectedRuleIds() {
+            var evaluator = createLlmEvaluator(true, 1.0f, List.of());
+            var metadata = JsonUtils.createObjectNode();
+            metadata.putArray("selected_rule_ids")
+                    .add(evaluator.getId().toString())
+                    .add("not-a-uuid");
+            var trace = createTrace(Source.PLAYGROUND).toBuilder().metadata(metadata).build();
+            whenFindAllLlmEvaluators(evaluator);
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verify(onlineScorePublisher).enqueueMessage(List.of(toLlmMessage(evaluator, trace)),
+                    AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+        }
+
+        @Test
+        void treatsNonArraySelectedRuleIdsAsAbsent() {
+            var metadata = JsonUtils.createObjectNode();
+            metadata.put("selected_rule_ids", "not-an-array");
+            var trace = createTrace(Source.PLAYGROUND).toBuilder().metadata(metadata).build();
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verifyNoInteractions(ruleEvaluatorService);
+            verifyNoInteractions(onlineScorePublisher);
+        }
+
+        @Test
+        void treatsMissingSelectedRuleIdsKeyAsAbsent() {
+            var metadata = JsonUtils.createObjectNode();
+            metadata.put("other_field", "value");
+            var trace = createTrace(Source.PLAYGROUND).toBuilder().metadata(metadata).build();
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verifyNoInteractions(ruleEvaluatorService);
+            verifyNoInteractions(onlineScorePublisher);
+        }
+
+        @Test
+        void skipsNonTextualEntriesInSelectedRuleIdsArray() {
+            var evaluator = createLlmEvaluator(true, 1.0f, List.of());
+            var metadata = JsonUtils.createObjectNode();
+            metadata.putArray("selected_rule_ids")
+                    .add(evaluator.getId().toString())
+                    .add(123);
+            var trace = createTrace(Source.PLAYGROUND).toBuilder().metadata(metadata).build();
+            whenFindAllLlmEvaluators(evaluator);
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verify(onlineScorePublisher).enqueueMessage(List.of(toLlmMessage(evaluator, trace)),
+                    AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+        }
+    }
+
+    @Nested
+    class RuleFilteringTests {
+
+        @Test
+        void skipsDisabledEvaluators() {
+            var trace = createTrace(Source.SDK);
+            var evaluator = createLlmEvaluator(false, 1.0f, List.of());
+            whenFindAllLlmEvaluators(evaluator);
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verifyNoInteractions(onlineScorePublisher);
+        }
+
+        @Test
+        void skipsTracesThatDontMatchEvaluatorFilters() {
+            var trace = createTrace(Source.SDK);
+            var nonMatchingFilter = TraceFilter.builder()
+                    .field(TraceField.NAME)
+                    .operator(Operator.EQUAL)
+                    .value("definitely-not-the-name-" + UUID.randomUUID())
+                    .build();
+            var evaluator = createLlmEvaluator(true, 1.0f, List.of(nonMatchingFilter));
+            whenFindAllLlmEvaluators(evaluator);
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verifyNoInteractions(onlineScorePublisher);
+        }
+
+        @Test
+        void processesTracesThatMatchEvaluatorFilters() {
+            var trace = createTrace(Source.SDK);
+            var matchingFilter = TraceFilter.builder()
+                    .field(TraceField.NAME)
+                    .operator(Operator.EQUAL)
+                    .value(trace.name())
+                    .build();
+            var evaluator = createLlmEvaluator(true, 1.0f, List.of(matchingFilter));
+            whenFindAllLlmEvaluators(evaluator);
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verify(onlineScorePublisher).enqueueMessage(List.of(toLlmMessage(evaluator, trace)),
+                    AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+        }
+    }
+
+    @Nested
+    class SamplingRateTests {
+
+        @Test
+        void doesNotEnqueueLlmJudgeWhenSamplingRateIsZero() {
+            var trace = createTrace(Source.SDK);
+            var evaluator = createLlmEvaluator(true, 0.0f, List.of());
+            whenFindAllLlmEvaluators(evaluator);
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verifyNoInteractions(onlineScorePublisher);
+        }
+
+        @Test
+        void doesNotEnqueuePythonEvaluatorWhenSamplingRateIsZero() {
+            when(serviceTogglesConfig.isPythonEvaluatorEnabled()).thenReturn(true);
+            var trace = createTrace(Source.SDK);
+            var evaluator = createPythonEvaluator(0.0f);
+            whenFindAllPythonEvaluators(evaluator);
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verifyNoInteractions(onlineScorePublisher);
+        }
+
+        @Test
+        void samplesAllTracesWhenSamplingRateIsOne() {
+            var trace1 = createTrace(Source.SDK);
+            var trace2 = createTrace(Source.SDK);
+            var evaluator = createLlmEvaluator(true, 1.0f, List.of());
+            whenFindAllLlmEvaluators(evaluator);
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace1, trace2), workspaceId, userName));
+
+            verify(onlineScorePublisher).enqueueMessage(
+                    List.of(toLlmMessage(evaluator, trace1), toLlmMessage(evaluator, trace2)),
+                    AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+        }
+    }
+
+    @Nested
+    class MultipleProjectsTests {
+
+        @Test
+        void processesTracesFromMultipleProjectsIndependently() {
+            var trace1 = createTrace(Source.SDK);
+            var otherProjectId = UUID.randomUUID();
+            var trace2 = createTrace(Source.SDK).toBuilder().projectId(otherProjectId).build();
+            var evaluator1 = createLlmEvaluator(true, 1.0f, List.of());
+            var evaluator2 = createLlmEvaluator(true, 1.0f, List.of());
+
+            when(ruleEvaluatorService
+                    .<LlmAsJudgeCode, TraceFilter, AutomationRuleEvaluatorLlmAsJudge>findAll(projectId, workspaceId))
+                    .thenReturn(List.of(evaluator1));
+            when(ruleEvaluatorService
+                    .<LlmAsJudgeCode, TraceFilter, AutomationRuleEvaluatorLlmAsJudge>findAll(otherProjectId,
+                            workspaceId))
+                    .thenReturn(List.of(evaluator2));
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace1, trace2), workspaceId, userName));
+
+            verify(onlineScorePublisher).enqueueMessage(List.of(toLlmMessage(evaluator1, trace1)),
+                    AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+            verify(onlineScorePublisher).enqueueMessage(List.of(toLlmMessage(evaluator2, trace2)),
+                    AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+        }
+    }
+
+    @Nested
+    class EmptyCasesTests {
+
+        @Test
+        void handlesEmptyTracesList() {
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(), workspaceId, userName));
+
+            verifyNoInteractions(ruleEvaluatorService);
+            verifyNoInteractions(onlineScorePublisher);
+        }
+
+        @Test
+        void filtersOutPartialTracesWithoutEndTime() {
+            var partialTrace = createTrace(Source.SDK).toBuilder().endTime(null).build();
+            var completeTrace = createTrace(Source.SDK);
+            var evaluator = createLlmEvaluator(true, 1.0f, List.of());
+            whenFindAllLlmEvaluators(evaluator);
+
+            onlineScoringSampler.onTracesCreated(
+                    new TracesCreated(List.of(partialTrace, completeTrace), workspaceId, userName));
+
+            verify(onlineScorePublisher).enqueueMessage(List.of(toLlmMessage(evaluator, completeTrace)),
+                    AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+        }
+
+        @Test
+        void handlesNoEvaluatorsFound() {
+            var trace = createTrace(Source.SDK);
+            whenFindAllLlmEvaluators();
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verifyNoInteractions(onlineScorePublisher);
+        }
+    }
+
+    @Nested
+    class TracesUpdatedTests {
+
+        @ParameterizedTest
+        @EnumSource(value = Source.class, names = {"SDK"})
+        @NullSource
+        void processesOnTracesUpdatedWithEndTimeForSdkOrNullSource(Source source) {
+            var trace = createTrace(source);
+            var traceUpdate = TraceUpdate.builder().endTime(Instant.now()).build();
+            var event = new TracesUpdated(Set.of(projectId), Set.of(trace.id()),
+                    workspaceId, userName, traceUpdate);
+            var evaluator = createLlmEvaluator(true, 1.0f, List.of());
+
+            when(traceService.getByIds(List.of(trace.id()))).thenReturn(Flux.just(trace));
+            whenFindAllLlmEvaluators(evaluator);
+
+            onlineScoringSampler.onTracesUpdated(event);
+
+            verify(onlineScorePublisher).enqueueMessage(List.of(toLlmMessage(evaluator, trace)),
+                    AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+        }
+
+        @Test
+        void skipsOnTracesUpdatedWhenEndTimeIsNull() {
+            var traceUpdate = TraceUpdate.builder().build();
+            var event = new TracesUpdated(Set.of(projectId), Set.of(UUID.randomUUID()),
+                    workspaceId, userName, traceUpdate);
+
+            onlineScoringSampler.onTracesUpdated(event);
+
+            verifyNoInteractions(traceService);
+            verifyNoInteractions(ruleEvaluatorService);
+            verifyNoInteractions(onlineScorePublisher);
+        }
+
+        @Test
+        void filtersOutPartialTracesReturnedByTraceService() {
+            var partialTrace = createTrace(Source.SDK).toBuilder().endTime(null).build();
+            var traceUpdate = TraceUpdate.builder().endTime(Instant.now()).build();
+            var event = new TracesUpdated(Set.of(projectId), Set.of(partialTrace.id()),
+                    workspaceId, userName, traceUpdate);
+
+            when(traceService.getByIds(List.of(partialTrace.id()))).thenReturn(Flux.just(partialTrace));
+
+            onlineScoringSampler.onTracesUpdated(event);
+
+            verifyNoInteractions(ruleEvaluatorService);
+            verifyNoInteractions(onlineScorePublisher);
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Source.class, mode = EnumSource.Mode.EXCLUDE, names = {"SDK"})
+        void skipsNonSdkTracesViaTracesUpdatedPath(Source source) {
+            var trace = createTrace(source);
+            var traceUpdate = TraceUpdate.builder().endTime(Instant.now()).build();
+            var event = new TracesUpdated(Set.of(projectId), Set.of(trace.id()),
+                    workspaceId, userName, traceUpdate);
+
+            when(traceService.getByIds(List.of(trace.id()))).thenReturn(Flux.just(trace));
+
+            onlineScoringSampler.onTracesUpdated(event);
+
+            verifyNoInteractions(ruleEvaluatorService);
+            verifyNoInteractions(onlineScorePublisher);
+        }
+    }
+
+    private Trace createTrace(Source source) {
+        return podamFactory.manufacturePojo(Trace.class).toBuilder()
+                .projectId(projectId)
+                .endTime(Instant.now())
+                .source(source)
+                .build();
+    }
+
+    private AutomationRuleEvaluatorLlmAsJudge createLlmEvaluator(
+            boolean enabled, float samplingRate, List<TraceFilter> filters) {
+        return podamFactory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder()
+                .projects(toProjects(Set.of(projectId)))
+                .samplingRate(samplingRate)
+                .enabled(enabled)
+                .filters(filters)
+                .build();
+    }
+
+    private AutomationRuleEvaluatorUserDefinedMetricPython createPythonEvaluator(float samplingRate) {
+        return podamFactory.manufacturePojo(AutomationRuleEvaluatorUserDefinedMetricPython.class).toBuilder()
+                .projects(toProjects(Set.of(projectId)))
+                .samplingRate(samplingRate)
+                .enabled(true)
+                .filters(List.of())
+                .build();
+    }
+
+    private void whenFindAllLlmEvaluators(AutomationRuleEvaluatorLlmAsJudge... evaluators) {
+        when(ruleEvaluatorService.<LlmAsJudgeCode, TraceFilter, AutomationRuleEvaluatorLlmAsJudge>findAll(
+                projectId, workspaceId))
+                .thenReturn(List.of(evaluators));
+    }
+
+    private void whenFindAllPythonEvaluators(AutomationRuleEvaluatorUserDefinedMetricPython... evaluators) {
+        when(ruleEvaluatorService.<AutomationRuleEvaluatorUserDefinedMetricPython.UserDefinedMetricPythonCode, TraceFilter, AutomationRuleEvaluatorUserDefinedMetricPython>findAll(
+                projectId, workspaceId))
+                .thenReturn(List.of(evaluators));
+    }
+
+    private TraceToScoreLlmAsJudge toLlmMessage(AutomationRuleEvaluatorLlmAsJudge evaluator, Trace trace) {
+        return TraceToScoreLlmAsJudge.builder()
+                .trace(trace)
+                .ruleId(evaluator.getId())
+                .ruleName(evaluator.getName())
+                .llmAsJudgeCode(evaluator.getCode())
+                .workspaceId(workspaceId)
+                .userName(userName)
+                .scoreNameMapping(Map.of())
+                .promptType(PromptType.MUSTACHE)
+                .build();
+    }
+
+    private ObjectNode metadataWithRuleIds(UUID... ruleIds) {
+        var metadata = JsonUtils.createObjectNode();
+        var array = metadata.putArray("selected_rule_ids");
+        for (var id : ruleIds) {
+            array.add(id.toString());
+        }
+        return metadata;
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerTest.java
@@ -208,7 +208,7 @@ class OnlineScoringSamplerTest {
         }
 
         @Test
-        void unionsSelectedRuleIdsAcrossMultipleNonSdkTraces() {
+        void scoresEachNonSdkTraceOnlyByItsOwnSelectedRuleIds() {
             var evalA = createLlmEvaluator(true, 1.0f, List.of());
             var evalB = createLlmEvaluator(true, 1.0f, List.of());
             var unrelated = createLlmEvaluator(true, 1.0f, List.of());
@@ -224,18 +224,18 @@ class OnlineScoringSamplerTest {
 
             onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(traceA, traceB), workspaceId, userName));
 
-            // evalA and evalB each enqueue once with both traces; unrelated never enqueues
+            // evalA enqueues traceA only; evalB enqueues traceB only; unrelated never enqueues.
             ArgumentCaptor<List<TraceToScoreLlmAsJudge>> captor = ArgumentCaptor.forClass(List.class);
             verify(onlineScorePublisher, times(2)).enqueueMessage(captor.capture(),
                     eq(AutomationRuleEvaluatorType.LLM_AS_JUDGE));
 
             assertThat(captor.getAllValues()).containsExactlyInAnyOrder(
-                    List.of(toLlmMessage(evalA, traceA), toLlmMessage(evalA, traceB)),
-                    List.of(toLlmMessage(evalB, traceA), toLlmMessage(evalB, traceB)));
+                    List.of(toLlmMessage(evalA, traceA)),
+                    List.of(toLlmMessage(evalB, traceB)));
         }
 
         @Test
-        void scoresMixedBatchAndNarrowsEvaluators() {
+        void scoresSdkTraceByAllEvaluatorsEvenWhenBatchIncludesNonSdkSelection() {
             var selected = createLlmEvaluator(true, 1.0f, List.of());
             var other = createLlmEvaluator(true, 1.0f, List.of());
             var sdkTrace = createTrace(Source.SDK);
@@ -247,9 +247,16 @@ class OnlineScoringSamplerTest {
             onlineScoringSampler
                     .onTracesCreated(new TracesCreated(List.of(sdkTrace, playgroundTrace), workspaceId, userName));
 
-            verify(onlineScorePublisher).enqueueMessage(
+            // Two enqueue calls (one per evaluator, parallelStream):
+            //   - selected: scores both traces (SDK + playground, since playground selected it)
+            //   - other:    scores only the SDK trace (playground did not select it)
+            ArgumentCaptor<List<TraceToScoreLlmAsJudge>> captor = ArgumentCaptor.forClass(List.class);
+            verify(onlineScorePublisher, times(2)).enqueueMessage(captor.capture(),
+                    eq(AutomationRuleEvaluatorType.LLM_AS_JUDGE));
+
+            assertThat(captor.getAllValues()).containsExactlyInAnyOrder(
                     List.of(toLlmMessage(selected, sdkTrace), toLlmMessage(selected, playgroundTrace)),
-                    AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+                    List.of(toLlmMessage(other, sdkTrace)));
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSamplerIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSamplerIntegrationTest.java
@@ -1,0 +1,240 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
+import com.comet.opik.api.ScoreSource;
+import com.comet.opik.api.Source;
+import com.comet.opik.api.Span;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorSpanLlmAsJudge;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorSpanLlmAsJudge.SpanLlmAsJudgeCode;
+import com.comet.opik.api.evaluators.LlmAsJudgeModelParameters;
+import com.comet.opik.api.events.SpansCreated;
+import com.comet.opik.api.resources.utils.AuthTestUtils;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.AutomationRuleEvaluatorResourceClient;
+import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
+import com.comet.opik.domain.FeedbackScoreService;
+import com.comet.opik.domain.llm.ChatCompletionService;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.comet.opik.utils.JsonUtils;
+import com.google.common.eventbus.EventBus;
+import com.google.inject.AbstractModule;
+import com.redis.testcontainers.RedisContainer;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import reactor.core.publisher.Mono;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class OnlineScoringSpanSamplerIntegrationTest {
+
+    private static final String API_KEY = "apiKey-" + UUID.randomUUID();
+    private static final String WORKSPACE_NAME = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+    private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+    private static final String USER_NAME = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+
+    private static final String TEST_EVALUATOR = """
+            {
+              "model": { "name": "gpt-4o", "temperature": 0.3 },
+              "messages": [
+                { "role": "USER", "content": "Score this: {{name}}" }
+              ],
+              "variables": { "name": "input.name" },
+              "schema": [
+                { "name": "Relevance",          "type": "INTEGER", "description": "Relevance" },
+                { "name": "Conciseness",        "type": "DOUBLE",  "description": "Conciseness" },
+                { "name": "Technical Accuracy", "type": "BOOLEAN", "description": "Technical accuracy" }
+              ]
+            }
+            """;
+
+    private static final String MOCK_AI_RESPONSE = """
+            {
+              "Relevance":{"score":4,"reason":"some reason"},
+              "Technical Accuracy":{"score":4.5,"reason":"some reason"},
+              "Conciseness":{"score":true,"reason":"some reason"}
+             }
+            """;
+
+    private final ChatCompletionService aiProxyService;
+    private final FeedbackScoreService feedbackScoreService;
+    private final EventBus eventBus;
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+    private final GenericContainer<?> ZOOKEEPER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE = ClickHouseContainerUtils.newClickHouseContainer(ZOOKEEPER);
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    {
+        Startables.deepStart(REDIS, MYSQL, CLICKHOUSE, ZOOKEEPER).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        DatabaseAnalyticsFactory databaseAnalyticsFactory = ClickHouseContainerUtils
+                .newDatabaseAnalyticsFactory(CLICKHOUSE, ClickHouseContainerUtils.DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE);
+
+        aiProxyService = Mockito.mock(ChatCompletionService.class);
+        feedbackScoreService = Mockito.mock(FeedbackScoreService.class);
+        eventBus = Mockito.mock(EventBus.class);
+
+        app = newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .redisUrl(REDIS.getRedisURI())
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .mockEventBus(eventBus)
+                        .modules(List.of(
+                                new AbstractModule() {
+                                    @Override
+                                    protected void configure() {
+                                        bind(ChatCompletionService.class).toInstance(aiProxyService);
+                                        bind(FeedbackScoreService.class).toInstance(feedbackScoreService);
+                                    }
+                                }))
+                        .customConfigs(List.of(
+                                new CustomConfig("onlineScoring.consumerGroupName", "test-span-group"),
+                                new CustomConfig("onlineScoring.consumerBatchSize", "1"),
+                                new CustomConfig("onlineScoring.poolingInterval", "100ms"),
+                                new CustomConfig("onlineScoring.streams[4].streamName", "test-span-stream"),
+                                new CustomConfig("serviceToggles.spanLlmAsJudgeEnabled", "true")))
+                        .build());
+    }
+
+    private AutomationRuleEvaluatorResourceClient evaluatorResourceClient;
+    private ProjectResourceClient projectResourceClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport clientSupport) {
+        var baseUrl = TestUtils.getBaseUrl(clientSupport);
+        ClientSupportUtils.config(clientSupport);
+
+        AuthTestUtils.mockTargetWorkspace(wireMock.server(), API_KEY, WORKSPACE_NAME, WORKSPACE_ID, USER_NAME);
+
+        projectResourceClient = new ProjectResourceClient(clientSupport, baseUrl, factory);
+        evaluatorResourceClient = new AutomationRuleEvaluatorResourceClient(clientSupport, baseUrl);
+
+        Mockito.reset(aiProxyService, feedbackScoreService, eventBus);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Source.class, names = {"SDK"})
+    @NullSource
+    void redisProducerAndConsumerBaseFlowForSpans(Source source, OnlineScoringSpanSampler spanSampler) {
+        Mockito.reset(feedbackScoreService, aiProxyService, eventBus);
+
+        var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        var projectId = projectResourceClient.createProject(projectName, API_KEY, WORKSPACE_NAME);
+
+        var evaluatorCode = JsonUtils.readValue(TEST_EVALUATOR, SpanLlmAsJudgeCode.class);
+        var evaluator = createSpanRule(projectId, evaluatorCode);
+        evaluatorResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
+
+        var span = createSpan(projectId, source);
+        var event = new SpansCreated(List.of(span), WORKSPACE_ID, USER_NAME);
+
+        var aiResponse = ChatResponse.builder().aiMessage(AiMessage.aiMessage(MOCK_AI_RESPONSE)).build();
+
+        ArgumentCaptor<List<FeedbackScoreBatchItem>> captor = ArgumentCaptor.forClass(List.class);
+        Mockito.when(feedbackScoreService.scoreBatchOfSpans(Mockito.anyList())).thenReturn(Mono.empty());
+        Mockito.when(aiProxyService.scoreTrace(
+                Mockito.any(ChatRequest.class),
+                Mockito.any(LlmAsJudgeModelParameters.class),
+                Mockito.eq(WORKSPACE_ID)))
+                .thenReturn(aiResponse);
+
+        spanSampler.onSpansCreated(event);
+
+        TestUtils.waitForMillis(300);
+
+        Mockito.verify(feedbackScoreService).scoreBatchOfSpans(captor.capture());
+
+        assertThat(captor.getValue())
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(
+                        expectedScore(span, "Relevance", new BigDecimal(4)),
+                        expectedScore(span, "Technical Accuracy", new BigDecimal("4.5")),
+                        expectedScore(span, "Conciseness", BigDecimal.ONE));
+    }
+
+    private FeedbackScoreBatchItem expectedScore(Span span, String name, BigDecimal value) {
+        return FeedbackScoreBatchItem.builder()
+                .id(span.id())
+                .projectId(span.projectId())
+                .projectName(span.projectName())
+                .name(name)
+                .value(value)
+                .reason("some reason")
+                .source(ScoreSource.ONLINE_SCORING)
+                .build();
+    }
+
+    private AutomationRuleEvaluatorSpanLlmAsJudge createSpanRule(UUID projectId, SpanLlmAsJudgeCode evaluatorCode) {
+        return AutomationRuleEvaluatorSpanLlmAsJudge.builder()
+                .projectIds(Set.of(projectId))
+                .name("span-evaluator-" + RandomStringUtils.secure().nextAlphanumeric(32))
+                .createdBy(USER_NAME)
+                .code(evaluatorCode)
+                .samplingRate(1.0f)
+                .enabled(true)
+                .filters(List.of())
+                .build();
+    }
+
+    private Span createSpan(UUID projectId, Source source) {
+        return factory.manufacturePojo(Span.class).toBuilder()
+                .projectId(projectId)
+                .source(source)
+                .feedbackScores(null)
+                .build();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSamplerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSamplerTest.java
@@ -1,7 +1,9 @@
 package com.comet.opik.api.resources.v1.events;
 
+import com.comet.opik.api.Source;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorSpanLlmAsJudge;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorSpanUserDefinedMetricPython;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
 import com.comet.opik.api.evaluators.LlmAsJudgeMessage;
 import com.comet.opik.api.evaluators.LlmAsJudgeModelParameters;
@@ -17,6 +19,7 @@ import com.comet.opik.domain.evaluators.OnlineScorePublisher;
 import com.comet.opik.domain.evaluators.SpanFilterEvaluationService;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
+import com.comet.opik.podam.PodamFactoryUtils;
 import dev.langchain4j.data.message.ChatMessageType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,17 +27,23 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.co.jemos.podam.api.PodamFactory;
 
 import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorSpanLlmAsJudge.SpanLlmAsJudgeCode;
+import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorSpanUserDefinedMetricPython.SpanUserDefinedMetricPythonCode;
 import static com.comet.opik.api.resources.utils.AutomationRuleEvaluatorTestUtils.toProjects;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -45,11 +54,14 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("OnlineScoringSpanSampler Tests")
 class OnlineScoringSpanSamplerTest {
+
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
 
     @Mock
     private AutomationRuleEvaluatorService ruleEvaluatorService;
@@ -111,8 +123,7 @@ class OnlineScoringSpanSamplerTest {
             // When
             sampler.onSpansCreated(event);
 
-            // Then
-            // When both toggles are disabled, findAll is never called since we return early
+            // Then, When both toggles are disabled, findAll is never called since we return early
             verify(ruleEvaluatorService, never()).findAll(any(), any(),
                     eq(AutomationRuleEvaluatorType.SPAN_LLM_AS_JUDGE));
             verify(ruleEvaluatorService, never()).findAll(any(), any(),
@@ -151,13 +162,15 @@ class OnlineScoringSpanSamplerTest {
                     eq(AutomationRuleEvaluatorType.SPAN_LLM_AS_JUDGE));
         }
 
-        @Test
+        @ParameterizedTest
+        @EnumSource(value = Source.class, names = {"SDK"})
+        @NullSource
         @DisplayName("Should process sampling when span LLM as Judge is enabled")
-        void shouldProcessSamplingWhenToggleEnabled() {
+        void shouldProcessSamplingWhenToggleEnabled(Source source) {
             // Given
             when(serviceTogglesConfig.isSpanLlmAsJudgeEnabled()).thenReturn(true);
             when(serviceTogglesConfig.isSpanUserDefinedMetricPythonEnabled()).thenReturn(false);
-            Span span = createTestSpan();
+            Span span = createTestSpan(projectId, source);
             SpansCreated event = new SpansCreated(List.of(span), workspaceId, userName);
 
             AutomationRuleEvaluatorSpanLlmAsJudge evaluator = createTestEvaluator(true, 1.0f, List.of());
@@ -185,6 +198,24 @@ class OnlineScoringSpanSamplerTest {
             assertThat(messages).hasSize(1);
             assertThat(messages.getFirst().span()).isEqualTo(span);
             assertThat(messages.getFirst().ruleId()).isEqualTo(evaluator.getId());
+        }
+    }
+
+    @Nested
+    class SourceFilteringTests {
+
+        @ParameterizedTest
+        @EnumSource(value = Source.class, mode = EnumSource.Mode.EXCLUDE, names = {"SDK"})
+        void shouldSkipNonSdkSourceSpans(Source source) {
+            var span = createTestSpan(projectId, source);
+            var event = new SpansCreated(List.of(span), workspaceId, userName);
+
+            sampler.onSpansCreated(event);
+
+            verifyNoInteractions(ruleEvaluatorService);
+            verifyNoInteractions(filterEvaluationService);
+            verifyNoInteractions(onlineScorePublisher);
+            verifyNoInteractions(serviceTogglesConfig);
         }
     }
 
@@ -364,6 +395,25 @@ class OnlineScoringSpanSamplerTest {
             // With rate 0.0, no spans should be sampled
             verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
         }
+
+        @Test
+        @DisplayName("Should respect sampling rate for python evaluators")
+        void shouldRespectSamplingRateForPythonEvaluators() {
+            when(serviceTogglesConfig.isSpanUserDefinedMetricPythonEnabled()).thenReturn(true);
+            var span = createTestSpan();
+            var event = new SpansCreated(List.of(span), workspaceId, userName);
+
+            var evaluator = newPythonEvaluator();
+            when(ruleEvaluatorService
+                    .<SpanUserDefinedMetricPythonCode, SpanFilter, AutomationRuleEvaluatorSpanUserDefinedMetricPython>findAll(
+                            projectId, workspaceId, AutomationRuleEvaluatorType.SPAN_USER_DEFINED_METRIC_PYTHON))
+                    .thenReturn(List.of(evaluator));
+
+            sampler.onSpansCreated(event);
+
+            // With rate 0.0, messages list is empty -> enqueueMessage must NOT be called
+            verifyNoInteractions(onlineScorePublisher);
+        }
     }
 
     @Nested
@@ -378,8 +428,8 @@ class OnlineScoringSpanSamplerTest {
             when(serviceTogglesConfig.isSpanUserDefinedMetricPythonEnabled()).thenReturn(false);
             UUID projectId2 = UUID.randomUUID();
 
-            Span span1 = createTestSpan(projectId);
-            Span span2 = createTestSpan(projectId2);
+            Span span1 = createTestSpan(projectId, null);
+            Span span2 = createTestSpan(projectId2, null);
             SpansCreated event = new SpansCreated(List.of(span1, span2), workspaceId, userName);
 
             AutomationRuleEvaluatorSpanLlmAsJudge evaluator1 = createTestEvaluator(true, 1.0f, List.of());
@@ -495,17 +545,17 @@ class OnlineScoringSpanSamplerTest {
     // Helper methods
 
     private Span createTestSpan() {
-        return createTestSpan(projectId);
+        return createTestSpan(projectId, null);
     }
 
-    private Span createTestSpan(UUID projectId) {
-        java.time.Instant now = java.time.Instant.now();
+    private Span createTestSpan(UUID projectId, Source source) {
         return Span.builder()
                 .id(UUID.randomUUID())
                 .projectId(projectId)
                 .traceId(UUID.randomUUID())
                 .name("test-span")
-                .startTime(now)
+                .startTime(Instant.now())
+                .source(source)
                 .build();
     }
 
@@ -543,10 +593,19 @@ class OnlineScoringSpanSamplerTest {
                 .enabled(enabled)
                 .filters(filters)
                 .code(code)
-                .createdAt(java.time.Instant.now())
+                .createdAt(Instant.now())
                 .createdBy(userName)
-                .lastUpdatedAt(java.time.Instant.now())
+                .lastUpdatedAt(Instant.now())
                 .lastUpdatedBy(userName)
+                .build();
+    }
+
+    private AutomationRuleEvaluatorSpanUserDefinedMetricPython newPythonEvaluator() {
+        return podamFactory.manufacturePojo(AutomationRuleEvaluatorSpanUserDefinedMetricPython.class).toBuilder()
+                .projects(toProjects(Set.of(projectId)))
+                .samplingRate(0.0f)
+                .enabled(true)
+                .filters(List.of())
                 .build();
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResourceTest.java
@@ -631,6 +631,7 @@ class AutomationRuleEvaluatorsResourceTest {
             var trace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectId(projectId)
                     .projectName(projectName) // Backend uses projectName, not projectId!
+                    .source(null)
                     .threadId(null) // Must be null for trace-level evaluation
                     .input(OBJECT_MAPPER.readTree(INPUT))
                     .output(OBJECT_MAPPER.readTree(OUTPUT))
@@ -1014,6 +1015,7 @@ class AutomationRuleEvaluatorsResourceTest {
             var trace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectId(projectId)
                     .projectName(projectName) // Backend uses projectName, not projectId!
+                    .source(null)
                     .threadId(null) // Must be null for trace-level evaluation
                     .input(OBJECT_MAPPER.readTree(INPUT))
                     .output(OBJECT_MAPPER.readTree(OUTPUT))
@@ -1048,6 +1050,7 @@ class AutomationRuleEvaluatorsResourceTest {
             var trace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectId(projectId)
                     .projectName(projectName) // Backend uses projectName, not projectId!
+                    .source(null)
                     .threadId("thread-" + RandomStringUtils.secure().nextAlphanumeric(36))
                     .input(OBJECT_MAPPER.readTree(INPUT))
                     .output(OBJECT_MAPPER.readTree(OUTPUT))
@@ -1105,6 +1108,7 @@ class AutomationRuleEvaluatorsResourceTest {
             var trace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectId(projectId)
                     .projectName(projectName) // Backend uses projectName, not projectId!
+                    .source(null)
                     .threadId(null) // Must be null for trace-level evaluation
                     .output(OBJECT_MAPPER.readTree("""
                             {
@@ -1160,6 +1164,7 @@ class AutomationRuleEvaluatorsResourceTest {
             var trace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectId(projectId)
                     .projectName(projectName) // Backend uses projectName, not projectId!
+                    .source(null)
                     .threadId("thread-" + RandomStringUtils.secure().nextAlphanumeric(36)) // Must have threadId for thread-level evaluation
                     .output(OBJECT_MAPPER.readTree("""
                             {
@@ -1218,6 +1223,7 @@ class AutomationRuleEvaluatorsResourceTest {
             var trace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectId(projectId)
                     .projectName(projectName) // Backend uses projectName, not projectId!
+                    .source(null)
                     .threadId(null)
                     .build();
             traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
@@ -1267,6 +1273,7 @@ class AutomationRuleEvaluatorsResourceTest {
             var trace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectId(projectId)
                     .projectName(projectName) // Backend uses projectName, not projectId!
+                    .source(null)
                     .threadId("thread-" + RandomStringUtils.secure().nextAlphanumeric(36)) // Must have threadId for thread-level evaluation
                     .build();
 
@@ -1358,6 +1365,7 @@ class AutomationRuleEvaluatorsResourceTest {
             var trace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectId(projectId)
                     .projectName(projectName) // Backend uses projectName, not projectId!
+                    .source(null)
                     .threadId(null)
                     .build();
             traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
@@ -1407,6 +1415,7 @@ class AutomationRuleEvaluatorsResourceTest {
             var trace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectId(projectId)
                     .projectName(projectName) // Backend uses projectName, not projectId!
+                    .source(null)
                     .threadId("thread-" + RandomStringUtils.secure().nextAlphanumeric(36)) // Must have threadId for thread-level evaluation
                     .build();
 
@@ -1465,6 +1474,7 @@ class AutomationRuleEvaluatorsResourceTest {
             var trace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectId(projectId)
                     .projectName(projectName) // Backend uses projectName, not projectId!
+                    .source(null)
                     .threadId(null)
                     .build();
             traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
@@ -1500,6 +1510,7 @@ class AutomationRuleEvaluatorsResourceTest {
                 var trace = factory.manufacturePojo(Trace.class).toBuilder()
                         .projectId(projectId)
                         .projectName(projectName) // Backend uses projectName, not projectId!
+                        .source(null)
                         .threadId(null)
                         .build();
                 traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);


### PR DESCRIPTION
## Details

Fixes online evaluation rules being applied to every trace and span — including playground, experiment, and optimization artifacts — which caused confusing double-scoring when using evaluation suites in the Playground. Automatic online evaluation now runs only on SDK-sourced traces/spans, while preserving the Playground "selected rules" flow.

- **Trace sampler**: source filter applied in a single-pass loop that also accumulates `selected_rule_ids`; non-SDK traces scored only when carrying explicit rule selections (Playground → dataset → selected rules). Evaluator narrowing uses the union across all scorable traces.
- **Span sampler**: source filter applied before the evaluator fetch; non-SDK spans skipped entirely (spans have no `selected_rule_ids` concept by design).
- **Backward compatibility**: `source == null` treated as SDK for pre-source-tracking rows (matches `Source.legacyFallbackDbValue` contract).
- **Observability**: `Sampled X/N` ratio log now always fires (even for empty sampled batches) — reveals misconfigured rules rejecting everything. `enqueueMessage` is guarded by `!messages.isEmpty()` to avoid wasteful Redis publisher machinery.
- **Threads**: `TraceThreadOnlineScoringSamplerListener` deliberately left out of scope — the thread model lacks a `source` field. Follow-up ticket to be filed.

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- OPIK-5768

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6 (1M context)
- Scope: full implementation (production changes + unit/integration tests + iterative reviews)
- Human verification: step-by-step code review, iterative refinement, test execution, branch-by-branch coverage analysis

## Testing

Exact commands run:
- `mvn compile -DskipTests` — clean compile
- `mvn spotless:check` — formatting check
- `mvn test -Dtest="OnlineScoringSamplerTest,OnlineScoringSpanSamplerTest"` — 52 unit tests green
- `mvn test -Dtest="OnlineScoringEngineTest"` — integration tests green (with parameterized SDK + null source and updated PLAYGROUND + selected_rule_ids flow)
- `mvn test -Dtest="OnlineScoringSpanSamplerIntegrationTest"` — new span pipeline integration test green (2 parameterized runs)

Scenarios validated:
- Happy path: SDK source + null source both scored end-to-end through Redis → scorer → FeedbackScoreService
- Bypass: non-SDK trace with `selected_rule_ids` metadata still scored by the explicitly selected evaluators
- Negative: non-SDK trace/span without metadata skipped (short-circuits before the evaluator DB call)
- Mixed batches: SDK + non-SDK-with-selection coexist; evaluator narrowing by union of `selected_rule_ids`
- Edge cases on `extractSelectedRuleIds`: malformed UUIDs (per-entry skip), non-array metadata, missing key, non-textual entries
- `shouldSampleTrace` branches: rule disabled / filter mismatch / sampling-rate rejection
- `messages.isEmpty()` guard: exercised for both LLM_AS_JUDGE and USER_DEFINED_METRIC_PYTHON paths
- `onTracesUpdated` PATCH flow: endTime present/absent; partial traces filtered from TraceService output
- Multi-project batches processed independently

Environment: local JVM (Docker-free unit tests) + Dropwizard app extension with MySQL/ClickHouse/Redis Testcontainers for integration tests.

Tests not run:
- Python span evaluator integration E2E — scoped out; follow-up candidate
- `TraceThreadOnlineScoringSamplerListener` source filtering — deferred; thread model lacks `source` field, requires design work

## Documentation

N/A — no user-facing documentation changes. Behavior change is covered by ticket description and PR summary. Follow-up tickets to file for deferred scope (threads source filter, Python span E2E, trace/span `TraceToScoreLlmAsJudge` mapper deduplication).