### PR TITLE
[OPIK-6078] [FE] fix: pass troubleshooting hash as second arg to buildDocsUrl

### DIFF
--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerEmptyState.tsx
@@ -50,7 +50,7 @@ const AgentRunnerEmptyState: React.FC = () => {
               <p className="comet-body-xs text-muted-slate">
                 Trouble connecting?{" "}
                 <a
-                  href={buildDocsUrl("/faq#troubleshooting")}
+                  href={buildDocsUrl("/faq", "#troubleshooting")}
                   target="_blank"
                   rel="noreferrer"
                   className="inline-flex items-center gap-1 underline hover:text-foreground"

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
@@ -71,7 +71,10 @@ const ConnectToOllieTab: React.FC<ConnectToOllieTabProps> = ({ connected }) => {
                   Run the command above in your repo. Once connected, Ollie can
                   inspect your code and help finish setup.{" "}
                   <a
-                    href={buildDocsUrl("/agents/local-runner#troubleshooting")}
+                    href={buildDocsUrl(
+                      "/agents/local-runner",
+                      "#troubleshooting",
+                    )}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="underline hover:text-foreground"

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/InstallWithAITab.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/InstallWithAITab.tsx
@@ -93,7 +93,7 @@ const InstallWithAITab: React.FC<InstallWithAITabProps> = ({
                   Connect your agent to Opik for observability, evaluation and
                   optimization.{" "}
                   <a
-                    href={buildDocsUrl("/faq#troubleshooting")}
+                    href={buildDocsUrl("/faq", "#troubleshooting")}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="underline hover:text-foreground"


### PR DESCRIPTION
## Details

<img width="1920" height="1832" alt="image" src="https://github.com/user-attachments/assets/f93a0c92-2017-4fce-a1bb-6723e049d94b" />

The FAQ troubleshooting CTAs on the onboarding pages linked to `https://www.comet.com/docs/opik/faq#troubleshooting?from=llm` — hash before query — so browsers treated `troubleshooting?from=llm` as the fragment and nothing resolved. Root cause: callers embedded the hash inside the `path` argument of `buildDocsUrl`, which always appends `?from=llm` after the path. Pass the hash via the dedicated second argument in all three call sites so the URL is assembled as `…/faq?from=llm#troubleshooting` and the anchor resolves.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-6078

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation
- Human verification: manual click-through in running app; all three CTAs now scroll to the Troubleshooting section

## Testing

- Manual verification in local dev app: clicked each CTA and confirmed the docs page scrolls to the Troubleshooting heading.
- Verified resulting URL structure: `…/faq?from=llm#troubleshooting` (hash after query).
- `npm run lint:fix` and `npm run typecheck` pass for the frontend workspace.

## Documentation

N/A — no docs changes required; the docs page already exposes the correct `id="troubleshooting"` anchor.