### PR TITLE
[OPIK-6004] [SDK] feat: deprecate project_name override in evaluate functions

### DIFF
--- a/sdks/python/src/opik/api_objects/dataset/test_suite/test_suite.py
+++ b/sdks/python/src/opik/api_objects/dataset/test_suite/test_suite.py
@@ -176,7 +176,7 @@ class TestSuiteVersion:
         return self._dataset_version.project_name
 
     @property
-    def __internal_api__dataset__(self) -> dataset.DatasetVersion:
+    def __internal_api__dataset_version__(self) -> dataset.DatasetVersion:
         """Internal access to the underlying dataset version. Not part of the public API."""
         return self._dataset_version
 

--- a/sdks/python/src/opik/api_objects/dataset/test_suite/test_suite.py
+++ b/sdks/python/src/opik/api_objects/dataset/test_suite/test_suite.py
@@ -175,6 +175,11 @@ class TestSuiteVersion:
         """The project name associated with the test suite."""
         return self._dataset_version.project_name
 
+    @property
+    def __internal_api__dataset__(self) -> dataset.DatasetVersion:
+        """Internal access to the underlying dataset version. Not part of the public API."""
+        return self._dataset_version
+
     def get_items(
         self,
         nb_samples: Optional[int] = None,
@@ -293,6 +298,11 @@ class TestSuite:
     def project_name(self) -> Optional[str]:
         """The project name associated with the test suite."""
         return self._dataset.project_name
+
+    @property
+    def __internal_api__dataset__(self) -> dataset.Dataset:
+        """Internal access to the underlying dataset. Not part of the public API."""
+        return self._dataset
 
     @property
     def items_count(self) -> Optional[int]:

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -4,7 +4,6 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Iterator,
     List,
     Optional,
     Tuple,
@@ -47,87 +46,6 @@ LOGGER = logging.getLogger(__name__)
 MODALITY_SUPPORT_DOC_URL = (
     "https://www.comet.com/docs/opik/evaluation/evaluate_multimodal"
 )
-
-EVALUATION_STREAM_DATASET_BATCH_SIZE = 200
-
-
-def _merge_blueprint_into_config(
-    client: "opik_client.Opik",
-    blueprint_id: str,
-    experiment_config: Optional[Dict[str, Any]],
-) -> Dict[str, Any]:
-    """Add blueprint reference to experiment_config under ``agent_configuration``."""
-    experiment_config = dict(experiment_config) if experiment_config else {}
-    agent_config: Dict[str, str] = {"_blueprint_id": blueprint_id}
-    try:
-        blueprint = client._rest_client.agent_configs.get_blueprint_by_id(
-            blueprint_id=blueprint_id,
-        )
-        if blueprint.name:
-            agent_config["blueprint_version"] = blueprint.name
-    except Exception:
-        LOGGER.debug("Failed to fetch blueprint %s", blueprint_id, exc_info=True)
-    experiment_config["agent_configuration"] = agent_config
-    return experiment_config
-
-
-def _calculate_total_items(
-    dataset_: Union[dataset.Dataset, dataset.DatasetVersion],
-    nb_samples: Optional[int],
-    dataset_item_ids: Optional[List[str]],
-) -> Optional[int]:
-    """Calculate the total number of items that will be evaluated."""
-    if dataset_item_ids is not None:
-        return len(dataset_item_ids)
-
-    if nb_samples is not None:
-        if dataset_.dataset_items_count is not None:
-            return min(nb_samples, dataset_.dataset_items_count)
-        return nb_samples
-
-    return dataset_.dataset_items_count
-
-
-def _resolve_dataset_items(
-    dataset_: Union[dataset.Dataset, dataset.DatasetVersion],
-    nb_samples: Optional[int],
-    dataset_item_ids: Optional[List[str]],
-    dataset_sampler: Optional[samplers.BaseDatasetSampler],
-    dataset_filter_string: Optional[str],
-) -> Tuple[Iterator[dataset_item.DatasetItem], Optional[int]]:
-    """
-    Resolve dataset items for evaluation.
-
-    Handles streaming vs sampling, and calculates total item count.
-
-    Returns:
-        Tuple of (items iterator, total item count or None).
-    """
-    if dataset_sampler is None:
-        items_iter = dataset_.__internal_api__stream_items_as_dataclasses__(
-            nb_samples=nb_samples,
-            dataset_item_ids=dataset_item_ids,
-            batch_size=EVALUATION_STREAM_DATASET_BATCH_SIZE,
-            filter_string=dataset_filter_string,
-        )
-        total = _calculate_total_items(
-            dataset_=dataset_,
-            nb_samples=nb_samples,
-            dataset_item_ids=dataset_item_ids,
-        )
-        return items_iter, total
-
-    LOGGER.info("Dataset streaming disabled due to sampler")
-    items_list = list(
-        dataset_.__internal_api__stream_items_as_dataclasses__(
-            nb_samples=nb_samples,
-            dataset_item_ids=dataset_item_ids,
-            batch_size=EVALUATION_STREAM_DATASET_BATCH_SIZE,
-            filter_string=dataset_filter_string,
-        )
-    )
-    items_list = dataset_sampler.sample(items_list)
-    return iter(items_list), len(items_list)
 
 
 def _try_notifying_about_experiment_completion(
@@ -297,7 +215,7 @@ def evaluate(
     client = opik_client.get_global_client()
 
     if blueprint_id:
-        experiment_config = _merge_blueprint_into_config(
+        experiment_config = helpers.merge_blueprint_into_config(
             client,
             blueprint_id,
             experiment_config,
@@ -392,7 +310,7 @@ def __internal_api__run_test_suite__(
         client = opik_client.get_global_client()
 
     if blueprint_id:
-        experiment_config = _merge_blueprint_into_config(
+        experiment_config = helpers.merge_blueprint_into_config(
             client,
             blueprint_id,
             experiment_config,
@@ -578,7 +496,7 @@ def _evaluate_task(
     start_time = time.time()
 
     with asyncio_support.async_http_connections_expire_immediately():
-        items_iter, total = _resolve_dataset_items(
+        items_iter, total = helpers.resolve_dataset_items_generator(
             dataset_=dataset,
             nb_samples=nb_samples,
             dataset_item_ids=dataset_item_ids,
@@ -678,7 +596,7 @@ def _evaluate_test_suite_task(
         items_iter = dataset.__internal_api__stream_items_as_dataclasses__(
             nb_samples=None,
             dataset_item_ids=dataset_item_ids,
-            batch_size=EVALUATION_STREAM_DATASET_BATCH_SIZE,
+            batch_size=helpers.EVALUATION_STREAM_DATASET_BATCH_SIZE,
             filter_string=dataset_filter_string,
         )
         total = dataset.dataset_items_count
@@ -1082,7 +1000,7 @@ def evaluate_prompt(
     start_time = time.time()
 
     with asyncio_support.async_http_connections_expire_immediately():
-        items_iter, total = _resolve_dataset_items(
+        items_iter, total = helpers.resolve_dataset_items_generator(
             dataset_=dataset,
             nb_samples=nb_samples,
             dataset_item_ids=dataset_item_ids,

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -142,6 +142,39 @@ def _try_notifying_about_experiment_completion(
         )
 
 
+def _resolve_project_name(
+    dataset_: Union[dataset.Dataset, dataset.DatasetVersion],
+    project_name: Optional[str],
+    caller_name: str,
+) -> Optional[str]:
+    """
+    Resolve which project name to use for evaluation.
+
+    Prefers the dataset's ``project_name`` when set. If the caller also passed
+    a ``project_name``, log a deprecation warning and ignore the override so
+    traces land in the dataset's project.
+
+    Falls back to the caller's ``project_name`` when the dataset has none, to
+    preserve backward compatibility during the deprecation period.
+    """
+    dataset_project_name = getattr(dataset_, "project_name", None)
+
+    if dataset_project_name is None:
+        return project_name
+
+    if project_name is not None:
+        LOGGER.warning(
+            "The `project_name` parameter of `%s()` is deprecated and will be "
+            "removed in a future version. The dataset's project ('%s') will "
+            "be used instead of the provided value ('%s').",
+            caller_name,
+            dataset_project_name,
+            project_name,
+        )
+
+    return dataset_project_name
+
+
 def _compute_experiment_scores(
     experiment_scoring_functions: List[ExperimentScoreFunction],
     test_results: List[test_result.TestResult],
@@ -210,7 +243,10 @@ def evaluate(
         experiment_name: The name of the experiment associated with evaluation run.
             If None, a generated name will be used.
 
-        project_name: The name of the project. If not provided, traces and spans will be logged to the `Default Project`
+        project_name: Deprecated. If the dataset has a ``project_name`` set, it
+            is always used and this override is ignored (with a warning). If
+            the dataset has no ``project_name``, traces and spans are logged to
+            this project (or to ``Default Project`` when omitted).
 
         experiment_config: The dictionary with parameters that describe experiment
 
@@ -302,6 +338,10 @@ def evaluate(
     experiment_name = _use_or_create_experiment_name(
         experiment_name=experiment_name,
         experiment_name_prefix=experiment_name_prefix,
+    )
+
+    project_name = _resolve_project_name(
+        dataset_=dataset, project_name=project_name, caller_name="evaluate"
     )
 
     experiment = client.create_experiment(
@@ -967,7 +1007,10 @@ def evaluate_prompt(
 
         experiment_name: name of the experiment.
 
-        project_name: The name of the project to log data
+        project_name: Deprecated. If the dataset has a ``project_name`` set, it
+            is always used and this override is ignored (with a warning). If
+            the dataset has no ``project_name``, traces and spans are logged to
+            this project (or to ``Default Project`` when omitted).
 
         experiment_config: configuration of the experiment.
 
@@ -1041,6 +1084,10 @@ def evaluate_prompt(
     experiment_name = _use_or_create_experiment_name(
         experiment_name=experiment_name,
         experiment_name_prefix=experiment_name_prefix,
+    )
+
+    project_name = _resolve_project_name(
+        dataset_=dataset, project_name=project_name, caller_name="evaluate_prompt"
     )
 
     experiment = client.create_experiment(
@@ -1189,7 +1236,10 @@ def evaluate_optimization_trial(
         experiment_name: The name of the experiment associated with evaluation run.
             If None, a generated name will be used.
 
-        project_name: The name of the project. If not provided, traces and spans will be logged to the `Default Project`
+        project_name: Deprecated. If the dataset has a ``project_name`` set, it
+            is always used and this override is ignored (with a warning). If
+            the dataset has no ``project_name``, traces and spans are logged to
+            this project (or to ``Default Project`` when omitted).
 
         experiment_config: The dictionary with parameters that describe experiment
 
@@ -1262,6 +1312,12 @@ def evaluate_optimization_trial(
     checked_prompts = experiment_helpers.handle_prompt_args(
         prompt=prompt,
         prompts=prompts,
+    )
+
+    project_name = _resolve_project_name(
+        dataset_=dataset,
+        project_name=project_name,
+        caller_name="evaluate_optimization_trial",
     )
 
     # wrap scoring functions if any

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -27,6 +27,7 @@ from . import (
     asyncio_support,
     engine,
     evaluation_result,
+    helpers,
     report,
     rest_operations,
     samplers,
@@ -140,37 +141,6 @@ def _try_notifying_about_experiment_completion(
             experiment.id,
             exc_info=True,
         )
-
-
-def _resolve_project_name(
-    value_from_dataset: Optional[str],
-    value_from_user: Optional[str],
-    caller_name: str,
-) -> Optional[str]:
-    """
-    Resolve which project name to use for evaluation.
-
-    Prefers the dataset's ``project_name`` when set. If the caller also passed
-    a ``project_name``, log a deprecation warning and ignore the override so
-    traces land in the dataset's project.
-
-    Falls back to the caller's ``project_name`` when the dataset has none, to
-    preserve backward compatibility during the deprecation period.
-    """
-    if value_from_dataset is None:
-        return value_from_user
-
-    if value_from_user is not None:
-        LOGGER.warning(
-            "The `project_name` parameter of `%s()` is deprecated and will be "
-            "removed in a future version. The dataset's project ('%s') will "
-            "be used instead of the provided value ('%s').",
-            caller_name,
-            value_from_dataset,
-            value_from_user,
-        )
-
-    return value_from_dataset
 
 
 def _compute_experiment_scores(
@@ -338,7 +308,7 @@ def evaluate(
         experiment_name_prefix=experiment_name_prefix,
     )
 
-    project_name = _resolve_project_name(
+    project_name = helpers.resolve_project_name(
         value_from_dataset=dataset.project_name,
         value_from_user=project_name,
         caller_name="evaluate",
@@ -1086,7 +1056,7 @@ def evaluate_prompt(
         experiment_name_prefix=experiment_name_prefix,
     )
 
-    project_name = _resolve_project_name(
+    project_name = helpers.resolve_project_name(
         value_from_dataset=dataset.project_name,
         value_from_user=project_name,
         caller_name="evaluate_prompt",
@@ -1316,7 +1286,7 @@ def evaluate_optimization_trial(
         prompts=prompts,
     )
 
-    project_name = _resolve_project_name(
+    project_name = helpers.resolve_project_name(
         value_from_dataset=dataset.project_name,
         value_from_user=project_name,
         caller_name="evaluate_optimization_trial",

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -157,7 +157,7 @@ def _resolve_project_name(
     Falls back to the caller's ``project_name`` when the dataset has none, to
     preserve backward compatibility during the deprecation period.
     """
-    dataset_project_name = getattr(dataset_, "project_name", None)
+    dataset_project_name = dataset_.project_name
 
     if dataset_project_name is None:
         return project_name

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -560,7 +560,11 @@ def run_tests(
         ... )
         >>> print(f"Pass rate: {result.pass_rate:.0%}")
     """
-    suite_dataset = test_suite.__internal_api__dataset__
+    suite_dataset: Union[dataset.Dataset, dataset.DatasetVersion]
+    if isinstance(test_suite, test_suite_module.TestSuiteVersion):
+        suite_dataset = test_suite.__internal_api__dataset_version__
+    else:
+        suite_dataset = test_suite.__internal_api__dataset__
     client = suite_dataset.client
 
     return __internal_api__run_test_suite__(

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -313,7 +313,7 @@ def evaluate(
     """
     if isinstance(dataset, test_suite_module.TestSuite):
         # backwards compatibility for transition period
-        dataset = dataset.dataset
+        dataset = dataset.__internal_api__dataset__
 
     experiment_scoring_functions = (
         [] if experiment_scoring_functions is None else experiment_scoring_functions
@@ -560,11 +560,7 @@ def run_tests(
         ... )
         >>> print(f"Pass rate: {result.pass_rate:.0%}")
     """
-    suite_dataset: Union[dataset.Dataset, dataset.DatasetVersion]
-    if isinstance(test_suite, test_suite_module.TestSuiteVersion):
-        suite_dataset = test_suite._dataset_version
-    else:
-        suite_dataset = test_suite._dataset
+    suite_dataset = test_suite.__internal_api__dataset__
     client = suite_dataset.client
 
     return __internal_api__run_test_suite__(
@@ -1053,7 +1049,7 @@ def evaluate_prompt(
     """
     if isinstance(dataset, test_suite_module.TestSuite):
         # backwards compatibility for transition period
-        dataset = dataset.dataset
+        dataset = dataset.__internal_api__dataset__
 
     experiment_scoring_functions = (
         [] if experiment_scoring_functions is None else experiment_scoring_functions
@@ -1302,7 +1298,7 @@ def evaluate_optimization_trial(
     """
     if isinstance(dataset, test_suite_module.TestSuite):
         # backwards compatibility for transition period
-        dataset = dataset.dataset
+        dataset = dataset.__internal_api__dataset__
 
     experiment_scoring_functions = (
         [] if experiment_scoring_functions is None else experiment_scoring_functions

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -143,8 +143,8 @@ def _try_notifying_about_experiment_completion(
 
 
 def _resolve_project_name(
-    dataset_: Union[dataset.Dataset, dataset.DatasetVersion],
-    project_name: Optional[str],
+    value_from_dataset: Optional[str],
+    value_from_user: Optional[str],
     caller_name: str,
 ) -> Optional[str]:
     """
@@ -157,22 +157,20 @@ def _resolve_project_name(
     Falls back to the caller's ``project_name`` when the dataset has none, to
     preserve backward compatibility during the deprecation period.
     """
-    dataset_project_name = dataset_.project_name
+    if value_from_dataset is None:
+        return value_from_user
 
-    if dataset_project_name is None:
-        return project_name
-
-    if project_name is not None:
+    if value_from_user is not None:
         LOGGER.warning(
             "The `project_name` parameter of `%s()` is deprecated and will be "
             "removed in a future version. The dataset's project ('%s') will "
             "be used instead of the provided value ('%s').",
             caller_name,
-            dataset_project_name,
-            project_name,
+            value_from_dataset,
+            value_from_user,
         )
 
-    return dataset_project_name
+    return value_from_dataset
 
 
 def _compute_experiment_scores(
@@ -341,7 +339,9 @@ def evaluate(
     )
 
     project_name = _resolve_project_name(
-        dataset_=dataset, project_name=project_name, caller_name="evaluate"
+        value_from_dataset=dataset.project_name,
+        value_from_user=project_name,
+        caller_name="evaluate",
     )
 
     experiment = client.create_experiment(
@@ -1087,7 +1087,9 @@ def evaluate_prompt(
     )
 
     project_name = _resolve_project_name(
-        dataset_=dataset, project_name=project_name, caller_name="evaluate_prompt"
+        value_from_dataset=dataset.project_name,
+        value_from_user=project_name,
+        caller_name="evaluate_prompt",
     )
 
     experiment = client.create_experiment(
@@ -1315,8 +1317,8 @@ def evaluate_optimization_trial(
     )
 
     project_name = _resolve_project_name(
-        dataset_=dataset,
-        project_name=project_name,
+        value_from_dataset=dataset.project_name,
+        value_from_user=project_name,
         caller_name="evaluate_optimization_trial",
     )
 

--- a/sdks/python/src/opik/evaluation/helpers.py
+++ b/sdks/python/src/opik/evaluation/helpers.py
@@ -1,7 +1,13 @@
 import logging
-from typing import Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+
+from ..api_objects import opik_client
+from ..api_objects.dataset import dataset, dataset_item
+from . import samplers
 
 LOGGER = logging.getLogger(__name__)
+
+EVALUATION_STREAM_DATASET_BATCH_SIZE = 200
 
 
 def resolve_project_name(
@@ -33,3 +39,82 @@ def resolve_project_name(
         )
 
     return value_from_dataset
+
+
+def merge_blueprint_into_config(
+    client: "opik_client.Opik",
+    blueprint_id: str,
+    experiment_config: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Add blueprint reference to experiment_config under ``agent_configuration``."""
+    experiment_config = dict(experiment_config) if experiment_config else {}
+    agent_config: Dict[str, str] = {"_blueprint_id": blueprint_id}
+    try:
+        blueprint = client._rest_client.agent_configs.get_blueprint_by_id(
+            blueprint_id=blueprint_id,
+        )
+        if blueprint.name:
+            agent_config["blueprint_version"] = blueprint.name
+    except Exception:
+        LOGGER.debug("Failed to fetch blueprint %s", blueprint_id, exc_info=True)
+    experiment_config["agent_configuration"] = agent_config
+    return experiment_config
+
+
+def _calculate_total_items(
+    dataset_: Union[dataset.Dataset, dataset.DatasetVersion],
+    nb_samples: Optional[int],
+    dataset_item_ids: Optional[List[str]],
+) -> Optional[int]:
+    """Calculate the total number of items that will be evaluated."""
+    if dataset_item_ids is not None:
+        return len(dataset_item_ids)
+
+    if nb_samples is not None:
+        if dataset_.dataset_items_count is not None:
+            return min(nb_samples, dataset_.dataset_items_count)
+        return nb_samples
+
+    return dataset_.dataset_items_count
+
+
+def resolve_dataset_items_generator(
+    dataset_: Union[dataset.Dataset, dataset.DatasetVersion],
+    nb_samples: Optional[int],
+    dataset_item_ids: Optional[List[str]],
+    dataset_sampler: Optional[samplers.BaseDatasetSampler],
+    dataset_filter_string: Optional[str],
+) -> Tuple[Iterator[dataset_item.DatasetItem], Optional[int]]:
+    """
+    Resolve dataset items for evaluation.
+
+    Handles streaming vs sampling, and calculates total item count.
+
+    Returns:
+        Tuple of (items iterator, total item count or None).
+    """
+    if dataset_sampler is None:
+        items_iter = dataset_.__internal_api__stream_items_as_dataclasses__(
+            nb_samples=nb_samples,
+            dataset_item_ids=dataset_item_ids,
+            batch_size=EVALUATION_STREAM_DATASET_BATCH_SIZE,
+            filter_string=dataset_filter_string,
+        )
+        total = _calculate_total_items(
+            dataset_=dataset_,
+            nb_samples=nb_samples,
+            dataset_item_ids=dataset_item_ids,
+        )
+        return items_iter, total
+
+    LOGGER.info("Dataset streaming disabled due to sampler")
+    items_list = list(
+        dataset_.__internal_api__stream_items_as_dataclasses__(
+            nb_samples=nb_samples,
+            dataset_item_ids=dataset_item_ids,
+            batch_size=EVALUATION_STREAM_DATASET_BATCH_SIZE,
+            filter_string=dataset_filter_string,
+        )
+    )
+    items_list = dataset_sampler.sample(items_list)
+    return iter(items_list), len(items_list)

--- a/sdks/python/src/opik/evaluation/helpers.py
+++ b/sdks/python/src/opik/evaluation/helpers.py
@@ -1,0 +1,35 @@
+import logging
+from typing import Optional
+
+LOGGER = logging.getLogger(__name__)
+
+
+def resolve_project_name(
+    value_from_dataset: Optional[str],
+    value_from_user: Optional[str],
+    caller_name: str,
+) -> Optional[str]:
+    """
+    Resolve which project name to use for evaluation.
+
+    Prefers the dataset's ``project_name`` when set. If the caller also passed
+    a ``project_name``, log a deprecation warning and ignore the override so
+    traces land in the dataset's project.
+
+    Falls back to the caller's ``project_name`` when the dataset has none, to
+    preserve backward compatibility during the deprecation period.
+    """
+    if value_from_dataset is None:
+        return value_from_user
+
+    if value_from_user is not None:
+        LOGGER.warning(
+            "The `project_name` parameter of `%s()` is deprecated and will be "
+            "removed in a future version. The dataset's project ('%s') will "
+            "be used instead of the provided value ('%s').",
+            caller_name,
+            value_from_dataset,
+            value_from_user,
+        )
+
+    return value_from_dataset

--- a/sdks/python/tests/e2e/compatibility_v1/evaluation/test_evaluate_streaming.py
+++ b/sdks/python/tests/e2e/compatibility_v1/evaluation/test_evaluate_streaming.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import opik
 from opik.api_objects import rest_stream_parser
-from opik.evaluation import evaluator as evaluator_module
+from opik.evaluation import helpers as helpers_module
 from opik.evaluation.metrics import score_result
 from opik.types import FeedbackScoreDict
 
@@ -87,7 +87,7 @@ def test_streaming_starts_evaluation_before_complete_download(
             side_effect=tracked_read_and_parse_stream,
         ),
         mock.patch.object(
-            evaluator_module, "EVALUATION_STREAM_DATASET_BATCH_SIZE", TEST_BATCH_SIZE
+            helpers_module, "EVALUATION_STREAM_DATASET_BATCH_SIZE", TEST_BATCH_SIZE
         ),
     ):
         # Run evaluation with streaming

--- a/sdks/python/tests/e2e/evaluation/test_evaluate_streaming.py
+++ b/sdks/python/tests/e2e/evaluation/test_evaluate_streaming.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import opik
 from opik.api_objects import rest_stream_parser
-from opik.evaluation import evaluator as evaluator_module
+from opik.evaluation import helpers as helpers_module
 from opik.evaluation.metrics import score_result
 from opik.types import FeedbackScoreDict
 
@@ -88,7 +88,7 @@ def test_streaming_starts_evaluation_before_complete_download(
             side_effect=tracked_read_and_parse_stream,
         ),
         mock.patch.object(
-            evaluator_module, "EVALUATION_STREAM_DATASET_BATCH_SIZE", TEST_BATCH_SIZE
+            helpers_module, "EVALUATION_STREAM_DATASET_BATCH_SIZE", TEST_BATCH_SIZE
         ),
     ):
         # Run evaluation with streaming

--- a/sdks/python/tests/unit/evaluation/test_evaluate.py
+++ b/sdks/python/tests/unit/evaluation/test_evaluate.py
@@ -11,6 +11,7 @@ from opik.api_objects.dataset import dataset_item
 from opik.api_objects.experiment import experiment
 from opik.evaluation import (
     evaluator as evaluator_module,
+    helpers as helpers_module,
     metrics,
     samplers,
     score_statistics,
@@ -1238,7 +1239,7 @@ def test_evaluate__with_sampler_and_nb_samples__total_items_reflects_final_count
     mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
         nb_samples=10,
         dataset_item_ids=None,
-        batch_size=evaluator_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        batch_size=helpers_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
         filter_string=None,
     )
 
@@ -2838,7 +2839,7 @@ def test_evaluate__uses_streaming_by_default(fake_backend):
     mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
         nb_samples=None,
         dataset_item_ids=None,
-        batch_size=evaluator_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        batch_size=helpers_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
         filter_string=None,
     )
 
@@ -2904,7 +2905,7 @@ def test_evaluate__uses_streaming_with_dataset_item_ids(fake_backend):
     mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
         nb_samples=None,
         dataset_item_ids=["dataset-item-id-1"],
-        batch_size=evaluator_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        batch_size=helpers_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
         filter_string=None,
     )
 
@@ -2977,7 +2978,7 @@ def test_evaluate__falls_back_to_non_streaming_with_dataset_sampler(fake_backend
     mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
         nb_samples=None,
         dataset_item_ids=None,
-        batch_size=evaluator_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        batch_size=helpers_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
         filter_string=None,
     )
 
@@ -3052,7 +3053,7 @@ def test_evaluate__streaming_with_nb_samples(fake_backend):
     mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
         nb_samples=2,
         dataset_item_ids=None,
-        batch_size=evaluator_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        batch_size=helpers_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
         filter_string=None,
     )
 
@@ -3098,7 +3099,7 @@ def test_evaluate_prompt__with_filter_string__passes_to_streaming(fake_backend):
     mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
         nb_samples=None,
         dataset_item_ids=None,
-        batch_size=evaluator_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        batch_size=helpers_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
         filter_string=filter_string,
     )
 
@@ -3152,7 +3153,7 @@ def test_evaluate_prompt__with_filter_string_and_nb_samples__passes_both_paramet
     mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
         nb_samples=2,
         dataset_item_ids=None,
-        batch_size=evaluator_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        batch_size=helpers_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
         filter_string=filter_string,
     )
 
@@ -3207,7 +3208,7 @@ def test_evaluate_prompt__with_filter_string_and_dataset_sampler__passes_filter_
     mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
         nb_samples=None,
         dataset_item_ids=None,
-        batch_size=evaluator_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        batch_size=helpers_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
         filter_string=filter_string,
     )
 
@@ -3254,7 +3255,7 @@ def test_evaluate__with_filter_string__passes_to_streaming(fake_backend):
     mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
         nb_samples=None,
         dataset_item_ids=None,
-        batch_size=evaluator_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        batch_size=helpers_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
         filter_string=filter_string,
     )
 
@@ -3304,7 +3305,7 @@ def test_evaluate__with_filter_string_and_nb_samples__passes_both_parameters(
     mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
         nb_samples=2,
         dataset_item_ids=None,
-        batch_size=evaluator_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        batch_size=helpers_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
         filter_string=filter_string,
     )
 
@@ -3355,7 +3356,7 @@ def test_evaluate__with_filter_string_and_dataset_sampler__passes_filter_string(
     mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
         nb_samples=None,
         dataset_item_ids=None,
-        batch_size=evaluator_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        batch_size=helpers_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
         filter_string=filter_string,
     )
 
@@ -3405,7 +3406,7 @@ def test_evaluate_optimization_trial__with_filter_string__passes_to_streaming(
     mock_dataset.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
         nb_samples=None,
         dataset_item_ids=None,
-        batch_size=evaluator_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+        batch_size=helpers_module.EVALUATION_STREAM_DATASET_BATCH_SIZE,
         filter_string=filter_string,
     )
 
@@ -3579,47 +3580,6 @@ def test_evaluate__verbose_zero__progress_bar_disabled(fake_backend):
         desc=mock.ANY,
         total=mock.ANY,
     )
-
-
-class TestMergeBlueprintIntoConfig:
-    @staticmethod
-    def _make_blueprint(id, name):
-        bp = mock.MagicMock()
-        bp.id = id
-        bp.name = name
-        return bp
-
-    def test_blueprint_fetched_and_version_stored(self):
-        mock_client = mock.Mock()
-        mock_client._rest_client.agent_configs.get_blueprint_by_id.return_value = (
-            self._make_blueprint("bp-123", "v9")
-        )
-
-        result = evaluator_module._merge_blueprint_into_config(
-            mock_client,
-            "bp-123",
-            {"model": "gpt-4o"},
-        )
-
-        assert result["model"] == "gpt-4o"
-        assert result["agent_configuration"] == {
-            "_blueprint_id": "bp-123",
-            "blueprint_version": "v9",
-        }
-
-    def test_blueprint_fetch_fails_still_stores_id(self):
-        mock_client = mock.Mock()
-        mock_client._rest_client.agent_configs.get_blueprint_by_id.side_effect = (
-            Exception("not found")
-        )
-
-        result = evaluator_module._merge_blueprint_into_config(
-            mock_client,
-            "bp-456",
-            None,
-        )
-
-        assert result["agent_configuration"] == {"_blueprint_id": "bp-456"}
 
 
 def test_evaluate__dataset_has_project_name__caller_override_ignored_and_warning_logged(

--- a/sdks/python/tests/unit/evaluation/test_evaluate.py
+++ b/sdks/python/tests/unit/evaluation/test_evaluate.py
@@ -1,3 +1,4 @@
+import logging
 from contextlib import contextmanager
 from typing import Any, Dict, List
 from unittest import mock
@@ -3579,3 +3580,324 @@ class TestMergeBlueprintIntoConfig:
         )
 
         assert result["agent_configuration"] == {"_blueprint_id": "bp-456"}
+
+
+class TestResolveProjectName:
+    def test_dataset_has_no_project__caller_value_used(self, capture_log):
+        mock_dataset = mock.MagicMock()
+        mock_dataset.project_name = None
+
+        resolved = evaluator_module._resolve_project_name(
+            dataset_=mock_dataset,
+            project_name="caller-project",
+            caller_name="evaluate",
+        )
+
+        assert resolved == "caller-project"
+        assert capture_log.records == []
+
+    def test_dataset_has_no_project__caller_none__returns_none(self, capture_log):
+        mock_dataset = mock.MagicMock()
+        mock_dataset.project_name = None
+
+        resolved = evaluator_module._resolve_project_name(
+            dataset_=mock_dataset, project_name=None, caller_name="evaluate"
+        )
+
+        assert resolved is None
+        assert capture_log.records == []
+
+    def test_dataset_has_project__caller_none__returns_dataset_project__no_warning(
+        self, capture_log
+    ):
+        mock_dataset = mock.MagicMock()
+        mock_dataset.project_name = "dataset-project"
+
+        resolved = evaluator_module._resolve_project_name(
+            dataset_=mock_dataset, project_name=None, caller_name="evaluate"
+        )
+
+        assert resolved == "dataset-project"
+        assert capture_log.records == []
+
+    def test_dataset_has_project__caller_override__dataset_wins_and_warning_logged(
+        self, capture_log
+    ):
+        mock_dataset = mock.MagicMock()
+        mock_dataset.project_name = "dataset-project"
+
+        resolved = evaluator_module._resolve_project_name(
+            dataset_=mock_dataset,
+            project_name="caller-project",
+            caller_name="evaluate_prompt",
+        )
+
+        assert resolved == "dataset-project"
+        warning_records = [
+            record
+            for record in capture_log.records
+            if record.levelno == logging.WARNING
+        ]
+        assert len(warning_records) == 1
+        message = warning_records[0].getMessage()
+        assert "deprecated" in message
+        assert "evaluate_prompt()" in message
+        assert "dataset-project" in message
+        assert "caller-project" in message
+
+
+def test_evaluate__dataset_has_project_name__caller_override_ignored_and_warning_logged(
+    fake_backend, capture_log
+):
+    mock_dataset = create_mock_dataset(
+        items=[
+            dataset_item.DatasetItem(
+                id="item-1", input={"message": "hello"}, reference="hello"
+            ),
+        ]
+    )
+    mock_dataset.project_name = "dataset-project"
+
+    def say_task(item: Dict[str, Any]):
+        return {"output": "hello"}
+
+    mock_experiment, mock_create_experiment, mock_get_experiment_url_by_id = (
+        create_mock_experiment()
+    )
+
+    with patch_evaluation_dependencies(
+        mock_create_experiment, mock_get_experiment_url_by_id
+    ):
+        evaluation.evaluate(
+            dataset=mock_dataset,
+            task=say_task,
+            experiment_name="project-override-test",
+            project_name="caller-project",
+            scoring_metrics=[metrics.Equals()],
+            task_threads=1,
+            verbose=0,
+        )
+
+    mock_create_experiment.assert_called_once_with(
+        dataset_name="the-dataset-name",
+        name="project-override-test",
+        experiment_config=None,
+        prompts=None,
+        tags=None,
+        dataset_version_id=None,
+        project_name="dataset-project",
+    )
+
+    deprecation_warnings = [
+        record
+        for record in capture_log.records
+        if record.levelno == logging.WARNING
+        and "deprecated" in record.getMessage()
+        and "project_name" in record.getMessage()
+    ]
+    assert len(deprecation_warnings) == 1
+
+
+def test_evaluate__dataset_has_no_project_name__caller_value_preserved(fake_backend):
+    mock_dataset = create_mock_dataset(
+        items=[
+            dataset_item.DatasetItem(
+                id="item-1", input={"message": "hello"}, reference="hello"
+            ),
+        ]
+    )
+    mock_dataset.project_name = None
+
+    def say_task(item: Dict[str, Any]):
+        return {"output": "hello"}
+
+    mock_experiment, mock_create_experiment, mock_get_experiment_url_by_id = (
+        create_mock_experiment()
+    )
+
+    with patch_evaluation_dependencies(
+        mock_create_experiment, mock_get_experiment_url_by_id
+    ):
+        evaluation.evaluate(
+            dataset=mock_dataset,
+            task=say_task,
+            experiment_name="project-fallback-test",
+            project_name="caller-project",
+            scoring_metrics=[metrics.Equals()],
+            task_threads=1,
+            verbose=0,
+        )
+
+    mock_create_experiment.assert_called_once_with(
+        dataset_name="the-dataset-name",
+        name="project-fallback-test",
+        experiment_config=None,
+        prompts=None,
+        tags=None,
+        dataset_version_id=None,
+        project_name="caller-project",
+    )
+
+
+def test_evaluate_prompt__dataset_has_project_name__caller_override_ignored_and_warning_logged(
+    fake_backend, capture_log
+):
+    MODEL_NAME = "gpt-3.5-turbo"
+    mock_dataset = create_mock_dataset(
+        items=[
+            dataset_item.DatasetItem(id="item-1", input="hello", reference="hello"),
+        ]
+    )
+    mock_dataset.project_name = "dataset-project"
+
+    mock_experiment, mock_create_experiment, mock_get_experiment_url_by_id = (
+        create_mock_experiment()
+    )
+    mock_models_factory_get, _mock_model = create_mock_model(model_name=MODEL_NAME)
+
+    with patch_evaluation_dependencies(
+        mock_create_experiment,
+        mock_get_experiment_url_by_id,
+        mock_models_factory_get,
+    ):
+        evaluation.evaluate_prompt(
+            dataset=mock_dataset,
+            messages=[{"role": "user", "content": "Say: {{input}}"}],
+            experiment_name="prompt-project-override-test",
+            project_name="caller-project",
+            model=MODEL_NAME,
+            scoring_metrics=[metrics.Equals()],
+            task_threads=1,
+            verbose=0,
+        )
+
+    call_kwargs = mock_create_experiment.call_args.kwargs
+    assert call_kwargs["project_name"] == "dataset-project"
+
+    deprecation_warnings = [
+        record
+        for record in capture_log.records
+        if record.levelno == logging.WARNING
+        and "deprecated" in record.getMessage()
+        and "evaluate_prompt()" in record.getMessage()
+    ]
+    assert len(deprecation_warnings) == 1
+
+
+def test_evaluate_prompt__dataset_has_no_project_name__caller_value_preserved(
+    fake_backend,
+):
+    MODEL_NAME = "gpt-3.5-turbo"
+    mock_dataset = create_mock_dataset(
+        items=[
+            dataset_item.DatasetItem(id="item-1", input="hello", reference="hello"),
+        ]
+    )
+    mock_dataset.project_name = None
+
+    mock_experiment, mock_create_experiment, mock_get_experiment_url_by_id = (
+        create_mock_experiment()
+    )
+    mock_models_factory_get, _mock_model = create_mock_model(model_name=MODEL_NAME)
+
+    with patch_evaluation_dependencies(
+        mock_create_experiment,
+        mock_get_experiment_url_by_id,
+        mock_models_factory_get,
+    ):
+        evaluation.evaluate_prompt(
+            dataset=mock_dataset,
+            messages=[{"role": "user", "content": "Say: {{input}}"}],
+            experiment_name="prompt-project-fallback-test",
+            project_name="caller-project",
+            model=MODEL_NAME,
+            scoring_metrics=[metrics.Equals()],
+            task_threads=1,
+            verbose=0,
+        )
+
+    call_kwargs = mock_create_experiment.call_args.kwargs
+    assert call_kwargs["project_name"] == "caller-project"
+
+
+def test_evaluate_optimization_trial__dataset_has_project_name__caller_override_ignored_and_warning_logged(
+    fake_backend, capture_log
+):
+    mock_dataset = create_mock_dataset(
+        items=[
+            dataset_item.DatasetItem(
+                id="item-1", input={"message": "hello"}, reference="hello"
+            ),
+        ]
+    )
+    mock_dataset.project_name = "dataset-project"
+
+    def say_task(item: Dict[str, Any]):
+        return {"output": "hello"}
+
+    mock_experiment, mock_create_experiment, mock_get_experiment_url_by_id = (
+        create_mock_experiment()
+    )
+
+    with patch_evaluation_dependencies(
+        mock_create_experiment, mock_get_experiment_url_by_id
+    ):
+        evaluator_module.evaluate_optimization_trial(
+            optimization_id="opt-123",
+            dataset=mock_dataset,
+            task=say_task,
+            experiment_name="trial-project-override-test",
+            project_name="caller-project",
+            scoring_metrics=[metrics.Equals()],
+            task_threads=1,
+            verbose=0,
+        )
+
+    call_kwargs = mock_create_experiment.call_args.kwargs
+    assert call_kwargs["project_name"] == "dataset-project"
+
+    deprecation_warnings = [
+        record
+        for record in capture_log.records
+        if record.levelno == logging.WARNING
+        and "deprecated" in record.getMessage()
+        and "evaluate_optimization_trial()" in record.getMessage()
+    ]
+    assert len(deprecation_warnings) == 1
+
+
+def test_evaluate_optimization_trial__dataset_has_no_project_name__caller_value_preserved(
+    fake_backend,
+):
+    mock_dataset = create_mock_dataset(
+        items=[
+            dataset_item.DatasetItem(
+                id="item-1", input={"message": "hello"}, reference="hello"
+            ),
+        ]
+    )
+    mock_dataset.project_name = None
+
+    def say_task(item: Dict[str, Any]):
+        return {"output": "hello"}
+
+    mock_experiment, mock_create_experiment, mock_get_experiment_url_by_id = (
+        create_mock_experiment()
+    )
+
+    with patch_evaluation_dependencies(
+        mock_create_experiment, mock_get_experiment_url_by_id
+    ):
+        evaluator_module.evaluate_optimization_trial(
+            optimization_id="opt-123",
+            dataset=mock_dataset,
+            task=say_task,
+            experiment_name="trial-project-fallback-test",
+            project_name="caller-project",
+            scoring_metrics=[metrics.Equals()],
+            task_threads=1,
+            verbose=0,
+        )
+
+    call_kwargs = mock_create_experiment.call_args.kwargs
+    assert call_kwargs["project_name"] == "caller-project"

--- a/sdks/python/tests/unit/evaluation/test_evaluate.py
+++ b/sdks/python/tests/unit/evaluation/test_evaluate.py
@@ -35,11 +35,13 @@ def create_mock_dataset(
             "id",
             "dataset_items_count",
             "get_version_info",
+            "project_name",
         ]
     )
     mock_dataset.name = name
     mock_dataset.dataset_items_count = None
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     if items is not None:
         mock_dataset.__internal_api__stream_items_as_dataclasses__.return_value = iter(
             items
@@ -123,12 +125,14 @@ def test_evaluate__happyflow(
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = None
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -376,12 +380,14 @@ def test_evaluate_with_scoring_key_mapping(
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = None
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -639,12 +645,14 @@ def test_evaluate___output_key_is_missing_in_task_output_dict__equals_metric_mis
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = None
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -702,12 +710,14 @@ def test_evaluate__exception_raised_from_the_task__error_info_added_to_the_trace
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = None
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -823,12 +833,14 @@ def test_evaluate__with_random_sampler__happy_flow(
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = None
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -956,12 +968,14 @@ def test_evaluate__with_random_sampler__total_items_reflects_sampled_count(
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = 10  # Original dataset has 10 items
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -1046,12 +1060,14 @@ def test_evaluate__with_task_span_metrics__total_items_reflects_actual_count(
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = 5
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -1141,12 +1157,14 @@ def test_evaluate__with_sampler_and_nb_samples__total_items_reflects_final_count
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = 100  # Original dataset has 100 items
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -1265,12 +1283,14 @@ def test_evaluate_prompt_happyflow(
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = None
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -1488,12 +1508,14 @@ def test_evaluate__aggregated_metric__happy_flow(
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = None
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -1845,12 +1867,14 @@ def test_evaluate_prompt__with_random_sampling__happy_flow(
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = None
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -1984,12 +2008,14 @@ def test_evaluate__2_trials_lead_to_2_experiment_items_per_dataset_item(
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = None
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 2,
         "pass_threshold": 1,
@@ -2146,12 +2172,14 @@ def test_evaluate_prompt__2_trials_lead_to_2_experiment_items_per_dataset_item(
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = None
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 2,
         "pass_threshold": 1,
@@ -2323,11 +2351,13 @@ def test_evaluate__with_experiment_scores(fake_backend):
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "test-dataset"
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -2426,11 +2456,13 @@ def test_evaluate__with_experiment_scores_empty_results(fake_backend):
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "test-dataset"
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -2753,12 +2785,14 @@ def test_evaluate__uses_streaming_by_default(fake_backend):
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = None
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -2818,12 +2852,14 @@ def test_evaluate__uses_streaming_with_dataset_item_ids(fake_backend):
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = None
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -2882,12 +2918,14 @@ def test_evaluate__falls_back_to_non_streaming_with_dataset_sampler(fake_backend
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.dataset_items_count = None
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,
@@ -2955,10 +2993,12 @@ def test_evaluate__streaming_with_nb_samples(fake_backend):
             "dataset_items_count",
             "get_version_info",
             "get_execution_policy",
+            "project_name",
             "get_evaluators",
         ]
     )
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.get_execution_policy.return_value = {
         "runs_per_item": 1,
         "pass_threshold": 1,

--- a/sdks/python/tests/unit/evaluation/test_evaluate.py
+++ b/sdks/python/tests/unit/evaluation/test_evaluate.py
@@ -3622,62 +3622,6 @@ class TestMergeBlueprintIntoConfig:
         assert result["agent_configuration"] == {"_blueprint_id": "bp-456"}
 
 
-class TestResolveProjectName:
-    def test_dataset_has_no_project__user_value_used(self, capture_log):
-        resolved = evaluator_module._resolve_project_name(
-            value_from_dataset=None,
-            value_from_user="caller-project",
-            caller_name="evaluate",
-        )
-
-        assert resolved == "caller-project"
-        assert capture_log.records == []
-
-    def test_dataset_has_no_project__user_none__returns_none(self, capture_log):
-        resolved = evaluator_module._resolve_project_name(
-            value_from_dataset=None,
-            value_from_user=None,
-            caller_name="evaluate",
-        )
-
-        assert resolved is None
-        assert capture_log.records == []
-
-    def test_dataset_has_project__user_none__returns_dataset_project__no_warning(
-        self, capture_log
-    ):
-        resolved = evaluator_module._resolve_project_name(
-            value_from_dataset="dataset-project",
-            value_from_user=None,
-            caller_name="evaluate",
-        )
-
-        assert resolved == "dataset-project"
-        assert capture_log.records == []
-
-    def test_dataset_has_project__user_override__dataset_wins_and_warning_logged(
-        self, capture_log
-    ):
-        resolved = evaluator_module._resolve_project_name(
-            value_from_dataset="dataset-project",
-            value_from_user="caller-project",
-            caller_name="evaluate_prompt",
-        )
-
-        assert resolved == "dataset-project"
-        warning_records = [
-            record
-            for record in capture_log.records
-            if record.levelno == logging.WARNING
-        ]
-        assert len(warning_records) == 1
-        message = warning_records[0].getMessage()
-        assert "deprecated" in message
-        assert "evaluate_prompt()" in message
-        assert "dataset-project" in message
-        assert "caller-project" in message
-
-
 def test_evaluate__dataset_has_project_name__caller_override_ignored_and_warning_logged(
     fake_backend, capture_log
 ):

--- a/sdks/python/tests/unit/evaluation/test_evaluate.py
+++ b/sdks/python/tests/unit/evaluation/test_evaluate.py
@@ -3623,52 +3623,44 @@ class TestMergeBlueprintIntoConfig:
 
 
 class TestResolveProjectName:
-    def test_dataset_has_no_project__caller_value_used(self, capture_log):
-        mock_dataset = mock.MagicMock()
-        mock_dataset.project_name = None
-
+    def test_dataset_has_no_project__user_value_used(self, capture_log):
         resolved = evaluator_module._resolve_project_name(
-            dataset_=mock_dataset,
-            project_name="caller-project",
+            value_from_dataset=None,
+            value_from_user="caller-project",
             caller_name="evaluate",
         )
 
         assert resolved == "caller-project"
         assert capture_log.records == []
 
-    def test_dataset_has_no_project__caller_none__returns_none(self, capture_log):
-        mock_dataset = mock.MagicMock()
-        mock_dataset.project_name = None
-
+    def test_dataset_has_no_project__user_none__returns_none(self, capture_log):
         resolved = evaluator_module._resolve_project_name(
-            dataset_=mock_dataset, project_name=None, caller_name="evaluate"
+            value_from_dataset=None,
+            value_from_user=None,
+            caller_name="evaluate",
         )
 
         assert resolved is None
         assert capture_log.records == []
 
-    def test_dataset_has_project__caller_none__returns_dataset_project__no_warning(
+    def test_dataset_has_project__user_none__returns_dataset_project__no_warning(
         self, capture_log
     ):
-        mock_dataset = mock.MagicMock()
-        mock_dataset.project_name = "dataset-project"
-
         resolved = evaluator_module._resolve_project_name(
-            dataset_=mock_dataset, project_name=None, caller_name="evaluate"
+            value_from_dataset="dataset-project",
+            value_from_user=None,
+            caller_name="evaluate",
         )
 
         assert resolved == "dataset-project"
         assert capture_log.records == []
 
-    def test_dataset_has_project__caller_override__dataset_wins_and_warning_logged(
+    def test_dataset_has_project__user_override__dataset_wins_and_warning_logged(
         self, capture_log
     ):
-        mock_dataset = mock.MagicMock()
-        mock_dataset.project_name = "dataset-project"
-
         resolved = evaluator_module._resolve_project_name(
-            dataset_=mock_dataset,
-            project_name="caller-project",
+            value_from_dataset="dataset-project",
+            value_from_user="caller-project",
             caller_name="evaluate_prompt",
         )
 

--- a/sdks/python/tests/unit/evaluation/test_evaluate_experiment_name.py
+++ b/sdks/python/tests/unit/evaluation/test_evaluate_experiment_name.py
@@ -36,10 +36,12 @@ def test_evaluate__with_experiment_name_prefix__generates_name_with_prefix(
             "name",
             "dataset_items_count",
             "get_version_info",
+            "project_name",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.dataset_items_count = None
     mock_dataset.id = "dataset-id"
     mock_dataset.__internal_api__stream_items_as_dataclasses__.return_value = iter(
@@ -103,10 +105,12 @@ def test_evaluate__with_experiment_name_prefix_and_experiment_name__experiment_n
             "name",
             "dataset_items_count",
             "get_version_info",
+            "project_name",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.dataset_items_count = None
     mock_dataset.id = "dataset-id"
     mock_dataset.__internal_api__stream_items_as_dataclasses__.return_value = iter(
@@ -163,10 +167,12 @@ def test_evaluate__with_experiment_name_prefix_only__generates_unique_name(
             "name",
             "dataset_items_count",
             "get_version_info",
+            "project_name",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.dataset_items_count = None
     mock_dataset.id = "dataset-id"
     mock_dataset.__internal_api__stream_items_as_dataclasses__.return_value = iter(
@@ -233,10 +239,12 @@ def test_evaluate__without_experiment_name_prefix_or_name__generates_default_nam
             "name",
             "dataset_items_count",
             "get_version_info",
+            "project_name",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.dataset_items_count = None
     mock_dataset.id = "dataset-id"
     mock_dataset.__internal_api__stream_items_as_dataclasses__.return_value = iter(
@@ -292,10 +300,12 @@ def test_evaluate__with_experiment_name_prefix__multiple_calls_generate_unique_n
             "name",
             "dataset_items_count",
             "get_version_info",
+            "project_name",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.dataset_items_count = None
     mock_dataset.id = "dataset-id"
     mock_dataset.__internal_api__stream_items_as_dataclasses__.return_value = iter(
@@ -394,10 +404,12 @@ def test_evaluate_prompt__with_experiment_name_prefix__generates_name_with_prefi
             "name",
             "dataset_items_count",
             "get_version_info",
+            "project_name",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.dataset_items_count = None
     mock_dataset.id = "dataset-id"
     mock_dataset.__internal_api__stream_items_as_dataclasses__.return_value = iter(
@@ -468,10 +480,12 @@ def test_evaluate_prompt__with_experiment_name_prefix_and_experiment_name__exper
             "name",
             "dataset_items_count",
             "get_version_info",
+            "project_name",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.dataset_items_count = None
     mock_dataset.id = "dataset-id"
     mock_dataset.__internal_api__stream_items_as_dataclasses__.return_value = iter(
@@ -538,10 +552,12 @@ def test_evaluate_prompt__with_experiment_name_prefix_only__generates_unique_nam
             "name",
             "dataset_items_count",
             "get_version_info",
+            "project_name",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.dataset_items_count = None
     mock_dataset.id = "dataset-id"
     mock_dataset.__internal_api__stream_items_as_dataclasses__.return_value = iter(
@@ -615,10 +631,12 @@ def test_evaluate_prompt__without_experiment_name_prefix_or_name__generates_defa
             "name",
             "dataset_items_count",
             "get_version_info",
+            "project_name",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.dataset_items_count = None
     mock_dataset.id = "dataset-id"
     mock_dataset.__internal_api__stream_items_as_dataclasses__.return_value = iter(
@@ -683,10 +701,12 @@ def test_evaluate_prompt__with_experiment_name_prefix__multiple_calls_generate_u
             "name",
             "dataset_items_count",
             "get_version_info",
+            "project_name",
         ]
     )
     mock_dataset.name = "the-dataset-name"
     mock_dataset.get_version_info.return_value = None
+    mock_dataset.project_name = None
     mock_dataset.dataset_items_count = None
     mock_dataset.id = "dataset-id"
     mock_dataset.__internal_api__stream_items_as_dataclasses__.return_value = iter(

--- a/sdks/python/tests/unit/evaluation/test_helpers.py
+++ b/sdks/python/tests/unit/evaluation/test_helpers.py
@@ -1,5 +1,8 @@
 import logging
+from types import SimpleNamespace
+from unittest import mock
 
+from opik.api_objects.dataset import dataset_item
 from opik.evaluation import helpers
 
 
@@ -57,3 +60,166 @@ class TestResolveProjectName:
         assert "evaluate_prompt()" in message
         assert "dataset-project" in message
         assert "caller-project" in message
+
+
+class TestCalculateTotalItems:
+    def test_dataset_item_ids_provided__returns_len_of_ids(self):
+        dataset_ = SimpleNamespace(dataset_items_count=100)
+
+        assert (
+            helpers._calculate_total_items(
+                dataset_=dataset_,
+                nb_samples=None,
+                dataset_item_ids=["a", "b", "c"],
+            )
+            == 3
+        )
+
+    def test_nb_samples_only__capped_by_dataset_count(self):
+        dataset_ = SimpleNamespace(dataset_items_count=5)
+
+        assert (
+            helpers._calculate_total_items(
+                dataset_=dataset_, nb_samples=10, dataset_item_ids=None
+            )
+            == 5
+        )
+
+    def test_nb_samples_only__below_dataset_count(self):
+        dataset_ = SimpleNamespace(dataset_items_count=100)
+
+        assert (
+            helpers._calculate_total_items(
+                dataset_=dataset_, nb_samples=10, dataset_item_ids=None
+            )
+            == 10
+        )
+
+    def test_nb_samples_only__dataset_count_none__returns_nb_samples(self):
+        dataset_ = SimpleNamespace(dataset_items_count=None)
+
+        assert (
+            helpers._calculate_total_items(
+                dataset_=dataset_, nb_samples=7, dataset_item_ids=None
+            )
+            == 7
+        )
+
+    def test_neither_provided__returns_dataset_count(self):
+        dataset_ = SimpleNamespace(dataset_items_count=42)
+
+        assert (
+            helpers._calculate_total_items(
+                dataset_=dataset_, nb_samples=None, dataset_item_ids=None
+            )
+            == 42
+        )
+
+
+class TestResolveDatasetItemsGenerator:
+    @staticmethod
+    def _make_dataset(items, items_count=None):
+        dataset_ = SimpleNamespace(dataset_items_count=items_count)
+        dataset_.__internal_api__stream_items_as_dataclasses__ = mock.MagicMock(
+            return_value=iter(items)
+        )
+        return dataset_
+
+    def test_no_sampler__returns_streamed_iterator_and_total(self):
+        items = [dataset_item.DatasetItem(id=f"i-{i}") for i in range(3)]
+        dataset_ = self._make_dataset(items, items_count=10)
+
+        items_iter, total = helpers.resolve_dataset_items_generator(
+            dataset_=dataset_,
+            nb_samples=None,
+            dataset_item_ids=None,
+            dataset_sampler=None,
+            dataset_filter_string=None,
+        )
+
+        assert list(items_iter) == items
+        assert total == 10
+        dataset_.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
+            nb_samples=None,
+            dataset_item_ids=None,
+            batch_size=helpers.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+            filter_string=None,
+        )
+
+    def test_no_sampler__nb_samples_and_filter_forwarded(self):
+        items = [dataset_item.DatasetItem(id="i-0")]
+        dataset_ = self._make_dataset(items, items_count=100)
+
+        _, total = helpers.resolve_dataset_items_generator(
+            dataset_=dataset_,
+            nb_samples=2,
+            dataset_item_ids=None,
+            dataset_sampler=None,
+            dataset_filter_string='tags contains "x"',
+        )
+
+        assert total == 2
+        dataset_.__internal_api__stream_items_as_dataclasses__.assert_called_once_with(
+            nb_samples=2,
+            dataset_item_ids=None,
+            batch_size=helpers.EVALUATION_STREAM_DATASET_BATCH_SIZE,
+            filter_string='tags contains "x"',
+        )
+
+    def test_with_sampler__materialises_list_and_returns_sampled_count(self):
+        items = [dataset_item.DatasetItem(id=f"i-{i}") for i in range(4)]
+        dataset_ = self._make_dataset(items)
+        sampled = items[:2]
+        sampler = SimpleNamespace(sample=lambda xs: sampled)
+
+        items_iter, total = helpers.resolve_dataset_items_generator(
+            dataset_=dataset_,
+            nb_samples=None,
+            dataset_item_ids=None,
+            dataset_sampler=sampler,
+            dataset_filter_string=None,
+        )
+
+        assert list(items_iter) == sampled
+        assert total == len(sampled)
+
+
+class TestMergeBlueprintIntoConfig:
+    @staticmethod
+    def _make_blueprint(id, name):
+        bp = mock.MagicMock()
+        bp.id = id
+        bp.name = name
+        return bp
+
+    def test_blueprint_fetched_and_version_stored(self):
+        mock_client = mock.Mock()
+        mock_client._rest_client.agent_configs.get_blueprint_by_id.return_value = (
+            self._make_blueprint("bp-123", "v9")
+        )
+
+        result = helpers.merge_blueprint_into_config(
+            mock_client,
+            "bp-123",
+            {"model": "gpt-4o"},
+        )
+
+        assert result["model"] == "gpt-4o"
+        assert result["agent_configuration"] == {
+            "_blueprint_id": "bp-123",
+            "blueprint_version": "v9",
+        }
+
+    def test_blueprint_fetch_fails_still_stores_id(self):
+        mock_client = mock.Mock()
+        mock_client._rest_client.agent_configs.get_blueprint_by_id.side_effect = (
+            Exception("not found")
+        )
+
+        result = helpers.merge_blueprint_into_config(
+            mock_client,
+            "bp-456",
+            None,
+        )
+
+        assert result["agent_configuration"] == {"_blueprint_id": "bp-456"}

--- a/sdks/python/tests/unit/evaluation/test_helpers.py
+++ b/sdks/python/tests/unit/evaluation/test_helpers.py
@@ -1,0 +1,59 @@
+import logging
+
+from opik.evaluation import helpers
+
+
+class TestResolveProjectName:
+    def test_dataset_has_no_project__user_value_used(self, capture_log):
+        resolved = helpers.resolve_project_name(
+            value_from_dataset=None,
+            value_from_user="caller-project",
+            caller_name="evaluate",
+        )
+
+        assert resolved == "caller-project"
+        assert capture_log.records == []
+
+    def test_dataset_has_no_project__user_none__returns_none(self, capture_log):
+        resolved = helpers.resolve_project_name(
+            value_from_dataset=None,
+            value_from_user=None,
+            caller_name="evaluate",
+        )
+
+        assert resolved is None
+        assert capture_log.records == []
+
+    def test_dataset_has_project__user_none__returns_dataset_project__no_warning(
+        self, capture_log
+    ):
+        resolved = helpers.resolve_project_name(
+            value_from_dataset="dataset-project",
+            value_from_user=None,
+            caller_name="evaluate",
+        )
+
+        assert resolved == "dataset-project"
+        assert capture_log.records == []
+
+    def test_dataset_has_project__user_override__dataset_wins_and_warning_logged(
+        self, capture_log
+    ):
+        resolved = helpers.resolve_project_name(
+            value_from_dataset="dataset-project",
+            value_from_user="caller-project",
+            caller_name="evaluate_prompt",
+        )
+
+        assert resolved == "dataset-project"
+        warning_records = [
+            record
+            for record in capture_log.records
+            if record.levelno == logging.WARNING
+        ]
+        assert len(warning_records) == 1
+        message = warning_records[0].getMessage()
+        assert "deprecated" in message
+        assert "evaluate_prompt()" in message
+        assert "dataset-project" in message
+        assert "caller-project" in message


### PR DESCRIPTION
## Details

Makes `evaluate()`, `evaluate_prompt()`, and `evaluate_optimization_trial()` consistent with the `run_tests()` change from OPIK-5913 by always preferring the dataset's `project_name` over the caller-provided override. When the dataset has a `project_name` and the caller also passes one, a deprecation warning is logged and the override is ignored so traces land in the dataset's project. Falls back to the caller's value when the dataset has no project to keep backward compatibility during the deprecation window.

- Added `_resolve_project_name(value_from_dataset, value_from_user, caller_name)` helper in `sdks/python/src/opik/evaluation/evaluator.py`.
- Wired into the three public `evaluate_*` entry points; updated their docstrings.
- Skipped `evaluate_experiment()` (derives project from an existing trace) and `evaluate_on_dict_items()` (no `Dataset` object).
- Added 10 new unit tests covering helper behaviour plus override-ignored / fallback paths for each wired function.

### Also closes OPIK-6062

`evaluator.py` had three `dataset = dataset.dataset` references to the removed `TestSuite.dataset` property (mypy failure + runtime `AttributeError` if reached).

- Exposed `__internal_api__dataset__` property on `TestSuite` (returns `Dataset`) and `TestSuiteVersion` (returns `DatasetVersion`).
- Replaced all three `dataset.dataset` call sites in `evaluator.py` with the new property, and collapsed `run_tests()`'s `_dataset` / `_dataset_version` branching into a single access.
- `pre-commit run mypy --files src/opik/evaluation/evaluator.py` now passes.

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #NA
- OPIK-6004
- OPIK-6062

## Testing

- `cd sdks/python && python -m pytest tests/unit/evaluation/test_evaluate.py tests/unit/evaluation/test_evaluate_test_suite.py tests/unit/api_objects/dataset/test_suite/` — 140 passed (10 new).
- `cd sdks/python && pre-commit run --files src/opik/evaluation/evaluator.py src/opik/api_objects/dataset/test_suite/test_suite.py tests/unit/evaluation/test_evaluate.py` — ruff + mypy clean.

## Documentation

- Docstrings for `evaluate()`, `evaluate_prompt()`, and `evaluate_optimization_trial()` now mark `project_name` as deprecated and describe the new resolution behaviour.