### PR TITLE
[OPIK-5903] [FE] fix: stabilize filters default to prevent trace panel crash

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
@@ -32,6 +32,7 @@ import get from "lodash/get";
 import { METADATA_AGENT_GRAPH_KEY } from "@/constants/traces";
 
 const MAX_SPANS_LOAD_SIZE = 15000;
+const EMPTY_FILTERS: unknown[] = [];
 
 type TraceDetailsPanelProps = {
   projectId?: string;
@@ -82,7 +83,7 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
     },
   );
 
-  const [filters = [], setFilters] = useQueryParam(
+  const [filters = EMPTY_FILTERS, setFilters] = useQueryParam(
     `trace_panel_filters`,
     JsonParam,
     {

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -123,6 +123,7 @@ import MetricsSummary from "@/v2/pages-shared/traces/MetricsSummary/MetricsSumma
 const getRowId = (d: Trace | Span) => d.id;
 
 const REFETCH_INTERVAL = 30000;
+const EMPTY_FILTERS: unknown[] = [];
 
 const SPAN_FEEDBACK_SCORE_SUFFIX = " (span)";
 
@@ -429,7 +430,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
     syncQueryWithLocalStorageOnInit: true,
   });
 
-  const [filters = [], setFilters] = useQueryParam(
+  const [filters = EMPTY_FILTERS, setFilters] = useQueryParam(
     `${type}_filters`,
     JsonParam,
     {


### PR DESCRIPTION
## Details

Fixes the "Maximum update depth exceeded" full-page crash that occurs when Ollie navigates to the trace page during onboarding (OPIK-5903). The inline `filters = []` destructuring default in `TraceDetailsPanel` and `TracesSpansTab` produced a fresh array reference on every render when the URL param was absent, turning Ollie's narrow-search navigate (which strips accumulated `replaceIn` defaults) into a render cascade that exceeded React's nested-update limit and surfaced in a Tooltip-wrapped button's composed ref chain.

- Replace the inline `= []` default with a module-level `EMPTY_FILTERS` constant in `TraceDetailsPanel.tsx` and `TracesSpansTab.tsx` so the fallback reference is stable across renders; `setFilters` keeps writing to the URL, so the constant is never mutated.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-5903

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: root-cause investigation and fix implementation
- Human verification: code review + live crash reproduction and post-fix verification via Chrome DevTools MCP (bisect of all 6 candidate search params confirmed the fix eliminates the crash with the real-Ollie strip-all-6 navigate payload)

## Testing

- `bash scripts/dev-runner.sh --lint-fe` → `lint:fix` + `typecheck` + `deps:validate` all pass
- Live browser verification via Chrome DevTools MCP against local dev-runner (`http://localhost:5174`):
  - Repro stub (`plugins/development/AssistantSidebar.tsx`, not committed) simulates Ollie's `bridge.emit("navigate", ...)` by firing `router.navigate({ to: ".../logs", search: { logsType, trace } })` 1.5 s after mount
  - **Before fix**: stripping all 6 accumulated URL defaults → "Something went wrong! Maximum update depth exceeded"
  - **After fix**: stripping all 6 → page renders normally, URL settles at the minimal shape Ollie produces
  - Bisect of the 6 candidate params confirmed the minimal crashing set was `{trace_panel_filters, time_range, size, height}`; stabilizing the `trace_panel_filters` default breaks the cascade for all tested combinations
- Same `EMPTY_FILTERS` pattern applied to `TracesSpansTab.tsx` for defense in depth against the sibling `${type}_filters` consumer

## Documentation

N/A — behavioral fix with no user-facing API change.