### PR TITLE
[OPIK-6042][FE]: agent config and thread views responsivennes are fixed;

### DIFF
--- a/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanel.tsx
+++ b/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanel.tsx
@@ -52,7 +52,10 @@ const calculateLeftPosition = (
   minWidth?: number,
 ) => {
   if (minWidth) {
-    return Math.min(containerWidth * percentage, containerWidth - minWidth);
+    return Math.max(
+      0,
+      Math.min(containerWidth * percentage, containerWidth - minWidth),
+    );
   } else {
     return containerWidth * percentage;
   }

--- a/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanel.tsx
+++ b/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanel.tsx
@@ -311,7 +311,7 @@ const ResizableSidePanel: React.FunctionComponent<ResizableSidePanelProps> = ({
             <div className="relative flex size-full">
               <div
                 className={cn(
-                  "absolute inset-x-0 top-0 flex h-[47px] items-center pr-5",
+                  "absolute inset-x-0 top-0 flex h-[47px] items-center overflow-hidden pr-5",
                   hideDefaultControls ? "pl-2" : "pl-6",
                 )}
               >

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
@@ -732,6 +732,7 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
       onClose={onClose}
       hideDefaultControls
       initialWidth={0.5}
+      minWidth={700}
       horizontalNavigation={horizontalNavigation}
     >
       {renderContent()}

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationDetailView.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationDetailView.tsx
@@ -107,7 +107,7 @@ const AgentConfigurationDetailView: React.FC<
               />
             )}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <DeployToPopover
               item={item}
               projectId={projectId}

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationTab.tsx
@@ -21,6 +21,9 @@ import AgentConfigurationEditPanel from "@/v2/pages-shared/agent-configuration/A
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import AgentConfigTagList from "./AgentConfigTagList";
 import AgentConfigurationEmptyState from "@/v2/pages/AgentConfigurationPage/AgentConfigurationEmptyState";
+import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
+
+const NARROW_CONTAINER_WIDTH = 900;
 
 type HistoryPopoverProps = {
   items: ConfigHistoryItem[];
@@ -154,6 +157,11 @@ const AgentConfigurationTab: React.FC<AgentConfigurationTabProps> = ({
     [allRows, setSelectedId],
   );
 
+  const [isNarrow, setIsNarrow] = useState<boolean | undefined>(undefined);
+  const { ref: containerRef } = useObserveResizeNode<HTMLDivElement>((node) => {
+    setIsNarrow(node.clientWidth < NARROW_CONTAINER_WIDTH);
+  });
+
   if (isPending) {
     return <Loader />;
   }
@@ -174,47 +182,65 @@ const AgentConfigurationTab: React.FC<AgentConfigurationTabProps> = ({
   const selectedItem = allRows[selectedIndex] as ConfigHistoryItem;
 
   return (
-    <div className="flex flex-col lg:flex-row lg:gap-0">
-      <div className="mx-6 mt-5 flex flex-col gap-4 lg:hidden">
-        <h1 className="comet-body-accented">Agent configuration</h1>
-        <HistoryPopover
-          items={allRows}
-          selectedIndex={selectedIndex}
-          onSelect={handleSelect}
-        />
-      </div>
+    <div
+      ref={containerRef}
+      className={cn("flex flex-col", isNarrow === false && "flex-row")}
+    >
+      {isNarrow !== undefined && (
+        <>
+          {isNarrow && (
+            <div className="mx-6 mt-5 flex flex-col gap-4">
+              <h1 className="comet-body-accented">Agent configuration</h1>
+              <HistoryPopover
+                items={allRows}
+                selectedIndex={selectedIndex}
+                onSelect={handleSelect}
+              />
+            </div>
+          )}
 
-      <div className="min-w-0 flex-1 [overflow-anchor:none] lg:w-[50vw]">
-        <div className="mx-6 mt-5 hidden lg:block">
-          <h1 className="comet-body-accented">Agent configuration</h1>
-        </div>
+          <div
+            className={cn(
+              "min-w-0 flex-1 [overflow-anchor:none]",
+              !isNarrow && "w-[50vw]",
+            )}
+          >
+            {!isNarrow && (
+              <div className="mx-6 mt-5">
+                <h1 className="comet-body-accented">Agent configuration</h1>
+              </div>
+            )}
 
-        {selectedItem ? (
-          <AgentConfigurationDetailView
-            item={selectedItem}
-            projectId={projectId}
-            versions={allRows}
-            onEdit={() => setEditItem(allRows[0])}
-          />
-        ) : (
-          <div className="flex h-full items-center justify-center text-muted-slate">
-            Select a version to view its configuration
+            {selectedItem ? (
+              <AgentConfigurationDetailView
+                item={selectedItem}
+                projectId={projectId}
+                versions={allRows}
+                onEdit={() => setEditItem(allRows[0])}
+              />
+            ) : (
+              <div className="flex h-full items-center justify-center text-muted-slate">
+                Select a version to view its configuration
+              </div>
+            )}
           </div>
-        )}
-      </div>
 
-      <div className="hidden w-[25vw] shrink-0 pr-2 lg:block">
-        <p className="comet-body-s-accented ml-3 mt-6">Version history</p>
+          {!isNarrow && (
+            <div className="w-[25vw] shrink-0 pr-2">
+              <p className="comet-body-s-accented ml-3 mt-6">Version history</p>
 
-        <AgentConfigurationHistoryTimeline
-          items={allRows}
-          selectedIndex={selectedIndex}
-          onSelect={handleSelect}
-          hasNextPage={hasNextPage}
-          isFetchingNextPage={isFetchingNextPage}
-          onLoadMore={fetchNextPage}
-        />
-      </div>
+              <AgentConfigurationHistoryTimeline
+                items={allRows}
+                selectedIndex={selectedIndex}
+                onSelect={handleSelect}
+                hasNextPage={hasNextPage}
+                isFetchingNextPage={isFetchingNextPage}
+                onLoadMore={fetchNextPage}
+              />
+            </div>
+          )}
+        </>
+      )}
 
       {editItem && (
         <AgentConfigurationEditPanel


### PR DESCRIPTION
## Details
* Fixed a bug with Ollie cutting the thread view 
* Fixed a bug with responsiveness of agent configurations

<img width="2994" height="1458" alt="image" src="https://github.com/user-attachments/assets/8df6042d-04e3-463c-ad38-b57ac829a478" />
<img width="1876" height="1368" alt="image" src="https://github.com/user-attachments/assets/771909a1-a4b8-425b-bdf6-b776ed5fe762" />

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6042

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools: Claude Code
  - Model(s): Opus 4.6
  - Scope: all pr
  - Human verification: yes

## Testing
* `npm run lint`
* `npm run typecheck`
* manual tests

## Documentation
