### PR TITLE
[NA] [BE] fix: materialize missing skip indexes on experiment_items and optimizations

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000079_materialize_missing_skip_indexes.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000079_materialize_missing_skip_indexes.sql
@@ -1,0 +1,16 @@
+--liquibase formatted sql
+--changeset thiagohora:000077_materialize_missing_skip_indexes
+--comment: Add and materialize missing skip indexes that were not materialized in previous migrations
+
+-- Add missing index from 000057 (project_id was added to experiment_items without an index)
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_items ON CLUSTER '{cluster}'
+    ADD INDEX IF NOT EXISTS idx_experiment_items_project_id project_id TYPE minmax GRANULARITY 1;
+
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_items ON CLUSTER '{cluster}'
+    MATERIALIZE INDEX idx_experiment_items_project_id;
+
+-- Materialize index from 000075 (idx_optimizations_project_id was added without materialization)
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.optimizations ON CLUSTER '{cluster}'
+    MATERIALIZE INDEX idx_optimizations_project_id;
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_items ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_experiment_items_project_id;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000080_materialize_missing_skip_indexes.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000080_materialize_missing_skip_indexes.sql
@@ -14,3 +14,4 @@ ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.optimizations ON CLUSTER '{cluster}'
     MATERIALIZE INDEX idx_optimizations_project_id;
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_items ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_experiment_items_project_id;
+

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000080_materialize_missing_skip_indexes.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000080_materialize_missing_skip_indexes.sql
@@ -1,5 +1,5 @@
 --liquibase formatted sql
---changeset thiagohora:000077_materialize_missing_skip_indexes
+--changeset thiagohora:000080_materialize_missing_skip_indexes
 --comment: Add and materialize missing skip indexes that were not materialized in previous migrations
 
 -- Add missing index from 000057 (project_id was added to experiment_items without an index)


### PR DESCRIPTION
## Details

Adds migration 000079 which backfills two skip indexes that were previously missing or never materialized:

- `idx_experiment_items_project_id` — `project_id` was added to `experiment_items` in migration 000057 without a skip index. Adds and materializes it.
- `idx_optimizations_project_id` — added in migration 000075 without a `MATERIALIZE INDEX` call. Materializes it.

Both tables are small enough to apply safely alongside a deploy.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: migration file generated and reviewed by human
- Human verification: yes

## Testing

Validated by auditing all `ADD INDEX` statements across migrations 000057–000082 and confirming each has a corresponding `MATERIALIZE INDEX` (or is on a brand-new empty table).

Apply order: this migration should be applied first, before 000080–000082.
Monitor completion: `SELECT * FROM system.mutations WHERE is_done = 0`.

## Documentation

No documentation changes required.