### PR TITLE
[OPIK-6026] [BE] fix: make analytics and BI reporting async, exception-safe, and timeout-bounded

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -466,6 +466,12 @@ usageReport:
   # Default: https://stats.comet.com/notify/event/
   # Description: URL to send the anonymous usage reports to
   url: ${OPIK_USAGE_REPORT_URL:-https://stats.comet.com/notify/event/}
+  # Default: 5s
+  # Description: HTTP connect timeout for usage report
+  connectTimeout: ${OPIK_USAGE_REPORT_CONNECT_TIMEOUT:-5s}
+  # Default: 10s
+  # Description: HTTP read timeout for usage report
+  readTimeout: ${OPIK_USAGE_REPORT_READ_TIMEOUT:-10s}
   # Description: Configuration for anonymous ID used to identify the installation
   # Default: empty
   anonymousId: ${OPIK_ANONYMOUS_ID:-}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentService.java
@@ -702,10 +702,10 @@ public class ExperimentService {
             try {
                 datasetService.getById(experiment.datasetId(), workspaceId)
                         .filter(dataset -> dataset.type() == DatasetType.TEST_SUITE)
-                        .ifPresent(dataset -> analyticsService.trackEvent(userName, "opik_eval_suite_run", Map.of(
+                        .ifPresent(dataset -> analyticsService.trackEvent("opik_eval_suite_run", Map.of(
                                 "eval_suite_id", dataset.id().toString(),
                                 "experiment_id", experiment.id().toString(),
-                                "project_id", String.valueOf(experiment.projectId()))));
+                                "project_id", String.valueOf(experiment.projectId())), userName));
             } catch (Exception e) {
                 log.warn("Failed to track eval_suite_run analytics event for experiment '{}'",
                         experiment.id(), e);

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/UsageReportConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/UsageReportConfig.java
@@ -1,8 +1,14 @@
 package com.comet.opik.infrastructure;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.util.Duration;
+import io.dropwizard.validation.MaxDuration;
+import io.dropwizard.validation.MinDuration;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+
+import java.util.concurrent.TimeUnit;
 
 @Data
 public class UsageReportConfig {
@@ -15,5 +21,15 @@ public class UsageReportConfig {
 
     @Valid @JsonProperty
     private String anonymousId;
+
+    @Valid @JsonProperty
+    @NotNull @MinDuration(value = 10, unit = TimeUnit.MILLISECONDS)
+    @MaxDuration(value = 60, unit = TimeUnit.SECONDS)
+    private Duration connectTimeout = Duration.seconds(5);
+
+    @Valid @JsonProperty
+    @NotNull @MinDuration(value = 10, unit = TimeUnit.MILLISECONDS)
+    @MaxDuration(value = 60, unit = TimeUnit.SECONDS)
+    private Duration readTimeout = Duration.seconds(10);
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/AnalyticsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/AnalyticsService.java
@@ -8,21 +8,60 @@ import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Product analytics event tracking service. Enriches events with environment metadata and
+ * delegates to {@link StatsClient} for async delivery.
+ *
+ * <p><strong>Contract:</strong> all methods are fire-and-forget. They must never throw, never block
+ * the calling thread on I/O, and never disrupt production API traffic. Implementations must guard
+ * against all exceptions — including non-obvious ones such as Lombok {@code @NonNull} null-checks
+ * that fire before user code. Use {@code catch (RuntimeException)} at the outermost scope.
+ *
+ * <p><strong>Async requirement:</strong> any I/O (network calls, DB queries) must be non-blocking
+ * or offloaded to a background thread. The current implementation relies on {@link StatsClient}
+ * for async HTTP via Jersey's {@link jakarta.ws.rs.client.InvocationCallback} API. Identity
+ * resolution ({@code resolveIdentity}) may hit the DB as a rare fallback; this is acceptable
+ * because all request-scoped callers resolve identity from the in-memory request context.
+ *
+ * <p><strong>Current limitations:</strong>
+ * <ul>
+ *   <li>Identity fallback ({@code usageReportService.getAnonymousId()}) performs a synchronous
+ *       DB read. This only fires when there is no request scope and no explicit identity — not
+ *       reachable from current request-scoped callers.</li>
+ *   <li>Requires {@code usageReport.enabled=true} at the transport level ({@link StatsClient}),
+ *       in addition to {@code analytics.enabled=true}, for events to actually be sent.</li>
+ * </ul>
+ */
 @ImplementedBy(AnalyticsServiceImpl.class)
 public interface AnalyticsService {
     String EVENT_PREFIX = "opik_";
 
+    /**
+     * Track an analytics event, resolving identity from the current request context.
+     *
+     * @param eventType  event name (auto-prefixed with {@value EVENT_PREFIX} if missing)
+     * @param properties event payload
+     */
     void trackEvent(String eventType, Map<String, String> properties);
 
-    void trackEvent(String identity, String eventType, Map<String, String> properties);
+    /**
+     * Track an analytics event with an explicit identity, bypassing request context resolution.
+     *
+     * @param eventType  event name (auto-prefixed with {@value EVENT_PREFIX} if missing)
+     * @param properties event payload
+     * @param identity   user or installation identifier
+     */
+    void trackEvent(String eventType, Map<String, String> properties, String identity);
 }
 
+@RequiredArgsConstructor(onConstructor_ = @Inject)
 @Singleton
 @Slf4j
 class AnalyticsServiceImpl implements AnalyticsService {
@@ -32,47 +71,42 @@ class AnalyticsServiceImpl implements AnalyticsService {
     private final @NonNull StatsClient statsClient;
     private final @NonNull Provider<RequestContext> requestContext;
 
-    @Inject
-    AnalyticsServiceImpl(@NonNull OpikConfiguration config, @NonNull UsageReportService usageReportService,
-            @NonNull StatsClient statsClient, @NonNull Provider<RequestContext> requestContext) {
-        this.config = config;
-        this.usageReportService = usageReportService;
-        this.statsClient = statsClient;
-        this.requestContext = requestContext;
+    @Override
+    public void trackEvent(String eventType, Map<String, String> properties) {
+        sendEvent(eventType, properties, null);
     }
 
     @Override
-    public void trackEvent(@NonNull String eventType, @NonNull Map<String, String> properties) {
-        sendEvent(resolveIdentity(), eventType, properties);
+    public void trackEvent(String eventType, Map<String, String> properties, String identity) {
+        sendEvent(eventType, properties, identity);
     }
 
-    @Override
-    public void trackEvent(@NonNull String identity, @NonNull String eventType,
-            @NonNull Map<String, String> properties) {
-        sendEvent(identity, eventType, properties);
-    }
+    private void sendEvent(String eventType, Map<String, String> properties, String identity) {
+        try {
+            if (!config.getAnalytics().isEnabled()) {
+                log.info("Analytics disabled — skipping event '{}'", eventType);
+                return;
+            }
 
-    private void sendEvent(String identity, String eventType, Map<String, String> properties) {
-        if (!config.getAnalytics().isEnabled()) {
-            log.info("Analytics disabled — skipping event '{}'", eventType);
-            return;
+            var resolvedIdentity = identity != null ? identity : resolveIdentity();
+            var prefixedEventType = eventType.startsWith(EVENT_PREFIX) ? eventType : EVENT_PREFIX + eventType;
+
+            var enrichedProperties = new HashMap<>(properties);
+            var environment = config.getAnalytics().getEnvironment();
+            if (StringUtils.isNotBlank(environment)) {
+                enrichedProperties.put("environment", environment);
+            }
+
+            var event = BiEvent.builder()
+                    .anonymousId(resolvedIdentity)
+                    .eventType(prefixedEventType)
+                    .eventProperties(enrichedProperties)
+                    .build();
+
+            statsClient.sendEvent(event);
+        } catch (RuntimeException exception) {
+            log.warn("Failed to send analytics event '{}'", eventType, exception);
         }
-
-        var prefixedEventType = eventType.startsWith(EVENT_PREFIX) ? eventType : EVENT_PREFIX + eventType;
-
-        var enrichedProperties = new HashMap<>(properties);
-        var environment = config.getAnalytics().getEnvironment();
-        if (StringUtils.isNotBlank(environment)) {
-            enrichedProperties.put("environment", environment);
-        }
-
-        var event = BiEvent.builder()
-                .anonymousId(identity)
-                .eventType(prefixedEventType)
-                .eventProperties(enrichedProperties)
-                .build();
-
-        statsClient.sendEvent(event);
     }
 
     private String resolveIdentity() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/BiEvent.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/BiEvent.java
@@ -10,5 +10,5 @@ import java.util.Map;
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-record BiEvent(String anonymousId, String eventType, Map<String, String> eventProperties) {
+public record BiEvent(String anonymousId, String eventType, Map<String, String> eventProperties) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/BiEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/BiEventListener.java
@@ -39,7 +39,22 @@ public class BiEventListener {
     private final BiEventService biEventService;
     private final AnalyticsService analyticsService;
 
-    private final Set<String> analyticsReportedWorkspaces = ConcurrentHashMap.newKeySet();
+    /**
+     * Best-effort, in-memory dedup for per-workspace first_trace_created analytics events.
+     *
+     * <p>Known limitations:
+     * <ul>
+     *   <li>Grows monotonically — entries are never evicted, leading to unbounded memory usage.
+     *       Each entry is ~116 bytes (36-char UUID string + ConcurrentHashMap.Node overhead),
+     *       so 1M workspaces ≈ 116 MB.</li>
+     *   <li>Lost on JVM restarts — workspaces will be re-reported after a redeployment.</li>
+     *   <li>Not shared across replicas — each instance tracks independently, so multi-replica
+     *       deployments will emit duplicates.</li>
+     * </ul>
+     *
+     * TODO: replace with a bounded or persistent dedup mechanism in a follow-up PR.
+     */
+    private static final Set<String> ANALYTICS_REPORTED_WORKSPACES = ConcurrentHashMap.newKeySet();
 
     @Inject
     public BiEventListener(@NonNull ProjectService projectService,
@@ -57,9 +72,22 @@ public class BiEventListener {
 
     @Subscribe
     public void onTracesCreated(TracesCreated event) {
-        if (config.getUsageReport().isEnabled()) {
-            checkIfItIsFirstTraceAndReport(event.workspaceId(), event);
+        if (!config.getUsageReport().isEnabled()) {
+            return;
         }
+
+        if (event.traces().isEmpty()) {
+            log.warn("No trace ids found for event '{}'", event);
+            return;
+        }
+
+        var projectIds = getNonDemoProjectIds(event.workspaceId(), event);
+        if (projectIds.isEmpty()) {
+            log.info("No project ids found for event");
+            return;
+        }
+
+        checkIfItIsFirstTraceAndReport(event.workspaceId(), event, projectIds);
 
         trackFirstTraceViaAnalytics(event.workspaceId(), event);
     }
@@ -75,20 +103,8 @@ public class BiEventListener {
         return projectIds;
     }
 
-    private void checkIfItIsFirstTraceAndReport(String workspaceId, TracesCreated event) {
+    private void checkIfItIsFirstTraceAndReport(String workspaceId, TracesCreated event, Set<UUID> projectIds) {
         if (usageReportService.isFirstTraceReport()) {
-            return;
-        }
-
-        if (event.traces().isEmpty()) {
-            log.warn("No trace ids found for event '{}'", event);
-            return;
-        }
-
-        Set<UUID> projectIds = getNonDemoProjectIds(workspaceId, event);
-
-        if (projectIds.isEmpty()) {
-            log.info("No project ids found for event");
             return;
         }
 
@@ -130,26 +146,17 @@ public class BiEventListener {
     }
 
     private void trackFirstTraceViaAnalytics(String workspaceId, TracesCreated event) {
-        if (event.traces().isEmpty()) {
+        if (!config.getAnalytics().isEnabled()) {
             return;
         }
 
-        if (analyticsReportedWorkspaces.contains(workspaceId)) {
+        if (!ANALYTICS_REPORTED_WORKSPACES.add(workspaceId)) {
             return;
         }
 
-        if (getNonDemoProjectIds(workspaceId, event).isEmpty()) {
-            return;
-        }
-
-        if (!analyticsReportedWorkspaces.add(workspaceId)) {
-            return;
-        }
-
-        analyticsService.trackEvent(event.userName(), "first_trace_created", Map.of(
+        analyticsService.trackEvent("first_trace_created", Map.of(
                 "workspace_id", workspaceId,
                 "user_name", event.userName(),
-                "date", Instant.now().toString()));
+                "date", Instant.now().toString()), event.userName());
     }
-
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/BiEventService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/BiEventService.java
@@ -7,10 +7,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 @ImplementedBy(BiEventServiceImpl.class)
-interface BiEventService {
-    void reportEvent(String anonymousId, String eventType, String biEventType, Map<String, String> eventProperties);
+public interface BiEventService {
+    CompletableFuture<Boolean> reportEvent(String anonymousId, String eventType, String biEventType,
+            Map<String, String> eventProperties);
 }
 
 @RequiredArgsConstructor(onConstructor_ = @Inject)
@@ -20,8 +22,8 @@ class BiEventServiceImpl implements BiEventService {
     private final @NonNull UsageReportService usageReport;
     private final @NonNull StatsClient statsClient;
 
-    public void reportEvent(@NonNull String anonymousId, @NonNull String eventType, @NonNull String biEventType,
-            @NonNull Map<String, String> eventProperties) {
+    public CompletableFuture<Boolean> reportEvent(@NonNull String anonymousId, @NonNull String eventType,
+            @NonNull String biEventType, @NonNull Map<String, String> eventProperties) {
 
         var event = BiEvent.builder()
                 .anonymousId(anonymousId)
@@ -29,8 +31,12 @@ class BiEventServiceImpl implements BiEventService {
                 .eventProperties(eventProperties)
                 .build();
 
-        if (statsClient.sendEvent(event)) {
-            usageReport.markEventAsReported(eventType);
-        }
+        return statsClient.sendEvent(event)
+                .thenApply(success -> {
+                    if (success) {
+                        usageReport.markEventAsReported(eventType);
+                    }
+                    return success;
+                });
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/DailyUsageReportJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/DailyUsageReportJob.java
@@ -13,10 +13,6 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,10 +23,8 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.function.Tuple4;
 
-import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.comet.opik.infrastructure.bi.UsageReportService.UserCount;
@@ -48,7 +42,7 @@ public class DailyUsageReportJob extends Job implements InterruptableJob {
     private final @NonNull UsageReportService usageReportService;
     private final @NonNull LockService lockService;
     private final @NonNull OpikConfiguration config;
-    private final @NonNull Client client;
+    private final @NonNull StatsClient statsClient;
     private final @NonNull TraceService traceService;
     private final @NonNull ExperimentService experimentService;
     private final @NonNull DatasetService datasetService;
@@ -109,34 +103,23 @@ public class DailyUsageReportJob extends Job implements InterruptableJob {
     private Mono<Void> reportEvent(String anonymousId) {
         return fetchAllReportData()
                 .flatMap(results -> Mono.just(mapResults(anonymousId, results)))
-                .flatMap(this::sendEvent)
-                .flatMap(this::processResponse)
+                .flatMap(biEvent -> {
+                    if (hasNoDataToSubmit(biEvent)) {
+                        log.info("No daily usage data to report");
+                        return Mono.empty();
+                    }
+                    return Mono.fromFuture(() -> statsClient.sendEvent(biEvent))
+                            .subscribeOn(Schedulers.boundedElastic());
+                })
+                .doOnNext(success -> {
+                    if (success) {
+                        usageReportService.markDailyReportAsSent();
+                        log.info("Daily usage reported successfully");
+                    } else {
+                        log.warn("Failed to report daily usage");
+                    }
+                })
                 .then();
-    }
-
-    private Mono<Void> processResponse(Response response) {
-        if (response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL && response.hasEntity()) {
-
-            var notificationEventResponse = response.readEntity(NotificationEventResponse.class);
-
-            if (notificationEventResponse.success()) {
-                usageReportService.markDailyReportAsSent();
-                log.info("Event reported successfully: {}", notificationEventResponse.message());
-            } else {
-                log.warn("Failed to report event: {}", notificationEventResponse.message());
-            }
-
-            return Mono.empty();
-        }
-
-        log.warn("Failed to report event: {}", response.getStatusInfo());
-        if (response.hasEntity()) {
-            log.warn("Response: {}", response.readEntity(String.class));
-        }
-
-        log.info("Daily usage report not send");
-
-        return Mono.empty();
     }
 
     private Mono<Tuple4<UserCount, Long, Long, Long>> fetchAllReportData() {
@@ -159,21 +142,6 @@ public class DailyUsageReportJob extends Job implements InterruptableJob {
                         "daily_traces", String.valueOf(results.getT2()),
                         "daily_experiments", String.valueOf(results.getT3()),
                         "daily_datasets", String.valueOf(results.getT4())));
-    }
-
-    private Mono<Response> sendEvent(BiEvent biEvent) {
-
-        if (hasNoDataToSubmit(biEvent)) {
-            log.info("No data to process");
-            return Mono.empty();
-        }
-
-        return Mono.fromFuture(
-                () -> (CompletableFuture<Response>) client.target(URI.create(config.getUsageReport().getUrl()))
-                        .request()
-                        .accept(MediaType.APPLICATION_JSON_TYPE)
-                        .async()
-                        .post(Entity.json(biEvent)));
     }
 
     private boolean hasNoDataToSubmit(BiEvent biEvent) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/InstallationReportService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/InstallationReportService.java
@@ -71,13 +71,11 @@ class InstallationReportServiceImpl implements InstallationReportService {
                 return null;
             }
 
-            biEventService.reportEvent(anonymousId,
+            return biEventService.reportEvent(anonymousId,
                     eventType,
                     NOTIFICATION_EVENT_TYPE,
                     Map.of("opik_app_version", config.getMetadata().getVersion()));
-
-            return null;
-        });
+        }).flatMap(future -> future != null ? Mono.fromFuture(future).then() : Mono.empty());
     }
 
     private String getAnonymousId() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/StatsClient.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/StatsClient.java
@@ -6,17 +6,54 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.InvocationCallback;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.glassfish.jersey.client.ClientProperties;
 
 import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
+/**
+ * Async HTTP client for sending BI and analytics events to the external stats endpoint.
+ * This is the single gateway for all outbound telemetry HTTP traffic.
+ *
+ * <p><strong>Contract:</strong> {@link #sendEvent} must never throw and must never block the
+ * calling thread. It returns a {@link CompletableFuture} that always resolves to {@code true}
+ * (sent successfully) or {@code false} (failed or disabled) — it never completes exceptionally.
+ * Callers can safely chain {@code thenAccept} without worrying about threading; the future
+ * completes on {@code ForkJoinPool} via {@code completeAsync}, not on Jersey's I/O thread.
+ *
+ * <p><strong>Async requirement:</strong> the HTTP call uses Jersey's
+ * {@link jakarta.ws.rs.client.InvocationCallback} API for truly non-blocking I/O. No thread is
+ * blocked during the network round-trip. Implementations must keep this guarantee — do not replace
+ * with synchronous HTTP calls. Guard all code paths against exceptions, including non-obvious ones
+ * such as Lombok {@code @NonNull} null-checks that fire before user code.
+ *
+ * <p><strong>Current limitations:</strong>
+ * <ul>
+ *   <li>Requires {@code usageReport.enabled=true} to send. When disabled, returns
+ *       {@code completedFuture(false)} immediately.</li>
+ *   <li>Connect and read timeouts are configurable via {@code UsageReportConfig} and applied
+ *       as per-request Jersey properties ({@link org.glassfish.jersey.client.ClientProperties}).
+ *       Shared across all event types (BI and analytics).</li>
+ * </ul>
+ */
 @ImplementedBy(StatsClientImpl.class)
 public interface StatsClient {
-    boolean sendEvent(BiEvent event);
+
+    /**
+     * Send a BI event to the external stats endpoint asynchronously.
+     *
+     * @param event the event to send (null-safe — returns {@code false} if null)
+     * @return a future that resolves to {@code true} on success, {@code false} on any failure;
+     *         never completes exceptionally
+     */
+    CompletableFuture<Boolean> sendEvent(BiEvent event);
 }
 
 @RequiredArgsConstructor(onConstructor_ = @Inject)
@@ -28,31 +65,74 @@ class StatsClientImpl implements StatsClient {
     private final @NonNull Client client;
 
     @Override
-    public boolean sendEvent(@NonNull BiEvent event) {
-        try (Response response = client.target(URI.create(config.getUsageReport().getUrl()))
-                .request()
-                .accept(MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.json(event))) {
+    public CompletableFuture<Boolean> sendEvent(BiEvent event) {
+        var eventType = Optional.ofNullable(event).map(BiEvent::eventType).orElse(null);
+        try {
+            var usageReport = config.getUsageReport();
+            if (!usageReport.isEnabled()) {
+                log.info("Usage reporting is disabled — skipping event '{}'", eventType);
+                return CompletableFuture.completedFuture(false);
+            }
+            if (event == null) {
+                log.warn("Usage reporting received null event, skipping");
+                return CompletableFuture.completedFuture(false);
+            }
 
-            if (response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL && response.hasEntity()) {
+            var result = new CompletableFuture<Boolean>();
+            client.target(URI.create(usageReport.getUrl()))
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .property(ClientProperties.CONNECT_TIMEOUT,
+                            (int) usageReport.getConnectTimeout().toMilliseconds())
+                    .property(ClientProperties.READ_TIMEOUT,
+                            (int) usageReport.getReadTimeout().toMilliseconds())
+                    .async()
+                    .post(Entity.json(event), new InvocationCallback<Response>() {
+                        @Override
+                        public void completed(Response response) {
+                            try {
+                                var success = processResponse(response, eventType);
+                                result.completeAsync(() -> success);
+                            } catch (RuntimeException exception) {
+                                log.warn("Failed to process response for event, type '{}'", eventType, exception);
+                                result.completeAsync(() -> false);
+                            }
+                        }
+
+                        @Override
+                        public void failed(Throwable throwable) {
+                            log.warn("Failed to send event, type '{}'", eventType, throwable);
+                            result.completeAsync(() -> false);
+                        }
+                    });
+
+            return result;
+        } catch (RuntimeException exception) {
+            log.warn("Failed to send event, type '{}'", eventType, exception);
+            return CompletableFuture.completedFuture(false);
+        }
+    }
+
+    private boolean processResponse(Response response, String eventType) {
+        try (response) {
+            var statusInfo = response.getStatusInfo();
+            if (statusInfo.getFamily() == Response.Status.Family.SUCCESSFUL
+                    && response.hasEntity()
+                    && response.bufferEntity()) {
                 var body = response.readEntity(NotificationEventResponse.class);
-
                 if (body.success()) {
-                    log.info("Event '{}' sent successfully: {}", event.eventType(), body.message());
+                    log.info("Successfully sent event, type '{}', message '{}'", eventType, body.message());
                     return true;
                 }
-
-                log.warn("Failed to send event '{}': {}", event.eventType(), body.message());
+                log.warn("Failed to send event, type '{}', message '{}'", eventType, body.message());
                 return false;
             }
-
-            log.warn("Failed to send event '{}': {}", event.eventType(), response.getStatusInfo());
-            if (response.hasEntity()) {
-                log.warn("Response body: {}", response.readEntity(String.class));
+            log.warn("Failed to send event, type '{}', statusInfo '{}'", eventType, statusInfo);
+            if (response.hasEntity() && response.bufferEntity()) {
+                var entity = response.readEntity(String.class);
+                log.warn("Failed event, type '{}', statusInfo '{}', response entity: '{}'",
+                        eventType, statusInfo, entity);
             }
-            return false;
-        } catch (Exception e) {
-            log.warn("Failed to send event '{}'", event.eventType(), e);
             return false;
         }
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/UsageReportService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/UsageReportService.java
@@ -26,7 +26,7 @@ import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONL
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
 
 @ImplementedBy(UsageReportServiceImpl.class)
-interface UsageReportService {
+public interface UsageReportService {
 
     record UserCount(long allTimes, long daily) {
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/BiEventListenerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/BiEventListenerTest.java
@@ -35,6 +35,7 @@ import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamUtils;
 
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -67,7 +68,7 @@ class BiEventListenerTest {
     private final WireMockUtils.WireMockRuntime wireMock;
 
     @RegisterApp
-    private final TestDropwizardAppExtension APP;
+    private final TestDropwizardAppExtension app;
 
     {
         Startables.deepStart(REDIS, MYSQL, CLICKHOUSE).join();
@@ -80,9 +81,10 @@ class BiEventListenerTest {
         MigrationUtils.runMysqlDbMigration(MYSQL);
         MigrationUtils.runClickhouseDbMigration(CLICKHOUSE);
 
-        mockBiEventResponse(BiEventListener.FIRST_TRACE_REPORT_BI_EVENT, wireMock.server());
+        mockBiEventResponse(wireMock.server());
+        mockAnalyticsEventResponse(wireMock.server());
 
-        APP = newTestDropwizardAppExtension(
+        app = newTestDropwizardAppExtension(
                 TestDropwizardAppExtensionUtils.AppContextConfig.builder()
                         .jdbcUrl(MYSQL.getJdbcUrl())
                         .databaseAnalyticsFactory(databaseAnalyticsFactory)
@@ -91,23 +93,23 @@ class BiEventListenerTest {
                         .usageReportUrl("%s/v1/notify/event".formatted(wireMock.runtimeInfo().getHttpBaseUrl()))
                         .usageReportEnabled(true)
                         .metadataVersion(VERSION)
+                        .customConfigs(List.of(
+                                new TestDropwizardAppExtensionUtils.CustomConfig(
+                                        "analytics.enabled", "true")))
                         .build());
     }
 
     private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
 
-    private String baseURI;
-    private ClientSupport client;
     private TraceResourceClient traceResourceClient;
 
     @BeforeAll
     void setUpAll(ClientSupport client) {
-        this.baseURI = TestUtils.getBaseUrl(client);
-        this.client = client;
+        var baseURI = TestUtils.getBaseUrl(client);
 
         ClientSupportUtils.config(client);
 
-        traceResourceClient = new TraceResourceClient(this.client, baseURI);
+        traceResourceClient = new TraceResourceClient(client, baseURI);
     }
 
     @AfterAll
@@ -123,42 +125,52 @@ class BiEventListenerTest {
         AuthTestUtils.mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, USER);
     }
 
-    private void mockBiEventResponse(String eventType, WireMockServer server) {
+    private void mockBiEventResponse(WireMockServer server) {
         server.stubFor(
                 post(urlPathEqualTo("/v1/notify/event"))
                         .withRequestBody(matchingJsonPath("$.anonymous_id", matching(
                                 "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")))
                         .withRequestBody(matchingJsonPath("$.event_type",
-                                matching(eventType)))
+                                matching(BiEventListener.FIRST_TRACE_REPORT_BI_EVENT)))
                         .withRequestBody(matchingJsonPath("$.event_properties.opik_app_version", matching(VERSION)))
                         .willReturn(WireMock.okJson(SUCCESS_RESPONSE)));
     }
 
+    private void mockAnalyticsEventResponse(WireMockServer server) {
+        server.stubFor(
+                post(urlPathEqualTo("/v1/notify/event"))
+                        .withRequestBody(matchingJsonPath("$.event_type",
+                                matching(AnalyticsService.EVENT_PREFIX + "first_trace_created")))
+                        .willReturn(WireMock.okJson(SUCCESS_RESPONSE)));
+    }
+
     @Test
-    void shouldReportFirstTraceCreatedEvent(UsageReportService usageReportService, CacheManager cacheManager) {
+    void shouldReportFirstTraceEvents(UsageReportService usageReportService, CacheManager cacheManager) {
         var workspaceId = UUID.randomUUID().toString();
         var workspaceName = UUID.randomUUID().toString();
         var apiKey = UUID.randomUUID().toString();
 
         mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
-        Trace trace = factory.manufacturePojo(Trace.class);
-
         cacheManager.evict(Metadata.FIRST_TRACE_CREATED.getValue(), false).block();
 
+        var trace = factory.manufacturePojo(Trace.class);
         traceResourceClient.createTrace(trace, apiKey, workspaceName);
+
+        var analyticsEventType = AnalyticsService.EVENT_PREFIX + "first_trace_created";
 
         Awaitility
                 .await()
                 .atMost(60, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
-                    verifyResponse(wireMock.server(), BiEventListener.FIRST_TRACE_REPORT_BI_EVENT);
+                    verifyBiEventSent();
+                    verifyAnalyticsEventSent(workspaceId, analyticsEventType);
                 });
 
         Assertions.assertThat(usageReportService.isFirstTraceReport()).isTrue();
 
+        // second trace in the same workspace — neither event should fire again
         trace = factory.manufacturePojo(Trace.class);
-
         traceResourceClient.createTrace(trace, apiKey, workspaceName);
 
         Awaitility
@@ -168,16 +180,30 @@ class BiEventListenerTest {
                     wireMock.server().verify(1, postRequestedFor(urlPathEqualTo("/v1/notify/event"))
                             .withRequestBody(matchingJsonPath("$.event_type",
                                     equalTo(BiEventListener.FIRST_TRACE_REPORT_BI_EVENT))));
+                    wireMock.server().verify(1, postRequestedFor(urlPathEqualTo("/v1/notify/event"))
+                            .withRequestBody(matchingJsonPath("$.event_type",
+                                    equalTo(analyticsEventType))));
                 });
     }
 
-    private void verifyResponse(WireMockServer server, String eventType) {
-        server.verify(
+    private void verifyBiEventSent() {
+        wireMock.server().verify(
                 postRequestedFor(urlPathEqualTo("/v1/notify/event"))
                         .withRequestBody(matchingJsonPath("$.anonymous_id", matching(
                                 "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"))
-                                .and(matchingJsonPath("$.event_type", equalTo(eventType)))
+                                .and(matchingJsonPath("$.event_type",
+                                        equalTo(BiEventListener.FIRST_TRACE_REPORT_BI_EVENT)))
                                 .and(matchingJsonPath("$.event_properties.opik_app_version", equalTo(VERSION)))));
     }
 
+    private void verifyAnalyticsEventSent(String workspaceId, String eventType) {
+        wireMock.server().verify(
+                postRequestedFor(urlPathEqualTo("/v1/notify/event"))
+                        .withRequestBody(matchingJsonPath("$.event_type", equalTo(eventType))
+                                .and(matchingJsonPath("$.anonymous_id", equalTo(USER)))
+                                .and(matchingJsonPath("$.event_properties.workspace_id",
+                                        equalTo(workspaceId)))
+                                .and(matchingJsonPath("$.event_properties.user_name",
+                                        equalTo(USER)))));
+    }
 }

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -217,6 +217,12 @@ usageReport:
   # Default: false
   # Description: Whether or not to send anonymous usage reports
   enabled: false
+  # Default: 5s
+  # Description: HTTP connect timeout for usage report
+  connectTimeout: 5s
+  # Default: 10s
+  # Description: HTTP read timeout for usage report
+  readTimeout: 10s
 
 # Configuration for application metadata
 metadata:


### PR DESCRIPTION
## Details

Harden the analytics and BI reporting infrastructure to prevent external API calls from blocking production traffic or leaking exceptions into API endpoints. This is a follow-up to PR #6333 which added analytics events but made synchronous HTTP calls on request threads.

Key changes:
- **Async HTTP via Jersey InvocationCallback**: `StatsClient.sendEvent()` returns `CompletableFuture<Boolean>` using the JAX-RS standard async callback API. No thread is blocked during the network round-trip. `completeAsync()` ensures callers' `thenAccept` chains run on `ForkJoinPool`, not Jersey's I/O thread.
- **Exception safety**: `AnalyticsServiceImpl.sendEvent()` wraps all logic in `catch(RuntimeException)`. `StatsClient` guards every path (outer try-catch, `InvocationCallback.completed()` catch, `InvocationCallback.failed()`). Neither service ever throws or completes exceptionally.
- **Configurable HTTP timeouts**: Added `connectTimeout` (5s default) and `readTimeout` (10s default) to `UsageReportConfig` with `@NotNull`, `@MinDuration`, `@MaxDuration` validation. Applied via `ClientProperties` constants per-request.
- **Consolidated StatsClient**: `DailyUsageReportJob` now delegates to `StatsClient` instead of maintaining its own HTTP implementation. Single gateway for all outbound telemetry traffic.
- **Feature flag gating**: `BiEventListener.onTracesCreated()` short-circuits on `usageReport.isEnabled()` at the top level. `trackFirstTraceViaAnalytics` additionally gates on `analytics.isEnabled()`. Prevents unnecessary DB queries when disabled.
- **Hoisted common preconditions**: `getNonDemoProjectIds()` DB query computed once in `onTracesCreated` and shared across both BI and analytics paths.
- **BiEventService returns CompletableFuture**: Callers that need to wait (`InstallationReportService`) can chain on the future. Fire-and-forget callers ignore it.
- **AnalyticsService cleanup**: Identity parameter moved to last position, single `sendEvent` with try-catch, `@RequiredArgsConstructor` replacing boilerplate constructor.

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- OPIK-6026

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (CLI)
- Model(s): Claude Opus 4.6 (1M context)
- Scope: Full implementation with human-guided iterative design decisions
- Human verification: Code review, manual adjustments to StatsClient/BiEventListener/config, all BI integration tests passing (BiEventListenerTest, DailyUsageReportJobTest, OpikGuiceyLifecycleEventListenerTest)

## Testing

- `mvn compile -DskipTests` — clean compile
- `mvn spotless:check` — passes
- `mvn test -Dtest="BiEventListenerTest"` — 1 test, 0 failures (covers both BI and analytics first-trace events + dedup verification)
- `mvn test -Dtest="OpikGuiceyLifecycleEventListenerTest"` — 2 tests, 0 failures (startup event + idempotency)
- `mvn test -Dtest="DailyUsageReportJobTest"` — passes (validates StatsClient consolidation)

Scenarios validated:
- Happy path: trace creation triggers both BI and analytics events via WireMock
- Dedup: second trace in same workspace does not re-trigger either event
- Startup report: installation event sent on first boot, not re-sent on second boot
- Daily report: job uses StatsClient, correct payload verified

Known test gaps (pre-existing, not introduced by this PR):
- `AnalyticsServiceImpl` unit tests (exception safety, identity resolution, prefix logic) — flagged for follow-up
- `StatsClient` error path tests (HTTP failure, timeout, null event) — flagged for follow-up

## Documentation

Javadocs added to `AnalyticsService` and `StatsClient` interfaces documenting:
- Fire-and-forget contract and exception safety requirements
- Async implementation requirements (InvocationCallback, completeAsync)
- Current limitations (identity DB fallback, dual enabled-flag requirement)
- Javadoc on `ANALYTICS_REPORTED_WORKSPACES` documenting unbounded growth limitation (~116 bytes/entry, ~116 MB at 1M workspaces) with TODO for follow-up