### PR TITLE
[OPIK-6008] [FE] fix: use dynamic project name in AgentConfigurationEmptyState

### DIFF
--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState.tsx
@@ -8,13 +8,14 @@ import { THEME_MODE } from "@/constants/theme";
 import TimelineStep from "@/shared/TimelineStep/TimelineStep";
 import CodeSnippet from "@/shared/CodeSnippet/CodeSnippet";
 import { INSTALL_OPIK_SKILLS_COMMAND } from "@/constants/shared";
+import useActiveProjectName from "@/hooks/useActiveProjectName";
 import emptyAgentConfigLightUrl from "/images/empty-agent-configuration-light.svg";
 import emptyAgentConfigDarkUrl from "/images/empty-agent-configuration-dark.svg";
 
-const AGENT_PROMPT = `Add Opik agent configuration to my project. Define a config schema with my agent's key parameters (such as model, temperature or prompts), and publish the first version`;
-
 const AgentConfigurationEmptyState: React.FC = () => {
   const { themeMode } = useTheme();
+  const projectName = useActiveProjectName();
+  const agentPrompt = `Add Opik agent configuration to the project "${projectName}". Define a config schema with my agent's key parameters (such as model, temperature or prompts), and publish the first version`;
   const imageUrl =
     themeMode === THEME_MODE.DARK
       ? emptyAgentConfigDarkUrl
@@ -43,7 +44,7 @@ const AgentConfigurationEmptyState: React.FC = () => {
               <h4 className="comet-body-s-accented">
                 Ask your coding agent to instrument app
               </h4>
-              <CodeSnippet title="Prompt" code={AGENT_PROMPT} />
+              <CodeSnippet title="Prompt" code={agentPrompt} />
             </div>
           </TimelineStep>
 


### PR DESCRIPTION
## Details

Replace hardcoded `"to my project"` in `AgentConfigurationEmptyState` with the actual project name via `useActiveProjectName()` hook, matching the existing pattern in `AgentRunnerEmptyState`.

<img width="1920" height="1284" alt="image" src="https://github.com/user-attachments/assets/ba10bb87-e10e-40a1-98ba-527b67a28daf" />

Before:

<img width="1455" height="826" alt="image" src="https://github.com/user-attachments/assets/903b3022-ea2e-4b5a-999b-41b8dd32e453" />

After:

<img width="1456" height="888" alt="image" src="https://github.com/user-attachments/assets/2224585b-f693-4123-9834-be0339b2f703" />

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6008

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full implementation
  - Human verification: Code reviewed, TypeScript compilation verified, pre-commit hooks passed

## Testing

- `npx tsc --noEmit` — clean, no type errors
- Pre-commit hooks passed: ESLint, Stylelint, TypeScript typecheck, dependency cruiser
- Scenarios validated:
  - Navigate to Agent Configuration page for a project with no config — prompt shows actual project name
  - Switch between projects — name updates correctly

## Documentation