### PR TITLE
[OPIK-5691] [BE][FE] feat: add eval suite analytics events

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -16,6 +16,7 @@ import com.comet.opik.api.DatasetItemBatchUpdate;
 import com.comet.opik.api.DatasetItemChanges;
 import com.comet.opik.api.DatasetItemStreamRequest;
 import com.comet.opik.api.DatasetItemsDelete;
+import com.comet.opik.api.DatasetType;
 import com.comet.opik.api.DatasetUpdate;
 import com.comet.opik.api.DatasetVersion;
 import com.comet.opik.api.ExperimentItem;
@@ -43,6 +44,7 @@ import com.comet.opik.infrastructure.FeatureFlags;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.auth.RequiredPermissions;
 import com.comet.opik.infrastructure.auth.WorkspaceUserPermission;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.infrastructure.ratelimit.RateLimited;
 import com.comet.opik.utils.FileNameUtils;
 import com.comet.opik.utils.RetryUtils;
@@ -90,6 +92,7 @@ import reactor.core.publisher.Flux;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -120,6 +123,7 @@ public class DatasetsResource {
     private final @NonNull CsvDatasetItemProcessor csvProcessor;
     private final @NonNull FeatureFlags featureFlags;
     private final @NonNull CsvDatasetExportService csvExportService;
+    private final @NonNull AnalyticsService analyticsService;
 
     @GET
     @Path("/{id}")
@@ -196,6 +200,13 @@ public class DatasetsResource {
         Dataset savedDataset = service.save(dataset);
         log.info("Created dataset with name '{}', id '{}', on workspace_id '{}'", savedDataset.name(),
                 savedDataset.id(), workspaceId);
+
+        if (savedDataset.type() == DatasetType.TEST_SUITE) {
+            analyticsService.trackEvent("eval_suite_created", Map.of(
+                    "eval_suite_id", savedDataset.id().toString(),
+                    "eval_suite_name", savedDataset.name(),
+                    "project_id", String.valueOf(savedDataset.projectId())));
+        }
 
         URI uri = uriInfo.getAbsolutePathBuilder().path("/%s".formatted(savedDataset.id().toString())).build();
         return Response.created(uri).build();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -202,7 +202,7 @@ public class DatasetsResource {
                 savedDataset.id(), workspaceId);
 
         if (savedDataset.type() == DatasetType.TEST_SUITE) {
-            analyticsService.trackEvent("eval_suite_created", Map.of(
+            analyticsService.trackEvent("opik_eval_suite_created", Map.of(
                     "eval_suite_id", savedDataset.id().toString(),
                     "eval_suite_name", savedDataset.name(),
                     "project_id", String.valueOf(savedDataset.projectId())));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentService.java
@@ -701,7 +701,7 @@ public class ExperimentService {
         try {
             datasetService.getById(experiment.datasetId(), workspaceId)
                     .filter(dataset -> dataset.type() == DatasetType.TEST_SUITE)
-                    .ifPresent(dataset -> analyticsService.trackEvent("eval_suite_run", Map.of(
+                    .ifPresent(dataset -> analyticsService.trackEvent("opik_eval_suite_run", Map.of(
                             "eval_suite_id", dataset.id().toString(),
                             "experiment_id", experiment.id().toString(),
                             "project_id", String.valueOf(experiment.projectId()))));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentService.java
@@ -698,17 +698,19 @@ public class ExperimentService {
     }
 
     private void trackEvalSuiteRunIfApplicable(Experiment experiment, String workspaceId) {
-        try {
-            datasetService.getById(experiment.datasetId(), workspaceId)
-                    .filter(dataset -> dataset.type() == DatasetType.TEST_SUITE)
-                    .ifPresent(dataset -> analyticsService.trackEvent("opik_eval_suite_run", Map.of(
-                            "eval_suite_id", dataset.id().toString(),
-                            "experiment_id", experiment.id().toString(),
-                            "project_id", String.valueOf(experiment.projectId()))));
-        } catch (Exception e) {
-            log.warn("Failed to track eval_suite_run analytics event for experiment '{}'",
-                    experiment.id(), e);
-        }
+        Schedulers.boundedElastic().schedule(() -> {
+            try {
+                datasetService.getById(experiment.datasetId(), workspaceId)
+                        .filter(dataset -> dataset.type() == DatasetType.TEST_SUITE)
+                        .ifPresent(dataset -> analyticsService.trackEvent("opik_eval_suite_run", Map.of(
+                                "eval_suite_id", dataset.id().toString(),
+                                "experiment_id", experiment.id().toString(),
+                                "project_id", String.valueOf(experiment.projectId()))));
+            } catch (Exception e) {
+                log.warn("Failed to track eval_suite_run analytics event for experiment '{}'",
+                        experiment.id(), e);
+            }
+        });
     }
 
     private Mono<UUID> handleCreateError(Throwable throwable, UUID id) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentService.java
@@ -694,15 +694,15 @@ public class ExperimentService {
         log.info("Posted experiment created event for experiment id '{}', datasetId '{}', workspaceId '{}'",
                 partialExperiment.id(), partialExperiment.datasetId(), workspaceId);
 
-        trackEvalSuiteRunIfApplicable(partialExperiment, workspaceId);
+        trackEvalSuiteRunIfApplicable(partialExperiment, workspaceId, userName);
     }
 
-    private void trackEvalSuiteRunIfApplicable(Experiment experiment, String workspaceId) {
+    private void trackEvalSuiteRunIfApplicable(Experiment experiment, String workspaceId, String userName) {
         Schedulers.boundedElastic().schedule(() -> {
             try {
                 datasetService.getById(experiment.datasetId(), workspaceId)
                         .filter(dataset -> dataset.type() == DatasetType.TEST_SUITE)
-                        .ifPresent(dataset -> analyticsService.trackEvent("opik_eval_suite_run", Map.of(
+                        .ifPresent(dataset -> analyticsService.trackEvent(userName, "opik_eval_suite_run", Map.of(
                                 "eval_suite_id", dataset.id().toString(),
                                 "experiment_id", experiment.id().toString(),
                                 "project_id", String.valueOf(experiment.projectId()))));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentService.java
@@ -4,6 +4,7 @@ import com.clickhouse.client.ClickHouseException;
 import com.comet.opik.api.BiInformationResponse;
 import com.comet.opik.api.Dataset;
 import com.comet.opik.api.DatasetLastExperimentCreated;
+import com.comet.opik.api.DatasetType;
 import com.comet.opik.api.DatasetVersion;
 import com.comet.opik.api.ExecutionPolicy;
 import com.comet.opik.api.Experiment;
@@ -32,6 +33,7 @@ import com.comet.opik.domain.experiments.aggregations.ExperimentAggregationPubli
 import com.comet.opik.infrastructure.FeatureFlags;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.google.common.base.Preconditions;
 import com.google.common.eventbus.EventBus;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -91,6 +93,7 @@ public class ExperimentService {
     private final @NonNull ExperimentGroupEnricher experimentGroupEnricher;
     private final @NonNull ExperimentAggregatesService experimentAggregatesService;
     private final @NonNull ExperimentAggregationPublisher experimentAggregationPublisher;
+    private final @NonNull AnalyticsService analyticsService;
 
     @WithSpan
     public Mono<ExperimentPage> find(
@@ -690,6 +693,22 @@ public class ExperimentService {
                 Optional.ofNullable(partialExperiment.type()).orElse(ExperimentType.REGULAR)));
         log.info("Posted experiment created event for experiment id '{}', datasetId '{}', workspaceId '{}'",
                 partialExperiment.id(), partialExperiment.datasetId(), workspaceId);
+
+        trackEvalSuiteRunIfApplicable(partialExperiment, workspaceId);
+    }
+
+    private void trackEvalSuiteRunIfApplicable(Experiment experiment, String workspaceId) {
+        try {
+            datasetService.getById(experiment.datasetId(), workspaceId)
+                    .filter(dataset -> dataset.type() == DatasetType.TEST_SUITE)
+                    .ifPresent(dataset -> analyticsService.trackEvent("eval_suite_run", Map.of(
+                            "eval_suite_id", dataset.id().toString(),
+                            "experiment_id", experiment.id().toString(),
+                            "project_id", String.valueOf(experiment.projectId()))));
+        } catch (Exception e) {
+            log.warn("Failed to track eval_suite_run analytics event for experiment '{}'",
+                    experiment.id(), e);
+        }
     }
 
     private Mono<UUID> handleCreateError(Throwable throwable, UUID id) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceIntegrationTest.java
@@ -19,6 +19,7 @@ import com.comet.opik.domain.Streamer;
 import com.comet.opik.domain.filter.FilterQueryBuilder;
 import com.comet.opik.infrastructure.FeatureFlags;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.infrastructure.db.IdGeneratorImpl;
 import com.comet.opik.infrastructure.json.JsonNodeMessageBodyWriter;
 import com.comet.opik.podam.PodamFactoryUtils;
@@ -70,6 +71,7 @@ class DatasetsResourceIntegrationTest {
     private static final FeatureFlags featureFlags = mock(FeatureFlags.class);
     public static final SortingFactoryDatasets sortingFactory = new SortingFactoryDatasets();
     private static final CsvDatasetExportService csvExportService = mock(CsvDatasetExportService.class);
+    private static final AnalyticsService analyticsService = mock(AnalyticsService.class);
     private static final ResourceExtension EXT;
 
     static {
@@ -79,7 +81,7 @@ class DatasetsResourceIntegrationTest {
                         service, itemService, expansionService, versionService, () -> requestContext,
                         new FiltersFactory(new FilterQueryBuilder()),
                         new IdGeneratorImpl(), new Streamer(), sortingFactory, csvProcessor,
-                        featureFlags, csvExportService))
+                        featureFlags, csvExportService, analyticsService))
                 .addProvider(JsonNodeMessageBodyWriter.class)
                 .addProvider(MultiPartFeature.class)
                 .setTestContainerFactory(new GrizzlyWebTestContainerFactory())

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentServiceTest.java
@@ -13,6 +13,7 @@ import com.comet.opik.infrastructure.ExperimentAggregatesConfig;
 import com.comet.opik.infrastructure.FeatureFlags;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.eventbus.EventBus;
@@ -102,6 +103,9 @@ class ExperimentServiceTest {
     @Mock
     private ExperimentAggregationPublisher experimentAggregationPublisher;
 
+    @Mock
+    private AnalyticsService analyticsService;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
 
@@ -126,7 +130,8 @@ class ExperimentServiceTest {
                 config,
                 experimentGroupEnricher,
                 experimentAggregatesService,
-                experimentAggregationPublisher);
+                experimentAggregationPublisher,
+                analyticsService);
     }
 
     @Nested

--- a/apps/opik-frontend/src/lib/analytics/tracking.ts
+++ b/apps/opik-frontend/src/lib/analytics/tracking.ts
@@ -4,6 +4,7 @@ export const OpikEvent = {
   ONBOARDING_AGENT_NAME_SUBMITTED: "opik_onboarding_agent_name_submitted",
   ONBOARDING_FIRST_TRACE_RECEIVED: "opik_onboarding_first_trace_received",
   ONBOARDING_SKIPPED: "opik_onboarding_skipped",
+  EVAL_SUITE_UI_CONFIGURED: "opik_eval_suite_ui_configured",
 } as const;
 
 type OpikEventValues = (typeof OpikEvent)[keyof typeof OpikEvent];

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/AddEditDatasetDialog/useDatasetForm.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/AddEditDatasetDialog/useDatasetForm.ts
@@ -16,6 +16,7 @@ import { MAX_RUNS_PER_ITEM } from "@/types/test-suites";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
 import { useClampedIntegerInput } from "@/hooks/useClampedIntegerInput";
+import { OpikEvent, trackEvent } from "@/lib/analytics/tracking";
 
 const JSON_MODE_FILE_SIZE_LIMIT_IN_MB = 20;
 const JSON_MODE_MAX_ITEMS = 1000;
@@ -245,6 +246,16 @@ const useDatasetForm = ({
 
   const onCreateSuccessHandler = useCallback(
     (newDataset: Dataset) => {
+      if (datasetType === DATASET_TYPE.TEST_SUITE) {
+        trackEvent(OpikEvent.EVAL_SUITE_UI_CONFIGURED, {
+          eval_suite_id: newDataset.id,
+          eval_suite_name: newDataset.name,
+          has_csv_upload: hasValidCsvFile,
+          num_assertions: assertions.filter((a) => a.trim()).length,
+          runs_per_item: runsPerItem,
+        });
+      }
+
       const navigateToDataset = () => {
         setOpen(false);
         onDatasetCreated?.(newDataset);
@@ -275,6 +286,9 @@ const useDatasetForm = ({
       onDatasetCreated,
       onCreateSuccess,
       setOpen,
+      datasetType,
+      assertions,
+      runsPerItem,
     ],
   );
 


### PR DESCRIPTION
## Details
Add three analytics events for the Eval Suite launch dashboards tracked in [OPIK-5245](https://comet-ml.atlassian.net/browse/OPIK-5245):

- **BE: `opik_eval_suite_created`** — fired in `DatasetsResource.createDataset()` when a `TEST_SUITE` dataset is created. Captures both UI and SDK paths. Properties: `eval_suite_id`, `eval_suite_name`, `project_id`.
- **BE: `opik_eval_suite_run`** — fired in `ExperimentService` when an experiment is created against a `TEST_SUITE` dataset. Wrapped in try/catch so analytics failures don't disrupt experiment creation. Properties: `eval_suite_id`, `experiment_id`, `project_id`.
- **FE: `opik_eval_suite_ui_configured`** — fired from `useDatasetForm` on the creation dialog's success handler, guarded by `datasetType === DATASET_TYPE.TEST_SUITE`. Properties: `eval_suite_id`, `eval_suite_name`, `has_csv_upload`, `num_assertions`, `runs_per_item`.

`item_count` was omitted from `opik_eval_suite_run` because the dataset enrichment needed to fetch it is too heavy for an analytics side-effect (3 separate DB queries for summaries + version lookup). Can be added later with a lightweight count query if the "test cases per suite" metric proves critical.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5691

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: All 3 event implementations (2 BE, 1 FE), Jira ticket description rewrite with PostHog feasibility analysis + HogQL queries.
- Human verification: Code reviewed manually; FE lint/typecheck/deps and BE build (`mvn install`) pass locally; manual smoke test pending.

## Testing

Local checks:
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run deps:validate` — clean (no new baseline violations)
- `./scripts/dev-runner.sh --build-be` — BUILD SUCCESS
- Spotless applied and clean

**Manual smoke (pending):**
- Create a test suite from the UI → expect `opik_eval_suite_created` (BE) + `opik_eval_suite_ui_configured` (FE) events
- Create a test suite via SDK → expect only `opik_eval_suite_created` (BE)
- Run an experiment against a test suite → expect `opik_eval_suite_run` (BE)
- Run an experiment against a regular dataset → expect NO analytics event
- Verify all events arrive in Segment Debugger / PostHog Live Events with correct properties

**Not run:**
- No unit tests added for analytics call sites. The BE events are guarded by `OPIK_ANALYTICS_ENABLED=false` (default) and wrapped in try/catch. FE event no-ops when `window.analytics` is absent.

## Documentation

Jira ticket [OPIK-5691](https://comet-ml.atlassian.net/browse/OPIK-5691) updated with:
- Full event specs (3 events), placement details, guard conditions
- Dashboard formulas table with PostHog insight types
- HogQL query for reuse rate metric
- Cross-ticket dependency note for regression metrics → OPIK-5890

[OPIK-5245]: https://comet-ml.atlassian.net/browse/OPIK-5245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPIK-5691]: https://comet-ml.atlassian.net/browse/OPIK-5691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ