### PR TITLE
[OPIK-5835] [FE] fix: project home fixes — loading states, theme, selector styling

### DIFF
--- a/apps/opik-frontend/src/hooks/useProjectOnboardingStats.ts
+++ b/apps/opik-frontend/src/hooks/useProjectOnboardingStats.ts
@@ -1,29 +1,31 @@
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import api, {
+  TRACES_KEY,
+  TRACES_REST_ENDPOINT,
   PROJECTS_REST_ENDPOINT,
   OPTIMIZATIONS_KEY,
   AGENT_CONFIGS_KEY,
-  PROJECT_STATISTICS_KEY,
 } from "@/api/api";
 import { ProjectStats } from "@/types/assistant-sidebar";
-import { generateProjectFilters, processFilters } from "@/lib/filters";
 
 function useOnboardingCountQuery(
   key: string,
   endpoint: string,
   enabled: boolean,
+  params?: Record<string, string>,
 ): UseQueryResult<number> {
   return useQuery({
     queryKey: [key, "onboarding-count", endpoint],
     queryFn: async ({ signal }) => {
       const { data } = await api.get(endpoint, {
         signal,
-        params: { size: 1, page: 1 },
+        params: { size: 1, page: 1, ...params },
       });
       return (data.total as number) ?? 0;
     },
     enabled,
     staleTime: 1_000,
+    refetchInterval: 30_000,
   });
 }
 
@@ -40,48 +42,45 @@ export default function useProjectOnboardingStats(
 ): ProjectStats | undefined {
   const enabled = !!projectId;
 
-  const { data: statsData } = useQuery({
-    queryKey: [PROJECT_STATISTICS_KEY, "onboarding-trace-count", projectId],
-    queryFn: async ({ signal }) => {
-      const { data } = await api.get(`${PROJECTS_REST_ENDPOINT}stats`, {
-        signal,
-        params: {
-          size: 1,
-          page: 1,
-          ...processFilters(generateProjectFilters(projectId!)),
-        },
-      });
-      const match = (data.content ?? []).find(
-        (s: { project_id?: string }) => s.project_id === projectId,
-      );
-      return (match?.trace_count as number) ?? 0;
-    },
-    enabled,
-    staleTime: 1_000,
-  });
+  const { data: traceTotal, isLoading: tracesLoading } =
+    useOnboardingCountQuery(TRACES_KEY, TRACES_REST_ENDPOINT, enabled, {
+      project_id: projectId!,
+    });
 
-  const { data: experimentTotal } = useOnboardingCountQuery(
-    "experiments",
-    `${PROJECTS_REST_ENDPOINT}${projectId}/experiments`,
-    enabled,
-  );
+  const { data: experimentTotal, isLoading: experimentsLoading } =
+    useOnboardingCountQuery(
+      "experiments",
+      `${PROJECTS_REST_ENDPOINT}${projectId}/experiments`,
+      enabled,
+    );
 
-  const { data: optimizationTotal } = useOnboardingCountQuery(
-    OPTIMIZATIONS_KEY,
-    `${PROJECTS_REST_ENDPOINT}${projectId}/optimizations`,
-    enabled,
-  );
+  const { data: optimizationTotal, isLoading: optimizationsLoading } =
+    useOnboardingCountQuery(
+      OPTIMIZATIONS_KEY,
+      `${PROJECTS_REST_ENDPOINT}${projectId}/optimizations`,
+      enabled,
+    );
 
-  const { data: blueprintTotal } = useOnboardingCountQuery(
-    AGENT_CONFIGS_KEY,
-    `/v1/private/agent-configs/blueprints/history/projects/${projectId}`,
-    enabled,
-  );
+  const { data: blueprintTotal, isLoading: blueprintsLoading } =
+    useOnboardingCountQuery(
+      AGENT_CONFIGS_KEY,
+      `/v1/private/agent-configs/blueprints/history/projects/${projectId}`,
+      enabled,
+    );
 
   if (!enabled) return undefined;
 
+  if (
+    tracesLoading ||
+    experimentsLoading ||
+    optimizationsLoading ||
+    blueprintsLoading
+  ) {
+    return undefined;
+  }
+
   return {
-    traceCount: statsData ?? 0,
+    traceCount: traceTotal ?? 0,
     experimentCount: experimentTotal ?? 0,
     optimizationCount: optimizationTotal ?? 0,
     blueprintVersionCount: blueprintTotal ?? 0,

--- a/apps/opik-frontend/src/hooks/useProjectOnboardingStats.ts
+++ b/apps/opik-frontend/src/hooks/useProjectOnboardingStats.ts
@@ -9,6 +9,11 @@ import api, {
 import { ProjectStats } from "@/types/assistant-sidebar";
 import { generateVisibilityFilters, processFilters } from "@/lib/filters";
 
+const VISIBILITY_FILTER_PARAMS = processFilters(
+  undefined,
+  generateVisibilityFilters(),
+);
+
 function useOnboardingCountQuery(
   key: string,
   endpoint: string,
@@ -46,7 +51,7 @@ export default function useProjectOnboardingStats(
   const { data: traceTotal, isLoading: tracesLoading } =
     useOnboardingCountQuery(TRACES_KEY, TRACES_REST_ENDPOINT, enabled, {
       project_id: projectId!,
-      ...processFilters(undefined, generateVisibilityFilters()),
+      ...VISIBILITY_FILTER_PARAMS,
     });
 
   const { data: experimentTotal, isLoading: experimentsLoading } =

--- a/apps/opik-frontend/src/hooks/useProjectOnboardingStats.ts
+++ b/apps/opik-frontend/src/hooks/useProjectOnboardingStats.ts
@@ -7,6 +7,7 @@ import api, {
   AGENT_CONFIGS_KEY,
 } from "@/api/api";
 import { ProjectStats } from "@/types/assistant-sidebar";
+import { generateVisibilityFilters, processFilters } from "@/lib/filters";
 
 function useOnboardingCountQuery(
   key: string,
@@ -15,7 +16,7 @@ function useOnboardingCountQuery(
   params?: Record<string, string>,
 ): UseQueryResult<number> {
   return useQuery({
-    queryKey: [key, "onboarding-count", endpoint],
+    queryKey: [key, "onboarding-count", endpoint, params],
     queryFn: async ({ signal }) => {
       const { data } = await api.get(endpoint, {
         signal,
@@ -45,6 +46,7 @@ export default function useProjectOnboardingStats(
   const { data: traceTotal, isLoading: tracesLoading } =
     useOnboardingCountQuery(TRACES_KEY, TRACES_REST_ENDPOINT, enabled, {
       project_id: projectId!,
+      ...processFilters(undefined, generateVisibilityFilters()),
     });
 
   const { data: experimentTotal, isLoading: experimentsLoading } =

--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -16,6 +16,7 @@ import {
   SidebarEventMap,
 } from "@/types/assistant-sidebar";
 import { useActiveWorkspaceName } from "@/store/AppStore";
+import { useTheme } from "@/contexts/theme-provider";
 import { useToast } from "@/ui/use-toast";
 import useWorkspace from "@/plugins/comet/useWorkspace";
 import useAssistantBackend from "@/plugins/comet/useAssistantBackend";
@@ -244,6 +245,7 @@ function useBridgeContext(
   surface: BridgeSurface,
 ): BridgeContext {
   const workspaceName = useActiveWorkspaceName();
+  const { themeMode } = useTheme();
   const workspace = useWorkspace();
 
   const { projectId } = useParams({ strict: false }) as {
@@ -270,7 +272,7 @@ function useBridgeContext(
       projectName,
       baseApiUrl: BASE_API_URL,
       assistantBackendUrl,
-      theme: "light",
+      theme: themeMode,
       surface,
       projectStats,
     }),
@@ -281,6 +283,7 @@ function useBridgeContext(
       resolvedProjectId,
       projectName,
       assistantBackendUrl,
+      themeMode,
       surface,
       projectStats,
     ],

--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
@@ -177,9 +177,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
               <span
                 className={cn(
                   "comet-body-s-accented block w-full truncate text-left hover:underline hover:underline-offset-4",
-                  isOnProjectHome
-                    ? "text-primary underline underline-offset-4"
-                    : "text-foreground",
+                  isOnProjectHome ? "text-primary" : "text-foreground",
                 )}
               >
                 {activeProject.name}


### PR DESCRIPTION
## Details

Follow-up fixes for the Project Home page (OPIK-5835):

- **useProjectOnboardingStats**: return `undefined` while queries are loading so Ollie can distinguish "loading" from "genuinely zero traces" (prevents onboarding flash); simplify trace count to reuse the shared `useOnboardingCountQuery` helper instead of the complex `/projects/stats` endpoint; add `refetchInterval: 30_000` so counts auto-update while the user stays on the page; include `params` in `queryKey` so React Query caches per-project; apply visibility filters so trace count only includes user-visible traces; precompute visibility filter params at module level to avoid `uniqid()` churn and infinite refetches
- **AssistantSidebar bridge**: read `themeMode` from `ThemeProvider` instead of hardcoded `"light"`, so the bridge context reflects the actual theme
- **ProjectSelector**: remove permanent underline from active project name (only hover-underline remains)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5835

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code CLI
- Model(s): Claude Opus 4.6
- Scope: assisted implementation
- Human verification: code review + manual testing

## Testing

- `scripts/dev-runner.sh --lint-fe` — all pass
- Manual: open project with traces → no onboarding flash
- Manual: open project with 0 traces → onboarding view shows after brief loading
- Manual: switch projects → trace count updates (no stale cache)
- Manual: toggle dark mode → bridge `theme` field updates (verify via `window.opikBridge.getContext().theme`)
- Manual: project selector active state shows blue text without underline

## Documentation

N/A