### PR TITLE
[NA] [FE] Split docs links between v1 and v2 workspaces

### DIFF
--- a/apps/opik-frontend/src/v1/pages-shared/annotation-queues/NoAnnotationQueuesPage.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/annotation-queues/NoAnnotationQueuesPage.tsx
@@ -42,7 +42,7 @@ const NoAnnotationQueuesPage: React.FC<NoAnnotationQueuesPageProps> = ({
         <>
           <Button variant="secondary" asChild>
             <a
-              href={buildDocsUrl("/evaluation/annotation_queues")}
+              href={buildDocsUrl("/v1/evaluation/annotation_queues")}
               target="_blank"
               rel="noreferrer"
             >

--- a/apps/opik-frontend/src/v1/pages-shared/automations/NoRulesPage.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/automations/NoRulesPage.tsx
@@ -37,7 +37,7 @@ const NoRulesPage: React.FC<NoRulesPageProps> = ({
         <>
           <Button variant="secondary" asChild>
             <a
-              href={buildDocsUrl("/production/rules")}
+              href={buildDocsUrl("/v1/production/rules")}
               target="_blank"
               rel="noreferrer"
             >

--- a/apps/opik-frontend/src/v1/pages-shared/dashboards/widgets/ProjectMetricsWidget/ProjectMetricsWidget.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/dashboards/widgets/ProjectMetricsWidget/ProjectMetricsWidget.tsx
@@ -340,7 +340,7 @@ const ProjectMetricsWidget: React.FunctionComponent<
           action={
             <DashboardWidget.EmptyState.DocsLink
               label="Learn how to add scores"
-              href={buildDocsUrl("/tracing/annotate_traces")}
+              href={buildDocsUrl("/v1/tracing/annotate_traces")}
             />
           }
         />
@@ -354,7 +354,7 @@ const ProjectMetricsWidget: React.FunctionComponent<
           action={
             <DashboardWidget.EmptyState.DocsLink
               label="Learn how to add scores"
-              href={buildDocsUrl("/tracing/annotate_traces")}
+              href={buildDocsUrl("/v1/tracing/annotate_traces")}
             />
           }
         />
@@ -371,7 +371,7 @@ const ProjectMetricsWidget: React.FunctionComponent<
           action={
             <DashboardWidget.EmptyState.DocsLink
               label="Learn how to track threads"
-              href={buildDocsUrl("/tracing/log_chat_conversations")}
+              href={buildDocsUrl("/v1/tracing/log_chat_conversations")}
             />
           }
         />

--- a/apps/opik-frontend/src/v1/pages-shared/datasets/AddEditTestSuiteDialog/AddEditTestSuiteDialog.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/datasets/AddEditTestSuiteDialog/AddEditTestSuiteDialog.tsx
@@ -440,7 +440,7 @@ const AddEditTestSuiteDialog = ({
                 )}
                 <Button variant="link" size="sm" className="h-5 px-1" asChild>
                   <a
-                    href={buildDocsUrl("/evaluation/manage_datasets")}
+                    href={buildDocsUrl("/v1/evaluation/manage_datasets")}
                     target="_blank"
                     rel="noopener noreferrer"
                   >

--- a/apps/opik-frontend/src/v1/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog.tsx
@@ -453,7 +453,7 @@ eval_results = evaluate(
     <div className="mt-4">
       <Button variant="secondary" asChild>
         <a
-          href={buildDocsUrl("/evaluation/metrics/custom_metric")}
+          href={buildDocsUrl("/v1/evaluation/metrics/custom_metric")}
           target="_blank"
           rel="noreferrer"
           className="flex items-center"

--- a/apps/opik-frontend/src/v1/pages-shared/llm/ManageAIProviderDialog/CustomProviderDetails.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/llm/ManageAIProviderDialog/CustomProviderDetails.tsx
@@ -117,7 +117,7 @@ const CustomProviderDetails: React.FC<CustomProviderDetailsProps> = ({
                   className="inline px-0"
                 >
                   <a
-                    href={buildDocsUrl("/playground")}
+                    href={buildDocsUrl("/v1/playground")}
                     target="_blank"
                     rel="noreferrer"
                   >

--- a/apps/opik-frontend/src/v1/pages-shared/llm/ManageAIProviderDialog/VertexAIProviderDetails.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/llm/ManageAIProviderDialog/VertexAIProviderDetails.tsx
@@ -78,7 +78,7 @@ const VertexAIProviderDetails: React.FC<VertexAIProviderDetailsProps> = ({
       <span className="comet-body-s mt-1 text-light-slate">
         <Button variant="link" size="sm" asChild className="px-0">
           <a
-            href={buildDocsUrl("/configuration/ai_providers", "#vertex-ai")}
+            href={buildDocsUrl("/v1/configuration/ai_providers", "#vertex-ai")}
             target="_blank"
             rel="noreferrer"
           >

--- a/apps/opik-frontend/src/v1/pages-shared/onboarding/EvaluationExamples/UsingPlaygroundTab.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/onboarding/EvaluationExamples/UsingPlaygroundTab.tsx
@@ -28,8 +28,7 @@ const UsingPlaygroundTab = () => {
             asChild
           >
             <a
-              href={buildDocsUrl(
-                "/prompt_engineering/playground#running-experiments-in-the-playground",
+              href={buildDocsUrl("/v1/prompt_engineering/playground#running-experiments-in-the-playground",
               )}
               target="_blank"
               rel="noreferrer"

--- a/apps/opik-frontend/src/v1/pages-shared/onboarding/EvaluationExamples/UsingPlaygroundTab.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/onboarding/EvaluationExamples/UsingPlaygroundTab.tsx
@@ -28,7 +28,8 @@ const UsingPlaygroundTab = () => {
             asChild
           >
             <a
-              href={buildDocsUrl("/v1/prompt_engineering/playground#running-experiments-in-the-playground",
+              href={buildDocsUrl(
+                "/v1/prompt_engineering/playground#running-experiments-in-the-playground",
               )}
               target="_blank"
               rel="noreferrer"

--- a/apps/opik-frontend/src/v1/pages-shared/onboarding/FrameworkIntegrations/FrameworkIntegrations.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/onboarding/FrameworkIntegrations/FrameworkIntegrations.tsx
@@ -96,7 +96,7 @@ const FrameworkIntegrations: React.FC<FrameworkIntegrationsProps> = ({
       </IntegrationTabs>
       <Button className="w-fit pl-2" variant="ghost" asChild>
         <a
-          href={buildDocsUrl("/tracing/integrations/overview")}
+          href={buildDocsUrl("/v1/tracing/integrations/overview")}
           target="_blank"
           rel="noreferrer"
         >

--- a/apps/opik-frontend/src/v1/pages-shared/onboarding/FrameworkIntegrations/quickstart-integrations.ts
+++ b/apps/opik-frontend/src/v1/pages-shared/onboarding/FrameworkIntegrations/quickstart-integrations.ts
@@ -48,7 +48,8 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: pythonLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/quickstart_notebook.ipynb",
-    documentation: buildDocsUrl("/v1/tracing/log_traces",
+    documentation: buildDocsUrl(
+      "/v1/tracing/log_traces",
       "#using-function-decorators",
     ),
     code: functionDecoratorsCode,

--- a/apps/opik-frontend/src/v1/pages-shared/onboarding/FrameworkIntegrations/quickstart-integrations.ts
+++ b/apps/opik-frontend/src/v1/pages-shared/onboarding/FrameworkIntegrations/quickstart-integrations.ts
@@ -48,8 +48,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: pythonLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/quickstart_notebook.ipynb",
-    documentation: buildDocsUrl(
-      "/tracing/log_traces",
+    documentation: buildDocsUrl("/v1/tracing/log_traces",
       "#using-function-decorators",
     ),
     code: functionDecoratorsCode,
@@ -61,7 +60,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logoWhite: openAIWhiteLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/openai.ipynb",
-    documentation: buildDocsUrl("/integrations/openai"),
+    documentation: buildDocsUrl("/v1/integrations/openai"),
     code: openAiCode,
     // executionUrl: "openai/run_stream",
     executionLogs: integrationLogsMap.OpenAI,
@@ -71,7 +70,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: anthropicLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/anthropic.ipynb",
-    documentation: buildDocsUrl("/integrations/openai"),
+    documentation: buildDocsUrl("/v1/integrations/openai"),
     code: anthropicCode,
     // executionUrl: "anthropic/run_stream",
     executionLogs: integrationLogsMap.Anthropic,
@@ -82,7 +81,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logoWhite: bedrockWhiteLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/bedrock.ipynb",
-    documentation: buildDocsUrl("/integrations/openai"),
+    documentation: buildDocsUrl("/v1/integrations/openai"),
     code: bedrockCode,
     executionLogs: integrationLogsMap.Bedrock,
   },
@@ -91,7 +90,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: geminiLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/gemini.ipynb",
-    documentation: buildDocsUrl("/integrations/openai"),
+    documentation: buildDocsUrl("/v1/integrations/openai"),
     code: geminiCode,
     executionLogs: integrationLogsMap.Gemini,
   },
@@ -100,7 +99,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: langChainLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/langchain.ipynb",
-    documentation: buildDocsUrl("/integrations/langchain"),
+    documentation: buildDocsUrl("/v1/integrations/langchain"),
     code: langChainCode,
     executionLogs: integrationLogsMap.LangChain,
   },
@@ -109,7 +108,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: langGraphLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/langgraph.ipynb",
-    documentation: buildDocsUrl("/integrations/langchain"),
+    documentation: buildDocsUrl("/v1/integrations/langchain"),
     code: langGraphCode,
     executionLogs: integrationLogsMap.LangGraph,
   },
@@ -118,7 +117,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: llamaIndexLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/llama-index.ipynb",
-    documentation: buildDocsUrl("/integrations/langchain"),
+    documentation: buildDocsUrl("/v1/integrations/langchain"),
     code: llamaIndexCode,
     executionLogs: integrationLogsMap.LlamaIndex,
   },
@@ -127,7 +126,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: haystackLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/haystack.ipynb",
-    documentation: buildDocsUrl("/integrations/langchain"),
+    documentation: buildDocsUrl("/v1/integrations/langchain"),
     code: haystackCode,
     executionLogs: integrationLogsMap.Haystack,
   },
@@ -136,7 +135,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: liteLLMLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/litellm.ipynb",
-    documentation: buildDocsUrl("/integrations/litellm"),
+    documentation: buildDocsUrl("/v1/integrations/litellm"),
     code: liteLLMCode,
     executionLogs: integrationLogsMap.LiteLLM,
   },
@@ -145,7 +144,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: ragasLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/ragas.ipynb",
-    documentation: buildDocsUrl("/integrations/ragas"),
+    documentation: buildDocsUrl("/v1/integrations/ragas"),
     code: ragasCode,
     executionLogs: integrationLogsMap.Ragas,
   },
@@ -154,7 +153,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: groqLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/groq.ipynb",
-    documentation: buildDocsUrl("/integrations/ragas"),
+    documentation: buildDocsUrl("/v1/integrations/ragas"),
     code: groqCode,
     executionLogs: integrationLogsMap.Groq,
   },
@@ -163,7 +162,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: dspyLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/dspy.ipynb",
-    documentation: buildDocsUrl("/integrations/ragas"),
+    documentation: buildDocsUrl("/v1/integrations/ragas"),
     code: dspyCode,
     executionLogs: integrationLogsMap.DSPy,
   },

--- a/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/IntegrationGrid.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/IntegrationGrid.tsx
@@ -127,8 +127,7 @@ const IntegrationGrid: React.FunctionComponent<IntegrationGridProps> = ({
         })}
 
         <a
-          href={buildDocsUrl(
-            "/integrations/overview",
+          href={buildDocsUrl("/v1/integrations/overview",
             "&utm_source=opik_frontend&utm_medium=integration_grid&utm_campaign=integrations_docs&utm_content=integration_card",
           )}
           target="_blank"

--- a/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/IntegrationGrid.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/IntegrationGrid.tsx
@@ -127,7 +127,8 @@ const IntegrationGrid: React.FunctionComponent<IntegrationGridProps> = ({
         })}
 
         <a
-          href={buildDocsUrl("/v1/integrations/overview",
+          href={buildDocsUrl(
+            "/v1/integrations/overview",
             "&utm_source=opik_frontend&utm_medium=integration_grid&utm_campaign=integrations_docs&utm_content=integration_card",
           )}
           target="_blank"

--- a/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/IntegrationTypeScriptSDK.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/IntegrationTypeScriptSDK.tsx
@@ -9,8 +9,7 @@ const IntegrationTypeScriptSDK: React.FC = () => {
 
   return (
     <a
-      href={buildDocsUrl(
-        "/reference/typescript-sdk/overview",
+      href={buildDocsUrl("/v1/reference/typescript-sdk/overview",
         "&utm_source=opik_frontend&utm_medium=integration_explorer&utm_campaign=typescript_sdk&utm_content=integration_card",
       )}
       target="_blank"

--- a/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/IntegrationTypeScriptSDK.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/IntegrationTypeScriptSDK.tsx
@@ -9,7 +9,8 @@ const IntegrationTypeScriptSDK: React.FC = () => {
 
   return (
     <a
-      href={buildDocsUrl("/v1/reference/typescript-sdk/overview",
+      href={buildDocsUrl(
+        "/v1/reference/typescript-sdk/overview",
         "&utm_source=opik_frontend&utm_medium=integration_explorer&utm_campaign=typescript_sdk&utm_content=integration_card",
       )}
       target="_blank"

--- a/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/components/HelpGuideDialog.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/components/HelpGuideDialog.tsx
@@ -36,7 +36,7 @@ const HelpGuideDialog: React.FunctionComponent<HelpGuideDialogProps> = ({
           <div className="comet-body-s mb-3 pb-2 text-muted-slate">
             Need help getting started? Find useful resources here, or{" "}
             <a
-              href="https://www.comet.com/docs/opik/quickstart"
+              href="https://www.comet.com/docs/opik/v1/quickstart"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1 text-primary hover:underline dark:text-primary-hover"
@@ -93,7 +93,7 @@ const HelpGuideDialog: React.FunctionComponent<HelpGuideDialogProps> = ({
 
               <div className="space-y-2">
                 <a
-                  href={buildDocsUrl("/opik-university")}
+                  href={buildDocsUrl("/v1/opik-university")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="comet-body-s flex items-center gap-1 text-primary hover:underline dark:text-primary-hover"
@@ -102,7 +102,7 @@ const HelpGuideDialog: React.FunctionComponent<HelpGuideDialogProps> = ({
                   <ExternalLink className="size-4" />
                 </a>
                 <a
-                  href={buildDocsUrl("/quickstart")}
+                  href={buildDocsUrl("/v1/quickstart")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="comet-body-s flex items-center gap-1 text-primary hover:underline dark:text-primary-hover"
@@ -111,7 +111,7 @@ const HelpGuideDialog: React.FunctionComponent<HelpGuideDialogProps> = ({
                   <ExternalLink className="size-4" />
                 </a>
                 <a
-                  href={buildDocsUrl("/cookbook/overview")}
+                  href={buildDocsUrl("/v1/cookbook/overview")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="comet-body-s flex items-center gap-1 text-primary hover:underline dark:text-primary-hover"
@@ -120,7 +120,7 @@ const HelpGuideDialog: React.FunctionComponent<HelpGuideDialogProps> = ({
                   <ExternalLink className="size-4" />
                 </a>
                 <a
-                  href={buildDocsUrl("/tracing/integrations/overview")}
+                  href={buildDocsUrl("/v1/tracing/integrations/overview")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="comet-body-s flex items-center gap-1 text-primary hover:underline dark:text-primary-hover"
@@ -129,7 +129,7 @@ const HelpGuideDialog: React.FunctionComponent<HelpGuideDialogProps> = ({
                   <ExternalLink className="size-4" />
                 </a>
                 <a
-                  href={buildDocsUrl("/tracing/log_agents")}
+                  href={buildDocsUrl("/v1/tracing/log_agents")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="comet-body-s flex items-center gap-1 text-primary hover:underline dark:text-primary-hover"
@@ -138,7 +138,7 @@ const HelpGuideDialog: React.FunctionComponent<HelpGuideDialogProps> = ({
                   <ExternalLink className="size-4" />
                 </a>
                 <a
-                  href={buildDocsUrl("/faq")}
+                  href={buildDocsUrl("/v1/faq")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="comet-body-s flex items-center gap-1 text-primary hover:underline dark:text-primary-hover"

--- a/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/components/QuickInstallDialog.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/components/QuickInstallDialog.tsx
@@ -44,7 +44,7 @@ Before you begin, you must understand and strictly adhere to these core principl
 
 3. Documentation & Resources:
 
-   - Reference official Opik documentation at https://www.comet.com/docs/opik/quickstart.md
+   - Reference official Opik documentation at https://www.comet.com/docs/opik/v1/quickstart.md
    - Follow Opik best practices and recommended patterns
    - Maintain detailed integration notes and configuration details
 
@@ -86,7 +86,7 @@ After verifying language compatibility, perform a full codebase scan with the fo
 
 ### Step 3: Discover Available Integrations
 
-After I confirm the LLM Touchpoints and entry point, find the list of supported integrations at https://www.comet.com/docs/opik/integrations/overview.md
+After I confirm the LLM Touchpoints and entry point, find the list of supported integrations at https://www.comet.com/docs/opik/v1/integrations/overview.md
 
 ### Step 4: Deep Analysis Confirmed files for LLM Frameworks & SDKs
 
@@ -123,12 +123,12 @@ Notify me that all integration steps are complete.
 If issues are reported:
 
 1. Parse the error or unexpected behavior from feedback.
-2. Re-query the Opik docs using https://www.comet.com/docs/opik/quickstart.md if needed.
+2. Re-query the Opik docs using https://www.comet.com/docs/opik/v1/quickstart.md if needed.
 3. Propose a minimal fix and await approval.
 4. Apply and revalidate.
 `;
 
-const QUICKSTART_DOCS_LINK = "https://www.comet.com/docs/opik/quickstart";
+const QUICKSTART_DOCS_LINK = "https://www.comet.com/docs/opik/v1/quickstart";
 const CURSOR_PROMPT_URL = `https://cursor.com/link/prompt?text=${encodeURIComponent(
   AI_ASSISTANT_PROMPT,
 )}`;

--- a/apps/opik-frontend/src/v1/pages-shared/traces/ThreadDetailsPanel/ThreadFeedbackScoresInfo.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/traces/ThreadDetailsPanel/ThreadFeedbackScoresInfo.tsx
@@ -16,7 +16,7 @@ const ThreadFeedbackScoresInfo: React.FC<ThreadFeedbackScoresInfoProps> = ({
     return null;
   }
 
-  //   const scoreDocsLink = buildDocsUrl("/tracing/annotate_traces");
+  //   const scoreDocsLink = buildDocsUrl("/v1/tracing/annotate_traces");
 
   return (
     <div className="comet-body-xs mt-2 flex gap-1.5 py-2 text-light-slate">

--- a/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTableNoData.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTableNoData.tsx
@@ -23,7 +23,7 @@ const FeedbackScoreTableNoData: React.FC<FeedbackScoreTableNoDataProps> = ({
     permissions: { canUpdateOnlineEvaluationRules, canAnnotateTraceSpanThread },
   } = usePermissions();
 
-  const evaluationDocsLink = buildDocsUrl("/production/rules");
+  const evaluationDocsLink = buildDocsUrl("/v1/production/rules");
 
   const getDescription = () => {
     if (canUpdateOnlineEvaluationRules && canAnnotateTraceSpanThread) {

--- a/apps/opik-frontend/src/v1/pages/AlertsPage/AddEditAlertPage/TestWebhookSection.tsx
+++ b/apps/opik-frontend/src/v1/pages/AlertsPage/AddEditAlertPage/TestWebhookSection.tsx
@@ -194,7 +194,7 @@ const TestWebhookSection: React.FunctionComponent<TestWebhookSectionProps> = ({
           </Button>
           <Button variant="ghost" asChild>
             <a
-              href={buildDocsUrl("/production/alerts")}
+              href={buildDocsUrl("/v1/production/alerts")}
               target="_blank"
               rel="noreferrer"
             >

--- a/apps/opik-frontend/src/v1/pages/AnnotationQueuePage/QueueItemsTab/NoQueueItemsPage.tsx
+++ b/apps/opik-frontend/src/v1/pages/AnnotationQueuePage/QueueItemsTab/NoQueueItemsPage.tsx
@@ -51,8 +51,7 @@ const NoQueueItemsPage: React.FC<NoQueueItemsPageProps> = ({
         <>
           <Button variant="secondary" asChild>
             <a
-              href={buildDocsUrl(
-                "/evaluation/annotation_queues",
+              href={buildDocsUrl("/v1/evaluation/annotation_queues",
                 "#adding-content-to-your-queue",
               )}
               target="_blank"

--- a/apps/opik-frontend/src/v1/pages/AnnotationQueuePage/QueueItemsTab/NoQueueItemsPage.tsx
+++ b/apps/opik-frontend/src/v1/pages/AnnotationQueuePage/QueueItemsTab/NoQueueItemsPage.tsx
@@ -51,7 +51,8 @@ const NoQueueItemsPage: React.FC<NoQueueItemsPageProps> = ({
         <>
           <Button variant="secondary" asChild>
             <a
-              href={buildDocsUrl("/v1/evaluation/annotation_queues",
+              href={buildDocsUrl(
+                "/v1/evaluation/annotation_queues",
                 "#adding-content-to-your-queue",
               )}
               target="_blank"

--- a/apps/opik-frontend/src/v1/pages/HomePageShared/SetGuardrailDialog.tsx
+++ b/apps/opik-frontend/src/v1/pages/HomePageShared/SetGuardrailDialog.tsx
@@ -11,7 +11,7 @@ import { useGuardrailConfigState } from "./useGuardrailConfigState";
 import { GuardrailTypes } from "@/types/guardrails";
 
 const GUARDRAIL_DOCS_LINK =
-  "https://www.comet.com/docs/opik/production/guardrails";
+  "https://www.comet.com/docs/opik/v1/production/guardrails";
 
 type SetGuardrailDialogProps = {
   open: boolean;

--- a/apps/opik-frontend/src/v1/pages/TestSuiteItemsPage/TestSuiteItemsTab/TestSuiteItemsTab.tsx
+++ b/apps/opik-frontend/src/v1/pages/TestSuiteItemsPage/TestSuiteItemsTab/TestSuiteItemsTab.tsx
@@ -658,8 +658,7 @@ function TestSuiteItemsTab({
           <DataTableNoData title={noDataText}>
             <Button variant="link">
               <a
-                href={buildDocsUrl(
-                  "/evaluation/manage_datasets",
+                href={buildDocsUrl("/v1/evaluation/manage_datasets",
                   "#insert-items",
                 )}
                 target="_blank"

--- a/apps/opik-frontend/src/v1/pages/TestSuiteItemsPage/TestSuiteItemsTab/TestSuiteItemsTab.tsx
+++ b/apps/opik-frontend/src/v1/pages/TestSuiteItemsPage/TestSuiteItemsTab/TestSuiteItemsTab.tsx
@@ -658,7 +658,8 @@ function TestSuiteItemsTab({
           <DataTableNoData title={noDataText}>
             <Button variant="link">
               <a
-                href={buildDocsUrl("/v1/evaluation/manage_datasets",
+                href={buildDocsUrl(
+                  "/v1/evaluation/manage_datasets",
                   "#insert-items",
                 )}
                 target="_blank"

--- a/apps/opik-frontend/src/v1/pages/TestSuitesPage/TestSuitesPage.tsx
+++ b/apps/opik-frontend/src/v1/pages/TestSuitesPage/TestSuitesPage.tsx
@@ -359,7 +359,7 @@ const TestSuitesPage: React.FunctionComponent = () => {
         A dataset is a collection of inputs and expected outputs used to
         evaluate your LLM application.{" "}
         <a
-          href={buildDocsUrl("/evaluation/manage_datasets")}
+          href={buildDocsUrl("/v1/evaluation/manage_datasets")}
           target="_blank"
           rel="noreferrer"
           className="text-primary"

--- a/apps/opik-frontend/src/v1/pages/TracesPage/NoTracesPage.tsx
+++ b/apps/opik-frontend/src/v1/pages/TracesPage/NoTracesPage.tsx
@@ -39,7 +39,7 @@ const NoTracesPage: React.FC<NoTracesPageProps> = ({
         <>
           <Button variant="secondary" asChild>
             <a
-              href={buildDocsUrl("/tracing/log_traces")}
+              href={buildDocsUrl("/v1/tracing/log_traces")}
               target="_blank"
               rel="noreferrer"
             >

--- a/apps/opik-frontend/src/v1/pages/TracesPage/ThreadsTab/NoThreadsPage.tsx
+++ b/apps/opik-frontend/src/v1/pages/TracesPage/ThreadsTab/NoThreadsPage.tsx
@@ -20,7 +20,7 @@ const NoThreadsPage = () => {
         <>
           <Button variant="secondary" asChild>
             <a
-              href={buildDocsUrl("/tracing/log_chat_conversations")}
+              href={buildDocsUrl("/v1/tracing/log_chat_conversations")}
               target="_blank"
               rel="noreferrer"
             >

--- a/apps/opik-frontend/src/v2/constants/explainers.ts
+++ b/apps/opik-frontend/src/v2/constants/explainers.ts
@@ -130,13 +130,13 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     title: "Project created",
     description:
       "Log traces to your project to capture LLM interactions, analyze performance, run experiments, and improve your application over time.",
-    docLink: "/v1/tracing/log_traces",
+    docLink: "/tracing/advanced/log_traces",
   },
   [EXPLAINER_ID.what_are_traces]: {
     id: EXPLAINER_ID.what_are_traces,
     description:
       "A trace is a step-by-step record of how your LLM application processes a single input, including LLM calls and other operations.",
-    docLink: "/v1/tracing/log_traces",
+    docLink: "/tracing/advanced/log_traces",
   },
   [EXPLAINER_ID.what_are_spans]: {
     id: EXPLAINER_ID.what_are_spans,
@@ -147,21 +147,21 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     id: EXPLAINER_ID.what_are_threads,
     description:
       "A thread represents a full conversation session, grouping together multiple related traces. Use threads to review and evaluate entire interactions in chat-based applications.",
-    docLink: "/v1/tracing/log_chat_conversations",
+    docLink: "/tracing/advanced/log_chat_conversations",
     type: "help",
   },
   [EXPLAINER_ID.whats_online_evaluation]: {
     id: EXPLAINER_ID.whats_online_evaluation,
     description:
       "Automatically score your production traces by defining LLM-as-a-Judge or code metrics.",
-    docLink: "/v1/production/rules",
+    docLink: "/production/online-evaluation/rules",
   },
   [EXPLAINER_ID.i_added_traces_to_an_test_suite_now_what]: {
     id: EXPLAINER_ID.i_added_traces_to_an_test_suite_now_what,
     title: "Traces added to test suite",
     description:
       "Your traces have been added to the test suite and can now be used in experiments to evaluate your agent.",
-    docLink: "/v1/evaluation/overview",
+    docLink: "/evaluation/overview",
     docHash: "#running-an-evaluation",
   },
   [EXPLAINER_ID.i_added_items_to_a_dataset_now_what]: {
@@ -169,7 +169,7 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     title: "Items added to dataset",
     description:
       "Your items have been added to the dataset and can now be used in experiments to evaluate your agent.",
-    docLink: "/v1/evaluation/overview",
+    docLink: "/evaluation/overview",
     docHash: "#running-an-evaluation",
   },
   [EXPLAINER_ID.why_would_i_want_to_add_traces_to_an_test_suite]: {
@@ -181,21 +181,21 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     id: EXPLAINER_ID.hows_the_cost_estimated,
     description:
       "Opik estimates the cost of each trace by calculating token usage across all LLM calls, using model-specific pricing.",
-    docLink: "/v1/tracing/cost_tracking",
+    docLink: "/tracing/advanced/cost_tracking",
     type: "help",
   },
   [EXPLAINER_ID.hows_the_thread_cost_estimated]: {
     id: EXPLAINER_ID.hows_the_thread_cost_estimated,
     description:
       "Opik estimates the cost of each thread by calculating token usage across all Traces and associated LLM calls, applying model-specific pricing.",
-    docLink: "/v1/tracing/cost_tracking",
+    docLink: "/tracing/advanced/cost_tracking",
     type: "help",
   },
   [EXPLAINER_ID.whats_that_prompt_select]: {
     id: EXPLAINER_ID.whats_that_prompt_select,
     description:
       "Select the LLM-as-a-Judge prompt to use. You can use one of the prompts provided by Opik, or you can [create your own metrics].",
-    docLink: "/v1/production/rules",
+    docLink: "/production/online-evaluation/rules",
     docHash: "#writing-your-own-llm-as-a-judge-metric",
     type: "help",
   },
@@ -233,7 +233,7 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     id: EXPLAINER_ID.what_are_annotation_queues,
     description:
       "Add traces or thread to an annotation queue to collect human feedback on your LLM outputs. Only queues created in this project appear here, and traces can be added to them only",
-    docLink: "/v1/evaluation/annotation_queues",
+    docLink: "/evaluation/advanced/annotation_queues",
   },
   [EXPLAINER_ID.how_to_choose_annotation_queue_type]: {
     id: EXPLAINER_ID.how_to_choose_annotation_queue_type,
@@ -244,34 +244,34 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     id: EXPLAINER_ID.whats_an_experiment,
     description:
       "Experiments help you test prompts and models, compare versions, and track improvements or issues.",
-    docLink: "/v1/evaluation/overview",
+    docLink: "/evaluation/overview",
   },
   [EXPLAINER_ID.whats_a_prompt_commit]: {
     id: EXPLAINER_ID.whats_a_prompt_commit,
     description:
       "Prompt commits capture the exact prompt version used in an experiment, ensuring reproducibility and traceability of results. Manage your prompts in the Prompt library.",
-    docLink: "/v1/prompt_engineering/prompt_management",
+    docLink: "/development/agent-configuration/overview",
     type: "help",
   },
   [EXPLAINER_ID.what_are_experiment_items]: {
     id: EXPLAINER_ID.what_are_experiment_items,
     description:
       "Experiment items are individual evaluations that connect a dataset sample with its LLM output, feedback scores, and trace.",
-    docLink: "/v1/evaluation/overview",
+    docLink: "/evaluation/overview",
     docHash: "#analyzing-evaluation-results",
   },
   [EXPLAINER_ID.whats_the_experiment_configuration]: {
     id: EXPLAINER_ID.whats_the_experiment_configuration,
     description:
       "The experiment configuration captures key settings, like the prompt, model, and temperature, to keep experiments reproducible and easy to analyze.",
-    docLink: "/v1/evaluation/concepts",
+    docLink: "/evaluation/concepts",
     docHash: "#experiment-configuration",
   },
   [EXPLAINER_ID.what_does_it_mean_to_compare_my_experiments]: {
     id: EXPLAINER_ID.what_does_it_mean_to_compare_my_experiments,
     description:
       "Compare experiments to understand how changes to prompts, models, or rules impact performance. Select at least two experiments from the same test suite to get started.",
-    docLink: "/v1/evaluation/overview",
+    docLink: "/evaluation/overview",
     docHash: "#analyzing-evaluation-results",
     type: "help",
   },
@@ -279,7 +279,7 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     id: EXPLAINER_ID.whats_the_test_suite_item,
     description:
       "Test suite items are individual input samples in an experiment, each representing a test case your LLM app processes and evaluates.",
-    docLink: "/v1/evaluation/concepts",
+    docLink: "/evaluation/concepts",
     docHash: "#experiments",
     type: "help",
   },
@@ -287,7 +287,7 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     id: EXPLAINER_ID.whats_an_test_suite,
     description:
       "A test suite is a collection of input-output examples used to evaluate your LLM application's performance.",
-    docLink: "/v1/evaluation/concepts",
+    docLink: "/evaluation/concepts",
     docHash: "#test-suites",
   },
   [EXPLAINER_ID.why_do_i_need_multiple_test_suites]: {
@@ -309,13 +309,13 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     id: EXPLAINER_ID.whats_the_prompt_library,
     description:
       "Store and version prompts to maintain consistency and simplify experimentation across projects",
-    docLink: "/v1/prompt_engineering/prompt_management",
+    docLink: "/development/agent-configuration/overview",
   },
   [EXPLAINER_ID.how_do_i_use_this_prompt]: {
     id: EXPLAINER_ID.how_do_i_use_this_prompt,
     description:
       "To use a saved prompt from your library, select it when configuring an experiment or in the playground. You can also reference its latest version or a specific commit.",
-    docLink: "/v1/prompt_engineering/prompt_management",
+    docLink: "/development/agent-configuration/overview",
     docHash: "#linking-prompts-to-experiments",
   },
   [EXPLAINER_ID.why_do_i_have_experiments_in_the_prompt_library]: {
@@ -327,7 +327,7 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     id: EXPLAINER_ID.what_are_commits,
     description:
       "Each edit in a prompt creates a new commit, ensuring version control and reproducibility.",
-    docLink: "/v1/prompt_engineering/prompt_management",
+    docLink: "/development/agent-configuration/overview",
     docHash: "#managing-prompts-stored-in-code",
     type: "help",
   },
@@ -335,19 +335,19 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     id: EXPLAINER_ID.how_do_i_write_my_prompt,
     description:
       "Write prompts as your LLM would receive them, including any dynamic placeholders or formatting.",
-    docLink: "/v1/agent_optimization/best-practices/prompt_engineering",
+    docLink: "/development/agent-configuration/overview",
   },
   [EXPLAINER_ID.what_happens_if_i_edit_my_prompt]: {
     id: EXPLAINER_ID.what_happens_if_i_edit_my_prompt,
     description:
       "Write prompts as your LLM would receive them, including any dynamic placeholders or formatting. Editing creates a new version automatically. View history in the Commits tab.",
-    docLink: "/v1/agent_optimization/best-practices/prompt_engineering",
+    docLink: "/development/agent-configuration/overview",
   },
   [EXPLAINER_ID.whats_the_playground]: {
     id: EXPLAINER_ID.whats_the_playground,
     description:
       "Test before saving a prompt to the library or running a full experiment. Or use it to explore different prompt variations and see how your LLM responds in real time.",
-    docLink: "/v1/prompt_engineering/playground",
+    docLink: "/development/playground",
   },
   [EXPLAINER_ID.whats_these_configuration_things]: {
     id: EXPLAINER_ID.whats_these_configuration_things,
@@ -403,7 +403,7 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     id: EXPLAINER_ID.whats_an_optimization_run,
     description:
       "Automatically test prompt variations and find the best-performing one.",
-    docLink: "/v1/agent_optimization/overview",
+    docLink: "/development/optimization-runs/overview",
   },
   [EXPLAINER_ID.whats_the_best_score]: {
     id: EXPLAINER_ID.whats_the_best_score,
@@ -448,21 +448,21 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     id: EXPLAINER_ID.why_would_i_compare_commits,
     description:
       "Compare prompt commits to understand how changes affect output quality and performance. Select at least two commits to get started.",
-    docLink: "/v1/evaluation/evaluate_prompt",
+    docLink: "/evaluation/advanced/evaluate_your_llm",
     type: "help",
   },
   [EXPLAINER_ID.whats_the_optimizer]: {
     id: EXPLAINER_ID.whats_the_optimizer,
     description:
       "An optimizer is a built-in algorithm from the Opik Agent Optimizer SDK that improves prompt effectiveness. Each one uses its own strategy and configurable settings to target specific optimization goals.",
-    docLink: "/v1/agent_optimization/opik_optimizer/concepts",
+    docLink: "/development/optimization-runs/optimization/concepts",
     type: "help",
   },
   [EXPLAINER_ID.what_are_trial_items]: {
     id: EXPLAINER_ID.what_are_trial_items,
     description:
       "Trial items are test suite samples processed during a trial. Each one generates an output and score that contribute to the trial's results.",
-    docLink: "/v1/agent_optimization/opik_optimizer/concepts",
+    docLink: "/development/optimization-runs/optimization/concepts",
   },
   [EXPLAINER_ID.whats_the_evaluation_run_configuration]: {
     id: EXPLAINER_ID.whats_the_evaluation_run_configuration,
@@ -473,98 +473,98 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     id: EXPLAINER_ID.metric_equals,
     description:
       "Checks if the output exactly matches an expected string. Use this for strict equality checks.",
-    docLink: "/v1/evaluation/metrics/heuristic_metrics",
+    docLink: "/evaluation/metrics/heuristic_metrics",
     docHash: "#equals",
   },
   [EXPLAINER_ID.metric_contains]: {
     id: EXPLAINER_ID.metric_contains,
     description:
       "Checks if the output contains a specific substring, can be both case sensitive or case insensitive.",
-    docLink: "/v1/evaluation/metrics/heuristic_metrics",
+    docLink: "/evaluation/metrics/heuristic_metrics",
     docHash: "#contains",
   },
   [EXPLAINER_ID.metric_regex_match]: {
     id: EXPLAINER_ID.metric_regex_match,
     description:
       "Checks if the output matches a specified regular expression pattern.",
-    docLink: "/v1/evaluation/metrics/heuristic_metrics",
+    docLink: "/evaluation/metrics/heuristic_metrics",
     docHash: "#regexmatch",
   },
   [EXPLAINER_ID.metric_is_json]: {
     id: EXPLAINER_ID.metric_is_json,
     description: "Checks if the output is a valid JSON object.",
-    docLink: "/v1/evaluation/metrics/heuristic_metrics",
+    docLink: "/evaluation/metrics/heuristic_metrics",
     docHash: "#isjson",
   },
   [EXPLAINER_ID.metric_levenshtein]: {
     id: EXPLAINER_ID.metric_levenshtein,
     description:
       "Calculates the Levenshtein distance between the output and an expected string.",
-    docLink: "/v1/evaluation/metrics/heuristic_metrics",
+    docLink: "/evaluation/metrics/heuristic_metrics",
     docHash: "#levenshteinratio",
   },
   [EXPLAINER_ID.metric_sentence_bleu]: {
     id: EXPLAINER_ID.metric_sentence_bleu,
     description:
       "Calculates a single-sentence BLEU score for a candidate vs. one or more references.",
-    docLink: "/v1/evaluation/metrics/heuristic_metrics",
+    docLink: "/evaluation/metrics/heuristic_metrics",
     docHash: "#bleu",
   },
   [EXPLAINER_ID.metric_corpus_bleu]: {
     id: EXPLAINER_ID.metric_corpus_bleu,
     description:
       "Calculates a corpus-level BLEU score for multiple candidates vs. their references.",
-    docLink: "/v1/evaluation/metrics/heuristic_metrics",
+    docLink: "/evaluation/metrics/heuristic_metrics",
     docHash: "#bleu",
   },
   [EXPLAINER_ID.metric_rouge]: {
     id: EXPLAINER_ID.metric_rouge,
     description:
       "Calculates the ROUGE score for a candidate vs. one or more references.",
-    docLink: "/v1/evaluation/metrics/heuristic_metrics",
+    docLink: "/evaluation/metrics/heuristic_metrics",
     docHash: "#rouge",
   },
   [EXPLAINER_ID.metric_hallucination]: {
     id: EXPLAINER_ID.metric_hallucination,
     description:
       "The hallucination metric allows you to check if the LLM response contains any hallucinated information. In order to check for hallucination, you will need to provide the LLM input, LLM output. If the context is provided, this will also be used to check for hallucinations.",
-    docLink: "/v1/evaluation/metrics/hallucination",
+    docLink: "/evaluation/metrics/hallucination",
   },
   [EXPLAINER_ID.metric_g_eval]: {
     id: EXPLAINER_ID.metric_g_eval,
     description:
       "G-Eval is a task agnostic LLM as a Judge metric that allows you to specify a set of criteria for your metric and it will use a Chain of Thought prompting technique to create some evaluation steps and return a score.",
-    docLink: "/v1/evaluation/metrics/g_eval",
+    docLink: "/evaluation/metrics/g_eval",
   },
   [EXPLAINER_ID.metric_moderation]: {
     id: EXPLAINER_ID.metric_moderation,
     description:
       "The Moderation metric allows you to evaluate the appropriateness of the LLM’s response to the given LLM output. It does this by asking the LLM to rate the appropriateness of the response on a scale of 1 to 10, where 1 is the least appropriate and 10 is the most appropriate.",
-    docLink: "/v1/evaluation/metrics/moderation",
+    docLink: "/evaluation/metrics/moderation",
   },
   [EXPLAINER_ID.metric_usefulness]: {
     id: EXPLAINER_ID.metric_usefulness,
     description:
       "The usefulness metric allows you to evaluate how useful an LLM response is given an input. It uses a language model to assess the usefulness and provides a score between 0.0 and 1.0, where higher values indicate higher usefulness. Along with the score, it provides a detailed explanation of why that score was assigned.",
-    docLink: "/v1/evaluation/metrics/usefulness",
+    docLink: "/evaluation/metrics/usefulness",
   },
   [EXPLAINER_ID.metric_answer_relevance]: {
     id: EXPLAINER_ID.metric_answer_relevance,
     description:
       "The Answer Relevance metric allows you to evaluate how relevant and appropriate the LLM’s response is to the given input question or prompt. To assess the relevance of the answer, you will need to provide the LLM input (question or prompt) and the LLM output (generated answer). Unlike the Hallucination metric, the Answer Relevance metric focuses on the appropriateness and pertinence of the response rather than factual accuracy.",
-    docLink: "/v1/evaluation/metrics/answer_relevance",
+    docLink: "/evaluation/metrics/answer_relevance",
   },
   [EXPLAINER_ID.metric_context_precision]: {
     id: EXPLAINER_ID.metric_context_precision,
     description:
       "The context precision metric evaluates the accuracy and relevance of an LLM’s response based on provided context, helping to identify potential hallucinations or misalignments with the given information.",
-    docLink: "/v1/evaluation/metrics/context_precision",
+    docLink: "/evaluation/metrics/context_precision",
   },
   [EXPLAINER_ID.metric_context_recall]: {
     id: EXPLAINER_ID.metric_context_recall,
     description:
       "The context recall metric evaluates the accuracy and relevance of an LLM’s response based on provided context, helping to identify potential hallucinations or misalignments with the given information.",
-    docLink: "/v1/evaluation/metrics/context_recall",
+    docLink: "/evaluation/metrics/context_recall",
   },
   [EXPLAINER_ID.trace_opik_ai]: {
     id: EXPLAINER_ID.trace_opik_ai,
@@ -586,39 +586,39 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     id: EXPLAINER_ID.prompt_generation_learn_more,
     description:
       "Not sure where to start? Tell us your goal in plain language, and we'll generate a ready-to-use prompt.",
-    docLink: "/v1/prompt_engineering/improve",
+    docLink: "/development/agent-configuration/overview",
     docHash: "#generate",
   },
   [EXPLAINER_ID.prompt_improvement_learn_more]: {
     id: EXPLAINER_ID.prompt_improvement_learn_more,
     description:
       "Give your prompt a boost! Add optional guidance, or let AI apply best-practice improvements for you.",
-    docLink: "/v1/prompt_engineering/improve",
+    docLink: "/development/agent-configuration/overview",
     docHash: "#improve",
   },
   [EXPLAINER_ID.prompt_improvement_optimizer]: {
     id: EXPLAINER_ID.prompt_improvement_optimizer,
     description:
       "Looking for advanced optimization algorithms? Check out the Opik optimizer!",
-    docLink: "/v1/agent_optimization/opik_optimizer/overview",
+    docLink: "/development/optimization-runs/overview",
   },
   [EXPLAINER_ID.whats_an_alert]: {
     id: EXPLAINER_ID.whats_an_alert,
     description:
       "Monitor important events in your project and get notified when something needs your attention.",
-    docLink: "/v1/production/alerts",
+    docLink: "/production/alerts/alerts",
   },
   [EXPLAINER_ID.what_are_dashboards]: {
     id: EXPLAINER_ID.what_are_dashboards,
     description:
       "Set up dashboards to monitor quality, cost, and performance of your projects and share experiment results",
-    docLink: "/v1/production/dashboards",
+    docLink: "/tracing/dashboards/dashboards",
   },
   [EXPLAINER_ID.whats_the_optimization_config]: {
     id: EXPLAINER_ID.whats_the_optimization_config,
     description:
       "Configure your setup and let Opik automatically find the best prompt.",
-    docLink: "/v1/agent_optimization/optimization_studio",
+    docLink: "/development/optimization-runs/optimization_studio",
   },
   [EXPLAINER_ID.whats_the_algorithm_section]: {
     id: EXPLAINER_ID.whats_the_algorithm_section,
@@ -636,13 +636,13 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     id: EXPLAINER_ID.whats_the_metric_settings,
     description:
       "Configure parameters for the selected evaluation metric to customize how your outputs are scored.",
-    docLink: "/v1/evaluation/metrics/overview",
+    docLink: "/evaluation/metrics/overview",
   },
   [EXPLAINER_ID.whats_the_algorithm_settings]: {
     id: EXPLAINER_ID.whats_the_algorithm_settings,
     description:
       "Configure parameters for the selected optimization algorithm to control how prompts are improved.",
-    docLink: "/v1/agent_optimization/opik_optimizer/concepts",
+    docLink: "/development/optimization-runs/optimization/concepts",
   },
   // Metric config explainers
   [EXPLAINER_ID.geval_task_introduction]: {

--- a/apps/opik-frontend/src/v2/pages-shared/TextPromptEditor/TextPromptEditor.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/TextPromptEditor/TextPromptEditor.tsx
@@ -6,7 +6,7 @@ import { Textarea } from "@/ui/textarea";
 import { Description } from "@/ui/description";
 import MarkdownPreview from "@/shared/MarkdownPreview/MarkdownPreview";
 import MediaTagsList from "@/v2/pages-shared/llm/PromptMessageMediaTags/MediaTagsList";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 interface TextPromptEditorProps {
   value: string;

--- a/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
@@ -38,7 +38,7 @@ import useAnnotationQueueUpdateMutation from "@/api/annotation-queues/useAnnotat
 import { Separator } from "@/ui/separator";
 import { Description } from "@/ui/description";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { usePermissions } from "@/contexts/PermissionsContext";
 
 const SCOPE_OPTIONS = [

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/AddEditRuleDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/AddEditRuleDialog.tsx
@@ -70,7 +70,7 @@ import {
 } from "@/constants/llm";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { Description } from "@/ui/description";
 import { ToastAction } from "@/ui/toast";
 import { useToast } from "@/ui/use-toast";

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -32,7 +32,7 @@ import { safelyGetPromptMustacheTags } from "@/lib/prompt";
 import { EvaluationRuleFormType } from "@/v2/pages-shared/automations/AddEditRuleDialog/schema";
 import useLLMProviderModelsData from "@/hooks/useLLMProviderModelsData";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
 import { updateProviderConfig } from "@/lib/modelUtils";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";

--- a/apps/opik-frontend/src/v2/pages-shared/automations/NoRulesPage.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/NoRulesPage.tsx
@@ -37,7 +37,7 @@ const NoRulesPage: React.FC<NoRulesPageProps> = ({
         <>
           <Button variant="secondary" asChild>
             <a
-              href={buildDocsUrl("/production/rules")}
+              href={buildDocsUrl("/production/online-evaluation/rules")}
               target="_blank"
               rel="noreferrer"
             >

--- a/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/ProjectMetricsBreakdownSection.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/ProjectMetricsBreakdownSection.tsx
@@ -15,7 +15,7 @@ import { Label } from "@/ui/label";
 import SelectBox from "@/shared/SelectBox/SelectBox";
 import TracesOrSpansPathsAutocomplete from "@/v2/pages-shared/traces/TracesOrSpansPathsAutocomplete/TracesOrSpansPathsAutocomplete";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 import { cn } from "@/lib/utils";
 import { BreakdownConfig } from "@/types/dashboard";

--- a/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/ProjectMetricsWidget.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/ProjectMetricsWidget.tsx
@@ -340,7 +340,7 @@ const ProjectMetricsWidget: React.FunctionComponent<
           action={
             <DashboardWidget.EmptyState.DocsLink
               label="Learn how to add scores"
-              href={buildDocsUrl("/tracing/annotate_traces")}
+              href={buildDocsUrl("/tracing/advanced/annotate_traces")}
             />
           }
         />
@@ -354,7 +354,7 @@ const ProjectMetricsWidget: React.FunctionComponent<
           action={
             <DashboardWidget.EmptyState.DocsLink
               label="Learn how to add scores"
-              href={buildDocsUrl("/tracing/annotate_traces")}
+              href={buildDocsUrl("/tracing/advanced/annotate_traces")}
             />
           }
         />
@@ -371,7 +371,7 @@ const ProjectMetricsWidget: React.FunctionComponent<
           action={
             <DashboardWidget.EmptyState.DocsLink
               label="Learn how to track threads"
-              href={buildDocsUrl("/tracing/log_chat_conversations")}
+              href={buildDocsUrl("/tracing/advanced/log_chat_conversations")}
             />
           }
         />

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/AddEditDatasetDialog/AddEditDatasetDialogWrapper.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/AddEditDatasetDialog/AddEditDatasetDialogWrapper.tsx
@@ -124,7 +124,9 @@ const AddEditDatasetDialogWrapper: React.FunctionComponent<
                   )}
                   <Button variant="link" size="sm" className="h-5 px-1" asChild>
                     <a
-                      href={buildDocsUrl("/evaluation/advanced/manage_datasets")}
+                      href={buildDocsUrl(
+                        "/evaluation/advanced/manage_datasets",
+                      )}
                       target="_blank"
                       rel="noopener noreferrer"
                     >

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/AddEditDatasetDialog/AddEditDatasetDialogWrapper.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/AddEditDatasetDialog/AddEditDatasetDialogWrapper.tsx
@@ -124,7 +124,7 @@ const AddEditDatasetDialogWrapper: React.FunctionComponent<
                   )}
                   <Button variant="link" size="sm" className="h-5 px-1" asChild>
                     <a
-                      href={buildDocsUrl("/evaluation/manage_datasets")}
+                      href={buildDocsUrl("/evaluation/advanced/manage_datasets")}
                       target="_blank"
                       rel="noopener noreferrer"
                     >

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.tsx
@@ -32,7 +32,7 @@ import {
 } from "@/types/feedback-definitions";
 import FeedbackDefinitionDetails from "./FeedbackDefinitionDetails";
 import ExplainerCallout from "@/shared/ExplainerCallout/ExplainerCallout";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 const TYPE_OPTIONS = [
   {

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/CreateDatasetSidebar/CreateDatasetSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/CreateDatasetSidebar/CreateDatasetSidebar.tsx
@@ -251,7 +251,7 @@ const CreateDatasetSidebar: React.FunctionComponent<
           )}
           <Button variant="link" size="sm" className="h-5 px-1" asChild>
             <a
-              href={buildDocsUrl("/evaluation/manage_datasets")}
+              href={buildDocsUrl("/evaluation/advanced/manage_datasets")}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemPanel/AddDatasetItemDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemPanel/AddDatasetItemDialog.tsx
@@ -21,7 +21,7 @@ import useDatasetItemBatchMutation from "@/api/datasets/useDatasetItemBatchMutat
 import { isValidJsonObject, safelyParseJSON } from "@/lib/utils";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
 import { useBooleanTimeoutState } from "@/hooks/useBooleanTimeoutState";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 const DATA_PREFILLED_CONTENT = `{
   "input": "<user question>",

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetListPage/DatasetListPage.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetListPage/DatasetListPage.tsx
@@ -59,7 +59,7 @@ type DatasetListPageProps = {
 const TYPE_CONFIG = {
   dataset: {
     title: "Datasets",
-    docsUrl: "/evaluation/manage_datasets",
+    docsUrl: "/evaluation/advanced/manage_datasets",
     entityName: "datasets",
     createButtonText: "Create dataset",
     noDataText: "There are no datasets yet",
@@ -86,7 +86,7 @@ const TYPE_CONFIG = {
   test_suite: {
     title: "Test suites",
     // TODO: replace with test suites documentation URL once it exists
-    docsUrl: "/evaluation/manage_datasets",
+    docsUrl: "/evaluation/advanced/manage_datasets",
     entityName: "test suites",
     createButtonText: "Create test suite",
     noDataText: "There are no test suites yet",

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/TestSuiteItemForm.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/TestSuiteItemForm.tsx
@@ -16,7 +16,7 @@ import { useClampedIntegerInput } from "@/hooks/useClampedIntegerInput";
 import AssertionsField from "@/shared/AssertionField/AssertionsField";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { Description } from "@/ui/description";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { ExecutionPolicy, MAX_RUNS_PER_ITEM } from "@/types/test-suites";
 import {
   ASSERTIONS_DESCRIPTION,

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/ExperimentsActionsPanel/ExperimentsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/ExperimentsActionsPanel/ExperimentsActionsPanel.tsx
@@ -10,7 +10,7 @@ import useExperimentBatchDeleteMutation from "@/api/datasets/useExperimentBatchD
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { Separator } from "@/ui/separator";
 import AddTagDialog from "@/v2/pages-shared/experiments/AddTagDialog/AddTagDialog";
 

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/AddNewPromptVersionDialog.tsx
@@ -42,7 +42,7 @@ import {
 import usePromptById from "@/api/prompts/usePromptById";
 import usePromptCreateMutation from "@/api/prompts/usePromptCreateMutation";
 import { usePermissions } from "@/contexts/PermissionsContext";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 type SaveMode = "update" | "new";
 

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariables.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariables.tsx
@@ -5,7 +5,7 @@ import { Alert, AlertTitle } from "@/ui/alert";
 import LLMPromptMessagesVariable from "@/v2/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariable";
 import { Description } from "@/ui/description";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINERS_MAP, EXPLAINER_ID } from "@/constants/explainers";
+import { EXPLAINERS_MAP, EXPLAINER_ID } from "@/v2/constants/explainers";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 
 const DEFAULT_DESCRIPTION =

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/CustomProviderDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/CustomProviderDetails.tsx
@@ -117,7 +117,7 @@ const CustomProviderDetails: React.FC<CustomProviderDetailsProps> = ({
                   className="inline px-0"
                 >
                   <a
-                    href={buildDocsUrl("/playground")}
+                    href={buildDocsUrl("/development/playground")}
                     target="_blank"
                     rel="noreferrer"
                   >

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/ManageAIProviderDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/ManageAIProviderDialog.tsx
@@ -29,7 +29,7 @@ import {
   createAIProviderFormSchema,
   AIProviderFormType,
 } from "@/v2/pages-shared/llm/ManageAIProviderDialog/schema";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
 import {
   convertCustomProviderModels,

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/VertexAIProviderDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/VertexAIProviderDetails.tsx
@@ -78,7 +78,10 @@ const VertexAIProviderDetails: React.FC<VertexAIProviderDetailsProps> = ({
       <span className="comet-body-s mt-1 text-light-slate">
         <Button variant="link" size="sm" asChild className="px-0">
           <a
-            href={buildDocsUrl("/administration/workspace-settings/ai_providers", "#vertex-ai")}
+            href={buildDocsUrl(
+              "/administration/workspace-settings/ai_providers",
+              "#vertex-ai",
+            )}
             target="_blank"
             rel="noreferrer"
           >

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/VertexAIProviderDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/VertexAIProviderDetails.tsx
@@ -78,7 +78,7 @@ const VertexAIProviderDetails: React.FC<VertexAIProviderDetailsProps> = ({
       <span className="comet-body-s mt-1 text-light-slate">
         <Button variant="link" size="sm" asChild className="px-0">
           <a
-            href={buildDocsUrl("/configuration/ai_providers", "#vertex-ai")}
+            href={buildDocsUrl("/administration/workspace-settings/ai_providers", "#vertex-ai")}
             target="_blank"
             rel="noreferrer"
           >

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptImprovementDialog/PromptImprovementDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptImprovementDialog/PromptImprovementDialog.tsx
@@ -32,7 +32,7 @@ import {
 } from "@/types/providers";
 import { PROVIDERS } from "@/constants/providers";
 import { MessageContent } from "@/types/llm";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ExplainerCallout from "@/shared/ExplainerCallout/ExplainerCallout";
 import {
   codeMirrorPromptTheme,

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSettings/PromptModelConfigs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSettings/PromptModelConfigs.tsx
@@ -30,7 +30,7 @@ import GeminiModelConfigs from "@/v2/pages-shared/llm/PromptModelSettings/provid
 import VertexAIModelConfigs from "@/v2/pages-shared/llm/PromptModelSettings/providerConfigs/VertexAIModelConfigs";
 import CustomModelConfigs from "@/v2/pages-shared/llm/PromptModelSettings/providerConfigs/CustomModelConfig";
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { parseComposedProviderType } from "@/lib/provider";
 
 interface PromptModelConfigsProps {

--- a/apps/opik-frontend/src/v2/pages-shared/llm/SetupProviderDialog/ProviderConfigurationStep.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/SetupProviderDialog/ProviderConfigurationStep.tsx
@@ -11,7 +11,7 @@ import VertexAIProviderDetails from "@/v2/pages-shared/llm/ManageAIProviderDialo
 import BedrockProviderDetails from "@/v2/pages-shared/llm/ManageAIProviderDialog/BedrockProviderDetails";
 import { AIProviderFormType } from "@/v2/pages-shared/llm/ManageAIProviderDialog/schema";
 import ExplainerCallout from "@/shared/ExplainerCallout/ExplainerCallout";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 interface ProviderConfigurationStepProps {
   selectedProviderType: PROVIDER_TYPE;

--- a/apps/opik-frontend/src/v2/pages-shared/llm/SetupProviderDialog/SetupProviderDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/SetupProviderDialog/SetupProviderDialog.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/v2/pages-shared/llm/ManageAIProviderDialog/schema";
 import { convertCustomProviderModels } from "@/lib/provider";
 import { useProviderOptions } from "@/hooks/useProviderOptions";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
 import { ChevronLeft } from "lucide-react";
 

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/EvaluationExamples/UsingPlaygroundTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/EvaluationExamples/UsingPlaygroundTab.tsx
@@ -29,7 +29,8 @@ const UsingPlaygroundTab = () => {
             asChild
           >
             <a
-              href={buildDocsUrl("/development/playground#running-experiments-in-the-playground",
+              href={buildDocsUrl(
+                "/development/playground#running-experiments-in-the-playground",
               )}
               target="_blank"
               rel="noreferrer"

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/EvaluationExamples/UsingPlaygroundTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/EvaluationExamples/UsingPlaygroundTab.tsx
@@ -29,8 +29,7 @@ const UsingPlaygroundTab = () => {
             asChild
           >
             <a
-              href={buildDocsUrl(
-                "/prompt_engineering/playground#running-experiments-in-the-playground",
+              href={buildDocsUrl("/development/playground#running-experiments-in-the-playground",
               )}
               target="_blank"
               rel="noreferrer"

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/FrameworkIntegrations/FrameworkIntegrations.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/FrameworkIntegrations/FrameworkIntegrations.tsx
@@ -98,7 +98,7 @@ const FrameworkIntegrations: React.FC<FrameworkIntegrationsProps> = ({
       </IntegrationTabs>
       <Button className="w-fit pl-2" variant="ghost" asChild>
         <a
-          href={buildDocsUrl("/tracing/integrations/overview")}
+          href={buildDocsUrl("/integrations/overview")}
           target="_blank"
           rel="noreferrer"
         >

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/FrameworkIntegrations/quickstart-integrations.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/FrameworkIntegrations/quickstart-integrations.ts
@@ -48,7 +48,8 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: pythonLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/quickstart_notebook.ipynb",
-    documentation: buildDocsUrl("/tracing/advanced/log_traces",
+    documentation: buildDocsUrl(
+      "/tracing/advanced/log_traces",
       "#using-function-decorators",
     ),
     code: functionDecoratorsCode,

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/FrameworkIntegrations/quickstart-integrations.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/FrameworkIntegrations/quickstart-integrations.ts
@@ -48,8 +48,7 @@ export const QUICKSTART_INTEGRATIONS: FrameworkIntegration[] = [
     logo: pythonLogoUrl,
     colab:
       "https://colab.research.google.com/github/comet-ml/opik/blob/main/apps/opik-documentation/documentation/docs/cookbook/quickstart_notebook.ipynb",
-    documentation: buildDocsUrl(
-      "/tracing/log_traces",
+    documentation: buildDocsUrl("/tracing/advanced/log_traces",
       "#using-function-decorators",
     ),
     code: functionDecoratorsCode,

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationExplorer/components/HelpGuideDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationExplorer/components/HelpGuideDialog.tsx
@@ -93,7 +93,7 @@ const HelpGuideDialog: React.FunctionComponent<HelpGuideDialogProps> = ({
 
               <div className="space-y-2">
                 <a
-                  href={buildDocsUrl("/opik-university")}
+                  href="https://www.comet.com/docs/opik/v1/opik-university/overview"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="comet-body-s flex items-center gap-1 text-primary hover:underline dark:text-primary-hover"
@@ -111,7 +111,7 @@ const HelpGuideDialog: React.FunctionComponent<HelpGuideDialogProps> = ({
                   <ExternalLink className="size-4" />
                 </a>
                 <a
-                  href={buildDocsUrl("/cookbook/overview")}
+                  href={buildDocsUrl("/integrations/overview")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="comet-body-s flex items-center gap-1 text-primary hover:underline dark:text-primary-hover"
@@ -120,7 +120,7 @@ const HelpGuideDialog: React.FunctionComponent<HelpGuideDialogProps> = ({
                   <ExternalLink className="size-4" />
                 </a>
                 <a
-                  href={buildDocsUrl("/tracing/integrations/overview")}
+                  href={buildDocsUrl("/integrations/overview")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="comet-body-s flex items-center gap-1 text-primary hover:underline dark:text-primary-hover"
@@ -129,7 +129,7 @@ const HelpGuideDialog: React.FunctionComponent<HelpGuideDialogProps> = ({
                   <ExternalLink className="size-4" />
                 </a>
                 <a
-                  href={buildDocsUrl("/tracing/log_agents")}
+                  href={buildDocsUrl("/tracing/advanced/log_agent_graphs")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="comet-body-s flex items-center gap-1 text-primary hover:underline dark:text-primary-hover"

--- a/apps/opik-frontend/src/v2/pages-shared/optimizations/AlgorithmSettings/AlgorithmConfigs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/optimizations/AlgorithmSettings/AlgorithmConfigs.tsx
@@ -18,7 +18,7 @@ import GepaOptimizerConfigs from "@/v2/pages-shared/optimizations/AlgorithmSetti
 import EvolutionaryOptimizerConfigs from "@/v2/pages-shared/optimizations/AlgorithmSettings/algorithmConfigs/EvolutionaryOptimizerConfigs";
 import HierarchicalReflectiveOptimizerConfigs from "@/v2/pages-shared/optimizations/AlgorithmSettings/algorithmConfigs/HierarchicalReflectiveOptimizerConfigs";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 interface AlgorithmConfigsProps {
   optimizerType: OPTIMIZER_TYPE;

--- a/apps/opik-frontend/src/v2/pages-shared/optimizations/AlgorithmSettings/algorithmConfigs/EvolutionaryOptimizerConfigs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/optimizations/AlgorithmSettings/algorithmConfigs/EvolutionaryOptimizerConfigs.tsx
@@ -6,7 +6,7 @@ import SliderInputControl from "@/shared/SliderInputControl/SliderInputControl";
 import { EvolutionaryOptimizerParameters } from "@/types/optimizations";
 import { DEFAULT_EVOLUTIONARY_OPTIMIZER_CONFIGS } from "@/constants/optimizations";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 interface EvolutionaryOptimizerConfigsProps {
   configs: Partial<EvolutionaryOptimizerParameters>;

--- a/apps/opik-frontend/src/v2/pages-shared/optimizations/AlgorithmSettings/algorithmConfigs/GepaOptimizerConfigs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/optimizations/AlgorithmSettings/algorithmConfigs/GepaOptimizerConfigs.tsx
@@ -5,7 +5,7 @@ import SliderInputControl from "@/shared/SliderInputControl/SliderInputControl";
 import { GepaOptimizerParameters } from "@/types/optimizations";
 import { DEFAULT_GEPA_OPTIMIZER_CONFIGS } from "@/constants/optimizations";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 interface GepaOptimizerConfigsProps {
   configs: Partial<GepaOptimizerParameters>;

--- a/apps/opik-frontend/src/v2/pages-shared/optimizations/AlgorithmSettings/algorithmConfigs/HierarchicalReflectiveOptimizerConfigs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/optimizations/AlgorithmSettings/algorithmConfigs/HierarchicalReflectiveOptimizerConfigs.tsx
@@ -5,7 +5,7 @@ import SliderInputControl from "@/shared/SliderInputControl/SliderInputControl";
 import { HierarchicalReflectiveOptimizerParameters } from "@/types/optimizations";
 import { DEFAULT_HIERARCHICAL_REFLECTIVE_OPTIMIZER_CONFIGS } from "@/constants/optimizations";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 interface HierarchicalReflectiveOptimizerConfigsProps {
   configs: Partial<HierarchicalReflectiveOptimizerParameters>;

--- a/apps/opik-frontend/src/v2/pages-shared/optimizations/MetricSettings/MetricConfigs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/optimizations/MetricSettings/MetricConfigs.tsx
@@ -24,7 +24,7 @@ import LevenshteinMetricConfigs from "@/v2/pages-shared/optimizations/MetricSett
 import NumericalSimilarityMetricConfigs from "@/v2/pages-shared/optimizations/MetricSettings/metricConfigs/NumericalSimilarityMetricConfigs";
 import CodeMetricConfigs from "@/v2/pages-shared/optimizations/MetricSettings/metricConfigs/CodeMetricConfigs";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 interface MetricConfigsProps {
   metricType: METRIC_TYPE;

--- a/apps/opik-frontend/src/v2/pages-shared/optimizations/MetricSettings/metricConfigs/EqualsMetricConfigs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/optimizations/MetricSettings/metricConfigs/EqualsMetricConfigs.tsx
@@ -4,7 +4,7 @@ import { Checkbox } from "@/ui/checkbox";
 import { Input } from "@/ui/input";
 import { EqualsMetricParameters } from "@/types/optimizations";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import DatasetVariablesHint from "../DatasetVariablesHint";
 
 interface EqualsMetricConfigsProps {

--- a/apps/opik-frontend/src/v2/pages-shared/optimizations/MetricSettings/metricConfigs/GEvalMetricConfigs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/optimizations/MetricSettings/metricConfigs/GEvalMetricConfigs.tsx
@@ -4,7 +4,7 @@ import { EditorView } from "@codemirror/view";
 import GEvalField from "./GEvalField";
 import DatasetVariablesHint from "../DatasetVariablesHint";
 
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 import { GEvalMetricParameters } from "@/types/optimizations";
 

--- a/apps/opik-frontend/src/v2/pages-shared/optimizations/MetricSettings/metricConfigs/JsonSchemaValidatorMetricConfigs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/optimizations/MetricSettings/metricConfigs/JsonSchemaValidatorMetricConfigs.tsx
@@ -4,7 +4,7 @@ import { Input } from "@/ui/input";
 import { JsonSchemaValidatorMetricParameters } from "@/types/optimizations";
 import { DEFAULT_JSON_SCHEMA_VALIDATOR_METRIC_CONFIGS } from "@/constants/optimizations";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import DatasetVariablesHint from "../DatasetVariablesHint";
 
 interface JsonSchemaValidatorMetricConfigsProps {

--- a/apps/opik-frontend/src/v2/pages-shared/optimizations/MetricSettings/metricConfigs/LevenshteinMetricConfigs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/optimizations/MetricSettings/metricConfigs/LevenshteinMetricConfigs.tsx
@@ -4,7 +4,7 @@ import { Checkbox } from "@/ui/checkbox";
 import { Input } from "@/ui/input";
 import { LevenshteinMetricParameters } from "@/types/optimizations";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import DatasetVariablesHint from "../DatasetVariablesHint";
 
 interface LevenshteinMetricConfigsProps {

--- a/apps/opik-frontend/src/v2/pages-shared/optimizations/MetricSettings/metricConfigs/NumericalSimilarityMetricConfigs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/optimizations/MetricSettings/metricConfigs/NumericalSimilarityMetricConfigs.tsx
@@ -3,7 +3,7 @@ import { Label } from "@/ui/label";
 import { Input } from "@/ui/input";
 import { NumericalSimilarityMetricParameters } from "@/types/optimizations";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import DatasetVariablesHint from "../DatasetVariablesHint";
 
 interface NumericalSimilarityMetricConfigsProps {

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
@@ -57,7 +57,7 @@ import {
 import AddEditDatasetDialog from "@/v2/pages-shared/datasets/AddEditDatasetDialog/AddEditDatasetDialog";
 import AddEditTestSuiteDialog from "@/v2/pages-shared/datasets/AddEditTestSuiteDialog/AddEditTestSuiteDialog";
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { usePermissions } from "@/contexts/PermissionsContext";
 
 const DEFAULT_SIZE = 100;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToQueueDialog/AddToQueueDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToQueueDialog/AddToQueueDialog.tsx
@@ -22,7 +22,7 @@ import { Alert, AlertDescription } from "@/ui/alert";
 import { cn } from "@/lib/utils";
 import AddEditAnnotationQueueDialog from "@/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog";
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { createFilter } from "@/lib/filters";
 import { getAnnotationQueueItemId } from "@/lib/annotation-queues";
 import { isObjectThread } from "@/lib/traces";

--- a/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoresEditor/FeedbackScoresEditor.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoresEditor/FeedbackScoresEditor.tsx
@@ -9,7 +9,7 @@ import { Link } from "@tanstack/react-router";
 import { ExternalLink, InfoIcon } from "lucide-react";
 import AnnotateRow from "../TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow";
 import { cn } from "@/lib/utils";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
 import { UpdateFeedbackScoreData } from "../TraceDetailsPanel/TraceAnnotateViewer/types";
 

--- a/apps/opik-frontend/src/v2/pages-shared/traces/GuardrailConfig/SetGuardrailDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/GuardrailConfig/SetGuardrailDialog.tsx
@@ -11,7 +11,7 @@ import { useGuardrailConfigState } from "./useGuardrailConfigState";
 import { GuardrailTypes } from "@/types/guardrails";
 
 const GUARDRAIL_DOCS_LINK =
-  "https://www.comet.com/docs/opik/production/guardrails";
+  "https://www.comet.com/docs/opik/production/gateway-guardrails/guardrails";
 
 type SetGuardrailDialogProps = {
   open: boolean;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadAnnotations.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadAnnotations.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { usePermissions } from "@/contexts/PermissionsContext";
 import { TraceFeedbackScore } from "@/types/traces";
 import FeedbackScoreTag from "@/shared/FeedbackScoreTag/FeedbackScoreTag";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import {
   DetailsActionSectionLayout,
   DetailsActionSectionValue,

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadFeedbackScoresInfo.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadFeedbackScoresInfo.tsx
@@ -16,7 +16,7 @@ const ThreadFeedbackScoresInfo: React.FC<ThreadFeedbackScoresInfoProps> = ({
     return null;
   }
 
-  //   const scoreDocsLink = buildDocsUrl("/tracing/annotate_traces");
+  //   const scoreDocsLink = buildDocsUrl("/tracing/advanced/annotate_traces");
 
   return (
     <div className="comet-body-xs mt-2 flex gap-1.5 py-2 text-light-slate">

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceAIViewer/TraceChatInput.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceAIViewer/TraceChatInput.tsx
@@ -7,7 +7,7 @@ import { TEXT_AREA_CLASSES } from "@/ui/textarea";
 import { Button } from "@/ui/button";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { TraceLLMChatType } from "@/types/ai-assistant";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 const RUN_HOT_KEYS = ["⌘", "⏎"];
 

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTableNoData.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTableNoData.tsx
@@ -23,7 +23,9 @@ const FeedbackScoreTableNoData: React.FC<FeedbackScoreTableNoDataProps> = ({
     permissions: { canUpdateOnlineEvaluationRules, canAnnotateTraceSpanThread },
   } = usePermissions();
 
-  const evaluationDocsLink = buildDocsUrl("/production/online-evaluation/rules");
+  const evaluationDocsLink = buildDocsUrl(
+    "/production/online-evaluation/rules",
+  );
 
   const getDescription = () => {
     if (canUpdateOnlineEvaluationRules && canAnnotateTraceSpanThread) {

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTableNoData.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTableNoData.tsx
@@ -23,7 +23,7 @@ const FeedbackScoreTableNoData: React.FC<FeedbackScoreTableNoDataProps> = ({
     permissions: { canUpdateOnlineEvaluationRules, canAnnotateTraceSpanThread },
   } = usePermissions();
 
-  const evaluationDocsLink = buildDocsUrl("/production/rules");
+  const evaluationDocsLink = buildDocsUrl("/production/online-evaluation/rules");
 
   const getDescription = () => {
     if (canUpdateOnlineEvaluationRules && canAnnotateTraceSpanThread) {

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -27,7 +27,7 @@ import {
   DetailsActionSection,
   DetailsActionSectionValue,
 } from "@/v2/pages-shared/traces/DetailsActionSection";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
 import useTraceFeedbackScoreDeleteMutation from "@/api/traces/useTraceFeedbackScoreDeleteMutation";
 import ConfigurableFeedbackScoreTable from "./FeedbackScoreTable/ConfigurableFeedbackScoreTable";

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
@@ -87,7 +87,7 @@ import TimeCell from "@/shared/DataTableCells/TimeCell";
 import useTracesStatistic from "@/api/traces/useTracesStatistic";
 import { useDynamicColumnsCache } from "@/hooks/useDynamicColumnsCache";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import {
   DetailsActionSectionParam,
   DetailsActionSectionValue,

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState.tsx
@@ -62,7 +62,7 @@ const AgentConfigurationEmptyState: React.FC = () => {
         <Button variant="outline" size="sm" asChild>
           <a
             // TODO: Add correct URL when docs ready
-            href={buildDocsUrl()}
+            href={buildDocsUrl("/development/agent-configuration/overview")}
             target="_blank"
             rel="noreferrer"
           >

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/TestWebhookSection.tsx
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/TestWebhookSection.tsx
@@ -194,7 +194,7 @@ const TestWebhookSection: React.FunctionComponent<TestWebhookSectionProps> = ({
           </Button>
           <Button variant="ghost" asChild>
             <a
-              href={buildDocsUrl("/production/alerts")}
+              href={buildDocsUrl("/production/alerts/alerts")}
               target="_blank"
               rel="noreferrer"
             >

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AlertsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AlertsPage.tsx
@@ -46,7 +46,7 @@ import {
 } from "@/shared/DataTable/utils";
 import { Separator } from "@/ui/separator";
 import AlertsActionsPanel from "@/v2/pages/AlertsPage/AlertsActionsPanel";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
 import { usePermissions } from "@/contexts/PermissionsContext";
 
@@ -356,7 +356,7 @@ const AlertsPage: React.FunctionComponent = () => {
           }
           primaryActionLabel="Create your first alert"
           onPrimaryAction={handleNewAlertClick}
-          docsUrl={buildDocsUrl("/production/alerts")}
+          docsUrl={buildDocsUrl("/production/alerts/alerts")}
         />
       ) : (
         <>

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/NoQueueItemsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/NoQueueItemsPage.tsx
@@ -51,8 +51,7 @@ const NoQueueItemsPage: React.FC<NoQueueItemsPageProps> = ({
         <>
           <Button variant="secondary" asChild>
             <a
-              href={buildDocsUrl(
-                "/evaluation/annotation_queues",
+              href={buildDocsUrl("/evaluation/advanced/annotation_queues",
                 "#adding-content-to-your-queue",
               )}
               target="_blank"

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/NoQueueItemsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/NoQueueItemsPage.tsx
@@ -51,7 +51,8 @@ const NoQueueItemsPage: React.FC<NoQueueItemsPageProps> = ({
         <>
           <Button variant="secondary" asChild>
             <a
-              href={buildDocsUrl("/evaluation/advanced/annotation_queues",
+              href={buildDocsUrl(
+                "/evaluation/advanced/annotation_queues",
                 "#adding-content-to-your-queue",
               )}
               target="_blank"

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
@@ -63,7 +63,7 @@ import { LOGS_TYPE } from "@/constants/traces";
 import useThreadsList from "@/api/traces/useThreadsList";
 import TimeCell from "@/shared/DataTableCells/TimeCell";
 import { generateTracesURL } from "@/lib/annotation-queues";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import useAppStore from "@/store/AppStore";
 import { generateAnnotationQueueIdFilter } from "@/lib/filters";
 import SelectBox, { SelectBoxProps } from "@/shared/SelectBox/SelectBox";

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuesPage/AnnotationQueuesPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuesPage/AnnotationQueuesPage.tsx
@@ -411,7 +411,7 @@ export const AnnotationQueuesPage: React.FC = () => {
           }
           primaryActionLabel="Create your first queue"
           onPrimaryAction={handleNewQueue}
-          docsUrl={buildDocsUrl("/evaluation/annotation_queues")}
+          docsUrl={buildDocsUrl("/evaluation/advanced/annotation_queues")}
         />
       ) : (
         <>

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsButton/CompareExperimentsButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsButton/CompareExperimentsButton.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/ui/button";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import CompareExperimentsDialog from "@/v2/pages/CompareExperimentsPage/CompareExperimentsDialog";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 interface CompareExperimentsButtonProps {
   size?: "default" | "sm" | "lg" | "icon";

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDialog.tsx
@@ -20,7 +20,7 @@ import { formatDate } from "@/lib/date";
 import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { Button } from "@/ui/button";
 import { Checkbox } from "@/ui/checkbox";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { createFilter } from "@/lib/filters";
 
 const DEFAULT_SIZE = 5;

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPage.tsx
@@ -15,7 +15,7 @@ import { Experiment } from "@/types/datasets";
 import { isTestSuiteExperiment } from "@/lib/experiments";
 import CompareExperimentsDetails from "@/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 const CompareExperimentsPage: React.FunctionComponent = () => {
   const [tab = "items", setTab] = useQueryParam("tab", StringParam, {

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/ExperimentDataset.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/ExperimentDataset.tsx
@@ -14,7 +14,7 @@ import ExperimentDatasetItems from "@/v2/pages/CompareExperimentsPage/CompareExp
 import useLocalStorageState from "use-local-storage-state";
 import difference from "lodash/difference";
 import union from "lodash/union";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
 import NavigationTag from "@/shared/NavigationTag/NavigationTag";
 import { RESOURCE_TYPE } from "@/shared/ResourceLink/ResourceLink";

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
@@ -29,7 +29,7 @@ import { Experiment } from "@/types/datasets";
 import { Switch } from "@/ui/switch";
 import { Label } from "@/ui/label";
 import { Separator } from "@/ui/separator";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { AGENT_CONFIGURATION_METADATA_KEY } from "@/utils/agent-configurations";
 import { isAgentConfigurationMetadata } from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/AgentConfigurationTab";
 

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -66,7 +66,7 @@ import SectionHeader from "@/shared/DataTableHeaders/SectionHeader";
 import CommentsCell from "@/shared/DataTableCells/CommentsCell";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
 import PageBodyStickyTableWrapper from "@/v2/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import DurationCell from "@/shared/DataTableCells/DurationCell";
 import CostCell from "@/shared/DataTableCells/CostCell";
 import useExperimentItemsState from "@/v2/pages-shared/experiments/useExperimentItemsState";

--- a/apps/opik-frontend/src/v2/pages/ConfigurationPage/AIProvidersTab/AIProvidersTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/ConfigurationPage/AIProvidersTab/AIProvidersTab.tsx
@@ -19,7 +19,7 @@ import ExplainerCallout from "@/shared/ExplainerCallout/ExplainerCallout";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import { Button } from "@/ui/button";
 import { COLUMN_NAME_ID, COLUMN_TYPE, ColumnData } from "@/types/shared";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { usePermissions } from "@/contexts/PermissionsContext";
 
 export const DEFAULT_COLUMNS: ColumnData<ProviderObject>[] = [

--- a/apps/opik-frontend/src/v2/pages/DashboardsPage/DashboardsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/DashboardsPage/DashboardsPage.tsx
@@ -375,7 +375,7 @@ const DashboardsPage: React.FunctionComponent = () => {
           }
           primaryActionLabel="Create your first dashboard"
           onPrimaryAction={handleNewDashboardClick}
-          docsUrl={buildDocsUrl("/production/dashboards")}
+          docsUrl={buildDocsUrl("/tracing/dashboards/dashboards")}
         />
       ) : (
         <>

--- a/apps/opik-frontend/src/v2/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
@@ -70,7 +70,7 @@ import { getIsGroupRow, renderCustomRow } from "@/shared/DataTable/utils";
 import { calculateGroupLabel, isGroupFullyExpanded } from "@/lib/groups";
 import MultiResourceCell from "@/shared/DataTableCells/MultiResourceCell";
 import FeedbackScoreListCell from "@/shared/DataTableCells/FeedbackScoreListCell";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
 import PageBodyStickyTableWrapper from "@/v2/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
@@ -81,7 +81,7 @@ const ConnectToOllieTab: React.FC<ConnectToOllieTabProps> = ({ connected }) => {
                   Run the command above in your repo. Once connected, Ollie can
                   inspect your code and help finish setup.{" "}
                   <a
-                    href={buildDocsUrl("/agents/local-runner#troubleshooting")}
+                    href={buildDocsUrl("/faq#troubleshooting")}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="underline hover:text-foreground"

--- a/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
@@ -72,7 +72,7 @@ import ThreadsActionsPanel from "@/v2/pages/LogsPage/ThreadsTab/ThreadsActionsPa
 import SelectionActionBar from "@/v2/components/SelectionActionBar/SelectionActionBar";
 import useThreadList from "@/api/traces/useThreadsList";
 import useThreadsStatistic from "@/api/traces/useThreadsStatistic";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import FeedbackScoreHeader from "@/shared/DataTableHeaders/FeedbackScoreHeader";
 import { formatScoreDisplay } from "@/lib/feedback-scores";
 import DataTableStateHandler from "@/shared/DataTableStateHandler/DataTableStateHandler";
@@ -794,7 +794,7 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
                 Quickstart guide
               </button>
               <a
-                href={buildDocsUrl("/tracing/log_chat_conversations")}
+                href={buildDocsUrl("/tracing/advanced/log_chat_conversations")}
                 target="_blank"
                 rel="noreferrer"
                 className="comet-body-s inline-flex items-center gap-1 underline underline-offset-4 hover:text-primary"

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -104,7 +104,7 @@ import { isAgentConfigurationMetadata } from "@/v2/pages-shared/traces/TraceDeta
 import { AGENT_CONFIGURATION_METADATA_KEY } from "@/utils/agent-configurations";
 import GuardrailsCell from "@/shared/DataTableCells/GuardrailsCell";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import {
   DetailsActionSection,
   DetailsActionSectionParam,
@@ -1384,7 +1384,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
                 Quickstart guide
               </button>
               <a
-                href={buildDocsUrl("/tracing/log_traces")}
+                href={buildDocsUrl("/tracing/advanced/log_traces")}
                 target="_blank"
                 rel="noreferrer"
                 className="comet-body-s inline-flex items-center gap-1 underline underline-offset-4 hover:text-primary"

--- a/apps/opik-frontend/src/v2/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
@@ -386,7 +386,7 @@ export const OnlineEvaluationPage: React.FC = () => {
           }
           primaryActionLabel="Create your first rule"
           onPrimaryAction={handleNewRuleClick}
-          docsUrl={buildDocsUrl("/production/rules")}
+          docsUrl={buildDocsUrl("/production/online-evaluation/rules")}
         />
       ) : (
         <>

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewConfigSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewConfigSidebar.tsx
@@ -22,7 +22,7 @@ import {
   OPTIMIZER_OPTIONS,
   OPTIMIZATION_METRIC_OPTIONS,
 } from "@/constants/optimizations";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
 import DatasetSamplePreview from "./DatasetSamplePreview";
 

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewHeader.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewHeader.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button } from "@/ui/button";
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 type OptimizationsNewHeaderProps = {
   isSubmitting: boolean;

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -339,7 +339,7 @@ const OptimizationsPage: React.FunctionComponent = () => {
           }
           primaryActionLabel="Create optimization run"
           onPrimaryAction={handleNewOptimizationClick}
-          docsUrl={buildDocsUrl("/agent_optimization/optimization_studio")}
+          docsUrl={buildDocsUrl("/development/optimization-runs/optimization_studio")}
         />
       ) : (
         <>

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -339,7 +339,9 @@ const OptimizationsPage: React.FunctionComponent = () => {
           }
           primaryActionLabel="Create optimization run"
           onPrimaryAction={handleNewOptimizationClick}
-          docsUrl={buildDocsUrl("/development/optimization-runs/optimization_studio")}
+          docsUrl={buildDocsUrl(
+            "/development/optimization-runs/optimization_studio",
+          )}
         />
       ) : (
         <>

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundOutputTable.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundOutputTable.tsx
@@ -17,7 +17,7 @@ import PlaygroundOutputCell from "@/v2/pages/PlaygroundPage/PlaygroundOutputs/Pl
 import PlaygroundOutputColumnHeader from "@/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundOutputColumnHeader";
 import PlaygroundVariableCell from "@/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundVariableCell";
 import DataTableNoData from "@/shared/DataTableNoData/DataTableNoData";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { useDatasetType } from "@/store/PlaygroundStore";
 import { DATASET_TYPE } from "@/types/datasets";
 import { useIncrementalDatasetHydration } from "@/v2/pages/PlaygroundPage/useIncrementalDatasetHydration";

--- a/apps/opik-frontend/src/v2/pages/ProjectsPage/AddEditProjectDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectsPage/AddEditProjectDialog.tsx
@@ -16,7 +16,7 @@ import { Textarea } from "@/ui/textarea";
 import useProjectUpdateMutation from "@/api/projects/useProjectUpdateMutation";
 import { useNavigate } from "@tanstack/react-router";
 import useAppStore from "@/store/AppStore";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
 import { useToast } from "@/ui/use-toast";
 import { ToastAction } from "@/ui/toast";

--- a/apps/opik-frontend/src/v2/pages/ProjectsPage/ProjectsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectsPage/ProjectsPage.tsx
@@ -52,7 +52,7 @@ import {
 import FeedbackScoreListCell from "@/shared/DataTableCells/FeedbackScoreListCell";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ErrorsCountCell from "@/shared/DataTableCells/ErrorsCountCell";
 import { LOGS_TYPE } from "@/constants/traces";
 import { LOGS_SOURCE } from "@/types/traces";

--- a/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/CommitsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/CommitsActionsPanel.tsx
@@ -7,7 +7,7 @@ import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import ComparePromptVersionDialog from "@/v2/pages/PromptPage/CommitsTab/ComparePromptVersionDialog";
 import AddTagDialog from "@/v2/pages/PromptPage/CommitsTab/AddTagDialog";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 type CommitsActionsPanelsProps = {
   versions: PromptVersion[];

--- a/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/CommitsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/CommitsTab.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/lib/table";
 import { generateSelectColumDef } from "@/shared/DataTable/utils";
 import CommitsActionsPanel from "@/v2/pages/PromptPage/CommitsTab/CommitsActionsPanel";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import DataTablePagination from "@/shared/DataTablePagination/DataTablePagination";
 import ColumnsButton from "@/shared/ColumnsButton/ColumnsButton";
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";

--- a/apps/opik-frontend/src/v2/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
@@ -53,7 +53,7 @@ import {
 } from "@/shared/ResourceLink/ResourceLink";
 import { Separator } from "@/ui/separator";
 import MultiResourceCell from "@/shared/DataTableCells/MultiResourceCell";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { getIsGroupRow, renderCustomRow } from "@/shared/DataTable/utils";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import { useExperimentsTableConfig } from "@/v2/pages-shared/experiments/useExperimentsTableConfig";

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptPage.tsx
@@ -8,7 +8,7 @@ import usePromptById from "@/api/prompts/usePromptById";
 import DateTag from "@/shared/DateTag/DateTag";
 import PromptTab from "@/v2/pages/PromptPage/PromptTab/PromptTab";
 import CommitsTab from "@/v2/pages/PromptPage/CommitsTab/CommitsTab";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
 import PromptTagsList from "@/v2/pages/PromptPage/PromptTagsList";
 import { Separator } from "@/ui/separator";

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/EditPromptVersionDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/EditPromptVersionDialog.tsx
@@ -33,7 +33,7 @@ import useCreatePromptVersionMutation from "@/api/prompts/useCreatePromptVersion
 import { useBooleanTimeoutState } from "@/hooks/useBooleanTimeoutState";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
 import { isValidJsonObject, safelyParseJSON } from "@/lib/utils";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { Description } from "@/ui/description";
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
 import { useMessageContent } from "@/hooks/useMessageContent";

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -20,7 +20,7 @@ import usePromptVersionById from "@/api/prompts/usePromptVersionById";
 import TryInPlaygroundButton from "@/v2/pages/PromptPage/TryInPlaygroundButton";
 import ImproveInPlaygroundButton from "@/v2/pages/PromptPage/ImproveInPlaygroundButton";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import RestoreVersionDialog from "./RestoreVersionDialog";
 import ChatPromptView from "./ChatPromptView";
 import TextPromptView from "./TextPromptView";

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/UseThisPromptDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/UseThisPromptDialog.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/ui/dialog";
 import CodeHighlighter from "@/shared/CodeHighlighter/CodeHighlighter";
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
 
 type UseThisPromptDialogProps = {

--- a/apps/opik-frontend/src/v2/pages/PromptsPage/AddEditPromptDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptsPage/AddEditPromptDialog.tsx
@@ -37,7 +37,7 @@ import { isValidJsonObject, safelyParseJSON } from "@/lib/utils";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
 import { useBooleanTimeoutState } from "@/hooks/useBooleanTimeoutState";
 import useAppStore, { useActiveProjectId } from "@/store/AppStore";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
 import { useMessageContent } from "@/hooks/useMessageContent";
 import ChatPromptRawView from "@/v2/pages-shared/llm/ChatPromptRawView/ChatPromptRawView";

--- a/apps/opik-frontend/src/v2/pages/PromptsPage/PromptsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptsPage/PromptsPage.tsx
@@ -365,7 +365,7 @@ const PromptsPage: React.FunctionComponent = () => {
           }
           primaryActionLabel="Create your first prompt"
           onPrimaryAction={handleNewPromptClick}
-          docsUrl={buildDocsUrl("/prompt_engineering/prompt_management")}
+          docsUrl={buildDocsUrl("/development/agent-configuration/overview")}
         />
       ) : (
         <>

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/CommentAndScoreViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/CommentAndScoreViewer.tsx
@@ -5,7 +5,7 @@ import UserCommentForm from "@/shared/UserComment/UserCommentForm";
 import { HotkeyDisplay } from "@/ui/hotkey-display";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { useSMEFlow } from "@/v2/pages/SMEFlowPage/SMEFlowContext";
 import { SME_ACTION, SME_HOTKEYS } from "@/v2/pages/SMEFlowPage/hotkeys";
 import { usePermissions } from "@/contexts/PermissionsContext";

--- a/apps/opik-frontend/src/v2/pages/TrialPage/ConfigurationTab/ConfigurationTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/TrialPage/ConfigurationTab/ConfigurationTab.tsx
@@ -31,7 +31,7 @@ import {
   OPTIMIZATION_PROMPT_KEY,
   OPTIMIZATION_EXAMPLES_KEY,
 } from "@/constants/experiments";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 const COLUMNS_WIDTH_KEY = "compare-trials-config-columns-width";
 

--- a/apps/opik-frontend/src/v2/pages/TrialPage/TrialsItemsTab/TrialItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/TrialPage/TrialsItemsTab/TrialItemsTab.tsx
@@ -55,7 +55,7 @@ import { calculateHeightStyle } from "@/shared/DataTable/utils";
 import SectionHeader from "@/shared/DataTableHeaders/SectionHeader";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
 import PageBodyStickyTableWrapper from "@/v2/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
+import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { generateDistinctColorMap } from "@/v2/pages-shared/experiments/OptimizationProgressChart/optimizationChartUtils";
 import { ToggleGroup, ToggleGroupItem } from "@/ui/toggle-group";
 


### PR DESCRIPTION
## Details

Split in-app documentation links between v1 and v2 workspaces so that v1 users are routed to the preserved legacy docs at `/docs/opik/v1/...` while v2 users go to the new latest-IA docs at `/docs/opik/...`. The two workspaces now have independent sources of truth for docs paths (separate `explainers.ts` + separate link literals), which makes future IA changes easier to maintain without cross-version bleed.

- Split `constants/explainers.ts`: v1 copy keeps legacy paths but now prefixed with `/v1`; new [`v2/constants/explainers.ts`](apps/opik-frontend/src/v2/constants/explainers.ts) uses the new latest IA
- Retarget 61 v2 imports to the new v2 explainers module; v1 imports unchanged (75 files)
- Update all literal `buildDocsUrl(...)` paths (v1: add `/v1/` prefix; v2: rewrite to new IA) and the 5 hard-coded docs URLs (v1 `SetGuardrailDialog`, `HelpGuideDialog`, `QuickInstallDialog`; v2 `SetGuardrailDialog` → new `gateway-guardrails` path; v2 Opik University → v1 docs since section doesn't exist in latest)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4 (1M context)
- Scope: Path mapping (against `fern/versions/latest.yml`), mechanical find/replace across v1 and v2 trees, prettier/lint fixes, PR scaffolding
- Human verification: Path mapping decisions reviewed with author before execution; each new docs URL curl-verified against live canonical tags; `npm run lint` and `npx tsc --noEmit` passing

## Testing

Ran locally:
- `npx tsc --noEmit` — clean
- `npm run lint` — clean (after `npm run lint:fix` for prettier)
- Live-docs canonical probe (curl + grep for `<link rel="canonical">`) against all 31 new v2 paths and the v1 paths with `/v1/` prefix. Results recorded in the task notes; all v2 paths return the expected canonical, and v1 paths resolve (some canonicalize to root where the v1 page was retired — content still renders).

Not run (pending reviewer validation):
- Frontend dev-server click-through across v1 and v2 workspaces (requires backend stack). Surfaces to spot-check: empty states (traces, threads, rules, annotation queues, dashboards, alerts, optimizations), explainer popovers, help guide + integration explorer, guardrail config, agent-configuration empty state, `QuickInstallDialog` raw-markdown fetches.

## Documentation

No docs content changes — this PR only updates how the frontend app links to the existing docs at `apps/opik-documentation/documentation/fern/versions/`.