### PR TITLE
[OPIK-6082] [DOCS] docs: add assignee pod label step to /comet:create-jira-ticket

### DIFF
--- a/.agents/commands/comet/create-jira-ticket.md
+++ b/.agents/commands/comet/create-jira-ticket.md
@@ -32,6 +32,16 @@ Every Task or Story **must** have a parent epic. Follow this logic:
 
 Set the parent via `"parent": "OPIK-XXXX"` in `additional_fields`.
 
+## Assignee Pod Label
+
+After an assignee is chosen, also add that assignee's `pod-<name>` label alongside any other labels on the ticket.
+
+- Known pods: `pod-whale`, `pod-frontier`, `pod-andromeda`, `pod-air`, `pod-iberi`.
+- If you already know the assignee's pod (e.g., from memory, prior tickets in the same area, or the user's own profile), add the matching `pod-<name>` label automatically — no need to ask.
+- **If uncertain, use `AskUserQuestion` to let the user pick the pod** from the list above. Include a final "Skip (no pod label)" option.
+- If no assignee is set, skip this step — do not add a pod label.
+- Never add more than one `pod-*` label.
+
 ## Template Sections to Fill
 
 Ask the user to provide details for each section, then format the description using the template below.
@@ -103,6 +113,7 @@ As a [type of user], I want to [action/goal] so that I can [benefit/outcome].
 12. Ask: "Add to the **active sprint** or the **next sprint**?"
 13. Ask: "Set a due date? (today / tomorrow / a week from today / leave unset)"
 14. Ask: "Should this be assigned to anyone?"
+15. If an assignee is chosen, determine their pod and add the corresponding `pod-<name>` label. If uncertain, ask the user to pick from the known pods (see **Assignee Pod Label**).
 
 ## Creating the Ticket
 


### PR DESCRIPTION
## Details

<img width="1920" height="1754" alt="image" src="https://github.com/user-attachments/assets/e1a59225-a37c-4f5a-a71b-f7a85f0a3467" />

<img width="1360" height="616" alt="image" src="https://github.com/user-attachments/assets/0da69f58-8937-469e-94ad-056f7fec9a80" />

Adds automatic pod labelling to the `/comet:create-jira-ticket` Claude Code command so tickets get the correct `pod-<name>` label based on the assignee, without the operator having to remember to set it. When the assignee's pod is unknown, the command now prompts the user via `AskUserQuestion` with the list of known pods.

- New **Assignee Pod Label** section added to `.agents/commands/comet/create-jira-ticket.md`, listing the known pods: `pod-whale`, `pod-frontier`, `pod-andromeda`, `pod-air`, `pod-iberi`.
- Example Conversation Flow gains step 15, firing right after the assignee question; no-assignee tickets skip the step entirely.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-6082

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: Full — Claude drafted the section, wired the step into the conversation flow, and updated both command copies.
- Human verification: Author reviewed the diff and confirmed wording, pod list, and placement before merge.

## Testing

- Opened `.agents/commands/comet/create-jira-ticket.md` and reviewed the rendered structure (new section + conversation step) — markdown-only change, no build/test command applicable.
- Validated the updated instructions by running `/comet:create-jira-ticket` in this session (the ticket itself — [OPIK-6082](https://comet-ml.atlassian.net/browse/OPIK-6082)) and confirming:
  - Assignee on a known pod (`Daniel Dimenshtein` → `pod-whale`) auto-applied the pod label with no extra prompt.
  - When asked to retroactively label [OPIK-6078](https://comet-ml.atlassian.net/browse/OPIK-6078), the `AskUserQuestion` fallback listed all five known pods.
  - No unit / integration test suite covers slash-command definitions in this repo; nothing to run.

## Documentation

This PR is the documentation change — the command definition at `.agents/commands/comet/create-jira-ticket.md` is the authoritative reference for the `/comet:create-jira-ticket` behavior.

[OPIK-6082]: https://comet-ml.atlassian.net/browse/OPIK-6082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ