### PR TITLE
[OPIK-6073] [FE] feat: add per-variant Run/Stop button in Playground experiment mode

### DIFF
--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundPromptOutput.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundPromptOutput.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { Clock, Coins, Pause, Play } from "lucide-react";
+import { Clock, Coins } from "lucide-react";
 
-import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { cn } from "@/lib/utils";
 import PlaygroundOutputLoader from "@/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputLoader/PlaygroundOutputLoader";
 import MarkdownPreview from "@/shared/MarkdownPreview/MarkdownPreview";
@@ -9,15 +8,13 @@ import {
   useOutputLoadingByPromptDatasetItemId,
   useOutputStaleStatusByPromptDatasetItemId,
   useOutputValueByPromptDatasetItemId,
-  useIsPromptRunning,
-  usePromptById,
   useOutputByPromptDatasetItemId,
 } from "@/store/PlaygroundStore";
-import { Button } from "@/ui/button";
 import { getAlphabetLetter } from "@/lib/utils";
 import { PLAYGROUND_PROMPT_COLORS } from "@/constants/llm";
 import usePromptModelDisplay from "@/v2/pages/PlaygroundPage/usePromptModelDisplay";
 import PlaygroundNoRunsYet from "@/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundNoRunsYet";
+import PlaygroundRunButton from "@/v2/pages/PlaygroundPage/PlaygroundRunButton";
 
 interface PlaygroundPromptOutputProps {
   promptId: string;
@@ -35,8 +32,6 @@ const PlaygroundPromptOutput = ({
   const value = useOutputValueByPromptDatasetItemId(promptId);
   const isLoading = useOutputLoadingByPromptDatasetItemId(promptId);
   const stale = useOutputStaleStatusByPromptDatasetItemId(promptId);
-  const isPromptRunning = useIsPromptRunning(promptId);
-  const prompt = usePromptById(promptId);
   const output = useOutputByPromptDatasetItemId(promptId);
 
   const usage = output?.usage;
@@ -68,48 +63,15 @@ const PlaygroundPromptOutput = ({
     PLAYGROUND_PROMPT_COLORS[promptIndex % PLAYGROUND_PROMPT_COLORS.length];
   const letter = getAlphabetLetter(promptIndex);
 
-  const hasEmptyMessages = prompt?.messages.some(
-    (m) => !m.content || m.content.length === 0,
-  );
-  const isPromptRunDisabled = !prompt?.model || !!hasEmptyMessages;
-  const promptRunDisabledReason = !prompt?.model
-    ? "Please select an LLM model for this prompt"
-    : hasEmptyMessages
-      ? "Message is empty. Please add some text to proceed"
-      : null;
-
-  const renderRunHeader = () => {
-    if (!onRun || !onStop) return null;
-    return (
-      <div className="flex items-center justify-end border-b px-4 py-2">
-        {isPromptRunning ? (
-          <Button size="2xs" variant="outline" onClick={onStop}>
-            <Pause className="mr-1 size-3.5" />
-            Stop
-          </Button>
-        ) : (
-          <TooltipWrapper
-            content={promptRunDisabledReason ?? "Run this prompt"}
-          >
-            <Button
-              size="2xs"
-              variant="outline"
-              onClick={onRun}
-              disabled={isPromptRunDisabled}
-              style={isPromptRunDisabled ? { pointerEvents: "auto" } : {}}
-            >
-              <Play className="mr-1 size-3.5" />
-              Run
-            </Button>
-          </TooltipWrapper>
-        )}
-      </div>
-    );
-  };
-
   return (
     <div className="flex min-w-[var(--min-prompt-width)] max-w-[var(--max-prompt-width)] flex-1 flex-col border-r">
-      {renderRunHeader()}
+      {onRun && onStop && (
+        <PlaygroundRunButton
+          promptId={promptId}
+          onRun={onRun}
+          onStop={onStop}
+        />
+      )}
       {hasOutput ? (
         <div className="flex-1 bg-background p-4">
           <div className="mb-3 flex items-center gap-5">

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -255,6 +255,8 @@ const PlaygroundPage = () => {
                   workspaceName={workspaceName}
                   providerKeys={providerKeys}
                   isPendingProviderKeys={isPendingProviderKeys}
+                  runSingle={runSingle}
+                  stopSingle={stopSingle}
                 />
               </div>
 

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -53,6 +53,7 @@ import useSavePromptToBlueprint from "@/v2/pages-shared/llm/BlueprintPromptsSele
 import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
 import useLoadBlueprintPrompt from "@/hooks/useLoadBlueprintPrompt";
 import { BlueprintPromptRef } from "@/types/playground";
+import PlaygroundRunButton from "@/v2/pages/PlaygroundPage/PlaygroundRunButton";
 
 interface PlaygroundPromptProps {
   workspaceName: string;
@@ -62,6 +63,8 @@ interface PlaygroundPromptProps {
   isPendingProviderKeys: boolean;
   providerResolver: ProviderResolver;
   modelResolver: ModelResolver;
+  onRun?: () => void;
+  onStop?: () => void;
 }
 
 const PlaygroundPrompt = ({
@@ -72,6 +75,8 @@ const PlaygroundPrompt = ({
   isPendingProviderKeys,
   providerResolver,
   modelResolver,
+  onRun,
+  onStop,
 }: PlaygroundPromptProps) => {
   const checkedIfModelIsValidRef = useRef(false);
   const activeProjectId = useActiveProjectId();
@@ -443,6 +448,15 @@ const PlaygroundPrompt = ({
           improvePromptConfig={improvePromptConfig}
         />
       </div>
+
+      {onRun && onStop && (
+        <PlaygroundRunButton
+          promptId={promptId}
+          onRun={onRun}
+          onStop={onStop}
+          className="flex items-center justify-end border-t px-4 py-2"
+        />
+      )}
 
       {selectedBlueprintRef && blueprintPromptData && (
         <SaveExistingPromptDialog

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompts.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompts.tsx
@@ -16,12 +16,16 @@ interface PlaygroundPromptsProps {
   workspaceName: string;
   providerKeys: COMPOSED_PROVIDER_TYPE[];
   isPendingProviderKeys: boolean;
+  runSingle?: (promptId: string) => void;
+  stopSingle?: (promptId: string) => void;
 }
 
 const PlaygroundPrompts = ({
   workspaceName,
   providerKeys,
   isPendingProviderKeys,
+  runSingle,
+  stopSingle,
 }: PlaygroundPromptsProps) => {
   const promptCount = usePromptCount();
   const promptIds = usePromptIds();
@@ -65,6 +69,8 @@ const PlaygroundPrompts = ({
           isPendingProviderKeys={isPendingProviderKeys}
           providerResolver={calculateModelProvider}
           modelResolver={calculateDefaultModel}
+          onRun={runSingle ? () => runSingle(promptId) : undefined}
+          onStop={stopSingle ? () => stopSingle(promptId) : undefined}
         />
       ))}
     </div>

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundRunButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundRunButton.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { Pause, Play } from "lucide-react";
+
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import { Button } from "@/ui/button";
+import { useIsPromptRunning, usePromptById } from "@/store/PlaygroundStore";
+
+interface PlaygroundRunButtonProps {
+  promptId: string;
+  onRun: () => void;
+  onStop: () => void;
+  className?: string;
+}
+
+const PlaygroundRunButton = ({
+  promptId,
+  onRun,
+  onStop,
+  className,
+}: PlaygroundRunButtonProps) => {
+  const prompt = usePromptById(promptId);
+  const isPromptRunning = useIsPromptRunning(promptId);
+
+  const hasEmptyMessages = prompt?.messages.some(
+    (m) => !m.content || m.content.length === 0,
+  );
+  const isPromptRunDisabled = !prompt?.model || !!hasEmptyMessages;
+
+  let promptRunDisabledReason: string | null = null;
+  if (!prompt?.model) {
+    promptRunDisabledReason = "Please select an LLM model for this prompt";
+  } else if (hasEmptyMessages) {
+    promptRunDisabledReason =
+      "Message is empty. Please add some text to proceed";
+  }
+
+  return (
+    <div
+      className={
+        className ?? "flex items-center justify-end border-b px-4 py-2"
+      }
+    >
+      {isPromptRunning ? (
+        <Button size="2xs" variant="outline" onClick={onStop}>
+          <Pause className="mr-1 size-3.5" />
+          Stop
+        </Button>
+      ) : (
+        <TooltipWrapper content={promptRunDisabledReason ?? "Run this prompt"}>
+          <Button
+            size="2xs"
+            variant="outline"
+            onClick={onRun}
+            disabled={isPromptRunDisabled}
+            style={isPromptRunDisabled ? { pointerEvents: "auto" } : {}}
+          >
+            <Play className="mr-1 size-3.5" />
+            Run
+          </Button>
+        </TooltipWrapper>
+      )}
+    </div>
+  );
+};
+
+export default PlaygroundRunButton;

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/useActionButtonActions.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/useActionButtonActions.tsx
@@ -50,6 +50,11 @@ import usePromptDatasetItemCombination, {
 const DEFAULT_MAX_CONCURRENT_REQUESTS = 5;
 const MAX_POLL_DURATION_MS = 5 * 60 * 1000; // 5 minutes
 
+interface PollScope {
+  scopedPromptIds?: string[];
+  pollKeySuffix?: string;
+}
+
 interface UseActionButtonActionsArguments {
   datasetItems: DatasetItem[];
   workspaceName: string;
@@ -85,7 +90,9 @@ const useActionButtonActions = ({
   const selectedRuleIds = useSelectedRuleIds();
   const datasetType = useDatasetType();
   const setExperimentByPromptId = useSetExperimentByPromptId();
-  const abortControllersRef = useRef(new Map<string, AbortController>());
+  const abortControllersRef = useRef(
+    new Map<string, { controller: AbortController; promptId: string }>(),
+  );
   const runExperimentExecution = useRunExperimentExecution();
 
   const isTestSuite = datasetType === DATASET_TYPE.TEST_SUITE;
@@ -137,17 +144,18 @@ const useActionButtonActions = ({
   const stopAll = useCallback(() => {
     clearRunningMap();
     isToStopRef.current = true;
-    abortControllersRef.current.forEach((controller) => controller.abort());
+    abortControllersRef.current.forEach(({ controller }) => controller.abort());
     abortControllersRef.current.clear();
   }, [clearRunningMap]);
 
   const stopSingle = useCallback(
     (promptId: string) => {
       setPromptRunning(promptId, false);
-      const controller = abortControllersRef.current.get(promptId);
-      if (controller) {
-        controller.abort();
-        abortControllersRef.current.delete(promptId);
+      for (const [key, entry] of abortControllersRef.current.entries()) {
+        if (entry.promptId === promptId) {
+          entry.controller.abort();
+          abortControllersRef.current.delete(key);
+        }
       }
     },
     [setPromptRunning],
@@ -210,8 +218,8 @@ const useActionButtonActions = ({
   ]);
 
   const addAbortController = useCallback(
-    (key: string, value: AbortController) => {
-      abortControllersRef.current.set(key, value);
+    (key: string, value: AbortController, promptId: string) => {
+      abortControllersRef.current.set(key, { controller: value, promptId });
     },
     [],
   );
@@ -224,7 +232,6 @@ const useActionButtonActions = ({
   const { createCombinations, processCombination } =
     usePromptDatasetItemCombination({
       workspaceName,
-      isToStopRef,
       datasetItems,
       datasetName,
       datasetVersionId,
@@ -246,23 +253,55 @@ const useActionButtonActions = ({
     [clearRunningMap, resetProgress, queryClient, toast],
   );
 
+  const finishPollScope = useCallback(
+    (scope?: PollScope) => {
+      if (scope?.scopedPromptIds) {
+        scope.scopedPromptIds.forEach((id) => setPromptRunning(id, false));
+      } else {
+        clearRunningMap();
+        isToStopRef.current = false;
+      }
+    },
+    [clearRunningMap, setPromptRunning],
+  );
+
   // TODO: OPIK-5724 — for datasets >20k items, replace with a dedicated BE count endpoint
   const pollAssertionEvaluation = useCallback(
-    async (experimentIds: string[], curDatasetId: string) => {
+    async (
+      experimentIds: string[],
+      curDatasetId: string,
+      scope?: PollScope,
+    ) => {
       const startTime = Date.now();
+      const pollKey = `poll-assertion${scope?.pollKeySuffix ?? ""}`;
+      const isScoped = !!scope?.scopedPromptIds;
+
       const poll = async () => {
-        if (isToStopRef.current) return;
+        if (!isScoped && isToStopRef.current) return;
 
         if (Date.now() - startTime > MAX_POLL_DURATION_MS) {
-          handlePollTimeout(
-            "Assertion evaluation polling timed out after 5 minutes",
-          );
+          if (isScoped) {
+            finishPollScope(scope);
+            toast({
+              title: "Timeout",
+              description:
+                "Assertion evaluation polling timed out after 5 minutes",
+              variant: "destructive",
+            });
+          } else {
+            handlePollTimeout(
+              "Assertion evaluation polling timed out after 5 minutes",
+            );
+          }
           return;
         }
 
         try {
           const controller = new AbortController();
-          abortControllersRef.current.set("poll-assertion", controller);
+          abortControllersRef.current.set(pollKey, {
+            controller,
+            promptId: scope?.scopedPromptIds?.[0] ?? "",
+          });
           const data = await getCompareExperimentsList(
             { signal: controller.signal },
             {
@@ -289,19 +328,20 @@ const useActionButtonActions = ({
             }
           }
 
-          if (totalItems > 0) {
+          if (!isScoped && totalItems > 0) {
             setProgress(scoredItems, totalItems);
           }
 
           if (totalItems > 0 && scoredItems >= totalItems) {
-            setProgress(totalItems, totalItems);
-            clearRunningMap();
-            isToStopRef.current = false;
+            if (!isScoped) {
+              setProgress(totalItems, totalItems);
+              setTimeout(() => resetProgress(), 3000);
+            }
+            finishPollScope(scope);
             queryClient.invalidateQueries({ queryKey: ["experiments"] });
             queryClient.invalidateQueries({
               queryKey: [COMPARE_EXPERIMENTS_KEY],
             });
-            setTimeout(() => resetProgress(), 3000);
             return;
           }
 
@@ -310,9 +350,10 @@ const useActionButtonActions = ({
           });
           setTimeout(poll, ASSERTION_POLL_INTERVAL_MS);
         } catch {
-          clearRunningMap();
-          isToStopRef.current = false;
-          resetProgress();
+          finishPollScope(scope);
+          if (!isScoped) {
+            resetProgress();
+          }
           toast({
             title: "Error",
             description: "Failed to poll assertion evaluation status",
@@ -327,8 +368,8 @@ const useActionButtonActions = ({
       workspaceName,
       setProgress,
       resetProgress,
-      clearRunningMap,
       handlePollTimeout,
+      finishPollScope,
       queryClient,
       toast,
     ],
@@ -339,21 +380,38 @@ const useActionButtonActions = ({
       experimentIds: string[],
       totalItems: number,
       curDatasetId: string,
+      scope?: PollScope,
     ) => {
       const startTime = Date.now();
+      const pollKey = `poll-experiment${scope?.pollKeySuffix ?? ""}`;
+      const isScoped = !!scope?.scopedPromptIds;
+
       const poll = async () => {
-        if (isToStopRef.current) return;
+        if (!isScoped && isToStopRef.current) return;
 
         if (Date.now() - startTime > MAX_POLL_DURATION_MS) {
-          handlePollTimeout(
-            "Experiment completion polling timed out after 5 minutes",
-          );
+          if (isScoped) {
+            finishPollScope(scope);
+            toast({
+              title: "Timeout",
+              description:
+                "Experiment completion polling timed out after 5 minutes",
+              variant: "destructive",
+            });
+          } else {
+            handlePollTimeout(
+              "Experiment completion polling timed out after 5 minutes",
+            );
+          }
           return;
         }
 
         try {
           const controller = new AbortController();
-          abortControllersRef.current.set("poll-experiment", controller);
+          abortControllersRef.current.set(pollKey, {
+            controller,
+            promptId: scope?.scopedPromptIds?.[0] ?? "",
+          });
           const results = await Promise.all(
             experimentIds.map((id) =>
               getExperimentById(
@@ -369,7 +427,9 @@ const useActionButtonActions = ({
             (sum, exp) => sum + (exp?.trace_count ?? 0),
             0,
           );
-          setProgress(Math.min(totalTraces, totalItems), totalItems);
+          if (!isScoped) {
+            setProgress(Math.min(totalTraces, totalItems), totalItems);
+          }
 
           const allDone = results.every(
             (exp) =>
@@ -378,21 +438,20 @@ const useActionButtonActions = ({
           );
 
           if (allDone) {
-            setProgress(totalItems, totalItems);
+            if (!isScoped) {
+              setProgress(totalItems, totalItems);
+              setProgressPhase("evaluating");
+              setProgress(0, totalItems);
+            }
             queryClient.invalidateQueries({ queryKey: ["experiments"] });
-
-            // Transition to evaluation phase
-            setProgressPhase("evaluating");
-            setProgress(0, totalItems);
-            pollAssertionEvaluation(experimentIds, curDatasetId);
+            pollAssertionEvaluation(experimentIds, curDatasetId, scope);
             return;
           }
 
           queryClient.invalidateQueries({ queryKey: ["experiments"] });
           setTimeout(poll, EXPERIMENT_POLL_INTERVAL_MS);
         } catch {
-          clearRunningMap();
-          isToStopRef.current = false;
+          finishPollScope(scope);
           toast({
             title: "Error",
             description: "Failed to poll experiment completion status",
@@ -406,7 +465,7 @@ const useActionButtonActions = ({
     [
       setProgress,
       setProgressPhase,
-      clearRunningMap,
+      finishPollScope,
       handlePollTimeout,
       queryClient,
       pollAssertionEvaluation,
@@ -535,26 +594,117 @@ const useActionButtonActions = ({
     return runAllViaFrontend();
   }, [isTestSuite, runAllViaBackend, runAllViaFrontend]);
 
-  const runSingle = useCallback(
+  const runSingleViaFrontend = useCallback(
     async (promptId: string) => {
       const prompt = usePlaygroundStore.getState().promptMap[promptId];
       if (!prompt) return;
 
-      isToStopRef.current = false;
       setPromptRunning(promptId, true);
+
       const logProcessor = createLogPlaygroundProcessor({
         ...logProcessorHandlers,
         projectName,
       });
 
+      const combinations: DatasetItemPromptCombination[] =
+        datasetItems.length > 0
+          ? datasetItems.map((di) => ({ datasetItem: di, prompt }))
+          : [{ prompt }];
+
       try {
-        await processCombination({ prompt }, logProcessor);
+        await new Promise<void>((resolve) => {
+          asyncLib.mapLimit(
+            combinations,
+            maxConcurrentRequests,
+            async (combination: DatasetItemPromptCombination) => {
+              await processCombination(combination, logProcessor);
+            },
+            () => resolve(),
+          );
+        });
       } finally {
         logProcessor.finishLogging();
         setPromptRunning(promptId, false);
       }
     },
-    [setPromptRunning, logProcessorHandlers, processCombination, projectName],
+    [
+      datasetItems,
+      maxConcurrentRequests,
+      setPromptRunning,
+      logProcessorHandlers,
+      processCombination,
+      projectName,
+    ],
+  );
+
+  const runSingleViaBackend = useCallback(
+    async (promptId: string) => {
+      if (!datasetName || !datasetId) return;
+      const prompt = usePlaygroundStore.getState().promptMap[promptId];
+      if (!prompt) return;
+
+      setPromptRunning(promptId, true);
+
+      try {
+        const response = await runExperimentExecution.mutateAsync({
+          datasetName,
+          datasetVersionId,
+          datasetId,
+          versionHash,
+          prompts: [prompt],
+          projectName,
+        });
+
+        const experiment = response.experiments[0];
+        if (!experiment) {
+          setPromptRunning(promptId, false);
+          return;
+        }
+
+        const existing =
+          usePlaygroundStore.getState().experimentByPromptId ?? {};
+        setExperimentByPromptId({
+          ...existing,
+          [promptId]: experiment.experiment_id,
+        });
+
+        queryClient.invalidateQueries({ queryKey: ["experiments"] });
+
+        pollExperimentCompletion(
+          [experiment.experiment_id],
+          response.total_items,
+          datasetId,
+          {
+            scopedPromptIds: [promptId],
+            pollKeySuffix: `-${promptId}`,
+          },
+        );
+      } catch {
+        setPromptRunning(promptId, false);
+      }
+    },
+    [
+      datasetName,
+      datasetId,
+      datasetVersionId,
+      versionHash,
+      projectName,
+      runExperimentExecution,
+      setPromptRunning,
+      setExperimentByPromptId,
+      queryClient,
+      pollExperimentCompletion,
+    ],
+  );
+
+  const runSingle = useCallback(
+    async (promptId: string) => {
+      if (isTestSuite) {
+        return runSingleViaBackend(promptId);
+      }
+      return runSingleViaFrontend(promptId);
+    },
+    [isTestSuite, runSingleViaBackend, runSingleViaFrontend],
   );
 
   return {

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/useActionButtonActions.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/useActionButtonActions.tsx
@@ -265,6 +265,29 @@ const useActionButtonActions = ({
     [clearRunningMap, setPromptRunning],
   );
 
+  const handlePollError = useCallback(
+    (
+      error: unknown,
+      scope: PollScope | undefined,
+      description: string,
+      onUnscopedCleanup?: () => void,
+    ) => {
+      const isScoped = !!scope?.scopedPromptIds;
+      finishPollScope(scope);
+      if (!isScoped) {
+        onUnscopedCleanup?.();
+      }
+      if ((error as Error)?.name !== "AbortError") {
+        toast({
+          title: "Error",
+          description,
+          variant: "destructive",
+        });
+      }
+    },
+    [finishPollScope, toast],
+  );
+
   // TODO: OPIK-5724 — for datasets >20k items, replace with a dedicated BE count endpoint
   const pollAssertionEvaluation = useCallback(
     async (
@@ -350,17 +373,12 @@ const useActionButtonActions = ({
           });
           setTimeout(poll, ASSERTION_POLL_INTERVAL_MS);
         } catch (error) {
-          finishPollScope(scope);
-          if (!isScoped) {
-            resetProgress();
-          }
-          if ((error as Error)?.name !== "AbortError") {
-            toast({
-              title: "Error",
-              description: "Failed to poll assertion evaluation status",
-              variant: "destructive",
-            });
-          }
+          handlePollError(
+            error,
+            scope,
+            "Failed to poll assertion evaluation status",
+            resetProgress,
+          );
         }
       };
 
@@ -374,6 +392,7 @@ const useActionButtonActions = ({
       finishPollScope,
       queryClient,
       toast,
+      handlePollError,
     ],
   );
 
@@ -453,14 +472,11 @@ const useActionButtonActions = ({
           queryClient.invalidateQueries({ queryKey: ["experiments"] });
           setTimeout(poll, EXPERIMENT_POLL_INTERVAL_MS);
         } catch (error) {
-          finishPollScope(scope);
-          if ((error as Error)?.name !== "AbortError") {
-            toast({
-              title: "Error",
-              description: "Failed to poll experiment completion status",
-              variant: "destructive",
-            });
-          }
+          handlePollError(
+            error,
+            scope,
+            "Failed to poll experiment completion status",
+          );
         }
       };
 
@@ -474,6 +490,7 @@ const useActionButtonActions = ({
       queryClient,
       pollAssertionEvaluation,
       toast,
+      handlePollError,
     ],
   );
 

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/useActionButtonActions.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/useActionButtonActions.tsx
@@ -349,16 +349,18 @@ const useActionButtonActions = ({
             queryKey: [COMPARE_EXPERIMENTS_KEY],
           });
           setTimeout(poll, ASSERTION_POLL_INTERVAL_MS);
-        } catch {
+        } catch (error) {
           finishPollScope(scope);
           if (!isScoped) {
             resetProgress();
           }
-          toast({
-            title: "Error",
-            description: "Failed to poll assertion evaluation status",
-            variant: "destructive",
-          });
+          if ((error as Error)?.name !== "AbortError") {
+            toast({
+              title: "Error",
+              description: "Failed to poll assertion evaluation status",
+              variant: "destructive",
+            });
+          }
         }
       };
 
@@ -450,13 +452,15 @@ const useActionButtonActions = ({
 
           queryClient.invalidateQueries({ queryKey: ["experiments"] });
           setTimeout(poll, EXPERIMENT_POLL_INTERVAL_MS);
-        } catch {
+        } catch (error) {
           finishPollScope(scope);
-          toast({
-            title: "Error",
-            description: "Failed to poll experiment completion status",
-            variant: "destructive",
-          });
+          if ((error as Error)?.name !== "AbortError") {
+            toast({
+              title: "Error",
+              description: "Failed to poll experiment completion status",
+              variant: "destructive",
+            });
+          }
         }
       };
 
@@ -658,6 +662,10 @@ const useActionButtonActions = ({
         const experiment = response.experiments[0];
         if (!experiment) {
           setPromptRunning(promptId, false);
+          return;
+        }
+
+        if (!usePlaygroundStore.getState().isRunningMap[promptId]) {
           return;
         }
 

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/usePromptDatasetItemCombination.ts
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/usePromptDatasetItemCombination.ts
@@ -1,8 +1,8 @@
-import { useCallback, RefObject } from "react";
+import { useCallback } from "react";
 import { LogProcessor } from "@/api/playground/createLogPlaygroundProcessor";
 import { DatasetItem } from "@/types/datasets";
 import { PlaygroundPromptType } from "@/types/playground";
-import {
+import usePlaygroundStore, {
   usePromptIds,
   usePromptMap,
   useUpdateOutput,
@@ -141,19 +141,21 @@ const transformMessageIntoProviderMessage = (
 
 interface UsePromptDatasetItemCombinationArgs {
   datasetItems: DatasetItem[];
-  isToStopRef: RefObject<boolean>;
   workspaceName: string;
   datasetName: string | null;
   datasetVersionId?: string;
   selectedRuleIds: string[] | null;
-  addAbortController: (key: string, value: AbortController) => void;
+  addAbortController: (
+    key: string,
+    value: AbortController,
+    promptId: string,
+  ) => void;
   deleteAbortController: (key: string) => void;
   throttlingSeconds: number;
 }
 
 const usePromptDatasetItemCombination = ({
   datasetItems,
-  isToStopRef,
   workspaceName,
   datasetName,
   datasetVersionId,
@@ -193,7 +195,7 @@ const usePromptDatasetItemCombination = ({
       { datasetItem, prompt }: DatasetItemPromptCombination,
       logProcessor: LogProcessor,
     ) => {
-      if (isToStopRef.current) {
+      if (!usePlaygroundStore.getState().isRunningMap[prompt.id]) {
         return;
       }
 
@@ -203,7 +205,7 @@ const usePromptDatasetItemCombination = ({
       const datasetItemData = await hydrateDatasetItemData(datasetItem);
       const key = datasetItemId ? `${datasetItemId}-${prompt.id}` : prompt.id;
 
-      addAbortController(key, controller);
+      addAbortController(key, controller, prompt.id);
 
       try {
         updateOutput(prompt.id, datasetItemId, {
@@ -296,8 +298,10 @@ const usePromptDatasetItemCombination = ({
       } finally {
         deleteAbortController(key);
 
-        // Apply throttling delay if configured
-        if (throttlingSeconds > 0 && !isToStopRef.current) {
+        if (
+          throttlingSeconds > 0 &&
+          usePlaygroundStore.getState().isRunningMap[prompt.id]
+        ) {
           await new Promise((resolve) =>
             setTimeout(resolve, throttlingSeconds * 1000),
           );
@@ -306,7 +310,6 @@ const usePromptDatasetItemCombination = ({
     },
 
     [
-      isToStopRef,
       hydrateDatasetItemData,
       hydratePromptMetadata,
       addAbortController,


### PR DESCRIPTION
## Details

Adds a per-variant **Run/Stop** button to each variant editor card in Playground experiment mode (dataset + test-suite), matching the Figma design (node `724:10629`). Users can now re-run a single variant across all dataset items or as a scoped single-variant experiment without re-running every variant.

- Shared `PlaygroundRunButton` extracted from `PlaygroundPromptOutput.renderRunHeader` so variant editor cards and the output panel render identical markup/disabled tooltips.
- `runSingle` now dispatches to `runSingleViaFrontend` (dataset — mirrors `runAllViaFrontend` for one `promptId`) or `runSingleViaBackend` (test-suite — calls `runExperimentExecution` with `prompts: [prompt]` and polls with a scoped key suffix).
- `stopSingle` matches abort-controller entries by their `promptId` tag (entries are now `{ controller, promptId }`), dropping the previous `key.endsWith` heuristic.
- `PollScope` (`scopedPromptIds`, `pollKeySuffix`) isolates per-variant polls from the global runAll poll; `finishPollScope` flips only scoped prompts back to not-running.
- `processCombination` short-circuits on per-prompt `isRunningMap[prompt.id]` instead of the shared `isToStopRef`, so stopping one variant genuinely doesn't cancel others.
- Thread `runSingle`/`stopSingle` through `PlaygroundPage` → `PlaygroundPrompts` → `PlaygroundPrompt`, rendered as a footer on the variant card in experiment mode.

### Known limitation (out of scope)

In **test-suite mode** the experiment runs on the backend (no cancel endpoint). Stop aborts the frontend poll and flips running state, but `PlaygroundOutputAssertionStatus` keeps its own `refetchInterval` poll reflecting backend progress until items finish or 5 minutes elapse. This predates this PR. Dataset mode stops immediately.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6073

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: implementation, refactoring, code review, commit/PR authoring
- Human verification: author reviewed diff, ran `npm run typecheck && npm run lint`, manually tested simple/dataset/test-suite flows in browser

## Testing

Commands run locally:
- `npm run typecheck` — passes
- `npm run lint` — passes

Scenarios validated manually against the local dev stack (`npm run start`):
- **Simple mode regression** — no dataset selected; existing per-variant Run button still works (unchanged code path).
- **Dataset mode** — dataset with 5+ items, two variants A/B with different models; Run on A fills only A's column; Run on B while A is mid-run fills both columns concurrently.
- **Per-variant Stop (dataset)** — with A running across many items, Stop on A aborts in-flight rows and skips queued rows; variant B is untouched.
- **Test-suite mode** — Run on one variant creates an experiment containing only that variant (confirmed on Experiments page); other variants' columns remain empty. (See Known limitation above for Stop behavior.)
- **Disabled state** — empty message in variant A disables its Run button with the matching tooltip.
- **Global Run/Stop experiment** — still runs all variants; per-variant Stop can abort an individual variant while a global run is in progress.

## Documentation

No documentation changes — UI-only feature surfaced inline with existing Playground controls.