### PR TITLE
[NA] [BE] fix: resolve flaky RetentionPolicyServiceTest parameter injection

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/retention/RetentionPolicyServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/retention/RetentionPolicyServiceTest.java
@@ -36,6 +36,7 @@ import org.testcontainers.mysql.MySQLContainer;
 import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import ru.vyarus.dropwizard.guice.test.jupiter.param.Jit;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -111,8 +112,8 @@ class RetentionPolicyServiceTest {
     private IdGenerator idGenerator;
 
     @BeforeAll
-    void beforeAll(ClientSupport client, RetentionPolicyService retentionPolicyService,
-            RetentionCatchUpService catchUpService, RetentionEstimationService estimationService,
+    void beforeAll(ClientSupport client, @Jit RetentionPolicyService retentionPolicyService,
+            @Jit RetentionCatchUpService catchUpService, @Jit RetentionEstimationService estimationService,
             TransactionTemplateAsync templateAsync, IdGenerator idGenerator) {
         this.baseURI = TestUtils.getBaseUrl(client);
         ClientSupportUtils.config(client);


### PR DESCRIPTION
## Details

Fix intermittent `ParameterResolutionException` in `RetentionPolicyServiceTest` on CI. The three retention services have no explicit Guice binding — they are only wired as JIT bindings via their Quartz jobs (`RetentionSlidingWindowJob`, `RetentionCatchUpJob`, `RetentionEstimationJob`). Since `dropwizard-jobs` instantiates jobs lazily at fire time, if `@BeforeAll` runs before Quartz has fired any retention job, guicey's `TestParametersSupport#supportsParameter` returns false (`Injector#getExistingBinding` only sees materialized bindings) and the test fails with `No ParameterResolver registered for parameter [RetentionPolicyService ...]`.

- Annotate the three service parameters in `@BeforeAll` with `@Jit` so guicey resolves them via `injector.getInstance()`, which forces the JIT binding on demand. `TransactionTemplateAsync` and `IdGenerator` don't need it — they have explicit `@Provides` bindings.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- N/A

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6 (1M context)
- Scope: full implementation
- Human verification: code review + local compile verification

## Testing

- `mvn test-compile` — verified the test file compiles against the new `@Jit` annotation import.
- `mvn spotless:check` — passes, no formatting changes needed.
- Did not run the full integration test locally (containers required); relying on CI to confirm the flake is gone. The change is isolated to test parameter annotations — no production code touched.

## Documentation

N/A