### PR TITLE
[OPIK-5920] [FE] feat: redirect to project homepage after onboarding

### DIFF
--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/NewQuickstart.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/NewQuickstart.tsx
@@ -4,18 +4,15 @@ import AgentOnboardingOverlay from "./AgentOnboarding/AgentOnboardingOverlay";
 import {
   AGENT_ONBOARDING_KEY,
   AGENT_ONBOARDING_STEPS,
-  TRACES_OLDEST_FIRST_SORTING,
 } from "./AgentOnboarding/AgentOnboardingContext";
 import useLocalStorageState from "use-local-storage-state";
 import useAppStore from "@/store/AppStore";
 import useProjectByName from "@/api/projects/useProjectByName";
-import { LOGS_TYPE } from "@/constants/traces";
 
 const NewQuickstart: React.FunctionComponent = () => {
   const [agentOnboardingState] = useLocalStorageState<{
     step: unknown;
     agentName?: string;
-    traceId?: string;
   }>(AGENT_ONBOARDING_KEY);
 
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
@@ -39,19 +36,10 @@ const NewQuickstart: React.FunctionComponent = () => {
   }
 
   if (project?.id) {
-    const traceId = agentOnboardingState?.traceId;
-
     return (
       <Navigate
-        to="/$workspaceName/projects/$projectId/logs"
+        to="/$workspaceName/projects/$projectId/home"
         params={{ workspaceName, projectId: project.id }}
-        search={{
-          logsType: LOGS_TYPE.traces,
-          ...(traceId && {
-            trace: traceId,
-            traces_sorting: TRACES_OLDEST_FIRST_SORTING,
-          }),
-        }}
       />
     );
   }


### PR DESCRIPTION
## Details

After the agent onboarding overlay reaches DONE, always redirect to the project homepage (`/projects/:id/home`) instead of the traces logs page. This applies to both paths — users who set up observability (capturing a trace) and users who skip the observability step.

- Opensource deployments are handled transparently: `ProjectHomePage` bounces to `/logs` when the `AssistantSidebar` plugin is missing, so no deployment flag is needed in `NewQuickstart`.
- Dropped the now-unused `traceId` branch, the `traceId` field from the locally-typed onboarding state, and the `LOGS_TYPE` / `TRACES_OLDEST_FIRST_SORTING` imports in `NewQuickstart.tsx`. `traceId` is still written to localStorage by `ConnectAgentStep` — left untouched since removing it is out of scope.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5920

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6 (1M context)
- Scope: assisted — plan, implementation, and local verification steps
- Human verification: code review + manual testing in local dev

## Testing

- `bash scripts/dev-runner.sh --lint-fe` — lint (eslint + stylelint), `tsc --noEmit` typecheck, and dependency-cruiser all green.
- Manual (cloud, v2 forced via `localStorage['opik-version-override'] = 'v2'`):
  - Scenario A — finish observability and click "View traces & start optimizing" → lands on `/projects/:id/home` (previously landed on `/logs?trace=…`).
  - Scenario B — click "Skip for now" on the observability step → lands on `/projects/:id/home` (previously landed on `/logs`).
- Opensource scenario (with `development` plugin folder active): both A and B reach `/home`, which `ProjectHomePage` redirects to `/logs` as expected.

No automated tests added — change is a one-line redirect target swap already covered by the manual onboarding scenarios above.

## Documentation

N/A