### PR TITLE
[OPIK-5858] [TS SDK] refactor: align TestSuite method names with Dataset API

### DIFF
--- a/sdks/typescript/examples/test_suite_example.ts
+++ b/sdks/typescript/examples/test_suite_example.ts
@@ -27,12 +27,14 @@ async function main() {
   });
 
   // --- Add test items ---
-  await suite.addItem({ input: "What is 2+2?", expected: "4" });
-  await suite.addItem({ input: "Capital of France?", expected: "Paris" });
-  await suite.addItem(
-    { input: "Explain gravity briefly", expected: "A force of attraction" },
-    { assertions: ["Response is concise"] }
-  );
+  await suite.insert([
+    { data: { input: "What is 2+2?", expected: "4" } },
+    { data: { input: "Capital of France?", expected: "Paris" } },
+    {
+      data: { input: "Explain gravity briefly", expected: "A force of attraction" },
+      assertions: ["Response is concise"],
+    },
+  ]);
   console.log("Added 3 test items");
 
   // Wait for items to be available

--- a/sdks/typescript/src/opik/evaluation/suite/TestSuite.ts
+++ b/sdks/typescript/src/opik/evaluation/suite/TestSuite.ts
@@ -18,7 +18,6 @@ import {
   executionPolicyEqual,
 } from "./suiteHelpers";
 import type { EvaluatorItemLike } from "./suiteHelpers";
-import type { LLMJudge } from "../suite_evaluators/LLMJudge";
 import { DatasetWriteType } from "@/rest_api/api/resources/datasets/types/DatasetWriteType";
 import type { DatasetItemUpdate } from "@/rest_api/api/types/DatasetItemUpdate";
 import { generateId } from "@/utils/generateId";

--- a/sdks/typescript/src/opik/evaluation/suite/TestSuite.ts
+++ b/sdks/typescript/src/opik/evaluation/suite/TestSuite.ts
@@ -18,15 +18,11 @@ import {
   executionPolicyEqual,
 } from "./suiteHelpers";
 import type { EvaluatorItemLike } from "./suiteHelpers";
+import type { LLMJudge } from "../suite_evaluators/LLMJudge";
 import { DatasetWriteType } from "@/rest_api/api/resources/datasets/types/DatasetWriteType";
 import type { DatasetItemUpdate } from "@/rest_api/api/types/DatasetItemUpdate";
 import { generateId } from "@/utils/generateId";
 
-export interface AddItemOptions {
-  assertions?: string[];
-  description?: string;
-  executionPolicy?: ExecutionPolicy;
-}
 
 export interface CreateTestSuiteOptions {
   name: string;
@@ -35,6 +31,12 @@ export interface CreateTestSuiteOptions {
   globalExecutionPolicy?: ExecutionPolicy;
   tags?: string[];
   projectName?: string;
+}
+
+export interface UpdateTestSuiteOptions {
+  globalAssertions?: string[];
+  globalExecutionPolicy?: ExecutionPolicy;
+  tags?: string[];
 }
 
 function validateSuiteName(name: string): void {
@@ -51,7 +53,7 @@ function extractAssertions(evaluators: EvaluatorItemLike[] | undefined): string[
 
 function prepareDatasetItemData(
   data: Record<string, unknown>,
-  options?: AddItemOptions
+  options?: Omit<TestSuiteItem, "data">
 ): DatasetItemData {
   if (options?.executionPolicy) {
     validateExecutionPolicy(options.executionPolicy, "item-level execution policy");
@@ -194,14 +196,7 @@ export class TestSuite {
   // Instance methods
   // ---------------------------------------------------------------------------
 
-  async addItem(
-    data: Record<string, unknown>,
-    options?: AddItemOptions
-  ): Promise<void> {
-    await this.dataset.insert([prepareDatasetItemData(data, options)]);
-  }
-
-  async addItems(items: TestSuiteItem[]): Promise<void> {
+  async insert(items: TestSuiteItem[]): Promise<void> {
     const datasetItems: DatasetItemData[] = items.map((item) =>
       prepareDatasetItemData(item.data, item)
     );
@@ -254,11 +249,7 @@ export class TestSuite {
     return resolveExecutionPolicy(versionInfo?.executionPolicy);
   }
 
-  async update(options: {
-    globalAssertions?: string[];
-    globalExecutionPolicy?: ExecutionPolicy;
-    tags?: string[];
-  }): Promise<void> {
+  async update(options: UpdateTestSuiteOptions): Promise<void> {
     if (options.globalExecutionPolicy) {
       validateExecutionPolicy(options.globalExecutionPolicy, "suite update");
     }
@@ -285,7 +276,7 @@ export class TestSuite {
       });
     }
 
-    const hasVersionUpdates = resolvedEvaluators || assertionsProvided || options.globalExecutionPolicy;
+    const hasVersionUpdates = resolvedEvaluators || assertionsProvided || options.globalExecutionPolicy !== undefined;
     if (hasVersionUpdates) {
       const versionInfo = await this.dataset.getVersionInfo();
       if (!versionInfo) {
@@ -332,7 +323,7 @@ export class TestSuite {
     }
   }
 
-  async deleteItems(itemIds: string[]): Promise<void> {
+  async delete(itemIds: string[]): Promise<void> {
     await this.dataset.delete(itemIds);
   }
 

--- a/sdks/typescript/src/opik/evaluation/suite/index.ts
+++ b/sdks/typescript/src/opik/evaluation/suite/index.ts
@@ -6,8 +6,8 @@ export { runTests } from "./runTests";
 export type { RunTestsOptions } from "./runTests";
 export { TestSuite } from "./TestSuite";
 export type {
-  AddItemOptions,
   CreateTestSuiteOptions,
+  UpdateTestSuiteOptions,
 } from "./TestSuite";
 export {
   serializeEvaluators,

--- a/sdks/typescript/src/opik/evaluation/suite/types.ts
+++ b/sdks/typescript/src/opik/evaluation/suite/types.ts
@@ -13,7 +13,7 @@ export const DEFAULT_EXECUTION_POLICY: Required<ExecutionPolicy> = {
 };
 
 /**
- * A single item to be added to a test suite via `addItems()`.
+ * A single item to be inserted into a test suite via `insert()`.
  */
 export interface TestSuiteItem {
   data: Record<string, unknown>;

--- a/sdks/typescript/tests/integration/evaluation/evaluateTestSuite.test.ts
+++ b/sdks/typescript/tests/integration/evaluation/evaluateTestSuite.test.ts
@@ -76,8 +76,8 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
           globalExecutionPolicy: { runsPerItem: 2, passThreshold: 1 },
         });
 
-        await suite.addItem({ input: "Q1", expected: "A1" });
-        await suite.addItem({ input: "Q2", expected: "A2" });
+        await suite.insert([{ data: { input: "Q1", expected: "A1" } }]);
+        await suite.insert([{ data: { input: "Q2", expected: "A2" } }]);
 
         await waitForSuiteItems(suite, 2);
 
@@ -121,7 +121,7 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
         expect(assertions).toHaveLength(1);
         expect(assertions[0]).toBe("Response is helpful");
 
-        await suite.addItem({ input: "Hello", expected: "Hi" });
+        await suite.insert([{ data: { input: "Hello", expected: "Hi" } }]);
         await waitForSuiteItems(suite, 1);
 
         const result = await runTests({ testSuite: suite, task: echoTask });
@@ -144,10 +144,12 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
           globalExecutionPolicy: { runsPerItem: 1, passThreshold: 1 },
         });
 
-        await suite.addItem(
-          { input: "Explain gravity", expected: "A force" },
-          { assertions: ["Response is concise"] }
-        );
+        await suite.insert([
+          {
+            data: { input: "Explain gravity", expected: "A force" },
+            assertions: ["Response is concise"],
+          },
+        ]);
 
         await waitForSuiteItems(suite, 1);
 
@@ -219,7 +221,7 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
           globalAssertions: ["Response is helpful"],
           globalExecutionPolicy: { runsPerItem: 2, passThreshold: 1 },
         });
-        await original.addItem({ input: "seed item" });
+        await original.insert([{ data: { input: "seed item" } }]);
         await waitForSuiteItems(original, 1);
 
         // Record version ID before getOrCreate
@@ -269,7 +271,7 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
           globalExecutionPolicy: { runsPerItem: 2, passThreshold: 1 },
         });
 
-        await suite.addItem({ input: "seed item" });
+        await suite.insert([{ data: { input: "seed item" } }]);
         await waitForSuiteItems(suite, 1);
 
         // Record version ID before the no-op update
@@ -309,7 +311,7 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
           globalExecutionPolicy: { runsPerItem: 1, passThreshold: 1 },
         });
 
-        await suite.addItem({ input: "seed item" });
+        await suite.insert([{ data: { input: "seed item" } }]);
         await waitForSuiteItems(suite, 1);
 
         const datasetRef = await client.getDataset(suiteName);
@@ -354,7 +356,7 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
           globalExecutionPolicy: { runsPerItem: 1, passThreshold: 1 },
         });
 
-        await suite.addItem({ input: "seed item" });
+        await suite.insert([{ data: { input: "seed item" } }]);
         await waitForSuiteItems(suite, 1);
 
         // Update only executionPolicy, omit assertions
@@ -386,7 +388,7 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
           globalExecutionPolicy: { runsPerItem: 3, passThreshold: 2 },
         });
 
-        await suite.addItem({ input: "seed item" });
+        await suite.insert([{ data: { input: "seed item" } }]);
         await waitForSuiteItems(suite, 1);
 
         // Update only assertions, omit executionPolicy
@@ -423,11 +425,17 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
           projectName,
         });
 
-        await suite.addItem({ input: "What is 2+2?", expected: "4" });
-        await suite.addItem({
-          input: "What is the capital of France?",
-          expected: "Paris",
-        });
+        await suite.insert([
+          { data: { input: "What is 2+2?", expected: "4" } },
+        ]);
+        await suite.insert([
+          {
+            data: {
+              input: "What is the capital of France?",
+              expected: "Paris",
+            },
+          },
+        ]);
 
         await waitForSuiteItems(suite, 2);
 
@@ -470,7 +478,7 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
           globalExecutionPolicy: { runsPerItem: 2, passThreshold: 1 },
         });
 
-        await suite.addItem({ input: "Hello world", expected: "Hi" });
+        await suite.insert([{ data: { input: "Hello world", expected: "Hi" } }]);
 
         await waitForSuiteItems(suite, 1);
 
@@ -528,10 +536,12 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
           globalExecutionPolicy: { runsPerItem: 1, passThreshold: 1 },
         });
 
-        await suite.addItem(
-          { input: "Explain gravity", expected: "A force of attraction" },
-          { assertions: ["Response is concise"] }
-        );
+        await suite.insert([
+          {
+            data: { input: "Explain gravity", expected: "A force of attraction" },
+            assertions: ["Response is concise"],
+          },
+        ]);
 
         await waitForSuiteItems(suite, 1);
 
@@ -568,8 +578,8 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
           name: suiteName,
         });
 
-        await suite.addItem({ input: "Item 1" });
-        await suite.addItem({ input: "Item 2" });
+        await suite.insert([{ data: { input: "Item 1" } }]);
+        await suite.insert([{ data: { input: "Item 2" } }]);
 
         await waitForSuiteItems(suite, 2);
 
@@ -580,7 +590,7 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
         const item1 = items.find((i) => i.data.input === "Item 1")!;
         expect(item1).toBeDefined();
 
-        await suite.deleteItems([item1.id]);
+        await suite.delete([item1.id]);
 
         // Wait for deletion to propagate
         await searchAndWaitForDone(
@@ -615,10 +625,12 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
           globalExecutionPolicy: { runsPerItem: 1, passThreshold: 1 },
         });
 
-        await suite.addItem(
-          { input: "Explain gravity", expected: "A force" },
-          { assertions: ["Response is accurate"] }
-        );
+        await suite.insert([
+          {
+            data: { input: "Explain gravity", expected: "A force" },
+            assertions: ["Response is accurate"],
+          },
+        ]);
 
         await waitForSuiteItems(suite, 1);
 
@@ -671,10 +683,12 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
           globalExecutionPolicy: { runsPerItem: 1, passThreshold: 1 },
         });
 
-        await suite.addItem(
-          { input: "What is AI?", expected: "Artificial Intelligence" },
-          { executionPolicy: { runsPerItem: 2, passThreshold: 1 } }
-        );
+        await suite.insert([
+          {
+            data: { input: "What is AI?", expected: "Artificial Intelligence" },
+            executionPolicy: { runsPerItem: 2, passThreshold: 1 },
+          },
+        ]);
 
         await waitForSuiteItems(suite, 1);
 
@@ -729,10 +743,12 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
           globalExecutionPolicy: { runsPerItem: 1, passThreshold: 1 },
         });
 
-        await suite.addItem(
-          { input: "Test input", expected: "Test output" },
-          { assertions: ["Response is correct"] }
-        );
+        await suite.insert([
+          {
+            data: { input: "Test input", expected: "Test output" },
+            assertions: ["Response is correct"],
+          },
+        ]);
 
         await waitForSuiteItems(suite, 1);
 
@@ -778,12 +794,13 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
           globalExecutionPolicy: { runsPerItem: 1, passThreshold: 1 },
         });
 
-        await suite.addItem(
-          { input: "Describe the sun", expected: "A star" },
+        await suite.insert([
           {
+            data: { input: "Describe the sun", expected: "A star" },
             assertions: ["Response is factual"],
             executionPolicy: { runsPerItem: 2, passThreshold: 1 },
-          }
+          },
+        ]
         );
 
         await waitForSuiteItems(suite, 1);

--- a/sdks/typescript/tests/unit/evaluation/suite/TestSuite.test.ts
+++ b/sdks/typescript/tests/unit/evaluation/suite/TestSuite.test.ts
@@ -96,13 +96,13 @@ describe("TestSuite", () => {
     });
   });
 
-  describe("addItem", () => {
-    it("should insert item via dataset with plain data", async () => {
+  describe("insert", () => {
+    it("should insert single item via dataset with plain data", async () => {
       const insertSpy = vi
         .spyOn(testDataset, "insert")
         .mockResolvedValue(undefined);
 
-      await suite.addItem({ input: "hello", expected: "world" });
+      await suite.insert([{ data: { input: "hello", expected: "world" } }]);
 
       expect(insertSpy).toHaveBeenCalledWith([
         { input: "hello", expected: "world" },
@@ -115,10 +115,12 @@ describe("TestSuite", () => {
         .spyOn(testDataset, "insert")
         .mockResolvedValue(undefined);
 
-      await suite.addItem(
-        { input: "test" },
-        { executionPolicy: { runsPerItem: 3, passThreshold: 2 } }
-      );
+      await suite.insert([
+        {
+          data: { input: "test" },
+          executionPolicy: { runsPerItem: 3, passThreshold: 2 },
+        },
+      ]);
 
       expect(insertSpy).toHaveBeenCalledWith([
         expect.objectContaining({
@@ -133,10 +135,12 @@ describe("TestSuite", () => {
         .spyOn(testDataset, "insert")
         .mockResolvedValue(undefined);
 
-      await suite.addItem(
-        { input: "test" },
-        { assertions: ["is accurate", "is concise"] }
-      );
+      await suite.insert([
+        {
+          data: { input: "test" },
+          assertions: ["is accurate", "is concise"],
+        },
+      ]);
 
       expect(insertSpy).toHaveBeenCalledWith([
         expect.objectContaining({
@@ -150,15 +154,13 @@ describe("TestSuite", () => {
         }),
       ]);
     });
-  });
 
-  describe("addItems", () => {
     it("should batch insert items via dataset", async () => {
       const insertSpy = vi
         .spyOn(testDataset, "insert")
         .mockResolvedValue(undefined);
 
-      await suite.addItems([
+      await suite.insert([
         { data: { input: "hello", expected: "world" } },
         { data: { input: "foo" }, assertions: ["is correct"] },
       ]);
@@ -179,26 +181,6 @@ describe("TestSuite", () => {
       );
     });
 
-    it("should pass executionPolicy per item", async () => {
-      const insertSpy = vi
-        .spyOn(testDataset, "insert")
-        .mockResolvedValue(undefined);
-
-      await suite.addItems([
-        {
-          data: { input: "test" },
-          executionPolicy: { runsPerItem: 3, passThreshold: 2 },
-        },
-      ]);
-
-      const insertedItems = insertSpy.mock.calls[0][0] as unknown[];
-      expect(insertedItems[0]).toEqual(
-        expect.objectContaining({
-          input: "test",
-          executionPolicy: { runsPerItem: 3, passThreshold: 2 },
-        })
-      );
-    });
   });
 
   describe("getGlobalAssertions", () => {
@@ -454,13 +436,13 @@ describe("TestSuite", () => {
     });
   });
 
-  describe("deleteItems", () => {
+  describe("delete", () => {
     it("should delegate to dataset.delete", async () => {
       const deleteSpy = vi
         .spyOn(testDataset, "delete")
         .mockResolvedValue(undefined);
 
-      await suite.deleteItems(["item-1", "item-2"]);
+      await suite.delete(["item-1", "item-2"]);
 
       expect(deleteSpy).toHaveBeenCalledWith(["item-1", "item-2"]);
     });
@@ -1103,13 +1085,15 @@ describe("TestSuite", () => {
       );
     });
 
-    it("should call validateExecutionPolicy when executionPolicy is provided in addItem", async () => {
+    it("should call validateExecutionPolicy when executionPolicy is provided in insert", async () => {
       vi.spyOn(testDataset, "insert").mockResolvedValue(undefined);
 
-      await suite.addItem(
-        { input: "test" },
-        { executionPolicy: { runsPerItem: 2, passThreshold: 1 } }
-      );
+      await suite.insert([
+        {
+          data: { input: "test" },
+          executionPolicy: { runsPerItem: 2, passThreshold: 1 },
+        },
+      ]);
 
       expect(validateExecutionPolicy).toHaveBeenCalledWith(
         { runsPerItem: 2, passThreshold: 1 },

--- a/sdks/typescript/tests/unit/evaluation/suite/evaluateTestSuite.test.ts
+++ b/sdks/typescript/tests/unit/evaluation/suite/evaluateTestSuite.test.ts
@@ -111,6 +111,11 @@ describe("evaluateTestSuite", () => {
       .spyOn(opikClient.api.experiments, "createExperiment")
       .mockImplementation(mockAPIFunction);
 
+    vi.spyOn(
+      opikClient.api.experiments,
+      "createExperimentItems"
+    ).mockImplementation(mockAPIFunction);
+
     streamDatasetItemsSpy = vi
       .spyOn(opikClient.api.datasets, "streamDatasetItems")
       .mockImplementation(() =>


### PR DESCRIPTION
## Details

Aligns TestSuite public API with Dataset by renaming `addItems()` → `insert()`, `deleteItems()` → `delete()`, and removing the single-item `addItem()` convenience method. This is a **breaking change** with no backwards compatibility, matching the approach taken in the Python SDK (OPIK-5800).

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues
- OPIK-5858

## AI-WATERMARK
AI-WATERMARK: yes
- Tools: Claude Code (CLI)
- Model(s): Claude Opus 4.6
- Scope: full implementation — source rename, test updates, example updates, code review, simplification
- Human verification: reviewed all diffs, confirmed TypeScript compiles cleanly, all 1641 unit tests pass

## Testing

- `npx tsc --noEmit` — zero compile errors
- `npm test` — 86 test files, 1641 passed, 2 skipped
- `grep -r 'addItem\|addItems\|deleteItems\|AddItemOptions' sdks/typescript/src sdks/typescript/tests sdks/typescript/examples` — zero hits, confirming complete rename

## Documentation

JSDoc on `TestSuiteItem` updated to reference `insert()` instead of `addItems()`. Example file updated to demonstrate the new API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)