### PR TITLE
[OPIK-5865][TS SDK] feat: Add toReportDict() / toDict() to EvaluationSuiteResult

### DIFF
--- a/sdks/typescript/src/opik/evaluation/suite/runTests.ts
+++ b/sdks/typescript/src/opik/evaluation/suite/runTests.ts
@@ -57,6 +57,7 @@ export async function runTests(
     return validateTaskResult(result);
   };
 
+  const startTime = performance.now();
   const evalResult = await evaluateTestSuite({
     dataset: testSuite.dataset,
     task: validatedTask,
@@ -65,6 +66,10 @@ export async function runTests(
     tags: experimentTags,
     ...rest,
   });
+  const totalTime = (performance.now() - startTime) / 1000;
 
-  return buildSuiteResult(evalResult);
+  return buildSuiteResult(evalResult, {
+    suiteName: testSuite.name,
+    totalTime: totalTime,
+  });
 }

--- a/sdks/typescript/src/opik/evaluation/suite/suiteResultConstructor.ts
+++ b/sdks/typescript/src/opik/evaluation/suite/suiteResultConstructor.ts
@@ -70,7 +70,8 @@ function groupByTrialId(
  * - passRate = itemsPassed / itemsWithAssertions (undefined if none have assertions)
  */
 export function buildSuiteResult(
-  evalResult: EvaluationResult
+  evalResult: EvaluationResult,
+  options: { suiteName?: string; totalTime?: number } = {}
 ): TestSuiteResult {
   const itemGroups = groupByDatasetItemId(evalResult.testResults);
 
@@ -94,6 +95,7 @@ export function buildSuiteResult(
     const policy =
       firstResult.resolvedExecutionPolicy ?? DEFAULT_EXECUTION_POLICY;
     const passThreshold = policy.passThreshold;
+    const configuredRunsPerItem = policy.runsPerItem;
     const passed = runsPassed >= passThreshold;
     const hasAssertions = testResults.some((tr) => tr.scoreResults.length > 0);
 
@@ -103,6 +105,7 @@ export function buildSuiteResult(
       hasAssertions,
       runsPassed,
       runsTotal,
+      configuredRunsPerItem,
       passThreshold,
       testResults,
     });
@@ -124,7 +127,7 @@ export function buildSuiteResult(
       : itemsWithAssertions.filter((r) => r.passed).length /
         itemsWithAssertions.length;
 
-  return {
+  return new TestSuiteResult({
     allItemsPassed,
     itemsPassed,
     itemsTotal,
@@ -133,5 +136,7 @@ export function buildSuiteResult(
     experimentId: evalResult.experimentId,
     experimentName: evalResult.experimentName,
     experimentUrl: evalResult.resultUrl,
-  };
+    suiteName: options.suiteName,
+    totalTime: options.totalTime,
+  });
 }

--- a/sdks/typescript/src/opik/evaluation/suite/types.ts
+++ b/sdks/typescript/src/opik/evaluation/suite/types.ts
@@ -1,5 +1,5 @@
 import type { ExecutionPolicyWrite } from "@/rest_api/api/types/ExecutionPolicyWrite";
-import type { EvaluationTestResult } from "../types";
+import type { EvaluationTestResult, EvaluationScoreResult } from "../types";
 
 /**
  * Execution policy for test suite items.
@@ -46,20 +46,155 @@ export type ItemResult = {
   hasAssertions: boolean;
   runsPassed: number;
   runsTotal: number;
+  /** Configured runsPerItem from the execution policy. */
+  configuredRunsPerItem: number;
   passThreshold: number;
   testResults: EvaluationTestResult[];
 };
 
+function isScorePassed(score: EvaluationScoreResult): boolean {
+  if (score.scoringFailed) return false;
+  return score.value === 1;
+}
+
 /**
  * Result of a test suite run.
+ *
+ * Contains pass/fail status for each item based on execution policy,
+ * as well as overall suite pass/fail status.
  */
-export type TestSuiteResult = {
-  allItemsPassed: boolean;
-  itemsPassed: number;
-  itemsTotal: number;
-  passRate: number | undefined;
-  itemResults: Map<string, ItemResult>;
-  experimentId: string;
-  experimentName?: string;
-  experimentUrl?: string;
-};
+export class TestSuiteResult {
+  readonly allItemsPassed: boolean;
+  readonly itemsPassed: number;
+  readonly itemsTotal: number;
+  readonly passRate: number | undefined;
+  readonly itemResults: Map<string, ItemResult>;
+  readonly experimentId: string;
+  readonly experimentName?: string;
+  readonly experimentUrl?: string;
+  readonly suiteName?: string;
+  readonly totalTime?: number;
+
+  constructor(data: {
+    allItemsPassed: boolean;
+    itemsPassed: number;
+    itemsTotal: number;
+    passRate: number | undefined;
+    itemResults: Map<string, ItemResult>;
+    experimentId: string;
+    experimentName?: string;
+    experimentUrl?: string;
+    suiteName?: string;
+    totalTime?: number;
+  }) {
+    this.allItemsPassed = data.allItemsPassed;
+    this.itemsPassed = data.itemsPassed;
+    this.itemsTotal = data.itemsTotal;
+    this.passRate = data.passRate;
+    this.itemResults = data.itemResults;
+    this.experimentId = data.experimentId;
+    this.experimentName = data.experimentName;
+    this.experimentUrl = data.experimentUrl;
+    this.suiteName = data.suiteName;
+    this.totalTime = data.totalTime;
+  }
+
+  /**
+   * Convert the result to a structured report dictionary.
+   *
+   * The returned object mirrors the structure produced by the Python SDK's
+   * `to_report_dict()` method (with camelCase keys per TypeScript conventions).
+   */
+  toReportDict(): Record<string, unknown> {
+    const items: Record<string, unknown>[] = [];
+
+    for (const [itemId, itemResult] of this.itemResults) {
+      // Group test results by trialId to build one run entry per trial.
+      const trialGroups = new Map<number, EvaluationTestResult[]>();
+      for (const tr of itemResult.testResults) {
+        const tid = tr.trialId ?? 0;
+        const group = trialGroups.get(tid) ?? [];
+        group.push(tr);
+        trialGroups.set(tid, group);
+      }
+
+      const runs: Record<string, unknown>[] = [];
+      for (const [trialId, trialResults] of trialGroups) {
+        const allScores = trialResults.flatMap((tr) => tr.scoreResults);
+
+        const assertions = allScores.map((score) => {
+          const assertion: Record<string, unknown> = {
+            name: score.name,
+            passed: isScorePassed(score),
+            value: score.value,
+            scoringFailed: score.scoringFailed ?? false,
+          };
+          if (score.reason !== undefined) {
+            assertion["reason"] = score.reason;
+          }
+          return assertion;
+        });
+
+        const runPassed =
+          assertions.length === 0 || assertions.every((a) => a["passed"]);
+
+        const firstResult = trialResults[0];
+        const run: Record<string, unknown> = {
+          trialId,
+          passed: runPassed,
+          input: firstResult.testCase.taskOutput["input"],
+          output: firstResult.testCase.taskOutput["output"],
+          assertions,
+        };
+
+        if (firstResult.testCase.traceId) {
+          run["traceId"] = firstResult.testCase.traceId;
+        }
+
+        runs.push(run);
+      }
+
+      items.push({
+        datasetItemId: itemId,
+        passed: itemResult.passed,
+        runsPassed: itemResult.runsPassed,
+        executionPolicy: {
+          runsPerItem: itemResult.configuredRunsPerItem,
+          passThreshold: itemResult.passThreshold,
+        },
+        runs,
+      });
+    }
+
+    const report: Record<string, unknown> = {
+      suitePassed: this.allItemsPassed,
+      itemsPassed: this.itemsPassed,
+      itemsTotal: this.itemsTotal,
+      passRate: this.passRate ?? null,
+      experimentId: this.experimentId,
+    };
+
+    if (this.suiteName !== undefined) {
+      report["suiteName"] = this.suiteName;
+    }
+    if (this.experimentName !== undefined) {
+      report["experimentName"] = this.experimentName;
+    }
+    if (this.experimentUrl !== undefined) {
+      report["experimentUrl"] = this.experimentUrl;
+    }
+    if (this.totalTime !== undefined) {
+      report["totalTimeSeconds"] = Math.round(this.totalTime * 1000) / 1000;
+    }
+
+    report["generatedAt"] = new Date().toISOString();
+    report["items"] = items;
+
+    return report;
+  }
+
+  /** Alias for {@link toReportDict}. */
+  toDict(): Record<string, unknown> {
+    return this.toReportDict();
+  }
+}

--- a/sdks/typescript/tests/unit/evaluation/suite/testSuiteResult.test.ts
+++ b/sdks/typescript/tests/unit/evaluation/suite/testSuiteResult.test.ts
@@ -1,0 +1,458 @@
+import { describe, it, expect } from "vitest";
+import { buildSuiteResult } from "@/evaluation/suite/suiteResultConstructor";
+import {
+  EvaluationResult,
+  EvaluationTestResult,
+  EvaluationScoreResult,
+  EvaluationTestCase,
+} from "@/evaluation/types";
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrors suiteResultConstructor.test.ts)
+// ---------------------------------------------------------------------------
+
+function makeTestCase(
+  datasetItemId: string,
+  taskOutput: Record<string, unknown> = {},
+  traceId: string = `trace-${datasetItemId}`
+): EvaluationTestCase {
+  return { traceId, datasetItemId, scoringInputs: {}, taskOutput };
+}
+
+function makeScore(
+  name: string,
+  value: number,
+  opts: { reason?: string; scoringFailed?: boolean } = {}
+): EvaluationScoreResult {
+  return {
+    name,
+    value,
+    ...(opts.reason !== undefined && { reason: opts.reason }),
+    ...(opts.scoringFailed !== undefined && {
+      scoringFailed: opts.scoringFailed,
+    }),
+  };
+}
+
+function makeTestResult(
+  datasetItemId: string,
+  scoreResults: EvaluationScoreResult[],
+  opts: {
+    trialId?: number;
+    taskOutput?: Record<string, unknown>;
+    traceId?: string;
+    resolvedExecutionPolicy?: { runsPerItem: number; passThreshold: number };
+  } = {}
+): EvaluationTestResult {
+  const {
+    trialId,
+    taskOutput = { input: "q", output: "a" },
+    traceId,
+    resolvedExecutionPolicy,
+  } = opts;
+  return {
+    testCase: makeTestCase(datasetItemId, taskOutput, traceId),
+    scoreResults,
+    ...(trialId !== undefined && { trialId }),
+    ...(resolvedExecutionPolicy !== undefined && { resolvedExecutionPolicy }),
+  };
+}
+
+function makeEvalResult(
+  testResults: EvaluationTestResult[],
+  opts: {
+    experimentId?: string;
+    experimentName?: string;
+    resultUrl?: string;
+  } = {}
+): EvaluationResult {
+  return {
+    experimentId: opts.experimentId ?? "exp-1",
+    testResults,
+    errors: [],
+    ...(opts.experimentName !== undefined && {
+      experimentName: opts.experimentName,
+    }),
+    ...(opts.resultUrl !== undefined && { resultUrl: opts.resultUrl }),
+  };
+}
+
+const DEFAULT_POLICY = { runsPerItem: 1, passThreshold: 1 };
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TestSuiteResult.toReportDict", () => {
+  describe("top-level fields", () => {
+    it("includes required fields when no optional data is set", () => {
+      const result = buildSuiteResult(
+        makeEvalResult([
+          makeTestResult("item-1", [makeScore("m", 1)], {
+            resolvedExecutionPolicy: DEFAULT_POLICY,
+          }),
+        ])
+      );
+
+      const dict = result.toReportDict();
+
+      expect(dict).toMatchObject({
+        suitePassed: true,
+        itemsPassed: 1,
+        itemsTotal: 1,
+        passRate: 1,
+        experimentId: "exp-1",
+      });
+      expect(typeof dict["generatedAt"]).toBe("string");
+      expect(Array.isArray(dict["items"])).toBe(true);
+    });
+
+    it("omits suiteName when not provided", () => {
+      const result = buildSuiteResult(makeEvalResult([]));
+      expect(result.toReportDict()).not.toHaveProperty("suiteName");
+    });
+
+    it("includes suiteName when provided", () => {
+      const result = buildSuiteResult(makeEvalResult([]), {
+        suiteName: "My Suite",
+      });
+      expect(result.toReportDict()["suiteName"]).toBe("My Suite");
+    });
+
+    it("omits totalTimeSeconds when not provided", () => {
+      const result = buildSuiteResult(makeEvalResult([]));
+      expect(result.toReportDict()).not.toHaveProperty("totalTimeSeconds");
+    });
+
+    it("includes totalTimeSeconds rounded to 3 decimal places", () => {
+      const result = buildSuiteResult(makeEvalResult([]), {
+        totalTime: 12.3456,
+      });
+      expect(result.toReportDict()["totalTimeSeconds"]).toBe(12.346);
+    });
+
+    it("includes experimentName and experimentUrl when present", () => {
+      const result = buildSuiteResult(
+        makeEvalResult([], {
+          experimentName: "run-42",
+          resultUrl: "https://example.com/exp",
+        })
+      );
+
+      const dict = result.toReportDict();
+      expect(dict["experimentName"]).toBe("run-42");
+      expect(dict["experimentUrl"]).toBe("https://example.com/exp");
+    });
+
+    it("omits experimentName and experimentUrl when absent", () => {
+      const result = buildSuiteResult(makeEvalResult([]));
+      const dict = result.toReportDict();
+      expect(dict).not.toHaveProperty("experimentName");
+      expect(dict).not.toHaveProperty("experimentUrl");
+    });
+
+    it("sets passRate to null when no items have assertions", () => {
+      const result = buildSuiteResult(
+        makeEvalResult([
+          makeTestResult("item-1", [], {
+            resolvedExecutionPolicy: DEFAULT_POLICY,
+          }),
+        ])
+      );
+      expect(result.toReportDict()["passRate"]).toBeNull();
+    });
+  });
+
+  describe("item structure", () => {
+    it("produces one item entry per dataset item", () => {
+      const result = buildSuiteResult(
+        makeEvalResult([
+          makeTestResult("item-1", [makeScore("m", 1)], {
+            resolvedExecutionPolicy: DEFAULT_POLICY,
+          }),
+          makeTestResult("item-2", [makeScore("m", 0)], {
+            resolvedExecutionPolicy: DEFAULT_POLICY,
+          }),
+        ])
+      );
+
+      const items = result.toReportDict()["items"] as Record<
+        string,
+        unknown
+      >[];
+      expect(items).toHaveLength(2);
+    });
+
+    it("item includes datasetItemId, passed, runsPassed, executionPolicy and runs", () => {
+      const result = buildSuiteResult(
+        makeEvalResult([
+          makeTestResult("item-1", [makeScore("m", 1)], {
+            resolvedExecutionPolicy: { runsPerItem: 2, passThreshold: 1 },
+          }),
+        ])
+      );
+
+      const item = (
+        result.toReportDict()["items"] as Record<string, unknown>[]
+      )[0];
+
+      expect(item["datasetItemId"]).toBe("item-1");
+      expect(item["passed"]).toBe(true);
+      expect(item["runsPassed"]).toBe(1);
+      expect(item["executionPolicy"]).toEqual({
+        runsPerItem: 2,
+        passThreshold: 1,
+      });
+    });
+  });
+
+  describe("run structure", () => {
+    it("single run: fields are populated from taskOutput and testCase", () => {
+      const result = buildSuiteResult(
+        makeEvalResult([
+          makeTestResult("item-1", [makeScore("check", 1)], {
+            trialId: 0,
+            taskOutput: { input: "hello", output: "world" },
+            traceId: "trace-abc",
+            resolvedExecutionPolicy: DEFAULT_POLICY,
+          }),
+        ])
+      );
+
+      const item = (
+        result.toReportDict()["items"] as Record<string, unknown>[]
+      )[0];
+      const runs = item["runs"] as Record<string, unknown>[];
+
+      expect(runs).toHaveLength(1);
+      expect(runs[0]["trialId"]).toBe(0);
+      expect(runs[0]["passed"]).toBe(true);
+      expect(runs[0]["input"]).toBe("hello");
+      expect(runs[0]["output"]).toBe("world");
+      expect(runs[0]["traceId"]).toBe("trace-abc");
+    });
+
+    it("run with all assertions passing → passed: true", () => {
+      const result = buildSuiteResult(
+        makeEvalResult([
+          makeTestResult(
+            "item-1",
+            [makeScore("a", 1), makeScore("b", 1)],
+            { resolvedExecutionPolicy: DEFAULT_POLICY }
+          ),
+        ])
+      );
+
+      const run = (
+        (result.toReportDict()["items"] as Record<string, unknown>[])[0][
+          "runs"
+        ] as Record<string, unknown>[]
+      )[0];
+      expect(run["passed"]).toBe(true);
+    });
+
+    it("run with any assertion failing → passed: false", () => {
+      const result = buildSuiteResult(
+        makeEvalResult([
+          makeTestResult(
+            "item-1",
+            [makeScore("a", 1), makeScore("b", 0)],
+            { resolvedExecutionPolicy: DEFAULT_POLICY }
+          ),
+        ])
+      );
+
+      const run = (
+        (result.toReportDict()["items"] as Record<string, unknown>[])[0][
+          "runs"
+        ] as Record<string, unknown>[]
+      )[0];
+      expect(run["passed"]).toBe(false);
+    });
+
+    it("run with no assertions → passed: true", () => {
+      const result = buildSuiteResult(
+        makeEvalResult([
+          makeTestResult("item-1", [], {
+            resolvedExecutionPolicy: DEFAULT_POLICY,
+          }),
+        ])
+      );
+
+      const run = (
+        (result.toReportDict()["items"] as Record<string, unknown>[])[0][
+          "runs"
+        ] as Record<string, unknown>[]
+      )[0];
+      expect(run["passed"]).toBe(true);
+    });
+
+    it("groups by trialId: multi-run item produces one run entry per trial", () => {
+      const policy = { runsPerItem: 3, passThreshold: 2 };
+      const result = buildSuiteResult(
+        makeEvalResult([
+          makeTestResult("item-1", [makeScore("m", 1)], {
+            trialId: 0,
+            resolvedExecutionPolicy: policy,
+          }),
+          makeTestResult("item-1", [makeScore("m", 0)], {
+            trialId: 1,
+            resolvedExecutionPolicy: policy,
+          }),
+          makeTestResult("item-1", [makeScore("m", 1)], {
+            trialId: 2,
+            resolvedExecutionPolicy: policy,
+          }),
+        ])
+      );
+
+      const runs = (
+        result.toReportDict()["items"] as Record<string, unknown>[]
+      )[0]["runs"] as Record<string, unknown>[];
+
+      expect(runs).toHaveLength(3);
+      expect(runs.map((r) => r["trialId"])).toEqual([0, 1, 2]);
+      expect(runs.map((r) => r["passed"])).toEqual([true, false, true]);
+    });
+  });
+
+  describe("assertion structure", () => {
+    it("assertion includes name, passed, value, scoringFailed", () => {
+      const result = buildSuiteResult(
+        makeEvalResult([
+          makeTestResult("item-1", [makeScore("is-correct", 1)], {
+            resolvedExecutionPolicy: DEFAULT_POLICY,
+          }),
+        ])
+      );
+
+      const assertion = (
+        (
+          (result.toReportDict()["items"] as Record<string, unknown>[])[0][
+            "runs"
+          ] as Record<string, unknown>[]
+        )[0]["assertions"] as Record<string, unknown>[]
+      )[0];
+
+      expect(assertion["name"]).toBe("is-correct");
+      expect(assertion["passed"]).toBe(true);
+      expect(assertion["value"]).toBe(1);
+      expect(assertion["scoringFailed"]).toBe(false);
+    });
+
+    it("value=1 → passed:true; value=0 → passed:false", () => {
+      const result = buildSuiteResult(
+        makeEvalResult([
+          makeTestResult(
+            "item-1",
+            [makeScore("pass-check", 1), makeScore("fail-check", 0)],
+            { resolvedExecutionPolicy: DEFAULT_POLICY }
+          ),
+        ])
+      );
+
+      const assertions = (
+        (
+          (result.toReportDict()["items"] as Record<string, unknown>[])[0][
+            "runs"
+          ] as Record<string, unknown>[]
+        )[0]["assertions"] as Record<string, unknown>[]
+      );
+
+      expect(assertions[0]["passed"]).toBe(true);
+      expect(assertions[1]["passed"]).toBe(false);
+    });
+
+    it("scoringFailed:true → passed:false regardless of value", () => {
+      const result = buildSuiteResult(
+        makeEvalResult([
+          makeTestResult(
+            "item-1",
+            [makeScore("flaky", 1, { scoringFailed: true, reason: "timeout" })],
+            { resolvedExecutionPolicy: DEFAULT_POLICY }
+          ),
+        ])
+      );
+
+      const assertion = (
+        (
+          (result.toReportDict()["items"] as Record<string, unknown>[])[0][
+            "runs"
+          ] as Record<string, unknown>[]
+        )[0]["assertions"] as Record<string, unknown>[]
+      )[0];
+
+      expect(assertion["passed"]).toBe(false);
+      expect(assertion["scoringFailed"]).toBe(true);
+      expect(assertion["reason"]).toBe("timeout");
+    });
+
+    it("omits reason when not set", () => {
+      const result = buildSuiteResult(
+        makeEvalResult([
+          makeTestResult("item-1", [makeScore("m", 1)], {
+            resolvedExecutionPolicy: DEFAULT_POLICY,
+          }),
+        ])
+      );
+
+      const assertion = (
+        (
+          (result.toReportDict()["items"] as Record<string, unknown>[])[0][
+            "runs"
+          ] as Record<string, unknown>[]
+        )[0]["assertions"] as Record<string, unknown>[]
+      )[0];
+
+      expect(assertion).not.toHaveProperty("reason");
+    });
+
+    it("includes reason when set", () => {
+      const result = buildSuiteResult(
+        makeEvalResult([
+          makeTestResult(
+            "item-1",
+            [makeScore("m", 0, { reason: "too verbose" })],
+            { resolvedExecutionPolicy: DEFAULT_POLICY }
+          ),
+        ])
+      );
+
+      const assertion = (
+        (
+          (result.toReportDict()["items"] as Record<string, unknown>[])[0][
+            "runs"
+          ] as Record<string, unknown>[]
+        )[0]["assertions"] as Record<string, unknown>[]
+      )[0];
+
+      expect(assertion["reason"]).toBe("too verbose");
+    });
+  });
+});
+
+describe("TestSuiteResult.toDict", () => {
+  it("returns the same object as toReportDict", () => {
+    const result = buildSuiteResult(
+      makeEvalResult([
+        makeTestResult("item-1", [makeScore("m", 1)], {
+          resolvedExecutionPolicy: DEFAULT_POLICY,
+        }),
+      ]),
+      { suiteName: "s", totalTime: 1.5 }
+    );
+
+    const dictResult = result.toDict();
+    const reportDictResult = result.toReportDict();
+
+    // toDict is an alias — same keys and values (generatedAt will differ by ms)
+    expect(Object.keys(dictResult).sort()).toEqual(
+      Object.keys(reportDictResult).sort()
+    );
+    expect(dictResult["suitePassed"]).toBe(reportDictResult["suitePassed"]);
+    expect(dictResult["suiteName"]).toBe(reportDictResult["suiteName"]);
+    expect(dictResult["totalTimeSeconds"]).toBe(
+      reportDictResult["totalTimeSeconds"]
+    );
+  });
+});


### PR DESCRIPTION
## Details
The Python SDK's EvaluationSuiteResult has to_report_dict() and to_dict() methods for serializing the result. The TS SDK's EvaluationSuiteResult has no equivalent.

## Summary

Adds `toReportDict()` and `toDict()` methods to the TypeScript SDK's `TestSuiteResult`, mirroring the equivalent methods already present in the Python SDK. Also extends `TestSuiteResult` with `suiteName` and `totalTime` fields populated automatically by `runTests()`.

## Changes by Component

### TypeScript SDK

- Converted `TestSuiteResult` from a plain `type` to a `class` with `readonly` properties, preserving the existing public API
- Added optional `suiteName?: string` and `totalTime?: number` fields to `TestSuiteResult`
- Added `configuredRunsPerItem: number` to `ItemResult` (sourced from the resolved execution policy)
- Implemented `toReportDict()` — builds a structured report dict grouping test results by `trialId`, with per-assertion `passed`/`scoringFailed`/`reason` fields and optional top-level fields (`suiteName`, `experimentName`, `experimentUrl`, `totalTimeSeconds`)
- Implemented `toDict()` as an alias for `toReportDict()`
- Added module-level `isScorePassed()` helper matching Python semantics (`scoringFailed → false`, `value === 1 → true`)
- Updated `buildSuiteResult()` to accept optional `{ suiteName?, totalTime? }` and return a `TestSuiteResult` class instance
- Updated `runTests()` to time the evaluation and pass `testSuite.name` / elapsed seconds into `buildSuiteResult()`
- Added 21 unit tests covering: required/optional top-level fields, item structure, run grouping by `trialId`, assertion pass/fail logic, `scoringFailed` handling, `reason` presence, and `toDict` aliasing

## Files Changed

```
 sdks/typescript/src/opik/evaluation/suite/runTests.ts          |   7 +-
 sdks/typescript/src/opik/evaluation/suite/suiteResultConstructor.ts |  11 +-
 sdks/typescript/src/opik/evaluation/suite/types.ts             | 157 ++++++-
 sdks/typescript/tests/unit/evaluation/suite/testSuiteResult.test.ts | 458 +++++++++++++++++++++
 4 files changed, 618 insertions(+), 15 deletions(-)
```

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-5865

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code v2.1.92
  - Model(s): Sonnet 4.6
  - Scope: Full implementation
  - Human verification: verified by developer

## Testing
Added new unit tests to cover added functionality

## Documentation
Nothing changed