### PR TITLE
[OPIK-5889] perf: Fixing sandbox to skip heavy opik imports

### DIFF
--- a/apps/opik-sandbox-executor-python/Dockerfile
+++ b/apps/opik-sandbox-executor-python/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /build
 COPY requirements.txt .
 COPY scoring_runner.py .
 
+
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Completely remove pip and all package management tools

--- a/apps/opik-sandbox-executor-python/requirements.txt
+++ b/apps/opik-sandbox-executor-python/requirements.txt
@@ -32,7 +32,7 @@ mdurl==0.1.2
 multidict==6.7.1
 mypy-boto3-bedrock-runtime==1.42.42
 openai==2.30.0
-opik==1.10.56
+opik==1.11.10
 packaging==26.0
 pluggy==1.6.0
 propcache==0.4.1

--- a/apps/opik-sandbox-executor-python/scoring_runner.py
+++ b/apps/opik-sandbox-executor-python/scoring_runner.py
@@ -1,18 +1,74 @@
 import inspect
 import json
+import sys
 import traceback
+import types
 import uuid
 from sys import argv
-from types import ModuleType
-from typing import Type, Union, List, Any, Dict
+from typing import Type, Union, List, Any
 
+# ---------------------------------------------------------------------------
+# Lightweight import patching
+# ---------------------------------------------------------------------------
+# The full `opik` package takes ~2.5s to import (pydantic_settings, REST
+# client, sentry, logfire, 40+ metric classes).  Under CPU contention in the
+# sandbox pods this alone can exhaust the 9s execution timeout.
+#
+# The `_opik` package provides pure-stdlib BaseMetric and ScoreResult (~8ms).
+# We register stub modules in sys.modules so that user code doing
+#   `from opik.evaluation.metrics import BaseMetric`
+# resolves to the lightweight versions without triggering the real `opik`
+# init.  If user code accesses anything else on these modules, the
+# __getattr__ fallback loads the real `opik` package transparently.
+# ---------------------------------------------------------------------------
+
+import _opik._base_metric
+import _opik._score_result
+
+_stubs: dict = {}
+
+
+def _load_real_opik() -> None:
+    """Replace all stubs with the real opik package (lazy fallback)."""
+    for name in list(_stubs):
+        if sys.modules.get(name) is _stubs[name]:
+            del sys.modules[name]
+    _stubs.clear()
+    import opik  # noqa: F811 — triggers the real init
+
+
+class _FallbackModule(types.ModuleType):
+    """Stub module that loads the real opik on first unknown attribute access."""
+
+    def __getattr__(self, name: str) -> Any:
+        _load_real_opik()
+        return getattr(sys.modules[self.__name__], name)
+
+
+for _name in ["opik", "opik.evaluation", "opik.evaluation.metrics"]:
+    _stub = _FallbackModule(_name)
+    _stub.__path__ = []  # type: ignore[attr-defined]
+    sys.modules[_name] = _stub
+    _stubs[_name] = _stub
+
+sys.modules["opik.evaluation.metrics.base_metric"] = _opik._base_metric
+sys.modules["opik.evaluation.metrics.score_result"] = _opik._score_result
+_stubs["opik.evaluation.metrics.base_metric"] = _opik._base_metric
+_stubs["opik.evaluation.metrics.score_result"] = _opik._score_result
+
+sys.modules["opik.evaluation.metrics"].base_metric = _opik._base_metric  # type: ignore[attr-defined]
+sys.modules["opik.evaluation.metrics"].score_result = _opik._score_result  # type: ignore[attr-defined]
+sys.modules["opik.evaluation.metrics"].BaseMetric = _opik._base_metric.BaseMetric  # type: ignore[attr-defined]
+sys.modules["opik.evaluation.metrics"].ScoreResult = _opik._score_result.ScoreResult  # type: ignore[attr-defined]
+
+# Now these resolve to the lightweight versions
 from opik.evaluation.metrics import BaseMetric
 from opik.evaluation.metrics.score_result import ScoreResult
 
 # Constants
 TRACE_THREAD_METRIC_TYPE = "trace_thread"  # Referenced in the payload_types.py as it's not available in the scoring_commands.py process
 
-def get_metric_class(module: ModuleType) -> Type[BaseMetric]:
+def get_metric_class(module: types.ModuleType) -> Type[BaseMetric]:
     for _, cls in inspect.getmembers(module, inspect.isclass):
         if issubclass(cls, BaseMetric) and cls != BaseMetric:
             return cls
@@ -36,7 +92,7 @@ code = argv[1]
 data = json.loads(argv[2])
 payload_type = argv[3] if len(argv) > 3 else None
 
-module = ModuleType(str(uuid.uuid4()))
+module = types.ModuleType(str(uuid.uuid4()))
 
 try:
     exec(code, module.__dict__)


### PR DESCRIPTION
## Details

The sandbox scoring runner starts a fresh Python process per execution. Importing the full `opik` package (~2.5s: pydantic_settings, REST client, sentry, logfire, 40+ metric classes) under 17-way CPU contention on 2-core pods was exhausting the 9s execution timeout before user code could run, causing 504 errors.

Patch `sys.modules` at startup so user code's `from opik.evaluation.metrics import BaseMetric` resolves to the lightweight `_opik` package (~8ms) instead of triggering the full `opik` init. A `_FallbackModule.__getattr__` transparently loads the real `opik` package if user code accesses anything beyond `BaseMetric` or `ScoreResult`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5889

## Testing

Tested locally with subprocess simulating the patching — user code importing `BaseMetric` resolves to lightweight `_opik`, no heavy modules loaded. Fallback to real `opik` verified when accessing other attributes.

Tests live in the SDK PR (merged): `TestLightweightOpikPackage` in `sdks/python/tests/unit/evaluation/metrics/test_base_metric.py`.

Depends on SDK `1.11.10` release (includes `_opik` package from #6292).

## Documentation