### PR TITLE
[NA][BE]Align opik-python-backend builder stage to docker:29.2.1

### DIFF
--- a/apps/opik-python-backend/Dockerfile
+++ b/apps/opik-python-backend/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build to reduce final image size
-FROM docker:28.4.0 AS builder
+FROM docker:29.2.1 AS builder
 
 # Build dependencies (only needed during pip install)
 RUN apk add --no-cache tini python3 py3-pip build-base python3-dev musl-dev gcc libffi-dev && \


### PR DESCRIPTION
## Summary
- The builder stage was pinned to `docker:28.4.0` while the runtime stage was on `docker:29.2.1`. There was no reason for the divergence — bump the builder to match.

## Test plan
- [ ] CI image build succeeds