### PR TITLE
[OPIK-6049] [SDK][FE] feat: add --workspace and --api-key to opik connect/endpoint CLI

### DIFF
--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
@@ -17,15 +17,15 @@ const ConnectToOllieTab: React.FC<ConnectToOllieTabProps> = ({ connected }) => {
   const apiKey = useUserApiKey();
   const workspaceName = useActiveWorkspaceName();
 
-  const buildEnvVars = () => {
+  const buildConnectCommand = () => {
     if (apiKey) {
-      return `export OPIK_API_KEY="${apiKey}"\nexport OPIK_WORKSPACE="${workspaceName}"`;
+      return `opik connect --project "${agentName}" --workspace "${workspaceName}" --api-key "${apiKey}"`;
     }
     const url = new URL(BASE_API_URL, window.location.origin).toString();
-    return `export OPIK_URL_OVERRIDE="${url}"`;
+    return `OPIK_URL_OVERRIDE="${url}" opik connect --project "${agentName}"`;
   };
 
-  const connectCommandText = `${buildEnvVars()}\nopik connect --project "${agentName}"`;
+  const connectCommandText = buildConnectCommand();
 
   return (
     <div className="flex flex-col gap-4 px-1">
@@ -52,7 +52,11 @@ const ConnectToOllieTab: React.FC<ConnectToOllieTabProps> = ({ connected }) => {
               creates a local connection between Opik and your machine so Ollie
               can help with setup.
             </p>
-            <CodeSnippet title="Terminal" code={connectCommandText} />
+            <CodeSnippet
+              title="Terminal"
+              code={connectCommandText}
+              copyText={connectCommandText}
+            />
           </div>
         </TimelineStep>
 

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
@@ -52,11 +52,7 @@ const ConnectToOllieTab: React.FC<ConnectToOllieTabProps> = ({ connected }) => {
               creates a local connection between Opik and your machine so Ollie
               can help with setup.
             </p>
-            <CodeSnippet
-              title="Terminal"
-              code={connectCommandText}
-              copyText={connectCommandText}
-            />
+            <CodeSnippet title="Terminal" code={connectCommandText} />
           </div>
         </TimelineStep>
 

--- a/sdks/python/src/opik/cli/_run.py
+++ b/sdks/python/src/opik/cli/_run.py
@@ -1,5 +1,6 @@
 """Shared CLI session runner for connect and endpoint commands."""
 
+import logging
 from typing import List, Optional
 
 import click
@@ -18,6 +19,8 @@ from .pairing import (
     run_pairing,
 )
 
+LOGGER = logging.getLogger(__name__)
+
 
 def _capture_cli_error(
     exception: Exception, error_type: str, **details: object
@@ -34,16 +37,22 @@ def _capture_cli_error(
 
 
 def run_cli_session(
-    ctx: click.Context,
     project_name: str,
     name: Optional[str],
     runner_type: RunnerType,
     command: Optional[List[str]] = None,
     watch: Optional[bool] = None,
     headless: bool = False,
+    api_key: Optional[str] = None,
+    workspace: Optional[str] = None,
 ) -> None:
-    api_key = ctx.obj.get("api_key") if ctx.obj else None
-    client = Opik(api_key=api_key, _show_misconfiguration_message=False)
+    client = Opik(api_key=api_key, workspace=workspace, _show_misconfiguration_message=False)
+
+    if not client.config.config_file_exists:
+        try:
+            client.config.save_to_file()
+        except OSError:
+            LOGGER.debug("Failed to save config file", exc_info=True)
     api = client.rest_client
     tui = RunnerTUI()
 

--- a/sdks/python/src/opik/cli/_run.py
+++ b/sdks/python/src/opik/cli/_run.py
@@ -86,7 +86,7 @@ def run_cli_session(
             try:
                 client.config.save_to_file()
             except OSError:
-                LOGGER.debug("Failed to save config file", exc_info=True)
+                LOGGER.warning("Failed to save config file", exc_info=True)
 
         launch_supervisor(
             result, api, tui, runner_type=runner_type, command=command, watch=watch

--- a/sdks/python/src/opik/cli/_run.py
+++ b/sdks/python/src/opik/cli/_run.py
@@ -46,13 +46,12 @@ def run_cli_session(
     api_key: Optional[str] = None,
     workspace: Optional[str] = None,
 ) -> None:
-    client = Opik(api_key=api_key, workspace=workspace, _show_misconfiguration_message=False)
-
-    if not client.config.config_file_exists:
-        try:
-            client.config.save_to_file()
-        except OSError:
-            LOGGER.debug("Failed to save config file", exc_info=True)
+    client = Opik(
+        project_name=project_name,
+        api_key=api_key,
+        workspace=workspace,
+        _show_misconfiguration_message=False,
+    )
     api = client.rest_client
     tui = RunnerTUI()
 
@@ -82,6 +81,12 @@ def run_cli_session(
                 workspace=client.config.workspace,
                 tui=tui,
             )
+
+        if not client.config.config_file_exists:
+            try:
+                client.config.save_to_file()
+            except OSError:
+                LOGGER.debug("Failed to save config file", exc_info=True)
 
         launch_supervisor(
             result, api, tui, runner_type=runner_type, command=command, watch=watch

--- a/sdks/python/src/opik/cli/_run.py
+++ b/sdks/python/src/opik/cli/_run.py
@@ -37,15 +37,16 @@ def _capture_cli_error(
 
 
 def run_cli_session(
+    ctx: click.Context,
     project_name: str,
     name: Optional[str],
     runner_type: RunnerType,
     command: Optional[List[str]] = None,
     watch: Optional[bool] = None,
     headless: bool = False,
-    api_key: Optional[str] = None,
     workspace: Optional[str] = None,
 ) -> None:
+    api_key = ctx.obj.get("api_key") if ctx.obj else None
     client = Opik(
         project_name=project_name,
         api_key=api_key,

--- a/sdks/python/src/opik/cli/connect.py
+++ b/sdks/python/src/opik/cli/connect.py
@@ -11,16 +11,31 @@ from .pairing import RunnerType
 @click.command()
 @click.option("--project", "project_name", required=True, help="Opik project name.")
 @click.option("--name", default=None, help="Runner name.")
+@click.option(
+    "--workspace",
+    default=None,
+    help="Opik workspace name. Overrides OPIK_WORKSPACE and config file.",
+)
+@click.option(
+    "--api-key",
+    "local_api_key",
+    default=None,
+    help="Opik API key. Overrides global --api-key and OPIK_API_KEY env var.",
+)
 @click.pass_context
 def connect(
     ctx: click.Context,
     project_name: str,
     name: Optional[str],
+    workspace: Optional[str],
+    local_api_key: Optional[str],
 ) -> None:
     """Connect a local bridge daemon to Opik."""
+    api_key = local_api_key or (ctx.obj.get("api_key") if ctx.obj else None)
     run_cli_session(
-        ctx=ctx,
         project_name=project_name,
         name=name,
         runner_type=RunnerType.CONNECT,
+        api_key=api_key,
+        workspace=workspace,
     )

--- a/sdks/python/src/opik/cli/connect.py
+++ b/sdks/python/src/opik/cli/connect.py
@@ -18,7 +18,6 @@ from .pairing import RunnerType
 )
 @click.option(
     "--api-key",
-    "local_api_key",
     default=None,
     help="Opik API key. Overrides global --api-key and OPIK_API_KEY env var.",
 )
@@ -28,14 +27,15 @@ def connect(
     project_name: str,
     name: Optional[str],
     workspace: Optional[str],
-    local_api_key: Optional[str],
+    api_key: Optional[str],
 ) -> None:
     """Connect a local bridge daemon to Opik."""
-    api_key = local_api_key or (ctx.obj.get("api_key") if ctx.obj else None)
+    if api_key:
+        ctx.obj["api_key"] = api_key
     run_cli_session(
+        ctx=ctx,
         project_name=project_name,
         name=name,
         runner_type=RunnerType.CONNECT,
-        api_key=api_key,
         workspace=workspace,
     )

--- a/sdks/python/src/opik/cli/endpoint.py
+++ b/sdks/python/src/opik/cli/endpoint.py
@@ -30,6 +30,17 @@ def _validate_command(command: Tuple[str, ...]) -> None:
 @click.option("--project", "project_name", required=True, help="Opik project name.")
 @click.option("--name", default=None, help="Runner name.")
 @click.option(
+    "--workspace",
+    default=None,
+    help="Opik workspace name. Overrides OPIK_WORKSPACE and config file.",
+)
+@click.option(
+    "--api-key",
+    "local_api_key",
+    default=None,
+    help="Opik API key. Overrides global --api-key and OPIK_API_KEY env var.",
+)
+@click.option(
     "--watch/--no-watch",
     default=None,
     help="Enable/disable file watcher. Auto-detected from command if omitted.",
@@ -46,6 +57,8 @@ def endpoint(
     ctx: click.Context,
     project_name: str,
     name: Optional[str],
+    workspace: Optional[str],
+    local_api_key: Optional[str],
     watch: Optional[bool],
     headless: bool,
     command: Tuple[str, ...],
@@ -63,12 +76,14 @@ def endpoint(
             "before running 'opik endpoint'."
         )
 
+    api_key = local_api_key or (ctx.obj.get("api_key") if ctx.obj else None)
     run_cli_session(
-        ctx=ctx,
         project_name=project_name,
         name=name,
         runner_type=RunnerType.ENDPOINT,
         command=list(command),
         watch=watch,
         headless=headless,
+        api_key=api_key,
+        workspace=workspace,
     )

--- a/sdks/python/src/opik/cli/endpoint.py
+++ b/sdks/python/src/opik/cli/endpoint.py
@@ -36,7 +36,6 @@ def _validate_command(command: Tuple[str, ...]) -> None:
 )
 @click.option(
     "--api-key",
-    "local_api_key",
     default=None,
     help="Opik API key. Overrides global --api-key and OPIK_API_KEY env var.",
 )
@@ -58,12 +57,14 @@ def endpoint(
     project_name: str,
     name: Optional[str],
     workspace: Optional[str],
-    local_api_key: Optional[str],
+    api_key: Optional[str],
     watch: Optional[bool],
     headless: bool,
     command: Tuple[str, ...],
 ) -> None:
     """Run a local endpoint process connected to Opik."""
+    if api_key:
+        ctx.obj["api_key"] = api_key
     _validate_command(command)
 
     from opik.runner.snapshot import has_entrypoint
@@ -76,14 +77,13 @@ def endpoint(
             "before running 'opik endpoint'."
         )
 
-    api_key = local_api_key or (ctx.obj.get("api_key") if ctx.obj else None)
     run_cli_session(
+        ctx=ctx,
         project_name=project_name,
         name=name,
         runner_type=RunnerType.ENDPOINT,
         command=list(command),
         watch=watch,
         headless=headless,
-        api_key=api_key,
         workspace=workspace,
     )

--- a/sdks/python/tests/unit/cli/test_connect.py
+++ b/sdks/python/tests/unit/cli/test_connect.py
@@ -100,3 +100,115 @@ class TestConnect:
 
         tui_instance = mock_tui_cls.return_value
         tui_instance.stop.assert_called_once()
+
+    @patch("opik.cli._run.RunnerTUI")
+    @patch("opik.cli._run.launch_supervisor")
+    @patch("opik.cli._run.run_pairing")
+    @patch("opik.cli._run.Opik")
+    def test_connect__workspace_and_api_key_passed__forwarded_to_opik_constructor(
+        self, mock_opik_cls, mock_run_pairing, mock_launch, mock_tui_cls
+    ):
+        client = MagicMock()
+        client.config.url_override = "https://api.test/"
+        client.config.config_file_exists = True
+        mock_opik_cls.return_value = client
+
+        mock_run_pairing.return_value = PairingResult(
+            runner_id="r-abc",
+            project_name="my-proj",
+            project_id="p-123",
+            bridge_key=b"\x00" * 32,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "connect",
+                "--project",
+                "my-proj",
+                "--workspace",
+                "my-ws",
+                "--api-key",
+                "my-key",
+            ],
+        )
+        assert result.exit_code == 0
+
+        mock_opik_cls.assert_called_once_with(
+            api_key="my-key",
+            workspace="my-ws",
+            _show_misconfiguration_message=False,
+        )
+
+    @patch("opik.cli._run.RunnerTUI")
+    @patch("opik.cli._run.launch_supervisor")
+    @patch("opik.cli._run.run_pairing")
+    @patch("opik.cli._run.Opik")
+    def test_connect__local_api_key_overrides_global(
+        self, mock_opik_cls, mock_run_pairing, mock_launch, mock_tui_cls
+    ):
+        client = MagicMock()
+        client.config.url_override = "https://api.test/"
+        client.config.config_file_exists = True
+        mock_opik_cls.return_value = client
+
+        mock_run_pairing.return_value = PairingResult(
+            runner_id="r-abc",
+            project_name="my-proj",
+            project_id="p-123",
+            bridge_key=b"\x00" * 32,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--api-key",
+                "global-key",
+                "connect",
+                "--project",
+                "my-proj",
+                "--api-key",
+                "local-key",
+            ],
+        )
+        assert result.exit_code == 0
+
+        mock_opik_cls.assert_called_once_with(
+            api_key="local-key",
+            workspace=None,
+            _show_misconfiguration_message=False,
+        )
+
+    @patch("opik.cli._run.RunnerTUI")
+    @patch("opik.cli._run.launch_supervisor")
+    @patch("opik.cli._run.run_pairing")
+    @patch("opik.cli._run.Opik")
+    def test_connect__no_local_api_key__falls_back_to_global(
+        self, mock_opik_cls, mock_run_pairing, mock_launch, mock_tui_cls
+    ):
+        client = MagicMock()
+        client.config.url_override = "https://api.test/"
+        client.config.config_file_exists = True
+        mock_opik_cls.return_value = client
+
+        mock_run_pairing.return_value = PairingResult(
+            runner_id="r-abc",
+            project_name="my-proj",
+            project_id="p-123",
+            bridge_key=b"\x00" * 32,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--api-key", "global-key", "connect", "--project", "my-proj"],
+        )
+        assert result.exit_code == 0
+
+        mock_opik_cls.assert_called_once_with(
+            api_key="global-key",
+            workspace=None,
+            _show_misconfiguration_message=False,
+        )

--- a/sdks/python/tests/unit/cli/test_connect.py
+++ b/sdks/python/tests/unit/cli/test_connect.py
@@ -136,6 +136,7 @@ class TestConnect:
         assert result.exit_code == 0
 
         mock_opik_cls.assert_called_once_with(
+            project_name="my-proj",
             api_key="my-key",
             workspace="my-ws",
             _show_misconfiguration_message=False,
@@ -176,6 +177,7 @@ class TestConnect:
         assert result.exit_code == 0
 
         mock_opik_cls.assert_called_once_with(
+            project_name="my-proj",
             api_key="local-key",
             workspace=None,
             _show_misconfiguration_message=False,
@@ -208,6 +210,7 @@ class TestConnect:
         assert result.exit_code == 0
 
         mock_opik_cls.assert_called_once_with(
+            project_name="my-proj",
             api_key="global-key",
             workspace=None,
             _show_misconfiguration_message=False,

--- a/sdks/python/tests/unit/cli/test_endpoint.py
+++ b/sdks/python/tests/unit/cli/test_endpoint.py
@@ -103,3 +103,133 @@ class TestEndpoint:
 
         tui_instance = mock_tui_cls.return_value
         tui_instance.stop.assert_called_once()
+
+    @patch("opik.runner.snapshot.has_entrypoint", return_value=True)
+    @patch("opik.cli._run.RunnerTUI")
+    @patch("opik.cli._run.launch_supervisor")
+    @patch("opik.cli._run.run_pairing")
+    @patch("opik.cli._run.Opik")
+    def test_endpoint__workspace_and_api_key_passed__forwarded_to_opik_constructor(
+        self, mock_opik_cls, mock_run_pairing, mock_launch, mock_tui_cls, _mock_ep
+    ):
+        client = MagicMock()
+        client.config.url_override = "https://api.test/"
+        client.config.config_file_exists = True
+        mock_opik_cls.return_value = client
+
+        mock_run_pairing.return_value = PairingResult(
+            runner_id="r-xyz",
+            project_name="my-proj",
+            project_id="p-123",
+            bridge_key=b"\x00" * 32,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "endpoint",
+                "--project",
+                "my-proj",
+                "--workspace",
+                "my-ws",
+                "--api-key",
+                "my-key",
+                "--",
+                "echo",
+                "hello",
+            ],
+        )
+        assert result.exit_code == 0
+
+        mock_opik_cls.assert_called_once_with(
+            api_key="my-key",
+            workspace="my-ws",
+            _show_misconfiguration_message=False,
+        )
+
+    @patch("opik.runner.snapshot.has_entrypoint", return_value=True)
+    @patch("opik.cli._run.RunnerTUI")
+    @patch("opik.cli._run.launch_supervisor")
+    @patch("opik.cli._run.run_pairing")
+    @patch("opik.cli._run.Opik")
+    def test_endpoint__local_api_key_overrides_global(
+        self, mock_opik_cls, mock_run_pairing, mock_launch, mock_tui_cls, _mock_ep
+    ):
+        client = MagicMock()
+        client.config.url_override = "https://api.test/"
+        client.config.config_file_exists = True
+        mock_opik_cls.return_value = client
+
+        mock_run_pairing.return_value = PairingResult(
+            runner_id="r-xyz",
+            project_name="my-proj",
+            project_id="p-123",
+            bridge_key=b"\x00" * 32,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--api-key",
+                "global-key",
+                "endpoint",
+                "--project",
+                "my-proj",
+                "--api-key",
+                "local-key",
+                "--",
+                "echo",
+                "hello",
+            ],
+        )
+        assert result.exit_code == 0
+
+        mock_opik_cls.assert_called_once_with(
+            api_key="local-key",
+            workspace=None,
+            _show_misconfiguration_message=False,
+        )
+
+    @patch("opik.runner.snapshot.has_entrypoint", return_value=True)
+    @patch("opik.cli._run.RunnerTUI")
+    @patch("opik.cli._run.launch_supervisor")
+    @patch("opik.cli._run.run_pairing")
+    @patch("opik.cli._run.Opik")
+    def test_endpoint__no_local_api_key__falls_back_to_global(
+        self, mock_opik_cls, mock_run_pairing, mock_launch, mock_tui_cls, _mock_ep
+    ):
+        client = MagicMock()
+        client.config.url_override = "https://api.test/"
+        client.config.config_file_exists = True
+        mock_opik_cls.return_value = client
+
+        mock_run_pairing.return_value = PairingResult(
+            runner_id="r-xyz",
+            project_name="my-proj",
+            project_id="p-123",
+            bridge_key=b"\x00" * 32,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--api-key",
+                "global-key",
+                "endpoint",
+                "--project",
+                "my-proj",
+                "--",
+                "echo",
+                "hello",
+            ],
+        )
+        assert result.exit_code == 0
+
+        mock_opik_cls.assert_called_once_with(
+            api_key="global-key",
+            workspace=None,
+            _show_misconfiguration_message=False,
+        )

--- a/sdks/python/tests/unit/cli/test_endpoint.py
+++ b/sdks/python/tests/unit/cli/test_endpoint.py
@@ -143,6 +143,7 @@ class TestEndpoint:
         assert result.exit_code == 0
 
         mock_opik_cls.assert_called_once_with(
+            project_name="my-proj",
             api_key="my-key",
             workspace="my-ws",
             _show_misconfiguration_message=False,
@@ -187,6 +188,7 @@ class TestEndpoint:
         assert result.exit_code == 0
 
         mock_opik_cls.assert_called_once_with(
+            project_name="my-proj",
             api_key="local-key",
             workspace=None,
             _show_misconfiguration_message=False,
@@ -229,6 +231,7 @@ class TestEndpoint:
         assert result.exit_code == 0
 
         mock_opik_cls.assert_called_once_with(
+            project_name="my-proj",
             api_key="global-key",
             workspace=None,
             _show_misconfiguration_message=False,


### PR DESCRIPTION
## Details

Add `--workspace` and `--api-key` as inline options on both `connect` and `endpoint` CLI subcommands, so users can run a single command instead of exporting environment variables:

```bash
# Before
export OPIK_API_KEY="..."
export OPIK_WORKSPACE="..."
opik connect --project "Test"

# After
opik connect --project "Test" --workspace "my-ws" --api-key "my-key"
```

**Precedence:**
- `--api-key`: local subcommand option > global `opik --api-key` > `OPIK_API_KEY` env > config file
- `--workspace`: local subcommand option > `OPIK_WORKSPACE` env > config file > `"default"`

**Config persistence:** If `~/.opik.config` doesn't exist after successful pairing, it is auto-saved so first-time users get a config file automatically. Also fixes a bug where `project_name` was not forwarded to the `Opik()` constructor, causing the config to save "Default Project" instead of the user-specified project.

**Frontend:** Updated the Get Started page to show the new single-command format with the full API key visible (no masking). Removed redundant `copyText` prop.

All new options default to `None`, so existing invocations are fully backward-compatible.

## Change checklist

- [ ] My change requires a change to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing unit tests pass locally with my changes

## Issues

Resolves OPIK-6049

## Testing

- 17 CLI unit tests pass (6 new tests for workspace/api-key forwarding and precedence)
- TypeScript compiles cleanly with no errors
- Existing tests unaffected (backward compatible)
- Manually tested live pairing flow against cloud backend

## Documentation

No documentation changes required. The CLI `--help` output automatically reflects the new flags.