### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -12494,6 +12494,13 @@ components:
           type: string
           description: Custom prompt to use for generation instead of auto-generated
             one
+        max_completion_tokens:
+          minimum: 100
+          type: integer
+          description: "Maximum number of tokens for the LLM response. Required by\
+            \ Anthropic, used as maxOutputTokens for Gemini. If not provided, defaults\
+            \ to 4000 for Anthropic models only."
+          format: int32
     DatasetExpansion_Write:
       required:
       - model
@@ -12529,6 +12536,13 @@ components:
           type: string
           description: Custom prompt to use for generation instead of auto-generated
             one
+        max_completion_tokens:
+          minimum: 100
+          type: integer
+          description: "Maximum number of tokens for the LLM response. Required by\
+            \ Anthropic, used as maxOutputTokens for Gemini. If not provided, defaults\
+            \ to 4000 for Anthropic models only."
+          format: int32
     AssertionResult_Compare:
       type: object
       properties:

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -12494,6 +12494,13 @@ components:
           type: string
           description: Custom prompt to use for generation instead of auto-generated
             one
+        max_completion_tokens:
+          minimum: 100
+          type: integer
+          description: "Maximum number of tokens for the LLM response. Required by\
+            \ Anthropic, used as maxOutputTokens for Gemini. If not provided, defaults\
+            \ to 4000 for Anthropic models only."
+          format: int32
     DatasetExpansion_Write:
       required:
       - model
@@ -12529,6 +12536,13 @@ components:
           type: string
           description: Custom prompt to use for generation instead of auto-generated
             one
+        max_completion_tokens:
+          minimum: 100
+          type: integer
+          description: "Maximum number of tokens for the LLM response. Required by\
+            \ Anthropic, used as maxOutputTokens for Gemini. If not provided, defaults\
+            \ to 4000 for Anthropic models only."
+          format: int32
     AssertionResult_Compare:
       type: object
       properties:

--- a/sdks/python/src/opik/rest_api/datasets/client.py
+++ b/sdks/python/src/opik/rest_api/datasets/client.py
@@ -715,6 +715,7 @@ class DatasetsClient:
         preserve_fields: typing.Optional[typing.Sequence[str]] = OMIT,
         variation_instructions: typing.Optional[str] = OMIT,
         custom_prompt: typing.Optional[str] = OMIT,
+        max_completion_tokens: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> DatasetExpansionResponse:
         """
@@ -739,6 +740,9 @@ class DatasetsClient:
         custom_prompt : typing.Optional[str]
             Custom prompt to use for generation instead of auto-generated one
 
+        max_completion_tokens : typing.Optional[int]
+            Maximum number of tokens for the LLM response. Required by Anthropic, used as maxOutputTokens for Gemini. If not provided, defaults to 4000 for Anthropic models only.
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -760,6 +764,7 @@ class DatasetsClient:
             preserve_fields=preserve_fields,
             variation_instructions=variation_instructions,
             custom_prompt=custom_prompt,
+            max_completion_tokens=max_completion_tokens,
             request_options=request_options,
         )
         return _response.data
@@ -2199,6 +2204,7 @@ class AsyncDatasetsClient:
         preserve_fields: typing.Optional[typing.Sequence[str]] = OMIT,
         variation_instructions: typing.Optional[str] = OMIT,
         custom_prompt: typing.Optional[str] = OMIT,
+        max_completion_tokens: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> DatasetExpansionResponse:
         """
@@ -2222,6 +2228,9 @@ class AsyncDatasetsClient:
 
         custom_prompt : typing.Optional[str]
             Custom prompt to use for generation instead of auto-generated one
+
+        max_completion_tokens : typing.Optional[int]
+            Maximum number of tokens for the LLM response. Required by Anthropic, used as maxOutputTokens for Gemini. If not provided, defaults to 4000 for Anthropic models only.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -2247,6 +2256,7 @@ class AsyncDatasetsClient:
             preserve_fields=preserve_fields,
             variation_instructions=variation_instructions,
             custom_prompt=custom_prompt,
+            max_completion_tokens=max_completion_tokens,
             request_options=request_options,
         )
         return _response.data

--- a/sdks/python/src/opik/rest_api/datasets/raw_client.py
+++ b/sdks/python/src/opik/rest_api/datasets/raw_client.py
@@ -975,6 +975,7 @@ class RawDatasetsClient:
         preserve_fields: typing.Optional[typing.Sequence[str]] = OMIT,
         variation_instructions: typing.Optional[str] = OMIT,
         custom_prompt: typing.Optional[str] = OMIT,
+        max_completion_tokens: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[DatasetExpansionResponse]:
         """
@@ -999,6 +1000,9 @@ class RawDatasetsClient:
         custom_prompt : typing.Optional[str]
             Custom prompt to use for generation instead of auto-generated one
 
+        max_completion_tokens : typing.Optional[int]
+            Maximum number of tokens for the LLM response. Required by Anthropic, used as maxOutputTokens for Gemini. If not provided, defaults to 4000 for Anthropic models only.
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -1016,6 +1020,7 @@ class RawDatasetsClient:
                 "preserve_fields": preserve_fields,
                 "variation_instructions": variation_instructions,
                 "custom_prompt": custom_prompt,
+                "max_completion_tokens": max_completion_tokens,
             },
             headers={
                 "content-type": "application/json",
@@ -3064,6 +3069,7 @@ class AsyncRawDatasetsClient:
         preserve_fields: typing.Optional[typing.Sequence[str]] = OMIT,
         variation_instructions: typing.Optional[str] = OMIT,
         custom_prompt: typing.Optional[str] = OMIT,
+        max_completion_tokens: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[DatasetExpansionResponse]:
         """
@@ -3088,6 +3094,9 @@ class AsyncRawDatasetsClient:
         custom_prompt : typing.Optional[str]
             Custom prompt to use for generation instead of auto-generated one
 
+        max_completion_tokens : typing.Optional[int]
+            Maximum number of tokens for the LLM response. Required by Anthropic, used as maxOutputTokens for Gemini. If not provided, defaults to 4000 for Anthropic models only.
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -3105,6 +3114,7 @@ class AsyncRawDatasetsClient:
                 "preserve_fields": preserve_fields,
                 "variation_instructions": variation_instructions,
                 "custom_prompt": custom_prompt,
+                "max_completion_tokens": max_completion_tokens,
             },
             headers={
                 "content-type": "application/json",

--- a/sdks/python/src/opik/rest_api/types/dataset_expansion.py
+++ b/sdks/python/src/opik/rest_api/types/dataset_expansion.py
@@ -32,6 +32,11 @@ class DatasetExpansion(UniversalBaseModel):
     Custom prompt to use for generation instead of auto-generated one
     """
 
+    max_completion_tokens: typing.Optional[int] = pydantic.Field(default=None)
+    """
+    Maximum number of tokens for the LLM response. Required by Anthropic, used as maxOutputTokens for Gemini. If not provided, defaults to 4000 for Anthropic models only.
+    """
+
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
     else:

--- a/sdks/typescript/src/opik/rest_api/api/resources/datasets/client/requests/DatasetExpansionWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/api/resources/datasets/client/requests/DatasetExpansionWrite.ts
@@ -17,4 +17,6 @@ export interface DatasetExpansionWrite {
     variationInstructions?: string;
     /** Custom prompt to use for generation instead of auto-generated one */
     customPrompt?: string;
+    /** Maximum number of tokens for the LLM response. Required by Anthropic, used as maxOutputTokens for Gemini. If not provided, defaults to 4000 for Anthropic models only. */
+    maxCompletionTokens?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/DatasetExpansion.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/DatasetExpansion.ts
@@ -11,4 +11,6 @@ export interface DatasetExpansion {
     variationInstructions?: string;
     /** Custom prompt to use for generation instead of auto-generated one */
     customPrompt?: string;
+    /** Maximum number of tokens for the LLM response. Required by Anthropic, used as maxOutputTokens for Gemini. If not provided, defaults to 4000 for Anthropic models only. */
+    maxCompletionTokens?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/resources/datasets/client/requests/DatasetExpansionWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/resources/datasets/client/requests/DatasetExpansionWrite.ts
@@ -19,6 +19,7 @@ export const DatasetExpansionWrite: core.serialization.Schema<
         core.serialization.string().optional(),
     ),
     customPrompt: core.serialization.property("custom_prompt", core.serialization.string().optional()),
+    maxCompletionTokens: core.serialization.property("max_completion_tokens", core.serialization.number().optional()),
 });
 
 export declare namespace DatasetExpansionWrite {
@@ -28,5 +29,6 @@ export declare namespace DatasetExpansionWrite {
         preserve_fields?: string[] | null;
         variation_instructions?: string | null;
         custom_prompt?: string | null;
+        max_completion_tokens?: number | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/DatasetExpansion.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/DatasetExpansion.ts
@@ -19,6 +19,7 @@ export const DatasetExpansion: core.serialization.ObjectSchema<
         core.serialization.string().optional(),
     ),
     customPrompt: core.serialization.property("custom_prompt", core.serialization.string().optional()),
+    maxCompletionTokens: core.serialization.property("max_completion_tokens", core.serialization.number().optional()),
 });
 
 export declare namespace DatasetExpansion {
@@ -28,5 +29,6 @@ export declare namespace DatasetExpansion {
         preserve_fields?: string[] | null;
         variation_instructions?: string | null;
         custom_prompt?: string | null;
+        max_completion_tokens?: number | null;
     }
 }


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

**Triggered by BE merge:** https://github.com/comet-ml/opik/pull/6277

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate