### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -8363,14 +8363,6 @@ components:
       - type
       type: object
       properties:
-        id:
-          type: string
-          format: uuid
-          readOnly: true
-        project_id:
-          type: string
-          format: uuid
-          readOnly: true
         key:
           maxLength: 255
           minLength: 0
@@ -8388,14 +8380,6 @@ components:
           - prompt_commit
         description:
           type: string
-        valid_from_blueprint_id:
-          type: string
-          format: uuid
-          readOnly: true
-        valid_to_blueprint_id:
-          type: string
-          format: uuid
-          readOnly: true
     ErrorMessage_Public:
       type: object
       properties:
@@ -8459,14 +8443,6 @@ components:
       - type
       type: object
       properties:
-        id:
-          type: string
-          format: uuid
-          readOnly: true
-        project_id:
-          type: string
-          format: uuid
-          readOnly: true
         key:
           maxLength: 255
           minLength: 0
@@ -8484,14 +8460,6 @@ components:
           - prompt_commit
         description:
           type: string
-        valid_from_blueprint_id:
-          type: string
-          format: uuid
-          readOnly: true
-        valid_to_blueprint_id:
-          type: string
-          format: uuid
-          readOnly: true
     BlueprintPage_History:
       type: object
       properties:
@@ -17853,16 +17821,6 @@ components:
           enum:
           - text
           - chat
-        exclude_blueprint_update_for_projects:
-          uniqueItems: true
-          type: array
-          description: Optional set of project IDs to exclude from automatic blueprint
-            creation when this prompt version is committed.
-          items:
-            type: string
-            description: Optional set of project IDs to exclude from automatic blueprint
-              creation when this prompt version is committed.
-            format: uuid
         project_id:
           type: string
           description: Project ID. Takes precedence over project_name when both are

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -8363,14 +8363,6 @@ components:
       - type
       type: object
       properties:
-        id:
-          type: string
-          format: uuid
-          readOnly: true
-        project_id:
-          type: string
-          format: uuid
-          readOnly: true
         key:
           maxLength: 255
           minLength: 0
@@ -8388,14 +8380,6 @@ components:
           - prompt_commit
         description:
           type: string
-        valid_from_blueprint_id:
-          type: string
-          format: uuid
-          readOnly: true
-        valid_to_blueprint_id:
-          type: string
-          format: uuid
-          readOnly: true
     ErrorMessage_Public:
       type: object
       properties:
@@ -8459,14 +8443,6 @@ components:
       - type
       type: object
       properties:
-        id:
-          type: string
-          format: uuid
-          readOnly: true
-        project_id:
-          type: string
-          format: uuid
-          readOnly: true
         key:
           maxLength: 255
           minLength: 0
@@ -8484,14 +8460,6 @@ components:
           - prompt_commit
         description:
           type: string
-        valid_from_blueprint_id:
-          type: string
-          format: uuid
-          readOnly: true
-        valid_to_blueprint_id:
-          type: string
-          format: uuid
-          readOnly: true
     BlueprintPage_History:
       type: object
       properties:
@@ -17853,16 +17821,6 @@ components:
           enum:
           - text
           - chat
-        exclude_blueprint_update_for_projects:
-          uniqueItems: true
-          type: array
-          description: Optional set of project IDs to exclude from automatic blueprint
-            creation when this prompt version is committed.
-          items:
-            type: string
-            description: Optional set of project IDs to exclude from automatic blueprint
-              creation when this prompt version is committed.
-            format: uuid
         project_id:
           type: string
           description: Project ID. Takes precedence over project_name when both are

--- a/sdks/python/src/opik/rest_api/prompts/client.py
+++ b/sdks/python/src/opik/rest_api/prompts/client.py
@@ -169,7 +169,6 @@ class PromptsClient:
         name: str,
         version: PromptVersionDetail,
         template_structure: typing.Optional[CreatePromptVersionDetailTemplateStructure] = OMIT,
-        exclude_blueprint_update_for_projects: typing.Optional[typing.Sequence[str]] = OMIT,
         project_id: typing.Optional[str] = OMIT,
         project_name: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
@@ -185,9 +184,6 @@ class PromptsClient:
 
         template_structure : typing.Optional[CreatePromptVersionDetailTemplateStructure]
             Template structure for the prompt: 'text' or 'chat'. Note: This field is only used when creating a new prompt. If a prompt with the given name already exists, this field is ignored and the existing prompt's template structure is used. Template structure is immutable after prompt creation.
-
-        exclude_blueprint_update_for_projects : typing.Optional[typing.Sequence[str]]
-            Optional set of project IDs to exclude from automatic blueprint creation when this prompt version is committed.
 
         project_id : typing.Optional[str]
             Project ID. Takes precedence over project_name when both are provided.
@@ -214,7 +210,6 @@ class PromptsClient:
             name=name,
             version=version,
             template_structure=template_structure,
-            exclude_blueprint_update_for_projects=exclude_blueprint_update_for_projects,
             project_id=project_id,
             project_name=project_name,
             request_options=request_options,
@@ -740,7 +735,6 @@ class AsyncPromptsClient:
         name: str,
         version: PromptVersionDetail,
         template_structure: typing.Optional[CreatePromptVersionDetailTemplateStructure] = OMIT,
-        exclude_blueprint_update_for_projects: typing.Optional[typing.Sequence[str]] = OMIT,
         project_id: typing.Optional[str] = OMIT,
         project_name: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
@@ -756,9 +750,6 @@ class AsyncPromptsClient:
 
         template_structure : typing.Optional[CreatePromptVersionDetailTemplateStructure]
             Template structure for the prompt: 'text' or 'chat'. Note: This field is only used when creating a new prompt. If a prompt with the given name already exists, this field is ignored and the existing prompt's template structure is used. Template structure is immutable after prompt creation.
-
-        exclude_blueprint_update_for_projects : typing.Optional[typing.Sequence[str]]
-            Optional set of project IDs to exclude from automatic blueprint creation when this prompt version is committed.
 
         project_id : typing.Optional[str]
             Project ID. Takes precedence over project_name when both are provided.
@@ -788,7 +779,6 @@ class AsyncPromptsClient:
             name=name,
             version=version,
             template_structure=template_structure,
-            exclude_blueprint_update_for_projects=exclude_blueprint_update_for_projects,
             project_id=project_id,
             project_name=project_name,
             request_options=request_options,

--- a/sdks/python/src/opik/rest_api/prompts/raw_client.py
+++ b/sdks/python/src/opik/rest_api/prompts/raw_client.py
@@ -219,7 +219,6 @@ class RawPromptsClient:
         name: str,
         version: PromptVersionDetail,
         template_structure: typing.Optional[CreatePromptVersionDetailTemplateStructure] = OMIT,
-        exclude_blueprint_update_for_projects: typing.Optional[typing.Sequence[str]] = OMIT,
         project_id: typing.Optional[str] = OMIT,
         project_name: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
@@ -235,9 +234,6 @@ class RawPromptsClient:
 
         template_structure : typing.Optional[CreatePromptVersionDetailTemplateStructure]
             Template structure for the prompt: 'text' or 'chat'. Note: This field is only used when creating a new prompt. If a prompt with the given name already exists, this field is ignored and the existing prompt's template structure is used. Template structure is immutable after prompt creation.
-
-        exclude_blueprint_update_for_projects : typing.Optional[typing.Sequence[str]]
-            Optional set of project IDs to exclude from automatic blueprint creation when this prompt version is committed.
 
         project_id : typing.Optional[str]
             Project ID. Takes precedence over project_name when both are provided.
@@ -262,7 +258,6 @@ class RawPromptsClient:
                     object_=version, annotation=PromptVersionDetail, direction="write"
                 ),
                 "template_structure": template_structure,
-                "exclude_blueprint_update_for_projects": exclude_blueprint_update_for_projects,
                 "project_id": project_id,
                 "project_name": project_name,
             },
@@ -1175,7 +1170,6 @@ class AsyncRawPromptsClient:
         name: str,
         version: PromptVersionDetail,
         template_structure: typing.Optional[CreatePromptVersionDetailTemplateStructure] = OMIT,
-        exclude_blueprint_update_for_projects: typing.Optional[typing.Sequence[str]] = OMIT,
         project_id: typing.Optional[str] = OMIT,
         project_name: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
@@ -1191,9 +1185,6 @@ class AsyncRawPromptsClient:
 
         template_structure : typing.Optional[CreatePromptVersionDetailTemplateStructure]
             Template structure for the prompt: 'text' or 'chat'. Note: This field is only used when creating a new prompt. If a prompt with the given name already exists, this field is ignored and the existing prompt's template structure is used. Template structure is immutable after prompt creation.
-
-        exclude_blueprint_update_for_projects : typing.Optional[typing.Sequence[str]]
-            Optional set of project IDs to exclude from automatic blueprint creation when this prompt version is committed.
 
         project_id : typing.Optional[str]
             Project ID. Takes precedence over project_name when both are provided.
@@ -1218,7 +1209,6 @@ class AsyncRawPromptsClient:
                     object_=version, annotation=PromptVersionDetail, direction="write"
                 ),
                 "template_structure": template_structure,
-                "exclude_blueprint_update_for_projects": exclude_blueprint_update_for_projects,
                 "project_id": project_id,
                 "project_name": project_name,
             },

--- a/sdks/python/src/opik/rest_api/types/agent_config_value_history.py
+++ b/sdks/python/src/opik/rest_api/types/agent_config_value_history.py
@@ -8,14 +8,10 @@ from .agent_config_value_history_type import AgentConfigValueHistoryType
 
 
 class AgentConfigValueHistory(UniversalBaseModel):
-    id: typing.Optional[str] = None
-    project_id: typing.Optional[str] = None
     key: str
     value: typing.Optional[str] = None
     type: AgentConfigValueHistoryType
     description: typing.Optional[str] = None
-    valid_from_blueprint_id: typing.Optional[str] = None
-    valid_to_blueprint_id: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/agent_config_value_public.py
+++ b/sdks/python/src/opik/rest_api/types/agent_config_value_public.py
@@ -8,14 +8,10 @@ from .agent_config_value_public_type import AgentConfigValuePublicType
 
 
 class AgentConfigValuePublic(UniversalBaseModel):
-    id: typing.Optional[str] = None
-    project_id: typing.Optional[str] = None
     key: str
     value: typing.Optional[str] = None
     type: AgentConfigValuePublicType
     description: typing.Optional[str] = None
-    valid_from_blueprint_id: typing.Optional[str] = None
-    valid_to_blueprint_id: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/typescript/src/opik/rest_api/api/resources/prompts/client/requests/CreatePromptVersionDetail.ts
+++ b/sdks/typescript/src/opik/rest_api/api/resources/prompts/client/requests/CreatePromptVersionDetail.ts
@@ -16,8 +16,6 @@ export interface CreatePromptVersionDetail {
     version: OpikApi.PromptVersionDetail;
     /** Template structure for the prompt: 'text' or 'chat'. Note: This field is only used when creating a new prompt. If a prompt with the given name already exists, this field is ignored and the existing prompt's template structure is used. Template structure is immutable after prompt creation. */
     templateStructure?: OpikApi.CreatePromptVersionDetailTemplateStructure;
-    /** Optional set of project IDs to exclude from automatic blueprint creation when this prompt version is committed. */
-    excludeBlueprintUpdateForProjects?: string[];
     /** Project ID. Takes precedence over project_name when both are provided. */
     projectId?: string;
     /** If provided, scopes the prompt to the specified project. Ignored when project_id is provided. */

--- a/sdks/typescript/src/opik/rest_api/api/types/AgentConfigValueHistory.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/AgentConfigValueHistory.ts
@@ -3,12 +3,8 @@
 import type * as OpikApi from "../index.js";
 
 export interface AgentConfigValueHistory {
-    id?: string;
-    projectId?: string;
     key: string;
     value?: string;
     type: OpikApi.AgentConfigValueHistoryType;
     description?: string;
-    validFromBlueprintId?: string;
-    validToBlueprintId?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/AgentConfigValuePublic.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/AgentConfigValuePublic.ts
@@ -3,12 +3,8 @@
 import type * as OpikApi from "../index.js";
 
 export interface AgentConfigValuePublic {
-    id?: string;
-    projectId?: string;
     key: string;
     value?: string;
     type: OpikApi.AgentConfigValuePublicType;
     description?: string;
-    validFromBlueprintId?: string;
-    validToBlueprintId?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/resources/prompts/client/requests/CreatePromptVersionDetail.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/resources/prompts/client/requests/CreatePromptVersionDetail.ts
@@ -16,10 +16,6 @@ export const CreatePromptVersionDetail: core.serialization.Schema<
         "template_structure",
         CreatePromptVersionDetailTemplateStructure.optional(),
     ),
-    excludeBlueprintUpdateForProjects: core.serialization.property(
-        "exclude_blueprint_update_for_projects",
-        core.serialization.list(core.serialization.string()).optional(),
-    ),
     projectId: core.serialization.property("project_id", core.serialization.string().optional()),
     projectName: core.serialization.property("project_name", core.serialization.string().optional()),
 });
@@ -29,7 +25,6 @@ export declare namespace CreatePromptVersionDetail {
         name: string;
         version: PromptVersionDetail.Raw;
         template_structure?: CreatePromptVersionDetailTemplateStructure.Raw | null;
-        exclude_blueprint_update_for_projects?: string[] | null;
         project_id?: string | null;
         project_name?: string | null;
     }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/AgentConfigValueHistory.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/AgentConfigValueHistory.ts
@@ -9,28 +9,17 @@ export const AgentConfigValueHistory: core.serialization.ObjectSchema<
     serializers.AgentConfigValueHistory.Raw,
     OpikApi.AgentConfigValueHistory
 > = core.serialization.object({
-    id: core.serialization.string().optional(),
-    projectId: core.serialization.property("project_id", core.serialization.string().optional()),
     key: core.serialization.string(),
     value: core.serialization.string().optional(),
     type: AgentConfigValueHistoryType,
     description: core.serialization.string().optional(),
-    validFromBlueprintId: core.serialization.property(
-        "valid_from_blueprint_id",
-        core.serialization.string().optional(),
-    ),
-    validToBlueprintId: core.serialization.property("valid_to_blueprint_id", core.serialization.string().optional()),
 });
 
 export declare namespace AgentConfigValueHistory {
     export interface Raw {
-        id?: string | null;
-        project_id?: string | null;
         key: string;
         value?: string | null;
         type: AgentConfigValueHistoryType.Raw;
         description?: string | null;
-        valid_from_blueprint_id?: string | null;
-        valid_to_blueprint_id?: string | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/AgentConfigValuePublic.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/AgentConfigValuePublic.ts
@@ -9,28 +9,17 @@ export const AgentConfigValuePublic: core.serialization.ObjectSchema<
     serializers.AgentConfigValuePublic.Raw,
     OpikApi.AgentConfigValuePublic
 > = core.serialization.object({
-    id: core.serialization.string().optional(),
-    projectId: core.serialization.property("project_id", core.serialization.string().optional()),
     key: core.serialization.string(),
     value: core.serialization.string().optional(),
     type: AgentConfigValuePublicType,
     description: core.serialization.string().optional(),
-    validFromBlueprintId: core.serialization.property(
-        "valid_from_blueprint_id",
-        core.serialization.string().optional(),
-    ),
-    validToBlueprintId: core.serialization.property("valid_to_blueprint_id", core.serialization.string().optional()),
 });
 
 export declare namespace AgentConfigValuePublic {
     export interface Raw {
-        id?: string | null;
-        project_id?: string | null;
         key: string;
         value?: string | null;
         type: AgentConfigValuePublicType.Raw;
         description?: string | null;
-        valid_from_blueprint_id?: string | null;
-        valid_to_blueprint_id?: string | null;
     }
 }


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

**Triggered by BE merge:** https://github.com/comet-ml/opik/pull/6214

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate