### PR TITLE
[OPIK-6030] [FE] Scope onboarding localStorage key by userName

### DIFF
--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext.tsx
@@ -7,8 +7,14 @@ import React, {
 import useLocalStorageState from "use-local-storage-state";
 import posthog from "posthog-js";
 import useSubmitOnboardingAnswerMutation from "@/api/feedback/useSubmitOnboardingAnswerMutation";
+import useAppStore from "@/store/AppStore";
 
-export const AGENT_ONBOARDING_KEY = "agent-onboarding";
+const AGENT_ONBOARDING_KEY_PREFIX = "agent-onboarding";
+
+export const getAgentOnboardingKey = (userName: string) =>
+  userName
+    ? `${AGENT_ONBOARDING_KEY_PREFIX}-${userName}`
+    : AGENT_ONBOARDING_KEY_PREFIX;
 
 export const TRACES_OLDEST_FIRST_SORTING = [{ id: "id", desc: false }];
 
@@ -62,8 +68,9 @@ interface AgentOnboardingProviderProps {
 const AgentOnboardingProvider: React.FC<AgentOnboardingProviderProps> = ({
   children,
 }) => {
+  const userName = useAppStore((s) => s.user.userName);
   const [state, setState] = useLocalStorageState<AgentOnboardingState>(
-    AGENT_ONBOARDING_KEY,
+    getAgentOnboardingKey(userName),
     { defaultValue: DEFAULT_STATE },
   );
 

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext.tsx
@@ -8,13 +8,32 @@ import useLocalStorageState from "use-local-storage-state";
 import posthog from "posthog-js";
 import useSubmitOnboardingAnswerMutation from "@/api/feedback/useSubmitOnboardingAnswerMutation";
 import useAppStore from "@/store/AppStore";
+import { isDefaultUser } from "@/constants/user";
 
-const AGENT_ONBOARDING_KEY_PREFIX = "agent-onboarding";
+const AGENT_ONBOARDING_LEGACY_KEY = "agent-onboarding";
 
 export const getAgentOnboardingKey = (userName: string) =>
   userName
-    ? `${AGENT_ONBOARDING_KEY_PREFIX}-${userName}`
-    : AGENT_ONBOARDING_KEY_PREFIX;
+    ? `${AGENT_ONBOARDING_LEGACY_KEY}-${userName}`
+    : AGENT_ONBOARDING_LEGACY_KEY;
+
+/**
+ * Migrate the global "agent-onboarding" localStorage entry to the
+ * per-user key so returning users are not forced through onboarding again.
+ * Runs once per user; the legacy key is removed after migration.
+ */
+const migrateLegacyOnboardingState = (userName: string) => {
+  if (!userName) return;
+
+  const userKey = getAgentOnboardingKey(userName);
+  if (localStorage.getItem(userKey) !== null) return;
+
+  const legacyKey = localStorage.getItem(AGENT_ONBOARDING_LEGACY_KEY);
+  if (legacyKey === null) return;
+
+  localStorage.setItem(userKey, legacyKey);
+  localStorage.removeItem(AGENT_ONBOARDING_LEGACY_KEY);
+};
 
 export const TRACES_OLDEST_FIRST_SORTING = [{ id: "id", desc: false }];
 
@@ -69,6 +88,12 @@ const AgentOnboardingProvider: React.FC<AgentOnboardingProviderProps> = ({
   children,
 }) => {
   const userName = useAppStore((s) => s.user.userName);
+  const isUserResolved = !isDefaultUser(userName);
+
+  if (isUserResolved) {
+    migrateLegacyOnboardingState(userName);
+  }
+
   const [state, setState] = useLocalStorageState<AgentOnboardingState>(
     getAgentOnboardingKey(userName),
     { defaultValue: DEFAULT_STATE },
@@ -112,7 +137,7 @@ const AgentOnboardingProvider: React.FC<AgentOnboardingProviderProps> = ({
     [state.step, submitAnswer, setState],
   );
 
-  if (state.step === AGENT_ONBOARDING_STEPS.DONE) {
+  if (!isUserResolved || state.step === AGENT_ONBOARDING_STEPS.DONE) {
     return null;
   }
 

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/NewQuickstart.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/NewQuickstart.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Navigate } from "@tanstack/react-router";
 import AgentOnboardingOverlay from "./AgentOnboarding/AgentOnboardingOverlay";
 import {
-  AGENT_ONBOARDING_KEY,
+  getAgentOnboardingKey,
   AGENT_ONBOARDING_STEPS,
 } from "./AgentOnboarding/AgentOnboardingContext";
 import useLocalStorageState from "use-local-storage-state";
@@ -10,10 +10,11 @@ import useAppStore from "@/store/AppStore";
 import useProjectByName from "@/api/projects/useProjectByName";
 
 const NewQuickstart: React.FunctionComponent = () => {
+  const userName = useAppStore((s) => s.user.userName);
   const [agentOnboardingState] = useLocalStorageState<{
     step: unknown;
     agentName?: string;
-  }>(AGENT_ONBOARDING_KEY);
+  }>(getAgentOnboardingKey(userName));
 
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
 

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/NewQuickstart.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/NewQuickstart.tsx
@@ -7,10 +7,12 @@ import {
 } from "./AgentOnboarding/AgentOnboardingContext";
 import useLocalStorageState from "use-local-storage-state";
 import useAppStore from "@/store/AppStore";
+import { isDefaultUser } from "@/constants/user";
 import useProjectByName from "@/api/projects/useProjectByName";
 
 const NewQuickstart: React.FunctionComponent = () => {
   const userName = useAppStore((s) => s.user.userName);
+  const isUserResolved = !isDefaultUser(userName);
   const [agentOnboardingState] = useLocalStorageState<{
     step: unknown;
     agentName?: string;
@@ -25,8 +27,12 @@ const NewQuickstart: React.FunctionComponent = () => {
 
   const { data: project, isPending } = useProjectByName(
     { projectName: agentName },
-    { enabled: isOnboardingDone && !!agentName },
+    { enabled: isUserResolved && isOnboardingDone && !!agentName },
   );
+
+  if (!isUserResolved) {
+    return null;
+  }
 
   if (!isOnboardingDone) {
     return <AgentOnboardingOverlay />;


### PR DESCRIPTION
Onboarding was skipped for new users in browsers where a previous user had already completed it, because the localStorage key was global. Now the key includes the userName so each user gets independent state.

## Details
<!--
REPLACE ME WITH:
Short 2-3 lines single paragraph explaining whats changed and the motivation (why).
If you need to have changes explained in detail include single line dot point(s).
-->

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
<!--
REPLACE ME WITH:

How you tested

Include:
- Exact commands run (for example: `mvn test`, `npm run lint && npm run test`, `pytest ...`)
- Scenarios validated (happy path, edge cases, regressions)
- Environment/context used (local process mode vs Docker, OS/browser when relevant)
- Any tests not run, with reason
- Relevant logs/artifacts links if available

Video evidence:
- External contributors: include a short recording for all contributions where possible.
- Internal contributors: include a short recording for complex changes where possible.
-->

## Documentation
