### PR TITLE
[OPIK-5709][FE] Eval suite version history: long version notes are truncated with ellipsis and full text not shown on hover

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/VersionHistoryTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/VersionHistoryTab.tsx
@@ -15,6 +15,7 @@ import { convertColumnDataToColumn } from "@/lib/table";
 import { generateActionsColumDef } from "@/shared/DataTable/utils";
 import { usePermissions } from "@/contexts/PermissionsContext";
 import VersionChangeSummaryCell from "./VersionChangeSummaryCell";
+import VersionNoteCell from "./VersionNoteCell";
 import VersionRowActionsCell from "./VersionRowActionsCell";
 
 interface VersionHistoryTabProps {
@@ -44,6 +45,7 @@ const COLUMNS: ColumnData<DatasetVersion>[] = [
     id: "change_description",
     label: "Version note",
     type: COLUMN_TYPE.string,
+    cell: VersionNoteCell as never,
   },
   {
     id: "tags",

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/VersionNoteCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/VersionNoteCell.tsx
@@ -1,0 +1,23 @@
+import { CellContext } from "@tanstack/react-table";
+import { DatasetVersion } from "@/types/datasets";
+import CellWrapper from "@/shared/DataTableCells/CellWrapper";
+import CellTooltipWrapper from "@/shared/DataTableCells/CellTooltipWrapper";
+
+const VersionNoteCell = (
+  context: CellContext<DatasetVersion, string>,
+) => {
+  const value = context.getValue();
+
+  return (
+    <CellWrapper
+      metadata={context.column.columnDef.meta}
+      tableMetadata={context.table.options.meta}
+    >
+      <CellTooltipWrapper content={value}>
+        <span className="truncate">{value}</span>
+      </CellTooltipWrapper>
+    </CellWrapper>
+  );
+};
+
+export default VersionNoteCell;

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/VersionNoteCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/VersionNoteCell.tsx
@@ -3,9 +3,7 @@ import { DatasetVersion } from "@/types/datasets";
 import CellWrapper from "@/shared/DataTableCells/CellWrapper";
 import CellTooltipWrapper from "@/shared/DataTableCells/CellTooltipWrapper";
 
-const VersionNoteCell = (
-  context: CellContext<DatasetVersion, string>,
-) => {
+const VersionNoteCell = (context: CellContext<DatasetVersion, string>) => {
   const value = context.getValue();
 
   return (


### PR DESCRIPTION
## Details
In the Evaluation Suite version history tab, version notes that exceed the visible area are truncated with an ellipsis ("..."). However, hovering over the truncated text does not display the full content in a tooltip or popover.

## Summary

Added a tooltip popover to the "Version note" column in the v2 Version History tab so that long notes are fully visible on hover instead of being truncated.

## Changes by Component

### Frontend
- Created `VersionNoteCell` component that wraps the version note text in `CellTooltipWrapper`, showing a popover with the full content on hover (for notes longer than 20 characters)
- Integrated `VersionNoteCell` as the custom cell renderer for the `change_description` column in the v2 `VersionHistoryTab`

## Files Changed

```
 .../VersionHistoryTab/VersionHistoryTab.tsx         |  2 ++
 .../datasets/VersionHistoryTab/VersionNoteCell.tsx  | 21 +++++++++++++++++++++
 2 files changed, 23 insertions(+)
```

## After applying the fix

https://github.com/user-attachments/assets/7508c5e9-c0fd-4b04-a138-f5496c1e295a


## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-5709

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code v2.1.92
  - Model(s): Opus 4.6 (1M context)
  - Scope: Full implementation
  - Human verification: Manually verified by developer

## Testing
Manual testing

## Documentation
NA