### PR TITLE
[NA] [DOCS] Update quickstart screenshot to showcase new UI

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/quickstart.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/quickstart.mdx
@@ -12,7 +12,7 @@ this guide is to help you log your first traces and start tracking your prompts 
 configuration in Opik.
 
 <Frame>
-  <img src="/img/v2/home/traces_page_for_quickstart.png" />
+  <img src="/img/v2/observability/traces-page.png" alt="Opik traces page showing trace details with span tree, outputs, and feedback scores" />
 </Frame>
 
 ## Prerequisites


### PR DESCRIPTION
## Details

Swap the hero image on the v2 quickstart page from the threads-list-only screenshot to the richer traces-page screenshot already used on the observability getting-started page. The new image shows the trace list, span tree, I/O panel and feedback scores, giving a much better first impression of the new UI.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: Pick best existing screenshot and update `docs-v2/quickstart.mdx` image reference
- Human verification: Reviewed the candidate images side-by-side and the resulting diff

## Testing

No code changes — documentation-only image swap. Verified:
- The new image path `/img/v2/observability/traces-page.png` already exists in `apps/opik-documentation/documentation/fern/img/v2/observability/`
- Same image is already referenced from `docs-v2/observability/getting-started.mdx` so the docs build pipeline already ships it

## Documentation

This PR *is* the documentation update.