### PR TITLE
[OPIK-5317] [INFRA] fix: use Markdown syntax in create-jira-ticket skill template

### DIFF
--- a/.agents/commands/comet/create-jira-ticket.md
+++ b/.agents/commands/comet/create-jira-ticket.md
@@ -39,15 +39,15 @@ Ask the user to provide details for each section, then format the description us
 ### Description Template
 
 ```
-h2. Description
+## Description
 
 [Brief overview of what needs to be done and why. Explain the context and motivation for this work.]
 
-h2. User Story
+## User Story
 
 As a [type of user], I want to [action/goal] so that I can [benefit/outcome].
 
-h2. User Journey
+## User Journey
 
 [Describe the step-by-step flow of how a user will interact with this feature:]
 1. User navigates to [location]
@@ -56,35 +56,35 @@ h2. User Journey
 4. User sees [result]
 [Continue as needed...]
 
-h2. Requirements
+## Requirements
 
-h3. Functional Requirements
+### Functional Requirements
 
 [List the functional requirements - what the system should DO]
 
-*1. [Requirement Category]*
-* [Specific requirement]
-* [Specific requirement]
+**1. [Requirement Category]**
+- [Specific requirement]
+- [Specific requirement]
 
-*2. [Requirement Category]*
-* [Specific requirement]
-* [Specific requirement]
+**2. [Requirement Category]**
+- [Specific requirement]
+- [Specific requirement]
 
-h3. Non-Functional Requirements
+### Non-Functional Requirements
 
 [List non-functional requirements - performance, security, scalability, etc.]
-* [Requirement]
-* [Requirement]
+- [Requirement]
+- [Requirement]
 
-h2. Acceptance Criteria
+## Acceptance Criteria
 
 [Checklist of criteria that must be met for the ticket to be considered complete]
-* [ ] [Criterion 1]
-* [ ] [Criterion 2]
-* [ ] [Criterion 3]
-* [ ] No lint errors or TypeScript errors (if applicable)
-* [ ] Unit tests added (if applicable)
-* [ ] Documentation updated (if applicable)
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+- [ ] [Criterion 3]
+- [ ] No lint errors or TypeScript errors (if applicable)
+- [ ] Unit tests added (if applicable)
+- [ ] Documentation updated (if applicable)
 ```
 
 ## Example Conversation Flow
@@ -165,6 +165,6 @@ Never display the ticket key as plain text — always wrap it in a markdown link
 ## Notes
 
 - The project key is always `OPIK`
-- Description uses Jira wiki markup (h2. for headers, * for bullets, *bold* for bold)
-- Acceptance criteria should be checkboxes using `* [ ]` syntax
+- Description uses Markdown format (## for headers, - for bullets, **bold** for bold). The Jira MCP tool converts Markdown to Jira wiki markup automatically.
+- Acceptance criteria should be checkboxes using `- [ ]` syntax
 - Always include standard acceptance criteria like "No lint errors" and "Tests added" where applicable


### PR DESCRIPTION
## Details

<img width="1920" height="2814" alt="image" src="https://github.com/user-attachments/assets/e0b6c04d-5e5a-4f88-aa85-fd04a9f083f6" />

Updated the `/comet:create-jira-ticket` skill template to use Markdown syntax (`##`, `###`, `**bold**`, `- bullets`) instead of Jira wiki markup (`h2.`, `h3.`, `*bold*`, `* bullets`).
The Jira MCP tool accepts Markdown and converts it to wiki markup automatically — using wiki markup in the template caused double-conversion, resulting in headings rendering as raw text (`h2. Description` instead of a heading).

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-5317

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: full implementation
  - Human verification: verified by creating OPIK-5899 via the skill and confirming headings render correctly

## Testing

- Created [OPIK-5899](https://comet-ml.atlassian.net/browse/OPIK-5899) via `/comet:create-jira-ticket` — headings render correctly in Jira
- No code changes, only a Markdown template file update — no build/test commands applicable

## Documentation

N/A — internal skill template only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OPIK-5899]: https://comet-ml.atlassian.net/browse/OPIK-5899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ