### PR TITLE
[OPIK-6031] [FE] fix: resize auto-resize textarea when tab becomes visible

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/fields/AutoResizeTextarea.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/fields/AutoResizeTextarea.tsx
@@ -27,7 +27,22 @@ const AutoResizeTextarea: React.FC<AutoResizeTextareaProps> = ({
   }, []);
 
   useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+
     resize();
+
+    // Re-resize when the element becomes visible (e.g. hidden tab with forceMount)
+    let lastWidth = el.offsetWidth;
+    const observer = new ResizeObserver(() => {
+      const currentWidth = el.offsetWidth;
+      if (currentWidth !== lastWidth) {
+        lastWidth = currentWidth;
+        resize();
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
   }, [value, resize]);
 
   const handleChange = useCallback(


### PR DESCRIPTION
## Details

The agent sandbox page force-mounts the Configuration tab (with `forceMount` + `hidden`) so that draft edits survive tab switches. However, `AutoResizeTextarea` calculated `scrollHeight` as 0 on mount because the element was `display:none`. This caused multiline string fields to render with zero height when switching to the Configuration tab.

Added a `ResizeObserver` to detect when the element's width changes (hidden → visible transition) and re-trigger the resize calculation.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6031

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: assisted (root cause analysis + implementation)
- Human verification: code review + manual testing

## Testing

- Reproduced the bug locally on `main`: multiline config fields in agent sandbox Configuration tab rendered with zero height
- Applied fix, verified fields now resize correctly when switching to the Configuration tab
- TypeScript type-check passed: `tsc --noEmit`
- Frontend lint passed via pre-commit hook

## Documentation

N/A