### PR TITLE
[OPIK-6026] [BE] fix: replace in-memory analytics dedup with Redis and cache anonymous ID

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -457,6 +457,9 @@ analytics:
   # Default: empty
   # Description: Environment name included in every analytics event (e.g. "staging", "production")
   environment: ${OPIK_ANALYTICS_ENVIRONMENT:-}
+  # Default: 30d
+  # Description: TTL for the per-workspace first_trace_created dedup key in Redis
+  firstTraceCreatedDedupTtl: ${OPIK_ANALYTICS_FIRST_TRACE_CREATED_DEDUP_TTL:-30d}
 
 # Configuration for anonymous usage reporting
 usageReport:

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/AnalyticsConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/AnalyticsConfig.java
@@ -1,8 +1,14 @@
 package com.comet.opik.infrastructure;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.util.Duration;
+import io.dropwizard.validation.MaxDuration;
+import io.dropwizard.validation.MinDuration;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+
+import java.util.concurrent.TimeUnit;
 
 @Data
 public class AnalyticsConfig {
@@ -13,4 +19,8 @@ public class AnalyticsConfig {
     @Valid @JsonProperty
     private String environment;
 
+    @Valid @JsonProperty
+    @NotNull @MinDuration(value = 1, unit = TimeUnit.DAYS)
+    @MaxDuration(value = 90, unit = TimeUnit.DAYS)
+    private Duration firstTraceCreatedDedupTtl;
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/AnalyticsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/AnalyticsService.java
@@ -33,8 +33,8 @@ import java.util.Map;
  * <p><strong>Current limitations:</strong>
  * <ul>
  *   <li>Identity fallback ({@code usageReportService.getAnonymousId()}) performs a synchronous
- *       DB read. This only fires when there is no request scope and no explicit identity — not
- *       reachable from current request-scoped callers.</li>
+ *       DB read on the first call only — the anonymous ID is immutable and cached in memory
+ *       after that. Not reachable from current request-scoped callers.</li>
  *   <li>Requires {@code usageReport.enabled=true} at the transport level ({@link StatsClient}),
  *       in addition to {@code analytics.enabled=true}, for events to actually be sent.</li>
  * </ul>
@@ -70,6 +70,8 @@ class AnalyticsServiceImpl implements AnalyticsService {
     private final @NonNull UsageReportService usageReportService;
     private final @NonNull StatsClient statsClient;
     private final @NonNull Provider<RequestContext> requestContext;
+
+    private volatile String cachedAnonymousId;
 
     @Override
     public void trackEvent(String eventType, Map<String, String> properties) {
@@ -118,6 +120,13 @@ class AnalyticsServiceImpl implements AnalyticsService {
         } catch (ProvisionException e) {
             log.debug("No request scope available, falling back to installation anonymous ID");
         }
-        return usageReportService.getAnonymousId().orElse("unknown");
+        return getAnonymousId();
+    }
+
+    private String getAnonymousId() {
+        if (cachedAnonymousId == null) {
+            cachedAnonymousId = usageReportService.getAnonymousId().orElse("unknown");
+        }
+        return cachedAnonymousId;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/AnalyticsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/AnalyticsService.java
@@ -32,9 +32,9 @@ import java.util.Map;
  *
  * <p><strong>Current limitations:</strong>
  * <ul>
- *   <li>Identity fallback ({@code usageReportService.getAnonymousId()}) performs a synchronous
- *       DB read on the first call only — the anonymous ID is immutable and cached in memory
- *       after that. Not reachable from current request-scoped callers.</li>
+ *   <li>Identity fallback ({@code usageReportService.getAnonymousId()}) is cached at the source
+ *       ({@link UsageReportService}) — DB read at most once per JVM lifetime. Not reachable
+ *       from current request-scoped callers.</li>
  *   <li>Requires {@code usageReport.enabled=true} at the transport level ({@link StatsClient}),
  *       in addition to {@code analytics.enabled=true}, for events to actually be sent.</li>
  * </ul>
@@ -70,8 +70,6 @@ class AnalyticsServiceImpl implements AnalyticsService {
     private final @NonNull UsageReportService usageReportService;
     private final @NonNull StatsClient statsClient;
     private final @NonNull Provider<RequestContext> requestContext;
-
-    private volatile String cachedAnonymousId;
 
     @Override
     public void trackEvent(String eventType, Map<String, String> properties) {
@@ -120,13 +118,6 @@ class AnalyticsServiceImpl implements AnalyticsService {
         } catch (ProvisionException e) {
             log.debug("No request scope available, falling back to installation anonymous ID");
         }
-        return getAnonymousId();
-    }
-
-    private String getAnonymousId() {
-        if (cachedAnonymousId == null) {
-            cachedAnonymousId = usageReportService.getAnonymousId().orElse("unknown");
-        }
-        return cachedAnonymousId;
+        return usageReportService.getAnonymousId().orElse("unknown");
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/BiEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/BiEventListener.java
@@ -7,10 +7,13 @@ import com.comet.opik.domain.ProjectService;
 import com.comet.opik.domain.TraceService;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.cache.CacheManager;
 import com.comet.opik.infrastructure.lock.LockService;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.Subscribe;
 import jakarta.inject.Inject;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -22,53 +25,25 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @EagerSingleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
 @Slf4j
 public class BiEventListener {
 
     public static final String FIRST_TRACE_REPORT_BI_EVENT = "opik_os_first_trace_created";
 
-    private final UsageReportService usageReportService;
-    private final ProjectService projectService;
-    private final TraceService traceService;
-    private final LockService lockService;
-    private final OpikConfiguration config;
-    private final BiEventService biEventService;
-    private final AnalyticsService analyticsService;
+    private static final String FIRST_TRACE_CREATED_KEY_FORMAT = "opik:analytics:first_trace_created:%s";
 
-    /**
-     * Best-effort, in-memory dedup for per-workspace first_trace_created analytics events.
-     *
-     * <p>Known limitations:
-     * <ul>
-     *   <li>Grows monotonically — entries are never evicted, leading to unbounded memory usage.
-     *       Each entry is ~116 bytes (36-char UUID string + ConcurrentHashMap.Node overhead),
-     *       so 1M workspaces ≈ 116 MB.</li>
-     *   <li>Lost on JVM restarts — workspaces will be re-reported after a redeployment.</li>
-     *   <li>Not shared across replicas — each instance tracks independently, so multi-replica
-     *       deployments will emit duplicates.</li>
-     * </ul>
-     *
-     * TODO: replace with a bounded or persistent dedup mechanism in a follow-up PR.
-     */
-    private static final Set<String> ANALYTICS_REPORTED_WORKSPACES = ConcurrentHashMap.newKeySet();
-
-    @Inject
-    public BiEventListener(@NonNull ProjectService projectService,
-            @NonNull UsageReportService usageReportService, @NonNull TraceService traceService,
-            @NonNull OpikConfiguration config, @NonNull LockService lockService,
-            @NonNull BiEventService biEventService, @NonNull AnalyticsService analyticsService) {
-        this.projectService = projectService;
-        this.traceService = traceService;
-        this.config = config;
-        this.usageReportService = usageReportService;
-        this.lockService = lockService;
-        this.biEventService = biEventService;
-        this.analyticsService = analyticsService;
-    }
+    private final @NonNull UsageReportService usageReportService;
+    private final @NonNull ProjectService projectService;
+    private final @NonNull TraceService traceService;
+    private final @NonNull LockService lockService;
+    private final @NonNull OpikConfiguration config;
+    private final @NonNull BiEventService biEventService;
+    private final @NonNull AnalyticsService analyticsService;
+    private final @NonNull CacheManager cacheManager;
 
     @Subscribe
     public void onTracesCreated(TracesCreated event) {
@@ -152,7 +127,8 @@ public class BiEventListener {
             return;
         }
 
-        if (!ANALYTICS_REPORTED_WORKSPACES.add(workspaceId)) {
+        var ttl = config.getAnalytics().getFirstTraceCreatedDedupTtl().toJavaDuration();
+        if (!cacheManager.putIfAbsentSync(firstTraceCreatedKey(workspaceId), true, ttl)) {
             return;
         }
 
@@ -160,5 +136,10 @@ public class BiEventListener {
                 "workspace_id", workspaceId,
                 "user_name", event.userName(),
                 "date", Instant.now().toString()), event.userName());
+    }
+
+    @VisibleForTesting
+    static String firstTraceCreatedKey(String workspaceId) {
+        return FIRST_TRACE_CREATED_KEY_FORMAT.formatted(workspaceId);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/UsageReportService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/UsageReportService.java
@@ -61,9 +61,16 @@ class UsageReportServiceImpl implements UsageReportService {
     private final @NonNull MetadataAnalyticsDAO metadataAnalyticsDAO;
     private final @NonNull CacheManager cacheManager;
 
+    private volatile String cachedAnonymousId;
+
     public Optional<String> getAnonymousId() {
-        return template.inTransaction(READ_ONLY,
+        if (cachedAnonymousId != null) {
+            return Optional.of(cachedAnonymousId);
+        }
+        var anonymousId = template.inTransaction(READ_ONLY,
                 handle -> handle.attach(MetadataDAO.class).getMetadataKey(Metadata.ANONYMOUS_ID.getValue()));
+        anonymousId.ifPresent(presentAnonymousId -> cachedAnonymousId = presentAnonymousId);
+        return anonymousId;
     }
 
     public void saveAnonymousId(@NonNull String id) {
@@ -71,6 +78,7 @@ class UsageReportServiceImpl implements UsageReportService {
             handle.attach(MetadataDAO.class).saveMetadataKey(Metadata.ANONYMOUS_ID.getValue(), id);
             return null;
         });
+        cachedAnonymousId = id;
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/cache/CacheManager.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/cache/CacheManager.java
@@ -34,6 +34,7 @@ public interface CacheManager {
     // Non-reactive API (both synchronous and asynchronous methods without reactiveness)
     CompletionStage<Boolean> evictAsync(String key, boolean usePatternMatching);
     CompletionStage<Void> putAsync(String key, Object value, Duration ttlDuration);
+    boolean putIfAbsentSync(String key, Object value, Duration ttlDuration);
     <T> T getSync(String key, Class<T> clazz);
     <T> T getSync(String key, TypeReference<T> clazz);
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedisCacheManager.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedisCacheManager.java
@@ -75,6 +75,12 @@ class RedisCacheManager implements CacheManager {
     }
 
     @Override
+    public boolean putIfAbsentSync(@NonNull String key, @NonNull Object value, @NonNull Duration ttlDuration) {
+        var json = JsonUtils.writeValueAsString(value);
+        return nonReactiveRedisClient.getBucket(key).setIfAbsent(json, ttlDuration);
+    }
+
+    @Override
     public <T> T getSync(@NonNull String key, @NonNull Class<T> clazz) {
         var json = nonReactiveRedisClient.<String>getBucket(key).get();
         if (StringUtils.isEmpty(json)) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/BiEventListenerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/BiEventListenerTest.java
@@ -153,6 +153,7 @@ class BiEventListenerTest {
         mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
         cacheManager.evict(Metadata.FIRST_TRACE_CREATED.getValue(), false).block();
+        cacheManager.evict(BiEventListener.firstTraceCreatedKey(workspaceId), false).block();
 
         var trace = factory.manufacturePojo(Trace.class);
         traceResourceClient.createTrace(trace, apiKey, workspaceName);

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -211,6 +211,9 @@ analytics:
   # Default: empty
   # Description: Environment name included in every analytics event (e.g. "staging", "production")
   environment:
+  # Default: 1d (minimum allowed, sufficient for test duration)
+  # Description: TTL for the per-workspace first_trace_created dedup key in Redis
+  firstTraceCreatedDedupTtl: 1d
 
 # Configuration for anonymous usage reporting
 usageReport:


### PR DESCRIPTION
## Details

Replace the unbounded `ConcurrentHashMap`-backed `ANALYTICS_REPORTED_WORKSPACES` set with Redis-based dedup via `CacheManager`, and cache the anonymous ID at the source (`UsageReportService`) to eliminate repeated DB reads across all BI callers. Follow-up to PR #6362 which hardened the analytics/BI infrastructure.

- **Redis dedup**: Atomic `SET NX EX` via new `CacheManager.putIfAbsentSync()` (backed by Redisson `setIfAbsent`). Single Redis round-trip replaces unbounded in-memory set that grew monotonically (~116 bytes/workspace), was lost on restart, and not shared across replicas. Estimated Redis usage: ~37 MB at 200K workspaces, ~184 MB at 1M (TTL-bounded, self-cleaning).
- **Configurable TTL**: `AnalyticsConfig.firstTraceCreatedDedupTtl` (default 30d, min 1d, max 90d, env-var `OPIK_ANALYTICS_FIRST_TRACE_CREATED_DEDUP_TTL`). Keys auto-expire — steady-state Redis usage proportional to workspace creation rate, not total workspaces.
- **Anonymous ID caching at the source**: `volatile String cachedAnonymousId` in `UsageReportServiceImpl` — DB hit at most once per JVM lifetime. All 5 callers benefit (`BiEventListener`, `DailyUsageReportJob`, `WelcomeWizardEventListener`, `AnalyticsService`, `InstallationReportService`). Previously `BiEventListener.sendBiEvent()` hit MySQL on every trace batch event.
- **Boilerplate reduction**: `@RequiredArgsConstructor(onConstructor_ = @Inject)` replaces 12-line constructor in `BiEventListener`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6026

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (CLI)
- Model(s): Claude Opus 4.6 (1M context)
- Scope: Full implementation with human-guided iterative design decisions
- Human verification: Code review, manual adjustments, BI integration tests passing

## Testing

- `mvn compile -DskipTests` — clean compile
- `mvn test -Dtest="BiEventListenerTest"` — 1 test, 0 failures
  - Verifies both BI and analytics first-trace events via WireMock
  - Verifies dedup (second trace doesn't re-fire either event)
  - Evicts Redis dedup key before test for clean state
- `mvn test -Dtest="OpikGuiceyLifecycleEventListenerTest"` — 2 tests, 0 failures (startup event + idempotency, exercises anonymous ID persistence and retrieval)
- `mvn test -Dtest="DailyUsageReportJobTest"` — passes (exercises `getAnonymousId()` which now benefits from cache)

Scenarios validated:
- Happy path: trace creation triggers analytics event, Redis key set with TTL
- Dedup: second trace in same workspace — `putIfAbsentSync` returns false, event not re-sent
- Clean state: Redis key eviction before test ensures isolation
- Anonymous ID: persisted at startup, cached in memory, served without DB reads on subsequent calls

## Documentation

Javadocs updated on `AnalyticsService` interface to reflect anonymous ID caching at the source. N/A for external documentation.