### PR TITLE
[OPIK-5692] [BE][FE] feat: add agent config & runner analytics events

### DIFF
--- a/.agents/skills/analytics-instrumentation/SKILL.md
+++ b/.agents/skills/analytics-instrumentation/SKILL.md
@@ -91,9 +91,9 @@ PostHog native:          Browser → posthog-js → PostHog (pageviews, feature 
 
 ## Event Property Conventions
 
-- **`_id` suffix → UUIDs only**: Properties ending in `_id` (e.g. `project_id`, `blueprint_id`) must contain UUID strings. Never pass a human-readable name into an `_id` field.
-- **`_name` suffix → human-readable text**: Properties ending in `_name` (e.g. `agent_name`, `blueprint_name`) hold display names.
-- **Don't mix identifiers**: If a code path has a name but not a UUID (or vice versa), use separate properties with the correct suffix and leave the unavailable one as an empty string. Don't reuse a single property for both.
+- **Consistent typing per property**: A given property key should always carry the same kind of value. Don't pass a UUID in one code path and a human-readable name in another for the same key.
+- **Separate ID and name properties**: When both a UUID and a display name exist, use distinct keys (e.g. `blueprint_id` for the UUID, `blueprint_name` for the display name). If one is unavailable in a code path, omit the key or send an empty string — don't repurpose the other key.
+- **Include `workspace_id`**: All backend analytics events should include the workspace ID for segmentation.
 
 ## Deciding Frontend vs Backend
 

--- a/.agents/skills/analytics-instrumentation/SKILL.md
+++ b/.agents/skills/analytics-instrumentation/SKILL.md
@@ -59,7 +59,7 @@ private final @NonNull AnalyticsService analyticsService;
 
 2. Call `trackEvent`:
 ```java
-analyticsService.trackEvent("onboarding_first_trace",
+analyticsService.trackEvent("opik_onboarding_first_trace",
     Map.of("trace_id", traceId, "project_id", projectId));
 ```
 
@@ -88,6 +88,12 @@ Frontend custom events:  Browser → Segment → PostHog
 Backend events:          Java → comet-stats → Segment → PostHog
 PostHog native:          Browser → posthog-js → PostHog (pageviews, feature flags, identification)
 ```
+
+## Event Property Conventions
+
+- **`_id` suffix → UUIDs only**: Properties ending in `_id` (e.g. `project_id`, `blueprint_id`) must contain UUID strings. Never pass a human-readable name into an `_id` field.
+- **`_name` suffix → human-readable text**: Properties ending in `_name` (e.g. `agent_name`, `blueprint_name`) hold display names.
+- **Don't mix identifiers**: If a code path has a name but not a UUID (or vice versa), use separate properties with the correct suffix and leave the unavailable one as an empty string. Don't reuse a single property for both.
 
 ## Deciding Frontend vs Backend
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResource.java
@@ -361,12 +361,12 @@ public class AgentConfigsResource {
 
     private void trackAgentConfigSaved(AgentBlueprint blueprint) {
         try {
-            analyticsService.trackEvent("agent_config_saved", Map.of(
+            analyticsService.trackEvent("opik_agent_config_saved", Map.of(
                     "project_id", String.valueOf(blueprint.projectId()),
                     "blueprint_id", blueprint.id().toString(),
                     "blueprint_name", String.valueOf(blueprint.name())));
         } catch (Exception e) {
-            log.warn("Failed to track agent_config_saved analytics event for blueprint '{}'",
+            log.warn("Failed to track opik_agent_config_saved analytics event for blueprint '{}'",
                     blueprint.id(), e);
         }
     }
@@ -382,24 +382,26 @@ public class AgentConfigsResource {
         var deployedToProd = request.envs().stream()
                 .anyMatch(env -> "prod".equalsIgnoreCase(env.envName()));
 
-        trackAgentConfigDeployedEvent(request.projectId(), envNames, blueprintIds, deployedToProd);
+        trackAgentConfigDeployedEvent(request.projectId(), envNames, blueprintIds, "",
+                deployedToProd);
     }
 
     private void trackAgentConfigDeployedByName(UUID projectId, String envName, String blueprintName) {
-        trackAgentConfigDeployedEvent(projectId, envName, blueprintName,
+        trackAgentConfigDeployedEvent(projectId, envName, "", blueprintName,
                 "prod".equalsIgnoreCase(envName));
     }
 
     private void trackAgentConfigDeployedEvent(UUID projectId, String environments,
-            String blueprintIdentifier, boolean deployedToProd) {
+            String blueprintIds, String blueprintName, boolean deployedToProd) {
         try {
-            analyticsService.trackEvent("agent_config_deployed", Map.of(
+            analyticsService.trackEvent("opik_agent_config_deployed", Map.of(
                     "project_id", projectId.toString(),
-                    "blueprint_id", blueprintIdentifier,
+                    "blueprint_id", blueprintIds,
+                    "blueprint_name", blueprintName,
                     "environments", environments,
                     "deployed_to_prod", String.valueOf(deployedToProd)));
         } catch (Exception e) {
-            log.warn("Failed to track agent_config_deployed analytics event for project '{}'",
+            log.warn("Failed to track opik_agent_config_deployed analytics event for project '{}'",
                     projectId, e);
         }
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResource.java
@@ -9,8 +9,6 @@ import com.comet.opik.api.error.ErrorMessage;
 import com.comet.opik.domain.AgentBlueprint;
 import com.comet.opik.domain.AgentConfig;
 import com.comet.opik.domain.AgentConfigService;
-import com.comet.opik.infrastructure.auth.RequestContext;
-import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.fasterxml.jackson.annotation.JsonView;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -20,7 +18,6 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -44,7 +41,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.URI;
-import java.util.Map;
 import java.util.UUID;
 
 @Path("/v1/private/agent-configs")
@@ -57,8 +53,6 @@ import java.util.UUID;
 public class AgentConfigsResource {
 
     private final @NonNull AgentConfigService agentConfigService;
-    private final @NonNull Provider<RequestContext> requestContext;
-    private final @NonNull AnalyticsService analyticsService;
 
     @POST
     @Path("/blueprints")
@@ -79,10 +73,6 @@ public class AgentConfigsResource {
         AgentBlueprint createdBlueprint = agentConfigService.createConfig(request).block();
 
         log.info("Created config with blueprint '{}' for project '{}'", createdBlueprint.id(), request.projectName());
-
-        trackAgentConfigSaved(createdBlueprint);
-        trackAgentConfigDeployedEvent(createdBlueprint.projectId(), "prod",
-                createdBlueprint.id().toString(), true);
 
         URI location = uriInfo.getAbsolutePathBuilder()
                 .path(createdBlueprint.id().toString())
@@ -176,8 +166,6 @@ public class AgentConfigsResource {
         AgentBlueprint blueprint = agentConfigService.updateConfig(request).block();
 
         log.info("Added blueprint '{}' to config for project '{}'", blueprint.id(), request.projectName());
-
-        trackAgentConfigSaved(blueprint);
 
         URI location = uriInfo.getAbsolutePathBuilder()
                 .path(blueprint.id().toString())
@@ -296,8 +284,6 @@ public class AgentConfigsResource {
 
         agentConfigService.createOrUpdateEnvs(request).block();
 
-        trackAgentConfigDeployed(request);
-
         return Response.noContent().build();
     }
 
@@ -317,8 +303,6 @@ public class AgentConfigsResource {
                 envName, request.blueprintName(), projectId);
 
         agentConfigService.setEnvByBlueprintName(projectId, envName, request.blueprintName()).block();
-
-        trackAgentConfigDeployedByName(projectId, envName, request.blueprintName());
 
         return Response.noContent().build();
     }
@@ -358,42 +342,5 @@ public class AgentConfigsResource {
         AgentBlueprint.BlueprintPage historyPage = agentConfigService.getHistory(projectId, page, size);
 
         return Response.ok(historyPage).build();
-    }
-
-    private void trackAgentConfigSaved(AgentBlueprint blueprint) {
-        String workspaceId = requestContext.get().getWorkspaceId();
-        analyticsService.trackEvent("opik_agent_config_saved", Map.of(
-                "workspace_id", workspaceId,
-                "project_id", String.valueOf(blueprint.projectId()),
-                "blueprint_id", blueprint.id().toString(),
-                "blueprint_name", String.valueOf(blueprint.name())));
-    }
-
-    private void trackAgentConfigDeployed(AgentConfigEnvUpdate request) {
-        for (var env : request.envs()) {
-            trackAgentConfigDeployedEvent(request.projectId(), env.envName(),
-                    env.blueprintId().toString(), "prod".equalsIgnoreCase(env.envName()));
-        }
-    }
-
-    private void trackAgentConfigDeployedByName(UUID projectId, String envName, String blueprintName) {
-        String workspaceId = requestContext.get().getWorkspaceId();
-        analyticsService.trackEvent("opik_agent_config_deployed", Map.of(
-                "workspace_id", workspaceId,
-                "project_id", projectId.toString(),
-                "blueprint_name", blueprintName,
-                "environment", envName,
-                "deployed_to_prod", String.valueOf("prod".equalsIgnoreCase(envName))));
-    }
-
-    private void trackAgentConfigDeployedEvent(UUID projectId, String envName,
-            String blueprintId, boolean deployedToProd) {
-        String workspaceId = requestContext.get().getWorkspaceId();
-        analyticsService.trackEvent("opik_agent_config_deployed", Map.of(
-                "workspace_id", workspaceId,
-                "project_id", projectId.toString(),
-                "blueprint_id", blueprintId,
-                "environment", envName,
-                "deployed_to_prod", String.valueOf(deployedToProd)));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResource.java
@@ -372,35 +372,31 @@ public class AgentConfigsResource {
     }
 
     private void trackAgentConfigDeployed(AgentConfigEnvUpdate request) {
-        try {
-            var envNames = request.envs().stream()
-                    .map(env -> env.envName())
-                    .collect(Collectors.joining(","));
-            var blueprintId = request.envs().stream()
-                    .findFirst()
-                    .map(env -> env.blueprintId().toString())
-                    .orElse("");
-            var deployedToProd = request.envs().stream()
-                    .anyMatch(env -> "prod".equalsIgnoreCase(env.envName()));
+        var envNames = request.envs().stream()
+                .map(env -> env.envName())
+                .collect(Collectors.joining(","));
+        var blueprintIds = request.envs().stream()
+                .map(env -> env.blueprintId().toString())
+                .distinct()
+                .collect(Collectors.joining(","));
+        var deployedToProd = request.envs().stream()
+                .anyMatch(env -> "prod".equalsIgnoreCase(env.envName()));
 
-            analyticsService.trackEvent("agent_config_deployed", Map.of(
-                    "project_id", request.projectId().toString(),
-                    "blueprint_id", blueprintId,
-                    "environments", envNames,
-                    "deployed_to_prod", String.valueOf(deployedToProd)));
-        } catch (Exception e) {
-            log.warn("Failed to track agent_config_deployed analytics event for project '{}'",
-                    request.projectId(), e);
-        }
+        trackAgentConfigDeployedEvent(request.projectId(), envNames, blueprintIds, deployedToProd);
     }
 
     private void trackAgentConfigDeployedByName(UUID projectId, String envName, String blueprintName) {
+        trackAgentConfigDeployedEvent(projectId, envName, blueprintName,
+                "prod".equalsIgnoreCase(envName));
+    }
+
+    private void trackAgentConfigDeployedEvent(UUID projectId, String environments,
+            String blueprintIdentifier, boolean deployedToProd) {
         try {
-            var deployedToProd = "prod".equalsIgnoreCase(envName);
             analyticsService.trackEvent("agent_config_deployed", Map.of(
                     "project_id", projectId.toString(),
-                    "blueprint_name", blueprintName,
-                    "environments", envName,
+                    "blueprint_id", blueprintIdentifier,
+                    "environments", environments,
                     "deployed_to_prod", String.valueOf(deployedToProd)));
         } catch (Exception e) {
             log.warn("Failed to track agent_config_deployed analytics event for project '{}'",

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResource.java
@@ -10,6 +10,7 @@ import com.comet.opik.domain.AgentBlueprint;
 import com.comet.opik.domain.AgentConfig;
 import com.comet.opik.domain.AgentConfigService;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.fasterxml.jackson.annotation.JsonView;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -43,7 +44,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.URI;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Path("/v1/private/agent-configs")
 @Consumes(MediaType.APPLICATION_JSON)
@@ -56,6 +59,7 @@ public class AgentConfigsResource {
 
     private final @NonNull AgentConfigService agentConfigService;
     private final @NonNull Provider<RequestContext> requestContext;
+    private final @NonNull AnalyticsService analyticsService;
 
     @POST
     @Path("/blueprints")
@@ -76,6 +80,8 @@ public class AgentConfigsResource {
         AgentBlueprint createdBlueprint = agentConfigService.createConfig(request).block();
 
         log.info("Created config with blueprint '{}' for project '{}'", createdBlueprint.id(), request.projectName());
+
+        trackAgentConfigSaved(createdBlueprint);
 
         URI location = uriInfo.getAbsolutePathBuilder()
                 .path(createdBlueprint.id().toString())
@@ -169,6 +175,8 @@ public class AgentConfigsResource {
         AgentBlueprint blueprint = agentConfigService.updateConfig(request).block();
 
         log.info("Added blueprint '{}' to config for project '{}'", blueprint.id(), request.projectName());
+
+        trackAgentConfigSaved(blueprint);
 
         URI location = uriInfo.getAbsolutePathBuilder()
                 .path(blueprint.id().toString())
@@ -287,6 +295,8 @@ public class AgentConfigsResource {
 
         agentConfigService.createOrUpdateEnvs(request).block();
 
+        trackAgentConfigDeployed(request);
+
         return Response.noContent().build();
     }
 
@@ -306,6 +316,8 @@ public class AgentConfigsResource {
                 envName, request.blueprintName(), projectId);
 
         agentConfigService.setEnvByBlueprintName(projectId, envName, request.blueprintName()).block();
+
+        trackAgentConfigDeployedByName(projectId, envName, request.blueprintName());
 
         return Response.noContent().build();
     }
@@ -345,5 +357,54 @@ public class AgentConfigsResource {
         AgentBlueprint.BlueprintPage historyPage = agentConfigService.getHistory(projectId, page, size);
 
         return Response.ok(historyPage).build();
+    }
+
+    private void trackAgentConfigSaved(AgentBlueprint blueprint) {
+        try {
+            analyticsService.trackEvent("agent_config_saved", Map.of(
+                    "project_id", String.valueOf(blueprint.projectId()),
+                    "blueprint_id", blueprint.id().toString(),
+                    "blueprint_name", String.valueOf(blueprint.name())));
+        } catch (Exception e) {
+            log.warn("Failed to track agent_config_saved analytics event for blueprint '{}'",
+                    blueprint.id(), e);
+        }
+    }
+
+    private void trackAgentConfigDeployed(AgentConfigEnvUpdate request) {
+        try {
+            var envNames = request.envs().stream()
+                    .map(env -> env.envName())
+                    .collect(Collectors.joining(","));
+            var blueprintId = request.envs().stream()
+                    .findFirst()
+                    .map(env -> env.blueprintId().toString())
+                    .orElse("");
+            var deployedToProd = request.envs().stream()
+                    .anyMatch(env -> "prod".equalsIgnoreCase(env.envName()));
+
+            analyticsService.trackEvent("agent_config_deployed", Map.of(
+                    "project_id", request.projectId().toString(),
+                    "blueprint_id", blueprintId,
+                    "environments", envNames,
+                    "deployed_to_prod", String.valueOf(deployedToProd)));
+        } catch (Exception e) {
+            log.warn("Failed to track agent_config_deployed analytics event for project '{}'",
+                    request.projectId(), e);
+        }
+    }
+
+    private void trackAgentConfigDeployedByName(UUID projectId, String envName, String blueprintName) {
+        try {
+            var deployedToProd = "prod".equalsIgnoreCase(envName);
+            analyticsService.trackEvent("agent_config_deployed", Map.of(
+                    "project_id", projectId.toString(),
+                    "blueprint_name", blueprintName,
+                    "environments", envName,
+                    "deployed_to_prod", String.valueOf(deployedToProd)));
+        } catch (Exception e) {
+            log.warn("Failed to track agent_config_deployed analytics event for project '{}'",
+                    projectId, e);
+        }
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResource.java
@@ -46,7 +46,6 @@ import lombok.extern.slf4j.Slf4j;
 import java.net.URI;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Path("/v1/private/agent-configs")
 @Consumes(MediaType.APPLICATION_JSON)
@@ -82,6 +81,8 @@ public class AgentConfigsResource {
         log.info("Created config with blueprint '{}' for project '{}'", createdBlueprint.id(), request.projectName());
 
         trackAgentConfigSaved(createdBlueprint);
+        trackAgentConfigDeployedEvent(createdBlueprint.projectId(), "prod",
+                createdBlueprint.id().toString(), true);
 
         URI location = uriInfo.getAbsolutePathBuilder()
                 .path(createdBlueprint.id().toString())
@@ -360,49 +361,39 @@ public class AgentConfigsResource {
     }
 
     private void trackAgentConfigSaved(AgentBlueprint blueprint) {
-        try {
-            analyticsService.trackEvent("opik_agent_config_saved", Map.of(
-                    "project_id", String.valueOf(blueprint.projectId()),
-                    "blueprint_id", blueprint.id().toString(),
-                    "blueprint_name", String.valueOf(blueprint.name())));
-        } catch (Exception e) {
-            log.warn("Failed to track opik_agent_config_saved analytics event for blueprint '{}'",
-                    blueprint.id(), e);
-        }
+        String workspaceId = requestContext.get().getWorkspaceId();
+        analyticsService.trackEvent("opik_agent_config_saved", Map.of(
+                "workspace_id", workspaceId,
+                "project_id", String.valueOf(blueprint.projectId()),
+                "blueprint_id", blueprint.id().toString(),
+                "blueprint_name", String.valueOf(blueprint.name())));
     }
 
     private void trackAgentConfigDeployed(AgentConfigEnvUpdate request) {
-        var envNames = request.envs().stream()
-                .map(env -> env.envName())
-                .collect(Collectors.joining(","));
-        var blueprintIds = request.envs().stream()
-                .map(env -> env.blueprintId().toString())
-                .distinct()
-                .collect(Collectors.joining(","));
-        var deployedToProd = request.envs().stream()
-                .anyMatch(env -> "prod".equalsIgnoreCase(env.envName()));
-
-        trackAgentConfigDeployedEvent(request.projectId(), envNames, blueprintIds, "",
-                deployedToProd);
+        for (var env : request.envs()) {
+            trackAgentConfigDeployedEvent(request.projectId(), env.envName(),
+                    env.blueprintId().toString(), "prod".equalsIgnoreCase(env.envName()));
+        }
     }
 
     private void trackAgentConfigDeployedByName(UUID projectId, String envName, String blueprintName) {
-        trackAgentConfigDeployedEvent(projectId, envName, "", blueprintName,
-                "prod".equalsIgnoreCase(envName));
+        String workspaceId = requestContext.get().getWorkspaceId();
+        analyticsService.trackEvent("opik_agent_config_deployed", Map.of(
+                "workspace_id", workspaceId,
+                "project_id", projectId.toString(),
+                "blueprint_name", blueprintName,
+                "environment", envName,
+                "deployed_to_prod", String.valueOf("prod".equalsIgnoreCase(envName))));
     }
 
-    private void trackAgentConfigDeployedEvent(UUID projectId, String environments,
-            String blueprintIds, String blueprintName, boolean deployedToProd) {
-        try {
-            analyticsService.trackEvent("opik_agent_config_deployed", Map.of(
-                    "project_id", projectId.toString(),
-                    "blueprint_id", blueprintIds,
-                    "blueprint_name", blueprintName,
-                    "environments", environments,
-                    "deployed_to_prod", String.valueOf(deployedToProd)));
-        } catch (Exception e) {
-            log.warn("Failed to track opik_agent_config_deployed analytics event for project '{}'",
-                    projectId, e);
-        }
+    private void trackAgentConfigDeployedEvent(UUID projectId, String envName,
+            String blueprintId, boolean deployedToProd) {
+        String workspaceId = requestContext.get().getWorkspaceId();
+        analyticsService.trackEvent("opik_agent_config_deployed", Map.of(
+                "workspace_id", workspaceId,
+                "project_id", projectId.toString(),
+                "blueprint_id", blueprintId,
+                "environment", envName,
+                "deployed_to_prod", String.valueOf(deployedToProd)));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResource.java
@@ -21,7 +21,6 @@ import com.comet.opik.domain.EndpointJobService;
 import com.comet.opik.domain.RunnerService;
 import com.comet.opik.infrastructure.LocalRunnerConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
-import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.infrastructure.ratelimit.RateLimited;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
@@ -79,7 +78,6 @@ public class LocalRunnersResource {
     private final @NonNull EndpointJobService endpointJobService;
     private final @NonNull ConnectBridgeService connectBridgeService;
     private final @NonNull LocalRunnerConfig runnerConfig;
-    private final @NonNull AnalyticsService analyticsService;
 
     @GET
     @Operation(operationId = "listRunners", summary = "List local runners", description = "List local runners owned by the current user in the workspace", responses = {
@@ -183,12 +181,6 @@ public class LocalRunnersResource {
         String workspaceId = requestContext.get().getWorkspaceId();
         String userName = requestContext.get().getUserName();
         UUID jobId = endpointJobService.createJob(workspaceId, userName, request);
-
-        analyticsService.trackEvent("opik_sandbox_job_created", Map.of(
-                "workspace_id", workspaceId,
-                "project_id", request.projectId().toString(),
-                "job_id", jobId.toString(),
-                "agent_name", request.agentName()));
 
         var uri = uriInfo.getAbsolutePathBuilder().path("/{jobId}").build(jobId);
         return Response.created(uri).build();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResource.java
@@ -184,14 +184,11 @@ public class LocalRunnersResource {
         String userName = requestContext.get().getUserName();
         UUID jobId = endpointJobService.createJob(workspaceId, userName, request);
 
-        try {
-            analyticsService.trackEvent("opik_sandbox_job_created", Map.of(
-                    "project_id", request.projectId().toString(),
-                    "job_id", jobId.toString(),
-                    "agent_name", request.agentName()));
-        } catch (Exception e) {
-            log.warn("Failed to track opik_sandbox_job_created analytics event for job '{}'", jobId, e);
-        }
+        analyticsService.trackEvent("opik_sandbox_job_created", Map.of(
+                "workspace_id", workspaceId,
+                "project_id", request.projectId().toString(),
+                "job_id", jobId.toString(),
+                "agent_name", request.agentName()));
 
         var uri = uriInfo.getAbsolutePathBuilder().path("/{jobId}").build(jobId);
         return Response.created(uri).build();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResource.java
@@ -21,6 +21,7 @@ import com.comet.opik.domain.EndpointJobService;
 import com.comet.opik.domain.RunnerService;
 import com.comet.opik.infrastructure.LocalRunnerConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.infrastructure.ratelimit.RateLimited;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
@@ -78,6 +79,7 @@ public class LocalRunnersResource {
     private final @NonNull EndpointJobService endpointJobService;
     private final @NonNull ConnectBridgeService connectBridgeService;
     private final @NonNull LocalRunnerConfig runnerConfig;
+    private final @NonNull AnalyticsService analyticsService;
 
     @GET
     @Operation(operationId = "listRunners", summary = "List local runners", description = "List local runners owned by the current user in the workspace", responses = {
@@ -181,6 +183,16 @@ public class LocalRunnersResource {
         String workspaceId = requestContext.get().getWorkspaceId();
         String userName = requestContext.get().getUserName();
         UUID jobId = endpointJobService.createJob(workspaceId, userName, request);
+
+        try {
+            analyticsService.trackEvent("sandbox_job_created", Map.of(
+                    "project_id", request.projectId().toString(),
+                    "job_id", jobId.toString(),
+                    "agent_name", request.agentName()));
+        } catch (Exception e) {
+            log.warn("Failed to track sandbox_job_created analytics event for job '{}'", jobId, e);
+        }
+
         var uri = uriInfo.getAbsolutePathBuilder().path("/{jobId}").build(jobId);
         return Response.created(uri).build();
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LocalRunnersResource.java
@@ -185,12 +185,12 @@ public class LocalRunnersResource {
         UUID jobId = endpointJobService.createJob(workspaceId, userName, request);
 
         try {
-            analyticsService.trackEvent("sandbox_job_created", Map.of(
+            analyticsService.trackEvent("opik_sandbox_job_created", Map.of(
                     "project_id", request.projectId().toString(),
                     "job_id", jobId.toString(),
                     "agent_name", request.agentName()));
         } catch (Exception e) {
-            log.warn("Failed to track sandbox_job_created analytics event for job '{}'", jobId, e);
+            log.warn("Failed to track opik_sandbox_job_created analytics event for job '{}'", jobId, e);
         }
 
         var uri = uriInfo.getAbsolutePathBuilder().path("/{jobId}").build(jobId);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
@@ -129,12 +129,12 @@ class AgentConfigServiceImpl implements AgentConfigService {
 
                             return blueprint;
                         })).subscribeOn(Schedulers.boundedElastic()),
-                        agentConfigConfiguration.getBlueprintLockDuration().toJavaDuration()))
-                .doOnNext(blueprint -> {
-                    trackAgentConfigSaved(workspaceId, blueprint);
-                    trackAgentConfigDeployed(workspaceId, blueprint.projectId(),
-                            blueprint.id(), String.valueOf(blueprint.name()), "prod");
-                });
+                        agentConfigConfiguration.getBlueprintLockDuration().toJavaDuration())
+                        .doOnNext(blueprint -> {
+                            trackAgentConfigSaved(workspaceId, projectId, blueprint);
+                            trackAgentConfigDeployed(workspaceId, projectId,
+                                    blueprint.id(), String.valueOf(blueprint.name()), "prod");
+                        }));
     }
 
     @Override
@@ -162,8 +162,8 @@ class AgentConfigServiceImpl implements AgentConfigService {
                             return createBlueprint(dao, request, existingConfig.id(), projectId, workspaceId,
                                     userName);
                         })).subscribeOn(Schedulers.boundedElastic()),
-                        agentConfigConfiguration.getBlueprintLockDuration().toJavaDuration()))
-                .doOnNext(blueprint -> trackAgentConfigSaved(workspaceId, blueprint));
+                        agentConfigConfiguration.getBlueprintLockDuration().toJavaDuration())
+                        .doOnNext(blueprint -> trackAgentConfigSaved(workspaceId, projectId, blueprint)));
     }
 
     @Override
@@ -694,10 +694,10 @@ class AgentConfigServiceImpl implements AgentConfigService {
         return updateConfig(request);
     }
 
-    private void trackAgentConfigSaved(String workspaceId, AgentBlueprint blueprint) {
+    private void trackAgentConfigSaved(String workspaceId, UUID projectId, AgentBlueprint blueprint) {
         analyticsService.trackEvent("opik_agent_config_saved", Map.of(
                 "workspace_id", workspaceId,
-                "project_id", String.valueOf(blueprint.projectId()),
+                "project_id", projectId.toString(),
                 "blueprint_id", blueprint.id().toString(),
                 "blueprint_name", String.valueOf(blueprint.name())));
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
@@ -7,6 +7,7 @@ import com.comet.opik.api.Project;
 import com.comet.opik.api.error.ErrorMessage;
 import com.comet.opik.api.validation.HasProjectIdentifier;
 import com.comet.opik.infrastructure.AgentConfigConfiguration;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.infrastructure.lock.LockService;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.WorkspaceUtils;
@@ -82,6 +83,7 @@ class AgentConfigServiceImpl implements AgentConfigService {
     private final @NonNull ProjectService projectService;
     private final @NonNull LockService lockService;
     private final @NonNull AgentConfigConfiguration agentConfigConfiguration;
+    private final @NonNull AnalyticsService analyticsService;
 
     @Override
     public Mono<AgentBlueprint> createConfig(@NonNull AgentConfigCreate request) {
@@ -127,7 +129,12 @@ class AgentConfigServiceImpl implements AgentConfigService {
 
                             return blueprint;
                         })).subscribeOn(Schedulers.boundedElastic()),
-                        agentConfigConfiguration.getBlueprintLockDuration().toJavaDuration()));
+                        agentConfigConfiguration.getBlueprintLockDuration().toJavaDuration()))
+                .doOnNext(blueprint -> {
+                    trackAgentConfigSaved(workspaceId, blueprint);
+                    trackAgentConfigDeployed(workspaceId, blueprint.projectId(),
+                            blueprint.id(), String.valueOf(blueprint.name()), "prod");
+                });
     }
 
     @Override
@@ -155,7 +162,8 @@ class AgentConfigServiceImpl implements AgentConfigService {
                             return createBlueprint(dao, request, existingConfig.id(), projectId, workspaceId,
                                     userName);
                         })).subscribeOn(Schedulers.boundedElastic()),
-                        agentConfigConfiguration.getBlueprintLockDuration().toJavaDuration()));
+                        agentConfigConfiguration.getBlueprintLockDuration().toJavaDuration()))
+                .doOnNext(blueprint -> trackAgentConfigSaved(workspaceId, blueprint));
     }
 
     @Override
@@ -494,7 +502,13 @@ class AgentConfigServiceImpl implements AgentConfigService {
                     upsertEnvs(dao, workspaceId, projectId, userName, request.envs());
 
                     return null;
-                })).subscribeOn(Schedulers.boundedElastic()));
+                })).subscribeOn(Schedulers.boundedElastic()))
+                .doOnSuccess(v -> {
+                    for (var env : request.envs()) {
+                        trackAgentConfigDeployed(workspaceId, projectId,
+                                env.blueprintId(), "", env.envName());
+                    }
+                });
     }
 
     @Override
@@ -506,9 +520,9 @@ class AgentConfigServiceImpl implements AgentConfigService {
         log.info("Setting environment '{}' to blueprint '{}' for project '{}' in workspace '{}'",
                 envName, blueprintName, projectId, workspaceId);
 
-        return lockService.<Void>executeWithLock(
+        return lockService.<UUID>executeWithLock(
                 new LockService.Lock(ENV_LOCK_FORMAT.formatted(workspaceId, projectId)),
-                Mono.<Void>fromRunnable(() -> transactionTemplate.inTransaction(WRITE, handle -> {
+                Mono.fromCallable(() -> transactionTemplate.inTransaction(WRITE, handle -> {
                     AgentConfigDAO dao = handle.attach(AgentConfigDAO.class);
 
                     AgentBlueprint blueprint = requireBlueprintByName(dao, workspaceId, projectId, blueprintName);
@@ -519,8 +533,11 @@ class AgentConfigServiceImpl implements AgentConfigService {
                                     .blueprintId(blueprint.id())
                                     .build()));
 
-                    return null;
-                })).subscribeOn(Schedulers.boundedElastic()));
+                    return blueprint.id();
+                })).subscribeOn(Schedulers.boundedElastic()))
+                .doOnNext(blueprintId -> trackAgentConfigDeployed(workspaceId, projectId,
+                        blueprintId, blueprintName, envName))
+                .then();
     }
 
     private void upsertEnvs(AgentConfigDAO dao, String workspaceId, UUID projectId, String userName,
@@ -675,5 +692,24 @@ class AgentConfigServiceImpl implements AgentConfigService {
                 .build();
 
         return updateConfig(request);
+    }
+
+    private void trackAgentConfigSaved(String workspaceId, AgentBlueprint blueprint) {
+        analyticsService.trackEvent("opik_agent_config_saved", Map.of(
+                "workspace_id", workspaceId,
+                "project_id", String.valueOf(blueprint.projectId()),
+                "blueprint_id", blueprint.id().toString(),
+                "blueprint_name", String.valueOf(blueprint.name())));
+    }
+
+    private void trackAgentConfigDeployed(String workspaceId, UUID projectId,
+            UUID blueprintId, String blueprintName, String envName) {
+        analyticsService.trackEvent("opik_agent_config_deployed", Map.of(
+                "workspace_id", workspaceId,
+                "project_id", projectId.toString(),
+                "blueprint_id", blueprintId.toString(),
+                "blueprint_name", blueprintName,
+                "environment", envName,
+                "deployed_to_prod", String.valueOf("prod".equalsIgnoreCase(envName))));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EndpointJobService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EndpointJobService.java
@@ -10,6 +10,7 @@ import com.comet.opik.api.runner.LocalRunnerJobStatus;
 import com.comet.opik.api.runner.LocalRunnerLogEntry;
 import com.comet.opik.api.runner.RunnerType;
 import com.comet.opik.infrastructure.LocalRunnerConfig;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.infrastructure.redis.StringRedisClient;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -130,16 +131,18 @@ class EndpointJobServiceImpl implements EndpointJobService {
     private final @NonNull IdGenerator idGenerator;
     private final @NonNull RunnerService runnerService;
     private final @NonNull LocalRunnerConfig runnerConfig;
+    private final @NonNull AnalyticsService analyticsService;
 
     @Inject
     EndpointJobServiceImpl(@NonNull StringRedisClient redisClient, @NonNull RedissonReactiveClient reactiveRedisClient,
             @NonNull IdGenerator idGenerator, @NonNull RunnerService runnerService,
-            @NonNull LocalRunnerConfig runnerConfig) {
+            @NonNull LocalRunnerConfig runnerConfig, @NonNull AnalyticsService analyticsService) {
         this.redisClient = redisClient;
         this.reactiveRedisClient = reactiveRedisClient;
         this.idGenerator = idGenerator;
         this.runnerService = runnerService;
         this.runnerConfig = runnerConfig;
+        this.analyticsService = analyticsService;
     }
 
     @Override
@@ -238,6 +241,12 @@ class EndpointJobServiceImpl implements EndpointJobService {
         pendingJobs.add(jobId.toString());
         RScoredSortedSet<String> runnerJobs = redisClient.getScoredSortedSet(runnerJobsKey(runnerId));
         runnerJobs.add(Instant.now().toEpochMilli(), jobId.toString());
+
+        analyticsService.trackEvent("opik_sandbox_job_created", Map.of(
+                "workspace_id", workspaceId,
+                "project_id", request.projectId().toString(),
+                "job_id", jobId.toString(),
+                "agent_name", request.agentName()));
 
         return jobId;
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/LocalRunnerReaperIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/LocalRunnerReaperIntegrationTest.java
@@ -9,6 +9,7 @@ import com.comet.opik.api.runner.LocalRunnerJobStatus;
 import com.comet.opik.api.runner.RunnerType;
 import com.comet.opik.infrastructure.LocalRunnerConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.infrastructure.redis.StringRedisClient;
 import com.redis.testcontainers.RedisContainer;
 import io.dropwizard.util.Duration;
@@ -95,7 +96,7 @@ class LocalRunnerReaperIntegrationTest {
         runnerService = new RunnerServiceImpl(stringRedis, idGenerator, projectService, runnerConfig,
                 () -> endpointJobService, () -> connectBridgeService, () -> requestContext);
         endpointJobService = new EndpointJobServiceImpl(stringRedis, redisClient.reactive(), idGenerator,
-                runnerService, runnerConfig);
+                runnerService, runnerConfig, Mockito.mock(AnalyticsService.class));
     }
 
     @BeforeEach

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/LocalRunnerServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/LocalRunnerServiceImplTest.java
@@ -18,6 +18,7 @@ import com.comet.opik.api.runner.LocalRunnerLogEntry;
 import com.comet.opik.api.runner.RunnerType;
 import com.comet.opik.infrastructure.LocalRunnerConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.infrastructure.redis.StringRedisClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -112,7 +113,7 @@ class LocalRunnerServiceImplTest {
         runnerService = new RunnerServiceImpl(stringRedis, idGenerator, projectService, runnerConfig,
                 () -> endpointJobService, () -> connectBridgeService, () -> requestContext);
         endpointJobService = new EndpointJobServiceImpl(stringRedis, redisClient.reactive(), idGenerator,
-                runnerService, runnerConfig);
+                runnerService, runnerConfig, Mockito.mock(AnalyticsService.class));
         connectBridgeService = new ConnectBridgeServiceImpl(stringRedis, idGenerator, runnerService, runnerConfig);
     }
 

--- a/apps/opik-frontend/package-lock.json
+++ b/apps/opik-frontend/package-lock.json
@@ -233,7 +233,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
       "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -880,8 +879,7 @@
     "node_modules/@codemirror/state": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
-      "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==",
-      "peer": true
+      "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A=="
     },
     "node_modules/@codemirror/theme-one-dark": {
       "version": "6.1.2",
@@ -898,7 +896,6 @@
       "version": "6.28.4",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.28.4.tgz",
       "integrity": "sha512-QScv95fiviSQ/CaVGflxAvvvDy/9wi0RFyDl4LkHHWiMr/UPebyuTspmYSeN5Nx6eujcPYwsQzA6ZIZucKZVHQ==",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.4.0",
         "style-mod": "^4.1.0",
@@ -919,7 +916,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -941,7 +937,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -1006,7 +1001,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -2076,7 +2070,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6418,7 +6411,6 @@
       "version": "5.45.0",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.45.0.tgz",
       "integrity": "sha512-y272cKRJp1BvehrWG4ashOBuqBj1Qm2O6fgYJ9LYSHrLdsCXl74GbSVjUQTReUdHuRIl9cEOoyPa6HYag400lw==",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.45.0"
       },
@@ -6451,7 +6443,6 @@
       "version": "1.36.3",
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.36.3.tgz",
       "integrity": "sha512-587W8jYCUtK9HsPSkmSbxm9VHH+ullmAT/ttOIbMjqhKLg9Sb30Gg6NxzGlzxRSF0t6QSy28wt+4ChPREVizFA==",
-      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.31.16",
         "@tanstack/react-store": "^0.2.1",
@@ -7145,7 +7136,6 @@
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -7156,7 +7146,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -7272,7 +7261,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -7720,7 +7708,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8206,7 +8193,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001629",
         "electron-to-chromium": "^1.4.796",
@@ -8412,7 +8398,6 @@
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
       "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -9176,14 +9161,12 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "peer": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/cytoscape": {
       "version": "3.30.4",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.30.4.tgz",
       "integrity": "sha512-OxtlZwQl1WbwMmLiyPSEBuzeTIQnwZhJYYWFzZ2PhEHVFwpeaqNIkUzSiso00D98qk60l8Gwon2RP304d3BJ1A==",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -9558,7 +9541,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9701,7 +9683,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -10401,7 +10382,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10457,7 +10437,6 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11386,7 +11365,6 @@
       "integrity": "sha512-VQe+Q5CYiGOgcCERXhcfNsbnrN92FDEKciMH/x6LppU9dd0j4aTjCTlqONFOIMcAm/5JxS3+utowbXV1OoFr+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -12417,7 +12395,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -12686,8 +12663,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
       "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lint-staged": {
       "version": "15.2.7",
@@ -14891,7 +14867,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -15076,7 +15051,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -15141,7 +15115,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
       "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -15305,7 +15278,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -15330,7 +15302,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -15399,7 +15370,6 @@
       "version": "7.54.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
       "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -16049,7 +16019,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.4.tgz",
       "integrity": "sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -16187,7 +16156,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.5.tgz",
       "integrity": "sha512-oDfX1mukIlxacPdQqNb6mV2tVCrnE+P3nVYioy72V5tlk56CPNcO4TCuFcaCRKKfJ1M3lH95CleRS+dVKL2qMg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -16627,7 +16595,6 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^2.7.1",
         "@csstools/css-tokenizer": "^2.4.1",
@@ -17020,7 +16987,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -17177,7 +17143,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17467,7 +17432,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17854,7 +17818,6 @@
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -18004,7 +17967,6 @@
       "integrity": "sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "3.0.5",
         "@vitest/mocker": "3.0.5",

--- a/apps/opik-frontend/package-lock.json
+++ b/apps/opik-frontend/package-lock.json
@@ -233,6 +233,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
       "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -879,7 +880,8 @@
     "node_modules/@codemirror/state": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
-      "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A=="
+      "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==",
+      "peer": true
     },
     "node_modules/@codemirror/theme-one-dark": {
       "version": "6.1.2",
@@ -896,6 +898,7 @@
       "version": "6.28.4",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.28.4.tgz",
       "integrity": "sha512-QScv95fiviSQ/CaVGflxAvvvDy/9wi0RFyDl4LkHHWiMr/UPebyuTspmYSeN5Nx6eujcPYwsQzA6ZIZucKZVHQ==",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.4.0",
         "style-mod": "^4.1.0",
@@ -916,6 +919,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -937,6 +941,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -1001,6 +1006,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -2070,6 +2076,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6411,6 +6418,7 @@
       "version": "5.45.0",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.45.0.tgz",
       "integrity": "sha512-y272cKRJp1BvehrWG4ashOBuqBj1Qm2O6fgYJ9LYSHrLdsCXl74GbSVjUQTReUdHuRIl9cEOoyPa6HYag400lw==",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.45.0"
       },
@@ -6443,6 +6451,7 @@
       "version": "1.36.3",
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.36.3.tgz",
       "integrity": "sha512-587W8jYCUtK9HsPSkmSbxm9VHH+ullmAT/ttOIbMjqhKLg9Sb30Gg6NxzGlzxRSF0t6QSy28wt+4ChPREVizFA==",
+      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.31.16",
         "@tanstack/react-store": "^0.2.1",
@@ -7136,6 +7145,7 @@
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -7146,6 +7156,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -7261,6 +7272,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -7708,6 +7720,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8193,6 +8206,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001629",
         "electron-to-chromium": "^1.4.796",
@@ -8398,6 +8412,7 @@
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
       "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -9161,12 +9176,14 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "peer": true
     },
     "node_modules/cytoscape": {
       "version": "3.30.4",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.30.4.tgz",
       "integrity": "sha512-OxtlZwQl1WbwMmLiyPSEBuzeTIQnwZhJYYWFzZ2PhEHVFwpeaqNIkUzSiso00D98qk60l8Gwon2RP304d3BJ1A==",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -9541,6 +9558,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9683,6 +9701,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -10382,6 +10401,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10437,6 +10457,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11365,6 +11386,7 @@
       "integrity": "sha512-VQe+Q5CYiGOgcCERXhcfNsbnrN92FDEKciMH/x6LppU9dd0j4aTjCTlqONFOIMcAm/5JxS3+utowbXV1OoFr+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -12395,6 +12417,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -12663,7 +12686,8 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
       "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lint-staged": {
       "version": "15.2.7",
@@ -14867,6 +14891,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -15051,6 +15076,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -15115,6 +15141,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
       "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -15278,6 +15305,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -15302,6 +15330,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -15370,6 +15399,7 @@
       "version": "7.54.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
       "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -16019,6 +16049,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.4.tgz",
       "integrity": "sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -16156,6 +16187,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.5.tgz",
       "integrity": "sha512-oDfX1mukIlxacPdQqNb6mV2tVCrnE+P3nVYioy72V5tlk56CPNcO4TCuFcaCRKKfJ1M3lH95CleRS+dVKL2qMg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -16595,6 +16627,7 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^2.7.1",
         "@csstools/css-tokenizer": "^2.4.1",
@@ -16987,6 +17020,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -17143,6 +17177,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17432,6 +17467,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "devOptional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17818,6 +17854,7 @@
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -17967,6 +18004,7 @@
       "integrity": "sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "3.0.5",
         "@vitest/mocker": "3.0.5",

--- a/apps/opik-frontend/src/lib/analytics/tracking.ts
+++ b/apps/opik-frontend/src/lib/analytics/tracking.ts
@@ -5,6 +5,7 @@ export const OpikEvent = {
   ONBOARDING_FIRST_TRACE_RECEIVED: "opik_onboarding_first_trace_received",
   ONBOARDING_SKIPPED: "opik_onboarding_skipped",
   EVAL_SUITE_UI_CONFIGURED: "opik_eval_suite_ui_configured",
+  AGENT_CONFIG_UI_DEPLOYED: "opik_agent_config_ui_deployed",
 } as const;
 
 type OpikEventValues = (typeof OpikEvent)[keyof typeof OpikEvent];

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/DeployToPopover.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/DeployToPopover.tsx
@@ -98,7 +98,7 @@ const DeployToPopover: React.FC<DeployToPopoverProps> = ({
       project_id: projectId,
       blueprint_id: item.id,
       environments: selectedStages,
-      deployed_to_prod: prodSelected,
+      deployed_to_prod: String(prodSelected),
       is_new_prod: isNewProd,
     });
 

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/DeployToPopover.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/DeployToPopover.tsx
@@ -17,6 +17,7 @@ import {
   isProdTag,
   isStageTag,
 } from "@/utils/agent-configurations";
+import { OpikEvent, trackEvent } from "@/lib/analytics/tracking";
 
 type DeployToPopoverProps = {
   item: ConfigHistoryItem;
@@ -92,6 +93,14 @@ const DeployToPopover: React.FC<DeployToPopoverProps> = ({
         },
       });
     }
+
+    trackEvent(OpikEvent.AGENT_CONFIG_UI_DEPLOYED, {
+      project_id: projectId,
+      blueprint_id: item.id,
+      environments: selectedStages,
+      deployed_to_prod: prodSelected,
+      is_new_prod: isNewProd,
+    });
 
     setOpen(false);
   };


### PR DESCRIPTION
## Details

Add PostHog instrumentation for Agent Configs and Sandbox Runner to track Opik 2.0 launch metrics defined in the parent epic OPIK-5245.

**Backend (3 events via `AnalyticsService`):** `opik_agent_config_saved` fires in `createAgentConfig()` and `updateAgentConfig()` to capture both UI and SDK config creation; `opik_agent_config_deployed` fires in `createOrUpdateEnvs()` and `setEnvByBlueprintName()` to capture all deployment paths; `opik_sandbox_job_created` fires in `createJob()` to capture runner adoption across UI and API.
**Frontend (1 event via `trackEvent()`):** `opik_agent_config_ui_deployed` fires from `DeployToPopover` with UI-specific context (`is_new_prod`) not available at the BE endpoint.

All BE calls wrapped in try/catch. User identity resolved automatically via the updated `AnalyticsService.resolveIdentity()`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5692

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-6
- Scope: full implementation
- Human verification: code review + manual testing on staging

## Testing

- Backend compiled cleanly: `cd apps/opik-backend && mvn compile -pl . -q` — zero errors
- Frontend type check passed: `tsc --project tsconfig.json --noEmit` — zero TS errors
- All pre-commit hooks passed: Spotless (Java formatting), ESLint, TypeScript typecheck, dependency cruiser (0 violations)
- `AgentConfigsResourceTest` and `LocalRunnersResourceTest` use Guice DI (`TestDropwizardAppExtension`) — `AnalyticsService` auto-injected via `@ImplementedBy`, no test changes needed
- Events will be validated on staging with `OPIK_ANALYTICS_ENABLED=true` and verified in PostHog

## Documentation

N/A — analytics events are internal instrumentation, no user-facing documentation changes needed.