### PR TITLE
[NA] [SDK] feat: update Sentry DSN and add error reporting for opik connect CLI

### DIFF
--- a/sdks/python/src/opik/cli/_run.py
+++ b/sdks/python/src/opik/cli/_run.py
@@ -24,7 +24,7 @@ def _capture_cli_error(
 ) -> None:
     sentry_sdk.set_tag("error_type", error_type)
     context = {k: v for k, v in details.items() if v is not None}
-    cause = exception.__cause__
+    cause = exception.__cause__ or exception.__context__
     if cause is not None:
         context["caused_by"] = type(cause).__name__
         if hasattr(cause, "status_code"):

--- a/sdks/python/src/opik/cli/_run.py
+++ b/sdks/python/src/opik/cli/_run.py
@@ -23,9 +23,16 @@ def _capture_cli_error(
     exception: Exception, error_type: str, **details: object
 ) -> None:
     sentry_sdk.set_tag("error_type", error_type)
-    sentry_sdk.set_context(
-        "cli_error", {k: v for k, v in details.items() if v is not None}
-    )
+    context = {k: v for k, v in details.items() if v is not None}
+    cause = exception.__cause__
+    if cause is not None:
+        context["caused_by"] = type(cause).__name__
+        context["caused_by_message"] = str(cause)
+        if hasattr(cause, "status_code"):
+            context["caused_by_status_code"] = cause.status_code
+        if hasattr(cause, "body"):
+            context["caused_by_body"] = str(cause.body)
+    sentry_sdk.set_context("cli_error", context)
     sentry_sdk.capture_exception(exception)
 
 

--- a/sdks/python/src/opik/cli/_run.py
+++ b/sdks/python/src/opik/cli/_run.py
@@ -27,11 +27,8 @@ def _capture_cli_error(
     cause = exception.__cause__
     if cause is not None:
         context["caused_by"] = type(cause).__name__
-        context["caused_by_message"] = str(cause)
         if hasattr(cause, "status_code"):
             context["caused_by_status_code"] = cause.status_code
-        if hasattr(cause, "body"):
-            context["caused_by_body"] = str(cause.body)
     sentry_sdk.set_context("cli_error", context)
     sentry_sdk.capture_exception(exception)
 

--- a/sdks/python/src/opik/cli/_run.py
+++ b/sdks/python/src/opik/cli/_run.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 import click
 import httpx
+import sentry_sdk
 
 from opik import Opik
 from opik.rest_api.core.api_error import ApiError
@@ -16,6 +17,12 @@ from .pairing import (
     run_headless,
     run_pairing,
 )
+
+
+def _capture_cli_error(exception: Exception, error_type: str, **details: object) -> None:
+    sentry_sdk.set_tag("error_type", error_type)
+    sentry_sdk.set_context("cli_error", {k: v for k, v in details.items() if v is not None})
+    sentry_sdk.capture_exception(exception)
 
 
 def run_cli_session(
@@ -31,6 +38,10 @@ def run_cli_session(
     client = Opik(api_key=api_key, _show_misconfiguration_message=False)
     api = client.rest_client
     tui = RunnerTUI()
+
+    # Global scope so background threads (heartbeat, bridge-poll) inherit the tag.
+    # Safe because the CLI process runs one command and exits.
+    sentry_sdk.set_tag("cli_command", f"opik-{runner_type.value}")
 
     try:
         runner_name = generate_runner_name(name)
@@ -60,19 +71,38 @@ def run_cli_session(
         )
     except KeyboardInterrupt:
         raise SystemExit(130)
+    except click.ClickException as e:
+        _capture_cli_error(e, error_type="ClickException", message=e.format_message())
+        raise
     except ApiError as e:
+        _capture_cli_error(
+            e,
+            error_type="ApiError",
+            message=str(e.body) if e.body else None,
+            status_code=e.status_code,
+        )
         click.echo(f"Error: {e.body}" if e.body else f"Error: {e.status_code}")
         raise SystemExit(1)
-    except httpx.ConnectError:
+    except httpx.ConnectError as e:
+        _capture_cli_error(
+            e,
+            error_type="ConnectError",
+            message=str(e),
+            url=client.config.url_override,
+        )
         click.echo(
             f"Error: Could not connect to Opik at {client.config.url_override}. "
             "Check that the backend is running."
         )
         raise SystemExit(1)
     except OSError as e:
+        _capture_cli_error(e, error_type="OSError", message=str(e))
         cmd_name = command[0] if command else "unknown"
         click.echo(f"Error: Could not execute command '{cmd_name}': {e}")
         raise SystemExit(1)
+    except Exception as e:
+        _capture_cli_error(e, error_type=type(e).__name__, message=str(e))
+        raise
     finally:
         tui.stop()
         client.end()

--- a/sdks/python/src/opik/cli/_run.py
+++ b/sdks/python/src/opik/cli/_run.py
@@ -19,9 +19,13 @@ from .pairing import (
 )
 
 
-def _capture_cli_error(exception: Exception, error_type: str, **details: object) -> None:
+def _capture_cli_error(
+    exception: Exception, error_type: str, **details: object
+) -> None:
     sentry_sdk.set_tag("error_type", error_type)
-    sentry_sdk.set_context("cli_error", {k: v for k, v in details.items() if v is not None})
+    sentry_sdk.set_context(
+        "cli_error", {k: v for k, v in details.items() if v is not None}
+    )
     sentry_sdk.capture_exception(exception)
 
 

--- a/sdks/python/src/opik/cli/healthcheck/smoke_test.py
+++ b/sdks/python/src/opik/cli/healthcheck/smoke_test.py
@@ -297,4 +297,6 @@ def run_smoke_test(
 
     # Re-raise the original exception if one occurred
     if original_exception is not None:
-        raise click.ClickException(f"Smoke test failed: {original_exception}")
+        raise click.ClickException(
+            f"Smoke test failed: {original_exception}"
+        ) from original_exception

--- a/sdks/python/src/opik/cli/pairing.py
+++ b/sdks/python/src/opik/cli/pairing.py
@@ -56,10 +56,10 @@ def hkdf_sha256(ikm: bytes, salt: bytes, info: bytes, length: int = 32) -> bytes
 def resolve_project_id(api: "OpikApi", project_name: str) -> str:
     try:
         return resolve_project_id_by_name(api, project_name)
-    except ApiError:
+    except ApiError as e:
         raise click.ClickException(
             f"Project '{project_name}' not found. Check the project name and try again."
-        )
+        ) from e
 
 
 _RUNNER_TYPE_BYTE = {

--- a/sdks/python/src/opik/config.py
+++ b/sdks/python/src/opik/config.py
@@ -190,7 +190,7 @@ class OpikConfig(pydantic_settings.BaseSettings):
     If set to True, Opik will send the information about the errors to Sentry.
     """
 
-    sentry_dsn: str = "https://34bd6f9621ca2783be63f320e35de0dc@o168229.ingest.us.sentry.io/4508620148441088"  # 24.07.2025
+    sentry_dsn: str = "https://fbde8a9ef528f379de25bdfb19749ca5@o168229.ingest.us.sentry.io/4508620148441088"  # 16.04.2026
     """
     Sentry project DSN which is used as a destination for sentry events.
     In case there is a need to update reporting rules and stop receiving events from existing users,

--- a/sdks/python/src/opik/error_tracking/error_filtering/filter_by_response_status_code.py
+++ b/sdks/python/src/opik/error_tracking/error_filtering/filter_by_response_status_code.py
@@ -10,6 +10,9 @@ class FilterByResponseStatusCode(event_filter.EventFilter):
         self._status_codes_to_drop = status_codes_to_drop
 
     def process_event(self, event: Event, hint: Hint) -> bool:
+        if event.get("tags", {}).get("cli_command"):
+            return True
+
         status_code = _try_get_status_code_from_error_tracking_extra(event)
 
         if status_code is None:

--- a/sdks/python/tests/unit/error_tracking/error_filtering/test_filter_by_response_status_code.py
+++ b/sdks/python/tests/unit/error_tracking/error_filtering/test_filter_by_response_status_code.py
@@ -43,3 +43,32 @@ def test_filter_by_response_status_code__status_code_from_exception_attribute__h
         )
         is False
     )
+
+
+def test_filter_by_response_status_code__cli_command_tag__bypasses_filter(
+    fake_basic_hint,
+    fake_error_event_with_status_code_401,
+):
+    tested = filter_by_response_status_code.FilterByResponseStatusCode(
+        status_codes_to_drop=[401]
+    )
+
+    event_with_cli_tag = {
+        **fake_error_event_with_status_code_401,
+        "tags": {"cli_command": "opik-connect"},
+    }
+
+    assert tested.process_event(event_with_cli_tag, fake_basic_hint) is True
+
+
+def test_filter_by_response_status_code__no_cli_command_tag__still_filters(
+    fake_basic_hint,
+    fake_error_event_with_status_code_401,
+):
+    tested = filter_by_response_status_code.FilterByResponseStatusCode(
+        status_codes_to_drop=[401]
+    )
+
+    event_without_tag = {**fake_error_event_with_status_code_401, "tags": {}}
+
+    assert tested.process_event(event_without_tag, fake_basic_hint) is False


### PR DESCRIPTION
## Details

Updates the Sentry DSN and adds comprehensive error reporting for the `opik connect` / `opik endpoint` CLI commands.

**Sentry reporting in `_run.py`:**
- All exception types (`ApiError`, `ConnectError`, `OSError`, `ClickException`, unexpected errors) are now captured via `sentry_sdk.capture_exception()`
- Each event is tagged with `cli_command: opik-connect` (or `opik-endpoint`) for filtering
- Each event gets an `error_type` tag and a `cli_error` context block with structured details (message, status_code, url) for fast triage

**Filter bypass for CLI events:**
- The existing `FilterByResponseStatusCode` (which drops HTTP 400-403) is bypassed when the `cli_command` tag is present, giving full visibility into CLI user pain points

**Tag is set on the global scope** (not `push_scope`) so background threads (heartbeat, bridge-poll, file-watcher) also inherit it. Safe because the CLI process runs one command and exits.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- NA

## Testing
- Unit tests added for the status code filter bypass (`cli_command` tag present → filter skipped, absent → filter applies)
- Manually tested against dev backend: triggered `ClickException` (non-existent project) and `ConnectError` (dead host) — both appeared in Sentry with correct tags and context

## Documentation
N/A