### PR TITLE
[OPIK-6026] [BE] Onboarding analytics events

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PairingResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PairingResource.java
@@ -8,6 +8,7 @@ import com.comet.opik.api.error.ErrorMessage;
 import com.comet.opik.domain.pairing.PairingService;
 import com.comet.opik.infrastructure.LocalRunnerConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.infrastructure.ratelimit.RateLimited;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -35,7 +36,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.URI;
+import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Path("/v1/private/pairing")
@@ -50,6 +54,7 @@ public class PairingResource {
     private final @NonNull Provider<RequestContext> requestContext;
     private final @NonNull PairingService pairingService;
     private final @NonNull LocalRunnerConfig runnerConfig;
+    private final @NonNull AnalyticsService analyticsService;
 
     @POST
     @Path("/sessions")
@@ -67,6 +72,14 @@ public class PairingResource {
         String workspaceId = requestContext.get().getWorkspaceId();
         String userName = requestContext.get().getUserName();
         CreateSessionResponse response = pairingService.create(workspaceId, userName, request);
+
+        analyticsService.trackEvent("opik_connect_started", Map.of(
+                "session_id", response.sessionId().toString(),
+                "project_id", request.projectId().toString(),
+                "workspace_id", workspaceId,
+                "user_name", userName,
+                "date", Instant.now().toString()));
+
         return Response.status(Response.Status.CREATED).entity(response).build();
     }
 
@@ -88,11 +101,30 @@ public class PairingResource {
         ensureEnabled();
         String workspaceId = requestContext.get().getWorkspaceId();
         String userName = requestContext.get().getUserName();
-        UUID runnerId = pairingService.activate(workspaceId, userName, sessionId, request);
-        URI location = uriInfo.getBaseUriBuilder()
-                .path("v1/private/local-runners/{runnerId}")
-                .build(runnerId);
-        return Response.created(location).build();
+
+        try {
+            UUID runnerId = pairingService.activate(workspaceId, userName, sessionId, request);
+
+            analyticsService.trackEvent("opik_connect_succeeded", Map.of(
+                    "session_id", sessionId.toString(),
+                    "workspace_id", workspaceId,
+                    "user_name", userName,
+                    "date", Instant.now().toString()));
+
+            URI location = uriInfo.getBaseUriBuilder()
+                    .path("v1/private/local-runners/{runnerId}")
+                    .build(runnerId);
+            return Response.created(location).build();
+        } catch (Exception e) {
+            Map<String, String> props = new HashMap<>();
+            props.put("session_id", sessionId.toString());
+            props.put("workspace_id", workspaceId);
+            props.put("user_name", userName);
+            props.put("error", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+            props.put("date", Instant.now().toString());
+            analyticsService.trackEvent("opik_connect_failed", props);
+            throw e;
+        }
     }
 
     private void ensureEnabled() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PairingResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PairingResource.java
@@ -37,7 +37,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.net.URI;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -116,13 +115,12 @@ public class PairingResource {
                     .build(runnerId);
             return Response.created(location).build();
         } catch (Exception e) {
-            Map<String, String> props = new HashMap<>();
-            props.put("session_id", sessionId.toString());
-            props.put("workspace_id", workspaceId);
-            props.put("user_name", userName);
-            props.put("error", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
-            props.put("date", Instant.now().toString());
-            analyticsService.trackEvent("opik_connect_failed", props);
+            analyticsService.trackEvent("opik_connect_failed", Map.of(
+                    "session_id", sessionId.toString(),
+                    "workspace_id", workspaceId,
+                    "user_name", userName,
+                    "error", e.getClass().getSimpleName(),
+                    "date", Instant.now().toString()));
             throw e;
         }
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -16,6 +16,7 @@ import com.comet.opik.api.sorting.SortingField;
 import com.comet.opik.domain.sorting.SortingQueryBuilder;
 import com.comet.opik.domain.stats.StatsMapper;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.utils.BinaryOperatorUtils;
 import com.comet.opik.utils.ErrorUtils;
@@ -143,6 +144,7 @@ class ProjectServiceImpl implements ProjectService {
     private final @NonNull TransactionTemplateAsync transactionTemplateAsync;
     private final @NonNull SortingFactoryProjects sortingFactory;
     private final @NonNull SortingQueryBuilder sortingQueryBuilder;
+    private final @NonNull AnalyticsService analyticsService;
 
     private NotFoundException createNotFoundError() {
         String message = "Project not found";
@@ -178,6 +180,13 @@ class ProjectServiceImpl implements ProjectService {
 
                 return newProject;
             });
+
+            analyticsService.trackEvent("project_created", Map.of(
+                    "project_id", newProject.id().toString(),
+                    "project_name", newProject.name(),
+                    "workspace_id", workspaceId,
+                    "user_name", userName,
+                    "date", Instant.now().toString()));
 
             return get(newProject.id(), workspaceId);
         } catch (UnableToExecuteStatementException e) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/AnalyticsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/AnalyticsService.java
@@ -1,11 +1,13 @@
 package com.comet.opik.infrastructure.bi;
 
 import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.infrastructure.auth.RequestContext;
 import com.google.inject.ImplementedBy;
+import com.google.inject.ProvisionException;
 import jakarta.inject.Inject;
+import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
@@ -17,9 +19,10 @@ public interface AnalyticsService {
     String EVENT_PREFIX = "opik_";
 
     void trackEvent(String eventType, Map<String, String> properties);
+
+    void trackEvent(String identity, String eventType, Map<String, String> properties);
 }
 
-@RequiredArgsConstructor(onConstructor_ = @Inject)
 @Singleton
 @Slf4j
 class AnalyticsServiceImpl implements AnalyticsService {
@@ -27,9 +30,29 @@ class AnalyticsServiceImpl implements AnalyticsService {
     private final @NonNull OpikConfiguration config;
     private final @NonNull UsageReportService usageReportService;
     private final @NonNull StatsClient statsClient;
+    private final @NonNull Provider<RequestContext> requestContext;
+
+    @Inject
+    AnalyticsServiceImpl(@NonNull OpikConfiguration config, @NonNull UsageReportService usageReportService,
+            @NonNull StatsClient statsClient, @NonNull Provider<RequestContext> requestContext) {
+        this.config = config;
+        this.usageReportService = usageReportService;
+        this.statsClient = statsClient;
+        this.requestContext = requestContext;
+    }
 
     @Override
     public void trackEvent(@NonNull String eventType, @NonNull Map<String, String> properties) {
+        sendEvent(resolveIdentity(), eventType, properties);
+    }
+
+    @Override
+    public void trackEvent(@NonNull String identity, @NonNull String eventType,
+            @NonNull Map<String, String> properties) {
+        sendEvent(identity, eventType, properties);
+    }
+
+    private void sendEvent(String identity, String eventType, Map<String, String> properties) {
         if (!config.getAnalytics().isEnabled()) {
             log.info("Analytics disabled — skipping event '{}'", eventType);
             return;
@@ -43,13 +66,24 @@ class AnalyticsServiceImpl implements AnalyticsService {
             enrichedProperties.put("environment", environment);
         }
 
-        var anonymousId = usageReportService.getAnonymousId().orElse("unknown");
         var event = BiEvent.builder()
-                .anonymousId(anonymousId)
+                .anonymousId(identity)
                 .eventType(prefixedEventType)
                 .eventProperties(enrichedProperties)
                 .build();
 
         statsClient.sendEvent(event);
+    }
+
+    private String resolveIdentity() {
+        try {
+            var userName = requestContext.get().getUserName();
+            if (StringUtils.isNotBlank(userName)) {
+                return userName;
+            }
+        } catch (ProvisionException e) {
+            log.debug("No request scope available, falling back to installation anonymous ID");
+        }
+        return usageReportService.getAnonymousId().orElse("unknown");
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/BiEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/BiEventListener.java
@@ -64,6 +64,17 @@ public class BiEventListener {
         trackFirstTraceViaAnalytics(event.workspaceId(), event);
     }
 
+    private Set<UUID> getNonDemoProjectIds(String workspaceId, TracesCreated event) {
+        Set<UUID> demoProjectIds = projectService.findByNames(workspaceId, DemoData.PROJECTS)
+                .stream()
+                .map(Project::id)
+                .collect(Collectors.toSet());
+
+        Set<UUID> projectIds = new HashSet<>(event.projectIds());
+        projectIds.removeAll(demoProjectIds);
+        return projectIds;
+    }
+
     private void checkIfItIsFirstTraceAndReport(String workspaceId, TracesCreated event) {
         if (usageReportService.isFirstTraceReport()) {
             return;
@@ -74,13 +85,7 @@ public class BiEventListener {
             return;
         }
 
-        Set<UUID> demoProjectIds = projectService.findByNames(workspaceId, DemoData.PROJECTS)
-                .stream()
-                .map(Project::id)
-                .collect(Collectors.toSet());
-
-        Set<UUID> projectIds = new HashSet<>(event.projectIds());
-        projectIds.removeAll(demoProjectIds);
+        Set<UUID> projectIds = getNonDemoProjectIds(workspaceId, event);
 
         if (projectIds.isEmpty()) {
             log.info("No project ids found for event");
@@ -126,6 +131,14 @@ public class BiEventListener {
 
     private void trackFirstTraceViaAnalytics(String workspaceId, TracesCreated event) {
         if (event.traces().isEmpty()) {
+            return;
+        }
+
+        if (analyticsReportedWorkspaces.contains(workspaceId)) {
+            return;
+        }
+
+        if (getNonDemoProjectIds(workspaceId, event).isEmpty()) {
             return;
         }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/BiEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/BiEventListener.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @EagerSingleton
@@ -36,28 +37,31 @@ public class BiEventListener {
     private final LockService lockService;
     private final OpikConfiguration config;
     private final BiEventService biEventService;
+    private final AnalyticsService analyticsService;
+
+    private final Set<String> analyticsReportedWorkspaces = ConcurrentHashMap.newKeySet();
 
     @Inject
     public BiEventListener(@NonNull ProjectService projectService,
             @NonNull UsageReportService usageReportService, @NonNull TraceService traceService,
             @NonNull OpikConfiguration config, @NonNull LockService lockService,
-            @NonNull BiEventService biEventService) {
+            @NonNull BiEventService biEventService, @NonNull AnalyticsService analyticsService) {
         this.projectService = projectService;
         this.traceService = traceService;
         this.config = config;
         this.usageReportService = usageReportService;
         this.lockService = lockService;
         this.biEventService = biEventService;
+        this.analyticsService = analyticsService;
     }
 
     @Subscribe
     public void onTracesCreated(TracesCreated event) {
-
-        if (!config.getUsageReport().isEnabled()) {
-            return;
+        if (config.getUsageReport().isEnabled()) {
+            checkIfItIsFirstTraceAndReport(event.workspaceId(), event);
         }
 
-        checkIfItIsFirstTraceAndReport(event.workspaceId(), event);
+        trackFirstTraceViaAnalytics(event.workspaceId(), event);
     }
 
     private void checkIfItIsFirstTraceAndReport(String workspaceId, TracesCreated event) {
@@ -118,6 +122,21 @@ public class BiEventListener {
                         "opik_app_version", config.getMetadata().getVersion(),
                         "traces_count", String.valueOf(traces),
                         "date", Instant.now().toString()));
+    }
+
+    private void trackFirstTraceViaAnalytics(String workspaceId, TracesCreated event) {
+        if (event.traces().isEmpty()) {
+            return;
+        }
+
+        if (!analyticsReportedWorkspaces.add(workspaceId)) {
+            return;
+        }
+
+        analyticsService.trackEvent(event.userName(), "first_trace_created", Map.of(
+                "workspace_id", workspaceId,
+                "user_name", event.userName(),
+                "date", Instant.now().toString()));
     }
 
 }


### PR DESCRIPTION
## Details
Add onboarding BI events via AnalyticsService to track user activation funnel.
Events added: `opik_project_created`, `opik_connect_started`, `opik_connect_succeeded`, `opik_connect_failed`, `opik_first_trace_created`.
AnalyticsService now resolves per-user identity from RequestContext (with explicit override for async contexts), so all events carry a user-level `anonymous_id` for funnel correlation.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6026

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-opus-4-6
  - Scope: full implementation
  - Human verification: reviewed changes, guided approach, verified compilation and tests

## Testing

- `mvn compile` — clean build, no errors
- `mvn test -Dtest="BiEventListenerTest"` — 1 test, 0 failures (integration test with DI auto-wiring validates BiEventListener still works with new AnalyticsService dependency)
- Tested locally, events are firing as expected
- Verified analytics defaults to disabled so existing tests are unaffected

## Documentation
N/A — internal analytics events, no user-facing documentation needed.