### PR TITLE
[OPIK-5768] [BE] fix: restrict online evaluation rules to SDK source threads

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ThreadTimestamps.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ThreadTimestamps.java
@@ -1,7 +1,11 @@
 package com.comet.opik.api;
 
+import lombok.Builder;
+import lombok.NonNull;
+
 import java.time.Instant;
 import java.util.UUID;
 
-public record ThreadTimestamps(UUID firstTraceId, Instant lastUpdatedAt) {
+@Builder(toBuilder = true)
+public record ThreadTimestamps(@NonNull UUID firstTraceId, @NonNull Instant maxLastUpdatedAt, Source firstTraceSource) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TraceThreadListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TraceThreadListener.java
@@ -59,22 +59,31 @@ public class TraceThreadListener {
                     UUID traceId = trace.id();
 
                     if (existing == null) {
-                        return new ThreadTimestamps(traceId, lastUpdatedAt);
+                        return ThreadTimestamps.builder()
+                                .firstTraceId(traceId)
+                                .maxLastUpdatedAt(lastUpdatedAt)
+                                .firstTraceSource(trace.source())
+                                .build();
                     }
 
                     // Keep the minimum trace ID (earliest timestamp in UUIDv7)
-                    // Note: UUIDv7 compareTo() works correctly here because UUIDv7s are
+                    // Note: UUIDv7 compareTo() works correctly here because UUID v7 are
                     // lexicographically ordered by their timestamp component
                     UUID minTraceId = traceId.compareTo(existing.firstTraceId()) < 0
                             ? traceId
                             : existing.firstTraceId();
 
                     // Keep the most recent lastUpdatedAt
-                    Instant maxLastUpdatedAt = lastUpdatedAt.isAfter(existing.lastUpdatedAt())
+                    var maxLastUpdatedAt = lastUpdatedAt.isAfter(existing.maxLastUpdatedAt())
                             ? lastUpdatedAt
-                            : existing.lastUpdatedAt();
+                            : existing.maxLastUpdatedAt();
 
-                    return new ThreadTimestamps(minTraceId, maxLastUpdatedAt);
+                    // Preserve the source from the first trace seen for this thread.
+                    // In practice traces in a thread originate from the same source, but this is not enforced.
+                    return existing.toBuilder()
+                            .firstTraceId(minTraceId)
+                            .maxLastUpdatedAt(maxLastUpdatedAt)
+                            .build();
                 });
             }
         });

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TraceThreadListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TraceThreadListener.java
@@ -78,11 +78,16 @@ public class TraceThreadListener {
                             ? lastUpdatedAt
                             : existing.maxLastUpdatedAt();
 
-                    // Preserve the source from the first trace seen for this thread.
+                    // Track the source from the chronologically earliest trace (matching firstTraceId).
                     // In practice traces in a thread originate from the same source, but this is not enforced.
+                    var earliestSource = traceId.compareTo(existing.firstTraceId()) < 0
+                            ? trace.source()
+                            : existing.firstTraceSource();
+
                     return existing.toBuilder()
                             .firstTraceId(minTraceId)
                             .maxLastUpdatedAt(maxLastUpdatedAt)
+                            .firstTraceSource(earliestSource)
                             .build();
                 });
             }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TraceThreadOnlineScoringSamplerListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TraceThreadOnlineScoringSamplerListener.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api.resources.v1.events;
 
+import com.comet.opik.api.Source;
 import com.comet.opik.api.TraceThreadSampling;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluator;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
@@ -8,7 +9,6 @@ import com.comet.opik.api.filter.Field;
 import com.comet.opik.api.filter.TraceFilter;
 import com.comet.opik.api.filter.TraceThreadField;
 import com.comet.opik.api.filter.TraceThreadFilter;
-import com.comet.opik.domain.TraceService;
 import com.comet.opik.domain.evaluators.AutomationRuleEvaluatorService;
 import com.comet.opik.domain.evaluators.TraceThreadFilterEvaluationService;
 import com.comet.opik.domain.evaluators.UserLog;
@@ -55,7 +55,6 @@ public class TraceThreadOnlineScoringSamplerListener {
     private final TraceThreadFilterEvaluationService filterEvaluationService;
     private final Logger userFacingLogger;
     private final TraceThreadService traceThreadService;
-    private final TraceService traceService;
 
     /**
      * Initializes a SecureRandom instance for trace thread processing.
@@ -65,12 +64,10 @@ public class TraceThreadOnlineScoringSamplerListener {
     public TraceThreadOnlineScoringSamplerListener(
             @NonNull AutomationRuleEvaluatorService ruleEvaluatorService,
             @NonNull TraceThreadFilterEvaluationService filterEvaluationService,
-            @NonNull TraceThreadService traceThreadService,
-            @NonNull TraceService traceService) {
+            @NonNull TraceThreadService traceThreadService) {
         this.ruleEvaluatorService = ruleEvaluatorService;
         this.filterEvaluationService = filterEvaluationService;
         this.traceThreadService = traceThreadService;
-        this.traceService = traceService;
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(TraceThreadOnlineScoringSamplerListener.class);
         try {
             this.secureRandom = SecureRandom.getInstanceStrong();
@@ -90,7 +87,13 @@ public class TraceThreadOnlineScoringSamplerListener {
     public void onTraceThreadOnlineScoringSampled(@NonNull TraceThreadsCreated event) {
 
         UUID projectId = event.projectId();
+
+        // Only score threads originating from SDK logging source. Non-SDK threads (playground,
+        // experiment, optimization) are skipped from online evaluation.
+        // Source is null for pre-existing threads whose ClickHouse
+        // DEFAULT 'unknown' maps to null via, so treated as SDK for backward compatibility.
         Map<UUID, TraceThreadModel> traceThreadModelMap = event.traceThreadModels().stream()
+                .filter(thread -> Source.isLoggingSource(thread.source()))
                 .collect(toMap(TraceThreadModel::id, Function.identity()));
 
         String workspaceId = event.workspaceId();
@@ -218,7 +221,7 @@ public class TraceThreadOnlineScoringSamplerListener {
         // Filter to only TraceFilter instances since TraceFilterEvaluationService expects TraceFilter
         List<TraceFilter> traceFilters = (List<TraceFilter>) evaluator.getFilters();
         if (traceFilters.isEmpty()) {
-            return true; // No filters means all threads should be sampled
+            return true; // No filters mean all threads should be sampled
         }
 
         // Convert TraceFilter to TraceThreadFilter

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadDAO.java
@@ -5,7 +5,6 @@ import com.comet.opik.api.TraceThreadStatus;
 import com.comet.opik.api.TraceThreadUpdate;
 import com.comet.opik.api.events.ProjectWithPendingClosureTraceThreads;
 import com.comet.opik.domain.TagOperations;
-import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils;
 import com.comet.opik.utils.template.TemplateUtils;
@@ -71,9 +70,6 @@ public interface TraceThreadDAO {
 
     Flux<List<TraceThreadModel>> streamPendingClosureThreads(UUID projectId, Instant lastUpdatedAt);
 
-    record ThreadIdWithTagsAndMetadata(UUID id, Set<String> tags, UUID projectId) {
-    }
-
     Mono<Void> bulkUpdate(@NonNull List<UUID> ids, @NonNull TraceThreadUpdate update, boolean mergeTags);
 }
 
@@ -83,7 +79,7 @@ public interface TraceThreadDAO {
 class TraceThreadDAOImpl implements TraceThreadDAO {
 
     private static final String INSERT_THREADS_SQL = """
-            INSERT INTO trace_threads(workspace_id, project_id, thread_id, id, status, created_by, last_updated_by, created_at, last_updated_at, tags, sampling_per_rule, scored_at)
+            INSERT INTO trace_threads(workspace_id, project_id, thread_id, id, status, created_by, last_updated_by, created_at, last_updated_at, tags, sampling_per_rule, scored_at, source)
             VALUES
                 <items:{item |
                     (
@@ -98,7 +94,8 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
                          parseDateTime64BestEffort(:last_updated_at<item.index> , 6),
                          :tags<item.index>,
                          mapFromArrays(:rule_ids<item.index>, :sampling<item.index>),
-                         :scored_at<item.index>
+                         :scored_at<item.index>,
+                         :source<item.index>
                      )
                      <if(item.hasNext)>
                         ,
@@ -109,7 +106,7 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
 
     private static final String UPDATE_THREAD_SQL = """
             INSERT INTO trace_threads (
-            	workspace_id, project_id, thread_id, id, status, tags, created_by, last_updated_by, created_at, sampling_per_rule, scored_at
+            	workspace_id, project_id, thread_id, id, status, tags, created_by, last_updated_by, created_at, sampling_per_rule, scored_at, source
             )
             SELECT
                 workspace_id,
@@ -122,7 +119,8 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
                 :user_name as last_updated_by,
                 created_at,
                 sampling_per_rule,
-                scored_at
+                scored_at,
+                source
             FROM trace_threads final
             WHERE workspace_id = :workspace_id
             AND project_id = :project_id
@@ -167,9 +165,9 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
             """;
 
     private static final String OPEN_CLOSURE_THREADS_SQL = """
-            INSERT INTO trace_threads(workspace_id, project_id, thread_id, id, status, created_by, last_updated_by, created_at, last_updated_at, tags, sampling_per_rule, scored_at)
+            INSERT INTO trace_threads(workspace_id, project_id, thread_id, id, status, created_by, last_updated_by, created_at, last_updated_at, tags, sampling_per_rule, scored_at, source)
             SELECT
-                workspace_id, project_id, thread_id, id, :status AS new_status, created_by, :user_name, created_at, now64(6), tags, sampling_per_rule, NULL
+                workspace_id, project_id, thread_id, id, :status AS new_status, created_by, :user_name, created_at, now64(6), tags, sampling_per_rule, NULL, source
             FROM (
                 SELECT *
                 FROM trace_threads
@@ -193,7 +191,7 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
             """;
 
     private static final String UPDATE_THREAD_SAMPLING_PER_RULE = """
-            INSERT INTO trace_threads(workspace_id, project_id, thread_id, id, status, created_by, last_updated_by, created_at, last_updated_at, tags, sampling_per_rule, scored_at)
+            INSERT INTO trace_threads(workspace_id, project_id, thread_id, id, status, created_by, last_updated_by, created_at, last_updated_at, tags, sampling_per_rule, scored_at, source)
             SELECT
                 new_tt.workspace_id,
                 new_tt.project_id,
@@ -206,7 +204,8 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
                 now64(6) AS last_updated_at,
                 if(empty(tt.thread_id), new_tt.tags, tt.tags) AS tags,
                 new_tt.sampling_per_rule AS sampling_per_rule,
-                if(empty(tt.thread_id), new_tt.scored_at, tt.scored_at) AS scored_at
+                if(empty(tt.thread_id), new_tt.scored_at, tt.scored_at) AS scored_at,
+                if(empty(tt.thread_id), new_tt.source, tt.source) AS source
             FROM (
                 <items:{item |
                     SELECT
@@ -221,7 +220,8 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
                         now64(6) AS last_updated_at,
                         :tags<item.index> AS tags,
                         mapFromArrays(:rule_ids<item.index>, :sampling<item.index>) AS sampling_per_rule,
-                        :scored_at<item.index> AS scored_at
+                        :scored_at<item.index> AS scored_at,
+                        :source<item.index> AS source
                     <if(item.hasNext)>UNION ALL<endif>
                 }>
             ) as new_tt
@@ -238,7 +238,8 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
                     now64(6) AS last_updated_at,
                     tt.tags AS tags,
                     tt.sampling_per_rule AS sampling_per_rule,
-                    tt.scored_at AS scored_at
+                    tt.scored_at AS scored_at,
+                    tt.source AS source
                 FROM trace_threads tt final
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
@@ -252,7 +253,7 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
             """;
 
     private static final String UPDATE_THREAD_SCORED_AT = """
-            INSERT INTO trace_threads(workspace_id, project_id, thread_id, id, status, created_by, last_updated_by, created_at, last_updated_at, tags, sampling_per_rule, scored_at)
+            INSERT INTO trace_threads(workspace_id, project_id, thread_id, id, status, created_by, last_updated_by, created_at, last_updated_at, tags, sampling_per_rule, scored_at, source)
             SELECT
                 workspace_id,
                 project_id,
@@ -265,7 +266,8 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
                 now64(6),
                 tags,
                 sampling_per_rule,
-                parseDateTime64BestEffort(:scored_at, 9)
+                parseDateTime64BestEffort(:scored_at, 9),
+                source
             FROM trace_threads final
             WHERE workspace_id = :workspace_id
             AND project_id = :project_id
@@ -274,7 +276,7 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
 
     public static final String GET_RECENT_CLOSED_THREADS_PER_PROJECT = """
             SELECT
-                workspace_id, project_id, thread_id, id, status, created_by, last_updated_by, created_at, last_updated_at, tags, sampling_per_rule, scored_at
+                workspace_id, project_id, thread_id, id, status, created_by, last_updated_by, created_at, last_updated_at, tags, sampling_per_rule, scored_at, source
             FROM trace_threads final
             WHERE workspace_id = :workspace_id
             AND project_id = :project_id
@@ -285,7 +287,6 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
 
     private final @NonNull TransactionTemplateAsync asyncTemplate;
     private final @NonNull ConnectionFactory connectionFactory;
-    private final @NonNull OpikConfiguration configuration;
 
     @Override
     public Mono<Long> save(@NonNull List<TraceThreadModel> traceThreads) {
@@ -339,6 +340,12 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
                     statement.bind("scored_at" + i, item.scoredAt().toString());
                 } else {
                     statement.bindNull("scored_at" + i, Instant.class);
+                }
+
+                if (item.source() != null) {
+                    statement.bind("source" + i, item.source().getValue());
+                } else {
+                    statement.bindNull("source" + i, String.class);
                 }
 
                 i++;
@@ -516,6 +523,12 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
                     statement.bindNull("scored_at" + i, Instant.class);
                 }
 
+                if (traceThreadModel.source() != null) {
+                    statement.bind("source" + i, traceThreadModel.source().getValue());
+                } else {
+                    statement.bindNull("source" + i, String.class);
+                }
+
                 i++;
             }
 
@@ -628,7 +641,8 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
                 last_updated_at,
                 tags,
                 sampling_per_rule,
-                scored_at
+                scored_at,
+                source
             )
             SELECT
                 tt.workspace_id,
@@ -643,7 +657,8 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
                 """ + TagOperations.tagUpdateFragment("tt.tags") + """
                 as tags,
                 tt.sampling_per_rule,
-                tt.scored_at
+                tt.scored_at,
+                tt.source
             FROM trace_threads tt
             WHERE tt.id IN :ids AND tt.workspace_id = :workspace_id
             ORDER BY (tt.workspace_id, tt.project_id, tt.thread_id, tt.id) DESC, tt.last_updated_at DESC

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadMapper.java
@@ -1,5 +1,6 @@
 package com.comet.opik.domain.threads;
 
+import com.comet.opik.api.Source;
 import com.comet.opik.api.TraceThreadStatus;
 import com.comet.opik.api.events.ProjectWithPendingClosureTraceThreads;
 import com.comet.opik.utils.RowUtils;
@@ -32,7 +33,7 @@ interface TraceThreadMapper {
     @Mapping(target = "lastMessage", ignore = true)
     @Mapping(target = "numberOfMessages", ignore = true)
     TraceThreadModel mapFromThreadIdModel(TraceThreadIdModel traceThread, String userName, TraceThreadStatus status,
-            Instant lastUpdatedAt);
+            Instant lastUpdatedAt, Source source);
 
     default TraceThreadModel mapFromRow(Row row) {
         return TraceThreadModel.builder()
@@ -64,6 +65,8 @@ interface TraceThreadMapper {
                 .firstMessage(RowUtils.getOptionalValue(row, "first_message", String.class))
                 .lastMessage(RowUtils.getOptionalValue(row, "last_message", String.class))
                 .numberOfMessages(RowUtils.getOptionalValue(row, "number_of_messages", Long.class))
+                .source(Source.fromString(RowUtils.getOptionalValue(row, "source", String.class))
+                        .orElse(null))
                 .build();
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadModel.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadModel.java
@@ -1,5 +1,6 @@
 package com.comet.opik.domain.threads;
 
+import com.comet.opik.api.Source;
 import com.comet.opik.api.TraceThreadStatus;
 import lombok.Builder;
 
@@ -14,6 +15,9 @@ import java.util.UUID;
  *
  * @param id The unique identifier for the trace thread it will also be referenced as trace thread id.
  * @param threadId The unique identifier for the thread, this is an external id provided by the user.
+ * @param source The origin source of the triggering traces. Persisted to ClickHouse; defaults to
+ *               'unknown' for pre-existing rows. {@link Source#isLoggingSource(Source)} treats null
+ *               (mapped from 'unknown') as SDK for backward compatibility.
  */
 @Builder(toBuilder = true)
 public record TraceThreadModel(
@@ -34,7 +38,8 @@ public record TraceThreadModel(
         Map<String, Integer> feedbackScores,
         String firstMessage,
         String lastMessage,
-        Long numberOfMessages) {
+        Long numberOfMessages,
+        Source source) {
 
     public boolean isInactive() {
         return status == TraceThreadStatus.INACTIVE;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
@@ -48,14 +48,10 @@ public interface TraceThreadService {
 
     Mono<Void> processTraceThreads(Map<String, ThreadTimestamps> threadInfo, UUID projectId);
 
-    Mono<List<TraceThreadModel>> getThreadsByProject(int page, int size, TraceThreadCriteria criteria);
-
     Flux<ProjectWithPendingClosureTraceThreads> getProjectsWithPendingClosureThreads(Instant now,
             Duration defaultTimeoutToMarkThreadAsInactive,
             Duration minLookback,
             int limit);
-
-    Mono<Duration> getMaxTimeoutMarkThreadAsInactive(Duration defaultTimeout);
 
     Mono<Void> processProjectWithTraceThreadsPendingClosure(UUID projectId, Instant now,
             Duration defaultTimeoutToMarkThreadAsInactive);
@@ -67,8 +63,6 @@ public interface TraceThreadService {
     Mono<Void> closeThreads(UUID projectId, Set<String> threadIds);
 
     Mono<UUID> getOrCreateThreadId(UUID projectId, String threadId);
-
-    Mono<UUID> getOrCreateThreadId(UUID projectId, String threadId, Instant timestamp);
 
     Mono<UUID> getThreadModelId(UUID projectId, String threadId);
 
@@ -117,12 +111,14 @@ class TraceThreadServiceImpl implements TraceThreadService {
                     String threadId = entry.getKey();
                     ThreadTimestamps timestamps = entry.getValue();
 
-                    // Extract timestamp from earliest trace (first trace in chronological order)
+                    // Extract timestamp from the earliest trace (first trace in chronological order)
                     Instant earliestTraceTimestamp = IdGenerator.extractTimestampFromUUIDv7(timestamps.firstTraceId());
 
                     return traceThreadIdService
                             .getOrCreateTraceThreadId(workspaceId, projectId, threadId, earliestTraceTimestamp)
-                            .map(traceThreadId -> mapToModel(traceThreadId, userName, timestamps.lastUpdatedAt()));
+                            .map(traceThreadId -> TraceThreadMapper.INSTANCE.mapFromThreadIdModel(
+                                    traceThreadId, userName, TraceThreadStatus.ACTIVE,
+                                    timestamps.maxLastUpdatedAt(), timestamps.firstTraceSource()));
                 }));
     }
 
@@ -131,8 +127,7 @@ class TraceThreadServiceImpl implements TraceThreadService {
         return getOrCreateThreadId(projectId, threadId, null);
     }
 
-    @Override
-    public Mono<UUID> getOrCreateThreadId(@NonNull UUID projectId, @NonNull String threadId, Instant timestamp) {
+    private Mono<UUID> getOrCreateThreadId(UUID projectId, String threadId, Instant timestamp) {
         return Mono.deferContextual(context -> traceThreadIdService
                 .getOrCreateTraceThreadId(context.get(RequestContext.WORKSPACE_ID), projectId, threadId, timestamp)
                 .map(TraceThreadIdModel::id));
@@ -209,11 +204,6 @@ class TraceThreadServiceImpl implements TraceThreadService {
         return traceThreadIdService.getTraceThreadIdsByThreadModelIds(threadModelIds);
     }
 
-    private TraceThreadModel mapToModel(TraceThreadIdModel traceThread, String userName, Instant lastUpdatedAt) {
-        return TraceThreadMapper.INSTANCE.mapFromThreadIdModel(traceThread, userName, TraceThreadStatus.ACTIVE,
-                lastUpdatedAt);
-    }
-
     private Mono<Void> saveTraceThreads(UUID projectId, List<TraceThreadModel> traceThreads) {
 
         if (traceThreads.isEmpty()) {
@@ -287,12 +277,6 @@ class TraceThreadServiceImpl implements TraceThreadService {
     }
 
     @Override
-    public Mono<List<TraceThreadModel>> getThreadsByProject(int page, int size, @NonNull TraceThreadCriteria criteria) {
-        return traceThreadDAO.findThreadsByProject(page, size, criteria)
-                .switchIfEmpty(Mono.just(List.of()));
-    }
-
-    @Override
     public Flux<ProjectWithPendingClosureTraceThreads> getProjectsWithPendingClosureThreads(
             @NonNull Instant now, @NonNull Duration defaultTimeoutToMarkThreadAsInactive,
             Duration minLookback, int limit) {
@@ -316,8 +300,7 @@ class TraceThreadServiceImpl implements TraceThreadService {
                                 cachedMaxInactivePeriod, limit));
     }
 
-    @Override
-    public Mono<Duration> getMaxTimeoutMarkThreadAsInactive(@NonNull Duration defaultTimeout) {
+    private Mono<Duration> getMaxTimeoutMarkThreadAsInactive(Duration defaultTimeout) {
         return workspaceConfigurationService.getMaxTimeoutMarkThreadAsInactive()
                 .map(maxTimeoutSeconds -> {
                     if (maxTimeoutSeconds > 0) {
@@ -368,9 +351,8 @@ class TraceThreadServiceImpl implements TraceThreadService {
                 })
                 .reduce(0L, Long::sum)
                 .doOnError(ex -> log.error(
-                        "Error when processing closure of pending trace threads  for project: '%s' workspaceId '%s'"
-                                .formatted(projectId, workspaceId),
-                        ex))
+                        "Error when processing closure of pending trace threads  for project: '{}' workspaceId '{}'",
+                        projectId, workspaceId, ex))
                 .flatMap(count -> {
                     var lock = new LockService.Lock(TraceThreadBufferConfig.BUFFER_SET_NAME, projectId.toString());
                     return lockService.unlockUsingToken(lock).thenReturn(count);

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000079_add_source_to_trace_threads.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000079_add_source_to_trace_threads.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+--changeset andrescrz:000079_add_source_to_trace_threads
+--comment: Add source column to trace_threads table to track ingestion origin for online-scoring source filter (OPIK-5768)
+
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.trace_threads ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS source Enum8('unknown' = 0, 'sdk' = 1, 'experiment' = 2, 'playground' = 3, 'optimization' = 4) DEFAULT 'unknown';
+
+-- No index added: no current query filters trace_threads by source directly.
+-- The source filter is applied in-memory by TraceThreadOnlineScoringSamplerListener.
+-- Add a set(0) index later if a ClickHouse query starts filtering by source.
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.trace_threads ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS source;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TraceThreadListenerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TraceThreadListenerTest.java
@@ -1,0 +1,363 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.Source;
+import com.comet.opik.api.ThreadTimestamps;
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.events.TracesCreated;
+import com.comet.opik.domain.IdGenerator;
+import com.comet.opik.domain.threads.TraceThreadService;
+import com.comet.opik.infrastructure.db.IdGeneratorImpl;
+import com.comet.opik.podam.PodamFactoryUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TraceThreadListenerTest {
+
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+    private final IdGenerator idGenerator = new IdGeneratorImpl();
+
+    @Mock
+    private TraceThreadService traceThreadService;
+
+    @InjectMocks
+    private TraceThreadListener listener;
+
+    private UUID projectId;
+    private String workspaceId;
+    private String userName;
+
+    @BeforeEach
+    void setUp() {
+        projectId = idGenerator.generateId();
+        workspaceId = UUID.randomUUID().toString();
+        userName = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+    }
+
+    @Nested
+    class SourcePropagationTests {
+
+        @ParameterizedTest
+        @EnumSource(Source.class)
+        @NullSource
+        void propagatesSourceFromSingleTrace(Source source) {
+            var threadId = randomThreadId();
+            var now = Instant.now();
+            var trace = createTrace(projectId, threadId, source, now);
+            var event = new TracesCreated(List.of(trace), workspaceId, userName);
+
+            when(traceThreadService.processTraceThreads(any(), eq(projectId)))
+                    .thenReturn(Mono.empty());
+
+            listener.onTracesCreated(event);
+
+            var captured = captureThreadInfo(projectId);
+            assertThat(captured).containsExactlyEntriesOf(Map.of(
+                    threadId, ThreadTimestamps.builder()
+                            .firstTraceId(trace.id())
+                            .maxLastUpdatedAt(now)
+                            .firstTraceSource(source)
+                            .build()));
+        }
+
+        static Stream<Arguments> sourceAlwaysMatchesEarliestTrace() {
+            return Stream.of(
+                    // processLaterFirst=true: later trace processed first, then earlier swaps firstTraceId + source
+                    Arguments.of(true, Source.SDK, Source.PLAYGROUND),
+                    // processLaterFirst=false: earlier trace processed first, later doesn't swap
+                    Arguments.of(false, Source.SDK, Source.PLAYGROUND),
+                    Arguments.of(true, Source.PLAYGROUND, Source.SDK),
+                    Arguments.of(false, Source.PLAYGROUND, Source.SDK));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void sourceAlwaysMatchesEarliestTrace(boolean processLaterFirst,
+                Source earlierSource, Source laterSource) {
+            var threadId = randomThreadId();
+            var now = Instant.now();
+            var earlierTime = now.minus(1, ChronoUnit.SECONDS);
+
+            var earlierTrace = createTrace(projectId, threadId, earlierSource, earlierTime);
+            var laterTrace = createTrace(projectId, threadId, laterSource, now);
+
+            var traces = processLaterFirst
+                    ? List.of(laterTrace, earlierTrace)
+                    : List.of(earlierTrace, laterTrace);
+            var event = new TracesCreated(traces, workspaceId, userName);
+
+            when(traceThreadService.processTraceThreads(any(), eq(projectId)))
+                    .thenReturn(Mono.empty());
+
+            listener.onTracesCreated(event);
+
+            var captured = captureThreadInfo(projectId);
+            assertThat(captured.get(threadId)).isEqualTo(ThreadTimestamps.builder()
+                    .firstTraceId(earlierTrace.id())
+                    .maxLastUpdatedAt(now)
+                    .firstTraceSource(earlierSource)
+                    .build());
+        }
+    }
+
+    @Nested
+    class ThreadIdFilteringTests {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"  "})
+        void skipsTracesWithBlankOrNullThreadId(String threadId) {
+            var trace = createTrace(projectId, threadId, Source.SDK, Instant.now());
+            var event = new TracesCreated(List.of(trace), workspaceId, userName);
+
+            listener.onTracesCreated(event);
+
+            verifyNoInteractions(traceThreadService);
+        }
+
+        @Test
+        void processesTraceWithNonBlankThreadId() {
+            var threadId = randomThreadId();
+            var now = Instant.now();
+            var trace = createTrace(projectId, threadId, Source.SDK, now);
+            var event = new TracesCreated(List.of(trace), workspaceId, userName);
+
+            when(traceThreadService.processTraceThreads(any(), eq(projectId)))
+                    .thenReturn(Mono.empty());
+
+            listener.onTracesCreated(event);
+
+            var captured = captureThreadInfo(projectId);
+            assertThat(captured).containsExactlyEntriesOf(Map.of(
+                    threadId, ThreadTimestamps.builder()
+                            .firstTraceId(trace.id())
+                            .maxLastUpdatedAt(now)
+                            .firstTraceSource(Source.SDK)
+                            .build()));
+        }
+    }
+
+    @Nested
+    class TimestampAggregationTests {
+
+        @Test
+        void keepsMaxLastUpdatedAtAcrossMultipleTraces() {
+            var threadId = randomThreadId();
+            var earlier = Instant.now().minus(10, ChronoUnit.SECONDS);
+            var later = Instant.now();
+
+            var trace1 = createTrace(projectId, threadId, Source.SDK, earlier);
+            var trace2 = createTrace(projectId, threadId, Source.SDK, later);
+            var event = new TracesCreated(List.of(trace1, trace2), workspaceId, userName);
+
+            when(traceThreadService.processTraceThreads(any(), eq(projectId)))
+                    .thenReturn(Mono.empty());
+
+            listener.onTracesCreated(event);
+
+            var captured = captureThreadInfo(projectId);
+            assertThat(captured.get(threadId)).isEqualTo(ThreadTimestamps.builder()
+                    .firstTraceId(trace1.id())
+                    .maxLastUpdatedAt(later)
+                    .firstTraceSource(Source.SDK)
+                    .build());
+        }
+
+        @Test
+        void fallsBackToInstantNowWhenLastUpdatedAtIsNull() {
+            var threadId = randomThreadId();
+            var before = Instant.now().minus(1, ChronoUnit.SECONDS);
+
+            var trace = podamFactory.manufacturePojo(Trace.class).toBuilder()
+                    .id(idGenerator.generateId())
+                    .projectId(projectId)
+                    .threadId(threadId)
+                    .source(Source.SDK)
+                    .lastUpdatedAt(null)
+                    .build();
+            var event = new TracesCreated(List.of(trace), workspaceId, userName);
+
+            when(traceThreadService.processTraceThreads(any(), eq(projectId)))
+                    .thenReturn(Mono.empty());
+
+            listener.onTracesCreated(event);
+
+            var timestamps = captureThreadInfo(projectId).get(threadId);
+            assertThat(timestamps.maxLastUpdatedAt()).isAfter(before);
+            // Full-object assertion using the captured maxLastUpdatedAt (unpredictable Instant.now())
+            assertThat(timestamps).isEqualTo(ThreadTimestamps.builder()
+                    .firstTraceId(trace.id())
+                    .maxLastUpdatedAt(timestamps.maxLastUpdatedAt())
+                    .firstTraceSource(Source.SDK)
+                    .build());
+        }
+    }
+
+    @Nested
+    class MultiProjectTests {
+
+        @Test
+        void groupsTracesByProjectAndCallsServicePerProject() {
+            var projectId2 = idGenerator.generateId();
+            var threadId1 = randomThreadId();
+            var threadId2 = randomThreadId();
+            var now = Instant.now();
+
+            var trace1 = createTrace(projectId, threadId1, Source.SDK, now);
+            var trace2 = createTrace(projectId2, threadId2, Source.PLAYGROUND, now);
+            var event = new TracesCreated(List.of(trace1, trace2), workspaceId, userName);
+
+            when(traceThreadService.processTraceThreads(any(), any()))
+                    .thenReturn(Mono.empty());
+
+            listener.onTracesCreated(event);
+
+            var captured1 = captureThreadInfo(projectId);
+            assertThat(captured1).containsExactlyEntriesOf(Map.of(
+                    threadId1, ThreadTimestamps.builder()
+                            .firstTraceId(trace1.id())
+                            .maxLastUpdatedAt(now)
+                            .firstTraceSource(Source.SDK)
+                            .build()));
+
+            var captured2 = captureThreadInfo(projectId2);
+            assertThat(captured2).containsExactlyEntriesOf(Map.of(
+                    threadId2, ThreadTimestamps.builder()
+                            .firstTraceId(trace2.id())
+                            .maxLastUpdatedAt(now)
+                            .firstTraceSource(Source.PLAYGROUND)
+                            .build()));
+        }
+    }
+
+    @Nested
+    class MultipleThreadsTests {
+
+        @Test
+        void handlesMultipleThreadsInSameProject() {
+            var threadId1 = randomThreadId();
+            var threadId2 = randomThreadId();
+            var now = Instant.now();
+
+            var trace1 = createTrace(projectId, threadId1, Source.SDK, now);
+            var trace2 = createTrace(projectId, threadId2, Source.PLAYGROUND, now);
+            var event = new TracesCreated(List.of(trace1, trace2), workspaceId, userName);
+
+            when(traceThreadService.processTraceThreads(any(), eq(projectId)))
+                    .thenReturn(Mono.empty());
+
+            listener.onTracesCreated(event);
+
+            var captured = captureThreadInfo(projectId);
+            assertThat(captured).containsExactlyInAnyOrderEntriesOf(Map.of(
+                    threadId1, ThreadTimestamps.builder()
+                            .firstTraceId(trace1.id())
+                            .maxLastUpdatedAt(now)
+                            .firstTraceSource(Source.SDK)
+                            .build(),
+                    threadId2, ThreadTimestamps.builder()
+                            .firstTraceId(trace2.id())
+                            .maxLastUpdatedAt(now)
+                            .firstTraceSource(Source.PLAYGROUND)
+                            .build()));
+        }
+    }
+
+    @Nested
+    class EmptyCasesTests {
+
+        @Test
+        void handlesEmptyTracesList() {
+            var event = new TracesCreated(List.of(), workspaceId, userName);
+
+            listener.onTracesCreated(event);
+
+            verifyNoInteractions(traceThreadService);
+        }
+
+        @Test
+        void handlesAllTracesWithoutThreadId() {
+            var trace = podamFactory.manufacturePojo(Trace.class).toBuilder()
+                    .id(idGenerator.generateId())
+                    .projectId(projectId)
+                    .threadId(null)
+                    .build();
+            var event = new TracesCreated(List.of(trace), workspaceId, userName);
+
+            listener.onTracesCreated(event);
+
+            verifyNoInteractions(traceThreadService);
+        }
+    }
+
+    @Nested
+    class ErrorHandlingTests {
+
+        @Test
+        void handlesServiceErrorGracefully() {
+            var threadId = randomThreadId();
+            var trace = createTrace(projectId, threadId, Source.SDK, Instant.now());
+            var event = new TracesCreated(List.of(trace), workspaceId, userName);
+
+            when(traceThreadService.processTraceThreads(any(), eq(projectId)))
+                    .thenReturn(Mono.error(new RuntimeException("DB connection failed")));
+
+            listener.onTracesCreated(event);
+
+            verify(traceThreadService).processTraceThreads(any(), eq(projectId));
+        }
+    }
+
+    // Helper methods
+
+    private Trace createTrace(UUID traceProjectId, String threadId, Source source, Instant lastUpdatedAt) {
+        return podamFactory.manufacturePojo(Trace.class).toBuilder()
+                .id(idGenerator.generateId(lastUpdatedAt))
+                .projectId(traceProjectId)
+                .threadId(threadId)
+                .source(source)
+                .lastUpdatedAt(lastUpdatedAt)
+                .build();
+    }
+
+    private String randomThreadId() {
+        return "thread-" + RandomStringUtils.secure().nextAlphanumeric(32);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, ThreadTimestamps> captureThreadInfo(UUID expectedProjectId) {
+        ArgumentCaptor<Map<String, ThreadTimestamps>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(traceThreadService).processTraceThreads(captor.capture(), eq(expectedProjectId));
+        return captor.getValue();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TraceThreadOnlineScoringSamplerListenerIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TraceThreadOnlineScoringSamplerListenerIntegrationTest.java
@@ -1,0 +1,189 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.Source;
+import com.comet.opik.api.TraceThreadStatus;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadLlmAsJudge;
+import com.comet.opik.api.events.TraceThreadsCreated;
+import com.comet.opik.api.resources.utils.AuthTestUtils;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.AutomationRuleEvaluatorResourceClient;
+import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
+import com.comet.opik.domain.threads.TraceThreadModel;
+import com.comet.opik.domain.threads.TraceThreadService;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.google.common.eventbus.EventBus;
+import com.google.inject.AbstractModule;
+import com.redis.testcontainers.RedisContainer;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import reactor.core.publisher.Mono;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@Slf4j
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class TraceThreadOnlineScoringSamplerListenerIntegrationTest {
+
+    private static final String API_KEY = "apiKey-" + UUID.randomUUID();
+    private static final String WORKSPACE_NAME = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+    private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+    private static final String USER_NAME = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+
+    private final TraceThreadService traceThreadService;
+    private final EventBus eventBus;
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+    private final GenericContainer<?> ZOOKEEPER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE = ClickHouseContainerUtils.newClickHouseContainer(ZOOKEEPER);
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    {
+        Startables.deepStart(REDIS, MYSQL, CLICKHOUSE, ZOOKEEPER).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        DatabaseAnalyticsFactory databaseAnalyticsFactory = ClickHouseContainerUtils
+                .newDatabaseAnalyticsFactory(CLICKHOUSE, ClickHouseContainerUtils.DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE);
+
+        traceThreadService = Mockito.mock(TraceThreadService.class);
+        eventBus = Mockito.mock(EventBus.class);
+
+        app = newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .redisUrl(REDIS.getRedisURI())
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .mockEventBus(eventBus)
+                        .modules(List.of(
+                                new AbstractModule() {
+                                    @Override
+                                    protected void configure() {
+                                        bind(TraceThreadService.class).toInstance(traceThreadService);
+                                    }
+                                }))
+                        .build());
+    }
+
+    private AutomationRuleEvaluatorResourceClient evaluatorResourceClient;
+    private ProjectResourceClient projectResourceClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport clientSupport) {
+        var baseUrl = TestUtils.getBaseUrl(clientSupport);
+        ClientSupportUtils.config(clientSupport);
+
+        AuthTestUtils.mockTargetWorkspace(wireMock.server(), API_KEY, WORKSPACE_NAME, WORKSPACE_ID, USER_NAME);
+
+        projectResourceClient = new ProjectResourceClient(clientSupport, baseUrl, factory);
+        evaluatorResourceClient = new AutomationRuleEvaluatorResourceClient(clientSupport, baseUrl);
+
+        Mockito.reset(traceThreadService, eventBus);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Source.class, names = {"SDK"})
+    @NullSource
+    void processesThreadsWithSdkOrNullSource(Source source,
+            TraceThreadOnlineScoringSamplerListener listener) {
+        Mockito.reset(traceThreadService, eventBus);
+
+        var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        var projectId = projectResourceClient.createProject(projectName, API_KEY, WORKSPACE_NAME);
+
+        var evaluator = createEvaluator(projectId);
+        evaluatorResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
+
+        var thread = createThread(projectId, source);
+        var event = new TraceThreadsCreated(List.of(thread), projectId, WORKSPACE_ID, USER_NAME);
+
+        Mockito.when(traceThreadService.updateThreadSampledValue(eq(projectId), any()))
+                .thenReturn(Mono.empty());
+
+        listener.onTraceThreadOnlineScoringSampled(event);
+
+        verify(traceThreadService).updateThreadSampledValue(eq(projectId), any());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Source.class, mode = EnumSource.Mode.EXCLUDE, names = {"SDK"})
+    void skipsNonSdkThreads(Source source,
+            TraceThreadOnlineScoringSamplerListener listener) {
+        Mockito.reset(traceThreadService, eventBus);
+
+        var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        var projectId = projectResourceClient.createProject(projectName, API_KEY, WORKSPACE_NAME);
+
+        var evaluator = createEvaluator(projectId);
+        evaluatorResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
+
+        var thread = createThread(projectId, source);
+        var event = new TraceThreadsCreated(List.of(thread), projectId, WORKSPACE_ID, USER_NAME);
+
+        listener.onTraceThreadOnlineScoringSampled(event);
+
+        verifyNoInteractions(traceThreadService);
+    }
+
+    private TraceThreadModel createThread(UUID projectId, Source source) {
+        return factory.manufacturePojo(TraceThreadModel.class).toBuilder()
+                .projectId(projectId)
+                .status(TraceThreadStatus.ACTIVE)
+                .source(source)
+                .build();
+    }
+
+    private AutomationRuleEvaluatorTraceThreadLlmAsJudge createEvaluator(UUID projectId) {
+        return factory.manufacturePojo(AutomationRuleEvaluatorTraceThreadLlmAsJudge.class).toBuilder()
+                .projectIds(Set.of(projectId))
+                .samplingRate(1.0f)
+                .enabled(true)
+                .filters(List.of())
+                .build();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TraceThreadOnlineScoringSamplerListenerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TraceThreadOnlineScoringSamplerListenerTest.java
@@ -1,0 +1,200 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.Source;
+import com.comet.opik.api.TraceThreadSampling;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadLlmAsJudge;
+import com.comet.opik.api.events.TraceThreadsCreated;
+import com.comet.opik.domain.evaluators.AutomationRuleEvaluatorService;
+import com.comet.opik.domain.evaluators.TraceThreadFilterEvaluationService;
+import com.comet.opik.domain.threads.TraceThreadModel;
+import com.comet.opik.domain.threads.TraceThreadService;
+import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
+import com.comet.opik.podam.PodamFactoryUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import reactor.core.publisher.Mono;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.comet.opik.api.resources.utils.AutomationRuleEvaluatorTestUtils.toProjects;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TraceThreadOnlineScoringSamplerListenerTest {
+
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+
+    @Mock
+    private AutomationRuleEvaluatorService ruleEvaluatorService;
+
+    @Mock
+    private TraceThreadFilterEvaluationService filterEvaluationService;
+
+    @Mock
+    private TraceThreadService traceThreadService;
+
+    private TraceThreadOnlineScoringSamplerListener listener;
+    private MockedStatic<UserFacingLoggingFactory> mockedFactory;
+
+    private UUID projectId;
+    private String workspaceId;
+    private String userName;
+
+    @BeforeEach
+    void setUp() {
+        mockedFactory = mockStatic(UserFacingLoggingFactory.class);
+        mockedFactory.when(() -> UserFacingLoggingFactory.getLogger(any(Class.class)))
+                .thenReturn(mock(Logger.class));
+
+        listener = new TraceThreadOnlineScoringSamplerListener(
+                ruleEvaluatorService,
+                filterEvaluationService,
+                traceThreadService);
+
+        projectId = UUID.randomUUID();
+        workspaceId = UUID.randomUUID().toString();
+        userName = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (mockedFactory != null) {
+            mockedFactory.close();
+        }
+    }
+
+    @Nested
+    class SourceFilteringTests {
+
+        @ParameterizedTest
+        @EnumSource(value = Source.class, names = {"SDK"})
+        @NullSource
+        void processesThreadsWithSdkOrNullSource(Source source) {
+            var thread = createThread(source);
+            var evaluator = createEvaluator();
+            var event = new TraceThreadsCreated(List.of(thread), projectId, workspaceId, userName);
+
+            doReturn(List.of(evaluator))
+                    .when(ruleEvaluatorService).findAll(projectId, workspaceId);
+            when(traceThreadService.updateThreadSampledValue(eq(projectId), any()))
+                    .thenReturn(Mono.empty());
+
+            listener.onTraceThreadOnlineScoringSampled(event);
+
+            verify(ruleEvaluatorService).findAll(projectId, workspaceId);
+
+            ArgumentCaptor<List<TraceThreadSampling>> captor = ArgumentCaptor.forClass(List.class);
+            verify(traceThreadService).updateThreadSampledValue(eq(projectId), captor.capture());
+            assertThat(captor.getValue()).isNotEmpty();
+            assertThat(captor.getValue())
+                    .allSatisfy(sampling -> assertThat(sampling.threadModelId()).isEqualTo(thread.id()));
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Source.class, mode = EnumSource.Mode.EXCLUDE, names = {"SDK"})
+        void skipsNonSdkThreads(Source source) {
+            var thread = createThread(source);
+            var event = new TraceThreadsCreated(List.of(thread), projectId, workspaceId, userName);
+
+            listener.onTraceThreadOnlineScoringSampled(event);
+
+            verifyNoInteractions(ruleEvaluatorService);
+            verifyNoInteractions(traceThreadService);
+        }
+
+        @Test
+        void filtersMixedBatchKeepingOnlySdkThreads() {
+            var sdkThread = createThread(Source.SDK);
+            var playgroundThread = createThread(Source.PLAYGROUND);
+            var evaluator = createEvaluator();
+            var event = new TraceThreadsCreated(List.of(sdkThread, playgroundThread), projectId,
+                    workspaceId, userName);
+
+            doReturn(List.of(evaluator))
+                    .when(ruleEvaluatorService).findAll(projectId, workspaceId);
+            when(traceThreadService.updateThreadSampledValue(eq(projectId), any()))
+                    .thenReturn(Mono.empty());
+
+            listener.onTraceThreadOnlineScoringSampled(event);
+
+            verify(ruleEvaluatorService).findAll(projectId, workspaceId);
+
+            ArgumentCaptor<List<TraceThreadSampling>> captor = ArgumentCaptor.forClass(List.class);
+            verify(traceThreadService).updateThreadSampledValue(eq(projectId), captor.capture());
+
+            // Only the SDK thread should appear in sampling results — playground was filtered out
+            assertThat(captor.getValue())
+                    .allSatisfy(sampling -> assertThat(sampling.threadModelId()).isEqualTo(sdkThread.id()));
+            assertThat(captor.getValue())
+                    .noneSatisfy(sampling -> assertThat(sampling.threadModelId()).isEqualTo(playgroundThread.id()));
+        }
+    }
+
+    @Nested
+    class EmptyCasesTests {
+
+        @Test
+        void handlesEmptyThreadsList() {
+            var event = new TraceThreadsCreated(List.of(), projectId, workspaceId, userName);
+
+            listener.onTraceThreadOnlineScoringSampled(event);
+
+            verifyNoInteractions(ruleEvaluatorService);
+            verifyNoInteractions(traceThreadService);
+        }
+
+        @Test
+        void handlesNoEvaluatorsFound() {
+            var thread = createThread(Source.SDK);
+            var event = new TraceThreadsCreated(List.of(thread), projectId, workspaceId, userName);
+
+            doReturn(List.of())
+                    .when(ruleEvaluatorService).findAll(projectId, workspaceId);
+
+            listener.onTraceThreadOnlineScoringSampled(event);
+
+            verify(ruleEvaluatorService).findAll(projectId, workspaceId);
+            verify(traceThreadService, never()).updateThreadSampledValue(any(), any());
+        }
+    }
+
+    private TraceThreadModel createThread(Source source) {
+        return podamFactory.manufacturePojo(TraceThreadModel.class).toBuilder()
+                .projectId(projectId)
+                .source(source)
+                .build();
+    }
+
+    private AutomationRuleEvaluatorTraceThreadLlmAsJudge createEvaluator() {
+        return podamFactory.manufacturePojo(AutomationRuleEvaluatorTraceThreadLlmAsJudge.class).toBuilder()
+                .projects(toProjects(Set.of(projectId)))
+                .samplingRate(1.0f)
+                .enabled(true)
+                .filters(List.of())
+                .build();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindTraceThreadsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindTraceThreadsResourceTest.java
@@ -69,7 +69,6 @@ import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import uk.co.jemos.podam.api.PodamFactory;
-import uk.co.jemos.podam.api.PodamUtils;
 
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -148,8 +147,6 @@ class FindTraceThreadsResourceTest {
     private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
     private final FilterQueryBuilder filterQueryBuilder = new FilterQueryBuilder();
 
-    private String baseURI;
-    private ClientSupport client;
     private ProjectResourceClient projectResourceClient;
     private TraceResourceClient traceResourceClient;
     private SpanResourceClient spanResourceClient;
@@ -159,16 +156,15 @@ class FindTraceThreadsResourceTest {
     @BeforeAll
     void setUpAll(ClientSupport client, com.comet.opik.domain.IdGenerator idGenerator) {
 
-        this.baseURI = TestUtils.getBaseUrl(client);
-        this.client = client;
+        var baseURI = TestUtils.getBaseUrl(client);
 
         ClientSupportUtils.config(client);
 
         mockTargetWorkspace(API_KEY, TEST_WORKSPACE, WORKSPACE_ID);
 
-        this.projectResourceClient = new ProjectResourceClient(this.client, baseURI, factory);
-        this.traceResourceClient = new TraceResourceClient(this.client, baseURI);
-        this.spanResourceClient = new SpanResourceClient(this.client, baseURI);
+        this.projectResourceClient = new ProjectResourceClient(client, baseURI, factory);
+        this.traceResourceClient = new TraceResourceClient(client, baseURI);
+        this.spanResourceClient = new SpanResourceClient(client, baseURI);
         this.annotationQueuesResourceClient = new AnnotationQueuesResourceClient(client, baseURI);
         this.idGenerator = idGenerator;
     }
@@ -221,10 +217,6 @@ class FindTraceThreadsResourceTest {
 
     private String getInvalidValue(Field field) {
         return FilterTestUtils.getInvalidValue(field);
-    }
-
-    private static int randomNumber(int minValue, int maxValue) {
-        return PodamUtils.getIntegerInRange(minValue, maxValue);
     }
 
     private void batchCreateSpansAndAssert(List<Span> expectedSpans, String apiKey, String workspaceName) {
@@ -776,7 +768,11 @@ class FindTraceThreadsResourceTest {
                     Arguments.of(false, Source.PLAYGROUND, Source.EXPERIMENT),
                     Arguments.of(true, Source.PLAYGROUND, Source.EXPERIMENT),
                     Arguments.of(false, Source.EXPERIMENT, Source.PLAYGROUND),
-                    Arguments.of(true, Source.EXPERIMENT, Source.PLAYGROUND));
+                    Arguments.of(true, Source.EXPERIMENT, Source.PLAYGROUND),
+                    Arguments.of(false, Source.OPTIMIZATION, Source.PLAYGROUND),
+                    Arguments.of(true, Source.EXPERIMENT, Source.OPTIMIZATION),
+                    Arguments.of(false, Source.SDK, Source.PLAYGROUND),
+                    Arguments.of(true, Source.SDK, Source.PLAYGROUND));
         }
 
         @ParameterizedTest(name = "stream={0}, source={1}")
@@ -1114,23 +1110,21 @@ class FindTraceThreadsResourceTest {
             List<FeedbackScoreItem.FeedbackScoreBatchItemThread> expectedScores = allThreadIds
                     .stream()
                     .filter(threadId -> isExpected(expectedThreadIndices, threadId, allThreadIds))
-                    .flatMap(threadId -> {
-                        return matchingScoreFunction.apply(targetScoreName, targetScoreValue).stream()
-                                .map(item -> item.toBuilder()
-                                        .threadId(threadId.toString())
-                                        .projectName(projectName)
-                                        .build());
-                    }).collect(Collectors.toList());
+                    .flatMap(threadId -> matchingScoreFunction.apply(targetScoreName, targetScoreValue).stream()
+                            .map(item -> item.toBuilder()
+                                    .threadId(threadId.toString())
+                                    .projectName(projectName)
+                                    .build()))
+                    .collect(Collectors.toList());
 
             List<FeedbackScoreItem.FeedbackScoreBatchItemThread> unexpectedScores = allThreadIds.stream()
                     .filter(threadId -> !isExpected(expectedThreadIndices, threadId, allThreadIds))
-                    .flatMap(threadId -> {
-                        return unmatchingScoreFunction.apply(targetScoreName, targetScoreValue).stream()
-                                .map(item -> item.toBuilder()
-                                        .threadId(threadId.toString())
-                                        .projectName(projectName)
-                                        .build());
-                    }).collect(Collectors.toList());
+                    .flatMap(threadId -> unmatchingScoreFunction.apply(targetScoreName, targetScoreValue).stream()
+                            .map(item -> item.toBuilder()
+                                    .threadId(threadId.toString())
+                                    .projectName(projectName)
+                                    .build()))
+                    .collect(Collectors.toList());
 
             List<FeedbackScoreItem.FeedbackScoreBatchItemThread> scoreItems = Stream
                     .concat(expectedScores.stream(), unexpectedScores.stream())
@@ -1457,10 +1451,10 @@ class FindTraceThreadsResourceTest {
 
             List<Trace> allTraces = List.of(
                     createTraceAtTimestamp(projectName, UUID.randomUUID().toString(),
-                            lowerBound.plus(Duration.ofMinutes(5)), "Within bounds"),
-                    createTraceAtTimestamp(projectName, UUID.randomUUID().toString(), baseTime, "Within bounds"),
+                            lowerBound.plus(Duration.ofMinutes(5))),
+                    createTraceAtTimestamp(projectName, UUID.randomUUID().toString(), baseTime),
                     createTraceAtTimestamp(projectName, UUID.randomUUID().toString(),
-                            upperBound.minus(Duration.ofMinutes(5)), "Within bounds"));
+                            upperBound.minus(Duration.ofMinutes(5))));
 
             createAndCloseThreads(allTraces, projectName, apiKey, workspaceName);
 
@@ -1495,13 +1489,11 @@ class FindTraceThreadsResourceTest {
 
             List<Trace> allTraces = List.of(
                     createTraceAtTimestamp(projectName, UUID.randomUUID().toString(),
-                            startTime.plus(Duration.ofMinutes(10)), "Should be included: near start of range"),
-                    createTraceAtTimestamp(projectName, UUID.randomUUID().toString(), withinBoundsTime,
-                            "Should be included: within range"),
+                            startTime.plus(Duration.ofMinutes(10))),
+                    createTraceAtTimestamp(projectName, UUID.randomUUID().toString(), withinBoundsTime),
                     createTraceAtTimestamp(projectName, UUID.randomUUID().toString(),
-                            endTime.minus(Duration.ofMinutes(10)), "Should be included: near end of range"),
-                    createTraceAtTimestamp(projectName, UUID.randomUUID().toString(), outsideBoundsTime,
-                            "Should NOT be included: outside range"));
+                            endTime.minus(Duration.ofMinutes(10))),
+                    createTraceAtTimestamp(projectName, UUID.randomUUID().toString(), outsideBoundsTime));
 
             createAndCloseThreads(allTraces, projectName, apiKey, workspaceName);
 
@@ -1535,14 +1527,14 @@ class FindTraceThreadsResourceTest {
 
             List<Trace> allTraces = List.of(
                     createTraceAtTimestamp(projectName, UUID.randomUUID().toString(),
-                            lowerBound.plus(Duration.ofMinutes(10)), "Within bounds"),
-                    createTraceAtTimestamp(projectName, UUID.randomUUID().toString(), baseTime, "Within bounds"),
+                            lowerBound.plus(Duration.ofMinutes(10))),
+                    createTraceAtTimestamp(projectName, UUID.randomUUID().toString(), baseTime),
                     createTraceAtTimestamp(projectName, UUID.randomUUID().toString(),
-                            upperBound.minus(Duration.ofMinutes(10)), "Within bounds"),
+                            upperBound.minus(Duration.ofMinutes(10))),
                     createTraceAtTimestamp(projectName, UUID.randomUUID().toString(),
-                            lowerBound.minus(Duration.ofMinutes(10)), "Outside bounds (before lower)"),
+                            lowerBound.minus(Duration.ofMinutes(10))),
                     createTraceAtTimestamp(projectName, UUID.randomUUID().toString(),
-                            upperBound.plus(Duration.ofMinutes(10)), "Outside bounds (after upper)"));
+                            upperBound.plus(Duration.ofMinutes(10))));
 
             createAndCloseThreads(allTraces, projectName, apiKey, workspaceName);
 
@@ -1577,10 +1569,10 @@ class FindTraceThreadsResourceTest {
 
             List<Trace> allTraces = List.of(
                     createTraceAtTimestamp(projectName, UUID.randomUUID().toString(),
-                            lowerBound.plus(Duration.ofMinutes(10)), "Within bounds"),
-                    createTraceAtTimestamp(projectName, UUID.randomUUID().toString(), baseTime, "Within bounds"),
+                            lowerBound.plus(Duration.ofMinutes(10))),
+                    createTraceAtTimestamp(projectName, UUID.randomUUID().toString(), baseTime),
                     createTraceAtTimestamp(projectName, UUID.randomUUID().toString(),
-                            lowerBound.minus(Duration.ofMinutes(10)), "Outside bounds (before lower)"));
+                            lowerBound.minus(Duration.ofMinutes(10))));
 
             createAndCloseThreads(allTraces, projectName, apiKey, workspaceName);
 
@@ -1641,7 +1633,7 @@ class FindTraceThreadsResourceTest {
             );
         }
 
-        private Trace createTraceAtTimestamp(String projectName, String threadId, Instant timestamp, String comment) {
+        private Trace createTraceAtTimestamp(String projectName, String threadId, Instant timestamp) {
             return createTrace().toBuilder()
                     .projectName(projectName)
                     .threadId(threadId)
@@ -1750,7 +1742,7 @@ class FindTraceThreadsResourceTest {
                 threadUsage.entrySet().stream()
                         .sorted(Map.Entry.comparingByKey())
                         .forEach(entry -> expectedStats.add(
-                                (ProjectStats.AvgValueStat) ProjectStats.AvgValueStat.builder()
+                                ProjectStats.AvgValueStat.builder()
                                         .name("usage_sum." + entry.getKey())
                                         .value(entry.getValue().doubleValue())
                                         .type(ProjectStats.StatsType.AVG)


### PR DESCRIPTION
## Details

Completes the OPIK-5768 source filter for trace threads — the third leg after traces and spans (PR #6217, now merged). Online evaluation rules now skip non-SDK threads (playground, experiment, optimization), while preserving backward compatibility for pre-existing rows.

- **Source pipeline**: `TraceThreadListener` extracts `trace.source()` into `ThreadTimestamps.firstTraceSource` → `TraceThreadService` passes it through MapStruct mapper → `TraceThreadModel.source` set at creation time.
- **ClickHouse persistence**: Migration 000079 adds `source Enum8(...)` column with DEFAULT `'unknown'`. All 7 DAO SQL templates updated (INSERT + all SELECT-based upserts). Null source binds as `bindNull` (delegates DEFAULT to ClickHouse).
- **Sampler filter**: `TraceThreadOnlineScoringSamplerListener` filters by `Source.isLoggingSource(thread.source())` before processing — non-SDK threads skip evaluator fetch entirely.
- **Backward compat**: Pre-existing rows DEFAULT to `'unknown'` → `Source.fromString("unknown")` returns `Optional.empty()` → null → `Source.isLoggingSource(null)` = true (SDK).

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- OPIK-5768
- Follow-up to #6217

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6 (1M context)
- Scope: full implementation (production + migration + tests)
- Human verification: step-by-step code review, iterative refinement, test execution, DAO SQL audit

## Testing

Exact commands run:
- `mvn compile -DskipTests` — clean compile
- `mvn spotless:check` — formatting
- `mvn test -Dtest="TraceThreadOnlineScoringSamplerListenerTest"` — 8 unit tests green
- `mvn test -Dtest="TraceThreadOnlineScoringSamplerListenerIntegrationTest"` — 5 integration tests green (real ClickHouse + evaluator storage)
- `mvn test -Dtest="FindTraceThreadsResourceTest"` — endpoint-level source filter with SDK added

Scenarios validated:
- SDK + null source threads processed (parameterized unit + integration)
- PLAYGROUND/EXPERIMENT/OPTIMIZATION threads skipped (parameterized unit + integration)
- Mixed batch: SDK thread kept, non-SDK filtered out
- Empty thread list, no evaluators found
- DAO persistence: source written and read back correctly through all SQL templates (verified via full audit of 7 WRITE + 2 READ queries)
- Backward compat: pre-existing rows (DEFAULT 'unknown') treated as SDK
- Endpoint-level: `FindTraceThreadsResourceTest.whenFilterBySource` now includes SDK source

Tests not run:
- `TraceThreadsClosingJobTest` — tests thread closure status, not scoring. Low risk from source filter (doesn't assert on sampling_per_rule). Will monitor in CI.

## Documentation

N/A — no user-facing documentation changes. Thread source filtering follows the same pattern established for traces/spans in #6217.