### PR TITLE
[OPIK-5982] [FE] fix: use textarea for multiline fields in agent config edit mode

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditView.tsx
@@ -21,6 +21,7 @@ import { Switch } from "@/ui/switch";
 import Loader from "@/shared/Loader/Loader";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import BlueprintTypeIcon from "@/v2/pages-shared/traces/ConfigurationTab/BlueprintTypeIcon";
+import AutoResizeTextarea from "./fields/AutoResizeTextarea";
 import BlueprintValuePromptCompact from "./fields/BlueprintValuePromptCompact";
 import useNavigationBlocker from "@/hooks/useNavigationBlocker";
 import FieldSection from "./fields/FieldSection";
@@ -436,19 +437,31 @@ const AgentConfigurationEditView = React.forwardRef<
                         </span>
                       ) : null;
 
+                      const isNumeric =
+                        v.type === BlueprintValueType.INT ||
+                        v.type === BlueprintValueType.FLOAT;
+
                       return (
                         <div className="flex flex-col gap-1">
-                          <div className="rounded-md border bg-background px-3 py-2">
-                            <Input
-                              variant="ghost"
-                              className="h-auto p-0"
-                              inputMode={inputMode}
+                          {isNumeric ? (
+                            <div className="rounded-md border bg-background px-3 py-2">
+                              <Input
+                                variant="ghost"
+                                className="h-auto p-0"
+                                inputMode={inputMode}
+                                value={currentValue}
+                                onChange={(e) =>
+                                  handleFieldChange(v.key, e.target.value)
+                                }
+                              />
+                            </div>
+                          ) : (
+                            <AutoResizeTextarea
+                              className="rounded-md border bg-background px-3 py-2"
                               value={currentValue}
-                              onChange={(e) =>
-                                handleFieldChange(v.key, e.target.value)
-                              }
+                              onChange={(val) => handleFieldChange(v.key, val)}
                             />
-                          </div>
+                          )}
                           {errorLine}
                         </div>
                       );

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/fields/AutoResizeTextarea.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/fields/AutoResizeTextarea.tsx
@@ -20,8 +20,9 @@ const AutoResizeTextarea: React.FC<AutoResizeTextareaProps> = ({
   const resize = useCallback(() => {
     const el = textareaRef.current;
     if (el) {
-      el.style.height = "auto";
-      el.style.height = el.scrollHeight + "px";
+      el.style.height = "0";
+      const border = el.offsetHeight - el.clientHeight;
+      el.style.height = el.scrollHeight + border + "px";
     }
   }, []);
 
@@ -39,6 +40,7 @@ const AutoResizeTextarea: React.FC<AutoResizeTextareaProps> = ({
   return (
     <textarea
       ref={textareaRef}
+      rows={1}
       className={cn(
         "comet-body-s w-full resize-none overflow-hidden bg-transparent text-foreground outline-none",
         className,


### PR DESCRIPTION
## Details

https://github.com/user-attachments/assets/3603a7ed-d06a-424d-8615-b314d41196c3

<img width="1920" height="2388" alt="image" src="https://github.com/user-attachments/assets/3ccafaf4-01c5-4801-bf2d-1804b08b6ee0" />

String fields in the agent configuration form used `<input>` elements which cannot accept newlines. This meant multiline content was collapsed into a single line in edit mode, and line breaks were lost on save.

This fix replaces `<Input>` with `AutoResizeTextarea` for all non-numeric (STRING) fields in the agent config edit view. The textarea auto-grows as users type or press Enter, starting at a single line height and expanding as needed. Numeric fields (INT/FLOAT) continue using `<Input>`. Border/padding styling is moved onto the textarea element itself so the auto-resize height calculation correctly accounts for `border-box` sizing.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-5982

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review + manual testing

## Testing

- `npx tsc --noEmit` — TypeScript compiles clean
- Pre-commit hook passed: eslint, stylelint, typecheck, dependency validation
- Manual testing: open agent config with multiline fields, verify textarea renders in edit mode, Enter creates new lines, content preserves on save, short fields start at single-line height, numeric fields still use single-line input

## Documentation
N/A