### PR TITLE
[OPIK-5497] [SDK] fix: normalize extracted URL to prevent false mismatch warning

### DIFF
--- a/sdks/python/src/opik/configurator/configure.py
+++ b/sdks/python/src/opik/configurator/configure.py
@@ -568,8 +568,9 @@ class OpikConfigurator:
         if extracted_base_url is None:
             return
 
+        normalized_extracted = url_helpers.get_base_url(extracted_base_url)
         if (
-            extracted_base_url != url_helpers.get_base_url(self.base_url)
+            normalized_extracted != url_helpers.get_base_url(self.base_url)
             and self.base_url != OPIK_BASE_URL_CLOUD
         ):
             LOGGER.warning(
@@ -577,7 +578,7 @@ class OpikConfigurator:
                 self.base_url,
             )
 
-        self.base_url = extracted_base_url
+        self.base_url = normalized_extracted
 
 
 def _set_environment_variables_for_integrations(

--- a/sdks/python/tests/unit/configurator/test_configure.py
+++ b/sdks/python/tests/unit/configurator/test_configure.py
@@ -894,11 +894,11 @@ class TestGetApiKey:
             "smart-api-key"
         )  # called 2 times, one in OpikConfig, another in OpikConfigurator
         mock_is_api_key_correct.assert_called_once_with(
-            "smart-api-key", url=configurator.base_url
+            "smart-api-key", url="https://some-url-from-smart-api-key.com"
         )
 
         assert configurator.api_key == "smart-api-key"
-        assert configurator.base_url == "https://some-url-from-smart-api-key.com"
+        assert configurator.base_url == "https://some-url-from-smart-api-key.com/"
         assert needs_update is True
 
     @patch(
@@ -923,7 +923,7 @@ class TestGetApiKey:
             "smart-api-key"
         )  # called 2 times, one in OpikConfig, another in OpikConfigurator
         mock_is_api_key_correct.assert_called_once_with(
-            "smart-api-key", url=configurator.base_url
+            "smart-api-key", url="https://url-from-smart-api-key.com"
         )
         mock_logger_warning.assert_called_once_with(
             "The url provided in the configure (%s) method doesn't match the domain linked to the API key provided and will be ignored",
@@ -931,8 +931,44 @@ class TestGetApiKey:
         )
 
         assert configurator.api_key == "smart-api-key"
-        assert configurator.base_url == "https://url-from-smart-api-key.com"
+        assert configurator.base_url == "https://url-from-smart-api-key.com/"
         assert needs_update is True
+
+    @pytest.mark.parametrize(
+        "configured_url, api_key_url",
+        [
+            # trailing slash only on one side
+            ("https://same-url.com/", "https://same-url.com"),
+            ("https://same-url.com", "https://same-url.com/"),
+            # both normalised the same way
+            ("https://same-url.com/", "https://same-url.com/"),
+        ],
+    )
+    @patch(
+        "opik.configurator.configure.opik_rest_helpers.is_api_key_correct",
+        return_value=True,
+    )
+    @patch("opik.configurator.configure.LOGGER.warning")
+    def test_try_set_url_from_api_key__same_url_with_different_slash_variants__no_warning(
+        self,
+        mock_logger_warning,
+        mock_is_api_key_correct,
+        configured_url,
+        api_key_url,
+    ):
+        with patch(
+            "opik.api_key.opik_api_key.parse_api_key",
+            return_value=SimpleNamespace(base_url=api_key_url),
+        ):
+            configurator = OpikConfigurator(
+                api_key="smart-api-key",
+                url=configured_url,
+                force=True,
+            )
+            configurator._set_api_key()
+
+        mock_logger_warning.assert_not_called()
+        assert configurator.base_url == "https://same-url.com/"
 
 
 class TestGetWorkspace:


### PR DESCRIPTION
## Details

`_try_set_url_from_api_key` compared the raw `extracted_base_url` (from the API key's embedded JSON, e.g. `"https://host.com"`) against `url_helpers.get_base_url(self.base_url)` (which always appends a trailing slash). A URL that was semantically identical — differing only in a trailing slash — failed the equality check and emitted a spurious *"URL doesn't match"* warning on every `configure()` call.

Fix: normalize both sides through `url_helpers.get_base_url()` before comparing, and store the normalized form in `self.base_url`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5497

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-sonnet-4-6
  - Scope: full implementation
  - Human verification: code review + test execution

## Testing

- `PYTHONPATH=src python -m pytest tests/unit/configurator/test_configure.py -q` — 97 passed
- Pre-commit hooks (ruff, mypy, format) all pass
- New parametrized test `test_try_set_url_from_api_key__same_url_with_different_slash_variants__no_warning` covers three trailing-slash variants that must not trigger the warning
- Existing tests updated to reflect normalized `base_url` storage and explicit URL assertions

## Documentation

N/A