### PR TITLE
[OPIK-5918] [FE] feat: add Ollie loading state for assistant sidebar

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -20,13 +20,12 @@ import { useTheme } from "@/contexts/theme-provider";
 import { useToast } from "@/ui/use-toast";
 import useWorkspace from "@/plugins/comet/useWorkspace";
 import useAssistantBackend from "@/plugins/comet/useAssistantBackend";
-import type { AssistantBackendPhase } from "@/plugins/comet/useAssistantBackend";
 import useProjectById from "@/api/projects/useProjectById";
 import useProjectOnboardingStats from "@/hooks/useProjectOnboardingStats";
 import useRunnerBridgeSync from "@/hooks/useRunnerBridgeSync";
 import { BASE_API_URL } from "@/api/api";
-import { Spinner } from "@/ui/spinner";
 import AssistantErrorState from "@/plugins/comet/AssistantErrorState";
+import OllieLoader, { OllieLoaderVariant } from "@/plugins/comet/OllieLoader";
 import {
   ASSISTANT_DEV_BASE_URL,
   IS_ASSISTANT_DEV,
@@ -67,28 +66,20 @@ function getStoredSidebarOpen(): boolean {
   }
 }
 
-const PHASE_MESSAGES: Partial<
-  Record<AssistantBackendPhase | "manifest", string>
-> = {
-  compute: "Starting assistant\u2026",
-  health: "Connecting\u2026",
-  manifest: "Loading interface\u2026",
-};
-
 interface AssistantSidebarLoaderProps {
-  phase: AssistantBackendPhase | "manifest";
   error: string | null;
   onWidthChange: (width: number) => void;
   onRetry?: () => void;
   retryCount?: number;
+  surface: BridgeSurface;
 }
 
 const AssistantSidebarLoader: React.FC<AssistantSidebarLoaderProps> = ({
-  phase,
   error,
   onWidthChange,
   onRetry,
   retryCount = 0,
+  surface,
 }) => {
   const [isOpen, setIsOpen] = useState(getStoredSidebarOpen);
   const initialWidth = useRef(
@@ -121,19 +112,13 @@ const AssistantSidebarLoader: React.FC<AssistantSidebarLoaderProps> = ({
     );
   }
 
-  const message = PHASE_MESSAGES[phase] ?? "Loading\u2026";
-
-  return (
-    <div className="relative size-full border-l">
-      <div className="absolute inset-0 animate-pulse bg-muted" />
-      <div className="relative flex size-full items-center justify-center">
-        <Spinner size={collapsed ? "xs" : "small"} />
-        {!collapsed && (
-          <span className="ml-2 text-sm text-light-slate">{message}</span>
-        )}
-      </div>
-    </div>
-  );
+  let variant: OllieLoaderVariant = "sidebar";
+  if (collapsed) {
+    variant = "collapsed";
+  } else if (surface === "page") {
+    variant = "page";
+  }
+  return <OllieLoader variant={variant} />;
 };
 
 const stopPropagation = (e: Event) => e.stopPropagation();
@@ -527,14 +512,13 @@ const AssistantSidebar: React.FC<AssistantSidebarProps> = ({
 
   if (!meta || !isBackendReady) {
     if (phase === "disabled") return null;
-    const effectivePhase = isBackendReady && !meta ? "manifest" : phase;
     return (
       <AssistantSidebarLoader
-        phase={effectivePhase}
         error={error}
         onWidthChange={onWidthChange}
         onRetry={retry}
         retryCount={retryCount}
+        surface={surface}
       />
     );
   }

--- a/apps/opik-frontend/src/plugins/comet/OllieLoader.tsx
+++ b/apps/opik-frontend/src/plugins/comet/OllieLoader.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+const MESSAGES = [
+  "Ollie is waking up\u2026",
+  "Loading traces\u2026",
+  "Crunching evaluation data\u2026",
+  "Almost ready\u2026",
+] as const;
+
+const ROTATION_INTERVAL_MS = 2200;
+
+export type OllieLoaderVariant = "page" | "sidebar" | "collapsed";
+
+const OWL_SIZE: Record<OllieLoaderVariant, string> = {
+  page: "size-[72px]",
+  sidebar: "size-[48px]",
+  collapsed: "size-6",
+};
+
+interface OllieLoaderProps {
+  variant?: OllieLoaderVariant;
+}
+
+const OwlArt: React.FC<{ className?: string }> = ({ className }) => (
+  <div className={cn("motion-safe:animate-ollie-breathe", className)}>
+    <svg
+      className="size-full"
+      viewBox="0 0 72 72"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <path d="M13.5 27L19.125 15.75L24.75 27" fill="#F46E41" />
+      <path d="M47.25 27L52.875 15.75L58.5 27" fill="#F46E41" />
+      <g
+        className="motion-safe:animate-ollie-blink"
+        style={{
+          transformOrigin: "center",
+          transformBox: "fill-box",
+        }}
+      >
+        <path
+          d="M51.75 21.9375C62.0018 21.9375 70.3125 30.2482 70.3125 40.5C70.3125 50.7518 62.0018 59.0625 51.75 59.0625C45.1063 59.0625 39.2797 55.5711 36 50.3242C32.7203 55.5711 26.8937 59.0625 20.25 59.0625C9.99821 59.0625 1.6875 50.7518 1.6875 40.5C1.6875 30.2482 9.99821 21.9375 20.25 21.9375C26.8934 21.9375 32.7202 25.4283 36 30.6748C39.2798 25.4283 45.1066 21.9375 51.75 21.9375ZM20.25 27.5625C13.1048 27.5625 7.3125 33.3548 7.3125 40.5C7.3125 47.6452 13.1048 53.4375 20.25 53.4375C27.3952 53.4375 33.1875 47.6452 33.1875 40.5C33.1875 33.3548 27.3952 27.5625 20.25 27.5625ZM51.75 27.5625C44.6048 27.5625 38.8125 33.3548 38.8125 40.5C38.8125 47.6452 44.6048 53.4375 51.75 53.4375C58.8952 53.4375 64.6875 47.6452 64.6875 40.5C64.6875 33.3548 58.8952 27.5625 51.75 27.5625Z"
+          fill="#F46E41"
+        />
+      </g>
+    </svg>
+  </div>
+);
+
+export function OllieLoader({
+  variant = "page",
+}: OllieLoaderProps): React.ReactElement {
+  const [index, setIndex] = useState(0);
+  const showText = variant !== "collapsed";
+
+  useEffect(() => {
+    if (!showText) return;
+    const id = window.setInterval(() => {
+      setIndex((current) => (current + 1) % MESSAGES.length);
+    }, ROTATION_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [showText]);
+
+  const owlSize = OWL_SIZE[variant];
+
+  const wrapperBg = variant === "page" ? "bg-muted" : "border-l bg-muted/40";
+
+  return (
+    <div
+      className={cn("flex size-full items-center justify-center", wrapperBg)}
+    >
+      <div className="flex flex-col items-center justify-center gap-2">
+        <OwlArt className={owlSize} />
+        {showText && (
+          <p
+            role="status"
+            aria-live="polite"
+            className={cn(
+              "text-center font-code text-foreground",
+              variant === "page"
+                ? "text-[16px] leading-5"
+                : "text-[13px] leading-4",
+            )}
+          >
+            <span
+              key={index}
+              className="inline-block motion-safe:animate-ollie-text-in"
+            >
+              {MESSAGES[index]}
+            </span>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default OllieLoader;

--- a/apps/opik-frontend/tailwind.config.ts
+++ b/apps/opik-frontend/tailwind.config.ts
@@ -153,10 +153,25 @@ module.exports = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        "ollie-breathe": {
+          "0%, 100%": { transform: "scale(1)", opacity: "0.95" },
+          "50%": { transform: "scale(1.04)", opacity: "1" },
+        },
+        "ollie-blink": {
+          "0%, 92%, 100%": { transform: "scaleY(1)" },
+          "95%": { transform: "scaleY(0.1)" },
+        },
+        "ollie-text-in": {
+          from: { opacity: "0", transform: "translateY(4px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "ollie-breathe": "ollie-breathe 3.2s ease-in-out infinite",
+        "ollie-blink": "ollie-blink 5.4s ease-in-out infinite",
+        "ollie-text-in": "ollie-text-in 300ms ease-out",
       },
       boxShadow: {
         "action-card": "var(--action-card-shadow)",


### PR DESCRIPTION
## Details

Replace the generic spinner + pulse overlay shown while the Ollie pod provisions with a branded Ollie owl loader (breathing animation + scoped eye blink) and a 2.2-second-rotating tagline. The new loader covers all three assistant surfaces — project homepage, docked sidebar, and the collapsed rail — with per-variant sizing and backdrop treatment.

- New `OllieLoader` component (inlined SVG owl, `motion-safe:` gated keyframes, stable `role=status aria-live=polite` live region with keyed inner `<span>` to replay the fade-in per message)
- `AssistantSidebarLoader` replaces its Spinner+pulse block with variant-based `<OllieLoader variant={collapsed ? "collapsed" : surface === "page" ? "page" : "sidebar"} />`; error path (`AssistantErrorState`) unchanged
- Three Tailwind keyframes/animations added (`ollie-breathe`, `ollie-blink`, `ollie-text-in`) — no new dependencies, no framer-motion
- Colors use design-system tokens (`bg-muted`, `text-foreground`) so the loader inverts correctly in dark mode

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5918

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: full implementation (plan, component, Tailwind keyframes, variant refactor, review fixes, simplification)
- Human verification: manual browser verification on `localhost:5175` (comet mode), code review + simplifier pass, `scripts/dev-runner.sh --lint-fe`

## Testing

- `bash scripts/dev-runner.sh --lint-fe` — `lint:fix`, `typecheck`, and `deps:validate` all pass
- Manual browser verification on `localhost:5175` (`npm run start -- --mode comet`):
  - **Page surface** (project homepage): owl renders at 72×72 on `bg-muted`, soft breathing, scoped eye blink every ~5s, tagline rotates through the four strings every ~2.2s with fade+slide; no layout shift
  - **Sidebar surface** (docked, expanded): 48×48 owl with smaller tagline on `border-l bg-muted/40` — rail stays interactive
  - **Collapsed surface**: 24×24 owl only, no tagline, same muted backdrop
  - **Error path**: killed backend → `AssistantErrorState` renders unchanged
  - **Reduced motion** (macOS → Reduce motion on): owl static, tagline still rotates, no fade/slide
  - **Dark mode**: text + background invert correctly (both `bg-muted` and `text-foreground` are tokenized)

## Documentation

N/A — visual change only, no user-facing docs or APIs affected.