### PR TITLE
[OPIK-5907] [FE] fix: prevent home page blink on stats refetch

### DIFF
--- a/apps/opik-frontend/src/hooks/useProjectOnboardingStats.ts
+++ b/apps/opik-frontend/src/hooks/useProjectOnboardingStats.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import api, {
   TRACES_KEY,
@@ -48,48 +49,61 @@ export default function useProjectOnboardingStats(
 ): ProjectStats | undefined {
   const enabled = !!projectId;
 
-  const { data: traceTotal, isLoading: tracesLoading } =
+  const { data: traceTotal, isFetched: tracesFetched } =
     useOnboardingCountQuery(TRACES_KEY, TRACES_REST_ENDPOINT, enabled, {
       project_id: projectId!,
       ...VISIBILITY_FILTER_PARAMS,
     });
 
-  const { data: experimentTotal, isLoading: experimentsLoading } =
+  const { data: experimentTotal, isFetched: experimentsFetched } =
     useOnboardingCountQuery(
       "experiments",
       `${PROJECTS_REST_ENDPOINT}${projectId}/experiments`,
       enabled,
     );
 
-  const { data: optimizationTotal, isLoading: optimizationsLoading } =
+  const { data: optimizationTotal, isFetched: optimizationsFetched } =
     useOnboardingCountQuery(
       OPTIMIZATIONS_KEY,
       `${PROJECTS_REST_ENDPOINT}${projectId}/optimizations`,
       enabled,
     );
 
-  const { data: blueprintTotal, isLoading: blueprintsLoading } =
+  const { data: blueprintTotal, isFetched: blueprintsFetched } =
     useOnboardingCountQuery(
       AGENT_CONFIGS_KEY,
       `/v1/private/agent-configs/blueprints/history/projects/${projectId}`,
       enabled,
     );
 
+  // Memoize so consumers (e.g. the bridge context) get a stable reference
+  // across refetches when values haven't changed. Without this, every 30s
+  // refetch re-renders the hook, returns a new object, and cascades into a
+  // `context:changed` emit to the Ollie iframe — causing a visible blink.
+  const stats = useMemo<ProjectStats>(
+    () => ({
+      traceCount: traceTotal ?? 0,
+      experimentCount: experimentTotal ?? 0,
+      optimizationCount: optimizationTotal ?? 0,
+      blueprintVersionCount: blueprintTotal ?? 0,
+    }),
+    [traceTotal, experimentTotal, optimizationTotal, blueprintTotal],
+  );
+
   if (!enabled) return undefined;
 
+  // Wait for every query's first fetch to complete (success OR error).
+  // Using `isFetched` instead of `isLoading` avoids a flicker back to
+  // `undefined` on each refetch when a query has errored (no cached data),
+  // which would otherwise happen every 30s and cause the Ollie iframe to blink.
   if (
-    tracesLoading ||
-    experimentsLoading ||
-    optimizationsLoading ||
-    blueprintsLoading
+    !tracesFetched ||
+    !experimentsFetched ||
+    !optimizationsFetched ||
+    !blueprintsFetched
   ) {
     return undefined;
   }
 
-  return {
-    traceCount: traceTotal ?? 0,
-    experimentCount: experimentTotal ?? 0,
-    optimizationCount: optimizationTotal ?? 0,
-    blueprintVersionCount: blueprintTotal ?? 0,
-  };
+  return stats;
 }


### PR DESCRIPTION
## Details

Fixes a regression in `useProjectOnboardingStats` where the Project Home page would visually blink every 30 seconds (when `refetchInterval` fires).

Root cause:
- The hook gated its return on `isLoading`, which in React Query v5 is `isPending && isFetching`.
- If a query errors (e.g. `/blueprints/history/...` returns 404 on some envs), `isPending` stays `true` forever since there's no cached data.
- Every 30s refetch flipped `isFetching` → `isLoading` true → hook returned `undefined` → bridge `context:changed` fired → Ollie iframe blinked.

Fix:
- Switch the gate from `isLoading` to `isFetched`. `isFetched` becomes `true` after the first fetch completes (success OR error) and stays `true` across refetches.
- Memoize the returned stats object so identical values don't produce new references that would cascade into `context:changed` emits.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5907

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code CLI
- Model(s): Claude Opus 4.6
- Scope: assisted implementation
- Human verification: code review + manual testing

## Testing

- `scripts/dev-runner.sh --lint-fe` — passes
- Manual: open project home page, observe console for `context:changed` / projectStats toggling. Before: `undefined` → object every 30s (visible blink). After: initial `undefined` → object, stable across refetches (no blink).
- Manual: verified with dev env where `blueprints/history` endpoint returns 404 — hook no longer flips back to `undefined`.

## Documentation

N/A