### PR TITLE
[OPIK-5757] [FE][SDK] Link experiment configuration to agent config versions

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/experiments/CompareExperimentsConfigCell/CompareExperimentsConfigCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/CompareExperimentsConfigCell/CompareExperimentsConfigCell.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import isUndefined from "lodash/isUndefined";
 import { CellContext } from "@tanstack/react-table";
+import { Link, useParams } from "@tanstack/react-router";
 import CellWrapper from "@/shared/DataTableCells/CellWrapper";
 import { ROW_HEIGHT } from "@/types/shared";
 import TextDiff from "@/shared/CodeDiff/TextDiff";
@@ -16,24 +17,55 @@ export type CompareConfig = {
   different: boolean;
 };
 
+export type AgentConfigLinkData = {
+  projectId: string;
+  blueprintId: string;
+};
+
 type CustomMeta = {
   onlyDiff: boolean;
+  agentConfigLinkData?: Record<string, AgentConfigLinkData>;
 };
 
 const CompareExperimentsConfigCell: React.FC<
   CellContext<CompareConfig, unknown>
 > = (context) => {
   const { custom } = context.column.columnDef.meta ?? {};
-  const { onlyDiff } = (custom ?? {}) as CustomMeta;
+  const { onlyDiff, agentConfigLinkData } = (custom ?? {}) as CustomMeta;
   const experimentId = context.column?.id;
   const compareConfig = context.row.original;
+  const { workspaceName } = useParams({ strict: false }) as {
+    workspaceName?: string;
+  };
 
   const data = compareConfig.data[experimentId];
   const baseData = compareConfig.data[compareConfig.base];
+  const linkData =
+    compareConfig.name === "agent_configuration"
+      ? agentConfigLinkData?.[experimentId]
+      : undefined;
 
   const renderContent = () => {
     if (isUndefined(data)) {
       return <span className="px-1.5 py-2.5 text-light-slate">No value</span>;
+    }
+
+    if (linkData && workspaceName) {
+      return (
+        <div className="comet-code size-full max-w-full overflow-hidden whitespace-pre-wrap break-words rounded-md border bg-code-block px-2 py-[11px]">
+          <Link
+            to="/$workspaceName/projects/$projectId/agent-configuration"
+            params={{
+              workspaceName,
+              projectId: linkData.projectId,
+            }}
+            search={{ configId: linkData.blueprintId }}
+            className="text-foreground underline hover:no-underline"
+          >
+            {data}
+          </Link>
+        </div>
+      );
     }
 
     return (

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
@@ -80,9 +80,9 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
     for (const exp of experiments) {
       const meta = exp.metadata as Record<string, unknown> | undefined;
       const config = meta?.[AGENT_CONFIGURATION_METADATA_KEY];
-      if (isAgentConfigurationMetadata(config)) {
+      if (isAgentConfigurationMetadata(config) && exp.project_id) {
         result[exp.id] = {
-          projectId: exp.project_id ?? "",
+          projectId: exp.project_id,
           blueprintId: config._blueprint_id,
         };
       }

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
@@ -6,6 +6,7 @@ import isObject from "lodash/isObject";
 import uniq from "lodash/uniq";
 import toLower from "lodash/toLower";
 import find from "lodash/find";
+import omit from "lodash/omit";
 import { flattie } from "flattie";
 
 import { COLUMN_TYPE, ColumnData } from "@/types/shared";
@@ -28,6 +29,8 @@ import { Switch } from "@/ui/switch";
 import { Label } from "@/ui/label";
 import { Separator } from "@/ui/separator";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { AGENT_CONFIGURATION_METADATA_KEY } from "@/utils/agent-configurations";
+import { isAgentConfigurationMetadata } from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/AgentConfigurationTab";
 
 const COLUMNS_WIDTH_KEY = "compare-experiments-config-columns-width";
 
@@ -71,6 +74,22 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
     defaultValue: {},
   });
 
+  const agentConfigLinkData = useMemo(() => {
+    const result: Record<string, { projectId: string; blueprintId: string }> =
+      {};
+    for (const exp of experiments) {
+      const meta = exp.metadata as Record<string, unknown> | undefined;
+      const config = meta?.[AGENT_CONFIGURATION_METADATA_KEY];
+      if (isAgentConfigurationMetadata(config)) {
+        result[exp.id] = {
+          projectId: exp.project_id ?? "",
+          blueprintId: config._blueprint_id,
+        };
+      }
+    }
+    return result;
+  }, [experiments]);
+
   const columns = useMemo(() => {
     const retVal = convertColumnDataToColumn<CompareConfig, CompareConfig>(
       DEFAULT_COLUMNS,
@@ -86,6 +105,7 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
           custom: {
             onlyDiff,
             experiment: find(experiments, (e) => e.id === id),
+            agentConfigLinkData,
           },
         },
         size: 400,
@@ -94,15 +114,29 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
     });
 
     return retVal;
-  }, [experimentsIds, onlyDiff, experiments]);
+  }, [experimentsIds, onlyDiff, experiments, agentConfigLinkData]);
 
   const flattenExperimentMetadataMap = useMemo(() => {
     return experiments.reduce<
       Record<string, Record<string, CompareFiledValue>>
     >((acc, experiment) => {
-      acc[experiment.id] = isObject(experiment.metadata)
-        ? flattie(experiment.metadata, ".", true)
+      const rawMetadata = experiment.metadata as
+        | Record<string, unknown>
+        | undefined;
+
+      const agentConfig = rawMetadata?.[AGENT_CONFIGURATION_METADATA_KEY];
+      const metadata = isObject(rawMetadata)
+        ? omit(rawMetadata, AGENT_CONFIGURATION_METADATA_KEY)
         : {};
+
+      acc[experiment.id] = isObject(metadata)
+        ? flattie(metadata, ".", true)
+        : {};
+
+      if (isAgentConfigurationMetadata(agentConfig)) {
+        acc[experiment.id]["agent_configuration"] =
+          agentConfig.blueprint_version ?? agentConfig._blueprint_id;
+      }
 
       return acc;
     }, {});

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
@@ -17,6 +17,7 @@ import CompareExperimentsActionsPanel from "@/v2/pages/CompareExperimentsPage/Co
 import CompareExperimentsConfigCell, {
   CompareConfig,
   CompareFiledValue,
+  AgentConfigLinkData,
 } from "@/v2/pages-shared/experiments/CompareExperimentsConfigCell/CompareExperimentsConfigCell";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
 import PageBodyStickyTableWrapper from "@/v2/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
@@ -75,8 +76,7 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
   });
 
   const agentConfigLinkData = useMemo(() => {
-    const result: Record<string, { projectId: string; blueprintId: string }> =
-      {};
+    const result: Record<string, AgentConfigLinkData> = {};
     for (const exp of experiments) {
       const meta = exp.metadata as Record<string, unknown> | undefined;
       const config = meta?.[AGENT_CONFIGURATION_METADATA_KEY];

--- a/sdks/python/src/opik/api_objects/dataset/test_suite/test_suite.py
+++ b/sdks/python/src/opik/api_objects/dataset/test_suite/test_suite.py
@@ -623,6 +623,7 @@ class TestSuite:
         client: Optional["opik_client_module.Opik"] = None,
         generate_report: bool = True,
         report_output_path: Optional[str] = None,
+        blueprint_id: Optional[str] = None,
     ) -> suite_types.TestSuiteResult:
         """
         Internal entry point used by the optimizer framework.
@@ -648,4 +649,5 @@ class TestSuite:
             experiment_type=experiment_type,
             generate_report=generate_report,
             report_output_path=report_output_path,
+            blueprint_id=blueprint_id,
         )

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -50,6 +50,26 @@ MODALITY_SUPPORT_DOC_URL = (
 EVALUATION_STREAM_DATASET_BATCH_SIZE = 200
 
 
+def _merge_blueprint_into_config(
+    client: "opik_client.Opik",
+    blueprint_id: str,
+    experiment_config: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Add blueprint reference to experiment_config under ``agent_configuration``."""
+    experiment_config = dict(experiment_config) if experiment_config else {}
+    agent_config: Dict[str, Any] = {"_blueprint_id": blueprint_id}
+    try:
+        blueprint = client._rest_client.agent_configs.get_blueprint_by_id(
+            blueprint_id=blueprint_id,
+        )
+        if blueprint.name:
+            agent_config["blueprint_version"] = blueprint.name
+    except Exception:
+        LOGGER.debug("Failed to fetch blueprint %s", blueprint_id, exc_info=True)
+    experiment_config["agent_configuration"] = agent_config
+    return experiment_config
+
+
 def _calculate_total_items(
     dataset_: Union[dataset.Dataset, dataset.DatasetVersion],
     nb_samples: Optional[int],
@@ -170,6 +190,7 @@ def evaluate(
     experiment_scoring_functions: Optional[List[ExperimentScoreFunction]] = None,
     experiment_tags: Optional[List[str]] = None,
     dataset_filter_string: Optional[str] = None,
+    blueprint_id: Optional[str] = None,
 ) -> evaluation_result.EvaluationResult:
     """
     Performs task evaluation on a given dataset. You can use either `scoring_metrics` or `scorer_functions` to calculate
@@ -271,6 +292,13 @@ def evaluate(
 
     client = opik_client.get_global_client()
 
+    if blueprint_id:
+        experiment_config = _merge_blueprint_into_config(
+            client,
+            blueprint_id,
+            experiment_config,
+        )
+
     experiment_name = _use_or_create_experiment_name(
         experiment_name=experiment_name,
         experiment_name_prefix=experiment_name_prefix,
@@ -333,6 +361,7 @@ def __internal_api__run_test_suite__(
     experiment_type: Optional[str] = None,
     generate_report: bool = True,
     report_output_path: Optional[str] = None,
+    blueprint_id: Optional[str] = None,
 ) -> "suite_types.TestSuiteResult":
     """
     Internal function that runs the full test suite evaluation pipeline:
@@ -351,6 +380,13 @@ def __internal_api__run_test_suite__(
 
     if client is None:
         client = opik_client.get_global_client()
+
+    if blueprint_id:
+        experiment_config = _merge_blueprint_into_config(
+            client,
+            blueprint_id,
+            experiment_config,
+        )
 
     @functools.wraps(task)
     def _validated_task(data: Dict[str, Any]) -> Any:
@@ -446,6 +482,7 @@ def run_tests(
     model: Optional[str] = None,
     generate_report: bool = True,
     report_output_path: Optional[str] = None,
+    blueprint_id: Optional[str] = None,
 ) -> "suite_types.TestSuiteResult":
     """
     Run a test suite against a task function.
@@ -507,6 +544,7 @@ def run_tests(
         evaluator_model=model,
         generate_report=generate_report,
         report_output_path=report_output_path,
+        blueprint_id=blueprint_id,
     )
 
 

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -57,7 +57,7 @@ def _merge_blueprint_into_config(
 ) -> Dict[str, Any]:
     """Add blueprint reference to experiment_config under ``agent_configuration``."""
     experiment_config = dict(experiment_config) if experiment_config else {}
-    agent_config: Dict[str, Any] = {"_blueprint_id": blueprint_id}
+    agent_config: Dict[str, str] = {"_blueprint_id": blueprint_id}
     try:
         blueprint = client._rest_client.agent_configs.get_blueprint_by_id(
             blueprint_id=blueprint_id,

--- a/sdks/python/tests/unit/evaluation/test_evaluate.py
+++ b/sdks/python/tests/unit/evaluation/test_evaluate.py
@@ -3538,3 +3538,19 @@ def test_evaluate__verbose_zero__progress_bar_disabled(fake_backend):
         desc=mock.ANY,
         total=mock.ANY,
     )
+
+
+class TestMergeBlueprintIntoConfig:
+    def test_blueprint_fetch_fails_still_stores_id(self):
+        mock_client = mock.Mock()
+        mock_client._rest_client.agent_configs.get_blueprint_by_id.side_effect = (
+            Exception("not found")
+        )
+
+        result = evaluator_module._merge_blueprint_into_config(
+            mock_client,
+            "bp-456",
+            None,
+        )
+
+        assert result["agent_configuration"] == {"_blueprint_id": "bp-456"}

--- a/sdks/python/tests/unit/evaluation/test_evaluate.py
+++ b/sdks/python/tests/unit/evaluation/test_evaluate.py
@@ -3541,6 +3541,31 @@ def test_evaluate__verbose_zero__progress_bar_disabled(fake_backend):
 
 
 class TestMergeBlueprintIntoConfig:
+    @staticmethod
+    def _make_blueprint(id, name):
+        bp = mock.MagicMock()
+        bp.id = id
+        bp.name = name
+        return bp
+
+    def test_blueprint_fetched_and_version_stored(self):
+        mock_client = mock.Mock()
+        mock_client._rest_client.agent_configs.get_blueprint_by_id.return_value = (
+            self._make_blueprint("bp-123", "v9")
+        )
+
+        result = evaluator_module._merge_blueprint_into_config(
+            mock_client,
+            "bp-123",
+            {"model": "gpt-4o"},
+        )
+
+        assert result["model"] == "gpt-4o"
+        assert result["agent_configuration"] == {
+            "_blueprint_id": "bp-123",
+            "blueprint_version": "v9",
+        }
+
     def test_blueprint_fetch_fails_still_stores_id(self):
         mock_client = mock.Mock()
         mock_client._rest_client.agent_configs.get_blueprint_by_id.side_effect = (

--- a/sdks/typescript/src/opik/evaluation/evaluate.ts
+++ b/sdks/typescript/src/opik/evaluation/evaluate.ts
@@ -55,6 +55,9 @@ export interface EvaluateOptions<T = Record<string, unknown>> {
 
   /** Optional list of tags to associate with the experiment */
   tags?: string[];
+
+  /** Optional agent configuration blueprint ID to link with the experiment */
+  blueprintId?: string;
 }
 
 export async function evaluate<T = Record<string, unknown>>(
@@ -72,6 +75,19 @@ export async function evaluate<T = Record<string, unknown>>(
   // Get Opik client
   const client = options.client ?? OpikSingleton.getInstance();
 
+  // Resolve agent config blueprint if provided
+  let experimentConfig = options.experimentConfig;
+  if (options.blueprintId) {
+    const agentConfig: Record<string, string> = { _blueprint_id: options.blueprintId };
+    try {
+      const blueprint = await client.api.agentConfigs.getBlueprintById(options.blueprintId);
+      if (blueprint.name) agentConfig.blueprint_version = blueprint.name;
+    } catch {
+      logger.debug(`Failed to fetch blueprint ${options.blueprintId}`);
+    }
+    experimentConfig = { ...experimentConfig, agent_configuration: agentConfig };
+  }
+
   // Get version info for experiment linking
   const versionInfo = await options.dataset.getVersionInfo();
 
@@ -79,7 +95,7 @@ export async function evaluate<T = Record<string, unknown>>(
   const experiment = await client.createExperiment({
     name: options.experimentName,
     datasetName: options.dataset.name,
-    experimentConfig: options.experimentConfig,
+    experimentConfig,
     prompts: options.prompts,
     datasetVersionId: versionInfo?.id,
     tags: options.tags,

--- a/sdks/typescript/src/opik/evaluation/evaluate.ts
+++ b/sdks/typescript/src/opik/evaluation/evaluate.ts
@@ -82,8 +82,8 @@ export async function evaluate<T = Record<string, unknown>>(
     try {
       const blueprint = await client.api.agentConfigs.getBlueprintById(options.blueprintId);
       if (blueprint.name) agentConfig.blueprint_version = blueprint.name;
-    } catch {
-      logger.debug(`Failed to fetch blueprint ${options.blueprintId}`);
+    } catch (error) {
+      logger.debug(`Failed to fetch blueprint ${options.blueprintId}: ${error}`);
     }
     experimentConfig = { ...experimentConfig, agent_configuration: agentConfig };
   }

--- a/sdks/typescript/tests/evaluation/evaluate.test.ts
+++ b/sdks/typescript/tests/evaluation/evaluate.test.ts
@@ -281,4 +281,71 @@ describe("evaluate function", () => {
 
     expect(createExperimentSpy).not.toHaveBeenCalled();
   });
+
+  test("should include blueprint metadata when blueprintId is provided", async () => {
+    const getBlueprintSpy = vi
+      .spyOn(opikClient.api.agentConfigs, "getBlueprintById")
+      .mockImplementation(() =>
+        createMockHttpResponsePromise({
+          id: "bp-123",
+          name: "v9",
+          type: "blueprint",
+          values: [],
+        })
+      );
+
+    const mockTask: EvaluationTask = async () => {
+      return { output: "result" };
+    };
+
+    await evaluate({
+      dataset: testDataset,
+      task: mockTask,
+      experimentName: "blueprint-test",
+      client: opikClient,
+      blueprintId: "bp-123",
+    });
+
+    expect(getBlueprintSpy).toHaveBeenCalledWith("bp-123");
+    expect(createExperimentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          agent_configuration: {
+            _blueprint_id: "bp-123",
+            blueprint_version: "v9",
+          },
+        }),
+      })
+    );
+  });
+
+  test("should store blueprint_id even when fetch fails", async () => {
+    vi.spyOn(opikClient.api.agentConfigs, "getBlueprintById").mockImplementation(
+      () => {
+        throw new Error("not found");
+      }
+    );
+
+    const mockTask: EvaluationTask = async () => {
+      return { output: "result" };
+    };
+
+    await evaluate({
+      dataset: testDataset,
+      task: mockTask,
+      experimentName: "blueprint-fail-test",
+      client: opikClient,
+      blueprintId: "bp-456",
+    });
+
+    expect(createExperimentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          agent_configuration: {
+            _blueprint_id: "bp-456",
+          },
+        }),
+      })
+    );
+  });
 });


### PR DESCRIPTION
### Linked Ollie PR: https://github.com/comet-ml/ollie-assist/pull/203

## Details

When experiments are run with an agent configuration, the blueprint reference is now stored in experiment metadata and displayed as a clickable link in the Configuration tab.

**SDK changes (Python + TypeScript):**
- Added `blueprint_id` parameter to `evaluate()`, `run_tests()`, and `__internal_api__run_optimization_suite__()`
- When passed, the SDK fetches the blueprint name and stores `{_blueprint_id, blueprint_version}` under `agent_configuration` in experiment metadata
- Best-effort: if blueprint fetch fails, `_blueprint_id` is still stored

**Frontend changes:**
- Configuration tab detects `agent_configuration` in experiment metadata, strips it from the flat key-value table, and adds it as an `agent_configuration` row with the blueprint version name as display text
- The version name is rendered as a clickable link (via TanStack Router `Link`) that navigates to the specific version on the agent configuration page (`?configId=<blueprintId>`)
- Each experiment resolves its own blueprint independently (no multi-experiment display bug)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5757

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-6
- Scope: Full implementation guided by human review
- Human verification: Yes — tested end-to-end with real experiments via Ollie

## Testing

- `npx tsc --noEmit` — FE, TS SDK both pass
- `npx eslint` — FE and TS SDK lint clean
- `npx vitest run` — FE 1348 tests pass, TS SDK 1348 tests pass
- `pytest tests/unit/evaluation/` — Python SDK 252 pass
- Manual E2E: created experiments via Ollie with `blueprint_id`, verified version link appears in Configuration tab and navigates to correct agent config page

## Documentation

N/A — SDK parameter is self-documenting via docstrings. No user-facing documentation changes required.