### PR TITLE
[OPIK-5819] [SDK] feat: add getTestSuiteExperiments to TS SDK

### DIFF
--- a/sdks/typescript/src/opik/client/Client.ts
+++ b/sdks/typescript/src/opik/client/Client.ts
@@ -989,48 +989,20 @@ export class OpikClient {
 
     const dataset = await this.getDataset(datasetName, projectName);
 
-    const pageSize = Math.min(100, maxResults);
-    const experiments: Experiment[] = [];
-
     try {
-      let page = 1;
-      while (experiments.length < maxResults) {
-        const pageExperiments = await this.api.experiments.findExperiments({
-          page,
-          size: pageSize,
-          datasetId: dataset.id,
-        });
-
-        const content = pageExperiments?.content ?? [];
-
-        if (content.length === 0) {
-          break;
-        }
-        const remainingItems = maxResults - experiments.length;
-        const itemsToProcess = Math.min(content.length, remainingItems);
-
-        for (let i = 0; i < itemsToProcess; i++) {
-          const exp = content[i];
-          experiments.push(
-            new Experiment(
-              {
-                id: exp.id,
-                name: exp.name,
-                datasetName: exp.datasetName ?? undefined,
-              },
-              this
-            )
-          );
-        }
-
-        if (itemsToProcess < content.length) {
-          break;
-        }
-
-        page += 1;
-      }
-
-      return experiments;
+      return await this.findExperimentsByDatasetId(
+        dataset.id,
+        maxResults,
+        (exp) =>
+          new Experiment(
+            {
+              id: exp.id,
+              name: exp.name,
+              datasetName: exp.datasetName ?? undefined,
+            },
+            this
+          )
+      );
     } catch (error) {
       logger.error(`Failed to get experiments for dataset "${datasetName}"`, {
         error,
@@ -1059,58 +1031,75 @@ export class OpikClient {
 
     const suiteDataset = await this.getDataset(name, projectName);
 
-    const pageSize = Math.min(100, maxResults);
-    const experiments: TestSuiteExperiment[] = [];
-
     try {
-      let page = 1;
-      while (experiments.length < maxResults) {
-        const pageExperiments = await this.api.experiments.findExperiments({
-          page,
-          size: pageSize,
-          datasetId: suiteDataset.id,
-        });
-
-        const content = pageExperiments?.content ?? [];
-
-        if (content.length === 0) {
-          break;
-        }
-        const remainingItems = maxResults - experiments.length;
-        const itemsToProcess = Math.min(content.length, remainingItems);
-
-        for (let i = 0; i < itemsToProcess; i++) {
-          const exp = content[i];
-          experiments.push(
-            new TestSuiteExperiment(
-              {
-                id: exp.id,
-                name: exp.name,
-                datasetName: exp.datasetName ?? undefined,
-                passRate: exp.passRate,
-                passedCount: exp.passedCount,
-                totalCount: exp.totalCount,
-                assertionScores: exp.assertionScores,
-              },
-              this
-            )
-          );
-        }
-
-        if (itemsToProcess < content.length) {
-          break;
-        }
-
-        page += 1;
-      }
-
-      return experiments;
+      return await this.findExperimentsByDatasetId(
+        suiteDataset.id,
+        maxResults,
+        (exp) =>
+          new TestSuiteExperiment(
+            {
+              id: exp.id,
+              name: exp.name,
+              datasetName: exp.datasetName ?? undefined,
+              passRate: exp.passRate,
+              passedCount: exp.passedCount,
+              totalCount: exp.totalCount,
+              assertionScores: exp.assertionScores,
+            },
+            this
+          )
+      );
     } catch (error) {
       logger.error(`Failed to get experiments for test suite "${name}"`, {
         error,
       });
       throw error;
     }
+  };
+
+  /**
+   * Paginated fetch of experiments for a given dataset ID, mapping each raw
+   * `ExperimentPublic` row to a caller-chosen entity. Used internally by
+   * `getDatasetExperiments` and `getTestSuiteExperiments` to share the
+   * loop shape and only differ on the constructed type.
+   */
+  private findExperimentsByDatasetId = async <T>(
+    datasetId: string,
+    maxResults: number,
+    factory: (exp: ExperimentPublic) => T
+  ): Promise<T[]> => {
+    const pageSize = Math.min(100, maxResults);
+    const experiments: T[] = [];
+    let page = 1;
+
+    while (experiments.length < maxResults) {
+      const pageExperiments = await this.api.experiments.findExperiments({
+        page,
+        size: pageSize,
+        datasetId,
+      });
+
+      const content = pageExperiments?.content ?? [];
+
+      if (content.length === 0) {
+        break;
+      }
+
+      const remainingItems = maxResults - experiments.length;
+      const itemsToProcess = Math.min(content.length, remainingItems);
+
+      for (let i = 0; i < itemsToProcess; i++) {
+        experiments.push(factory(content[i]));
+      }
+
+      if (itemsToProcess < content.length) {
+        break;
+      }
+
+      page += 1;
+    }
+
+    return experiments;
   };
 
   /**

--- a/sdks/typescript/src/opik/client/Client.ts
+++ b/sdks/typescript/src/opik/client/Client.ts
@@ -20,6 +20,7 @@ import { DatasetBatchQueue } from "./DatasetBatchQueue";
 import { Dataset, DatasetItemData, DatasetNotFoundError } from "@/dataset";
 import type { TestSuite, CreateTestSuiteOptions } from "@/evaluation/suite";
 import { Experiment } from "@/experiment/Experiment";
+import { TestSuiteExperiment } from "@/experiment/TestSuiteExperiment";
 import { buildMetadataAndPromptVersions } from "@/experiment/helpers";
 import { ExperimentType } from "@/rest_api/api/types";
 import { ExperimentNotFoundError } from "@/errors/experiment/errors";
@@ -1032,6 +1033,80 @@ export class OpikClient {
       return experiments;
     } catch (error) {
       logger.error(`Failed to get experiments for dataset "${datasetName}"`, {
+        error,
+      });
+      throw error;
+    }
+  };
+
+  /**
+   * Retrieves all experiments associated with a test suite.
+   *
+   * @param name The name of the test suite
+   * @param maxResults Maximum number of experiments to return (default: 100)
+   * @param projectName Optional project name to scope the suite lookup. If not provided, uses the client's configured project.
+   * @returns A list of TestSuiteExperiment objects associated with the test suite,
+   *   each carrying the suite-specific assertion aggregates (`passRate`, `passedCount`,
+   *   `totalCount`, `assertionScores`) populated by the backend.
+   * @throws {DatasetNotFoundError} If the test suite doesn't exist
+   */
+  public getTestSuiteExperiments = async (
+    name: string,
+    maxResults: number = 100,
+    projectName?: string
+  ): Promise<TestSuiteExperiment[]> => {
+    logger.debug(`Getting experiments for test suite "${name}"`);
+
+    const suiteDataset = await this.getDataset(name, projectName);
+
+    const pageSize = Math.min(100, maxResults);
+    const experiments: TestSuiteExperiment[] = [];
+
+    try {
+      let page = 1;
+      while (experiments.length < maxResults) {
+        const pageExperiments = await this.api.experiments.findExperiments({
+          page,
+          size: pageSize,
+          datasetId: suiteDataset.id,
+        });
+
+        const content = pageExperiments?.content ?? [];
+
+        if (content.length === 0) {
+          break;
+        }
+        const remainingItems = maxResults - experiments.length;
+        const itemsToProcess = Math.min(content.length, remainingItems);
+
+        for (let i = 0; i < itemsToProcess; i++) {
+          const exp = content[i];
+          experiments.push(
+            new TestSuiteExperiment(
+              {
+                id: exp.id,
+                name: exp.name,
+                datasetName: exp.datasetName ?? undefined,
+                passRate: exp.passRate,
+                passedCount: exp.passedCount,
+                totalCount: exp.totalCount,
+                assertionScores: exp.assertionScores,
+              },
+              this
+            )
+          );
+        }
+
+        if (itemsToProcess < content.length) {
+          break;
+        }
+
+        page += 1;
+      }
+
+      return experiments;
+    } catch (error) {
+      logger.error(`Failed to get experiments for test suite "${name}"`, {
         error,
       });
       throw error;

--- a/sdks/typescript/src/opik/experiment/TestSuiteExperiment.ts
+++ b/sdks/typescript/src/opik/experiment/TestSuiteExperiment.ts
@@ -1,0 +1,30 @@
+import { OpikClient } from "@/client/Client";
+import { Experiment, ExperimentData } from "./Experiment";
+import type { AssertionScoreAveragePublic } from "@/rest_api/api/types/AssertionScoreAveragePublic";
+
+export interface TestSuiteExperimentData extends ExperimentData {
+  passRate?: number;
+  passedCount?: number;
+  totalCount?: number;
+  assertionScores?: AssertionScoreAveragePublic[];
+}
+
+/**
+ * Represents an experiment run against a test suite. Extends `Experiment`
+ * with the aggregate assertion statistics the backend populates only for
+ * evaluation-suite experiments (null/undefined for regular dataset experiments).
+ */
+export class TestSuiteExperiment extends Experiment {
+  public readonly passRate?: number;
+  public readonly passedCount?: number;
+  public readonly totalCount?: number;
+  public readonly assertionScores?: AssertionScoreAveragePublic[];
+
+  constructor(data: TestSuiteExperimentData, opik: OpikClient) {
+    super(data, opik);
+    this.passRate = data.passRate;
+    this.passedCount = data.passedCount;
+    this.totalCount = data.totalCount;
+    this.assertionScores = data.assertionScores;
+  }
+}

--- a/sdks/typescript/src/opik/experiment/index.ts
+++ b/sdks/typescript/src/opik/experiment/index.ts
@@ -1,2 +1,3 @@
 export * from "./Experiment";
 export * from "./ExperimentItem";
+export * from "./TestSuiteExperiment";

--- a/sdks/typescript/tests/experiment/client-experiment.test.ts
+++ b/sdks/typescript/tests/experiment/client-experiment.test.ts
@@ -11,6 +11,8 @@ import {
 } from "../mockUtils";
 import { ExperimentNotFoundError } from "@/errors/experiment/errors";
 import { createMockExperiment, verifyExperiment } from "./utils";
+import { Experiment } from "@/experiment/Experiment";
+import { TestSuiteExperiment } from "@/experiment/TestSuiteExperiment";
 
 interface ExperimentTestContext extends TestContext {
   client: Opik;
@@ -531,6 +533,196 @@ describe("Opik experiment operations", () => {
 
       await expect(
         client.getDatasetExperiments("test-dataset")
+      ).rejects.toThrow(apiError);
+    });
+  });
+
+  describe("getTestSuiteExperiments", () => {
+    it<ExperimentTestContext>("should retrieve all experiments for a test suite", async ({
+      client,
+      spies,
+      expect,
+    }) => {
+      const suiteId = "suite-123";
+      spies.getDatasetByIdentifier.mockImplementationOnce(() =>
+        createMockHttpResponsePromise({ id: suiteId, name: "test-suite" })
+      );
+
+      const mockExperiments = [
+        {
+          ...createMockExperiment({
+            id: "experiment-1",
+            dataset_name: "test-suite",
+          }),
+          passRate: 0.8,
+          passedCount: 4,
+          totalCount: 5,
+          assertionScores: [
+            { name: "accuracy", value: 0.9 },
+            { name: "relevance", value: 0.7 },
+          ],
+        },
+        {
+          ...createMockExperiment({
+            id: "experiment-2",
+            dataset_name: "test-suite",
+          }),
+          passRate: 1,
+          passedCount: 5,
+          totalCount: 5,
+          assertionScores: [],
+        },
+      ];
+
+      spies.findExperiments.mockImplementationOnce(() =>
+        createMockHttpResponsePromise({ content: mockExperiments })
+      );
+
+      const results = await client.getTestSuiteExperiments("test-suite");
+
+      expect(spies.getDatasetByIdentifier).toHaveBeenCalledWith({
+        datasetName: "test-suite",
+        projectName: "opik-sdk-typescript",
+      });
+      expect(spies.findExperiments).toHaveBeenCalledWith({
+        page: 1,
+        size: 100,
+        datasetId: suiteId,
+      });
+      expect(results).toHaveLength(2);
+      expect(results[0]).toBeInstanceOf(TestSuiteExperiment);
+      expect(results[0]).toBeInstanceOf(Experiment);
+      expect(results[0].id).toBe("experiment-1");
+      expect(results[0].passRate).toBe(0.8);
+      expect(results[0].passedCount).toBe(4);
+      expect(results[0].totalCount).toBe(5);
+      expect(results[0].assertionScores).toEqual([
+        { name: "accuracy", value: 0.9 },
+        { name: "relevance", value: 0.7 },
+      ]);
+      expect(results[1].id).toBe("experiment-2");
+      expect(results[1].passRate).toBe(1);
+      expect(results[1].assertionScores).toEqual([]);
+    });
+
+    it<ExperimentTestContext>("should leave suite-specific fields undefined when the backend omits them", async ({
+      client,
+      spies,
+      expect,
+    }) => {
+      const suiteId = "suite-legacy";
+      spies.getDatasetByIdentifier.mockImplementationOnce(() =>
+        createMockHttpResponsePromise({ id: suiteId, name: "legacy-suite" })
+      );
+
+      spies.findExperiments.mockImplementationOnce(() =>
+        createMockHttpResponsePromise({
+          content: [
+            createMockExperiment({
+              id: "experiment-legacy",
+              dataset_name: "legacy-suite",
+            }),
+          ],
+        })
+      );
+
+      const results = await client.getTestSuiteExperiments("legacy-suite");
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toBeInstanceOf(TestSuiteExperiment);
+      expect(results[0].passRate).toBeUndefined();
+      expect(results[0].passedCount).toBeUndefined();
+      expect(results[0].totalCount).toBeUndefined();
+      expect(results[0].assertionScores).toBeUndefined();
+    });
+
+    it<ExperimentTestContext>("should handle pagination when there are more experiments than the limit", async ({
+      client,
+      spies,
+      expect,
+    }) => {
+      const suiteId = "suite-123";
+      spies.getDatasetByIdentifier.mockImplementationOnce(() =>
+        createMockHttpResponsePromise({ id: suiteId, name: "test-suite" })
+      );
+
+      const page1Experiments = Array.from({ length: 20 }, (_, i) =>
+        createMockExperiment({ id: `exp-${i}`, dataset_name: "test-suite" })
+      );
+      const page2Experiments = Array.from({ length: 10 }, (_, i) =>
+        createMockExperiment({
+          id: `exp-${i + 20}`,
+          dataset_name: "test-suite",
+        })
+      );
+
+      spies.findExperiments.mockImplementationOnce(() =>
+        createMockHttpResponsePromise({ content: page1Experiments })
+      );
+
+      spies.findExperiments.mockImplementationOnce(() =>
+        createMockHttpResponsePromise({ content: page2Experiments })
+      );
+
+      spies.findExperiments.mockImplementationOnce(() =>
+        createMockHttpResponsePromise({ content: [] })
+      );
+
+      const results = await client.getTestSuiteExperiments("test-suite", 25);
+
+      expect(spies.getDatasetByIdentifier).toHaveBeenCalledWith({
+        datasetName: "test-suite",
+        projectName: "opik-sdk-typescript",
+      });
+      expect(spies.findExperiments).toHaveBeenCalledTimes(2);
+      expect(spies.findExperiments).toHaveBeenNthCalledWith(1, {
+        page: 1,
+        size: 25,
+        datasetId: suiteId,
+      });
+      expect(spies.findExperiments).toHaveBeenNthCalledWith(2, {
+        page: 2,
+        size: 25,
+        datasetId: suiteId,
+      });
+      expect(results).toHaveLength(25);
+    });
+
+    it<ExperimentTestContext>("should handle test suite not found error", async ({
+      client,
+      spies,
+      expect,
+    }) => {
+      const error = new Error("Suite not found");
+      spies.getDatasetByIdentifier.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      await expect(
+        client.getTestSuiteExperiments("nonexistent-suite")
+      ).rejects.toThrow("Suite not found");
+    });
+
+    it<ExperimentTestContext>("should handle API errors when getting test suite experiments", async ({
+      client,
+      spies,
+      expect,
+    }) => {
+      const suiteId = "suite-123";
+      spies.getDatasetByIdentifier.mockImplementationOnce(() =>
+        createMockHttpResponsePromise({ id: suiteId, name: "test-suite" })
+      );
+
+      const apiError = new OpikApiError({
+        message: "API error",
+        statusCode: 500,
+      });
+      spies.findExperiments.mockImplementationOnce(() => {
+        throw apiError;
+      });
+
+      await expect(
+        client.getTestSuiteExperiments("test-suite")
       ).rejects.toThrow(apiError);
     });
   });

--- a/sdks/typescript/tests/integration/evaluation/testSuiteCrud.test.ts
+++ b/sdks/typescript/tests/integration/evaluation/testSuiteCrud.test.ts
@@ -111,6 +111,34 @@ describe.skipIf(!shouldRunApiTests)(
     );
 
     it(
+      "getTestSuiteExperiments — returns experiments run against the suite",
+      async () => {
+        const name = `client-suite-experiments-${Date.now()}`;
+        createdSuiteNames.push(name);
+
+        await client.createTestSuite({ name });
+        const experiment = await client.createExperiment({
+          name: `exp-${Date.now()}`,
+          datasetName: name,
+        });
+        await client.flush();
+
+        const clientResults = await searchAndWaitForDone(
+          async () => {
+            const experiments = await client.getTestSuiteExperiments(name);
+            return experiments.filter((e) => e.id === experiment.id);
+          },
+          1,
+          WAIT_OPTIONS.timeout,
+          WAIT_OPTIONS.interval
+        );
+        expect(clientResults.length).toBeGreaterThanOrEqual(1);
+        expect(clientResults[0].id).toBe(experiment.id);
+      },
+      30000
+    );
+
+    it(
       "getTestSuites — returns a list that includes a created suite",
       async () => {
         const name = `client-suite-list-${Date.now()}`;

--- a/sdks/typescript/tests/integration/evaluation/testSuiteCrud.test.ts
+++ b/sdks/typescript/tests/integration/evaluation/testSuiteCrud.test.ts
@@ -9,7 +9,8 @@
  * Happy-path only — edge cases are covered in the TestSuite unit tests.
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Opik, TestSuite } from "@/index";
+import { Opik, TestSuite, runTests } from "@/index";
+import { TestSuiteExperiment } from "@/experiment/TestSuiteExperiment";
 import { searchAndWaitForDone } from "@/utils/searchHelpers";
 import {
   shouldRunIntegrationTests,
@@ -111,31 +112,67 @@ describe.skipIf(!shouldRunApiTests)(
     );
 
     it(
-      "getTestSuiteExperiments — returns experiments run against the suite",
+      "getTestSuiteExperiments — returns TestSuiteExperiment instances with suite aggregates populated after runTests",
       async () => {
         const name = `client-suite-experiments-${Date.now()}`;
         createdSuiteNames.push(name);
 
-        await client.createTestSuite({ name });
-        const experiment = await client.createExperiment({
-          name: `exp-${Date.now()}`,
-          datasetName: name,
+        const suite = await TestSuite.create(client, {
+          name,
+          globalAssertions: ["Response is helpful"],
+          globalExecutionPolicy: { runsPerItem: 1, passThreshold: 1 },
         });
+
+        await suite.insert([{ data: { input: "Q1", expected: "A1" } }]);
+        await suite.insert([{ data: { input: "Q2", expected: "A2" } }]);
+
+        await searchAndWaitForDone(
+          async () => suite.getItems(),
+          2,
+          WAIT_OPTIONS.timeout,
+          WAIT_OPTIONS.interval
+        );
+
+        const runResult = await runTests({
+          testSuite: suite,
+          task: async (item) => ({
+            input: item.input,
+            output: `Echo: ${item.input}`,
+          }),
+        });
+
         await client.flush();
 
         const clientResults = await searchAndWaitForDone(
           async () => {
             const experiments = await client.getTestSuiteExperiments(name);
-            return experiments.filter((e) => e.id === experiment.id);
+            return experiments.filter(
+              (e) =>
+                e.id === runResult.experimentId &&
+                e.totalCount !== undefined &&
+                e.totalCount > 0
+            );
           },
           1,
           WAIT_OPTIONS.timeout,
           WAIT_OPTIONS.interval
         );
+
         expect(clientResults.length).toBeGreaterThanOrEqual(1);
-        expect(clientResults[0].id).toBe(experiment.id);
+        const [fetched] = clientResults;
+
+        expect(fetched).toBeInstanceOf(TestSuiteExperiment);
+        expect(fetched.id).toBe(runResult.experimentId);
+        expect(fetched.datasetName).toBe(name);
+        expect(fetched.totalCount).toBe(2);
+        expect(fetched.passedCount).toBeGreaterThanOrEqual(0);
+        expect(fetched.passedCount).toBeLessThanOrEqual(2);
+        expect(fetched.passRate).toBeGreaterThanOrEqual(0);
+        expect(fetched.passRate).toBeLessThanOrEqual(1);
+        expect(Array.isArray(fetched.assertionScores)).toBe(true);
+        expect(fetched.assertionScores!.length).toBeGreaterThanOrEqual(1);
       },
-      30000
+      90000
     );
 
     it(

--- a/sdks/typescript/tests/unit/client/apiCompatibility.test.ts
+++ b/sdks/typescript/tests/unit/client/apiCompatibility.test.ts
@@ -210,6 +210,30 @@ describe("API backward compatibility — no projectName specified anywhere", () 
       expect(experiments.length).toBeGreaterThanOrEqual(1);
       expect(experiments[0]).toBeInstanceOf(Experiment);
     });
+
+    it("getTestSuiteExperiments(suiteName) works without projectName", async () => {
+      vi.spyOn(
+        client.api.experiments,
+        "findExperiments"
+      ).mockImplementation(() =>
+        createMockHttpResponsePromise({
+          content: [
+            {
+              id: "exp-id-456",
+              datasetId: "ds-id",
+              datasetName: "my-suite",
+              name: "my-experiment",
+            },
+          ],
+          total: 1,
+        })
+      );
+
+      const experiments = await client.getTestSuiteExperiments("my-suite");
+
+      expect(experiments.length).toBeGreaterThanOrEqual(1);
+      expect(experiments[0]).toBeInstanceOf(Experiment);
+    });
   });
 
   describe("Prompt operations without projectName", () => {


### PR DESCRIPTION
## Details

The TS SDK exposes `client.getDatasetExperiments(name, maxResults?, projectName?)` but had no equivalent for evaluation suites (`TestSuite`). Users who created a suite via `createTestSuite` had no way to later list the experiments run against it.

**Fix:** Add `OpikClient.getTestSuiteExperiments(name, maxResults?, projectName?): Promise<TestSuiteExperiment[]>`, mirroring `getDatasetExperiments` but resolving the dataset via `getDataset(name)` so the same `DatasetNotFoundError` behavior applies. Since a `TestSuite` wraps a `Dataset` of type `EvaluationSuite` with `suite.id === suite.dataset.id`, the existing `findExperiments({ datasetId })` endpoint returns exactly the suite's experiments — no backend or generated-API changes needed. This aligns with the Python SDK's `client.get_test_suite_experiments(...)`.

**Dedicated type:** Evaluation-suite experiments carry four aggregate fields the backend only populates for suite runs — `passRate`, `passedCount`, `totalCount`, `assertionScores` — that were previously dropped when instantiating `Experiment`. Introduces a dedicated `TestSuiteExperiment extends Experiment` class that surfaces these fields so callers can inspect suite assertion outcomes.

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-5819

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: TDD implementation (client method, `TestSuiteExperiment` class, unit + integration tests), commit/PR authoring
- Human verification: author reviewed diff, confirmed scope matches ticket, confirmed Python-SDK alignment, full TS SDK unit suite green

## Testing

- `npm test -- tests/experiment/client-experiment.test.ts` — new `getTestSuiteExperiments` describe block (5 cases) passes: happy path with new fields, pagination, dataset-not-found error propagation, generic API error propagation, legacy response with omitted suite fields
- `npm test -- tests/unit/client/apiCompatibility.test.ts` — new case confirms `getTestSuiteExperiments(name)` is callable without `projectName`
- `npm run typecheck` / `npm run lint` / `npm run build` — clean
- Full unit suite: 1772/1774 pass (2 pre-existing unrelated failures in `tests/lazy-loading.test.ts`, reproduced on clean `main`)
- New integration case in `tests/integration/evaluation/testSuiteCrud.test.ts` (guarded by `shouldRunApiTests`) covers the end-to-end happy path against a real backend

## Documentation

N/A — public API surface addition is self-documenting via TSDoc comments on the new client method and `TestSuiteExperiment` class; no dedicated docs page or migration guide required.