### PR TITLE
[OPIK-5909] [FE] perf: speed up Ollie assistant start times

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/AssistantPrewarmer.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantPrewarmer.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { usePrewarmAssistantCompute } from "@/plugins/comet/useAssistantBackend";
+
+const AssistantPrewarmer: React.FC = () => {
+  usePrewarmAssistantCompute();
+  return null;
+};
+
+export default AssistantPrewarmer;

--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -37,6 +37,14 @@ const BRIDGE_PROTOCOL_VERSION = 1;
 const LOADER_DEFAULT_WIDTH = 400;
 const LOADER_COLLAPSED_WIDTH = 33;
 
+// Pod may serve /console/manifest.json before /health/ready flips — retry
+// with backoff so transient 404/503 during warmup don't permanently fail.
+// Budget (~140s) exceeds the 2 min health-poll timeout so manifest doesn't
+// give up before health polling does.
+const MANIFEST_RETRY_COUNT = 30;
+const MANIFEST_RETRY_BASE_DELAY_MS = 500;
+const MANIFEST_RETRY_MAX_DELAY_MS = 5000;
+
 function getStoredSidebarWidth(): number {
   try {
     const parsed = parseInt(
@@ -334,12 +342,12 @@ function useAssistantMeta(backendUrl: string | null): AssistantMeta | null {
     },
     enabled: !IS_ASSISTANT_DEV && !!manifestUrl,
     staleTime: Infinity,
-    // Pod may serve /console/manifest.json before /health/ready flips — retry
-    // with backoff so transient 404/503 during warmup don't permanently fail.
-    // Budget (~140s) exceeds the 2 min health-poll timeout so manifest doesn't
-    // give up before health polling does.
-    retry: 30,
-    retryDelay: (attempt) => Math.min(500 * 2 ** attempt, 5000),
+    retry: MANIFEST_RETRY_COUNT,
+    retryDelay: (attempt) =>
+      Math.min(
+        MANIFEST_RETRY_BASE_DELAY_MS * 2 ** attempt,
+        MANIFEST_RETRY_MAX_DELAY_MS,
+      ),
   });
 
   if (IS_ASSISTANT_DEV) return DEV_META;

--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -334,7 +334,12 @@ function useAssistantMeta(backendUrl: string | null): AssistantMeta | null {
     },
     enabled: !IS_ASSISTANT_DEV && !!manifestUrl,
     staleTime: Infinity,
-    retry: 1,
+    // Pod may serve /console/manifest.json before /health/ready flips — retry
+    // with backoff so transient 404/503 during warmup don't permanently fail.
+    // Budget (~140s) exceeds the 2 min health-poll timeout so manifest doesn't
+    // give up before health polling does.
+    retry: 30,
+    retryDelay: (attempt) => Math.min(500 * 2 ** attempt, 5000),
   });
 
   if (IS_ASSISTANT_DEV) return DEV_META;
@@ -353,17 +358,34 @@ const AssistantSidebar: React.FC<AssistantSidebarProps> = ({
 }) => {
   const {
     backendUrl,
+    probeUrl,
     isReady: isBackendReady,
     error,
     phase,
     retry,
     retryCount,
   } = useAssistantBackend();
-  const meta = useAssistantMeta(backendUrl);
+  const meta = useAssistantMeta(probeUrl);
   const context = useBridgeContext(backendUrl ?? "", surface);
   const router = useRouter();
 
   const { toast } = useToast();
+
+  // Warm DNS/TCP/TLS to the pod origin while health polling is in flight.
+  // Attributes must be set BEFORE appendChild — browsers evaluate the hint at
+  // insertion time, and late crossorigin changes may not upgrade the handshake.
+  useEffect(() => {
+    if (!probeUrl || IS_ASSISTANT_DEV) return;
+    const origin = new URL(probeUrl).origin;
+    const link = document.createElement("link");
+    link.rel = "preconnect";
+    link.href = origin;
+    link.setAttribute("crossorigin", "use-credentials");
+    document.head.appendChild(link);
+    return () => {
+      link.remove();
+    };
+  }, [probeUrl]);
 
   const contextRef = useLatestRef(context);
   const onWidthChangeRef = useLatestRef(onWidthChange);

--- a/apps/opik-frontend/src/plugins/comet/useAssistantBackend.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAssistantBackend.ts
@@ -4,7 +4,7 @@ import cometApi from "@/plugins/comet/api";
 import { useActiveWorkspaceName } from "@/store/AppStore";
 import { IS_ASSISTANT_DEV } from "@/plugins/comet/constants/assistant";
 
-const HEALTH_POLL_INTERVAL_MS = 5000;
+const HEALTH_POLL_INTERVAL_MS = 1000;
 const HEALTH_POLL_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
 const HEALTH_KEEPALIVE_MS = 30_000; // 30s keepalive after ready
 
@@ -12,6 +12,29 @@ interface ComputeResult {
   baseUrl: string | null;
   enabled: boolean;
 }
+
+const getComputeQueryKey = (workspaceName: string) =>
+  ["assistant-compute", { workspaceName }] as const;
+
+const fetchAssistantCompute = async (
+  workspaceName: string,
+  signal?: AbortSignal,
+): Promise<ComputeResult> => {
+  const { data } = await cometApi.get<{
+    computeURL: string;
+    enabled: boolean;
+  }>("/opik/ollie/compute", {
+    headers: { "Comet-Workspace": workspaceName },
+    signal,
+  });
+
+  if (!data.enabled) {
+    return { baseUrl: null, enabled: false };
+  }
+
+  const baseUrl = data.computeURL.replace(/\/api\/get-python-panel-url$/, "");
+  return { baseUrl, enabled: true };
+};
 
 export type AssistantBackendPhase =
   | "idle"
@@ -23,6 +46,7 @@ export type AssistantBackendPhase =
 
 interface UseAssistantBackendResult {
   backendUrl: string | null;
+  probeUrl: string | null;
   isReady: boolean;
   isLoading: boolean;
   error: string | null;
@@ -33,6 +57,7 @@ interface UseAssistantBackendResult {
 
 const DEV_RESULT: UseAssistantBackendResult = {
   backendUrl: "/assistant-api",
+  probeUrl: "/assistant-api",
   isReady: true,
   isLoading: false,
   error: null,
@@ -46,8 +71,10 @@ const notReadyResult = (
   phase: AssistantBackendPhase,
   retry: () => void,
   retryCount: number,
+  probeUrl: string | null = null,
 ): UseAssistantBackendResult => ({
   backendUrl: null,
+  probeUrl,
   isReady: false,
   isLoading: false,
   error,
@@ -66,32 +93,13 @@ export default function useAssistantBackend(
   const configEnabled = options?.enabled ?? true;
   const workspaceName = useActiveWorkspaceName();
 
-  // Phase 1: Call compute endpoint to spawn/locate the user's pod
   const {
     data: computeResult,
     isLoading: isComputeLoading,
     error: computeError,
   } = useQuery<ComputeResult>({
-    queryKey: ["assistant-compute", { workspaceName }],
-    queryFn: async ({ signal }) => {
-      const { data } = await cometApi.get<{
-        computeURL: string;
-        enabled: boolean;
-      }>("/opik/ollie/compute", {
-        headers: { "Comet-Workspace": workspaceName },
-        signal,
-      });
-
-      if (!data.enabled) {
-        return { baseUrl: null, enabled: false };
-      }
-
-      const baseUrl = data.computeURL.replace(
-        /\/api\/get-python-panel-url$/,
-        "",
-      );
-      return { baseUrl, enabled: true };
-    },
+    queryKey: getComputeQueryKey(workspaceName),
+    queryFn: ({ signal }) => fetchAssistantCompute(workspaceName, signal),
     enabled: !IS_ASSISTANT_DEV && configEnabled && !!workspaceName,
     staleTime: Infinity,
     retry: 2,
@@ -148,6 +156,7 @@ export default function useAssistantBackend(
     // dead pod URL doesn't linger while refetch is in-flight.
     queryClient.resetQueries({ queryKey: ["assistant-health"] });
     queryClient.resetQueries({ queryKey: ["assistant-compute"] });
+    queryClient.resetQueries({ queryKey: ["assistant-manifest"] });
   }, [queryClient]);
 
   // User-initiated retry — increments retryCount for UI escalation
@@ -156,7 +165,6 @@ export default function useAssistantBackend(
     resetBackend();
   }, [resetBackend]);
 
-  // Phase 2: Poll health endpoint until the pod is ready
   const { data: healthResult, error: healthError } = useQuery<{
     ready: boolean;
   }>({
@@ -199,7 +207,6 @@ export default function useAssistantBackend(
   const podStateRef = useRef<"never" | "ready" | "down">("never");
 
   if (isReady && podStateRef.current !== "ready") {
-    // Pod just became ready — reset retryCount if recovering from failure
     if (podStateRef.current === "down" && retryCount > 0) {
       queueMicrotask(() => setRetryCount(0));
     }
@@ -246,6 +253,7 @@ export default function useAssistantBackend(
 
   return {
     backendUrl: isReady ? baseUrl : null,
+    probeUrl: computeEnabled ? baseUrl : null,
     isReady,
     isLoading: isComputeLoading || (shouldPollHealth && !isReady),
     error: null,
@@ -253,4 +261,21 @@ export default function useAssistantBackend(
     retry,
     retryCount,
   };
+}
+
+// Shares the `assistant-compute` queryKey so the sidebar's later subscription
+// reuses the prewarmed cache instead of re-issuing the request.
+export function usePrewarmAssistantCompute(): void {
+  const workspaceName = useActiveWorkspaceName();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (IS_ASSISTANT_DEV) return;
+    if (!workspaceName) return;
+    queryClient.prefetchQuery({
+      queryKey: getComputeQueryKey(workspaceName),
+      queryFn: ({ signal }) => fetchAssistantCompute(workspaceName, signal),
+      staleTime: Infinity,
+    });
+  }, [workspaceName, queryClient]);
 }

--- a/apps/opik-frontend/src/plugins/comet/useAssistantBackend.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAssistantBackend.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import cometApi from "@/plugins/comet/api";
 import { useActiveWorkspaceName } from "@/store/AppStore";
+import usePluginsStore from "@/store/PluginsStore";
 import { IS_ASSISTANT_DEV } from "@/plugins/comet/constants/assistant";
 
 const HEALTH_POLL_INTERVAL_MS = 1000;
@@ -267,15 +268,17 @@ export default function useAssistantBackend(
 // reuses the prewarmed cache instead of re-issuing the request.
 export function usePrewarmAssistantCompute(): void {
   const workspaceName = useActiveWorkspaceName();
+  const assistantPlugin = usePluginsStore((state) => state.AssistantSidebar);
   const queryClient = useQueryClient();
 
   useEffect(() => {
     if (IS_ASSISTANT_DEV) return;
+    if (!assistantPlugin) return;
     if (!workspaceName) return;
     queryClient.prefetchQuery({
       queryKey: getComputeQueryKey(workspaceName),
       queryFn: ({ signal }) => fetchAssistantCompute(workspaceName, signal),
       staleTime: Infinity,
     });
-  }, [workspaceName, queryClient]);
+  }, [assistantPlugin, workspaceName, queryClient]);
 }

--- a/apps/opik-frontend/src/plugins/comet/useAssistantBackend.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAssistantBackend.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import cometApi from "@/plugins/comet/api";
 import { useActiveWorkspaceName } from "@/store/AppStore";
-import usePluginsStore from "@/store/PluginsStore";
 import { IS_ASSISTANT_DEV } from "@/plugins/comet/constants/assistant";
 
 const HEALTH_POLL_INTERVAL_MS = 1000;
@@ -265,20 +264,20 @@ export default function useAssistantBackend(
 }
 
 // Shares the `assistant-compute` queryKey so the sidebar's later subscription
-// reuses the prewarmed cache instead of re-issuing the request.
+// reuses the prewarmed cache instead of re-issuing the request. Plugin-level
+// gating (OSS vs Comet) is handled by whether the AssistantPrewarmer plugin
+// component is registered in the store.
 export function usePrewarmAssistantCompute(): void {
   const workspaceName = useActiveWorkspaceName();
-  const assistantPlugin = usePluginsStore((state) => state.AssistantSidebar);
   const queryClient = useQueryClient();
 
   useEffect(() => {
     if (IS_ASSISTANT_DEV) return;
-    if (!assistantPlugin) return;
     if (!workspaceName) return;
     queryClient.prefetchQuery({
       queryKey: getComputeQueryKey(workspaceName),
       queryFn: ({ signal }) => fetchAssistantCompute(workspaceName, signal),
       staleTime: Infinity,
     });
-  }, [assistantPlugin, workspaceName, queryClient]);
+  }, [workspaceName, queryClient]);
 }

--- a/apps/opik-frontend/src/store/PluginsStore.ts
+++ b/apps/opik-frontend/src/store/PluginsStore.ts
@@ -30,6 +30,7 @@ type PluginStore = {
     surface?: BridgeSurface;
     onWidthChange: (width: number) => void;
   }> | null;
+  AssistantPrewarmer: React.ComponentType | null;
   UpgradeButton: React.ComponentType | null;
   init: unknown;
   setupPlugins: (folderName: string) => Promise<void>;
@@ -51,6 +52,7 @@ const PLUGIN_NAMES = [
   "WorkspaceSelector",
   "SidebarWorkspaceSelector",
   "AssistantSidebar",
+  "AssistantPrewarmer",
   "UpgradeButton",
   "init",
 ];
@@ -70,6 +72,7 @@ const usePluginsStore = create<PluginStore>((set) => ({
   WorkspaceSelector: null,
   SidebarWorkspaceSelector: null,
   AssistantSidebar: null,
+  AssistantPrewarmer: null,
   UpgradeButton: null,
   init: null,
   setupPlugins: async (folderName: string) => {

--- a/apps/opik-frontend/src/v2/layout/WorkspaceGuard/WorkspaceGuard.tsx
+++ b/apps/opik-frontend/src/v2/layout/WorkspaceGuard/WorkspaceGuard.tsx
@@ -7,7 +7,6 @@ import PermissionsGuard from "@/v2/layout/PermissionsGuard/PermissionsGuard";
 import WorkspaceVersionResolver from "@/shared/WorkspaceVersionResolver/WorkspaceVersionResolver";
 import { PermissionsProvider } from "@/contexts/PermissionsContext";
 import { DEFAULT_PERMISSIONS } from "@/types/permissions";
-import { usePrewarmAssistantCompute } from "@/plugins/comet/useAssistantBackend";
 
 const WorkspaceGuard = ({
   Layout = PageLayout,
@@ -20,9 +19,12 @@ const WorkspaceGuard = ({
   const PermissionsProviderPlugin = usePluginStore(
     (state) => state.PermissionsProvider,
   );
-  // Kick off the Ollie pod provisioning as soon as the workspace resolves,
-  // so cold-start overlaps with onboarding instead of blocking sidebar mount.
-  usePrewarmAssistantCompute();
+  // Kick off Ollie pod provisioning as soon as the workspace resolves, so
+  // cold-start overlaps with onboarding instead of blocking sidebar mount.
+  // Rendered via plugin store so OSS builds don't import plugin internals.
+  const AssistantPrewarmer = usePluginStore(
+    (state) => state.AssistantPrewarmer,
+  );
 
   if (!WorkspacePreloader) {
     return <Loader />;
@@ -38,6 +40,7 @@ const WorkspaceGuard = ({
 
   return (
     <WorkspacePreloader>
+      {AssistantPrewarmer ? <AssistantPrewarmer /> : null}
       <WorkspaceVersionResolver>
         {PermissionsProviderPlugin ? (
           <PermissionsProviderPlugin>

--- a/apps/opik-frontend/src/v2/layout/WorkspaceGuard/WorkspaceGuard.tsx
+++ b/apps/opik-frontend/src/v2/layout/WorkspaceGuard/WorkspaceGuard.tsx
@@ -7,6 +7,7 @@ import PermissionsGuard from "@/v2/layout/PermissionsGuard/PermissionsGuard";
 import WorkspaceVersionResolver from "@/shared/WorkspaceVersionResolver/WorkspaceVersionResolver";
 import { PermissionsProvider } from "@/contexts/PermissionsContext";
 import { DEFAULT_PERMISSIONS } from "@/types/permissions";
+import { usePrewarmAssistantCompute } from "@/plugins/comet/useAssistantBackend";
 
 const WorkspaceGuard = ({
   Layout = PageLayout,
@@ -19,6 +20,9 @@ const WorkspaceGuard = ({
   const PermissionsProviderPlugin = usePluginStore(
     (state) => state.PermissionsProvider,
   );
+  // Kick off the Ollie pod provisioning as soon as the workspace resolves,
+  // so cold-start overlaps with onboarding instead of blocking sidebar mount.
+  usePrewarmAssistantCompute();
 
   if (!WorkspacePreloader) {
     return <Loader />;


### PR DESCRIPTION
## Details

Ollie (the Comet AI assistant sidebar) currently takes ~15s to become usable. Profiling the startup path in `apps/opik-frontend/src/plugins/comet/` shows four strictly-serial phases: pod provisioning (`GET /opik/ollie/compute`) → health polling → manifest fetch → iframe shell load. The pod cold-start dominates, but the frontend-side latency on top of it is avoidable.

This PR does four things, none of which change backend behavior:

- **Prewarm pod provisioning at workspace load**: `useAssistantBackend` previously only fired when `AssistantSidebar` mounted, which happens inside `PageLayout`. Onboarding routes (`/get-started`, `/quickstart`) render under `PartialPageLayout` and don't mount the sidebar, so a new user finished onboarding, navigated to the main app, and only *then* waited on `/opik/ollie/compute`. A new `usePrewarmAssistantCompute` hook (shares the `["assistant-compute", ...]` queryKey via `queryClient.prefetchQuery`) is wired into `WorkspaceGuard` so the pod starts booting as soon as the workspace resolves. The sidebar's later subscription hits the cached result with no extra HTTP call.
- **Tighten health poll interval**: `HEALTH_POLL_INTERVAL_MS` 5000 → 1000. The 5 s flat interval meant the pod could be ready for up to 5 s before the UI noticed. Keepalive (post-ready) stays at 30 s.
- **Parallelize manifest fetch with health polling**: `useAssistantBackend` now returns a `probeUrl` alongside `backendUrl`. `probeUrl` is non-null as soon as Phase 1 resolves (independent of `isReady`), while `backendUrl` stays gated on health-ready. `useAssistantMeta` switches to `probeUrl`, so the pod's static `/console/manifest.json` is fetched in parallel with health polling instead of after it. Manifest retry budget raised to 30 with 500·2^n backoff capped at 5 s (~140 s total) so it doesn't give up before the 2 min health-poll timeout; `resetBackend` now also clears the manifest query key so the retry button recovers cleanly.
- **Preconnect to the pod origin**: A `<link rel="preconnect" crossorigin="use-credentials">` is injected into `document.head` as soon as `probeUrl` is known, warming DNS/TCP/TLS for the subsequent manifest fetch and iframe shell load.

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5909

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code CLI
- Model(s): Claude Opus 4.6
- Scope: assisted implementation
- Human verification: code review + `pnpm tsc --noEmit` + `pnpm eslint src --max-warnings=0` + manual timing in staging

## Testing

- `npx tsc --project tsconfig.json --noEmit` — clean
- `npx eslint src --max-warnings=0` — clean
- Manual: fresh user lands on `/get-started` → `/opik/ollie/compute` fires immediately on onboarding page load (visible in Network panel), not after navigating into the main app
- Manual: navigate into a workspace page that mounts the sidebar → sidebar becomes interactive noticeably faster because the pod was warming during onboarding
- Manual: click the sidebar "retry" button while in error state → compute, health, AND manifest queries all reset, sidebar recovers without a full page reload
- Manual: verify in Network panel that `manifest.json` request starts before `/health/ready` returns `ok` (parallel instead of serial)
- Manual: DevTools → Network → filter "preconnect" — confirm the `<link rel="preconnect">` to the pod origin is inserted during health polling

## Documentation

No documentation changes needed.