### PR TITLE
[NA] [BE][FE] chore: sync provider model definitions

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/AnthropicModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/AnthropicModelName.java
@@ -17,7 +17,8 @@ public enum AnthropicModelName implements StructuredOutputSupported {
     CLAUDE_SONNET_4("claude-sonnet-4-20250514"),
     CLAUDE_SONNET_4_5("claude-sonnet-4-5"),
     CLAUDE_SONNET_4_5_20250929("claude-sonnet-4-5-20250929"),
-    CLAUDE_SONNET_4_6("claude-sonnet-4-6");
+    CLAUDE_SONNET_4_6("claude-sonnet-4-6"),
+    CLAUDE_OPUS_4_7("claude-opus-4-7");
 
     private final String value;
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiModelName.java
@@ -30,13 +30,13 @@ public enum GeminiModelName implements StructuredOutputSupported {
     GEMINI_3_PRO("gemini-3-pro-preview", true),
     GEMINI_3_1_FLASH_IMAGE_PREVIEW("gemini-3.1-flash-image-preview", true),
     GEMINI_3_1_FLASH_LITE_PREVIEW("gemini-3.1-flash-lite-preview", true),
+    GEMINI_3_1_FLASH_TTS_PREVIEW("gemini-3.1-flash-tts-preview", false),
     GEMINI_3_1_PRO("gemini-3.1-pro-preview", true),
     GEMINI_PRO_VISION("gemini-pro-vision", false),
     LYRIA_3_CLIP_PREVIEW("lyria-3-clip-preview", false),
     LYRIA_3_PRO_PREVIEW("lyria-3-pro-preview", false),
     NANO_BANANA_PRO_PREVIEW("nano-banana-pro-preview", false),
-    TEXT_EMBEDDING("text-embedding-004", false),
-    GEMINI_3_1_FLASH_TTS_PREVIEW("gemini-3.1-flash-tts-preview", false);
+    TEXT_EMBEDDING("text-embedding-004", false);
 
     private static final String WARNING_UNKNOWN_MODEL = "could not find GeminiModelName with value '{}'";
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
@@ -51,6 +51,7 @@ public enum OpenRouterModelName implements StructuredOutputSupported {
     ANTHROPIC_CLAUDE_OPUS_4_5("anthropic/claude-opus-4.5"),
     ANTHROPIC_CLAUDE_OPUS_4_6("anthropic/claude-opus-4.6"),
     ANTHROPIC_CLAUDE_OPUS_4_6_FAST("anthropic/claude-opus-4.6-fast"),
+    ANTHROPIC_CLAUDE_OPUS_4_7("anthropic/claude-opus-4.7"),
     ANTHROPIC_CLAUDE_SONNET_4("anthropic/claude-sonnet-4"),
     ANTHROPIC_CLAUDE_SONNET_4_5("anthropic/claude-sonnet-4.5"),
     ANTHROPIC_CLAUDE_SONNET_4_6("anthropic/claude-sonnet-4.6"),

--- a/apps/opik-backend/src/main/resources/llm-models-default.yaml
+++ b/apps/opik-backend/src/main/resources/llm-models-default.yaml
@@ -124,6 +124,7 @@ anthropic:
     structuredOutput: true
   - id: "claude-sonnet-4-6"
     structuredOutput: true
+  - id: "claude-opus-4-7"
 gemini:
   - id: "aqa"
   - id: "gemini-1.0-pro"
@@ -153,6 +154,7 @@ gemini:
     structuredOutput: true
   - id: "gemini-3.1-flash-lite-preview"
     structuredOutput: true
+  - id: "gemini-3.1-flash-tts-preview"
   - id: "gemini-3.1-pro-preview"
     structuredOutput: true
   - id: "gemini-pro-vision"
@@ -160,7 +162,6 @@ gemini:
   - id: "lyria-3-pro-preview"
   - id: "nano-banana-pro-preview"
   - id: "text-embedding-004"
-  - id: "gemini-3.1-flash-tts-preview"
 vertex-ai:
   - id: "gemini-2.0-flash-001"
     qualifiedName: "vertex_ai/gemini-2.0-flash-001"
@@ -233,6 +234,7 @@ openrouter:
   - id: "anthropic/claude-opus-4.5"
   - id: "anthropic/claude-opus-4.6"
   - id: "anthropic/claude-opus-4.6-fast"
+  - id: "anthropic/claude-opus-4.7"
   - id: "anthropic/claude-sonnet-4"
   - id: "anthropic/claude-sonnet-4.5"
   - id: "anthropic/claude-sonnet-4.6"

--- a/apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts
+++ b/apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts
@@ -109,6 +109,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
 
   [PROVIDER_TYPE.ANTHROPIC]: [
     {
+      value: PROVIDER_MODEL_TYPE.CLAUDE_OPUS_4_7,
+      label: "Claude Opus 4.7",
+    },
+    {
       value: PROVIDER_MODEL_TYPE.CLAUDE_OPUS_4_6,
       label: "Claude Opus 4.6",
     },
@@ -278,6 +282,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
     {
       value: PROVIDER_MODEL_TYPE.ANTHROPIC_CLAUDE_OPUS_4_6_FAST,
       label: "anthropic/claude-opus-4.6-fast",
+    },
+    {
+      value: PROVIDER_MODEL_TYPE.ANTHROPIC_CLAUDE_OPUS_4_7,
+      label: "anthropic/claude-opus-4.7",
     },
     {
       value: PROVIDER_MODEL_TYPE.ANTHROPIC_CLAUDE_SONNET_4,

--- a/apps/opik-frontend/src/types/providers.ts
+++ b/apps/opik-frontend/src/types/providers.ts
@@ -102,6 +102,7 @@ export enum PROVIDER_MODEL_TYPE {
   CLAUDE_SONNET_4_5 = "claude-sonnet-4-5",
   CLAUDE_SONNET_4_5_20250929 = "claude-sonnet-4-5-20250929",
   CLAUDE_SONNET_4_6 = "claude-sonnet-4-6",
+  CLAUDE_OPUS_4_7 = "claude-opus-4-7",
 
   //  <---- OpenRouter
   AI21_JAMBA_LARGE_1_7 = "ai21/jamba-large-1.7",
@@ -138,6 +139,7 @@ export enum PROVIDER_MODEL_TYPE {
   ANTHROPIC_CLAUDE_OPUS_4_5 = "anthropic/claude-opus-4.5",
   ANTHROPIC_CLAUDE_OPUS_4_6 = "anthropic/claude-opus-4.6",
   ANTHROPIC_CLAUDE_OPUS_4_6_FAST = "anthropic/claude-opus-4.6-fast",
+  ANTHROPIC_CLAUDE_OPUS_4_7 = "anthropic/claude-opus-4.7",
   ANTHROPIC_CLAUDE_SONNET_4 = "anthropic/claude-sonnet-4",
   ANTHROPIC_CLAUDE_SONNET_4_5 = "anthropic/claude-sonnet-4.5",
   ANTHROPIC_CLAUDE_SONNET_4_6 = "anthropic/claude-sonnet-4.6",
@@ -574,13 +576,13 @@ export enum PROVIDER_MODEL_TYPE {
   GEMINI_3_PRO = "gemini-3-pro-preview",
   GEMINI_3_1_FLASH_IMAGE_PREVIEW = "gemini-3.1-flash-image-preview",
   GEMINI_3_1_FLASH_LITE_PREVIEW = "gemini-3.1-flash-lite-preview",
+  GEMINI_3_1_FLASH_TTS_PREVIEW = "gemini-3.1-flash-tts-preview",
   GEMINI_3_1_PRO = "gemini-3.1-pro-preview",
   GEMINI_PRO_VISION = "gemini-pro-vision",
   LYRIA_3_CLIP_PREVIEW = "lyria-3-clip-preview",
   LYRIA_3_PRO_PREVIEW = "lyria-3-pro-preview",
   NANO_BANANA_PRO_PREVIEW = "nano-banana-pro-preview",
   TEXT_EMBEDDING = "text-embedding-004",
-  GEMINI_3_1_FLASH_TTS_PREVIEW = "gemini-3.1-flash-tts-preview",
 
   //   <------ vertex ai
   VERTEX_AI_GEMINI_2_0_FLASH = "vertex_ai/gemini-2.0-flash-001",


### PR DESCRIPTION
## Details

Automated sync of LLM provider model definitions from source APIs and prices JSON.

**Sync summary:**
```
## Provider Model Sync

### Openrouter
- Added 1 model(s):
  + anthropic/claude-opus-4.7
- Stale 109 model(s) (not in source, manual review needed):
  ? ai21/jamba-mini-1.7
  ? alibaba/tongyi-deepresearch-30b-a3b:free
  ? allenai/molmo-2-8b
  ? allenai/olmo-2-0325-32b-instruct
  ? allenai/olmo-3-7b-instruct
  ? allenai/olmo-3-7b-think
  ? allenai/olmo-3.1-32b-think
  ? anthropic/claude-3.5-sonnet
  ? arcee-ai/afm-4.5b
  ? arcee-ai/trinity-mini:free
  ? arliai/qwq-32b-arliai-rpr-v1
  ? arliai/qwq-32b-arliai-rpr-v1:free
  ? deepcogito/cogito-v2-preview-deepseek-671b
  ? deepcogito/cogito-v2-preview-llama-109b-moe
  ? deepcogito/cogito-v2-preview-llama-405b
  ? deepcogito/cogito-v2-preview-llama-70b
  ? deepseek/deepseek-chat-v3-0324:free
  ? deepseek/deepseek-prover-v2
  ? deepseek/deepseek-r1-0528-qwen3-8b
  ? deepseek/deepseek-r1-0528-qwen3-8b:free
  ? deepseek/deepseek-r1-0528:free
  ? deepseek/deepseek-r1-distill-llama-70b:free
  ? deepseek/deepseek-r1-distill-qwen-14b
  ? deepseek/deepseek-r1:free
  ? deepseek/deepseek-v3.1-terminus:exacto
  ? eleutherai/llemma_7b
  ? google/gemini-2.0-flash-exp:free
  ? google/gemini-2.5-flash-image-preview
  ? google/gemini-2.5-flash-preview-09-2025
  ? google/gemini-3-pro-preview
  ? google/gemma-2-9b-it
  ? inception/mercury
  ? inception/mercury-coder
  ? kwaipilot/kat-coder-pro
  ? kwaipilot/kat-coder-pro:free
  ? liquid/lfm-2.2-6b
  ? liquid/lfm2-8b-a1b
  ? meituan/longcat-flash-chat
  ? meituan/longcat-flash-chat:free
  ? meta-llama/llama-3.1-405b
  ? meta-llama/llama-3.1-405b-instruct
  ? meta-llama/llama-3.2-90b-vision-instruct
  ? meta-llama/llama-guard-2-8b
  ? microsoft/mai-ds-r1
  ? microsoft/mai-ds-r1:free
  ? microsoft/phi-3-medium-128k-instruct
  ? microsoft/phi-3-mini-128k-instruct
  ? microsoft/phi-3.5-mini-128k-instruct
  ? microsoft/phi-4-multimodal-instruct
  ? microsoft/phi-4-reasoning-plus
  ? mistralai/codestral-2501
  ? mistralai/devstral-small-2505
  ? mistralai/magistral-medium-2506
  ? mistralai/magistral-medium-2506:thinking
  ? mistralai/magistral-small-2506
  ? mistralai/ministral-3b
  ? mistralai/ministral-8b
  ? mistralai/mistral-7b-instruct
  ? mistralai/mistral-7b-instruct-v0.2
  ? mistralai/mistral-7b-instruct-v0.3
  ? mistralai/mistral-7b-instruct:free
  ? mistralai/mistral-nemo:free
  ? mistralai/mistral-small
  ? mistralai/mistral-small-24b-instruct-2501:free
  ? mistralai/mistral-small-3.1-24b-instruct:free
  ? mistralai/mistral-small-3.2-24b-instruct:free
  ? mistralai/mistral-tiny
  ? mistralai/pixtral-12b
  ? moonshotai/kimi-dev-72b
  ? moonshotai/kimi-k2-0905:exacto
  ? moonshotai/kimi-k2:free
  ? moonshotai/kimi-linear-48b-a3b-instruct
  ? neversleep/llama-3.1-lumimaid-8b
  ? neversleep/noromaid-20b
  ? nousresearch/deephermes-3-mistral-24b-preview
  ? nvidia/llama-3.1-nemotron-ultra-253b-v1
  ? openai/chatgpt-4o-latest
  ? openai/codex-mini
  ? openai/gpt-5.2-chat-latest
  ? openai/gpt-oss-120b:exacto
  ? opengvlab/internvl3-78b
  ? openrouter/healer-alpha
  ? openrouter/hunter-alpha
  ? perplexity/sonar-reasoning
  ? qwen/qwen-2.5-72b-instruct:free
  ? qwen/qwen-2.5-coder-32b-instruct:free
  ? qwen/qwen-2.5-vl-7b-instruct
  ? qwen/qwen2.5-coder-7b-instruct
  ? qwen/qwen2.5-vl-32b-instruct:free
  ? qwen/qwen3-14b:free
  ? qwen/qwen3-235b-a22b:free
  ? qwen/qwen3-30b-a3b:free
  ? qwen/qwen3-4b:free
  ? qwen/qwen3-coder:exacto
  ? qwen/qwen3.6-plus-preview:free
  ? qwen/qwen3.6-plus:free
  ? raifle/sorcererlm-8x22b
  ? reka/reka-edge
  ? stepfun-ai/step3
  ? stepfun/step-3.5-flash:free
  ? thedrummer/anubis-70b-v1.1
  ? thudm/glm-4.1v-9b-thinking
  ? tngtech/deepseek-r1t-chimera
  ? tngtech/deepseek-r1t-chimera:free
  ? tngtech/deepseek-r1t2-chimera:free
  ? x-ai/grok-4.1-fast:free
  ? x-ai/grok-4.20-beta
  ? x-ai/grok-4.20-multi-agent-beta
  ? z-ai/glm-4.6:exacto
- Total models: 454 (dropdown: 454)

### Openai
- Stale 15 model(s) (not in source, manual review needed):
  ? chatgpt-4o-latest
  ? gpt-4-0125-preview
  ? gpt-4-0314
  ? gpt-4-1106-preview
  ? gpt-4-turbo-2024-04-09
  ? gpt-4-turbo-preview
  ? gpt-4o-2024-05-13
  ? gpt-4o-2024-08-06
  ? gpt-4o-2024-11-20
  ? gpt-4o-mini-2024-07-18
  ? o1-2024-12-17
  ? o1-mini
  ? o1-mini-2024-09-12
  ? o1-preview
  ? o1-preview-2024-09-12
- Deprecated 4 model(s) (past deprecation_date, excluded from dropdown):
  ✗ gpt-4-0125-preview
  ✗ gpt-4-0314
  ✗ gpt-4-0613
  ✗ gpt-4-1106-preview
- Total models: 62 (dropdown: 19)

### Anthropic
- Added 1 model(s):
  + claude-opus-4-7
- Stale 2 model(s) (not in source, manual review needed):
  ? claude-3-7-sonnet-20250219
  ? claude-sonnet-4-5
- Deprecated 1 model(s) (past deprecation_date, excluded from dropdown):
  ✗ claude-3-7-sonnet-20250219
- Total models: 11 (dropdown: 9)

### Gemini
- Stale 6 model(s) (not in source, manual review needed):
  ? aqa
  ? gemini-1.0-pro
  ? gemini-1.5-flash-latest
  ? gemini-1.5-pro-latest
  ? gemini-pro-vision
  ? text-embedding-004
- Deprecated 2 model(s) (past deprecation_date, excluded from dropdown):
  ✗ gemini-3-pro-preview
  ✗ text-embedding-004
- Total models: 22 (dropdown: 11)

### Vertexai
- Stale 9 model(s) (not in source, manual review needed):
  ? vertex_ai/gemini-2.0-flash-001
  ? vertex_ai/gemini-2.0-flash-lite-001
  ? vertex_ai/gemini-2.5-flash
  ? vertex_ai/gemini-2.5-flash-lite-preview-06-17
  ? vertex_ai/gemini-2.5-flash-preview-04-17
  ? vertex_ai/gemini-2.5-pro
  ? vertex_ai/gemini-2.5-pro-exp-03-25
  ? vertex_ai/gemini-2.5-pro-preview-03-25
  ? vertex_ai/gemini-2.5-pro-preview-05-06
- Total models: 12 (dropdown: 7)

```

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: GitHub Actions (`sync_provider_models.yml`)
  - Model(s): N/A (scripted automation)
  - Scope: Automated model list sync
  - Human verification: Requires manual review before merge

## Testing

- Script dry-run passed in CI
- Changes are add-only; stale/deprecated models flagged for manual review

## Documentation

N/A