### PR TITLE
[OPIK-6052] [FE] fix: unify sidebar collapse/expand behavior across pages

### DIFF
--- a/apps/opik-frontend/src/constants/assistantSidebar.ts
+++ b/apps/opik-frontend/src/constants/assistantSidebar.ts
@@ -1,12 +1,12 @@
 export const ASSISTANT_SIDEBAR_DEFAULT_WIDTH = 400;
 export const ASSISTANT_SIDEBAR_COLLAPSED_WIDTH = 33;
 
+const WIDTH_STORAGE_KEY = "assistant-sidebar-width";
+const OPEN_STORAGE_KEY = "assistant-sidebar-open";
+
 export const getStoredAssistantSidebarWidth = (): number => {
   try {
-    const parsed = parseInt(
-      localStorage.getItem("assistant-sidebar-width") ?? "",
-      10,
-    );
+    const parsed = parseInt(localStorage.getItem(WIDTH_STORAGE_KEY) ?? "", 10);
     if (parsed > 0) return parsed;
   } catch {
     /* localStorage unavailable */
@@ -16,9 +16,17 @@ export const getStoredAssistantSidebarWidth = (): number => {
 
 export const isAssistantSidebarOpen = (): boolean => {
   try {
-    const stored = localStorage.getItem("assistant-sidebar-open");
+    const stored = localStorage.getItem(OPEN_STORAGE_KEY);
     return stored === null ? true : stored === "true";
   } catch {
     return true;
+  }
+};
+
+export const setAssistantSidebarOpen = (open: boolean): void => {
+  try {
+    localStorage.setItem(OPEN_STORAGE_KEY, String(open));
+  } catch {
+    /* localStorage unavailable */
   }
 };

--- a/apps/opik-frontend/src/constants/assistantSidebar.ts
+++ b/apps/opik-frontend/src/constants/assistantSidebar.ts
@@ -1,0 +1,24 @@
+export const ASSISTANT_SIDEBAR_DEFAULT_WIDTH = 400;
+export const ASSISTANT_SIDEBAR_COLLAPSED_WIDTH = 33;
+
+export const getStoredAssistantSidebarWidth = (): number => {
+  try {
+    const parsed = parseInt(
+      localStorage.getItem("assistant-sidebar-width") ?? "",
+      10,
+    );
+    if (parsed > 0) return parsed;
+  } catch {
+    /* localStorage unavailable */
+  }
+  return ASSISTANT_SIDEBAR_DEFAULT_WIDTH;
+};
+
+export const isAssistantSidebarOpen = (): boolean => {
+  try {
+    const stored = localStorage.getItem("assistant-sidebar-open");
+    return stored === null ? true : stored === "true";
+  } catch {
+    return true;
+  }
+};

--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -30,11 +30,13 @@ import {
   ASSISTANT_DEV_BASE_URL,
   IS_ASSISTANT_DEV,
 } from "@/plugins/comet/constants/assistant";
+import {
+  ASSISTANT_SIDEBAR_COLLAPSED_WIDTH,
+  getStoredAssistantSidebarWidth,
+  isAssistantSidebarOpen,
+} from "@/constants/assistantSidebar";
 
 const BRIDGE_PROTOCOL_VERSION = 1;
-
-const LOADER_DEFAULT_WIDTH = 400;
-const LOADER_COLLAPSED_WIDTH = 33;
 
 // Pod may serve /console/manifest.json before /health/ready flips — retry
 // with backoff so transient 404/503 during warmup don't permanently fail.
@@ -43,28 +45,6 @@ const LOADER_COLLAPSED_WIDTH = 33;
 const MANIFEST_RETRY_COUNT = 30;
 const MANIFEST_RETRY_BASE_DELAY_MS = 500;
 const MANIFEST_RETRY_MAX_DELAY_MS = 5000;
-
-function getStoredSidebarWidth(): number {
-  try {
-    const parsed = parseInt(
-      localStorage.getItem("assistant-sidebar-width") ?? "",
-      10,
-    );
-    if (parsed > 0) return parsed;
-  } catch {
-    /* localStorage unavailable */
-  }
-  return LOADER_DEFAULT_WIDTH;
-}
-
-function getStoredSidebarOpen(): boolean {
-  try {
-    const stored = localStorage.getItem("assistant-sidebar-open");
-    return stored === null ? true : stored === "true";
-  } catch {
-    return true;
-  }
-}
 
 interface AssistantSidebarLoaderProps {
   error: string | null;
@@ -81,9 +61,11 @@ const AssistantSidebarLoader: React.FC<AssistantSidebarLoaderProps> = ({
   retryCount = 0,
   surface,
 }) => {
-  const [isOpen, setIsOpen] = useState(getStoredSidebarOpen);
+  const [isOpen, setIsOpen] = useState(isAssistantSidebarOpen);
   const initialWidth = useRef(
-    getStoredSidebarOpen() ? getStoredSidebarWidth() : LOADER_COLLAPSED_WIDTH,
+    isAssistantSidebarOpen()
+      ? getStoredAssistantSidebarWidth()
+      : ASSISTANT_SIDEBAR_COLLAPSED_WIDTH,
   );
 
   useEffect(() => {
@@ -94,7 +76,11 @@ const AssistantSidebarLoader: React.FC<AssistantSidebarLoaderProps> = ({
     setIsOpen((prev) => {
       const next = !prev;
       localStorage.setItem("assistant-sidebar-open", String(next));
-      onWidthChange(next ? getStoredSidebarWidth() : LOADER_COLLAPSED_WIDTH);
+      onWidthChange(
+        next
+          ? getStoredAssistantSidebarWidth()
+          : ASSISTANT_SIDEBAR_COLLAPSED_WIDTH,
+      );
       return next;
     });
   }, [onWidthChange]);

--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -34,6 +34,7 @@ import {
   ASSISTANT_SIDEBAR_COLLAPSED_WIDTH,
   getStoredAssistantSidebarWidth,
   isAssistantSidebarOpen,
+  setAssistantSidebarOpen,
 } from "@/constants/assistantSidebar";
 
 const BRIDGE_PROTOCOL_VERSION = 1;
@@ -75,7 +76,7 @@ const AssistantSidebarLoader: React.FC<AssistantSidebarLoaderProps> = ({
   const handleToggle = useCallback(() => {
     setIsOpen((prev) => {
       const next = !prev;
-      localStorage.setItem("assistant-sidebar-open", String(next));
+      setAssistantSidebarOpen(next);
       onWidthChange(
         next
           ? getStoredAssistantSidebarWidth()

--- a/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
+++ b/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
@@ -58,9 +58,14 @@ const PageLayout = () => {
 
   const isAssistantOpen =
     assistantSidebarWidth > ASSISTANT_SIDEBAR_COLLAPSED_WIDTH;
-
-  const assistantWrapperWidth =
-    isPhone && isAssistantOpen ? "100vw" : `${assistantSidebarWidth}px`;
+  // On phones when the assistant is open, render it as a fixed overlay so it
+  // doesn't consume flex-row width and collapse main content. The layout var
+  // stays 0px so `.comet-content-inset`'s calc resolves correctly.
+  const isPhoneAssistantOverlay = isPhone && isAssistantOpen;
+  const layoutAssistantWidth =
+    showAssistantSidebar && !isPhoneAssistantOverlay
+      ? `${assistantSidebarWidth}px`
+      : "0px";
 
   const expanded = isPhone
     ? false
@@ -102,9 +107,7 @@ const PageLayout = () => {
         {
           "--banner-height": `${bannerHeight}px`,
           "--sidebar-width": expanded ? "240px" : "54px",
-          "--assistant-sidebar-width": showAssistantSidebar
-            ? assistantWrapperWidth
-            : "0px",
+          "--assistant-sidebar-width": layoutAssistantWidth,
         } as React.CSSProperties
       }
     >
@@ -141,8 +144,16 @@ const PageLayout = () => {
 
         {showAssistantSidebar ? (
           <div
-            className="relative z-[1] shrink-0"
-            style={{ width: assistantWrapperWidth }}
+            className={
+              isPhoneAssistantOverlay
+                ? "fixed inset-0 z-40"
+                : "relative z-[1] shrink-0"
+            }
+            style={
+              isPhoneAssistantOverlay
+                ? undefined
+                : { width: `${assistantSidebarWidth}px` }
+            }
           >
             <SilentErrorBoundary>
               <AssistantSidebar onWidthChange={setAssistantSidebarWidth} />

--- a/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
+++ b/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Outlet, useMatchRoute } from "@tanstack/react-router";
 import SideBar from "@/v2/layout/SideBar/SideBar";
 import TopBar from "@/v2/layout/TopBar/TopBar";
@@ -12,6 +12,12 @@ import LayoutDialogs from "@/v2/layout/LayoutDialogs";
 import { PortalContainerProvider } from "@/lib/portal-container";
 import SilentErrorBoundary from "@/shared/SilentErrorBoundary/SilentErrorBoundary";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useIsPhone } from "@/hooks/useIsPhone";
+import {
+  ASSISTANT_SIDEBAR_COLLAPSED_WIDTH,
+  getStoredAssistantSidebarWidth,
+  isAssistantSidebarOpen,
+} from "@/constants/assistantSidebar";
 
 const PageLayout = () => {
   const [hostContainer, setHostContainer] = useState<HTMLDivElement | null>(
@@ -19,10 +25,14 @@ const PageLayout = () => {
   );
   const [storedExpanded = true, setStoredExpanded] =
     useLocalStorageState<boolean>("sidebar-expanded");
+  const [smallScreenExpanded, setSmallScreenExpanded] = useState(false);
   const [bannerHeight, setBannerHeight] = useState(0);
   const [showWelcomeWizard, setShowWelcomeWizard] = useState(false);
-  const [assistantSidebarWidth, setAssistantSidebarWidth] = useState(0);
-  const sidebarWrapperRef = useRef<HTMLDivElement>(null);
+  const [assistantSidebarWidth, setAssistantSidebarWidth] = useState(() =>
+    isAssistantSidebarOpen()
+      ? getStoredAssistantSidebarWidth()
+      : ASSISTANT_SIDEBAR_COLLAPSED_WIDTH,
+  );
 
   const welcomeWizardEnabled = useIsFeatureEnabled(
     FeatureToggleKeys.WELCOME_WIZARD_ENABLED,
@@ -43,15 +53,28 @@ const PageLayout = () => {
   const showAssistantSidebar = !!AssistantSidebar && !isProjectHome;
 
   const assistantWidth = showAssistantSidebar ? assistantSidebarWidth : 0;
-  const isMobile = useMediaQuery(`(max-width: ${1023 + assistantWidth}px)`);
-  const expanded = isMobile ? false : storedExpanded;
+  const { isPhone } = useIsPhone();
+  const isSmall = useMediaQuery(`(max-width: ${1023 + assistantWidth}px)`);
 
-  const handleSidebarWidthChange = useCallback((width: number) => {
-    if (sidebarWrapperRef.current) {
-      sidebarWrapperRef.current.style.width = `${width}px`;
+  const isAssistantOpen =
+    assistantSidebarWidth > ASSISTANT_SIDEBAR_COLLAPSED_WIDTH;
+
+  const assistantWrapperWidth =
+    isPhone && isAssistantOpen ? "100vw" : `${assistantSidebarWidth}px`;
+
+  const expanded = isPhone
+    ? false
+    : isSmall
+      ? smallScreenExpanded
+      : storedExpanded;
+
+  const toggleExpanded = useCallback(() => {
+    if (isSmall) {
+      setSmallScreenExpanded((s) => !s);
+    } else {
+      setStoredExpanded((s) => !s);
     }
-    setAssistantSidebarWidth(width);
-  }, []);
+  }, [isSmall, setStoredExpanded]);
 
   useEffect(() => {
     if (
@@ -79,9 +102,9 @@ const PageLayout = () => {
         {
           "--banner-height": `${bannerHeight}px`,
           "--sidebar-width": expanded ? "240px" : "54px",
-          "--assistant-sidebar-width": `${
-            showAssistantSidebar ? assistantSidebarWidth : 0
-          }px`,
+          "--assistant-sidebar-width": showAssistantSidebar
+            ? assistantWrapperWidth
+            : "0px",
         } as React.CSSProperties
       }
     >
@@ -97,8 +120,8 @@ const PageLayout = () => {
 
             <SideBar
               expanded={expanded}
-              setExpanded={setStoredExpanded}
-              locked={isMobile}
+              canToggle={!isPhone}
+              onToggle={toggleExpanded}
             />
             <main className="comet-content-inset absolute bottom-0 right-0 top-[var(--banner-height)] flex transition-all">
               <TopBar />
@@ -117,9 +140,12 @@ const PageLayout = () => {
         </PortalContainerProvider>
 
         {showAssistantSidebar ? (
-          <div ref={sidebarWrapperRef} className="relative z-[1] w-0 shrink-0">
+          <div
+            className="relative z-[1] shrink-0"
+            style={{ width: assistantWrapperWidth }}
+          >
             <SilentErrorBoundary>
-              <AssistantSidebar onWidthChange={handleSidebarWidthChange} />
+              <AssistantSidebar onWidthChange={setAssistantSidebarWidth} />
             </SilentErrorBoundary>
           </div>
         ) : null}

--- a/apps/opik-frontend/src/v2/layout/SideBar/SideBar.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/SideBar.tsx
@@ -2,9 +2,7 @@ import React from "react";
 import { Link, useRouterState } from "@tanstack/react-router";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useActiveWorkspaceName } from "@/store/AppStore";
-import { OnChangeFn } from "@/types/shared";
 import { Button } from "@/ui/button";
-import { cn } from "@/lib/utils";
 import Logo from "@/shared/Logo/Logo";
 import { useActiveProjectInitializer } from "@/hooks/useActiveProjectInitializer";
 import ProjectSidebarContent from "@/v2/layout/SideBar/ProjectSidebarContent";
@@ -14,14 +12,14 @@ const HOME_PATH = "/$workspaceName/home";
 
 type SideBarProps = {
   expanded: boolean;
-  setExpanded: OnChangeFn<boolean | undefined>;
-  locked?: boolean;
+  canToggle: boolean;
+  onToggle: () => void;
 };
 
 const SideBar: React.FunctionComponent<SideBarProps> = ({
   expanded,
-  setExpanded,
-  locked = false,
+  canToggle,
+  onToggle,
 }) => {
   useActiveProjectInitializer();
   const workspaceName = useActiveWorkspaceName();
@@ -45,17 +43,16 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
         </Link>
       </div>
       <div className="relative flex h-[calc(100%-var(--header-height))]">
-        <Button
-          variant="outline"
-          size="icon-2xs"
-          onClick={() => setExpanded((s) => !s)}
-          className={cn(
-            "absolute -right-3 top-2 hidden rounded-full z-50",
-            !locked && "lg:group-hover:flex",
-          )}
-        >
-          {expanded ? <ChevronLeft /> : <ChevronRight />}
-        </Button>
+        {canToggle && (
+          <Button
+            variant="outline"
+            size="icon-2xs"
+            onClick={onToggle}
+            className="absolute -right-3 top-2 z-50 hidden rounded-full max-lg:flex lg:group-hover:flex"
+          >
+            {expanded ? <ChevronLeft /> : <ChevronRight />}
+          </Button>
+        )}
         <div className="flex min-h-0 grow flex-col justify-between overflow-auto p-3">
           {isProjectRoute ? (
             <ProjectSidebarContent expanded={expanded} />

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundAddVariant.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundAddVariant.tsx
@@ -74,9 +74,10 @@ const PlaygroundAddVariant = ({ providerKeys }: PlaygroundAddVariantProps) => {
     <div
       ref={stripRef}
       className={cn(
-        "group/variant flex w-[var(--add-variant-width)] shrink-0 cursor-pointer items-start justify-center self-stretch border-r bg-background hover:bg-primary-100",
+        "group/variant flex w-[var(--add-variant-width)] shrink-0 cursor-pointer items-start justify-center self-stretch bg-background hover:bg-primary-100",
         addVariantOpen && "bg-primary-100",
       )}
+      style={{ boxShadow: "1px 0 0 hsl(var(--border))" }}
       onClick={() => setAddVariantOpen(true)}
     >
       <div className="flex h-[50vh] items-center">


### PR DESCRIPTION
## Details

The nav sidebar previously behaved differently on project vs workspace pages: on small-medium screens it would auto-collapse with no way for the user to re-expand, and the transition point depended on whether the assistant (Ollie) sidebar was visible. Replaced with a single three-tier policy that applies to every page:

- **Phone** (`pointer: coarse` + size, via the existing `useIsPhone` hook): always collapsed, no toggle button rendered.
- **Small-medium**: collapsed by default but the user can expand — state held in a session-only `useState`, so a refresh returns to collapsed.
- **Big**: expanded by default and the user's persisted choice (`localStorage`) is respected.

Additional fixes in the same area:

- **First-paint flash** on medium screens: `assistantSidebarWidth` used to initialize at `0` and jump to its real value after the plugin's `useEffect` ran, which re-shifted the breakpoint and visibly re-collapsed the nav sidebar. Now seeded synchronously from `localStorage` so first paint already has the correct breakpoint.
- **Mobile assistant overflow**: a desktop-resized-wide assistant used to overflow on phones. On `isPhone && open`, the assistant wrapper now takes `100vw` regardless of the stored width; the `--assistant-sidebar-width` CSS var mirrors this so `main.scss`'s `calc()` stays consistent.
- **API cleanup**: `SideBar` now accepts `canToggle` + `onToggle` instead of a raw setter — capability and mechanism are separate props. Dropped an obsolete ref-based imperative DOM-write pattern whose original feedback-loop protection is now provided by React's setter-reference stability.
- **Shared module**: extracted `ASSISTANT_SIDEBAR_*` constants and the `getStoredAssistantSidebarWidth` / `isAssistantSidebarOpen` localStorage helpers into `src/constants/assistantSidebar.ts` so the plugin (`plugins/comet/AssistantSidebar.tsx`) and the layout (`v2/layout/PageLayout/PageLayout.tsx`) share one source of truth.

**Extra, same area**: in the Prompt Playground, the "Add variant" strip no longer shows a double-border against the assistant sidebar. Replaced its `border-r` with a non-inset `1px` box-shadow — the `overflow-x: auto` parent clips it when the strip sits flush against the container's right edge (adjacent to the assistant sidebar, no empty space) and leaves it visible when a wide viewport exposes empty space beyond the strip.

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6052

## Testing

Manual verification across viewport tiers and both contexts:

- [ ] Phone (touch device / DevTools mobile): sidebar always collapsed, no toggle chevron rendered.
- [ ] Small-medium (≤ `1023 + assistant-width`): sidebar starts collapsed, clicking the chevron expands it, refresh returns to collapsed.
- [ ] Big: sidebar follows `localStorage` preference; collapse/expand persists across refresh.
- [ ] On workspace pages with Ollie open on a ~1200px viewport: no expanded→collapsed flash on refresh.
- [ ] On a phone with a previously desktop-resized Ollie: opening the assistant shows it at `100vw`, not overflowing.
- [ ] Prompt playground with Ollie adjacent: "Add variant" strip shows no double-border. On a wide viewport with few variants (empty space to the right of the strip): the 1px separator is visible.

## Documentation

N/A

## Video
https://github.com/user-attachments/assets/f59afcf6-4659-4550-8004-df1c91f62fba

