### PR TITLE
[OPIK-5998] [BE] Fix getDatasetByIdentifier not returning dataset_items_count

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -283,7 +283,7 @@ public class DatasetsResource {
 
         log.info("Finding dataset by name '{}', projectName '{}' on workspace_id '{}'", identifier.datasetName(),
                 identifier.projectName(), workspaceId);
-        Dataset dataset = service.findByName(identifier, visibility);
+        Dataset dataset = service.findByNameDetailed(identifier, visibility);
         log.info("Found dataset by name '{}', id '{}' on workspace_id '{}'", identifier.datasetName(), dataset.id(),
                 workspaceId);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetService.java
@@ -80,7 +80,7 @@ public interface DatasetService {
 
     List<Dataset> findByIds(Set<UUID> ids, String workspaceId);
 
-    Dataset findByName(DatasetIdentifier identifier, Visibility visibility);
+    Dataset findByNameDetailed(DatasetIdentifier identifier, Visibility visibility);
 
     Mono<Dataset> resolveDatasetByNameAsync(DatasetIdentifier identifier);
 
@@ -271,8 +271,7 @@ class DatasetServiceImpl implements DatasetService {
         String workspaceId = requestContext.get().getWorkspaceId();
         Visibility visibility = requestContext.get().getVisibility();
 
-        return enrichDatasetWithAdditionalInformation(List.of(findById(id, workspaceId, visibility)))
-                .get(0);
+        return enrichDatasetWithAdditionalInformation(List.of(findById(id, workspaceId, visibility))).getFirst();
     }
 
     @Override
@@ -366,8 +365,7 @@ class DatasetServiceImpl implements DatasetService {
         return verifyVisibility(dataset, visibility);
     }
 
-    @Override
-    public Dataset findByName(@NonNull DatasetIdentifier identifier, Visibility visibility) {
+    private Dataset findByName(@NonNull DatasetIdentifier identifier, Visibility visibility) {
         var workspaceId = requestContext.get().getWorkspaceId();
         UUID projectId = null;
 
@@ -383,6 +381,11 @@ class DatasetServiceImpl implements DatasetService {
         }
 
         return verifyVisibility(dataset, visibility);
+    }
+
+    @Override
+    public Dataset findByNameDetailed(@NonNull DatasetIdentifier identifier, Visibility visibility) {
+        return enrichDatasetWithAdditionalInformation(List.of(findByName(identifier, visibility))).getFirst();
     }
 
     @Override

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -1634,6 +1634,56 @@ class DatasetsResourceTest {
         }
 
         @Test
+        @DisplayName("when retrieving dataset by name with items, experiments and optimizations, then return enriched dataset")
+        void getDatasetByIdentifier__whenDatasetHasItemsExperimentsAndOptimizations__thenReturnEnrichedDataset() {
+            var dataset = buildDataset();
+            createAndAssert(dataset);
+
+            // Create dataset items
+            var datasetItems = PodamFactoryUtils.manufacturePojoList(factory, DatasetItem.class);
+            var batch = DatasetItemBatch.builder().datasetName(dataset.name()).items(datasetItems).build();
+            putAndAssert(batch, TEST_WORKSPACE, API_KEY);
+
+            // Create experiment and its items
+            var experiment = experimentResourceClient.createPartialExperiment()
+                    .datasetName(dataset.name())
+                    .build();
+            createAndAssert(experiment, API_KEY, TEST_WORKSPACE);
+
+            var trace = factory.manufacturePojo(Trace.class);
+            createTrace(trace, API_KEY, TEST_WORKSPACE);
+
+            var experimentItem = factory.manufacturePojo(ExperimentItem.class).toBuilder()
+                    .experimentId(experiment.id())
+                    .traceId(trace.id())
+                    .build();
+
+            Instant beforeCreateExperimentItems = Instant.now();
+            createAndAssert(ExperimentItemsBatch.builder()
+                    .experimentItems(Set.of(experimentItem))
+                    .build(), API_KEY, TEST_WORKSPACE);
+
+            // Create optimizations
+            Instant beforeCreateOptimizations = Instant.now();
+            int optimizationCount = 3;
+            for (int i = 0; i < optimizationCount; i++) {
+                var optimization = optimizationResourceClient.createPartialOptimization()
+                        .datasetName(dataset.name())
+                        .build();
+                optimizationResourceClient.create(optimization, API_KEY, TEST_WORKSPACE);
+            }
+
+            var identifier = DatasetIdentifier.builder().datasetName(dataset.name()).build();
+            var actualEntity = datasetResourceClient.getDatasetByIdentifier(identifier, API_KEY, TEST_WORKSPACE);
+
+            assertThat(actualEntity.datasetItemsCount()).isEqualTo(datasetItems.size());
+            assertThat(actualEntity.experimentCount()).isEqualTo(1);
+            assertThat(actualEntity.mostRecentExperimentAt()).isAfter(beforeCreateExperimentItems);
+            assertThat(actualEntity.optimizationCount()).isEqualTo(optimizationCount);
+            assertThat(actualEntity.mostRecentOptimizationAt()).isAfter(beforeCreateOptimizations);
+        }
+
+        @Test
         @DisplayName("when dataset not found by dataset name, then return 404")
         void getDatasetByIdentifier__whenDatasetItemNotFound__thenReturn404() {
             var name = UUID.randomUUID().toString();


### PR DESCRIPTION
## Details

The `POST /v1/private/datasets/retrieve` endpoint (`getDatasetByIdentifier`) was returning `dataset_items_count: null` for all dataset types. This happened because `DatasetService.findByName()` did not call `enrichDatasetWithAdditionalInformation()`, unlike `findById()` and `find()` (paginated list) which do.

The Python SDK uses this endpoint to refresh the cached `dataset_items_count` after insert/delete/clear operations, so users were never seeing updated counts.

**Fix:** Added a new `findByNameDetailed()` method that wraps `findByName()` with `enrichDatasetWithAdditionalInformation()`, keeping the original `findByName()` unchanged for callers that don't need enriched data (`delete`, `resolveDatasetByName`). The `getDatasetByIdentifier` resource endpoint now calls `findByNameDetailed()`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5998

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code (Opus 4.6)
  - Model(s): claude-opus-4-6
  - Scope: Implementation and test
  - Human verification: yes

## Testing

- `mvn spotless:check` — passes
- `mvn test -Dtest="DatasetsResourceTest$GetDataset"` — all 12 tests pass (11 existing + 1 new)
- New test `getDatasetByIdentifier__whenDatasetHasItemsExperimentsAndOptimizations__thenReturnEnrichedDataset` verifies that the `/retrieve` endpoint returns enriched data (`datasetItemsCount`, `experimentCount`, `mostRecentExperimentAt`, `optimizationCount`, `mostRecentOptimizationAt`) with known non-zero values

## Documentation

N/A — No documentation changes needed, this is a bug fix restoring expected behavior.
