### PR TITLE
[NA] [FE] Update onboarding Connect to Ollie flow with opik connect steps

### DIFF
--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
@@ -208,7 +208,7 @@ const ConnectAgentStep: React.FC = () => {
 
         {showOllieTab && (
           <TabsContent value="connect-to-ollie">
-            <ConnectToOllieTab projectId={projectId} />
+            <ConnectToOllieTab connected={connected} />
           </TabsContent>
         )}
 

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
@@ -4,14 +4,18 @@ import { Button } from "@/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/ui/tabs";
 import Slack from "@/icons/slack.svg?react";
 import usePluginsStore from "@/store/PluginsStore";
+import { useUserApiKey } from "@/store/AppStore";
 import useProjectByName from "@/api/projects/useProjectByName";
 import useTracesList from "@/api/traces/useTracesList";
+import useSandboxConnectionStatus from "@/api/agent-sandbox/useSandboxConnectionStatus";
+import { RunnerConnectionStatus } from "@/types/agent-sandbox";
 import {
   useAgentOnboarding,
   AGENT_ONBOARDING_STEPS,
   TRACES_OLDEST_FIRST_SORTING,
 } from "./AgentOnboardingContext";
 import AgentOnboardingCard from "./AgentOnboardingCard";
+import ConnectToOllieTab from "./ConnectToOllieTab";
 import InstallWithAITab from "./InstallWithAITab";
 import ManualIntegrationList from "./ManualIntegrationList";
 import ManualIntegrationDetail from "./ManualIntegrationDetail";
@@ -26,7 +30,12 @@ const TRACE_POLL_INTERVAL = 5000;
 const ConnectAgentStep: React.FC = () => {
   const { goToStep, agentName } = useAgentOnboarding();
   const InviteDevButton = usePluginsStore((state) => state.InviteDevButton);
-  const [activeTab, setActiveTab] = useState("install-with-ai");
+  const apiKey = useUserApiKey();
+  const showOllieTab = !!apiKey;
+  const [activeTab, setActiveTab] = useState(
+    showOllieTab ? "connect-to-ollie" : "install-with-ai",
+  );
+  const [manualCategory, setManualCategory] = useState<string | null>(null);
   const [selectedIntegrationId, setSelectedIntegrationId] = useState<
     string | null
   >(null);
@@ -53,6 +62,15 @@ const ConnectAgentStep: React.FC = () => {
 
   const firstTraceId = tracesData?.content?.[0]?.id;
   const traceReceived = !!firstTraceId;
+
+  const { data: runner } = useSandboxConnectionStatus(
+    { projectId: projectId ?? "", runnerType: "connect" },
+    { enabled: !!projectId && activeTab === "connect-to-ollie" },
+  );
+  const connected = runner?.status === RunnerConnectionStatus.CONNECTED;
+
+  const isOllieTab = activeTab === "connect-to-ollie";
+  const primaryReady = isOllieTab ? connected : traceReceived;
 
   const handleViewTraces = () => {
     goToStep(AGENT_ONBOARDING_STEPS.DONE, {
@@ -144,11 +162,11 @@ const ConnectAgentStep: React.FC = () => {
 
   return (
     <AgentOnboardingCard
-      title={`Connect ${agentName} to Opik`}
-      description="Follow these steps to start sending traces to Opik."
+      title={`Set up Opik for ${agentName}`}
+      description="Connect your repo so Opik can help set up tracing, or instrument your code manually."
       showFooterSeparator
       footer={
-        traceReceived ? (
+        primaryReady ? (
           <Button
             onClick={handleViewTraces}
             id="onboarding-step2-view-traces"
@@ -173,21 +191,40 @@ const ConnectAgentStep: React.FC = () => {
     >
       <Tabs value={activeTab} onValueChange={handleTabChange}>
         <TabsList variant="underline">
-          <TabsTrigger value="install-with-ai" variant="underline">
-            Install with AI
-          </TabsTrigger>
+          {showOllieTab && (
+            <TabsTrigger value="connect-to-ollie" variant="underline">
+              AI-assisted setup
+            </TabsTrigger>
+          )}
+          {!showOllieTab && (
+            <TabsTrigger value="install-with-ai" variant="underline">
+              Use Opik skills
+            </TabsTrigger>
+          )}
           <TabsTrigger value="manual-integration" variant="underline">
-            Manual integration
+            Manual setup
           </TabsTrigger>
         </TabsList>
 
-        <TabsContent value="install-with-ai">
-          <InstallWithAITab traceReceived={traceReceived} />
-        </TabsContent>
+        {showOllieTab && (
+          <TabsContent value="connect-to-ollie">
+            <ConnectToOllieTab projectId={projectId} />
+          </TabsContent>
+        )}
+
+        {!showOllieTab && (
+          <TabsContent value="install-with-ai">
+            <InstallWithAITab traceReceived={traceReceived} />
+          </TabsContent>
+        )}
 
         <TabsContent value="manual-integration">
           <ManualIntegrationList
             onSelectIntegration={setSelectedIntegrationId}
+            showInstallWithAI={showOllieTab}
+            traceReceived={traceReceived}
+            activeCategory={manualCategory}
+            onCategoryChange={setManualCategory}
           />
         </TabsContent>
       </Tabs>

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { useAgentOnboarding } from "./AgentOnboardingContext";
+import { useUserApiKey, useActiveWorkspaceName } from "@/store/AppStore";
+import { buildDocsUrl, maskAPIKey } from "@/lib/utils";
+import { BASE_API_URL } from "@/api/api";
+import useSandboxConnectionStatus from "@/api/agent-sandbox/useSandboxConnectionStatus";
+import TimelineStep from "@/shared/TimelineStep/TimelineStep";
+import CodeSnippet from "@/shared/CodeSnippet/CodeSnippet";
+import { RunnerConnectionStatus } from "@/types/agent-sandbox";
+
+const INSTALL_COMMAND = "pip install opik";
+
+interface ConnectToOllieTabProps {
+  projectId?: string;
+}
+
+const ConnectToOllieTab: React.FC<ConnectToOllieTabProps> = ({ projectId }) => {
+  const { agentName } = useAgentOnboarding();
+  const apiKey = useUserApiKey();
+  const workspaceName = useActiveWorkspaceName();
+
+  const { data: runner } = useSandboxConnectionStatus(
+    { projectId: projectId ?? "", runnerType: "connect" },
+    { enabled: !!projectId },
+  );
+  const connected = runner?.status === RunnerConnectionStatus.CONNECTED;
+
+  const buildEnvVars = (shouldMaskAPIKey: boolean) => {
+    if (apiKey) {
+      const displayedKey = shouldMaskAPIKey ? maskAPIKey(apiKey) : apiKey;
+      return `export OPIK_API_KEY="${displayedKey}"\nexport OPIK_WORKSPACE="${workspaceName}"`;
+    }
+    const url = new URL(BASE_API_URL, window.location.origin).toString();
+    return `export OPIK_URL_OVERRIDE="${url}"`;
+  };
+
+  const connectCommandText = `${buildEnvVars(
+    false,
+  )}\nopik connect --project "${agentName}"`;
+  const displayConnectCommandText = `${buildEnvVars(
+    true,
+  )}\nopik connect --project "${agentName}"`;
+
+  return (
+    <div className="flex flex-col gap-4 px-1">
+      <p className="comet-body-s text-muted-slate">
+        Ollie is Opik&apos;s AI coding assistant. When you connect your repo,
+        Ollie can inspect your code, help add Opik tracing, and guide you
+        through setup.
+      </p>
+      <div className="flex flex-col">
+        <TimelineStep number={1}>
+          <div className="flex flex-col gap-2.5">
+            <h4 className="comet-body-s-accented">Install Opik</h4>
+            <CodeSnippet title="Terminal" code={INSTALL_COMMAND} />
+          </div>
+        </TimelineStep>
+
+        <TimelineStep number={2}>
+          <div className="flex flex-col gap-2.5">
+            <h4 className="comet-body-s-accented">
+              Connect your repo to Ollie
+            </h4>
+            <p className="comet-body-xs text-muted-slate">
+              Run this command in the repository you want Ollie to work in. This
+              creates a local connection between Opik and your machine so Ollie
+              can help with setup.
+            </p>
+            <CodeSnippet
+              title="Terminal"
+              code={displayConnectCommandText}
+              copyText={connectCommandText}
+            />
+          </div>
+        </TimelineStep>
+
+        <TimelineStep isLast completed={connected}>
+          <div className="flex flex-col gap-1">
+            <h4 className="comet-body-s-accented text-primary">
+              {connected
+                ? "Repo connected"
+                : "Waiting for your repo to connect\u2026"}
+            </h4>
+            <p className="comet-body-xs text-muted-slate">
+              {connected ? (
+                "Ollie can now inspect your code and help you set up tracing in Opik."
+              ) : (
+                <>
+                  Run the command above in your repo. Once connected, Ollie can
+                  inspect your code and help finish setup.{" "}
+                  <a
+                    href={buildDocsUrl("/agents/local-runner#troubleshooting")}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-foreground"
+                  >
+                    Connect troubleshooting
+                  </a>
+                </>
+              )}
+            </p>
+          </div>
+        </TimelineStep>
+      </div>
+    </div>
+  );
+};
+
+export default ConnectToOllieTab;

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
@@ -3,27 +3,19 @@ import { useAgentOnboarding } from "./AgentOnboardingContext";
 import { useUserApiKey, useActiveWorkspaceName } from "@/store/AppStore";
 import { buildDocsUrl, maskAPIKey } from "@/lib/utils";
 import { BASE_API_URL } from "@/api/api";
-import useSandboxConnectionStatus from "@/api/agent-sandbox/useSandboxConnectionStatus";
 import TimelineStep from "@/shared/TimelineStep/TimelineStep";
 import CodeSnippet from "@/shared/CodeSnippet/CodeSnippet";
-import { RunnerConnectionStatus } from "@/types/agent-sandbox";
 
 const INSTALL_COMMAND = "pip install opik";
 
 interface ConnectToOllieTabProps {
-  projectId?: string;
+  connected: boolean;
 }
 
-const ConnectToOllieTab: React.FC<ConnectToOllieTabProps> = ({ projectId }) => {
+const ConnectToOllieTab: React.FC<ConnectToOllieTabProps> = ({ connected }) => {
   const { agentName } = useAgentOnboarding();
   const apiKey = useUserApiKey();
   const workspaceName = useActiveWorkspaceName();
-
-  const { data: runner } = useSandboxConnectionStatus(
-    { projectId: projectId ?? "", runnerType: "connect" },
-    { enabled: !!projectId },
-  );
-  const connected = runner?.status === RunnerConnectionStatus.CONNECTED;
 
   const buildEnvVars = (shouldMaskAPIKey: boolean) => {
     if (apiKey) {

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/InstallWithAITab.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/InstallWithAITab.tsx
@@ -84,7 +84,7 @@ const InstallWithAITab: React.FC<InstallWithAITabProps> = ({
             <h4 className="comet-body-s-accented text-primary">
               {traceReceived
                 ? "First trace received! You're all set."
-                : "Waiting for first trace…"}
+                : "Waiting for first trace\u2026"}
             </h4>
             <p className="comet-body-xs text-muted-slate">
               {traceReceived ? (

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ManualIntegrationList.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ManualIntegrationList.tsx
@@ -15,7 +15,7 @@ import {
 import { buildDocsUrl } from "@/lib/utils";
 import InstallWithAITab from "./InstallWithAITab";
 
-const INSTALL_WITH_AI = "install-with-ai" as const;
+const INSTALL_WITH_AI = "install-with-ai";
 
 type ManualIntegrationListProps = {
   onSelectIntegration: (id: string) => void;

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ManualIntegrationList.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ManualIntegrationList.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { ExternalLink } from "lucide-react";
 import { useTheme } from "@/contexts/theme-provider";
 import { THEME_MODE } from "@/constants/theme";
@@ -13,9 +13,16 @@ import {
   getIntegrationsByCategory,
 } from "@/constants/integrations";
 import { buildDocsUrl } from "@/lib/utils";
+import InstallWithAITab from "./InstallWithAITab";
+
+const INSTALL_WITH_AI = "install-with-ai" as const;
 
 type ManualIntegrationListProps = {
   onSelectIntegration: (id: string) => void;
+  showInstallWithAI?: boolean;
+  traceReceived?: boolean;
+  activeCategory?: string | null;
+  onCategoryChange?: (category: string) => void;
 };
 
 const CATEGORY_TABS = [
@@ -29,13 +36,22 @@ const CATEGORY_TABS = [
 
 const ManualIntegrationList: React.FC<ManualIntegrationListProps> = ({
   onSelectIntegration,
+  showInstallWithAI = false,
+  traceReceived = false,
+  activeCategory: controlledCategory,
+  onCategoryChange,
 }) => {
   const { agentName } = useAgentOnboarding();
   const apiKey = useUserApiKey();
   const { themeMode } = useTheme();
-  const [activeCategory, setActiveCategory] = useState<string>(
-    INTEGRATION_CATEGORIES.ALL,
-  );
+
+  const defaultCategory = showInstallWithAI
+    ? INSTALL_WITH_AI
+    : INTEGRATION_CATEGORIES.ALL;
+  const activeCategory = controlledCategory ?? defaultCategory;
+  const setActiveCategory = (value: string) => {
+    onCategoryChange?.(value);
+  };
 
   const integrations = useMemo(
     () => getIntegrationsByCategory(activeCategory),
@@ -88,6 +104,14 @@ const ManualIntegrationList: React.FC<ManualIntegrationListProps> = ({
           size="sm"
           className="justify-start"
         >
+          {showInstallWithAI && (
+            <ToggleGroupItem
+              value={INSTALL_WITH_AI}
+              className="text-muted-slate"
+            >
+              Use Opik skills
+            </ToggleGroupItem>
+          )}
           {CATEGORY_TABS.map((tab) => (
             <ToggleGroupItem
               key={tab.value}
@@ -99,48 +123,52 @@ const ManualIntegrationList: React.FC<ManualIntegrationListProps> = ({
           ))}
         </ToggleGroup>
 
-        <div className="grid grid-cols-4 gap-2">
-          {integrations.map((integration) => (
-            <div key={integration.id} title={integration.title}>
-              <IntegrationCard
-                title={integration.title}
-                icon={
-                  <img
-                    alt={integration.title}
-                    src={
-                      themeMode === THEME_MODE.DARK && integration.whiteIcon
-                        ? integration.whiteIcon
-                        : integration.icon
-                    }
-                    className="size-4 shrink-0"
-                  />
-                }
-                className="h-8 gap-1 overflow-hidden p-[0.375rem_0.5rem] [&>div:last-child]:min-w-0 [&_h3]:truncate [&_h3]:font-normal"
-                iconClassName="min-w-0"
-                onClick={() => onSelectIntegration(integration.id)}
-                id={`onboarding-integration-card-${integration.id}`}
-                data-fs-element={`OnboardingIntegrationCard-${integration.id}`}
-              />
-            </div>
-          ))}
+        {activeCategory === INSTALL_WITH_AI ? (
+          <InstallWithAITab traceReceived={traceReceived} />
+        ) : (
+          <div className="grid grid-cols-4 gap-2">
+            {integrations.map((integration) => (
+              <div key={integration.id} title={integration.title}>
+                <IntegrationCard
+                  title={integration.title}
+                  icon={
+                    <img
+                      alt={integration.title}
+                      src={
+                        themeMode === THEME_MODE.DARK && integration.whiteIcon
+                          ? integration.whiteIcon
+                          : integration.icon
+                      }
+                      className="size-4 shrink-0"
+                    />
+                  }
+                  className="h-8 gap-1 overflow-hidden p-[0.375rem_0.5rem] [&>div:last-child]:min-w-0 [&_h3]:truncate [&_h3]:font-normal"
+                  iconClassName="min-w-0"
+                  onClick={() => onSelectIntegration(integration.id)}
+                  id={`onboarding-integration-card-${integration.id}`}
+                  data-fs-element={`OnboardingIntegrationCard-${integration.id}`}
+                />
+              </div>
+            ))}
 
-          <a
-            href={buildDocsUrl(
-              "/integrations/overview",
-              "&utm_source=opik_frontend&utm_medium=onboarding&utm_campaign=integrations_docs",
-            )}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex h-8 items-center gap-1 rounded-lg border bg-background px-3 py-1.5 transition-all duration-200 hover:bg-primary-foreground"
-            id="onboarding-integration-view-all"
-            data-fs-element="OnboardingIntegrationViewAll"
-          >
-            <span className="comet-body-s-accented truncate font-normal text-foreground">
-              View all
-            </span>
-            <ExternalLink className="size-3 shrink-0 text-foreground" />
-          </a>
-        </div>
+            <a
+              href={buildDocsUrl(
+                "/integrations/overview",
+                "&utm_source=opik_frontend&utm_medium=onboarding&utm_campaign=integrations_docs",
+              )}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex h-8 items-center gap-1 rounded-lg border bg-background px-3 py-1.5 transition-all duration-200 hover:bg-primary-foreground"
+              id="onboarding-integration-view-all"
+              data-fs-element="OnboardingIntegrationViewAll"
+            >
+              <span className="comet-body-s-accented truncate font-normal text-foreground">
+                View all
+              </span>
+              <ExternalLink className="size-3 shrink-0 text-foreground" />
+            </a>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Details

Update the onboarding "Get Started" page with improved tab structure, labels, and opik connect flow:
- Rename tabs: "AI-assisted setup" / "Manual setup" / "Use Opik skills"
- Replace skills-based "Connect to Ollie" flow with `opik connect` steps (install, configure, connect, wait)
- Hide "AI-assisted setup" tab on OSS deployments (no API key)
- Add back "All integrations" toggle in manual setup
- Filter connection status by `runnerType: "connect"` so only `opik connect` triggers connected state
- Gate primary CTA on runner connection status for AI-assisted tab, trace received for manual tab

<img width="897" height="794" alt="Screenshot 2026-04-14 at 11 17 45" src="https://github.com/user-attachments/assets/45469b70-f35f-4476-a5f7-861f582743dd" />

<img width="700" height="792" alt="Screenshot 2026-04-14 at 11 18 33" src="https://github.com/user-attachments/assets/84d5a6e6-48c3-49de-8865-9a5c412a630e" />

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full implementation with human review
  - Human verification: Manual testing of Cloud and OSS views

## Testing

- Verified Cloud view: "AI-assisted setup" tab appears as default, shows pip install + opik connect steps
- Verified Cloud "Manual setup": shows "Use Opik skills", "All integrations", "LLM providers", "Frameworks & tools" toggles
- Verified OSS view: "AI-assisted setup" tab hidden, "Use Opik skills" is default tab on OSS
- Verified env vars: Cloud shows `OPIK_API_KEY` + `OPIK_WORKSPACE`, OSS shows `OPIK_URL_OVERRIDE`
- Verified category state persists when navigating back from integration detail view
- Ran `npx tsc --noEmit` — no type errors
- Ran `npx eslint` on changed files — all clean after prettier fix

## Documentation

No documentation changes needed.