### PR TITLE
[OPIK-5835] [FE] feat: comet-only project home with embedded Ollie

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -10,6 +10,7 @@ import { useParams, useRouter } from "@tanstack/react-router";
 import {
   AssistantSidebarBridge,
   BridgeContext,
+  BridgeSurface,
   HostEventMap,
   RunnerBridgeState,
   SidebarEventMap,
@@ -238,7 +239,10 @@ function emitHostEvent<E extends keyof HostEventMap>(
   }
 }
 
-function useBridgeContext(assistantBackendUrl: string): BridgeContext {
+function useBridgeContext(
+  assistantBackendUrl: string,
+  surface: BridgeSurface,
+): BridgeContext {
   const workspaceName = useActiveWorkspaceName();
   const workspace = useWorkspace();
 
@@ -267,6 +271,7 @@ function useBridgeContext(assistantBackendUrl: string): BridgeContext {
       baseApiUrl: BASE_API_URL,
       assistantBackendUrl,
       theme: "light",
+      surface,
       projectStats,
     }),
     [
@@ -276,6 +281,7 @@ function useBridgeContext(assistantBackendUrl: string): BridgeContext {
       resolvedProjectId,
       projectName,
       assistantBackendUrl,
+      surface,
       projectStats,
     ],
   );
@@ -332,10 +338,12 @@ function useAssistantMeta(backendUrl: string | null): AssistantMeta | null {
 }
 
 interface AssistantSidebarProps {
+  surface?: BridgeSurface;
   onWidthChange: (width: number) => void;
 }
 
 const AssistantSidebar: React.FC<AssistantSidebarProps> = ({
+  surface = "sidebar",
   onWidthChange,
 }) => {
   const {
@@ -347,7 +355,7 @@ const AssistantSidebar: React.FC<AssistantSidebarProps> = ({
     retryCount,
   } = useAssistantBackend();
   const meta = useAssistantMeta(backendUrl);
-  const context = useBridgeContext(backendUrl ?? "");
+  const context = useBridgeContext(backendUrl ?? "", surface);
   const router = useRouter();
 
   const { toast } = useToast();
@@ -410,15 +418,24 @@ const AssistantSidebar: React.FC<AssistantSidebarProps> = ({
     }),
   );
 
-  // Expose bridge and meta on window for iframe access
+  // Expose bridge and meta on window for iframe access.
+  // Guard the cleanup: when another AssistantSidebar instance mounts (e.g.
+  // switching between sidebar and page surface), it overwrites these globals
+  // with its own bridge/meta. A later unmount of the previous instance must
+  // NOT clobber the new values — only clear if the global still matches ours.
   useEffect(() => {
-    window.opikBridge = bridgeRef.current;
+    const bridge = bridgeRef.current;
+    window.opikBridge = bridge;
     if (meta) {
       window.__opikAssistantMeta__ = meta;
     }
     return () => {
-      delete window.opikBridge;
-      delete window.__opikAssistantMeta__;
+      if (window.opikBridge === bridge) {
+        delete window.opikBridge;
+      }
+      if (meta && window.__opikAssistantMeta__ === meta) {
+        delete window.__opikAssistantMeta__;
+      }
     };
   }, [meta]);
 
@@ -449,6 +466,28 @@ const AssistantSidebar: React.FC<AssistantSidebarProps> = ({
       node.addEventListener("focusin", stopPropagation);
     }
   }, []);
+
+  // On the page surface, the iframe fills the whole main area, so clicks
+  // inside Ollie never bubble to the parent document. Detect the resulting
+  // window blur and synthesize the events Radix's DismissableLayer is
+  // waiting for, so any open popover/select/dropdown closes. Different
+  // Radix versions listen on `pointerdown` and/or `mousedown`; dispatch both.
+  useEffect(() => {
+    if (surface !== "page") return;
+    const handleBlur = () => {
+      // Only dismiss when focus actually moved INTO our iframe (skip
+      // tab/window switches).
+      if (document.activeElement !== iframeRef.current) return;
+      document.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true, composed: true }),
+      );
+      document.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, composed: true }),
+      );
+    };
+    window.addEventListener("blur", handleBlur);
+    return () => window.removeEventListener("blur", handleBlur);
+  }, [surface]);
 
   if (!meta || !isBackendReady) {
     if (phase === "disabled") return null;

--- a/apps/opik-frontend/src/store/PluginsStore.ts
+++ b/apps/opik-frontend/src/store/PluginsStore.ts
@@ -6,6 +6,7 @@ import { GoogleColabCardCoreProps } from "@/types/shared";
 import { InviteDevButtonProps } from "@/plugins/comet/InviteDevButton";
 import { SidebarInviteDevButtonProps } from "@/plugins/comet/SidebarInviteDevButton";
 import { CollaboratorsTabTriggerProps } from "@/plugins/comet/CollaboratorsTabTrigger";
+import { BridgeSurface } from "@/types/assistant-sidebar";
 
 type PluginStore = {
   UserMenu: React.ComponentType | null;
@@ -26,6 +27,7 @@ type PluginStore = {
   WorkspaceSelector: React.ComponentType | null;
   SidebarWorkspaceSelector: React.ComponentType<{ expanded?: boolean }> | null;
   AssistantSidebar: React.ComponentType<{
+    surface?: BridgeSurface;
     onWidthChange: (width: number) => void;
   }> | null;
   UpgradeButton: React.ComponentType | null;

--- a/apps/opik-frontend/src/types/assistant-sidebar.ts
+++ b/apps/opik-frontend/src/types/assistant-sidebar.ts
@@ -1,6 +1,7 @@
 import { RunnerConnectionStatus } from "@/types/agent-sandbox";
 
 export type BridgeTheme = "light" | "dark";
+export type BridgeSurface = "sidebar" | "page";
 export type NotificationType = "success" | "error" | "info";
 
 export interface ProjectStats {
@@ -19,6 +20,7 @@ export interface BridgeContext {
   baseApiUrl: string;
   assistantBackendUrl: string;
   theme: BridgeTheme;
+  surface: BridgeSurface;
   projectStats?: ProjectStats;
 }
 

--- a/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
+++ b/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Outlet } from "@tanstack/react-router";
+import { Outlet, useMatchRoute } from "@tanstack/react-router";
 import SideBar from "@/v2/layout/SideBar/SideBar";
 import TopBar from "@/v2/layout/TopBar/TopBar";
 import useLocalStorageState from "use-local-storage-state";
@@ -35,7 +35,12 @@ const PageLayout = () => {
   const RetentionBanner = usePluginsStore((state) => state.RetentionBanner);
   const AssistantSidebar = usePluginsStore((state) => state.AssistantSidebar);
 
-  const showAssistantSidebar = !!AssistantSidebar;
+  const matchRoute = useMatchRoute();
+  const isProjectHome = !!matchRoute({
+    to: "/$workspaceName/projects/$projectId/home",
+  });
+
+  const showAssistantSidebar = !!AssistantSidebar && !isProjectHome;
 
   const assistantWidth = showAssistantSidebar ? assistantSidebarWidth : 0;
   const isMobile = useMediaQuery(`(max-width: ${1023 + assistantWidth}px)`);

--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
@@ -8,15 +8,10 @@ import {
   Plus,
   Trash,
 } from "lucide-react";
-import { Link, useNavigate } from "@tanstack/react-router";
+import { Link, useMatchRoute, useNavigate } from "@tanstack/react-router";
 
 import { cn } from "@/lib/utils";
-import {
-  Popover,
-  PopoverAnchor,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/ui/popover";
+import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
 import { Separator } from "@/ui/separator";
 import { Button } from "@/ui/button";
 import {
@@ -54,6 +49,13 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   const activeProjectId = useActiveProjectId();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const navigate = useNavigate();
+  const matchRoute = useMatchRoute();
+  const isOnProjectHome =
+    !!activeProjectId &&
+    !!matchRoute({
+      to: "/$workspaceName/projects/$projectId/home",
+      params: { workspaceName, projectId: activeProjectId },
+    });
 
   const {
     permissions: { canCreateProjects },
@@ -93,74 +95,166 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
     [navigate, workspaceName],
   );
 
+  const renderExpandedLoading = () => (
+    <button className="flex w-full items-center gap-2 rounded-md px-2 py-1.5">
+      <Spinner size="xs" />
+      <span className="comet-body-s flex-1 text-left text-muted-slate">
+        Loading…
+      </span>
+    </button>
+  );
+
+  const renderProjectLabel = () => (
+    <PopoverTrigger asChild>
+      <button
+        className="flex items-center gap-0.5 text-light-slate"
+        aria-label="Open project selector"
+      >
+        <span className="comet-body-s">Project</span>
+        {open ? (
+          <ChevronUp className="size-3.5" />
+        ) : (
+          <ChevronDown className="size-3.5" />
+        )}
+      </button>
+    </PopoverTrigger>
+  );
+
+  const renderExpandedNoProject = () => (
+    <PopoverTrigger asChild>
+      <button
+        className={cn(
+          "flex w-full items-center gap-2 rounded-md px-2 py-1.5",
+          open && "bg-primary-foreground",
+        )}
+      >
+        <ProjectIcon index={activeIconIndex} size="lg" />
+        <div className="flex min-w-0 flex-1 flex-col items-start">
+          <div className="flex w-full items-center gap-0.5">
+            <span className="comet-body-s text-light-slate">Project</span>
+            <span className="shrink-0 text-light-slate">
+              {open ? (
+                <ChevronUp className="size-3.5" />
+              ) : (
+                <ChevronDown className="size-3.5" />
+              )}
+            </span>
+          </div>
+          <span className="comet-body-s-accented truncate text-left text-muted-slate">
+            Select project
+          </span>
+        </div>
+      </button>
+    </PopoverTrigger>
+  );
+
+  const renderExpandedActiveProject = () => {
+    if (!activeProject) return null;
+    return (
+      <div
+        className={cn(
+          "flex w-full items-center gap-2 rounded-md px-2 py-1.5",
+          open && "bg-primary-foreground",
+        )}
+      >
+        <Link
+          to="/$workspaceName/projects/$projectId/home"
+          params={{ workspaceName, projectId: activeProject.id }}
+          className="shrink-0"
+        >
+          <ProjectIcon index={activeIconIndex} size="lg" />
+        </Link>
+        <div className="flex min-w-0 flex-1 flex-col items-start">
+          {renderProjectLabel()}
+          <Link
+            to="/$workspaceName/projects/$projectId/home"
+            params={{ workspaceName, projectId: activeProject.id }}
+            className="w-full"
+          >
+            <TooltipWrapper content={activeProject.name}>
+              <span
+                className={cn(
+                  "comet-body-s-accented block w-full truncate text-left hover:underline hover:underline-offset-4",
+                  isOnProjectHome
+                    ? "text-primary underline underline-offset-4"
+                    : "text-foreground",
+                )}
+              >
+                {activeProject.name}
+              </span>
+            </TooltipWrapper>
+          </Link>
+        </div>
+      </div>
+    );
+  };
+
+  const renderExpandedTrigger = () => {
+    if (isLoading) return renderExpandedLoading();
+    if (!activeProject) return renderExpandedNoProject();
+    return renderExpandedActiveProject();
+  };
+
+  const renderCollapsedIcon = () => {
+    const iconContent = isLoading ? (
+      <Spinner size="xs" />
+    ) : (
+      <ProjectIcon index={activeIconIndex} size="md" />
+    );
+
+    if (!activeProject) {
+      return (
+        <PopoverTrigger asChild>
+          <button
+            className={cn(
+              "flex size-7 items-center justify-center rounded-md",
+              open ? "bg-primary-foreground" : "hover:bg-primary-foreground",
+            )}
+          >
+            {iconContent}
+          </button>
+        </PopoverTrigger>
+      );
+    }
+
+    return (
+      <TooltipWrapper content={activeProject.name} side="right">
+        <Link
+          to="/$workspaceName/projects/$projectId/home"
+          params={{ workspaceName, projectId: activeProject.id }}
+          className={cn(
+            "flex size-7 items-center justify-center rounded-md",
+            isOnProjectHome
+              ? "bg-primary-100 hover:bg-primary-200"
+              : "hover:bg-primary-foreground",
+          )}
+        >
+          {iconContent}
+        </Link>
+      </TooltipWrapper>
+    );
+  };
+
+  const renderCollapsedTrigger = () => (
+    <div className="relative w-fit self-center">
+      {renderCollapsedIcon()}
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon-2xs"
+          aria-label="Open project selector"
+          className="absolute -bottom-1 -left-1 size-3.5 rounded bg-background text-light-slate shadow-sm hover:text-foreground [&>svg]:size-3.5"
+        >
+          {open ? <ChevronUp /> : <ChevronDown />}
+        </Button>
+      </PopoverTrigger>
+    </div>
+  );
+
   return (
     <>
       <Popover open={open} onOpenChange={setOpen}>
-        <PopoverAnchor asChild>
-          <PopoverTrigger asChild>
-            {expanded ? (
-              <button
-                className={cn(
-                  "flex w-full items-center gap-2 rounded-md px-2 py-1.5",
-                  open && "bg-primary-foreground",
-                )}
-              >
-                {isLoading ? (
-                  <>
-                    <Spinner size="xs" />
-                    <span className="comet-body-s flex-1 text-left text-muted-slate">
-                      Loading…
-                    </span>
-                  </>
-                ) : (
-                  <>
-                    <ProjectIcon index={activeIconIndex} size="lg" />
-                    <div className="flex min-w-0 flex-1 flex-col items-start">
-                      <div className="flex w-full items-center gap-0.5">
-                        <span className="comet-body-s text-light-slate">
-                          Project
-                        </span>
-                        <span className="shrink-0 text-light-slate">
-                          {open ? (
-                            <ChevronUp className="size-3.5" />
-                          ) : (
-                            <ChevronDown className="size-3.5" />
-                          )}
-                        </span>
-                      </div>
-                      {activeProject ? (
-                        <TooltipWrapper content={activeProject.name}>
-                          <span className="comet-body-s-accented w-full truncate text-left text-foreground hover:underline hover:underline-offset-4">
-                            {activeProject.name}
-                          </span>
-                        </TooltipWrapper>
-                      ) : (
-                        <span className="comet-body-s-accented truncate text-left text-muted-slate">
-                          Select project
-                        </span>
-                      )}
-                    </div>
-                  </>
-                )}
-              </button>
-            ) : (
-              <button
-                className={cn(
-                  "flex size-7 items-center justify-center rounded-md",
-                  open
-                    ? "bg-primary-foreground"
-                    : "hover:bg-primary-foreground",
-                )}
-              >
-                {isLoading ? (
-                  <Spinner size="xs" />
-                ) : (
-                  <ProjectIcon index={activeIconIndex} size="md" />
-                )}
-              </button>
-            )}
-          </PopoverTrigger>
-        </PopoverAnchor>
+        {expanded ? renderExpandedTrigger() : renderCollapsedTrigger()}
         <PopoverContent
           align="start"
           side="bottom"

--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
@@ -96,12 +96,14 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   );
 
   const renderExpandedLoading = () => (
-    <button className="flex w-full items-center gap-2 rounded-md px-2 py-1.5">
-      <Spinner size="xs" />
-      <span className="comet-body-s flex-1 text-left text-muted-slate">
-        Loading…
-      </span>
-    </button>
+    <PopoverTrigger asChild>
+      <button className="flex w-full items-center gap-2 rounded-md px-2 py-1.5">
+        <Spinner size="xs" />
+        <span className="comet-body-s flex-1 text-left text-muted-slate">
+          Loading…
+        </span>
+      </button>
+    </PopoverTrigger>
   );
 
   const renderProjectLabel = () => (

--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSidebarContent.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSidebarContent.tsx
@@ -24,9 +24,9 @@ const ProjectSidebarContent: React.FC<ProjectSidebarContentProps> = ({
 
   return (
     <>
+      <ProjectSelector expanded={expanded} />
+      {expanded && <Separator className="my-2" />}
       <div className="flex min-h-0 flex-1 flex-col overflow-auto">
-        <ProjectSelector expanded={expanded} />
-        {expanded && <Separator className="my-2" />}
         <ul className="flex flex-col">
           <SideBarMenuItems expanded={expanded} />
         </ul>

--- a/apps/opik-frontend/src/v2/pages/ProjectHomePage/ProjectHomePage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectHomePage/ProjectHomePage.tsx
@@ -1,16 +1,28 @@
+import noop from "lodash/noop";
 import { Navigate, useParams } from "@tanstack/react-router";
+import usePluginsStore from "@/store/PluginsStore";
 
 const ProjectHomePage = () => {
   const { workspaceName, projectId } = useParams({
     strict: false,
   }) as { workspaceName: string; projectId: string };
 
+  const AssistantSidebar = usePluginsStore((state) => state.AssistantSidebar);
+
+  if (!AssistantSidebar) {
+    return (
+      <Navigate
+        to="/$workspaceName/projects/$projectId/logs"
+        params={{ workspaceName, projectId }}
+        replace
+      />
+    );
+  }
+
   return (
-    <Navigate
-      to="/$workspaceName/projects/$projectId/logs"
-      params={{ workspaceName, projectId }}
-      replace
-    />
+    <div className="-mx-6 flex h-full">
+      <AssistantSidebar surface="page" onWidthChange={noop} />
+    </div>
   );
 };
 

--- a/apps/opik-frontend/src/v2/router.tsx
+++ b/apps/opik-frontend/src/v2/router.tsx
@@ -185,9 +185,6 @@ const projectHomeRoute = createRoute({
   path: "/home",
   getParentRoute: () => projectScopedRoute,
   component: ProjectHomePage,
-  staticData: {
-    title: "Project home",
-  },
 });
 
 // ----------- logs (project-scoped)


### PR DESCRIPTION
## Details


https://github.com/user-attachments/assets/a51f82e9-1736-4c3a-bc00-c59038473819



Adds a dedicated Project Home page for Comet-plugin builds that embeds the existing Ollie assistant inline as the main content; OSS builds keep the current redirect to `/logs`.

Key changes:
- `BridgeContext` gains a `surface: 'sidebar' | 'page'` field so Ollie can adapt its UI based on render surface
- `PageLayout` suppresses the right-side assistant sidebar when the user is on `/home` to avoid duplicate iframes
- `ProjectSelector` splits into a navigate-to-home link (icon + project name) and a dropdown trigger ("Project ▾"), with an active state when on the home page; collapsed mode shows the icon as a home link with a small chevron overlay for the dropdown
- `ProjectSidebarContent` moves the selector outside the scroll container so the collapsed chevron overlay isn't clipped
- `AssistantSidebar` guards `window.opikBridge` cleanup so switching between sidebar/page surfaces doesn't clobber the new instance's bridge
- Page-surface iframe dispatches synthetic `pointerdown`/`mousedown` on `window.blur` so Radix-based dropdowns dismiss when the user clicks into the Ollie iframe

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-5835

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code CLI
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review + manual testing in Comet and OSS builds

## Testing

- `scripts/dev-runner.sh --lint-fe` (lint:fix + typecheck + deps:validate) — all pass
- Manual: Comet build → project home renders Ollie inline, sidebar suppressed; navigate away → sidebar reappears
- Manual: OSS build → project home redirects to `/logs`
- Manual: Project selector split-click (icon/name → home, chevron → dropdown), active state on home, tooltip on collapsed icon
- Manual: Open dropdown → click Ollie iframe → dropdown dismisses
- Manual: `window.opikBridge.getContext().surface` returns `"page"` on home, `"sidebar"` elsewhere

## Documentation

N/A