### PR TITLE
[OPIK-5889] perf: lightweight _opik package to fix Online Scoring 504 timeouts

### DIFF
--- a/apps/opik-sandbox-executor-python/scoring_runner.py
+++ b/apps/opik-sandbox-executor-python/scoring_runner.py
@@ -1,11 +1,67 @@
 import inspect
 import json
+import sys
 import traceback
+import types
 import uuid
 from sys import argv
-from types import ModuleType
 from typing import Type, Union, List, Any, Dict
 
+# ---------------------------------------------------------------------------
+# Lightweight import patching
+# ---------------------------------------------------------------------------
+# The full `opik` package takes ~2.5s to import (pydantic_settings, REST
+# client, sentry, logfire, 40+ metric classes).  Under CPU contention in the
+# sandbox pods this alone can exhaust the 9s execution timeout.
+#
+# The `_opik` package provides pure-stdlib BaseMetric and ScoreResult (~8ms).
+# We register stub modules in sys.modules so that user code doing
+#   `from opik.evaluation.metrics import BaseMetric`
+# resolves to the lightweight versions without triggering the real `opik`
+# init.  If user code accesses anything else on these modules, the
+# __getattr__ fallback loads the real `opik` package transparently.
+# ---------------------------------------------------------------------------
+
+import _opik._base_metric
+import _opik._score_result
+
+_stubs: dict = {}
+
+
+def _load_real_opik() -> None:
+    """Replace all stubs with the real opik package (lazy fallback)."""
+    for name in list(_stubs):
+        if sys.modules.get(name) is _stubs[name]:
+            del sys.modules[name]
+    _stubs.clear()
+    import opik  # noqa: F811 — triggers the real init
+
+
+class _FallbackModule(types.ModuleType):
+    """Stub module that loads the real opik on first unknown attribute access."""
+
+    def __getattr__(self, name: str) -> Any:
+        _load_real_opik()
+        return getattr(sys.modules[self.__name__], name)
+
+
+for _name in ["opik", "opik.evaluation", "opik.evaluation.metrics"]:
+    _stub = _FallbackModule(_name)
+    _stub.__path__ = []  # type: ignore[attr-defined]
+    sys.modules[_name] = _stub
+    _stubs[_name] = _stub
+
+sys.modules["opik.evaluation.metrics.base_metric"] = _opik._base_metric
+sys.modules["opik.evaluation.metrics.score_result"] = _opik._score_result
+_stubs["opik.evaluation.metrics.base_metric"] = _opik._base_metric
+_stubs["opik.evaluation.metrics.score_result"] = _opik._score_result
+
+sys.modules["opik.evaluation.metrics"].base_metric = _opik._base_metric  # type: ignore[attr-defined]
+sys.modules["opik.evaluation.metrics"].score_result = _opik._score_result  # type: ignore[attr-defined]
+sys.modules["opik.evaluation.metrics"].BaseMetric = _opik._base_metric.BaseMetric  # type: ignore[attr-defined]
+sys.modules["opik.evaluation.metrics"].ScoreResult = _opik._score_result.ScoreResult  # type: ignore[attr-defined]
+
+# Now these resolve to the lightweight versions
 from opik.evaluation.metrics import BaseMetric
 from opik.evaluation.metrics.score_result import ScoreResult
 

--- a/sdks/python/src/_opik/__init__.py
+++ b/sdks/python/src/_opik/__init__.py
@@ -1,0 +1,14 @@
+"""Lightweight entrypoint for core Opik metric types.
+
+Provides :class:`BaseMetric` and :class:`ScoreResult` without pulling in
+the full ``opik`` package, keeping import time near zero.
+
+Usage::
+
+    from _opik import BaseMetric, ScoreResult
+"""
+
+from ._score_result import ScoreResult
+from ._base_metric import BaseMetric
+
+__all__ = ["BaseMetric", "ScoreResult"]

--- a/sdks/python/src/_opik/_base_metric.py
+++ b/sdks/python/src/_opik/_base_metric.py
@@ -1,0 +1,43 @@
+"""Lightweight BaseMetric ABC with no heavy dependencies."""
+
+import abc
+from typing import Any, List, Optional, Union
+
+from . import _score_result
+
+
+class BaseMetric(abc.ABC):
+    """Abstract base class for all metrics.
+
+    Subclass this and implement :meth:`score` to create a custom metric.
+    The lightweight version carries no tracking or configuration overhead,
+    making it suitable for contexts that only need the metric interface.
+
+    Args:
+        name: Display name for the metric.  Defaults to the class name.
+        track: Whether the metric should be tracked by Opik.
+        project_name: Optional project to associate tracked results with.
+    """
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        track: bool = True,
+        project_name: Optional[str] = None,
+    ) -> None:
+        self.name = name if name is not None else self.__class__.__name__
+        self.track = track
+        self.project_name = project_name
+
+    @abc.abstractmethod
+    def score(
+        self, *args: Any, **kwargs: Any
+    ) -> Union[_score_result.ScoreResult, List[_score_result.ScoreResult]]:
+        """Compute the metric score. Must be implemented by subclasses."""
+        raise NotImplementedError()
+
+    async def ascore(
+        self, *args: Any, **kwargs: Any
+    ) -> Union[_score_result.ScoreResult, List[_score_result.ScoreResult]]:
+        """Async variant of :meth:`score`. Defaults to calling ``score``."""
+        return self.score(*args, **kwargs)

--- a/sdks/python/src/_opik/_score_result.py
+++ b/sdks/python/src/_opik/_score_result.py
@@ -1,0 +1,25 @@
+"""Lightweight ScoreResult dataclass with no heavy dependencies."""
+
+import dataclasses
+from typing import Any, Dict, Optional
+
+
+@dataclasses.dataclass
+class ScoreResult:
+    """Result returned by a metric's ``score`` method.
+
+    Attributes:
+        name: Metric name that produced this result.
+        value: Numeric score value.
+        reason: Optional human-readable explanation.
+        category_name: Optional category label.
+        metadata: Optional dictionary of extra metadata.
+        scoring_failed: Flag indicating the scoring could not complete.
+    """
+
+    name: str
+    value: float
+    reason: Optional[str] = None
+    category_name: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    scoring_failed: bool = False

--- a/sdks/python/src/opik/evaluation/metrics/base_metric.py
+++ b/sdks/python/src/opik/evaluation/metrics/base_metric.py
@@ -1,12 +1,12 @@
-import abc
 from typing import Any, List, Optional, Union
 
 import opik
 import opik.config as opik_config
+import _opik._base_metric as _opik_base_metric
 from ..metrics import score_result
 
 
-class BaseMetric(abc.ABC):
+class BaseMetric(_opik_base_metric.BaseMetric):
     """
     Abstract base class for all metrics. When creating a new metric, you should inherit
     from this class and implement the abstract methods.
@@ -40,8 +40,7 @@ class BaseMetric(abc.ABC):
         track: bool = True,
         project_name: Optional[str] = None,
     ) -> None:
-        self.name = name if name is not None else self.__class__.__name__
-        self.track = track
+        super().__init__(name=name, track=track, project_name=project_name)
 
         config = opik_config.OpikConfig()
 
@@ -53,7 +52,6 @@ class BaseMetric(abc.ABC):
             self.score = track_decorator(self.score)  # type: ignore
             self.ascore = track_decorator(self.ascore)  # type: ignore
 
-    @abc.abstractmethod
     def score(
         self, *args: Any, **kwargs: Any
     ) -> Union[score_result.ScoreResult, List[score_result.ScoreResult]]:

--- a/sdks/python/src/opik/evaluation/metrics/score_result.py
+++ b/sdks/python/src/opik/evaluation/metrics/score_result.py
@@ -1,12 +1,3 @@
-import dataclasses
-from typing import Optional, Dict, Any
+from _opik import ScoreResult
 
-
-@dataclasses.dataclass
-class ScoreResult:
-    name: str
-    value: float
-    reason: Optional[str] = None
-    category_name: Optional[str] = None
-    metadata: Optional[Dict[str, Any]] = None
-    scoring_failed: bool = False
+__all__ = ["ScoreResult"]

--- a/sdks/python/tests/unit/evaluation/metrics/test_base_metric.py
+++ b/sdks/python/tests/unit/evaluation/metrics/test_base_metric.py
@@ -1,4 +1,7 @@
 import asyncio
+import subprocess
+import sys
+
 import pytest
 from typing import Any, List, Union
 
@@ -84,3 +87,148 @@ def test_base_metric_ascore_returns_expected_result():
         name="DummyMetric", value=0.5, reason="Test metric score"
     )
     assert actual_result == expected_result
+
+
+class TestLightweightOpikPackage:
+    """Tests for the _opik lightweight package and sys.modules patching.
+
+    These run in subprocesses to get a clean module state.
+    """
+
+    def test_opik_lightweight_import_does_not_load_heavy_modules(self):
+        """Verify that importing from _opik stays lightweight.
+
+        The _opik package must only use stdlib modules. If this test fails,
+        someone added a dependency to _opik that pulls in heavy packages.
+
+        HOW TO FIX: Remove the heavy import from _opik/. The _opik package
+        must only depend on stdlib (abc, dataclasses, typing).
+        """
+        code = """
+import sys
+
+from _opik import BaseMetric, ScoreResult
+
+# Verify basic functionality works
+class SimpleMetric(BaseMetric):
+    def score(self, **kwargs):
+        return ScoreResult(name="simple", value=1.0)
+
+metric = SimpleMetric()
+result = metric.score()
+assert result.name == "simple"
+assert result.value == 1.0
+
+# Only these opik-related modules should be loaded
+ALLOWED = {"_opik", "_opik._base_metric", "_opik._score_result"}
+loaded = {m for m in sys.modules if m.startswith(("opik", "_opik"))}
+unexpected = sorted(loaded - ALLOWED)
+
+if unexpected:
+    print("FAIL")
+    print(
+        "Lightweight _opik import loaded unexpected modules.\\n"
+        "The _opik package must only use stdlib.\\n"
+        "Unexpected modules:\\n  " + "\\n  ".join(unexpected)
+    )
+    sys.exit(1)
+
+print("LIGHTWEIGHT_OK")
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"Lightweight _opik loaded unexpected modules.\n"
+            f"See stdout for details:\n{result.stdout}\n{result.stderr}"
+        )
+        assert "LIGHTWEIGHT_OK" in result.stdout
+
+    def test_sys_modules_patch_intercepts_opik_imports(self):
+        """Verify the sys.modules patching works like scoring_runner.py does.
+
+        User code does `from opik.evaluation.metrics import BaseMetric` and
+        it should resolve to the lightweight _opik.BaseMetric without
+        triggering the real opik import.
+
+        HOW TO FIX if this fails: Check that _opik._base_metric.BaseMetric
+        and _opik._score_result.ScoreResult match the interface expected by
+        opik.evaluation.metrics.BaseMetric users.
+        """
+        code = """
+import sys
+import types
+
+import _opik._base_metric
+import _opik._score_result
+
+# Patch sys.modules the same way scoring_runner.py does
+for name in ["opik", "opik.evaluation", "opik.evaluation.metrics"]:
+    stub = types.ModuleType(name)
+    stub.__path__ = []
+    sys.modules[name] = stub
+
+sys.modules["opik.evaluation.metrics.base_metric"] = _opik._base_metric
+sys.modules["opik.evaluation.metrics.score_result"] = _opik._score_result
+sys.modules["opik.evaluation.metrics"].base_metric = _opik._base_metric
+sys.modules["opik.evaluation.metrics"].score_result = _opik._score_result
+sys.modules["opik.evaluation.metrics"].BaseMetric = _opik._base_metric.BaseMetric
+sys.modules["opik.evaluation.metrics"].ScoreResult = _opik._score_result.ScoreResult
+
+# Now simulate what user code does
+from opik.evaluation.metrics import BaseMetric
+from opik.evaluation.metrics.score_result import ScoreResult
+
+class UserMetric(BaseMetric):
+    def score(self, output="", **kwargs):
+        return ScoreResult(name="user_metric", value=0.75, reason="test")
+
+metric = UserMetric()
+result = metric.score(output="hello")
+assert result.name == "user_metric"
+assert result.value == 0.75
+assert result.reason == "test"
+
+# Verify heavy opik modules were NOT loaded
+heavy = [m for m in sys.modules if m.startswith("opik.") and m not in {
+    "opik.evaluation", "opik.evaluation.metrics",
+    "opik.evaluation.metrics.base_metric", "opik.evaluation.metrics.score_result",
+}]
+if heavy:
+    print("FAIL")
+    print(f"Patching did not prevent heavy imports: {heavy}")
+    sys.exit(1)
+
+print("PATCH_OK")
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"sys.modules patching failed.\n"
+            f"See stdout for details:\n{result.stdout}\n{result.stderr}"
+        )
+        assert "PATCH_OK" in result.stdout
+
+    def test_opik_base_metric_is_subclass_of_lightweight(self):
+        """Verify that opik.evaluation.metrics.BaseMetric subclasses _opik.BaseMetric.
+
+        This ensures isinstance() works across both import paths.
+        """
+        from _opik import BaseMetric as LightweightBaseMetric
+        from opik.evaluation.metrics import BaseMetric as FullBaseMetric
+
+        assert issubclass(FullBaseMetric, LightweightBaseMetric)
+
+    def test_score_result_is_same_class(self):
+        """Verify that ScoreResult is the same class from both paths."""
+        from _opik import ScoreResult as LightweightScoreResult
+        from opik.evaluation.metrics.score_result import (
+            ScoreResult as FullScoreResult,
+        )
+
+        assert LightweightScoreResult is FullScoreResult


### PR DESCRIPTION
## Summary
- Adds `_opik` package with pure-stdlib `BaseMetric` and `ScoreResult` (~8ms import vs ~2.5s for full `opik`)
- Patches `sys.modules` in `scoring_runner.py` so user code's `from opik.evaluation.metrics import BaseMetric` resolves to the lightweight version inside sandbox containers
- Falls back to the real `opik` package transparently if user code accesses anything beyond `BaseMetric`/`ScoreResult`
- `opik.BaseMetric` now subclasses `_opik.BaseMetric` — `isinstance()` works across both import paths
- `ScoreResult` is the same class object from both paths

## Context
Each sandbox Docker container execution starts a fresh Python process. The full `opik` import chain (~2.5s: pydantic_settings, REST client, sentry, logfire, 40+ metric classes) under 17-way CPU contention on 2-core pods consumed the entire 9s timeout before user code could run, causing 504 errors.

## Test plan
- [ ] Verify `_opik` import stays lightweight (allowlist test)
- [ ] Verify `sys.modules` patching intercepts `from opik.evaluation.metrics import BaseMetric`
- [ ] Verify `isinstance()` compatibility across import paths
- [ ] Verify `ScoreResult` identity across import paths
- [ ] Verify existing SDK tests pass (no regressions from BaseMetric subclassing)
- [ ] CI green

Based on SDK team's approach from #6292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)