### PR TITLE
[NA] [SDK] refactor: remove internal agent config exports

### DIFF
--- a/sdks/python/src/opik/__init__.py
+++ b/sdks/python/src/opik/__init__.py
@@ -11,7 +11,7 @@ from .api_objects.experiment.experiment_item import (
     ExperimentItemContent,
     ExperimentItemReferences,
 )
-from .api_objects.agent_config import Config, Blueprint
+from .api_objects.agent_config import Config
 from .api_objects.agent_config.context import agent_config_context
 from .exceptions import ConfigNotFound, ConfigMismatch
 from .api_objects.opik_client import Opik, get_global_client, set_global_client
@@ -88,7 +88,6 @@ __all__ = [
     "Config",
     "ConfigNotFound",
     "ConfigMismatch",
-    "Blueprint",
     "agent_config_context",
     "update_current_trace",
     "update_current_span",

--- a/sdks/python/src/opik/api_objects/agent_config/__init__.py
+++ b/sdks/python/src/opik/api_objects/agent_config/__init__.py
@@ -1,16 +1,11 @@
 from .base import Config
-from .cache import SharedCacheRegistry, get_global_registry
+from .cache import get_global_registry
 from .config import ConfigManager
-from .blueprint import Blueprint
 from .context import agent_config_context
-from .types import FieldValueSpec
 
 __all__ = [
     "Config",
     "ConfigManager",
-    "Blueprint",
-    "FieldValueSpec",
-    "SharedCacheRegistry",
     "get_global_registry",
     "agent_config_context",
 ]


### PR DESCRIPTION
## Details

Removes agent configuration exports from the SDK's public API. Configuration system remains internal for now.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves N/A

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-haiku-4-5-20251001
- Scope: Code refactoring
- Human verification: Manual code review

## Testing

Verified staged changes are properly committed:
- `git log -1` confirms commit message and changes
- Pre-commit hooks passed

## Documentation

N/A