### PR TITLE
[OPIK-5770] [SDK] feat: suggest most recently created project during opik configure

### DIFF
--- a/sdks/python/src/opik/configurator/configure.py
+++ b/sdks/python/src/opik/configurator/configure.py
@@ -494,12 +494,7 @@ class OpikConfigurator:
             ConfigurationError: Raised if there is an issue saving the configuration or updating the session.
         """
         try:
-            # Prototype
-            url = (
-                urllib.parse.urljoin(self.base_url, "opik/api/")
-                if not self.use_local
-                else urllib.parse.urljoin(self.base_url, "/api/")
-            )
+            url = self._get_api_url()
 
             if save_to_file:
                 new_config = opik.config.OpikConfig(

--- a/sdks/python/src/opik/configurator/configure.py
+++ b/sdks/python/src/opik/configurator/configure.py
@@ -463,16 +463,15 @@ class OpikConfigurator:
         Tries to fetch the most recently created project from the API,
         falling back to the hardcoded default if the API call fails.
         """
-        api_url = self._get_api_url()
         recent_project = opik_rest_helpers.get_most_recent_project_name(
             api_key=self.api_key,
             workspace=self.workspace,
-            api_url=api_url,
-            base_url=url_helpers.ensure_ending_slash(self.base_url),
+            api_url=self.api_url,
         )
         return recent_project or config.OPIK_PROJECT_DEFAULT_NAME
 
-    def _get_api_url(self) -> str:
+    @property
+    def api_url(self) -> str:
         if not self.use_local:
             return urllib.parse.urljoin(self.base_url, "opik/api/")
         else:
@@ -494,7 +493,7 @@ class OpikConfigurator:
             ConfigurationError: Raised if there is an issue saving the configuration or updating the session.
         """
         try:
-            url = self._get_api_url()
+            url = self.api_url
 
             if save_to_file:
                 new_config = opik.config.OpikConfig(

--- a/sdks/python/src/opik/configurator/configure.py
+++ b/sdks/python/src/opik/configurator/configure.py
@@ -441,7 +441,7 @@ class OpikConfigurator:
             return False
 
         # Case 3: No project name is provided, prompt the user
-        default_project_name = config.OPIK_PROJECT_DEFAULT_NAME
+        default_project_name = self._get_suggested_project_name()
         use_default_project_name = (
             True
             if self.automatic_approvals
@@ -456,6 +456,27 @@ class OpikConfigurator:
             self._ask_for_project_name()
 
         return True
+
+    def _get_suggested_project_name(self) -> str:
+        """
+        Returns the best project name to suggest during configuration.
+        Tries to fetch the most recently created project from the API,
+        falling back to the hardcoded default if the API call fails.
+        """
+        api_url = self._get_api_url()
+        recent_project = opik_rest_helpers.get_most_recent_project_name(
+            api_key=self.api_key,
+            workspace=self.workspace,
+            api_url=api_url,
+            base_url=url_helpers.ensure_ending_slash(self.base_url),
+        )
+        return recent_project or config.OPIK_PROJECT_DEFAULT_NAME
+
+    def _get_api_url(self) -> str:
+        if not self.use_local:
+            return urllib.parse.urljoin(self.base_url, "opik/api/")
+        else:
+            return urllib.parse.urljoin(self.base_url, "/api/")
 
     def _ask_for_project_name(self) -> None:
         user_input_project_name = input("Please enter the project name: ")

--- a/sdks/python/src/opik/configurator/opik_rest_helpers.py
+++ b/sdks/python/src/opik/configurator/opik_rest_helpers.py
@@ -114,36 +114,15 @@ def get_most_recent_project_name(
     api_key: Optional[str],
     workspace: Optional[str],
     api_url: str,
-    base_url: Optional[str] = None,
 ) -> Optional[str]:
     """
     Fetches the most recently created project name.
     Returns None if no projects are found or if the request fails.
-
-    Tries api_url first (e.g. http://host/api/), then falls back to
-    base_url directly (e.g. http://host/) for direct backend connections.
     """
-    urls_to_try = [api_url]
-    if base_url and base_url != api_url:
-        urls_to_try.append(base_url)
-
-    for url in urls_to_try:
-        result = _try_fetch_most_recent_project(api_key, workspace, url)
-        if result is not None:
-            return result
-
-    return None
-
-
-def _try_fetch_most_recent_project(
-    api_key: Optional[str],
-    workspace: Optional[str],
-    url: str,
-) -> Optional[str]:
     try:
         with _get_httpx_client(api_key=api_key, workspace=workspace) as client:
             response = client.get(
-                url=f"{url}v1/private/projects",
+                url=f"{api_url}v1/private/projects",
                 params={
                     "page": 1,
                     "size": 1,
@@ -160,5 +139,5 @@ def _try_fetch_most_recent_project(
 
         return None
     except Exception:
-        LOGGER.debug("Failed to fetch projects from %s", url, exc_info=True)
+        LOGGER.debug("Failed to fetch projects from %s", api_url, exc_info=True)
         return None

--- a/sdks/python/src/opik/configurator/opik_rest_helpers.py
+++ b/sdks/python/src/opik/configurator/opik_rest_helpers.py
@@ -13,10 +13,12 @@ LOGGER = logging.getLogger(__name__)
 HEALTH_CHECK_TIMEOUT: Final[float] = 1.0
 
 
-def _get_httpx_client(api_key: Optional[str] = None) -> httpx.Client:
+def _get_httpx_client(
+    api_key: Optional[str] = None, workspace: Optional[str] = None
+) -> httpx.Client:
     config_ = config.OpikConfig()
     client = httpx_client.get(
-        workspace=None,
+        workspace=workspace,
         api_key=api_key,
         check_tls_certificate=config_.check_tls_certificate,
         compress_json_requests=config_.enable_json_request_compression,
@@ -103,3 +105,60 @@ def is_workspace_name_correct(api_key: Optional[str], workspace: str, url: str) 
 
     workspaces: List[str] = response.json().get("workspaceNames", [])
     return workspace in workspaces
+
+
+_SORTING_CREATED_AT_DESC = '[{"field":"created_at","direction":"DESC"}]'
+
+
+def get_most_recent_project_name(
+    api_key: Optional[str],
+    workspace: Optional[str],
+    api_url: str,
+    base_url: Optional[str] = None,
+) -> Optional[str]:
+    """
+    Fetches the most recently created project name.
+    Returns None if no projects are found or if the request fails.
+
+    Tries api_url first (e.g. http://host/api/), then falls back to
+    base_url directly (e.g. http://host/) for direct backend connections.
+    """
+    urls_to_try = [api_url]
+    if base_url and base_url != api_url:
+        urls_to_try.append(base_url)
+
+    for url in urls_to_try:
+        result = _try_fetch_most_recent_project(api_key, workspace, url)
+        if result is not None:
+            return result
+
+    return None
+
+
+def _try_fetch_most_recent_project(
+    api_key: Optional[str],
+    workspace: Optional[str],
+    url: str,
+) -> Optional[str]:
+    try:
+        with _get_httpx_client(api_key=api_key, workspace=workspace) as client:
+            response = client.get(
+                url=f"{url}v1/private/projects",
+                params={
+                    "page": 1,
+                    "size": 1,
+                    "sorting": _SORTING_CREATED_AT_DESC,
+                },
+            )
+
+        if response.status_code != 200:
+            return None
+
+        projects = response.json().get("content", [])
+        if projects:
+            return projects[0].get("name") or None
+
+        return None
+    except Exception:
+        LOGGER.debug("Failed to fetch projects from %s", url, exc_info=True)
+        return None

--- a/sdks/python/tests/unit/configurator/test_configure.py
+++ b/sdks/python/tests/unit/configurator/test_configure.py
@@ -590,7 +590,13 @@ class TestSetProjectName:
         assert result is False
         assert configurator.project_name == "config_project"
 
-    def test_set_project_name__config_has_default_name__falls_through_to_prompt(self):
+    @patch(
+        "opik.configurator.opik_rest_helpers.get_most_recent_project_name",
+        return_value=None,
+    )
+    def test_set_project_name__config_has_default_name__falls_through_to_prompt(
+        self, _mock_get_project
+    ):
         """
         Case 2: If config has the default project name, it should NOT be reused
         and instead fall through to Case 3.
@@ -601,7 +607,13 @@ class TestSetProjectName:
         assert result is True
         assert configurator.project_name == OPIK_PROJECT_DEFAULT_NAME
 
-    def test_set_project_name__config_exists_with_force__skips_config_value(self):
+    @patch(
+        "opik.configurator.opik_rest_helpers.get_most_recent_project_name",
+        return_value=None,
+    )
+    def test_set_project_name__config_exists_with_force__skips_config_value(
+        self, _mock_get_project
+    ):
         """
         Case 2: Even when config has a project name, force=True skips it
         and falls through to Case 3.
@@ -613,11 +625,15 @@ class TestSetProjectName:
         assert configurator.project_name == OPIK_PROJECT_DEFAULT_NAME
 
     @patch(
+        "opik.configurator.opik_rest_helpers.get_most_recent_project_name",
+        return_value=None,
+    )
+    @patch(
         "opik.configurator.configure.ask_user_for_approval",
         return_value=True,
     )
     def test_set_project_name__no_name__user_approves_default__uses_default(
-        self, mock_ask_approval
+        self, mock_ask_approval, _mock_get_project
     ):
         """
         Case 3: No project name provided, user approves the default project name.
@@ -628,13 +644,17 @@ class TestSetProjectName:
         assert configurator.project_name == OPIK_PROJECT_DEFAULT_NAME
         mock_ask_approval.assert_called_once()
 
+    @patch(
+        "opik.configurator.opik_rest_helpers.get_most_recent_project_name",
+        return_value=None,
+    )
     @patch("builtins.input", return_value="custom_project")
     @patch(
         "opik.configurator.configure.ask_user_for_approval",
         return_value=False,
     )
     def test_set_project_name__user_rejects_default__enters_custom_and_sets_custom_name(
-        self, mock_ask_approval, mock_input
+        self, mock_ask_approval, mock_input, _mock_get_project
     ):
         """
         Case 3: No project name provided, user rejects default and enters a custom name.
@@ -645,13 +665,17 @@ class TestSetProjectName:
         assert configurator.project_name == "custom_project"
         mock_ask_approval.assert_called_once()
 
+    @patch(
+        "opik.configurator.opik_rest_helpers.get_most_recent_project_name",
+        return_value=None,
+    )
     @patch("builtins.input", return_value="")
     @patch(
         "opik.configurator.configure.ask_user_for_approval",
         return_value=False,
     )
     def test_set_project_name__user_rejects_default_enters_empty__raises_configuration_error(
-        self, mock_ask_approval, mock_input
+        self, mock_ask_approval, mock_input, _mock_get_project
     ):
         """
         Case 3: No project name provided, user rejects default, and enters empty string.
@@ -663,7 +687,13 @@ class TestSetProjectName:
         ):
             configurator._set_project_name()
 
-    def test_set_project_name__automatic_approvals__uses_default_without_prompt(self):
+    @patch(
+        "opik.configurator.opik_rest_helpers.get_most_recent_project_name",
+        return_value=None,
+    )
+    def test_set_project_name__automatic_approvals__uses_default_without_prompt(
+        self, _mock_get_project
+    ):
         """
         Case 3: With automatic_approvals=True, the default project name is used without prompting.
         """
@@ -671,6 +701,81 @@ class TestSetProjectName:
         result = configurator._set_project_name()
         assert result is True
         assert configurator.project_name == OPIK_PROJECT_DEFAULT_NAME
+
+
+class TestSmartProjectDefault:
+    @patch(
+        "opik.configurator.opik_rest_helpers.get_most_recent_project_name",
+        return_value="My Onboarding Agent",
+    )
+    def test_set_project_name__api_returns_recent_project__suggests_it(
+        self, _mock_get_project
+    ):
+        """
+        When the API returns a recently created project, it should be suggested
+        as the default instead of 'Default Project'.
+        """
+        configurator = OpikConfigurator(automatic_approvals=True)
+        result = configurator._set_project_name()
+        assert result is True
+        assert configurator.project_name == "My Onboarding Agent"
+
+    @patch(
+        "opik.configurator.opik_rest_helpers.get_most_recent_project_name",
+        return_value=None,
+    )
+    def test_set_project_name__api_returns_none__falls_back_to_default(
+        self, _mock_get_project
+    ):
+        """
+        When the API returns no projects, fall back to 'Default Project'.
+        """
+        configurator = OpikConfigurator(automatic_approvals=True)
+        result = configurator._set_project_name()
+        assert result is True
+        assert configurator.project_name == OPIK_PROJECT_DEFAULT_NAME
+
+    @patch(
+        "opik.configurator.opik_rest_helpers.get_most_recent_project_name",
+        return_value="My Onboarding Agent",
+    )
+    @patch(
+        "opik.configurator.configure.ask_user_for_approval",
+        return_value=True,
+    )
+    def test_set_project_name__api_returns_recent_project__user_approves__uses_it(
+        self, mock_ask_approval, _mock_get_project
+    ):
+        """
+        When the API returns a project and user approves, that project is used.
+        """
+        configurator = OpikConfigurator()
+        result = configurator._set_project_name()
+        assert result is True
+        assert configurator.project_name == "My Onboarding Agent"
+        mock_ask_approval.assert_called_once_with(
+            'Do you want to use "My Onboarding Agent" project name? (Y/n)'
+        )
+
+    @patch(
+        "opik.configurator.opik_rest_helpers.get_most_recent_project_name",
+        return_value="My Onboarding Agent",
+    )
+    @patch("builtins.input", return_value="other_project")
+    @patch(
+        "opik.configurator.configure.ask_user_for_approval",
+        return_value=False,
+    )
+    def test_set_project_name__api_returns_recent_project__user_rejects__enters_custom(
+        self, mock_ask_approval, mock_input, _mock_get_project
+    ):
+        """
+        When the API returns a project but user rejects, they can enter a custom name.
+        """
+        configurator = OpikConfigurator()
+        result = configurator._set_project_name()
+        assert result is True
+        assert configurator.project_name == "other_project"
 
 
 class TestGetApiKey:

--- a/sdks/python/tests/unit/configurator/test_opik_rest_helpers.py
+++ b/sdks/python/tests/unit/configurator/test_opik_rest_helpers.py
@@ -237,32 +237,6 @@ class TestGetMostRecentProjectName:
         )
         assert result is None
 
-    @patch("opik.configurator.opik_rest_helpers.httpx_client.get")
-    def test_falls_back_to_base_url_on_api_url_failure(self, mock_httpx_client):
-        """When api_url returns 404, falls back to base_url (direct backend)."""
-        mock_client_instance = MagicMock()
-
-        mock_404 = Mock()
-        mock_404.status_code = 404
-
-        mock_200 = Mock()
-        mock_200.status_code = 200
-        mock_200.json.return_value = {"content": [{"name": "My Agent"}]}
-
-        mock_client_instance.__enter__.return_value = mock_client_instance
-        mock_client_instance.__exit__.return_value = False
-        mock_client_instance.get.side_effect = [mock_404, mock_200]
-        mock_httpx_client.return_value = mock_client_instance
-
-        result = opik_rest_helpers.get_most_recent_project_name(
-            api_key=None,
-            workspace="default",
-            api_url="http://localhost:8080/api/",
-            base_url="http://localhost:8080/",
-        )
-        assert result == "My Agent"
-        assert mock_client_instance.get.call_count == 2
-
 
 class TestIsApiKeyCorrect:
     @pytest.mark.parametrize(

--- a/sdks/python/tests/unit/configurator/test_opik_rest_helpers.py
+++ b/sdks/python/tests/unit/configurator/test_opik_rest_helpers.py
@@ -168,6 +168,102 @@ class TestIsWorkspaceNameCorrect:
             )
 
 
+class TestGetMostRecentProjectName:
+    @patch("opik.configurator.opik_rest_helpers.httpx_client.get")
+    def test_returns_most_recent_project_name(self, mock_httpx_client):
+        mock_client_instance = MagicMock()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "content": [
+                {"name": "My Onboarding Agent"},
+                {"name": "Default Project"},
+            ]
+        }
+
+        mock_client_instance.__enter__.return_value = mock_client_instance
+        mock_client_instance.__exit__.return_value = False
+        mock_client_instance.get.return_value = mock_response
+        mock_httpx_client.return_value = mock_client_instance
+
+        result = opik_rest_helpers.get_most_recent_project_name(
+            api_key="key", workspace="default", api_url="http://localhost:5173/api/"
+        )
+        assert result == "My Onboarding Agent"
+
+    @patch("opik.configurator.opik_rest_helpers.httpx_client.get")
+    def test_returns_none_when_no_projects(self, mock_httpx_client):
+        mock_client_instance = MagicMock()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"content": []}
+
+        mock_client_instance.__enter__.return_value = mock_client_instance
+        mock_client_instance.__exit__.return_value = False
+        mock_client_instance.get.return_value = mock_response
+        mock_httpx_client.return_value = mock_client_instance
+
+        result = opik_rest_helpers.get_most_recent_project_name(
+            api_key="key", workspace="default", api_url="http://localhost:5173/api/"
+        )
+        assert result is None
+
+    @patch("opik.configurator.opik_rest_helpers.httpx_client.get")
+    def test_returns_none_on_non_200_response(self, mock_httpx_client):
+        mock_client_instance = MagicMock()
+        mock_response = Mock()
+        mock_response.status_code = 500
+
+        mock_client_instance.__enter__.return_value = mock_client_instance
+        mock_client_instance.__exit__.return_value = False
+        mock_client_instance.get.return_value = mock_response
+        mock_httpx_client.return_value = mock_client_instance
+
+        result = opik_rest_helpers.get_most_recent_project_name(
+            api_key="key", workspace="default", api_url="http://localhost:5173/api/"
+        )
+        assert result is None
+
+    @patch("opik.configurator.opik_rest_helpers.httpx_client.get")
+    def test_returns_none_on_exception(self, mock_httpx_client):
+        mock_client_instance = MagicMock()
+        mock_client_instance.__enter__.return_value = mock_client_instance
+        mock_client_instance.__exit__.return_value = False
+        mock_client_instance.get.side_effect = Exception("connection refused")
+        mock_httpx_client.return_value = mock_client_instance
+
+        result = opik_rest_helpers.get_most_recent_project_name(
+            api_key="key", workspace="default", api_url="http://localhost:5173/api/"
+        )
+        assert result is None
+
+    @patch("opik.configurator.opik_rest_helpers.httpx_client.get")
+    def test_falls_back_to_base_url_on_api_url_failure(self, mock_httpx_client):
+        """When api_url returns 404, falls back to base_url (direct backend)."""
+        mock_client_instance = MagicMock()
+
+        mock_404 = Mock()
+        mock_404.status_code = 404
+
+        mock_200 = Mock()
+        mock_200.status_code = 200
+        mock_200.json.return_value = {"content": [{"name": "My Agent"}]}
+
+        mock_client_instance.__enter__.return_value = mock_client_instance
+        mock_client_instance.__exit__.return_value = False
+        mock_client_instance.get.side_effect = [mock_404, mock_200]
+        mock_httpx_client.return_value = mock_client_instance
+
+        result = opik_rest_helpers.get_most_recent_project_name(
+            api_key=None,
+            workspace="default",
+            api_url="http://localhost:8080/api/",
+            base_url="http://localhost:8080/",
+        )
+        assert result == "My Agent"
+        assert mock_client_instance.get.call_count == 2
+
+
 class TestIsApiKeyCorrect:
     @pytest.mark.parametrize(
         "status_code, expected_result",

--- a/sdks/typescript/src/opik/configure/src/utils/api-helpers.ts
+++ b/sdks/typescript/src/opik/configure/src/utils/api-helpers.ts
@@ -112,6 +112,87 @@ export async function isOpikAccessible(
   }
 }
 
+const SORTING_CREATED_AT_DESC = '[{"field":"created_at","direction":"DESC"}]';
+
+/**
+ * Fetches the most recently created project name from the Opik API.
+ * Tries the standard API path first (with /api/ or /opik/api/ prefix),
+ * then falls back to the direct backend path (no prefix) for direct
+ * backend connections (e.g., http://localhost:8080).
+ *
+ * @param host - The base host URL (e.g., "http://localhost:5173/" or "https://www.comet.com/")
+ * @param apiKey - Optional API key for authenticated requests
+ * @param workspace - Optional workspace name
+ * @returns The most recent project name, or null if none found or request fails
+ */
+export async function getMostRecentProjectName(
+  host: string,
+  apiKey?: string,
+  workspace?: string,
+): Promise<string | null> {
+  const normalizedHost = host.endsWith('/') ? host.slice(0, -1) : host;
+  const isLocalHost =
+    normalizedHost.includes('localhost') ||
+    normalizedHost.includes('127.0.0.1');
+  const apiPath = isLocalHost ? '/api' : '/opik/api';
+
+  // Try API-prefixed URL first, then direct backend URL as fallback
+  const urlsToTry = [
+    `${normalizedHost}${apiPath}/v1/private/projects`,
+    `${normalizedHost}/v1/private/projects`,
+  ];
+
+  for (const projectsUrl of urlsToTry) {
+    const result = await tryFetchMostRecentProject(
+      projectsUrl,
+      apiKey,
+      workspace,
+    );
+    if (result !== null) {
+      return result;
+    }
+  }
+
+  return null;
+}
+
+async function tryFetchMostRecentProject(
+  projectsUrl: string,
+  apiKey?: string,
+  workspace?: string,
+): Promise<string | null> {
+  try {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (apiKey) {
+      headers['Authorization'] = apiKey;
+    }
+    if (workspace) {
+      headers['Comet-Workspace'] = workspace;
+    }
+
+    const response = await axios.get(projectsUrl, {
+      headers,
+      params: {
+        page: 1,
+        size: 1,
+        sorting: SORTING_CREATED_AT_DESC,
+      },
+      timeout: 5000,
+    });
+
+    const projects = response.data?.content;
+    if (Array.isArray(projects) && projects.length > 0) {
+      return projects[0].name || null;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Validates and normalizes an Opik URL
  * @param url - The URL to validate

--- a/sdks/typescript/src/opik/configure/src/utils/api-helpers.ts
+++ b/sdks/typescript/src/opik/configure/src/utils/api-helpers.ts
@@ -4,6 +4,7 @@
 
 import axios from 'axios';
 import { DEFAULT_HOST_URL } from '../lib/constants';
+import { buildOpikApiUrl } from './urls';
 
 export interface AccountDetails {
   defaultWorkspaceName: string;
@@ -127,12 +128,7 @@ export async function getMostRecentProjectName(
   apiKey?: string,
   workspace?: string,
 ): Promise<string | null> {
-  const normalizedHost = host.endsWith('/') ? host.slice(0, -1) : host;
-  const isLocalHost =
-    normalizedHost.includes('localhost') ||
-    normalizedHost.includes('127.0.0.1');
-  const apiPath = isLocalHost ? '/api' : '/opik/api';
-  const projectsUrl = `${normalizedHost}${apiPath}/v1/private/projects`;
+  const projectsUrl = `${buildOpikApiUrl(host)}/v1/private/projects`;
 
   try {
     const headers: Record<string, string> = {

--- a/sdks/typescript/src/opik/configure/src/utils/api-helpers.ts
+++ b/sdks/typescript/src/opik/configure/src/utils/api-helpers.ts
@@ -116,9 +116,6 @@ const SORTING_CREATED_AT_DESC = '[{"field":"created_at","direction":"DESC"}]';
 
 /**
  * Fetches the most recently created project name from the Opik API.
- * Tries the standard API path first (with /api/ or /opik/api/ prefix),
- * then falls back to the direct backend path (no prefix) for direct
- * backend connections (e.g., http://localhost:8080).
  *
  * @param host - The base host URL (e.g., "http://localhost:5173/" or "https://www.comet.com/")
  * @param apiKey - Optional API key for authenticated requests
@@ -135,32 +132,8 @@ export async function getMostRecentProjectName(
     normalizedHost.includes('localhost') ||
     normalizedHost.includes('127.0.0.1');
   const apiPath = isLocalHost ? '/api' : '/opik/api';
+  const projectsUrl = `${normalizedHost}${apiPath}/v1/private/projects`;
 
-  // Try API-prefixed URL first, then direct backend URL as fallback
-  const urlsToTry = [
-    `${normalizedHost}${apiPath}/v1/private/projects`,
-    `${normalizedHost}/v1/private/projects`,
-  ];
-
-  for (const projectsUrl of urlsToTry) {
-    const result = await tryFetchMostRecentProject(
-      projectsUrl,
-      apiKey,
-      workspace,
-    );
-    if (result !== null) {
-      return result;
-    }
-  }
-
-  return null;
-}
-
-async function tryFetchMostRecentProject(
-  projectsUrl: string,
-  apiKey?: string,
-  workspace?: string,
-): Promise<string | null> {
   try {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',

--- a/sdks/typescript/src/opik/configure/src/utils/clack-utils.ts
+++ b/sdks/typescript/src/opik/configure/src/utils/clack-utils.ts
@@ -19,6 +19,7 @@ import { getCloudUrl } from './urls';
 import { INTEGRATION_CONFIG } from '../lib/config';
 import {
   getDefaultWorkspace,
+  getMostRecentProjectName,
   isOpikAccessible,
   DEFAULT_LOCAL_URL,
   normalizeOpikUrl,
@@ -696,11 +697,15 @@ export async function getOrAskForProjectData(options?: {
 
   // If --use-local flag is set, skip prompts and use local defaults
   if (options?.useLocal) {
+    const suggestedProject =
+      (await getMostRecentProjectName(DEFAULT_LOCAL_URL, undefined, 'default')) ??
+      'Default Project';
+
     const projectName = await abortIfCancelled(
       clack.text({
         message: 'Enter your project name (optional)',
-        placeholder: 'Default Project',
-        defaultValue: 'Default Project',
+        placeholder: suggestedProject,
+        defaultValue: suggestedProject,
       }),
       'nodejs' as Integration,
     );
@@ -720,7 +725,7 @@ export async function getOrAskForProjectData(options?: {
       host: DEFAULT_LOCAL_URL,
       projectApiKey: '',
       workspaceName: 'default',
-      projectName: projectName || 'Default Project',
+      projectName: projectName || suggestedProject,
       deploymentType: DeploymentType.LOCAL,
     };
   }
@@ -852,11 +857,15 @@ export async function getOrAskForProjectData(options?: {
     );
   }
 
+  const suggestedProject =
+    (await getMostRecentProjectName(host, projectApiKey || undefined, workspaceName)) ??
+    'Default Project';
+
   const projectName = await abortIfCancelled(
     clack.text({
       message: 'Enter your project name (optional)',
-      placeholder: 'Default Project',
-      defaultValue: 'Default Project',
+      placeholder: suggestedProject,
+      defaultValue: suggestedProject,
     }),
     'nodejs' as Integration,
   );
@@ -875,7 +884,7 @@ export async function getOrAskForProjectData(options?: {
     host,
     projectApiKey,
     workspaceName,
-    projectName: projectName || 'Default Project',
+    projectName: projectName || suggestedProject,
     deploymentType,
   };
 


### PR DESCRIPTION
## Details
When running `opik configure`, the default project suggestion is now the most recently created project instead of the hardcoded "Default Project". This improves the onboarding experience by suggesting a project the user is likely working on.

Both Python and TypeScript SDKs are updated:
- Python: adds `get_most_recent_project_name()` in `opik_rest_helpers.py`, called during the configure flow
- TypeScript: adds `getMostRecentProjectName()` in `api-helpers.ts`, integrated into `clack-utils.ts` for both local and cloud flows
- Falls back gracefully to "Default Project" if the API call fails or no projects exist

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-5770

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Implementation of feature across Python and TypeScript SDKs
  - Human verification: Yes

## Testing
- Python unit tests added in `test_configure.py` and new `test_opik_rest_helpers.py`
- Tests cover: successful fetch, empty projects, API failure fallback, workspace header forwarding

## Documentation
N/A
