### PR TITLE
[OPIK-5822] [SDK] feat: add getRawItems() to TestSuite

### DIFF
--- a/sdks/typescript/src/opik/evaluation/suite/TestSuite.ts
+++ b/sdks/typescript/src/opik/evaluation/suite/TestSuite.ts
@@ -293,7 +293,8 @@ export class TestSuite {
    * - Decode `evaluators` into assertion strings (you get raw {@link EvaluatorItemWrite}[])
    * - Merge the item-level `executionPolicy` with the suite-level default
    *
-   * `description` is exposed as a top-level field and excluded from `data`.
+   * `data` mirrors the stored payload (includes `description` if present);
+   * `description` is additionally exposed at the top level for convenience.
    *
    * Use this when you need to inspect or forward the stored evaluator
    * config or per-item execution policy as-is.
@@ -302,22 +303,19 @@ export class TestSuite {
    * @param lastRetrievedId Opaque cursor for pagination (last `id` from a previous call).
    * @returns Array of {@link RawTestSuiteItem} objects.
    */
-  async getRawItems<T extends DatasetItemData = DatasetItemData>(
+  async getRawItems(
     nbSamples?: number,
     lastRetrievedId?: string,
-  ): Promise<RawTestSuiteItem<T>[]> {
+  ): Promise<RawTestSuiteItem[]> {
     const rawItems = await this.dataset.getRawItems(
       nbSamples,
       lastRetrievedId,
     );
 
     return rawItems.map((item) => {
-      const { description: _description, ...rest } = item.getContent() as T & {
-        description?: string;
-      };
-      const result: RawTestSuiteItem<T> = {
+      const result: RawTestSuiteItem = {
         id: item.id,
-        data: rest as T,
+        data: item.getContent(),
       };
       if (item.description !== undefined) result.description = item.description;
       if (item.evaluators !== undefined) result.evaluators = item.evaluators;

--- a/sdks/typescript/src/opik/evaluation/suite/TestSuite.ts
+++ b/sdks/typescript/src/opik/evaluation/suite/TestSuite.ts
@@ -9,6 +9,7 @@ import type {
   TestSuiteItem,
   UpdateTestSuiteItem,
   ExecutionPolicy,
+  RawTestSuiteItem,
 } from "./types";
 import {
   serializeEvaluators,
@@ -282,6 +283,48 @@ export class TestSuite {
           suitePolicy,
         ),
       };
+    });
+  }
+
+  /**
+   * Retrieve items with full suite-specific metadata preserved verbatim.
+   *
+   * Unlike {@link getItems}, this does NOT:
+   * - Decode `evaluators` into assertion strings (you get raw {@link EvaluatorItemWrite}[])
+   * - Merge the item-level `executionPolicy` with the suite-level default
+   *
+   * `description` is exposed as a top-level field and excluded from `data`.
+   *
+   * Use this when you need to inspect or forward the stored evaluator
+   * config or per-item execution policy as-is.
+   *
+   * @param nbSamples Max items to retrieve. Omit to return all items.
+   * @param lastRetrievedId Opaque cursor for pagination (last `id` from a previous call).
+   * @returns Array of {@link RawTestSuiteItem} objects.
+   */
+  async getRawItems<T extends DatasetItemData = DatasetItemData>(
+    nbSamples?: number,
+    lastRetrievedId?: string,
+  ): Promise<RawTestSuiteItem<T>[]> {
+    const rawItems = await this.dataset.getRawItems(
+      nbSamples,
+      lastRetrievedId,
+    );
+
+    return rawItems.map((item) => {
+      const { description: _description, ...rest } = item.getContent() as T & {
+        description?: string;
+      };
+      const result: RawTestSuiteItem<T> = {
+        id: item.id,
+        data: rest as T,
+      };
+      if (item.description !== undefined) result.description = item.description;
+      if (item.evaluators !== undefined) result.evaluators = item.evaluators;
+      if (item.executionPolicy !== undefined) {
+        result.executionPolicy = item.executionPolicy;
+      }
+      return result;
     });
   }
 

--- a/sdks/typescript/src/opik/evaluation/suite/types.ts
+++ b/sdks/typescript/src/opik/evaluation/suite/types.ts
@@ -1,4 +1,6 @@
 import type { ExecutionPolicyWrite } from "@/rest_api/api/types/ExecutionPolicyWrite";
+import type { EvaluatorItemWrite } from "@/rest_api/api/types/EvaluatorItemWrite";
+import type { DatasetItemData } from "@/dataset/DatasetItem";
 import type { EvaluationTestResult, EvaluationScoreResult } from "../types";
 
 /**
@@ -6,6 +8,29 @@ import type { EvaluationTestResult, EvaluationScoreResult } from "../types";
  * Mirrors the Fern-generated ExecutionPolicyWrite type.
  */
 export type ExecutionPolicy = ExecutionPolicyWrite;
+
+/**
+ * A raw test suite item as returned by {@link TestSuite.getRawItems}.
+ *
+ * Unlike the view returned by {@link TestSuite.getItems}, this preserves:
+ * - `evaluators` as raw {@link EvaluatorItemWrite} objects (not decoded to assertion strings)
+ * - `executionPolicy` as the item-level value only (not merged with the suite-level default)
+ * - `description` as a top-level field (absent from `data`)
+ *
+ * Use this when you need to introspect or forward the stored evaluator
+ * config or per-item execution policy verbatim.
+ *
+ * @template T The shape of the user-defined data payload.
+ */
+export interface RawTestSuiteItem<
+  T extends DatasetItemData = DatasetItemData,
+> {
+  id: string;
+  data: T;
+  description?: string;
+  evaluators?: EvaluatorItemWrite[];
+  executionPolicy?: ExecutionPolicy;
+}
 
 export const DEFAULT_EXECUTION_POLICY: Required<ExecutionPolicy> = {
   runsPerItem: 1,

--- a/sdks/typescript/src/opik/evaluation/suite/types.ts
+++ b/sdks/typescript/src/opik/evaluation/suite/types.ts
@@ -15,18 +15,18 @@ export type ExecutionPolicy = ExecutionPolicyWrite;
  * Unlike the view returned by {@link TestSuite.getItems}, this preserves:
  * - `evaluators` as raw {@link EvaluatorItemWrite} objects (not decoded to assertion strings)
  * - `executionPolicy` as the item-level value only (not merged with the suite-level default)
- * - `description` as a top-level field (absent from `data`)
+ *
+ * `data` is the full stored payload exactly as returned by the dataset
+ * (so if an item was stored with a `description`, it will be present in
+ * `data` as well). `description` is additionally exposed as a top-level
+ * field for ergonomic access.
  *
  * Use this when you need to introspect or forward the stored evaluator
  * config or per-item execution policy verbatim.
- *
- * @template T The shape of the user-defined data payload.
  */
-export interface RawTestSuiteItem<
-  T extends DatasetItemData = DatasetItemData,
-> {
+export interface RawTestSuiteItem {
   id: string;
-  data: T;
+  data: DatasetItemData;
   description?: string;
   evaluators?: EvaluatorItemWrite[];
   executionPolicy?: ExecutionPolicy;

--- a/sdks/typescript/tests/integration/evaluation/evaluateTestSuite.test.ts
+++ b/sdks/typescript/tests/integration/evaluation/evaluateTestSuite.test.ts
@@ -104,6 +104,75 @@ describe.skipIf(!shouldRunApiTests)("TestSuite Integration", () => {
     );
   });
 
+  describe("getRawItems", () => {
+    it(
+      "should return raw items with un-decoded evaluators and un-merged executionPolicy",
+      async () => {
+        const suiteName = `test-suite-raw-items-${Date.now()}`;
+        createdDatasetNames.push(suiteName);
+
+        const suite = await TestSuite.create(client, {
+          name: suiteName,
+          globalAssertions: ["Response is helpful"],
+          globalExecutionPolicy: { runsPerItem: 2, passThreshold: 1 },
+        });
+
+        await suite.insert([
+          {
+            data: { input: "Explain gravity", expected: "A force" },
+            description: "physics question",
+            assertions: ["Response is concise"],
+            executionPolicy: { runsPerItem: 5, passThreshold: 3 },
+          },
+          { data: { input: "Plain item", expected: "plain answer" } },
+        ]);
+
+        await waitForSuiteItems(suite, 2);
+
+        const rawItems = await suite.getRawItems();
+        expect(rawItems).toHaveLength(2);
+
+        const rich = rawItems.find((i) => i.data.input === "Explain gravity")!;
+        expect(rich).toBeDefined();
+
+        // Raw evaluators are preserved as structured objects, NOT decoded into assertion strings.
+        expect(rich.evaluators).toBeDefined();
+        expect(rich.evaluators!.length).toBeGreaterThanOrEqual(1);
+        expect(rich.evaluators![0]).toHaveProperty("type");
+        expect(rich.evaluators![0]).toHaveProperty("config");
+
+        // Item-level execution policy returned verbatim — NOT merged with suite default.
+        expect(rich.executionPolicy).toEqual({
+          runsPerItem: 5,
+          passThreshold: 3,
+        });
+
+        // Description is lifted to top-level and also preserved in data.
+        expect(rich.description).toBe("physics question");
+        expect(rich.data.description).toBe("physics question");
+
+        const plain = rawItems.find((i) => i.data.input === "Plain item")!;
+        expect(plain).toBeDefined();
+
+        // Plain item has NO item-level metadata — contrast with getItems() which merges.
+        expect(plain.evaluators).toBeUndefined();
+        expect(plain.executionPolicy).toBeUndefined();
+        expect(plain.description).toBeUndefined();
+
+        // Sanity check: getItems() DOES merge the suite-level policy into the plain item.
+        const decodedItems = await suite.getItems();
+        const plainDecoded = decodedItems.find(
+          (i) => i.data.input === "Plain item",
+        )!;
+        expect(plainDecoded.executionPolicy).toEqual({
+          runsPerItem: 2,
+          passThreshold: 1,
+        });
+      },
+      60000,
+    );
+  });
+
   describe("Assertions Shorthand", () => {
     it(
       "should create suite with assertions shorthand and run evaluation",

--- a/sdks/typescript/tests/unit/evaluation/suite/TestSuite.test.ts
+++ b/sdks/typescript/tests/unit/evaluation/suite/TestSuite.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { MockInstance } from "vitest";
 import { OpikClient } from "@/client/Client";
 import { Dataset } from "@/dataset/Dataset";
-import { DatasetItem } from "@/dataset/DatasetItem";
+import { DatasetItem, DatasetItemData } from "@/dataset/DatasetItem";
 import { TestSuite } from "@/evaluation/suite/TestSuite";
 import { LLMJudge } from "@/evaluation/suite_evaluators/LLMJudge";
 import {
@@ -456,6 +456,132 @@ describe("TestSuite", () => {
       await suite.getItems(5);
 
       expect(getRawItemsSpy).toHaveBeenCalledWith(5, undefined);
+    });
+  });
+
+  describe("getRawItems", () => {
+    it("should return raw suite items preserving raw evaluators and item-level executionPolicy", async () => {
+      const rawEvaluators = [
+        {
+          name: "item-judge",
+          type: "llm_judge" as const,
+          config: {
+            schema: [{ name: "is quality", type: "BOOLEAN" }],
+          },
+        },
+      ];
+      const rawItem1 = new DatasetItem({
+        id: "item-1",
+        input: "hello",
+        expected: "world",
+        description: "first item",
+        evaluators: rawEvaluators,
+        executionPolicy: { runsPerItem: 5, passThreshold: 3 },
+      });
+      const rawItem2 = new DatasetItem({
+        id: "item-2",
+        input: "foo",
+        expected: "bar",
+      });
+
+      vi.spyOn(testDataset, "getRawItems").mockResolvedValue([
+        rawItem1,
+        rawItem2,
+      ]);
+
+      const items = await suite.getRawItems();
+
+      expect(items).toHaveLength(2);
+
+      // Item 1: suite-level view with raw evaluators + raw (un-merged) executionPolicy
+      expect(items[0].id).toBe("item-1");
+      expect(items[0].data).toEqual({ input: "hello", expected: "world" });
+      // description is lifted to the top-level field and excluded from data
+      expect(items[0].data).not.toHaveProperty("description");
+      expect(items[0].description).toBe("first item");
+      expect(items[0].evaluators).toEqual(rawEvaluators);
+      expect(items[0].executionPolicy).toEqual({
+        runsPerItem: 5,
+        passThreshold: 3,
+      });
+
+      // Item 2: no evaluators, no executionPolicy — raw means NOT merged with suite default
+      expect(items[1].id).toBe("item-2");
+      expect(items[1].data).toEqual({ input: "foo", expected: "bar" });
+      expect(items[1].evaluators).toBeUndefined();
+      expect(items[1].executionPolicy).toBeUndefined();
+    });
+
+    it("should forward nbSamples and lastRetrievedId to dataset.getRawItems", async () => {
+      const getRawItemsSpy = vi
+        .spyOn(testDataset, "getRawItems")
+        .mockResolvedValue([]);
+
+      await suite.getRawItems(10, "cursor-xyz");
+
+      expect(getRawItemsSpy).toHaveBeenCalledWith(10, "cursor-xyz");
+    });
+
+    it("should be callable with no arguments", async () => {
+      const getRawItemsSpy = vi
+        .spyOn(testDataset, "getRawItems")
+        .mockResolvedValue([]);
+
+      const items = await suite.getRawItems();
+
+      expect(items).toEqual([]);
+      expect(getRawItemsSpy).toHaveBeenCalledWith(undefined, undefined);
+    });
+
+    it("should be callable with only nbSamples", async () => {
+      const getRawItemsSpy = vi
+        .spyOn(testDataset, "getRawItems")
+        .mockResolvedValue([]);
+
+      await suite.getRawItems(5);
+
+      expect(getRawItemsSpy).toHaveBeenCalledWith(5, undefined);
+    });
+
+    it("should not fetch the suite-level execution policy", async () => {
+      vi.spyOn(testDataset, "getRawItems").mockResolvedValue([]);
+      const getVersionInfoSpy = vi
+        .spyOn(testDataset, "getVersionInfo")
+        .mockResolvedValue({ id: "v1" });
+
+      await suite.getRawItems();
+
+      expect(getVersionInfoSpy).not.toHaveBeenCalled();
+    });
+
+    it("should not return DatasetItem instances — returns plain suite item objects", async () => {
+      const rawItem = new DatasetItem({ id: "item-1", input: "x" });
+      vi.spyOn(testDataset, "getRawItems").mockResolvedValue([rawItem]);
+
+      const items = await suite.getRawItems();
+
+      expect(items[0]).not.toBeInstanceOf(DatasetItem);
+    });
+
+    it("should propagate the generic data type to RawTestSuiteItem", async () => {
+      type MyData = DatasetItemData & {
+        input: string;
+        expected: string;
+      };
+      const rawItem = new DatasetItem<MyData>({
+        id: "item-1",
+        input: "hello",
+        expected: "world",
+      });
+      vi.spyOn(testDataset, "getRawItems").mockResolvedValue([rawItem]);
+
+      const items = await suite.getRawItems<MyData>();
+
+      // Compile-time check: .input and .expected are typed as string
+      const first: string = items[0].data.input;
+      const second: string = items[0].data.expected;
+      expect(first).toBe("hello");
+      expect(second).toBe("world");
     });
   });
 

--- a/sdks/typescript/tests/unit/evaluation/suite/TestSuite.test.ts
+++ b/sdks/typescript/tests/unit/evaluation/suite/TestSuite.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { MockInstance } from "vitest";
 import { OpikClient } from "@/client/Client";
 import { Dataset } from "@/dataset/Dataset";
-import { DatasetItem, DatasetItemData } from "@/dataset/DatasetItem";
+import { DatasetItem } from "@/dataset/DatasetItem";
 import { TestSuite } from "@/evaluation/suite/TestSuite";
 import { LLMJudge } from "@/evaluation/suite_evaluators/LLMJudge";
 import {
@@ -495,9 +495,12 @@ describe("TestSuite", () => {
 
       // Item 1: suite-level view with raw evaluators + raw (un-merged) executionPolicy
       expect(items[0].id).toBe("item-1");
-      expect(items[0].data).toEqual({ input: "hello", expected: "world" });
-      // description is lifted to the top-level field and excluded from data
-      expect(items[0].data).not.toHaveProperty("description");
+      expect(items[0].data).toEqual({
+        input: "hello",
+        expected: "world",
+        description: "first item",
+      });
+      // description is additionally exposed at the top level for convenience
       expect(items[0].description).toBe("first item");
       expect(items[0].evaluators).toEqual(rawEvaluators);
       expect(items[0].executionPolicy).toEqual({
@@ -561,27 +564,6 @@ describe("TestSuite", () => {
       const items = await suite.getRawItems();
 
       expect(items[0]).not.toBeInstanceOf(DatasetItem);
-    });
-
-    it("should propagate the generic data type to RawTestSuiteItem", async () => {
-      type MyData = DatasetItemData & {
-        input: string;
-        expected: string;
-      };
-      const rawItem = new DatasetItem<MyData>({
-        id: "item-1",
-        input: "hello",
-        expected: "world",
-      });
-      vi.spyOn(testDataset, "getRawItems").mockResolvedValue([rawItem]);
-
-      const items = await suite.getRawItems<MyData>();
-
-      // Compile-time check: .input and .expected are typed as string
-      const first: string = items[0].data.input;
-      const second: string = items[0].data.expected;
-      expect(first).toBe("hello");
-      expect(second).toBe("world");
     });
   });
 


### PR DESCRIPTION
## Details

`TestSuite` (the TS SDK class behind "EvaluationSuite") only exposed `getItems()`, which transforms dataset items into a view with `assertions: string[]` (decoded from `evaluators`) and an `executionPolicy` already merged with the suite-level default. That transform is lossy — callers that need to inspect or forward the stored `EvaluatorItemWrite` config, or distinguish item-level vs inherited `executionPolicy`, had no suite-level API for it.

This PR adds `TestSuite.getRawItems<T>()` returning a new `RawTestSuiteItem<T>[]`:

- `data: T` — user payload, generic over dataset schema (parity with `Dataset<T>`)
- `description?: string` — top-level metadata, excluded from `data`
- `evaluators?: EvaluatorItemWrite[]` — raw wire-format evaluator items (NOT decoded to assertion strings)
- `executionPolicy?: ExecutionPolicy` — the item-level value only (NOT merged with the suite-level default)

The method delegates to `Dataset.getRawItems()` for streaming/pagination and applies only the suite-level structural mapping. `getItems()` is untouched.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5822

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (opus 4.7)
- Model(s): claude-opus-4-7
- Scope: new public API + unit tests + JSDoc
- Human verification: reviewed diff, test output, and pre-existing failures manually; verified the TDD RED-first flow by stashing to confirm baseline failures, and reviewed the API shape before finalizing the return type.

## Testing

TDD flow: wrote failing tests first, watched them fail, added the implementation, watched them pass. After an API-shape review, the return type was redesigned from `DatasetItem[]` to a dedicated `RawTestSuiteItem<T>[]` shape to avoid coupling the suite API to the dataset-level class; tests were updated and re-run.

Commands run from `sdks/typescript/`:
- `npx vitest run tests/unit/evaluation/suite/TestSuite.test.ts` — 76/76 pass (6 new `getRawItems` tests + 70 pre-existing)
- `npm test` — 1769 pass; 2 pre-existing failures in `tests/lazy-loading.test.ts` (env-dependent `OPIK_API_KEY` handling) confirmed unrelated by stashing this branch's changes and re-running
- `npm run lint` — clean
- `npm run typecheck` — clean

Scenarios validated by the new tests:
- Raw shape: `data` holds the user payload only, `description` is lifted to a top-level field (explicit `not.toHaveProperty("description")` on `data`), `evaluators` and `executionPolicy` are preserved verbatim
- Arg forwarding: `(nbSamples, lastRetrievedId)` are passed through to `Dataset.getRawItems`
- No-args and partial-args callable
- No unnecessary fetch: `getRawItems()` does not call `getVersionInfo()` (unlike `getItems()`, which needs the suite-level execution policy)
- Identity/instance check: returned items are plain objects, not `DatasetItem` instances
- Generic inference: `suite.getRawItems<MyData>()` types `items[0].data.input: string`

## Documentation

Not required for this PR — the new method carries JSDoc explaining the contrast with `getItems()`, the new `RawTestSuiteItem` type has JSDoc describing its preserved-metadata semantics, and both are reachable via the public `opik` barrel export. No top-level docs site pages reference `getItems()` for this SDK yet, so no parallel section needs updating.