### PR TITLE
[NA] [SDK] feat: add python_executable to runner checklist

### DIFF
--- a/sdks/python/src/opik/runner/snapshot.py
+++ b/sdks/python/src/opik/runner/snapshot.py
@@ -4,6 +4,7 @@ import logging
 import os
 import platform
 import re
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
@@ -70,6 +71,7 @@ def build_checklist(
         "runner_type": runner_type,
         "command": " ".join(command) if command else None,
         "platform": platform.system().lower(),
+        "python_executable": sys.executable,
         "file_tree": file_tree,
         "instrumentation": {
             "tracing": any(_matches_any(line, _TRACING_PATTERNS) for line in matches),


### PR DESCRIPTION
## Details
Include `sys.executable` as `python_executable` in the runner checklist payload sent on connect. This allows Ollie to use the exact Python interpreter path for `pip` commands instead of bare `pip`, which can resolve to a different interpreter than the one running `opik connect`.

Companion to comet-ml/ollie-assist#191.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full implementation
  - Human verification: Reviewed by Boris Feld

## Testing
- Run `opik connect` and verify the checklist includes `python_executable` pointing to the correct interpreter
- Older ollie-assist versions ignore the new field (it's optional in the Checklist model)

## Documentation
No documentation changes needed.