### PR TITLE
[OPIK-5962] [FE] feat: add pairing status screen with honest V1/V2 routing

### DIFF
--- a/apps/opik-frontend/src/WorkspaceVersionGate.tsx
+++ b/apps/opik-frontend/src/WorkspaceVersionGate.tsx
@@ -9,14 +9,14 @@
  *
  * Level 1 — WorkspaceVersionGate (this component, BEFORE the router):
  *   1. Check localStorage override ("opik-version-override") → use immediately
- *   2. Check if the path forces a version (e.g. /pair/* is V2-only)
- *   3. Else parse the workspace name from window.location.pathname
- *   4. If found → fetch version from API with per-request Comet-Workspace header
- *   5. If not found (e.g. root "/") → default to v1 optimistically
+ *   2. Else parse the workspace name from window.location
+ *      (path segment for normal URLs, ?workspace= query for pair links)
+ *   3. If found → fetch version from API with per-request Comet-Workspace header
+ *   4. If not found (e.g. root "/") → default to v1 optimistically
  *
- * Steps 1, 2, 5 are synchronous and run at module load, so the first paint
+ * Steps 1 and 4 are synchronous and run at module load, so the first paint
  * already knows which App to render — no Loader flash in the common cases.
- * Only step 4 (workspace in URL, version unknown) falls back to a Loader.
+ * Only step 3 (workspace in URL, version unknown) falls back to a Loader.
  *
  * Level 2 — WorkspaceVersionResolver (INSIDE the router, after WorkspacePreloader):
  *   1. Workspace is now fully resolved (auth, access, header set)
@@ -31,7 +31,7 @@ import React, { Suspense, useEffect } from "react";
 import useAppStore, { useWorkspaceVersion } from "@/store/AppStore";
 import { fetchWorkspaceVersion } from "@/api/workspaces/useWorkspaceVersion";
 import {
-  getWorkspaceNameFromPath,
+  getWorkspaceNameFromUrl,
   resolveSyncWorkspaceVersion,
 } from "@/lib/workspaceVersion";
 import Loader from "@/shared/Loader/Loader";
@@ -39,9 +39,6 @@ import Loader from "@/shared/Loader/Loader";
 const V1App = React.lazy(() => import("@/v1/App"));
 const V2App = React.lazy(() => import("@/v2/App"));
 
-// Populate the store synchronously at module load so the first render
-// already has a version — avoids a Loader flash on /pair/*, root "/", and
-// any path with a localStorage version override.
 const initialVersion = resolveSyncWorkspaceVersion();
 if (initialVersion) {
   useAppStore.getState().setWorkspaceVersion(initialVersion);
@@ -52,7 +49,7 @@ const WorkspaceVersionGate = () => {
 
   useEffect(() => {
     if (useAppStore.getState().workspaceVersion) return;
-    const workspaceName = getWorkspaceNameFromPath();
+    const workspaceName = getWorkspaceNameFromUrl();
     if (!workspaceName) return;
 
     let cancelled = false;

--- a/apps/opik-frontend/src/lib/workspaceVersion.ts
+++ b/apps/opik-frontend/src/lib/workspaceVersion.ts
@@ -4,10 +4,6 @@ export const DEFAULT_WORKSPACE_VERSION: WorkspaceVersion = "v1";
 
 const OPIK_VERSION_OVERRIDE_KEY = "opik-version-override";
 
-// Path segments (directly under basepath) that are only valid in V2.
-// Add new V2-only top-level routes here — nothing else needs to change.
-const V2_ONLY_SEGMENTS: ReadonlySet<string> = new Set(["pair"]);
-
 export function getVersionOverride(): WorkspaceVersion | null {
   const override = localStorage.getItem(OPIK_VERSION_OVERRIDE_KEY);
   return override === "v1" || override === "v2" ? override : null;
@@ -22,33 +18,24 @@ function getRelativePathSegments(): string[] {
   return relative.split("/").filter(Boolean);
 }
 
-export function getWorkspaceNameFromPath(): string | null {
-  return getRelativePathSegments()[0] || null;
-}
-
-// Returns a version that the current path forces regardless of workspace.
-// Used by WorkspaceVersionGate to short-circuit V2-only routes (e.g. /pair/*)
-// without an API call and without touching localStorage.
-//
-// The pairing URL from the SDK is always of the form `.../opik/pair/v1`.
-// On cloud (VITE_BASE_URL=/opik), the `/opik` prefix is stripped by
-// getRelativePathSegments so the first segment is "pair". On OSS
-// (VITE_BASE_URL=/), nothing is stripped and "opik" remains as the first
-// segment — skip it so detection works in both deployments.
-export function getForcedVersionFromPath(): WorkspaceVersion | null {
+// Pair URLs from the SDK look like `.../pair/v1?workspace=my-ws` — the
+// workspace is in the query string, not the path. On OSS (VITE_BASE_URL=/),
+// the `/opik` prefix is not stripped by getRelativePathSegments, so skip it
+// to detect the "pair" head in both cloud and OSS deployments.
+export function getWorkspaceNameFromUrl(): string | null {
   const segments = getRelativePathSegments();
   const head = segments[0] === "opik" ? segments[1] : segments[0];
-  return head && V2_ONLY_SEGMENTS.has(head) ? "v2" : null;
+  if (head === "pair") {
+    return new URLSearchParams(window.location.search).get("workspace");
+  }
+  return segments[0] || null;
 }
 
-// Resolves the workspace version synchronously when possible. Returns null
-// only when the workspace name is in the URL but its version requires an
-// API fetch — the one case that needs to fall back to a Loader.
+// Returns null only when the workspace is in the URL but needs an API fetch
+// to resolve its version — the one case that requires a Loader fallback.
 export function resolveSyncWorkspaceVersion(): WorkspaceVersion | null {
   const override = getVersionOverride();
   if (override) return override;
-  const forced = getForcedVersionFromPath();
-  if (forced) return forced;
-  if (!getWorkspaceNameFromPath()) return DEFAULT_WORKSPACE_VERSION;
+  if (!getWorkspaceNameFromUrl()) return DEFAULT_WORKSPACE_VERSION;
   return null;
 }

--- a/apps/opik-frontend/src/shared/PairingStatusScreen/PairingStatusScreen.tsx
+++ b/apps/opik-frontend/src/shared/PairingStatusScreen/PairingStatusScreen.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { useTheme } from "@/contexts/theme-provider";
+import { THEME_MODE } from "@/constants/theme";
+import opikLogoUrl from "/images/opik-logo.png";
+import opikLogoInvertedUrl from "/images/opik-logo-inverted.png";
+
+export type PairingStatus = "loading" | "success" | "error";
+export type RunnerVariant = "connect" | "endpoint";
+export type PairingErrorKind =
+  | "invalid_link"
+  | "tampered_link"
+  | "expired_link"
+  | "unreachable"
+  | "insecure_context"
+  | "v1_workspace";
+
+export interface PairingStatusScreenProps {
+  status: PairingStatus;
+  runnerVariant?: RunnerVariant;
+  errorKind?: PairingErrorKind;
+}
+
+function getCopy(props: PairingStatusScreenProps): {
+  headline: string;
+  subtitle: string;
+} {
+  if (props.status === "loading") {
+    const headline =
+      props.runnerVariant === "endpoint"
+        ? "Connecting your agent"
+        : props.runnerVariant === "connect"
+          ? "Connecting to your codebase"
+          : "Connecting";
+    return {
+      headline,
+      subtitle: "Finalizing the pairing — this only takes a moment.",
+    };
+  }
+
+  if (props.status === "success") {
+    const headline =
+      props.runnerVariant === "endpoint"
+        ? "Your agent is connected to Opik"
+        : "Opik is connected to your codebase";
+    return {
+      headline,
+      subtitle: "Pairing successful — you can safely close this tab.",
+    };
+  }
+
+  switch (props.errorKind) {
+    case "tampered_link":
+      return {
+        headline: "This pairing link can't be trusted",
+        subtitle:
+          "The link appears to have been modified. Run the CLI command again.",
+      };
+    case "expired_link":
+      return {
+        headline: "This pairing link has expired",
+        subtitle: "Run the CLI command again to generate a fresh link.",
+      };
+    case "unreachable":
+      return {
+        headline: "Couldn't reach Opik",
+        subtitle: "Check your connection and try again.",
+      };
+    case "insecure_context":
+      return {
+        headline: "Secure connection required",
+        subtitle: "Pairing requires HTTPS. Open the link on a secure page.",
+      };
+    case "v1_workspace":
+      return {
+        headline: "Workspace upgrade required",
+        subtitle:
+          "Opik Connect requires Opik 2.0. Please upgrade your workspace to continue.",
+      };
+    default:
+      return {
+        headline: "This pairing link is invalid",
+        subtitle: "Run the CLI command again to generate a fresh link.",
+      };
+  }
+}
+
+export const PairingStatusScreen: React.FC<PairingStatusScreenProps> = (
+  props,
+) => {
+  const { headline, subtitle } = getCopy(props);
+  const { themeMode } = useTheme();
+
+  return (
+    <main
+      aria-label="Pairing status"
+      className="flex min-h-screen flex-col items-center justify-center p-6"
+    >
+      <img
+        src={themeMode === THEME_MODE.DARK ? opikLogoInvertedUrl : opikLogoUrl}
+        alt="Opik"
+        className="mb-10 h-10"
+      />
+      <div className="flex flex-col items-center gap-2">
+        <h1 className="comet-title-s text-center">{headline}</h1>
+        <p className="comet-body text-center text-muted-slate">{subtitle}</p>
+      </div>
+    </main>
+  );
+};
+
+export default PairingStatusScreen;

--- a/apps/opik-frontend/src/v1/pages/PairV1Page/PairV1Page.tsx
+++ b/apps/opik-frontend/src/v1/pages/PairV1Page/PairV1Page.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import PairingStatusScreen from "@/shared/PairingStatusScreen/PairingStatusScreen";
+
+const PairV1Page: React.FC = () => (
+  <PairingStatusScreen status="error" errorKind="v1_workspace" />
+);
+
+export default PairV1Page;

--- a/apps/opik-frontend/src/v1/router.tsx
+++ b/apps/opik-frontend/src/v1/router.tsx
@@ -48,6 +48,7 @@ import DashboardsPage from "@/v1/pages/DashboardsPage/DashboardsPage";
 import TestSuitesPage from "@/v1/pages/TestSuitesPage/TestSuitesPage";
 import TestSuitePage from "@/v1/pages/TestSuitePage/TestSuitePage";
 import TestSuiteItemsPage from "@/v1/pages/TestSuiteItemsPage/TestSuiteItemsPage";
+import PairV1Page from "@/v1/pages/PairV1Page/PairV1Page";
 
 const TanStackRouterDevtools =
   process.env.NODE_ENV === "production"
@@ -91,6 +92,28 @@ const workspaceGuardEmptyLayoutRoute = createRoute({
   id: "workspaceGuardEmptyLayout",
   getParentRoute: () => rootRoute,
   component: () => <WorkspaceGuard Layout={EmptyPageLayout} />,
+});
+
+// ----------- pairing (root-level, no layout — V1 shows upgrade-required screen)
+// TanStack strips the router basepath before matching, so the canonical
+// route is basepath-relative: "/pair/v1" covers cloud (basepath "/opik"
+// → URL "/opik/pair/v1" strips to "/pair/v1").
+//
+// The legacy "/opik/pair/v1" alias below is an OSS-only fallback: the
+// Python SDK hardcodes "{origin}/opik/pair/v1" regardless of deployment
+// (see sdks/python/src/opik/cli/pairing.py), so on OSS (basepath "/") the
+// "/opik/" prefix isn't stripped and the router sees "/opik/pair/v1".
+// TODO: make the Python SDK build basepath-aware pairing URLs and drop
+// this alias once shipped CLI versions roll over.
+const pairingRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/pair/v1",
+  component: PairV1Page,
+});
+const pairingRouteOssAlias = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/opik/pair/v1",
+  component: PairV1Page,
 });
 
 const baseRoute = createRoute({
@@ -528,6 +551,8 @@ const automationLogsRoute = createRoute({
 });
 
 const routeTree = rootRoute.addChildren([
+  pairingRoute,
+  pairingRouteOssAlias,
   workspaceGuardEmptyLayoutRoute.addChildren([automationLogsRoute]),
   workspaceGuardPartialLayoutRoute.addChildren([
     quickstartRoute,

--- a/apps/opik-frontend/src/v2/pages/PairingPage/PairingPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PairingPage/PairingPage.tsx
@@ -1,14 +1,11 @@
 import React, { useEffect, useMemo } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
-import { CheckCircle2, CircleAlert } from "lucide-react";
+import { useMutation } from "@tanstack/react-query";
 import api from "@/api/api";
-import { fetchWorkspaceVersion } from "@/api/workspaces/useWorkspaceVersion";
-import { Spinner } from "@/ui/spinner";
-
-// ---------------------------------------------------------------------------
-// Binary helpers
-// ---------------------------------------------------------------------------
+import PairingStatusScreen, {
+  PairingErrorKind,
+  PairingStatusScreenProps,
+  RunnerVariant,
+} from "@/shared/PairingStatusScreen/PairingStatusScreen";
 
 function uuidFromBytes(bytes: Uint8Array): string {
   const h = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
@@ -25,18 +22,12 @@ function uuidToBytes(uuid: string): Uint8Array {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Fragment parsing
-// ---------------------------------------------------------------------------
-
-type RunnerType = "connect" | "endpoint";
-
 interface PairingPayload {
   sessionId: string;
   activationKey: Uint8Array;
   projectId: string;
   runnerName: string;
-  runnerType: RunnerType;
+  runnerType: RunnerVariant;
 }
 
 function parsePairingPayload(fragment: string): PairingPayload {
@@ -50,7 +41,7 @@ function parsePairingPayload(fragment: string): PairingPayload {
   if (bytes.length < 65 + nameLen) throw new Error("bad link");
 
   const typeOffset = 65 + nameLen;
-  const runnerType: RunnerType =
+  const runnerType: RunnerVariant =
     bytes.length > typeOffset && bytes[typeOffset] === 0x01
       ? "endpoint"
       : "connect";
@@ -63,10 +54,6 @@ function parsePairingPayload(fragment: string): PairingPayload {
     runnerType,
   };
 }
-
-// ---------------------------------------------------------------------------
-// Crypto (SubtleCrypto)
-// ---------------------------------------------------------------------------
 
 async function computeActivationHmac(
   activationKey: Uint8Array,
@@ -124,10 +111,6 @@ async function deriveBridgeKey(
   return new Uint8Array(await crypto.subtle.sign("HMAC", expandKey, expandMsg));
 }
 
-// ---------------------------------------------------------------------------
-// Activate + derive + store — runs once on mount
-// ---------------------------------------------------------------------------
-
 async function activate(
   payload: PairingPayload,
   workspace: string | null,
@@ -158,15 +141,24 @@ async function activate(
   }
 }
 
-// ---------------------------------------------------------------------------
-// Page component
-// ---------------------------------------------------------------------------
+function httpStatus(err: unknown): number | undefined {
+  if (err && typeof err === "object" && "response" in err) {
+    return (err as { response?: { status?: number } }).response?.status;
+  }
+  return undefined;
+}
 
-type WorkspacePhase = "missing" | "checking" | "ok" | "v1";
-type Status = "loading" | "success" | "error";
+function mapActivationError(err: unknown): PairingErrorKind {
+  if (err instanceof Error && err.message === "SECURE_CONTEXT_REQUIRED") {
+    return "insecure_context";
+  }
+  const status = httpStatus(err);
+  if (status === 403) return "tampered_link";
+  if (status === 404) return "expired_link";
+  return "unreachable";
+}
 
 const PairingPage: React.FC = () => {
-  const navigate = useNavigate();
   const fragment = window.location.hash.slice(1);
 
   const [payload, parseError] = useMemo<
@@ -184,21 +176,6 @@ const PairingPage: React.FC = () => {
     "workspace",
   );
 
-  const versionQuery = useQuery({
-    queryKey: ["pairing-workspace-version", workspaceName],
-    queryFn: ({ signal }) =>
-      fetchWorkspaceVersion({ workspaceName: workspaceName!, signal }),
-    enabled: !!workspaceName,
-    staleTime: 5 * 60 * 1000,
-  });
-
-  const workspacePhase: WorkspacePhase = useMemo(() => {
-    if (!workspaceName) return "missing";
-    if (versionQuery.isPending) return "checking";
-    if (versionQuery.data === "v2") return "ok";
-    return "v1";
-  }, [workspaceName, versionQuery.isPending, versionQuery.data]);
-
   const {
     mutate: runActivation,
     isIdle: activationIdle,
@@ -211,89 +188,33 @@ const PairingPage: React.FC = () => {
       try {
         await activate(p, workspaceName);
       } catch (err) {
-        // 409 = runner already paired; treat as success so the user still
-        // gets redirected to their agent instead of seeing an error screen.
-        const status =
-          err && typeof err === "object" && "response" in err
-            ? (err as { response?: { status?: number } }).response?.status
-            : undefined;
-        if (status !== 409) throw err;
+        // 409 = session already activated; treat as success so repeat opens
+        // still land on the success screen rather than an error.
+        if (httpStatus(err) !== 409) throw err;
       }
-    },
-    onSuccess: (_data, variables) => {
-      if (!workspaceName) return;
-      navigate({
-        to: "/$workspaceName/projects/$projectId/agent-configuration",
-        params: { workspaceName, projectId: variables.projectId },
-      });
     },
   });
 
   useEffect(() => {
-    if (workspacePhase !== "ok" || !payload || !activationIdle) return;
+    if (!payload || !workspaceName || !activationIdle) return;
     runActivation(payload);
-  }, [workspacePhase, payload, activationIdle, runActivation]);
+  }, [payload, workspaceName, activationIdle, runActivation]);
 
-  function getActivationErrorMessage(err: unknown): string {
-    if (err instanceof Error && err.message === "SECURE_CONTEXT_REQUIRED") {
-      return "Pairing requires a secure connection (HTTPS).";
-    }
-    const s =
-      err && typeof err === "object" && "response" in err
-        ? (err as { response?: { status?: number } }).response?.status
-        : undefined;
-    if (s === 403)
-      return "This pairing link is invalid or has been tampered with.";
-    if (s === 404)
-      return "This pairing link has expired. Run the CLI command again.";
-    return "Could not reach Opik. Check your connection.";
+  let screenProps: PairingStatusScreenProps;
+  if (parseError || !workspaceName) {
+    screenProps = { status: "error", errorKind: "invalid_link" };
+  } else if (activationIsError) {
+    screenProps = {
+      status: "error",
+      errorKind: mapActivationError(activationError),
+    };
+  } else if (activationIsSuccess) {
+    screenProps = { status: "success", runnerVariant: payload?.runnerType };
+  } else {
+    screenProps = { status: "loading", runnerVariant: payload?.runnerType };
   }
 
-  function getDisplay(): { status: Status; message: string } {
-    // Fragment-level errors surface first: a bad link is invalid regardless
-    // of workspace state, and we shouldn't block on the version query to
-    // tell the user.
-    if (parseError) return { status: "error", message: parseError };
-    if (workspacePhase === "missing") {
-      return { status: "error", message: "This pairing link is invalid." };
-    }
-    if (workspacePhase === "v1") {
-      return {
-        status: "error",
-        message:
-          "Opik Connect requires Opik 2.0. Please upgrade your workspace to continue.",
-      };
-    }
-    if (workspacePhase === "checking") {
-      return { status: "loading", message: "Connecting…" };
-    }
-    if (activationIsError) {
-      return {
-        status: "error",
-        message: getActivationErrorMessage(activationError),
-      };
-    }
-    if (activationIsSuccess) return { status: "success", message: "Connected" };
-    return { status: "loading", message: "Connecting…" };
-  }
-
-  const { status, message } = getDisplay();
-
-  const icon =
-    status === "loading" ? (
-      <Spinner size="medium" />
-    ) : status === "success" ? (
-      <CheckCircle2 className="size-8 shrink-0 text-green-600" />
-    ) : (
-      <CircleAlert className="size-8 shrink-0 text-destructive" />
-    );
-
-  return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-3 p-6">
-      {icon}
-      <p className="comet-body text-center text-muted-slate">{message}</p>
-    </div>
-  );
+  return <PairingStatusScreen {...screenProps} />;
 };
 
 export default PairingPage;


### PR DESCRIPTION
## Details

Introduces a shared `PairingStatusScreen` component and reworks how `/pair/v1` links are routed across V1 and V2.

**Before:** V1 had no `/pair/*` route, so the app-version gate force-loaded V2 for any `/pair/*` URL via a `V2_ONLY_SEGMENTS` hack. V2's `PairingPage` then re-fetched the workspace version itself (`versionQuery`) to catch the "loaded V2 but workspace is actually v1" case and show the correct error. Version resolution lived in two places, and v1-workspace users downloaded the entire V2 bundle just to render an error.

**After:**
- Gate resolves workspace version honestly from the pair link's `?workspace=` query param before any app loads.
- v2 workspace → V2App → full activation flow.
- v1 workspace → V1App → new minimal `/pair/v1` route rendering "Workspace upgrade required."
- `V2_ONLY_SEGMENTS` and `getForcedVersionFromPath` are gone.
- V2 `PairingPage` no longer refetches the version — it trusts the gate.
- `PairingStatusScreen` moved to `@/shared/` so both V1 and V2 can render it; success/error icons removed per design (the title copy alone is sufficient).

Each app only knows about itself — no cross-version optimism, no wasted bundle downloads on the v1 → upgrade-required path.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5962

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-opus-4-6
  - Scope: Full implementation
  - Human verification: Manually reviewed diff, ran \`npm run typecheck\` and \`npx eslint\` (both clean), tested screen states with generated pairing URLs on localhost

## Testing
Tested locally via \`npm run dev\` in \`apps/opik-frontend\`:
- v2 workspace pair link (with \`?workspace=<v2-ws>\`) → V2App bundle loads, activation flow runs, success/error/loading screens render without icons
- v1 workspace pair link (with \`?workspace=<v1-ws>\`) → V1App bundle loads, "Workspace upgrade required" screen shown
- \`/pair/v1\` with no \`?workspace=\` → invalid-link screen
- \`/pair/v1?workspace=<v2-ws>#garbage\` → invalid-link screen
- Regular workspace URLs (e.g. \`/my-ws/home\`) route to the correct app version via the normal path-based resolution
- \`npm run typecheck\` and \`npx eslint src --max-warnings=0\` pass

## Documentation
No documentation changes required — internal routing refactor + UI-only visual tweak.