### PR TITLE
[OPIK-6088] [INFRA] fix: pre-commit hook stages phantom deletions in worktrees

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -4,6 +4,14 @@ set -e
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 cd "$REPO_ROOT" || exit 1
 
+# Warn if the installed hook has drifted from the tracked source. Hooks live in
+# the common git dir so they're shared across worktrees and the main clone.
+installed_hook="$(git rev-parse --git-common-dir 2>/dev/null)/hooks/pre-commit"
+tracked_hook="$REPO_ROOT/.hooks/pre-commit"
+if [ -f "$installed_hook" ] && [ -f "$tracked_hook" ] && ! cmp -s "$installed_hook" "$tracked_hook"; then
+  echo "WARNING: .git/hooks/pre-commit differs from .hooks/pre-commit. Run 'make hooks' to update." >&2
+fi
+
 # Check if dev-runner.sh exists
 if [ ! -f scripts/dev-runner.sh ]; then
   echo "dev-runner.sh not found. Cannot run linting checks."
@@ -36,7 +44,9 @@ run_precommit_scope() {
     exit 1
   fi
 
-  git add -u
+  # -C pins the work tree so an inherited GIT_DIR (worktree commits) can't
+  # trick `git add -u` into using cwd as the work tree.
+  git -C "$REPO_ROOT" add -u
 }
 
 # Check for staged Java files
@@ -50,7 +60,7 @@ if staged_files | grep -E '\.java$' >/dev/null; then
   fi
 
   # Add any potentially modified files by Spotless back to the index
-  git add -u
+  git -C "$REPO_ROOT" add -u
 else
   echo "No Java files changed. Skipping Spotless."
 fi
@@ -66,7 +76,7 @@ if staged_files | grep -E '^apps/opik-frontend/' >/dev/null; then
   fi
 
   # Add any potentially modified files by lint back to the index
-  git add -u
+  git -C "$REPO_ROOT" add -u
 else
   echo "No frontend files changed. Skipping lint and typecheck."
 fi

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -4,14 +4,6 @@ set -e
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 cd "$REPO_ROOT" || exit 1
 
-# Warn if the installed hook has drifted from the tracked source. Hooks live in
-# the common git dir so they're shared across worktrees and the main clone.
-installed_hook="$(git rev-parse --git-common-dir 2>/dev/null)/hooks/pre-commit"
-tracked_hook="$REPO_ROOT/.hooks/pre-commit"
-if [ -f "$installed_hook" ] && [ -f "$tracked_hook" ] && ! cmp -s "$installed_hook" "$tracked_hook"; then
-  echo "WARNING: .git/hooks/pre-commit differs from .hooks/pre-commit. Run 'make hooks' to update." >&2
-fi
-
 # Check if dev-runner.sh exists
 if [ ! -f scripts/dev-runner.sh ]; then
   echo "dev-runner.sh not found. Cannot run linting checks."

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ AI_DIR := .agents
 CURSOR_DIR := .cursor
 CLAUDE_DIR := .claude
 HOOKS_SRC := .hooks
-HOOKS_DEST := .git/hooks
+# Resolve via git-common-dir so `make hooks` works from both the main clone and worktrees.
+HOOKS_DEST := $(shell git rev-parse --git-common-dir 2>/dev/null)/hooks
 SDK_DIFF_BASE ?= origin/main
 
 define link_agent_config

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ CURSOR_DIR := .cursor
 CLAUDE_DIR := .claude
 HOOKS_SRC := .hooks
 # Resolve via git-common-dir so `make hooks` works from both the main clone and worktrees.
-HOOKS_DEST := $(shell git rev-parse --git-common-dir 2>/dev/null)/hooks
+# Empty when not in a git repo so the recipes can fail loudly instead of acting on /hooks.
+GIT_COMMON_DIR := $(shell git rev-parse --git-common-dir 2>/dev/null)
+HOOKS_DEST := $(if $(GIT_COMMON_DIR),$(GIT_COMMON_DIR)/hooks)
 SDK_DIFF_BASE ?= origin/main
 
 define link_agent_config
@@ -137,12 +139,16 @@ clean-agents:
 
 # Install Git hooks from .hooks/ to .git/hooks/
 hooks:
+	@if [ -z "$(HOOKS_DEST)" ]; then \
+		echo "Error: not in a git repository."; \
+		exit 1; \
+	fi
 	@if [ ! -d "$(HOOKS_SRC)" ]; then \
 		echo "Error: $(HOOKS_SRC)/ does not exist."; \
 		exit 1; \
 	fi
 	@if [ ! -d "$(HOOKS_DEST)" ]; then \
-		echo "Error: $(HOOKS_DEST)/ does not exist. Is this a git repository?"; \
+		echo "Error: $(HOOKS_DEST)/ does not exist."; \
 		exit 1; \
 	fi
 	@cp $(HOOKS_SRC)/pre-commit $(HOOKS_DEST)/pre-commit
@@ -151,6 +157,10 @@ hooks:
 
 # Remove Git hooks
 hooks-remove:
+	@if [ -z "$(HOOKS_DEST)" ]; then \
+		echo "Error: not in a git repository."; \
+		exit 1; \
+	fi
 	@if [ -f "$(HOOKS_DEST)/pre-commit" ]; then \
 		rm -f $(HOOKS_DEST)/pre-commit; \
 		echo "Pre-commit hook removed."; \

--- a/Makefile
+++ b/Makefile
@@ -162,12 +162,13 @@ hooks-remove:
 		echo "Error: $(MAKEFILE_DIR) is not in a git repository."; \
 		exit 1; \
 	fi
-	@if [ -f "$(HOOKS_DEST)/pre-commit" ]; then \
-		rm -f $(HOOKS_DEST)/pre-commit; \
-		echo "Pre-commit hook removed."; \
-	else \
-		echo "No pre-commit hook found."; \
-	fi
+	@cd "$(MAKEFILE_DIR)" && \
+		if [ -f "$(HOOKS_DEST)/pre-commit" ]; then \
+			rm -f $(HOOKS_DEST)/pre-commit; \
+			echo "Pre-commit hook removed."; \
+		else \
+			echo "No pre-commit hook found."; \
+		fi
 
 # Run SDK pre-commit style checks (changed files only / explicit script checks)
 precommit-sdks:

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,15 @@ AI_DIR := .agents
 CURSOR_DIR := .cursor
 CLAUDE_DIR := .claude
 HOOKS_SRC := .hooks
-# Resolve via git-common-dir so `make hooks` works from both the main clone and worktrees.
-# Empty when not in a git repo so the recipes can fail loudly instead of acting on /hooks.
-GIT_COMMON_DIR := $(shell git rev-parse --git-common-dir 2>/dev/null)
+# Anchor hook paths to this Makefile's directory so `make hooks` resolves to the
+# Opik repo regardless of where make was invoked from (subdir, -f from another
+# repo, etc.). Without this, running from a different git repo with its own
+# .hooks/ would silently install that repo's hook into that repo's .git/hooks/.
+MAKEFILE_DIR := $(patsubst %/,%,$(dir $(realpath $(firstword $(MAKEFILE_LIST)))))
+# Resolve git-common-dir from the Makefile's dir so the lookup is independent
+# of make's invocation cwd. Empty when MAKEFILE_DIR is not in a git repo so the
+# recipes fail loudly instead of acting on /hooks.
+GIT_COMMON_DIR := $(shell cd "$(MAKEFILE_DIR)" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null)
 HOOKS_DEST := $(if $(GIT_COMMON_DIR),$(GIT_COMMON_DIR)/hooks)
 SDK_DIFF_BASE ?= origin/main
 
@@ -140,25 +146,20 @@ clean-agents:
 # Install Git hooks from .hooks/ to .git/hooks/
 hooks:
 	@if [ -z "$(HOOKS_DEST)" ]; then \
-		echo "Error: not in a git repository."; \
+		echo "Error: $(MAKEFILE_DIR) is not in a git repository."; \
 		exit 1; \
 	fi
-	@if [ ! -d "$(HOOKS_SRC)" ]; then \
-		echo "Error: $(HOOKS_SRC)/ does not exist."; \
-		exit 1; \
-	fi
-	@if [ ! -d "$(HOOKS_DEST)" ]; then \
-		echo "Error: $(HOOKS_DEST)/ does not exist."; \
-		exit 1; \
-	fi
-	@cp $(HOOKS_SRC)/pre-commit $(HOOKS_DEST)/pre-commit
-	@chmod +x $(HOOKS_DEST)/pre-commit
-	@echo "Pre-commit hook installed."
+	@cd "$(MAKEFILE_DIR)" && \
+		if [ ! -d "$(HOOKS_SRC)" ]; then echo "Error: $(MAKEFILE_DIR)/$(HOOKS_SRC)/ does not exist."; exit 1; fi && \
+		if [ ! -d "$(HOOKS_DEST)" ]; then echo "Error: $(HOOKS_DEST)/ does not exist."; exit 1; fi && \
+		cp $(HOOKS_SRC)/pre-commit $(HOOKS_DEST)/pre-commit && \
+		chmod +x $(HOOKS_DEST)/pre-commit && \
+		echo "Pre-commit hook installed."
 
 # Remove Git hooks
 hooks-remove:
 	@if [ -z "$(HOOKS_DEST)" ]; then \
-		echo "Error: not in a git repository."; \
+		echo "Error: $(MAKEFILE_DIR) is not in a git repository."; \
 		exit 1; \
 	fi
 	@if [ -f "$(HOOKS_DEST)/pre-commit" ]; then \


### PR DESCRIPTION
## Details

<img width="1920" height="3604" alt="image" src="https://github.com/user-attachments/assets/1a87b685-ce55-4364-aa31-4c5501d2efab" />

Fixes the `.hooks/pre-commit` hook so `git commit` from a git worktree no longer stages thousands of phantom deletions, and hardens `make hooks` against cwd-based failure modes raised in code review.

**Hook fix (`.hooks/pre-commit`):** root cause was that `git commit` exports `GIT_DIR`, which makes `git add -u` fall back to cwd as the work tree — and the old hook's `cd scripts` then treated `scripts/` as the whole repo. The fix captures `REPO_ROOT` once at hook start and pins every `git add -u` with `git -C "$REPO_ROOT"` (ticket Option A), so the work tree stays correct regardless of any later `cd`.

**Install fix (`Makefile`):**
- `HOOKS_DEST` now resolves via `git rev-parse --git-common-dir` so `make hooks` works from both the main clone and worktrees. Previously `.git/hooks` broke in worktrees because `.git` is a file there.
- Both `make hooks` and `make hooks-remove` bail with `Error: not in a git repository.` before any `cp`/`rm` if `git rev-parse` fails (addresses Baz's review comment about the `/hooks` fallback).
- Paths are anchored to `MAKEFILE_DIR` (`$(dir $(realpath $(firstword $(MAKEFILE_LIST))))`) so `make hooks` resolves to the Opik repo regardless of where make was invoked from. Without this, running with `-f /opik/Makefile` from a different git repo with its own `.hooks/pre-commit` silently installed *that repo's* hook into *that repo's* `.git/hooks/`. Addresses [#discussion_r3159753458](https://github.com/comet-ml/opik/pull/6387#discussion_r3159753458).

A divergence-warning at the top of the hook (cmp installed vs tracked) was added in the first commit and removed in a follow-up during review — it duplicated the `git rev-parse --git-common-dir` call in two places (Makefile + hook), and the catastrophic pre-fix case it was supposed to detect can't carry the warning code anyway. The proper structural answer (`git config core.hooksPath .hooks` to eliminate the drift class entirely) is tracked as a follow-up: **[OPIK-6237](https://comet-ml.atlassian.net/browse/OPIK-6237)**. The `MAKEFILE_DIR` anchoring introduced here will be reused by OPIK-6237's `git config` write — not throwaway work.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6088
- Follow-up: OPIK-6237 (switch hook install to `core.hooksPath`)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation
- Human verification: code review + manual reproduction of the bug and fix with `--dry-run` matrix + end-to-end commit + adversarial-repo robustness probe

## Testing

Reproduced the original bug and verified the hook fix with a dry-run harness that mirrors what `git commit` sets up:

```sh
# Before (buggy pattern): 10,122 phantom deletions
GIT_DIR=$(git rev-parse --git-dir) GIT_INDEX_FILE=$(git rev-parse --git-dir)/index \
  sh -c 'cd scripts && git add -u --dry-run | wc -l'
# 10122

# After (git -C "$REPO_ROOT"): 0 phantoms, only real modifications surface
GIT_DIR=$(git rev-parse --git-dir) GIT_INDEX_FILE=$(git rev-parse --git-dir)/index \
  sh -c 'REPO_ROOT=$(git rev-parse --show-toplevel); cd scripts && git -C "$REPO_ROOT" add -u --dry-run -v'
```

### Hook (`.hooks/pre-commit`) verification matrix

- Old hook in worktree → 10,122 phantoms (baseline reproduction)
- New hook from `scripts/` subdir in worktree → 0 phantoms
- New hook at worktree root → 0 phantoms
- New hook in main clone → 0 phantoms
- End-to-end `git commit` of this PR's own changes through the new hook → only intended files staged
- Hook routing: real FE file staged → hook detected scope, ran `dev-runner.sh --lint-fe`, aborted commit cleanly when lint failed (no `node_modules` in test env) — quality gate preserved, HEAD unchanged

### `Makefile` (`make hooks`/`make hooks-remove`) verification matrix

- From Opik worktree (real run): installs worktree's local `.hooks/pre-commit` into main clone's `.git/hooks/` (preserves dev-on-worktree workflow)
- From main clone: same install, resolves to absolute path under common `.git/hooks/`
- From a main-clone subdir: now works (was a loud error before — `.hooks` not found relative to subdir)
- From `/tmp` with `-f /opik/Makefile`: now installs into Opik (was a silent no-op before)
- From `/tmp/adversarial-repo` with its own `.hooks/pre-commit`: now installs Opik's hook into Opik's `.git/hooks/`, adversarial repo untouched (verified `head -1 .git/hooks/pre-commit` post-install — Opik content, not adversarial)
- From a non-git dir hosting a copy of the Makefile: errors loudly with `not in a git repository`

Not run end-to-end: lint-succeeds-and-modifies-files-then-restages path. Requires `npm install` in `apps/opik-frontend/` for real ESLint. Bounded near-zero risk: the only behavioral change in the hook is `git add -u` → `git -C "$REPO_ROOT" add -u`, functionally identical when cwd is `$REPO_ROOT`. Re-stage logic itself is unchanged.

Out of scope (intentionally): rare `GIT_DIR` env-var export class ("Tier 3" hardening). OPIK-6237 will obsolete the entire `cp`/`chmod` machinery once `core.hooksPath` lands, so additional copy-mode hardening here would be discarded.

## Documentation

N/A — no user-facing or developer docs needed for OPIK-6088 itself. Migration documentation will land with the OPIK-6237 follow-up (one-time-per-clone setup note for `core.hooksPath`).

[OPIK-6237]: https://comet-ml.atlassian.net/browse/OPIK-6237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ