### PR TITLE
[OPIK-5913] [SDK] fix: remove project_name parameter from run_tests

### DIFF
--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -437,7 +437,6 @@ def run_tests(
     *,
     experiment_name: Optional[str] = None,
     experiment_name_prefix: Optional[str] = None,
-    project_name: Optional[str] = None,
     experiment_config: Optional[Dict[str, Any]] = None,
     prompts: Optional[List[base_prompt.BasePrompt]] = None,
     experiment_tags: Optional[List[str]] = None,
@@ -463,7 +462,6 @@ def run_tests(
         task: A callable that takes a dict and returns a result.
         experiment_name: Optional explicit name for the experiment.
         experiment_name_prefix: Optional prefix for auto-generated name.
-        project_name: Optional project name for tracking.
         experiment_config: Optional configuration dict for the experiment.
         prompts: Optional list of Prompt objects to associate.
         experiment_tags: Optional list of tags for the experiment.
@@ -498,7 +496,7 @@ def run_tests(
         client=client,
         experiment_name_prefix=experiment_name_prefix,
         experiment_name=experiment_name,
-        project_name=project_name or test_suite.project_name,
+        project_name=test_suite.project_name,
         experiment_config=experiment_config,
         prompts=prompts,
         experiment_tags=experiment_tags,

--- a/sdks/python/tests/unit/api_objects/dataset/test_suite/test_test_suite.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_suite/test_test_suite.py
@@ -782,6 +782,32 @@ class TestInternalRunOptimizationSuite:
         assert result is fake_result
         mock_run.assert_called_once()
 
+    def test_run_tests_uses_test_suite_project_name(self):
+        from opik.evaluation.evaluator import run_tests
+
+        mock_dataset = _create_mock_dataset()
+        mock_dataset.project_name = "my-agent-project"
+        suite = test_suite.TestSuite(
+            name="test_suite",
+            dataset_=mock_dataset,
+        )
+
+        fake_result = mock.MagicMock(spec=suite_types.TestSuiteResult)
+
+        with mock.patch(
+            "opik.evaluation.evaluator.__internal_api__run_test_suite__",
+            return_value=fake_result,
+        ) as mock_run:
+            run_tests(
+                test_suite=suite,
+                task=lambda data: {"input": data, "output": "resp"},
+                experiment_name="proj-test",
+                verbose=0,
+            )
+
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs["project_name"] == "my-agent-project"
+
 
 class TestTestSuiteResultPassRate:
     """Unit tests for TestSuiteResult.pass_rate property."""


### PR DESCRIPTION
## Details

<img width="1920" height="1838" alt="image" src="https://github.com/user-attachments/assets/c041f438-577e-4281-855f-f74d1141b67a" />

Remove the redundant `project_name` parameter from the public `run_tests()` function.

Traces and experiments belong to the agent's project where the test suite is defined, so `project_name` was always falling back to `test_suite.project_name`. No callers (tests or production code) ever passed this parameter explicitly — removing it simplifies the API and prevents confusion.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-5913

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review + unit tests

## Testing

- Ran all 64 related unit tests: `cd sdks/python && python -m pytest tests/unit/evaluation/test_evaluate_test_suite.py tests/unit/api_objects/dataset/test_suite/test_test_suite.py -v`
- All tests pass — none used the removed parameter explicitly
- Pre-commit hooks passed on commit

## Documentation

N/A