### PR TITLE
[OPIK-6060] [FE] fix: link Agent Configuration empty state "View docs" to correct URL

### DIFF
--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState.tsx
@@ -61,8 +61,9 @@ const AgentConfigurationEmptyState: React.FC = () => {
 
         <Button variant="outline" size="sm" asChild>
           <a
-            // TODO: Add correct URL when docs ready
-            href={buildDocsUrl()}
+            href={buildDocsUrl(
+              "/latest/development/agent-configuration/overview",
+            )}
             target="_blank"
             rel="noreferrer"
           >


### PR DESCRIPTION
## Details

https://github.com/user-attachments/assets/3fa9bb54-8140-440c-9913-9fb7c2a8a2f0

<img width="1920" height="1418" alt="image" src="https://github.com/user-attachments/assets/f7c369e7-d029-47b7-9d75-17ada29f5cea" />

The "View docs" button on the Agent Configuration empty state was calling `buildDocsUrl()` with no path argument (a placeholder TODO), so it navigated users to the generic Opik docs home instead of the Agent Configuration overview page.

- Pass `"/latest/development/agent-configuration/overview"` to `buildDocsUrl()` so the link resolves to the correct docs page.
- Remove the stale `// TODO: Add correct URL when docs ready` comment.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-6060

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation (one-line fix and PR authoring)
- Human verification: manual code review before PR creation; lint + typecheck run locally

## Testing

- `npx eslint src/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState.tsx --max-warnings=0` — passes
- `npx tsc -p tsconfig.json --noEmit` — passes
- Not run: runtime verification in dev server (fix is a static URL path change; trivially verifiable by inspecting the generated `href`)

## Documentation

N/A — no documentation updates required for this link fix.