### PR TITLE
[OPIK-5950] [FE] fix: surface no-agents-registered state in agent sandbox

### DIFF
--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerConnectedState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerConnectedState.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { ArrowRight, ArrowUpRight, Loader2, Save } from "lucide-react";
+import { ArrowRight, ArrowUpRight, Save } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -14,6 +14,7 @@ import useConfigHistoryListInfinite from "@/api/agent-configs/useConfigHistoryLi
 import useAgentConfigCreateMutation from "@/api/agent-configs/useAgentConfigCreateMutation";
 import { LocalRunner } from "@/types/agent-sandbox";
 import AgentRunnerInputForm from "./AgentRunnerInputForm";
+import AgentRunnerLoading from "./AgentRunnerLoading";
 import AgentConfigurationEditView, {
   AgentConfigurationEditViewHandle,
   AgentConfigurationEditViewState,
@@ -200,10 +201,7 @@ const AgentRunnerConnectedState: React.FC<AgentRunnerConnectedStateProps> = ({
               isRunning={isRunning}
             />
           ) : (
-            <div className="flex flex-col items-center gap-2 py-8 text-muted-slate">
-              <Loader2 className="size-5 animate-spin text-primary" />
-              <p className="comet-body-s">Loading agent...</p>
-            </div>
+            <AgentRunnerLoading runnerId={runner.id} />
           )}
         </TabsContent>
 

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerLoading.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerLoading.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import { AlertCircle, Loader2 } from "lucide-react";
+
+const NO_AGENTS_GRACE_MS = 20_000;
+
+type AgentRunnerLoadingProps = {
+  runnerId: string;
+};
+
+const AgentRunnerLoading: React.FC<AgentRunnerLoadingProps> = ({
+  runnerId,
+}) => {
+  const [isGraceElapsed, setIsGraceElapsed] = useState(false);
+
+  useEffect(() => {
+    setIsGraceElapsed(false);
+    const timer = window.setTimeout(
+      () => setIsGraceElapsed(true),
+      NO_AGENTS_GRACE_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [runnerId]);
+
+  if (isGraceElapsed) {
+    return (
+      <div className="flex flex-col items-center gap-1 py-8 text-muted-slate">
+        <AlertCircle className="mb-2 size-5 text-destructive" />
+        <p className="comet-body-s font-medium text-foreground">
+          No agents registered
+        </p>
+        <p className="comet-body-xs mt-1 max-w-sm text-center">
+          The runner is connected but has not registered any agents. Check your{" "}
+          <code>opik endpoint</code> terminal for startup errors.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-2 py-8 text-muted-slate">
+      <Loader2 className="size-5 animate-spin text-primary" />
+      <p className="comet-body-s">Loading agent...</p>
+    </div>
+  );
+};
+
+export default AgentRunnerLoading;

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerLoading.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerLoading.tsx
@@ -28,10 +28,22 @@ const AgentRunnerLoading: React.FC<AgentRunnerLoadingProps> = ({
         <p className="comet-body-s font-medium text-foreground">
           No agents registered
         </p>
-        <p className="comet-body-xs mt-1 max-w-sm text-center">
-          The runner is connected but has not registered any agents. Check your{" "}
-          <code>opik endpoint</code> terminal for startup errors.
-        </p>
+        <div className="comet-body-xs mt-1 max-w-sm text-center">
+          <p>
+            The runner is connected but has not registered any agents. Common
+            causes:
+          </p>
+          <ul className="mt-1 inline-block list-inside list-disc text-left">
+            <li>
+              Missing <code>@opik.track(entrypoint=True)</code> decorator
+            </li>
+            <li>Process exited or crashed before registration</li>
+            <li>Script didn&apos;t import the entrypoint module</li>
+          </ul>
+          <p className="mt-2">
+            Check your <code>opik endpoint</code> terminal for details.
+          </p>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Details

<img width="1494" height="929" alt="image" src="https://github.com/user-attachments/assets/8d7964d3-8c13-4bb9-8a03-2ece9d5361c7" />


The Agent Sandbox input panel previously showed "Loading agent..." forever when a runner paired successfully but registered zero agents (crash-looping subprocess, missing `@opik.track(entrypoint=True)` decorator, or script exiting before registration completes). After a 20-second grace period, the panel now renders a concise error state pointing users to the `opik endpoint` terminal where the actual startup error is already reported, so they can self-diagnose without digging into backend state.

- New `AgentRunnerLoading` component encapsulates the spinner + timeout-elapsed error state
- Visual treatment matches the page's existing muted empty-state language (centered column, icon, short message) — no new Alert pattern introduced

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-5950

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-opus-4-7
  - Scope: full implementation (component extraction, grace-period logic, visual treatment iteration)
  - Human verification: manual browser testing (crash-loop repro + happy path regression), code review, lint + typecheck + deps:validate

## Testing

- Ran `bash scripts/dev-runner.sh --lint-fe` locally — `lint:fix`, `typecheck`, and `deps:validate` all pass
- Manual browser verification on `localhost:5174`:
  - **Crash-loop repro**: ran `opik endpoint` from a directory without `main.py` so the subprocess crash-loops; runner pairs but registers no agents. Verified the input panel shows the "Loading agent..." spinner for ~20 seconds, then transitions to the new error state
  - **Happy path**: ran `opik endpoint` against `bank-support-agent/main.py` and confirmed the input form renders as before; no spurious error state
  - **Recovery**: fixed the command while the error state was visible; confirmed the UI auto-dismisses within one poll tick (no reload required)
- Did not add unit tests — the existing `AgentRunnerContent.test.tsx` covers the parent orchestration, and the new component is visual state with a `setTimeout`

## Documentation

N/A — no doc changes; the terminal output from `opik endpoint` is already authoritative for startup errors and the new UI message points users there.