### PR TITLE
[OPIK-5992] [FE] fix: use shared INSTALL_OPIK_SKILLS_COMMAND constant

### DIFF
--- a/apps/opik-frontend/src/constants/shared.ts
+++ b/apps/opik-frontend/src/constants/shared.ts
@@ -12,6 +12,8 @@ export const PROJECT_NAME_PLACEHOLDER = "PROJECT_NAME_PLACEHOLDER";
 export const PLAYGROUND_PROJECT_NAME = "playground";
 export const USER_FEEDBACK_NAME = "User feedback";
 export const PIP_INSTALL_OPIK_COMMAND = "pip install opik";
+export const INSTALL_OPIK_SKILLS_COMMAND =
+  "npx skills add comet-ml/opik-skills -g --all";
 export const INSTALL_OPIK_SECTION_TITLE =
   "1. Install Opik using pip from the command line";
 export const INSTALL_SDK_SECTION_TITLE = "2. Install the SDK";

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState.tsx
@@ -7,10 +7,9 @@ import { useTheme } from "@/contexts/theme-provider";
 import { THEME_MODE } from "@/constants/theme";
 import TimelineStep from "@/shared/TimelineStep/TimelineStep";
 import CodeSnippet from "@/shared/CodeSnippet/CodeSnippet";
+import { INSTALL_OPIK_SKILLS_COMMAND } from "@/constants/shared";
 import emptyAgentConfigLightUrl from "/images/empty-agent-configuration-light.svg";
 import emptyAgentConfigDarkUrl from "/images/empty-agent-configuration-dark.svg";
-
-const INSTALL_COMMAND = "npx skills add comet-ml/opik-skills -g";
 
 const AGENT_PROMPT = `Add Opik agent configuration to my project. Define a config schema with my agent's key parameters (such as model, temperature or prompts), and publish the first version`;
 
@@ -32,7 +31,10 @@ const AgentConfigurationEmptyState: React.FC = () => {
               <h4 className="comet-body-s-accented">
                 Install the Opik skills package
               </h4>
-              <CodeSnippet title="Terminal" code={INSTALL_COMMAND} />
+              <CodeSnippet
+                title="Terminal"
+                code={INSTALL_OPIK_SKILLS_COMMAND}
+              />
             </div>
           </TimelineStep>
 

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/InstallWithAITab.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/InstallWithAITab.tsx
@@ -7,8 +7,7 @@ import CodeSnippet from "@/shared/CodeSnippet/CodeSnippet";
 import claudeCodeLogo from "/images/integrations/claude_code.svg";
 import codexLogo from "/images/integrations/codex.svg";
 import cursorLogo from "/images/integrations/cursor.svg";
-
-const INSTALL_COMMAND = "npx skills add comet-ml/opik-skills -g --all";
+import { INSTALL_OPIK_SKILLS_COMMAND } from "@/constants/shared";
 
 interface InstallWithAITabProps {
   traceReceived: boolean;
@@ -58,7 +57,7 @@ const InstallWithAITab: React.FC<InstallWithAITabProps> = ({
               Install the Opik skill so it&apos;s available in Claude Code,
               Codex, Cursor, Windsurf, and other AI editors.
             </p>
-            <CodeSnippet title="Terminal" code={INSTALL_COMMAND} />
+            <CodeSnippet title="Terminal" code={INSTALL_OPIK_SKILLS_COMMAND} />
           </div>
         </TimelineStep>
 


### PR DESCRIPTION
## Details

<img width="1352" height="2372" alt="image" src="https://github.com/user-attachments/assets/a0d6b439-c71f-4bf9-91d9-a782a6925176" />

Extract the duplicated opik-skills install command into a shared `INSTALL_OPIK_SKILLS_COMMAND` constant in `constants/shared.ts`. Fixes `AgentConfigurationEmptyState.tsx` which was missing the `--all` flag, causing users to get incomplete skill installation.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5992

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full implementation
  - Human verification: Reviewed diff, verified TypeScript compilation

## Testing

- `npx tsc --noEmit` — passes with no errors
- Pre-commit hooks (ESLint, Stylelint, dependency-cruiser) — all pass
- Scenarios validated: both `AgentConfigurationEmptyState` and `InstallWithAITab` now render the correct command with `--all`

## Documentation

No documentation changes needed.