### PR TITLE
[NA] [FE] fix: improve empty state copy on AgentConfigurationPage

### DIFF
--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState.tsx
@@ -51,7 +51,8 @@ const AgentConfigurationEmptyState: React.FC = () => {
             <div className="flex flex-col gap-1">
               <h4 className="comet-body-s-accented">Run your agent</h4>
               <p className="comet-body-xs text-muted-slate">
-                Your configuration will appear here automatically after your next trace is logged.
+                Your configuration will appear here automatically after your
+                next trace is logged.
               </p>
             </div>
           </TimelineStep>

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState.tsx
@@ -51,7 +51,7 @@ const AgentConfigurationEmptyState: React.FC = () => {
             <div className="flex flex-col gap-1">
               <h4 className="comet-body-s-accented">Run your agent</h4>
               <p className="comet-body-xs text-muted-slate">
-                Your configuration will appear here automatically
+                Your configuration will appear here automatically after your next trace is logged.
               </p>
             </div>
           </TimelineStep>


### PR DESCRIPTION
## Details
Clarifies the helper text in the Agent Configuration empty state so users understand *when* their configuration will appear. The previous copy — "Your configuration will appear here automatically" — was vague; the updated copy adds "after your next trace is logged." to set the right expectation.

<img width="727" height="583" alt="image" src="https://github.com/user-attachments/assets/4f2a667d-d888-4e9c-a9ae-6d0261b5d473" />


## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-sonnet-4-6
  - Scope: assisted (PR workflow automation)
  - Human verification: manual review

## Testing

- `npm run lint` — passes with no warnings
- Visual check: text change in `AgentConfigurationEmptyState.tsx` renders correctly in the timeline step

## Documentation

N/A — copy-only change, no public API or docs affected.