### PR TITLE
[OPIK-6090] [FE] fix: improve test suite add/edit item UX consistency

### DIFF
--- a/apps/opik-frontend/src/constants/test-suites.ts
+++ b/apps/opik-frontend/src/constants/test-suites.ts
@@ -1,6 +1,3 @@
-export const ASSERTIONS_DESCRIPTION =
-  "Define the conditions for this test to pass";
-
 export const PASS_CRITERIA_TITLE = "Pass criteria";
 export const PASS_CRITERIA_DESCRIPTION =
   "Set the number of runs per item and the minimum required to pass.";

--- a/apps/opik-frontend/src/shared/AssertionField/AssertionField.tsx
+++ b/apps/opik-frontend/src/shared/AssertionField/AssertionField.tsx
@@ -24,7 +24,7 @@ const WRAPPER_CLASSES =
 const EDITABLE_WRAPPER_CLASSES = "bg-background";
 
 const READONLY_WRAPPER_CLASSES =
-  "border-dashed bg-gray-100 focus-within:border-border";
+  "border-dashed bg-gray-100 focus-within:border-border opacity-60";
 
 const TEXTAREA_CLASSES =
   "flex w-full rounded-l-md border-none bg-transparent px-3 py-1.5 text-sm text-foreground placeholder:text-light-slate focus:outline-none min-h-8 resize-none";

--- a/apps/opik-frontend/src/shared/AssertionField/AssertionsField.tsx
+++ b/apps/opik-frontend/src/shared/AssertionField/AssertionsField.tsx
@@ -1,11 +1,28 @@
 import React, { useEffect, useRef } from "react";
 import { CheckCheck, Plus } from "lucide-react";
 
-import { Button } from "@/ui/button";
-import { Separator } from "@/ui/separator";
 import AssertionField from "./AssertionField";
 
+type AssertionsVariant = "item" | "global";
+
+const VARIANT_CONFIG: Record<
+  AssertionsVariant,
+  { title: string; description: string }
+> = {
+  item: {
+    title: "Assertions",
+    description: "Define the conditions for this test to pass",
+  },
+  global: {
+    title: "Global assertions",
+    description:
+      "Define the global conditions all items in this test suite must pass.",
+  },
+};
+
 interface AssertionsFieldProps {
+  variant: AssertionsVariant;
+  headerContent?: React.ReactNode;
   readOnlyAssertions?: string[];
   editableAssertions: string[];
   onChangeEditable: (index: number, value: string) => void;
@@ -15,6 +32,8 @@ interface AssertionsFieldProps {
 }
 
 const AssertionsField: React.FC<AssertionsFieldProps> = ({
+  variant,
+  headerContent,
   readOnlyAssertions = [],
   editableAssertions,
   onChangeEditable,
@@ -29,66 +48,79 @@ const AssertionsField: React.FC<AssertionsFieldProps> = ({
     prevCountRef.current = editableAssertions.length;
   }, [editableAssertions.length]);
 
+  const { title, description } = VARIANT_CONFIG[variant];
   const hasReadOnly = readOnlyAssertions.length > 0;
   const hasEditable = editableAssertions.length > 0;
-  const hasAny = hasReadOnly || hasEditable;
 
   return (
-    <div className="flex flex-col gap-2 pt-1.5">
-      {!hasAny && (
-        <div className="flex flex-col items-center justify-center gap-1.5 rounded-md border bg-muted/50 p-4">
-          <div className="flex size-6 items-center justify-center rounded-full border">
-            <CheckCheck className="size-3 text-muted-slate" />
+    <div className="flex flex-col gap-1">
+      <span className="comet-body-s-accented">{title}</span>
+      <div className="flex items-center justify-between">
+        <span className="comet-body-xs text-light-slate">{description}</span>
+        <div className="flex shrink-0 items-center gap-3">
+          {hasEditable && (
+            <button
+              type="button"
+              className="comet-body-xs-accented inline-flex items-center text-primary"
+              onClick={onAdd}
+            >
+              <Plus className="mr-0.5 size-3" />
+              Assertion
+            </button>
+          )}
+          {headerContent}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 pt-1.5">
+        {!hasEditable && (
+          <button
+            type="button"
+            onClick={onAdd}
+            className="flex flex-col items-center justify-center gap-1.5 rounded-md border bg-muted/50 p-4"
+          >
+            <div className="flex size-6 items-center justify-center rounded-full border">
+              <CheckCheck className="size-3 text-muted-slate" />
+            </div>
+            <span className="comet-body-xs text-muted-slate">
+              No custom assertions added yet
+            </span>
+            <span className="comet-body-xs-accented inline-flex items-center text-primary">
+              <Plus className="mr-0.5 size-3" />
+              Assertion
+            </span>
+          </button>
+        )}
+
+        {hasEditable && (
+          <div className="flex flex-col gap-2">
+            {editableAssertions.map((assertion, index) => (
+              <AssertionField
+                key={index}
+                autoFocus={
+                  shouldAutoFocusLast && index === editableAssertions.length - 1
+                }
+                placeholder={placeholder}
+                value={assertion}
+                onChange={(e) => onChangeEditable(index, e.target.value)}
+                onRemove={() => onRemoveEditable(index)}
+              />
+            ))}
           </div>
-          <span className="comet-body-xs text-muted-slate">
-            No assertions added yet
-          </span>
-        </div>
-      )}
+        )}
 
-      {hasReadOnly && (
-        <div className="flex flex-col gap-2">
-          {readOnlyAssertions.map((assertion, index) => (
-            <AssertionField
-              key={`global-${index}`}
-              isReadOnly
-              value={assertion}
-            />
-          ))}
-        </div>
-      )}
-
-      {hasReadOnly && hasEditable && <Separator className="my-1" />}
-
-      {hasEditable && (
-        <div className="flex flex-col gap-2">
-          {editableAssertions.map((assertion, index) => (
-            <AssertionField
-              key={index}
-              autoFocus={
-                shouldAutoFocusLast && index === editableAssertions.length - 1
-              }
-              placeholder={placeholder}
-              value={assertion}
-              onChange={(e) => onChangeEditable(index, e.target.value)}
-              onRemove={() => onRemoveEditable(index)}
-            />
-          ))}
-        </div>
-      )}
-
-      {
-        <Button
-          type="button"
-          variant="ghost"
-          size="2xs"
-          className="w-fit"
-          onClick={onAdd}
-        >
-          <Plus className="mr-0.5 size-3" />
-          Assertion
-        </Button>
-      }
+        {hasReadOnly && (
+          <div className="flex flex-col gap-2">
+            {readOnlyAssertions.map((assertion, index) => (
+              <AssertionField
+                key={`global-${index}`}
+                isReadOnly
+                value={assertion}
+              />
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/apps/opik-frontend/src/shared/EvaluationCriteriaSection/EvaluationCriteriaSection.tsx
+++ b/apps/opik-frontend/src/shared/EvaluationCriteriaSection/EvaluationCriteriaSection.tsx
@@ -1,0 +1,159 @@
+import React from "react";
+import { RotateCcw, Settings2 } from "lucide-react";
+
+import { Input } from "@/ui/input";
+import { Label } from "@/ui/label";
+import { cn } from "@/lib/utils";
+import { useClampedIntegerInput } from "@/hooks/useClampedIntegerInput";
+import AssertionsField from "@/shared/AssertionField/AssertionsField";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import { MAX_RUNS_PER_ITEM } from "@/types/test-suites";
+import {
+  PASS_CRITERIA_TITLE,
+  PASS_CRITERIA_DESCRIPTION,
+} from "@/constants/test-suites";
+
+export interface EvaluationCriteriaSectionProps {
+  suiteAssertions: string[];
+  editableAssertions: string[];
+  onChangeAssertion: (index: number, value: string) => void;
+  onRemoveAssertion: (index: number) => void;
+  onAddAssertion: () => void;
+  runsPerItem: number;
+  passThreshold: number;
+  onRunsPerItemChange: (value: number) => void;
+  onPassThresholdChange: (value: number) => void;
+  useGlobalPolicy: boolean;
+  onRevertToDefaults: () => void;
+  onOpenSettings?: () => void;
+}
+
+const EvaluationCriteriaSection: React.FunctionComponent<
+  EvaluationCriteriaSectionProps
+> = ({
+  suiteAssertions,
+  editableAssertions,
+  onChangeAssertion,
+  onRemoveAssertion,
+  onAddAssertion,
+  runsPerItem,
+  passThreshold,
+  onRunsPerItemChange,
+  onPassThresholdChange,
+  useGlobalPolicy,
+  onRevertToDefaults,
+  onOpenSettings,
+}) => {
+  const runsInput = useClampedIntegerInput({
+    value: runsPerItem,
+    min: 1,
+    max: MAX_RUNS_PER_ITEM,
+    onCommit: (v) => {
+      onRunsPerItemChange(v);
+      if (passThreshold > v) onPassThresholdChange(v);
+    },
+  });
+
+  const thresholdInput = useClampedIntegerInput({
+    value: passThreshold,
+    min: 1,
+    max: runsPerItem,
+    onCommit: onPassThresholdChange,
+  });
+
+  const manageSettingsButton = onOpenSettings ? (
+    <button
+      type="button"
+      className="comet-body-xs inline-flex shrink-0 items-center gap-1 border-b border-foreground text-foreground"
+      onClick={onOpenSettings}
+    >
+      <Settings2 className="size-3.5 shrink-0" />
+      Manage global assertions
+    </button>
+  ) : undefined;
+
+  return (
+    <div>
+      <AssertionsField
+        variant="item"
+        headerContent={manageSettingsButton}
+        readOnlyAssertions={suiteAssertions}
+        editableAssertions={editableAssertions}
+        onChangeEditable={onChangeAssertion}
+        onRemoveEditable={onRemoveAssertion}
+        onAdd={onAddAssertion}
+      />
+
+      <h3 className="comet-body-s-accented mb-1 mt-6">{PASS_CRITERIA_TITLE}</h3>
+      <p className="comet-body-xs mb-4 text-light-slate">
+        {PASS_CRITERIA_DESCRIPTION}
+      </p>
+
+      <div className="flex items-start overflow-hidden rounded-md border">
+        <div className="flex flex-1 gap-4 p-3">
+          <div className="flex flex-1 flex-col gap-1">
+            <Label className="comet-body-xs-accented">Runs for this item</Label>
+            <Input
+              dimension="sm"
+              className={cn("[&::-webkit-inner-spin-button]:appearance-none", {
+                "border-destructive": runsInput.isInvalid,
+              })}
+              type="number"
+              min={1}
+              max={MAX_RUNS_PER_ITEM}
+              value={runsInput.displayValue}
+              onChange={runsInput.onChange}
+              onFocus={runsInput.onFocus}
+              onBlur={runsInput.onBlur}
+              onKeyDown={runsInput.onKeyDown}
+            />
+            <span className="comet-body-xs text-light-slate">
+              Sets how many times this item runs.
+            </span>
+          </div>
+          <div className="flex flex-1 flex-col gap-1">
+            <Label className="comet-body-xs-accented">Pass threshold</Label>
+            <Input
+              dimension="sm"
+              className={cn("[&::-webkit-inner-spin-button]:appearance-none", {
+                "border-destructive": thresholdInput.isInvalid,
+              })}
+              type="number"
+              min={1}
+              max={runsPerItem}
+              value={thresholdInput.displayValue}
+              onChange={thresholdInput.onChange}
+              onFocus={thresholdInput.onFocus}
+              onBlur={thresholdInput.onBlur}
+              onKeyDown={thresholdInput.onKeyDown}
+            />
+            <span className="comet-body-xs text-light-slate">
+              Define how many runs must succeed.
+            </span>
+          </div>
+        </div>
+        <TooltipWrapper
+          content={
+            useGlobalPolicy
+              ? "Already using the suite's defaults"
+              : "Revert to the default values for this test suite"
+          }
+        >
+          <button
+            type="button"
+            className={cn(
+              "flex items-center justify-center self-stretch border-l px-2",
+              useGlobalPolicy && "cursor-default opacity-50",
+            )}
+            onClick={useGlobalPolicy ? undefined : onRevertToDefaults}
+            aria-disabled={useGlobalPolicy}
+          >
+            <RotateCcw className="size-3.5 text-muted-slate" />
+          </button>
+        </TooltipWrapper>
+      </div>
+    </div>
+  );
+};
+
+export default EvaluationCriteriaSection;

--- a/apps/opik-frontend/src/v1/pages/TestSuiteItemsPage/EditTestSuiteSettingsDialog.tsx
+++ b/apps/opik-frontend/src/v1/pages/TestSuiteItemsPage/EditTestSuiteSettingsDialog.tsx
@@ -202,25 +202,15 @@ const SettingsForm: React.FC<SettingsFormProps> = ({
               </div>
             </div>
 
-            <div className="flex flex-col gap-1 pb-4">
-              <div className="mb-1">
-                <Label className="comet-body-s-accented">
-                  Global assertions
-                </Label>
-                <p className="comet-body-xs text-light-slate">
-                  Define the global conditions all items in this test suite must
-                  pass.
-                </p>
-              </div>
-              <div className="pt-1.5">
-                <AssertionsField
-                  editableAssertions={fields.map((f) => f.value)}
-                  onChangeEditable={(index, value) => update(index, { value })}
-                  onRemoveEditable={(index) => remove(index)}
-                  onAdd={() => append({ value: "" })}
-                  placeholder="e.g. Response should be factually accurate and cite sources"
-                />
-              </div>
+            <div className="pb-4">
+              <AssertionsField
+                variant="global"
+                editableAssertions={fields.map((f) => f.value)}
+                onChangeEditable={(index, value) => update(index, { value })}
+                onRemoveEditable={(index) => remove(index)}
+                onAdd={() => append({ value: "" })}
+                placeholder="e.g. Response should be factually accurate and cite sources"
+              />
             </div>
           </div>
         </DialogAutoScrollBody>

--- a/apps/opik-frontend/src/v1/pages/TestSuiteItemsPage/TestSuiteItemPanel/TestSuiteItemForm.tsx
+++ b/apps/opik-frontend/src/v1/pages/TestSuiteItemsPage/TestSuiteItemPanel/TestSuiteItemForm.tsx
@@ -18,7 +18,6 @@ import { Description } from "@/ui/description";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
 import { ExecutionPolicy, MAX_RUNS_PER_ITEM } from "@/types/test-suites";
 import {
-  ASSERTIONS_DESCRIPTION,
   PASS_CRITERIA_TITLE,
   PASS_CRITERIA_DESCRIPTION,
 } from "@/constants/test-suites";
@@ -208,12 +207,9 @@ const EvaluationCriteriaSection: React.FC<EvaluationCriteriaSectionProps> = ({
         </div>
       </div>
 
-      <div className="flex flex-col gap-1">
-        <span className="comet-body-s-accented">Assertions</span>
-        <div className="flex items-center justify-between">
-          <span className="comet-body-xs text-light-slate">
-            {ASSERTIONS_DESCRIPTION}
-          </span>
+      <AssertionsField
+        variant="item"
+        headerContent={
           <button
             type="button"
             className="comet-body-xs inline-flex shrink-0 items-center gap-1 border-b border-foreground text-foreground"
@@ -222,16 +218,13 @@ const EvaluationCriteriaSection: React.FC<EvaluationCriteriaSectionProps> = ({
             <Settings2 className="size-3.5 shrink-0" />
             Manage global assertions
           </button>
-        </div>
-
-        <AssertionsField
-          readOnlyAssertions={suiteAssertions}
-          editableAssertions={fields.map((f) => f.value)}
-          onChangeEditable={(index, value) => update(index, { value })}
-          onRemoveEditable={(index) => remove(index)}
-          onAdd={() => append({ value: "" })}
-        />
-      </div>
+        }
+        readOnlyAssertions={suiteAssertions}
+        editableAssertions={fields.map((f) => f.value)}
+        onChangeEditable={(index, value) => update(index, { value })}
+        onRemoveEditable={(index) => remove(index)}
+        onAdd={() => append({ value: "" })}
+      />
     </div>
   );
 };

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/AddEditTestSuiteDialog/AddEditTestSuiteDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/AddEditTestSuiteDialog/AddEditTestSuiteDialog.tsx
@@ -104,31 +104,23 @@ const AddEditTestSuiteDialog: React.FunctionComponent<
               />
             </div>
           </div>
-          <div className="flex flex-col gap-1 pb-4">
-            <div className="mb-1">
-              <Label className="comet-body-s-accented">Global assertions</Label>
-              <p className="comet-body-xs text-light-slate">
-                Define the global conditions all items in this test suite must
-                pass.
-              </p>
-            </div>
-            <div className="pt-1.5">
-              <AssertionsField
-                editableAssertions={assertions}
-                onChangeEditable={(index, value) => {
-                  setAssertions((prev) => {
-                    const next = [...prev];
-                    next[index] = value;
-                    return next;
-                  });
-                }}
-                onRemoveEditable={(index) => {
-                  setAssertions((prev) => prev.filter((_, i) => i !== index));
-                }}
-                onAdd={() => setAssertions((prev) => [...prev, ""])}
-                placeholder="e.g. Response should be factually accurate and cite sources"
-              />
-            </div>
+          <div className="pb-4">
+            <AssertionsField
+              variant="global"
+              editableAssertions={assertions}
+              onChangeEditable={(index, value) => {
+                setAssertions((prev) => {
+                  const next = [...prev];
+                  next[index] = value;
+                  return next;
+                });
+              }}
+              onRemoveEditable={(index) => {
+                setAssertions((prev) => prev.filter((_, i) => i !== index));
+              }}
+              onAdd={() => setAssertions((prev) => [...prev, ""])}
+              placeholder="e.g. Response should be factually accurate and cite sources"
+            />
           </div>
         </>
       )}

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/CreateDatasetSidebar/CreateDatasetSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/CreateDatasetSidebar/CreateDatasetSidebar.tsx
@@ -367,35 +367,23 @@ const CreateDatasetSidebar: React.FunctionComponent<
                   />
                 </div>
               </div>
-              <div className="flex flex-col gap-1 pb-4">
-                <div className="mb-1">
-                  <Label className="comet-body-s-accented">
-                    Global assertions
-                  </Label>
-                  <p className="comet-body-xs text-light-slate">
-                    Define the global conditions all items in this test suite
-                    must pass.
-                  </p>
-                </div>
-                <div className="pt-1.5">
-                  <AssertionsField
-                    editableAssertions={assertions}
-                    onChangeEditable={(index, value) => {
-                      setAssertions((prev) => {
-                        const next = [...prev];
-                        next[index] = value;
-                        return next;
-                      });
-                    }}
-                    onRemoveEditable={(index) => {
-                      setAssertions((prev) =>
-                        prev.filter((_, i) => i !== index),
-                      );
-                    }}
-                    onAdd={() => setAssertions((prev) => [...prev, ""])}
-                    placeholder="e.g. Response should be factually accurate and cite sources"
-                  />
-                </div>
+              <div className="pb-4">
+                <AssertionsField
+                  variant="global"
+                  editableAssertions={assertions}
+                  onChangeEditable={(index, value) => {
+                    setAssertions((prev) => {
+                      const next = [...prev];
+                      next[index] = value;
+                      return next;
+                    });
+                  }}
+                  onRemoveEditable={(index) => {
+                    setAssertions((prev) => prev.filter((_, i) => i !== index));
+                  }}
+                  onAdd={() => setAssertions((prev) => [...prev, ""])}
+                  placeholder="e.g. Response should be factually accurate and cite sources"
+                />
               </div>
             </AccordionContent>
           </AccordionItem>

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/EditTestSuiteSettingsDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/EditTestSuiteSettingsDialog.tsx
@@ -99,25 +99,15 @@ const SettingsForm: React.FC<SettingsFormProps> = ({
         </DialogHeader>
         <DialogAutoScrollBody>
           <div className="flex flex-col">
-            <div className="mb-4 flex flex-col gap-1">
-              <div className="mb-1">
-                <Label className="comet-body-s-accented">
-                  Global assertions
-                </Label>
-                <p className="comet-body-xs text-light-slate">
-                  Define the global conditions all items in this test suite must
-                  pass.
-                </p>
-              </div>
-              <div className="pt-1.5">
-                <AssertionsField
-                  editableAssertions={fields.map((f) => f.value)}
-                  onChangeEditable={(index, value) => update(index, { value })}
-                  onRemoveEditable={(index) => remove(index)}
-                  onAdd={() => append({ value: "" })}
-                  placeholder="e.g. Response should be factually accurate and cite sources"
-                />
-              </div>
+            <div className="mb-4">
+              <AssertionsField
+                variant="global"
+                editableAssertions={fields.map((f) => f.value)}
+                onChangeEditable={(index, value) => update(index, { value })}
+                onRemoveEditable={(index) => remove(index)}
+                onAdd={() => append({ value: "" })}
+                placeholder="e.g. Response should be factually accurate and cite sources"
+              />
             </div>
 
             <div className="mb-4">

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/TestSuiteItemForm.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/TestSuiteItemForm.tsx
@@ -1,28 +1,18 @@
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import { Controller, useFieldArray, useFormContext } from "react-hook-form";
 import TextareaAutosize from "react-textarea-autosize";
 import CodeMirror from "@uiw/react-codemirror";
 import { EditorView } from "@codemirror/view";
 import { jsonLanguage } from "@codemirror/lang-json";
-import { RotateCcw, Settings2 } from "lucide-react";
 
-import { Input } from "@/ui/input";
-import { Label } from "@/ui/label";
 import { Separator } from "@/ui/separator";
 import { TEXT_AREA_CLASSES } from "@/ui/textarea";
 import { cn } from "@/lib/utils";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
-import { useClampedIntegerInput } from "@/hooks/useClampedIntegerInput";
-import AssertionsField from "@/shared/AssertionField/AssertionsField";
-import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { Description } from "@/ui/description";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
-import { ExecutionPolicy, MAX_RUNS_PER_ITEM } from "@/types/test-suites";
-import {
-  ASSERTIONS_DESCRIPTION,
-  PASS_CRITERIA_TITLE,
-  PASS_CRITERIA_DESCRIPTION,
-} from "@/constants/test-suites";
+import { ExecutionPolicy } from "@/types/test-suites";
+import EvaluationCriteriaSection from "@/shared/EvaluationCriteriaSection/EvaluationCriteriaSection";
 import { TestSuiteItemFormValues } from "./testSuiteItemFormSchema";
 
 const EDITOR_EXTENSIONS = [jsonLanguage, EditorView.lineWrapping];
@@ -115,31 +105,34 @@ const DataSection: React.FC = () => {
   );
 };
 
-interface EvaluationCriteriaSectionProps {
+interface FormEvaluationCriteriaSectionProps {
   suiteAssertions: string[];
   suitePolicy: ExecutionPolicy;
   onOpenSettings: () => void;
 }
 
-const EvaluationCriteriaSection: React.FC<EvaluationCriteriaSectionProps> = ({
-  suiteAssertions,
-  suitePolicy,
-  onOpenSettings,
-}) => {
+const FormEvaluationCriteriaSection: React.FC<
+  FormEvaluationCriteriaSectionProps
+> = ({ suiteAssertions, suitePolicy, onOpenSettings }) => {
   const form = useFormContext<TestSuiteItemFormValues>();
   const { fields, append, remove, update } = useFieldArray({
     control: form.control,
     name: "assertions",
   });
 
-  const runsPerItem = form.watch("runsPerItem");
+  const rawRunsPerItem = form.watch("runsPerItem");
+  const rawPassThreshold = form.watch("passThreshold");
   const useGlobalPolicy = form.watch("useGlobalPolicy");
 
-  const runsInput = useClampedIntegerInput({
-    value: runsPerItem,
-    min: 1,
-    max: MAX_RUNS_PER_ITEM,
-    onCommit: (v) => {
+  const runsPerItem = useGlobalPolicy
+    ? suitePolicy.runs_per_item
+    : rawRunsPerItem;
+  const passThreshold = useGlobalPolicy
+    ? suitePolicy.pass_threshold
+    : rawPassThreshold;
+
+  const handleRunsChange = useCallback(
+    (v: number) => {
       form.setValue("useGlobalPolicy", false);
       form.setValue("runsPerItem", v, { shouldDirty: true });
       const currentThreshold = form.getValues("passThreshold");
@@ -147,120 +140,38 @@ const EvaluationCriteriaSection: React.FC<EvaluationCriteriaSectionProps> = ({
         form.setValue("passThreshold", v, { shouldDirty: true });
       }
     },
-  });
+    [form],
+  );
 
-  const thresholdInput = useClampedIntegerInput({
-    value: form.watch("passThreshold"),
-    min: 1,
-    max: runsPerItem,
-    onCommit: (v) => {
+  const handleThresholdChange = useCallback(
+    (v: number) => {
       form.setValue("useGlobalPolicy", false);
       form.setValue("passThreshold", v, { shouldDirty: true });
     },
-  });
+    [form],
+  );
 
-  const handleRevertPolicy = () => {
+  const handleRevertPolicy = useCallback(() => {
     form.setValue("useGlobalPolicy", true, { shouldDirty: true });
     form.setValue("runsPerItem", suitePolicy.runs_per_item);
     form.setValue("passThreshold", suitePolicy.pass_threshold);
-  };
+  }, [form, suitePolicy]);
 
   return (
-    <div>
-      <div className="flex flex-col gap-1">
-        <span className="comet-body-s-accented">Assertions</span>
-        <div className="flex items-center justify-between">
-          <span className="comet-body-xs text-light-slate">
-            {ASSERTIONS_DESCRIPTION}
-          </span>
-          <button
-            type="button"
-            className="comet-body-xs inline-flex shrink-0 items-center gap-1 border-b border-foreground text-foreground"
-            onClick={onOpenSettings}
-          >
-            <Settings2 className="size-3.5 shrink-0" />
-            Manage global assertions
-          </button>
-        </div>
-
-        <AssertionsField
-          readOnlyAssertions={suiteAssertions}
-          editableAssertions={fields.map((f) => f.value)}
-          onChangeEditable={(index, value) => update(index, { value })}
-          onRemoveEditable={(index) => remove(index)}
-          onAdd={() => append({ value: "" })}
-        />
-      </div>
-
-      <h3 className="comet-body-s-accented mb-1 mt-6">{PASS_CRITERIA_TITLE}</h3>
-      <p className="comet-body-xs mb-4 text-light-slate">
-        {PASS_CRITERIA_DESCRIPTION}
-      </p>
-
-      <div className="flex items-start overflow-hidden rounded-md border">
-        <div className="flex flex-1 gap-4 p-3">
-          <div className="flex flex-1 flex-col gap-1">
-            <Label className="comet-body-xs-accented">Runs for this item</Label>
-            <Input
-              dimension="sm"
-              className={cn("[&::-webkit-inner-spin-button]:appearance-none", {
-                "border-destructive": runsInput.isInvalid,
-              })}
-              type="number"
-              min={1}
-              max={MAX_RUNS_PER_ITEM}
-              value={runsInput.displayValue}
-              onChange={runsInput.onChange}
-              onFocus={runsInput.onFocus}
-              onBlur={runsInput.onBlur}
-              onKeyDown={runsInput.onKeyDown}
-            />
-            <span className="comet-body-xs text-light-slate">
-              Sets how many times this item runs.
-            </span>
-          </div>
-          <div className="flex flex-1 flex-col gap-1">
-            <Label className="comet-body-xs-accented">Pass threshold</Label>
-            <Input
-              dimension="sm"
-              className={cn("[&::-webkit-inner-spin-button]:appearance-none", {
-                "border-destructive": thresholdInput.isInvalid,
-              })}
-              type="number"
-              min={1}
-              max={runsPerItem}
-              value={thresholdInput.displayValue}
-              onChange={thresholdInput.onChange}
-              onFocus={thresholdInput.onFocus}
-              onBlur={thresholdInput.onBlur}
-              onKeyDown={thresholdInput.onKeyDown}
-            />
-            <span className="comet-body-xs text-light-slate">
-              Define how many runs must succeed.
-            </span>
-          </div>
-        </div>
-        <TooltipWrapper
-          content={
-            useGlobalPolicy
-              ? "Already using the suite's defaults"
-              : "Revert to the default values for this test suite"
-          }
-        >
-          <button
-            type="button"
-            className={cn(
-              "flex items-center justify-center self-stretch border-l px-2",
-              useGlobalPolicy && "cursor-default opacity-50",
-            )}
-            onClick={useGlobalPolicy ? undefined : handleRevertPolicy}
-            aria-disabled={useGlobalPolicy}
-          >
-            <RotateCcw className="size-3.5 text-muted-slate" />
-          </button>
-        </TooltipWrapper>
-      </div>
-    </div>
+    <EvaluationCriteriaSection
+      suiteAssertions={suiteAssertions}
+      editableAssertions={fields.map((f) => f.value)}
+      onChangeAssertion={(index, value) => update(index, { value })}
+      onRemoveAssertion={(index) => remove(index)}
+      onAddAssertion={() => append({ value: "" })}
+      runsPerItem={runsPerItem}
+      passThreshold={passThreshold}
+      onRunsPerItemChange={handleRunsChange}
+      onPassThresholdChange={handleThresholdChange}
+      useGlobalPolicy={useGlobalPolicy}
+      onRevertToDefaults={handleRevertPolicy}
+      onOpenSettings={onOpenSettings}
+    />
   );
 };
 
@@ -274,7 +185,7 @@ const TestSuiteItemForm: React.FC<TestSuiteItemFormProps> = ({
       <DescriptionSection />
       <DataSection />
       <Separator />
-      <EvaluationCriteriaSection
+      <FormEvaluationCriteriaSection
         suiteAssertions={suiteAssertions}
         suitePolicy={suitePolicy}
         onOpenSettings={onOpenSettings}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx
@@ -7,6 +7,7 @@ import { ReactNode } from "react";
 import { PermissionsProvider } from "@/contexts/PermissionsContext";
 import { DEFAULT_PERMISSIONS } from "@/types/permissions";
 import { DATASET_TYPE } from "@/types/datasets";
+import { TooltipProvider } from "@/ui/tooltip";
 
 const mockAddTracesToDataset = vi.fn();
 const mockAddSpansToDataset = vi.fn();
@@ -19,9 +20,21 @@ const ALL_DATASETS = [
     type: DATASET_TYPE.DATASET,
   },
   {
+    id: "dataset-2",
+    name: "Test Dataset 2",
+    description: "Second test dataset",
+    type: DATASET_TYPE.DATASET,
+  },
+  {
     id: "suite-1",
     name: "Test Suite 1",
     description: "First test suite",
+    type: DATASET_TYPE.TEST_SUITE,
+  },
+  {
+    id: "suite-2",
+    name: "Test Suite 2",
+    description: "Second test suite",
     type: DATASET_TYPE.TEST_SUITE,
   },
 ];
@@ -104,9 +117,11 @@ describe("AddToDatasetDialog", () => {
 
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>
-      <PermissionsProvider value={DEFAULT_PERMISSIONS}>
-        {children}
-      </PermissionsProvider>
+      <TooltipProvider>
+        <PermissionsProvider value={DEFAULT_PERMISSIONS}>
+          {children}
+        </PermissionsProvider>
+      </TooltipProvider>
     </QueryClientProvider>
   );
 
@@ -163,17 +178,27 @@ describe("AddToDatasetDialog", () => {
     datasetType: DATASET_TYPE.TEST_SUITE,
   };
 
+  const openDropdownAndSelect = (itemName: string) => {
+    const trigger = screen.getByRole("button", {
+      name: new RegExp(`Select a|${itemName}`),
+    });
+    fireEvent.click(trigger);
+    const items = screen.getAllByText(itemName);
+    fireEvent.click(items[items.length - 1]);
+  };
+
   it("should render the test suite dialog when open", () => {
     render(<AddToDatasetDialog {...testSuiteModeProps} />, { wrapper });
 
-    expect(screen.getByText("Select a test suite")).toBeInTheDocument();
-    expect(screen.getByText("Test Suite 1")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Select a test suite/i }),
+    ).toBeInTheDocument();
   });
 
   it("should display enrichment checkboxes when selecting a dataset with traces", () => {
     render(<AddToDatasetDialog {...datasetModeProps} />, { wrapper });
 
-    fireEvent.click(screen.getByText("Test Dataset 1"));
+    openDropdownAndSelect("Test Dataset 1");
 
     expect(screen.getByLabelText("Nested spans")).toBeInTheDocument();
     expect(screen.getByLabelText("Tags")).toBeInTheDocument();
@@ -186,7 +211,7 @@ describe("AddToDatasetDialog", () => {
   it("should have all enrichment checkboxes checked by default", () => {
     render(<AddToDatasetDialog {...datasetModeProps} />, { wrapper });
 
-    fireEvent.click(screen.getByText("Test Dataset 1"));
+    openDropdownAndSelect("Test Dataset 1");
 
     expect(screen.getByLabelText("Nested spans")).toBeChecked();
     expect(screen.getByLabelText("Tags")).toBeChecked();
@@ -199,7 +224,7 @@ describe("AddToDatasetDialog", () => {
   it("should allow unchecking enrichment options", async () => {
     render(<AddToDatasetDialog {...datasetModeProps} />, { wrapper });
 
-    fireEvent.click(screen.getByText("Test Dataset 1"));
+    openDropdownAndSelect("Test Dataset 1");
 
     const spansCheckbox = screen.getByLabelText("Nested spans");
     const tagsCheckbox = screen.getByLabelText("Tags");
@@ -222,7 +247,7 @@ describe("AddToDatasetDialog", () => {
 
     render(<AddToDatasetDialog {...propsWithSpan} />, { wrapper });
 
-    fireEvent.click(screen.getByText("Test Dataset 1"));
+    openDropdownAndSelect("Test Dataset 1");
 
     expect(screen.queryByLabelText("Nested spans")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Tags")).toBeInTheDocument();
@@ -240,7 +265,7 @@ describe("AddToDatasetDialog", () => {
 
     render(<AddToDatasetDialog {...propsWithSpan} />, { wrapper });
 
-    fireEvent.click(screen.getByText("Test Dataset 1"));
+    openDropdownAndSelect("Test Dataset 1");
 
     expect(screen.getByLabelText("Tags")).toBeChecked();
     expect(screen.getByLabelText("Feedback scores")).toBeChecked();
@@ -257,7 +282,7 @@ describe("AddToDatasetDialog", () => {
 
     render(<AddToDatasetDialog {...propsWithSpan} />, { wrapper });
 
-    fireEvent.click(screen.getByText("Test Dataset 1"));
+    openDropdownAndSelect("Test Dataset 1");
 
     const tagsCheckbox = screen.getByLabelText("Tags");
     const usageCheckbox = screen.getByLabelText("Usage metrics");
@@ -275,6 +300,11 @@ describe("AddToDatasetDialog", () => {
   it("should list only datasets matching dataset type when adding to a dataset", () => {
     render(<AddToDatasetDialog {...datasetModeProps} />, { wrapper });
 
+    const trigger = screen.getByRole("button", {
+      name: /Select a dataset/i,
+    });
+    fireEvent.click(trigger);
+
     expect(screen.getByText("Test Dataset 1")).toBeInTheDocument();
     expect(screen.getByText("First test dataset")).toBeInTheDocument();
     expect(screen.queryByText("Test Suite 1")).not.toBeInTheDocument();
@@ -283,22 +313,37 @@ describe("AddToDatasetDialog", () => {
   it("should list only test suites when adding to a test suite", () => {
     render(<AddToDatasetDialog {...testSuiteModeProps} />, { wrapper });
 
+    const trigger = screen.getByRole("button", {
+      name: /Select a test suite/i,
+    });
+    fireEvent.click(trigger);
+
     expect(screen.getByText("Test Suite 1")).toBeInTheDocument();
     expect(screen.getByText("First test suite")).toBeInTheDocument();
     expect(screen.queryByText("Test Dataset 1")).not.toBeInTheDocument();
   });
 
-  it("should display search input", () => {
+  it("should display search input in dropdown", () => {
     render(<AddToDatasetDialog {...datasetModeProps} />, { wrapper });
 
-    const searchInput = screen.getByPlaceholderText("Search");
+    const trigger = screen.getByRole("button", {
+      name: /Select a dataset/i,
+    });
+    fireEvent.click(trigger);
+
+    const searchInput = screen.getByPlaceholderText("Search datasets");
     expect(searchInput).toBeInTheDocument();
   });
 
-  it("should display create new test suite button", () => {
+  it("should display add test suite option in dropdown", () => {
     render(<AddToDatasetDialog {...testSuiteModeProps} />, { wrapper });
 
-    expect(screen.getByText("Create new test suite")).toBeInTheDocument();
+    const trigger = screen.getByRole("button", {
+      name: /Select a test suite/i,
+    });
+    fireEvent.click(trigger);
+
+    expect(screen.getByText("Add test suite")).toBeInTheDocument();
   });
 
   it("should show alert when no valid rows are present", () => {
@@ -334,7 +379,7 @@ describe("AddToDatasetDialog", () => {
     ).toBeInTheDocument();
   });
 
-  it("should disable create new test suite button when no valid rows", () => {
+  it("should disable dropdown when no valid rows", () => {
     const propsWithInvalidRows = {
       ...testSuiteModeProps,
       selectedRows: [{ ...mockTrace, input: undefined as unknown as object }],
@@ -342,14 +387,16 @@ describe("AddToDatasetDialog", () => {
 
     render(<AddToDatasetDialog {...propsWithInvalidRows} />, { wrapper });
 
-    const createButton = screen.getByText("Create new test suite");
-    expect(createButton).toBeDisabled();
+    const trigger = screen.getByRole("button", {
+      name: /Select a test suite/i,
+    });
+    expect(trigger).toBeDisabled();
   });
 
   it("should call addTracesToDataset mutation when clicking on dataset with only traces", async () => {
     render(<AddToDatasetDialog {...datasetModeProps} />, { wrapper });
 
-    fireEvent.click(screen.getByText("Test Dataset 1"));
+    openDropdownAndSelect("Test Dataset 1");
 
     fireEvent.click(screen.getByRole("button", { name: "Add to dataset" }));
 
@@ -381,7 +428,7 @@ describe("AddToDatasetDialog", () => {
 
     render(<AddToDatasetDialog {...propsWithSpan} />, { wrapper });
 
-    fireEvent.click(screen.getByText("Test Dataset 1"));
+    openDropdownAndSelect("Test Dataset 1");
 
     fireEvent.click(screen.getByRole("button", { name: "Add to dataset" }));
 
@@ -407,7 +454,7 @@ describe("AddToDatasetDialog", () => {
   it("should respect unchecked enrichment options when adding traces", async () => {
     render(<AddToDatasetDialog {...datasetModeProps} />, { wrapper });
 
-    fireEvent.click(screen.getByText("Test Dataset 1"));
+    openDropdownAndSelect("Test Dataset 1");
 
     fireEvent.click(screen.getByLabelText("Nested spans"));
     fireEvent.click(screen.getByLabelText("Tags"));
@@ -440,7 +487,7 @@ describe("AddToDatasetDialog", () => {
 
     render(<AddToDatasetDialog {...propsWithSpan} />, { wrapper });
 
-    fireEvent.click(screen.getByText("Test Dataset 1"));
+    openDropdownAndSelect("Test Dataset 1");
 
     fireEvent.click(screen.getByLabelText("Tags"));
     fireEvent.click(screen.getByLabelText("Comments"));

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 import isUndefined from "lodash/isUndefined";
-import { Database, MessageCircleWarning, Plus } from "lucide-react";
+import { Database, ListChecks, MessageCircleWarning, Plus } from "lucide-react";
 import { keepPreviousData } from "@tanstack/react-query";
 
 import { Span, Trace } from "@/types/traces";
@@ -26,39 +26,28 @@ import {
   AccordionTrigger,
 } from "@/ui/accordion";
 import useProjectDatasetsList from "@/api/datasets/useProjectDatasetsList";
-import Loader from "@/shared/Loader/Loader";
-import DataTablePagination from "@/shared/DataTablePagination/DataTablePagination";
-import SearchInput from "@/shared/SearchInput/SearchInput";
 import useAddTracesToDatasetMutation from "@/api/datasets/useAddTracesToDatasetMutation";
 import useAddSpansToDatasetMutation from "@/api/datasets/useAddSpansToDatasetMutation";
 import useDatasetVersionsList from "@/api/datasets/useDatasetVersionsList";
 import { Dataset, DATASET_TYPE } from "@/types/datasets";
-import { COLUMN_TYPE } from "@/types/shared";
+import { COLUMN_TYPE, DropdownOption } from "@/types/shared";
 import { Filter } from "@/types/filters";
-import {
-  DEFAULT_EXECUTION_POLICY,
-  MAX_RUNS_PER_ITEM,
-} from "@/types/test-suites";
+import { DEFAULT_EXECUTION_POLICY } from "@/types/test-suites";
 import { Alert, AlertDescription } from "@/ui/alert";
 import { Button } from "@/ui/button";
 import { Checkbox } from "@/ui/checkbox";
-import { Input } from "@/ui/input";
 import { Label } from "@/ui/label";
-import { cn } from "@/lib/utils";
 import { isObjectSpan } from "@/lib/traces";
 import { useToast } from "@/ui/use-toast";
 import { extractAssertions, packAssertions } from "@/lib/assertion-converters";
-import { useClampedIntegerInput } from "@/hooks/useClampedIntegerInput";
-import AssertionsField from "@/shared/AssertionField/AssertionsField";
-import {
-  ASSERTIONS_DESCRIPTION,
-  PASS_CRITERIA_TITLE,
-} from "@/constants/test-suites";
 import AddEditDatasetDialog from "@/v2/pages-shared/datasets/AddEditDatasetDialog/AddEditDatasetDialog";
 import AddEditTestSuiteDialog from "@/v2/pages-shared/datasets/AddEditTestSuiteDialog/AddEditTestSuiteDialog";
 import ExplainerDescription from "@/shared/ExplainerDescription/ExplainerDescription";
+import EvaluationCriteriaSection from "@/shared/EvaluationCriteriaSection/EvaluationCriteriaSection";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/constants/explainers";
 import { usePermissions } from "@/contexts/PermissionsContext";
+import LoadableSelectBox from "@/shared/LoadableSelectBox/LoadableSelectBox";
+import { Separator } from "@/ui/separator";
 
 const DEFAULT_SIZE = 100;
 
@@ -107,9 +96,6 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
   );
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const activeProjectId = useActiveProjectId();
-  const [search, setSearch] = useState("");
-  const [page, setPage] = useState(1);
-  const [size, setSize] = useState(DEFAULT_SIZE);
   const [openDialog, setOpenDialog] = useState<boolean>(false);
   const [fetching, setFetching] = useState<boolean>(false);
   const [selectedDataset, setSelectedDataset] = useState<Dataset | null>(null);
@@ -137,6 +123,7 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
   const [passThreshold, setPassThreshold] = useState(
     DEFAULT_EXECUTION_POLICY.pass_threshold,
   );
+  const [useGlobalPolicy, setUseGlobalPolicy] = useState(true);
 
   const { mutate: addTracesToDataset } = useAddTracesToDatasetMutation();
   const { mutate: addSpansToDataset } = useAddSpansToDatasetMutation();
@@ -167,15 +154,14 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
     if (!isTestSuiteMode || !selectedDataset?.id) return;
     setRunsPerItem(suiteExecutionPolicy.runs_per_item);
     setPassThreshold(suiteExecutionPolicy.pass_threshold);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isTestSuiteMode, selectedDataset?.id]);
+    setUseGlobalPolicy(true);
+  }, [isTestSuiteMode, selectedDataset?.id, suiteExecutionPolicy]);
 
   const { data, isPending } = useProjectDatasetsList(
     {
       projectId: activeProjectId!,
-      search,
-      page,
-      size,
+      page: 1,
+      size: DEFAULT_SIZE,
       filters: typeFilter,
     },
     {
@@ -184,8 +170,48 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
     },
   );
 
-  const datasets = data?.content ?? [];
-  const total = data?.total ?? 0;
+  const datasets = useMemo(() => data?.content ?? [], [data?.content]);
+
+  const datasetOptions: DropdownOption<string>[] = useMemo(
+    () =>
+      datasets.map((d) => ({
+        value: d.id,
+        label: d.name,
+        description: d.description,
+      })),
+    [datasets],
+  );
+
+  const datasetsById = useMemo(() => {
+    const map = new Map<string, Dataset>();
+    datasets.forEach((d) => map.set(d.id, d));
+    return map;
+  }, [datasets]);
+
+  useEffect(() => {
+    if (!isPending && datasets.length === 1 && !selectedDataset) {
+      setSelectedDataset(datasets[0]);
+    }
+  }, [isPending, datasets, selectedDataset]);
+
+  const emptyDropdownState = useMemo(
+    () => (
+      <div className="flex min-h-32 flex-col items-center justify-center gap-1 px-6 py-4 text-center">
+        {isTestSuiteMode ? (
+          <ListChecks className="mb-1 size-5 text-muted-slate" />
+        ) : (
+          <Database className="mb-1 size-5 text-muted-slate" />
+        )}
+        <span className="comet-body-s-accented">No {entityName}s yet</span>
+        <span className="comet-body-xs text-muted-slate">
+          {isTestSuiteMode
+            ? "Define test cases with assertions to evaluate your LLM application's performance."
+            : "Define inputs and expected outputs to evaluate your LLM application's performance."}
+        </span>
+      </div>
+    ),
+    [entityName, isTestSuiteMode],
+  );
 
   const validRows = useMemo(() => {
     return selectedRows.filter((r) => !isUndefined(r.input));
@@ -234,22 +260,25 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
     setAssertions((prev) => [...prev, ""]);
   }, []);
 
-  const runsInput = useClampedIntegerInput({
-    value: runsPerItem,
-    min: 1,
-    max: MAX_RUNS_PER_ITEM,
-    onCommit: (v) => {
+  const handleRunsPerItemChange = useCallback(
+    (v: number) => {
+      setUseGlobalPolicy(false);
       setRunsPerItem(v);
       if (passThreshold > v) setPassThreshold(v);
     },
-  });
+    [passThreshold],
+  );
 
-  const thresholdInput = useClampedIntegerInput({
-    value: passThreshold,
-    min: 1,
-    max: runsPerItem,
-    onCommit: setPassThreshold,
-  });
+  const handlePassThresholdChange = useCallback((v: number) => {
+    setUseGlobalPolicy(false);
+    setPassThreshold(v);
+  }, []);
+
+  const handleRevertToDefaults = useCallback(() => {
+    setUseGlobalPolicy(true);
+    setRunsPerItem(suiteExecutionPolicy.runs_per_item);
+    setPassThreshold(suiteExecutionPolicy.pass_threshold);
+  }, [suiteExecutionPolicy]);
 
   const buildEvaluatorParams = useCallback(() => {
     const nonEmptyAssertions = assertions.map((a) => a.trim()).filter(Boolean);
@@ -350,79 +379,24 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
     ],
   );
 
-  const renderListItems = () => {
-    if (isPending || fetching) {
-      return <Loader />;
-    }
-
-    if (datasets.length === 0) {
-      const text = search
-        ? "No search results"
-        : `There are no ${entityName}s yet`;
-
-      return (
-        <div className="comet-body-s flex h-32 items-center justify-center text-muted-slate">
-          {text}
-        </div>
-      );
-    }
-
-    return datasets.map((d) => {
-      const isSelected = selectedDataset?.id === d.id;
-      return (
-        <div
-          key={d.id}
-          className={cn(
-            "rounded-sm px-4 py-2.5 flex flex-col",
-            noValidRows
-              ? "cursor-default"
-              : "cursor-pointer hover:bg-primary-foreground",
-            isSelected && "bg-muted",
-          )}
-          onClick={() => {
-            if (noValidRows || d.id === selectedDataset?.id) return;
-            setSelectedDataset(d);
-            setAssertions([]);
-            setRunsPerItem(DEFAULT_EXECUTION_POLICY.runs_per_item);
-            setPassThreshold(DEFAULT_EXECUTION_POLICY.pass_threshold);
-            setTimeout(() => {
-              configSectionRef.current?.scrollIntoView({
-                behavior: "smooth",
-                block: "nearest",
-              });
-            }, 0);
-          }}
-        >
-          <div className="flex flex-col gap-0.5">
-            <div className="flex items-center gap-2">
-              <Database
-                className={cn(
-                  "size-4 shrink-0",
-                  noValidRows ? "text-muted-gray" : "text-muted-slate",
-                )}
-              />
-              <span
-                className={cn(
-                  "comet-body-s-accented truncate w-full",
-                  noValidRows && "text-muted-gray",
-                )}
-              >
-                {d.name}
-              </span>
-            </div>
-            <div
-              className={cn(
-                "comet-body-s pl-6 whitespace-pre-line break-words",
-                noValidRows ? "text-muted-gray" : "text-light-slate",
-              )}
-            >
-              {d.description}
-            </div>
-          </div>
-        </div>
-      );
-    });
-  };
+  const handleDatasetSelect = useCallback(
+    (datasetId: string) => {
+      const dataset = datasetsById.get(datasetId) ?? null;
+      if (!dataset || dataset.id === selectedDataset?.id) return;
+      setSelectedDataset(dataset);
+      setAssertions([]);
+      setRunsPerItem(DEFAULT_EXECUTION_POLICY.runs_per_item);
+      setPassThreshold(DEFAULT_EXECUTION_POLICY.pass_threshold);
+      setUseGlobalPolicy(true);
+      setTimeout(() => {
+        configSectionRef.current?.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        });
+      }, 0);
+    },
+    [datasetsById, selectedDataset?.id],
+  );
 
   const renderAlert = () => {
     const text = noValidRows
@@ -539,42 +513,38 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
                 {...EXPLAINERS_MAP[noSelectionExplainerId]}
               />
             )}
-            <div className="my-2 flex items-center justify-between">
-              <h3 className="comet-title-xs">Select a {entityName}</h3>
-              {canCreateDatasets && (
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  onClick={() => {
-                    setOpenDialog(true);
-                  }}
-                  disabled={noValidRows}
-                >
-                  <Plus className="mr-1 size-4" />
-                  Create new {entityName}
-                </Button>
-              )}
+            <div className="my-2">
+              <Label className="comet-body-s-accented mb-1">
+                Select a {entityName}
+              </Label>
+              <LoadableSelectBox
+                value={selectedDataset?.id ?? ""}
+                onChange={handleDatasetSelect}
+                options={datasetOptions}
+                placeholder={`Select a ${entityName}`}
+                searchPlaceholder={`Search ${entityName}s`}
+                isLoading={isPending}
+                disabled={noValidRows}
+                buttonClassName="w-full"
+                optionsCount={DEFAULT_SIZE}
+                emptyState={emptyDropdownState}
+                actionPanel={
+                  canCreateDatasets ? (
+                    <>
+                      <Separator className="my-1" />
+                      <div
+                        className="flex h-10 cursor-pointer items-center gap-2 rounded-md px-4 hover:bg-primary-foreground"
+                        onClick={() => setOpenDialog(true)}
+                      >
+                        <Plus className="size-4 shrink-0" />
+                        <span className="comet-body-s">Add {entityName}</span>
+                      </div>
+                    </>
+                  ) : undefined
+                }
+              />
             </div>
-            <SearchInput
-              searchText={search}
-              setSearchText={setSearch}
-              className="w-full"
-            />
             {renderAlert()}
-            <div className="my-4 flex max-h-[225px] min-h-36 max-w-full flex-col justify-stretch overflow-y-auto">
-              {renderListItems()}
-            </div>
-            {total > DEFAULT_SIZE && (
-              <div className="pt-4">
-                <DataTablePagination
-                  page={page}
-                  pageChange={setPage}
-                  size={size}
-                  sizeChange={setSize}
-                  total={total}
-                ></DataTablePagination>
-              </div>
-            )}
             {!isTestSuiteMode && selectedDataset && (
               <div ref={configSectionRef}>
                 {hasOnlyTraces && renderMetadataConfiguration("trace", true)}
@@ -582,78 +552,21 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
               </div>
             )}
             {isTestSuiteMode && selectedDataset && (
-              <Accordion
-                ref={configSectionRef}
-                type="single"
-                collapsible
-                defaultValue="assertions"
-                className="mt-2"
-              >
-                <AccordionItem value="assertions" className="border-t">
-                  <AccordionTrigger>{PASS_CRITERIA_TITLE}</AccordionTrigger>
-                  <AccordionContent className="px-3">
-                    <div className="flex flex-col gap-4">
-                      <div className="flex flex-col gap-1">
-                        <span className="comet-body-s-accented">
-                          Assertions
-                        </span>
-                        <span className="comet-body-xs text-light-slate">
-                          {ASSERTIONS_DESCRIPTION}
-                        </span>
-                        <AssertionsField
-                          readOnlyAssertions={suiteAssertions}
-                          editableAssertions={assertions}
-                          onChangeEditable={handleAssertionChange}
-                          onRemoveEditable={handleAssertionRemove}
-                          onAdd={handleAssertionAdd}
-                        />
-                      </div>
-                      <div className="flex gap-4">
-                        <div className="flex flex-1 flex-col gap-1">
-                          <Label className="comet-body-xs-accented">
-                            Runs per item
-                          </Label>
-                          <Input
-                            dimension="sm"
-                            className="[&::-webkit-inner-spin-button]:appearance-none"
-                            type="number"
-                            min={1}
-                            max={MAX_RUNS_PER_ITEM}
-                            value={runsInput.displayValue}
-                            onChange={runsInput.onChange}
-                            onFocus={runsInput.onFocus}
-                            onBlur={runsInput.onBlur}
-                            onKeyDown={runsInput.onKeyDown}
-                          />
-                          <span className="comet-body-xs text-light-slate">
-                            Suite default: {suiteExecutionPolicy.runs_per_item}
-                          </span>
-                        </div>
-                        <div className="flex flex-1 flex-col gap-1">
-                          <Label className="comet-body-xs-accented">
-                            Pass threshold
-                          </Label>
-                          <Input
-                            dimension="sm"
-                            className="[&::-webkit-inner-spin-button]:appearance-none"
-                            type="number"
-                            min={1}
-                            max={runsPerItem}
-                            value={thresholdInput.displayValue}
-                            onChange={thresholdInput.onChange}
-                            onFocus={thresholdInput.onFocus}
-                            onBlur={thresholdInput.onBlur}
-                            onKeyDown={thresholdInput.onKeyDown}
-                          />
-                          <span className="comet-body-xs text-light-slate">
-                            Suite default: {suiteExecutionPolicy.pass_threshold}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
+              <div ref={configSectionRef} className="mt-4">
+                <EvaluationCriteriaSection
+                  suiteAssertions={suiteAssertions}
+                  editableAssertions={assertions}
+                  onChangeAssertion={handleAssertionChange}
+                  onRemoveAssertion={handleAssertionRemove}
+                  onAddAssertion={handleAssertionAdd}
+                  runsPerItem={runsPerItem}
+                  passThreshold={passThreshold}
+                  onRunsPerItemChange={handleRunsPerItemChange}
+                  onPassThresholdChange={handlePassThresholdChange}
+                  useGlobalPolicy={useGlobalPolicy}
+                  onRevertToDefaults={handleRevertToDefaults}
+                />
+              </div>
             )}
           </DialogAutoScrollBody>
           <DialogFooter>

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
@@ -155,7 +155,8 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
     setRunsPerItem(suiteExecutionPolicy.runs_per_item);
     setPassThreshold(suiteExecutionPolicy.pass_threshold);
     setUseGlobalPolicy(true);
-  }, [isTestSuiteMode, selectedDataset?.id, suiteExecutionPolicy]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isTestSuiteMode, selectedDataset?.id]);
 
   const { data, isPending } = useProjectDatasetsList(
     {


### PR DESCRIPTION
## Details

Fix UI inconsistencies in test suite dialogs by consolidating the assertion field UI and extracting a shared pass criteria component.

- **Consolidated `+ Assertion` button** into `AssertionsField` — previously duplicated in parent components, causing double buttons in some views.
- **Added `variant` prop** (`"item"` | `"global"`) to `AssertionsField` so it owns its title/description instead of relying on parents to repeat strings.
- **Added `headerContent` slot** to `AssertionsField` for optional extra actions (e.g., "Manage global assertions" link).
- **Extracted `EvaluationCriteriaSection`** as a shared component for pass criteria UI (runs per item, pass threshold, revert-to-defaults), used by v2 test suite item form and AddToDatasetDialog.
- **Removed unused constants** (`ASSERTIONS_TITLE`, `ASSERTIONS_DESCRIPTION`, etc.) from `test-suites.ts` — inlined into `AssertionsField`'s variant config.
- **Fixed pre-existing lint warnings** in `AddToDatasetDialog` (unstable `datasets` reference).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6090

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Implementation, review, and PR creation
  - Human verification: Visual testing in browser, lint/typecheck/test validation

## Testing

- `npx tsc --noEmit` — zero errors
- `npx eslint <changed files> --max-warnings=0` — zero errors, zero warnings
- Pre-commit hook passed (lint:fix, typecheck, dependency validation)
- Verified v1 and v2 test suite item forms, settings dialogs, create sidebar, and AddToDatasetDialog

## Documentation

No documentation changes needed.