### PR TITLE
[OPIK-6082] [DOCS] docs: add assignee pod label step to /comet:create-jira-ticket

### DIFF
--- a/.agents/commands/comet/create-jira-ticket.md
+++ b/.agents/commands/comet/create-jira-ticket.md
@@ -32,6 +32,16 @@ Every Task or Story **must** have a parent epic. Follow this logic:
 
 Set the parent via `"parent": "OPIK-XXXX"` in `additional_fields`.
 
+## Assignee Pod Label
+
+After an assignee is chosen, also add that assignee's `pod-<name>` label alongside any other labels on the ticket.
+
+- Known pods: `pod-whale`, `pod-frontier`, `pod-andromeda`, `pod-air`, `pod-iberi`.
+- If you already know the assignee's pod (e.g., from memory, prior tickets in the same area, or the user's own profile), add the matching `pod-<name>` label automatically — no need to ask.
+- **If uncertain, use `AskUserQuestion` to let the user pick the pod** from the list above. Include a final "Skip (no pod label)" option.
+- If no assignee is set, skip this step — do not add a pod label.
+- Never add more than one `pod-*` label.
+
 ## Template Sections to Fill
 
 Ask the user to provide details for each section, then format the description using the template below.
@@ -103,6 +113,7 @@ As a [type of user], I want to [action/goal] so that I can [benefit/outcome].
 12. Ask: "Add to the **active sprint** or the **next sprint**?"
 13. Ask: "Set a due date? (today / tomorrow / a week from today / leave unset)"
 14. Ask: "Should this be assigned to anyone?"
+15. If an assignee is chosen, determine their pod and add the corresponding `pod-<name>` label. If uncertain, ask the user to pick from the known pods (see **Assignee Pod Label**).
 
 ## Creating the Ticket
 


### PR DESCRIPTION
## Summary
- Add a new **Assignee Pod Label** section to the `/comet:create-jira-ticket` command instructions, listing the known pods (`pod-whale`, `pod-frontier`, `pod-andromeda`, `pod-air`, `pod-iberi`).
- Wire the pod-label step into the Example Conversation Flow as step 15, right after the assignee question: if the assignee's pod is known, apply `pod-<name>` automatically; if uncertain, prompt the user to pick via `AskUserQuestion`; skip entirely when no assignee is set.
- No code changes — only updates to the command template under `.agents/commands/comet/`.

## Test plan
- [ ] Run `/comet:create-jira-ticket` and assign to a user with a known pod — verify the corresponding `pod-*` label is added automatically.
- [ ] Run `/comet:create-jira-ticket` and assign to a user with an unknown pod — verify an `AskUserQuestion` with the five known pods (plus Skip) is shown.
- [ ] Run `/comet:create-jira-ticket` without an assignee — verify no `pod-*` label is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)