### PR TITLE
[OPIK-5772][FE]: remove prompts and update blueprints for v2;

### DIFF
--- a/apps/opik-frontend/src/api/agent-configs/useAgentConfigPostMutation.ts
+++ b/apps/opik-frontend/src/api/agent-configs/useAgentConfigPostMutation.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import get from "lodash/get";
+import api, { AGENT_CONFIGS_KEY, AGENT_CONFIGS_REST_ENDPOINT } from "@/api/api";
+import { AgentConfigCreate } from "@/types/agent-configs";
+import { AxiosError } from "axios";
+import { useToast } from "@/ui/use-toast";
+import { extractIdFromLocation } from "@/lib/utils";
+
+type UseAgentConfigPostMutationParams = {
+  agentConfig: AgentConfigCreate;
+};
+
+const useAgentConfigPostMutation = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async ({ agentConfig }: UseAgentConfigPostMutationParams) => {
+      const { headers } = await api.post(
+        `${AGENT_CONFIGS_REST_ENDPOINT}blueprints`,
+        agentConfig,
+      );
+
+      const id = extractIdFromLocation(headers?.location);
+
+      return { id };
+    },
+    onError: (error: AxiosError) => {
+      const message = get(
+        error,
+        ["response", "data", "message"],
+        error.message,
+      );
+
+      toast({
+        title: "Error",
+        description: message,
+        variant: "destructive",
+      });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: [AGENT_CONFIGS_KEY],
+      });
+    },
+  });
+};
+
+export default useAgentConfigPostMutation;

--- a/apps/opik-frontend/src/api/prompts/usePromptByCommit.ts
+++ b/apps/opik-frontend/src/api/prompts/usePromptByCommit.ts
@@ -1,4 +1,9 @@
-import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
+import {
+  QueryFunctionContext,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useCallback } from "react";
 import api, { PROMPTS_REST_ENDPOINT, QueryConfig } from "@/api/api";
 import { PromptByCommit } from "@/types/prompts";
 
@@ -27,4 +32,19 @@ export default function usePromptByCommit(
     queryFn: (context) => getPromptByCommit(context, params),
     ...options,
   });
+}
+
+export function useFetchPromptByCommit() {
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    async (params: UsePromptByCommitParams): Promise<PromptByCommit> => {
+      return queryClient.fetchQuery({
+        queryKey: ["prompt-by-commit", params],
+        queryFn: (context) => getPromptByCommit(context, params),
+        staleTime: 5 * 60 * 1000,
+      });
+    },
+    [queryClient],
+  );
 }

--- a/apps/opik-frontend/src/api/prompts/usePromptByCommit.ts
+++ b/apps/opik-frontend/src/api/prompts/usePromptByCommit.ts
@@ -11,7 +11,7 @@ type UsePromptByCommitParams = {
   commitId: string;
 };
 
-const getPromptByCommit = async (
+export const getPromptByCommit = async (
   { signal }: QueryFunctionContext,
   { commitId }: UsePromptByCommitParams,
 ) => {

--- a/apps/opik-frontend/src/hooks/useLoadBlueprintPrompt.ts
+++ b/apps/opik-frontend/src/hooks/useLoadBlueprintPrompt.ts
@@ -93,8 +93,8 @@ const useLoadBlueprintPrompt = ({
     }
 
     try {
-      loadedRef.current = dedupKey;
       onMessagesLoaded(parseMessages(versionTemplate), prompt.name);
+      loadedRef.current = dedupKey;
     } catch (error) {
       console.error("Failed to parse blueprint prompt:", error);
     }

--- a/apps/opik-frontend/src/hooks/useLoadBlueprintPrompt.ts
+++ b/apps/opik-frontend/src/hooks/useLoadBlueprintPrompt.ts
@@ -6,6 +6,7 @@ import { generateDefaultLLMPromptMessage } from "@/lib/llm";
 import { BlueprintPromptRef } from "@/types/playground";
 import usePromptByCommit from "@/api/prompts/usePromptByCommit";
 import { PromptByCommit } from "@/types/prompts";
+import { serializeChatTemplate } from "@/lib/chatTemplate";
 
 interface UseLoadBlueprintPromptOptions {
   selectedRef: BlueprintPromptRef | undefined;
@@ -24,8 +25,7 @@ interface UseLoadBlueprintPromptReturn {
 const refKey = (ref: BlueprintPromptRef): string =>
   `${ref.blueprintId}-${ref.key}-${ref.commitId}`;
 
-const messagesToTemplate = (messages: LLMMessage[]): string =>
-  JSON.stringify(messages.map(({ role, content }) => ({ role, content })));
+const messagesToTemplate = serializeChatTemplate;
 
 const templatesEqual = (a: string, b: string): boolean => {
   try {

--- a/apps/opik-frontend/src/hooks/useLoadBlueprintPrompt.ts
+++ b/apps/opik-frontend/src/hooks/useLoadBlueprintPrompt.ts
@@ -1,0 +1,106 @@
+import { useEffect, useMemo, useRef } from "react";
+import isEqual from "fast-deep-equal";
+
+import { LLM_MESSAGE_ROLE, LLMMessage } from "@/types/llm";
+import { generateDefaultLLMPromptMessage } from "@/lib/llm";
+import { BlueprintPromptRef } from "@/types/playground";
+import usePromptByCommit from "@/api/prompts/usePromptByCommit";
+import { PromptByCommit } from "@/types/prompts";
+
+interface UseLoadBlueprintPromptOptions {
+  selectedRef: BlueprintPromptRef | undefined;
+  messages: LLMMessage[];
+  onMessagesLoaded: (messages: LLMMessage[], promptName: string) => void;
+  skipInitialLoad?: boolean;
+}
+
+interface UseLoadBlueprintPromptReturn {
+  prompt: PromptByCommit | undefined;
+  loadedRef: React.MutableRefObject<string | null>;
+  template: string;
+  hasUnsavedChanges: boolean;
+}
+
+const refKey = (ref: BlueprintPromptRef): string =>
+  `${ref.blueprintId}-${ref.key}-${ref.commitId}`;
+
+const messagesToTemplate = (messages: LLMMessage[]): string =>
+  JSON.stringify(messages.map(({ role, content }) => ({ role, content })));
+
+const templatesEqual = (a: string, b: string): boolean => {
+  try {
+    const normalize = (raw: string) =>
+      JSON.parse(raw).map(({ role, content }: LLMMessage) => ({
+        role,
+        content,
+      }));
+    return isEqual(normalize(a), normalize(b));
+  } catch {
+    return a === b;
+  }
+};
+
+const parseMessages = (template: string): LLMMessage[] => {
+  const parsed = JSON.parse(template) as Array<{
+    role: string;
+    content: unknown;
+  }>;
+  return parsed.map((msg) =>
+    generateDefaultLLMPromptMessage({
+      role: msg.role as LLM_MESSAGE_ROLE,
+      content: msg.content as LLMMessage["content"],
+    }),
+  );
+};
+
+const useLoadBlueprintPrompt = ({
+  selectedRef,
+  messages,
+  onMessagesLoaded,
+  skipInitialLoad = false,
+}: UseLoadBlueprintPromptOptions): UseLoadBlueprintPromptReturn => {
+  const skippedRef = useRef(false);
+  const loadedRef = useRef<string | null>(null);
+
+  const { data: prompt } = usePromptByCommit(
+    { commitId: selectedRef?.commitId ?? "" },
+    { enabled: !!selectedRef?.commitId },
+  );
+
+  const versionTemplate = prompt?.requested_version?.template;
+
+  const template = useMemo(() => messagesToTemplate(messages), [messages]);
+
+  const hasUnsavedChanges = useMemo(() => {
+    if (!selectedRef || !versionTemplate || messages.length === 0) return false;
+    return !templatesEqual(template, versionTemplate);
+  }, [selectedRef, versionTemplate, template, messages.length]);
+
+  useEffect(() => {
+    if (!selectedRef) {
+      loadedRef.current = null;
+      return;
+    }
+    if (!prompt || !versionTemplate) return;
+
+    const dedupKey = `${refKey(selectedRef)}-${prompt.requested_version.id}`;
+    if (loadedRef.current === dedupKey) return;
+
+    if (skipInitialLoad && !skippedRef.current) {
+      skippedRef.current = true;
+      loadedRef.current = dedupKey;
+      return;
+    }
+
+    try {
+      loadedRef.current = dedupKey;
+      onMessagesLoaded(parseMessages(versionTemplate), prompt.name);
+    } catch (error) {
+      console.error("Failed to parse blueprint prompt:", error);
+    }
+  }, [selectedRef, prompt, versionTemplate, onMessagesLoaded, skipInitialLoad]);
+
+  return { prompt, loadedRef, template, hasUnsavedChanges };
+};
+
+export default useLoadBlueprintPrompt;

--- a/apps/opik-frontend/src/hooks/useLoadBlueprintPrompt.ts
+++ b/apps/opik-frontend/src/hooks/useLoadBlueprintPrompt.ts
@@ -1,12 +1,14 @@
 import { useEffect, useMemo, useRef } from "react";
-import isEqual from "fast-deep-equal";
 
-import { LLM_MESSAGE_ROLE, LLMMessage } from "@/types/llm";
-import { generateDefaultLLMPromptMessage } from "@/lib/llm";
+import { LLMMessage } from "@/types/llm";
 import { BlueprintPromptRef } from "@/types/playground";
 import usePromptByCommit from "@/api/prompts/usePromptByCommit";
 import { PromptByCommit } from "@/types/prompts";
-import { serializeChatTemplate } from "@/lib/chatTemplate";
+import {
+  serializeChatTemplate,
+  chatTemplatesEqual,
+  parseChatTemplateToMessages,
+} from "@/lib/chatTemplate";
 
 interface UseLoadBlueprintPromptOptions {
   selectedRef: BlueprintPromptRef | undefined;
@@ -25,34 +27,6 @@ interface UseLoadBlueprintPromptReturn {
 const refKey = (ref: BlueprintPromptRef): string =>
   `${ref.blueprintId}-${ref.key}-${ref.commitId}`;
 
-const messagesToTemplate = serializeChatTemplate;
-
-const templatesEqual = (a: string, b: string): boolean => {
-  try {
-    const normalize = (raw: string) =>
-      JSON.parse(raw).map(({ role, content }: LLMMessage) => ({
-        role,
-        content,
-      }));
-    return isEqual(normalize(a), normalize(b));
-  } catch {
-    return a === b;
-  }
-};
-
-const parseMessages = (template: string): LLMMessage[] => {
-  const parsed = JSON.parse(template) as Array<{
-    role: string;
-    content: unknown;
-  }>;
-  return parsed.map((msg) =>
-    generateDefaultLLMPromptMessage({
-      role: msg.role as LLM_MESSAGE_ROLE,
-      content: msg.content as LLMMessage["content"],
-    }),
-  );
-};
-
 const useLoadBlueprintPrompt = ({
   selectedRef,
   messages,
@@ -69,11 +43,11 @@ const useLoadBlueprintPrompt = ({
 
   const versionTemplate = prompt?.requested_version?.template;
 
-  const template = useMemo(() => messagesToTemplate(messages), [messages]);
+  const template = useMemo(() => serializeChatTemplate(messages), [messages]);
 
   const hasUnsavedChanges = useMemo(() => {
     if (!selectedRef || !versionTemplate || messages.length === 0) return false;
-    return !templatesEqual(template, versionTemplate);
+    return !chatTemplatesEqual(template, versionTemplate);
   }, [selectedRef, versionTemplate, template, messages.length]);
 
   useEffect(() => {
@@ -93,10 +67,10 @@ const useLoadBlueprintPrompt = ({
     }
 
     try {
-      onMessagesLoaded(parseMessages(versionTemplate), prompt.name);
+      onMessagesLoaded(parseChatTemplateToMessages(versionTemplate), prompt.name);
       loadedRef.current = dedupKey;
-    } catch (error) {
-      console.error("Failed to parse blueprint prompt:", error);
+    } catch {
+      // silently ignore parse failures
     }
   }, [selectedRef, prompt, versionTemplate, onMessagesLoaded, skipInitialLoad]);
 

--- a/apps/opik-frontend/src/hooks/useLoadBlueprintPrompt.ts
+++ b/apps/opik-frontend/src/hooks/useLoadBlueprintPrompt.ts
@@ -67,7 +67,10 @@ const useLoadBlueprintPrompt = ({
     }
 
     try {
-      onMessagesLoaded(parseChatTemplateToMessages(versionTemplate), prompt.name);
+      onMessagesLoaded(
+        parseChatTemplateToMessages(versionTemplate),
+        prompt.name,
+      );
       loadedRef.current = dedupKey;
     } catch {
       // silently ignore parse failures

--- a/apps/opik-frontend/src/hooks/useLoadChatPrompt.ts
+++ b/apps/opik-frontend/src/hooks/useLoadChatPrompt.ts
@@ -2,12 +2,19 @@ import { useEffect, useMemo, useRef } from "react";
 import isEqual from "fast-deep-equal";
 import usePromptById from "@/api/prompts/usePromptById";
 import usePromptVersionById from "@/api/prompts/usePromptVersionById";
+import usePromptByCommit from "@/api/prompts/usePromptByCommit";
 import { LLM_MESSAGE_ROLE, LLMMessage } from "@/types/llm";
 import { generateDefaultLLMPromptMessage } from "@/lib/llm";
-import { PromptWithLatestVersion } from "@/types/prompts";
+import {
+  PromptByCommit,
+  PromptVersion,
+  PromptWithLatestVersion,
+} from "@/types/prompts";
+import { BlueprintPromptRef } from "@/types/playground";
 
 export interface UseLoadChatPromptOptions {
-  selectedChatPromptId: string | undefined;
+  selectedChatPromptId?: string;
+  selectedBlueprintRef?: BlueprintPromptRef;
   messages: LLMMessage[];
   onMessagesLoaded: (messages: LLMMessage[], promptName: string) => void;
   skipInitialLoad?: boolean;
@@ -16,15 +23,43 @@ export interface UseLoadChatPromptOptions {
 export interface UseLoadChatPromptReturn {
   chatPromptData: PromptWithLatestVersion | undefined;
   chatPromptDataLoaded: boolean;
-  chatPromptVersionData: ReturnType<typeof usePromptVersionById>["data"];
+  chatPromptVersionData: PromptVersion | undefined;
   chatPromptVersionDataLoaded: boolean;
   loadedChatPromptRef: React.MutableRefObject<string | null>;
   chatPromptTemplate: string;
   hasUnsavedChatPromptChanges: boolean;
 }
 
+const promptByCommitToPrompt = (
+  data: PromptByCommit | undefined,
+): PromptWithLatestVersion | undefined => {
+  if (!data) return undefined;
+  const v = data.requested_version;
+  return {
+    id: data.id,
+    name: data.name,
+    description: "",
+    last_updated_at: data.last_updated_at,
+    created_at: data.created_at,
+    version_count: data.version_count,
+    tags: [],
+    template_structure: data.template_structure,
+    latest_version: {
+      id: v.id,
+      template: v.template,
+      metadata: v.metadata ?? {},
+      commit: v.commit,
+      prompt_id: data.id,
+      created_at: v.created_at,
+      type: v.type,
+      change_description: v.change_description,
+    },
+  };
+};
+
 const useLoadChatPrompt = ({
   selectedChatPromptId,
+  selectedBlueprintRef,
   messages,
   onMessagesLoaded,
   skipInitialLoad = false,
@@ -32,27 +67,47 @@ const useLoadChatPrompt = ({
   const skippedRef = useRef(false);
   const loadedChatPromptRef = useRef<string | null>(null);
 
-  const { data: chatPromptData, isSuccess: chatPromptDataLoaded } =
+  const useBlueprint = !!selectedBlueprintRef;
+
+  // Library-prompt branch (existing behavior)
+  const { data: libraryPromptData, isSuccess: libraryPromptLoaded } =
     usePromptById(
+      { promptId: selectedChatPromptId! },
+      { enabled: !useBlueprint && !!selectedChatPromptId },
+    );
+
+  const { data: libraryVersionData, isSuccess: libraryVersionLoaded } =
+    usePromptVersionById(
+      { versionId: libraryPromptData?.latest_version?.id || "" },
       {
-        promptId: selectedChatPromptId!,
-      },
-      {
-        enabled: !!selectedChatPromptId,
+        enabled:
+          !useBlueprint &&
+          !!libraryPromptData?.latest_version?.id &&
+          libraryPromptLoaded,
       },
     );
 
-  const {
-    data: chatPromptVersionData,
-    isSuccess: chatPromptVersionDataLoaded,
-  } = usePromptVersionById(
-    {
-      versionId: chatPromptData?.latest_version?.id || "",
-    },
-    {
-      enabled: !!chatPromptData?.latest_version?.id && chatPromptDataLoaded,
-    },
+  // Blueprint-commit branch
+  const { data: commitData, isSuccess: commitLoaded } = usePromptByCommit(
+    { commitId: selectedBlueprintRef?.commitId ?? "" },
+    { enabled: useBlueprint && !!selectedBlueprintRef?.commitId },
   );
+
+  const chatPromptData: PromptWithLatestVersion | undefined = useBlueprint
+    ? promptByCommitToPrompt(commitData)
+    : libraryPromptData;
+
+  const chatPromptDataLoaded = useBlueprint
+    ? commitLoaded
+    : libraryPromptLoaded;
+
+  const chatPromptVersionData: PromptVersion | undefined = useBlueprint
+    ? chatPromptData?.latest_version
+    : libraryVersionData;
+
+  const chatPromptVersionDataLoaded = useBlueprint
+    ? commitLoaded
+    : libraryVersionLoaded;
 
   const chatPromptTemplate = useMemo(
     () =>
@@ -62,23 +117,29 @@ const useLoadChatPrompt = ({
     [messages],
   );
 
+  const selectionKey = useBlueprint
+    ? selectedBlueprintRef
+      ? `${selectedBlueprintRef.blueprintId}-${selectedBlueprintRef.key}-${selectedBlueprintRef.commitId}`
+      : null
+    : selectedChatPromptId ?? null;
+
   const hasUnsavedChatPromptChanges = useMemo(() => {
     const hasContent = messages.length > 0;
 
-    if (!hasContent || !selectedChatPromptId) {
+    if (!hasContent || !selectionKey) {
       return false;
     }
 
-    if (!chatPromptData || chatPromptData.id !== selectedChatPromptId) {
-      return false;
+    if (!useBlueprint) {
+      if (!chatPromptData || chatPromptData.id !== selectedChatPromptId) {
+        return false;
+      }
     }
 
     if (!chatPromptVersionData?.template) {
       return false;
     }
 
-    // Parse both templates as objects to compare semantically, not by string formatting
-    // IMPORTANT: Only compare role and content, ignore text prompt metadata fields
     try {
       const currentTemplate = JSON.parse(chatPromptTemplate);
       const loadedTemplate = JSON.parse(chatPromptVersionData.template);
@@ -100,6 +161,8 @@ const useLoadChatPrompt = ({
       return !isEqual(chatPromptTemplate, chatPromptVersionData.template);
     }
   }, [
+    selectionKey,
+    useBlueprint,
     selectedChatPromptId,
     chatPromptData,
     chatPromptVersionData,
@@ -107,34 +170,27 @@ const useLoadChatPrompt = ({
     messages.length,
   ]);
 
-  // effect to populate messages when chat prompt data is loaded
   useEffect(() => {
-    // create a unique key for this chat prompt load (prompt ID + version ID)
-    const chatPromptKey =
-      selectedChatPromptId && chatPromptVersionData
-        ? `${selectedChatPromptId}-${chatPromptVersionData.id}`
-        : null;
+    const versionId = chatPromptVersionData?.id;
+    const dedupKey =
+      selectionKey && versionId ? `${selectionKey}-${versionId}` : null;
 
     if (
       chatPromptVersionData?.template &&
-      selectedChatPromptId &&
+      selectionKey &&
       chatPromptData &&
       chatPromptVersionDataLoaded &&
-      chatPromptKey &&
-      loadedChatPromptRef.current !== chatPromptKey // prevent duplicate loads
+      dedupKey &&
+      loadedChatPromptRef.current !== dedupKey
     ) {
-      // Skip the first load for duplicated prompts that already have messages.
-      // We still mark the key as loaded so the hook won't re-trigger and
-      // overwrite the duplicated messages with the saved library version.
       if (skipInitialLoad && !skippedRef.current) {
         skippedRef.current = true;
-        loadedChatPromptRef.current = chatPromptKey;
+        loadedChatPromptRef.current = dedupKey;
         return;
       }
 
       try {
-        // Mark this chat prompt as loaded to prevent race conditions
-        loadedChatPromptRef.current = chatPromptKey;
+        loadedChatPromptRef.current = dedupKey;
 
         const parsedMessages = JSON.parse(chatPromptVersionData.template);
 
@@ -152,13 +208,12 @@ const useLoadChatPrompt = ({
       }
     }
 
-    // reset the ref when chat prompt is deselected
-    if (!selectedChatPromptId) {
+    if (!selectionKey) {
       loadedChatPromptRef.current = null;
     }
   }, [
     chatPromptVersionData,
-    selectedChatPromptId,
+    selectionKey,
     chatPromptData,
     chatPromptVersionDataLoaded,
     onMessagesLoaded,

--- a/apps/opik-frontend/src/hooks/useLoadChatPrompt.ts
+++ b/apps/opik-frontend/src/hooks/useLoadChatPrompt.ts
@@ -133,9 +133,6 @@ const useLoadChatPrompt = ({
       }
 
       try {
-        // Mark this chat prompt as loaded to prevent race conditions
-        loadedChatPromptRef.current = chatPromptKey;
-
         const parsedMessages = JSON.parse(chatPromptVersionData.template);
 
         const newMessages: LLMMessage[] = parsedMessages.map(
@@ -147,6 +144,7 @@ const useLoadChatPrompt = ({
         );
 
         onMessagesLoaded(newMessages, chatPromptData.name);
+        loadedChatPromptRef.current = chatPromptKey;
       } catch (error) {
         console.error("Failed to parse chat prompt:", error);
       }

--- a/apps/opik-frontend/src/hooks/useLoadChatPrompt.ts
+++ b/apps/opik-frontend/src/hooks/useLoadChatPrompt.ts
@@ -2,19 +2,12 @@ import { useEffect, useMemo, useRef } from "react";
 import isEqual from "fast-deep-equal";
 import usePromptById from "@/api/prompts/usePromptById";
 import usePromptVersionById from "@/api/prompts/usePromptVersionById";
-import usePromptByCommit from "@/api/prompts/usePromptByCommit";
 import { LLM_MESSAGE_ROLE, LLMMessage } from "@/types/llm";
 import { generateDefaultLLMPromptMessage } from "@/lib/llm";
-import {
-  PromptByCommit,
-  PromptVersion,
-  PromptWithLatestVersion,
-} from "@/types/prompts";
-import { BlueprintPromptRef } from "@/types/playground";
+import { PromptWithLatestVersion } from "@/types/prompts";
 
 export interface UseLoadChatPromptOptions {
-  selectedChatPromptId?: string;
-  selectedBlueprintRef?: BlueprintPromptRef;
+  selectedChatPromptId: string | undefined;
   messages: LLMMessage[];
   onMessagesLoaded: (messages: LLMMessage[], promptName: string) => void;
   skipInitialLoad?: boolean;
@@ -23,43 +16,15 @@ export interface UseLoadChatPromptOptions {
 export interface UseLoadChatPromptReturn {
   chatPromptData: PromptWithLatestVersion | undefined;
   chatPromptDataLoaded: boolean;
-  chatPromptVersionData: PromptVersion | undefined;
+  chatPromptVersionData: ReturnType<typeof usePromptVersionById>["data"];
   chatPromptVersionDataLoaded: boolean;
   loadedChatPromptRef: React.MutableRefObject<string | null>;
   chatPromptTemplate: string;
   hasUnsavedChatPromptChanges: boolean;
 }
 
-const promptByCommitToPrompt = (
-  data: PromptByCommit | undefined,
-): PromptWithLatestVersion | undefined => {
-  if (!data) return undefined;
-  const v = data.requested_version;
-  return {
-    id: data.id,
-    name: data.name,
-    description: "",
-    last_updated_at: data.last_updated_at,
-    created_at: data.created_at,
-    version_count: data.version_count,
-    tags: [],
-    template_structure: data.template_structure,
-    latest_version: {
-      id: v.id,
-      template: v.template,
-      metadata: v.metadata ?? {},
-      commit: v.commit,
-      prompt_id: data.id,
-      created_at: v.created_at,
-      type: v.type,
-      change_description: v.change_description,
-    },
-  };
-};
-
 const useLoadChatPrompt = ({
   selectedChatPromptId,
-  selectedBlueprintRef,
   messages,
   onMessagesLoaded,
   skipInitialLoad = false,
@@ -67,47 +32,27 @@ const useLoadChatPrompt = ({
   const skippedRef = useRef(false);
   const loadedChatPromptRef = useRef<string | null>(null);
 
-  const useBlueprint = !!selectedBlueprintRef;
-
-  // Library-prompt branch (existing behavior)
-  const { data: libraryPromptData, isSuccess: libraryPromptLoaded } =
+  const { data: chatPromptData, isSuccess: chatPromptDataLoaded } =
     usePromptById(
-      { promptId: selectedChatPromptId! },
-      { enabled: !useBlueprint && !!selectedChatPromptId },
-    );
-
-  const { data: libraryVersionData, isSuccess: libraryVersionLoaded } =
-    usePromptVersionById(
-      { versionId: libraryPromptData?.latest_version?.id || "" },
       {
-        enabled:
-          !useBlueprint &&
-          !!libraryPromptData?.latest_version?.id &&
-          libraryPromptLoaded,
+        promptId: selectedChatPromptId!,
+      },
+      {
+        enabled: !!selectedChatPromptId,
       },
     );
 
-  // Blueprint-commit branch
-  const { data: commitData, isSuccess: commitLoaded } = usePromptByCommit(
-    { commitId: selectedBlueprintRef?.commitId ?? "" },
-    { enabled: useBlueprint && !!selectedBlueprintRef?.commitId },
+  const {
+    data: chatPromptVersionData,
+    isSuccess: chatPromptVersionDataLoaded,
+  } = usePromptVersionById(
+    {
+      versionId: chatPromptData?.latest_version?.id || "",
+    },
+    {
+      enabled: !!chatPromptData?.latest_version?.id && chatPromptDataLoaded,
+    },
   );
-
-  const chatPromptData: PromptWithLatestVersion | undefined = useBlueprint
-    ? promptByCommitToPrompt(commitData)
-    : libraryPromptData;
-
-  const chatPromptDataLoaded = useBlueprint
-    ? commitLoaded
-    : libraryPromptLoaded;
-
-  const chatPromptVersionData: PromptVersion | undefined = useBlueprint
-    ? chatPromptData?.latest_version
-    : libraryVersionData;
-
-  const chatPromptVersionDataLoaded = useBlueprint
-    ? commitLoaded
-    : libraryVersionLoaded;
 
   const chatPromptTemplate = useMemo(
     () =>
@@ -117,29 +62,23 @@ const useLoadChatPrompt = ({
     [messages],
   );
 
-  const selectionKey = useBlueprint
-    ? selectedBlueprintRef
-      ? `${selectedBlueprintRef.blueprintId}-${selectedBlueprintRef.key}-${selectedBlueprintRef.commitId}`
-      : null
-    : selectedChatPromptId ?? null;
-
   const hasUnsavedChatPromptChanges = useMemo(() => {
     const hasContent = messages.length > 0;
 
-    if (!hasContent || !selectionKey) {
+    if (!hasContent || !selectedChatPromptId) {
       return false;
     }
 
-    if (!useBlueprint) {
-      if (!chatPromptData || chatPromptData.id !== selectedChatPromptId) {
-        return false;
-      }
+    if (!chatPromptData || chatPromptData.id !== selectedChatPromptId) {
+      return false;
     }
 
     if (!chatPromptVersionData?.template) {
       return false;
     }
 
+    // Parse both templates as objects to compare semantically, not by string formatting
+    // IMPORTANT: Only compare role and content, ignore text prompt metadata fields
     try {
       const currentTemplate = JSON.parse(chatPromptTemplate);
       const loadedTemplate = JSON.parse(chatPromptVersionData.template);
@@ -161,8 +100,6 @@ const useLoadChatPrompt = ({
       return !isEqual(chatPromptTemplate, chatPromptVersionData.template);
     }
   }, [
-    selectionKey,
-    useBlueprint,
     selectedChatPromptId,
     chatPromptData,
     chatPromptVersionData,
@@ -170,27 +107,34 @@ const useLoadChatPrompt = ({
     messages.length,
   ]);
 
+  // effect to populate messages when chat prompt data is loaded
   useEffect(() => {
-    const versionId = chatPromptVersionData?.id;
-    const dedupKey =
-      selectionKey && versionId ? `${selectionKey}-${versionId}` : null;
+    // create a unique key for this chat prompt load (prompt ID + version ID)
+    const chatPromptKey =
+      selectedChatPromptId && chatPromptVersionData
+        ? `${selectedChatPromptId}-${chatPromptVersionData.id}`
+        : null;
 
     if (
       chatPromptVersionData?.template &&
-      selectionKey &&
+      selectedChatPromptId &&
       chatPromptData &&
       chatPromptVersionDataLoaded &&
-      dedupKey &&
-      loadedChatPromptRef.current !== dedupKey
+      chatPromptKey &&
+      loadedChatPromptRef.current !== chatPromptKey // prevent duplicate loads
     ) {
+      // Skip the first load for duplicated prompts that already have messages.
+      // We still mark the key as loaded so the hook won't re-trigger and
+      // overwrite the duplicated messages with the saved library version.
       if (skipInitialLoad && !skippedRef.current) {
         skippedRef.current = true;
-        loadedChatPromptRef.current = dedupKey;
+        loadedChatPromptRef.current = chatPromptKey;
         return;
       }
 
       try {
-        loadedChatPromptRef.current = dedupKey;
+        // Mark this chat prompt as loaded to prevent race conditions
+        loadedChatPromptRef.current = chatPromptKey;
 
         const parsedMessages = JSON.parse(chatPromptVersionData.template);
 
@@ -208,12 +152,13 @@ const useLoadChatPrompt = ({
       }
     }
 
-    if (!selectionKey) {
+    // reset the ref when chat prompt is deselected
+    if (!selectedChatPromptId) {
       loadedChatPromptRef.current = null;
     }
   }, [
     chatPromptVersionData,
-    selectionKey,
+    selectedChatPromptId,
     chatPromptData,
     chatPromptVersionDataLoaded,
     onMessagesLoaded,

--- a/apps/opik-frontend/src/lib/chatTemplate.ts
+++ b/apps/opik-frontend/src/lib/chatTemplate.ts
@@ -1,4 +1,34 @@
+import isEqual from "fast-deep-equal";
+import { LLM_MESSAGE_ROLE, LLMMessage } from "@/types/llm";
+import { generateDefaultLLMPromptMessage } from "@/lib/llm";
+
 export const serializeChatTemplate = (
   messages: Array<{ role: string; content: unknown }>,
 ): string =>
   JSON.stringify(messages.map(({ role, content }) => ({ role, content })));
+
+export const chatTemplatesEqual = (a: string, b: string): boolean => {
+  try {
+    const normalize = (raw: string) =>
+      JSON.parse(raw).map(({ role, content }: { role: string; content: unknown }) => ({
+        role,
+        content,
+      }));
+    return isEqual(normalize(a), normalize(b));
+  } catch {
+    return a === b;
+  }
+};
+
+export const parseChatTemplateToMessages = (template: string): LLMMessage[] => {
+  const parsed = JSON.parse(template) as Array<{
+    role: string;
+    content: unknown;
+  }>;
+  return parsed.map((msg) =>
+    generateDefaultLLMPromptMessage({
+      role: msg.role as LLM_MESSAGE_ROLE,
+      content: msg.content as LLMMessage["content"],
+    }),
+  );
+};

--- a/apps/opik-frontend/src/lib/chatTemplate.ts
+++ b/apps/opik-frontend/src/lib/chatTemplate.ts
@@ -10,10 +10,12 @@ export const serializeChatTemplate = (
 export const chatTemplatesEqual = (a: string, b: string): boolean => {
   try {
     const normalize = (raw: string) =>
-      JSON.parse(raw).map(({ role, content }: { role: string; content: unknown }) => ({
-        role,
-        content,
-      }));
+      JSON.parse(raw).map(
+        ({ role, content }: { role: string; content: unknown }) => ({
+          role,
+          content,
+        }),
+      );
     return isEqual(normalize(a), normalize(b));
   } catch {
     return a === b;

--- a/apps/opik-frontend/src/lib/chatTemplate.ts
+++ b/apps/opik-frontend/src/lib/chatTemplate.ts
@@ -1,0 +1,4 @@
+export const serializeChatTemplate = (
+  messages: Array<{ role: string; content: unknown }>,
+): string =>
+  JSON.stringify(messages.map(({ role, content }) => ({ role, content })));

--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -55,6 +55,7 @@
 
     --warning: 348 86% 61%;
     --success: 142 64% 32%;
+    --library-loaded: 78 75% 59%;
 
     /* Gray scale for utility classes */
     --gray-100: #f3f4f6;
@@ -307,6 +308,7 @@
 
     --warning: 348 86% 61%;
     --success: 142 64% 40%;
+    --library-loaded: 78 75% 65%;
 
     /* Gray scale for utility classes - Dark Mode */
     --gray-100: 217.2 32.6% 15%;

--- a/apps/opik-frontend/src/store/PlaygroundStore.ts
+++ b/apps/opik-frontend/src/store/PlaygroundStore.ts
@@ -450,7 +450,18 @@ const usePlaygroundStore = create<PlaygroundStore>()(
           ...rest
         } = state;
         /* eslint-enable @typescript-eslint/no-unused-vars */
-        return rest;
+
+        // skipInitialPromptLoad is only meaningful within a single session
+        const cleanedPromptMap = Object.fromEntries(
+          Object.entries(rest.promptMap).map(([id, prompt]) => {
+            if (!prompt.skipInitialPromptLoad) return [id, prompt];
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { skipInitialPromptLoad, ...cleanPrompt } = prompt;
+            return [id, cleanPrompt];
+          }),
+        );
+
+        return { ...rest, promptMap: cleanedPromptMap };
       },
     },
   ),

--- a/apps/opik-frontend/src/types/agent-configs.ts
+++ b/apps/opik-frontend/src/types/agent-configs.ts
@@ -1,3 +1,9 @@
+export interface BlueprintPromptRef {
+  blueprintId: string;
+  key: string;
+  commitId: string;
+}
+
 export enum BlueprintValueType {
   STRING = "string",
   INT = "integer",

--- a/apps/opik-frontend/src/types/llm.ts
+++ b/apps/opik-frontend/src/types/llm.ts
@@ -29,6 +29,12 @@ export type MessageContent =
   | string
   | Array<TextPart | ImagePart | VideoPart | AudioPart>;
 
+export interface MessageBlueprintRef {
+  blueprintId: string;
+  key: string;
+  commitId: string;
+}
+
 export interface LLMMessage {
   id: string;
   content: MessageContent;
@@ -36,6 +42,7 @@ export interface LLMMessage {
   promptId?: string;
   promptVersionId?: string;
   autoImprove?: boolean;
+  blueprintRef?: MessageBlueprintRef;
 }
 
 export type ProviderMessageType = Omit<LLMMessage, "id"> & {

--- a/apps/opik-frontend/src/types/llm.ts
+++ b/apps/opik-frontend/src/types/llm.ts
@@ -1,5 +1,5 @@
 import { DropdownOption } from "@/types/shared";
-import type { BlueprintPromptRef } from "@/types/playground";
+import type { BlueprintPromptRef } from "@/types/agent-configs";
 
 export enum LLM_MESSAGE_ROLE {
   system = "system",

--- a/apps/opik-frontend/src/types/llm.ts
+++ b/apps/opik-frontend/src/types/llm.ts
@@ -1,4 +1,5 @@
 import { DropdownOption } from "@/types/shared";
+import type { BlueprintPromptRef } from "@/types/playground";
 
 export enum LLM_MESSAGE_ROLE {
   system = "system",
@@ -36,11 +37,7 @@ export interface LLMMessage {
   promptId?: string;
   promptVersionId?: string;
   autoImprove?: boolean;
-  blueprintRef?: {
-    blueprintId: string;
-    key: string;
-    commitId: string;
-  };
+  blueprintRef?: BlueprintPromptRef;
 }
 
 export type ProviderMessageType = Omit<LLMMessage, "id"> & {

--- a/apps/opik-frontend/src/types/llm.ts
+++ b/apps/opik-frontend/src/types/llm.ts
@@ -29,12 +29,6 @@ export type MessageContent =
   | string
   | Array<TextPart | ImagePart | VideoPart | AudioPart>;
 
-export interface MessageBlueprintRef {
-  blueprintId: string;
-  key: string;
-  commitId: string;
-}
-
 export interface LLMMessage {
   id: string;
   content: MessageContent;
@@ -42,7 +36,11 @@ export interface LLMMessage {
   promptId?: string;
   promptVersionId?: string;
   autoImprove?: boolean;
-  blueprintRef?: MessageBlueprintRef;
+  blueprintRef?: {
+    blueprintId: string;
+    key: string;
+    commitId: string;
+  };
 }
 
 export type ProviderMessageType = Omit<LLMMessage, "id"> & {

--- a/apps/opik-frontend/src/types/playground.ts
+++ b/apps/opik-frontend/src/types/playground.ts
@@ -23,11 +23,8 @@ export interface PromptLibraryMetadata {
   };
 }
 
-export interface BlueprintPromptRef {
-  blueprintId: string;
-  key: string;
-  commitId: string;
-}
+import type { BlueprintPromptRef } from "@/types/agent-configs";
+export type { BlueprintPromptRef } from "@/types/agent-configs";
 
 export interface PlaygroundPromptType {
   name: string;

--- a/apps/opik-frontend/src/types/playground.ts
+++ b/apps/opik-frontend/src/types/playground.ts
@@ -23,6 +23,12 @@ export interface PromptLibraryMetadata {
   };
 }
 
+export interface BlueprintPromptRef {
+  blueprintId: string;
+  key: string;
+  commitId: string;
+}
+
 export interface PlaygroundPromptType {
   name: string;
   id: string;
@@ -31,6 +37,7 @@ export interface PlaygroundPromptType {
   provider: COMPOSED_PROVIDER_TYPE | "";
   configs: LLMPromptConfigsType;
   loadedChatPromptId?: string;
+  loadedBlueprintRef?: BlueprintPromptRef;
   skipInitialPromptLoad?: boolean;
 }
 

--- a/apps/opik-frontend/src/utils/agent-configurations.ts
+++ b/apps/opik-frontend/src/utils/agent-configurations.ts
@@ -40,11 +40,3 @@ export const formatBlueprintValue = (v: BlueprintValue): string => {
       return v.value;
   }
 };
-
-export const generateBlueprintDescription = (
-  values: Array<{ key: string; value: unknown }>,
-): string => {
-  if (!values.length) return "";
-  const changes = values.map(({ key, value }) => `${key} to ${value}`);
-  return `Changed ${changes.join(", ")}`;
-};

--- a/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
+++ b/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
@@ -4,7 +4,6 @@ import {
   Bot,
   ChartLine,
   Database,
-  FileTerminal,
   FlaskConical,
   LayoutDashboard,
   ListChecks,
@@ -113,14 +112,6 @@ const getMenuItems = ({
       id: "prompt_engineering",
       label: "Prompt engineering",
       items: [
-        {
-          id: "prompts",
-          path: projectPath("/prompts"),
-          type: MENU_ITEM_TYPE.router,
-          icon: FileTerminal,
-          label: "Prompt library",
-          disabled: !projectPrefix,
-        },
         ...(canUsePlayground
           ? [
               {

--- a/apps/opik-frontend/src/v2/pages-shared/DatasetVersionSelectBox/DatasetVersionSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/DatasetVersionSelectBox/DatasetVersionSelectBox.tsx
@@ -318,7 +318,7 @@ function DatasetVersionSelectBox({
               <SelectValue
                 placeholder={
                   <div className="flex w-full items-center text-light-slate">
-                    <Database className="mr-2 size-4 text-[#b8e54a]" />
+                    <Database className="mr-2 size-4 text-library-loaded" />
                     <span className="truncate font-normal">
                       Select a test suite
                     </span>
@@ -327,7 +327,7 @@ function DatasetVersionSelectBox({
               >
                 <div className="flex w-full items-center justify-between gap-2 text-foreground">
                   <div className="flex min-w-0 items-center gap-2">
-                    <Database className="size-4 shrink-0 text-[#b8e54a]" />
+                    <Database className="size-4 shrink-0 text-library-loaded" />
                     <span className="min-w-0 truncate">
                       {selectedDataset?.name}
                     </span>

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditPanel.tsx
@@ -31,6 +31,7 @@ const AgentConfigurationEditPanel: React.FC<
     isDirty: false,
     isSaving: false,
     hasErrors: false,
+    isEmpty: false,
     collapsibleKeys: [],
     hasExpandableFields: false,
   });
@@ -158,7 +159,12 @@ const AgentConfigurationEditPanel: React.FC<
           <Button
             size="sm"
             onClick={handleSave}
-            disabled={state.isSaving || state.hasErrors || !state.isDirty}
+            disabled={
+              state.isSaving ||
+              state.hasErrors ||
+              !state.isDirty ||
+              state.isEmpty
+            }
           >
             {state.isSaving ? "Saving…" : "Save as new version"}
           </Button>

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
@@ -6,6 +6,8 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { Plus, RotateCcw, Trash } from "lucide-react";
+import { Button } from "@/ui/button";
 import {
   BlueprintValue,
   BlueprintValueType,
@@ -34,6 +36,10 @@ import {
   useAgentConfigurationSave,
   AgentConfigPayload,
 } from "./useAgentConfigurationSave";
+import NewBlueprintFieldEditor, {
+  NewFieldDraft,
+  createNewFieldDraft,
+} from "./NewBlueprintFieldEditor";
 
 export type AgentConfigurationEditViewHandle = {
   hasChanges: () => boolean;
@@ -99,13 +105,18 @@ const AgentConfigurationEditView = React.forwardRef<
     const [dirtyPromptKeys, setDirtyPromptKeys] = useState<
       Record<string, boolean>
     >({});
+    const [removedKeys, setRemovedKeys] = useState<Set<string>>(new Set());
+    const [newFields, setNewFields] = useState<NewFieldDraft[]>([]);
     const originalValues = useRef<Record<string, string>>({});
     const initialized = useRef(false);
+    const newFieldIdRef = useRef(0);
 
     const handleSaveComplete = useCallback(
       (newBlueprintId?: string) => {
         originalValues.current = { ...draftValues };
         setDirtyPromptKeys({});
+        setRemovedKeys(new Set());
+        setNewFields([]);
         setDescription("");
         onSaved(newBlueprintId);
       },
@@ -128,6 +139,8 @@ const AgentConfigurationEditView = React.forwardRef<
       projectId,
       onSaved: handleSaveComplete,
       dirtyPromptKeys,
+      removedKeys,
+      newFields,
     });
 
     useImperativeHandle(ref, () => ({
@@ -157,6 +170,40 @@ const AgentConfigurationEditView = React.forwardRef<
       }
     };
 
+    const toggleRemoved = useCallback(
+      (key: string) => {
+        setRemovedKeys((prev) => {
+          const next = new Set(prev);
+          if (next.has(key)) next.delete(key);
+          else next.add(key);
+          return next;
+        });
+        clearError(key);
+      },
+      [clearError],
+    );
+
+    const handleAddNewField = useCallback(() => {
+      const id = `new-${++newFieldIdRef.current}`;
+      setNewFields((prev) => [...prev, createNewFieldDraft(id)]);
+    }, []);
+
+    const updateNewField = useCallback(
+      (next: NewFieldDraft) => {
+        setNewFields((prev) => prev.map((f) => (f.id === next.id ? next : f)));
+        if (errors[next.id]) clearError(next.id);
+      },
+      [errors, clearError],
+    );
+
+    const removeNewField = useCallback(
+      (id: string) => {
+        setNewFields((prev) => prev.filter((f) => f.id !== id));
+        clearError(id);
+      },
+      [clearError],
+    );
+
     const collapsibleKeys = useMemo(
       () => collectMultiLineKeys(agentConfig?.values ?? []),
       [agentConfig],
@@ -167,12 +214,18 @@ const AgentConfigurationEditView = React.forwardRef<
 
     const currentValues = useMemo<BlueprintValue[]>(() => {
       if (!agentConfig) return [];
-      return agentConfig.values.map((v) =>
-        v.type === BlueprintValueType.PROMPT
-          ? v
-          : { ...v, value: draftValues[v.key] ?? v.value },
-      );
-    }, [agentConfig, draftValues]);
+      const kept = agentConfig.values
+        .filter((v) => !removedKeys.has(v.key))
+        .map((v) =>
+          v.type === BlueprintValueType.PROMPT
+            ? v
+            : { ...v, value: draftValues[v.key] ?? v.value },
+        );
+      const added: BlueprintValue[] = newFields
+        .filter((f) => f.key.trim())
+        .map((f) => ({ key: f.key.trim(), type: f.type, value: f.value }));
+      return [...kept, ...added];
+    }, [agentConfig, draftValues, removedKeys, newFields]);
 
     const diffPromptTemplates = useMemo<Record<string, string>>(() => {
       const out: Record<string, string> = {};
@@ -181,8 +234,13 @@ const AgentConfigurationEditView = React.forwardRef<
           out[key] = handle.getCurrentTemplate();
         }
       }
+      for (const field of newFields) {
+        if (field.type !== BlueprintValueType.PROMPT) continue;
+        const key = field.key.trim();
+        if (key) out[key] = field.value;
+      }
       return out;
-    }, [dirtyPromptKeys, promptRefs]);
+    }, [dirtyPromptKeys, promptRefs, newFields]);
 
     const hasErrors = Object.values(errors).some(Boolean);
     const isDirty = hasChanges();
@@ -252,11 +310,13 @@ const AgentConfigurationEditView = React.forwardRef<
           {(agentConfig?.values ?? []).map((v) => {
             const isPrompt = v.type === BlueprintValueType.PROMPT;
             const collapsible = isMultiLineField(v);
+            const isRemoved = removedKeys.has(v.key);
             const isChanged =
-              v.type === BlueprintValueType.PROMPT
+              isRemoved ||
+              (v.type === BlueprintValueType.PROMPT
                 ? !!dirtyPromptKeys[v.key]
                 : draftValues[v.key] !== undefined &&
-                  draftValues[v.key] !== originalValues.current[v.key];
+                  draftValues[v.key] !== originalValues.current[v.key]);
 
             const fieldExpandable = collapsible;
             const fieldExpanded = fieldExpandable
@@ -287,84 +347,131 @@ const AgentConfigurationEditView = React.forwardRef<
             ) : null;
 
             return (
-              <FieldSection
+              <div
                 key={v.key}
-                label={v.key}
-                icon={<BlueprintTypeIcon type={v.type} variant="secondary" />}
-                description={v.description}
-                expandable={fieldExpandable}
-                expanded={fieldExpanded}
-                onToggle={
-                  fieldExpandable ? () => controller.toggle(v.key) : undefined
-                }
-                afterLabel={booleanSwitch}
-                trailing={modifiedDot}
+                className={isRemoved ? "opacity-60" : undefined}
               >
-                {isPrompt ? (
-                  <div className="flex flex-col gap-1">
-                    <BlueprintValuePromptCompact
-                      key={v.value}
-                      value={v}
-                      projectId={projectId}
-                      isEditing
-                      tone="white"
-                      expanded={!!fieldExpanded}
-                      ref={(el) => {
-                        promptRefs.current[v.key] = el;
-                      }}
-                      onDirtyChange={(isDirty) => {
-                        setDirtyPromptKeys((prev) => ({
-                          ...prev,
-                          [v.key]: isDirty,
-                        }));
-                        clearError(v.key);
-                      }}
-                    />
-                    {errors[v.key] && (
-                      <span className="comet-body-xs text-destructive">
-                        {errors[v.key]}
-                      </span>
-                    )}
-                  </div>
-                ) : (
-                  (() => {
-                    if (isBoolean) return null;
-                    if (fieldExpandable && !fieldExpanded) return null;
+                <FieldSection
+                  label={v.key}
+                  icon={<BlueprintTypeIcon type={v.type} variant="secondary" />}
+                  description={v.description}
+                  expandable={fieldExpandable}
+                  expanded={fieldExpanded}
+                  onToggle={
+                    fieldExpandable ? () => controller.toggle(v.key) : undefined
+                  }
+                  afterLabel={booleanSwitch}
+                  trailing={
+                    <div className="flex items-center gap-1">
+                      {modifiedDot}
+                      <TooltipWrapper
+                        content={isRemoved ? "Restore field" : "Remove field"}
+                      >
+                        <Button
+                          variant="minimal"
+                          size="icon-xs"
+                          onClick={() => toggleRemoved(v.key)}
+                        >
+                          {isRemoved ? <RotateCcw /> : <Trash />}
+                        </Button>
+                      </TooltipWrapper>
+                    </div>
+                  }
+                >
+                  {isRemoved ? null : isPrompt ? (
+                    <div className="flex flex-col gap-1">
+                      <BlueprintValuePromptCompact
+                        key={v.value}
+                        value={v}
+                        projectId={projectId}
+                        isEditing
+                        tone="white"
+                        expanded={!!fieldExpanded}
+                        ref={(el) => {
+                          promptRefs.current[v.key] = el;
+                        }}
+                        onDirtyChange={(isDirty) => {
+                          setDirtyPromptKeys((prev) => ({
+                            ...prev,
+                            [v.key]: isDirty,
+                          }));
+                          clearError(v.key);
+                        }}
+                      />
+                      {errors[v.key] && (
+                        <span className="comet-body-xs text-destructive">
+                          {errors[v.key]}
+                        </span>
+                      )}
+                    </div>
+                  ) : (
+                    (() => {
+                      if (isBoolean) return null;
+                      if (fieldExpandable && !fieldExpanded) return null;
 
-                    const inputMode =
-                      v.type === BlueprintValueType.INT
-                        ? "numeric"
-                        : v.type === BlueprintValueType.FLOAT
-                          ? "decimal"
-                          : "text";
-                    const currentValue = draftValues[v.key] ?? "";
-                    const errorLine = errors[v.key] ? (
-                      <span className="comet-body-xs text-destructive">
-                        {errors[v.key]}
-                      </span>
-                    ) : null;
+                      const inputMode =
+                        v.type === BlueprintValueType.INT
+                          ? "numeric"
+                          : v.type === BlueprintValueType.FLOAT
+                            ? "decimal"
+                            : "text";
+                      const currentValue = draftValues[v.key] ?? "";
+                      const errorLine = errors[v.key] ? (
+                        <span className="comet-body-xs text-destructive">
+                          {errors[v.key]}
+                        </span>
+                      ) : null;
 
-                    return (
-                      <div className="flex flex-col gap-1">
-                        <div className="rounded-md border bg-background px-3 py-2">
-                          <Input
-                            variant="ghost"
-                            className="h-auto p-0"
-                            inputMode={inputMode}
-                            value={currentValue}
-                            onChange={(e) =>
-                              handleFieldChange(v.key, e.target.value)
-                            }
-                          />
+                      return (
+                        <div className="flex flex-col gap-1">
+                          <div className="rounded-md border bg-background px-3 py-2">
+                            <Input
+                              variant="ghost"
+                              className="h-auto p-0"
+                              inputMode={inputMode}
+                              value={currentValue}
+                              onChange={(e) =>
+                                handleFieldChange(v.key, e.target.value)
+                              }
+                            />
+                          </div>
+                          {errorLine}
                         </div>
-                        {errorLine}
-                      </div>
-                    );
-                  })()
-                )}
-              </FieldSection>
+                      );
+                    })()
+                  )}
+                </FieldSection>
+              </div>
             );
           })}
+
+          {newFields.length > 0 &&
+            newFields.map((field) => {
+              const reservedKeys = new Set([
+                ...(agentConfig?.values
+                  ?.filter((v) => !removedKeys.has(v.key))
+                  ?.map((v) => v.key) ?? []),
+                ...newFields
+                  .filter((f) => f.id !== field.id)
+                  .map((f) => f.key.trim())
+                  .filter(Boolean),
+              ]);
+              return (
+                <NewBlueprintFieldEditor
+                  key={field.id}
+                  field={field}
+                  reservedKeys={reservedKeys}
+                  onChange={updateNewField}
+                  onRemove={() => removeNewField(field.id)}
+                  error={errors[field.id]}
+                />
+              );
+            })}
+
+          <Button variant="outline" size="sm" onClick={handleAddNewField}>
+            <Plus className="mr-1 size-3.5" />
+            Add field
+          </Button>
         </div>
 
         {DialogComponent}

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
@@ -9,6 +9,7 @@ import React, {
 import { Plus, RotateCcw, Trash } from "lucide-react";
 import { Button } from "@/ui/button";
 import { serializeChatTemplate } from "@/lib/chatTemplate";
+import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
 import {
   BlueprintValue,
   BlueprintValueType,
@@ -239,7 +240,12 @@ const AgentConfigurationEditView = React.forwardRef<
       for (const field of newFields) {
         if (field.type !== BlueprintValueType.PROMPT) continue;
         const key = field.key.trim();
-        if (key) out[key] = serializeChatTemplate(field.messages);
+        if (!key) continue;
+        const isTextPrompt =
+          field.promptStructure === PROMPT_TEMPLATE_STRUCTURE.TEXT;
+        out[key] = isTextPrompt
+          ? field.value
+          : serializeChatTemplate(field.messages);
       }
       return out;
     }, [dirtyPromptKeys, promptRefs, newFields]);

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
@@ -364,10 +364,7 @@ const AgentConfigurationEditView = React.forwardRef<
             ) : null;
 
             return (
-              <div
-                key={v.key}
-                className={isRemoved ? "opacity-60" : undefined}
-              >
+              <div key={v.key} className={isRemoved ? "opacity-60" : undefined}>
                 <FieldSection
                   label={v.key}
                   icon={<BlueprintTypeIcon type={v.type} variant="secondary" />}

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
@@ -8,6 +8,7 @@ import React, {
 } from "react";
 import { Plus, RotateCcw, Trash } from "lucide-react";
 import { Button } from "@/ui/button";
+import { serializeChatTemplate } from "@/lib/chatTemplate";
 import {
   BlueprintValue,
   BlueprintValueType,
@@ -237,7 +238,7 @@ const AgentConfigurationEditView = React.forwardRef<
       for (const field of newFields) {
         if (field.type !== BlueprintValueType.PROMPT) continue;
         const key = field.key.trim();
-        if (key) out[key] = field.value;
+        if (key) out[key] = serializeChatTemplate(field.messages);
       }
       return out;
     }, [dirtyPromptKeys, promptRefs, newFields]);

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
@@ -457,27 +457,32 @@ const AgentConfigurationEditView = React.forwardRef<
           })}
 
           {newFields.length > 0 &&
-            newFields.map((field) => {
-              const reservedKeys = new Set([
-                ...(agentConfig?.values
+            (() => {
+              const existingKeys = new Set(
+                agentConfig?.values
                   ?.filter((v) => !removedKeys.has(v.key))
-                  ?.map((v) => v.key) ?? []),
-                ...newFields
-                  .filter((f) => f.id !== field.id)
-                  .map((f) => f.key.trim())
-                  .filter(Boolean),
-              ]);
-              return (
-                <NewBlueprintFieldEditor
-                  key={field.id}
-                  field={field}
-                  reservedKeys={reservedKeys}
-                  onChange={updateNewField}
-                  onRemove={() => removeNewField(field.id)}
-                  error={errors[field.id]}
-                />
+                  ?.map((v) => v.key) ?? [],
               );
-            })}
+              return newFields.map((field) => {
+                const reservedKeys = new Set([
+                  ...existingKeys,
+                  ...newFields
+                    .filter((f) => f.id !== field.id)
+                    .map((f) => f.key.trim())
+                    .filter(Boolean),
+                ]);
+                return (
+                  <NewBlueprintFieldEditor
+                    key={field.id}
+                    field={field}
+                    reservedKeys={reservedKeys}
+                    onChange={updateNewField}
+                    onRemove={() => removeNewField(field.id)}
+                    error={errors[field.id]}
+                  />
+                );
+              });
+            })()}
 
           <Button variant="outline" size="sm" onClick={handleAddNewField}>
             <Plus className="mr-1 size-3.5" />

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
@@ -52,6 +52,7 @@ export type AgentConfigurationEditViewState = {
   isDirty: boolean;
   isSaving: boolean;
   hasErrors: boolean;
+  isEmpty: boolean;
   collapsibleKeys: string[];
   hasExpandableFields: boolean;
 };
@@ -246,6 +247,13 @@ const AgentConfigurationEditView = React.forwardRef<
     const hasErrors = Object.values(errors).some(Boolean);
     const isDirty = hasChanges();
 
+    const isEmpty = useMemo(() => {
+      const keptCount =
+        (agentConfig?.values ?? []).filter((v) => !removedKeys.has(v.key))
+          .length + newFields.length;
+      return keptCount === 0;
+    }, [agentConfig, removedKeys, newFields]);
+
     const hasExpandableFields = useMemo(
       () => hasAnyExpandableField(agentConfig?.values ?? []),
       [agentConfig],
@@ -256,6 +264,7 @@ const AgentConfigurationEditView = React.forwardRef<
         isDirty,
         isSaving,
         hasErrors,
+        isEmpty,
         collapsibleKeys,
         hasExpandableFields,
       });
@@ -263,6 +272,7 @@ const AgentConfigurationEditView = React.forwardRef<
       isDirty,
       isSaving,
       hasErrors,
+      isEmpty,
       collapsibleKeys,
       hasExpandableFields,
       onStateChange,

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
@@ -487,10 +487,12 @@ const AgentConfigurationEditView = React.forwardRef<
               });
             })()}
 
-          <Button variant="outline" size="sm" onClick={handleAddNewField}>
-            <Plus className="mr-1 size-3.5" />
-            Add field
-          </Button>
+          <div className="flex justify-end">
+            <Button variant="outline" size="sm" onClick={handleAddNewField}>
+              <Plus className="mr-1 size-3.5" />
+              Add field
+            </Button>
+          </div>
         </div>
 
         {DialogComponent}

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/BlueprintDiffDialog/BlueprintDiffCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/BlueprintDiffDialog/BlueprintDiffCell.tsx
@@ -93,24 +93,29 @@ export const PromptDiffPair: React.FC<{
     );
   };
 
+  const hasBase = !!baseCommit || !!baseTemplate;
+  const hasDiff = !!diffCommit || !!diffTemplate;
+
   return (
     <>
       <TableCell className="w-1/2 py-3 pr-2 align-top">
-        {baseCommit ? (
+        {hasBase ? (
           <div className="flex flex-col gap-1">
-            <Tag
-              className={cn(
-                "flex w-fit items-center gap-1",
-                commitsChanged &&
-                  "border-[var(--diff-removed-border)] bg-[var(--diff-removed-bg)] text-[var(--diff-removed-text)]",
-              )}
-              variant="gray"
-              size="sm"
-              title={baseCommit}
-            >
-              <GitCommitVertical className="size-3.5 shrink-0" />
-              {baseCommit.slice(0, 8)}
-            </Tag>
+            {baseCommit && (
+              <Tag
+                className={cn(
+                  "flex w-fit items-center gap-1",
+                  commitsChanged &&
+                    "border-[var(--diff-removed-border)] bg-[var(--diff-removed-bg)] text-[var(--diff-removed-text)]",
+                )}
+                variant="gray"
+                size="sm"
+                title={baseCommit}
+              >
+                <GitCommitVertical className="size-3.5 shrink-0" />
+                {baseCommit.slice(0, 8)}
+              </Tag>
+            )}
             {renderDiffContent(baseText, true)}
           </div>
         ) : (
@@ -118,21 +123,23 @@ export const PromptDiffPair: React.FC<{
         )}
       </TableCell>
       <TableCell className="w-1/2 py-3 pl-2 align-top">
-        {diffCommit ? (
+        {hasDiff ? (
           <div className="flex flex-col gap-1">
-            <Tag
-              className={cn(
-                "flex w-fit items-center gap-1",
-                commitsChanged &&
-                  "border-[var(--diff-added-border)] bg-[var(--diff-added-bg)] text-[var(--diff-added-text)]",
-              )}
-              variant="gray"
-              size="sm"
-              title={diffCommit}
-            >
-              <GitCommitVertical className="size-3.5 shrink-0" />
-              {diffCommit.slice(0, 8)}
-            </Tag>
+            {diffCommit && (
+              <Tag
+                className={cn(
+                  "flex w-fit items-center gap-1",
+                  commitsChanged &&
+                    "border-[var(--diff-added-border)] bg-[var(--diff-added-bg)] text-[var(--diff-added-text)]",
+                )}
+                variant="gray"
+                size="sm"
+                title={diffCommit}
+              >
+                <GitCommitVertical className="size-3.5 shrink-0" />
+                {diffCommit.slice(0, 8)}
+              </Tag>
+            )}
             {renderDiffContent(diffText, false)}
           </div>
         ) : (

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/BlueprintDiffDialog/BlueprintDiffRow.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/BlueprintDiffDialog/BlueprintDiffRow.tsx
@@ -44,8 +44,8 @@ const BlueprintDiffRow: React.FC<{ pair: DiffPair }> = ({ pair }) => {
     text: string | undefined,
     side: DiffSide,
   ) => {
-    if (!value) return <EmptyDiffCell />;
-    return <DiffCellBox text={text!} changed={changed ?? false} side={side} />;
+    if (!value || text === undefined) return <EmptyDiffCell />;
+    return <DiffCellBox text={text} changed={changed ?? false} side={side} />;
   };
 
   return (

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/BlueprintDiffDialog/BlueprintDiffRow.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/BlueprintDiffDialog/BlueprintDiffRow.tsx
@@ -63,10 +63,14 @@ const BlueprintDiffRow: React.FC<{ pair: DiffPair }> = ({ pair }) => {
           <p className="comet-body-xs mt-1 text-light-slate">{description}</p>
         )}
       </TableCell>
-      {isPrompt && baseValue?.value && diffValue?.value ? (
+      {isPrompt &&
+      (baseValue?.value ||
+        diffValue?.value ||
+        basePromptTemplate ||
+        diffPromptTemplate) ? (
         <PromptDiffPair
-          baseCommit={baseValue.value}
-          diffCommit={diffValue.value}
+          baseCommit={baseValue?.value ?? ""}
+          diffCommit={diffValue?.value ?? ""}
           baseTemplate={basePromptTemplate}
           diffTemplate={diffPromptTemplate}
         />

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/NewBlueprintFieldEditor.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/NewBlueprintFieldEditor.tsx
@@ -16,9 +16,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/ui/select";
-import { validateBlueprintFieldValue } from "./blueprintFieldValidation";
-
-const FIELD_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+import {
+  BLUEPRINT_FIELD_NAME_PATTERN,
+  validateBlueprintFieldValue,
+} from "./blueprintFieldValidation";
 
 const TYPE_OPTIONS: { value: BlueprintValueType; label: string }[] = [
   { value: BlueprintValueType.STRING, label: "String" },
@@ -80,7 +81,7 @@ const NewBlueprintFieldEditor: React.FC<NewBlueprintFieldEditorProps> = ({
   const trimmedKey = field.key.trim();
   const keyError = useMemo(() => {
     if (!trimmedKey) return null;
-    if (!FIELD_NAME_PATTERN.test(trimmedKey))
+    if (!BLUEPRINT_FIELD_NAME_PATTERN.test(trimmedKey))
       return "Use letters, digits and underscore; start with a letter or underscore";
     if (reservedKeys.has(trimmedKey))
       return "A field with this name already exists";

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/NewBlueprintFieldEditor.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/NewBlueprintFieldEditor.tsx
@@ -16,6 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/ui/select";
+import { validateBlueprintFieldValue } from "./blueprintFieldValidation";
 
 const FIELD_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
@@ -85,6 +86,38 @@ const NewBlueprintFieldEditor: React.FC<NewBlueprintFieldEditorProps> = ({
       return "A field with this name already exists";
     return null;
   }, [trimmedKey, reservedKeys]);
+
+  // Inline validation for the value field. We only show it once the user has
+  // typed something, to avoid yelling at them about an empty initial value.
+  const valueError = useMemo(() => {
+    if (
+      field.type === BlueprintValueType.PROMPT ||
+      field.type === BlueprintValueType.BOOLEAN
+    ) {
+      return null;
+    }
+    if (!field.value) return null;
+    return validateBlueprintFieldValue(field.type, field.value) || null;
+  }, [field.type, field.value]);
+
+  // For PROMPT, surface a hint when there are no messages or every message is
+  // empty. We don't gate on it (the user may still be drafting) but we do
+  // signal it.
+  const promptError = useMemo(() => {
+    if (field.type !== BlueprintValueType.PROMPT) return null;
+    if (field.messages.length === 0) return "Add at least one message";
+    const allEmpty = field.messages.every((m) => {
+      if (typeof m.content === "string") return !m.content.trim();
+      if (Array.isArray(m.content)) {
+        return m.content.every(
+          (part) =>
+            part.type === "text" && !(part as { text?: string }).text?.trim(),
+        );
+      }
+      return true;
+    });
+    return allEmpty ? "Messages must not be empty" : null;
+  }, [field.type, field.messages]);
 
   const handleTypeChange = (next: BlueprintValueType) => {
     onChange({ ...field, type: next, ...initialStateForType(next) });
@@ -173,9 +206,9 @@ const NewBlueprintFieldEditor: React.FC<NewBlueprintFieldEditorProps> = ({
         />
       )}
 
-      {(keyError || error) && (
+      {(keyError || valueError || promptError || error) && (
         <span className="comet-body-xs text-destructive">
-          {keyError ?? error}
+          {keyError ?? valueError ?? promptError ?? error}
         </span>
       )}
     </div>

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/NewBlueprintFieldEditor.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/NewBlueprintFieldEditor.tsx
@@ -1,12 +1,14 @@
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import { Trash } from "lucide-react";
 
 import { BlueprintValueType } from "@/types/agent-configs";
+import { LLM_MESSAGE_ROLE, LLMMessage } from "@/types/llm";
+import { generateDefaultLLMPromptMessage } from "@/lib/llm";
 import BlueprintTypeIcon from "@/v2/pages-shared/traces/ConfigurationTab/BlueprintTypeIcon";
+import LLMPromptMessages from "@/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessages";
 import { Button } from "@/ui/button";
 import { Input } from "@/ui/input";
 import { Switch } from "@/ui/switch";
-import { Textarea } from "@/ui/textarea";
 import {
   Select,
   SelectContent,
@@ -29,25 +31,34 @@ export interface NewFieldDraft {
   id: string;
   key: string;
   type: BlueprintValueType;
+  // Used for scalar types and as the BOOLEAN's "true"/"false".
   value: string;
+  // Used only when type === PROMPT.
+  messages: LLMMessage[];
 }
+
+const buildDefaultPromptMessages = (): LLMMessage[] => [
+  generateDefaultLLMPromptMessage({ role: LLM_MESSAGE_ROLE.system }),
+];
 
 export const createNewFieldDraft = (id: string): NewFieldDraft => ({
   id,
   key: "",
   type: BlueprintValueType.STRING,
   value: "",
+  messages: [],
 });
 
-export const defaultValueForType = (type: BlueprintValueType): string => {
-  switch (type) {
-    case BlueprintValueType.BOOLEAN:
-      return "false";
-    case BlueprintValueType.PROMPT:
-      return "";
-    default:
-      return "";
+const initialStateForType = (
+  type: BlueprintValueType,
+): Pick<NewFieldDraft, "value" | "messages"> => {
+  if (type === BlueprintValueType.BOOLEAN) {
+    return { value: "false", messages: [] };
   }
+  if (type === BlueprintValueType.PROMPT) {
+    return { value: "", messages: buildDefaultPromptMessages() };
+  }
+  return { value: "", messages: [] };
 };
 
 interface NewBlueprintFieldEditorProps {
@@ -76,8 +87,28 @@ const NewBlueprintFieldEditor: React.FC<NewBlueprintFieldEditorProps> = ({
   }, [trimmedKey, reservedKeys]);
 
   const handleTypeChange = (next: BlueprintValueType) => {
-    onChange({ ...field, type: next, value: defaultValueForType(next) });
+    onChange({ ...field, type: next, ...initialStateForType(next) });
   };
+
+  const handleMessagesChange = useCallback(
+    (messages: LLMMessage[]) => onChange({ ...field, messages }),
+    [field, onChange],
+  );
+
+  const handleAddMessage = useCallback(() => {
+    const lastRole = field.messages.at(-1)?.role;
+    const nextRole =
+      lastRole === LLM_MESSAGE_ROLE.user
+        ? LLM_MESSAGE_ROLE.assistant
+        : LLM_MESSAGE_ROLE.user;
+    onChange({
+      ...field,
+      messages: [
+        ...field.messages,
+        generateDefaultLLMPromptMessage({ role: nextRole }),
+      ],
+    });
+  }, [field, onChange]);
 
   return (
     <div className="flex flex-col gap-2 rounded-md border border-dashed border-amber-400/50 bg-primary-foreground p-3">
@@ -119,11 +150,13 @@ const NewBlueprintFieldEditor: React.FC<NewBlueprintFieldEditorProps> = ({
           }
         />
       ) : field.type === BlueprintValueType.PROMPT ? (
-        <Textarea
-          value={field.value}
-          onChange={(e) => onChange({ ...field, value: e.target.value })}
-          placeholder="System message for the new prompt"
-          className="min-h-20"
+        <LLMPromptMessages
+          messages={field.messages}
+          onChange={handleMessagesChange}
+          onAddMessage={handleAddMessage}
+          hidePromptActions
+          disableMedia
+          compact
         />
       ) : (
         <Input

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/NewBlueprintFieldEditor.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/NewBlueprintFieldEditor.tsx
@@ -1,0 +1,152 @@
+import React, { useMemo } from "react";
+import { Trash } from "lucide-react";
+
+import { BlueprintValueType } from "@/types/agent-configs";
+import BlueprintTypeIcon from "@/v2/pages-shared/traces/ConfigurationTab/BlueprintTypeIcon";
+import { Button } from "@/ui/button";
+import { Input } from "@/ui/input";
+import { Switch } from "@/ui/switch";
+import { Textarea } from "@/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/ui/select";
+
+const FIELD_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+const TYPE_OPTIONS: { value: BlueprintValueType; label: string }[] = [
+  { value: BlueprintValueType.STRING, label: "String" },
+  { value: BlueprintValueType.INT, label: "Integer" },
+  { value: BlueprintValueType.FLOAT, label: "Float" },
+  { value: BlueprintValueType.BOOLEAN, label: "Boolean" },
+  { value: BlueprintValueType.PROMPT, label: "Prompt" },
+];
+
+export interface NewFieldDraft {
+  id: string;
+  key: string;
+  type: BlueprintValueType;
+  value: string;
+}
+
+export const createNewFieldDraft = (id: string): NewFieldDraft => ({
+  id,
+  key: "",
+  type: BlueprintValueType.STRING,
+  value: "",
+});
+
+export const defaultValueForType = (type: BlueprintValueType): string => {
+  switch (type) {
+    case BlueprintValueType.BOOLEAN:
+      return "false";
+    case BlueprintValueType.PROMPT:
+      return "";
+    default:
+      return "";
+  }
+};
+
+interface NewBlueprintFieldEditorProps {
+  field: NewFieldDraft;
+  reservedKeys: Set<string>;
+  onChange: (next: NewFieldDraft) => void;
+  onRemove: () => void;
+  error?: string;
+}
+
+const NewBlueprintFieldEditor: React.FC<NewBlueprintFieldEditorProps> = ({
+  field,
+  reservedKeys,
+  onChange,
+  onRemove,
+  error,
+}) => {
+  const trimmedKey = field.key.trim();
+  const keyError = useMemo(() => {
+    if (!trimmedKey) return null;
+    if (!FIELD_NAME_PATTERN.test(trimmedKey))
+      return "Use letters, digits and underscore; start with a letter or underscore";
+    if (reservedKeys.has(trimmedKey))
+      return "A field with this name already exists";
+    return null;
+  }, [trimmedKey, reservedKeys]);
+
+  const handleTypeChange = (next: BlueprintValueType) => {
+    onChange({ ...field, type: next, value: defaultValueForType(next) });
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-dashed border-amber-400/50 bg-primary-foreground p-3">
+      <div className="flex items-center gap-2">
+        <BlueprintTypeIcon type={field.type} variant="secondary" />
+        <Input
+          value={field.key}
+          onChange={(e) => onChange({ ...field, key: e.target.value })}
+          placeholder="field_name"
+          className="h-8 flex-1"
+        />
+        <Select value={field.type} onValueChange={handleTypeChange}>
+          <SelectTrigger className="h-8 w-[140px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {TYPE_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button
+          variant="minimal"
+          size="icon-sm"
+          onClick={onRemove}
+          aria-label="Remove field"
+        >
+          <Trash />
+        </Button>
+      </div>
+
+      {field.type === BlueprintValueType.BOOLEAN ? (
+        <Switch
+          checked={field.value === "true"}
+          onCheckedChange={(checked) =>
+            onChange({ ...field, value: String(checked) })
+          }
+        />
+      ) : field.type === BlueprintValueType.PROMPT ? (
+        <Textarea
+          value={field.value}
+          onChange={(e) => onChange({ ...field, value: e.target.value })}
+          placeholder="System message for the new prompt"
+          className="min-h-20"
+        />
+      ) : (
+        <Input
+          inputMode={
+            field.type === BlueprintValueType.INT
+              ? "numeric"
+              : field.type === BlueprintValueType.FLOAT
+                ? "decimal"
+                : "text"
+          }
+          value={field.value}
+          onChange={(e) => onChange({ ...field, value: e.target.value })}
+          placeholder="Initial value"
+        />
+      )}
+
+      {(keyError || error) && (
+        <span className="comet-body-xs text-destructive">
+          {keyError ?? error}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default NewBlueprintFieldEditor;

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/NewBlueprintFieldEditor.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/NewBlueprintFieldEditor.tsx
@@ -3,11 +3,13 @@ import { Trash } from "lucide-react";
 
 import { BlueprintValueType } from "@/types/agent-configs";
 import { LLM_MESSAGE_ROLE, LLMMessage } from "@/types/llm";
+import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
 import { generateDefaultLLMPromptMessage } from "@/lib/llm";
 import BlueprintTypeIcon from "@/v2/pages-shared/traces/ConfigurationTab/BlueprintTypeIcon";
 import LLMPromptMessages from "@/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessages";
 import { Button } from "@/ui/button";
 import { Input } from "@/ui/input";
+import { Textarea } from "@/ui/textarea";
 import { Switch } from "@/ui/switch";
 import {
   Select,
@@ -21,12 +23,17 @@ import {
   validateBlueprintFieldValue,
 } from "./blueprintFieldValidation";
 
-const TYPE_OPTIONS: { value: BlueprintValueType; label: string }[] = [
+// Composite key so the dropdown can distinguish chat vs text prompts
+// while both map to BlueprintValueType.PROMPT on save.
+type FieldTypeOption = BlueprintValueType | "prompt_chat" | "prompt_text";
+
+const TYPE_OPTIONS: { value: FieldTypeOption; label: string }[] = [
   { value: BlueprintValueType.STRING, label: "String" },
   { value: BlueprintValueType.INT, label: "Integer" },
   { value: BlueprintValueType.FLOAT, label: "Float" },
   { value: BlueprintValueType.BOOLEAN, label: "Boolean" },
-  { value: BlueprintValueType.PROMPT, label: "Prompt" },
+  { value: "prompt_chat", label: "Chat prompt" },
+  { value: "prompt_text", label: "Text prompt" },
 ];
 
 export interface NewFieldDraft {
@@ -35,8 +42,10 @@ export interface NewFieldDraft {
   type: BlueprintValueType;
   // Used for scalar types and as the BOOLEAN's "true"/"false".
   value: string;
-  // Used only when type === PROMPT.
+  // Used only when type === PROMPT with chat structure.
   messages: LLMMessage[];
+  // Distinguishes chat vs text prompts.
+  promptStructure?: PROMPT_TEMPLATE_STRUCTURE;
 }
 
 const buildDefaultPromptMessages = (): LLMMessage[] => [
@@ -51,16 +60,35 @@ export const createNewFieldDraft = (id: string): NewFieldDraft => ({
   messages: [],
 });
 
+const fieldTypeToOption = (field: NewFieldDraft): FieldTypeOption => {
+  if (field.type !== BlueprintValueType.PROMPT) return field.type;
+  return field.promptStructure === PROMPT_TEMPLATE_STRUCTURE.TEXT
+    ? "prompt_text"
+    : "prompt_chat";
+};
+
 const initialStateForType = (
   type: BlueprintValueType,
-): Pick<NewFieldDraft, "value" | "messages"> => {
+  promptStructure?: PROMPT_TEMPLATE_STRUCTURE,
+): Pick<NewFieldDraft, "value" | "messages" | "promptStructure"> => {
   if (type === BlueprintValueType.BOOLEAN) {
-    return { value: "false", messages: [] };
+    return { value: "false", messages: [], promptStructure: undefined };
   }
   if (type === BlueprintValueType.PROMPT) {
-    return { value: "", messages: buildDefaultPromptMessages() };
+    if (promptStructure === PROMPT_TEMPLATE_STRUCTURE.TEXT) {
+      return {
+        value: "",
+        messages: [],
+        promptStructure: PROMPT_TEMPLATE_STRUCTURE.TEXT,
+      };
+    }
+    return {
+      value: "",
+      messages: buildDefaultPromptMessages(),
+      promptStructure: PROMPT_TEMPLATE_STRUCTURE.CHAT,
+    };
   }
-  return { value: "", messages: [] };
+  return { value: "", messages: [], promptStructure: undefined };
 };
 
 interface NewBlueprintFieldEditorProps {
@@ -101,11 +129,11 @@ const NewBlueprintFieldEditor: React.FC<NewBlueprintFieldEditorProps> = ({
     return validateBlueprintFieldValue(field.type, field.value) || null;
   }, [field.type, field.value]);
 
-  // For PROMPT, surface a hint when there are no messages or every message is
-  // empty. We don't gate on it (the user may still be drafting) but we do
-  // signal it.
   const promptError = useMemo(() => {
     if (field.type !== BlueprintValueType.PROMPT) return null;
+    if (field.promptStructure === PROMPT_TEMPLATE_STRUCTURE.TEXT) {
+      return !field.value.trim() ? "Prompt must not be empty" : null;
+    }
     if (field.messages.length === 0) return "Add at least one message";
     const allEmpty = field.messages.every((m) => {
       if (typeof m.content === "string") return !m.content.trim();
@@ -118,10 +146,34 @@ const NewBlueprintFieldEditor: React.FC<NewBlueprintFieldEditorProps> = ({
       return true;
     });
     return allEmpty ? "Messages must not be empty" : null;
-  }, [field.type, field.messages]);
+  }, [field.type, field.promptStructure, field.messages, field.value]);
 
-  const handleTypeChange = (next: BlueprintValueType) => {
-    onChange({ ...field, type: next, ...initialStateForType(next) });
+  const handleTypeChange = (next: FieldTypeOption) => {
+    if (next === "prompt_chat") {
+      onChange({
+        ...field,
+        type: BlueprintValueType.PROMPT,
+        ...initialStateForType(
+          BlueprintValueType.PROMPT,
+          PROMPT_TEMPLATE_STRUCTURE.CHAT,
+        ),
+      });
+    } else if (next === "prompt_text") {
+      onChange({
+        ...field,
+        type: BlueprintValueType.PROMPT,
+        ...initialStateForType(
+          BlueprintValueType.PROMPT,
+          PROMPT_TEMPLATE_STRUCTURE.TEXT,
+        ),
+      });
+    } else {
+      onChange({
+        ...field,
+        type: next,
+        ...initialStateForType(next),
+      });
+    }
   };
 
   const handleMessagesChange = useCallback(
@@ -154,7 +206,10 @@ const NewBlueprintFieldEditor: React.FC<NewBlueprintFieldEditorProps> = ({
           placeholder="field_name"
           className="h-8 flex-1"
         />
-        <Select value={field.type} onValueChange={handleTypeChange}>
+        <Select
+          value={fieldTypeToOption(field)}
+          onValueChange={handleTypeChange}
+        >
           <SelectTrigger className="h-8 w-[140px]">
             <SelectValue />
           </SelectTrigger>
@@ -182,6 +237,14 @@ const NewBlueprintFieldEditor: React.FC<NewBlueprintFieldEditorProps> = ({
           onCheckedChange={(checked) =>
             onChange({ ...field, value: String(checked) })
           }
+        />
+      ) : field.type === BlueprintValueType.PROMPT &&
+        field.promptStructure === PROMPT_TEMPLATE_STRUCTURE.TEXT ? (
+        <Textarea
+          className="comet-code min-h-24"
+          value={field.value}
+          onChange={(e) => onChange({ ...field, value: e.target.value })}
+          placeholder="Enter prompt template"
         />
       ) : field.type === BlueprintValueType.PROMPT ? (
         <LLMPromptMessages

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/NewBlueprintFieldEditor.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/NewBlueprintFieldEditor.tsx
@@ -197,7 +197,7 @@ const NewBlueprintFieldEditor: React.FC<NewBlueprintFieldEditorProps> = ({
   }, [field, onChange]);
 
   return (
-    <div className="flex flex-col gap-2 rounded-md border border-dashed border-amber-400/50 bg-primary-foreground p-3">
+    <div className="flex flex-col gap-2 rounded-md border border-dashed border-warning-box-icon-bg/50 bg-primary-foreground p-3">
       <div className="flex items-center gap-2">
         <BlueprintTypeIcon type={field.type} variant="secondary" />
         <Input

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/blueprintFieldValidation.test.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/blueprintFieldValidation.test.ts
@@ -1,0 +1,115 @@
+import { BlueprintValueType } from "@/types/agent-configs";
+import {
+  BLUEPRINT_FIELD_NAME_PATTERN,
+  validateBlueprintFieldValue,
+} from "./blueprintFieldValidation";
+
+describe("BLUEPRINT_FIELD_NAME_PATTERN", () => {
+  it.each(["name", "_private", "my_field_2", "A", "_"])(
+    "accepts valid name: %s",
+    (name) => {
+      expect(BLUEPRINT_FIELD_NAME_PATTERN.test(name)).toBe(true);
+    },
+  );
+
+  it.each(["", "2start", "has space", "has-dash", "special!"])(
+    "rejects invalid name: %s",
+    (name) => {
+      expect(BLUEPRINT_FIELD_NAME_PATTERN.test(name)).toBe(false);
+    },
+  );
+});
+
+describe("validateBlueprintFieldValue", () => {
+  describe("STRING", () => {
+    it("returns empty string for non-empty value", () => {
+      expect(
+        validateBlueprintFieldValue(BlueprintValueType.STRING, "hello"),
+      ).toBe("");
+    });
+
+    it("returns error for empty value", () => {
+      expect(validateBlueprintFieldValue(BlueprintValueType.STRING, "")).toBe(
+        "Must not be empty",
+      );
+    });
+
+    it("returns error for whitespace-only value", () => {
+      expect(
+        validateBlueprintFieldValue(BlueprintValueType.STRING, "   "),
+      ).toBe("Must not be empty");
+    });
+  });
+
+  describe("INT", () => {
+    it("returns empty string for valid integer", () => {
+      expect(validateBlueprintFieldValue(BlueprintValueType.INT, "42")).toBe(
+        "",
+      );
+    });
+
+    it("returns empty string for negative integer", () => {
+      expect(validateBlueprintFieldValue(BlueprintValueType.INT, "-5")).toBe(
+        "",
+      );
+    });
+
+    it("returns error for float value", () => {
+      expect(validateBlueprintFieldValue(BlueprintValueType.INT, "3.14")).toBe(
+        "Must be an integer",
+      );
+    });
+
+    it("returns error for non-numeric value", () => {
+      expect(
+        validateBlueprintFieldValue(BlueprintValueType.INT, "abc"),
+      ).toBeTruthy();
+    });
+
+    it("returns error for empty value", () => {
+      expect(validateBlueprintFieldValue(BlueprintValueType.INT, "")).toBe(
+        "Must not be empty",
+      );
+    });
+  });
+
+  describe("FLOAT", () => {
+    it("returns empty string for valid float", () => {
+      expect(
+        validateBlueprintFieldValue(BlueprintValueType.FLOAT, "3.14"),
+      ).toBe("");
+    });
+
+    it("returns empty string for integer value", () => {
+      expect(validateBlueprintFieldValue(BlueprintValueType.FLOAT, "42")).toBe(
+        "",
+      );
+    });
+
+    it("returns error for non-numeric value", () => {
+      expect(validateBlueprintFieldValue(BlueprintValueType.FLOAT, "abc")).toBe(
+        "Must be a valid number",
+      );
+    });
+
+    it("returns error for empty value", () => {
+      expect(validateBlueprintFieldValue(BlueprintValueType.FLOAT, "")).toBe(
+        "Must not be empty",
+      );
+    });
+  });
+
+  describe("BOOLEAN and PROMPT (no schema)", () => {
+    it("returns empty string for BOOLEAN regardless of value", () => {
+      expect(validateBlueprintFieldValue(BlueprintValueType.BOOLEAN, "")).toBe(
+        "",
+      );
+    });
+
+    it("returns empty string for PROMPT regardless of value", () => {
+      expect(validateBlueprintFieldValue(BlueprintValueType.PROMPT, "")).toBe(
+        "",
+      );
+    });
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/blueprintFieldValidation.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/blueprintFieldValidation.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 
 import { BlueprintValueType } from "@/types/agent-configs";
 
+export const BLUEPRINT_FIELD_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
 const nonEmptyString = z.string().min(1, "Must not be empty");
 
 const FIELD_SCHEMAS: Partial<Record<BlueprintValueType, z.ZodType>> = {
@@ -21,5 +23,5 @@ export const validateBlueprintFieldValue = (
   const schema = FIELD_SCHEMAS[type];
   if (!schema) return "";
   const result = schema.safeParse(value.trim());
-  return result.success ? "" : result.error.issues[0].message;
+  return result.success ? "" : result.error.issues[0]?.message ?? "Invalid";
 };

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/blueprintFieldValidation.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/blueprintFieldValidation.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+import { BlueprintValueType } from "@/types/agent-configs";
+
+const nonEmptyString = z.string().min(1, "Must not be empty");
+
+const FIELD_SCHEMAS: Partial<Record<BlueprintValueType, z.ZodType>> = {
+  [BlueprintValueType.INT]: nonEmptyString.pipe(
+    z.coerce.number().int("Must be an integer"),
+  ),
+  [BlueprintValueType.FLOAT]: nonEmptyString.pipe(
+    z.coerce.number({ message: "Must be a valid number" }),
+  ),
+  [BlueprintValueType.STRING]: nonEmptyString,
+};
+
+export const validateBlueprintFieldValue = (
+  type: BlueprintValueType,
+  value: string,
+): string => {
+  const schema = FIELD_SCHEMAS[type];
+  if (!schema) return "";
+  const result = schema.safeParse(value.trim());
+  return result.success ? "" : result.error.issues[0].message;
+};

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/fields/blueprintFieldLayout.test.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/fields/blueprintFieldLayout.test.ts
@@ -76,9 +76,9 @@ describe("collectMultiLineKeys", () => {
     expect(collectMultiLineKeys([])).toEqual([]);
   });
 
-  it("excludes PROMPT fields", () => {
+  it("includes PROMPT fields", () => {
     const values = [makeValue({ key: "p", type: BlueprintValueType.PROMPT })];
-    expect(collectMultiLineKeys(values)).toEqual([]);
+    expect(collectMultiLineKeys(values)).toEqual(["p"]);
   });
 
   it("collects STRING fields with long values", () => {

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/fields/blueprintFieldLayout.test.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/fields/blueprintFieldLayout.test.ts
@@ -1,0 +1,131 @@
+import { BlueprintValue, BlueprintValueType } from "@/types/agent-configs";
+import {
+  isMultiLineField,
+  collectMultiLineKeys,
+  hasAnyExpandableField,
+} from "./blueprintFieldLayout";
+
+const makeValue = (
+  overrides: Partial<BlueprintValue> & { type: BlueprintValueType },
+): BlueprintValue => ({
+  key: "field",
+  value: "",
+  ...overrides,
+});
+
+describe("isMultiLineField", () => {
+  it("returns true for PROMPT type", () => {
+    expect(
+      isMultiLineField(makeValue({ type: BlueprintValueType.PROMPT })),
+    ).toBe(true);
+  });
+
+  it("returns false for BOOLEAN type", () => {
+    expect(
+      isMultiLineField(makeValue({ type: BlueprintValueType.BOOLEAN })),
+    ).toBe(false);
+  });
+
+  it("returns false for INT type", () => {
+    expect(isMultiLineField(makeValue({ type: BlueprintValueType.INT }))).toBe(
+      false,
+    );
+  });
+
+  it("returns false for FLOAT type", () => {
+    expect(
+      isMultiLineField(makeValue({ type: BlueprintValueType.FLOAT })),
+    ).toBe(false);
+  });
+
+  it("returns true for STRING with newline", () => {
+    expect(
+      isMultiLineField(
+        makeValue({ type: BlueprintValueType.STRING, value: "line1\nline2" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true for STRING exceeding 80 chars", () => {
+    expect(
+      isMultiLineField(
+        makeValue({ type: BlueprintValueType.STRING, value: "a".repeat(81) }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for short STRING without newlines", () => {
+    expect(
+      isMultiLineField(
+        makeValue({ type: BlueprintValueType.STRING, value: "short" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for STRING at exactly 80 chars", () => {
+    expect(
+      isMultiLineField(
+        makeValue({ type: BlueprintValueType.STRING, value: "a".repeat(80) }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("collectMultiLineKeys", () => {
+  it("returns empty array for empty input", () => {
+    expect(collectMultiLineKeys([])).toEqual([]);
+  });
+
+  it("excludes PROMPT fields", () => {
+    const values = [makeValue({ key: "p", type: BlueprintValueType.PROMPT })];
+    expect(collectMultiLineKeys(values)).toEqual([]);
+  });
+
+  it("collects STRING fields with long values", () => {
+    const values = [
+      makeValue({
+        key: "long",
+        type: BlueprintValueType.STRING,
+        value: "a".repeat(81),
+      }),
+      makeValue({
+        key: "short",
+        type: BlueprintValueType.STRING,
+        value: "small",
+      }),
+    ];
+    expect(collectMultiLineKeys(values)).toEqual(["long"]);
+  });
+});
+
+describe("hasAnyExpandableField", () => {
+  it("returns false for empty array", () => {
+    expect(hasAnyExpandableField([])).toBe(false);
+  });
+
+  it("returns true when PROMPT field present", () => {
+    expect(
+      hasAnyExpandableField([makeValue({ type: BlueprintValueType.PROMPT })]),
+    ).toBe(true);
+  });
+
+  it("returns true when multi-line STRING present", () => {
+    expect(
+      hasAnyExpandableField([
+        makeValue({
+          type: BlueprintValueType.STRING,
+          value: "line1\nline2",
+        }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false when only scalar single-line fields", () => {
+    expect(
+      hasAnyExpandableField([
+        makeValue({ type: BlueprintValueType.INT, value: "1" }),
+        makeValue({ type: BlueprintValueType.BOOLEAN, value: "true" }),
+      ]),
+    ).toBe(false);
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.test.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.test.ts
@@ -1,0 +1,219 @@
+import { BlueprintValueType } from "@/types/agent-configs";
+import { LLM_MESSAGE_ROLE, LLMMessage } from "@/types/llm";
+import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
+import { NewFieldDraft } from "./NewBlueprintFieldEditor";
+import { isMessageEmpty, validateNewField } from "./useAgentConfigurationSave";
+
+const makeMessage = (
+  content: LLMMessage["content"],
+  role = LLM_MESSAGE_ROLE.user,
+): LLMMessage => ({
+  id: crypto.randomUUID(),
+  content,
+  role,
+});
+
+const makeDraft = (overrides: Partial<NewFieldDraft> = {}): NewFieldDraft => ({
+  id: "draft-1",
+  key: "valid_key",
+  type: BlueprintValueType.STRING,
+  value: "some value",
+  messages: [],
+  ...overrides,
+});
+
+describe("isMessageEmpty", () => {
+  it("returns true for empty string content", () => {
+    expect(isMessageEmpty(makeMessage(""))).toBe(true);
+  });
+
+  it("returns true for whitespace-only string content", () => {
+    expect(isMessageEmpty(makeMessage("   \n\t  "))).toBe(true);
+  });
+
+  it("returns false for non-empty string content", () => {
+    expect(isMessageEmpty(makeMessage("hello"))).toBe(false);
+  });
+
+  it("returns true for empty array content", () => {
+    expect(isMessageEmpty(makeMessage([]))).toBe(true);
+  });
+
+  it("returns true when all text parts are empty", () => {
+    expect(
+      isMessageEmpty(
+        makeMessage([
+          { type: "text", text: "" },
+          { type: "text", text: "   " },
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when any text part has content", () => {
+    expect(
+      isMessageEmpty(
+        makeMessage([
+          { type: "text", text: "" },
+          { type: "text", text: "hello" },
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for non-string non-array content", () => {
+    expect(isMessageEmpty(makeMessage(undefined as never))).toBe(true);
+  });
+});
+
+describe("validateNewField", () => {
+  const noExisting = new Set<string>();
+  const noSiblings = new Set<string>();
+
+  describe("key validation", () => {
+    it("returns error for empty key", () => {
+      expect(
+        validateNewField(makeDraft({ key: "" }), noExisting, noSiblings),
+      ).toBe("Field name is required");
+    });
+
+    it("returns error for whitespace-only key", () => {
+      expect(
+        validateNewField(makeDraft({ key: "   " }), noExisting, noSiblings),
+      ).toBe("Field name is required");
+    });
+
+    it("returns error for invalid key pattern", () => {
+      expect(
+        validateNewField(makeDraft({ key: "2bad" }), noExisting, noSiblings),
+      ).toBe(
+        "Use letters, digits and underscore; start with a letter or underscore",
+      );
+    });
+
+    it("returns error when key exists in existing keys", () => {
+      expect(
+        validateNewField(
+          makeDraft({ key: "taken" }),
+          new Set(["taken"]),
+          noSiblings,
+        ),
+      ).toBe("A field with this name already exists");
+    });
+
+    it("returns error for duplicate sibling key", () => {
+      expect(
+        validateNewField(
+          makeDraft({ key: "dup" }),
+          noExisting,
+          new Set(["dup"]),
+        ),
+      ).toBe("Duplicate field name in the new fields");
+    });
+  });
+
+  describe("PROMPT type - TEXT structure", () => {
+    it("returns empty string for non-empty text prompt", () => {
+      expect(
+        validateNewField(
+          makeDraft({
+            type: BlueprintValueType.PROMPT,
+            promptStructure: PROMPT_TEMPLATE_STRUCTURE.TEXT,
+            value: "some template",
+          }),
+          noExisting,
+          noSiblings,
+        ),
+      ).toBe("");
+    });
+
+    it("returns error for empty text prompt", () => {
+      expect(
+        validateNewField(
+          makeDraft({
+            type: BlueprintValueType.PROMPT,
+            promptStructure: PROMPT_TEMPLATE_STRUCTURE.TEXT,
+            value: "   ",
+          }),
+          noExisting,
+          noSiblings,
+        ),
+      ).toBe("Prompt must not be empty");
+    });
+  });
+
+  describe("PROMPT type - CHAT structure", () => {
+    it("returns error when messages array is empty", () => {
+      expect(
+        validateNewField(
+          makeDraft({
+            type: BlueprintValueType.PROMPT,
+            messages: [],
+          }),
+          noExisting,
+          noSiblings,
+        ),
+      ).toBe("Add at least one message");
+    });
+
+    it("returns error when all messages are empty", () => {
+      expect(
+        validateNewField(
+          makeDraft({
+            type: BlueprintValueType.PROMPT,
+            messages: [makeMessage(""), makeMessage("   ")],
+          }),
+          noExisting,
+          noSiblings,
+        ),
+      ).toBe("Messages must not be empty");
+    });
+
+    it("returns empty string when at least one message has content", () => {
+      expect(
+        validateNewField(
+          makeDraft({
+            type: BlueprintValueType.PROMPT,
+            messages: [makeMessage(""), makeMessage("hello")],
+          }),
+          noExisting,
+          noSiblings,
+        ),
+      ).toBe("");
+    });
+  });
+
+  describe("BOOLEAN type", () => {
+    it("returns empty string regardless of value", () => {
+      expect(
+        validateNewField(
+          makeDraft({ type: BlueprintValueType.BOOLEAN, value: "" }),
+          noExisting,
+          noSiblings,
+        ),
+      ).toBe("");
+    });
+  });
+
+  describe("scalar types delegate to validateBlueprintFieldValue", () => {
+    it("returns error for invalid INT value", () => {
+      expect(
+        validateNewField(
+          makeDraft({ type: BlueprintValueType.INT, value: "abc" }),
+          noExisting,
+          noSiblings,
+        ),
+      ).toBeTruthy();
+    });
+
+    it("returns empty string for valid INT value", () => {
+      expect(
+        validateNewField(
+          makeDraft({ type: BlueprintValueType.INT, value: "42" }),
+          noExisting,
+          noSiblings,
+        ),
+      ).toBe("");
+    });
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
@@ -59,6 +59,22 @@ type UseAgentConfigurationSaveParams = {
 
 const FIELD_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
+const isMessageEmpty = (message: { content: unknown }): boolean => {
+  const content = message.content;
+  if (typeof content === "string") return !content.trim();
+  if (Array.isArray(content)) {
+    return content.every(
+      (part) =>
+        part &&
+        typeof part === "object" &&
+        "type" in part &&
+        part.type === "text" &&
+        !(part as { text?: string }).text?.trim(),
+    );
+  }
+  return true;
+};
+
 const validateNewField = (
   field: NewFieldDraft,
   existingKeys: Set<string>,
@@ -70,20 +86,23 @@ const validateNewField = (
     return "Use letters, digits and underscore; start with a letter or underscore";
   if (existingKeys.has(key)) return "A field with this name already exists";
   if (siblingKeys.has(key)) return "Duplicate field name in the new fields";
-  if (
-    field.type !== BlueprintValueType.PROMPT &&
-    field.type !== BlueprintValueType.BOOLEAN
-  ) {
+  if (field.type === BlueprintValueType.PROMPT) {
+    if (field.messages.length === 0) return "Add at least one message";
+    if (field.messages.some(isMessageEmpty))
+      return "Messages must not be empty";
+    return "";
+  }
+  if (field.type !== BlueprintValueType.BOOLEAN) {
     const err = validateField(field.type, field.value);
     if (err) return err;
   }
-  if (field.type === BlueprintValueType.PROMPT && !field.value.trim())
-    return "Prompt content must not be empty";
   return "";
 };
 
-const buildChatTemplateFromText = (text: string): string =>
-  JSON.stringify([{ role: "system", content: text }]);
+const buildChatTemplateFromMessages = (
+  messages: Array<{ role: string; content: unknown }>,
+): string =>
+  JSON.stringify(messages.map(({ role, content }) => ({ role, content })));
 
 export const useAgentConfigurationSave = ({
   agentConfig,
@@ -196,8 +215,8 @@ export const useAgentConfigurationSave = ({
         }
       }
 
-      // Materialize new PROMPT fields by creating brand-new prompts in the
-      // library; reuse the user-entered value as the system message.
+      // Materialize new PROMPT fields by creating brand-new chat prompts in
+      // the library from the user-entered messages.
       const addedValues: BlueprintValue[] = [];
       for (const field of added) {
         const key = field.key.trim();
@@ -207,7 +226,7 @@ export const useAgentConfigurationSave = ({
             created = (await createPrompt({
               prompt: {
                 name: key,
-                template: buildChatTemplateFromText(field.value),
+                template: buildChatTemplateFromMessages(field.messages),
                 template_structure: PROMPT_TEMPLATE_STRUCTURE.CHAT,
                 project_id: projectId,
               },

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
@@ -31,7 +31,7 @@ export type AgentConfigPayload = {
   blueprint: BlueprintCreate;
 };
 
-const isMessageEmpty = (message: LLMMessage): boolean => {
+export const isMessageEmpty = (message: LLMMessage): boolean => {
   const { content } = message;
   if (typeof content === "string") return !content.trim();
   if (Array.isArray(content)) {
@@ -43,7 +43,7 @@ const isMessageEmpty = (message: LLMMessage): boolean => {
   return true;
 };
 
-const validateNewField = (
+export const validateNewField = (
   field: NewFieldDraft,
   existingKeys: ReadonlySet<string>,
   siblingKeys: ReadonlySet<string>,

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
@@ -14,6 +14,7 @@ import {
   PROMPT_TEMPLATE_STRUCTURE,
   PromptWithLatestVersion,
 } from "@/types/prompts";
+import { LLMMessage } from "@/types/llm";
 import { NewFieldDraft } from "./NewBlueprintFieldEditor";
 import { validateBlueprintFieldValue } from "./blueprintFieldValidation";
 
@@ -26,6 +27,46 @@ export type AgentConfigPayload = {
   blueprint: BlueprintCreate;
 };
 
+const FIELD_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+const isMessageEmpty = (message: LLMMessage): boolean => {
+  const { content } = message;
+  if (typeof content === "string") return !content.trim();
+  if (Array.isArray(content)) {
+    return content.every(
+      (part) =>
+        part.type === "text" && !(part as { text?: string }).text?.trim(),
+    );
+  }
+  return true;
+};
+
+const validateNewField = (
+  field: NewFieldDraft,
+  existingKeys: ReadonlySet<string>,
+  siblingKeys: ReadonlySet<string>,
+): string => {
+  const key = field.key.trim();
+  if (!key) return "Field name is required";
+  if (!FIELD_NAME_PATTERN.test(key))
+    return "Use letters, digits and underscore; start with a letter or underscore";
+  if (existingKeys.has(key)) return "A field with this name already exists";
+  if (siblingKeys.has(key)) return "Duplicate field name in the new fields";
+  if (field.type === BlueprintValueType.PROMPT) {
+    if (field.messages.length === 0) return "Add at least one message";
+    if (field.messages.every(isMessageEmpty))
+      return "Messages must not be empty";
+    return "";
+  }
+  if (field.type !== BlueprintValueType.BOOLEAN) {
+    return validateBlueprintFieldValue(field.type, field.value);
+  }
+  return "";
+};
+
+const buildChatTemplateFromMessages = (messages: LLMMessage[]): string =>
+  JSON.stringify(messages.map(({ role, content }) => ({ role, content })));
+
 type UseAgentConfigurationSaveParams = {
   agentConfig: AgentConfig | undefined;
   draftValues: Record<string, string>;
@@ -37,53 +78,6 @@ type UseAgentConfigurationSaveParams = {
   removedKeys?: Set<string>;
   newFields?: NewFieldDraft[];
 };
-
-const FIELD_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
-
-const isMessageEmpty = (message: { content: unknown }): boolean => {
-  const content = message.content;
-  if (typeof content === "string") return !content.trim();
-  if (Array.isArray(content)) {
-    return content.every(
-      (part) =>
-        part &&
-        typeof part === "object" &&
-        "type" in part &&
-        part.type === "text" &&
-        !(part as { text?: string }).text?.trim(),
-    );
-  }
-  return true;
-};
-
-const validateNewField = (
-  field: NewFieldDraft,
-  existingKeys: Set<string>,
-  siblingKeys: Set<string>,
-): string => {
-  const key = field.key.trim();
-  if (!key) return "Field name is required";
-  if (!FIELD_NAME_PATTERN.test(key))
-    return "Use letters, digits and underscore; start with a letter or underscore";
-  if (existingKeys.has(key)) return "A field with this name already exists";
-  if (siblingKeys.has(key)) return "Duplicate field name in the new fields";
-  if (field.type === BlueprintValueType.PROMPT) {
-    if (field.messages.length === 0) return "Add at least one message";
-    if (field.messages.some(isMessageEmpty))
-      return "Messages must not be empty";
-    return "";
-  }
-  if (field.type !== BlueprintValueType.BOOLEAN) {
-    const err = validateBlueprintFieldValue(field.type, field.value);
-    if (err) return err;
-  }
-  return "";
-};
-
-const buildChatTemplateFromMessages = (
-  messages: Array<{ role: string; content: unknown }>,
-): string =>
-  JSON.stringify(messages.map(({ role, content }) => ({ role, content })));
 
 export const useAgentConfigurationSave = ({
   agentConfig,
@@ -120,45 +114,45 @@ export const useAgentConfigurationSave = ({
         originalValues.current !== null &&
         draftValues[key] !== originalValues.current[key],
     );
-    const hasPromptChanges = dirtyPromptKeys
-      ? Object.values(dirtyPromptKeys).some(Boolean)
-      : false;
+    const hasPromptChanges =
+      !!dirtyPromptKeys && Object.values(dirtyPromptKeys).some(Boolean);
     const hasRemovals = (removedKeys?.size ?? 0) > 0;
     const hasAdditions = (newFields?.length ?? 0) > 0;
     return hasScalarChanges || hasPromptChanges || hasRemovals || hasAdditions;
   }, [draftValues, originalValues, dirtyPromptKeys, removedKeys, newFields]);
 
-  const validateAndBuildPayload = useCallback(
-    async (type: BlueprintType): Promise<AgentConfigPayload | null> => {
-      if (!agentConfig) return null;
-
-      const removed = removedKeys ?? new Set<string>();
-      const added = newFields ?? [];
+  // Collect errors for every editable field. Returns the error map; the
+  // caller decides whether to abort the save.
+  const collectValidationErrors = useCallback(
+    (removed: ReadonlySet<string>, added: NewFieldDraft[]) => {
+      if (!agentConfig) return {};
 
       const newErrors: Record<string, string> = {};
-      agentConfig.values
-        .filter(
-          (v) =>
-            !removed.has(v.key) &&
-            v.type !== BlueprintValueType.PROMPT &&
-            v.type !== BlueprintValueType.BOOLEAN,
-        )
-        .forEach((v) => {
-          const err = validateBlueprintFieldValue(
-            v.type,
-            draftValues[v.key] ?? "",
-          );
-          if (err) newErrors[v.key] = err;
-        });
 
-      for (const [key, handle] of Object.entries(promptRefs.current)) {
-        if (removed.has(key)) continue;
-        if (handle) {
-          const err = handle.validate();
-          if (err) newErrors[key] = err;
+      // Existing scalar fields (PROMPT and BOOLEAN don't need value parsing)
+      for (const v of agentConfig.values) {
+        if (
+          removed.has(v.key) ||
+          v.type === BlueprintValueType.PROMPT ||
+          v.type === BlueprintValueType.BOOLEAN
+        ) {
+          continue;
         }
+        const err = validateBlueprintFieldValue(
+          v.type,
+          draftValues[v.key] ?? "",
+        );
+        if (err) newErrors[v.key] = err;
       }
 
+      // Existing prompt fields delegate validation to the editor handle
+      for (const [key, handle] of Object.entries(promptRefs.current)) {
+        if (!handle || removed.has(key)) continue;
+        const err = handle.validate();
+        if (err) newErrors[key] = err;
+      }
+
+      // New fields: key uniqueness + per-type value validation
       const existingKeys = new Set(
         agentConfig.values.filter((v) => !removed.has(v.key)).map((v) => v.key),
       );
@@ -169,20 +163,110 @@ export const useAgentConfigurationSave = ({
         else seenNewKeys.add(field.key.trim());
       }
 
-      if (Object.values(newErrors).some(Boolean)) {
-        setErrors(newErrors);
+      return newErrors;
+    },
+    [agentConfig, draftValues],
+  );
+
+  // Save dirty existing prompts. Returns a key→commit map of any new commits.
+  // Throws on failure (caught by caller).
+  const saveDirtyPromptVersions = useCallback(
+    async (removed: ReadonlySet<string>) => {
+      const results = await Promise.all(
+        Object.entries(promptRefs.current)
+          .filter(([key, handle]) => handle && !removed.has(key))
+          .map(([, handle]) => handle!.saveVersion()),
+      );
+
+      const commits = new Map<string, string>();
+      for (const r of results) {
+        if (r) commits.set(r.key, r.commit);
+      }
+      return commits;
+    },
+    [],
+  );
+
+  // Materialize new PROMPT fields by creating brand-new chat prompts in the
+  // library. Scalar fields pass through with their entered value. Returns
+  // null if any prompt creation fails.
+  const materializeNewFields = useCallback(
+    async (added: NewFieldDraft[]): Promise<BlueprintValue[] | null> => {
+      const out: BlueprintValue[] = [];
+      for (const field of added) {
+        const key = field.key.trim();
+        if (field.type !== BlueprintValueType.PROMPT) {
+          out.push({ key, type: field.type, value: field.value });
+          continue;
+        }
+        try {
+          const created = (await createPrompt({
+            prompt: {
+              name: key,
+              template: buildChatTemplateFromMessages(field.messages),
+              template_structure: PROMPT_TEMPLATE_STRUCTURE.CHAT,
+              project_id: projectId,
+            },
+            withResponse: true,
+          })) as PromptWithLatestVersion;
+          const commit = created?.latest_version?.commit;
+          if (!commit) return null;
+          out.push({ key, type: BlueprintValueType.PROMPT, value: commit });
+        } catch {
+          return null;
+        }
+      }
+      return out;
+    },
+    [createPrompt, projectId],
+  );
+
+  // Build a self-contained list of values for the new blueprint version.
+  // Removed keys are omitted; new fields are appended; PROMPT entries use
+  // newly-created commits when available; scalar entries use the latest
+  // draft value (falling back to the original).
+  const buildBlueprintValues = useCallback(
+    (
+      removed: ReadonlySet<string>,
+      newCommits: ReadonlyMap<string, string>,
+      addedValues: BlueprintValue[],
+    ): BlueprintValue[] => {
+      if (!agentConfig) return addedValues;
+      const kept = agentConfig.values
+        .filter((v) => !removed.has(v.key))
+        .map((v) => {
+          const value =
+            v.type === BlueprintValueType.PROMPT
+              ? newCommits.get(v.key) ?? v.value
+              : draftValues[v.key] ?? v.value;
+          return {
+            key: v.key,
+            type: v.type,
+            value,
+            ...(v.description ? { description: v.description } : {}),
+          };
+        });
+      return [...kept, ...addedValues];
+    },
+    [agentConfig, draftValues],
+  );
+
+  const validateAndBuildPayload = useCallback(
+    async (type: BlueprintType): Promise<AgentConfigPayload | null> => {
+      if (!agentConfig) return null;
+
+      const removed = removedKeys ?? new Set<string>();
+      const added = newFields ?? [];
+
+      const validationErrors = collectValidationErrors(removed, added);
+      if (Object.values(validationErrors).some(Boolean)) {
+        setErrors(validationErrors);
         return null;
       }
 
-      let promptResults: Awaited<
-        ReturnType<BlueprintValuePromptHandle["saveVersion"]>
-      >[];
+      let newCommits: Map<string, string>;
       try {
-        promptResults = await Promise.all(
-          Object.entries(promptRefs.current)
-            .filter(([key, handle]) => handle && !removed.has(key))
-            .map(([, handle]) => handle!.saveVersion()),
-        );
+        newCommits = await saveDirtyPromptVersions(removed);
       } catch {
         toast({
           title: "Failed to save prompt versions",
@@ -192,85 +276,29 @@ export const useAgentConfigurationSave = ({
         return null;
       }
 
-      const newCommits = new Map<string, string>();
-      for (const result of promptResults) {
-        if (result) {
-          newCommits.set(result.key, result.commit);
-        }
-      }
-
-      // Materialize new PROMPT fields by creating brand-new chat prompts in
-      // the library from the user-entered messages.
-      const addedValues: BlueprintValue[] = [];
-      for (const field of added) {
-        const key = field.key.trim();
-        if (field.type === BlueprintValueType.PROMPT) {
-          let created: PromptWithLatestVersion | undefined;
-          try {
-            created = (await createPrompt({
-              prompt: {
-                name: key,
-                template: buildChatTemplateFromMessages(field.messages),
-                template_structure: PROMPT_TEMPLATE_STRUCTURE.CHAT,
-                project_id: projectId,
-              },
-              withResponse: true,
-            })) as PromptWithLatestVersion;
-          } catch {
-            return null;
-          }
-          const commit = created?.latest_version?.commit;
-          if (!commit) return null;
-          addedValues.push({
-            key,
-            type: BlueprintValueType.PROMPT,
-            value: commit,
-          });
-        } else {
-          addedValues.push({ key, type: field.type, value: field.value });
-        }
-      }
-
-      // Always send the full set of values. Removed keys are omitted; new
-      // fields are appended. PROMPT-typed entries use the newly created
-      // commit if one was saved this round, otherwise the existing one.
-      // Scalar entries use the draft value if edited, otherwise the original.
-      const values: BlueprintValue[] = [
-        ...agentConfig.values
-          .filter((v) => !removed.has(v.key))
-          .map((v) => {
-            const isPrompt = v.type === BlueprintValueType.PROMPT;
-            const value = isPrompt
-              ? newCommits.get(v.key) ?? v.value
-              : draftValues[v.key] ?? v.value;
-            return {
-              key: v.key,
-              type: v.type,
-              value,
-              ...(v.description ? { description: v.description } : {}),
-            };
-          }),
-        ...addedValues,
-      ];
+      const addedValues = await materializeNewFields(added);
+      if (addedValues === null) return null;
 
       return {
         project_id: projectId,
         blueprint: {
           description: description || undefined,
           type,
-          values,
+          values: buildBlueprintValues(removed, newCommits, addedValues),
         },
       };
     },
     [
       agentConfig,
-      draftValues,
-      description,
-      projectId,
-      toast,
       removedKeys,
       newFields,
-      createPrompt,
+      collectValidationErrors,
+      saveDirtyPromptVersions,
+      materializeNewFields,
+      buildBlueprintValues,
+      projectId,
+      description,
+      toast,
     ],
   );
 
@@ -284,9 +312,10 @@ export const useAgentConfigurationSave = ({
     );
   }, [validateAndBuildPayload, createConfig, onSaved]);
 
-  const buildMaskPayload = useCallback(async () => {
-    return validateAndBuildPayload(BlueprintType.MASK);
-  }, [validateAndBuildPayload]);
+  const buildMaskPayload = useCallback(
+    () => validateAndBuildPayload(BlueprintType.MASK),
+    [validateAndBuildPayload],
+  );
 
   return {
     handleSave,

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
@@ -140,25 +140,22 @@ export const useAgentConfigurationSave = ({
         }
       }
 
-      const values: BlueprintValue[] = agentConfig.values
-        .filter((v) => {
-          if (v.type === BlueprintValueType.PROMPT) {
-            return newCommits.has(v.key);
-          }
-          return (
-            originalValues.current !== null &&
-            draftValues[v.key] !== originalValues.current[v.key]
-          );
-        })
-        .map((v) => ({
+      // Always send the full set of values. PROMPT-typed entries use the
+      // newly created commit if one was saved this round, otherwise the
+      // existing one. Scalar entries use the draft value if the user edited
+      // them, otherwise the original value.
+      const values: BlueprintValue[] = agentConfig.values.map((v) => {
+        const isPrompt = v.type === BlueprintValueType.PROMPT;
+        const value = isPrompt
+          ? newCommits.get(v.key) ?? v.value
+          : draftValues[v.key] ?? v.value;
+        return {
           key: v.key,
           type: v.type,
-          value:
-            v.type === BlueprintValueType.PROMPT
-              ? newCommits.get(v.key) ?? v.value
-              : draftValues[v.key],
+          value,
           ...(v.description ? { description: v.description } : {}),
-        }));
+        };
+      });
 
       return {
         project_id: projectId,
@@ -169,7 +166,7 @@ export const useAgentConfigurationSave = ({
         },
       };
     },
-    [agentConfig, draftValues, originalValues, description, projectId, toast],
+    [agentConfig, draftValues, description, projectId, toast],
   );
 
   const handleSave = useCallback(async () => {

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
@@ -8,8 +8,14 @@ import {
   BlueprintValueType,
 } from "@/types/agent-configs";
 import useAgentConfigCreateMutation from "@/api/agent-configs/useAgentConfigCreateMutation";
+import usePromptCreateMutation from "@/api/prompts/usePromptCreateMutation";
 import { BlueprintValuePromptHandle } from "@/v2/pages-shared/traces/ConfigurationTab/BlueprintValuePrompt";
 import { useToast } from "@/ui/use-toast";
+import {
+  PROMPT_TEMPLATE_STRUCTURE,
+  PromptWithLatestVersion,
+} from "@/types/prompts";
+import { NewFieldDraft } from "./NewBlueprintFieldEditor";
 
 import type useAgentConfigById from "@/api/agent-configs/useAgentConfigById";
 
@@ -47,7 +53,37 @@ type UseAgentConfigurationSaveParams = {
   projectId: string;
   onSaved: (newBlueprintId?: string) => void;
   dirtyPromptKeys?: Record<string, boolean>;
+  removedKeys?: Set<string>;
+  newFields?: NewFieldDraft[];
 };
+
+const FIELD_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+const validateNewField = (
+  field: NewFieldDraft,
+  existingKeys: Set<string>,
+  siblingKeys: Set<string>,
+): string => {
+  const key = field.key.trim();
+  if (!key) return "Field name is required";
+  if (!FIELD_NAME_PATTERN.test(key))
+    return "Use letters, digits and underscore; start with a letter or underscore";
+  if (existingKeys.has(key)) return "A field with this name already exists";
+  if (siblingKeys.has(key)) return "Duplicate field name in the new fields";
+  if (
+    field.type !== BlueprintValueType.PROMPT &&
+    field.type !== BlueprintValueType.BOOLEAN
+  ) {
+    const err = validateField(field.type, field.value);
+    if (err) return err;
+  }
+  if (field.type === BlueprintValueType.PROMPT && !field.value.trim())
+    return "Prompt content must not be empty";
+  return "";
+};
+
+const buildChatTemplateFromText = (text: string): string =>
+  JSON.stringify([{ role: "system", content: text }]);
 
 export const useAgentConfigurationSave = ({
   agentConfig,
@@ -57,10 +93,13 @@ export const useAgentConfigurationSave = ({
   projectId,
   onSaved,
   dirtyPromptKeys,
+  removedKeys,
+  newFields,
 }: UseAgentConfigurationSaveParams) => {
   const { toast } = useToast();
   const { mutate: createConfig, isPending: isSaving } =
     useAgentConfigCreateMutation();
+  const { mutateAsync: createPrompt } = usePromptCreateMutation();
   const [errors, setErrors] = useState<Record<string, string>>({});
   const promptRefs = useRef<Record<string, BlueprintValuePromptHandle | null>>(
     {},
@@ -84,17 +123,23 @@ export const useAgentConfigurationSave = ({
     const hasPromptChanges = dirtyPromptKeys
       ? Object.values(dirtyPromptKeys).some(Boolean)
       : false;
-    return hasScalarChanges || hasPromptChanges;
-  }, [draftValues, originalValues, dirtyPromptKeys]);
+    const hasRemovals = (removedKeys?.size ?? 0) > 0;
+    const hasAdditions = (newFields?.length ?? 0) > 0;
+    return hasScalarChanges || hasPromptChanges || hasRemovals || hasAdditions;
+  }, [draftValues, originalValues, dirtyPromptKeys, removedKeys, newFields]);
 
   const validateAndBuildPayload = useCallback(
     async (type: BlueprintType): Promise<AgentConfigPayload | null> => {
       if (!agentConfig) return null;
 
+      const removed = removedKeys ?? new Set<string>();
+      const added = newFields ?? [];
+
       const newErrors: Record<string, string> = {};
       agentConfig.values
         .filter(
           (v) =>
+            !removed.has(v.key) &&
             v.type !== BlueprintValueType.PROMPT &&
             v.type !== BlueprintValueType.BOOLEAN,
         )
@@ -104,10 +149,21 @@ export const useAgentConfigurationSave = ({
         });
 
       for (const [key, handle] of Object.entries(promptRefs.current)) {
+        if (removed.has(key)) continue;
         if (handle) {
           const err = handle.validate();
           if (err) newErrors[key] = err;
         }
+      }
+
+      const existingKeys = new Set(
+        agentConfig.values.filter((v) => !removed.has(v.key)).map((v) => v.key),
+      );
+      const seenNewKeys = new Set<string>();
+      for (const field of added) {
+        const err = validateNewField(field, existingKeys, seenNewKeys);
+        if (err) newErrors[field.id] = err;
+        else seenNewKeys.add(field.key.trim());
       }
 
       if (Object.values(newErrors).some(Boolean)) {
@@ -120,9 +176,9 @@ export const useAgentConfigurationSave = ({
       >[];
       try {
         promptResults = await Promise.all(
-          Object.values(promptRefs.current)
-            .filter(Boolean)
-            .map((handle) => handle!.saveVersion()),
+          Object.entries(promptRefs.current)
+            .filter(([key, handle]) => handle && !removed.has(key))
+            .map(([, handle]) => handle!.saveVersion()),
         );
       } catch {
         toast({
@@ -140,22 +196,59 @@ export const useAgentConfigurationSave = ({
         }
       }
 
-      // Always send the full set of values. PROMPT-typed entries use the
-      // newly created commit if one was saved this round, otherwise the
-      // existing one. Scalar entries use the draft value if the user edited
-      // them, otherwise the original value.
-      const values: BlueprintValue[] = agentConfig.values.map((v) => {
-        const isPrompt = v.type === BlueprintValueType.PROMPT;
-        const value = isPrompt
-          ? newCommits.get(v.key) ?? v.value
-          : draftValues[v.key] ?? v.value;
-        return {
-          key: v.key,
-          type: v.type,
-          value,
-          ...(v.description ? { description: v.description } : {}),
-        };
-      });
+      // Materialize new PROMPT fields by creating brand-new prompts in the
+      // library; reuse the user-entered value as the system message.
+      const addedValues: BlueprintValue[] = [];
+      for (const field of added) {
+        const key = field.key.trim();
+        if (field.type === BlueprintValueType.PROMPT) {
+          let created: PromptWithLatestVersion | undefined;
+          try {
+            created = (await createPrompt({
+              prompt: {
+                name: key,
+                template: buildChatTemplateFromText(field.value),
+                template_structure: PROMPT_TEMPLATE_STRUCTURE.CHAT,
+                project_id: projectId,
+              },
+              withResponse: true,
+            })) as PromptWithLatestVersion;
+          } catch {
+            return null;
+          }
+          const commit = created?.latest_version?.commit;
+          if (!commit) return null;
+          addedValues.push({
+            key,
+            type: BlueprintValueType.PROMPT,
+            value: commit,
+          });
+        } else {
+          addedValues.push({ key, type: field.type, value: field.value });
+        }
+      }
+
+      // Always send the full set of values. Removed keys are omitted; new
+      // fields are appended. PROMPT-typed entries use the newly created
+      // commit if one was saved this round, otherwise the existing one.
+      // Scalar entries use the draft value if edited, otherwise the original.
+      const values: BlueprintValue[] = [
+        ...agentConfig.values
+          .filter((v) => !removed.has(v.key))
+          .map((v) => {
+            const isPrompt = v.type === BlueprintValueType.PROMPT;
+            const value = isPrompt
+              ? newCommits.get(v.key) ?? v.value
+              : draftValues[v.key] ?? v.value;
+            return {
+              key: v.key,
+              type: v.type,
+              value,
+              ...(v.description ? { description: v.description } : {}),
+            };
+          }),
+        ...addedValues,
+      ];
 
       return {
         project_id: projectId,
@@ -166,7 +259,16 @@ export const useAgentConfigurationSave = ({
         },
       };
     },
-    [agentConfig, draftValues, description, projectId, toast],
+    [
+      agentConfig,
+      draftValues,
+      description,
+      projectId,
+      toast,
+      removedKeys,
+      newFields,
+      createPrompt,
+    ],
   );
 
   const handleSave = useCallback(async () => {

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
@@ -15,6 +15,7 @@ import {
   PromptWithLatestVersion,
 } from "@/types/prompts";
 import { LLMMessage } from "@/types/llm";
+import { serializeChatTemplate } from "@/lib/chatTemplate";
 import { NewFieldDraft } from "./NewBlueprintFieldEditor";
 import {
   BLUEPRINT_FIELD_NAME_PATTERN,
@@ -65,8 +66,7 @@ const validateNewField = (
   return "";
 };
 
-const buildChatTemplateFromMessages = (messages: LLMMessage[]): string =>
-  JSON.stringify(messages.map(({ role, content }) => ({ role, content })));
+const buildChatTemplateFromMessages = serializeChatTemplate;
 
 type UseAgentConfigurationSaveParams = {
   agentConfig: AgentConfig | undefined;

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
@@ -69,8 +69,6 @@ const validateNewField = (
   return "";
 };
 
-const buildChatTemplateFromMessages = serializeChatTemplate;
-
 type UseAgentConfigurationSaveParams = {
   agentConfig: AgentConfig | undefined;
   draftValues: Record<string, string>;
@@ -207,7 +205,7 @@ export const useAgentConfigurationSave = ({
           field.promptStructure === PROMPT_TEMPLATE_STRUCTURE.TEXT;
         const template = isTextPrompt
           ? field.value
-          : buildChatTemplateFromMessages(field.messages);
+          : serializeChatTemplate(field.messages);
         try {
           const created = (await createPrompt({
             prompt: {

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
@@ -16,7 +16,10 @@ import {
 } from "@/types/prompts";
 import { LLMMessage } from "@/types/llm";
 import { NewFieldDraft } from "./NewBlueprintFieldEditor";
-import { validateBlueprintFieldValue } from "./blueprintFieldValidation";
+import {
+  BLUEPRINT_FIELD_NAME_PATTERN,
+  validateBlueprintFieldValue,
+} from "./blueprintFieldValidation";
 
 import type useAgentConfigById from "@/api/agent-configs/useAgentConfigById";
 
@@ -26,8 +29,6 @@ export type AgentConfigPayload = {
   project_id: string;
   blueprint: BlueprintCreate;
 };
-
-const FIELD_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 const isMessageEmpty = (message: LLMMessage): boolean => {
   const { content } = message;
@@ -48,7 +49,7 @@ const validateNewField = (
 ): string => {
   const key = field.key.trim();
   if (!key) return "Field name is required";
-  if (!FIELD_NAME_PATTERN.test(key))
+  if (!BLUEPRINT_FIELD_NAME_PATTERN.test(key))
     return "Use letters, digits and underscore; start with a letter or underscore";
   if (existingKeys.has(key)) return "A field with this name already exists";
   if (siblingKeys.has(key)) return "Duplicate field name in the new fields";

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
@@ -1,5 +1,4 @@
 import React, { useCallback, useRef, useState } from "react";
-import { z } from "zod";
 
 import {
   BlueprintCreate,
@@ -16,33 +15,15 @@ import {
   PromptWithLatestVersion,
 } from "@/types/prompts";
 import { NewFieldDraft } from "./NewBlueprintFieldEditor";
+import { validateBlueprintFieldValue } from "./blueprintFieldValidation";
 
 import type useAgentConfigById from "@/api/agent-configs/useAgentConfigById";
 
 type AgentConfig = NonNullable<ReturnType<typeof useAgentConfigById>["data"]>;
 
-const nonEmptyString = z.string().min(1, "Must not be empty");
-
-const FIELD_SCHEMAS: Partial<Record<BlueprintValueType, z.ZodType>> = {
-  [BlueprintValueType.INT]: nonEmptyString.pipe(
-    z.coerce.number().int("Must be an integer"),
-  ),
-  [BlueprintValueType.FLOAT]: nonEmptyString.pipe(
-    z.coerce.number({ message: "Must be a valid number" }),
-  ),
-  [BlueprintValueType.STRING]: nonEmptyString,
-};
-
 export type AgentConfigPayload = {
   project_id: string;
   blueprint: BlueprintCreate;
-};
-
-const validateField = (type: string, value: string): string => {
-  const schema = FIELD_SCHEMAS[type as BlueprintValueType];
-  if (!schema) return "";
-  const result = schema.safeParse(value.trim());
-  return result.success ? "" : result.error.issues[0].message;
 };
 
 type UseAgentConfigurationSaveParams = {
@@ -93,7 +74,7 @@ const validateNewField = (
     return "";
   }
   if (field.type !== BlueprintValueType.BOOLEAN) {
-    const err = validateField(field.type, field.value);
+    const err = validateBlueprintFieldValue(field.type, field.value);
     if (err) return err;
   }
   return "";
@@ -163,7 +144,10 @@ export const useAgentConfigurationSave = ({
             v.type !== BlueprintValueType.BOOLEAN,
         )
         .forEach((v) => {
-          const err = validateField(v.type, draftValues[v.key] ?? "");
+          const err = validateBlueprintFieldValue(
+            v.type,
+            draftValues[v.key] ?? "",
+          );
           if (err) newErrors[v.key] = err;
         });
 

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts
@@ -55,6 +55,9 @@ const validateNewField = (
   if (existingKeys.has(key)) return "A field with this name already exists";
   if (siblingKeys.has(key)) return "Duplicate field name in the new fields";
   if (field.type === BlueprintValueType.PROMPT) {
+    if (field.promptStructure === PROMPT_TEMPLATE_STRUCTURE.TEXT) {
+      return field.value.trim() ? "" : "Prompt must not be empty";
+    }
     if (field.messages.length === 0) return "Add at least one message";
     if (field.messages.every(isMessageEmpty))
       return "Messages must not be empty";
@@ -188,7 +191,7 @@ export const useAgentConfigurationSave = ({
     [],
   );
 
-  // Materialize new PROMPT fields by creating brand-new chat prompts in the
+  // Materialize new PROMPT fields by creating brand-new prompts in the
   // library. Scalar fields pass through with their entered value. Returns
   // null if any prompt creation fails.
   const materializeNewFields = useCallback(
@@ -200,12 +203,19 @@ export const useAgentConfigurationSave = ({
           out.push({ key, type: field.type, value: field.value });
           continue;
         }
+        const isTextPrompt =
+          field.promptStructure === PROMPT_TEMPLATE_STRUCTURE.TEXT;
+        const template = isTextPrompt
+          ? field.value
+          : buildChatTemplateFromMessages(field.messages);
         try {
           const created = (await createPrompt({
             prompt: {
               name: key,
-              template: buildChatTemplateFromMessages(field.messages),
-              template_structure: PROMPT_TEMPLATE_STRUCTURE.CHAT,
+              template,
+              template_structure: isTextPrompt
+                ? PROMPT_TEMPLATE_STRUCTURE.TEXT
+                : PROMPT_TEMPLATE_STRUCTURE.CHAT,
               project_id: projectId,
             },
             withResponse: true,

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/BestPromptCard/BestPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/BestPromptCard/BestPrompt.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useMemo, useState } from "react";
-import { Link, useNavigate } from "@tanstack/react-router";
-import { ArrowRight, Save, Split } from "lucide-react";
+import React, { useMemo, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, Split } from "lucide-react";
 import isUndefined from "lodash/isUndefined";
 import isObject from "lodash/isObject";
 import get from "lodash/get";
@@ -9,7 +9,6 @@ import { OPTIMIZATION_PROMPT_KEY } from "@/constants/experiments";
 import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { Experiment } from "@/types/datasets";
 import { Optimization, OPTIMIZATION_STATUS } from "@/types/optimizations";
-import { IN_PROGRESS_OPTIMIZATION_STATUSES } from "@/lib/optimizations";
 import {
   Card,
   CardContent,
@@ -35,11 +34,6 @@ import {
   MessagesList,
   NamedPromptsList,
 } from "@/v2/pages-shared/prompts/PromptMessageDisplay";
-import { useSaveToPromptLibrary } from "@/v2/pages-shared/shared/useSaveToPromptLibrary";
-import AddNewPromptVersionDialog from "@/v2/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog";
-import { PROMPT_TEMPLATE_STRUCTURE, PromptVersion } from "@/types/prompts";
-import { useToast } from "@/ui/use-toast";
-import { ToastAction } from "@/ui/toast";
 
 type BestPromptProps = {
   optimization: Optimization;
@@ -54,16 +48,10 @@ export const BestPrompt: React.FC<BestPromptProps> = ({
   experiment,
   scoreMap,
   baselineExperiment,
-  status,
 }) => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const activeProjectId = useActiveProjectId();
-  const navigate = useNavigate();
-  const { toast } = useToast();
   const [diffOpen, setDiffOpen] = useState(false);
-
-  const isInProgress =
-    status && IN_PROGRESS_OPTIMIZATION_STATUSES.includes(status);
 
   const { score, percentage } = useMemo(() => {
     const retVal: {
@@ -136,78 +124,6 @@ export const BestPrompt: React.FC<BestPromptProps> = ({
     );
   }, [extractedPrompt, fallbackPrompt]);
 
-  const {
-    canSaveToLibrary,
-    saveDialogOpen,
-    openSaveDialog,
-    closeSaveDialog,
-    dialogKey,
-    existingPrompt,
-    saveTemplate,
-    saveMetadata,
-  } = useSaveToPromptLibrary({
-    projectId: activeProjectId!,
-    promptName: optimization.name,
-    extractedPrompt,
-    optimizationId: optimization.id,
-    optimizationName: optimization.name,
-    experimentId: experiment.id,
-  });
-
-  const canSave = canSaveToLibrary && !isInProgress;
-
-  const handlePromptSaved = useCallback(
-    (_version: PromptVersion, promptName?: string, promptId?: string) => {
-      closeSaveDialog();
-
-      if (promptId && promptName) {
-        const isNewPrompt = promptId !== existingPrompt?.id;
-        const message = isNewPrompt ? (
-          <span>
-            New prompt <b>{promptName}</b> created
-          </span>
-        ) : (
-          <span>
-            New version saved to <b>{promptName}</b>
-          </span>
-        );
-
-        toast({
-          description: message,
-          actions: [
-            <ToastAction
-              key="save-new-prompt-version"
-              altText="Go to prompt"
-              variant="link"
-              size="sm"
-              className="px-0"
-              onClick={() =>
-                navigate({
-                  to: "/$workspaceName/projects/$projectId/prompts/$promptId",
-                  params: {
-                    workspaceName,
-                    projectId: activeProjectId!,
-                    promptId,
-                  },
-                })
-              }
-            >
-              Go to prompt
-            </ToastAction>,
-          ],
-        });
-      }
-    },
-    [
-      closeSaveDialog,
-      toast,
-      workspaceName,
-      navigate,
-      existingPrompt?.id,
-      activeProjectId,
-    ],
-  );
-
   return (
     <Card className="flex h-full flex-col">
       <CardHeader className="shrink-0 gap-y-0.5 px-5">
@@ -225,17 +141,6 @@ export const BestPrompt: React.FC<BestPromptProps> = ({
                   variant="ghost"
                   size="icon-xs"
                 />
-                {canSave && (
-                  <TooltipWrapper content="Save to Prompt library">
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      onClick={openSaveDialog}
-                    >
-                      <Save />
-                    </Button>
-                  </TooltipWrapper>
-                )}
               </div>
             </div>
             <CardDescription className="!mt-0">
@@ -361,20 +266,6 @@ export const BestPrompt: React.FC<BestPromptProps> = ({
           )}
         </div>
       </CardContent>
-
-      {canSave && (
-        <AddNewPromptVersionDialog
-          key={dialogKey}
-          open={saveDialogOpen}
-          setOpen={closeSaveDialog}
-          prompt={existingPrompt}
-          template={saveTemplate}
-          templateStructure={PROMPT_TEMPLATE_STRUCTURE.CHAT}
-          defaultName={optimization.name}
-          metadata={saveMetadata}
-          onSave={handlePromptSaved}
-        />
-      )}
     </Card>
   );
 };

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/BestPromptCard/BestPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/BestPromptCard/BestPrompt.tsx
@@ -8,7 +8,7 @@ import get from "lodash/get";
 import { OPTIMIZATION_PROMPT_KEY } from "@/constants/experiments";
 import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { Experiment } from "@/types/datasets";
-import { Optimization, OPTIMIZATION_STATUS } from "@/types/optimizations";
+import { Optimization } from "@/types/optimizations";
 import {
   Card,
   CardContent,
@@ -40,7 +40,6 @@ type BestPromptProps = {
   experiment: Experiment;
   scoreMap: Record<string, { score: number; percentage?: number }>;
   baselineExperiment?: Experiment | null;
-  status?: OPTIMIZATION_STATUS;
 };
 
 export const BestPrompt: React.FC<BestPromptProps> = ({

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
@@ -5,21 +5,55 @@ import { Button } from "@/ui/button";
 import LoadableSelectBox from "@/shared/LoadableSelectBox/LoadableSelectBox";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import useConfigHistoryListInfinite from "@/api/agent-configs/useConfigHistoryListInfinite";
-import {
-  BlueprintValue,
-  BlueprintValueType,
-  ConfigHistoryItem,
-} from "@/types/agent-configs";
+import { BlueprintValueType } from "@/types/agent-configs";
 import { BlueprintPromptRef } from "@/types/playground";
 
 interface BlueprintPromptsSelectBoxProps {
   projectId: string;
   value?: BlueprintPromptRef;
-  onValueChange: (value?: BlueprintPromptRef) => void;
+  onValueChange: (value: BlueprintPromptRef) => void;
   onClear?: () => void;
   hasUnsavedChanges?: boolean;
   disabled?: boolean;
 }
+
+interface LoadedDisplayProps {
+  promptKey: string;
+  hasUnsavedChanges: boolean;
+  onClear?: () => void;
+}
+
+const LoadedDisplay: React.FC<LoadedDisplayProps> = ({
+  promptKey,
+  hasUnsavedChanges,
+  onClear,
+}) => (
+  <div className="flex min-w-0 items-center px-1">
+    <TooltipWrapper content={hasUnsavedChanges ? "Unsaved changes" : promptKey}>
+      <div className="flex min-w-0 items-center gap-1">
+        <FileTerminal className="size-3.5 shrink-0 text-[#b8e54a]" />
+        <span className="comet-body-xs-accented truncate text-light-slate">
+          {promptKey}
+        </span>
+        {hasUnsavedChanges && (
+          <span className="mb-auto size-1 shrink-0 rounded-full bg-warning" />
+        )}
+      </div>
+    </TooltipWrapper>
+    {onClear && (
+      <TooltipWrapper content="Detach prompt">
+        <Button
+          variant="minimal"
+          size="icon-xs"
+          className="shrink-0"
+          onClick={onClear}
+        >
+          <XCircle />
+        </Button>
+      </TooltipWrapper>
+    )}
+  </div>
+);
 
 const BlueprintPromptsSelectBox: React.FC<BlueprintPromptsSelectBoxProps> = ({
   projectId,
@@ -32,13 +66,9 @@ const BlueprintPromptsSelectBox: React.FC<BlueprintPromptsSelectBoxProps> = ({
   const [open, setOpen] = useState(false);
 
   const { data, isLoading } = useConfigHistoryListInfinite({ projectId });
+  const latestBlueprint = data?.pages?.[0]?.content?.[0];
 
-  const latestBlueprint: ConfigHistoryItem | undefined = useMemo(
-    () => data?.pages?.[0]?.content?.[0],
-    [data],
-  );
-
-  const promptValues: BlueprintValue[] = useMemo(
+  const promptValues = useMemo(
     () =>
       latestBlueprint?.values?.filter(
         (v) => v.type === BlueprintValueType.PROMPT,
@@ -66,33 +96,11 @@ const BlueprintPromptsSelectBox: React.FC<BlueprintPromptsSelectBoxProps> = ({
 
   if (value) {
     return (
-      <div className="flex min-w-0 items-center px-1">
-        <TooltipWrapper
-          content={hasUnsavedChanges ? "Unsaved changes" : value.key}
-        >
-          <div className="flex min-w-0 items-center gap-1">
-            <FileTerminal className="size-3.5 shrink-0 text-[#b8e54a]" />
-            <span className="comet-body-xs-accented truncate text-light-slate">
-              {value.key}
-            </span>
-            {hasUnsavedChanges && (
-              <span className="mb-auto size-1 shrink-0 rounded-full bg-warning" />
-            )}
-          </div>
-        </TooltipWrapper>
-        {onClear && (
-          <TooltipWrapper content="Detach prompt">
-            <Button
-              variant="minimal"
-              size="icon-xs"
-              className="shrink-0"
-              onClick={onClear}
-            >
-              <XCircle />
-            </Button>
-          </TooltipWrapper>
-        )}
-      </div>
+      <LoadedDisplay
+        promptKey={value.key}
+        hasUnsavedChanges={hasUnsavedChanges}
+        onClear={onClear}
+      />
     );
   }
 

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
@@ -1,13 +1,16 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { FileTerminal, XCircle } from "lucide-react";
+import { useQueries } from "@tanstack/react-query";
 
 import { Button } from "@/ui/button";
 import LoadableSelectBox from "@/shared/LoadableSelectBox/LoadableSelectBox";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import useConfigHistoryListInfinite from "@/api/agent-configs/useConfigHistoryListInfinite";
 import useAgentConfigById from "@/api/agent-configs/useAgentConfigById";
-import { BlueprintValueType } from "@/types/agent-configs";
+import { BlueprintValue, BlueprintValueType } from "@/types/agent-configs";
 import { BlueprintPromptRef } from "@/types/playground";
+import { PROMPT_TEMPLATE_STRUCTURE, PromptByCommit } from "@/types/prompts";
+import api, { PROMPTS_REST_ENDPOINT } from "@/api/api";
 
 interface BlueprintPromptsSelectBoxProps {
   projectId: string;
@@ -17,6 +20,7 @@ interface BlueprintPromptsSelectBoxProps {
   onOpenChange?: (open: boolean) => void;
   hasUnsavedChanges?: boolean;
   disabled?: boolean;
+  filterByTemplateStructure?: PROMPT_TEMPLATE_STRUCTURE;
 }
 
 interface LoadedDisplayProps {
@@ -57,6 +61,44 @@ const LoadedDisplay: React.FC<LoadedDisplayProps> = ({
   </div>
 );
 
+const fetchPromptByCommit = async (
+  commitId: string,
+): Promise<PromptByCommit> => {
+  const { data } = await api.get(
+    `${PROMPTS_REST_ENDPOINT}by-commit/${commitId}`,
+  );
+  return data;
+};
+
+const useFilteredPromptValues = (
+  promptValues: BlueprintValue[],
+  filter?: PROMPT_TEMPLATE_STRUCTURE,
+) => {
+  const queries = useQueries({
+    queries: filter
+      ? promptValues.map((v) => ({
+          queryKey: ["prompt-by-commit", { commitId: v.value }],
+          queryFn: () => fetchPromptByCommit(v.value),
+          staleTime: 5 * 60 * 1000,
+          enabled: !!v.value,
+        }))
+      : [],
+  });
+
+  return useMemo(() => {
+    if (!filter) return { values: promptValues, isResolving: false };
+
+    const isResolving = queries.some((q) => q.isLoading);
+    if (isResolving) return { values: [], isResolving: true };
+
+    const filtered = promptValues.filter((_, i) => {
+      const structure = queries[i]?.data?.template_structure;
+      return structure === filter;
+    });
+    return { values: filtered, isResolving: false };
+  }, [filter, promptValues, queries]);
+};
+
 const BlueprintPromptsSelectBox: React.FC<BlueprintPromptsSelectBoxProps> = ({
   projectId,
   value,
@@ -65,6 +107,7 @@ const BlueprintPromptsSelectBox: React.FC<BlueprintPromptsSelectBoxProps> = ({
   onOpenChange,
   hasUnsavedChanges = false,
   disabled = false,
+  filterByTemplateStructure,
 }) => {
   const [open, setOpen] = useState(false);
 
@@ -80,20 +123,23 @@ const BlueprintPromptsSelectBox: React.FC<BlueprintPromptsSelectBoxProps> = ({
     useConfigHistoryListInfinite({ projectId });
   const latestBlueprintId = history?.pages?.[0]?.content?.[0]?.id;
 
-  // The history list returns a summary; fetch the full blueprint to get
-  // PROMPT-typed values, mirroring AgentConfigurationDetailView.
   const { data: blueprint, isLoading: isLoadingBlueprint } = useAgentConfigById(
     { blueprintId: latestBlueprintId ?? "" },
   );
 
-  const isLoading = isLoadingHistory || isLoadingBlueprint;
-
-  const promptValues = useMemo(
+  const allPromptValues = useMemo(
     () =>
       blueprint?.values?.filter((v) => v.type === BlueprintValueType.PROMPT) ??
       [],
     [blueprint],
   );
+
+  const { values: promptValues, isResolving } = useFilteredPromptValues(
+    allPromptValues,
+    filterByTemplateStructure,
+  );
+
+  const isLoading = isLoadingHistory || isLoadingBlueprint || isResolving;
 
   const options = useMemo(
     () => promptValues.map((v) => ({ label: v.key, value: v.key })),

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { FileTerminal, XCircle } from "lucide-react";
-import { useQueries } from "@tanstack/react-query";
+import { QueryFunctionContext, useQueries } from "@tanstack/react-query";
 
 import { Button } from "@/ui/button";
 import LoadableSelectBox from "@/shared/LoadableSelectBox/LoadableSelectBox";
@@ -9,8 +9,8 @@ import useConfigHistoryListInfinite from "@/api/agent-configs/useConfigHistoryLi
 import useAgentConfigById from "@/api/agent-configs/useAgentConfigById";
 import { BlueprintValue, BlueprintValueType } from "@/types/agent-configs";
 import { BlueprintPromptRef } from "@/types/playground";
-import { PROMPT_TEMPLATE_STRUCTURE, PromptByCommit } from "@/types/prompts";
-import api, { PROMPTS_REST_ENDPOINT } from "@/api/api";
+import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
+import { getPromptByCommit } from "@/api/prompts/usePromptByCommit";
 
 interface BlueprintPromptsSelectBoxProps {
   projectId: string;
@@ -61,14 +61,7 @@ const LoadedDisplay: React.FC<LoadedDisplayProps> = ({
   </div>
 );
 
-const fetchPromptByCommit = async (
-  commitId: string,
-): Promise<PromptByCommit> => {
-  const { data } = await api.get(
-    `${PROMPTS_REST_ENDPOINT}by-commit/${commitId}`,
-  );
-  return data;
-};
+const PROMPT_COMMIT_STALE_TIME = 5 * 60 * 1000;
 
 const useFilteredPromptValues = (
   promptValues: BlueprintValue[],
@@ -78,8 +71,9 @@ const useFilteredPromptValues = (
     queries: filter
       ? promptValues.map((v) => ({
           queryKey: ["prompt-by-commit", { commitId: v.value }],
-          queryFn: () => fetchPromptByCommit(v.value),
-          staleTime: 5 * 60 * 1000,
+          queryFn: (context: QueryFunctionContext) =>
+            getPromptByCommit(context, { commitId: v.value }),
+          staleTime: PROMPT_COMMIT_STALE_TIME,
           enabled: !!v.value,
         }))
       : [],

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/ui/button";
 import LoadableSelectBox from "@/shared/LoadableSelectBox/LoadableSelectBox";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import useConfigHistoryListInfinite from "@/api/agent-configs/useConfigHistoryListInfinite";
+import useAgentConfigById from "@/api/agent-configs/useAgentConfigById";
 import { BlueprintValueType } from "@/types/agent-configs";
 import { BlueprintPromptRef } from "@/types/playground";
 
@@ -65,15 +66,23 @@ const BlueprintPromptsSelectBox: React.FC<BlueprintPromptsSelectBoxProps> = ({
 }) => {
   const [open, setOpen] = useState(false);
 
-  const { data, isLoading } = useConfigHistoryListInfinite({ projectId });
-  const latestBlueprint = data?.pages?.[0]?.content?.[0];
+  const { data: history, isLoading: isLoadingHistory } =
+    useConfigHistoryListInfinite({ projectId });
+  const latestBlueprintId = history?.pages?.[0]?.content?.[0]?.id;
+
+  // The history list returns a summary; fetch the full blueprint to get
+  // PROMPT-typed values, mirroring AgentConfigurationDetailView.
+  const { data: blueprint, isLoading: isLoadingBlueprint } = useAgentConfigById(
+    { blueprintId: latestBlueprintId ?? "" },
+  );
+
+  const isLoading = isLoadingHistory || isLoadingBlueprint;
 
   const promptValues = useMemo(
     () =>
-      latestBlueprint?.values?.filter(
-        (v) => v.type === BlueprintValueType.PROMPT,
-      ) ?? [],
-    [latestBlueprint],
+      blueprint?.values?.filter((v) => v.type === BlueprintValueType.PROMPT) ??
+      [],
+    [blueprint],
   );
 
   const options = useMemo(
@@ -84,14 +93,14 @@ const BlueprintPromptsSelectBox: React.FC<BlueprintPromptsSelectBoxProps> = ({
   const handleChange = useCallback(
     (key: string) => {
       const match = promptValues.find((v) => v.key === key);
-      if (!match || !latestBlueprint) return;
+      if (!match || !latestBlueprintId) return;
       onValueChange({
-        blueprintId: latestBlueprint.id,
+        blueprintId: latestBlueprintId,
         key: match.key,
         commitId: match.value,
       });
     },
-    [latestBlueprint, promptValues, onValueChange],
+    [latestBlueprintId, promptValues, onValueChange],
   );
 
   if (value) {

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
@@ -10,12 +10,7 @@ import {
   BlueprintValueType,
   ConfigHistoryItem,
 } from "@/types/agent-configs";
-
-export interface BlueprintPromptRef {
-  blueprintId: string;
-  key: string;
-  commitId: string;
-}
+import { BlueprintPromptRef } from "@/types/playground";
 
 interface BlueprintPromptsSelectBoxProps {
   projectId: string;

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
@@ -14,6 +14,7 @@ interface BlueprintPromptsSelectBoxProps {
   value?: BlueprintPromptRef;
   onValueChange: (value: BlueprintPromptRef) => void;
   onClear?: () => void;
+  onOpenChange?: (open: boolean) => void;
   hasUnsavedChanges?: boolean;
   disabled?: boolean;
 }
@@ -61,10 +62,19 @@ const BlueprintPromptsSelectBox: React.FC<BlueprintPromptsSelectBoxProps> = ({
   value,
   onValueChange,
   onClear,
+  onOpenChange,
   hasUnsavedChanges = false,
   disabled = false,
 }) => {
   const [open, setOpen] = useState(false);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      onOpenChange?.(next);
+    },
+    [onOpenChange],
+  );
 
   const { data: history, isLoading: isLoadingHistory } =
     useConfigHistoryListInfinite({ projectId });
@@ -124,7 +134,7 @@ const BlueprintPromptsSelectBox: React.FC<BlueprintPromptsSelectBoxProps> = ({
       searchPlaceholder="Search prompt"
       onChange={handleChange}
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={handleOpenChange}
       isLoading={isLoading}
       optionsCount={options.length}
       trigger={

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
@@ -115,7 +115,9 @@ const BlueprintPromptsSelectBox: React.FC<BlueprintPromptsSelectBoxProps> = ({
 
   const { data: history, isLoading: isLoadingHistory } =
     useConfigHistoryListInfinite({ projectId });
-  const latestBlueprintId = history?.pages?.[0]?.content?.[0]?.id;
+  const latestBlueprint = history?.pages?.[0]?.content?.[0];
+  const latestBlueprintId = latestBlueprint?.id;
+  const latestBlueprintName = latestBlueprint?.name;
 
   const { data: blueprint, isLoading: isLoadingBlueprint } = useAgentConfigById(
     { blueprintId: latestBlueprintId ?? "" },
@@ -192,7 +194,8 @@ const BlueprintPromptsSelectBox: React.FC<BlueprintPromptsSelectBoxProps> = ({
         <div className="comet-body-xs flex items-start gap-1.5 border-t border-border px-3 py-2 text-light-slate">
           <Info className="mt-0.5 size-3 shrink-0" />
           <span>
-            Prompts are taken from the latest agent configuration version.
+            Prompts are loaded from the latest agent configuration
+            {latestBlueprintName ? ` (${latestBlueprintName})` : ""}.
           </span>
         </div>
       }

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { FileTerminal, XCircle } from "lucide-react";
+import { FileTerminal, Info, XCircle } from "lucide-react";
 import { QueryFunctionContext, useQueries } from "@tanstack/react-query";
 
 import { Button } from "@/ui/button";
@@ -37,7 +37,7 @@ const LoadedDisplay: React.FC<LoadedDisplayProps> = ({
   <div className="flex min-w-0 items-center px-1">
     <TooltipWrapper content={hasUnsavedChanges ? "Unsaved changes" : promptKey}>
       <div className="flex min-w-0 items-center gap-1">
-        <FileTerminal className="size-3.5 shrink-0 text-[#b8e54a]" />
+        <FileTerminal className="size-3.5 shrink-0 text-library-loaded" />
         <span className="comet-body-xs-accented truncate text-light-slate">
           {promptKey}
         </span>
@@ -188,6 +188,14 @@ const BlueprintPromptsSelectBox: React.FC<BlueprintPromptsSelectBoxProps> = ({
       }
       minWidth={360}
       disabled={isDisabled}
+      actionPanel={
+        <div className="comet-body-xs flex items-start gap-1.5 border-t border-border px-3 py-2 text-light-slate">
+          <Info className="mt-0.5 size-3 shrink-0" />
+          <span>
+            Prompts are taken from the latest agent configuration version.
+          </span>
+        </div>
+      }
     />
   );
 };

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx
@@ -1,0 +1,133 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { FileTerminal, XCircle } from "lucide-react";
+
+import { Button } from "@/ui/button";
+import LoadableSelectBox from "@/shared/LoadableSelectBox/LoadableSelectBox";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import useConfigHistoryListInfinite from "@/api/agent-configs/useConfigHistoryListInfinite";
+import {
+  BlueprintValue,
+  BlueprintValueType,
+  ConfigHistoryItem,
+} from "@/types/agent-configs";
+
+export interface BlueprintPromptRef {
+  blueprintId: string;
+  key: string;
+  commitId: string;
+}
+
+interface BlueprintPromptsSelectBoxProps {
+  projectId: string;
+  value?: BlueprintPromptRef;
+  onValueChange: (value?: BlueprintPromptRef) => void;
+  onClear?: () => void;
+  hasUnsavedChanges?: boolean;
+  disabled?: boolean;
+}
+
+const BlueprintPromptsSelectBox: React.FC<BlueprintPromptsSelectBoxProps> = ({
+  projectId,
+  value,
+  onValueChange,
+  onClear,
+  hasUnsavedChanges = false,
+  disabled = false,
+}) => {
+  const [open, setOpen] = useState(false);
+
+  const { data, isLoading } = useConfigHistoryListInfinite({ projectId });
+
+  const latestBlueprint: ConfigHistoryItem | undefined = useMemo(
+    () => data?.pages?.[0]?.content?.[0],
+    [data],
+  );
+
+  const promptValues: BlueprintValue[] = useMemo(
+    () =>
+      latestBlueprint?.values?.filter(
+        (v) => v.type === BlueprintValueType.PROMPT,
+      ) ?? [],
+    [latestBlueprint],
+  );
+
+  const options = useMemo(
+    () => promptValues.map((v) => ({ label: v.key, value: v.key })),
+    [promptValues],
+  );
+
+  const handleChange = useCallback(
+    (key: string) => {
+      const match = promptValues.find((v) => v.key === key);
+      if (!match || !latestBlueprint) return;
+      onValueChange({
+        blueprintId: latestBlueprint.id,
+        key: match.key,
+        commitId: match.value,
+      });
+    },
+    [latestBlueprint, promptValues, onValueChange],
+  );
+
+  if (value) {
+    return (
+      <div className="flex min-w-0 items-center px-1">
+        <TooltipWrapper
+          content={hasUnsavedChanges ? "Unsaved changes" : value.key}
+        >
+          <div className="flex min-w-0 items-center gap-1">
+            <FileTerminal className="size-3.5 shrink-0 text-[#b8e54a]" />
+            <span className="comet-body-xs-accented truncate text-light-slate">
+              {value.key}
+            </span>
+            {hasUnsavedChanges && (
+              <span className="mb-auto size-1 shrink-0 rounded-full bg-warning" />
+            )}
+          </div>
+        </TooltipWrapper>
+        {onClear && (
+          <TooltipWrapper content="Detach prompt">
+            <Button
+              variant="minimal"
+              size="icon-xs"
+              className="shrink-0"
+              onClick={onClear}
+            >
+              <XCircle />
+            </Button>
+          </TooltipWrapper>
+        )}
+      </div>
+    );
+  }
+
+  const isDisabled = disabled || (!isLoading && options.length === 0);
+  const triggerTooltip = isDisabled
+    ? "No agent configuration prompts found for this project"
+    : "Load prompt from agent configuration";
+
+  return (
+    <LoadableSelectBox
+      options={options}
+      searchPlaceholder="Search prompt"
+      onChange={handleChange}
+      open={open}
+      onOpenChange={setOpen}
+      isLoading={isLoading}
+      optionsCount={options.length}
+      trigger={
+        <div>
+          <TooltipWrapper content={triggerTooltip}>
+            <Button variant="minimal" size="icon-sm" disabled={isDisabled}>
+              <FileTerminal />
+            </Button>
+          </TooltipWrapper>
+        </div>
+      }
+      minWidth={360}
+      disabled={isDisabled}
+    />
+  );
+};
+
+export default BlueprintPromptsSelectBox;

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveAsNewBlueprintFieldDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveAsNewBlueprintFieldDialog.tsx
@@ -11,8 +11,7 @@ import {
 import { Button } from "@/ui/button";
 import { Input } from "@/ui/input";
 import { Label } from "@/ui/label";
-
-const FIELD_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+import { BLUEPRINT_FIELD_NAME_PATTERN } from "@/v2/pages-shared/agent-configuration/blueprintFieldValidation";
 
 interface SaveAsNewBlueprintFieldDialogProps {
   open: boolean;
@@ -24,7 +23,7 @@ interface SaveAsNewBlueprintFieldDialogProps {
 
 const validate = (value: string, existing: Set<string>): string | null => {
   if (!value) return "Field name is required";
-  if (!FIELD_NAME_PATTERN.test(value))
+  if (!BLUEPRINT_FIELD_NAME_PATTERN.test(value))
     return "Use letters, digits and underscore; start with a letter or underscore";
   if (existing.has(value)) return "A field with this name already exists";
   return null;

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveAsNewBlueprintFieldDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveAsNewBlueprintFieldDialog.tsx
@@ -1,0 +1,91 @@
+import React, { useMemo, useState } from "react";
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/ui/dialog";
+import { Button } from "@/ui/button";
+import { Input } from "@/ui/input";
+import { Label } from "@/ui/label";
+
+const FIELD_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+interface SaveAsNewBlueprintFieldDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existingFieldNames: string[];
+  isSaving: boolean;
+  onSave: (fieldName: string) => void;
+}
+
+const validate = (value: string, existing: Set<string>): string | null => {
+  if (!value) return "Field name is required";
+  if (!FIELD_NAME_PATTERN.test(value))
+    return "Use letters, digits and underscore; start with a letter or underscore";
+  if (existing.has(value)) return "A field with this name already exists";
+  return null;
+};
+
+const SaveAsNewBlueprintFieldDialog: React.FC<
+  SaveAsNewBlueprintFieldDialogProps
+> = ({ open, onOpenChange, existingFieldNames, isSaving, onSave }) => {
+  const [fieldName, setFieldName] = useState("");
+  const existing = useMemo(
+    () => new Set(existingFieldNames),
+    [existingFieldNames],
+  );
+
+  const trimmed = fieldName.trim();
+  const error = trimmed ? validate(trimmed, existing) : null;
+  const canSave = !!trimmed && !error;
+
+  const handleClose = (next: boolean) => {
+    if (!next) setFieldName("");
+    onOpenChange(next);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add to agent configuration</DialogTitle>
+        </DialogHeader>
+        <p className="comet-body-s pb-4 text-muted-slate">
+          Creates a new prompt and adds it to the latest agent configuration as
+          a new field. The same name is used for both the prompt and the
+          configuration field.
+        </p>
+        <div className="flex flex-col gap-2 pb-4">
+          <Label htmlFor="fieldName">Field name</Label>
+          <Input
+            id="fieldName"
+            value={fieldName}
+            onChange={(e) => setFieldName(e.target.value)}
+            placeholder="e.g. summarization_prompt"
+            autoFocus
+          />
+          {error && <p className="comet-body-xs text-destructive">{error}</p>}
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline" disabled={isSaving}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button
+            onClick={() => onSave(trimmed)}
+            disabled={!canSave || isSaving}
+          >
+            Save to configuration
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default SaveAsNewBlueprintFieldDialog;

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveAsNewBlueprintFieldDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveAsNewBlueprintFieldDialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@/ui/button";
 import { Input } from "@/ui/input";
 import { Label } from "@/ui/label";
+import { Textarea } from "@/ui/textarea";
 import { BLUEPRINT_FIELD_NAME_PATTERN } from "@/v2/pages-shared/agent-configuration/blueprintFieldValidation";
 
 interface SaveAsNewBlueprintFieldDialogProps {
@@ -18,7 +19,7 @@ interface SaveAsNewBlueprintFieldDialogProps {
   onOpenChange: (open: boolean) => void;
   existingFieldNames: string[];
   isSaving: boolean;
-  onSave: (fieldName: string) => void;
+  onSave: (fieldName: string, changeDescription: string) => void;
 }
 
 const validate = (value: string, existing: Set<string>): string | null => {
@@ -33,6 +34,7 @@ const SaveAsNewBlueprintFieldDialog: React.FC<
   SaveAsNewBlueprintFieldDialogProps
 > = ({ open, onOpenChange, existingFieldNames, isSaving, onSave }) => {
   const [fieldName, setFieldName] = useState("");
+  const [changeDescription, setChangeDescription] = useState("");
   const existing = useMemo(
     () => new Set(existingFieldNames),
     [existingFieldNames],
@@ -43,7 +45,10 @@ const SaveAsNewBlueprintFieldDialog: React.FC<
   const canSave = !!trimmed && !error;
 
   const handleClose = (next: boolean) => {
-    if (!next) setFieldName("");
+    if (!next) {
+      setFieldName("");
+      setChangeDescription("");
+    }
     onOpenChange(next);
   };
 
@@ -69,6 +74,18 @@ const SaveAsNewBlueprintFieldDialog: React.FC<
           />
           {error && <p className="comet-body-xs text-destructive">{error}</p>}
         </div>
+        <div className="flex flex-col gap-2 pb-4">
+          <Label htmlFor="changeDescription">
+            Change description (optional)
+          </Label>
+          <Textarea
+            id="changeDescription"
+            value={changeDescription}
+            onChange={(e) => setChangeDescription(e.target.value)}
+            placeholder="What changed in this version?"
+            className="min-h-20"
+          />
+        </div>
         <DialogFooter>
           <DialogClose asChild>
             <Button variant="outline" disabled={isSaving}>
@@ -76,7 +93,7 @@ const SaveAsNewBlueprintFieldDialog: React.FC<
             </Button>
           </DialogClose>
           <Button
-            onClick={() => onSave(trimmed)}
+            onClick={() => onSave(trimmed, changeDescription.trim())}
             disabled={!canSave || isSaving}
           >
             Save to configuration

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveExistingPromptDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveExistingPromptDialog.tsx
@@ -46,9 +46,8 @@ const SaveExistingPromptDialog: React.FC<SaveExistingPromptDialogProps> = ({
           <DialogTitle>Update {promptName}</DialogTitle>
         </DialogHeader>
         <p className="comet-body-s pb-4 text-muted-slate">
-          Saves a new version of the prompt and updates the agent configuration
-          field <span className="comet-body-s-accented">{fieldName}</span> to
-          point at it.
+          Creates a new agent configuration version with the updated prompt for
+          field <span className="comet-body-s-accented">{fieldName}</span>.
         </p>
         <div className="flex flex-col gap-2 pb-4">
           <Label htmlFor="changeDescription">

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveExistingPromptDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveExistingPromptDialog.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from "react";
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/ui/dialog";
+import { Button } from "@/ui/button";
+import { Label } from "@/ui/label";
+import { Textarea } from "@/ui/textarea";
+
+interface SaveExistingPromptDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  promptName: string;
+  fieldName: string;
+  isSaving: boolean;
+  onSave: (changeDescription: string) => void;
+}
+
+const SaveExistingPromptDialog: React.FC<SaveExistingPromptDialogProps> = ({
+  open,
+  onOpenChange,
+  promptName,
+  fieldName,
+  isSaving,
+  onSave,
+}) => {
+  const [changeDescription, setChangeDescription] = useState("");
+
+  const handleSave = () => onSave(changeDescription.trim());
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setChangeDescription("");
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Update {promptName}</DialogTitle>
+        </DialogHeader>
+        <p className="comet-body-s pb-4 text-muted-slate">
+          Saves a new version of the prompt and updates the agent configuration
+          field <span className="comet-body-s-accented">{fieldName}</span> to
+          point at it.
+        </p>
+        <div className="flex flex-col gap-2 pb-4">
+          <Label htmlFor="changeDescription">
+            Change description (optional)
+          </Label>
+          <Textarea
+            id="changeDescription"
+            value={changeDescription}
+            onChange={(e) => setChangeDescription(e.target.value)}
+            placeholder="What changed in this version?"
+            className="min-h-20"
+          />
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline" disabled={isSaving}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button onClick={handleSave} disabled={isSaving}>
+            Save new version
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default SaveExistingPromptDialog;

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.ts
@@ -32,33 +32,24 @@ interface SaveAsNewFieldArgs {
   template: string;
 }
 
-interface UseSavePromptToBlueprintReturn {
-  existingFieldNames: string[];
-  saveExistingVersion: (args: SaveExistingArgs) => Promise<{
-    version: PromptVersion;
-    newRef: BlueprintPromptRef;
-  } | null>;
-  saveAsNewField: (
-    args: SaveAsNewFieldArgs,
-  ) => Promise<BlueprintPromptRef | null>;
-  isSaving: boolean;
+interface SaveExistingResult {
+  version: PromptVersion;
+  newRef: BlueprintPromptRef;
 }
 
-const stripValueForPayload = (v: BlueprintValue): BlueprintValue => ({
+const stripBlueprintValue = (v: BlueprintValue): BlueprintValue => ({
   key: v.key,
   type: v.type,
   value: v.value,
   ...(v.description ? { description: v.description } : {}),
 });
 
-const useSavePromptToBlueprint = (
-  projectId: string,
-): UseSavePromptToBlueprintReturn => {
+const useSavePromptToBlueprint = (projectId: string) => {
   const queryClient = useQueryClient();
 
   const { data: history } = useConfigHistoryListInfinite({ projectId });
   const latestBlueprintId = history?.pages?.[0]?.content?.[0]?.id;
-  const { data: latestBlueprintFull } = useAgentConfigById({
+  const { data: latestBlueprint } = useAgentConfigById({
     blueprintId: latestBlueprintId ?? "",
   });
 
@@ -88,11 +79,14 @@ const useSavePromptToBlueprint = (
   );
 
   // Updates an existing prompt loaded from a blueprint. The backend
-  // auto-publishes a new blueprint version pinning this commit.
-  const saveExistingVersion = useCallback<
-    UseSavePromptToBlueprintReturn["saveExistingVersion"]
-  >(
-    async ({ ref, promptName, template, changeDescription }) => {
+  // auto-publishes a new blueprint version pinning the new commit.
+  const saveExistingVersion = useCallback(
+    async ({
+      ref,
+      promptName,
+      template,
+      changeDescription,
+    }: SaveExistingArgs): Promise<SaveExistingResult | null> => {
       try {
         const version = await createPromptVersion({
           name: promptName,
@@ -109,7 +103,7 @@ const useSavePromptToBlueprint = (
           newRef: { ...ref, commitId: version.commit },
         };
       } catch {
-        // useCreatePromptVersionMutation already toasts the error
+        // The mutation already toasts the error.
         return null;
       }
     },
@@ -117,16 +111,16 @@ const useSavePromptToBlueprint = (
   );
 
   // Creates a brand-new prompt and either appends it to the latest blueprint
-  // as a new PROMPT-typed value (preserving all existing values) or, if the
-  // project has no blueprint yet, creates the first blueprint with this
-  // single value.
-  const saveAsNewField = useCallback<
-    UseSavePromptToBlueprintReturn["saveAsNewField"]
-  >(
-    async ({ fieldName, template }) => {
-      let newPrompt: PromptWithLatestVersion | undefined;
+  // (PATCH) or, if the project has no blueprint yet, creates the first one
+  // (POST) containing only this single value.
+  const saveAsNewField = useCallback(
+    async ({
+      fieldName,
+      template,
+    }: SaveAsNewFieldArgs): Promise<BlueprintPromptRef | null> => {
+      let createdPrompt: PromptWithLatestVersion;
       try {
-        newPrompt = (await createPrompt({
+        createdPrompt = (await createPrompt({
           prompt: {
             name: fieldName,
             template,
@@ -139,45 +133,31 @@ const useSavePromptToBlueprint = (
         return null;
       }
 
-      const commit = newPrompt?.latest_version?.commit;
-      if (!commit || !newPrompt?.id) return null;
+      const commit = createdPrompt?.latest_version?.commit;
+      if (!commit) return null;
 
-      const newValue: BlueprintValue = {
-        key: fieldName,
-        type: BlueprintValueType.PROMPT,
-        value: commit,
-      };
-
-      const hasExistingBlueprint = !!latestBlueprintFull;
       const values: BlueprintValue[] = [
-        ...(latestBlueprintFull?.values?.map(stripValueForPayload) ?? []),
-        newValue,
+        ...(latestBlueprint?.values?.map(stripBlueprintValue) ?? []),
+        { key: fieldName, type: BlueprintValueType.PROMPT, value: commit },
       ];
 
-      let blueprintIdForRef: string;
+      const writeBlueprint = latestBlueprint ? patchBlueprint : postBlueprint;
       try {
-        const mutation = hasExistingBlueprint ? patchBlueprint : postBlueprint;
-        const { id } = await mutation({
+        const { id } = await writeBlueprint({
           agentConfig: {
             project_id: projectId,
             blueprint: { type: BlueprintType.BLUEPRINT, values },
           },
         });
         if (!id) return null;
-        blueprintIdForRef = id;
+        invalidateAfterSave(commit);
+        return { blueprintId: id, key: fieldName, commitId: commit };
       } catch {
         return null;
       }
-
-      invalidateAfterSave(commit);
-      return {
-        blueprintId: blueprintIdForRef,
-        key: fieldName,
-        commitId: commit,
-      };
     },
     [
-      latestBlueprintFull,
+      latestBlueprint,
       createPrompt,
       patchBlueprint,
       postBlueprint,
@@ -187,7 +167,7 @@ const useSavePromptToBlueprint = (
   );
 
   return {
-    existingFieldNames: latestBlueprintFull?.values?.map((v) => v.key) ?? [],
+    existingFieldNames: latestBlueprint?.values?.map((v) => v.key) ?? [],
     saveExistingVersion,
     saveAsNewField,
     isSaving,

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.ts
@@ -80,8 +80,8 @@ const useSavePromptToBlueprint = (projectId: string) => {
     [queryClient],
   );
 
-  // Updates an existing prompt loaded from a blueprint. The backend
-  // auto-publishes a new blueprint version pinning the new commit.
+  // Updates an existing prompt version and publishes a new blueprint version
+  // with the updated commit. If no blueprint exists yet, creates the first one.
   const saveExistingVersion = useCallback(
     async ({
       ref,
@@ -90,8 +90,9 @@ const useSavePromptToBlueprint = (projectId: string) => {
       templateStructure = PROMPT_TEMPLATE_STRUCTURE.CHAT,
       changeDescription,
     }: SaveExistingArgs): Promise<SaveExistingResult | null> => {
+      let version: PromptVersion;
       try {
-        const version = await createPromptVersion({
+        version = await createPromptVersion({
           name: promptName,
           template,
           templateStructure,
@@ -99,18 +100,51 @@ const useSavePromptToBlueprint = (projectId: string) => {
           projectId,
           onSuccess: () => {},
         });
-        if (!version.commit) return null;
+      } catch {
+        return null;
+      }
+      if (!version.commit) return null;
+
+      const values: BlueprintValue[] = latestBlueprint
+        ? latestBlueprint.values.map((v) =>
+            v.key === ref.key
+              ? { ...stripBlueprintValue(v), value: version.commit }
+              : stripBlueprintValue(v),
+          )
+        : [
+            {
+              key: ref.key,
+              type: BlueprintValueType.PROMPT,
+              value: version.commit,
+            },
+          ];
+
+      const writeBlueprint = latestBlueprint ? patchBlueprint : postBlueprint;
+      try {
+        const { id } = await writeBlueprint({
+          agentConfig: {
+            project_id: projectId,
+            blueprint: { type: BlueprintType.BLUEPRINT, values },
+          },
+        });
+        if (!id) return null;
         invalidateAfterSave(version.commit);
         return {
           version,
-          newRef: { ...ref, commitId: version.commit },
+          newRef: { ...ref, blueprintId: id, commitId: version.commit },
         };
       } catch {
-        // The mutation already toasts the error.
         return null;
       }
     },
-    [createPromptVersion, projectId, invalidateAfterSave],
+    [
+      createPromptVersion,
+      latestBlueprint,
+      patchBlueprint,
+      postBlueprint,
+      projectId,
+      invalidateAfterSave,
+    ],
   );
 
   // Creates a brand-new prompt and either appends it to the latest blueprint

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.ts
@@ -105,19 +105,25 @@ const useSavePromptToBlueprint = (projectId: string) => {
       }
       if (!version.commit) return null;
 
-      const values: BlueprintValue[] = latestBlueprint
-        ? latestBlueprint.values.map((v) =>
-            v.key === ref.key
-              ? { ...stripBlueprintValue(v), value: version.commit }
-              : stripBlueprintValue(v),
-          )
-        : [
-            {
-              key: ref.key,
-              type: BlueprintValueType.PROMPT,
-              value: version.commit,
-            },
-          ];
+      const newEntry: BlueprintValue = {
+        key: ref.key,
+        type: BlueprintValueType.PROMPT,
+        value: version.commit,
+      };
+      let values: BlueprintValue[];
+      if (latestBlueprint) {
+        const found = latestBlueprint.values.some((v) => v.key === ref.key);
+        values = latestBlueprint.values.map((v) =>
+          v.key === ref.key
+            ? { ...stripBlueprintValue(v), value: version.commit }
+            : stripBlueprintValue(v),
+        );
+        if (!found) {
+          values.push(newEntry);
+        }
+      } else {
+        values = [newEntry];
+      }
 
       const writeBlueprint = latestBlueprint ? patchBlueprint : postBlueprint;
       try {

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.ts
@@ -1,0 +1,187 @@
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import {
+  BlueprintType,
+  BlueprintValue,
+  BlueprintValueType,
+} from "@/types/agent-configs";
+import {
+  PROMPT_TEMPLATE_STRUCTURE,
+  PromptVersion,
+  PromptWithLatestVersion,
+} from "@/types/prompts";
+import useAgentConfigById from "@/api/agent-configs/useAgentConfigById";
+import useAgentConfigCreateMutation from "@/api/agent-configs/useAgentConfigCreateMutation";
+import useConfigHistoryListInfinite from "@/api/agent-configs/useConfigHistoryListInfinite";
+import useCreatePromptVersionMutation from "@/api/prompts/useCreatePromptVersionMutation";
+import usePromptCreateMutation from "@/api/prompts/usePromptCreateMutation";
+import { AGENT_CONFIGS_KEY } from "@/api/api";
+import { BlueprintPromptRef } from "@/types/playground";
+
+interface SaveExistingArgs {
+  ref: BlueprintPromptRef;
+  promptName: string;
+  template: string;
+  changeDescription?: string;
+}
+
+interface SaveAsNewFieldArgs {
+  fieldName: string;
+  template: string;
+}
+
+interface UseSavePromptToBlueprintReturn {
+  existingFieldNames: string[];
+  saveExistingVersion: (args: SaveExistingArgs) => Promise<{
+    version: PromptVersion;
+    newRef: BlueprintPromptRef;
+  } | null>;
+  saveAsNewField: (
+    args: SaveAsNewFieldArgs,
+  ) => Promise<BlueprintPromptRef | null>;
+  isSaving: boolean;
+}
+
+const stripValueForPayload = (v: BlueprintValue): BlueprintValue => ({
+  key: v.key,
+  type: v.type,
+  value: v.value,
+  ...(v.description ? { description: v.description } : {}),
+});
+
+const useSavePromptToBlueprint = (
+  projectId: string,
+): UseSavePromptToBlueprintReturn => {
+  const queryClient = useQueryClient();
+
+  const { data: history } = useConfigHistoryListInfinite({ projectId });
+  const latestBlueprintId = history?.pages?.[0]?.content?.[0]?.id;
+  const { data: latestBlueprintFull } = useAgentConfigById({
+    blueprintId: latestBlueprintId ?? "",
+  });
+
+  const { mutateAsync: createPromptVersion, isPending: isCreatingVersion } =
+    useCreatePromptVersionMutation();
+  const { mutateAsync: createPrompt, isPending: isCreatingPrompt } =
+    usePromptCreateMutation();
+  const { mutateAsync: createBlueprint, isPending: isCreatingBlueprint } =
+    useAgentConfigCreateMutation();
+
+  const isSaving = isCreatingVersion || isCreatingPrompt || isCreatingBlueprint;
+
+  const invalidateAfterSave = useCallback(
+    (commit: string) => {
+      queryClient.invalidateQueries({
+        queryKey: ["prompt-by-commit", { commitId: commit }],
+      });
+      queryClient.invalidateQueries({ queryKey: [AGENT_CONFIGS_KEY] });
+    },
+    [queryClient],
+  );
+
+  // Updates an existing prompt loaded from a blueprint. The backend
+  // auto-publishes a new blueprint version pinning this commit.
+  const saveExistingVersion = useCallback<
+    UseSavePromptToBlueprintReturn["saveExistingVersion"]
+  >(
+    async ({ ref, promptName, template, changeDescription }) => {
+      try {
+        const version = await createPromptVersion({
+          name: promptName,
+          template,
+          templateStructure: PROMPT_TEMPLATE_STRUCTURE.CHAT,
+          ...(changeDescription && { changeDescription }),
+          projectId,
+          onSuccess: () => {},
+        });
+        if (!version.commit) return null;
+        invalidateAfterSave(version.commit);
+        return {
+          version,
+          newRef: { ...ref, commitId: version.commit },
+        };
+      } catch {
+        // useCreatePromptVersionMutation already toasts the error
+        return null;
+      }
+    },
+    [createPromptVersion, projectId, invalidateAfterSave],
+  );
+
+  // Creates a brand-new prompt and either appends it to the latest blueprint
+  // as a new PROMPT-typed value (preserving all existing values) or, if the
+  // project has no blueprint yet, creates the first blueprint with this
+  // single value.
+  const saveAsNewField = useCallback<
+    UseSavePromptToBlueprintReturn["saveAsNewField"]
+  >(
+    async ({ fieldName, template }) => {
+      let newPrompt: PromptWithLatestVersion | undefined;
+      try {
+        newPrompt = (await createPrompt({
+          prompt: {
+            name: fieldName,
+            template,
+            template_structure: PROMPT_TEMPLATE_STRUCTURE.CHAT,
+            project_id: projectId,
+          },
+          withResponse: true,
+        })) as PromptWithLatestVersion;
+      } catch {
+        return null;
+      }
+
+      const commit = newPrompt?.latest_version?.commit;
+      if (!commit || !newPrompt?.id) return null;
+
+      const newValue: BlueprintValue = {
+        key: fieldName,
+        type: BlueprintValueType.PROMPT,
+        value: commit,
+      };
+
+      const values: BlueprintValue[] = [
+        ...(latestBlueprintFull?.values?.map(stripValueForPayload) ?? []),
+        newValue,
+      ];
+
+      let blueprintIdForRef: string;
+      try {
+        const { id } = await createBlueprint({
+          agentConfig: {
+            project_id: projectId,
+            blueprint: { type: BlueprintType.BLUEPRINT, values },
+          },
+        });
+        if (!id) return null;
+        blueprintIdForRef = id;
+      } catch {
+        return null;
+      }
+
+      invalidateAfterSave(commit);
+      return {
+        blueprintId: blueprintIdForRef,
+        key: fieldName,
+        commitId: commit,
+      };
+    },
+    [
+      latestBlueprintFull,
+      createPrompt,
+      createBlueprint,
+      projectId,
+      invalidateAfterSave,
+    ],
+  );
+
+  return {
+    existingFieldNames: latestBlueprintFull?.values?.map((v) => v.key) ?? [],
+    saveExistingVersion,
+    saveAsNewField,
+    isSaving,
+  };
+};
+
+export default useSavePromptToBlueprint;

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.ts
@@ -13,6 +13,7 @@ import {
 } from "@/types/prompts";
 import useAgentConfigById from "@/api/agent-configs/useAgentConfigById";
 import useAgentConfigCreateMutation from "@/api/agent-configs/useAgentConfigCreateMutation";
+import useAgentConfigPostMutation from "@/api/agent-configs/useAgentConfigPostMutation";
 import useConfigHistoryListInfinite from "@/api/agent-configs/useConfigHistoryListInfinite";
 import useCreatePromptVersionMutation from "@/api/prompts/useCreatePromptVersionMutation";
 import usePromptCreateMutation from "@/api/prompts/usePromptCreateMutation";
@@ -65,10 +66,16 @@ const useSavePromptToBlueprint = (
     useCreatePromptVersionMutation();
   const { mutateAsync: createPrompt, isPending: isCreatingPrompt } =
     usePromptCreateMutation();
-  const { mutateAsync: createBlueprint, isPending: isCreatingBlueprint } =
+  const { mutateAsync: postBlueprint, isPending: isPostingBlueprint } =
+    useAgentConfigPostMutation();
+  const { mutateAsync: patchBlueprint, isPending: isPatchingBlueprint } =
     useAgentConfigCreateMutation();
 
-  const isSaving = isCreatingVersion || isCreatingPrompt || isCreatingBlueprint;
+  const isSaving =
+    isCreatingVersion ||
+    isCreatingPrompt ||
+    isPostingBlueprint ||
+    isPatchingBlueprint;
 
   const invalidateAfterSave = useCallback(
     (commit: string) => {
@@ -141,6 +148,7 @@ const useSavePromptToBlueprint = (
         value: commit,
       };
 
+      const hasExistingBlueprint = !!latestBlueprintFull;
       const values: BlueprintValue[] = [
         ...(latestBlueprintFull?.values?.map(stripValueForPayload) ?? []),
         newValue,
@@ -148,7 +156,8 @@ const useSavePromptToBlueprint = (
 
       let blueprintIdForRef: string;
       try {
-        const { id } = await createBlueprint({
+        const mutation = hasExistingBlueprint ? patchBlueprint : postBlueprint;
+        const { id } = await mutation({
           agentConfig: {
             project_id: projectId,
             blueprint: { type: BlueprintType.BLUEPRINT, values },
@@ -170,7 +179,8 @@ const useSavePromptToBlueprint = (
     [
       latestBlueprintFull,
       createPrompt,
-      createBlueprint,
+      patchBlueprint,
+      postBlueprint,
       projectId,
       invalidateAfterSave,
     ],

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.ts
@@ -24,12 +24,14 @@ interface SaveExistingArgs {
   ref: BlueprintPromptRef;
   promptName: string;
   template: string;
+  templateStructure?: PROMPT_TEMPLATE_STRUCTURE;
   changeDescription?: string;
 }
 
 interface SaveAsNewFieldArgs {
   fieldName: string;
   template: string;
+  templateStructure?: PROMPT_TEMPLATE_STRUCTURE;
 }
 
 interface SaveExistingResult {
@@ -85,13 +87,14 @@ const useSavePromptToBlueprint = (projectId: string) => {
       ref,
       promptName,
       template,
+      templateStructure = PROMPT_TEMPLATE_STRUCTURE.CHAT,
       changeDescription,
     }: SaveExistingArgs): Promise<SaveExistingResult | null> => {
       try {
         const version = await createPromptVersion({
           name: promptName,
           template,
-          templateStructure: PROMPT_TEMPLATE_STRUCTURE.CHAT,
+          templateStructure,
           ...(changeDescription && { changeDescription }),
           projectId,
           onSuccess: () => {},
@@ -117,6 +120,7 @@ const useSavePromptToBlueprint = (projectId: string) => {
     async ({
       fieldName,
       template,
+      templateStructure = PROMPT_TEMPLATE_STRUCTURE.CHAT,
     }: SaveAsNewFieldArgs): Promise<BlueprintPromptRef | null> => {
       let createdPrompt: PromptWithLatestVersion;
       try {
@@ -124,7 +128,7 @@ const useSavePromptToBlueprint = (projectId: string) => {
           prompt: {
             name: fieldName,
             template,
-            template_structure: PROMPT_TEMPLATE_STRUCTURE.CHAT,
+            template_structure: templateStructure,
             project_id: projectId,
           },
           withResponse: true,

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.ts
@@ -32,6 +32,7 @@ interface SaveAsNewFieldArgs {
   fieldName: string;
   template: string;
   templateStructure?: PROMPT_TEMPLATE_STRUCTURE;
+  changeDescription?: string;
 }
 
 interface SaveExistingResult {
@@ -130,7 +131,11 @@ const useSavePromptToBlueprint = (projectId: string) => {
         const { id } = await writeBlueprint({
           agentConfig: {
             project_id: projectId,
-            blueprint: { type: BlueprintType.BLUEPRINT, values },
+            blueprint: {
+              type: BlueprintType.BLUEPRINT,
+              values,
+              ...(changeDescription && { description: changeDescription }),
+            },
           },
         });
         if (!id) return null;
@@ -161,6 +166,7 @@ const useSavePromptToBlueprint = (projectId: string) => {
       fieldName,
       template,
       templateStructure = PROMPT_TEMPLATE_STRUCTURE.CHAT,
+      changeDescription,
     }: SaveAsNewFieldArgs): Promise<BlueprintPromptRef | null> => {
       let createdPrompt: PromptWithLatestVersion;
       try {
@@ -190,7 +196,11 @@ const useSavePromptToBlueprint = (projectId: string) => {
         const { id } = await writeBlueprint({
           agentConfig: {
             project_id: projectId,
-            blueprint: { type: BlueprintType.BLUEPRINT, values },
+            blueprint: {
+              type: BlueprintType.BLUEPRINT,
+              values,
+              ...(changeDescription && { description: changeDescription }),
+            },
           },
         });
         if (!id) return null;

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.tsx
@@ -1,10 +1,12 @@
 import { useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 
 import {
   BlueprintType,
   BlueprintValue,
   BlueprintValueType,
+  ConfigHistoryItem,
 } from "@/types/agent-configs";
 import {
   PROMPT_TEMPLATE_STRUCTURE,
@@ -19,6 +21,9 @@ import useCreatePromptVersionMutation from "@/api/prompts/useCreatePromptVersion
 import usePromptCreateMutation from "@/api/prompts/usePromptCreateMutation";
 import { AGENT_CONFIGS_KEY } from "@/api/api";
 import { BlueprintPromptRef } from "@/types/playground";
+import { useActiveWorkspaceName } from "@/store/AppStore";
+import { useToast } from "@/ui/use-toast";
+import { ToastAction } from "@/ui/toast";
 
 interface SaveExistingArgs {
   ref: BlueprintPromptRef;
@@ -49,6 +54,9 @@ const stripBlueprintValue = (v: BlueprintValue): BlueprintValue => ({
 
 const useSavePromptToBlueprint = (projectId: string) => {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const workspaceName = useActiveWorkspaceName();
+  const { toast } = useToast();
 
   const { data: history } = useConfigHistoryListInfinite({ projectId });
   const latestBlueprintId = history?.pages?.[0]?.content?.[0]?.id;
@@ -71,14 +79,54 @@ const useSavePromptToBlueprint = (projectId: string) => {
     isPostingBlueprint ||
     isPatchingBlueprint;
 
-  const invalidateAfterSave = useCallback(
-    (commit: string) => {
+  const showSavedToast = useCallback(
+    (blueprintId: string) => {
+      const data = queryClient.getQueryData<{
+        pages: Array<{ content: ConfigHistoryItem[] }>;
+      }>([AGENT_CONFIGS_KEY, "history", { projectId }]);
+      const newVersion = data?.pages
+        ?.flatMap((p) => p.content)
+        ?.find((c) => c.id === blueprintId);
+      const versionLabel = newVersion?.name;
+      const versionSuffix = versionLabel ? ` (${versionLabel})` : "";
+
+      toast({
+        title: "Prompt saved",
+        description: `The prompt has been updated. A new version of the agent configuration${versionSuffix} is ready. You can edit it or deploy it to any environment.`,
+        actions: workspaceName
+          ? [
+              <ToastAction
+                key="view-agent-configuration"
+                altText="View agent configuration"
+                variant="link"
+                size="sm"
+                className="px-0"
+                onClick={() =>
+                  navigate({
+                    to: "/$workspaceName/projects/$projectId/agent-configuration",
+                    params: { workspaceName, projectId },
+                    search: { configId: blueprintId },
+                  })
+                }
+              >
+                {versionLabel ? `View ${versionLabel}` : "View configuration"}
+              </ToastAction>,
+            ]
+          : undefined,
+      });
+    },
+    [queryClient, projectId, workspaceName, navigate, toast],
+  );
+
+  const finalizeSave = useCallback(
+    async (commit: string, blueprintId: string) => {
       queryClient.invalidateQueries({
         queryKey: ["prompt-by-commit", { commitId: commit }],
       });
-      queryClient.invalidateQueries({ queryKey: [AGENT_CONFIGS_KEY] });
+      await queryClient.invalidateQueries({ queryKey: [AGENT_CONFIGS_KEY] });
+      showSavedToast(blueprintId);
     },
-    [queryClient],
+    [queryClient, showSavedToast],
   );
 
   // Updates an existing prompt version and publishes a new blueprint version
@@ -139,7 +187,7 @@ const useSavePromptToBlueprint = (projectId: string) => {
           },
         });
         if (!id) return null;
-        invalidateAfterSave(version.commit);
+        await finalizeSave(version.commit, id);
         return {
           version,
           newRef: { ...ref, blueprintId: id, commitId: version.commit },
@@ -154,7 +202,7 @@ const useSavePromptToBlueprint = (projectId: string) => {
       patchBlueprint,
       postBlueprint,
       projectId,
-      invalidateAfterSave,
+      finalizeSave,
     ],
   );
 
@@ -204,7 +252,7 @@ const useSavePromptToBlueprint = (projectId: string) => {
           },
         });
         if (!id) return null;
-        invalidateAfterSave(commit);
+        await finalizeSave(commit, id);
         return { blueprintId: id, key: fieldName, commitId: commit };
       } catch {
         return null;
@@ -216,7 +264,7 @@ const useSavePromptToBlueprint = (projectId: string) => {
       patchBlueprint,
       postBlueprint,
       projectId,
-      invalidateAfterSave,
+      finalizeSave,
     ],
   );
 

--- a/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.tsx
@@ -100,7 +100,7 @@ const useSavePromptToBlueprint = (projectId: string) => {
                 altText="View agent configuration"
                 variant="link"
                 size="sm"
-                className="px-0"
+                className="comet-body-s-accented gap-1.5 px-0"
                 onClick={() =>
                   navigate({
                     to: "/$workspaceName/projects/$projectId/agent-configuration",

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessage.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessage.tsx
@@ -94,12 +94,6 @@ interface LLMPromptMessageProps {
   errorText?: string;
   possibleTypes?: DropdownOption<LLM_MESSAGE_ROLE>[];
   onChangeMessage: (changes: Partial<LLMMessage>) => void;
-  onReplaceWithChatPrompt?: (
-    messages: LLMMessage[],
-    promptId: string,
-    promptVersionId: string,
-  ) => void;
-  onClearOtherPromptLinks?: () => void;
   onFocus?: () => void;
   disableMedia?: boolean;
   promptVariables?: string[];
@@ -123,8 +117,6 @@ const LLMPromptMessage = forwardRef<
       errorText,
       possibleTypes = MESSAGE_TYPE_OPTIONS,
       onChangeMessage,
-      onReplaceWithChatPrompt,
-      onClearOtherPromptLinks,
       onFocus,
       onDuplicateMessage,
       onRemoveMessage,
@@ -310,8 +302,6 @@ const LLMPromptMessage = forwardRef<
                   <LLMPromptMessageActions
                     message={message}
                     onChangeMessage={onChangeMessage}
-                    onReplaceWithChatPrompt={onReplaceWithChatPrompt}
-                    onClearOtherPromptLinks={onClearOtherPromptLinks}
                     setIsLoading={setIsLoading}
                     setIsHoldActionsVisible={setIsHoldActionsVisible}
                     improvePromptConfig={improvePromptConfig}

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
@@ -285,6 +285,7 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
           onClear={handleDetach}
           onOpenChange={onPromptSelectBoxOpenChange}
           hasUnsavedChanges={hasUnsavedChanges}
+          filterByTemplateStructure={PROMPT_TEMPLATE_STRUCTURE.TEXT}
         />
 
         {hasContent && (

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
@@ -227,11 +227,12 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
   );
 
   const handleSaveNewField = useCallback(
-    async (fieldName: string) => {
+    async (fieldName: string, changeDescription: string) => {
       const newRef = await saveAsNewField({
         fieldName,
         template: getTextFromMessageContent(content),
         templateStructure: PROMPT_TEMPLATE_STRUCTURE.TEXT,
+        changeDescription: changeDescription || undefined,
       });
       if (newRef) {
         onChangeMessage({ blueprintRef: newRef });

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
@@ -106,7 +106,7 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
     if (loadedCommitRef.current === blueprintRef.commitId) return;
     loadedCommitRef.current = blueprintRef.commitId;
 
-    if (commitData.template_structure !== PROMPT_TEMPLATE_STRUCTURE.TEXT) {
+    if (commitData.template_structure === PROMPT_TEMPLATE_STRUCTURE.CHAT) {
       return;
     }
 

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
@@ -27,7 +27,6 @@ import {
 import { useToast } from "@/ui/use-toast";
 import {
   getTextFromMessageContent,
-  convertMessageToMessagesJson,
   parsePromptVersionContent,
 } from "@/lib/llm";
 import usePromptByCommit from "@/api/prompts/usePromptByCommit";
@@ -209,7 +208,8 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
       const result = await saveExistingVersion({
         ref: blueprintRef,
         promptName: commitData.name,
-        template: convertMessageToMessagesJson(message),
+        template: getTextFromMessageContent(content),
+        templateStructure: PROMPT_TEMPLATE_STRUCTURE.TEXT,
         changeDescription: changeDescription || undefined,
       });
       if (result) {
@@ -218,14 +218,15 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
       }
       setShowSaveExisting(false);
     },
-    [blueprintRef, commitData, message, saveExistingVersion, onChangeMessage],
+    [blueprintRef, commitData, content, saveExistingVersion, onChangeMessage],
   );
 
   const handleSaveNewField = useCallback(
     async (fieldName: string) => {
       const newRef = await saveAsNewField({
         fieldName,
-        template: convertMessageToMessagesJson(message),
+        template: getTextFromMessageContent(content),
+        templateStructure: PROMPT_TEMPLATE_STRUCTURE.TEXT,
       });
       if (newRef) {
         onChangeMessage({ blueprintRef: newRef });
@@ -233,7 +234,7 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
       }
       setShowSaveNew(false);
     },
-    [message, saveAsNewField, onChangeMessage],
+    [content, saveAsNewField, onChangeMessage],
   );
 
   const saveTooltip = blueprintRef

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
@@ -217,10 +217,9 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
         templateStructure: PROMPT_TEMPLATE_STRUCTURE.TEXT,
         changeDescription: changeDescription || undefined,
       });
-      if (result) {
-        onChangeMessage({ blueprintRef: result.newRef });
-        loadedCommitRef.current = result.newRef.commitId;
-      }
+      if (!result) return;
+      onChangeMessage({ blueprintRef: result.newRef });
+      loadedCommitRef.current = result.newRef.commitId;
       setShowSaveExisting(false);
     },
     [blueprintRef, commitData, content, saveExistingVersion, onChangeMessage],
@@ -234,10 +233,9 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
         templateStructure: PROMPT_TEMPLATE_STRUCTURE.TEXT,
         changeDescription: changeDescription || undefined,
       });
-      if (newRef) {
-        onChangeMessage({ blueprintRef: newRef });
-        loadedCommitRef.current = newRef.commitId;
-      }
+      if (!newRef) return;
+      onChangeMessage({ blueprintRef: newRef });
+      loadedCommitRef.current = newRef.commitId;
       setShowSaveNew(false);
     },
     [content, saveAsNewField, onChangeMessage],

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
@@ -10,6 +10,7 @@ import isEqual from "fast-deep-equal";
 
 import { OnChangeFn } from "@/types/shared";
 import { LLMMessage, MessageContent } from "@/types/llm";
+import { BlueprintPromptRef } from "@/types/playground";
 import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
 import { Button } from "@/ui/button";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
@@ -31,7 +32,6 @@ import {
 } from "@/lib/llm";
 import usePromptByCommit from "@/api/prompts/usePromptByCommit";
 import useSavePromptToBlueprint from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint";
-import { BlueprintPromptRef } from "@/types/playground";
 
 export interface ImprovePromptConfig {
   model: string;
@@ -228,13 +228,7 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
         template: convertMessageToMessagesJson(message),
       });
       if (newRef) {
-        onChangeMessage({
-          blueprintRef: {
-            blueprintId: newRef.blueprintId,
-            key: newRef.key,
-            commitId: newRef.commitId,
-          },
-        });
+        onChangeMessage({ blueprintRef: newRef });
         loadedCommitRef.current = newRef.commitId;
       }
       setShowSaveNew(false);
@@ -249,8 +243,8 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
   return (
     <>
       <div className="flex min-w-0 cursor-default flex-nowrap items-center">
-        <div className="shrink-0">
-          {improvePromptConfig && !hasContent && (
+        {improvePromptConfig && (
+          <div className="shrink-0">
             <TooltipWrapper content={promptButtonTooltip}>
               <Button
                 variant="minimal"
@@ -259,28 +253,15 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
                 type="button"
                 disabled={isPromptButtonDisabled}
               >
-                <Sparkles />
+                {hasContent ? <Wand2 /> : <Sparkles />}
               </Button>
             </TooltipWrapper>
-          )}
-          {improvePromptConfig && hasContent && (
-            <TooltipWrapper content={promptButtonTooltip}>
-              <Button
-                variant="minimal"
-                size="icon-sm"
-                onClick={handleOpenWizard}
-                type="button"
-                disabled={isPromptButtonDisabled}
-              >
-                <Wand2 />
-              </Button>
-            </TooltipWrapper>
-          )}
-        </div>
+          </div>
+        )}
 
         <BlueprintPromptsSelectBox
           projectId={activeProjectId!}
-          value={blueprintRef as BlueprintPromptRef | undefined}
+          value={blueprintRef}
           onValueChange={handleSelectRef}
           onClear={handleDetach}
           onOpenChange={onPromptSelectBoxOpenChange}

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
@@ -5,23 +5,19 @@ import React, {
   useRef,
   useState,
 } from "react";
-import useLocalStorageState from "use-local-storage-state";
 import { Save, Sparkles, Wand2 } from "lucide-react";
-import isUndefined from "lodash/isUndefined";
 import isEqual from "fast-deep-equal";
 
 import { OnChangeFn } from "@/types/shared";
 import { LLMMessage, MessageContent } from "@/types/llm";
-import { PromptVersion, PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
-import { PLAYGROUND_SELECTED_DATASET_VERSION_KEY } from "@/constants/llm";
+import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
 import { Button } from "@/ui/button";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import usePromptById from "@/api/prompts/usePromptById";
-import { usePermissions } from "@/contexts/PermissionsContext";
 import { useActiveProjectId } from "@/store/AppStore";
-import PromptsSelectBox from "@/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox";
+import BlueprintPromptsSelectBox from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox";
+import SaveExistingPromptDialog from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveExistingPromptDialog";
+import SaveAsNewBlueprintFieldDialog from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveAsNewBlueprintFieldDialog";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
-import AddNewPromptVersionDialog from "@/v2/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog";
 import PromptImprovementDialog from "@/v2/pages-shared/llm/PromptImprovementDialog/PromptImprovementDialog";
 import {
   LLMPromptConfigsType,
@@ -32,10 +28,10 @@ import {
   getTextFromMessageContent,
   convertMessageToMessagesJson,
   parsePromptVersionContent,
-  parseChatTemplateToLLMMessages,
 } from "@/lib/llm";
-
-type ConfirmType = "load" | "save";
+import usePromptByCommit from "@/api/prompts/usePromptByCommit";
+import useSavePromptToBlueprint from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint";
+import { BlueprintPromptRef } from "@/types/playground";
 
 export interface ImprovePromptConfig {
   model: string;
@@ -48,12 +44,6 @@ export interface ImprovePromptConfig {
 type LLMPromptLibraryActionsProps = {
   message: LLMMessage;
   onChangeMessage: (changes: Partial<LLMMessage>) => void;
-  onReplaceWithChatPrompt?: (
-    messages: LLMMessage[],
-    promptId: string,
-    promptVersionId: string,
-  ) => void;
-  onClearOtherPromptLinks?: () => void;
   setIsLoading: OnChangeFn<boolean>;
   setIsHoldActionsVisible: OnChangeFn<boolean>;
   improvePromptConfig?: ImprovePromptConfig;
@@ -62,46 +52,138 @@ type LLMPromptLibraryActionsProps = {
 const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
   message,
   onChangeMessage,
-  onReplaceWithChatPrompt,
-  onClearOtherPromptLinks,
   setIsLoading,
   setIsHoldActionsVisible,
   improvePromptConfig,
 }) => {
   const activeProjectId = useActiveProjectId();
-
-  const {
-    permissions: { canCreatePrompts },
-  } = usePermissions();
-
-  const resetKeyRef = useRef(0);
-  const [open, setOpen] = useState<boolean | ConfirmType>(false);
-  const selectedPromptIdRef = useRef<string | undefined>();
-  const tempPromptIdRef = useRef<string | undefined>();
-  const isPromptSelectBoxOpenedRef = useRef<boolean>(false);
-  const [showImproveWizard, setShowImproveWizard] = useState(false);
-
   const { toast } = useToast();
 
-  const [datasetId] = useLocalStorageState<string | null>(
-    PLAYGROUND_SELECTED_DATASET_VERSION_KEY,
-    {
-      defaultValue: null,
+  const resetKeyRef = useRef(0);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [showSaveExisting, setShowSaveExisting] = useState(false);
+  const [showSaveNew, setShowSaveNew] = useState(false);
+  const [showImproveWizard, setShowImproveWizard] = useState(false);
+  const pendingRefRef = useRef<BlueprintPromptRef | undefined>();
+  const loadedCommitRef = useRef<string | null>(null);
+
+  const { content, blueprintRef } = message;
+
+  // Resolve the loaded blueprint commit
+  const { data: commitData } = usePromptByCommit(
+    { commitId: blueprintRef?.commitId ?? "" },
+    { enabled: !!blueprintRef?.commitId },
+  );
+
+  const { existingFieldNames, saveExistingVersion, saveAsNewField, isSaving } =
+    useSavePromptToBlueprint(activeProjectId!);
+
+  // Content checks
+  const hasContent = useMemo(
+    () => Boolean(getTextFromMessageContent(content).trim()),
+    [content],
+  );
+
+  const loadedVersion = commitData?.requested_version;
+  const loadedVersionForParse = useMemo(
+    () =>
+      loadedVersion
+        ? {
+            template: loadedVersion.template,
+            metadata: loadedVersion.metadata ?? undefined,
+          }
+        : undefined,
+    [loadedVersion],
+  );
+
+  const hasUnsavedChanges = useMemo(() => {
+    if (!blueprintRef || !loadedVersionForParse) return false;
+    return !isEqual(content, parsePromptVersionContent(loadedVersionForParse));
+  }, [blueprintRef, loadedVersionForParse, content]);
+
+  // Populate message content when a blueprint prompt is loaded
+  useEffect(() => {
+    if (!blueprintRef || !commitData) return;
+    if (loadedCommitRef.current === blueprintRef.commitId) return;
+    loadedCommitRef.current = blueprintRef.commitId;
+
+    if (commitData.template_structure !== PROMPT_TEMPLATE_STRUCTURE.TEXT) {
+      return;
+    }
+
+    const loadedContent = parsePromptVersionContent(loadedVersionForParse);
+    onChangeMessage({ content: loadedContent });
+    setIsLoading(false);
+  }, [
+    blueprintRef,
+    commitData,
+    loadedVersionForParse,
+    onChangeMessage,
+    setIsLoading,
+  ]);
+
+  // Auto-open improvement wizard
+  useEffect(() => {
+    if (
+      message.autoImprove &&
+      improvePromptConfig &&
+      blueprintRef &&
+      hasContent
+    ) {
+      const timeoutId = setTimeout(() => {
+        onChangeMessage({ autoImprove: false });
+        if (!improvePromptConfig.model?.trim()) {
+          toast({
+            title: "Model configuration required",
+            description:
+              "Please configure a model and provider before improving the prompt.",
+          });
+          return;
+        }
+        setShowImproveWizard(true);
+      }, 300);
+      return () => clearTimeout(timeoutId);
+    }
+  }, [
+    message.autoImprove,
+    improvePromptConfig,
+    blueprintRef,
+    hasContent,
+    onChangeMessage,
+    toast,
+  ]);
+
+  const handleSelectRef = useCallback(
+    (ref: BlueprintPromptRef) => {
+      if (hasContent) {
+        pendingRefRef.current = ref;
+        resetKeyRef.current++;
+        setConfirmOpen(true);
+      } else {
+        setIsLoading(true);
+        onChangeMessage({ blueprintRef: ref });
+      }
     },
+    [hasContent, onChangeMessage, setIsLoading],
   );
 
-  const { promptId, content } = message;
-  const { data: promptData } = usePromptById(
-    { promptId: promptId! },
-    { enabled: !!promptId },
+  const handleConfirmLoad = useCallback(() => {
+    setIsLoading(true);
+    onChangeMessage({ blueprintRef: pendingRefRef.current });
+    pendingRefRef.current = undefined;
+  }, [onChangeMessage, setIsLoading]);
+
+  const handleDetach = useCallback(() => {
+    onChangeMessage({ blueprintRef: undefined });
+    loadedCommitRef.current = null;
+  }, [onChangeMessage]);
+
+  const onPromptSelectBoxOpenChange = useCallback(
+    (open: boolean) => setIsHoldActionsVisible(open),
+    [setIsHoldActionsVisible],
   );
 
-  // Check if content has meaningful text
-  const hasContent = useMemo(() => {
-    return Boolean(getTextFromMessageContent(content).trim());
-  }, [content]);
-  const showGenerateButton = improvePromptConfig && !hasContent;
-  const showImproveButton = improvePromptConfig && hasContent;
+  // Improve prompt buttons
   const hasModel = Boolean(improvePromptConfig?.model?.trim());
   const isPromptButtonDisabled = !hasModel;
   const promptButtonTooltip = !hasModel
@@ -110,188 +192,78 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
       ? "Improve prompt"
       : "Generate prompt";
 
-  const handleOpenWizard = useCallback(() => {
-    setShowImproveWizard(true);
-  }, []);
+  const handleOpenWizard = useCallback(() => setShowImproveWizard(true), []);
 
-  // Auto-open improvement wizard when message autoImprove flag is set
-  useEffect(() => {
-    if (
-      message.autoImprove &&
-      improvePromptConfig &&
-      promptId && // Only trigger for message loaded from prompt library
-      hasContent // Only trigger if there's content to improve
-    ) {
-      // Use a small delay to ensure the component is fully mounted and model is loaded
-      const timeoutId = setTimeout(() => {
-        // Clear the flag first to prevent other instances from triggering
-        onChangeMessage({ autoImprove: false });
-
-        // Validate model and provider are configured
-        if (!hasModel) {
-          toast({
-            title: "Model configuration required",
-            description:
-              "Please configure a model and provider before improving the prompt. Select a model from the dropdown above.",
-          });
-          return;
-        }
-
-        setShowImproveWizard(true);
-      }, 300);
-
-      return () => clearTimeout(timeoutId);
+  // Save handlers
+  const handleClickSave = useCallback(() => {
+    if (blueprintRef) {
+      setShowSaveExisting(true);
+    } else {
+      setShowSaveNew(true);
     }
-  }, [
-    message.autoImprove,
-    improvePromptConfig,
-    promptId,
-    hasContent,
-    hasModel,
-    onChangeMessage,
-    toast,
-  ]);
+  }, [blueprintRef]);
 
-  const handleUpdateExternalPromptId = useCallback(
-    (selectedPromptId?: string) => {
-      if (selectedPromptId) {
-        selectedPromptIdRef.current = selectedPromptId;
-        setIsLoading(true);
+  const handleSaveExisting = useCallback(
+    async (changeDescription: string) => {
+      if (!blueprintRef || !commitData) return;
+      const result = await saveExistingVersion({
+        ref: blueprintRef,
+        promptName: commitData.name,
+        template: convertMessageToMessagesJson(message),
+        changeDescription: changeDescription || undefined,
+      });
+      if (result) {
+        onChangeMessage({ blueprintRef: result.newRef });
+        loadedCommitRef.current = result.newRef.commitId;
       }
+      setShowSaveExisting(false);
+    },
+    [blueprintRef, commitData, message, saveExistingVersion, onChangeMessage],
+  );
 
-      onChangeMessage({
-        promptId: selectedPromptId,
+  const handleSaveNewField = useCallback(
+    async (fieldName: string) => {
+      const newRef = await saveAsNewField({
+        fieldName,
+        template: convertMessageToMessagesJson(message),
       });
-    },
-    [onChangeMessage, setIsLoading],
-  );
-
-  const handleDetachPrompt = useCallback(() => {
-    onChangeMessage({
-      promptId: undefined,
-      promptVersionId: undefined,
-    });
-  }, [onChangeMessage]);
-
-  const onSaveHandler = useCallback(
-    (version: PromptVersion) => {
-      onChangeMessage({
-        promptId: version.prompt_id,
-        content: parsePromptVersionContent(version),
-        promptVersionId: version.id,
-      });
-    },
-    [onChangeMessage],
-  );
-
-  const saveDisabled =
-    message.content === "" || (!canCreatePrompts && !promptId);
-  const saveWarning = Boolean(
-    !saveDisabled &&
-      promptId &&
-      promptData?.id === promptId &&
-      !isEqual(
-        message.content,
-        parsePromptVersionContent(promptData?.latest_version),
-      ),
-  );
-  const saveTooltip = saveWarning
-    ? !datasetId
-      ? "This prompt version hasn't been saved"
-      : "This prompt version hasn't been saved. Save it to link it to the experiment and make comparisons easier."
-    : "Save to prompt library";
-
-  const onPromptSelectBoxOpenChange = useCallback(
-    (open: boolean) => {
-      isPromptSelectBoxOpenedRef.current = open;
-      setIsHoldActionsVisible(isPromptSelectBoxOpenedRef.current);
-    },
-    [setIsHoldActionsVisible],
-  );
-
-  const confirmConfig = useMemo(() => {
-    return {
-      onConfirm: () => {
-        handleUpdateExternalPromptId(tempPromptIdRef.current);
-      },
-      title: "Load prompt",
-      description:
-        "You have unsaved changes in your message field. Loading a new prompt will overwrite them with the prompt's content. This action cannot be undone.",
-      confirmText: "Load prompt",
-    };
-  }, [handleUpdateExternalPromptId]);
-
-  // This effect is used to set the template and promptVersionId after it is loaded,
-  // after it was set in handleUpdateExternalPromptId function
-  useEffect(() => {
-    if (
-      selectedPromptIdRef.current &&
-      selectedPromptIdRef.current === promptId &&
-      selectedPromptIdRef.current === promptData?.id
-    ) {
-      selectedPromptIdRef.current = undefined;
-
-      const template = promptData.latest_version?.template ?? "";
-      const versionId = promptData.latest_version?.id;
-      const isChatPrompt =
-        promptData.template_structure === PROMPT_TEMPLATE_STRUCTURE.CHAT;
-
-      // If it's a chat prompt and we have the callback, replace all messages
-      if (isChatPrompt && onReplaceWithChatPrompt && template) {
-        const newMessages = parseChatTemplateToLLMMessages(template, {
-          promptId: promptData.id,
-          promptVersionId: versionId,
-          useTimestamp: true,
+      if (newRef) {
+        onChangeMessage({
+          blueprintRef: {
+            blueprintId: newRef.blueprintId,
+            key: newRef.key,
+            commitId: newRef.commitId,
+          },
         });
-
-        if (newMessages.length > 0) {
-          onReplaceWithChatPrompt(newMessages, promptData.id, versionId || "");
-          setIsLoading(false);
-          return;
-        }
+        loadedCommitRef.current = newRef.commitId;
       }
+      setShowSaveNew(false);
+    },
+    [message, saveAsNewField, onChangeMessage],
+  );
 
-      // For string prompts or if chat prompt parsing failed, update just this message
-      // and clear prompt links from other messages
-      if (onClearOtherPromptLinks) {
-        onClearOtherPromptLinks();
-      }
-      onChangeMessage({
-        content: parsePromptVersionContent(promptData.latest_version),
-        promptVersionId: promptData.latest_version?.id,
-        promptId: promptData.id,
-      });
-      setIsLoading(false);
-    }
-  }, [
-    onChangeMessage,
-    promptData,
-    promptId,
-    setIsLoading,
-    onReplaceWithChatPrompt,
-    onClearOtherPromptLinks,
-  ]);
+  const saveTooltip = blueprintRef
+    ? "Update prompt in agent configuration"
+    : "Save as new field in agent configuration";
 
   return (
     <>
       <div className="flex min-w-0 cursor-default flex-nowrap items-center">
         <div className="shrink-0">
-          {showGenerateButton && (
-            <div className="shrink-0">
-              <TooltipWrapper content={promptButtonTooltip}>
-                <Button
-                  variant="minimal"
-                  size="icon-sm"
-                  onClick={handleOpenWizard}
-                  type="button"
-                  disabled={isPromptButtonDisabled}
-                >
-                  <Sparkles />
-                </Button>
-              </TooltipWrapper>
-            </div>
+          {improvePromptConfig && !hasContent && (
+            <TooltipWrapper content={promptButtonTooltip}>
+              <Button
+                variant="minimal"
+                size="icon-sm"
+                onClick={handleOpenWizard}
+                type="button"
+                disabled={isPromptButtonDisabled}
+              >
+                <Sparkles />
+              </Button>
+            </TooltipWrapper>
           )}
-          {showImproveButton && (
+          {improvePromptConfig && hasContent && (
             <TooltipWrapper content={promptButtonTooltip}>
               <Button
                 variant="minimal"
@@ -306,39 +278,23 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
           )}
         </div>
 
-        <PromptsSelectBox
-          compact
+        <BlueprintPromptsSelectBox
           projectId={activeProjectId!}
-          refetchOnMount
-          value={promptId}
-          onValueChange={(id) => {
-            if (id !== promptId) {
-              if (content === "" || isUndefined(id)) {
-                handleUpdateExternalPromptId(id);
-              } else {
-                setOpen("load");
-                resetKeyRef.current = resetKeyRef.current + 1;
-                tempPromptIdRef.current = id;
-              }
-            }
-          }}
+          value={blueprintRef as BlueprintPromptRef | undefined}
+          onValueChange={handleSelectRef}
+          onClear={handleDetach}
           onOpenChange={onPromptSelectBoxOpenChange}
-          onClear={handleDetachPrompt}
-          filterByTemplateStructure={PROMPT_TEMPLATE_STRUCTURE.TEXT}
-          hasUnsavedChanges={saveWarning}
-          promptName={promptData?.name}
+          hasUnsavedChanges={hasUnsavedChanges}
         />
 
-        {!saveDisabled && (
+        {hasContent && (
           <div className="shrink-0">
             <TooltipWrapper content={saveTooltip}>
               <Button
                 variant="minimal"
                 size="icon-sm"
-                onClick={() => {
-                  resetKeyRef.current = resetKeyRef.current + 1;
-                  setOpen("save");
-                }}
+                onClick={handleClickSave}
+                disabled={isSaving}
               >
                 <Save />
               </Button>
@@ -348,21 +304,31 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
 
         <ConfirmDialog
           key={`confirm-${resetKeyRef.current}`}
-          open={open === "load"}
-          setOpen={setOpen}
-          {...confirmConfig}
+          open={confirmOpen}
+          setOpen={setConfirmOpen}
+          onConfirm={handleConfirmLoad}
+          title="Load prompt"
+          description="You have unsaved changes in your message field. Loading a new prompt will overwrite them. This action cannot be undone."
+          confirmText="Load prompt"
         />
-        <AddNewPromptVersionDialog
-          key={`save-${resetKeyRef.current}`}
-          open={open === "save"}
-          setOpen={setOpen}
-          prompt={promptData}
-          template={convertMessageToMessagesJson(message)}
-          metadata={{
-            created_from: "opik_ui",
-            type: "messages_json",
-          }}
-          onSave={onSaveHandler}
+
+        {blueprintRef && commitData && (
+          <SaveExistingPromptDialog
+            open={showSaveExisting}
+            onOpenChange={setShowSaveExisting}
+            promptName={commitData.name}
+            fieldName={blueprintRef.key}
+            isSaving={isSaving}
+            onSave={handleSaveExisting}
+          />
+        )}
+
+        <SaveAsNewBlueprintFieldDialog
+          open={showSaveNew}
+          onOpenChange={setShowSaveNew}
+          existingFieldNames={existingFieldNames}
+          isSaving={isSaving}
+          onSave={handleSaveNewField}
         />
       </div>
       {improvePromptConfig && (

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/lib/llm";
 import usePromptByCommit from "@/api/prompts/usePromptByCommit";
 import useSavePromptToBlueprint from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint";
+import { usePermissions } from "@/contexts/PermissionsContext";
 
 export interface ImprovePromptConfig {
   model: string;
@@ -57,6 +58,9 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
 }) => {
   const activeProjectId = useActiveProjectId();
   const { toast } = useToast();
+  const {
+    permissions: { canCreatePrompts },
+  } = usePermissions();
 
   const resetKeyRef = useRef(0);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -107,6 +111,7 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
     loadedCommitRef.current = blueprintRef.commitId;
 
     if (commitData.template_structure === PROMPT_TEMPLATE_STRUCTURE.CHAT) {
+      setIsLoading(false);
       return;
     }
 
@@ -277,7 +282,7 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
                 variant="minimal"
                 size="icon-sm"
                 onClick={handleClickSave}
-                disabled={isSaving}
+                disabled={!canCreatePrompts || isSaving}
               >
                 <Save />
               </Button>

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
@@ -306,13 +306,15 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
           />
         )}
 
-        <SaveAsNewBlueprintFieldDialog
-          open={showSaveNew}
-          onOpenChange={setShowSaveNew}
-          existingFieldNames={existingFieldNames}
-          isSaving={isSaving}
-          onSave={handleSaveNewField}
-        />
+        {showSaveNew && (
+          <SaveAsNewBlueprintFieldDialog
+            open={showSaveNew}
+            onOpenChange={setShowSaveNew}
+            existingFieldNames={existingFieldNames}
+            isSaving={isSaving}
+            onSave={handleSaveNewField}
+          />
+        )}
       </div>
       {improvePromptConfig && (
         <PromptImprovementDialog

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessages.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessages.tsx
@@ -104,28 +104,6 @@ const LLMPromptMessages = ({
     [onChange, messages],
   );
 
-  const handleReplaceWithChatPrompt = useCallback(
-    (newMessages: LLMMessage[]) => {
-      // Replace all messages with the chat prompt's messages
-      onChange(newMessages);
-    },
-    [onChange],
-  );
-
-  const handleClearOtherPromptLinks = useCallback(
-    (currentMessageId: string) => () => {
-      // Clear prompt links from all messages except the current one
-      onChange(
-        messages.map((m) =>
-          m.id !== currentMessageId
-            ? { ...m, promptId: undefined, promptVersionId: undefined }
-            : m,
-        ),
-      );
-    },
-    [onChange, messages],
-  );
-
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event;
@@ -181,8 +159,6 @@ const LLMPromptMessages = ({
               onChangeMessage={(changes) =>
                 handleChangeMessage(message.id, changes)
               }
-              onReplaceWithChatPrompt={handleReplaceWithChatPrompt}
-              onClearOtherPromptLinks={handleClearOtherPromptLinks(message.id)}
               onFocus={() => handleMessageFocus(message.id)}
               message={message}
               disableMedia={disableMedia}

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
@@ -153,7 +153,7 @@ const PromptsSelectBox: React.FC<PromptsSelectBoxProps> = ({
             content={hasUnsavedChanges ? "Unsaved changes" : displayName}
           >
             <div className="flex min-w-0 items-center gap-1">
-              <FileTerminal className="size-3.5 shrink-0 text-[#b8e54a]" />
+              <FileTerminal className="size-3.5 shrink-0 text-library-loaded" />
               <span className="comet-body-xs-accented truncate text-light-slate">
                 {displayName}
               </span>

--- a/apps/opik-frontend/src/v2/pages-shared/playground/useLoadPlayground.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/playground/useLoadPlayground.ts
@@ -20,6 +20,7 @@ import useProviderKeys from "@/api/provider-keys/useProviderKeys";
 import { MessageContent } from "@/types/llm";
 import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
 import { formatDatasetVersionKey } from "@/utils/datasetVersionStorage";
+import { BlueprintPromptRef } from "@/types/playground";
 
 interface NamedPromptContent {
   name: string;
@@ -30,6 +31,7 @@ interface LoadPlaygroundOptions {
   promptContent?: MessageContent;
   promptId?: string;
   promptVersionId?: string;
+  blueprintRef?: BlueprintPromptRef;
   autoImprove?: boolean;
   datasetId?: string;
   datasetVersionId?: string;
@@ -83,6 +85,7 @@ function useLoadPlayground() {
       options: {
         promptId?: string;
         promptVersionId?: string;
+        blueprintRef?: BlueprintPromptRef;
         autoImprove?: boolean;
         templateStructure?: PROMPT_TEMPLATE_STRUCTURE;
         initPrompt?: Partial<ReturnType<typeof generateDefaultPrompt>>;
@@ -91,6 +94,7 @@ function useLoadPlayground() {
       const {
         promptId,
         promptVersionId,
+        blueprintRef,
         autoImprove = false,
         templateStructure,
         initPrompt,
@@ -103,6 +107,10 @@ function useLoadPlayground() {
         providerResolver: calculateModelProvider,
         modelResolver: calculateDefaultModel,
       });
+
+      if (blueprintRef) {
+        newPrompt.loadedBlueprintRef = blueprintRef;
+      }
 
       if (templateStructure === PROMPT_TEMPLATE_STRUCTURE.CHAT) {
         if (promptId) {
@@ -167,6 +175,7 @@ function useLoadPlayground() {
         promptContent = "",
         promptId,
         promptVersionId,
+        blueprintRef,
         autoImprove = false,
         datasetId,
         datasetVersionId,
@@ -190,6 +199,7 @@ function useLoadPlayground() {
         const newPrompt = createPromptFromContent(promptContent, {
           promptId,
           promptVersionId,
+          blueprintRef,
           autoImprove,
           templateStructure,
         });

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ConfigurationTab/BlueprintValuesList.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ConfigurationTab/BlueprintValuesList.tsx
@@ -14,11 +14,16 @@ import {
   useFieldsCollapse,
 } from "@/v2/pages-shared/agent-configuration/fields/useFieldsCollapse";
 
-const renderScalarValue = (v: BlueprintValue) => (
-  <div className="comet-body-s whitespace-pre-wrap break-words text-foreground">
-    {formatBlueprintValue(v)}
-  </div>
-);
+const renderScalarValue = (v: BlueprintValue) => {
+  if (v.value === null || v.value === undefined) {
+    return <div className="comet-body-xs text-light-slate">No value</div>;
+  }
+  return (
+    <div className="comet-body-s whitespace-pre-wrap break-words text-foreground">
+      {formatBlueprintValue(v)}
+    </div>
+  );
+};
 
 type BlueprintValuesListProps = {
   values: BlueprintValue[];

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -107,6 +107,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
     const legacyTabMap: Record<string, string> = {
       input: canShowMessagesTab ? "messages" : "details",
       metadata: "details",
+      prompts: "details",
     };
     const normalizedTab = legacyTabMap[tab] ?? tab;
 

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -15,7 +15,6 @@ import TagList from "../TagList/TagList";
 import MessagesTab from "./MessagesTab";
 import DetailsTab from "./DetailsTab";
 import AgentGraphTab from "./AgentGraphTab";
-import PromptsTab from "./PromptsTab";
 import AgentConfigurationTab, {
   isAgentConfigurationMetadata,
 } from "./AgentConfigurationTab";
@@ -33,8 +32,6 @@ import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
 import useTraceFeedbackScoreDeleteMutation from "@/api/traces/useTraceFeedbackScoreDeleteMutation";
 import ConfigurableFeedbackScoreTable from "./FeedbackScoreTable/ConfigurableFeedbackScoreTable";
 import { detectLLMMessages } from "@/shared/PrettyLLMMessage/llmMessages";
-import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
-import { FeatureToggleKeys } from "@/types/feature-toggles";
 import { useUnifiedMedia } from "@/hooks/useUnifiedMedia";
 
 type TraceDataViewerProps = {
@@ -73,15 +70,6 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
   );
   const hasSpanAgentGraph =
     Boolean(agentGraphData) && type !== TRACE_TYPE_FOR_TREE;
-  const showOptimizerPrompts = useIsFeatureEnabled(
-    FeatureToggleKeys.OPTIMIZATION_STUDIO_ENABLED,
-  );
-  const hasPrompts = useMemo(() => {
-    if (!showOptimizerPrompts) return false;
-    const prompts = (data.metadata as Record<string, unknown>)?.opik_prompts;
-    return Array.isArray(prompts) && prompts.length > 0;
-  }, [data.metadata, showOptimizerPrompts]);
-
   const hasAgentConfiguration = useMemo(() => {
     const config = (data.metadata as Record<string, unknown>)?.[
       AGENT_CONFIGURATION_METADATA_KEY
@@ -125,7 +113,6 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
     // Fall back when a tab is not available
     if (normalizedTab === "messages" && !canShowMessagesTab) return "details";
     if (normalizedTab === "graph" && !hasSpanAgentGraph) return defaultTab;
-    if (normalizedTab === "prompts" && !hasPrompts) return defaultTab;
     if (normalizedTab === "configuration" && !hasAgentConfiguration)
       return defaultTab;
 
@@ -135,7 +122,6 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
     defaultTab,
     canShowMessagesTab,
     hasSpanAgentGraph,
-    hasPrompts,
     hasAgentConfiguration,
   ]);
 
@@ -284,11 +270,6 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
                 {...EXPLAINERS_MAP[EXPLAINER_ID.what_are_feedback_scores]}
               />
             </TabsTrigger>
-            {hasPrompts && (
-              <TabsTrigger variant="underline" value="prompts">
-                Prompts
-              </TabsTrigger>
-            )}
             {hasSpanAgentGraph && (
               <TabsTrigger variant="underline" value="graph">
                 Agent graph
@@ -356,11 +337,6 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
               )}
             </div>
           </TabsContent>
-          {hasPrompts && (
-            <TabsContent value="prompts">
-              <PromptsTab data={data} search={search} />
-            </TabsContent>
-          )}
           {hasSpanAgentGraph && (
             <TabsContent value="graph">
               <AgentGraphTab data={agentGraphData} />

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationDetailView.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationDetailView.tsx
@@ -9,7 +9,6 @@ import { Card } from "@/ui/card";
 import DeployToPopover from "./DeployToPopover";
 import BlueprintValuesList from "@/v2/pages-shared/traces/ConfigurationTab/BlueprintValuesList";
 import BlueprintDiffDialog from "./BlueprintDiffDialog/BlueprintDiffDialog";
-import { generateBlueprintDescription } from "@/utils/agent-configurations";
 import { Button } from "@/ui/button";
 import useAgentConfigById from "@/api/agent-configs/useAgentConfigById";
 import useTracesList from "@/api/traces/useTracesList";
@@ -76,10 +75,10 @@ const AgentConfigurationDetailView: React.FC<
     setDiffOpen(true);
   };
 
-  const description =
-    item.description || generateBlueprintDescription(item.values);
+  const description = item.description;
 
-  const descriptionIsLong = description.length > DESCRIPTION_TRUNCATE_LENGTH;
+  const descriptionIsLong =
+    (description?.length ?? 0) > DESCRIPTION_TRUNCATE_LENGTH;
 
   const collapsibleKeys = useMemo(
     () => collectMultiLineKeys(agentConfig?.values ?? []),
@@ -140,33 +139,35 @@ const AgentConfigurationDetailView: React.FC<
             </Button>
           </div>
         </div>
-        <div className="comet-body-s flex w-full min-w-0 items-start gap-1 text-light-slate">
-          <FilePen className="mt-1 size-3 shrink-0" />
-          <div
-            className={cn(
-              "flex min-w-0 flex-1 items-baseline gap-1",
-              notesExpanded && "flex-wrap",
-            )}
-          >
-            <span
+        {description && (
+          <div className="comet-body-s flex w-full min-w-0 items-start gap-1 text-light-slate">
+            <FilePen className="mt-1 size-3 shrink-0" />
+            <div
               className={cn(
-                "min-w-0",
-                notesExpanded ? "break-words" : "truncate",
+                "flex min-w-0 flex-1 items-baseline gap-1",
+                notesExpanded && "flex-wrap",
               )}
             >
-              {description}
-            </span>
-            {descriptionIsLong && (
-              <button
-                type="button"
-                className="shrink-0 text-light-slate underline"
-                onClick={() => setNotesExpanded((v) => !v)}
+              <span
+                className={cn(
+                  "min-w-0",
+                  notesExpanded ? "break-words" : "truncate",
+                )}
               >
-                {notesExpanded ? "Show less" : "Show more"}
-              </button>
-            )}
+                {description}
+              </span>
+              {descriptionIsLong && (
+                <button
+                  type="button"
+                  className="shrink-0 text-light-slate underline"
+                  onClick={() => setNotesExpanded((v) => !v)}
+                >
+                  {notesExpanded ? "Show less" : "Show more"}
+                </button>
+              )}
+            </div>
           </div>
-        </div>
+        )}
         <div className="comet-body-s mt-1 flex items-center gap-1 text-light-slate">
           <Clock className="size-3 shrink-0" />
           <TooltipWrapper

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationDetailView.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationDetailView.tsx
@@ -75,6 +75,8 @@ const AgentConfigurationDetailView: React.FC<
     setDiffOpen(true);
   };
 
+  const isLatestVersion = versions[0]?.id === item.id;
+
   const description = item.description;
 
   const descriptionIsLong =
@@ -133,10 +135,24 @@ const AgentConfigurationDetailView: React.FC<
                 }}
               />
             )}
-            <Button size="xs" variant="outline" onClick={onEdit}>
-              <Pencil className="mr-1.5 size-3.5 text-light-slate" />
-              Edit configuration
-            </Button>
+            <TooltipWrapper
+              content={
+                isLatestVersion
+                  ? undefined
+                  : "Editing is only available for the latest version"
+              }
+            >
+              <Button
+                size="xs"
+                variant="outline"
+                onClick={onEdit}
+                disabled={!isLatestVersion}
+                style={!isLatestVersion ? { pointerEvents: "auto" } : undefined}
+              >
+                <Pencil className="mr-1.5 size-3.5 text-light-slate" />
+                Edit configuration
+              </Button>
+            </TooltipWrapper>
           </div>
         </div>
         {description && (

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationDetailView.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationDetailView.tsx
@@ -61,14 +61,14 @@ const AgentConfigurationDetailView: React.FC<
   const hasTraces = (tracesData?.total ?? 0) > 0;
 
   const [diffOpen, setDiffOpen] = useState(false);
-  const [diffBase, setDiffBase] = useState<{
+  const [comparedVersion, setComparedVersion] = useState<{
     label: string;
     blueprintId: string;
   } | null>(null);
   const [notesExpanded, setNotesExpanded] = useState(false);
 
   const handleSelectDiffVersion = (versionItem: ConfigHistoryItem) => {
-    setDiffBase({
+    setComparedVersion({
       label: versionItem.name,
       blueprintId: versionItem.id,
     });
@@ -199,17 +199,17 @@ const AgentConfigurationDetailView: React.FC<
         )}
       </Card>
 
-      {diffBase && (
+      {comparedVersion && (
         <BlueprintDiffDialog
           open={diffOpen}
           setOpen={setDiffOpen}
           base={{
-            label: diffBase.label,
-            blueprintId: diffBase.blueprintId,
-          }}
-          diff={{
             label: item.name,
             blueprintId: item.id,
+          }}
+          diff={{
+            label: comparedVersion.label,
+            blueprintId: comparedVersion.blueprintId,
           }}
         />
       )}

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationHistoryTimeline.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationHistoryTimeline.tsx
@@ -7,7 +7,7 @@ import { ConfigHistoryItem } from "@/types/agent-configs";
 import { formatDate, getTimeFromNow } from "@/lib/date";
 import DataTableNoData from "@/shared/DataTableNoData/DataTableNoData";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import { generateBlueprintDescription } from "@/utils/agent-configurations";
+
 import AgentConfigTagList from "./AgentConfigTagList";
 
 type AgentConfigurationHistoryTimelineProps = {
@@ -91,18 +91,16 @@ const AgentConfigurationHistoryTimeline: React.FC<
                 </span>
                 <AgentConfigTagList tags={item.tags} size="sm" maxWidth={200} />
               </div>
-              {(() => {
-                const desc =
-                  item.description || generateBlueprintDescription(item.values);
-                return (
-                  <p className="comet-body-xs mt-1.5 flex min-w-0 items-center gap-1 text-light-slate">
-                    <FilePen className="size-3 shrink-0" />
-                    <TooltipWrapper content={desc}>
-                      <span className="w-fit max-w-full truncate">{desc}</span>
-                    </TooltipWrapper>
-                  </p>
-                );
-              })()}
+              {item.description && (
+                <p className="comet-body-xs mt-1.5 flex min-w-0 items-center gap-1 text-light-slate">
+                  <FilePen className="size-3 shrink-0" />
+                  <TooltipWrapper content={item.description}>
+                    <span className="w-fit max-w-full truncate">
+                      {item.description}
+                    </span>
+                  </TooltipWrapper>
+                </p>
+              )}
               <div className="comet-body-xs mt-1.5 flex items-center gap-3 text-light-slate">
                 <TooltipWrapper
                   content={`${formatDate(item.created_at, {

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationTab.tsx
@@ -11,7 +11,6 @@ import { StringParam, useQueryParam } from "use-query-params";
 
 import { cn } from "@/lib/utils";
 import { getTimeFromNow } from "@/lib/date";
-import { generateBlueprintDescription } from "@/utils/agent-configurations";
 import Loader from "@/shared/Loader/Loader";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
 import useConfigHistoryListInfinite from "@/api/agent-configs/useConfigHistoryListInfinite";
@@ -76,9 +75,6 @@ const HistoryPopover: React.FC<HistoryPopoverProps> = ({
       >
         {items.map((item, index) => {
           const isSelected = index === selectedIndex;
-          const blueprintDescription =
-            item.description || generateBlueprintDescription(item.values);
-
           return (
             <button
               key={item.id}
@@ -98,14 +94,16 @@ const HistoryPopover: React.FC<HistoryPopoverProps> = ({
                 <AgentConfigTagList tags={item.tags} size="sm" maxWidth={150} />
               </div>
               <div className="mt-1 flex flex-col gap-1 pl-[18px]">
-                <p className="comet-body-xs flex min-w-0 items-center gap-1 text-light-slate">
-                  <FilePen className="size-3 shrink-0" />
-                  <TooltipWrapper content={blueprintDescription}>
-                    <span className="w-fit max-w-full truncate">
-                      {blueprintDescription}
-                    </span>
-                  </TooltipWrapper>
-                </p>
+                {item.description && (
+                  <p className="comet-body-xs flex min-w-0 items-center gap-1 text-light-slate">
+                    <FilePen className="size-3 shrink-0" />
+                    <TooltipWrapper content={item.description}>
+                      <span className="w-fit max-w-full truncate">
+                        {item.description}
+                      </span>
+                    </TooltipWrapper>
+                  </p>
+                )}
                 <div className="comet-body-xs flex items-center gap-1 text-light-slate">
                   <Clock className="size-3 shrink-0" />
                   <span>{getTimeFromNow(item.created_at)}</span>

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerConnectedState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerConnectedState.tsx
@@ -55,6 +55,7 @@ const AgentRunnerConnectedState: React.FC<AgentRunnerConnectedStateProps> = ({
     isDirty: false,
     isSaving: false,
     hasErrors: false,
+    isEmpty: false,
     collapsibleKeys: [],
     hasExpandableFields: false,
   });
@@ -246,7 +247,8 @@ const AgentRunnerConnectedState: React.FC<AgentRunnerConnectedStateProps> = ({
                     disabled={
                       editState.isSaving ||
                       editState.hasErrors ||
-                      !editState.isDirty
+                      !editState.isDirty ||
+                      editState.isEmpty
                     }
                   >
                     <Save className="mr-1 size-3.5" />

--- a/apps/opik-frontend/src/v2/pages/LogsPage/LogsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/LogsPage.tsx
@@ -67,7 +67,7 @@ const LogsPage = () => {
             className="-mt-3 mb-4 flex min-h-8 items-center justify-between"
             direction="horizontal"
           >
-            <div className="text-muted-slate">{project.description}</div>
+            <div className="comet-body-s text-muted-slate">{project.description}</div>
           </PageBodyStickyContainer>
         )}
         {needsDefaultResolution ? (

--- a/apps/opik-frontend/src/v2/pages/LogsPage/LogsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/LogsPage.tsx
@@ -67,7 +67,9 @@ const LogsPage = () => {
             className="-mt-3 mb-4 flex min-h-8 items-center justify-between"
             direction="horizontal"
           >
-            <div className="comet-body-s text-muted-slate">{project.description}</div>
+            <div className="comet-body-s text-muted-slate">
+              {project.description}
+            </div>
           </PageBodyStickyContainer>
         )}
         {needsDefaultResolution ? (

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationSidebar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Experiment } from "@/types/datasets";
-import { Optimization, OPTIMIZATION_STATUS } from "@/types/optimizations";
+import { Optimization } from "@/types/optimizations";
 import { BestPrompt } from "@/v2/pages-shared/experiments/BestPromptCard";
 import BestPromptPlaceholder from "./BestPromptPlaceholder";
 
@@ -14,7 +14,6 @@ type OptimizationSidebarProps = {
   bestExperiment: Experiment | undefined;
   baselineExperiment: Experiment | undefined;
   scoreMap: Record<string, ScoreData>;
-  status?: OPTIMIZATION_STATUS;
 };
 
 const OptimizationSidebar: React.FC<OptimizationSidebarProps> = ({
@@ -22,7 +21,6 @@ const OptimizationSidebar: React.FC<OptimizationSidebarProps> = ({
   bestExperiment,
   baselineExperiment,
   scoreMap,
-  status,
 }) => {
   return (
     <div className="w-2/5 shrink-0 overflow-auto">
@@ -32,7 +30,6 @@ const OptimizationSidebar: React.FC<OptimizationSidebarProps> = ({
           optimization={optimization}
           scoreMap={scoreMap}
           baselineExperiment={baselineExperiment}
-          status={status}
         />
       ) : (
         optimization?.studio_config && (

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPageContent.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPageContent.tsx
@@ -29,6 +29,7 @@ const OptimizationsNewPageContent: React.FC = () => {
     blueprintRef,
     blueprintFieldNames,
     isSavingBlueprint,
+    hasUnsavedBlueprintChanges,
     handleBlueprintRefChange,
     handleBlueprintRefClear,
     handleSaveBlueprintExisting,
@@ -57,6 +58,7 @@ const OptimizationsNewPageContent: React.FC = () => {
           blueprintRef={blueprintRef}
           blueprintFieldNames={blueprintFieldNames}
           isSavingBlueprint={isSavingBlueprint}
+          hasUnsavedBlueprintChanges={hasUnsavedBlueprintChanges}
           onBlueprintRefChange={handleBlueprintRefChange}
           onBlueprintRefClear={handleBlueprintRefClear}
           onSaveBlueprintExisting={handleSaveBlueprintExisting}

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPageContent.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPageContent.tsx
@@ -27,6 +27,7 @@ const OptimizationsNewPageContent: React.FC = () => {
     handleNameChange,
     getFirstMetricParamsError,
     blueprintRef,
+    blueprintPromptName,
     blueprintFieldNames,
     isSavingBlueprint,
     hasUnsavedBlueprintChanges,
@@ -56,6 +57,7 @@ const OptimizationsNewPageContent: React.FC = () => {
           onModelChange={handleModelChange}
           onModelConfigChange={handleModelConfigChange}
           blueprintRef={blueprintRef}
+          blueprintPromptName={blueprintPromptName}
           blueprintFieldNames={blueprintFieldNames}
           isSavingBlueprint={isSavingBlueprint}
           hasUnsavedBlueprintChanges={hasUnsavedBlueprintChanges}

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPageContent.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPageContent.tsx
@@ -26,6 +26,13 @@ const OptimizationsNewPageContent: React.FC = () => {
     handleCancel,
     handleNameChange,
     getFirstMetricParamsError,
+    blueprintRef,
+    blueprintFieldNames,
+    isSavingBlueprint,
+    handleBlueprintRefChange,
+    handleBlueprintRefClear,
+    handleSaveBlueprintExisting,
+    handleSaveBlueprintNewField,
   } = useOptimizationsNewFormHandlers();
 
   return (
@@ -40,12 +47,20 @@ const OptimizationsNewPageContent: React.FC = () => {
       <div className="flex gap-6">
         <OptimizationsNewPromptSection
           form={form}
+          projectId={activeProjectId!}
           model={model}
           config={config}
           datasetVariables={datasetVariables}
           onNameChange={handleNameChange}
           onModelChange={handleModelChange}
           onModelConfigChange={handleModelConfigChange}
+          blueprintRef={blueprintRef}
+          blueprintFieldNames={blueprintFieldNames}
+          isSavingBlueprint={isSavingBlueprint}
+          onBlueprintRefChange={handleBlueprintRefChange}
+          onBlueprintRefClear={handleBlueprintRefClear}
+          onSaveBlueprintExisting={handleSaveBlueprintExisting}
+          onSaveBlueprintNewField={handleSaveBlueprintNewField}
         />
 
         <OptimizationsNewConfigSidebar

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
@@ -36,6 +36,7 @@ type OptimizationsNewPromptSectionProps = {
   onModelChange: (model: PROVIDER_MODEL_TYPE) => void;
   onModelConfigChange: (configs: Partial<LLMPromptConfigsType>) => void;
   blueprintRef?: BlueprintPromptRef;
+  blueprintPromptName?: string;
   blueprintFieldNames: string[];
   isSavingBlueprint: boolean;
   hasUnsavedBlueprintChanges: boolean;
@@ -57,6 +58,7 @@ const OptimizationsNewPromptSection: React.FC<
   onModelChange,
   onModelConfigChange,
   blueprintRef,
+  blueprintPromptName,
   blueprintFieldNames,
   isSavingBlueprint,
   hasUnsavedBlueprintChanges,
@@ -215,20 +217,22 @@ const OptimizationsNewPromptSection: React.FC<
         <SaveExistingPromptDialog
           open={showSaveExisting}
           onOpenChange={setShowSaveExisting}
-          promptName={blueprintRef.key}
+          promptName={blueprintPromptName ?? blueprintRef.key}
           fieldName={blueprintRef.key}
           isSaving={isSavingBlueprint}
           onSave={handleSaveExisting}
         />
       )}
 
-      <SaveAsNewBlueprintFieldDialog
-        open={showSaveNew}
-        onOpenChange={setShowSaveNew}
-        existingFieldNames={blueprintFieldNames}
-        isSaving={isSavingBlueprint}
-        onSave={handleSaveNew}
-      />
+      {showSaveNew && (
+        <SaveAsNewBlueprintFieldDialog
+          open={showSaveNew}
+          onOpenChange={setShowSaveNew}
+          existingFieldNames={blueprintFieldNames}
+          isSaving={isSavingBlueprint}
+          onSave={handleSaveNew}
+        />
+      )}
     </div>
   );
 };

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
@@ -19,6 +19,7 @@ import LLMPromptMessages from "@/v2/pages-shared/llm/LLMPromptMessages/LLMPrompt
 import OptimizationModelSelect from "@/v2/pages-shared/optimizations/OptimizationModelSelect/OptimizationModelSelect";
 import OptimizationTemperatureConfig from "@/v2/pages-shared/optimizations/OptimizationConfigForm/OptimizationTemperatureConfig";
 import { OPTIMIZATION_MESSAGE_TYPE_OPTIONS } from "@/constants/optimizations";
+import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
 import BlueprintPromptsSelectBox from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox";
 import SaveExistingPromptDialog from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveExistingPromptDialog";
 import SaveAsNewBlueprintFieldDialog from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveAsNewBlueprintFieldDialog";
@@ -130,6 +131,7 @@ const OptimizationsNewPromptSection: React.FC<
               onValueChange={onBlueprintRefChange}
               onClear={onBlueprintRefClear}
               hasUnsavedChanges={hasUnsavedBlueprintChanges}
+              filterByTemplateStructure={PROMPT_TEMPLATE_STRUCTURE.CHAT}
             />
             {hasMessages && (
               <TooltipWrapper

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 import { UseFormReturn } from "react-hook-form";
+import { Save } from "lucide-react";
 import { Input } from "@/ui/input";
 import { Label } from "@/ui/label";
+import { Button } from "@/ui/button";
 import {
   FormControl,
   FormField,
@@ -17,28 +19,84 @@ import LLMPromptMessages from "@/v2/pages-shared/llm/LLMPromptMessages/LLMPrompt
 import OptimizationModelSelect from "@/v2/pages-shared/optimizations/OptimizationModelSelect/OptimizationModelSelect";
 import OptimizationTemperatureConfig from "@/v2/pages-shared/optimizations/OptimizationConfigForm/OptimizationTemperatureConfig";
 import { OPTIMIZATION_MESSAGE_TYPE_OPTIONS } from "@/constants/optimizations";
+import BlueprintPromptsSelectBox from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox";
+import SaveExistingPromptDialog from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveExistingPromptDialog";
+import SaveAsNewBlueprintFieldDialog from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveAsNewBlueprintFieldDialog";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import { BlueprintPromptRef } from "@/types/playground";
 
 type OptimizationsNewPromptSectionProps = {
   form: UseFormReturn<OptimizationConfigFormType>;
+  projectId: string;
   model: PROVIDER_MODEL_TYPE | "";
   config: OptimizationConfigFormType["modelConfig"];
   datasetVariables: string[];
   onNameChange: (value: string) => void;
   onModelChange: (model: PROVIDER_MODEL_TYPE) => void;
   onModelConfigChange: (configs: Partial<LLMPromptConfigsType>) => void;
+  blueprintRef?: BlueprintPromptRef;
+  blueprintFieldNames: string[];
+  isSavingBlueprint: boolean;
+  onBlueprintRefChange: (ref: BlueprintPromptRef) => void;
+  onBlueprintRefClear: () => void;
+  onSaveBlueprintExisting: (changeDescription: string) => Promise<unknown>;
+  onSaveBlueprintNewField: (fieldName: string) => Promise<unknown>;
 };
 
 const OptimizationsNewPromptSection: React.FC<
   OptimizationsNewPromptSectionProps
 > = ({
   form,
+  projectId,
   model,
   config,
   datasetVariables,
   onNameChange,
   onModelChange,
   onModelConfigChange,
+  blueprintRef,
+  blueprintFieldNames,
+  isSavingBlueprint,
+  onBlueprintRefChange,
+  onBlueprintRefClear,
+  onSaveBlueprintExisting,
+  onSaveBlueprintNewField,
 }) => {
+  const [showSaveExisting, setShowSaveExisting] = useState(false);
+  const [showSaveNew, setShowSaveNew] = useState(false);
+
+  const hasMessages = form
+    .watch("messages")
+    .some((msg) =>
+      typeof msg.content === "string"
+        ? msg.content.trim()
+        : Array.isArray(msg.content) && msg.content.length > 0,
+    );
+
+  const handleClickSave = useCallback(() => {
+    if (blueprintRef) {
+      setShowSaveExisting(true);
+    } else {
+      setShowSaveNew(true);
+    }
+  }, [blueprintRef]);
+
+  const handleSaveExisting = useCallback(
+    async (changeDescription: string) => {
+      await onSaveBlueprintExisting(changeDescription);
+      setShowSaveExisting(false);
+    },
+    [onSaveBlueprintExisting],
+  );
+
+  const handleSaveNew = useCallback(
+    async (fieldName: string) => {
+      await onSaveBlueprintNewField(fieldName);
+      setShowSaveNew(false);
+    },
+    [onSaveBlueprintNewField],
+  );
+
   return (
     <div className="flex-1 space-y-6">
       <FormField
@@ -62,7 +120,33 @@ const OptimizationsNewPromptSection: React.FC<
 
       <div>
         <div className="mb-2 flex h-8 items-center justify-between">
-          <Label className="comet-body-s-accented">Prompt</Label>
+          <div className="flex items-center gap-1">
+            <Label className="comet-body-s-accented">Prompt</Label>
+            <BlueprintPromptsSelectBox
+              projectId={projectId}
+              value={blueprintRef}
+              onValueChange={onBlueprintRefChange}
+              onClear={onBlueprintRefClear}
+            />
+            {hasMessages && (
+              <TooltipWrapper
+                content={
+                  blueprintRef
+                    ? "Update prompt in agent configuration"
+                    : "Save as new field in agent configuration"
+                }
+              >
+                <Button
+                  variant="minimal"
+                  size="icon-sm"
+                  onClick={handleClickSave}
+                  disabled={isSavingBlueprint}
+                >
+                  <Save />
+                </Button>
+              </TooltipWrapper>
+            )}
+          </div>
           <div className="flex h-full items-center gap-1">
             <FormField
               control={form.control}
@@ -121,6 +205,25 @@ const OptimizationsNewPromptSection: React.FC<
           }}
         />
       </div>
+
+      {blueprintRef && (
+        <SaveExistingPromptDialog
+          open={showSaveExisting}
+          onOpenChange={setShowSaveExisting}
+          promptName={blueprintRef.key}
+          fieldName={blueprintRef.key}
+          isSaving={isSavingBlueprint}
+          onSave={handleSaveExisting}
+        />
+      )}
+
+      <SaveAsNewBlueprintFieldDialog
+        open={showSaveNew}
+        onOpenChange={setShowSaveNew}
+        existingFieldNames={blueprintFieldNames}
+        isSaving={isSavingBlueprint}
+        onSave={handleSaveNew}
+      />
     </div>
   );
 };

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
@@ -44,7 +44,10 @@ type OptimizationsNewPromptSectionProps = {
   onBlueprintRefChange: (ref: BlueprintPromptRef) => void;
   onBlueprintRefClear: () => void;
   onSaveBlueprintExisting: (changeDescription: string) => Promise<unknown>;
-  onSaveBlueprintNewField: (fieldName: string) => Promise<unknown>;
+  onSaveBlueprintNewField: (
+    fieldName: string,
+    changeDescription: string,
+  ) => Promise<unknown>;
 };
 
 const OptimizationsNewPromptSection: React.FC<
@@ -100,8 +103,8 @@ const OptimizationsNewPromptSection: React.FC<
   );
 
   const handleSaveNew = useCallback(
-    async (fieldName: string) => {
-      await onSaveBlueprintNewField(fieldName);
+    async (fieldName: string, changeDescription: string) => {
+      await onSaveBlueprintNewField(fieldName, changeDescription);
       setShowSaveNew(false);
     },
     [onSaveBlueprintNewField],

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
@@ -37,6 +37,7 @@ type OptimizationsNewPromptSectionProps = {
   blueprintRef?: BlueprintPromptRef;
   blueprintFieldNames: string[];
   isSavingBlueprint: boolean;
+  hasUnsavedBlueprintChanges: boolean;
   onBlueprintRefChange: (ref: BlueprintPromptRef) => void;
   onBlueprintRefClear: () => void;
   onSaveBlueprintExisting: (changeDescription: string) => Promise<unknown>;
@@ -57,6 +58,7 @@ const OptimizationsNewPromptSection: React.FC<
   blueprintRef,
   blueprintFieldNames,
   isSavingBlueprint,
+  hasUnsavedBlueprintChanges,
   onBlueprintRefChange,
   onBlueprintRefClear,
   onSaveBlueprintExisting,
@@ -120,13 +122,14 @@ const OptimizationsNewPromptSection: React.FC<
 
       <div>
         <div className="mb-2 flex h-8 items-center justify-between">
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-0.5">
             <Label className="comet-body-s-accented">Prompt</Label>
             <BlueprintPromptsSelectBox
               projectId={projectId}
               value={blueprintRef}
               onValueChange={onBlueprintRefChange}
               onClear={onBlueprintRefClear}
+              hasUnsavedChanges={hasUnsavedBlueprintChanges}
             />
             {hasMessages && (
               <TooltipWrapper

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from "react";
 import { UseFormReturn } from "react-hook-form";
 import { Save } from "lucide-react";
+import { usePermissions } from "@/contexts/PermissionsContext";
 import { Input } from "@/ui/input";
 import { Label } from "@/ui/label";
 import { Button } from "@/ui/button";
@@ -67,6 +68,10 @@ const OptimizationsNewPromptSection: React.FC<
   onSaveBlueprintExisting,
   onSaveBlueprintNewField,
 }) => {
+  const {
+    permissions: { canCreatePrompts },
+  } = usePermissions();
+
   const [showSaveExisting, setShowSaveExisting] = useState(false);
   const [showSaveNew, setShowSaveNew] = useState(false);
 
@@ -147,7 +152,7 @@ const OptimizationsNewPromptSection: React.FC<
                   variant="minimal"
                   size="icon-sm"
                   onClick={handleClickSave}
-                  disabled={isSavingBlueprint}
+                  disabled={!canCreatePrompts || isSavingBlueprint}
                 >
                   <Save />
                 </Button>

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
@@ -96,7 +96,8 @@ const OptimizationsNewPromptSection: React.FC<
 
   const handleSaveExisting = useCallback(
     async (changeDescription: string) => {
-      await onSaveBlueprintExisting(changeDescription);
+      const result = await onSaveBlueprintExisting(changeDescription);
+      if (!result) return;
       setShowSaveExisting(false);
     },
     [onSaveBlueprintExisting],
@@ -104,7 +105,11 @@ const OptimizationsNewPromptSection: React.FC<
 
   const handleSaveNew = useCallback(
     async (fieldName: string, changeDescription: string) => {
-      await onSaveBlueprintNewField(fieldName, changeDescription);
+      const result = await onSaveBlueprintNewField(
+        fieldName,
+        changeDescription,
+      );
+      if (!result) return;
       setShowSaveNew(false);
     },
     [onSaveBlueprintNewField],

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
@@ -1,10 +1,7 @@
-import React, { useCallback, useState } from "react";
+import React from "react";
 import { UseFormReturn } from "react-hook-form";
-import { Save } from "lucide-react";
 import { Input } from "@/ui/input";
 import { Label } from "@/ui/label";
-import { Button } from "@/ui/button";
-import { Separator } from "@/ui/separator";
 import {
   FormControl,
   FormField,
@@ -20,13 +17,6 @@ import LLMPromptMessages from "@/v2/pages-shared/llm/LLMPromptMessages/LLMPrompt
 import OptimizationModelSelect from "@/v2/pages-shared/optimizations/OptimizationModelSelect/OptimizationModelSelect";
 import OptimizationTemperatureConfig from "@/v2/pages-shared/optimizations/OptimizationConfigForm/OptimizationTemperatureConfig";
 import { OPTIMIZATION_MESSAGE_TYPE_OPTIONS } from "@/constants/optimizations";
-import { useActiveProjectId } from "@/store/AppStore";
-import PromptsSelectBox from "@/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox";
-import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
-import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import useLoadChatPrompt from "@/hooks/useLoadChatPrompt";
-import { usePermissions } from "@/contexts/PermissionsContext";
-import AddNewPromptVersionDialog from "@/v2/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog";
 
 type OptimizationsNewPromptSectionProps = {
   form: UseFormReturn<OptimizationConfigFormType>;
@@ -49,50 +39,6 @@ const OptimizationsNewPromptSection: React.FC<
   onModelChange,
   onModelConfigChange,
 }) => {
-  const activeProjectId = useActiveProjectId();
-
-  const {
-    permissions: { canCreatePrompts },
-  } = usePermissions();
-
-  const [selectedChatPromptId, setSelectedChatPromptId] = useState<
-    string | undefined
-  >(undefined);
-  const [showSaveChatPromptDialog, setShowSaveChatPromptDialog] =
-    useState(false);
-  const [lastImportedPromptName, setLastImportedPromptName] =
-    useState<string>("");
-
-  const messages = form.watch("messages");
-
-  const handleMessagesLoaded = useCallback(
-    (newMessages: LLMMessage[], promptName: string) => {
-      setLastImportedPromptName(promptName);
-      form.setValue("messages", newMessages, { shouldValidate: true });
-
-      // hack: needed to be able to save the prompt with the same name
-      if (promptName) {
-        onNameChange(promptName);
-      }
-    },
-    [form, onNameChange],
-  );
-
-  const { chatPromptData, chatPromptTemplate, hasUnsavedChatPromptChanges } =
-    useLoadChatPrompt({
-      selectedChatPromptId,
-      messages,
-      onMessagesLoaded: handleMessagesLoaded,
-    });
-
-  const handleImportChatPrompt = useCallback((loadedPromptId: string) => {
-    setSelectedChatPromptId(loadedPromptId);
-  }, []);
-
-  const handleSaveChatPrompt = useCallback(() => {
-    setShowSaveChatPromptDialog(true);
-  }, []);
-
   return (
     <div className="flex-1 space-y-6">
       <FormField
@@ -118,40 +64,6 @@ const OptimizationsNewPromptSection: React.FC<
         <div className="mb-2 flex h-8 items-center justify-between">
           <Label className="comet-body-s-accented">Prompt</Label>
           <div className="flex h-full items-center gap-1">
-            <TooltipWrapper
-              content={chatPromptData?.name || "Load chat prompt"}
-            >
-              <div className="flex h-full min-w-40 max-w-60 flex-auto flex-nowrap">
-                <PromptsSelectBox
-                  projectId={activeProjectId!}
-                  value={selectedChatPromptId}
-                  onValueChange={(value) =>
-                    value && handleImportChatPrompt(value)
-                  }
-                  clearable={false}
-                  filterByTemplateStructure={PROMPT_TEMPLATE_STRUCTURE.CHAT}
-                />
-              </div>
-            </TooltipWrapper>
-            <TooltipWrapper
-              content={
-                hasUnsavedChatPromptChanges
-                  ? "This prompt version hasn't been saved"
-                  : "Save as chat prompt"
-              }
-            >
-              <Button
-                variant="outline"
-                size="icon-sm"
-                onClick={handleSaveChatPrompt}
-                disabled={!canCreatePrompts && !selectedChatPromptId}
-                badge={hasUnsavedChatPromptChanges}
-                type="button"
-              >
-                <Save />
-              </Button>
-            </TooltipWrapper>
-            <Separator orientation="vertical" className="h-6" />
             <FormField
               control={form.control}
               name="modelName"
@@ -209,24 +121,6 @@ const OptimizationsNewPromptSection: React.FC<
           }}
         />
       </div>
-
-      {/* Save Chat Prompt Dialog */}
-      <AddNewPromptVersionDialog
-        open={showSaveChatPromptDialog}
-        setOpen={setShowSaveChatPromptDialog}
-        prompt={chatPromptData}
-        template={chatPromptTemplate}
-        templateStructure={PROMPT_TEMPLATE_STRUCTURE.CHAT}
-        defaultName={lastImportedPromptName}
-        onSave={(version, _promptName, savedPromptId) => {
-          setShowSaveChatPromptDialog(false);
-
-          // Update the loaded chat prompt ID to the saved prompt
-          if (savedPromptId) {
-            setSelectedChatPromptId(savedPromptId);
-          }
-        }}
-      />
     </div>
   );
 };

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
@@ -30,6 +30,7 @@ import usePromptByCommit from "@/api/prompts/usePromptByCommit";
 import { LLM_MESSAGE_ROLE, LLMMessage } from "@/types/llm";
 import { generateDefaultLLMPromptMessage } from "@/lib/llm";
 import useSavePromptToBlueprint from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint";
+import isEqual from "fast-deep-equal";
 
 const getBreadcrumbTitle = (name: string) =>
   name?.trim() ? `${name} (new)` : "... (new)";
@@ -120,6 +121,23 @@ export const useOptimizationsNewFormHandlers = () => {
     setBlueprintRef(undefined);
     loadedCommitRef.current = null;
   }, []);
+
+  const messages = form.watch("messages");
+  const hasUnsavedBlueprintChanges = useMemo(() => {
+    const loadedTemplate = commitPromptData?.requested_version?.template;
+    if (!blueprintRef || !loadedTemplate || messages.length === 0) return false;
+    try {
+      const loaded = JSON.parse(loadedTemplate) as Array<{
+        role: string;
+        content: unknown;
+      }>;
+      const normalize = (msgs: Array<{ role: string; content: unknown }>) =>
+        msgs.map(({ role, content }) => ({ role, content }));
+      return !isEqual(normalize(messages), normalize(loaded));
+    } catch {
+      return false;
+    }
+  }, [blueprintRef, commitPromptData, messages]);
 
   const {
     existingFieldNames: blueprintFieldNames,
@@ -410,6 +428,7 @@ export const useOptimizationsNewFormHandlers = () => {
     blueprintRef,
     blueprintFieldNames,
     isSavingBlueprint,
+    hasUnsavedBlueprintChanges,
     handleBlueprintRefChange,
     handleBlueprintRefClear,
     handleSaveBlueprintExisting,

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
@@ -30,6 +30,7 @@ import usePromptByCommit from "@/api/prompts/usePromptByCommit";
 import { LLM_MESSAGE_ROLE, LLMMessage } from "@/types/llm";
 import { generateDefaultLLMPromptMessage } from "@/lib/llm";
 import useSavePromptToBlueprint from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint";
+import { serializeChatTemplate } from "@/lib/chatTemplate";
 import isEqual from "fast-deep-equal";
 
 const getBreadcrumbTitle = (name: string) =>
@@ -358,12 +359,10 @@ export const useOptimizationsNewFormHandlers = () => {
   }, []);
 
   // Build the chat template string from current form messages
-  const getBlueprintTemplate = useCallback((): string => {
-    const messages = form.getValues("messages");
-    return JSON.stringify(
-      messages.map(({ role, content }) => ({ role, content })),
-    );
-  }, [form]);
+  const getBlueprintTemplate = useCallback(
+    () => serializeChatTemplate(form.getValues("messages")),
+    [form],
+  );
 
   const handleSaveBlueprintExisting = useCallback(
     async (changeDescription: string) => {

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
@@ -27,11 +27,12 @@ import useLLMProviderModelsData from "@/hooks/useLLMProviderModelsData";
 import useDatasetSamplePreview from "./useDatasetSamplePreview";
 import { BlueprintPromptRef } from "@/types/playground";
 import usePromptByCommit from "@/api/prompts/usePromptByCommit";
-import { LLM_MESSAGE_ROLE, LLMMessage } from "@/types/llm";
-import { generateDefaultLLMPromptMessage } from "@/lib/llm";
 import useSavePromptToBlueprint from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint";
-import { serializeChatTemplate } from "@/lib/chatTemplate";
-import isEqual from "fast-deep-equal";
+import {
+  serializeChatTemplate,
+  chatTemplatesEqual,
+  parseChatTemplateToMessages,
+} from "@/lib/chatTemplate";
 
 const getBreadcrumbTitle = (name: string) =>
   name?.trim() ? `${name} (new)` : "... (new)";
@@ -96,27 +97,13 @@ export const useOptimizationsNewFormHandlers = () => {
     if (!template) return;
 
     try {
-      const parsed = JSON.parse(template) as Array<{
-        role: string;
-        content: unknown;
-      }>;
-      const messages: LLMMessage[] = parsed.map((msg) =>
-        generateDefaultLLMPromptMessage({
-          role: msg.role as LLM_MESSAGE_ROLE,
-          content: msg.content as LLMMessage["content"],
-        }),
-      );
+      const messages = parseChatTemplateToMessages(template);
       form.setValue("messages", messages, { shouldValidate: true });
       loadedCommitRef.current = commitId;
     } catch {
       // ignore parse failures
     }
   }, [commitPromptData, blueprintRef, form]);
-
-  const handleBlueprintRefChange = useCallback(
-    (ref: BlueprintPromptRef) => setBlueprintRef(ref),
-    [],
-  );
 
   const handleBlueprintRefClear = useCallback(() => {
     setBlueprintRef(undefined);
@@ -127,17 +114,7 @@ export const useOptimizationsNewFormHandlers = () => {
   const hasUnsavedBlueprintChanges = useMemo(() => {
     const loadedTemplate = commitPromptData?.requested_version?.template;
     if (!blueprintRef || !loadedTemplate || messages.length === 0) return false;
-    try {
-      const loaded = JSON.parse(loadedTemplate) as Array<{
-        role: string;
-        content: unknown;
-      }>;
-      const normalize = (msgs: Array<{ role: string; content: unknown }>) =>
-        msgs.map(({ role, content }) => ({ role, content }));
-      return !isEqual(normalize(messages), normalize(loaded));
-    } catch {
-      return false;
-    }
+    return !chatTemplatesEqual(serializeChatTemplate(messages), loadedTemplate);
   }, [blueprintRef, commitPromptData, messages]);
 
   const {
@@ -425,10 +402,11 @@ export const useOptimizationsNewFormHandlers = () => {
     handleNameChange,
     getFirstMetricParamsError,
     blueprintRef,
+    blueprintPromptName: commitPromptData?.name,
     blueprintFieldNames,
     isSavingBlueprint,
     hasUnsavedBlueprintChanges,
-    handleBlueprintRefChange,
+    handleBlueprintRefChange: setBlueprintRef,
     handleBlueprintRefClear,
     handleSaveBlueprintExisting,
     handleSaveBlueprintNewField,

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
@@ -365,10 +365,11 @@ export const useOptimizationsNewFormHandlers = () => {
   );
 
   const handleSaveBlueprintNewField = useCallback(
-    async (fieldName: string) => {
+    async (fieldName: string, changeDescription: string) => {
       const newRef = await saveBlueprintNewField({
         fieldName,
         template: getBlueprintTemplate(),
+        changeDescription: changeDescription || undefined,
       });
       if (newRef) {
         setBlueprintRef(newRef);

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useFormContext } from "react-hook-form";
 
@@ -25,6 +25,11 @@ import {
 } from "@/lib/optimizations";
 import useLLMProviderModelsData from "@/hooks/useLLMProviderModelsData";
 import useDatasetSamplePreview from "./useDatasetSamplePreview";
+import { BlueprintPromptRef } from "@/types/playground";
+import usePromptByCommit from "@/api/prompts/usePromptByCommit";
+import { LLM_MESSAGE_ROLE, LLMMessage } from "@/types/llm";
+import { generateDefaultLLMPromptMessage } from "@/lib/llm";
+import useSavePromptToBlueprint from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint";
 
 const getBreadcrumbTitle = (name: string) =>
   name?.trim() ? `${name} (new)` : "... (new)";
@@ -67,6 +72,61 @@ export const useOptimizationsNewFormHandlers = () => {
   });
 
   const { calculateModelProvider } = useLLMProviderModelsData();
+
+  // Blueprint prompt integration
+  const [blueprintRef, setBlueprintRef] = useState<
+    BlueprintPromptRef | undefined
+  >();
+  const loadedCommitRef = useRef<string | null>(null);
+
+  const { data: commitPromptData } = usePromptByCommit(
+    { commitId: blueprintRef?.commitId ?? "" },
+    { enabled: !!blueprintRef?.commitId },
+  );
+
+  // Populate form messages when a blueprint prompt is loaded
+  useEffect(() => {
+    if (!commitPromptData || !blueprintRef) return;
+    const commitId = blueprintRef.commitId;
+    if (loadedCommitRef.current === commitId) return;
+    loadedCommitRef.current = commitId;
+
+    const template = commitPromptData.requested_version?.template;
+    if (!template) return;
+
+    try {
+      const parsed = JSON.parse(template) as Array<{
+        role: string;
+        content: unknown;
+      }>;
+      const messages: LLMMessage[] = parsed.map((msg) =>
+        generateDefaultLLMPromptMessage({
+          role: msg.role as LLM_MESSAGE_ROLE,
+          content: msg.content as LLMMessage["content"],
+        }),
+      );
+      form.setValue("messages", messages, { shouldValidate: true });
+    } catch {
+      // ignore parse failures
+    }
+  }, [commitPromptData, blueprintRef, form]);
+
+  const handleBlueprintRefChange = useCallback(
+    (ref: BlueprintPromptRef) => setBlueprintRef(ref),
+    [],
+  );
+
+  const handleBlueprintRefClear = useCallback(() => {
+    setBlueprintRef(undefined);
+    loadedCommitRef.current = null;
+  }, []);
+
+  const {
+    existingFieldNames: blueprintFieldNames,
+    saveExistingVersion: saveBlueprintExisting,
+    saveAsNewField: saveBlueprintNewField,
+    isSaving: isSavingBlueprint,
+  } = useSavePromptToBlueprint(activeProjectId!);
 
   const handleDatasetChange = useCallback(
     (id: string | null) => {
@@ -279,6 +339,52 @@ export const useOptimizationsNewFormHandlers = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Build the chat template string from current form messages
+  const getBlueprintTemplate = useCallback((): string => {
+    const messages = form.getValues("messages");
+    return JSON.stringify(
+      messages.map(({ role, content }) => ({ role, content })),
+    );
+  }, [form]);
+
+  const handleSaveBlueprintExisting = useCallback(
+    async (changeDescription: string) => {
+      if (!blueprintRef || !commitPromptData) return null;
+      const result = await saveBlueprintExisting({
+        ref: blueprintRef,
+        promptName: commitPromptData.name,
+        template: getBlueprintTemplate(),
+        changeDescription: changeDescription || undefined,
+      });
+      if (result) {
+        setBlueprintRef(result.newRef);
+        loadedCommitRef.current = result.newRef.commitId;
+      }
+      return result;
+    },
+    [
+      blueprintRef,
+      commitPromptData,
+      saveBlueprintExisting,
+      getBlueprintTemplate,
+    ],
+  );
+
+  const handleSaveBlueprintNewField = useCallback(
+    async (fieldName: string) => {
+      const newRef = await saveBlueprintNewField({
+        fieldName,
+        template: getBlueprintTemplate(),
+      });
+      if (newRef) {
+        setBlueprintRef(newRef);
+        loadedCommitRef.current = newRef.commitId;
+      }
+      return newRef;
+    },
+    [saveBlueprintNewField, getBlueprintTemplate],
+  );
+
   return {
     form,
     isSubmitting,
@@ -301,5 +407,12 @@ export const useOptimizationsNewFormHandlers = () => {
     handleCancel,
     handleNameChange,
     getFirstMetricParamsError,
+    blueprintRef,
+    blueprintFieldNames,
+    isSavingBlueprint,
+    handleBlueprintRefChange,
+    handleBlueprintRefClear,
+    handleSaveBlueprintExisting,
+    handleSaveBlueprintNewField,
   };
 };

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts
@@ -91,7 +91,6 @@ export const useOptimizationsNewFormHandlers = () => {
     if (!commitPromptData || !blueprintRef) return;
     const commitId = blueprintRef.commitId;
     if (loadedCommitRef.current === commitId) return;
-    loadedCommitRef.current = commitId;
 
     const template = commitPromptData.requested_version?.template;
     if (!template) return;
@@ -108,6 +107,7 @@ export const useOptimizationsNewFormHandlers = () => {
         }),
       );
       form.setValue("messages", messages, { shouldValidate: true });
+      loadedCommitRef.current = commitId;
     } catch {
       // ignore parse failures
     }

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundHeader.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundHeader.tsx
@@ -253,7 +253,7 @@ const PlaygroundHeader = ({
             className="flex items-center gap-1.5 px-2 text-muted-slate hover:text-primary-hover"
             onClick={() => setRunOnDatasetOpen(true)}
           >
-            <Database className="size-3.5 shrink-0 text-[#b8e54a]" />
+            <Database className="size-3.5 shrink-0 text-library-loaded" />
             <span className="comet-body-xs max-w-[200px] truncate">
               {chipLabel}
             </span>

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -149,7 +149,7 @@ const PlaygroundPrompt = ({
     const lastMessage = last(messages);
 
     newMessage.role = lastMessage
-      ? getNextMessageType(lastMessage!)
+      ? getNextMessageType(lastMessage)
       : LLM_MESSAGE_ROLE.system;
 
     updatePrompt(promptId, {
@@ -323,6 +323,27 @@ const PlaygroundPrompt = ({
     [saveAsNewField, blueprintPromptTemplate, updatePrompt, promptId],
   );
 
+  const handleImproveAccept = useCallback(
+    (messageId: string, improvedContent: LLMMessage["content"]) => {
+      const updatedMessages = messages.map((msg) =>
+        msg.id === messageId ? { ...msg, content: improvedContent } : msg,
+      );
+      updatePrompt(promptId, { messages: updatedMessages });
+    },
+    [messages, updatePrompt, promptId],
+  );
+
+  const improvePromptConfig = useMemo(
+    () => ({
+      model,
+      provider,
+      configs,
+      workspaceName,
+      onAccept: handleImproveAccept,
+    }),
+    [model, provider, configs, workspaceName, handleImproveAccept],
+  );
+
   const promptColor =
     PLAYGROUND_PROMPT_COLORS[index % PLAYGROUND_PROMPT_COLORS.length];
 
@@ -418,20 +439,7 @@ const PlaygroundPrompt = ({
           promptVariables={promptVariablesArray}
           jsonTreeData={datasetSampleData}
           hidePromptActions={false}
-          improvePromptConfig={{
-            model,
-            provider,
-            configs,
-            workspaceName,
-            onAccept: (messageId, improvedContent) => {
-              const updatedMessages = messages.map((msg) =>
-                msg.id === messageId
-                  ? { ...msg, content: improvedContent }
-                  : msg,
-              );
-              updatePrompt(promptId, { messages: updatedMessages });
-            },
-          }}
+          improvePromptConfig={improvePromptConfig}
         />
       </div>
 
@@ -446,13 +454,15 @@ const PlaygroundPrompt = ({
         />
       )}
 
-      <SaveAsNewBlueprintFieldDialog
-        open={showSaveAsNewFieldDialog}
-        onOpenChange={setShowSaveAsNewFieldDialog}
-        existingFieldNames={existingFieldNames}
-        isSaving={isSaving}
-        onSave={handleSaveAsNewField}
-      />
+      {showSaveAsNewFieldDialog && (
+        <SaveAsNewBlueprintFieldDialog
+          open={showSaveAsNewFieldDialog}
+          onOpenChange={setShowSaveAsNewFieldDialog}
+          existingFieldNames={existingFieldNames}
+          isSaving={isSaving}
+          onSave={handleSaveAsNewField}
+        />
+      )}
     </div>
   );
 };

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -310,10 +310,11 @@ const PlaygroundPrompt = ({
   );
 
   const handleSaveAsNewField = useCallback(
-    async (fieldName: string) => {
+    async (fieldName: string, changeDescription: string) => {
       const newRef = await saveAsNewField({
         fieldName,
         template: blueprintPromptTemplate,
+        changeDescription: changeDescription || undefined,
       });
       if (!newRef) return;
 

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -47,10 +47,12 @@ import {
 } from "@/hooks/useLLMProviderModelsData";
 import { useActiveProjectId } from "@/store/AppStore";
 import { usePermissions } from "@/contexts/PermissionsContext";
-import PromptsSelectBox from "@/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox";
+import BlueprintPromptsSelectBox from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox";
 import AddNewPromptVersionDialog from "@/v2/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog";
 import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
 import useLoadChatPrompt from "@/hooks/useLoadChatPrompt";
+import { AGENT_CONFIGS_KEY } from "@/api/api";
+import { BlueprintPromptRef } from "@/types/playground";
 
 interface PlaygroundPromptProps {
   workspaceName: string;
@@ -100,8 +102,7 @@ const PlaygroundPrompt = ({
   const [lastImportedPromptName, setLastImportedPromptName] =
     useState<string>("");
 
-  // Get the loaded chat prompt ID from the prompt data
-  const selectedChatPromptId = prompt?.loadedChatPromptId;
+  const selectedBlueprintRef = prompt?.loadedBlueprintRef;
 
   const handleChatPromptMessagesLoaded = useCallback(
     (newMessages: LLMMessage[], promptName: string) => {
@@ -117,7 +118,7 @@ const PlaygroundPrompt = ({
     chatPromptTemplate,
     hasUnsavedChatPromptChanges,
   } = useLoadChatPrompt({
-    selectedChatPromptId,
+    selectedBlueprintRef,
     messages,
     onMessagesLoaded: handleChatPromptMessagesLoaded,
     skipInitialLoad: prompt?.skipInitialPromptLoad,
@@ -263,16 +264,15 @@ const PlaygroundPrompt = ({
     model,
   ]);
 
-  // Handler for importing chat prompt
-  const handleImportChatPrompt = useCallback(
-    (loadedPromptId: string) => {
-      updatePrompt(promptId, { loadedChatPromptId: loadedPromptId });
+  const handleImportBlueprintPrompt = useCallback(
+    (ref?: BlueprintPromptRef) => {
+      updatePrompt(promptId, { loadedBlueprintRef: ref });
     },
     [promptId, updatePrompt],
   );
 
   const handleDetachPrompt = useCallback(() => {
-    updatePrompt(promptId, { loadedChatPromptId: undefined });
+    updatePrompt(promptId, { loadedBlueprintRef: undefined });
   }, [promptId, updatePrompt]);
 
   // Handler for saving chat prompt
@@ -320,15 +320,12 @@ const PlaygroundPrompt = ({
         </div>
 
         <div className="flex min-w-0 items-center overflow-hidden pl-4 [@media(hover:hover)]:max-w-0 [@media(hover:hover)]:pl-0 [@media(hover:hover)]:group-hover/prompt:max-w-none [@media(hover:hover)]:group-hover/prompt:pl-4">
-          <PromptsSelectBox
-            compact
+          <BlueprintPromptsSelectBox
             projectId={activeProjectId!}
-            value={selectedChatPromptId}
-            onValueChange={(value) => value && handleImportChatPrompt(value)}
+            value={selectedBlueprintRef}
+            onValueChange={handleImportBlueprintPrompt}
             onClear={handleDetachPrompt}
-            filterByTemplateStructure={PROMPT_TEMPLATE_STRUCTURE.CHAT}
             hasUnsavedChanges={hasUnsavedChatPromptChanges}
-            promptName={chatPromptData?.name}
           />
 
           <div className="flex shrink-0 items-center">
@@ -338,7 +335,7 @@ const PlaygroundPrompt = ({
                   variant="minimal"
                   size="icon-sm"
                   onClick={handleSaveChatPrompt}
-                  disabled={!canCreatePrompts && !selectedChatPromptId}
+                  disabled={!canCreatePrompts && !selectedBlueprintRef}
                 >
                   <Save />
                 </Button>
@@ -398,18 +395,32 @@ const PlaygroundPrompt = ({
         onSave={(version, _, savedPromptId) => {
           setShowSaveChatPromptDialog(false);
 
-          // Update the loaded chat prompt ID to the saved prompt
-          if (savedPromptId) {
+          if (!savedPromptId) return;
+
+          // If this prompt was loaded from a blueprint, update the in-memory
+          // ref to point at the new commit. The backend auto-creates a new
+          // blueprint version pinning this commit; we invalidate the agent
+          // config cache so the selector reflects it.
+          if (selectedBlueprintRef && version.commit) {
+            const newRef: BlueprintPromptRef = {
+              ...selectedBlueprintRef,
+              commitId: version.commit,
+            };
+            updatePrompt(promptId, { loadedBlueprintRef: newRef });
+
+            const newDedupKey = `${newRef.blueprintId}-${newRef.key}-${newRef.commitId}-${version.id}`;
+            loadedChatPromptRef.current = newDedupKey;
+
+            queryClient.invalidateQueries({
+              queryKey: ["prompt-by-commit", { commitId: version.commit }],
+            });
+            queryClient.invalidateQueries({ queryKey: [AGENT_CONFIGS_KEY] });
+          } else {
             updatePrompt(promptId, { loadedChatPromptId: savedPromptId });
 
-            // Update the ref to mark this new version as "already loaded"
-            // This prevents the useEffect from re-loading messages when we invalidate queries
             const newChatPromptKey = `${savedPromptId}-${version.id}`;
             loadedChatPromptRef.current = newChatPromptKey;
 
-            // Invalidate the prompt queries to refetch the latest data
-            // This ensures the unsaved changes indicator updates correctly
-            // CRITICAL: Query keys must match the format used in the hooks (objects, not strings)
             queryClient.invalidateQueries({
               queryKey: ["prompt", { promptId: savedPromptId }],
             });

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -50,6 +50,7 @@ import BlueprintPromptsSelectBox from "@/v2/pages-shared/llm/BlueprintPromptsSel
 import SaveExistingPromptDialog from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveExistingPromptDialog";
 import SaveAsNewBlueprintFieldDialog from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveAsNewBlueprintFieldDialog";
 import useSavePromptToBlueprint from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint";
+import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
 import useLoadBlueprintPrompt from "@/hooks/useLoadBlueprintPrompt";
 import { BlueprintPromptRef } from "@/types/playground";
 
@@ -368,6 +369,7 @@ const PlaygroundPrompt = ({
             onValueChange={handleImportBlueprintPrompt}
             onClear={handleDetachPrompt}
             hasUnsavedChanges={hasUnsavedBlueprintChanges}
+            filterByTemplateStructure={PROMPT_TEMPLATE_STRUCTURE.CHAT}
           />
 
           <div className="flex shrink-0 items-center">

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -7,7 +7,6 @@ import React, {
 } from "react";
 import { Trash, Save } from "lucide-react";
 import last from "lodash/last";
-import { useQueryClient } from "@tanstack/react-query";
 
 import { LLM_MESSAGE_ROLE, LLMMessage } from "@/types/llm";
 import {
@@ -48,42 +47,11 @@ import {
 import { useActiveProjectId } from "@/store/AppStore";
 import { usePermissions } from "@/contexts/PermissionsContext";
 import BlueprintPromptsSelectBox from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox";
-import AddNewPromptVersionDialog from "@/v2/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog";
-import {
-  PROMPT_TEMPLATE_STRUCTURE,
-  PromptByCommit,
-  PromptWithLatestVersion,
-} from "@/types/prompts";
+import SaveExistingPromptDialog from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveExistingPromptDialog";
+import SaveAsNewBlueprintFieldDialog from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveAsNewBlueprintFieldDialog";
+import useSavePromptToBlueprint from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint";
 import useLoadBlueprintPrompt from "@/hooks/useLoadBlueprintPrompt";
-import { AGENT_CONFIGS_KEY } from "@/api/api";
 import { BlueprintPromptRef } from "@/types/playground";
-
-const promptByCommitToLibraryShape = (
-  data: PromptByCommit | undefined,
-): PromptWithLatestVersion | undefined => {
-  if (!data) return undefined;
-  const v = data.requested_version;
-  return {
-    id: data.id,
-    name: data.name,
-    description: "",
-    last_updated_at: data.last_updated_at,
-    created_at: data.created_at,
-    version_count: data.version_count,
-    tags: [],
-    template_structure: data.template_structure,
-    latest_version: {
-      id: v.id,
-      template: v.template,
-      metadata: v.metadata ?? {},
-      commit: v.commit,
-      prompt_id: data.id,
-      created_at: v.created_at,
-      type: v.type,
-      change_description: v.change_description,
-    },
-  };
-};
 
 interface PlaygroundPromptProps {
   workspaceName: string;
@@ -105,7 +73,6 @@ const PlaygroundPrompt = ({
   modelResolver,
 }: PlaygroundPromptProps) => {
   const checkedIfModelIsValidRef = useRef(false);
-  const queryClient = useQueryClient();
   const activeProjectId = useActiveProjectId();
 
   const prompt = usePromptById(promptId);
@@ -128,16 +95,14 @@ const PlaygroundPrompt = ({
     permissions: { canCreatePrompts },
   } = usePermissions();
 
-  const [showSaveChatPromptDialog, setShowSaveChatPromptDialog] =
+  const [showSaveExistingDialog, setShowSaveExistingDialog] = useState(false);
+  const [showSaveAsNewFieldDialog, setShowSaveAsNewFieldDialog] =
     useState(false);
-  const [lastImportedPromptName, setLastImportedPromptName] =
-    useState<string>("");
 
   const selectedBlueprintRef = prompt?.loadedBlueprintRef;
 
   const handleBlueprintPromptLoaded = useCallback(
-    (newMessages: LLMMessage[], promptName: string) => {
-      setLastImportedPromptName(promptName);
+    (newMessages: LLMMessage[]) => {
       updatePrompt(promptId, { messages: newMessages });
     },
     [promptId, updatePrompt],
@@ -155,10 +120,8 @@ const PlaygroundPrompt = ({
     skipInitialLoad: prompt?.skipInitialPromptLoad,
   });
 
-  const blueprintPromptForDialog = useMemo(
-    () => promptByCommitToLibraryShape(blueprintPromptData),
-    [blueprintPromptData],
-  );
+  const { existingFieldNames, saveExistingVersion, saveAsNewField, isSaving } =
+    useSavePromptToBlueprint(activeProjectId!);
 
   // Clear the one-time flag so it doesn't persist to localStorage
   useEffect(() => {
@@ -311,40 +274,52 @@ const PlaygroundPrompt = ({
     updatePrompt(promptId, { loadedBlueprintRef: undefined });
   }, [promptId, updatePrompt]);
 
-  const handleSaveChatPrompt = useCallback(() => {
-    setShowSaveChatPromptDialog(true);
-  }, []);
+  const handleClickSave = useCallback(() => {
+    if (selectedBlueprintRef) {
+      setShowSaveExistingDialog(true);
+    } else {
+      setShowSaveAsNewFieldDialog(true);
+    }
+  }, [selectedBlueprintRef]);
 
-  // After saving a new prompt version, update the local blueprint ref to point
-  // at the new commit. The backend auto-publishes a new blueprint version that
-  // pins this commit; invalidating AGENT_CONFIGS_KEY makes the selector pick
-  // it up.
-  const handleSaveBlueprintPromptVersion = useCallback(
-    (version: { id: string; commit?: string }) => {
-      setShowSaveChatPromptDialog(false);
-
-      if (!selectedBlueprintRef || !version.commit) return;
-
-      const newRef: BlueprintPromptRef = {
-        ...selectedBlueprintRef,
-        commitId: version.commit,
-      };
-      updatePrompt(promptId, { loadedBlueprintRef: newRef });
-
-      loadedBlueprintRef.current = `${newRef.blueprintId}-${newRef.key}-${newRef.commitId}-${version.id}`;
-
-      queryClient.invalidateQueries({
-        queryKey: ["prompt-by-commit", { commitId: version.commit }],
+  const handleSaveExistingVersion = useCallback(
+    async (changeDescription: string) => {
+      if (!selectedBlueprintRef || !blueprintPromptData) return;
+      const result = await saveExistingVersion({
+        ref: selectedBlueprintRef,
+        promptName: blueprintPromptData.name,
+        template: blueprintPromptTemplate,
+        changeDescription: changeDescription || undefined,
       });
-      queryClient.invalidateQueries({ queryKey: [AGENT_CONFIGS_KEY] });
+      if (!result) return;
+
+      updatePrompt(promptId, { loadedBlueprintRef: result.newRef });
+      loadedBlueprintRef.current = `${result.newRef.blueprintId}-${result.newRef.key}-${result.newRef.commitId}-${result.version.id}`;
+      setShowSaveExistingDialog(false);
     },
     [
       selectedBlueprintRef,
+      blueprintPromptData,
+      blueprintPromptTemplate,
+      saveExistingVersion,
       updatePrompt,
       promptId,
       loadedBlueprintRef,
-      queryClient,
     ],
+  );
+
+  const handleSaveAsNewField = useCallback(
+    async (fieldName: string) => {
+      const newRef = await saveAsNewField({
+        fieldName,
+        template: blueprintPromptTemplate,
+      });
+      if (!newRef) return;
+
+      updatePrompt(promptId, { loadedBlueprintRef: newRef });
+      setShowSaveAsNewFieldDialog(false);
+    },
+    [saveAsNewField, blueprintPromptTemplate, updatePrompt, promptId],
   );
 
   const promptColor =
@@ -397,12 +372,18 @@ const PlaygroundPrompt = ({
 
           <div className="flex shrink-0 items-center">
             {hasMessageContent && (
-              <TooltipWrapper content="Save to prompt library">
+              <TooltipWrapper
+                content={
+                  selectedBlueprintRef
+                    ? "Update prompt in agent configuration"
+                    : "Save as new field in agent configuration"
+                }
+              >
                 <Button
                   variant="minimal"
                   size="icon-sm"
-                  onClick={handleSaveChatPrompt}
-                  disabled={!canCreatePrompts && !selectedBlueprintRef}
+                  onClick={handleClickSave}
+                  disabled={!canCreatePrompts || isSaving}
                 >
                   <Save />
                 </Button>
@@ -452,14 +433,23 @@ const PlaygroundPrompt = ({
         />
       </div>
 
-      <AddNewPromptVersionDialog
-        open={showSaveChatPromptDialog}
-        setOpen={setShowSaveChatPromptDialog}
-        prompt={blueprintPromptForDialog}
-        template={blueprintPromptTemplate}
-        templateStructure={PROMPT_TEMPLATE_STRUCTURE.CHAT}
-        defaultName={lastImportedPromptName}
-        onSave={handleSaveBlueprintPromptVersion}
+      {selectedBlueprintRef && blueprintPromptData && (
+        <SaveExistingPromptDialog
+          open={showSaveExistingDialog}
+          onOpenChange={setShowSaveExistingDialog}
+          promptName={blueprintPromptData.name}
+          fieldName={selectedBlueprintRef.key}
+          isSaving={isSaving}
+          onSave={handleSaveExistingVersion}
+        />
+      )}
+
+      <SaveAsNewBlueprintFieldDialog
+        open={showSaveAsNewFieldDialog}
+        onOpenChange={setShowSaveAsNewFieldDialog}
+        existingFieldNames={existingFieldNames}
+        isSaving={isSaving}
+        onSave={handleSaveAsNewField}
       />
     </div>
   );

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -49,10 +49,41 @@ import { useActiveProjectId } from "@/store/AppStore";
 import { usePermissions } from "@/contexts/PermissionsContext";
 import BlueprintPromptsSelectBox from "@/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox";
 import AddNewPromptVersionDialog from "@/v2/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog";
-import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
-import useLoadChatPrompt from "@/hooks/useLoadChatPrompt";
+import {
+  PROMPT_TEMPLATE_STRUCTURE,
+  PromptByCommit,
+  PromptWithLatestVersion,
+} from "@/types/prompts";
+import useLoadBlueprintPrompt from "@/hooks/useLoadBlueprintPrompt";
 import { AGENT_CONFIGS_KEY } from "@/api/api";
 import { BlueprintPromptRef } from "@/types/playground";
+
+const promptByCommitToLibraryShape = (
+  data: PromptByCommit | undefined,
+): PromptWithLatestVersion | undefined => {
+  if (!data) return undefined;
+  const v = data.requested_version;
+  return {
+    id: data.id,
+    name: data.name,
+    description: "",
+    last_updated_at: data.last_updated_at,
+    created_at: data.created_at,
+    version_count: data.version_count,
+    tags: [],
+    template_structure: data.template_structure,
+    latest_version: {
+      id: v.id,
+      template: v.template,
+      metadata: v.metadata ?? {},
+      commit: v.commit,
+      prompt_id: data.id,
+      created_at: v.created_at,
+      type: v.type,
+      change_description: v.change_description,
+    },
+  };
+};
 
 interface PlaygroundPromptProps {
   workspaceName: string;
@@ -104,7 +135,7 @@ const PlaygroundPrompt = ({
 
   const selectedBlueprintRef = prompt?.loadedBlueprintRef;
 
-  const handleChatPromptMessagesLoaded = useCallback(
+  const handleBlueprintPromptLoaded = useCallback(
     (newMessages: LLMMessage[], promptName: string) => {
       setLastImportedPromptName(promptName);
       updatePrompt(promptId, { messages: newMessages });
@@ -113,16 +144,21 @@ const PlaygroundPrompt = ({
   );
 
   const {
-    chatPromptData,
-    loadedChatPromptRef,
-    chatPromptTemplate,
-    hasUnsavedChatPromptChanges,
-  } = useLoadChatPrompt({
-    selectedBlueprintRef,
+    prompt: blueprintPromptData,
+    loadedRef: loadedBlueprintRef,
+    template: blueprintPromptTemplate,
+    hasUnsavedChanges: hasUnsavedBlueprintChanges,
+  } = useLoadBlueprintPrompt({
+    selectedRef: selectedBlueprintRef,
     messages,
-    onMessagesLoaded: handleChatPromptMessagesLoaded,
+    onMessagesLoaded: handleBlueprintPromptLoaded,
     skipInitialLoad: prompt?.skipInitialPromptLoad,
   });
+
+  const blueprintPromptForDialog = useMemo(
+    () => promptByCommitToLibraryShape(blueprintPromptData),
+    [blueprintPromptData],
+  );
 
   // Clear the one-time flag so it doesn't persist to localStorage
   useEffect(() => {
@@ -265,7 +301,7 @@ const PlaygroundPrompt = ({
   ]);
 
   const handleImportBlueprintPrompt = useCallback(
-    (ref?: BlueprintPromptRef) => {
+    (ref: BlueprintPromptRef) => {
       updatePrompt(promptId, { loadedBlueprintRef: ref });
     },
     [promptId, updatePrompt],
@@ -275,10 +311,41 @@ const PlaygroundPrompt = ({
     updatePrompt(promptId, { loadedBlueprintRef: undefined });
   }, [promptId, updatePrompt]);
 
-  // Handler for saving chat prompt
   const handleSaveChatPrompt = useCallback(() => {
     setShowSaveChatPromptDialog(true);
   }, []);
+
+  // After saving a new prompt version, update the local blueprint ref to point
+  // at the new commit. The backend auto-publishes a new blueprint version that
+  // pins this commit; invalidating AGENT_CONFIGS_KEY makes the selector pick
+  // it up.
+  const handleSaveBlueprintPromptVersion = useCallback(
+    (version: { id: string; commit?: string }) => {
+      setShowSaveChatPromptDialog(false);
+
+      if (!selectedBlueprintRef || !version.commit) return;
+
+      const newRef: BlueprintPromptRef = {
+        ...selectedBlueprintRef,
+        commitId: version.commit,
+      };
+      updatePrompt(promptId, { loadedBlueprintRef: newRef });
+
+      loadedBlueprintRef.current = `${newRef.blueprintId}-${newRef.key}-${newRef.commitId}-${version.id}`;
+
+      queryClient.invalidateQueries({
+        queryKey: ["prompt-by-commit", { commitId: version.commit }],
+      });
+      queryClient.invalidateQueries({ queryKey: [AGENT_CONFIGS_KEY] });
+    },
+    [
+      selectedBlueprintRef,
+      updatePrompt,
+      promptId,
+      loadedBlueprintRef,
+      queryClient,
+    ],
+  );
 
   const promptColor =
     PLAYGROUND_PROMPT_COLORS[index % PLAYGROUND_PROMPT_COLORS.length];
@@ -325,7 +392,7 @@ const PlaygroundPrompt = ({
             value={selectedBlueprintRef}
             onValueChange={handleImportBlueprintPrompt}
             onClear={handleDetachPrompt}
-            hasUnsavedChanges={hasUnsavedChatPromptChanges}
+            hasUnsavedChanges={hasUnsavedBlueprintChanges}
           />
 
           <div className="flex shrink-0 items-center">
@@ -388,47 +455,11 @@ const PlaygroundPrompt = ({
       <AddNewPromptVersionDialog
         open={showSaveChatPromptDialog}
         setOpen={setShowSaveChatPromptDialog}
-        prompt={chatPromptData}
-        template={chatPromptTemplate}
+        prompt={blueprintPromptForDialog}
+        template={blueprintPromptTemplate}
         templateStructure={PROMPT_TEMPLATE_STRUCTURE.CHAT}
         defaultName={lastImportedPromptName}
-        onSave={(version, _, savedPromptId) => {
-          setShowSaveChatPromptDialog(false);
-
-          if (!savedPromptId) return;
-
-          // If this prompt was loaded from a blueprint, update the in-memory
-          // ref to point at the new commit. The backend auto-creates a new
-          // blueprint version pinning this commit; we invalidate the agent
-          // config cache so the selector reflects it.
-          if (selectedBlueprintRef && version.commit) {
-            const newRef: BlueprintPromptRef = {
-              ...selectedBlueprintRef,
-              commitId: version.commit,
-            };
-            updatePrompt(promptId, { loadedBlueprintRef: newRef });
-
-            const newDedupKey = `${newRef.blueprintId}-${newRef.key}-${newRef.commitId}-${version.id}`;
-            loadedChatPromptRef.current = newDedupKey;
-
-            queryClient.invalidateQueries({
-              queryKey: ["prompt-by-commit", { commitId: version.commit }],
-            });
-            queryClient.invalidateQueries({ queryKey: [AGENT_CONFIGS_KEY] });
-          } else {
-            updatePrompt(promptId, { loadedChatPromptId: savedPromptId });
-
-            const newChatPromptKey = `${savedPromptId}-${version.id}`;
-            loadedChatPromptRef.current = newChatPromptKey;
-
-            queryClient.invalidateQueries({
-              queryKey: ["prompt", { promptId: savedPromptId }],
-            });
-            queryClient.invalidateQueries({
-              queryKey: ["prompt-version", { versionId: version.id }],
-            });
-          }
-        }}
+        onSave={handleSaveBlueprintPromptVersion}
       />
     </div>
   );

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/useHydratePromptMetadata.ts
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/useHydratePromptMetadata.ts
@@ -9,6 +9,7 @@ import { PROMPT_TEMPLATE_STRUCTURE, PromptVersion } from "@/types/prompts";
 import { parsePromptVersionContent } from "@/lib/llm";
 import { useFetchPrompt } from "@/api/prompts/usePromptById";
 import { useFetchPromptVersion } from "@/api/prompts/usePromptVersionById";
+import { useFetchPromptByCommit } from "@/api/prompts/usePromptByCommit";
 
 type NormalizedMessage = { role: string; content: unknown };
 
@@ -53,11 +54,56 @@ const buildMetadata = (
 export function useHydratePromptMetadata() {
   const fetchPrompt = useFetchPrompt();
   const fetchPromptVersion = useFetchPromptVersion();
+  const fetchPromptByCommit = useFetchPromptByCommit();
 
   return useCallback(
     async (
       prompt: PlaygroundPromptType,
     ): Promise<PromptLibraryMetadata | undefined> => {
+      // For prompts loaded from an agent configuration blueprint
+      const blueprintRef = prompt.loadedBlueprintRef;
+      if (blueprintRef) {
+        try {
+          const commitData = await fetchPromptByCommit({
+            commitId: blueprintRef.commitId,
+          });
+          const version = commitData.requested_version;
+          if (!version?.template) return undefined;
+
+          let libraryMessages: NormalizedMessage[];
+          try {
+            const parsed = JSON.parse(version.template);
+            libraryMessages = normalizeForComparison(parsed);
+          } catch {
+            return undefined;
+          }
+
+          const currentMessages = normalizeForComparison(
+            prompt.messages.map((m) => ({ role: m.role, content: m.content })),
+          );
+
+          if (!isEqual(currentMessages, libraryMessages)) {
+            return undefined;
+          }
+
+          return buildMetadata(
+            {
+              name: commitData.name,
+              id: commitData.id,
+              template_structure: commitData.template_structure,
+            },
+            {
+              id: version.id,
+              template: version.template,
+              commit: version.commit,
+              metadata: version.metadata ?? undefined,
+            },
+          );
+        } catch {
+          return undefined;
+        }
+      }
+
       // For CHAT prompts - check prompt-level library link
       const chatPromptId = prompt.loadedChatPromptId;
       if (chatPromptId) {
@@ -140,6 +186,6 @@ export function useHydratePromptMetadata() {
 
       return undefined;
     },
-    [fetchPrompt, fetchPromptVersion],
+    [fetchPrompt, fetchPromptVersion, fetchPromptByCommit],
   );
 }

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/useHydratePromptMetadata.ts
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/useHydratePromptMetadata.ts
@@ -10,13 +10,10 @@ import { parsePromptVersionContent } from "@/lib/llm";
 import { useFetchPrompt } from "@/api/prompts/usePromptById";
 import { useFetchPromptVersion } from "@/api/prompts/usePromptVersionById";
 import { useFetchPromptByCommit } from "@/api/prompts/usePromptByCommit";
-
-type NormalizedMessage = { role: string; content: unknown };
-
-const normalizeForComparison = (
-  messages: Array<{ role: string; content: unknown }>,
-): NormalizedMessage[] =>
-  messages.map(({ role, content }) => ({ role, content }));
+import {
+  serializeChatTemplate,
+  chatTemplatesEqual,
+} from "@/lib/chatTemplate";
 
 const parseTemplateJson = (template: string | undefined): unknown => {
   if (!template) return null;
@@ -25,21 +22,6 @@ const parseTemplateJson = (template: string | undefined): unknown => {
   } catch {
     return template;
   }
-};
-
-// True when the playground messages still match the chat template stored on
-// the loaded prompt version. Returns false if anything fails to parse.
-const matchesChatTemplate = (
-  template: string,
-  current: Array<{ role: string; content: unknown }>,
-): boolean => {
-  let libraryMessages: NormalizedMessage[];
-  try {
-    libraryMessages = normalizeForComparison(JSON.parse(template));
-  } catch {
-    return false;
-  }
-  return isEqual(normalizeForComparison(current), libraryMessages);
 };
 
 interface VersionData {
@@ -89,7 +71,7 @@ export function useHydratePromptMetadata() {
           });
           const version = commitData.requested_version;
           if (!version?.template) return undefined;
-          if (!matchesChatTemplate(version.template, currentMessages))
+          if (!chatTemplatesEqual(serializeChatTemplate(currentMessages), version.template))
             return undefined;
 
           return buildMetadata(
@@ -129,7 +111,7 @@ export function useHydratePromptMetadata() {
           const templateToCompare =
             versionData?.template ?? promptData.latest_version.template;
           if (!templateToCompare) return undefined;
-          if (!matchesChatTemplate(templateToCompare, currentMessages))
+          if (!chatTemplatesEqual(serializeChatTemplate(currentMessages), templateToCompare))
             return undefined;
 
           return buildMetadata(promptData, {

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/useHydratePromptMetadata.ts
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/useHydratePromptMetadata.ts
@@ -10,10 +10,7 @@ import { parsePromptVersionContent } from "@/lib/llm";
 import { useFetchPrompt } from "@/api/prompts/usePromptById";
 import { useFetchPromptVersion } from "@/api/prompts/usePromptVersionById";
 import { useFetchPromptByCommit } from "@/api/prompts/usePromptByCommit";
-import {
-  serializeChatTemplate,
-  chatTemplatesEqual,
-} from "@/lib/chatTemplate";
+import { serializeChatTemplate, chatTemplatesEqual } from "@/lib/chatTemplate";
 
 const parseTemplateJson = (template: string | undefined): unknown => {
   if (!template) return null;
@@ -71,7 +68,12 @@ export function useHydratePromptMetadata() {
           });
           const version = commitData.requested_version;
           if (!version?.template) return undefined;
-          if (!chatTemplatesEqual(serializeChatTemplate(currentMessages), version.template))
+          if (
+            !chatTemplatesEqual(
+              serializeChatTemplate(currentMessages),
+              version.template,
+            )
+          )
             return undefined;
 
           return buildMetadata(
@@ -111,7 +113,12 @@ export function useHydratePromptMetadata() {
           const templateToCompare =
             versionData?.template ?? promptData.latest_version.template;
           if (!templateToCompare) return undefined;
-          if (!chatTemplatesEqual(serializeChatTemplate(currentMessages), templateToCompare))
+          if (
+            !chatTemplatesEqual(
+              serializeChatTemplate(currentMessages),
+              templateToCompare,
+            )
+          )
             return undefined;
 
           return buildMetadata(promptData, {

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/useHydratePromptMetadata.ts
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/useHydratePromptMetadata.ts
@@ -27,6 +27,21 @@ const parseTemplateJson = (template: string | undefined): unknown => {
   }
 };
 
+// True when the playground messages still match the chat template stored on
+// the loaded prompt version. Returns false if anything fails to parse.
+const matchesChatTemplate = (
+  template: string,
+  current: Array<{ role: string; content: unknown }>,
+): boolean => {
+  let libraryMessages: NormalizedMessage[];
+  try {
+    libraryMessages = normalizeForComparison(JSON.parse(template));
+  } catch {
+    return false;
+  }
+  return isEqual(normalizeForComparison(current), libraryMessages);
+};
+
 interface VersionData {
   id: string;
   template?: string;
@@ -60,7 +75,12 @@ export function useHydratePromptMetadata() {
     async (
       prompt: PlaygroundPromptType,
     ): Promise<PromptLibraryMetadata | undefined> => {
-      // For prompts loaded from an agent configuration blueprint
+      const currentMessages = prompt.messages.map((m) => ({
+        role: m.role,
+        content: m.content,
+      }));
+
+      // Loaded from an agent configuration blueprint
       const blueprintRef = prompt.loadedBlueprintRef;
       if (blueprintRef) {
         try {
@@ -69,22 +89,8 @@ export function useHydratePromptMetadata() {
           });
           const version = commitData.requested_version;
           if (!version?.template) return undefined;
-
-          let libraryMessages: NormalizedMessage[];
-          try {
-            const parsed = JSON.parse(version.template);
-            libraryMessages = normalizeForComparison(parsed);
-          } catch {
+          if (!matchesChatTemplate(version.template, currentMessages))
             return undefined;
-          }
-
-          const currentMessages = normalizeForComparison(
-            prompt.messages.map((m) => ({ role: m.role, content: m.content })),
-          );
-
-          if (!isEqual(currentMessages, libraryMessages)) {
-            return undefined;
-          }
 
           return buildMetadata(
             {
@@ -104,46 +110,27 @@ export function useHydratePromptMetadata() {
         }
       }
 
-      // For CHAT prompts - check prompt-level library link
+      // Loaded from a CHAT prompt in the library (legacy path)
       const chatPromptId = prompt.loadedChatPromptId;
       if (chatPromptId) {
         try {
           const promptData = await fetchPrompt({ promptId: chatPromptId });
-
           if (!promptData?.latest_version?.id) return undefined;
 
-          // Fetch the version data for more accurate comparison
           let versionData: PromptVersion | undefined;
           try {
             versionData = await fetchPromptVersion({
               versionId: promptData.latest_version.id,
             });
           } catch {
-            // Fall back to latest_version from prompt data
+            // Fall back to latest_version embedded in the prompt response
           }
 
           const templateToCompare =
             versionData?.template ?? promptData.latest_version.template;
-
           if (!templateToCompare) return undefined;
-
-          // Parse the library template for comparison
-          let libraryMessages: NormalizedMessage[];
-          try {
-            const parsed = JSON.parse(templateToCompare);
-            libraryMessages = normalizeForComparison(parsed);
-          } catch {
+          if (!matchesChatTemplate(templateToCompare, currentMessages))
             return undefined;
-          }
-
-          // Compare current messages to library template
-          const currentMessages = normalizeForComparison(
-            prompt.messages.map((m) => ({ role: m.role, content: m.content })),
-          );
-
-          if (!isEqual(currentMessages, libraryMessages)) {
-            return undefined; // Prompt was edited
-          }
 
           return buildMetadata(promptData, {
             id: versionData?.id ?? promptData.latest_version.id,

--- a/apps/opik-frontend/src/v2/redirect/v1RedirectConfig.tsx
+++ b/apps/opik-frontend/src/v2/redirect/v1RedirectConfig.tsx
@@ -9,9 +9,8 @@ type V1RedirectEntry = {
 
 const V1_REDIRECT_PATHS: V1RedirectEntry[] = [
   { from: "/experiments", to: "/experiments", catchAll: true },
-  { from: "/test-suites", to: "/test-suites", catchAll: true },
-  { from: "/datasets", to: "/test-suites", catchAll: true },
-  { from: "/prompts", to: "/prompts", catchAll: true },
+  { from: "/evaluation-suites", to: "/evaluation-suites", catchAll: true },
+  { from: "/datasets", to: "/evaluation-suites", catchAll: true },
   { from: "/playground", to: "/playground" },
   { from: "/optimizations", to: "/optimizations", catchAll: true },
   { from: "/online-evaluation", to: "/online-evaluation" },

--- a/apps/opik-frontend/src/v2/redirect/v1RedirectConfig.tsx
+++ b/apps/opik-frontend/src/v2/redirect/v1RedirectConfig.tsx
@@ -9,8 +9,8 @@ type V1RedirectEntry = {
 
 const V1_REDIRECT_PATHS: V1RedirectEntry[] = [
   { from: "/experiments", to: "/experiments", catchAll: true },
-  { from: "/evaluation-suites", to: "/evaluation-suites", catchAll: true },
-  { from: "/datasets", to: "/evaluation-suites", catchAll: true },
+  { from: "/test-suites", to: "/test-suites", catchAll: true },
+  { from: "/datasets", to: "/test-suites", catchAll: true },
   { from: "/playground", to: "/playground" },
   { from: "/optimizations", to: "/optimizations", catchAll: true },
   { from: "/online-evaluation", to: "/online-evaluation" },

--- a/apps/opik-frontend/src/v2/router.tsx
+++ b/apps/opik-frontend/src/v2/router.tsx
@@ -23,8 +23,6 @@ import ProjectPage from "@/v2/pages/ProjectPage/ProjectPage";
 import ProjectsPage from "@/v2/pages/ProjectsPage/ProjectsPage";
 import LogsPage from "@/v2/pages/LogsPage/LogsPage";
 import WorkspacePage from "@/v2/pages/WorkspacePage/WorkspacePage";
-import PromptsPage from "@/v2/pages/PromptsPage/PromptsPage";
-import PromptPage from "@/v2/pages/PromptPage/PromptPage";
 import RedirectProjects from "@/v2/redirect/RedirectProjects";
 import RedirectDatasets from "@/v2/redirect/RedirectDatasets";
 import { createV1RedirectRoutes } from "@/v2/redirect/v1RedirectConfig";
@@ -320,30 +318,6 @@ const testSuiteItemsRoute = createRoute({
   component: TestSuiteItemsPage,
 });
 
-// ----------- prompts (project-scoped)
-const promptsRoute = createRoute({
-  path: "/prompts",
-  getParentRoute: () => projectScopedRoute,
-  staticData: {
-    title: "Prompt library",
-  },
-});
-
-const promptsListRoute = createRoute({
-  path: "/",
-  getParentRoute: () => promptsRoute,
-  component: PromptsPage,
-});
-
-const promptRoute = createRoute({
-  path: "/$promptId",
-  getParentRoute: () => promptsRoute,
-  component: PromptPage,
-  staticData: {
-    param: "promptId",
-  },
-});
-
 // ----------- playground (project-scoped)
 const playgroundRoute = createRoute({
   path: "/playground",
@@ -620,7 +594,6 @@ const routeTree = rootRoute.addChildren([
             testSuitesListRoute,
             testSuiteRoute.addChildren([testSuiteItemsRoute]),
           ]),
-          promptsRoute.addChildren([promptsListRoute, promptRoute]),
           playgroundRoute.addChildren([playgroundIndexRoute]),
           optimizationsRoute.addChildren([
             optimizationsListRoute,

--- a/apps/opik-frontend/tailwind.config.ts
+++ b/apps/opik-frontend/tailwind.config.ts
@@ -120,6 +120,8 @@ module.exports = {
         "warning-box-icon-bg": "hsl(var(--warning-box-icon-bg))",
         "warning-box-icon-text": "hsl(var(--warning-box-icon-text))",
 
+        "library-loaded": "hsl(var(--library-loaded))",
+
         /* Chart colors (Figma Design System) */
         "chart-blue": "var(--chart-blue)",
         "chart-yellow": "var(--chart-yellow)",


### PR DESCRIPTION
## Details
<img width="1516" height="738" alt="image" src="https://github.com/user-attachments/assets/0e79f3d5-9dd2-4d86-807a-45bc0a872264" />
<img width="1454" height="618" alt="image" src="https://github.com/user-attachments/assets/60025960-0c75-48cc-8634-910b1f48d72a" />
<img width="1487" height="728" alt="image" src="https://github.com/user-attachments/assets/dce5b4db-8275-4893-9cab-76afa66eb986" />


### Summary
* Removed prompts from v2;
* Playground and optimisation studio now have prompts taken from the latest config version;
* Updated the integration of blueprints with a new API;
* Added a way to add new fields;


### Navigation & routing
- **Remove `/prompts` route and Prompt library sidebar item** from v2.
  - [getMenuItems.ts](apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts), [router.tsx](apps/opik-frontend/src/v2/router.tsx)
- **Drop the `/prompts` v1-compat redirect** entry; align stale `/evaluation-suites` lines to `/test-suites` to match `origin/main` after a previous rebase resolution had reverted them.
  - [v1RedirectConfig.tsx](apps/opik-frontend/src/v2/redirect/v1RedirectConfig.tsx)
- Map legacy `?traceTab=prompts` query param to `details` so old links don't land on a missing tab.
  - [TraceDataViewer.tsx](apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx)

### New: `BlueprintPromptsSelectBox` (playground & message-level)
- Adds [BlueprintPromptsSelectBox.tsx](apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/BlueprintPromptsSelectBox.tsx) — a prompt picker that lists prompt-typed fields from the active agent-config blueprint, **filtered by template structure** (CHAT vs TEXT) so the right shape is offered in the right place.
- Adds two save dialogs:
  - [SaveExistingPromptDialog.tsx](apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveExistingPromptDialog.tsx) — save a new commit to an existing blueprint field.
  - [SaveAsNewBlueprintFieldDialog.tsx](apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/SaveAsNewBlueprintFieldDialog.tsx) — create a new prompt-typed blueprint field from the editor.
- [useSavePromptToBlueprint.ts](apps/opik-frontend/src/v2/pages-shared/llm/BlueprintPromptsSelectBox/useSavePromptToBlueprint.ts) centralizes the save pipeline (publish blueprint version → patch agent config) and is reused by both dialogs.

### Playground integration
- Replaces `PromptsSelectBox` and `AddNewPromptVersionDialog` with the new blueprint-aware components in:
  - [PlaygroundPrompt.tsx](apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx)
  - [LLMPromptMessageActions.tsx](apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx) (per-message TEXT prompt save/load)
  - [LLMPromptMessage.tsx](apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessage.tsx) (drops `onReplaceWithChatPrompt` / `onClearOtherPromptLinks` props)
- New [`BlueprintPromptRef`](apps/opik-frontend/src/types/agent-configs.ts) type (`{ blueprintId, key, commitId }`) replaces the old `loadedChatPromptId` on `PlaygroundPromptType`.
- New [useLoadBlueprintPrompt.ts](apps/opik-frontend/src/hooks/useLoadBlueprintPrompt.ts) hydrates playground prompts from a blueprint commit and tracks unsaved changes against it.
- [useLoadPlayground.ts](apps/opik-frontend/src/v2/pages-shared/playground/useLoadPlayground.ts) and [useHydratePromptMetadata.ts](apps/opik-frontend/src/v2/pages/PlaygroundPage/useHydratePromptMetadata.ts) now accept and resolve a `blueprintRef`.
- [PlaygroundStore.ts](apps/opik-frontend/src/store/PlaygroundStore.ts) strips `skipInitialPromptLoad` from persisted state — it's only meaningful within a single session.

### Optimization studio
- Wire the blueprint prompt selector into the **new optimization** flow so users pick / save against blueprint fields instead of the library.
  - [OptimizationsNewPageContent.tsx](apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPageContent.tsx), [OptimizationsNewPromptSection.tsx](apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx), [useOptimizationsNewFormHandlers.ts](apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.ts)
- Show an **unsaved-changes** indicator on the optimization prompt; remove the "save to prompt library" button + flow from the **best prompt** card.
  - [BestPrompt.tsx](apps/opik-frontend/src/v2/pages-shared/experiments/BestPromptCard/BestPrompt.tsx), [OptimizationSidebar.tsx](apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationSidebar.tsx)

### Agent configuration editor
- **Add / remove blueprint fields** while editing a configuration; new prompt-typed fields use a chat editor.
  - [AgentConfigurationEditView.tsx](apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx), [NewBlueprintFieldEditor.tsx](apps/opik-frontend/src/v2/pages-shared/agent-configuration/NewBlueprintFieldEditor.tsx)
- Inline value validation for new fields, with unit tests.
  - [blueprintFieldValidation.ts](apps/opik-frontend/src/v2/pages-shared/agent-configuration/blueprintFieldValidation.ts), [blueprintFieldValidation.test.ts](apps/opik-frontend/src/v2/pages-shared/agent-configuration/blueprintFieldValidation.test.ts), [blueprintFieldLayout.test.ts](apps/opik-frontend/src/v2/pages-shared/agent-configuration/fields/blueprintFieldLayout.test.ts)
- Show **added/removed** prompts (not just edited values) in the blueprint diff view.
  - [BlueprintDiffCell.tsx](apps/opik-frontend/src/v2/pages-shared/agent-configuration/BlueprintDiffDialog/BlueprintDiffCell.tsx), [BlueprintDiffRow.tsx](apps/opik-frontend/src/v2/pages-shared/agent-configuration/BlueprintDiffDialog/BlueprintDiffRow.tsx)
- Refactor save pipelines for clarity; **POST** for first-time config creation, **PATCH** for updates; always send the full value set when patching.
  - [useAgentConfigurationSave.ts](apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.ts), [useAgentConfigurationSave.test.ts](apps/opik-frontend/src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.test.ts), [useAgentConfigPostMutation.ts](apps/opik-frontend/src/api/agent-configs/useAgentConfigPostMutation.ts)
- Explicitly publish the blueprint when saving a prompt version.
- Remove autogenerated blueprint descriptions from the version picker; only show description when the user provided one.
  - [AgentConfigurationTab.tsx](apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationTab.tsx), [agent-configurations.ts](apps/opik-frontend/src/utils/agent-configurations.ts) (removes `generateBlueprintDescription`)
- Trace `BlueprintValuesList` now renders "No value" for null/undefined scalars instead of an empty cell.
  - [BlueprintValuesList.tsx](apps/opik-frontend/src/v2/pages-shared/traces/ConfigurationTab/BlueprintValuesList.tsx)

### Shared utilities
- New [chatTemplate.ts](apps/opik-frontend/src/lib/chatTemplate.ts): `serializeChatTemplate`, `chatTemplatesEqual`, `parseChatTemplateToMessages` — single source of truth for chat-template serialization, used by load/save hooks and the playground.

### Misc
- Disable Save when an agent-config edit form is empty.
  - [AgentRunnerConnectedState.tsx](apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerConnectedState.tsx)
- Replace hardcoded color with the `text-library-loaded` Tailwind token in PlaygroundHeader.


## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-5772

## AI-WATERMARK

  - Tools: Claude Code
  - Model(s): Opus 4.6
  - Scope:  1M
  - Human verification: Yes

## Testing
- Manually
- QA has left the feedback as well
- `npm run lint`
- `npm run typecheck`

## Documentation
