### PR TITLE
[NA] [FE] Update workspace sidebar menu order and navigation

### DIFF
--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSidebarContent.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSidebarContent.tsx
@@ -5,7 +5,6 @@ import ProjectSelector from "@/v2/layout/SideBar/ProjectSelector/ProjectSelector
 import GitHubStarListItem from "@/v2/layout/SideBar/GitHubStarListItem/GitHubStarListItem";
 import SidebarMenuItem from "@/v2/layout/SideBar/MenuItem/SidebarMenuItem";
 import { getWorkspaceMenuItems } from "@/v2/layout/SideBar/helpers/getMenuItems";
-import { usePermissions } from "@/contexts/PermissionsContext";
 import { Separator } from "@/ui/separator";
 
 interface ProjectSidebarContentProps {
@@ -16,11 +15,8 @@ const ProjectSidebarContent: React.FC<ProjectSidebarContentProps> = ({
   expanded,
 }) => {
   useActiveWorkspaceName();
-  const {
-    permissions: { canViewDashboards },
-  } = usePermissions();
 
-  const workspaceItems = getWorkspaceMenuItems({ canViewDashboards });
+  const workspaceItems = getWorkspaceMenuItems();
 
   return (
     <>

--- a/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
+++ b/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
@@ -182,20 +182,14 @@ const getMenuItems = ({
   ];
 };
 
-export const getWorkspaceMenuItems = ({
-  canViewDashboards,
-}: {
-  canViewDashboards: boolean;
-}): MenuItemGroup[] => {
+export const getWorkspaceMenuItems = (): MenuItemGroup[] => {
   return [
     {
       id: "workspace-nav",
       items: [
         {
           id: "workspace",
-          path: canViewDashboards
-            ? "/$workspaceName/dashboards"
-            : "/$workspaceName/projects",
+          path: "/$workspaceName/projects",
           type: MENU_ITEM_TYPE.router,
           icon: LayoutDashboard,
           label: "Workspace",
@@ -224,13 +218,6 @@ export const getWorkspaceSidebarMenuItems = ({
       id: "workspace-sidebar",
       items: [
         {
-          id: "configuration",
-          path: "/$workspaceName/configuration",
-          type: MENU_ITEM_TYPE.router,
-          icon: Settings2,
-          label: "Configuration",
-        },
-        {
           id: "projects",
           path: "/$workspaceName/projects",
           type: MENU_ITEM_TYPE.router,
@@ -248,6 +235,13 @@ export const getWorkspaceSidebarMenuItems = ({
               },
             ]
           : []),
+        {
+          id: "configuration",
+          path: "/$workspaceName/configuration",
+          type: MENU_ITEM_TYPE.router,
+          icon: Settings2,
+          label: "Configuration",
+        },
       ],
     },
   ];


### PR DESCRIPTION
## Details

Reorders the workspace sidebar menu so the primary navigation matches how users think about the workspace, and simplifies the "Workspace" entry in the project sidebar so it always goes to Projects regardless of dashboard permissions.

- Workspace sidebar order changed from `Configuration, Projects, Dashboards` to `Projects, Dashboards, Configuration`.
- "Workspace" item in the project sidebar now always routes to `/$workspaceName/projects` (previously routed to `/$workspaceName/dashboards` when `canViewDashboards` was true).
- Removed the now-unused `canViewDashboards` parameter from `getWorkspaceMenuItems` and its one caller.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-6
- Scope: Menu config edits in `apps/opik-frontend/src/v2/layout/SideBar/`
- Human verification: Reviewed rendered order in the running v2 frontend (Projects → Dashboards → Configuration) with `localStorage` v2 override; confirmed DOM hrefs match new order.

## Testing

- `npm run typecheck` — passed
- `npm run lint` — passed
- Manual: launched the frontend dev server, forced v2 via `localStorage.setItem('opik-version-override', 'v2')`, navigated to `/default/configuration`, and verified the sidebar renders `Projects → Dashboards → Configuration` in that order.

## Documentation

N/A — no user-facing documentation or configuration changes.