### PR TITLE
[OPIK-5890] [BE][FE] feat: add optimization flow analytics events

### DIFF
--- a/.agents/skills/analytics-instrumentation/SKILL.md
+++ b/.agents/skills/analytics-instrumentation/SKILL.md
@@ -50,25 +50,71 @@ trackEvent(OpikEvent.ONBOARDING_AGENT_NAME_SUBMITTED, {
 - **Config**: `apps/opik-backend/src/main/java/com/comet/opik/infrastructure/AnalyticsConfig.java`
 - **YAML config**: `apps/opik-backend/config.yml` (under `analytics:`)
 
-### Adding a new event
+### API
+`AnalyticsService` exposes two overloads:
 
-1. Inject `AnalyticsService` into your service or listener:
 ```java
-private final @NonNull AnalyticsService analyticsService;
+void trackEvent(String eventType, Map<String, String> properties);
+void trackEvent(String eventType, Map<String, String> properties, String identity);
 ```
 
-2. Call `trackEvent`:
-```java
-analyticsService.trackEvent("opik_onboarding_first_trace",
-    Map.of("trace_id", traceId, "project_id", projectId));
-```
+- 2-arg resolves identity from the current request scope via `RequestContext`.
+- 3-arg takes an explicit identity — use it any time the call executes outside a request scope (reactive schedulers, background threads, event listeners).
 
 ### How it works
-- `trackEvent()` no-ops when `OPIK_ANALYTICS_ENABLED` is `false` (default)
-- `opik_` prefix is auto-prepended if missing
-- `environment` property is auto-injected from `OPIK_ANALYTICS_ENVIRONMENT`
-- Events flow: Backend → comet-stats → Segment → PostHog
-- Uses the same comet-stats endpoint as existing usage reporting (`usageReport.url`)
+- `trackEvent()` no-ops when `OPIK_ANALYTICS_ENABLED` is `false` (default).
+- `opik_` prefix is auto-prepended if missing — but keep the prefix in code for grep-ability.
+- `environment` property is auto-injected from `OPIK_ANALYTICS_ENVIRONMENT`.
+- Events flow: Backend → comet-stats → Segment → PostHog.
+- `AnalyticsService.sendEvent` wraps the body in `catch (RuntimeException)` — callers must not add their own try/catch.
+
+### From a synchronous request handler
+
+Inject and call inline. The 2-arg overload resolves identity from `RequestContext`.
+
+```java
+private final @NonNull AnalyticsService analyticsService;
+
+analyticsService.trackEvent("opik_onboarding_first_trace",
+        Map.of("trace_id", traceId, "project_id", projectId));
+```
+
+### From a reactive chain (`doOnSuccess`, `doOnNext`, etc.)
+
+Two things are required: **offload with `Schedulers.boundedElastic()`** and **pass identity explicitly**.
+
+**Why offload**: when identity is absent `AnalyticsService.resolveIdentity()` falls back to `UsageReportService.getAnonymousId()`, which is a synchronous JDBC read. Inside a `doOnSuccess` lambda that runs on the reactor event loop, that read blocks a scheduler-critical thread.
+
+**Why explicit identity**: `RequestContext` is bound to the request thread via a Guice scope — inside the scheduler's lambda it throws `ProvisionException`, and you silently degrade to the anonymous-ID fallback, losing user attribution.
+
+Capture `userName` up front from the reactor context alongside `workspaceId`, then pass both into the scheduled call:
+
+```java
+return Mono.deferContextual(ctx -> {
+    String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
+    // Use getOrDefault on paths that internal/system callers reach without seeding USER_NAME
+    // (e.g. a self-triggered cancellation written only with WORKSPACE_ID in the context).
+    String userName = ctx.getOrDefault(RequestContext.USER_NAME, null);
+
+    return someDao.write(...)
+            .doOnSuccess(__ -> Schedulers.boundedElastic().schedule(
+                    () -> analyticsService.trackEvent("opik_thing_happened",
+                            Map.of(
+                                    "thing_id", thing.id().toString(),
+                                    "workspace_id", workspaceId),
+                            userName)));
+});
+```
+
+If you already depend on a `Schedulers.boundedElastic().schedule(() -> { ... })` block that does other non-reactive work (e.g. a blocking `datasetService.getById` like `ExperimentService.trackEvalSuiteRunIfApplicable`), add the `trackEvent` call inside that existing lambda instead of nesting another.
+
+### Don'ts
+
+- **Don't add try/catch around `trackEvent`** — `sendEvent` catches `RuntimeException` internally. Extra catches are noise and diverge from the codebase pattern.
+- **Don't add helper methods that only delegate to `trackEvent`** — inline the call at the entry point. Wrap in a helper only when it encapsulates real logic (e.g. applicability check + enrichment + tracking).
+- **Don't re-fetch ClickHouse rows to get "fresh" values for analytics payloads** — a write and a read-after-write can land on different replicas, so you may see a stale snapshot or even a spurious `NotFound`. Use the pre-write snapshot; some analytics drift is acceptable, a failed user-facing request is not.
+- **Don't add unit tests that `verify(analyticsService)...`** — the codebase convention is for existing integration tests to exercise these paths organically. Sister analytics PRs (#6326 eval suite, #6333 onboarding, #6338 agent config) ship without emission assertions.
+- **Don't assume `trackEvent` is fully non-blocking** — the Javadoc contract is aspirational; the identity-fallback path is synchronous JDBC today. Offload from reactive chains as shown above.
 
 ## Environment Variables
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
@@ -13,6 +13,7 @@ import com.comet.opik.domain.attachment.PreSignerService;
 import com.comet.opik.domain.optimization.OptimizationLogSyncService;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.infrastructure.queues.Queue;
 import com.comet.opik.infrastructure.queues.QueueProducer;
 import com.google.common.base.Preconditions;
@@ -39,6 +40,7 @@ import java.time.Instant;
 import java.util.AbstractMap;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -86,6 +88,7 @@ class OptimizationServiceImpl implements OptimizationService {
     private final @NonNull OpikConfiguration config;
     private final @NonNull OptimizationLogSyncService logSyncService;
     private final @NonNull RedissonReactiveClient redisClient;
+    private final @NonNull AnalyticsService analyticsService;
 
     // Redis key pattern for cancellation signals (Python worker checks this)
     private static final String CANCEL_KEY_PATTERN = "opik:cancel:%s";
@@ -226,6 +229,8 @@ class OptimizationServiceImpl implements OptimizationService {
                                         .doOnSuccess(__ -> {
                                             postOptimizationCreatedEvent(newOptimization, workspaceId,
                                                     userName);
+                                            trackOptimizationCreated(newOptimization, workspaceId,
+                                                    userName);
 
                                             // Only enqueue job for NEW Studio optimizations
                                             if (shouldEnqueueJob) {
@@ -316,6 +321,7 @@ class OptimizationServiceImpl implements OptimizationService {
                                 // Safe to call multiple times - just syncs and reduces TTL
                                 if (update.status() != null && update.status().isTerminal()) {
                                     finalizeLogsAsync(workspaceId, id);
+                                    trackOptimizationCompleted(optimization, update.status(), workspaceId);
                                 }
                             });
                 }));
@@ -376,6 +382,26 @@ class OptimizationServiceImpl implements OptimizationService {
         }
         log.error("Unexpected exception creating optimization with id '{}'", id);
         return Mono.error(throwable);
+    }
+
+    private void trackOptimizationCreated(Optimization optimization, String workspaceId, String userName) {
+        analyticsService.trackEvent(userName, "optimization_created", Map.of(
+                "optimization_id", optimization.id().toString(),
+                "dataset_name", String.valueOf(optimization.datasetName()),
+                "objective_name", String.valueOf(optimization.objectiveName()),
+                "project_id", String.valueOf(optimization.projectId()),
+                "workspace_id", workspaceId));
+    }
+
+    private void trackOptimizationCompleted(Optimization optimization, OptimizationStatus status,
+            String workspaceId) {
+        analyticsService.trackEvent("optimization_completed", Map.of(
+                "optimization_id", optimization.id().toString(),
+                "status", status.getValue(),
+                "workspace_id", workspaceId,
+                "num_trials", String.valueOf(optimization.numTrials()),
+                "baseline_objective_score", String.valueOf(optimization.baselineObjectiveScore()),
+                "best_objective_score", String.valueOf(optimization.bestObjectiveScore())));
     }
 
     private void postOptimizationCreatedEvent(Optimization newOptimization, String workspaceId, String userName) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
@@ -229,8 +229,10 @@ class OptimizationServiceImpl implements OptimizationService {
                                         .doOnSuccess(__ -> {
                                             postOptimizationCreatedEvent(newOptimization, workspaceId,
                                                     userName);
-                                            trackOptimizationCreated(newOptimization, workspaceId,
-                                                    userName);
+                                            if (existingOpt.isEmpty()) {
+                                                trackOptimizationCreated(newOptimization, workspaceId,
+                                                        userName);
+                                            }
 
                                             // Only enqueue job for NEW Studio optimizations
                                             if (shouldEnqueueJob) {
@@ -385,7 +387,7 @@ class OptimizationServiceImpl implements OptimizationService {
     }
 
     private void trackOptimizationCreated(Optimization optimization, String workspaceId, String userName) {
-        analyticsService.trackEvent(userName, "optimization_created", Map.of(
+        analyticsService.trackEvent(userName, "opik_optimization_created", Map.of(
                 "optimization_id", optimization.id().toString(),
                 "dataset_name", String.valueOf(optimization.datasetName()),
                 "objective_name", String.valueOf(optimization.objectiveName()),
@@ -395,7 +397,7 @@ class OptimizationServiceImpl implements OptimizationService {
 
     private void trackOptimizationCompleted(Optimization optimization, OptimizationStatus status,
             String workspaceId) {
-        analyticsService.trackEvent("optimization_completed", Map.of(
+        analyticsService.trackEvent("opik_optimization_completed", Map.of(
                 "optimization_id", optimization.id().toString(),
                 "status", status.getValue(),
                 "workspace_id", workspaceId,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
@@ -230,8 +230,23 @@ class OptimizationServiceImpl implements OptimizationService {
                                             postOptimizationCreatedEvent(newOptimization, workspaceId,
                                                     userName);
                                             if (existingOpt.isEmpty()) {
-                                                trackOptimizationCreated(newOptimization, workspaceId,
-                                                        userName);
+                                                Schedulers.boundedElastic().schedule(
+                                                        () -> analyticsService.trackEvent(
+                                                                "opik_optimization_created",
+                                                                Map.of(
+                                                                        "optimization_id",
+                                                                        newOptimization.id().toString(),
+                                                                        "dataset_name",
+                                                                        String.valueOf(
+                                                                                newOptimization.datasetName()),
+                                                                        "objective_name",
+                                                                        String.valueOf(
+                                                                                newOptimization.objectiveName()),
+                                                                        "project_id",
+                                                                        String.valueOf(
+                                                                                newOptimization.projectId()),
+                                                                        "workspace_id", workspaceId),
+                                                                userName));
                                             }
 
                                             // Only enqueue job for NEW Studio optimizations
@@ -326,22 +341,22 @@ class OptimizationServiceImpl implements OptimizationService {
                                 // Safe to call multiple times - just syncs and reduces TTL
                                 if (update.status() != null && update.status().isTerminal()) {
                                     finalizeLogsAsync(workspaceId, id);
+                                    // Only emit completion event on the transition into a terminal state
+                                    if (!optimization.status().isTerminal()) {
+                                        Schedulers.boundedElastic().schedule(() -> analyticsService.trackEvent(
+                                                "opik_optimization_completed",
+                                                Map.of(
+                                                        "optimization_id", optimization.id().toString(),
+                                                        "status", update.status().getValue(),
+                                                        "workspace_id", workspaceId,
+                                                        "num_trials", String.valueOf(optimization.numTrials()),
+                                                        "baseline_objective_score",
+                                                        String.valueOf(optimization.baselineObjectiveScore()),
+                                                        "best_objective_score",
+                                                        String.valueOf(optimization.bestObjectiveScore())),
+                                                userName));
+                                    }
                                 }
-                            })
-                            .flatMap(count -> {
-                                // Only emit completion event on the transition into a terminal state.
-                                // Re-fetch so numTrials / baseline / best score reflect the final state
-                                // rather than the pre-update snapshot.
-                                boolean isTransitionIntoTerminal = update.status() != null
-                                        && update.status().isTerminal()
-                                        && !optimization.status().isTerminal();
-                                if (!isTransitionIntoTerminal) {
-                                    return Mono.just(count);
-                                }
-                                return optimizationDAO.getById(id)
-                                        .doOnNext(fresh -> trackOptimizationCompleted(fresh, update.status(),
-                                                workspaceId, userName))
-                                        .thenReturn(count);
                             });
                 }));
     }
@@ -401,26 +416,6 @@ class OptimizationServiceImpl implements OptimizationService {
         }
         log.error("Unexpected exception creating optimization with id '{}'", id);
         return Mono.error(throwable);
-    }
-
-    private void trackOptimizationCreated(Optimization optimization, String workspaceId, String userName) {
-        Schedulers.boundedElastic().schedule(() -> analyticsService.trackEvent("opik_optimization_created", Map.of(
-                "optimization_id", optimization.id().toString(),
-                "dataset_name", String.valueOf(optimization.datasetName()),
-                "objective_name", String.valueOf(optimization.objectiveName()),
-                "project_id", String.valueOf(optimization.projectId()),
-                "workspace_id", workspaceId), userName));
-    }
-
-    private void trackOptimizationCompleted(Optimization optimization, OptimizationStatus status,
-            String workspaceId, String userName) {
-        Schedulers.boundedElastic().schedule(() -> analyticsService.trackEvent("opik_optimization_completed", Map.of(
-                "optimization_id", optimization.id().toString(),
-                "status", status.getValue(),
-                "workspace_id", workspaceId,
-                "num_trials", String.valueOf(optimization.numTrials()),
-                "baseline_objective_score", String.valueOf(optimization.baselineObjectiveScore()),
-                "best_objective_score", String.valueOf(optimization.bestObjectiveScore())), userName));
     }
 
     private void postOptimizationCreatedEvent(Optimization newOptimization, String workspaceId, String userName) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
@@ -303,6 +303,9 @@ class OptimizationServiceImpl implements OptimizationService {
                 .switchIfEmpty(Mono.error(failWithNotFound("Optimization", id)))
                 .flatMap(optimization -> Mono.deferContextual(ctx -> {
                     String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
+                    // USER_NAME is absent on the internal cancelOptimization() path, where only
+                    // WORKSPACE_ID is seeded — fall back and let AnalyticsService resolve identity.
+                    String userName = ctx.getOrDefault(RequestContext.USER_NAME, null);
 
                     // Validate cancellation request for Studio optimizations
                     boolean isStudioCancellation = update.status() == OptimizationStatus.CANCELLED
@@ -323,7 +326,11 @@ class OptimizationServiceImpl implements OptimizationService {
                                 // Safe to call multiple times - just syncs and reduces TTL
                                 if (update.status() != null && update.status().isTerminal()) {
                                     finalizeLogsAsync(workspaceId, id);
-                                    trackOptimizationCompleted(optimization, update.status(), workspaceId);
+                                    // Only emit completion event on the transition into a terminal state
+                                    if (!optimization.status().isTerminal()) {
+                                        trackOptimizationCompleted(optimization, update.status(), workspaceId,
+                                                userName);
+                                    }
                                 }
                             });
                 }));
@@ -387,23 +394,23 @@ class OptimizationServiceImpl implements OptimizationService {
     }
 
     private void trackOptimizationCreated(Optimization optimization, String workspaceId, String userName) {
-        analyticsService.trackEvent(userName, "opik_optimization_created", Map.of(
+        analyticsService.trackEvent("opik_optimization_created", Map.of(
                 "optimization_id", optimization.id().toString(),
                 "dataset_name", String.valueOf(optimization.datasetName()),
                 "objective_name", String.valueOf(optimization.objectiveName()),
                 "project_id", String.valueOf(optimization.projectId()),
-                "workspace_id", workspaceId));
+                "workspace_id", workspaceId), userName);
     }
 
     private void trackOptimizationCompleted(Optimization optimization, OptimizationStatus status,
-            String workspaceId) {
+            String workspaceId, String userName) {
         analyticsService.trackEvent("opik_optimization_completed", Map.of(
                 "optimization_id", optimization.id().toString(),
                 "status", status.getValue(),
                 "workspace_id", workspaceId,
                 "num_trials", String.valueOf(optimization.numTrials()),
                 "baseline_objective_score", String.valueOf(optimization.baselineObjectiveScore()),
-                "best_objective_score", String.valueOf(optimization.bestObjectiveScore())));
+                "best_objective_score", String.valueOf(optimization.bestObjectiveScore())), userName);
     }
 
     private void postOptimizationCreatedEvent(Optimization newOptimization, String workspaceId, String userName) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
@@ -321,17 +321,27 @@ class OptimizationServiceImpl implements OptimizationService {
 
                     return signalCancellationIfNeeded(id, optimization, update)
                             .then(optimizationDAO.update(id, update))
-                            .doOnSuccess(result -> {
+                            .doOnSuccess(__ -> {
                                 // Sync logs when optimization reaches terminal status
                                 // Safe to call multiple times - just syncs and reduces TTL
                                 if (update.status() != null && update.status().isTerminal()) {
                                     finalizeLogsAsync(workspaceId, id);
-                                    // Only emit completion event on the transition into a terminal state
-                                    if (!optimization.status().isTerminal()) {
-                                        trackOptimizationCompleted(optimization, update.status(), workspaceId,
-                                                userName);
-                                    }
                                 }
+                            })
+                            .flatMap(count -> {
+                                // Only emit completion event on the transition into a terminal state.
+                                // Re-fetch so numTrials / baseline / best score reflect the final state
+                                // rather than the pre-update snapshot.
+                                boolean isTransitionIntoTerminal = update.status() != null
+                                        && update.status().isTerminal()
+                                        && !optimization.status().isTerminal();
+                                if (!isTransitionIntoTerminal) {
+                                    return Mono.just(count);
+                                }
+                                return optimizationDAO.getById(id)
+                                        .doOnNext(fresh -> trackOptimizationCompleted(fresh, update.status(),
+                                                workspaceId, userName))
+                                        .thenReturn(count);
                             });
                 }));
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
@@ -404,23 +404,23 @@ class OptimizationServiceImpl implements OptimizationService {
     }
 
     private void trackOptimizationCreated(Optimization optimization, String workspaceId, String userName) {
-        analyticsService.trackEvent("opik_optimization_created", Map.of(
+        Schedulers.boundedElastic().schedule(() -> analyticsService.trackEvent("opik_optimization_created", Map.of(
                 "optimization_id", optimization.id().toString(),
                 "dataset_name", String.valueOf(optimization.datasetName()),
                 "objective_name", String.valueOf(optimization.objectiveName()),
                 "project_id", String.valueOf(optimization.projectId()),
-                "workspace_id", workspaceId), userName);
+                "workspace_id", workspaceId), userName));
     }
 
     private void trackOptimizationCompleted(Optimization optimization, OptimizationStatus status,
             String workspaceId, String userName) {
-        analyticsService.trackEvent("opik_optimization_completed", Map.of(
+        Schedulers.boundedElastic().schedule(() -> analyticsService.trackEvent("opik_optimization_completed", Map.of(
                 "optimization_id", optimization.id().toString(),
                 "status", status.getValue(),
                 "workspace_id", workspaceId,
                 "num_trials", String.valueOf(optimization.numTrials()),
                 "baseline_objective_score", String.valueOf(optimization.baselineObjectiveScore()),
-                "best_objective_score", String.valueOf(optimization.bestObjectiveScore())), userName);
+                "best_objective_score", String.valueOf(optimization.bestObjectiveScore())), userName));
     }
 
     private void postOptimizationCreatedEvent(Optimization newOptimization, String workspaceId, String userName) {

--- a/apps/opik-frontend/src/lib/analytics/tracking.ts
+++ b/apps/opik-frontend/src/lib/analytics/tracking.ts
@@ -6,6 +6,7 @@ export const OpikEvent = {
   ONBOARDING_SKIPPED: "opik_onboarding_skipped",
   EVAL_SUITE_UI_CONFIGURED: "opik_eval_suite_ui_configured",
   AGENT_CONFIG_UI_DEPLOYED: "opik_agent_config_ui_deployed",
+  OPTIMIZATION_WIZARD_STARTED: "opik_optimization_wizard_started",
 } as const;
 
 type OpikEventValues = (typeof OpikEvent)[keyof typeof OpikEvent];

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPage.tsx
@@ -3,6 +3,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryParam, StringParam } from "use-query-params";
 import useAppStore from "@/store/AppStore";
+import { OpikEvent, trackEvent } from "@/lib/analytics/tracking";
 import useGetOrCreateDemoDataset from "@/api/datasets/useGetOrCreateDemoDataset";
 import useOptimizationById from "@/api/optimizations/useOptimizationById";
 import {
@@ -21,6 +22,13 @@ const OptimizationsNewPage: React.FC = () => {
   const { getOrCreateDataset } = useGetOrCreateDemoDataset();
   const datasetCreationRef = useRef<string | null>(null);
   const [isPreparingDataset, setIsPreparingDataset] = useState(false);
+
+  useEffect(() => {
+    trackEvent(OpikEvent.OPTIMIZATION_WIZARD_STARTED, {
+      from_template: Boolean(templateId),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const templateData = useMemo(
     () => OPTIMIZATION_DEMO_TEMPLATES.find((t) => t.id === templateId) ?? null,


### PR DESCRIPTION
## Details

Add PostHog instrumentation for the Optimization flow to track launch metrics defined in parent epic OPIK-5245.

**Backend (2 events via `AnalyticsService` in `OptimizationService`):** `opik_optimization_created` fires on upsert to capture both UI and SDK creation paths; `opik_optimization_completed` fires on terminal status transition (completed/error/cancelled) and includes `num_trials`, `baseline_objective_score`, `best_objective_score` for improvement delta and variation count analysis.
**Frontend (1 event via `trackEvent()`):** `opik_optimization_wizard_started` fires on wizard page mount (v2 only) with `from_template` property.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5890

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-6
- Scope: full implementation
- Human verification: code review + manual testing on staging

## Testing

- Backend compiled cleanly: `cd apps/opik-backend && mvn compile -pl . -q` — zero errors
- Backend test compilation: `mvn test-compile -pl . -q` — zero errors
- Backend tests passed: `mvn test -pl . -Dtest="OptimizationsResourceTest,OptimizationsResourceProjectScopedDatasetCreationTest,OptimizationsResourceFindProjectOptimizationsTest"` — **44 tests, 0 failures**
- Frontend type check passed: `npm run typecheck` — zero TS errors
- All pre-commit hooks passed: Spotless (Java formatting), ESLint, TypeScript typecheck, dependency cruiser (0 violations)

## Documentation

N/A — analytics events are internal instrumentation, no user-facing documentation changes needed.