### PR TITLE
[NA] [FE] [SDK] comet deployment bug

### DIFF
--- a/apps/opik-frontend/src/v2/pages/PairingPage/PairingPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PairingPage/PairingPage.tsx
@@ -123,7 +123,19 @@ async function deriveBridgeKey(
 // Activate + derive + store — runs once on mount
 // ---------------------------------------------------------------------------
 
+function extractWorkspaceFromPath(): string | null {
+  // Cloud URLs: /{workspace}/opik/pair/v1
+  // OSS URLs:   /opik/pair/v1
+  const match = window.location.pathname.match(/^\/([^/]+)\/opik\/pair\/v1/);
+  return match ? match[1] : null;
+}
+
 async function activate(payload: PairingPayload): Promise<void> {
+  const workspace = extractWorkspaceFromPath();
+  if (workspace) {
+    api.defaults.headers.common["Comet-Workspace"] = workspace;
+  }
+
   const hmac = await computeActivationHmac(
     payload.activationKey,
     payload.sessionId,

--- a/apps/opik-frontend/src/v2/router.tsx
+++ b/apps/opik-frontend/src/v2/router.tsx
@@ -99,9 +99,15 @@ const workspaceGuardEmptyLayoutRoute = createRoute({
 });
 
 // ----------- pairing (root-level, no layout)
+// OSS: /opik/pair/v1   Cloud: /$workspaceName/opik/pair/v1
 const pairingRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/opik/pair/v1",
+  component: PairingPage,
+});
+const workspacePairingRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/$workspaceName/opik/pair/v1",
   component: PairingPage,
 });
 
@@ -543,6 +549,7 @@ const v1RedirectRoutes = createV1RedirectRoutes(workspaceRoute);
 
 const routeTree = rootRoute.addChildren([
   pairingRoute,
+  workspacePairingRoute,
   workspaceGuardEmptyLayoutRoute.addChildren([automationLogsRoute]),
   workspaceGuardPartialLayoutRoute.addChildren([
     quickstartRoute,

--- a/sdks/python/src/opik/cli/_run.py
+++ b/sdks/python/src/opik/cli/_run.py
@@ -51,6 +51,7 @@ def run_cli_session(
                 runner_name=runner_name,
                 runner_type=runner_type,
                 base_url=client.config.url_override,
+                workspace=client.config.workspace,
                 tui=tui,
             )
 

--- a/sdks/python/src/opik/cli/pairing.py
+++ b/sdks/python/src/opik/cli/pairing.py
@@ -75,6 +75,7 @@ def build_pairing_link(
     project_id: str,
     runner_name: str,
     runner_type: RunnerType = RunnerType.CONNECT,
+    workspace: Optional[str] = None,
 ) -> str:
     session_bytes = uuid.UUID(session_id).bytes
     project_bytes = uuid.UUID(project_id).bytes
@@ -91,6 +92,8 @@ def build_pairing_link(
 
     fragment = base64.urlsafe_b64encode(payload).rstrip(b"=").decode("ascii")
     domain_root = get_base_url(base_url)
+    if workspace:
+        return f"{domain_root}{workspace}/opik/pair/v1#{fragment}"
     return f"{domain_root}opik/pair/v1#{fragment}"
 
 
@@ -255,6 +258,7 @@ def run_pairing(
     runner_name: str,
     runner_type: RunnerType,
     base_url: str,
+    workspace: Optional[str] = None,
     tui: Optional["RunnerTUI"] = None,
     ttl_seconds: int = DEFAULT_TTL_SECONDS,
 ) -> PairingResult:
@@ -267,6 +271,7 @@ def run_pairing(
         session.project_id,
         runner_name,
         runner_type,
+        workspace=workspace,
     )
 
     if tui:


### PR DESCRIPTION
## Details

 Pairing links fail on cloud deployments with 403 "Workspace name should be provided" because the PairingPage is a standalone route with no app initialization, so the `Comet-Workspace` header is never set. The CLI now includes the workspace in the pairing URL path (`/{workspace}/opik/pair/v1#...`) and the frontend extracts it to set the header before activating. OSS deployments are unaffected — workspace is omitted and the URL stays `/opik/pair/v1#...`.

  ## Change checklist
  - [ ] User facing
  - [ ] Documentation update

  ## Issues

  ## Testing

  - `cd sdks/python && uv run python -m pytest tests/unit/cli/test_pairing.py tests/unit/cli/test_endpoint.py -v` — 32 passed
  - `cd sdks/python && uv run python -m pytest tests/unit/cli/ tests/unit/runner/ -v` — 482 passed
  - Manual verification on test.dev.comet.com: decoded pairing fragment in browser console, POSTed activate with `Comet-Workspace`
  header via fetch, got 201 success
  - OSS path (`/opik/pair/v1`) unchanged, no workspace extracted (regex returns null)

  ## Documentation