### PR TITLE
[NA] [BE] Set forceWorkspaceVersion disabled by default. OSS Opik V2.

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -987,17 +987,17 @@ serviceToggles:
   # Valid values: comma-separated workspace IDs (e.g. "ws-id-1,ws-id-2"), or "" (empty, disabled).
   # Scope: Per-workspace — only listed workspace IDs are affected, all others follow normal determination.
   # Priority: Highest — overrides forceWorkspaceVersion and all other determination logic for listed workspaces.
-  # Use case: gradual V2 rollout — set forceWorkspaceVersion to "version_1" and allowlist specific workspace IDs for V2.
+  # Use case: gradual V2 rollout — allowlist specific workspace IDs for V2 while the rest use entity-based determination.
   # Operational impact: empty/missing means no allowlisting. Non-allowlisted workspaces are unaffected.
   v2WorkspaceAllowlist: ${TOGGLE_V2_WORKSPACE_ALLOWLIST:-""}
-  # Default: version_1
+  # Default: disabled
   # Description: Forces ALL workspaces to a specific navigation version.
   # Valid values: "disabled" (use version 1 entity check), "version_1" (force legacy), "version_2" (force project-first).
   # Scope: Global — applies to all workspaces regardless of their entity state.
   # Priority: Second highest — overridden by v2WorkspaceAllowlist for listed workspaces.
   # Overrides: When not "disabled", overrides the version entity check and auth gate entirely.
-  # Operational impact: Set to "version_1" until V2 is ready, then change to "disabled" to enable entity-based determination.
-  forceWorkspaceVersion: ${TOGGLE_FORCE_WORKSPACE_VERSION:-"version_1"}
+  # Operational impact: Default is "disabled" (entity-based determination). Override to "version_1" or "version_2" if global enforcement is needed.
+  forceWorkspaceVersion: ${TOGGLE_FORCE_WORKSPACE_VERSION:-"disabled"}
 
 # Local Runner configuration
 localRunner:

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -556,17 +556,16 @@ serviceToggles:
   # Valid values: comma-separated workspace IDs (e.g. "ws-id-1,ws-id-2"), or "" (empty, disabled).
   # Scope: Per-workspace — only listed workspace IDs are affected, all others follow normal determination.
   # Priority: Highest — overrides forceWorkspaceVersion and all other determination logic for listed workspaces.
-  # Use case: gradual V2 rollout — set forceWorkspaceVersion to "version_1" and allowlist specific workspace IDs for V2.
+  # Use case: gradual V2 rollout — allowlist specific workspace IDs for V2 while the rest use entity-based determination.
   # Operational impact: empty/missing means no allowlisting. Non-allowlisted workspaces are unaffected.
   v2WorkspaceAllowlist: ""
-  # Default: version_1
+  # Default: disabled
   # Description: Forces ALL workspaces to a specific navigation version.
   # Valid values: "disabled" (use version 1 entity check), "version_1" (force legacy), "version_2" (force project-first).
   # Scope: Global — applies to all workspaces regardless of their entity state.
   # Priority: Second highest — overridden by v2WorkspaceAllowlist for listed workspaces.
   # Overrides: When not "disabled", overrides the version entity check and auth gate entirely.
-  # Operational impact: Set to "version_1" until V2 is ready, then change to "disabled" to enable entity-based determination.
-  # For tests, changed to "disabled" as it will be the final state
+  # Operational impact: Default is "disabled" (entity-based determination). Override to "version_1" or "version_2" if global enforcement is needed.
   forceWorkspaceVersion: "disabled"
 
 # Local Runner configuration

--- a/apps/opik-documentation/documentation/fern/openapi/ai_examples_override.yml
+++ b/apps/opik-documentation/documentation/fern/openapi/ai_examples_override.yml
@@ -3609,7 +3609,7 @@ paths:
               customllmProviderEnabled: true
               ollamaProviderEnabled: false
               collaboratorsTabEnabled: true
-              forceWorkspaceVersion: v2.3.1
+              forceWorkspaceVersion: disabled
   /v1/private/experiments/batch:
     patch:
       x-fern-examples:


### PR DESCRIPTION
## Details
Set forceWorkspaceVersion disabled by default. OSS Opik V2.

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues
N/A

## Testing
- Verified locally with `./opik.sh --build --port-mapping`
- Tested under: https://pr-6380.dev.comet.com/

## Documentation
- Updated related configuration docs. 
