### PR TITLE
[OPIK-6027] [FE] feat: add demo project button in onboarding and demo project banner

### DIFF
--- a/apps/opik-frontend/src/api/projects/useDemoProject.ts
+++ b/apps/opik-frontend/src/api/projects/useDemoProject.ts
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import api, { PROJECTS_REST_ENDPOINT, QueryConfig } from "@/api/api";
 import { Project } from "@/types/projects";
@@ -40,15 +41,25 @@ export default function useDemoProject(
   { workspaceName, poll = false }: UseDemoProjectParams,
   options?: QueryConfig<Project | null>,
 ) {
+  // `query.state.dataUpdatedAt` resets on every successful fetch (even null),
+  // so deriving the cap from it would never trigger. Track start time in a ref.
+  const pollStartRef = useRef<number | null>(null);
+
   return useQuery({
     queryKey: ["project", { workspaceName }],
     queryFn: (context) => getDemoProject(context),
     refetchInterval: poll
       ? (query) => {
-          if (query.state.data) return false;
-          const firstFetchAt = query.state.dataUpdatedAt;
-          if (!firstFetchAt) return POLL_INTERVAL_MS;
-          if (Date.now() - firstFetchAt > MAX_POLL_DURATION_MS) return false;
+          if (query.state.data) {
+            pollStartRef.current = null;
+            return false;
+          }
+          if (pollStartRef.current === null) {
+            pollStartRef.current = Date.now();
+          }
+          if (Date.now() - pollStartRef.current > MAX_POLL_DURATION_MS) {
+            return false;
+          }
           return POLL_INTERVAL_MS;
         }
       : undefined,

--- a/apps/opik-frontend/src/api/projects/useDemoProject.ts
+++ b/apps/opik-frontend/src/api/projects/useDemoProject.ts
@@ -5,7 +5,18 @@ import { DEMO_PROJECT_NAME } from "@/constants/shared";
 
 type UseDemoProjectParams = {
   workspaceName: string;
+  // Enable polling while the demo project is missing. Demo data creation on
+  // user signup is asynchronous on the backend — the `post_user_signup`
+  // endpoint returns immediately while `create_demo_data()` runs in the
+  // background for ~30–60s. Callers that render during onboarding should
+  // set this so the "View Demo project" button surfaces as soon as the
+  // project is ready, without a page reload. Off by default so ambient
+  // usages outside onboarding don't keep a background poll running.
+  poll?: boolean;
 };
+
+const POLL_INTERVAL_MS = 5000;
+const MAX_POLL_DURATION_MS = 5 * 60 * 1000;
 
 const getDemoProject = async ({ signal }: QueryFunctionContext) => {
   try {
@@ -19,19 +30,28 @@ const getDemoProject = async ({ signal }: QueryFunctionContext) => {
       },
     );
 
-    return data;
+    return data ?? null;
   } catch (e) {
     return null;
   }
 };
 
 export default function useDemoProject(
-  params: UseDemoProjectParams,
+  { workspaceName, poll = false }: UseDemoProjectParams,
   options?: QueryConfig<Project | null>,
 ) {
   return useQuery({
-    queryKey: ["project", params],
+    queryKey: ["project", { workspaceName }],
     queryFn: (context) => getDemoProject(context),
+    refetchInterval: poll
+      ? (query) => {
+          if (query.state.data) return false;
+          const firstFetchAt = query.state.dataUpdatedAt;
+          if (!firstFetchAt) return POLL_INTERVAL_MS;
+          if (Date.now() - firstFetchAt > MAX_POLL_DURATION_MS) return false;
+          return POLL_INTERVAL_MS;
+        }
+      : undefined,
     ...options,
   });
 }

--- a/apps/opik-frontend/src/constants/shared.ts
+++ b/apps/opik-frontend/src/constants/shared.ts
@@ -6,7 +6,7 @@ import {
   ROW_HEIGHT,
 } from "@/types/shared";
 
-export const DEMO_PROJECT_NAME = "Demo Project";
+export const DEMO_PROJECT_NAME = "Opik Demo Agent Observability";
 export const SNIPPET_PROJECT_NAME = "my-ai-project";
 export const PROJECT_NAME_PLACEHOLDER = "PROJECT_NAME_PLACEHOLDER";
 export const PLAYGROUND_PROJECT_NAME = "playground";

--- a/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
+++ b/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
@@ -57,10 +57,7 @@ const DemoProjectBanner: React.FC<DemoProjectBannerProps> = ({
   }
 
   return (
-    <div
-      ref={ref}
-      className="z-10 flex h-8 items-center gap-1.5 bg-slate-100 px-4"
-    >
+    <div ref={ref} className="z-10 flex h-8 items-center gap-1.5 bg-muted px-4">
       <span className="comet-body-xs text-foreground">
         Connect your repo so Opik can help set up tracing, or instrument your
         code manually.

--- a/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
+++ b/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useRef } from "react";
+import { Link } from "@tanstack/react-router";
+import useLocalStorageState from "use-local-storage-state";
+import { PlugZap } from "lucide-react";
+
+import { useActiveProjectId, useActiveWorkspaceName } from "@/store/AppStore";
+import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
+import useProjectById from "@/api/projects/useProjectById";
+import { DEMO_PROJECT_NAME } from "@/constants/shared";
+import {
+  AGENT_ONBOARDING_KEY,
+  AGENT_ONBOARDING_STEPS,
+} from "@/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext";
+
+interface DemoProjectBannerProps {
+  onChangeHeight: (height: number) => void;
+}
+
+interface AgentOnboardingState {
+  step: string | null;
+  agentName: string;
+}
+
+const DemoProjectBanner: React.FC<DemoProjectBannerProps> = ({
+  onChangeHeight,
+}) => {
+  const heightRef = useRef(0);
+  const activeProjectId = useActiveProjectId();
+  const workspaceName = useActiveWorkspaceName();
+
+  const { data: project } = useProjectById(
+    { projectId: activeProjectId! },
+    { enabled: !!activeProjectId },
+  );
+
+  const [onboardingState] =
+    useLocalStorageState<AgentOnboardingState>(AGENT_ONBOARDING_KEY);
+
+  const { ref } = useObserveResizeNode<HTMLDivElement>((node) => {
+    heightRef.current = node.clientHeight;
+    onChangeHeight(node.clientHeight);
+  });
+
+  const isDemoProject = project?.name === DEMO_PROJECT_NAME;
+  const isOnboardingActive =
+    !!onboardingState?.step &&
+    onboardingState.step !== AGENT_ONBOARDING_STEPS.DONE;
+
+  const hideBanner = !isDemoProject || !isOnboardingActive;
+
+  useEffect(() => {
+    onChangeHeight(!hideBanner ? heightRef.current : 0);
+  }, [hideBanner, onChangeHeight]);
+
+  if (hideBanner) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={ref}
+      className="z-10 flex h-8 items-center gap-1.5 bg-slate-100 px-4"
+    >
+      <span className="comet-body-xs text-foreground">
+        Connect your repo so Opik can help set up tracing, or instrument your
+        code manually.
+      </span>
+      <Link
+        to="/$workspaceName/get-started"
+        params={{ workspaceName }}
+        className="comet-body-xs inline-flex items-center gap-0.5 text-foreground underline underline-offset-2"
+      >
+        <PlugZap className="size-3" />
+        Connect your agent
+      </Link>
+    </div>
+  );
+};
+
+export default DemoProjectBanner;

--- a/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
+++ b/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
@@ -10,15 +10,12 @@ import { DEMO_PROJECT_NAME } from "@/constants/shared";
 import {
   AGENT_ONBOARDING_KEY,
   AGENT_ONBOARDING_STEPS,
+  AgentOnboardingState,
 } from "@/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext";
+import useAutoCompleteAgentOnboarding from "./useAutoCompleteAgentOnboarding";
 
 interface DemoProjectBannerProps {
   onChangeHeight: (height: number) => void;
-}
-
-interface AgentOnboardingState {
-  step: string | null;
-  agentName: string;
 }
 
 const DemoProjectBanner: React.FC<DemoProjectBannerProps> = ({
@@ -42,11 +39,20 @@ const DemoProjectBanner: React.FC<DemoProjectBannerProps> = ({
   });
 
   const isDemoProject = project?.name === DEMO_PROJECT_NAME;
+  const isOnboardingProject =
+    !!onboardingState?.agentName && project?.name === onboardingState.agentName;
+  const isRelevantProject = isDemoProject || isOnboardingProject;
+
   const isOnboardingActive =
     !!onboardingState?.step &&
     onboardingState.step !== AGENT_ONBOARDING_STEPS.DONE;
 
-  const hideBanner = !isDemoProject || !isOnboardingActive;
+  useAutoCompleteAgentOnboarding({
+    activeProjectId,
+    enabled: isOnboardingProject && isOnboardingActive,
+  });
+
+  const hideBanner = !isRelevantProject || !isOnboardingActive;
 
   useEffect(() => {
     onChangeHeight(!hideBanner ? heightRef.current : 0);

--- a/apps/opik-frontend/src/v2/layout/DemoProjectBanner/useAutoCompleteAgentOnboarding.ts
+++ b/apps/opik-frontend/src/v2/layout/DemoProjectBanner/useAutoCompleteAgentOnboarding.ts
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+import useLocalStorageState from "use-local-storage-state";
+
+import useTracesList from "@/api/traces/useTracesList";
+import {
+  AGENT_ONBOARDING_KEY,
+  AGENT_ONBOARDING_STEPS,
+  AgentOnboardingState,
+} from "@/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext";
+
+interface UseAutoCompleteAgentOnboardingParams {
+  activeProjectId: string | null;
+  enabled: boolean;
+}
+
+// Auto-complete onboarding when the user lands on their own agent project that
+// already has traces. This covers the case where a user connected their agent
+// and logged traces in a previous session but never clicked "Explore Opik" to
+// finalize the flow — without this, they'd keep seeing the banner forever.
+// The `enabled` flag (caller's isOnboardingProject && isOnboardingActive) stops
+// the effect from re-firing after DONE is written — the localStorage hook
+// returns a new object reference on every render, so we can't rely on identity.
+const useAutoCompleteAgentOnboarding = ({
+  activeProjectId,
+  enabled,
+}: UseAutoCompleteAgentOnboardingParams) => {
+  const [, setOnboardingState] =
+    useLocalStorageState<AgentOnboardingState>(AGENT_ONBOARDING_KEY);
+
+  const { data: tracesData } = useTracesList(
+    {
+      projectId: activeProjectId ?? "",
+      page: 1,
+      size: 1,
+    },
+    {
+      enabled: !!activeProjectId && enabled,
+    },
+  );
+  const hasTraces = (tracesData?.total ?? 0) > 0;
+
+  useEffect(() => {
+    if (enabled && hasTraces) {
+      setOnboardingState((prev) =>
+        prev ? { ...prev, step: AGENT_ONBOARDING_STEPS.DONE } : prev,
+      );
+    }
+  }, [enabled, hasTraces, setOnboardingState]);
+};
+
+export default useAutoCompleteAgentOnboarding;

--- a/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
+++ b/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
@@ -18,6 +18,7 @@ import {
   getStoredAssistantSidebarWidth,
   isAssistantSidebarOpen,
 } from "@/constants/assistantSidebar";
+import DemoProjectBanner from "@/v2/layout/DemoProjectBanner/DemoProjectBanner";
 
 const PageLayout = () => {
   const [hostContainer, setHostContainer] = useState<HTMLDivElement | null>(
@@ -26,7 +27,9 @@ const PageLayout = () => {
   const [storedExpanded = true, setStoredExpanded] =
     useLocalStorageState<boolean>("sidebar-expanded");
   const [smallScreenExpanded, setSmallScreenExpanded] = useState(false);
-  const [bannerHeight, setBannerHeight] = useState(0);
+  const [retentionBannerHeight, setRetentionBannerHeight] = useState(0);
+  const [demoBannerHeight, setDemoBannerHeight] = useState(0);
+  const bannerHeight = retentionBannerHeight + demoBannerHeight;
   const [showWelcomeWizard, setShowWelcomeWizard] = useState(false);
   const [assistantSidebarWidth, setAssistantSidebarWidth] = useState(() =>
     isAssistantSidebarOpen()
@@ -118,8 +121,9 @@ const PageLayout = () => {
             className="relative min-w-0 flex-1 overflow-hidden [transform:translateZ(0)]"
           >
             {RetentionBanner ? (
-              <RetentionBanner onChangeHeight={setBannerHeight} />
+              <RetentionBanner onChangeHeight={setRetentionBannerHeight} />
             ) : null}
+            <DemoProjectBanner onChangeHeight={setDemoBannerHeight} />
 
             <SideBar
               expanded={expanded}

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationExplorer/components/HelpLinks.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationExplorer/components/HelpLinks.tsx
@@ -6,6 +6,7 @@ import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import Slack from "@/icons/slack.svg?react";
 import { Link } from "@tanstack/react-router";
 import usePluginsStore from "@/store/PluginsStore";
+import useDemoProject from "@/api/projects/useDemoProject";
 
 export const VIDEO_TUTORIAL_LINK =
   "https://www.youtube.com/watch?v=h1XK-dMtUJI";
@@ -131,6 +132,11 @@ PlaygroundButton.displayName = "HelpLinks.Playground";
 
 const DemoProjectButton: React.FC = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const { data: demoProject } = useDemoProject({ workspaceName });
+
+  if (!demoProject) {
+    return null;
+  }
 
   return (
     <Button
@@ -141,9 +147,10 @@ const DemoProjectButton: React.FC = () => {
       data-fs-element="HelpLinksDemoProject"
     >
       <Link
-        to={"/$workspaceName/projects"}
+        to="/$workspaceName/projects/$projectId/logs"
         params={{
           workspaceName,
+          projectId: demoProject.id,
         }}
       >
         <MousePointerClick className="mr-2 size-4" />

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext.tsx
@@ -18,11 +18,11 @@ export const AGENT_ONBOARDING_STEPS = {
   DONE: "done",
 } as const;
 
-type AgentOnboardingStep =
+export type AgentOnboardingStep =
   | null
   | (typeof AGENT_ONBOARDING_STEPS)[keyof typeof AGENT_ONBOARDING_STEPS];
 
-interface AgentOnboardingState {
+export interface AgentOnboardingState {
   step: AgentOnboardingStep;
   agentName: string;
   traceId?: string;

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
@@ -1,11 +1,19 @@
 import React, { useEffect, useState } from "react";
 import useLocalStorageState from "use-local-storage-state";
-import { ArrowRight, ChevronsRight, MonitorPlay, Undo2 } from "lucide-react";
+import {
+  ArrowRight,
+  ChevronsRight,
+  ExternalLink,
+  MonitorPlay,
+  Undo2,
+} from "lucide-react";
 import { Button } from "@/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/ui/tabs";
+import { Link } from "@tanstack/react-router";
 import Slack from "@/icons/slack.svg?react";
 import usePluginsStore from "@/store/PluginsStore";
-import { useUserApiKey } from "@/store/AppStore";
+import { useUserApiKey, useActiveWorkspaceName } from "@/store/AppStore";
+import useDemoProject from "@/api/projects/useDemoProject";
 import useProjectByName from "@/api/projects/useProjectByName";
 import useTracesList from "@/api/traces/useTracesList";
 import useSandboxConnectionStatus from "@/api/agent-sandbox/useSandboxConnectionStatus";
@@ -34,6 +42,8 @@ const ConnectAgentStep: React.FC = () => {
   const { goToStep, agentName } = useAgentOnboarding();
   const InviteDevButton = usePluginsStore((state) => state.InviteDevButton);
   const apiKey = useUserApiKey();
+  const workspaceName = useActiveWorkspaceName();
+  const { data: demoProject } = useDemoProject({ workspaceName });
   const showOllieTab = !!apiKey;
   const [activeTab, setActiveTab] = useState(
     showOllieTab ? "connect-to-ollie" : "install-with-ai",
@@ -194,16 +204,40 @@ const ConnectAgentStep: React.FC = () => {
             <ArrowRight className="size-3.5" />
           </Button>
         ) : (
-          <Button
-            variant="link"
-            onClick={handleSkip}
-            className="comet-body-s px-0 text-muted-slate"
-            id="onboarding-step2-skip"
-            data-fs-element="onboarding-step2-skip"
-          >
-            Skip for now
-            <ChevronsRight className="size-3.5" />
-          </Button>
+          <div className="flex w-full items-center justify-between">
+            {demoProject ? (
+              <Button
+                variant="link"
+                className="comet-body-s px-0 text-foreground"
+                asChild
+                id="onboarding-step2-view-demo"
+                data-fs-element="onboarding-step2-view-demo"
+              >
+                <Link
+                  to="/$workspaceName/projects/$projectId/logs"
+                  params={{
+                    workspaceName,
+                    projectId: demoProject.id,
+                  }}
+                >
+                  View Demo project
+                  <ExternalLink className="ml-1 size-3.5" />
+                </Link>
+              </Button>
+            ) : (
+              <div />
+            )}
+            <Button
+              variant="link"
+              onClick={handleSkip}
+              className="comet-body-s px-0 text-muted-slate"
+              id="onboarding-step2-skip"
+              data-fs-element="onboarding-step2-skip"
+            >
+              Skip for now
+              <ChevronsRight className="size-3.5" />
+            </Button>
+          </div>
         )
       }
     >

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
@@ -200,7 +200,7 @@ const ConnectAgentStep: React.FC = () => {
             <Button
               variant="link"
               onClick={handleSkip}
-              className="comet-body-s px-0 text-muted-slate"
+              className="comet-body-s ml-auto px-0 text-muted-slate"
               id="onboarding-step2-skip"
               data-fs-element="onboarding-step2-skip"
             >

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
@@ -1,19 +1,11 @@
 import React, { useEffect, useState } from "react";
 import useLocalStorageState from "use-local-storage-state";
-import {
-  ArrowRight,
-  ChevronsRight,
-  ExternalLink,
-  MonitorPlay,
-  Undo2,
-} from "lucide-react";
+import { ArrowRight, ChevronsRight, MonitorPlay, Undo2 } from "lucide-react";
 import { Button } from "@/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/ui/tabs";
-import { Link } from "@tanstack/react-router";
 import Slack from "@/icons/slack.svg?react";
 import usePluginsStore from "@/store/PluginsStore";
-import { useUserApiKey, useActiveWorkspaceName } from "@/store/AppStore";
-import useDemoProject from "@/api/projects/useDemoProject";
+import { useUserApiKey } from "@/store/AppStore";
 import useProjectByName from "@/api/projects/useProjectByName";
 import useTracesList from "@/api/traces/useTracesList";
 import useSandboxConnectionStatus from "@/api/agent-sandbox/useSandboxConnectionStatus";
@@ -29,6 +21,7 @@ import ConnectToOllieTab from "./ConnectToOllieTab";
 import InstallWithAITab from "./InstallWithAITab";
 import ManualIntegrationList from "./ManualIntegrationList";
 import ManualIntegrationDetail from "./ManualIntegrationDetail";
+import ViewDemoProjectButton from "./ViewDemoProjectButton";
 import { INTEGRATIONS } from "@/constants/integrations";
 import {
   SLACK_LINK,
@@ -42,8 +35,6 @@ const ConnectAgentStep: React.FC = () => {
   const { goToStep, agentName } = useAgentOnboarding();
   const InviteDevButton = usePluginsStore((state) => state.InviteDevButton);
   const apiKey = useUserApiKey();
-  const workspaceName = useActiveWorkspaceName();
-  const { data: demoProject } = useDemoProject({ workspaceName });
   const showOllieTab = !!apiKey;
   const [activeTab, setActiveTab] = useState(
     showOllieTab ? "connect-to-ollie" : "install-with-ai",
@@ -205,28 +196,7 @@ const ConnectAgentStep: React.FC = () => {
           </Button>
         ) : (
           <div className="flex w-full items-center justify-between">
-            {demoProject ? (
-              <Button
-                variant="link"
-                className="comet-body-s px-0 text-foreground"
-                asChild
-                id="onboarding-step2-view-demo"
-                data-fs-element="onboarding-step2-view-demo"
-              >
-                <Link
-                  to="/$workspaceName/projects/$projectId/logs"
-                  params={{
-                    workspaceName,
-                    projectId: demoProject.id,
-                  }}
-                >
-                  View Demo project
-                  <ExternalLink className="ml-1 size-3.5" />
-                </Link>
-              </Button>
-            ) : (
-              <div />
-            )}
+            <ViewDemoProjectButton />
             <Button
               variant="link"
               onClick={handleSkip}

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ViewDemoProjectButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ViewDemoProjectButton.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { ArrowUpRight } from "lucide-react";
-import { Button } from "@/ui/button";
 import { Link } from "@tanstack/react-router";
+
+import { Button } from "@/ui/button";
 import { useActiveWorkspaceName } from "@/store/AppStore";
 import useDemoProject from "@/api/projects/useDemoProject";
 

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ViewDemoProjectButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ViewDemoProjectButton.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { ArrowUpRight } from "lucide-react";
+import { Button } from "@/ui/button";
+import { Link } from "@tanstack/react-router";
+import { useActiveWorkspaceName } from "@/store/AppStore";
+import useDemoProject from "@/api/projects/useDemoProject";
+
+const ViewDemoProjectButton: React.FC = () => {
+  const workspaceName = useActiveWorkspaceName();
+  const { data: demoProject } = useDemoProject({ workspaceName });
+
+  if (!demoProject) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="link"
+      className="comet-body-s px-0 text-foreground"
+      asChild
+      id="onboarding-step2-view-demo"
+      data-fs-element="onboarding-step2-view-demo"
+    >
+      <Link
+        to="/$workspaceName/projects/$projectId/logs"
+        params={{
+          workspaceName,
+          projectId: demoProject.id,
+        }}
+      >
+        View Demo project
+        <ArrowUpRight className="ml-1 size-3.5" />
+      </Link>
+    </Button>
+  );
+};
+
+export default ViewDemoProjectButton;

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ViewDemoProjectButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ViewDemoProjectButton.tsx
@@ -8,7 +8,7 @@ import useDemoProject from "@/api/projects/useDemoProject";
 
 const ViewDemoProjectButton: React.FC = () => {
   const workspaceName = useActiveWorkspaceName();
-  const { data: demoProject } = useDemoProject({ workspaceName });
+  const { data: demoProject } = useDemoProject({ workspaceName, poll: true });
 
   if (!demoProject) {
     return null;


### PR DESCRIPTION
## Details


https://github.com/user-attachments/assets/2cb471d6-7636-48c7-a9db-da6671672450



Add a "View Demo project" button to the onboarding flow and a demo project banner for users who haven't completed onboarding.

- **Onboarding button**: "View Demo project" link button in `ConnectAgentStep` footer (same tab). Only shown when the demo project exists. Left-aligned with "Skip for now" right-aligned.
- **Demo project banner**: Full-width banner at the top of the page (using the existing `--banner-height` mechanism) when viewing the demo project and onboarding is not finished. Contains a "Connect your agent" link that navigates back to the onboarding flow.
- **HelpLinks.DemoProject**: Updated to link directly to the demo project logs page; hidden when demo project doesn't exist.
- **DEMO_PROJECT_NAME fix**: Updated from `"Demo Project"` to `"Opik Demo Agent Observability"` to match the backend demo data generator.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6027

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review + manual testing

## Testing

- `scripts/dev-runner.sh --lint-fe` — lint:fix, typecheck, deps:validate all pass
- Manual verification needed:
  - Start onboarding → verify "View Demo project" button appears only when demo project exists
  - Click "View Demo project" → navigates to demo project logs (same tab)
  - On demo project page → verify banner appears at top when onboarding is active
  - Click "Connect your agent" on banner → navigates back to onboarding (resumes at same step)
  - Complete onboarding → revisit demo project → verify banner is gone
  - Non-demo project → verify no banner shows

## Documentation

N/A