### PR TITLE
[OPIK-6013] [FE] fix: CSV upload overlay stuck when server-side processing enabled

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/datasets/AddEditDatasetDialog/useDatasetForm.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/AddEditDatasetDialog/useDatasetForm.ts
@@ -254,7 +254,7 @@ const useDatasetForm = ({
         ? () => onCreateSuccess(newDataset, navigateToDataset)
         : navigateToDataset;
 
-      if (hasValidCsvFile) {
+      if (hasValidCsvFile && !isCsvUploadEnabled) {
         setIsOverlayShown(true);
       }
 
@@ -271,6 +271,7 @@ const useDatasetForm = ({
       applyEvaluationCriteria,
       uploadItems,
       hasValidCsvFile,
+      isCsvUploadEnabled,
       onDatasetCreated,
       onCreateSuccess,
       setOpen,

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/CsvUploadDialog/CsvUploadDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/CsvUploadDialog/CsvUploadDialog.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button } from "@/ui/button";
-import { Dialog, DialogContent } from "@/ui/dialog";
+import { Dialog, DialogContent, DialogTitle } from "@/ui/dialog";
 import Loader from "@/shared/Loader/Loader";
 
 type CsvUploadDialogProps = {
@@ -17,6 +17,9 @@ const CsvUploadDialog: React.FC<CsvUploadDialogProps> = ({
   return (
     <Dialog open={open}>
       <DialogContent className="max-w-sm [&>button.absolute]:hidden">
+        <DialogTitle className="sr-only">
+          {isCsvMode ? "Upload in progress" : "Processing CSV"}
+        </DialogTitle>
         <Loader
           className="min-h-40"
           message={


### PR DESCRIPTION
## Details

When creating a dataset/test suite with a CSV file and server-side CSV processing enabled (`CSV_UPLOAD_ENABLED=true`), the `CsvUploadDialog` overlay showed "Upload in progress..." but never dismissed. This happened because the new sidebar flow (introduced in #6234) keeps the panel open for a success step instead of closing entirely, so the `useEffect` that previously reset `isOverlayShown` via `open` changing to `false` never fired.

- Skip showing the overlay when `isCsvUploadEnabled` is true — the upload is sent to the server for background processing and a toast already confirms acceptance
- Add a visually-hidden `DialogTitle` to `CsvUploadDialog` for Radix UI accessibility compliance

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6013

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full implementation with human guidance and testing
  - Human verification: Manually tested both CSV upload modes locally

## Testing

- Enabled `CSV_UPLOAD_ENABLED=true` via `TOGGLE_CSV_UPLOAD_ENABLED=true` env var and restarted backend
- Created a dataset with CSV upload — verified overlay no longer appears and success step shows immediately
- Verified toast notification still appears confirming background processing
- Disabled the flag and verified the old client-side CSV flow still shows the "Processing the CSV" overlay with Close button
- `npx tsc --noEmit` — no type errors
- Pre-commit hook passed (lint, typecheck, dependency validation)

## Documentation
No documentation changes needed.