### PR TITLE
[NA] [BE/FE] feat: add tag whitelist/blacklist filtering for Group by Tags in dashboard widgets

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/metrics/BreakdownConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/metrics/BreakdownConfig.java
@@ -5,13 +5,17 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 
+import java.util.List;
+
 /**
  * Configuration for grouping metrics by a specific dimension.
  * Simplified configuration - always shows top 10 groups by value descending,
  * with remaining groups aggregated into "Others".
  *
- * @param field       The field to group by
- * @param metadataKey Required when field is METADATA - the key to extract from metadata JSON
+ * @param field            The field to group by
+ * @param metadataKey      Required when field is METADATA - the key to extract from metadata JSON
+ * @param tagValues        Optional list of tag values to include or exclude when field is TAGS
+ * @param tagValuesExclude When true, tagValues act as a blacklist; when false (default), as a whitelist
  */
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -19,7 +23,9 @@ import lombok.Builder;
 public record BreakdownConfig(
         BreakdownField field,
         String metadataKey,
-        String subMetric) {
+        String subMetric,
+        List<String> tagValues,
+        Boolean tagValuesExclude) {
 
     /**
      * Creates a default config with no grouping.

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/metrics/BreakdownQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/metrics/BreakdownQueryBuilder.java
@@ -2,6 +2,9 @@ package com.comet.opik.api.metrics;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static com.comet.opik.api.metrics.BreakdownField.SPAN_METRICS;
 
 public class BreakdownQueryBuilder {
@@ -73,11 +76,43 @@ public class BreakdownQueryBuilder {
     }
 
     /**
+     * Builds the ClickHouse array literal from a list of tag values, escaping single quotes.
+     */
+    private static String buildTagValuesArray(List<String> tagValues) {
+        return tagValues.stream()
+                .map(v -> "'" + v.replace("'", "''") + "'")
+                .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    /**
+     * Builds a tag-filtered arrayJoin expression with optional include/exclude filtering.
+     *
+     * @param tableAlias the table alias prefix (e.g. "s" for spans, "t" for traces)
+     * @param tagValues  the list of tag values to filter by (non-null, non-empty)
+     * @param exclude    when true, excludes the listed tags; when false, includes only them
+     */
+    private static String buildTagFilteredExpression(String tableAlias, List<String> tagValues, boolean exclude) {
+        String tagsExpr = "if(empty(" + tableAlias + ".tags), ['Unknown'], " + tableAlias + ".tags)";
+        String tagValuesArray = buildTagValuesArray(tagValues);
+        String predicate = exclude
+                ? "x -> NOT has(" + tagValuesArray + ", x)"
+                : "x -> has(" + tagValuesArray + ", x)";
+        return "arrayJoin(arrayFilter(" + predicate + ", " + tagsExpr + "))";
+    }
+
+    private static boolean hasTagFilter(BreakdownConfig breakdown) {
+        return breakdown.tagValues() != null && !breakdown.tagValues().isEmpty();
+    }
+
+    /**
      * Get breakdown expression for span metrics using 's.' table alias.
      */
     private static String getSpanBreakdownExpression(BreakdownConfig breakdown) {
         return switch (breakdown.field()) {
-            case TAGS -> "arrayJoin(if(empty(s.tags), ['Unknown'], s.tags))";
+            case TAGS -> hasTagFilter(breakdown)
+                    ? buildTagFilteredExpression("s", breakdown.tagValues(),
+                            Boolean.TRUE.equals(breakdown.tagValuesExclude()))
+                    : "arrayJoin(if(empty(s.tags), ['Unknown'], s.tags))";
             case METADATA -> "ifNull(JSONExtractString(s.metadata, :metadata_key), 'Unknown')";
             case NAME -> "ifNull(s.name, 'Unknown')";
             case ERROR_INFO -> "if(length(s.error_info) > 0, 'Has Error', 'No Error')";
@@ -95,7 +130,10 @@ public class BreakdownQueryBuilder {
      */
     private static String getTraceOrThreadBreakdownExpression(BreakdownConfig breakdown) {
         return switch (breakdown.field()) {
-            case TAGS -> "arrayJoin(if(empty(t.tags), ['Unknown'], t.tags))";
+            case TAGS -> hasTagFilter(breakdown)
+                    ? buildTagFilteredExpression("t", breakdown.tagValues(),
+                            Boolean.TRUE.equals(breakdown.tagValuesExclude()))
+                    : "arrayJoin(if(empty(t.tags), ['Unknown'], t.tags))";
             case METADATA -> "ifNull(JSONExtractString(t.metadata, :metadata_key), 'Unknown')";
             case NAME -> "ifNull(t.name, 'Unknown')";
             case ERROR_INFO -> "if(length(t.error_info) > 0, 'Has Error', 'No Error')";

--- a/apps/opik-frontend/src/api/projects/useProjectMetric.ts
+++ b/apps/opik-frontend/src/api/projects/useProjectMetric.ts
@@ -71,6 +71,10 @@ const processBreakdownConfig = (breakdown?: BreakdownConfig) => {
     field: breakdown.field,
     ...(breakdown.metadataKey && { metadata_key: breakdown.metadataKey }),
     ...(breakdown.subMetric && { sub_metric: breakdown.subMetric }),
+    ...(breakdown.tagValues?.length && {
+      tag_values: breakdown.tagValues,
+      tag_values_exclude: breakdown.tagValuesMode === "exclude",
+    }),
   };
 };
 

--- a/apps/opik-frontend/src/types/dashboard.ts
+++ b/apps/opik-frontend/src/types/dashboard.ts
@@ -68,6 +68,8 @@ export interface BreakdownConfig {
   metadataKey?: string;
   subMetric?: string;
   aggregateTotal?: boolean;
+  tagValues?: string[];
+  tagValuesMode?: "include" | "exclude";
 }
 
 export interface ProjectMetricsWidget {

--- a/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/ProjectMetricsBreakdownSection.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/ProjectMetricsBreakdownSection.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useCallback } from "react";
+import React, { useMemo, useEffect, useCallback, useState } from "react";
 import { Control, useController } from "react-hook-form";
 import get from "lodash/get";
 
@@ -11,10 +11,12 @@ import {
 } from "@/ui/accordion";
 import { ToggleGroup, ToggleGroupItem } from "@/ui/toggle-group";
 import { Label } from "@/ui/label";
+import { Input } from "@/ui/input";
 
 import SelectBox from "@/shared/SelectBox/SelectBox";
 import TracesOrSpansPathsAutocomplete from "@/v2/pages-shared/traces/TracesOrSpansPathsAutocomplete/TracesOrSpansPathsAutocomplete";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
+import RemovableTag from "@/shared/RemovableTag/RemovableTag";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 import { cn } from "@/lib/utils";
@@ -53,7 +55,10 @@ const ProjectMetricsBreakdownSection: React.FC<
   onBreakdownChange,
 }) => {
   const isMetadataBreakdown = breakdown.field === BREAKDOWN_FIELD.METADATA;
+  const isTagsBreakdown = breakdown.field === BREAKDOWN_FIELD.TAGS;
   const hasBreakdownField = breakdown.field !== BREAKDOWN_FIELD.NONE;
+
+  const [tagInput, setTagInput] = useState("");
 
   const isGroupByDisabled =
     !metricType ||
@@ -70,6 +75,64 @@ const ProjectMetricsBreakdownSection: React.FC<
     control,
     name: "breakdown.metadataKey",
   });
+
+  const { field: breakdownTagValuesController } = useController({
+    control,
+    name: "breakdown.tagValues",
+  });
+
+  const { field: breakdownTagValuesModeController } = useController({
+    control,
+    name: "breakdown.tagValuesMode",
+  });
+
+  const tagValues: string[] = useMemo(
+    () => breakdownTagValuesController.value ?? [],
+    [breakdownTagValuesController.value],
+  );
+  const tagValuesMode: "include" | "exclude" =
+    breakdownTagValuesModeController.value ?? "include";
+
+  const handleAddTag = useCallback(
+    (value: string) => {
+      const trimmed = value.trim();
+      if (!trimmed || tagValues.includes(trimmed)) return;
+      const next = [...tagValues, trimmed];
+      breakdownTagValuesController.onChange(next);
+      onBreakdownChange({ tagValues: next });
+      setTagInput("");
+    },
+    [tagValues, breakdownTagValuesController, onBreakdownChange],
+  );
+
+  const handleRemoveTag = useCallback(
+    (tag: string) => {
+      const next = tagValues.filter((t) => t !== tag);
+      breakdownTagValuesController.onChange(next);
+      onBreakdownChange({ tagValues: next });
+    },
+    [tagValues, breakdownTagValuesController, onBreakdownChange],
+  );
+
+  const handleTagInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter" || e.key === ",") {
+        e.preventDefault();
+        handleAddTag(tagInput);
+      }
+    },
+    [tagInput, handleAddTag],
+  );
+
+  const handleTagValuesModeChange = useCallback(
+    (value: string) => {
+      if (!value) return;
+      const mode = value as "include" | "exclude";
+      breakdownTagValuesModeController.onChange(mode);
+      onBreakdownChange({ tagValuesMode: mode });
+    },
+    [breakdownTagValuesModeController, onBreakdownChange],
+  );
 
   const compatibleBreakdownFields = useMemo(() => {
     if (!metricType) return [BREAKDOWN_FIELD.NONE];
@@ -89,18 +152,31 @@ const ProjectMetricsBreakdownSection: React.FC<
       if (field === BREAKDOWN_FIELD.NONE) {
         breakdownFieldController.onChange(BREAKDOWN_FIELD.NONE);
         breakdownMetadataKeyController.onChange(undefined);
+        breakdownTagValuesController.onChange(undefined);
+        breakdownTagValuesModeController.onChange(undefined);
+        setTagInput("");
         onBreakdownChange({
           field: BREAKDOWN_FIELD.NONE,
           metadataKey: undefined,
+          tagValues: undefined,
+          tagValuesMode: undefined,
         });
       } else {
         breakdownFieldController.onChange(field);
+        const isTagsField = field === BREAKDOWN_FIELD.TAGS;
+        if (!isTagsField) {
+          breakdownTagValuesController.onChange(undefined);
+          breakdownTagValuesModeController.onChange(undefined);
+          setTagInput("");
+        }
         onBreakdownChange({
           field,
           metadataKey:
             field === BREAKDOWN_FIELD.METADATA
               ? breakdown.metadataKey
               : undefined,
+          tagValues: isTagsField ? breakdown.tagValues : undefined,
+          tagValuesMode: isTagsField ? breakdown.tagValuesMode : undefined,
           aggregateTotal: true,
         });
       }
@@ -108,8 +184,12 @@ const ProjectMetricsBreakdownSection: React.FC<
     [
       breakdownFieldController,
       breakdownMetadataKeyController,
+      breakdownTagValuesController,
+      breakdownTagValuesModeController,
       onBreakdownChange,
       breakdown.metadataKey,
+      breakdown.tagValues,
+      breakdown.tagValuesMode,
     ],
   );
 
@@ -129,9 +209,14 @@ const ProjectMetricsBreakdownSection: React.FC<
     if (isGroupByDisabled && hasBreakdownField) {
       breakdownFieldController.onChange(BREAKDOWN_FIELD.NONE);
       breakdownMetadataKeyController.onChange(undefined);
+      breakdownTagValuesController.onChange(undefined);
+      breakdownTagValuesModeController.onChange(undefined);
+      setTagInput("");
       onBreakdownChange({
         field: BREAKDOWN_FIELD.NONE,
         metadataKey: undefined,
+        tagValues: undefined,
+        tagValuesMode: undefined,
       });
     }
   }, [
@@ -139,6 +224,8 @@ const ProjectMetricsBreakdownSection: React.FC<
     hasBreakdownField,
     breakdownFieldController,
     breakdownMetadataKeyController,
+    breakdownTagValuesController,
+    breakdownTagValuesModeController,
     onBreakdownChange,
   ]);
 
@@ -240,6 +327,57 @@ const ProjectMetricsBreakdownSection: React.FC<
                 )}
               </div>
             </div>
+            {isTagsBreakdown && (
+              <div className="flex-1">
+                <Label className="comet-body-s-accented mb-1 flex items-center gap-1">
+                  Filter tags
+                </Label>
+                <div className="flex flex-col gap-2">
+                  <ToggleGroup
+                    type="single"
+                    variant="ghost"
+                    value={tagValuesMode}
+                    onValueChange={handleTagValuesModeChange}
+                    className="w-fit justify-start"
+                  >
+                    <ToggleGroupItem
+                      value="include"
+                      aria-label="Include"
+                      className="gap-1.5"
+                    >
+                      Include
+                    </ToggleGroupItem>
+                    <ToggleGroupItem
+                      value="exclude"
+                      aria-label="Exclude"
+                      className="gap-1.5"
+                    >
+                      Exclude
+                    </ToggleGroupItem>
+                  </ToggleGroup>
+                  <Input
+                    placeholder="Type a tag and press Enter"
+                    value={tagInput}
+                    onChange={(e) => setTagInput(e.target.value)}
+                    onKeyDown={handleTagInputKeyDown}
+                    onBlur={() => {
+                      if (tagInput.trim()) handleAddTag(tagInput);
+                    }}
+                  />
+                  {tagValues.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      {tagValues.map((tag) => (
+                        <RemovableTag
+                          key={tag}
+                          label={tag}
+                          onDelete={handleRemoveTag}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
             <div className="min-w-fit">
               <Label className="comet-body-s-accented mb-1 flex items-center gap-1">
                 Aggregation mode{" "}

--- a/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/schema.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/schema.ts
@@ -8,6 +8,8 @@ export const BreakdownConfigSchema = z
     field: z.nativeEnum(BREAKDOWN_FIELD).default(BREAKDOWN_FIELD.NONE),
     metadataKey: z.string().optional(),
     aggregateTotal: z.boolean().optional(),
+    tagValues: z.array(z.string()).optional(),
+    tagValuesMode: z.enum(["include", "exclude"]).optional(),
   })
   .refine(
     (data) => {


### PR DESCRIPTION
## Details

- Backend: Added tagValues (List<String>) and tagValuesExclude (Boolean) to BreakdownConfig
- Backend: BreakdownQueryBuilder generates arrayFilter(has(...)) ClickHouse expressions for tag filtering
- Frontend: Updated BreakdownConfig interface, Zod schema, and API layer to pass tag_values/tag_values_exclude
- Frontend: Added tag filter UI in ProjectMetricsBreakdownSection with include/exclude mode toggle and removable tag chips

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #6182 


## Testing

N/A

## Documentation

N/A