### PR TITLE
[OPIK-6043] [FE] fix: set logs page title to "Logs" (+OPIK-5462 project dashboards title)

### DIFF
--- a/apps/opik-frontend/src/v2/pages/LogsPage/LogsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/LogsPage.tsx
@@ -44,10 +44,10 @@ const LogsPage = () => {
           direction="horizontal"
         >
           <h1
-            data-testid="traces-page-title"
+            data-testid="logs-page-title"
             className="comet-body-accented truncate break-words"
           >
-            {projectName}
+            Logs
           </h1>
           {isGuardrailsEnabled && (
             <div className="flex shrink-0 items-center gap-2">
@@ -62,16 +62,6 @@ const LogsPage = () => {
             </div>
           )}
         </PageBodyStickyContainer>
-        {project?.description && (
-          <PageBodyStickyContainer
-            className="-mt-3 mb-4 flex min-h-8 items-center justify-between"
-            direction="horizontal"
-          >
-            <div className="comet-body-s text-muted-slate">
-              {project.description}
-            </div>
-          </PageBodyStickyContainer>
-        )}
         {needsDefaultResolution ? (
           <Loader />
         ) : (

--- a/apps/opik-frontend/src/v2/pages/LogsPage/LogsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/LogsPage.tsx
@@ -43,12 +43,7 @@ const LogsPage = () => {
           className="mb-4 mt-6 flex items-center justify-between"
           direction="horizontal"
         >
-          <h1
-            data-testid="logs-page-title"
-            className="comet-body-accented truncate break-words"
-          >
-            Logs
-          </h1>
+          <h1 className="comet-body-accented truncate break-words">Logs</h1>
           {isGuardrailsEnabled && (
             <div className="flex shrink-0 items-center gap-2">
               <Button

--- a/apps/opik-frontend/src/v2/pages/ProjectDashboardsPage/ProjectDashboardsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectDashboardsPage/ProjectDashboardsPage.tsx
@@ -115,7 +115,7 @@ const ProjectDashboardsPage: React.FunctionComponent = () => {
         <h1 className="comet-body-accented truncate break-words">Dashboards</h1>
       </PageBodyStickyContainer>
       <PageBodyStickyContainer
-        className="flex flex-wrap items-center justify-between gap-x-8 gap-y-2 pb-3 pt-2"
+        className="flex flex-wrap items-center justify-between gap-x-8 gap-y-2 pb-3"
         direction="bidirectional"
         limitWidth
       >

--- a/apps/opik-frontend/src/v2/pages/ProjectDashboardsPage/ProjectDashboardsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectDashboardsPage/ProjectDashboardsPage.tsx
@@ -109,7 +109,13 @@ const ProjectDashboardsPage: React.FunctionComponent = () => {
   return (
     <PageBodyScrollContainer>
       <PageBodyStickyContainer
-        className="mt-6 flex flex-wrap items-center justify-between gap-x-8 gap-y-2 pb-3 pt-2"
+        className="mb-4 mt-6 flex items-center justify-between"
+        direction="horizontal"
+      >
+        <h1 className="comet-body-accented truncate break-words">Dashboards</h1>
+      </PageBodyStickyContainer>
+      <PageBodyStickyContainer
+        className="flex flex-wrap items-center justify-between gap-x-8 gap-y-2 pb-3 pt-2"
         direction="bidirectional"
         limitWidth
       >


### PR DESCRIPTION
## Details

<img width="1495" height="928" alt="image" src="https://github.com/user-attachments/assets/8d4646f9-4b19-42e6-8a02-88b0d591a85e" />
<img width="1489" height="929" alt="image" src="https://github.com/user-attachments/assets/851825ea-daf3-4ecf-9b21-4acca3fc289b" />


Bring the v2 Logs and project Dashboards pages in line with the rest of the v2 header pattern. The Logs page heading now renders the literal `"Logs"` (instead of the project name) and drops the project-description subheader, since the sidebar already scopes the user to a single project. The project Dashboards page gains the missing `<h1>Dashboards</h1>` header so it matches Projects, Experiments, Logs, etc.


- Remove copied-over `data-testid="traces-page-title"` from v2 LogsPage — other v2 page titles don't carry one.
- v1 TracesPage and its e2e coverage are left untouched.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6043
- OPIK-5462

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: assisted (implementation + verification)
- Human verification: code review + lint/typecheck/deps check

## Testing
- `bash scripts/dev-runner.sh --lint-fe` — lint:fix + typecheck + deps:validate all green.
- Manual visual check pending via dev server (v2 Logs and Project Dashboards pages).
- No backend or SDK code touched; no BE/SDK tests needed.

## Documentation
N/A — no user-facing docs or API surface changed.