### PR TITLE
[OPIK-5941] [SDK] fix: raise ConfigMismatch when prompt belongs to different project than config

### DIFF
--- a/sdks/python/src/opik/api_objects/agent_config/base.py
+++ b/sdks/python/src/opik/api_objects/agent_config/base.py
@@ -109,6 +109,30 @@ def _init_fallback_cache_entry(
     )
 
 
+def _validate_prompt_project_names(
+    config: "Config",
+    project_name: str,
+) -> None:
+    """Raise ConfigMismatch if any Prompt/ChatPrompt field belongs to a different project."""
+    from opik.api_objects.prompt.base_prompt import BasePrompt  # avoid circular import
+
+    mismatched = []
+    for name in type(config).__field_names__:
+        value = object.__getattribute__(config, name)
+        if isinstance(value, BasePrompt):
+            prompt_project = value.project_name
+            if prompt_project is not None and prompt_project != project_name:
+                mismatched.append((name, prompt_project))
+
+    if mismatched:
+        details = ", ".join(f"{name!r} (project={proj!r})" for name, proj in mismatched)
+        raise ConfigMismatch(
+            f"Config project is {project_name!r}, but the following prompt field(s) "
+            f"belong to a different project: {details}. "
+            f"All prompts referenced in a config must belong to the same project as the config."
+        )
+
+
 def _validate_blueprint_schema(cls: typing.Type["Config"], bp: typing.Any) -> None:
     """Raise ConfigMismatch if ``bp`` is missing any field declared on ``cls``."""
     missing_keys = [name for name in cls.__field_names__ if name not in bp.keys()]
@@ -392,6 +416,7 @@ class Config:
         mask_id: typing.Optional[str],
         field_types: typing.Dict[str, typing.Any],
     ) -> T:
+        _validate_prompt_project_names(fallback, project_name)
         fields_with_values = fallback._extract_fields_with_values()
         try:
             bp = manager.create_blueprint(
@@ -424,6 +449,7 @@ class Config:
         manager: typing.Any,
         description: typing.Optional[str] = None,
     ) -> str:
+        _validate_prompt_project_names(self, manager.project_name)
         fields_with_values = self._extract_fields_with_values()
         field_types = self._infer_field_types()
 

--- a/sdks/python/tests/e2e/test_agent_config.py
+++ b/sdks/python/tests/e2e/test_agent_config.py
@@ -168,10 +168,13 @@ def test_prompt_field_and_trace_metadata__happyflow(
     prompt_name = f"e2e-prompt-{uuid.uuid4().hex[:8]}"
     chat_prompt_name = f"e2e-chat-prompt-{uuid.uuid4().hex[:8]}"
 
-    prompt_v1 = opik_client.create_prompt(name=prompt_name, prompt="Hello v1")
+    prompt_v1 = opik_client.create_prompt(
+        name=prompt_name, prompt="Hello v1", project_name=project_name
+    )
     chat_prompt_v1 = opik_client.create_chat_prompt(
         name=chat_prompt_name,
         messages=[{"role": "user", "content": "Hi v1"}],
+        project_name=project_name,
     )
 
     class PromptConfig(opik.Config):

--- a/sdks/python/tests/unit/api_objects/agent_config/test_base.py
+++ b/sdks/python/tests/unit/api_objects/agent_config/test_base.py
@@ -1628,3 +1628,161 @@ class TestTypeInference:
             "declared_as_float": bool,
             "declared_as_any": str,
         }
+
+
+# ---------------------------------------------------------------------------
+# Prompt project-name validation tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_prompt(project_name=None):
+    """Return a mock BasePrompt with the given project_name."""
+    from opik.api_objects.prompt.base_prompt import BasePrompt
+
+    p = mock.Mock(spec=BasePrompt)
+    p.project_name = project_name
+    return p
+
+
+class TestCreateConfigPromptProjectValidation:
+    """Tests for _validate_prompt_project_names called from create_config."""
+
+    def test_create_config__prompt_same_project__succeeds(self, mock_opik_client):
+        prompt = _make_mock_prompt(project_name="test-project")
+
+        class MyConfig(Config):
+            system_prompt: object
+
+        cfg = MyConfig(system_prompt=prompt)
+
+        # Validation passes when project_name matches. Any subsequent error
+        # (e.g. type serialization) is irrelevant to the validation under test.
+        try:
+            mock_opik_client.create_config(cfg, project_name="test-project")
+        except ConfigMismatch:
+            pytest.fail("ConfigMismatch should not be raised when project_name matches")
+        except Exception:
+            pass  # Backend/serialisation errors are acceptable in this unit test
+
+    def test_create_config__prompt_different_project__raises_config_mismatch(
+        self, mock_opik_client
+    ):
+        prompt = _make_mock_prompt(project_name="other-project")
+
+        class MyConfig(Config):
+            system_prompt: object
+
+        cfg = MyConfig(system_prompt=prompt)
+
+        with pytest.raises(ConfigMismatch, match="system_prompt"):
+            mock_opik_client.create_config(cfg, project_name="test-project")
+
+    def test_create_config__prompt_no_project_name__succeeds(self, mock_opik_client):
+        """A prompt with project_name=None skips the project check."""
+        prompt = _make_mock_prompt(project_name=None)
+
+        class MyConfig(Config):
+            system_prompt: object
+
+        cfg = MyConfig(system_prompt=prompt)
+
+        try:
+            mock_opik_client.create_config(cfg, project_name="test-project")
+        except ConfigMismatch:
+            pytest.fail("ConfigMismatch should not be raised when project_name is None")
+        except Exception:
+            pass
+
+    def test_create_config__multiple_prompts_one_wrong__error_names_bad_field(
+        self, mock_opik_client
+    ):
+        good_prompt = _make_mock_prompt(project_name="test-project")
+        bad_prompt = _make_mock_prompt(project_name="wrong-project")
+
+        class MyConfig(Config):
+            good: object
+            bad: object
+
+        cfg = MyConfig(good=good_prompt, bad=bad_prompt)
+
+        with pytest.raises(ConfigMismatch, match="bad"):
+            mock_opik_client.create_config(cfg, project_name="test-project")
+
+    def test_create_config__multiple_prompts_both_wrong__error_names_all_bad_fields(
+        self, mock_opik_client
+    ):
+        prompt_a = _make_mock_prompt(project_name="proj-a")
+        prompt_b = _make_mock_prompt(project_name="proj-b")
+
+        class MyConfig(Config):
+            field_a: object
+            field_b: object
+
+        cfg = MyConfig(field_a=prompt_a, field_b=prompt_b)
+
+        with pytest.raises(ConfigMismatch) as exc_info:
+            mock_opik_client.create_config(cfg, project_name="test-project")
+
+        msg = str(exc_info.value)
+        assert "field_a" in msg
+        assert "field_b" in msg
+
+    def test_create_config__non_prompt_fields__not_checked(
+        self, mock_rest_client, mock_opik_client
+    ):
+        """Plain scalar values are not prompt-checked, only BasePrompt instances are."""
+
+        class MyConfig(Config):
+            temperature: float
+            model: str
+
+        cfg = MyConfig(temperature=0.7, model="gpt-4")
+
+        created_raw = AgentBlueprintPublic(
+            id="bp-1",
+            name="v1",
+            type="blueprint",
+            values=[],
+        )
+        mock_rest_client.agent_configs.get_blueprint_by_id.return_value = created_raw
+        mock_rest_client.agent_configs.get_latest_blueprint.side_effect = (
+            rest_api_core.ApiError(status_code=404, body="not found")
+        )
+
+        mock_opik_client.create_config(cfg, project_name="test-project")
+
+
+class TestGetOrCreateConfigPromptProjectValidation:
+    """Tests for _validate_prompt_project_names called from _create_from_fallback."""
+
+    def test_get_or_create_config__fallback_prompt_same_project__succeeds(
+        self, mock_opik_client
+    ):
+        prompt = _make_mock_prompt(project_name="test-project")
+
+        class MyConfig(Config):
+            system_prompt: object
+
+        fallback = MyConfig(system_prompt=prompt)
+
+        # Default conftest: get_latest_blueprint raises 404, so the auto-create path
+        # is taken. Validation should pass; any subsequent error is not under test.
+        try:
+            mock_opik_client.get_or_create_config(fallback=fallback)
+        except ConfigMismatch:
+            pytest.fail("ConfigMismatch should not be raised when project_name matches")
+        except Exception:
+            pass
+
+    def test_get_or_create_config__fallback_prompt_different_project__raises_config_mismatch(
+        self, mock_opik_client
+    ):
+        prompt = _make_mock_prompt(project_name="other-project")
+
+        class MyConfig(Config):
+            system_prompt: object
+
+        fallback = MyConfig(system_prompt=prompt)
+
+        with pytest.raises(ConfigMismatch, match="system_prompt"):
+            mock_opik_client.get_or_create_config(fallback=fallback)

--- a/sdks/typescript/src/opik/client/Client.ts
+++ b/sdks/typescript/src/opik/client/Client.ts
@@ -30,6 +30,7 @@ import {
   PromptType,
 } from "@/prompt";
 import { ChatPrompt } from "@/prompt/ChatPrompt";
+import { BasePrompt } from "@/prompt/BasePrompt";
 import { PromptTemplateStructure, type CreateChatPromptOptions, type CommonPromptOptions } from "@/prompt/types";
 import { PromptTemplateStructureMismatch } from "@/prompt/errors";
 import {
@@ -1060,7 +1061,7 @@ export class OpikClient {
         // No structure validation needed for text prompts
       },
       (promptData, versionData) =>
-        Prompt.fromApiResponse(promptData, versionData, this),
+        Prompt.fromApiResponse(promptData, versionData, this, resolvedProjectName),
       () =>
         new Prompt(
           {
@@ -1071,6 +1072,7 @@ export class OpikClient {
             description: options.description,
             tags: options.tags,
             synced: false,
+            projectName: resolvedProjectName,
           },
           this
         ),
@@ -1127,7 +1129,7 @@ export class OpikClient {
         }
       },
       (promptData, versionData) =>
-        ChatPrompt.fromApiResponse(promptData, versionData, this),
+        ChatPrompt.fromApiResponse(promptData, versionData, this, resolvedProjectName),
       () =>
         new ChatPrompt(
           {
@@ -1138,6 +1140,7 @@ export class OpikClient {
             description: options.description,
             tags: options.tags,
             synced: false,
+            projectName: resolvedProjectName,
           },
           this
         ),
@@ -1947,6 +1950,21 @@ export class OpikClient {
       );
     }
 
+    // Validate that all Prompt/ChatPrompt values in the fallback belong to this project.
+    for (const [key, value] of Object.entries(fallback)) {
+      if (
+        value instanceof BasePrompt &&
+        value.projectName !== undefined &&
+        value.projectName !== projectName
+      ) {
+        throw new ConfigMismatchError(
+          `Field "${key}": prompt project "${value.projectName}" does not match ` +
+          `config project "${projectName}". All prompts referenced in a config must ` +
+          `belong to the same project as the config.`
+        );
+      }
+    }
+
     // Auto-create from fallback (handle 409 race: another caller created it concurrently)
     let blueprint: Blueprint;
     try {
@@ -2082,6 +2100,21 @@ export class OpikClient {
     options?: { projectName?: string; description?: string }
   ): Promise<string> => {
     const projectName = options?.projectName ?? this.config.projectName;
+
+    for (const [key, value] of Object.entries(values)) {
+      if (
+        value instanceof BasePrompt &&
+        value.projectName !== undefined &&
+        value.projectName !== projectName
+      ) {
+        throw new ConfigMismatchError(
+          `Field "${key}": prompt project "${value.projectName}" does not match ` +
+          `config project "${projectName}". All prompts referenced in a config must ` +
+          `belong to the same project as the config.`
+        );
+      }
+    }
+
     const manager = new ConfigManager(projectName, this);
     const serialized = serializeValuesRecord(values as Record<string, unknown>);
 

--- a/sdks/typescript/src/opik/client/Client.ts
+++ b/sdks/typescript/src/opik/client/Client.ts
@@ -1209,7 +1209,7 @@ export class OpikClient {
       }
 
       // Step 4: Create the Prompt object with metadata
-      return Prompt.fromApiResponse(promptData, versionData, this);
+      return Prompt.fromApiResponse(promptData, versionData, this, resolvedProjectName);
     } catch (error) {
       if (error instanceof OpikApiError && error.statusCode === 404) {
         return null;
@@ -1287,7 +1287,7 @@ export class OpikClient {
       }
 
       // Step 4: Create the ChatPrompt object with metadata
-      return ChatPrompt.fromApiResponse(promptData, versionData, this);
+      return ChatPrompt.fromApiResponse(promptData, versionData, this, resolvedProjectName);
     } catch (error) {
       if (error instanceof OpikApiError && error.statusCode === 404) {
         return null;
@@ -1392,14 +1392,16 @@ export class OpikClient {
 
             const templateStructure = versionResponse.templateStructure;
 
+            const searchProjectName = this.resolveProjectName();
             // Default to text for backwards compatibility
             if (!templateStructure || templateStructure === PromptTemplateStructure.Text) {
-              return Prompt.fromApiResponse(promptData, versionResponse, this);
+              return Prompt.fromApiResponse(promptData, versionResponse, this, searchProjectName);
             } else if (templateStructure === PromptTemplateStructure.Chat) {
               return ChatPrompt.fromApiResponse(
                 promptData,
                 versionResponse,
-                this
+                this,
+                searchProjectName
               );
             }
 
@@ -1813,6 +1815,30 @@ export class OpikClient {
   }
 
   /** Build a Config from a local fallback object (no backend involved). */
+  /**
+   * Validates that every BasePrompt value in `values` belongs to `projectName`.
+   * Prompts with an undefined projectName are skipped (cannot be validated).
+   * Throws ConfigMismatchError on the first mismatch found.
+   */
+  private _validatePromptProjects(
+    values: Record<string, unknown>,
+    projectName: string
+  ): void {
+    for (const [key, value] of Object.entries(values)) {
+      if (
+        value instanceof BasePrompt &&
+        value.projectName !== undefined &&
+        value.projectName !== projectName
+      ) {
+        throw new ConfigMismatchError(
+          `Field "${key}": prompt project "${value.projectName}" does not match ` +
+          `config project "${projectName}". All prompts referenced in a config must ` +
+          `belong to the same project as the config.`
+        );
+      }
+    }
+  }
+
   private _makeFallbackConfig<T extends Record<string, unknown>>(
     fallback: T,
     maskId: string | undefined
@@ -1951,19 +1977,7 @@ export class OpikClient {
     }
 
     // Validate that all Prompt/ChatPrompt values in the fallback belong to this project.
-    for (const [key, value] of Object.entries(fallback)) {
-      if (
-        value instanceof BasePrompt &&
-        value.projectName !== undefined &&
-        value.projectName !== projectName
-      ) {
-        throw new ConfigMismatchError(
-          `Field "${key}": prompt project "${value.projectName}" does not match ` +
-          `config project "${projectName}". All prompts referenced in a config must ` +
-          `belong to the same project as the config.`
-        );
-      }
-    }
+    this._validatePromptProjects(fallback as Record<string, unknown>, projectName);
 
     // Auto-create from fallback (handle 409 race: another caller created it concurrently)
     let blueprint: Blueprint;
@@ -2101,19 +2115,7 @@ export class OpikClient {
   ): Promise<string> => {
     const projectName = options?.projectName ?? this.config.projectName;
 
-    for (const [key, value] of Object.entries(values)) {
-      if (
-        value instanceof BasePrompt &&
-        value.projectName !== undefined &&
-        value.projectName !== projectName
-      ) {
-        throw new ConfigMismatchError(
-          `Field "${key}": prompt project "${value.projectName}" does not match ` +
-          `config project "${projectName}". All prompts referenced in a config must ` +
-          `belong to the same project as the config.`
-        );
-      }
-    }
+    this._validatePromptProjects(values as Record<string, unknown>, projectName);
 
     const manager = new ConfigManager(projectName, this);
     const serialized = serializeValuesRecord(values as Record<string, unknown>);

--- a/sdks/typescript/src/opik/prompt/BasePrompt.ts
+++ b/sdks/typescript/src/opik/prompt/BasePrompt.ts
@@ -19,6 +19,7 @@ export interface BasePromptData {
   tags?: string[];
   templateStructure?: PromptTemplateStructure;
   synced?: boolean;
+  projectName?: string;
 }
 
 /**
@@ -32,6 +33,7 @@ export abstract class BasePrompt {
   public readonly type: PromptType;
   public readonly changeDescription: string | undefined;
   public readonly templateStructure: PromptTemplateStructure;
+  public readonly projectName: string | undefined;
 
   /** Whether the prompt has been successfully synced with the backend. */
   public readonly synced: boolean;
@@ -57,6 +59,7 @@ export abstract class BasePrompt {
     this._tags = data.tags ? [...data.tags] : [];
     this._metadata = data.metadata;
     this.opik = opik;
+    this.projectName = data.projectName;
   }
 
   // Public getters for mutable fields

--- a/sdks/typescript/src/opik/prompt/ChatPrompt.ts
+++ b/sdks/typescript/src/opik/prompt/ChatPrompt.ts
@@ -106,6 +106,7 @@ export class ChatPrompt extends BasePrompt {
     promptData: OpikApi.PromptPublic,
     apiResponse: OpikApi.PromptVersionDetail,
     opik: OpikClient,
+    projectName?: string,
   ): ChatPrompt {
     // Validate required fields
     if (!apiResponse.template) {
@@ -172,6 +173,7 @@ export class ChatPrompt extends BasePrompt {
         description: promptData.description,
         tags: promptData.tags,
         synced: true,
+        projectName,
       },
       opik,
     );

--- a/sdks/typescript/src/opik/prompt/Prompt.ts
+++ b/sdks/typescript/src/opik/prompt/Prompt.ts
@@ -85,6 +85,7 @@ export class Prompt extends BasePrompt {
     promptData: OpikApi.PromptPublic,
     apiResponse: OpikApi.PromptVersionDetail,
     opik: OpikClient,
+    projectName?: string,
   ): Prompt {
     // Validate required fields
     if (!apiResponse.template) {
@@ -134,6 +135,7 @@ export class Prompt extends BasePrompt {
         description: promptData.description,
         tags: promptData.tags,
         synced: true,
+        projectName,
       },
       opik,
     );

--- a/sdks/typescript/tests/unit/client/client-agentConfig.test.ts
+++ b/sdks/typescript/tests/unit/client/client-agentConfig.test.ts
@@ -6,6 +6,8 @@ import * as OpikApi from "@/rest_api/api";
 import { trackStorage } from "@/decorators/track";
 import { Prompt } from "@/prompt/Prompt";
 import { ChatPrompt } from "@/prompt/ChatPrompt";
+import { ConfigMismatchError } from "@/errors/agent-config/errors";
+import { PromptType } from "@/prompt/types";
 import {
   mockAPIFunction,
   createMockHttpResponsePromise,
@@ -419,6 +421,264 @@ describe("Blueprint prompt class hints", () => {
       opik
     );
     expect(bp.values["p"]).toBeInstanceOf(Prompt);
+  });
+});
+
+describe("createConfig prompt project validation", () => {
+  let client: Opik;
+
+  /** Build a minimal Prompt with a given projectName (no backend needed). */
+  function makePrompt(projectName?: string): Prompt {
+    return new Prompt(
+      {
+        name: "test-prompt",
+        prompt: "Hello {{name}}",
+        type: PromptType.MUSTACHE,
+        synced: false,
+        projectName,
+      },
+      client,
+    );
+  }
+
+  /** Build a minimal ChatPrompt with a given projectName (no backend needed). */
+  function makeChatPrompt(projectName?: string): ChatPrompt {
+    return new ChatPrompt(
+      {
+        name: "test-chat-prompt",
+        messages: [{ role: "user", content: "Hi" }],
+        type: PromptType.MUSTACHE,
+        synced: false,
+        projectName,
+      },
+      client,
+    );
+  }
+
+  beforeEach(() => {
+    client = new Opik({ projectName: "test-project" });
+  });
+
+  it("should throw ConfigMismatchError when a Prompt field belongs to a different project", async () => {
+    const prompt = makePrompt("other-project");
+
+    await expect(
+      client.createConfig(
+        { systemPrompt: prompt },
+        { projectName: "test-project" },
+      ),
+    ).rejects.toBeInstanceOf(ConfigMismatchError);
+  });
+
+  it("should throw ConfigMismatchError when a ChatPrompt field belongs to a different project", async () => {
+    const chatPrompt = makeChatPrompt("other-project");
+
+    await expect(
+      client.createConfig(
+        { systemPrompt: chatPrompt },
+        { projectName: "test-project" },
+      ),
+    ).rejects.toBeInstanceOf(ConfigMismatchError);
+  });
+
+  it("should include the field name in the error message", async () => {
+    const prompt = makePrompt("wrong-project");
+
+    await expect(
+      client.createConfig(
+        { myField: prompt },
+        { projectName: "test-project" },
+      ),
+    ).rejects.toThrow("myField");
+  });
+
+  it("should not throw ConfigMismatchError when a Prompt field has projectName matching the config project", async () => {
+    const prompt = makePrompt("test-project");
+
+    try {
+      await client.createConfig({ systemPrompt: prompt }, { projectName: "test-project" });
+    } catch (error) {
+      if (error instanceof ConfigMismatchError) {
+        throw new Error(`Should not throw ConfigMismatchError, but got: ${(error as Error).message}`);
+      }
+    }
+  });
+
+  it("should not throw ConfigMismatchError when a Prompt field has no projectName set", async () => {
+    const prompt = makePrompt(undefined);
+
+    try {
+      await client.createConfig({ systemPrompt: prompt }, { projectName: "test-project" });
+    } catch (error) {
+      if (error instanceof ConfigMismatchError) {
+        throw new Error(`Should not throw ConfigMismatchError, but got: ${(error as Error).message}`);
+      }
+    }
+  });
+
+  it("should not throw ConfigMismatchError for plain scalar values (no prompt instances)", async () => {
+    const getLatestSpy = vi
+      .spyOn(client.api.agentConfigs, "getLatestBlueprint")
+      .mockImplementation(() =>
+        (() => { throw new OpikApiError({ message: "Not found", statusCode: 404 }); })()
+      );
+    const createSpy = vi
+      .spyOn(client.api.agentConfigs, "createAgentConfig")
+      .mockImplementation(mockAPIFunction);
+    const getBySpy = vi
+      .spyOn(client.api.agentConfigs, "getBlueprintById")
+      .mockImplementation(() =>
+        createMockHttpResponsePromise({
+          id: "bp-1",
+          type: "blueprint" as OpikApi.AgentBlueprintPublicType,
+          values: [],
+        } as OpikApi.AgentBlueprintPublic)
+      );
+    const retrieveProjectSpy = vi
+      .spyOn(client.api.projects, "retrieveProject")
+      .mockImplementation(() =>
+        createMockHttpResponsePromise({ id: "proj-1", name: "test-project" })
+      );
+
+    await expect(
+      client.createConfig(
+        { temperature: 0.7, model: "gpt-4" },
+        { projectName: "test-project" },
+      ),
+    ).resolves.toBeDefined();
+
+    getLatestSpy.mockRestore();
+    createSpy.mockRestore();
+    getBySpy.mockRestore();
+    retrieveProjectSpy.mockRestore();
+  });
+
+  it("should validate against the resolved project when no explicit projectName option is given", async () => {
+    // client was created with projectName: "test-project", so that's what gets used
+    const prompt = makePrompt("different-project");
+
+    await expect(
+      client.createConfig({ systemPrompt: prompt }), // no options.projectName
+    ).rejects.toBeInstanceOf(ConfigMismatchError);
+  });
+});
+
+describe("getOrCreateConfig prompt project validation", () => {
+  let client: Opik;
+  let retrieveProjectSpy: MockInstance<typeof client.api.projects.retrieveProject>;
+  let getBlueprintByEnvSpy: MockInstance<typeof client.api.agentConfigs.getBlueprintByEnv>;
+  let getLatestBlueprintSpy: MockInstance<typeof client.api.agentConfigs.getLatestBlueprint>;
+
+  /** Wrap a getOrCreateConfig call inside the track context required by the implementation. */
+  function callInsideTrack<T extends Record<string, unknown>>(
+    fallback: T,
+    opts?: { projectName?: string },
+  ) {
+    return trackStorage.run(
+      { span: { update: vi.fn() }, trace: { update: vi.fn() } } as unknown as Parameters<
+        typeof trackStorage.run
+      >[0],
+      () => client.getOrCreateConfig({ fallback, ...opts }),
+    );
+  }
+
+  function makePrompt(projectName?: string): Prompt {
+    return new Prompt(
+      { name: "p", prompt: "Hi", type: PromptType.MUSTACHE, synced: false, projectName },
+      client,
+    );
+  }
+
+  function makeChatPrompt(projectName?: string): ChatPrompt {
+    return new ChatPrompt(
+      { name: "p", messages: [{ role: "user", content: "Hi" }], type: PromptType.MUSTACHE, synced: false, projectName },
+      client,
+    );
+  }
+
+  beforeEach(() => {
+    client = new Opik({ projectName: "test-project" });
+
+    retrieveProjectSpy = vi
+      .spyOn(client.api.projects, "retrieveProject")
+      .mockImplementation(() =>
+        createMockHttpResponsePromise({ id: "proj-1", name: "test-project" })
+      );
+
+    // Simulate empty project: both env-tagged and project-wide lookups return 404
+    getBlueprintByEnvSpy = vi
+      .spyOn(client.api.agentConfigs, "getBlueprintByEnv")
+      .mockImplementation(() => {
+        throw new OpikApiError({ message: "Not found", statusCode: 404 });
+      });
+
+    getLatestBlueprintSpy = vi
+      .spyOn(client.api.agentConfigs, "getLatestBlueprint")
+      .mockImplementation(() => {
+        throw new OpikApiError({ message: "Not found", statusCode: 404 });
+      });
+  });
+
+  afterEach(() => {
+    retrieveProjectSpy.mockRestore();
+    getBlueprintByEnvSpy.mockRestore();
+    getLatestBlueprintSpy.mockRestore();
+  });
+
+  it("should throw ConfigMismatchError when fallback has a Prompt from a different project", async () => {
+    const prompt = makePrompt("other-project");
+
+    await expect(callInsideTrack({ systemPrompt: prompt })).rejects.toBeInstanceOf(
+      ConfigMismatchError,
+    );
+  });
+
+  it("should throw ConfigMismatchError when fallback has a ChatPrompt from a different project", async () => {
+    const chatPrompt = makeChatPrompt("other-project");
+
+    await expect(callInsideTrack({ systemPrompt: chatPrompt })).rejects.toBeInstanceOf(
+      ConfigMismatchError,
+    );
+  });
+
+  it("should include the field name in the error message", async () => {
+    const prompt = makePrompt("wrong-project");
+
+    await expect(callInsideTrack({ myField: prompt })).rejects.toThrow("myField");
+  });
+
+  it("should not throw ConfigMismatchError when fallback prompt belongs to the same project", async () => {
+    const prompt = makePrompt("test-project");
+
+    try {
+      await callInsideTrack({ systemPrompt: prompt });
+    } catch (error) {
+      if (error instanceof ConfigMismatchError) {
+        throw new Error(`Should not throw ConfigMismatchError, but got: ${(error as Error).message}`);
+      }
+      // Other errors (serialization, blueprint field validation, etc.) are acceptable
+    }
+  });
+
+  it("should not throw ConfigMismatchError when fallback prompt has no projectName", async () => {
+    const prompt = makePrompt(undefined);
+
+    try {
+      await callInsideTrack({ systemPrompt: prompt });
+    } catch (error) {
+      if (error instanceof ConfigMismatchError) {
+        throw new Error(`Should not throw ConfigMismatchError, but got: ${(error as Error).message}`);
+      }
+    }
+  });
+
+  it("should validate against the resolved project when no explicit projectName option is given", async () => {
+    // client was created with projectName: "test-project"
+    const prompt = makePrompt("different-project");
+
+    await expect(callInsideTrack({ systemPrompt: prompt })).rejects.toBeInstanceOf(
+      ConfigMismatchError,
+    );
   });
 });
 

--- a/sdks/typescript/tests/unit/client/client-agentConfig.test.ts
+++ b/sdks/typescript/tests/unit/client/client-agentConfig.test.ts
@@ -561,6 +561,43 @@ describe("createConfig prompt project validation", () => {
       client.createConfig({ systemPrompt: prompt }), // no options.projectName
     ).rejects.toBeInstanceOf(ConfigMismatchError);
   });
+
+  it("should throw ConfigMismatchError for a prompt with a different projectName (e.g. from getPrompt)", async () => {
+    // Simulates a prompt returned by getPrompt({ projectName: "other-project" })
+    const prompt = new Prompt(
+      {
+        name: "fetched-prompt",
+        prompt: "Hello",
+        type: PromptType.MUSTACHE,
+        synced: true,
+        projectName: "other-project",
+      },
+      client,
+    );
+
+    await expect(
+      client.createConfig({ systemPrompt: prompt }, { projectName: "test-project" }),
+    ).rejects.toBeInstanceOf(ConfigMismatchError);
+  });
+
+  it("should throw ConfigMismatchError for a searchPrompts result from a different project", async () => {
+    // searchPrompts uses this.resolveProjectName() → "other-project" if client configured that way
+    const otherClient = new Opik({ projectName: "other-project" });
+    const prompt = new Prompt(
+      {
+        name: "search-result",
+        prompt: "Hello",
+        type: PromptType.MUSTACHE,
+        synced: true,
+        projectName: "other-project",
+      },
+      otherClient,
+    );
+
+    await expect(
+      client.createConfig({ systemPrompt: prompt }, { projectName: "test-project" }),
+    ).rejects.toBeInstanceOf(ConfigMismatchError);
+  });
 });
 
 describe("getOrCreateConfig prompt project validation", () => {


### PR DESCRIPTION
## Details

Fixes a bug where using a `Prompt` or `ChatPrompt` whose `project_name` differs from the `AgentConfig`'s project caused `get_or_create_config` to silently fall back to local defaults rather than surfacing the mismatch as an error.

Both `create_config` and `get_or_create_config` (first-time auto-create path) now raise `ConfigMismatch` / `ConfigMismatchError` immediately when any prompt field belongs to a different project.

**Python (`sdks/python`):**
- Added `_validate_prompt_project_names(config, project_name)` in `agent_config/base.py`; checks all `BasePrompt` field values against the config's project.
- Called from `_create_from_instance` (`create_config`) and `_create_from_fallback` (`get_or_create_config` auto-create).

**TypeScript (`sdks/typescript`):**
- Added `projectName?: string` to `BasePromptData` / `BasePrompt`; threaded through `Prompt.fromApiResponse`, `ChatPrompt.fromApiResponse`, and the `createPrompt` / `createChatPrompt` factories so the project name is preserved on each instance.
- Validation added in `Client.createConfig` and `Client._resolveNullBlueprint` (the auto-create branch of `getOrCreateConfig`).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5941

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Sonnet 4.6
- Scope: full implementation
- Human verification: code review

## Testing

**Python:**
```
cd sdks/python
python -m pytest tests/unit/api_objects/agent_config/test_base.py -q
# 89 passed
```

New test classes:
- `TestCreateConfigPromptProjectValidation` — 6 cases covering `create_config` (same project, different project, no project, multiple fields, scalars)
- `TestGetOrCreateConfigPromptProjectValidation` — 2 cases covering `get_or_create_config` auto-create path

**TypeScript:**
```
cd sdks/typescript
npx tsc --noEmit          # clean
vitest run tests/unit/client/client-agentConfig.test.ts
# 37 passed
```

New describe blocks:
- `createConfig prompt project validation` — 7 tests
- `getOrCreateConfig prompt project validation` — 6 tests

## Documentation

N/A — error messages are self-explanatory.