### PR TITLE
[OPIK-5241] [NA] fix: correct typo in AWS secret access key reference for CDN configuration

### DIFF
--- a/.github/workflows/sync_provider_models.yml
+++ b/.github/workflows/sync_provider_models.yml
@@ -93,7 +93,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_OPIK_CDN_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_OPIK_CDN_SECRERT }}
+          aws-secret-access-key: ${{ secrets.AWS_OPIK_CDN_SECRET }}
           aws-region: us-east-1
           role-to-assume: ${{ vars.AWS_OPIK_CDN_ROLE }}
           role-session-name: sync-provider-models


### PR DESCRIPTION
## Details
Fix secret name

## Change checklist


## Issues

- Resolves #
- OPIK-5241

## AI-WATERMARK

AI-WATERMARK: no

## Testing
not required

## Documentation
