### PR TITLE
[NA] [FE] Rename Agent sandbox to Agent playground and restructure sidebar

### DIFF
--- a/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
+++ b/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
@@ -63,9 +63,71 @@ const getMenuItems = ({
       ],
     },
     {
+      id: "development",
+      label: "Development",
+      items: [
+        {
+          id: "agent_runner",
+          path: projectPath("/agent-runner"),
+          type: MENU_ITEM_TYPE.router,
+          icon: GitBranch,
+          label: "Agent playground",
+          disabled: !projectPrefix,
+        },
+        ...(canUsePlayground
+          ? [
+              {
+                id: "playground",
+                path: projectPath("/playground"),
+                type: MENU_ITEM_TYPE.router as const,
+                icon: Blocks,
+                label: "Prompt playground",
+                disabled: !projectPrefix,
+              },
+            ]
+          : []),
+        {
+          id: "agent_configuration",
+          path: projectPath("/agent-configuration"),
+          type: MENU_ITEM_TYPE.router,
+          icon: Workflow,
+          label: "Agent configuration",
+          disabled: !projectPrefix,
+        },
+        {
+          id: "optimizations",
+          path: projectPath("/optimizations"),
+          type: MENU_ITEM_TYPE.router,
+          icon: Sparkles,
+          label: "Optimization runs",
+          disabled: !projectPrefix,
+        },
+      ],
+    },
+    {
       id: "evaluation",
       label: "Evaluation",
       items: [
+        ...(canViewDatasets
+          ? [
+              {
+                id: "test_suites",
+                path: projectPath("/test-suites"),
+                type: MENU_ITEM_TYPE.router as const,
+                icon: ListChecks,
+                label: "Test suites",
+                disabled: !projectPrefix,
+              },
+              {
+                id: "datasets",
+                path: projectPath("/datasets"),
+                type: MENU_ITEM_TYPE.router as const,
+                icon: Database,
+                label: "Datasets",
+                disabled: !projectPrefix,
+              },
+            ]
+          : []),
         ...(canViewExperiments
           ? [
               {
@@ -78,80 +140,12 @@ const getMenuItems = ({
               },
             ]
           : []),
-        ...(canViewDatasets
-          ? [
-              {
-                id: "datasets",
-                path: projectPath("/datasets"),
-                type: MENU_ITEM_TYPE.router as const,
-                icon: Database,
-                label: "Datasets",
-                disabled: !projectPrefix,
-              },
-              {
-                id: "test_suites",
-                path: projectPath("/test-suites"),
-                type: MENU_ITEM_TYPE.router as const,
-                icon: ListChecks,
-                label: "Test suites",
-                disabled: !projectPrefix,
-              },
-            ]
-          : []),
         {
           id: "annotation_queues",
           path: projectPath("/annotation-queues"),
           type: MENU_ITEM_TYPE.router,
           icon: UserPen,
           label: "Annotation queues",
-          disabled: !projectPrefix,
-        },
-      ],
-    },
-    {
-      id: "prompt_engineering",
-      label: "Prompt engineering",
-      items: [
-        ...(canUsePlayground
-          ? [
-              {
-                id: "playground",
-                path: projectPath("/playground"),
-                type: MENU_ITEM_TYPE.router as const,
-                icon: Blocks,
-                label: "Playground",
-                disabled: !projectPrefix,
-              },
-            ]
-          : []),
-      ],
-    },
-    {
-      id: "optimization",
-      label: "Optimization",
-      items: [
-        {
-          id: "optimizations",
-          path: projectPath("/optimizations"),
-          type: MENU_ITEM_TYPE.router,
-          icon: Sparkles,
-          label: "Optimization studio",
-          disabled: !projectPrefix,
-        },
-        {
-          id: "agent_configuration",
-          path: projectPath("/agent-configuration"),
-          type: MENU_ITEM_TYPE.router,
-          icon: Workflow,
-          label: "Agent configuration",
-          disabled: !projectPrefix,
-        },
-        {
-          id: "agent_runner",
-          path: projectPath("/agent-runner"),
-          type: MENU_ITEM_TYPE.router,
-          icon: GitBranch,
-          label: "Agent sandbox",
           disabled: !projectPrefix,
         },
       ],

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
@@ -145,7 +145,7 @@ const AgentRunnerContent: React.FC<AgentRunnerContentProps> = ({
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-3 border-b bg-gray-100 px-4 py-3">
-        <h1 className="comet-title-xs">Agent sandbox</h1>
+        <h1 className="comet-title-xs">Agent playground</h1>
 
         {isConnected ? (
           <TooltipWrapper content="Your agent is connected to Opik">

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerEmptyState.tsx
@@ -20,8 +20,8 @@ const AgentRunnerEmptyState: React.FC = () => {
           <h2 className="comet-title-m">Connect your agent</h2>
         </div>
         <p className="comet-body-s mb-8 text-muted-slate">
-          Link your agent to Opik to start using the Agent sandbox and improve
-          performance.
+          Link your agent to Opik to start using the Agent playground and
+          improve performance.
         </p>
 
         <div className="flex flex-col">

--- a/apps/opik-frontend/src/v2/router.tsx
+++ b/apps/opik-frontend/src/v2/router.tsx
@@ -404,7 +404,7 @@ const agentRunnerRoute = createRoute({
   path: "/agent-runner",
   getParentRoute: () => projectScopedRoute,
   staticData: {
-    title: "Agent sandbox",
+    title: "Agent playground",
   },
   component: AgentRunnerPage,
 });


### PR DESCRIPTION
## Details
Renames "Agent sandbox" to "Agent playground" and restructures the v2 sidebar. Introduces a new "Development" section (Agent playground, Prompt playground, Agent configuration, Optimization runs) and reorganizes the "Evaluation" section (Test suites, Datasets, Experiments).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: no

## Testing
- Verified sidebar rendering and navigation locally

## Documentation
N/A