### PR TITLE
[OPIK-5901] [CI] ci: add guardrails backend to E2E test path triggers

### DIFF
--- a/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
@@ -10,6 +10,7 @@ on:
         paths:
           - 'sdks/python/**'
           - 'apps/opik-backend/**'
+          - 'apps/opik-guardrails-backend/**'
           - '.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml'
     push:
         branches:
@@ -17,6 +18,7 @@ on:
         paths:
           - 'sdks/python/**'
           - 'apps/opik-backend/**'
+          - 'apps/opik-guardrails-backend/**'
           - '.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml'
 
 concurrency:

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -10,6 +10,7 @@ on:
         paths:
           - 'sdks/python/**'
           - 'apps/opik-backend/**'
+          - 'apps/opik-guardrails-backend/**'
           - '.github/workflows/python_sdk_e2e_tests.yml'
     push:
         branches:
@@ -17,6 +18,7 @@ on:
         paths:
           - 'sdks/python/**'
           - 'apps/opik-backend/**'
+          - 'apps/opik-guardrails-backend/**'
           - '.github/workflows/python_sdk_e2e_tests.yml'
 
 concurrency:

--- a/.github/workflows/typescript_sdk_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_e2e_tests.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'sdks/typescript/**'
       - 'apps/opik-backend/**'
+      - 'apps/opik-guardrails-backend/**'
       - '.github/workflows/typescript_sdk_e2e_tests.yml'
   push:
     branches:
@@ -13,6 +14,7 @@ on:
     paths:
       - 'sdks/typescript/**'
       - 'apps/opik-backend/**'
+      - 'apps/opik-guardrails-backend/**'
       - '.github/workflows/typescript_sdk_e2e_tests.yml'
 
 concurrency:


### PR DESCRIPTION
## Details

<img width="1920" height="2106" alt="image" src="https://github.com/user-attachments/assets/cfb1b9b5-0561-4af4-916c-8bd9566d7354" />

Changes to `apps/opik-guardrails-backend/` (Dockerfile, Python code, configs) previously triggered zero CI workflows. This adds `apps/opik-guardrails-backend/**` to the path triggers of 3 existing E2E test workflows so that guardrails backend changes are validated pre-merge.

Discovered during review of PR #6266 — a Dockerfile fix that had no automated test coverage.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5901

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review

## Testing

CI-only change — no runtime code modified. Verified by inspecting the YAML diffs to confirm the new path entries are correctly placed under both `on.pull_request.paths` and `on.push.paths` in all 3 workflow files.

## Documentation

N/A