### PR TITLE
[OPIK-5860] [TS SDK] refactor: rename assertions → globalAssertions, executionPolicy → globalExecutionPolicy

### DIFF
--- a/sdks/typescript/examples/test_suite_example.ts
+++ b/sdks/typescript/examples/test_suite_example.ts
@@ -21,8 +21,8 @@ async function main() {
 
   const suite = await TestSuite.create(client, {
     name: suiteName,
-    assertions: ["Response answers the question"],
-    executionPolicy: { runsPerItem: 1, passThreshold: 1 },
+    globalAssertions: ["Response answers the question"],
+    globalExecutionPolicy: { runsPerItem: 1, passThreshold: 1 },
     projectName: "my-project",
   });
 

--- a/sdks/typescript/src/opik/evaluation/suite/TestSuite.ts
+++ b/sdks/typescript/src/opik/evaluation/suite/TestSuite.ts
@@ -42,8 +42,8 @@ export interface AddItemOptions {
 export interface CreateTestSuiteOptions {
   name: string;
   description?: string;
-  assertions?: string[];
-  executionPolicy?: ExecutionPolicy;
+  globalAssertions?: string[];
+  globalExecutionPolicy?: ExecutionPolicy;
   tags?: string[];
   projectName?: string;
 }
@@ -62,7 +62,7 @@ function extractAssertions(evaluators: EvaluatorItemLike[] | undefined): string[
 
 function prepareDatasetItemData(
   data: Record<string, unknown>,
-  options?: { assertions?: string[]; description?: string; executionPolicy?: ExecutionPolicy }
+  options?: AddItemOptions
 ): DatasetItemData {
   if (options?.executionPolicy) {
     validateExecutionPolicy(options.executionPolicy, "item-level execution policy");
@@ -142,13 +142,13 @@ export class TestSuite {
     validateSuiteName(options.name);
 
     const resolvedEvaluators = resolveEvaluators(
-      options.assertions,
+      options.globalAssertions,
       undefined,
       "suite-level assertions"
     );
 
-    if (options.executionPolicy) {
-      validateExecutionPolicy(options.executionPolicy, "suite creation");
+    if (options.globalExecutionPolicy) {
+      validateExecutionPolicy(options.globalExecutionPolicy, "suite creation");
     }
 
     const resolvedProjectName = client.resolveProjectName(options.projectName);
@@ -168,7 +168,7 @@ export class TestSuite {
       client
     );
 
-    if (resolvedEvaluators || options.executionPolicy) {
+    if (resolvedEvaluators || options.globalExecutionPolicy) {
       const evaluators = resolvedEvaluators
         ? serializeEvaluators(resolvedEvaluators)
         : undefined;
@@ -177,10 +177,10 @@ export class TestSuite {
         override: true,
         body: {
           ...(evaluators && { evaluators }),
-          ...(options.executionPolicy && {
+          ...(options.globalExecutionPolicy && {
             execution_policy: {
-              runs_per_item: options.executionPolicy.runsPerItem,
-              pass_threshold: options.executionPolicy.passThreshold,
+              runs_per_item: options.globalExecutionPolicy.runsPerItem,
+              pass_threshold: options.globalExecutionPolicy.passThreshold,
             },
           }),
         },
@@ -210,14 +210,14 @@ export class TestSuite {
       const suite = await TestSuite.get(client, options.name, options.projectName);
 
       const hasUpdates =
-        options.assertions !== undefined ||
-        options.executionPolicy !== undefined ||
+        options.globalAssertions !== undefined ||
+        options.globalExecutionPolicy !== undefined ||
         options.tags !== undefined;
 
       if (hasUpdates) {
         await suite.update({
-          assertions: options.assertions,
-          executionPolicy: options.executionPolicy,
+          globalAssertions: options.globalAssertions,
+          globalExecutionPolicy: options.globalExecutionPolicy,
           tags: options.tags,
         });
       }
@@ -284,7 +284,7 @@ export class TestSuite {
     }>
   > {
     const rawItems = await this.dataset.getRawItems();
-    const suitePolicy = await this.getExecutionPolicy();
+    const suitePolicy = await this.getGlobalExecutionPolicy();
 
     return rawItems.map((item) => {
       const { id, ...data } = item.getContent(true);
@@ -301,7 +301,7 @@ export class TestSuite {
     });
   }
 
-  async getAssertions(): Promise<string[]> {
+  async getGlobalAssertions(): Promise<string[]> {
     const versionInfo = await this.dataset.getVersionInfo();
     return extractAssertions(versionInfo?.evaluators);
   }
@@ -314,31 +314,31 @@ export class TestSuite {
     return this.dataset.getItemsCount();
   }
 
-  async getExecutionPolicy(): Promise<Required<ExecutionPolicy>> {
+  async getGlobalExecutionPolicy(): Promise<Required<ExecutionPolicy>> {
     const versionInfo = await this.dataset.getVersionInfo();
     return resolveExecutionPolicy(versionInfo?.executionPolicy);
   }
 
   async update(options: {
-    assertions?: string[];
-    executionPolicy?: ExecutionPolicy;
+    globalAssertions?: string[];
+    globalExecutionPolicy?: ExecutionPolicy;
     tags?: string[];
   }): Promise<void> {
-    if (options.executionPolicy) {
-      validateExecutionPolicy(options.executionPolicy, "suite update");
+    if (options.globalExecutionPolicy) {
+      validateExecutionPolicy(options.globalExecutionPolicy, "suite update");
     }
 
     const resolvedEvaluators = resolveEvaluators(
-      options.assertions,
+      options.globalAssertions,
       undefined,
       "suite-level assertions"
     );
 
-    const assertionsProvided = options.assertions !== undefined;
+    const assertionsProvided = options.globalAssertions !== undefined;
 
-    if (!resolvedEvaluators && !assertionsProvided && !options.executionPolicy && !options.tags) {
+    if (!resolvedEvaluators && !assertionsProvided && !options.globalExecutionPolicy && !options.tags) {
       throw new Error(
-        "At least one of 'assertions', 'executionPolicy', or 'tags' must be provided."
+        "At least one of 'globalAssertions', 'globalExecutionPolicy', or 'tags' must be provided."
       );
     }
 
@@ -350,7 +350,7 @@ export class TestSuite {
       });
     }
 
-    const hasVersionUpdates = resolvedEvaluators || assertionsProvided || options.executionPolicy;
+    const hasVersionUpdates = resolvedEvaluators || assertionsProvided || options.globalExecutionPolicy;
     if (hasVersionUpdates) {
       const versionInfo = await this.dataset.getVersionInfo();
       if (!versionInfo) {
@@ -367,7 +367,7 @@ export class TestSuite {
           : (versionInfo.evaluators
             ? deserializeEvaluators(versionInfo.evaluators)
             : []));
-      const executionPolicy = options.executionPolicy ??
+      const executionPolicy = options.globalExecutionPolicy ??
         resolveExecutionPolicy(versionInfo.executionPolicy);
 
       await this.client.api.datasets.applyDatasetItemChanges(this.dataset.id, {

--- a/sdks/typescript/tests/integration/evaluation/evaluateTestSuite.test.ts
+++ b/sdks/typescript/tests/integration/evaluation/evaluateTestSuite.test.ts
@@ -72,8 +72,8 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
 
         const suite = await TestSuite.create(client, {
           name: suiteName,
-          assertions: ["Response is helpful"],
-          executionPolicy: { runsPerItem: 2, passThreshold: 1 },
+          globalAssertions: ["Response is helpful"],
+          globalExecutionPolicy: { runsPerItem: 2, passThreshold: 1 },
         });
 
         await suite.addItem({ input: "Q1", expected: "A1" });
@@ -81,11 +81,11 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
 
         await waitForSuiteItems(suite, 2);
 
-        const assertions = await suite.getAssertions();
+        const assertions = await suite.getGlobalAssertions();
         expect(assertions).toHaveLength(1);
         expect(assertions[0]).toBe("Response is helpful");
 
-        const policy = await suite.getExecutionPolicy();
+        const policy = await suite.getGlobalExecutionPolicy();
         expect(policy).toEqual({ runsPerItem: 2, passThreshold: 1 });
 
         const items = await suite.getItems();
@@ -99,7 +99,6 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
             passThreshold: 1,
           });
         }
-
       },
       60000
     );
@@ -114,11 +113,11 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
 
         const suite = await TestSuite.create(client, {
           name: suiteName,
-          assertions: ["Response is helpful"],
-          executionPolicy: { runsPerItem: 1, passThreshold: 1 },
+          globalAssertions: ["Response is helpful"],
+          globalExecutionPolicy: { runsPerItem: 1, passThreshold: 1 },
         });
 
-        const assertions = await suite.getAssertions();
+        const assertions = await suite.getGlobalAssertions();
         expect(assertions).toHaveLength(1);
         expect(assertions[0]).toBe("Response is helpful");
 
@@ -141,8 +140,8 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
 
         const suite = await TestSuite.create(client, {
           name: suiteName,
-          assertions: ["Response is helpful"],
-          executionPolicy: { runsPerItem: 1, passThreshold: 1 },
+          globalAssertions: ["Response is helpful"],
+          globalExecutionPolicy: { runsPerItem: 1, passThreshold: 1 },
         });
 
         await suite.addItem(
@@ -170,7 +169,7 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
 
         const created = await TestSuite.create(client, {
           name: suiteName,
-          assertions: ["Response is helpful"],
+          globalAssertions: ["Response is helpful"],
         });
 
         expect(created.projectName).toBeDefined();
@@ -192,7 +191,7 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
 
         const suite1 = await TestSuite.getOrCreate(client, {
           name: suiteName,
-          assertions: ["Response is helpful"],
+          globalAssertions: ["Response is helpful"],
         });
 
         expect(suite1.name).toBe(suiteName);
@@ -218,8 +217,8 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
 
         const suite = await TestSuite.create(client, {
           name: suiteName,
-          assertions: ["Response is helpful"],
-          executionPolicy: { runsPerItem: 1, passThreshold: 1 },
+          globalAssertions: ["Response is helpful"],
+          globalExecutionPolicy: { runsPerItem: 1, passThreshold: 1 },
           projectName,
         });
 
@@ -267,8 +266,8 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
 
         const suite = await TestSuite.create(client, {
           name: suiteName,
-          assertions: ["Response is helpful"],
-          executionPolicy: { runsPerItem: 2, passThreshold: 1 },
+          globalAssertions: ["Response is helpful"],
+          globalExecutionPolicy: { runsPerItem: 2, passThreshold: 1 },
         });
 
         await suite.addItem({ input: "Hello world", expected: "Hi" });
@@ -296,20 +295,20 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
 
         const suite = await TestSuite.create(client, {
           name: suiteName,
-          assertions: ["Response is helpful"],
-          executionPolicy: { runsPerItem: 1, passThreshold: 1 },
+          globalAssertions: ["Response is helpful"],
+          globalExecutionPolicy: { runsPerItem: 1, passThreshold: 1 },
         });
 
         await suite.update({
-          assertions: ["Response is concise"],
-          executionPolicy: { runsPerItem: 3, passThreshold: 2 },
+          globalAssertions: ["Response is concise"],
+          globalExecutionPolicy: { runsPerItem: 3, passThreshold: 2 },
         });
 
-        const assertions = await suite.getAssertions();
+        const assertions = await suite.getGlobalAssertions();
         expect(assertions).toHaveLength(1);
         expect(assertions[0]).toBe("Response is concise");
 
-        const policy = await suite.getExecutionPolicy();
+        const policy = await suite.getGlobalExecutionPolicy();
         expect(policy).toEqual({ runsPerItem: 3, passThreshold: 2 });
       },
       60000
@@ -325,8 +324,8 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
 
         const suite = await TestSuite.create(client, {
           name: suiteName,
-          assertions: ["Response is helpful"],
-          executionPolicy: { runsPerItem: 1, passThreshold: 1 },
+          globalAssertions: ["Response is helpful"],
+          globalExecutionPolicy: { runsPerItem: 1, passThreshold: 1 },
         });
 
         await suite.addItem(

--- a/sdks/typescript/tests/unit/client/testSuiteMethods.test.ts
+++ b/sdks/typescript/tests/unit/client/testSuiteMethods.test.ts
@@ -103,8 +103,8 @@ describe("TestSuite static methods", () => {
     it("should create initial version when assertions are provided", async () => {
       const suite = await TestSuite.create(opikClient, {
         name: "my-suite",
-        assertions: ["is accurate"],
-        executionPolicy: { runsPerItem: 3, passThreshold: 2 },
+        globalAssertions: ["is accurate"],
+        globalExecutionPolicy: { runsPerItem: 3, passThreshold: 2 },
       });
 
       expect(suite).toBeInstanceOf(TestSuite);
@@ -128,8 +128,8 @@ describe("TestSuite static methods", () => {
     it("should create suite with assertions shorthand", async () => {
       const suite = await TestSuite.create(opikClient, {
         name: "my-suite",
-        assertions: ["is accurate", "is concise"],
-        executionPolicy: { runsPerItem: 2, passThreshold: 1 },
+        globalAssertions: ["is accurate", "is concise"],
+        globalExecutionPolicy: { runsPerItem: 2, passThreshold: 1 },
       });
 
       expect(suite).toBeInstanceOf(TestSuite);
@@ -233,25 +233,25 @@ describe("TestSuite static methods", () => {
       expect(createDatasetSpy).not.toHaveBeenCalled();
     });
 
-    it("should call update() when existing suite found and options have assertions/tags/executionPolicy", async () => {
+    it("should call update() when existing suite found and options have globalAssertions/tags/globalExecutionPolicy", async () => {
       const updateSpy = vi
         .spyOn(TestSuite.prototype, "update")
         .mockResolvedValue(undefined);
 
       const suite = await TestSuite.getOrCreate(opikClient, {
         name: "test-suite",
-        assertions: ["is accurate"],
+        globalAssertions: ["is accurate"],
         tags: ["prod"],
-        executionPolicy: { runsPerItem: 2, passThreshold: 1 },
+        globalExecutionPolicy: { runsPerItem: 2, passThreshold: 1 },
       });
 
       expect(suite).toBeInstanceOf(TestSuite);
       expect(suite.name).toBe("test-suite");
       expect(createDatasetSpy).not.toHaveBeenCalled();
       expect(updateSpy).toHaveBeenCalledWith({
-        assertions: ["is accurate"],
+        globalAssertions: ["is accurate"],
         tags: ["prod"],
-        executionPolicy: { runsPerItem: 2, passThreshold: 1 },
+        globalExecutionPolicy: { runsPerItem: 2, passThreshold: 1 },
       });
     });
 

--- a/sdks/typescript/tests/unit/evaluation/suite/TestSuite.test.ts
+++ b/sdks/typescript/tests/unit/evaluation/suite/TestSuite.test.ts
@@ -379,14 +379,14 @@ describe("TestSuite", () => {
     });
   });
 
-  describe("getAssertions", () => {
+  describe("getGlobalAssertions", () => {
     it("should return empty array when versionInfo has no evaluators", async () => {
       vi.spyOn(testDataset, "getVersionInfo").mockResolvedValue({
         id: "v1",
         versionName: "v1",
       });
 
-      const assertions = await suite.getAssertions();
+      const assertions = await suite.getGlobalAssertions();
 
       expect(assertions).toEqual([]);
     });
@@ -394,7 +394,7 @@ describe("TestSuite", () => {
     it("should return empty array when versionInfo is undefined", async () => {
       vi.spyOn(testDataset, "getVersionInfo").mockResolvedValue(undefined);
 
-      const assertions = await suite.getAssertions();
+      const assertions = await suite.getGlobalAssertions();
 
       expect(assertions).toEqual([]);
     });
@@ -425,7 +425,7 @@ describe("TestSuite", () => {
         executionPolicy: { runsPerItem: 1, passThreshold: 1 },
       });
 
-      const assertions = await suite.getAssertions();
+      const assertions = await suite.getGlobalAssertions();
 
       expect(assertions).toEqual(["is correct", "is concise"]);
     });
@@ -450,7 +450,7 @@ describe("TestSuite", () => {
         ],
       });
 
-      const assertions = await suite.getAssertions();
+      const assertions = await suite.getGlobalAssertions();
 
       expect(Array.isArray(assertions)).toBe(true);
       for (const a of assertions) {
@@ -501,14 +501,14 @@ describe("TestSuite", () => {
     });
   });
 
-  describe("getExecutionPolicy", () => {
+  describe("getGlobalExecutionPolicy", () => {
     it("should resolve execution policy from versionInfo", async () => {
       vi.spyOn(testDataset, "getVersionInfo").mockResolvedValue({
         id: "v1",
         executionPolicy: { runsPerItem: 5, passThreshold: 3 },
       });
 
-      const policy = await suite.getExecutionPolicy();
+      const policy = await suite.getGlobalExecutionPolicy();
 
       expect(policy).toEqual({ runsPerItem: 5, passThreshold: 3 });
     });
@@ -516,7 +516,7 @@ describe("TestSuite", () => {
     it("should return default execution policy when versionInfo is undefined", async () => {
       vi.spyOn(testDataset, "getVersionInfo").mockResolvedValue(undefined);
 
-      const policy = await suite.getExecutionPolicy();
+      const policy = await suite.getGlobalExecutionPolicy();
 
       expect(policy).toEqual(DEFAULT_EXECUTION_POLICY);
     });
@@ -527,7 +527,7 @@ describe("TestSuite", () => {
         versionName: "v1",
       });
 
-      const policy = await suite.getExecutionPolicy();
+      const policy = await suite.getGlobalExecutionPolicy();
 
       expect(policy).toEqual(DEFAULT_EXECUTION_POLICY);
     });
@@ -645,7 +645,7 @@ describe("TestSuite", () => {
   });
 
   describe("update", () => {
-    it("should accept assertions and call applyDatasetItemChanges", async () => {
+    it("should accept globalAssertions and call applyDatasetItemChanges", async () => {
       vi.spyOn(testDataset, "getVersionInfo").mockResolvedValue({
         id: "version-1",
         versionName: "v1",
@@ -664,8 +664,8 @@ describe("TestSuite", () => {
         );
 
       await suite.update({
-        assertions: ["is correct"],
-        executionPolicy: { runsPerItem: 3, passThreshold: 2 },
+        globalAssertions: ["is correct"],
+        globalExecutionPolicy: { runsPerItem: 3, passThreshold: 2 },
       });
 
       expect(applyChangesSpy).toHaveBeenCalledWith("suite-ds-id", {
@@ -683,7 +683,7 @@ describe("TestSuite", () => {
       });
     });
 
-    it("should support partial update with assertions only (no executionPolicy)", async () => {
+    it("should support partial update with globalAssertions only (no globalExecutionPolicy)", async () => {
       vi.spyOn(testDataset, "getVersionInfo").mockResolvedValue({
         id: "version-1",
         versionName: "v1",
@@ -702,7 +702,7 @@ describe("TestSuite", () => {
             }) as never
         );
 
-      await suite.update({ assertions: ["is correct"] });
+      await suite.update({ globalAssertions: ["is correct"] });
 
       // Should use current executionPolicy from versionInfo as fallback
       expect(applyChangesSpy).toHaveBeenCalledWith("suite-ds-id", {
@@ -716,7 +716,7 @@ describe("TestSuite", () => {
       });
     });
 
-    it("should support partial update with executionPolicy only (no assertions)", async () => {
+    it("should support partial update with globalExecutionPolicy only (no globalAssertions)", async () => {
       vi.spyOn(testDataset, "getVersionInfo").mockResolvedValue({
         id: "version-1",
         versionName: "v1",
@@ -735,7 +735,7 @@ describe("TestSuite", () => {
             }) as never
         );
 
-      await suite.update({ executionPolicy: { runsPerItem: 5, passThreshold: 3 } });
+      await suite.update({ globalExecutionPolicy: { runsPerItem: 5, passThreshold: 3 } });
 
       expect(applyChangesSpy).toHaveBeenCalledWith("suite-ds-id", {
         override: false,
@@ -778,9 +778,9 @@ describe("TestSuite", () => {
       expect(applyChangesSpy).not.toHaveBeenCalled();
     });
 
-    it("should throw when none of assertions, executionPolicy, or tags are provided", async () => {
+    it("should throw when none of globalAssertions, globalExecutionPolicy, or tags are provided", async () => {
       await expect(suite.update({})).rejects.toThrow(
-        "At least one of 'assertions', 'executionPolicy', or 'tags' must be provided."
+        "At least one of 'globalAssertions', 'globalExecutionPolicy', or 'tags' must be provided."
       );
     });
   });
@@ -804,7 +804,7 @@ describe("TestSuite", () => {
       ).rejects.toThrow("Test suite name must be a non-empty string");
     });
 
-    it("should call validateExecutionPolicy when executionPolicy is provided in create", async () => {
+    it("should call validateExecutionPolicy when globalExecutionPolicy is provided in create", async () => {
       vi.spyOn(opikClient.api.datasets, "createDataset").mockImplementation(
         () =>
           ({
@@ -825,7 +825,7 @@ describe("TestSuite", () => {
 
       await TestSuite.create(opikClient, {
         name: "valid-suite",
-        executionPolicy: { runsPerItem: 3, passThreshold: 2 },
+        globalExecutionPolicy: { runsPerItem: 3, passThreshold: 2 },
       });
 
       expect(validateExecutionPolicy).toHaveBeenCalledWith(
@@ -866,8 +866,8 @@ describe("TestSuite", () => {
       );
 
       await suite.update({
-        assertions: ["is correct"],
-        executionPolicy: { runsPerItem: 5, passThreshold: 3 },
+        globalAssertions: ["is correct"],
+        globalExecutionPolicy: { runsPerItem: 5, passThreshold: 3 },
       });
 
       expect(validateExecutionPolicy).toHaveBeenCalledWith(


### PR DESCRIPTION
## Details

⚠️ **BREAKING CHANGE** — renames suite-level parameters with no backwards compatibility, as specified in the ticket.

TS SDK equivalent of OPIK-5799 (Python SDK). The parameters `assertions` and `executionPolicy` on suite-level methods are ambiguous since items can also have their own assertions and execution policies. Renaming to `global*` clarifies scope.

### Renamed (suite-level only)

| Location | Before | After |
|---|---|---|
| `CreateTestSuiteOptions` | `assertions`, `executionPolicy` | `globalAssertions`, `globalExecutionPolicy` |
| `update()` options | `assertions`, `executionPolicy` | `globalAssertions`, `globalExecutionPolicy` |
| `TestSuite` methods | `getAssertions()`, `getExecutionPolicy()` | `getGlobalAssertions()`, `getGlobalExecutionPolicy()` |
| Error message in `update()` | references `'assertions'`, `'executionPolicy'` | references `'globalAssertions'`, `'globalExecutionPolicy'` |

### Unchanged (item-level)

- `AddItemOptions.assertions` / `AddItemOptions.executionPolicy`
- `TestSuiteItem.assertions` / `TestSuiteItem.executionPolicy`
- `getItems()` return shape (`assertions`, `executionPolicy` per item)
- Internal REST API field names (`versionInfo.executionPolicy`, `item.executionPolicy`)
- `EvaluationEngine` internal fields

### Files changed

- `sdks/typescript/src/opik/evaluation/suite/TestSuite.ts` — interfaces, methods, method bodies
- `sdks/typescript/tests/unit/client/testSuiteMethods.test.ts` — unit tests
- `sdks/typescript/tests/unit/evaluation/suite/TestSuite.test.ts` — unit tests
- `sdks/typescript/tests/integration/evaluation/evaluateTestSuite.test.ts` — integration tests
- `sdks/typescript/examples/test_suite_example.ts` — example

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5860

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-6
- Scope: Full implementation, tests, and PR
- Human verification: Yes

## Testing

**Build**: `npm run build` succeeds cleanly.

**Unit tests** (1642 pass, 0 failures):
```
npx vitest run --exclude 'tests/integration/**'
# 86 files, 1642 tests, 0 failures
```

**Verification**:
- Grep confirms zero remaining `getAssertions()`/`getExecutionPolicy()` method names
- Grep confirms zero remaining suite-level `assertions:`/`executionPolicy:` in create/getOrCreate/update calls
- All item-level `assertions`/`executionPolicy` usages confirmed untouched

## Documentation

Example file updated. API docs will need a migration note for the breaking change.