### PR TITLE
[OPIK-5947] [FE] fix: force iframe remount on assistant surface change

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -457,7 +457,10 @@ const AssistantSidebar: React.FC<AssistantSidebarProps> = ({
   // Guard the cleanup: when another AssistantSidebar instance mounts (e.g.
   // switching between sidebar and page surface), it overwrites these globals
   // with its own bridge/meta. A later unmount of the previous instance must
-  // NOT clobber the new values — only clear if the global still matches ours.
+  // NOT clobber the new values — only clean up when our bridge is still the
+  // active one. Meta cleanup is tied to bridge ownership because both serve
+  // the same iframe and meta is a shared React Query cache reference that
+  // cannot be compared with === across instances.
   useEffect(() => {
     const bridge = bridgeRef.current;
     window.opikBridge = bridge;
@@ -467,8 +470,6 @@ const AssistantSidebar: React.FC<AssistantSidebarProps> = ({
     return () => {
       if (window.opikBridge === bridge) {
         delete window.opikBridge;
-      }
-      if (meta && window.__opikAssistantMeta__ === meta) {
         delete window.__opikAssistantMeta__;
       }
     };


### PR DESCRIPTION
## Details

When navigating between project home (page surface) and other pages (sidebar surface), the old AssistantSidebar instance's cleanup incorrectly deletes `window.__opikAssistantMeta__` — the manifest metadata the new instance just set. This happens because React Query caches the manifest with `staleTime: Infinity`, so all instances share the same object reference, making the `===` identity guard always true.

Without the manifest metadata, `shell.html` falls back to relative `./assistant.js` URLs, loading an unhashed build on staging that lacks surface support and always renders ChatSidebar.

**Fix**: Tie meta cleanup to bridge ownership. Since each instance creates a unique bridge object, only delete both globals when our bridge is still the active one. If a newer instance already replaced the bridge, neither is deleted.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5947
- OPIK-5978

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: assisted (root cause found via staged debug logging, human verified fix on staging)
- Human verification: code review + staging testing

## Testing

- Verified on staging with debug logs: `metaDeleted=false` on old instance cleanup
- Navigate project home → other page → back to project home: ChatPage renders correctly
- Sidebar mode still works correctly on non-home pages
- First load on project home still renders ChatPage

## Documentation

N/A