### PR TITLE
Add admin port to opik-backend service for Prometheus metrics scraping

### DIFF
--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -84,6 +84,8 @@ component:
       name: opik-backend
     metrics:
       enabled: false
+      portName: admin
+      path: /metrics
     image:
       repository: opik-backend
       pullPolicy: IfNotPresent
@@ -189,6 +191,10 @@ component:
         port:  8080
         protocol: TCP
         targetPort:  8080
+      - name: admin
+        port:  8081
+        protocol: TCP
+        targetPort:  8081
       - name: swagger
         port:  3003
         protocol: TCP


### PR DESCRIPTION
## Summary
- Adds Dropwizard admin port (8081) to the opik-backend Kubernetes Service definition
- Sets default `metrics.portName: admin` and `metrics.path: /metrics` for the backend component

## Context (DND-995)

We enabled Opik `ServiceMonitor` resources across all ST-SaaS clusters ([dply-managed-clients#316](https://github.com/comet-ml/dply-managed-clients/pull/316)) to get Prometheus metrics scraping for Opik services. The ServiceMonitors were created successfully and Prometheus discovered them, but all targets show `health: down` with `404 Not Found`.

**Root cause**: The opik-backend is a Dropwizard application that serves Prometheus metrics on the **admin connector** (port 8081, path `/metrics`). However, the helm chart's Service definition only exposes:
- Port 8080 (`http`) — application connector
- Port 3003 (`swagger`) — Swagger UI

The ServiceMonitor was targeting port 8080 (the `http` port) where no `/metrics` endpoint exists, resulting in 404s.

**Evidence** (from Prometheus targets on Cisco cluster):
```
Job: opik-backend  Health: down  LastError: server returned HTTP status 404 Not Found  ScrapeURL: http://10.191.33.77:8080/metrics
Job: opik-frontend  Health: down  LastError: server returned HTTP status 404 Not Found  ScrapeURL: http://10.191.36.8:5173/metrics
Job: opik-python-backend  Health: down  LastError: server returned HTTP status 404 NOT FOUND  ScrapeURL: http://10.191.57.196:8000/metrics
```

## Changes

**`deployment/helm_chart/opik/values.yaml`**:
1. Added `admin` port (8081) to `component.backend.service.ports`
2. Set `component.backend.metrics.portName: admin` (so ServiceMonitor targets the admin port)
3. Set `component.backend.metrics.path: /metrics` (Dropwizard default admin metrics path)

## Notes
- **frontend** and **python-backend** don't expose Prometheus metrics endpoints — their ServiceMonitors will need to be disabled separately in customer overrides (or these components need metrics middleware added)
- The `metrics.enabled` default remains `false` — no change in behavior for existing installations
- ST-SaaS customers already have `metrics.enabled: true` set in their override values; this fix makes those ServiceMonitors actually work for the backend

## Test plan
- [ ] `helm template` renders correctly with admin port in Service
- [ ] `helm template` with `metrics.enabled=true` renders ServiceMonitor targeting port `admin`
- [ ] Deploy to a ST-SaaS cluster and verify Prometheus target shows `up=1`

## Related
- [DND-995](https://comet-ml.atlassian.net/browse/DND-995): Enable Opik metrics (ServiceMonitor) on all ST-SaaS clusters
- [CUST-5162](https://comet-ml.atlassian.net/browse/CUST-5162): Zoox health report dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DND-995]: https://comet-ml.atlassian.net/browse/DND-995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ