### PR TITLE
[opik chart] Expose resources on backend init containers

### DIFF
--- a/deployment/helm_chart/opik/templates/deployment.yaml
+++ b/deployment/helm_chart/opik/templates/deployment.yaml
@@ -105,6 +105,10 @@ spec:
                 sleep 5;
               done;
               echo "MySQL is available at {{ $value.waitForMysql.mysql.host }}:{{ $value.waitForMysql.mysql.port }}";
+          {{- with $value.waitForMysql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- end }}
       {{- if and (eq $key "backend") $value.waitForClickhouse }}
         - name: wait-for-clickhouse-service
@@ -120,6 +124,10 @@ spec:
                 sleep 5;
                 echo "Clickhouse is not available. Waiting for the Clickhouse...";
               done
+          {{- with $value.waitForClickhouse.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- end }}
       {{- if and (eq $key "backend") $value.run_migration }}
         - name: backend-migrations
@@ -139,6 +147,10 @@ spec:
               mountPath: /etc/pki/ca-trust/extracted/java/cacerts
           {{- end }}
           {{- with $value.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $value.run_migration_resources }}
+          resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- end}}

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -107,6 +107,9 @@ component:
     backendConfigMap:
       enabled: true
     run_migration: true
+    # Resource requests/limits for the `backend-migrations` init container.
+    # Empty ({}) by default — no resources set.
+    run_migration_resources: {}
     waitForClickhouse:
       clickhouse:
         host: clickhouse-opik-clickhouse
@@ -116,6 +119,9 @@ component:
         registry: docker.io
         repository: curlimages/curl
         tag: 8.12.1
+      # Resource requests/limits for the `wait-for-clickhouse-service` init container.
+      # Empty ({}) by default — no resources set.
+      resources: {}
     waitForMysql:
       enabled: false
       mysql:
@@ -125,6 +131,9 @@ component:
         registry: docker.io
         repository: busybox
         tag: 1.36
+      # Resource requests/limits for the `wait-for-mysql-service` init container.
+      # Empty ({}) by default — no resources set.
+      resources: {}
     resources:
       requests:
         ephemeral-storage: 10Gi


### PR DESCRIPTION
## Summary

The backend deployment template hardcodes three init containers with no values interface for resource requests/limits:
- \`wait-for-mysql-service\`
- \`wait-for-clickhouse-service\`
- \`backend-migrations\`

This makes it impossible to set resources on these containers via override values. They end up running with **BestEffort QoS** regardless of how the override-values are configured, which breaks scheduling predictability in clusters that rely on requests/limits for capacity planning or HPA.

## Changes

### \`templates/deployment.yaml\`

Added \`{{- with <path>.resources }}\` conditional blocks to all three init containers. Pattern matches the existing main container resources block.

### \`values.yaml\`

Added three new sibling \`resources: {}\` defaults:

| Values path | Init container |
|---|---|
| \`component.backend.waitForMysql.resources\` | \`wait-for-mysql-service\` |
| \`component.backend.waitForClickhouse.resources\` | \`wait-for-clickhouse-service\` |
| \`component.backend.run_migration_resources\` | \`backend-migrations\` |

\`run_migration_resources\` is a separate sibling key rather than \`run_migration.resources\` because \`run_migration\` is a bool in the existing values (changing its shape would break backward compat).

## Backward compatibility

Default \`{}\` renders nothing — no \`resources:\` block generated for any init container unless values are explicitly set. Verified via \`helm template\`:

**Default (no values set)**: init containers render without any resources block (identical to pre-PR behavior).

**With values set**:
\`\`\`yaml
initContainers:
  - name: wait-for-clickhouse-service
    ...
    resources:
      limits:
        cpu: 200m
        memory: 128Mi
      requests:
        cpu: 50m
        memory: 64Mi
  - name: backend-migrations
    ...
    resources:
      limits:
        cpu: 500m
        memory: 512Mi
      requests:
        cpu: 100m
        memory: 256Mi
\`\`\`