### PR TITLE
[OPIK-5942] [FE] fix: carry dataset type through "Open in Playground" navigation

### DIFF
--- a/apps/opik-frontend/src/hooks/useLoadPlayground.ts
+++ b/apps/opik-frontend/src/hooks/useLoadPlayground.ts
@@ -3,8 +3,13 @@ import { useNavigate } from "@tanstack/react-router";
 import useLocalStorageState from "use-local-storage-state";
 
 import useAppStore from "@/store/AppStore";
-import { usePromptMap, useSetPromptMap } from "@/store/PlaygroundStore";
+import {
+  usePromptMap,
+  useSetPromptMap,
+  useSetDatasetType,
+} from "@/store/PlaygroundStore";
 import { generateDefaultPrompt } from "@/lib/playground";
+import { DATASET_TYPE } from "@/types/datasets";
 import {
   generateDefaultLLMPromptMessage,
   getTextFromMessageContent,
@@ -33,6 +38,7 @@ interface LoadPlaygroundOptions {
   autoImprove?: boolean;
   datasetId?: string;
   datasetVersionId?: string;
+  datasetType?: DATASET_TYPE | null;
   templateStructure?: PROMPT_TEMPLATE_STRUCTURE;
   namedPrompts?: NamedPromptContent[];
 }
@@ -43,6 +49,7 @@ function useLoadPlayground() {
 
   const promptMap = usePromptMap();
   const setPromptMap = useSetPromptMap();
+  const setDatasetType = useSetDatasetType();
 
   const [lastPickedModel] = useLastPickedModel({
     key: PLAYGROUND_LAST_PICKED_MODEL,
@@ -169,6 +176,7 @@ function useLoadPlayground() {
         autoImprove = false,
         datasetId,
         datasetVersionId,
+        datasetType,
         templateStructure,
         namedPrompts,
       } = options;
@@ -208,6 +216,8 @@ function useLoadPlayground() {
         );
       }
 
+      setDatasetType(datasetType ?? null);
+
       navigate({
         to: "/$workspaceName/playground",
         params: {
@@ -220,6 +230,7 @@ function useLoadPlayground() {
       navigate,
       setPromptMap,
       setDatasetVersionKey,
+      setDatasetType,
       workspaceName,
     ],
   );

--- a/apps/opik-frontend/src/v1/pages/TestSuiteItemsPage/TestSuiteItemsPage.tsx
+++ b/apps/opik-frontend/src/v1/pages/TestSuiteItemsPage/TestSuiteItemsPage.tsx
@@ -161,6 +161,7 @@ function TestSuiteItemsPage(): React.ReactElement {
               loadPlayground({
                 datasetId: suiteId,
                 datasetVersionId: versionId,
+                datasetType: DATASET_TYPE.TEST_SUITE,
               })
             }
           >

--- a/apps/opik-frontend/src/v1/pages/TestSuiteItemsPage/UseTestSuiteDropdown.tsx
+++ b/apps/opik-frontend/src/v1/pages/TestSuiteItemsPage/UseTestSuiteDropdown.tsx
@@ -11,6 +11,7 @@ import AddExperimentDialog from "@/v1/pages-shared/experiments/AddExperimentDial
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
 import useLoadPlayground from "@/hooks/useLoadPlayground";
 import { usePermissions } from "@/contexts/PermissionsContext";
+import { DATASET_TYPE } from "@/types/datasets";
 
 export interface UseTestSuiteDropdownProps {
   datasetName?: string;
@@ -45,8 +46,9 @@ function UseTestSuiteDropdown({
     loadPlayground({
       datasetId,
       datasetVersionId,
+      datasetType: isTestSuite ? DATASET_TYPE.TEST_SUITE : DATASET_TYPE.DATASET,
     });
-  }, [loadPlayground, datasetId, datasetVersionId]);
+  }, [loadPlayground, datasetId, datasetVersionId, isTestSuite]);
 
   const handleOpenPlaygroundClick = () => {
     if (isPlaygroundEmpty) {

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPage.tsx
@@ -125,6 +125,7 @@ function DatasetItemsPage(): React.ReactElement {
   } = useDatasetItemsSave({
     datasetId,
     datasetName: dataset?.name,
+    datasetType,
     buildPayload,
     buildInitialVersionPayload,
     hasNoVersion,

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPageHeader.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPageHeader.tsx
@@ -98,6 +98,7 @@ const DatasetItemsPageHeader: React.FunctionComponent<
             entityName={entityName}
             projectId={activeProjectId}
             isEmpty={dataset?.dataset_items_count === 0}
+            isTestSuite={isTestSuite}
           />
           {isTestSuite && (
             <Button

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/useDatasetItemsSave.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/useDatasetItemsSave.tsx
@@ -9,12 +9,14 @@ import { useToast } from "@/ui/use-toast";
 import useLoadPlayground from "@/v2/pages-shared/playground/useLoadPlayground";
 import { useNavigateToExperiment } from "@/v2/pages-shared/experiments/useNavigateToExperiment";
 import { useTestSuiteSavePayload } from "@/hooks/useTestSuiteSavePayload";
+import { DATASET_TYPE } from "@/types/datasets";
 
 type SavePayload = ReturnType<typeof useTestSuiteSavePayload>;
 
 interface UseDatasetItemsSaveParams {
   datasetId: string;
   datasetName: string | undefined;
+  datasetType: DATASET_TYPE | undefined;
   buildPayload: SavePayload["buildPayload"];
   buildInitialVersionPayload: SavePayload["buildInitialVersionPayload"];
   hasNoVersion: boolean;
@@ -24,6 +26,7 @@ interface UseDatasetItemsSaveParams {
 const useDatasetItemsSave = ({
   datasetId,
   datasetName,
+  datasetType,
   buildPayload,
   buildInitialVersionPayload,
   hasNoVersion,
@@ -75,6 +78,7 @@ const useDatasetItemsSave = ({
               loadPlayground({
                 datasetId,
                 datasetVersionId: versionId,
+                datasetType,
               })
             }
           >
@@ -84,7 +88,14 @@ const useDatasetItemsSave = ({
         ],
       });
     },
-    [toast, navigateToExperiment, loadPlayground, datasetName, datasetId],
+    [
+      toast,
+      navigateToExperiment,
+      loadPlayground,
+      datasetName,
+      datasetId,
+      datasetType,
+    ],
   );
 
   const changesMutation = useDatasetItemChangesMutation({

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/UseDatasetDropdown.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/UseDatasetDropdown.tsx
@@ -12,6 +12,7 @@ import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import useLoadPlayground from "@/v2/pages-shared/playground/useLoadPlayground";
 import { usePermissions } from "@/contexts/PermissionsContext";
+import { DATASET_TYPE } from "@/types/datasets";
 
 export interface UseDatasetDropdownProps {
   datasetName?: string;
@@ -50,6 +51,7 @@ function UseDatasetDropdown({
     loadPlayground({
       datasetId,
       datasetVersionId,
+      datasetType: DATASET_TYPE.DATASET,
     });
   }, [loadPlayground, datasetId, datasetVersionId]);
 

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/UseDatasetDropdown.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/UseDatasetDropdown.tsx
@@ -22,6 +22,7 @@ export interface UseDatasetDropdownProps {
   entityName?: string;
   projectId?: string | null;
   isEmpty?: boolean;
+  isTestSuite?: boolean;
 }
 
 function UseDatasetDropdown({
@@ -32,6 +33,7 @@ function UseDatasetDropdown({
   entityName = "dataset",
   projectId,
   isEmpty = false,
+  isTestSuite = false,
 }: UseDatasetDropdownProps) {
   const resetKeyRef = useRef(0);
   const resetDialogKeyRef = useRef(0);
@@ -51,9 +53,9 @@ function UseDatasetDropdown({
     loadPlayground({
       datasetId,
       datasetVersionId,
-      datasetType: DATASET_TYPE.DATASET,
+      datasetType: isTestSuite ? DATASET_TYPE.TEST_SUITE : DATASET_TYPE.DATASET,
     });
-  }, [loadPlayground, datasetId, datasetVersionId]);
+  }, [loadPlayground, datasetId, datasetVersionId, isTestSuite]);
 
   const handleOpenPlaygroundClick = () => {
     if (isPlaygroundEmpty) {

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/UseDatasetDropdown.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/UseDatasetDropdown.tsx
@@ -22,7 +22,7 @@ export interface UseDatasetDropdownProps {
   entityName?: string;
   projectId?: string | null;
   isEmpty?: boolean;
-  isTestSuite?: boolean;
+  isTestSuite: boolean;
 }
 
 function UseDatasetDropdown({
@@ -33,7 +33,7 @@ function UseDatasetDropdown({
   entityName = "dataset",
   projectId,
   isEmpty = false,
-  isTestSuite = false,
+  isTestSuite,
 }: UseDatasetDropdownProps) {
   const resetKeyRef = useRef(0);
   const resetDialogKeyRef = useRef(0);

--- a/apps/opik-frontend/src/v2/pages-shared/playground/useLoadPlayground.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/playground/useLoadPlayground.ts
@@ -3,8 +3,13 @@ import { useNavigate } from "@tanstack/react-router";
 import useLocalStorageState from "use-local-storage-state";
 
 import useAppStore, { useActiveProjectId } from "@/store/AppStore";
-import { usePromptMap, useSetPromptMap } from "@/store/PlaygroundStore";
+import {
+  usePromptMap,
+  useSetPromptMap,
+  useSetDatasetType,
+} from "@/store/PlaygroundStore";
 import { generateDefaultPrompt } from "@/lib/playground";
+import { DATASET_TYPE } from "@/types/datasets";
 import {
   generateDefaultLLMPromptMessage,
   getTextFromMessageContent,
@@ -33,6 +38,7 @@ interface LoadPlaygroundOptions {
   autoImprove?: boolean;
   datasetId?: string;
   datasetVersionId?: string;
+  datasetType?: DATASET_TYPE | null;
   templateStructure?: PROMPT_TEMPLATE_STRUCTURE;
   namedPrompts?: NamedPromptContent[];
 }
@@ -44,6 +50,7 @@ function useLoadPlayground() {
 
   const promptMap = usePromptMap();
   const setPromptMap = useSetPromptMap();
+  const setDatasetType = useSetDatasetType();
 
   const [lastPickedModel] = useLastPickedModel({
     key: PLAYGROUND_LAST_PICKED_MODEL,
@@ -170,6 +177,7 @@ function useLoadPlayground() {
         autoImprove = false,
         datasetId,
         datasetVersionId,
+        datasetType,
         templateStructure,
         namedPrompts,
       } = options;
@@ -208,6 +216,8 @@ function useLoadPlayground() {
         );
       }
 
+      setDatasetType(datasetType ?? null);
+
       navigate({
         to: "/$workspaceName/projects/$projectId/playground",
         params: {
@@ -221,6 +231,7 @@ function useLoadPlayground() {
       navigate,
       setPromptMap,
       setDatasetVersionKey,
+      setDatasetType,
       workspaceName,
       activeProjectId,
     ],


### PR DESCRIPTION
## Details

<img width="1920" height="2266" alt="image" src="https://github.com/user-attachments/assets/724ea96a-d14f-4221-b72c-e99d1a9699bb" />

Clicking **Open in Playground** from a test suite or dataset page only synced the dataset reference into the Playground store but left the dataset *type* untouched, so whatever type was previously selected in the Playground persisted. That caused experiments to be created with the wrong type — e.g., a test suite opened while a regular dataset was preselected ran as a regular-dataset experiment, and vice versa.

Both `useLoadPlayground` hooks (v1 and v2) now accept a `datasetType` option and always call `setDatasetType(...)` on navigation, so the store's dataset type is aligned with the source page on every load. All dataset-aware callers (`UseDatasetDropdown`, `UseTestSuiteDropdown`, `TestSuiteItemsPage` save toast, `useDatasetItemsSave` toast) now pass the correct type; prompt-only callers intentionally fall through to `null`, which clears any stale type.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-5942

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6 (1M context)
- Scope: assisted — root-cause investigation, fix implementation, caller audit
- Human verification: code review + manual testing of both reproduction cases from the ticket

## Testing

Commands run:
- `npx tsc --noEmit` — passed
- `npx eslint` on changed files — passed
- `pre-commit run --files <changed>` — passed
- Full frontend pre-commit (lint:fix + typecheck + depcruise) ran via Husky on commit — passed

Scenarios validated manually:
- Case 1: Playground empty or regular dataset preselected → open from test suite page → type becomes `test_suite`, experiment runs as test suite experiment
- Case 2: Playground has test suite selected → open from regular dataset page → type becomes `dataset`, experiment runs as regular dataset experiment
- Regression check: Playground dropdown selection still sets type correctly (unchanged code path)
- Regression check: Prompt-only `Try in Playground` / `Improve in Playground` buttons do not retain a stale dataset type after navigation

## Documentation

N/A — internal bug fix, no user docs affected.