### PR TITLE
[OPIK-6026] [BE] fix: StatsClient and BiEventListener allow events when analytics OR usage-report is enabled

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/BiEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/BiEventListener.java
@@ -72,7 +72,7 @@ public class BiEventListener {
 
     @Subscribe
     public void onTracesCreated(TracesCreated event) {
-        if (!config.getUsageReport().isEnabled()) {
+        if (!config.getUsageReport().isEnabled() && !config.getAnalytics().isEnabled()) {
             return;
         }
 
@@ -87,7 +87,9 @@ public class BiEventListener {
             return;
         }
 
-        checkIfItIsFirstTraceAndReport(event.workspaceId(), event, projectIds);
+        if (config.getUsageReport().isEnabled()) {
+            checkIfItIsFirstTraceAndReport(event.workspaceId(), event, projectIds);
+        }
 
         trackFirstTraceViaAnalytics(event.workspaceId(), event);
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/StatsClient.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/StatsClient.java
@@ -34,10 +34,15 @@ import java.util.concurrent.CompletableFuture;
  * with synchronous HTTP calls. Guard all code paths against exceptions, including non-obvious ones
  * such as Lombok {@code @NonNull} null-checks that fire before user code.
  *
+ * <p><strong>Transport gate:</strong> {@link #sendEvent} sends to the stats endpoint when
+ * <em>either</em> {@code usageReport.enabled=true} (self-hosted BI stream) or
+ * {@code analytics.enabled=true} (product analytics stream) is set. When both are disabled,
+ * returns {@code completedFuture(false)} immediately. Per-stream gates in upstream listeners
+ * still decide which events are produced in the first place — this is purely a transport-level
+ * permission check for events that have already been constructed.
+ *
  * <p><strong>Current limitations:</strong>
  * <ul>
- *   <li>Requires {@code usageReport.enabled=true} to send. When disabled, returns
- *       {@code completedFuture(false)} immediately.</li>
  *   <li>Connect and read timeouts are configurable via {@code UsageReportConfig} and applied
  *       as per-request Jersey properties ({@link org.glassfish.jersey.client.ClientProperties}).
  *       Shared across all event types (BI and analytics).</li>
@@ -69,8 +74,9 @@ class StatsClientImpl implements StatsClient {
         var eventType = Optional.ofNullable(event).map(BiEvent::eventType).orElse(null);
         try {
             var usageReport = config.getUsageReport();
-            if (!usageReport.isEnabled()) {
-                log.info("Usage reporting is disabled — skipping event '{}'", eventType);
+            var analytics = config.getAnalytics();
+            if (!usageReport.isEnabled() && !analytics.isEnabled()) {
+                log.info("Both usage reporting and analytics are disabled — skipping event '{}'", eventType);
                 return CompletableFuture.completedFuture(false);
             }
             if (event == null) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/BiEventListenerAnalyticsOnlyTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/BiEventListenerAnalyticsOnlyTest.java
@@ -1,0 +1,162 @@
+package com.comet.opik.infrastructure.bi;
+
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.resources.utils.AuthTestUtils;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.infrastructure.cache.CacheManager;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.redis.testcontainers.RedisContainer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamUtils;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension;
+import static com.comet.opik.infrastructure.bi.DailyUsageReportJobTest.SUCCESS_RESPONSE;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class BiEventListenerAnalyticsOnlyTest {
+
+    private static final String USER = UUID.randomUUID().toString();
+    private static final String VERSION = "%s.%s.%s".formatted(PodamUtils.getIntegerInRange(1, 99),
+            PodamUtils.getIntegerInRange(1, 99), PodamUtils.getIntegerInRange(1, 99));
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final Network network = Network.newNetwork();
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer(false);
+    private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer(false,
+            network);
+    private final ClickHouseContainer CLICKHOUSE = ClickHouseContainerUtils.newClickHouseContainer(false, network,
+            ZOOKEEPER_CONTAINER);
+
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(REDIS, MYSQL, CLICKHOUSE).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
+                CLICKHOUSE, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE);
+
+        mockAnyEventResponse(wireMock.server());
+
+        // analytics.enabled=true, usageReport.enabled=false (default in config-test.yml).
+        // The StatsClient transport permits sending when either flag is true, so the
+        // analytics event should flow; the opik_os_* BI event must remain gated off.
+        app = newTestDropwizardAppExtension(
+                TestDropwizardAppExtensionUtils.AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .redisUrl(REDIS.getRedisURI())
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .metadataVersion(VERSION)
+                        .customConfigs(List.of(
+                                new TestDropwizardAppExtensionUtils.CustomConfig(
+                                        "analytics.enabled", "true"),
+                                new TestDropwizardAppExtensionUtils.CustomConfig(
+                                        "usageReport.url",
+                                        "%s/v1/notify/event".formatted(wireMock.runtimeInfo().getHttpBaseUrl()))))
+                        .build());
+    }
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    private TraceResourceClient traceResourceClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport client) {
+        var baseURI = TestUtils.getBaseUrl(client);
+
+        ClientSupportUtils.config(client);
+
+        traceResourceClient = new TraceResourceClient(client, baseURI);
+    }
+
+    @AfterAll
+    void tearDownAll() {
+        MYSQL.stop();
+        wireMock.server().stop();
+        CLICKHOUSE.stop();
+        ZOOKEEPER_CONTAINER.stop();
+        network.close();
+    }
+
+    private void mockTargetWorkspace(String apiKey, String workspaceName, String workspaceId) {
+        AuthTestUtils.mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, USER);
+    }
+
+    private void mockAnyEventResponse(WireMockServer server) {
+        server.stubFor(post(urlPathEqualTo("/v1/notify/event"))
+                .willReturn(WireMock.okJson(SUCCESS_RESPONSE)));
+    }
+
+    @Test
+    void shouldSendAnalyticsEventButNotBiEventWhenOnlyAnalyticsEnabled(CacheManager cacheManager) {
+        var workspaceId = UUID.randomUUID().toString();
+        var workspaceName = UUID.randomUUID().toString();
+        var apiKey = UUID.randomUUID().toString();
+
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        cacheManager.evict(Metadata.FIRST_TRACE_CREATED.getValue(), false).block();
+
+        var trace = factory.manufacturePojo(Trace.class);
+        traceResourceClient.createTrace(trace, apiKey, workspaceName);
+
+        var analyticsEventType = AnalyticsService.EVENT_PREFIX + "first_trace_created";
+
+        Awaitility
+                .await()
+                .atMost(60, TimeUnit.SECONDS)
+                .untilAsserted(() -> wireMock.server().verify(
+                        postRequestedFor(urlPathEqualTo("/v1/notify/event"))
+                                .withRequestBody(matchingJsonPath("$.event_type", equalTo(analyticsEventType)))
+                                .withRequestBody(matchingJsonPath("$.event_properties.workspace_id",
+                                        equalTo(workspaceId)))));
+
+        wireMock.server().verify(0, postRequestedFor(urlPathEqualTo("/v1/notify/event"))
+                .withRequestBody(matchingJsonPath("$.event_type",
+                        equalTo(BiEventListener.FIRST_TRACE_REPORT_BI_EVENT))));
+    }
+}


### PR DESCRIPTION
## Details

`StatsClient.sendEvent` previously short-circuited whenever `usageReport.enabled=false`, which dropped every event produced by `AnalyticsService` — even when `analytics.enabled=true`. `BiEventListener.onTracesCreated` had the same problem one level up: it returned early on `!usageReport.enabled`, so `trackFirstTraceViaAnalytics` never ran even with analytics on.

This PR aligns both gates with the intent of the two independent feature flags:

### Changes

- **`StatsClient.sendEvent`**: send when `usageReport.enabled || analytics.enabled`. Updated the class Javadoc (`Transport gate` section) and log message to reflect the new semantics.
- **`BiEventListener.onTracesCreated`**: skip only when both flags are disabled. Gate the `opik_os_first_trace_created` BI event (`checkIfItIsFirstTraceAndReport`) on `usageReport.enabled` specifically, so the self-hosted BI stream stays off when only analytics is enabled. `trackFirstTraceViaAnalytics` already gates internally on `analytics.enabled`.

### Behavior matrix

| `analytics.enabled` | `usageReport.enabled` | Product analytics (`opik_*`) | Self-hosted BI (`opik_os_*`) |
|---|---|---|---|
| false | false | — | — |
| **true** | **false** | **flow** | — |
| false | true | — | flow |
| true | true | flow | flow |

Row 2 (analytics-only) is the case that was previously broken — events were dropped at both `BiEventListener` and `StatsClient`.

### Not touched (intentionally)

- `AnalyticsServiceImpl.sendEvent` — already correctly gates on `analytics.enabled` at source.
- `DailyUsageReportJob`, `InstallationReportService`, `WelcomeWizardEventListener`, `OpikGuiceyLifecycleEventListener` — self-hosted BI streams stay gated on `usageReport.enabled` at source.
- `config.yml` — no new env vars, no schema changes. `OPIK_ANALYTICS_ENABLED` and `OPIK_USAGE_REPORT_ENABLED` keep their existing meanings.

## Change checklist

- [X] User facing
- [ ] Documentation update

## Issues

- OPIK-6026 (follow-up)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (CLI)
- Model(s): Claude Opus 4.7 (1M context)
- Scope: Full implementation with human-guided design decisions
- Human verification: Code review, manual adjustments to test harness, compile + spotless pass locally

## Testing

- `mvn compile test-compile -DskipTests` — clean compile
- `mvn spotless:check` — passes
- New test `BiEventListenerAnalyticsOnlyTest` added: configures `analytics.enabled=true` with `usageReport.enabled=false` (the default in `config-test.yml`), triggers trace creation, and asserts:
  - `opik_first_trace_created` analytics event **is** POSTed to the stats endpoint (via WireMock)
  - `opik_os_first_trace_created` BI event is **not** POSTed (verified with `verify(0, ...)`)
- Existing `BiEventListenerTest` (both flags on) is unchanged and still asserts both streams fire.

Note: testcontainers-based tests require Docker; I couldn't run them locally, but the harness matches the existing `BiEventListenerTest` pattern and CI has Docker.

## Documentation

N/A — internal transport/listener gating. No new config keys, env vars, or schema changes. The existing `OPIK_ANALYTICS_ENABLED` and `OPIK_USAGE_REPORT_ENABLED` flags keep their documented meanings; this PR only fixes the gating logic so they behave independently as already documented.

