### PR TITLE
[OPIK-5958] [FE] fix: rename step 3 from "Publish and deploy" to "Run your agent"

### DIFF
--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState.tsx
@@ -47,7 +47,7 @@ const AgentConfigurationEmptyState: React.FC = () => {
 
           <TimelineStep number={3} isLast>
             <div className="flex flex-col gap-1">
-              <h4 className="comet-body-s-accented">Publish and deploy</h4>
+              <h4 className="comet-body-s-accented">Run your agent</h4>
               <p className="comet-body-xs text-muted-slate">
                 Your configuration will appear here automatically
               </p>


### PR DESCRIPTION
## Details

Renames the third step label in the Agent Configuration empty state from "Publish and deploy" to "Run your agent". The previous label was ambiguous — users had no clear publish action available, so the instruction was misleading. The new label accurately reflects what happens next: users run their agent and the configuration will appear automatically.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5958

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: full implementation (single-line text change)
- Human verification: code review

## Testing

- Verified the text change renders correctly in `AgentConfigurationEmptyState.tsx`
- `npx eslint` — no errors on changed file
- `npx tsc --noEmit` — no type errors

## Documentation

N/A — UI copy change only, no public API or behavioral change.