### PR TITLE
[OPIK-5846] [FE] feat: split add-to-dataset action and fix SDK code highlighting

### DIFF
--- a/apps/opik-frontend/src/constants/explainers.ts
+++ b/apps/opik-frontend/src/constants/explainers.ts
@@ -10,6 +10,7 @@ export enum EXPLAINER_ID {
   what_are_threads = "what_are_threads",
   whats_online_evaluation = "whats_online_evaluation",
   i_added_traces_to_an_test_suite_now_what = "i_added_traces_to_an_test_suite_now_what",
+  i_added_items_to_a_dataset_now_what = "i_added_items_to_a_dataset_now_what",
   how_to_choose_annotation_queue_type = "how_to_choose_annotation_queue_type",
   why_would_i_want_to_add_traces_to_an_test_suite = "why_would_i_want_to_add_traces_to_an_test_suite",
   hows_the_cost_estimated = "hows_the_cost_estimated",
@@ -160,6 +161,14 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     title: "Traces added to test suite",
     description:
       "Your traces have been added to the test suite and can now be used in experiments to evaluate your agent.",
+    docLink: "/evaluation/overview",
+    docHash: "#running-an-evaluation",
+  },
+  [EXPLAINER_ID.i_added_items_to_a_dataset_now_what]: {
+    id: EXPLAINER_ID.i_added_items_to_a_dataset_now_what,
+    title: "Traces added to dataset",
+    description:
+      "Your traces have been added to the dataset and can now be used in experiments to evaluate your agent.",
     docLink: "/evaluation/overview",
     docHash: "#running-an-evaluation",
   },

--- a/apps/opik-frontend/src/constants/explainers.ts
+++ b/apps/opik-frontend/src/constants/explainers.ts
@@ -166,9 +166,9 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
   },
   [EXPLAINER_ID.i_added_items_to_a_dataset_now_what]: {
     id: EXPLAINER_ID.i_added_items_to_a_dataset_now_what,
-    title: "Traces added to dataset",
+    title: "Items added to dataset",
     description:
-      "Your traces have been added to the dataset and can now be used in experiments to evaluate your agent.",
+      "Your items have been added to the dataset and can now be used in experiments to evaluate your agent.",
     docLink: "/evaluation/overview",
     docHash: "#running-an-evaluation",
   },

--- a/apps/opik-frontend/src/shared/CodeHighlighter/CodeHighlighter.tsx
+++ b/apps/opik-frontend/src/shared/CodeHighlighter/CodeHighlighter.tsx
@@ -6,6 +6,7 @@ import { EditorState, Extension } from "@codemirror/state";
 import { jsonLanguage } from "@codemirror/lang-json";
 import { yamlLanguage } from "@codemirror/lang-yaml";
 import { pythonLanguage } from "@codemirror/lang-python";
+import { javascriptLanguage } from "@codemirror/lang-javascript";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
 import { useCodemirrorLineHighlight } from "@/hooks/useCodemirrorLineHighlight";
 import CopyButton from "@/shared/CopyButton/CopyButton";
@@ -14,12 +15,14 @@ export enum SUPPORTED_LANGUAGE {
   json = "json",
   yaml = "yaml",
   python = "python",
+  javascript = "javascript",
 }
 
 const PLUGINS_MAP: Record<SUPPORTED_LANGUAGE, Extension> = {
   [SUPPORTED_LANGUAGE.json]: jsonLanguage,
   [SUPPORTED_LANGUAGE.yaml]: yamlLanguage,
   [SUPPORTED_LANGUAGE.python]: pythonLanguage,
+  [SUPPORTED_LANGUAGE.javascript]: javascriptLanguage,
 };
 
 type CodeHighlighterProps = {

--- a/apps/opik-frontend/src/shared/CodeHighlighter/CodeHighlighter.tsx
+++ b/apps/opik-frontend/src/shared/CodeHighlighter/CodeHighlighter.tsx
@@ -6,7 +6,6 @@ import { EditorState, Extension } from "@codemirror/state";
 import { jsonLanguage } from "@codemirror/lang-json";
 import { yamlLanguage } from "@codemirror/lang-yaml";
 import { pythonLanguage } from "@codemirror/lang-python";
-import { javascriptLanguage } from "@codemirror/lang-javascript";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
 import { useCodemirrorLineHighlight } from "@/hooks/useCodemirrorLineHighlight";
 import CopyButton from "@/shared/CopyButton/CopyButton";
@@ -15,14 +14,12 @@ export enum SUPPORTED_LANGUAGE {
   json = "json",
   yaml = "yaml",
   python = "python",
-  javascript = "javascript",
 }
 
 const PLUGINS_MAP: Record<SUPPORTED_LANGUAGE, Extension> = {
   [SUPPORTED_LANGUAGE.json]: jsonLanguage,
   [SUPPORTED_LANGUAGE.yaml]: yamlLanguage,
   [SUPPORTED_LANGUAGE.python]: pythonLanguage,
-  [SUPPORTED_LANGUAGE.javascript]: javascriptLanguage,
 };
 
 type CodeHighlighterProps = {

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/CreateDatasetSidebar/CreateDatasetSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/CreateDatasetSidebar/CreateDatasetSidebar.tsx
@@ -15,7 +15,10 @@ import {
   AccordionItem,
   CustomAccordionTrigger,
 } from "@/ui/accordion";
-import CopyButton from "@/shared/CopyButton/CopyButton";
+import CodeHighlighter, {
+  SUPPORTED_LANGUAGE,
+} from "@/shared/CodeHighlighter/CodeHighlighter";
+
 import ResizableSidePanel from "@/shared/ResizableSidePanel/ResizableSidePanel";
 import AssertionsField from "@/shared/AssertionField/AssertionsField";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
@@ -146,9 +149,6 @@ const CreateDatasetSidebar: React.FunctionComponent<
       ? `import { Opik } from 'opik';\n\nconst client = new Opik();\nconst suite = await client.getOrCreateTestSuite({ name: "${jsEscapedName}", projectName: "${jsProjectName}" });`
       : `import { Opik } from 'opik';\n\nconst client = new Opik();\nconst dataset = await client.getOrCreateDataset("${jsEscapedName}", undefined, "${jsProjectName}");`;
 
-  const activeSnippet =
-    sdkLanguage === "python" ? pythonSnippet : typescriptSnippet;
-
   useEffect(() => {
     if (!open) {
       const timeout = setTimeout(() => {
@@ -271,13 +271,8 @@ const CreateDatasetSidebar: React.FunctionComponent<
         />
       </div>
       <div className="mb-4">
-        <div className="mb-2 flex items-center justify-between">
+        <div className="mb-2">
           <Label>Use SDK</Label>
-          <CopyButton
-            text={activeSnippet}
-            tooltipText="Copy code"
-            message="Code copied to clipboard"
-          />
         </div>
         <Tabs
           value={sdkLanguage}
@@ -292,14 +287,20 @@ const CreateDatasetSidebar: React.FunctionComponent<
             </TabsTrigger>
           </TabsList>
           <TabsContent value="python" className="mt-0">
-            <pre className="overflow-x-auto rounded-b-md border border-t-0 border-border bg-primary-foreground p-3 font-mono text-[13px] leading-relaxed">
-              {pythonSnippet}
-            </pre>
+            <div className="overflow-hidden rounded-b-md border border-t-0 border-border">
+              <CodeHighlighter
+                data={pythonSnippet}
+                language={SUPPORTED_LANGUAGE.python}
+              />
+            </div>
           </TabsContent>
           <TabsContent value="typescript" className="mt-0">
-            <pre className="overflow-x-auto rounded-b-md border border-t-0 border-border bg-primary-foreground p-3 font-mono text-[13px] leading-relaxed">
-              {typescriptSnippet}
-            </pre>
+            <div className="overflow-hidden rounded-b-md border border-t-0 border-border">
+              <CodeHighlighter
+                data={typescriptSnippet}
+                language={SUPPORTED_LANGUAGE.javascript}
+              />
+            </div>
           </TabsContent>
         </Tabs>
       </div>

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/CreateDatasetSidebar/CreateDatasetSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/CreateDatasetSidebar/CreateDatasetSidebar.tsx
@@ -298,7 +298,7 @@ const CreateDatasetSidebar: React.FunctionComponent<
             <div className="overflow-hidden rounded-b-md border border-t-0 border-border">
               <CodeHighlighter
                 data={typescriptSnippet}
-                language={SUPPORTED_LANGUAGE.javascript}
+                language={SUPPORTED_LANGUAGE.python}
               />
             </div>
           </TabsContent>

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsActionsPanel.tsx
@@ -44,6 +44,7 @@ type DatasetItemsActionsPanelProps = {
   isDraftMode?: boolean;
   entityName?: string;
   renderExpansionDialog: (props: ExpansionDialogRenderProps) => React.ReactNode;
+  compact?: boolean;
 };
 
 const DatasetItemsActionsPanel: React.FunctionComponent<
@@ -61,6 +62,7 @@ const DatasetItemsActionsPanel: React.FunctionComponent<
   isDraftMode = false,
   entityName = "dataset",
   renderExpansionDialog,
+  compact = false,
 }) => {
   const resetKeyRef = useRef(0);
   const [expansionDialogOpen, setExpansionDialogOpen] =
@@ -198,17 +200,25 @@ const DatasetItemsActionsPanel: React.FunctionComponent<
       />
       {canEditDatasets && (
         <>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => {
-              setExpansionDialogOpen(true);
-              resetKeyRef.current = resetKeyRef.current + 1;
-            }}
-          >
-            <Sparkles className="mr-2 size-4" />
-            Expand with AI
-          </Button>
+          <TooltipWrapper content={compact ? "Expand with AI" : undefined}>
+            <Button
+              variant="secondary"
+              size={compact ? "icon-sm" : "sm"}
+              onClick={() => {
+                setExpansionDialogOpen(true);
+                resetKeyRef.current = resetKeyRef.current + 1;
+              }}
+            >
+              {compact ? (
+                <Sparkles className="size-4" />
+              ) : (
+                <>
+                  <Sparkles className="mr-2 size-4" />
+                  Expand with AI
+                </>
+              )}
+            </Button>
+          </TooltipWrapper>
           <TooltipWrapper content="Manage tags">
             <Button
               variant="outline"

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
@@ -43,7 +43,9 @@ import SelectAllBanner from "@/shared/SelectAllBanner/SelectAllBanner";
 import { Button } from "@/ui/button";
 import { Separator } from "@/ui/separator";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import { Check, Loader2 } from "lucide-react";
+import { Check, Loader2, Plus } from "lucide-react";
+import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
+import ExpandableSearchInput from "@/shared/ExpandableSearchInput/ExpandableSearchInput";
 import {
   convertColumnDataToColumn,
   injectColumnCallback,
@@ -130,6 +132,7 @@ interface DatasetItemsTabProps {
 }
 
 const POLLING_INTERVAL_MS = 3000;
+const COMPACT_TOOLBAR_BREAKPOINT = 850;
 
 const DRAFT_STATUS_BORDER_CLASSES: Record<string, string> = {
   [DATASET_ITEM_DRAFT_STATUS.added]: "border-l-2 border-l-green-500",
@@ -204,6 +207,15 @@ function DatasetItemsTab({
   const [openCreatePanel, setOpenCreatePanel] = useState<boolean>(false);
   const [openDialog, setOpenDialog] = useState<boolean>(false);
   const resetDialogKeyRef = useRef(0);
+
+  const [isCompactToolbar, setIsCompactToolbar] = useState(false);
+  const [isSearchExpanded, setIsSearchExpanded] = useState(false);
+  const isCollapsingRef = useRef(false);
+  const handleToolbarResize = useCallback((node: HTMLDivElement) => {
+    setIsCompactToolbar(node.clientWidth < COMPACT_TOOLBAR_BREAKPOINT);
+  }, []);
+  const { ref: toolbarRef } =
+    useObserveResizeNode<HTMLDivElement>(handleToolbarResize);
 
   const transformedFilters = useMemo(
     () => (filters ? transformDataColumnFilters(filters) : filters),
@@ -334,6 +346,26 @@ function DatasetItemsTab({
     },
     [setSearch, setPage, page],
   );
+
+  // ExpandableSearchInput calls onExpandedChange(false) before onChange("") on collapse.
+  // We use this ref to skip the clearing onChange so the search filter stays active.
+  const handleCompactSearchChange = useCallback(
+    (value: string) => {
+      if (isCollapsingRef.current && value === "") {
+        isCollapsingRef.current = false;
+        return;
+      }
+      handleSearchChange(value || null);
+    },
+    [handleSearchChange],
+  );
+
+  const handleSearchExpandedChange = useCallback((expanded: boolean) => {
+    setIsSearchExpanded(expanded);
+    if (!expanded) {
+      isCollapsingRef.current = true;
+    }
+  }, []);
 
   const selectedRows: DatasetItem[] = useMemo(
     () => rows.filter((row) => rowSelection[row.id]),
@@ -511,22 +543,42 @@ function DatasetItemsTab({
 
   return (
     <>
-      <div className="mb-4 flex items-center justify-between gap-8">
+      <div
+        ref={toolbarRef}
+        className="relative mb-4 flex items-center justify-between gap-8"
+      >
         <div className="flex items-center gap-2">
-          <TooltipWrapper
-            content={isDraftMode ? "Save changes to search" : undefined}
-          >
-            <div>
-              <SearchInput
-                searchText={search ?? ""}
-                setSearchText={handleSearchChange}
-                placeholder="Search"
-                className="w-[320px]"
-                dimension="sm"
-                disabled={isDraftMode}
-              />
-            </div>
-          </TooltipWrapper>
+          {isCompactToolbar ? (
+            <ExpandableSearchInput
+              value={search ?? ""}
+              placeholder="Search"
+              onChange={handleCompactSearchChange}
+              disabled={isDraftMode}
+              buttonVariant="outline"
+              tooltip={isDraftMode ? "Save changes to search" : "Search items"}
+              onExpandedChange={handleSearchExpandedChange}
+              className={
+                isSearchExpanded
+                  ? "absolute inset-x-0 top-0 z-10 bg-soft-background"
+                  : ""
+              }
+            />
+          ) : (
+            <TooltipWrapper
+              content={isDraftMode ? "Save changes to search" : undefined}
+            >
+              <div>
+                <SearchInput
+                  searchText={search ?? ""}
+                  setSearchText={handleSearchChange}
+                  placeholder="Search"
+                  className="w-[320px]"
+                  dimension="sm"
+                  disabled={isDraftMode}
+                />
+              </div>
+            </TooltipWrapper>
+          )}
           <TooltipWrapper
             content={isDraftMode ? "Save changes to filter" : undefined}
           >
@@ -555,6 +607,7 @@ function DatasetItemsTab({
             isDraftMode={isDraftMode}
             entityName={entityName}
             renderExpansionDialog={renderExpansionDialog}
+            compact={isCompactToolbar}
           />
           <Separator orientation="vertical" className="mx-2 h-4" />
           <DataTableRowHeightSelector
@@ -569,13 +622,15 @@ function DatasetItemsTab({
             onOrderChange={setColumnsOrder}
           />
           {canEditDatasets && (
-            <Button
-              variant="default"
-              size="sm"
-              onClick={handleNewDatasetItemClick}
-            >
-              Add item
-            </Button>
+            <TooltipWrapper content={isCompactToolbar ? "Add item" : undefined}>
+              <Button
+                variant="default"
+                size={isCompactToolbar ? "icon-sm" : "sm"}
+                onClick={handleNewDatasetItemClick}
+              >
+                {isCompactToolbar ? <Plus /> : "Add item"}
+              </Button>
+            </TooltipWrapper>
           )}
         </div>
       </div>

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
@@ -9,6 +9,7 @@ import {
 } from "use-query-params";
 import useLocalStorageState from "use-local-storage-state";
 import { keepPreviousData } from "@tanstack/react-query";
+import { Check, Loader2, Plus } from "lucide-react";
 
 import DataTable from "@/shared/DataTable/DataTable";
 import DataTablePagination from "@/shared/DataTablePagination/DataTablePagination";
@@ -43,7 +44,6 @@ import SelectAllBanner from "@/shared/SelectAllBanner/SelectAllBanner";
 import { Button } from "@/ui/button";
 import { Separator } from "@/ui/separator";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import { Check, Loader2, Plus } from "lucide-react";
 import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
 import ExpandableSearchInput from "@/shared/ExpandableSearchInput/ExpandableSearchInput";
 import {

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
@@ -209,7 +209,7 @@ function DatasetItemsTab({
   const resetDialogKeyRef = useRef(0);
 
   const [isCompactToolbar, setIsCompactToolbar] = useState(false);
-  const [isSearchExpanded, setIsSearchExpanded] = useState(false);
+  const [isSearchExpanded, setIsSearchExpanded] = useState(Boolean(search));
   const isCollapsingRef = useRef(false);
   const handleToolbarResize = useCallback((node: HTMLDivElement) => {
     setIsCompactToolbar(node.clientWidth < COMPACT_TOOLBAR_BREAKPOINT);

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx
@@ -6,33 +6,39 @@ import { Trace, Span, SPAN_TYPE } from "@/types/traces";
 import { ReactNode } from "react";
 import { PermissionsProvider } from "@/contexts/PermissionsContext";
 import { DEFAULT_PERMISSIONS } from "@/types/permissions";
+import { DATASET_TYPE } from "@/types/datasets";
 
-// Create mock functions that can be accessed in tests
 const mockAddTracesToDataset = vi.fn();
 const mockAddSpansToDataset = vi.fn();
 
-// Mock the API hooks
+const ALL_DATASETS = [
+  {
+    id: "dataset-1",
+    name: "Test Dataset 1",
+    description: "First test dataset",
+    type: DATASET_TYPE.DATASET,
+  },
+  {
+    id: "suite-1",
+    name: "Test Suite 1",
+    description: "First test suite",
+    type: DATASET_TYPE.TEST_SUITE,
+  },
+];
+
 vi.mock("@/api/datasets/useProjectDatasetsList", () => ({
-  default: vi.fn(() => ({
-    data: {
-      content: [
-        {
-          id: "dataset-1",
-          name: "Test Dataset 1",
-          description: "First test dataset",
-          type: "dataset",
-        },
-        {
-          id: "dataset-2",
-          name: "Test Dataset 2",
-          description: "Second test dataset",
-          type: "test_suite",
-        },
-      ],
-      total: 2,
+  default: vi.fn(
+    (params: { filters?: Array<{ field: string; value: string }> }) => {
+      const typeFilter = params.filters?.find((f) => f.field === "type");
+      const content = typeFilter
+        ? ALL_DATASETS.filter((d) => d.type === typeFilter.value)
+        : ALL_DATASETS;
+      return {
+        data: { content, total: content.length },
+        isPending: false,
+      };
     },
-    isPending: false,
-  })),
+  ),
 }));
 
 vi.mock("@/api/datasets/useDatasetVersionsList", () => ({
@@ -53,7 +59,6 @@ vi.mock("@/api/datasets/useAddSpansToDatasetMutation", () => ({
   }),
 }));
 
-// Mock the store
 vi.mock("@/store/AppStore", () => ({
   default: vi.fn((selector) =>
     selector({
@@ -64,18 +69,23 @@ vi.mock("@/store/AppStore", () => ({
   useActiveProjectId: () => "test-project-id",
 }));
 
-// Mock the toast hook
 vi.mock("@/ui/use-toast", () => ({
   useToast: () => ({
     toast: vi.fn(),
   }),
 }));
 
-// Mock the AddEditTestSuiteDialog component
 vi.mock(
   "@/v2/pages-shared/datasets/AddEditTestSuiteDialog/AddEditTestSuiteDialog",
   () => ({
     default: () => <div data-testid="add-edit-test-suite-dialog" />,
+  }),
+);
+
+vi.mock(
+  "@/v2/pages-shared/datasets/AddEditDatasetDialog/AddEditDatasetDialog",
+  () => ({
+    default: () => <div data-testid="add-edit-dataset-dialog" />,
   }),
 );
 
@@ -137,26 +147,34 @@ describe("AddToDatasetDialog", () => {
     project_id: "project-1",
   };
 
-  const defaultProps = {
+  const baseProps = {
     selectedRows: [mockTrace],
     open: true,
     setOpen: vi.fn(),
   };
 
-  it("should render the dialog when open", () => {
-    render(<AddToDatasetDialog {...defaultProps} />, { wrapper });
+  const datasetModeProps = {
+    ...baseProps,
+    datasetType: DATASET_TYPE.DATASET,
+  };
+
+  const testSuiteModeProps = {
+    ...baseProps,
+    datasetType: DATASET_TYPE.TEST_SUITE,
+  };
+
+  it("should render the test suite dialog when open", () => {
+    render(<AddToDatasetDialog {...testSuiteModeProps} />, { wrapper });
 
     expect(screen.getByText("Select a test suite")).toBeInTheDocument();
-    expect(screen.getByText("Test Dataset 1")).toBeInTheDocument();
+    expect(screen.getByText("Test Suite 1")).toBeInTheDocument();
   });
 
-  it("should display enrichment checkboxes when selecting a legacy dataset with traces", () => {
-    render(<AddToDatasetDialog {...defaultProps} />, { wrapper });
+  it("should display enrichment checkboxes when selecting a dataset with traces", () => {
+    render(<AddToDatasetDialog {...datasetModeProps} />, { wrapper });
 
-    // Select the legacy dataset (type: "dataset")
     fireEvent.click(screen.getByText("Test Dataset 1"));
 
-    // Metadata config should be visible and expanded by default
     expect(screen.getByLabelText("Nested spans")).toBeInTheDocument();
     expect(screen.getByLabelText("Tags")).toBeInTheDocument();
     expect(screen.getByLabelText("Feedback scores")).toBeInTheDocument();
@@ -166,9 +184,8 @@ describe("AddToDatasetDialog", () => {
   });
 
   it("should have all enrichment checkboxes checked by default", () => {
-    render(<AddToDatasetDialog {...defaultProps} />, { wrapper });
+    render(<AddToDatasetDialog {...datasetModeProps} />, { wrapper });
 
-    // Select the legacy dataset
     fireEvent.click(screen.getByText("Test Dataset 1"));
 
     expect(screen.getByLabelText("Nested spans")).toBeChecked();
@@ -180,9 +197,8 @@ describe("AddToDatasetDialog", () => {
   });
 
   it("should allow unchecking enrichment options", async () => {
-    render(<AddToDatasetDialog {...defaultProps} />, { wrapper });
+    render(<AddToDatasetDialog {...datasetModeProps} />, { wrapper });
 
-    // Select the legacy dataset first
     fireEvent.click(screen.getByText("Test Dataset 1"));
 
     const spansCheckbox = screen.getByLabelText("Nested spans");
@@ -198,20 +214,17 @@ describe("AddToDatasetDialog", () => {
     expect(screen.getByLabelText("Feedback scores")).toBeChecked();
   });
 
-  it("should display span enrichment checkboxes when selecting a legacy dataset with spans", () => {
+  it("should display span enrichment checkboxes when selecting a dataset with spans", () => {
     const propsWithSpan = {
-      ...defaultProps,
+      ...datasetModeProps,
       selectedRows: [mockSpan],
     };
 
     render(<AddToDatasetDialog {...propsWithSpan} />, { wrapper });
 
-    // Select the legacy dataset
     fireEvent.click(screen.getByText("Test Dataset 1"));
 
-    // Spans don't have "Nested spans" option
     expect(screen.queryByLabelText("Nested spans")).not.toBeInTheDocument();
-    // But they have all other options
     expect(screen.getByLabelText("Tags")).toBeInTheDocument();
     expect(screen.getByLabelText("Feedback scores")).toBeInTheDocument();
     expect(screen.getByLabelText("Comments")).toBeInTheDocument();
@@ -221,13 +234,12 @@ describe("AddToDatasetDialog", () => {
 
   it("should have all span enrichment checkboxes checked by default", () => {
     const propsWithSpan = {
-      ...defaultProps,
+      ...datasetModeProps,
       selectedRows: [mockSpan],
     };
 
     render(<AddToDatasetDialog {...propsWithSpan} />, { wrapper });
 
-    // Select the legacy dataset
     fireEvent.click(screen.getByText("Test Dataset 1"));
 
     expect(screen.getByLabelText("Tags")).toBeChecked();
@@ -239,13 +251,12 @@ describe("AddToDatasetDialog", () => {
 
   it("should allow unchecking span enrichment options", async () => {
     const propsWithSpan = {
-      ...defaultProps,
+      ...datasetModeProps,
       selectedRows: [mockSpan],
     };
 
     render(<AddToDatasetDialog {...propsWithSpan} />, { wrapper });
 
-    // Select the legacy dataset first
     fireEvent.click(screen.getByText("Test Dataset 1"));
 
     const tagsCheckbox = screen.getByLabelText("Tags");
@@ -261,31 +272,38 @@ describe("AddToDatasetDialog", () => {
     expect(screen.getByLabelText("Feedback scores")).toBeChecked();
   });
 
-  it("should display available datasets", () => {
-    render(<AddToDatasetDialog {...defaultProps} />, { wrapper });
+  it("should list only datasets matching dataset type when adding to a dataset", () => {
+    render(<AddToDatasetDialog {...datasetModeProps} />, { wrapper });
 
     expect(screen.getByText("Test Dataset 1")).toBeInTheDocument();
     expect(screen.getByText("First test dataset")).toBeInTheDocument();
-    expect(screen.getByText("Test Dataset 2")).toBeInTheDocument();
-    expect(screen.getByText("Second test dataset")).toBeInTheDocument();
+    expect(screen.queryByText("Test Suite 1")).not.toBeInTheDocument();
+  });
+
+  it("should list only test suites when adding to a test suite", () => {
+    render(<AddToDatasetDialog {...testSuiteModeProps} />, { wrapper });
+
+    expect(screen.getByText("Test Suite 1")).toBeInTheDocument();
+    expect(screen.getByText("First test suite")).toBeInTheDocument();
+    expect(screen.queryByText("Test Dataset 1")).not.toBeInTheDocument();
   });
 
   it("should display search input", () => {
-    render(<AddToDatasetDialog {...defaultProps} />, { wrapper });
+    render(<AddToDatasetDialog {...datasetModeProps} />, { wrapper });
 
     const searchInput = screen.getByPlaceholderText("Search");
     expect(searchInput).toBeInTheDocument();
   });
 
   it("should display create new test suite button", () => {
-    render(<AddToDatasetDialog {...defaultProps} />, { wrapper });
+    render(<AddToDatasetDialog {...testSuiteModeProps} />, { wrapper });
 
     expect(screen.getByText("Create new test suite")).toBeInTheDocument();
   });
 
   it("should show alert when no valid rows are present", () => {
     const propsWithInvalidRows = {
-      ...defaultProps,
+      ...testSuiteModeProps,
       selectedRows: [{ ...mockTrace, input: undefined as unknown as object }],
     };
 
@@ -300,7 +318,7 @@ describe("AddToDatasetDialog", () => {
 
   it("should show alert when only some rows are valid", () => {
     const propsWithPartialValid = {
-      ...defaultProps,
+      ...testSuiteModeProps,
       selectedRows: [
         mockTrace,
         { ...mockTrace, id: "trace-2", input: undefined as unknown as object },
@@ -318,7 +336,7 @@ describe("AddToDatasetDialog", () => {
 
   it("should disable create new test suite button when no valid rows", () => {
     const propsWithInvalidRows = {
-      ...defaultProps,
+      ...testSuiteModeProps,
       selectedRows: [{ ...mockTrace, input: undefined as unknown as object }],
     };
 
@@ -329,15 +347,11 @@ describe("AddToDatasetDialog", () => {
   });
 
   it("should call addTracesToDataset mutation when clicking on dataset with only traces", async () => {
-    render(<AddToDatasetDialog {...defaultProps} />, { wrapper });
+    render(<AddToDatasetDialog {...datasetModeProps} />, { wrapper });
 
-    // Select the dataset
-    const dataset = screen.getByText("Test Dataset 1");
-    fireEvent.click(dataset);
+    fireEvent.click(screen.getByText("Test Dataset 1"));
 
-    // Click the "Add to test suite" button
-    const addButton = screen.getAllByText("Add to test suite")[1]; // Get the button, not the dialog title
-    fireEvent.click(addButton);
+    fireEvent.click(screen.getByRole("button", { name: "Add to dataset" }));
 
     await waitFor(() => {
       expect(mockAddTracesToDataset).toHaveBeenCalledWith(
@@ -361,19 +375,15 @@ describe("AddToDatasetDialog", () => {
 
   it("should call addSpansToDataset mutation when clicking on dataset with only spans", async () => {
     const propsWithSpan = {
-      ...defaultProps,
+      ...datasetModeProps,
       selectedRows: [mockSpan],
     };
 
     render(<AddToDatasetDialog {...propsWithSpan} />, { wrapper });
 
-    // Select the dataset
-    const dataset = screen.getByText("Test Dataset 1");
-    fireEvent.click(dataset);
+    fireEvent.click(screen.getByText("Test Dataset 1"));
 
-    // Click the "Add to test suite" button
-    const addButton = screen.getAllByText("Add to test suite")[1]; // Get the button, not the dialog title
-    fireEvent.click(addButton);
+    fireEvent.click(screen.getByRole("button", { name: "Add to dataset" }));
 
     await waitFor(() => {
       expect(mockAddSpansToDataset).toHaveBeenCalledWith(
@@ -395,19 +405,15 @@ describe("AddToDatasetDialog", () => {
   });
 
   it("should respect unchecked enrichment options when adding traces", async () => {
-    render(<AddToDatasetDialog {...defaultProps} />, { wrapper });
+    render(<AddToDatasetDialog {...datasetModeProps} />, { wrapper });
 
-    // Select the legacy dataset first to show metadata config
     fireEvent.click(screen.getByText("Test Dataset 1"));
 
-    // Uncheck some options
     fireEvent.click(screen.getByLabelText("Nested spans"));
     fireEvent.click(screen.getByLabelText("Tags"));
     fireEvent.click(screen.getByLabelText("Usage metrics"));
 
-    // Click the "Add to test suite" button
-    const addButton = screen.getAllByText("Add to test suite")[1];
-    fireEvent.click(addButton);
+    fireEvent.click(screen.getByRole("button", { name: "Add to dataset" }));
 
     await waitFor(() => {
       expect(mockAddTracesToDataset).toHaveBeenCalledWith(
@@ -428,23 +434,19 @@ describe("AddToDatasetDialog", () => {
 
   it("should respect unchecked enrichment options when adding spans", async () => {
     const propsWithSpan = {
-      ...defaultProps,
+      ...datasetModeProps,
       selectedRows: [mockSpan],
     };
 
     render(<AddToDatasetDialog {...propsWithSpan} />, { wrapper });
 
-    // Select the legacy dataset first to show metadata config
     fireEvent.click(screen.getByText("Test Dataset 1"));
 
-    // Uncheck some options
     fireEvent.click(screen.getByLabelText("Tags"));
     fireEvent.click(screen.getByLabelText("Comments"));
     fireEvent.click(screen.getByLabelText("Metadata"));
 
-    // Click the "Add to test suite" button
-    const addButton = screen.getAllByText("Add to test suite")[1];
-    fireEvent.click(addButton);
+    fireEvent.click(screen.getByRole("button", { name: "Add to dataset" }));
 
     await waitFor(() => {
       expect(mockAddSpansToDataset).toHaveBeenCalledWith(

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
@@ -33,6 +33,8 @@ import useAddTracesToDatasetMutation from "@/api/datasets/useAddTracesToDatasetM
 import useAddSpansToDatasetMutation from "@/api/datasets/useAddSpansToDatasetMutation";
 import useDatasetVersionsList from "@/api/datasets/useDatasetVersionsList";
 import { Dataset, DATASET_TYPE } from "@/types/datasets";
+import { COLUMN_TYPE } from "@/types/shared";
+import { Filter } from "@/types/filters";
 import {
   DEFAULT_EXECUTION_POLICY,
   MAX_RUNS_PER_ITEM,
@@ -52,6 +54,7 @@ import {
   ASSERTIONS_DESCRIPTION,
   PASS_CRITERIA_TITLE,
 } from "@/constants/test-suites";
+import AddEditDatasetDialog from "@/v2/pages-shared/datasets/AddEditDatasetDialog/AddEditDatasetDialog";
 import AddEditTestSuiteDialog from "@/v2/pages-shared/datasets/AddEditTestSuiteDialog/AddEditTestSuiteDialog";
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
@@ -72,13 +75,36 @@ type AddToDatasetDialogProps = {
   selectedRows: Array<Trace | Span>;
   open: boolean;
   setOpen: (open: boolean) => void;
+  datasetType: DATASET_TYPE;
 };
 
 const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
   selectedRows,
   open,
   setOpen,
+  datasetType,
 }) => {
+  const isTestSuiteMode = datasetType === DATASET_TYPE.TEST_SUITE;
+  const entityName = isTestSuiteMode ? "test suite" : "dataset";
+  const noSelectionExplainerId = isTestSuiteMode
+    ? EXPLAINER_ID.why_would_i_want_to_add_traces_to_an_test_suite
+    : EXPLAINER_ID.whats_an_experiment;
+  const successToastExplainerId = isTestSuiteMode
+    ? EXPLAINER_ID.i_added_traces_to_an_test_suite_now_what
+    : EXPLAINER_ID.i_added_items_to_a_dataset_now_what;
+  const typeFilter = useMemo(
+    () =>
+      [
+        {
+          id: "type",
+          field: "type",
+          type: COLUMN_TYPE.string,
+          operator: "=" as const,
+          value: datasetType,
+        },
+      ] as Filter[],
+    [datasetType],
+  );
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const activeProjectId = useActiveProjectId();
   const [search, setSearch] = useState("");
@@ -115,7 +141,6 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
   const { mutate: addTracesToDataset } = useAddTracesToDatasetMutation();
   const { mutate: addSpansToDataset } = useAddSpansToDatasetMutation();
 
-  // Fetch the latest version of the selected dataset to get suite-level assertions
   const { data: versionsData } = useDatasetVersionsList(
     {
       datasetId: selectedDataset?.id ?? "",
@@ -123,7 +148,7 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
       size: 1,
     },
     {
-      enabled: Boolean(selectedDataset?.id),
+      enabled: isTestSuiteMode && Boolean(selectedDataset?.id),
     },
   );
 
@@ -138,12 +163,11 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
     );
   }, [versionsData]);
 
-  // Sync form state with suite defaults when selected dataset changes or version data loads
   useEffect(() => {
-    if (!selectedDataset?.id) return;
+    if (!isTestSuiteMode || !selectedDataset?.id) return;
     setRunsPerItem(suiteExecutionPolicy.runs_per_item);
     setPassThreshold(suiteExecutionPolicy.pass_threshold);
-  }, [selectedDataset?.id, suiteExecutionPolicy]);
+  }, [isTestSuiteMode, selectedDataset?.id, suiteExecutionPolicy]);
 
   const { data, isPending } = useProjectDatasetsList(
     {
@@ -151,6 +175,7 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
       search,
       page,
       size,
+      filters: typeFilter,
     },
     {
       placeholderData: keepPreviousData,
@@ -188,15 +213,12 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
         itemType = "Spans";
       }
 
-      const explainer =
-        EXPLAINERS_MAP[EXPLAINER_ID.i_added_traces_to_an_test_suite_now_what];
-
       toast({
-        title: `${itemType} added to test suite`,
-        description: explainer.description,
+        title: `${itemType} added to ${entityName}`,
+        description: EXPLAINERS_MAP[successToastExplainerId].description,
       });
     },
-    [toast],
+    [toast, entityName, successToastExplainerId],
   );
 
   const handleAssertionChange = useCallback((index: number, value: string) => {
@@ -254,7 +276,7 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
       setFetching(true);
       setOpen(false);
 
-      const evalParams = buildEvaluatorParams();
+      const evalParams = isTestSuiteMode ? buildEvaluatorParams() : {};
 
       // If we have only traces, use the enriched endpoint for traces
       if (hasOnlyTraces) {
@@ -323,6 +345,7 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
       hasOnlySpans,
       validTraces,
       validSpans,
+      isTestSuiteMode,
     ],
   );
 
@@ -334,7 +357,7 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
     if (datasets.length === 0) {
       const text = search
         ? "No search results"
-        : "There are no test suites yet";
+        : `There are no ${entityName}s yet`;
 
       return (
         <div className="comet-body-s flex h-32 items-center justify-center text-muted-slate">
@@ -402,8 +425,8 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
 
   const renderAlert = () => {
     const text = noValidRows
-      ? "There are no rows that can be added as test suite items. The input field is missing."
-      : "Only rows with input fields will be added as test suite items.";
+      ? `There are no rows that can be added as ${entityName} items. The input field is missing.`
+      : `Only rows with input fields will be added as ${entityName} items.`;
 
     if (noValidRows || partialValid) {
       return (
@@ -506,19 +529,17 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="max-w-lg sm:max-w-[560px]">
           <DialogHeader>
-            <DialogTitle>Add to test suite</DialogTitle>
+            <DialogTitle>Add to {entityName}</DialogTitle>
           </DialogHeader>
           <DialogAutoScrollBody>
             {!selectedDataset && (
               <ExplainerDescription
                 className="mb-4"
-                {...EXPLAINERS_MAP[
-                  EXPLAINER_ID.why_would_i_want_to_add_traces_to_an_test_suite
-                ]}
+                {...EXPLAINERS_MAP[noSelectionExplainerId]}
               />
             )}
             <div className="my-2 flex items-center justify-between">
-              <h3 className="comet-title-xs">Select a test suite</h3>
+              <h3 className="comet-title-xs">Select a {entityName}</h3>
               {canCreateDatasets && (
                 <Button
                   variant="ghost"
@@ -529,7 +550,7 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
                   disabled={noValidRows}
                 >
                   <Plus className="mr-1 size-4" />
-                  Create new test suite
+                  Create new {entityName}
                 </Button>
               )}
             </div>
@@ -553,13 +574,13 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
                 ></DataTablePagination>
               </div>
             )}
-            {selectedDataset?.type === DATASET_TYPE.DATASET && (
+            {!isTestSuiteMode && selectedDataset && (
               <div ref={configSectionRef}>
                 {hasOnlyTraces && renderMetadataConfiguration("trace", true)}
                 {hasOnlySpans && renderMetadataConfiguration("span")}
               </div>
             )}
-            {selectedDataset?.type === DATASET_TYPE.TEST_SUITE && (
+            {isTestSuiteMode && selectedDataset && (
               <Accordion
                 ref={configSectionRef}
                 type="single"
@@ -650,19 +671,30 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
               }}
               disabled={!selectedDataset || noValidRows || fetching}
             >
-              Add to test suite
+              Add to {entityName}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      <AddEditTestSuiteDialog
-        open={openDialog}
-        setOpen={setOpenDialog}
-        onDatasetCreated={(dataset) => {
-          setSelectedDataset(dataset);
-        }}
-        hideUpload={true}
-      />
+      {isTestSuiteMode ? (
+        <AddEditTestSuiteDialog
+          open={openDialog}
+          setOpen={setOpenDialog}
+          onDatasetCreated={(dataset) => {
+            setSelectedDataset(dataset);
+          }}
+          hideUpload={true}
+        />
+      ) : (
+        <AddEditDatasetDialog
+          open={openDialog}
+          setOpen={setOpenDialog}
+          onDatasetCreated={(dataset) => {
+            setSelectedDataset(dataset);
+          }}
+          hideUpload={true}
+        />
+      )}
     </>
   );
 };

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
@@ -179,7 +179,7 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
     },
     {
       placeholderData: keepPreviousData,
-      enabled: !!activeProjectId,
+      enabled: !!activeProjectId && open,
     },
   );
 

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
@@ -167,7 +167,8 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
     if (!isTestSuiteMode || !selectedDataset?.id) return;
     setRunsPerItem(suiteExecutionPolicy.runs_per_item);
     setPassThreshold(suiteExecutionPolicy.pass_threshold);
-  }, [isTestSuiteMode, selectedDataset?.id, suiteExecutionPolicy]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isTestSuiteMode, selectedDataset?.id]);
 
   const { data, isPending } = useProjectDatasetsList(
     {

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToDropdown/AddToDropdown.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToDropdown/AddToDropdown.tsx
@@ -1,5 +1,11 @@
 import React, { useRef, useState } from "react";
-import { ChevronDown, Database, ListChecks, UserPen } from "lucide-react";
+import {
+  ChevronDown,
+  Database,
+  ListChecks,
+  UserPen,
+  LucideIcon,
+} from "lucide-react";
 
 import { Button, ButtonProps } from "@/ui/button";
 import {
@@ -13,6 +19,28 @@ import AddToDatasetDialog from "@/v2/pages-shared/traces/AddToDatasetDialog/AddT
 import AddToQueueDialog from "@/v2/pages-shared/traces/AddToQueueDialog/AddToQueueDialog";
 import { usePermissions } from "@/contexts/PermissionsContext";
 import { DATASET_TYPE } from "@/types/datasets";
+
+type DatasetOption = {
+  datasetType: DATASET_TYPE;
+  label: string;
+  icon: LucideIcon;
+  openValue: number;
+};
+
+const DATASET_OPTIONS: DatasetOption[] = [
+  {
+    datasetType: DATASET_TYPE.TEST_SUITE,
+    label: "Test suite",
+    icon: ListChecks,
+    openValue: 1,
+  },
+  {
+    datasetType: DATASET_TYPE.DATASET,
+    label: "Dataset",
+    icon: Database,
+    openValue: 3,
+  },
+];
 
 export type AddToDropdownProps = {
   getDataForExport: () => Promise<Array<Trace | Span | Thread>>;
@@ -50,24 +78,16 @@ const AddToDropdown: React.FunctionComponent<AddToDropdownProps> = (props) => {
 
   return (
     <>
-      {showAddToDataset && (
-        <>
+      {showAddToDataset &&
+        DATASET_OPTIONS.map((opt) => (
           <AddToDatasetDialog
-            key={`test-suite-${resetKeyRef.current}`}
+            key={`${opt.label}-${resetKeyRef.current}`}
             selectedRows={selectedRows as Array<Trace | Span>}
-            datasetType={DATASET_TYPE.TEST_SUITE}
-            open={open === 1}
+            datasetType={opt.datasetType}
+            open={open === opt.openValue}
             setOpen={() => setOpen(0)}
           />
-          <AddToDatasetDialog
-            key={`dataset-${resetKeyRef.current}`}
-            selectedRows={selectedRows as Array<Trace | Span>}
-            datasetType={DATASET_TYPE.DATASET}
-            open={open === 3}
-            setOpen={() => setOpen(0)}
-          />
-        </>
-      )}
+        ))}
       {showAddToQueue && (
         <AddToQueueDialog
           key={`queue-${resetKeyRef.current}`}
@@ -89,30 +109,20 @@ const AddToDropdown: React.FunctionComponent<AddToDropdownProps> = (props) => {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-60">
-          {showAddToDataset && (
-            <DropdownMenuItem
-              onClick={() => {
-                setOpen(1);
-                resetKeyRef.current = resetKeyRef.current + 1;
-              }}
-              disabled={disabled}
-            >
-              <ListChecks className="mr-2 size-4" />
-              Test suite
-            </DropdownMenuItem>
-          )}
-          {showAddToDataset && (
-            <DropdownMenuItem
-              onClick={() => {
-                setOpen(3);
-                resetKeyRef.current = resetKeyRef.current + 1;
-              }}
-              disabled={disabled}
-            >
-              <Database className="mr-2 size-4" />
-              Dataset
-            </DropdownMenuItem>
-          )}
+          {showAddToDataset &&
+            DATASET_OPTIONS.map((opt) => (
+              <DropdownMenuItem
+                key={opt.label}
+                onClick={() => {
+                  setOpen(opt.openValue);
+                  resetKeyRef.current = resetKeyRef.current + 1;
+                }}
+                disabled={disabled}
+              >
+                <opt.icon className="mr-2 size-4" />
+                {opt.label}
+              </DropdownMenuItem>
+            ))}
           {showAddToQueue && (
             <DropdownMenuItem
               onClick={() => {

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToDropdown/AddToDropdown.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToDropdown/AddToDropdown.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from "react";
-import { ChevronDown, Database, UserPen } from "lucide-react";
+import { ChevronDown, Database, ListChecks, UserPen } from "lucide-react";
 
 import { Button, ButtonProps } from "@/ui/button";
 import {
@@ -12,6 +12,7 @@ import { Span, Trace, Thread } from "@/types/traces";
 import AddToDatasetDialog from "@/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog";
 import AddToQueueDialog from "@/v2/pages-shared/traces/AddToQueueDialog/AddToQueueDialog";
 import { usePermissions } from "@/contexts/PermissionsContext";
+import { DATASET_TYPE } from "@/types/datasets";
 
 export type AddToDropdownProps = {
   getDataForExport: () => Promise<Array<Trace | Span | Thread>>;
@@ -50,12 +51,22 @@ const AddToDropdown: React.FunctionComponent<AddToDropdownProps> = (props) => {
   return (
     <>
       {showAddToDataset && (
-        <AddToDatasetDialog
-          key={`dataset-${resetKeyRef.current}`}
-          selectedRows={selectedRows as Array<Trace | Span>}
-          open={open === 1}
-          setOpen={() => setOpen(0)}
-        />
+        <>
+          <AddToDatasetDialog
+            key={`test-suite-${resetKeyRef.current}`}
+            selectedRows={selectedRows as Array<Trace | Span>}
+            datasetType={DATASET_TYPE.TEST_SUITE}
+            open={open === 1}
+            setOpen={() => setOpen(0)}
+          />
+          <AddToDatasetDialog
+            key={`dataset-${resetKeyRef.current}`}
+            selectedRows={selectedRows as Array<Trace | Span>}
+            datasetType={DATASET_TYPE.DATASET}
+            open={open === 3}
+            setOpen={() => setOpen(0)}
+          />
+        </>
       )}
       {showAddToQueue && (
         <AddToQueueDialog
@@ -86,8 +97,20 @@ const AddToDropdown: React.FunctionComponent<AddToDropdownProps> = (props) => {
               }}
               disabled={disabled}
             >
-              <Database className="mr-2 size-4" />
+              <ListChecks className="mr-2 size-4" />
               Test suite
+            </DropdownMenuItem>
+          )}
+          {showAddToDataset && (
+            <DropdownMenuItem
+              onClick={() => {
+                setOpen(3);
+                resetKeyRef.current = resetKeyRef.current + 1;
+              }}
+              disabled={disabled}
+            >
+              <Database className="mr-2 size-4" />
+              Dataset
             </DropdownMenuItem>
           )}
           {showAddToQueue && (


### PR DESCRIPTION
## Details

Split the "Add to dataset" action on the Logs page into two separate options — "Add to dataset" and "Add to test suite" — so entries are filtered by type and settings shown accordingly. Also fixed the SDK code snippets in the Create Dataset/Test Suite sidebar to use proper syntax highlighting via CodeHighlighter instead of plain `<pre>` tags.

- The AddToDatasetDialog now accepts a `datasetType` prop and filters the dataset list accordingly
- The AddToDropdown renders two separate menu items for datasets vs test suites
- CodeHighlighter now supports JavaScript/TypeScript syntax highlighting
- Python and TypeScript SDK snippets in the create sidebar use CodeHighlighter with language-aware highlighting and a built-in copy button

### Responsive toolbar for dataset/test suite items page

When the Ollie assistant sidebar is open and compresses the content area, the dataset items toolbar now adapts:

- Toolbar detects available width via `ResizeObserver` and switches to compact mode below 850px
- "Add item" button becomes a `+` icon button with tooltip
- "Expand with AI" button becomes an icon-only sparkles button with tooltip
- Search input becomes an expandable search icon (magnifying glass) that overlays the toolbar when expanded
- Closing the expandable search preserves the active search filter (does not clear the term)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5846

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: syntax highlighting fix, responsive toolbar compact mode
  - Human verification: yes — reviewed and tested in browser

## Testing

- Ran `npm run lint:fix` — passed with 0 warnings
- Ran `tsc --project tsconfig.json --noEmit` — passed with no type errors
- Ran `depcruise` dependency validation — passed
- Verified syntax highlighting renders correctly for both Python and TypeScript SDK snippets in the Create Dataset and Create Test Suite sidebars
- Verified compact toolbar activates when assistant sidebar compresses the page
- Verified search term persists when collapsing the expandable search icon

## Documentation

No documentation changes needed.