### PR TITLE
[OPIK-6091] [BE] fix: resolve opik.* submodule imports in Python sandbox

### DIFF
--- a/apps/opik-sandbox-executor-python/scoring_runner.py
+++ b/apps/opik-sandbox-executor-python/scoring_runner.py
@@ -49,7 +49,7 @@ def _load_real_opik() -> None:
     import opik  # noqa: F401,F811 — triggers the real init
 
 
-class _LazyOpikStub(types.ModuleType):
+class _FallbackModule(types.ModuleType):
     """Stub module that lazy-loads the real `opik` package on first use.
 
     Handles both fallback routes with one class:
@@ -79,7 +79,7 @@ class _LazyOpikStub(types.ModuleType):
 
 
 for _name in ["opik", "opik.evaluation", "opik.evaluation.metrics"]:
-    _stub = _LazyOpikStub(_name)
+    _stub = _FallbackModule(_name)
     _stub.__path__ = []  # type: ignore[attr-defined]
     sys.modules[_name] = _stub
     _stubs[_name] = _stub

--- a/apps/opik-sandbox-executor-python/scoring_runner.py
+++ b/apps/opik-sandbox-executor-python/scoring_runner.py
@@ -1,3 +1,5 @@
+import importlib.abc
+import importlib.util
 import inspect
 import json
 import sys
@@ -5,7 +7,7 @@ import traceback
 import types
 import uuid
 from sys import argv
-from typing import Type, Union, List, Any
+from typing import Type, Union, List, Any, Optional
 
 # ---------------------------------------------------------------------------
 # Lightweight import patching
@@ -19,7 +21,11 @@ from typing import Type, Union, List, Any
 #   `from opik.evaluation.metrics import BaseMetric`
 # resolves to the lightweight versions without triggering the real `opik`
 # init.  If user code accesses anything else on these modules, the
-# __getattr__ fallback loads the real `opik` package transparently.
+# __getattr__ fallback loads the real `opik` package transparently.  A
+# meta-path finder covers the case where user code imports an `opik.*`
+# submodule that we did not stub (e.g. `opik.evaluation.metrics.conversation`)
+# — Python's import machinery does not consult `__getattr__` when resolving
+# submodule paths, so we need an explicit finder to trigger the fallback.
 # ---------------------------------------------------------------------------
 
 import _opik._base_metric
@@ -34,7 +40,7 @@ def _load_real_opik() -> None:
         if sys.modules.get(name) is _stubs[name]:
             del sys.modules[name]
     _stubs.clear()
-    import opik  # noqa: F811 — triggers the real init
+    import opik  # noqa: F401,F811 — triggers the real init
 
 
 class _FallbackModule(types.ModuleType):
@@ -45,11 +51,33 @@ class _FallbackModule(types.ModuleType):
         return getattr(sys.modules[self.__name__], name)
 
 
+class _OpikFallbackFinder(importlib.abc.MetaPathFinder):
+    """Load the real `opik` when user code imports a non-stubbed `opik.*` submodule.
+
+    Python's import system resolves `from opik.x.y import z` via the parent
+    module's `__path__`, not via `__getattr__`. Our stubs have `__path__ = []`
+    so submodule lookups fail before `_FallbackModule.__getattr__` ever runs.
+    This finder detects such imports, swaps the stubs out for the real opik
+    package, then defers to the standard finders to resolve the requested name.
+    """
+
+    def find_spec(self, fullname: str, path: Optional[List[str]], target: Optional[types.ModuleType] = None):
+        if not (fullname == "opik" or fullname.startswith("opik.")):
+            return None
+        if not _stubs:
+            return None
+        sys.meta_path.remove(self)
+        _load_real_opik()
+        return importlib.util.find_spec(fullname)
+
+
 for _name in ["opik", "opik.evaluation", "opik.evaluation.metrics"]:
     _stub = _FallbackModule(_name)
     _stub.__path__ = []  # type: ignore[attr-defined]
     sys.modules[_name] = _stub
     _stubs[_name] = _stub
+
+sys.meta_path.insert(0, _OpikFallbackFinder())
 
 sys.modules["opik.evaluation.metrics.base_metric"] = _opik._base_metric
 sys.modules["opik.evaluation.metrics.score_result"] = _opik._score_result

--- a/apps/opik-sandbox-executor-python/scoring_runner.py
+++ b/apps/opik-sandbox-executor-python/scoring_runner.py
@@ -1,4 +1,3 @@
-import importlib.abc
 import importlib.util
 import inspect
 import json
@@ -7,7 +6,7 @@ import traceback
 import types
 import uuid
 from sys import argv
-from typing import Type, Union, List, Any, Optional
+from typing import Type, Union, List, Any
 
 # ---------------------------------------------------------------------------
 # Lightweight import patching
@@ -20,12 +19,15 @@ from typing import Type, Union, List, Any, Optional
 # We register stub modules in sys.modules so that user code doing
 #   `from opik.evaluation.metrics import BaseMetric`
 # resolves to the lightweight versions without triggering the real `opik`
-# init.  If user code accesses anything else on these modules, the
-# __getattr__ fallback loads the real `opik` package transparently.  A
-# meta-path finder covers the case where user code imports an `opik.*`
-# submodule that we did not stub (e.g. `opik.evaluation.metrics.conversation`)
-# — Python's import machinery does not consult `__getattr__` when resolving
-# submodule paths, so we need an explicit finder to trigger the fallback.
+# init.  Any other usage — attribute access (`opik.Client`) or submodule
+# imports (`from opik.evaluation.metrics.conversation import X`) — falls
+# back to loading the real `opik` package.  Python's import machinery
+# resolves dotted submodule paths via the parent's `__path__` and
+# `sys.meta_path` finders, not via `__getattr__`, so a single stub class
+# plays both roles: a `ModuleType` for attribute access, and a
+# `find_spec` finder on `sys.meta_path` for submodule resolution.  Both
+# routes funnel through `_load_real_opik`, which evicts the stubs from
+# `sys.modules` and `sys.meta_path` and runs `import opik` exactly once.
 # ---------------------------------------------------------------------------
 
 import _opik._base_metric
@@ -35,49 +37,55 @@ _stubs: dict = {}
 
 
 def _load_real_opik() -> None:
-    """Replace all stubs with the real opik package (lazy fallback)."""
-    for name in list(_stubs):
-        if sys.modules.get(name) is _stubs[name]:
+    """Evict all stubs and trigger the real `opik` package init (idempotent)."""
+    if not _stubs:
+        return
+    for name, stub in _stubs.items():
+        if sys.modules.get(name) is stub:
             del sys.modules[name]
+        if stub in sys.meta_path:
+            sys.meta_path.remove(stub)
     _stubs.clear()
     import opik  # noqa: F401,F811 — triggers the real init
 
 
-class _FallbackModule(types.ModuleType):
-    """Stub module that loads the real opik on first unknown attribute access."""
+class _LazyOpikStub(types.ModuleType):
+    """Stub module that lazy-loads the real `opik` package on first use.
+
+    Handles both fallback routes with one class:
+
+    - ``__getattr__`` — covers attribute access on the stub
+      (``from opik import Client``).
+    - ``find_spec`` — covers submodule imports that the installed stubs
+      don't satisfy (``from opik.evaluation.metrics.conversation import X``).
+      Python consults ``sys.meta_path`` for dotted-path resolution, not
+      the parent module's ``__getattr__``, so the stub registers itself
+      as a meta-path finder as well.
+
+    Both routes delegate to ``_load_real_opik``, after which the stub is
+    out of ``sys.modules`` and ``sys.meta_path`` and the standard import
+    machinery takes over with the real ``opik`` package.
+    """
 
     def __getattr__(self, name: str) -> Any:
         _load_real_opik()
         return getattr(sys.modules[self.__name__], name)
 
-
-class _OpikFallbackFinder(importlib.abc.MetaPathFinder):
-    """Load the real `opik` when user code imports a non-stubbed `opik.*` submodule.
-
-    Python's import system resolves `from opik.x.y import z` via the parent
-    module's `__path__`, not via `__getattr__`. Our stubs have `__path__ = []`
-    so submodule lookups fail before `_FallbackModule.__getattr__` ever runs.
-    This finder detects such imports, swaps the stubs out for the real opik
-    package, then defers to the standard finders to resolve the requested name.
-    """
-
-    def find_spec(self, fullname: str, path: Optional[List[str]], target: Optional[types.ModuleType] = None):
-        if not (fullname == "opik" or fullname.startswith("opik.")):
+    def find_spec(self, fullname: str, path, target=None):
+        if not _stubs or not (fullname == "opik" or fullname.startswith("opik.")):
             return None
-        if not _stubs:
-            return None
-        sys.meta_path.remove(self)
         _load_real_opik()
         return importlib.util.find_spec(fullname)
 
 
 for _name in ["opik", "opik.evaluation", "opik.evaluation.metrics"]:
-    _stub = _FallbackModule(_name)
+    _stub = _LazyOpikStub(_name)
     _stub.__path__ = []  # type: ignore[attr-defined]
     sys.modules[_name] = _stub
     _stubs[_name] = _stub
 
-sys.meta_path.insert(0, _OpikFallbackFinder())
+# One instance serves all `opik.*` submodule lookups — any stub will do.
+sys.meta_path.insert(0, _stubs["opik"])
 
 sys.modules["opik.evaluation.metrics.base_metric"] = _opik._base_metric
 sys.modules["opik.evaluation.metrics.score_result"] = _opik._score_result

--- a/sdks/python/tests/unit/evaluation/metrics/test_base_metric.py
+++ b/sdks/python/tests/unit/evaluation/metrics/test_base_metric.py
@@ -214,6 +214,198 @@ print("PATCH_OK")
         )
         assert "PATCH_OK" in result.stdout
 
+    def test_submodule_import_of_non_stubbed_opik_child_triggers_real_load(self):
+        """Verify the meta-path finder fallback resolves non-stubbed `opik.*` submodules.
+
+        The stubs installed in `sys.modules` for `opik`, `opik.evaluation`, and
+        `opik.evaluation.metrics` have `__path__ = []`. That stops `PathFinder`
+        from resolving submodules like `opik.evaluation.metrics.conversation`
+        that are not pre-registered — and Python's import machinery does not
+        consult `__getattr__` for dotted-path resolution, so the attribute
+        fallback never fires. `scoring_runner.py` installs a `find_spec`
+        hook on the stub so that any non-stubbed `opik.*` submodule import
+        triggers the real opik load and then resolves through the standard
+        finders.
+
+        HOW TO FIX if this fails: Check `_FallbackModule.find_spec` in
+        `apps/opik-sandbox-executor-python/scoring_runner.py` — it must
+        return a spec for `opik.*` names when `_stubs` is non-empty.
+        """
+        code = """
+import importlib.util
+import sys
+import types
+from typing import Any
+
+import _opik._base_metric
+import _opik._score_result
+
+_stubs = {}
+
+
+def _load_real_opik():
+    if not _stubs:
+        return
+    for name, stub in _stubs.items():
+        if sys.modules.get(name) is stub:
+            del sys.modules[name]
+        if stub in sys.meta_path:
+            sys.meta_path.remove(stub)
+    _stubs.clear()
+    import opik  # noqa: F401
+
+
+class _FallbackModule(types.ModuleType):
+    def __getattr__(self, name):
+        _load_real_opik()
+        return getattr(sys.modules[self.__name__], name)
+
+    def find_spec(self, fullname, path, target=None):
+        if not _stubs or not (fullname == "opik" or fullname.startswith("opik.")):
+            return None
+        _load_real_opik()
+        return importlib.util.find_spec(fullname)
+
+
+for _name in ["opik", "opik.evaluation", "opik.evaluation.metrics"]:
+    stub = _FallbackModule(_name)
+    stub.__path__ = []
+    sys.modules[_name] = stub
+    _stubs[_name] = stub
+
+sys.modules["opik.evaluation.metrics.base_metric"] = _opik._base_metric
+sys.modules["opik.evaluation.metrics.score_result"] = _opik._score_result
+sys.modules["opik.evaluation.metrics"].base_metric = _opik._base_metric
+sys.modules["opik.evaluation.metrics"].score_result = _opik._score_result
+
+sys.meta_path.insert(0, _stubs["opik"])
+
+# Before first real access, the stubs are in place.
+assert _stubs, "stubs should be installed before user code runs"
+
+# User code imports a non-stubbed submodule — this goes through find_spec.
+from opik.evaluation.metrics.conversation import conversation_thread_metric, types as conv_types
+
+# The finder should have triggered the real opik load.
+assert not _stubs, "real opik load should have cleared the stubs"
+assert "opik.evaluation.metrics.conversation" in sys.modules
+assert conversation_thread_metric.__file__.endswith(
+    "opik/evaluation/metrics/conversation/conversation_thread_metric.py"
+)
+assert conv_types.__file__.endswith("opik/evaluation/metrics/conversation/types.py")
+
+# The class is really usable.
+cls = conversation_thread_metric.ConversationThreadMetric
+assert callable(cls)
+
+print("SUBMODULE_OK")
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"Submodule import through fallback finder failed.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "SUBMODULE_OK" in result.stdout
+
+    def test_lightweight_path_stays_lightweight_with_finder_installed(self):
+        """Verify the finder doesn't disturb the fast path.
+
+        When user code uses only `BaseMetric` / `ScoreResult`, the finder
+        must stay out of the way — no real opik import should happen.
+
+        HOW TO FIX if this fails: The `find_spec` early-exit on missing
+        stubs (or on non-`opik.*` names) is likely broken — it's claiming
+        names it shouldn't.
+        """
+        code = """
+import importlib.util
+import sys
+import types
+from typing import Any
+
+import _opik._base_metric
+import _opik._score_result
+
+_stubs = {}
+
+
+def _load_real_opik():
+    if not _stubs:
+        return
+    for name, stub in _stubs.items():
+        if sys.modules.get(name) is stub:
+            del sys.modules[name]
+        if stub in sys.meta_path:
+            sys.meta_path.remove(stub)
+    _stubs.clear()
+    import opik  # noqa: F401
+
+
+class _FallbackModule(types.ModuleType):
+    def __getattr__(self, name):
+        _load_real_opik()
+        return getattr(sys.modules[self.__name__], name)
+
+    def find_spec(self, fullname, path, target=None):
+        if not _stubs or not (fullname == "opik" or fullname.startswith("opik.")):
+            return None
+        _load_real_opik()
+        return importlib.util.find_spec(fullname)
+
+
+for _name in ["opik", "opik.evaluation", "opik.evaluation.metrics"]:
+    stub = _FallbackModule(_name)
+    stub.__path__ = []
+    sys.modules[_name] = stub
+    _stubs[_name] = stub
+
+sys.modules["opik.evaluation.metrics.base_metric"] = _opik._base_metric
+sys.modules["opik.evaluation.metrics.score_result"] = _opik._score_result
+sys.modules["opik.evaluation.metrics"].base_metric = _opik._base_metric
+sys.modules["opik.evaluation.metrics"].score_result = _opik._score_result
+sys.modules["opik.evaluation.metrics"].BaseMetric = _opik._base_metric.BaseMetric
+sys.modules["opik.evaluation.metrics"].ScoreResult = _opik._score_result.ScoreResult
+
+sys.meta_path.insert(0, _stubs["opik"])
+
+# Simulate user code that only touches the lightweight path.
+from opik.evaluation.metrics import BaseMetric
+from opik.evaluation.metrics.score_result import ScoreResult
+
+class UserMetric(BaseMetric):
+    def score(self, **kwargs):
+        return ScoreResult(name="user", value=0.42)
+
+assert UserMetric().score().value == 0.42
+
+# Real opik must not have been loaded.
+heavy = [m for m in sys.modules if m.startswith("opik.") and m not in {
+    "opik.evaluation", "opik.evaluation.metrics",
+    "opik.evaluation.metrics.base_metric", "opik.evaluation.metrics.score_result",
+}]
+if heavy:
+    print("FAIL")
+    print(f"Lightweight path loaded unexpected modules: {heavy}")
+    sys.exit(1)
+assert _stubs, "stubs should still be in place — finder should not have triggered"
+
+print("LIGHT_PATH_OK")
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"Finder disturbed the lightweight path.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "LIGHT_PATH_OK" in result.stdout
+
     def test_opik_base_metric_is_subclass_of_lightweight(self):
         """Verify that opik.evaluation.metrics.BaseMetric subclasses _opik.BaseMetric.
 


### PR DESCRIPTION
## Details

Follow-up to #6386 — fix the two Python-backend tests that failed under `DockerExecutor`. Root cause sits in #6319: the sandbox stubs for `opik`, `opik.evaluation`, `opik.evaluation.metrics` have `__path__ = []`, so any user code importing a non-stubbed submodule (`opik.evaluation.metrics.conversation`, `heuristics`, `llm_judges`, `aggregated_metric`, …) blows up with `ModuleNotFoundError` before the `_FallbackModule.__getattr__` hook ever runs.

- Python's import machinery resolves submodules via the parent's `__path__`, not via `__getattr__` — the existing fallback only covers attribute access (`from opik import X`), not submodule imports (`from opik.x.y import z`).
- Added `_OpikFallbackFinder` on `sys.meta_path` that intercepts unresolved `opik.*` submodule imports, runs the same `_load_real_opik()` the attribute fallback uses, then defers to the standard PathFinder with the now-real `__path__`.
- Lightweight fast path (`BaseMetric` / `ScoreResult` only) is untouched; the finder returns early and costs a single `startswith` check per `opik.*` import until the real package is loaded, after which `_stubs` is empty and it's a no-op.
- Production impact: any customer-authored rule importing from the broken submodule paths has been silently failing since #6319 merged on 2026-04-16 — scoring returns 400 internally, feedback score never gets written, end-user-facing trace submission is always 200 (async), so it's invisible unless you're watching `execution_outcome_counter{outcome="invalid_code"}`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6091

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: investigation, root-cause analysis, fix in `scoring_runner.py`, commit message, PR description
- Human verification: diff reviewed; local repros run for (a) the failing `ModuleNotFoundError` and (b) the fixed path; scoring_runner exec'd end-to-end for lightweight, conversation-thread, wrong-data, and syntax-error scenarios

## Testing

Local verification (CI on this PR will still fail against `:latest` until the sandbox image rebuilds post-merge — same pattern as #6386):

- Reproduced the `ModuleNotFoundError` deterministically by exec'ing the pre-fix stub setup and running `from opik.evaluation.metrics.conversation import conversation_thread_metric, types`.
- Verified the fix resolves that import via the new finder, and that the lightweight path (`from opik.evaluation.metrics import BaseMetric` / `score_result`) still avoids loading real opik.
- Ran `scoring_runner.py` end-to-end as a standalone process against four scenarios:
  - Lightweight `BaseMetric` metric — returns correct score
  - `score_result` import path — returns correct score
  - `ConversationThreadMetric` with `type: trace_thread` — returns `{"value": 1.0, "reason": "n=2", "scoring_failed": false}` (matches `test_conversation_thread_metric_with_trace_thread_type` expectation)
  - `ConversationThreadMetric` without `type: trace_thread` (list data) — returns `{"error": "The provided 'code' and 'data' fields can't be evaluated: ..."}` (matches `test_conversation_thread_metric_wrong_data_structure_fails` expectation)
  - Invalid syntax — still fails with the pre-existing `"Field 'code' contains invalid Python code: SyntaxError..."` message
- Not run locally: the full `pytest` suite against a rebuilt Docker image (rebuild happens on merge via `build_apps.yml`).

## Documentation

None — internal sandbox runner behavior, no user-facing surface change.