### PR TITLE
[NA] [BE][FE] chore: sync provider model definitions

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
@@ -340,6 +340,7 @@ public enum OpenRouterModelName implements StructuredOutputSupported {
     OPENGVLAB_INTERNVL3_78B("opengvlab/internvl3-78b"),
     OPENROUTER_AUTO("openrouter/auto"),
     OPENROUTER_BODYBUILDER("openrouter/bodybuilder"),
+    OPENROUTER_ELEPHANT_ALPHA("openrouter/elephant-alpha"),
     OPENROUTER_FREE("openrouter/free"),
     OPENROUTER_HEALER_ALPHA("openrouter/healer-alpha"),
     OPENROUTER_HUNTER_ALPHA("openrouter/hunter-alpha"),

--- a/apps/opik-backend/src/main/resources/llm-models-default.yaml
+++ b/apps/opik-backend/src/main/resources/llm-models-default.yaml
@@ -67,6 +67,8 @@ openai:
     structuredOutput: true
   - id: "gpt-5.4"
     structuredOutput: true
+  - id: "gpt-5.4-mini"
+  - id: "gpt-5.4-nano"
   - id: "gpt-5.4-pro"
   - id: "gpt-image-1"
   - id: "gpt-image-1-mini"
@@ -103,19 +105,25 @@ openai:
   - id: "o4-mini-deep-research"
     structuredOutput: true
     reasoning: true
-
 anthropic:
   - id: "claude-3-7-sonnet-20250219"
   - id: "claude-haiku-4-5-20251001"
+    structuredOutput: true
   - id: "claude-opus-4-1-20250805"
+    structuredOutput: true
   - id: "claude-opus-4-20250514"
+    structuredOutput: true
   - id: "claude-opus-4-5-20251101"
+    structuredOutput: true
   - id: "claude-opus-4-6"
+    structuredOutput: true
   - id: "claude-sonnet-4-20250514"
+    structuredOutput: true
   - id: "claude-sonnet-4-5"
   - id: "claude-sonnet-4-5-20250929"
+    structuredOutput: true
   - id: "claude-sonnet-4-6"
-
+    structuredOutput: true
 gemini:
   - id: "aqa"
   - id: "gemini-1.0-pro"
@@ -148,9 +156,10 @@ gemini:
   - id: "gemini-3.1-pro-preview"
     structuredOutput: true
   - id: "gemini-pro-vision"
+  - id: "lyria-3-clip-preview"
+  - id: "lyria-3-pro-preview"
   - id: "nano-banana-pro-preview"
   - id: "text-embedding-004"
-
 vertex-ai:
   - id: "gemini-2.0-flash-001"
     qualifiedName: "vertex_ai/gemini-2.0-flash-001"
@@ -187,7 +196,6 @@ vertex-ai:
   - id: "gemini-3.1-pro-preview"
     qualifiedName: "vertex_ai/gemini-3.1-pro-preview"
     structuredOutput: true
-
 openrouter:
   - id: "ai21/jamba-large-1.7"
   - id: "ai21/jamba-mini-1.7"
@@ -223,6 +231,7 @@ openrouter:
   - id: "anthropic/claude-opus-4.1"
   - id: "anthropic/claude-opus-4.5"
   - id: "anthropic/claude-opus-4.6"
+  - id: "anthropic/claude-opus-4.6-fast"
   - id: "anthropic/claude-sonnet-4"
   - id: "anthropic/claude-sonnet-4.5"
   - id: "anthropic/claude-sonnet-4.6"
@@ -231,6 +240,7 @@ openrouter:
   - id: "arcee-ai/maestro-reasoning"
   - id: "arcee-ai/spotlight"
   - id: "arcee-ai/trinity-large-preview:free"
+  - id: "arcee-ai/trinity-large-thinking"
   - id: "arcee-ai/trinity-mini"
   - id: "arcee-ai/trinity-mini:free"
   - id: "arcee-ai/virtuoso-large"
@@ -249,21 +259,28 @@ openrouter:
   - id: "bytedance-seed/seed-2.0-lite"
   - id: "bytedance-seed/seed-2.0-mini"
   - id: "bytedance/ui-tars-1.5-7b"
+  - id: "cognitivecomputations/dolphin-mistral-24b-venice-edition:free"
   - id: "cohere/command-a"
+    structuredOutput: true
   - id: "cohere/command-r-08-2024"
+    structuredOutput: true
   - id: "cohere/command-r-plus-08-2024"
+    structuredOutput: true
   - id: "cohere/command-r7b-12-2024"
+    structuredOutput: true
   - id: "deepcogito/cogito-v2-preview-deepseek-671b"
   - id: "deepcogito/cogito-v2-preview-llama-109b-moe"
   - id: "deepcogito/cogito-v2-preview-llama-405b"
   - id: "deepcogito/cogito-v2-preview-llama-70b"
   - id: "deepcogito/cogito-v2.1-671b"
   - id: "deepseek/deepseek-chat"
+    structuredOutput: true
   - id: "deepseek/deepseek-chat-v3-0324"
   - id: "deepseek/deepseek-chat-v3-0324:free"
   - id: "deepseek/deepseek-chat-v3.1"
   - id: "deepseek/deepseek-prover-v2"
   - id: "deepseek/deepseek-r1"
+    structuredOutput: true
     reasoning: true
   - id: "deepseek/deepseek-r1-0528"
     reasoning: true
@@ -291,23 +308,30 @@ openrouter:
   - id: "eleutherai/llemma_7b"
   - id: "essentialai/rnj-1-instruct"
   - id: "google/gemini-2.0-flash-001"
+    structuredOutput: true
   - id: "google/gemini-2.0-flash-exp:free"
+    structuredOutput: true
   - id: "google/gemini-2.0-flash-lite-001"
   - id: "google/gemini-2.5-flash"
+    structuredOutput: true
   - id: "google/gemini-2.5-flash-image"
   - id: "google/gemini-2.5-flash-image-preview"
   - id: "google/gemini-2.5-flash-lite"
   - id: "google/gemini-2.5-flash-lite-preview-09-2025"
   - id: "google/gemini-2.5-flash-preview-09-2025"
   - id: "google/gemini-2.5-pro"
+    structuredOutput: true
   - id: "google/gemini-2.5-pro-preview"
   - id: "google/gemini-2.5-pro-preview-05-06"
   - id: "google/gemini-3-flash-preview"
+    structuredOutput: true
   - id: "google/gemini-3-pro-image-preview"
   - id: "google/gemini-3-pro-preview"
+    structuredOutput: true
   - id: "google/gemini-3.1-flash-image-preview"
   - id: "google/gemini-3.1-flash-lite-preview"
   - id: "google/gemini-3.1-pro-preview"
+    structuredOutput: true
   - id: "google/gemini-3.1-pro-preview-customtools"
   - id: "google/gemma-2-27b-it"
   - id: "google/gemma-2-9b-it"
@@ -320,7 +344,14 @@ openrouter:
   - id: "google/gemma-3n-e2b-it:free"
   - id: "google/gemma-3n-e4b-it"
   - id: "google/gemma-3n-e4b-it:free"
+  - id: "google/gemma-4-26b-a4b-it"
+  - id: "google/gemma-4-26b-a4b-it:free"
+  - id: "google/gemma-4-31b-it"
+  - id: "google/gemma-4-31b-it:free"
+  - id: "google/lyria-3-clip-preview"
+  - id: "google/lyria-3-pro-preview"
   - id: "gryphe/mythomax-l2-13b"
+    structuredOutput: true
   - id: "ibm-granite/granite-4.0-h-micro"
   - id: "inception/mercury"
   - id: "inception/mercury-2"
@@ -328,6 +359,7 @@ openrouter:
   - id: "inflection/inflection-3-pi"
   - id: "inflection/inflection-3-productivity"
   - id: "kwaipilot/kat-coder-pro"
+  - id: "kwaipilot/kat-coder-pro-v2"
   - id: "kwaipilot/kat-coder-pro:free"
   - id: "liquid/lfm-2-24b-a2b"
   - id: "liquid/lfm-2.2-6b"
@@ -338,17 +370,26 @@ openrouter:
   - id: "meituan/longcat-flash-chat"
   - id: "meituan/longcat-flash-chat:free"
   - id: "meta-llama/llama-3-70b-instruct"
+    structuredOutput: true
   - id: "meta-llama/llama-3-8b-instruct"
+    structuredOutput: true
   - id: "meta-llama/llama-3.1-405b"
   - id: "meta-llama/llama-3.1-405b-instruct"
+    structuredOutput: true
   - id: "meta-llama/llama-3.1-70b-instruct"
+    structuredOutput: true
   - id: "meta-llama/llama-3.1-8b-instruct"
+    structuredOutput: true
   - id: "meta-llama/llama-3.2-11b-vision-instruct"
+    structuredOutput: true
   - id: "meta-llama/llama-3.2-1b-instruct"
   - id: "meta-llama/llama-3.2-3b-instruct"
+    structuredOutput: true
   - id: "meta-llama/llama-3.2-3b-instruct:free"
   - id: "meta-llama/llama-3.2-90b-vision-instruct"
+    structuredOutput: true
   - id: "meta-llama/llama-3.3-70b-instruct"
+    structuredOutput: true
   - id: "meta-llama/llama-3.3-70b-instruct:free"
   - id: "meta-llama/llama-4-maverick"
   - id: "meta-llama/llama-4-scout"
@@ -372,7 +413,9 @@ openrouter:
   - id: "minimax/minimax-m2.1"
   - id: "minimax/minimax-m2.5"
   - id: "minimax/minimax-m2.5:free"
+  - id: "minimax/minimax-m2.7"
   - id: "mistralai/codestral-2501"
+    structuredOutput: true
   - id: "mistralai/codestral-2508"
   - id: "mistralai/devstral-2512"
   - id: "mistralai/devstral-medium"
@@ -384,8 +427,10 @@ openrouter:
   - id: "mistralai/magistral-small-2506"
   - id: "mistralai/ministral-14b-2512"
   - id: "mistralai/ministral-3b"
+    structuredOutput: true
   - id: "mistralai/ministral-3b-2512"
   - id: "mistralai/ministral-8b"
+    structuredOutput: true
   - id: "mistralai/ministral-8b-2512"
   - id: "mistralai/mistral-7b-instruct"
   - id: "mistralai/mistral-7b-instruct-v0.1"
@@ -393,27 +438,40 @@ openrouter:
   - id: "mistralai/mistral-7b-instruct-v0.3"
   - id: "mistralai/mistral-7b-instruct:free"
   - id: "mistralai/mistral-large"
+    structuredOutput: true
   - id: "mistralai/mistral-large-2407"
+    structuredOutput: true
   - id: "mistralai/mistral-large-2411"
+    structuredOutput: true
   - id: "mistralai/mistral-large-2512"
   - id: "mistralai/mistral-medium-3"
   - id: "mistralai/mistral-medium-3.1"
   - id: "mistralai/mistral-nemo"
+    structuredOutput: true
   - id: "mistralai/mistral-nemo:free"
   - id: "mistralai/mistral-saba"
+    structuredOutput: true
   - id: "mistralai/mistral-small"
+    structuredOutput: true
   - id: "mistralai/mistral-small-24b-instruct-2501"
+    structuredOutput: true
   - id: "mistralai/mistral-small-24b-instruct-2501:free"
+  - id: "mistralai/mistral-small-2603"
   - id: "mistralai/mistral-small-3.1-24b-instruct"
   - id: "mistralai/mistral-small-3.1-24b-instruct:free"
   - id: "mistralai/mistral-small-3.2-24b-instruct"
   - id: "mistralai/mistral-small-3.2-24b-instruct:free"
   - id: "mistralai/mistral-small-creative"
   - id: "mistralai/mistral-tiny"
+    structuredOutput: true
   - id: "mistralai/mixtral-8x22b-instruct"
+    structuredOutput: true
   - id: "mistralai/mixtral-8x7b-instruct"
+    structuredOutput: true
   - id: "mistralai/pixtral-12b"
+    structuredOutput: true
   - id: "mistralai/pixtral-large-2411"
+    structuredOutput: true
   - id: "mistralai/voxtral-small-24b-2507"
   - id: "moonshotai/kimi-dev-72b"
   - id: "moonshotai/kimi-k2"
@@ -441,6 +499,7 @@ openrouter:
   - id: "nvidia/llama-3.3-nemotron-super-49b-v1.5"
   - id: "nvidia/nemotron-3-nano-30b-a3b"
   - id: "nvidia/nemotron-3-nano-30b-a3b:free"
+  - id: "nvidia/nemotron-3-super-120b-a12b"
   - id: "nvidia/nemotron-3-super-120b-a12b:free"
   - id: "nvidia/nemotron-nano-12b-v2-vl"
   - id: "nvidia/nemotron-nano-12b-v2-vl:free"
@@ -458,18 +517,28 @@ openrouter:
   - id: "openai/gpt-4-turbo"
   - id: "openai/gpt-4-turbo-preview"
   - id: "openai/gpt-4.1"
+    structuredOutput: true
   - id: "openai/gpt-4.1-mini"
+    structuredOutput: true
   - id: "openai/gpt-4.1-nano"
+    structuredOutput: true
   - id: "openai/gpt-4o"
+    structuredOutput: true
   - id: "openai/gpt-4o-2024-05-13"
+    structuredOutput: true
   - id: "openai/gpt-4o-2024-08-06"
+    structuredOutput: true
   - id: "openai/gpt-4o-2024-11-20"
+    structuredOutput: true
   - id: "openai/gpt-4o-audio-preview"
   - id: "openai/gpt-4o-mini"
+    structuredOutput: true
   - id: "openai/gpt-4o-mini-2024-07-18"
+    structuredOutput: true
   - id: "openai/gpt-4o-mini-search-preview"
   - id: "openai/gpt-4o-search-preview"
   - id: "openai/gpt-4o:extended"
+    structuredOutput: true
   - id: "openai/gpt-5"
   - id: "openai/gpt-5-chat"
   - id: "openai/gpt-5-codex"
@@ -484,23 +553,30 @@ openrouter:
   - id: "openai/gpt-5.1-codex-max"
   - id: "openai/gpt-5.1-codex-mini"
   - id: "openai/gpt-5.2"
+    structuredOutput: true
   - id: "openai/gpt-5.2-chat"
   - id: "openai/gpt-5.2-chat-latest"
+    structuredOutput: true
   - id: "openai/gpt-5.2-codex"
   - id: "openai/gpt-5.2-pro"
   - id: "openai/gpt-5.3-chat"
   - id: "openai/gpt-5.3-codex"
   - id: "openai/gpt-5.4"
+  - id: "openai/gpt-5.4-mini"
+  - id: "openai/gpt-5.4-nano"
   - id: "openai/gpt-5.4-pro"
   - id: "openai/gpt-audio"
   - id: "openai/gpt-audio-mini"
   - id: "openai/gpt-oss-120b"
+    structuredOutput: true
   - id: "openai/gpt-oss-120b:exacto"
   - id: "openai/gpt-oss-120b:free"
   - id: "openai/gpt-oss-20b"
+    structuredOutput: true
   - id: "openai/gpt-oss-20b:free"
   - id: "openai/gpt-oss-safeguard-20b"
   - id: "openai/o1"
+    structuredOutput: true
     reasoning: true
   - id: "openai/o1-pro"
     reasoning: true
@@ -509,8 +585,10 @@ openrouter:
   - id: "openai/o3-deep-research"
     reasoning: true
   - id: "openai/o3-mini"
+    structuredOutput: true
     reasoning: true
   - id: "openai/o3-mini-high"
+    structuredOutput: true
     reasoning: true
   - id: "openai/o3-pro"
     reasoning: true
@@ -522,8 +600,11 @@ openrouter:
     reasoning: true
   - id: "opengvlab/internvl3-78b"
   - id: "openrouter/auto"
+    structuredOutput: true
   - id: "openrouter/bodybuilder"
+  - id: "openrouter/elephant-alpha"
   - id: "openrouter/free"
+    structuredOutput: true
   - id: "openrouter/healer-alpha"
   - id: "openrouter/hunter-alpha"
   - id: "perplexity/sonar"
@@ -534,9 +615,11 @@ openrouter:
   - id: "perplexity/sonar-reasoning-pro"
   - id: "prime-intellect/intellect-3"
   - id: "qwen/qwen-2.5-72b-instruct"
+    structuredOutput: true
   - id: "qwen/qwen-2.5-72b-instruct:free"
   - id: "qwen/qwen-2.5-7b-instruct"
   - id: "qwen/qwen-2.5-coder-32b-instruct"
+    structuredOutput: true
   - id: "qwen/qwen-2.5-coder-32b-instruct:free"
   - id: "qwen/qwen-2.5-vl-7b-instruct"
   - id: "qwen/qwen-max"
@@ -595,9 +678,16 @@ openrouter:
   - id: "qwen/qwen3.5-9b"
   - id: "qwen/qwen3.5-flash-02-23"
   - id: "qwen/qwen3.5-plus-02-15"
+  - id: "qwen/qwen3.6-plus"
+  - id: "qwen/qwen3.6-plus-preview:free"
+  - id: "qwen/qwen3.6-plus:free"
   - id: "qwen/qwq-32b"
+    structuredOutput: true
     reasoning: true
   - id: "raifle/sorcererlm-8x22b"
+  - id: "reka/reka-edge"
+  - id: "rekaai/reka-edge"
+  - id: "rekaai/reka-flash-3"
   - id: "relace/relace-apply-3"
   - id: "relace/relace-search"
   - id: "sao10k/l3-euryale-70b"
@@ -636,10 +726,14 @@ openrouter:
   - id: "x-ai/grok-4-fast"
   - id: "x-ai/grok-4.1-fast"
   - id: "x-ai/grok-4.1-fast:free"
+  - id: "x-ai/grok-4.20"
   - id: "x-ai/grok-4.20-beta"
+  - id: "x-ai/grok-4.20-multi-agent"
   - id: "x-ai/grok-4.20-multi-agent-beta"
   - id: "x-ai/grok-code-fast-1"
   - id: "xiaomi/mimo-v2-flash"
+  - id: "xiaomi/mimo-v2-omni"
+  - id: "xiaomi/mimo-v2-pro"
   - id: "z-ai/glm-4-32b"
   - id: "z-ai/glm-4.5"
   - id: "z-ai/glm-4.5-air"
@@ -652,3 +746,5 @@ openrouter:
   - id: "z-ai/glm-4.7-flash"
   - id: "z-ai/glm-5"
   - id: "z-ai/glm-5-turbo"
+  - id: "z-ai/glm-5.1"
+  - id: "z-ai/glm-5v-turbo"

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryTest.java
@@ -72,7 +72,11 @@ class LlmProviderFactoryTest {
         EncryptionUtils.setConfig(config);
         llmProviderClientConfig = config.getLlmProviderClient();
         opikConfiguration = config;
-        registryService = new LlmModelRegistryService(config.getLlmModelRegistry());
+        // Use a curated test registry so tests are not coupled to the
+        // auto-synced llm-models-default.yaml (whose entries can flip over time).
+        var registryConfig = config.getLlmModelRegistry();
+        registryConfig.setDefaultResource("llm-models-test.yaml");
+        registryService = new LlmModelRegistryService(registryConfig);
     }
 
     private OpikConfiguration createMockConfigWithFreeModel(boolean enabled, String actualModel,
@@ -450,7 +454,7 @@ class LlmProviderFactoryTest {
         var mockConfig = createMockConfigWithFreeModel(false, "gpt-4o-mini", "openai");
         var llmProviderFactory = new LlmProviderFactoryImpl(llmProviderApiKeyService, mockConfig, registryService);
 
-        // claude-sonnet-4-6 has no structuredOutput (defaults to false) in the default YAML
+        // Model from test file with no structuredOutput (defaults to false)
         var strategy = llmProviderFactory.getStructuredOutputStrategy("claude-sonnet-4-6");
 
         assertThat(strategy).isInstanceOf(

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryTest.java
@@ -5,6 +5,8 @@ import com.comet.opik.api.ProviderApiKey;
 import com.comet.opik.domain.LlmProviderApiKeyService;
 import com.comet.opik.domain.llm.LlmProviderFactory;
 import com.comet.opik.domain.llm.LlmProviderService;
+import com.comet.opik.domain.llm.structuredoutput.InstructionStrategy;
+import com.comet.opik.domain.llm.structuredoutput.ToolCallingStrategy;
 import com.comet.opik.infrastructure.EncryptionUtils;
 import com.comet.opik.infrastructure.FreeModelConfig;
 import com.comet.opik.infrastructure.LlmProviderClientConfig;
@@ -33,9 +35,10 @@ import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.Validators;
 import jakarta.validation.Validator;
 import jakarta.ws.rs.BadRequestException;
-import lombok.SneakyThrows;
 import org.apache.commons.lang3.EnumUtils;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -57,7 +60,6 @@ import static org.mockito.Mockito.when;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LlmProviderFactoryTest {
     private LlmProviderClientConfig llmProviderClientConfig;
-    private OpikConfiguration opikConfiguration;
     private LlmModelRegistryService registryService;
 
     private static final ObjectMapper objectMapper = Jackson.newObjectMapper();
@@ -71,7 +73,6 @@ class LlmProviderFactoryTest {
                 "src/test/resources/config-test.yml");
         EncryptionUtils.setConfig(config);
         llmProviderClientConfig = config.getLlmProviderClient();
-        opikConfiguration = config;
         // Use a curated test registry so tests are not coupled to the
         // auto-synced llm-models-default.yaml (whose entries can flip over time).
         var registryConfig = config.getLlmModelRegistry();
@@ -79,8 +80,7 @@ class LlmProviderFactoryTest {
         registryService = new LlmModelRegistryService(registryConfig);
     }
 
-    private OpikConfiguration createMockConfigWithFreeModel(boolean enabled, String actualModel,
-            String spanProvider) {
+    private OpikConfiguration createMockConfigWithFreeModel(boolean enabled, String actualModel, String spanProvider) {
         OpikConfiguration mockConfig = mock(OpikConfiguration.class);
         FreeModelConfig freeModelConfig = new FreeModelConfig();
         freeModelConfig.setEnabled(enabled);
@@ -92,10 +92,9 @@ class LlmProviderFactoryTest {
         return mockConfig;
     }
 
-    @SneakyThrows
     @ParameterizedTest
     @MethodSource
-    void testGetService(String model, LlmProvider llmProvider, String providerClass) {
+    void testGetService(String model, LlmProvider llmProvider, String providerClass) throws IOException {
         // setup
         LlmProviderApiKeyService llmProviderApiKeyService = mock(LlmProviderApiKeyService.class);
         String workspaceId = UUID.randomUUID().toString();
@@ -162,7 +161,6 @@ class LlmProviderFactoryTest {
      * Comprehensive test for custom LLM provider model matching.
      * Tests both the legacy format (provider_name = null) and new format (provider_name set).
      */
-    @SneakyThrows
     @ParameterizedTest(name = "{0}")
     @MethodSource
     void testCustomLlmProviderMatching_shouldMatch(
@@ -203,7 +201,6 @@ class LlmProviderFactoryTest {
         assertThat(actual).isNotNull();
     }
 
-    @SneakyThrows
     @ParameterizedTest(name = "{0}")
     @MethodSource
     void testCustomLlmProviderMatching_shouldNotMatch(
@@ -338,9 +335,8 @@ class LlmProviderFactoryTest {
 
     // ========== OPIK_DEFAULT Provider Tests ==========
 
-    @SneakyThrows
-    @org.junit.jupiter.api.Test
-    @org.junit.jupiter.api.DisplayName("getLlmProvider returns OPIK_FREE when model matches and provider is enabled")
+    @Test
+    @DisplayName("getLlmProvider returns OPIK_FREE when model matches and provider is enabled")
     void testGetLlmProvider_returnsOpikFree_whenModelMatchesAndEnabled() {
         // setup
         LlmProviderApiKeyService llmProviderApiKeyService = mock(LlmProviderApiKeyService.class);
@@ -356,9 +352,8 @@ class LlmProviderFactoryTest {
         assertThat(result).isEqualTo(LlmProvider.OPIK_FREE);
     }
 
-    @SneakyThrows
-    @org.junit.jupiter.api.Test
-    @org.junit.jupiter.api.DisplayName("getLlmProvider throws exception when model matches but provider is disabled")
+    @Test
+    @DisplayName("getLlmProvider throws exception when model matches but provider is disabled")
     void testGetLlmProvider_throwsException_whenModelMatchesButDisabled() {
         // setup
         LlmProviderApiKeyService llmProviderApiKeyService = mock(LlmProviderApiKeyService.class);
@@ -373,9 +368,8 @@ class LlmProviderFactoryTest {
                 .hasMessageContaining("not supported");
     }
 
-    @SneakyThrows
-    @org.junit.jupiter.api.Test
-    @org.junit.jupiter.api.DisplayName("getResolvedModelInfo returns actual model and provider for OPIK_FREE")
+    @Test
+    @DisplayName("getResolvedModelInfo returns actual model and provider for OPIK_FREE")
     void testGetResolvedModelInfo_returnsActualModelAndProvider_forOpikFree() {
         // setup
         LlmProviderApiKeyService llmProviderApiKeyService = mock(LlmProviderApiKeyService.class);
@@ -395,9 +389,8 @@ class LlmProviderFactoryTest {
         assertThat(result.provider()).isEqualTo(spanProvider);
     }
 
-    @SneakyThrows
-    @org.junit.jupiter.api.Test
-    @org.junit.jupiter.api.DisplayName("getResolvedModelInfo returns original model and provider for non-OPIK_FREE")
+    @Test
+    @DisplayName("getResolvedModelInfo returns original model and provider for non-OPIK_FREE")
     void testGetResolvedModelInfo_returnsOriginalModelAndProvider_forOtherProviders() {
         // setup
         LlmProviderApiKeyService llmProviderApiKeyService = mock(LlmProviderApiKeyService.class);
@@ -415,9 +408,8 @@ class LlmProviderFactoryTest {
         assertThat(result.provider()).isEqualTo(LlmProvider.OPEN_AI.getValue());
     }
 
-    @SneakyThrows
-    @org.junit.jupiter.api.Test
-    @org.junit.jupiter.api.DisplayName("getLlmProvider returns OPEN_ROUTER for openrouter route slugs")
+    @Test
+    @DisplayName("getLlmProvider returns OPEN_ROUTER for openrouter route slugs")
     void testGetLlmProvider_returnsOpenRouter_forOpenRouterRouteSlug() {
         // setup
         LlmProviderApiKeyService llmProviderApiKeyService = mock(LlmProviderApiKeyService.class);
@@ -433,8 +425,8 @@ class LlmProviderFactoryTest {
 
     // ========== Structured Output Strategy Tests ==========
 
-    @org.junit.jupiter.api.Test
-    @org.junit.jupiter.api.DisplayName("getStructuredOutputStrategy returns ToolCallingStrategy for registry model with structuredOutput=true")
+    @Test
+    @DisplayName("getStructuredOutputStrategy returns ToolCallingStrategy for registry model with structuredOutput=true")
     void testGetStructuredOutputStrategy_returnsToolCalling_whenRegistryModelSupportsIt() {
         LlmProviderApiKeyService llmProviderApiKeyService = mock(LlmProviderApiKeyService.class);
         var mockConfig = createMockConfigWithFreeModel(false, "gpt-4o-mini", "openai");
@@ -443,12 +435,11 @@ class LlmProviderFactoryTest {
         // gpt-4o has structuredOutput: true in the default YAML
         var strategy = llmProviderFactory.getStructuredOutputStrategy("gpt-4o");
 
-        assertThat(strategy).isInstanceOf(
-                com.comet.opik.domain.llm.structuredoutput.ToolCallingStrategy.class);
+        assertThat(strategy).isInstanceOf(ToolCallingStrategy.class);
     }
 
-    @org.junit.jupiter.api.Test
-    @org.junit.jupiter.api.DisplayName("getStructuredOutputStrategy returns InstructionStrategy for registry model with structuredOutput=false")
+    @Test
+    @DisplayName("getStructuredOutputStrategy returns InstructionStrategy for registry model with structuredOutput=false")
     void testGetStructuredOutputStrategy_returnsInstruction_whenRegistryModelDoesNotSupportIt() {
         LlmProviderApiKeyService llmProviderApiKeyService = mock(LlmProviderApiKeyService.class);
         var mockConfig = createMockConfigWithFreeModel(false, "gpt-4o-mini", "openai");
@@ -457,7 +448,6 @@ class LlmProviderFactoryTest {
         // Model from test file with no structuredOutput (defaults to false)
         var strategy = llmProviderFactory.getStructuredOutputStrategy("claude-sonnet-4-6");
 
-        assertThat(strategy).isInstanceOf(
-                com.comet.opik.domain.llm.structuredoutput.InstructionStrategy.class);
+        assertThat(strategy).isInstanceOf(InstructionStrategy.class);
     }
 }

--- a/apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts
+++ b/apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts
@@ -1433,6 +1433,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       label: "openrouter/bodybuilder",
     },
     {
+      value: PROVIDER_MODEL_TYPE.OPENROUTER_ELEPHANT_ALPHA,
+      label: "openrouter/elephant-alpha",
+    },
+    {
       value: PROVIDER_MODEL_TYPE.OPENROUTER_FREE,
       label: "openrouter/free",
     },

--- a/apps/opik-frontend/src/types/providers.ts
+++ b/apps/opik-frontend/src/types/providers.ts
@@ -426,6 +426,7 @@ export enum PROVIDER_MODEL_TYPE {
   OPENGVLAB_INTERNVL3_78B = "opengvlab/internvl3-78b",
   OPENROUTER_AUTO = "openrouter/auto",
   OPENROUTER_BODYBUILDER = "openrouter/bodybuilder",
+  OPENROUTER_ELEPHANT_ALPHA = "openrouter/elephant-alpha",
   OPENROUTER_FREE = "openrouter/free",
   OPENROUTER_HEALER_ALPHA = "openrouter/healer-alpha",
   OPENROUTER_HUNTER_ALPHA = "openrouter/hunter-alpha",


### PR DESCRIPTION
## Details

Automated sync of LLM provider model definitions from source APIs and prices JSON.

**Sync summary:**
```
## Provider Model Sync

### Openrouter
- Added 1 model(s):
  + openrouter/elephant-alpha
- Stale 108 model(s) (not in source, manual review needed):
  ? ai21/jamba-mini-1.7
  ? alibaba/tongyi-deepresearch-30b-a3b:free
  ? allenai/molmo-2-8b
  ? allenai/olmo-3-7b-instruct
  ? allenai/olmo-3-7b-think
  ? allenai/olmo-3.1-32b-think
  ? anthropic/claude-3.5-sonnet
  ? arcee-ai/afm-4.5b
  ? arcee-ai/trinity-mini:free
  ? arliai/qwq-32b-arliai-rpr-v1
  ? arliai/qwq-32b-arliai-rpr-v1:free
  ? deepcogito/cogito-v2-preview-deepseek-671b
  ? deepcogito/cogito-v2-preview-llama-109b-moe
  ? deepcogito/cogito-v2-preview-llama-405b
  ? deepcogito/cogito-v2-preview-llama-70b
  ? deepseek/deepseek-chat-v3-0324:free
  ? deepseek/deepseek-prover-v2
  ? deepseek/deepseek-r1-0528-qwen3-8b
  ? deepseek/deepseek-r1-0528-qwen3-8b:free
  ? deepseek/deepseek-r1-0528:free
  ? deepseek/deepseek-r1-distill-llama-70b:free
  ? deepseek/deepseek-r1-distill-qwen-14b
  ? deepseek/deepseek-r1:free
  ? deepseek/deepseek-v3.1-terminus:exacto
  ? eleutherai/llemma_7b
  ? google/gemini-2.0-flash-exp:free
  ? google/gemini-2.5-flash-image-preview
  ? google/gemini-2.5-flash-preview-09-2025
  ? google/gemini-3-pro-preview
  ? google/gemma-2-9b-it
  ? inception/mercury
  ? inception/mercury-coder
  ? kwaipilot/kat-coder-pro
  ? kwaipilot/kat-coder-pro:free
  ? liquid/lfm-2.2-6b
  ? liquid/lfm2-8b-a1b
  ? meituan/longcat-flash-chat
  ? meituan/longcat-flash-chat:free
  ? meta-llama/llama-3.1-405b
  ? meta-llama/llama-3.1-405b-instruct
  ? meta-llama/llama-3.2-90b-vision-instruct
  ? meta-llama/llama-guard-2-8b
  ? microsoft/mai-ds-r1
  ? microsoft/mai-ds-r1:free
  ? microsoft/phi-3-medium-128k-instruct
  ? microsoft/phi-3-mini-128k-instruct
  ? microsoft/phi-3.5-mini-128k-instruct
  ? microsoft/phi-4-multimodal-instruct
  ? microsoft/phi-4-reasoning-plus
  ? mistralai/codestral-2501
  ? mistralai/devstral-small-2505
  ? mistralai/magistral-medium-2506
  ? mistralai/magistral-medium-2506:thinking
  ? mistralai/magistral-small-2506
  ? mistralai/ministral-3b
  ? mistralai/ministral-8b
  ? mistralai/mistral-7b-instruct
  ? mistralai/mistral-7b-instruct-v0.2
  ? mistralai/mistral-7b-instruct-v0.3
  ? mistralai/mistral-7b-instruct:free
  ? mistralai/mistral-nemo:free
  ? mistralai/mistral-small
  ? mistralai/mistral-small-24b-instruct-2501:free
  ? mistralai/mistral-small-3.1-24b-instruct:free
  ? mistralai/mistral-small-3.2-24b-instruct:free
  ? mistralai/mistral-tiny
  ? mistralai/pixtral-12b
  ? moonshotai/kimi-dev-72b
  ? moonshotai/kimi-k2-0905:exacto
  ? moonshotai/kimi-k2:free
  ? moonshotai/kimi-linear-48b-a3b-instruct
  ? neversleep/llama-3.1-lumimaid-8b
  ? neversleep/noromaid-20b
  ? nousresearch/deephermes-3-mistral-24b-preview
  ? nvidia/llama-3.1-nemotron-ultra-253b-v1
  ? openai/chatgpt-4o-latest
  ? openai/codex-mini
  ? openai/gpt-5.2-chat-latest
  ? openai/gpt-oss-120b:exacto
  ? opengvlab/internvl3-78b
  ? openrouter/healer-alpha
  ? openrouter/hunter-alpha
  ? perplexity/sonar-reasoning
  ? qwen/qwen-2.5-72b-instruct:free
  ? qwen/qwen-2.5-coder-32b-instruct:free
  ? qwen/qwen-2.5-vl-7b-instruct
  ? qwen/qwen2.5-coder-7b-instruct
  ? qwen/qwen2.5-vl-32b-instruct:free
  ? qwen/qwen3-14b:free
  ? qwen/qwen3-235b-a22b:free
  ? qwen/qwen3-30b-a3b:free
  ? qwen/qwen3-4b:free
  ? qwen/qwen3-coder:exacto
  ? qwen/qwen3.6-plus-preview:free
  ? qwen/qwen3.6-plus:free
  ? raifle/sorcererlm-8x22b
  ? reka/reka-edge
  ? stepfun-ai/step3
  ? stepfun/step-3.5-flash:free
  ? thedrummer/anubis-70b-v1.1
  ? thudm/glm-4.1v-9b-thinking
  ? tngtech/deepseek-r1t-chimera
  ? tngtech/deepseek-r1t-chimera:free
  ? tngtech/deepseek-r1t2-chimera:free
  ? x-ai/grok-4.1-fast:free
  ? x-ai/grok-4.20-beta
  ? x-ai/grok-4.20-multi-agent-beta
  ? z-ai/glm-4.6:exacto
- Total models: 452 (dropdown: 452)

### Openai
- Stale 15 model(s) (not in source, manual review needed):
  ? chatgpt-4o-latest
  ? gpt-4-0125-preview
  ? gpt-4-0314
  ? gpt-4-1106-preview
  ? gpt-4-turbo-2024-04-09
  ? gpt-4-turbo-preview
  ? gpt-4o-2024-05-13
  ? gpt-4o-2024-08-06
  ? gpt-4o-2024-11-20
  ? gpt-4o-mini-2024-07-18
  ? o1-2024-12-17
  ? o1-mini
  ? o1-mini-2024-09-12
  ? o1-preview
  ? o1-preview-2024-09-12
- Deprecated 4 model(s) (past deprecation_date, excluded from dropdown):
  ✗ gpt-4-0125-preview
  ✗ gpt-4-0314
  ✗ gpt-4-0613
  ✗ gpt-4-1106-preview
- Total models: 62 (dropdown: 19)

### Anthropic
- Stale 2 model(s) (not in source, manual review needed):
  ? claude-3-7-sonnet-20250219
  ? claude-sonnet-4-5
- Deprecated 1 model(s) (past deprecation_date, excluded from dropdown):
  ✗ claude-3-7-sonnet-20250219
- Total models: 10 (dropdown: 8)

### Gemini
- Stale 6 model(s) (not in source, manual review needed):
  ? aqa
  ? gemini-1.0-pro
  ? gemini-1.5-flash-latest
  ? gemini-1.5-pro-latest
  ? gemini-pro-vision
  ? text-embedding-004
- Deprecated 2 model(s) (past deprecation_date, excluded from dropdown):
  ✗ gemini-3-pro-preview
  ✗ text-embedding-004
- Total models: 21 (dropdown: 10)

### Vertexai
- Stale 9 model(s) (not in source, manual review needed):
  ? vertex_ai/gemini-2.0-flash-001
  ? vertex_ai/gemini-2.0-flash-lite-001
  ? vertex_ai/gemini-2.5-flash
  ? vertex_ai/gemini-2.5-flash-lite-preview-06-17
  ? vertex_ai/gemini-2.5-flash-preview-04-17
  ? vertex_ai/gemini-2.5-pro
  ? vertex_ai/gemini-2.5-pro-exp-03-25
  ? vertex_ai/gemini-2.5-pro-preview-03-25
  ? vertex_ai/gemini-2.5-pro-preview-05-06
- Total models: 12 (dropdown: 7)

```

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: GitHub Actions (`sync_provider_models.yml`)
  - Model(s): N/A (scripted automation)
  - Scope: Automated model list sync
  - Human verification: Requires manual review before merge

## Testing

- Script dry-run passed in CI
- Changes are add-only; stale/deprecated models flagged for manual review

## Documentation

N/A