### PR TITLE
[OPIK-5872] [BE] Fix demo data race conditions on signup

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
+++ b/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
@@ -106,6 +106,14 @@ def project_exists(base_url, workspace_name, comet_api_key, project_name):
     _, status_code = make_http_request(base_url, request, workspace_name, comet_api_key)
     return status_code == 200
 
+def api_key_ready(base_url, workspace_name, comet_api_key):
+    request = {
+        "url": "/v1/private/projects",
+        "method": "GET",
+    }
+    _, status_code = make_http_request(base_url, request, workspace_name, comet_api_key)
+    return status_code == 200
+
 def calculate_time_shift_to_now(traces):
     """
     Calculate time shift to move the latest end_time to 'now' while preserving time differences.
@@ -322,13 +330,20 @@ def create_demo_chatbot_project(context: DemoDataContext, base_url: str, workspa
 
         try:
             project_name = "Opik Demo Agent Observability"
+
+            # Wait for API key to be ready (exponential backoff: 0.5s, 1s, 2s, 4s, 8s ≈ 15.5s total)
+            max_retries = 5
+            for attempt in range(max_retries):
+                if api_key_ready(base_url, workspace_name, comet_api_key):
+                    break
+                if attempt == max_retries - 1:
+                    logger.error("API key not ready for workspace %s after %d retries, aborting demo data creation", workspace_name, max_retries)
+                    return
+                time.sleep(0.5 * (2 ** attempt))
+
             if project_exists(base_url, workspace_name, comet_api_key, project_name):
                 logger.info("%s project already exists", project_name)
                 return
-
-            # Demo traces and spans
-            # We have a simple chatbot application built using llama-index.
-            # We gave it the content of Opik documentation as context, and then asked it a few questions.
 
             client = opik.Opik(
                 project_name=project_name,
@@ -338,13 +353,23 @@ def create_demo_chatbot_project(context: DemoDataContext, base_url: str, workspa
                 _use_batching=True,
             )
 
-            # Extract thread IDs before processing traces
-            threads = [trace["thread_id"] for trace in demo_traces if "thread_id" in trace and trace["thread_id"] is not None]
+            # Extract unique thread IDs before processing traces
+            threads = list({trace["thread_id"] for trace in demo_traces if "thread_id" in trace and trace["thread_id"] is not None})
             
             time_shift = process_traces_with_time_shift(demo_traces, context, client)
             process_spans_with_time_shift(demo_spans, time_shift, context, client)
-            client.flush()
+            flush_result = client.flush()
+            if not flush_result:
+                logger.error("Failed to flush demo traces for workspace %s project %s", workspace_name, project_name)
 
+            # Wait for project to be queryable (exponential backoff: 0.5s, 1s, 2s, 4s, 8s ≈ 15.5s total)
+            for attempt in range(max_retries):
+                if project_exists(base_url, workspace_name, comet_api_key, project_name):
+                    break
+                if attempt == max_retries - 1:
+                    logger.error("Project %s not found for workspace %s after %d retries, skipping thread/feedback operations", project_name, workspace_name, max_retries)
+                    return
+                time.sleep(0.5 * (2 ** attempt))
 
             done = False
             max_attempts = 10
@@ -356,7 +381,7 @@ def create_demo_chatbot_project(context: DemoDataContext, base_url: str, workspa
                     done = True
                     attempts = 0
                 except Exception as e:
-                    logger.error(f"Error closing threads {threads} attempt {attempts}: {e}")
+                    logger.error(f"Error closing threads for workspace {workspace_name} attempt {attempts}: status={getattr(e, 'status_code', 'unknown')}, body={getattr(e, 'body', str(e))}")
                     attempts += 1
                     time.sleep(0.5)
 
@@ -390,13 +415,13 @@ def create_demo_chatbot_project(context: DemoDataContext, base_url: str, workspa
                         done = True
                         attempts = 0
                     except Exception as e:
-                        logger.error(f"Error scoring batch of threads attempt {attempts}: {e}")
+                        logger.error(f"Error scoring batch of threads for workspace {workspace_name} attempt {attempts}: status={getattr(e, 'status_code', 'unknown')}, body={getattr(e, 'body', str(e))}")
                         attempts += 1
                         time.sleep(0.5)
                 if not done:
-                    logger.error("Failed to score batch of threads after %d attempts", max_attempts)
+                    logger.error("Failed to score batch of threads for workspace %s after %d attempts", workspace_name, max_attempts)
         except Exception as e:
-            logger.error(e)
+            logger.error(f"Error creating demo chatbot project for workspace {workspace_name}: {e}")
         finally:
             # Close the client
             if client:


### PR DESCRIPTION
## Details

After the demo data simplification (d3b3c4f5aa / OPIK-4972), demo data creation became fast enough to likely outrun backend state propagation, causing what appear to be two race conditions on user signup:

- **Probable 401 race**: `post_user_signup` probably fires before the API key is fully propagated — SDK trace ingestion and HTTP calls get rejected with "User with provided api key not found!"
- **Probable 404 race**: traces are likely ingested but the project isn't queryable yet — `close_trace_thread` fails with "Project name: Opik Demo Agent Observability not found"

Previously, creating 3 other demo projects (~56K lines of data) acted as an accidental delay that probably masked both issues. The exact root cause hasn't been confirmed yet — the 401 could also be related to auth format changes from the SDK upgrade (1.10.20 → 1.10.56) in the same commit.

**Fixes:**
- Add `api_key_ready()` poll with exponential backoff before starting demo data creation
- Add `project_exists()` poll with exponential backoff after flush, before thread/feedback operations
- Deduplicate thread IDs via set comprehension (~100+ entries → ~15-20 unique)
- Include `workspace_name` in all error logs for traceability
- Strip verbose HTTP headers from error messages (only log status code + body)
- Check and log `flush()` result to surface silent SDK auth failures

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5872

## Testing

- Code review + staging deployment needed
- After deploy, trigger new user signup and verify:
  - "Opik Demo Agent Observability" project appears with traces, spans, closed threads, and feedback scores
  - No 401/404 errors in `opik-python-backend` logs
  - Error messages (if any) include workspace name and are concise (no HTTP header dumps)
- Grafana query to monitor: `{namespace="cometml-production", component="opik-python-backend"} |= "Error" |= "threads"`

## Documentation

N/A