### PR TITLE
[OPIK-6027] [FE] feat: rework onboarding step 2 CTAs and demo banner

### DIFF
--- a/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
+++ b/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
@@ -79,8 +79,9 @@ const DemoProjectBanner: React.FC<DemoProjectBannerProps> = ({
           onClick={handleCreateYourOwn}
           className="text-foreground underline underline-offset-2"
         >
-          create your own
+          click here to create your own
         </Link>
+        .
       </span>
     </div>
   );

--- a/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
+++ b/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import { Link } from "@tanstack/react-router";
 import useLocalStorageState from "use-local-storage-state";
-import { PlugZap } from "lucide-react";
 
 import { useActiveProjectId, useActiveWorkspaceName } from "@/store/AppStore";
 import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
@@ -12,7 +11,6 @@ import {
   AGENT_ONBOARDING_STEPS,
   AgentOnboardingState,
 } from "@/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext";
-import useAutoCompleteAgentOnboarding from "./useAutoCompleteAgentOnboarding";
 
 interface DemoProjectBannerProps {
   onChangeHeight: (height: number) => void;
@@ -30,9 +28,10 @@ const DemoProjectBanner: React.FC<DemoProjectBannerProps> = ({
     { enabled: !!activeProjectId },
   );
 
-  const [onboardingState] = useLocalStorageState<AgentOnboardingState>(
-    `${AGENT_ONBOARDING_KEY}-${workspaceName}`,
-  );
+  const [onboardingState, setOnboardingState] =
+    useLocalStorageState<AgentOnboardingState>(
+      `${AGENT_ONBOARDING_KEY}-${workspaceName}`,
+    );
 
   const { ref } = useObserveResizeNode<HTMLDivElement>((node) => {
     heightRef.current = node.clientHeight;
@@ -40,20 +39,11 @@ const DemoProjectBanner: React.FC<DemoProjectBannerProps> = ({
   });
 
   const isDemoProject = project?.name === DEMO_PROJECT_NAME;
-  const isOnboardingProject =
-    !!onboardingState?.agentName && project?.name === onboardingState.agentName;
-  const isRelevantProject = isDemoProject || isOnboardingProject;
-
   const isOnboardingActive =
     !!onboardingState?.step &&
     onboardingState.step !== AGENT_ONBOARDING_STEPS.DONE;
 
-  useAutoCompleteAgentOnboarding({
-    activeProjectId,
-    enabled: isOnboardingProject && isOnboardingActive,
-  });
-
-  const hideBanner = !isRelevantProject || !isOnboardingActive;
+  const hideBanner = !isDemoProject || !isOnboardingActive;
 
   useEffect(() => {
     onChangeHeight(!hideBanner ? heightRef.current : 0);
@@ -63,20 +53,29 @@ const DemoProjectBanner: React.FC<DemoProjectBannerProps> = ({
     return null;
   }
 
+  // Send the user back to Step 1 (project naming) instead of resuming whichever
+  // onboarding step they were on. Pre-fill is preserved by keeping agentName —
+  // AgentNameStep initializes its input from it and the create-project mutation
+  // auto-advances on 409 when the name still belongs to their existing project.
+  const handleCreateYourOwn = () => {
+    setOnboardingState((prev) =>
+      prev ? { ...prev, step: AGENT_ONBOARDING_STEPS.AGENT_NAME } : prev,
+    );
+  };
+
   return (
     <div ref={ref} className="z-10 flex h-8 items-center gap-1.5 bg-muted px-4">
       <span className="comet-body-xs text-foreground">
-        Connect your repo so Opik can help set up tracing, or instrument your
-        code manually.
+        You are viewing a demo project,{" "}
+        <Link
+          to="/$workspaceName/get-started"
+          params={{ workspaceName }}
+          onClick={handleCreateYourOwn}
+          className="text-foreground underline underline-offset-2"
+        >
+          create your own
+        </Link>
       </span>
-      <Link
-        to="/$workspaceName/get-started"
-        params={{ workspaceName }}
-        className="comet-body-xs inline-flex items-center gap-0.5 text-foreground underline underline-offset-2"
-      >
-        <PlugZap className="size-3" />
-        Connect your agent
-      </Link>
     </div>
   );
 };

--- a/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
+++ b/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
@@ -72,9 +72,9 @@ const DemoProjectBanner: React.FC<DemoProjectBannerProps> = ({
   return (
     <div
       ref={ref}
-      className="z-10 flex h-8 items-center gap-1.5 bg-primary px-4"
+      className="z-10 flex h-8 items-center justify-center gap-1.5 bg-primary px-4"
     >
-      <span className="comet-body-xs text-white">
+      <span className="comet-body-xs text-center text-white">
         You are viewing a demo project,{" "}
         <Link
           to="/$workspaceName/get-started"

--- a/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
+++ b/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
@@ -11,6 +11,7 @@ import {
   AGENT_ONBOARDING_STEPS,
   AgentOnboardingState,
 } from "@/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext";
+import useAutoCompleteAgentOnboarding from "./useAutoCompleteAgentOnboarding";
 
 interface DemoProjectBannerProps {
   onChangeHeight: (height: number) => void;
@@ -42,6 +43,11 @@ const DemoProjectBanner: React.FC<DemoProjectBannerProps> = ({
   const isOnboardingActive =
     !!onboardingState?.step &&
     onboardingState.step !== AGENT_ONBOARDING_STEPS.DONE;
+
+  useAutoCompleteAgentOnboarding({
+    agentName: onboardingState?.agentName,
+    enabled: isDemoProject && isOnboardingActive,
+  });
 
   const hideBanner = !isDemoProject || !isOnboardingActive;
 

--- a/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
+++ b/apps/opik-frontend/src/v2/layout/DemoProjectBanner/DemoProjectBanner.tsx
@@ -70,14 +70,17 @@ const DemoProjectBanner: React.FC<DemoProjectBannerProps> = ({
   };
 
   return (
-    <div ref={ref} className="z-10 flex h-8 items-center gap-1.5 bg-muted px-4">
-      <span className="comet-body-xs text-foreground">
+    <div
+      ref={ref}
+      className="z-10 flex h-8 items-center gap-1.5 bg-primary px-4"
+    >
+      <span className="comet-body-xs text-white">
         You are viewing a demo project,{" "}
         <Link
           to="/$workspaceName/get-started"
           params={{ workspaceName }}
           onClick={handleCreateYourOwn}
-          className="text-foreground underline underline-offset-2"
+          className="text-white underline underline-offset-2"
         >
           click here to create your own
         </Link>

--- a/apps/opik-frontend/src/v2/layout/DemoProjectBanner/useAutoCompleteAgentOnboarding.ts
+++ b/apps/opik-frontend/src/v2/layout/DemoProjectBanner/useAutoCompleteAgentOnboarding.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import useLocalStorageState from "use-local-storage-state";
 
+import useProjectByName from "@/api/projects/useProjectByName";
 import useTracesList from "@/api/traces/useTracesList";
 import { useActiveWorkspaceName } from "@/store/AppStore";
 import {
@@ -10,7 +11,7 @@ import {
 } from "@/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext";
 
 interface UseAutoCompleteAgentOnboardingParams {
-  projectId: string | null;
+  agentName: string | undefined;
   enabled: boolean;
 }
 
@@ -22,13 +23,19 @@ interface UseAutoCompleteAgentOnboardingParams {
 // the localStorage hook returns a new object reference on every render, so
 // we can't rely on identity.
 const useAutoCompleteAgentOnboarding = ({
-  projectId,
+  agentName,
   enabled,
 }: UseAutoCompleteAgentOnboardingParams) => {
   const workspaceName = useActiveWorkspaceName();
   const [, setOnboardingState] = useLocalStorageState<AgentOnboardingState>(
     `${AGENT_ONBOARDING_KEY}-${workspaceName}`,
   );
+
+  const { data: agentProject } = useProjectByName(
+    { projectName: agentName ?? "" },
+    { enabled: enabled && !!agentName },
+  );
+  const projectId = agentProject?.id;
 
   const { data: tracesData } = useTracesList(
     {
@@ -37,7 +44,7 @@ const useAutoCompleteAgentOnboarding = ({
       size: 1,
     },
     {
-      enabled: !!projectId && enabled,
+      enabled: enabled && !!projectId,
     },
   );
   const hasTraces = (tracesData?.total ?? 0) > 0;

--- a/apps/opik-frontend/src/v2/layout/DemoProjectBanner/useAutoCompleteAgentOnboarding.ts
+++ b/apps/opik-frontend/src/v2/layout/DemoProjectBanner/useAutoCompleteAgentOnboarding.ts
@@ -10,19 +10,19 @@ import {
 } from "@/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext";
 
 interface UseAutoCompleteAgentOnboardingParams {
-  activeProjectId: string | null;
+  projectId: string | null;
   enabled: boolean;
 }
 
-// Auto-complete onboarding when the user lands on their own agent project that
-// already has traces. This covers the case where a user connected their agent
-// and logged traces in a previous session but never clicked "Explore Opik" to
-// finalize the flow — without this, they'd keep seeing the banner forever.
-// The `enabled` flag (caller's isOnboardingProject && isOnboardingActive) stops
-// the effect from re-firing after DONE is written — the localStorage hook
-// returns a new object reference on every render, so we can't rely on identity.
+// Auto-complete onboarding when the user's agent project already has traces.
+// Covers the case where a user connected their agent and logged traces in a
+// previous session but never clicked "Explore Opik" to finalize the flow —
+// without this, they'd keep seeing the demo-project banner forever.
+// The `enabled` flag stops the effect from re-firing after DONE is written —
+// the localStorage hook returns a new object reference on every render, so
+// we can't rely on identity.
 const useAutoCompleteAgentOnboarding = ({
-  activeProjectId,
+  projectId,
   enabled,
 }: UseAutoCompleteAgentOnboardingParams) => {
   const workspaceName = useActiveWorkspaceName();
@@ -32,12 +32,12 @@ const useAutoCompleteAgentOnboarding = ({
 
   const { data: tracesData } = useTracesList(
     {
-      projectId: activeProjectId ?? "",
+      projectId: projectId ?? "",
       page: 1,
       size: 1,
     },
     {
-      enabled: !!activeProjectId && enabled,
+      enabled: !!projectId && enabled,
     },
   );
   const hasTraces = (tracesData?.total ?? 0) > 0;

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/AgentNameStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/AgentNameStep.tsx
@@ -45,11 +45,16 @@ const AgentNameStep: React.FC = () => {
       });
     } catch (err) {
       const axiosError = err as AxiosError;
+      // Project with this name already exists — treat as success and reuse it.
+      // This is the common case when a user returns via the demo banner and
+      // submits the same name they entered before.
       if (axiosError.response?.status === HttpStatusCode.Conflict) {
-        setError("A project with this name already exists");
-      } else {
-        setError("Failed to create project. Please try again.");
+        goToStep(AGENT_ONBOARDING_STEPS.CONNECT_AGENT, {
+          agentName: trimmedName,
+        });
+        return;
       }
+      setError("Failed to create project. Please try again.");
     }
   };
 

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
@@ -23,7 +23,6 @@ import InstallWithAITab from "./InstallWithAITab";
 import ManualIntegrationList from "./ManualIntegrationList";
 import ManualIntegrationDetail from "./ManualIntegrationDetail";
 import ShowDemoProjectButton from "./ShowDemoProjectButton";
-import useAutoCompleteAgentOnboarding from "@/v2/layout/DemoProjectBanner/useAutoCompleteAgentOnboarding";
 import { INTEGRATIONS } from "@/constants/integrations";
 import {
   SLACK_LINK,
@@ -113,11 +112,6 @@ const ConnectAgentStep: React.FC = () => {
 
   const isOllieTab = activeTab === "connect-to-ollie";
   const primaryReady = isOllieTab ? connected : traceReceived;
-
-  useAutoCompleteAgentOnboarding({
-    projectId: projectId ?? null,
-    enabled: !!projectId,
-  });
 
   const handleViewTraces = () => {
     goToStep(AGENT_ONBOARDING_STEPS.DONE, {

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import useLocalStorageState from "use-local-storage-state";
-import { ArrowRight, ChevronsRight, MonitorPlay, Undo2 } from "lucide-react";
+import { ArrowRight, MonitorPlay, Undo2 } from "lucide-react";
 import { useFeatureFlagVariantKey } from "posthog-js/react";
 import { Button } from "@/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/ui/tabs";
@@ -22,7 +22,8 @@ import ConnectToOllieTab from "./ConnectToOllieTab";
 import InstallWithAITab from "./InstallWithAITab";
 import ManualIntegrationList from "./ManualIntegrationList";
 import ManualIntegrationDetail from "./ManualIntegrationDetail";
-import ViewDemoProjectButton from "./ViewDemoProjectButton";
+import ShowDemoProjectButton from "./ShowDemoProjectButton";
+import useAutoCompleteAgentOnboarding from "@/v2/layout/DemoProjectBanner/useAutoCompleteAgentOnboarding";
 import { INTEGRATIONS } from "@/constants/integrations";
 import {
   SLACK_LINK,
@@ -113,6 +114,11 @@ const ConnectAgentStep: React.FC = () => {
   const isOllieTab = activeTab === "connect-to-ollie";
   const primaryReady = isOllieTab ? connected : traceReceived;
 
+  useAutoCompleteAgentOnboarding({
+    projectId: projectId ?? null,
+    enabled: !!projectId,
+  });
+
   const handleViewTraces = () => {
     goToStep(AGENT_ONBOARDING_STEPS.DONE, {
       agentName,
@@ -127,11 +133,6 @@ const ConnectAgentStep: React.FC = () => {
   const handleTabChange = (value: string) => {
     setActiveTab(value);
     setSelectedIntegrationId(null);
-  };
-
-  const handleSkip = () => {
-    trackEvent(OpikEvent.ONBOARDING_SKIPPED, { agent_name: agentName });
-    goToStep(AGENT_ONBOARDING_STEPS.DONE, { agentName });
   };
 
   if (selectedIntegration) {
@@ -218,19 +219,7 @@ const ConnectAgentStep: React.FC = () => {
             <ArrowRight className="size-3.5" />
           </Button>
         ) : (
-          <div className="flex w-full items-center justify-between">
-            <ViewDemoProjectButton />
-            <Button
-              variant="link"
-              onClick={handleSkip}
-              className="comet-body-s ml-auto px-0 text-muted-slate"
-              id="onboarding-step2-skip"
-              data-fs-element="onboarding-step2-skip"
-            >
-              Skip for now
-              <ChevronsRight className="size-3.5" />
-            </Button>
-          </div>
+          <ShowDemoProjectButton />
         )
       }
     >

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ShowDemoProjectButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ShowDemoProjectButton.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ArrowRight, Loader2 } from "lucide-react";
+import { ChevronsRight, Loader2 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 
 import { Button } from "@/ui/button";
@@ -13,11 +13,13 @@ const ShowDemoProjectButton: React.FC = () => {
   if (!demoProject) {
     return (
       <Button
+        variant="link"
         disabled
+        className="comet-body-s ml-auto px-0 text-muted-slate"
         id="onboarding-step2-show-demo"
         data-fs-element="onboarding-step2-show-demo"
       >
-        <Loader2 className="mr-2 size-4 animate-spin" />
+        <Loader2 className="mr-1.5 size-3.5 animate-spin" />
         Generating demo data…
       </Button>
     );
@@ -25,7 +27,9 @@ const ShowDemoProjectButton: React.FC = () => {
 
   return (
     <Button
+      variant="link"
       asChild
+      className="comet-body-s ml-auto px-0 text-muted-slate"
       id="onboarding-step2-show-demo"
       data-fs-element="onboarding-step2-show-demo"
     >
@@ -37,7 +41,7 @@ const ShowDemoProjectButton: React.FC = () => {
         }}
       >
         Show me a demo project
-        <ArrowRight className="ml-1 size-3.5" />
+        <ChevronsRight className="size-3.5" />
       </Link>
     </Button>
   );

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ShowDemoProjectButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ShowDemoProjectButton.tsx
@@ -1,26 +1,33 @@
 import React from "react";
-import { ArrowUpRight } from "lucide-react";
+import { ArrowRight, Loader2 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 
 import { Button } from "@/ui/button";
 import { useActiveWorkspaceName } from "@/store/AppStore";
 import useDemoProject from "@/api/projects/useDemoProject";
 
-const ViewDemoProjectButton: React.FC = () => {
+const ShowDemoProjectButton: React.FC = () => {
   const workspaceName = useActiveWorkspaceName();
   const { data: demoProject } = useDemoProject({ workspaceName, poll: true });
 
   if (!demoProject) {
-    return null;
+    return (
+      <Button
+        disabled
+        id="onboarding-step2-show-demo"
+        data-fs-element="onboarding-step2-show-demo"
+      >
+        <Loader2 className="mr-2 size-4 animate-spin" />
+        Generating demo data…
+      </Button>
+    );
   }
 
   return (
     <Button
-      variant="link"
-      className="comet-body-s px-0 text-foreground"
       asChild
-      id="onboarding-step2-view-demo"
-      data-fs-element="onboarding-step2-view-demo"
+      id="onboarding-step2-show-demo"
+      data-fs-element="onboarding-step2-show-demo"
     >
       <Link
         to="/$workspaceName/projects/$projectId/logs"
@@ -29,11 +36,11 @@ const ViewDemoProjectButton: React.FC = () => {
           projectId: demoProject.id,
         }}
       >
-        View Demo project
-        <ArrowUpRight className="ml-1 size-3.5" />
+        Show me a demo project
+        <ArrowRight className="ml-1 size-3.5" />
       </Link>
     </Button>
   );
 };
 
-export default ViewDemoProjectButton;
+export default ShowDemoProjectButton;

--- a/apps/opik-frontend/src/v2/pages/ProjectPage/ProjectPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectPage/ProjectPage.tsx
@@ -17,9 +17,17 @@ const ProjectPage = () => {
 
   const activeProjectId = useActiveProjectId();
 
+  // The URL is the source of truth for the active project when we're on a
+  // project route. Re-assert whenever activeProjectId drifts from the URL —
+  // e.g. useActiveProjectInitializer (in SideBar) may write asynchronously
+  // after useProjectsList resolves and overwrite what we set on mount.
+  // Without this listener, the sidebar would get stuck showing a stale
+  // project while breadcrumbs/URL show the real one.
   useEffect(() => {
-    setActiveProject(workspaceName, projectId);
-  }, [projectId, workspaceName]);
+    if (activeProjectId !== projectId) {
+      setActiveProject(workspaceName, projectId);
+    }
+  }, [projectId, workspaceName, activeProjectId]);
 
   const { data, isPending, isError } = useProjectById({
     projectId,


### PR DESCRIPTION
## Details

Follow-up PR on OPIK-6027 iterating on the onboarding flow based on product feedback, plus a related race-condition fix.


https://github.com/user-attachments/assets/0e92e81f-eb70-4a9b-a609-622e8aec9991



- **Single Step-2 CTA**: replaced the "View Demo project" + "Skip for now" pair with a single `ShowDemoProjectButton`.
  - Enabled state: "Show me a demo project" — navigates to the demo project's logs page.
  - Loading state: disabled with `Loader2` spinner + "Generating demo data…" while `useDemoProject` polls for the async backend generation. Stays in loading indefinitely if the project never appears (OSS without demo data is the known edge case; the connect-your-agent path works independently).
- **Banner simplification**: now shows only on the demo project (no longer on the user's own agent project). New copy: "You are viewing a demo project, create your own". Clicking the link resets onboarding step to `AGENT_NAME` and navigates to `/get-started`.
- **AgentNameStep**: pre-fills the input with the existing `agentName` (already in place) and auto-advances to `CONNECT_AGENT` on 409 Conflict — supports the banner round-trip cleanly.
- **`useAutoCompleteAgentOnboarding`**: takes `agentName` and fetches the agent project itself, keeping the hook where it semantically belongs (inside the banner).
- **ProjectPage activeProjectId fix**: pre-existing race between `useActiveProjectInitializer` (in `SideBar`) and `ProjectPage` was surfacing consistently in the demo flow — `ProjectPage` wrote the URL project ID on mount, then `useActiveProjectInitializer`'s async `useProjectsList` resolved later and overwrote it with "latest project", leaving the sidebar stuck on a stale project while breadcrumbs/URL showed the real one. `ProjectPage` now listens for drift and re-asserts the URL as the source of truth.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6027

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation + PR authoring
- Human verification: code review + manual review of each iteration

## Testing

- \`scripts/dev-runner.sh --lint-fe\` — lint:fix, typecheck, deps:validate all pass
- Manual verification needed (demo project generation blocker OPIK-xxxx is still open; full E2E not possible until that's resolved):
  - Step 2 with demo seeded → single button "Show me a demo project"; click → demo logs
  - Step 2 without demo (wipe demo project, start fresh) → button in loading state "Generating demo data…"; regenerate demo → button transitions within ~5s
  - Step 2 with agent connected + traces → "Explore Opik" button (unchanged path)
  - Banner: visible on demo project while onboarding active; hidden when onboarding done
  - Banner click → /get-started, Step 1 pre-filled with previous agentName
  - Same-name submit on Step 1 → auto-advances to Step 2 (no error)
  - Different-name submit → standard create path → Step 2
  - Sidebar project selector stays in sync with URL when navigating from onboarding to demo project

## Documentation

N/A