### PR TITLE
[DND-938][HELM] Expose resources on backend init containers

### DIFF
--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Comet Opik
 
-![Version: 1.11.2](https://img.shields.io/badge/Version-1.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.2](https://img.shields.io/badge/AppVersion-1.11.2-informational?style=flat-square)
+![Version: 1.11.8](https://img.shields.io/badge/Version-1.11.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.8](https://img.shields.io/badge/AppVersion-1.11.8-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opik)](https://artifacthub.io/packages/search?repo=opik)
 
 # Run Comet Opik with Helm
@@ -266,6 +266,7 @@ Call opik api on http://localhost:5173/api
 | component.backend.replicaCount | int | `1` |  |
 | component.backend.resources.requests.ephemeral-storage | string | `"10Gi"` |  |
 | component.backend.run_migration | bool | `true` |  |
+| component.backend.run_migration_resources | object | `{}` |  |
 | component.backend.service.ports[0].name | string | `"http"` |  |
 | component.backend.service.ports[0].port | int | `8080` |  |
 | component.backend.service.ports[0].protocol | string | `"TCP"` |  |
@@ -283,12 +284,14 @@ Call opik api on http://localhost:5173/api
 | component.backend.waitForClickhouse.image.registry | string | `"docker.io"` |  |
 | component.backend.waitForClickhouse.image.repository | string | `"curlimages/curl"` |  |
 | component.backend.waitForClickhouse.image.tag | string | `"8.12.1"` |  |
+| component.backend.waitForClickhouse.resources | object | `{}` |  |
 | component.backend.waitForMysql.enabled | bool | `false` |  |
 | component.backend.waitForMysql.image.registry | string | `"docker.io"` |  |
 | component.backend.waitForMysql.image.repository | string | `"busybox"` |  |
 | component.backend.waitForMysql.image.tag | float | `1.36` |  |
 | component.backend.waitForMysql.mysql.host | string | `"opik-mysql"` |  |
 | component.backend.waitForMysql.mysql.port | int | `3306` |  |
+| component.backend.waitForMysql.resources | object | `{}` |  |
 | component.frontend.autoscaling.behavior.scaleDown.policies[0].periodSeconds | int | `60` |  |
 | component.frontend.autoscaling.behavior.scaleDown.policies[0].type | string | `"Percent"` |  |
 | component.frontend.autoscaling.behavior.scaleDown.policies[0].value | int | `50` |  |

--- a/deployment/helm_chart/opik/templates/deployment.yaml
+++ b/deployment/helm_chart/opik/templates/deployment.yaml
@@ -105,6 +105,10 @@ spec:
                 sleep 5;
               done;
               echo "MySQL is available at {{ $value.waitForMysql.mysql.host }}:{{ $value.waitForMysql.mysql.port }}";
+          {{- with $value.waitForMysql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- end }}
       {{- if and (eq $key "backend") $value.waitForClickhouse }}
         - name: wait-for-clickhouse-service
@@ -120,6 +124,10 @@ spec:
                 sleep 5;
                 echo "Clickhouse is not available. Waiting for the Clickhouse...";
               done
+          {{- with $value.waitForClickhouse.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- end }}
       {{- if and (eq $key "backend") $value.run_migration }}
         - name: backend-migrations
@@ -139,6 +147,10 @@ spec:
               mountPath: /etc/pki/ca-trust/extracted/java/cacerts
           {{- end }}
           {{- with $value.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $value.run_migration_resources }}
+          resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- end}}

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -107,6 +107,9 @@ component:
     backendConfigMap:
       enabled: true
     run_migration: true
+    # Resource requests/limits for the `backend-migrations` init container.
+    # Empty ({}) by default — no resources set.
+    run_migration_resources: {}
     waitForClickhouse:
       clickhouse:
         host: clickhouse-opik-clickhouse
@@ -116,6 +119,9 @@ component:
         registry: docker.io
         repository: curlimages/curl
         tag: 8.12.1
+      # Resource requests/limits for the `wait-for-clickhouse-service` init container.
+      # Empty ({}) by default — no resources set.
+      resources: {}
     waitForMysql:
       enabled: false
       mysql:
@@ -125,6 +131,9 @@ component:
         registry: docker.io
         repository: busybox
         tag: 1.36
+      # Resource requests/limits for the `wait-for-mysql-service` init container.
+      # Empty ({}) by default — no resources set.
+      resources: {}
     resources:
       requests:
         ephemeral-storage: 10Gi


### PR DESCRIPTION
## Details
- Add values interface for resource requests/limits on three hardcoded backend init containers: \`wait-for-mysql-service\`, \`wait-for-clickhouse-service\`, \`backend-migrations\`
- Currently these init containers run with BestEffort QoS regardless of override-values; no way to set resources without patching the chart
- Backwards compatible — default \`{}\` renders nothing, no resources block generated unless values are set

## Change checklist
- [x] Helm chart template updated to support resources on three backend init containers
- [x] Default values remain empty (\`{}\`) — no rendered output change when unset
- [x] Verified via \`helm template\` with and without values
- [x] Chart README will be regenerated automatically via \`update readme\` label

## Issues
DND-938

## Testing
- [x] Helm template renders correctly with resources configured (verified via \`helm template\`)
- [x] Helm template renders correctly without resources (backwards compat — default \`{}\` renders nothing)

## Documentation
No external documentation changes needed — new values are internal Helm chart options discoverable via \`helm show values\`. Chart README will be regenerated automatically via the \`update readme\` label.

## Usage

\`\`\`yaml
component:
  backend:
    waitForMysql:
      resources:
        requests: {cpu: 50m, memory: 64Mi}
        limits:   {cpu: 200m, memory: 128Mi}
    waitForClickhouse:
      resources:
        requests: {cpu: 50m, memory: 64Mi}
        limits:   {cpu: 200m, memory: 128Mi}
    run_migration_resources:
      requests: {cpu: 100m, memory: 256Mi}
      limits:   {cpu: 500m, memory: 512Mi}
\`\`\`

Note: \`run_migration_resources\` is a separate sibling key rather than \`run_migration.resources\` because \`run_migration\` is a bool in the existing values — changing its shape would break backward compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)