### PR TITLE
[NA] [FE] [DOCS] Rename Ollie to Opik Connect in user-facing copy

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/building_evaluation_suites.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/building_evaluation_suites.mdx
@@ -1,21 +1,21 @@
 ---
 headline: Building Test Suites | Opik Documentation
-og:description: Create and manage Test Suites using the SDK, UI, or Ollie to build
+og:description: Create and manage Test Suites using the SDK, UI, or Opik Connect to build
   regression tests from real production failures
 og:site_name: Opik Documentation
 og:title: Building Test Suites — Opik
 title: Building Test Suites
 ---
 
-Test suites grow as you debug and improve your agent. There are three ways to build them: with Ollie, through the UI, or via the SDK.
+Test suites grow as you debug and improve your agent. There are three ways to build them: with Opik Connect, through the UI, or via the SDK.
 
-## With Ollie
+## With Opik Connect
 
-The fastest way to turn a production failure into a test case. Open Ollie from any trace view and describe what went wrong:
+The fastest way to turn a production failure into a test case. Open Opik Connect from any trace view and describe what went wrong:
 
 *"Add this trace to my customer-support-qa suite with the assertion: the response must cite a specific step from the provided context"*
 
-Ollie creates the test item directly — no copy-pasting required. You can also ask Ollie to run the suite after making changes:
+Opik Connect creates the test item directly — no copy-pasting required. You can also ask Opik Connect to run the suite after making changes:
 
 *"Run the customer-support-qa suite against the updated prompt"*
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/overview.mdx
@@ -39,11 +39,11 @@ Start in the Opik dashboard. Browse traces, filter by error status or low feedba
 
 ### Add it to a test suite
 
-Turn the failure into a test case. Add the trace to a test suite with a natural-language assertion that captures the expected behavior — for example, *"The response must not hallucinate facts not present in the context"*. You can do this through [Ollie](/tracing/debug-agents) (Opik's AI assistant), the UI, or the SDK.
+Turn the failure into a test case. Add the trace to a test suite with a natural-language assertion that captures the expected behavior — for example, *"The response must not hallucinate facts not present in the context"*. You can do this through [Opik Connect](/tracing/debug-agents) (Opik's AI assistant), the UI, or the SDK.
 
 ### Update your agent
 
-Fix the root cause. Update a prompt via [Agent Configuration](/development/agent-configuration/getting-started), adjust tool definitions, or change retrieval parameters. Use Ollie to help diagnose the issue and suggest fixes.
+Fix the root cause. Update a prompt via [Agent Configuration](/development/agent-configuration/getting-started), adjust tool definitions, or change retrieval parameters. Use Opik Connect to help diagnose the issue and suggest fixes.
 
 ### Validate with the test suite
 
@@ -76,5 +76,5 @@ Opik provides two complementary approaches to evaluation:
 
 - [Getting started](/evaluation/getting-started) — Run your first evaluation in minutes
 - [Concepts](/evaluation/concepts) — Understand Test Suites vs Datasets & Metrics
-- [Building Test Suites](/evaluation/advanced/building-test-suites) — Create and manage suites via the SDK, UI, or Ollie
-- [Debugging agents with Ollie](/tracing/debug-agents) — The full workflow for turning production failures into test cases
+- [Building Test Suites](/evaluation/advanced/building-test-suites) — Create and manage suites via the SDK, UI, or Opik Connect
+- [Debugging agents with Opik Connect](/tracing/debug-agents) — The full workflow for turning production failures into test cases

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/agent_sandbox.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/agent_sandbox.mdx
@@ -135,8 +135,8 @@ UI, check that the process is still running locally and that your network connec
   <Accordion title="What is the difference between opik connect and opik endpoint?">
     They serve different purposes:
 
-    - **`opik connect`** starts a lightweight bridge daemon that gives [Ollie](/tracing/ollie)
-      remote access to your repository. Ollie can then read your source files, propose code
+    - **`opik connect`** starts a lightweight bridge daemon that gives [Opik Connect](/tracing/ollie)
+      remote access to your repository. Opik Connect can then read your source files, propose code
       changes, and rerun your agent — all from the Opik UI. It does not run your agent process
       itself.
 
@@ -145,12 +145,12 @@ UI, check that the process is still running locally and that your network connec
       [Agent Configuration](/development/agent-configuration/overview) without changing code.
 
     You can use both at the same time: `opik endpoint` to run and test your agent in the sandbox,
-    and `opik connect` to let Ollie inspect and edit your code.
+    and `opik connect` to let Opik Connect inspect and edit your code.
   </Accordion>
 </AccordionGroup>
 
 ## Next steps
 
-- [Ollie](/tracing/ollie) — Use Ollie with `opik connect` to debug and improve your agent's code
-- [Debugging agents with Ollie](/tracing/debug-agents) — The debug-fix-verify workflow
+- [Opik Connect](/tracing/ollie) — Use Opik Connect with `opik connect` to debug and improve your agent's code
+- [Debugging agents with Opik Connect](/tracing/debug-agents) — The debug-fix-verify workflow
 - [Getting started with Observability](/tracing/getting-started) — Configure your Opik environment

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/agent_sandbox.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/agent_sandbox.mdx
@@ -135,7 +135,7 @@ UI, check that the process is still running locally and that your network connec
   <Accordion title="What is the difference between opik connect and opik endpoint?">
     They serve different purposes:
 
-    - **`opik connect`** starts a lightweight bridge daemon that gives [Opik Connect](/tracing/ollie)
+    - **`opik connect`** starts a lightweight bridge daemon that gives [Opik Connect](/opik-connect)
       remote access to your repository. Opik Connect can then read your source files, propose code
       changes, and rerun your agent — all from the Opik UI. It does not run your agent process
       itself.
@@ -151,6 +151,6 @@ UI, check that the process is still running locally and that your network connec
 
 ## Next steps
 
-- [Opik Connect](/tracing/ollie) — Use Opik Connect with `opik connect` to debug and improve your agent's code
+- [Opik Connect](/opik-connect) — Use Opik Connect with `opik connect` to debug and improve your agent's code
 - [Debugging agents with Opik Connect](/tracing/debug-agents) — The debug-fix-verify workflow
 - [Getting started with Observability](/tracing/getting-started) — Configure your Opik environment

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/debug_agents.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/debug_agents.mdx
@@ -9,7 +9,7 @@ title: Debugging agents with Opik Connect
 
 Your agent returned the wrong answer, ignored context it was given, or took twice as long as it
 should. The trace is right there in Opik — but tracing alone doesn't tell you *why* it happened or
-how to fix it. That's where [Opik Connect](/ollie) comes in.
+how to fix it. That's where [Opik Connect](/opik-connect) comes in.
 
 ## What Opik Connect has access to
 
@@ -99,6 +99,6 @@ debugging scenarios:
 
 ## Next steps
 
-- [Opik Connect overview](/ollie) — Full introduction to Opik Connect's capabilities and setup
+- [Opik Connect overview](/opik-connect) — Full introduction to Opik Connect's capabilities and setup
 - [Agent sandbox](/development/agent-sandbox) — How `opik connect` discovers and runs your agent
 - [Evaluation overview](/evaluation/overview) — Build the regression net Opik Connect populates for you

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/debug_agents.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/debug_agents.mdx
@@ -1,66 +1,66 @@
 ---
-headline: Debugging Agents with Ollie | Opik Documentation
-og:description: Use Ollie to investigate failing traces, identify root causes in your
+headline: Debugging Agents with Opik Connect | Opik Documentation
+og:description: Use Opik Connect to investigate failing traces, identify root causes in your
   code, and verify fixes with test suites — all from the Opik dashboard
 og:site_name: Opik Documentation
-og:title: Debugging Agents with Ollie — Opik
-title: Debugging agents with Ollie
+og:title: Debugging Agents with Opik Connect — Opik
+title: Debugging agents with Opik Connect
 ---
 
 Your agent returned the wrong answer, ignored context it was given, or took twice as long as it
 should. The trace is right there in Opik — but tracing alone doesn't tell you *why* it happened or
-how to fix it. That's where [Ollie](/ollie) comes in.
+how to fix it. That's where [Opik Connect](/ollie) comes in.
 
-## What Ollie has access to
+## What Opik Connect has access to
 
-Ollie is more than a chatbot — it has tools that let it act on your workspace and your code.
+Opik Connect is more than a chatbot — it has tools that let it act on your workspace and your code.
 
-- **Read and analyze traces** — Ollie reads full span trees including inputs, outputs, latencies, token counts, and feedback scores. It can drill into individual spans, compare traces side by side, and search across your project for patterns.
-- **Search your workspace** — Traces, threads, datasets, experiments, and prompts are all queryable. Ollie can aggregate data, find outliers, and surface trends you'd otherwise need to query manually.
-- **Read and edit your code** — When you connect your repository with [`opik connect`](/development/agent-sandbox), Ollie gains secure, read-only access to your source files. It can propose edits that you review and approve before anything changes on disk.
-- **Run your agent** — With `opik connect` active, Ollie can rerun your agent using inputs from a failing trace to verify a fix in real time. New traces stream back into Opik automatically.
-- **Manage test suites** — Ollie can add traces as test cases to test suites, define assertions, trigger evaluation runs, and summarize pass/fail results.
-- **Navigate the Opik UI** — Ollie can link you directly to traces, experiments, datasets, and prompts it references during a conversation.
+- **Read and analyze traces** — Opik Connect reads full span trees including inputs, outputs, latencies, token counts, and feedback scores. It can drill into individual spans, compare traces side by side, and search across your project for patterns.
+- **Search your workspace** — Traces, threads, datasets, experiments, and prompts are all queryable. Opik Connect can aggregate data, find outliers, and surface trends you'd otherwise need to query manually.
+- **Read and edit your code** — When you connect your repository with [`opik connect`](/development/agent-sandbox), Opik Connect gains secure, read-only access to your source files. It can propose edits that you review and approve before anything changes on disk.
+- **Run your agent** — With `opik connect` active, Opik Connect can rerun your agent using inputs from a failing trace to verify a fix in real time. New traces stream back into Opik automatically.
+- **Manage test suites** — Opik Connect can add traces as test cases to test suites, define assertions, trigger evaluation runs, and summarize pass/fail results.
+- **Navigate the Opik UI** — Opik Connect can link you directly to traces, experiments, datasets, and prompts it references during a conversation.
 
 <Note>
   Code access and agent execution require [`opik connect`](/development/agent-sandbox) to be running
-  in your project directory. Without it, Ollie can still analyze traces and search your workspace
+  in your project directory. Without it, Opik Connect can still analyze traces and search your workspace
   but cannot read your source files or rerun your agent.
 </Note>
 
 ## The debug-fix-verify loop
 
 The fastest way to improve agent quality is a tight loop: find a bad trace, understand it, fix it,
-and make sure it stays fixed. Ollie handles this end-to-end.
+and make sure it stays fixed. Opik Connect handles this end-to-end.
 
 <Steps>
   <Step title="Find a failing trace">
     Start in the Opik dashboard. Filter traces by error status, low feedback score, or latency
     spike to find a run that didn't behave as expected.
   </Step>
-  <Step title="Ask Ollie what went wrong">
-    Open Ollie from the trace view and describe what looks off. Ollie reads the full span tree —
+  <Step title="Ask Opik Connect what went wrong">
+    Open Opik Connect from the trace view and describe what looks off. Opik Connect reads the full span tree —
     every LLM call, tool invocation, and retrieval step — and identifies the root cause.
 
     <Frame>
-      <img src="/img/v2/ollie/step-2-ask-ollie.png" alt="Ollie analyzing a trace and identifying the root cause" />
+      <img src="/img/v2/ollie/step-2-ask-ollie.png" alt="Opik Connect analyzing a trace and identifying the root cause" />
     </Frame>
   </Step>
-  <Step title="Let Ollie fix your code">
-    Once Ollie knows where the bug lives, it reads the relevant source file via `opik connect`
+  <Step title="Let Opik Connect fix your code">
+    Once Opik Connect knows where the bug lives, it reads the relevant source file via `opik connect`
     and proposes a change. You see the diff and approve it — nothing happens without your click.
 
     <Frame>
-      <img src="/img/v2/ollie/step-4-suggested-fix.png" alt="Ollie proposing a code fix with a diff view" />
+      <img src="/img/v2/ollie/step-4-suggested-fix.png" alt="Opik Connect proposing a code fix with a diff view" />
     </Frame>
   </Step>
   <Step title="Verify with a test suite">
-    Ask Ollie to add the original trace as a regression test case, then run the suite against
+    Ask Opik Connect to add the original trace as a regression test case, then run the suite against
     your updated agent. You get a pass/fail summary and a test that catches the bug if it ever
     comes back.
 
     <Frame>
-      <img src="/img/v2/ollie/step-6-eval-verification.png" alt="Ollie running a test suite and showing pass/fail results" />
+      <img src="/img/v2/ollie/step-6-eval-verification.png" alt="Opik Connect running a test suite and showing pass/fail results" />
     </Frame>
   </Step>
 </Steps>
@@ -70,7 +70,7 @@ regression guard built directly from real failures.
 
 ## Example prompts
 
-Ollie works best when you describe the problem in plain language. Here are prompts for common
+Opik Connect works best when you describe the problem in plain language. Here are prompts for common
 debugging scenarios:
 
 ### Investigating failures
@@ -99,6 +99,6 @@ debugging scenarios:
 
 ## Next steps
 
-- [Ollie overview](/ollie) — Full introduction to Ollie's capabilities and setup
+- [Opik Connect overview](/ollie) — Full introduction to Opik Connect's capabilities and setup
 - [Agent sandbox](/development/agent-sandbox) — How `opik connect` discovers and runs your agent
-- [Evaluation overview](/evaluation/overview) — Build the regression net Ollie populates for you
+- [Evaluation overview](/evaluation/overview) — Build the regression net Opik Connect populates for you

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/getting-started.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/getting-started.mdx
@@ -25,7 +25,7 @@ using Opik Connect for AI-assisted setup, the Opik skill for automated integrati
 
 <Tabs>
   <Tab title="Opik Connect">
-    Opik Connect links your local repository to Opik so that [Opik Connect](/tracing/ollie), Opik's AI coding assistant,
+    Opik Connect links your local repository to Opik so that [Opik Connect](/opik-connect), Opik's AI coding assistant,
     can inspect your code, add tracing, and guide you through setup.
 
     <Steps>
@@ -66,7 +66,7 @@ using Opik Connect for AI-assisted setup, the Opik skill for automated integrati
     </Steps>
 
     Once connected, open Opik and Opik Connect will be able to help you instrument your code and
-    set up tracing. See the [Opik Connect documentation](/tracing/ollie) for more details.
+    set up tracing. See the [Opik Connect documentation](/opik-connect) for more details.
   </Tab>
   <Tab title="AI Integration">
     The simplest way to add observability is using the Opik Skills with your favorite coding agent:
@@ -160,7 +160,7 @@ full execution path of a request, including all nested spans, inputs, outputs, a
   <img src="/img/v2/observability/traces-page.png" alt="Opik traces page showing trace details with span tree, outputs, and feedback scores" />
 </Frame>
 
-You can use [Opik Connect](/tracing/ollie) to analyze your traces, identify issues in your agent's
+You can use [Opik Connect](/opik-connect) to analyze your traces, identify issues in your agent's
 behavior, and get actionable suggestions for improvement.
 
 ## Next steps

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/getting-started.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/getting-started.mdx
@@ -25,7 +25,7 @@ using Opik Connect for AI-assisted setup, the Opik skill for automated integrati
 
 <Tabs>
   <Tab title="Opik Connect">
-    Opik Connect links your local repository to Opik so that [Ollie](/tracing/ollie), Opik's AI coding assistant,
+    Opik Connect links your local repository to Opik so that [Opik Connect](/tracing/ollie), Opik's AI coding assistant,
     can inspect your code, add tracing, and guide you through setup.
 
     <Steps>
@@ -54,19 +54,19 @@ using Opik Connect for AI-assisted setup, the Opik skill for automated integrati
         </Tabs>
       </Step>
       <Step title="Connect your repository">
-        Run this command in the repository you want Ollie to work in:
+        Run this command in the repository you want Opik Connect to work in:
 
         ```bash
         opik connect --project "<YOUR_PROJECT_NAME>"
         ```
 
-        This creates a local connection between Opik and your machine so Ollie can inspect your
+        This creates a local connection between Opik and your machine so Opik Connect can inspect your
         code and help add tracing.
       </Step>
     </Steps>
 
-    Once connected, open Opik and Ollie will be able to help you instrument your code and
-    set up tracing. See the [Ollie documentation](/tracing/ollie) for more details.
+    Once connected, open Opik and Opik Connect will be able to help you instrument your code and
+    set up tracing. See the [Opik Connect documentation](/tracing/ollie) for more details.
   </Tab>
   <Tab title="AI Integration">
     The simplest way to add observability is using the Opik Skills with your favorite coding agent:
@@ -160,7 +160,7 @@ full execution path of a request, including all nested spans, inputs, outputs, a
   <img src="/img/v2/observability/traces-page.png" alt="Opik traces page showing trace details with span tree, outputs, and feedback scores" />
 </Frame>
 
-You can use [Ollie](/tracing/ollie) to analyze your traces, identify issues in your agent's
+You can use [Opik Connect](/tracing/ollie) to analyze your traces, identify issues in your agent's
 behavior, and get actionable suggestions for improvement.
 
 ## Next steps

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/overview.mdx
@@ -112,7 +112,7 @@ With Opik, you can:
     </Frame>
   </Step>
   <Step title="Analyze and improve">
-    Use traces to debug failures, identify slow steps, and track quality over time. Attach feedback scores, run evaluations against datasets, and use [Ollie](/tracing/debug-agents) — Opik's AI assistant — to help root-cause issues automatically.
+    Use traces to debug failures, identify slow steps, and track quality over time. Attach feedback scores, run evaluations against datasets, and use [Opik Connect](/tracing/debug-agents) — Opik's AI assistant — to help root-cause issues automatically.
   </Step>
 </Steps>
 
@@ -135,5 +135,5 @@ Opik has first-class support for 30+ frameworks in Python, TypeScript, and OpenT
 
 - [Getting started](/tracing/getting-started) — Add observability to your agent in minutes
 - [Concepts](/tracing/concepts) — Understand traces, spans, threads, and feedback scores
-- [Debugging agents with Ollie](/tracing/debug-agents) — Use AI-assisted root-cause analysis
+- [Debugging agents with Opik Connect](/tracing/debug-agents) — Use AI-assisted root-cause analysis
 - [Cost tracking](/tracing/advanced/cost_tracking) — Monitor token usage and spending

--- a/apps/opik-documentation/documentation/fern/docs-v2/ollie.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/ollie.mdx
@@ -1,50 +1,50 @@
 ---
-headline: Ollie | Opik Documentation
-og:description: Meet Ollie — the AI assistant built into Opik that doesn't just
+headline: Opik Connect | Opik Documentation
+og:description: Meet Opik Connect — the AI assistant built into Opik that doesn't just
   analyze your traces, it helps you improve your agent's code directly from the
   Opik platform.
 og:site_name: Opik Documentation
-og:title: Ollie — Your AI co-pilot for shipping better agents
-title: Ollie
+og:title: Opik Connect — Your AI co-pilot for shipping better agents
+title: Opik Connect
 ---
 
-With **Ollie** and `opik connect`, Opik becomes the place you actually fix it. Opik is no longer just a place to watch what your agent did. Ask a question about any trace, let Ollie read your code, have it edit the file, rerun your agent, and verify the fix with a test suite — all without leaving the browser.
+With **Opik Connect**, Opik becomes the place you actually fix it. Opik is no longer just a place to watch what your agent did. Ask a question about any trace, let Opik Connect read your code, have it edit the file, rerun your agent, and verify the fix with a test suite — all without leaving the browser.
 
 <Frame>
   <img src="/img/v2/ollie/hero.png" />
 </Frame>
 
-## Meet Ollie
+## Meet Opik Connect
 
-Ollie is a conversational AI assistant built into Opik. It lives next to every trace, dataset, experiment, and prompt you've logged — and when you pair your local project with `opik connect`, Ollie can also read your source files, run your agent, and propose code changes. One assistant, full context: your data on one side, your code on the other.
+Opik Connect is a conversational AI assistant built into Opik. It lives next to every trace, dataset, experiment, and prompt you've logged — and when you pair your local project with `opik connect`, Opik Connect can also read your source files, run your agent, and propose code changes. One assistant, full context: your data on one side, your code on the other.
 
-## What Ollie can do
+## What Opik Connect can do
 
 <CardGroup cols={2}>
   <Card title="Investigate any trace" icon="fa-regular fa-magnifying-glass-chart">
-    Ollie reads full span trees, identifies root causes, and compares failing
+    Opik Connect reads full span trees, identifies root causes, and compares failing
     runs to successful ones. Ask *"why did the final answer ignore the context?"*
     and get a grounded answer, not a guess.
   </Card>
   <Card title="Connect to your code" icon="fa-regular fa-link">
-    Pair your local project with `opik connect` and Ollie gains the ability to
+    Pair your local project with `opik connect` and Opik Connect gains the ability to
     read your source files, propose edits (with your approval), and rerun your
     agent with the changes in place.
   </Card>
   <Card title="Close the loop" icon="fa-regular fa-arrows-rotate">
-    Every fix becomes a test. Ollie can add a failing trace to a test suite,
+    Every fix becomes a test. Opik Connect can add a failing trace to a test suite,
     then trigger the suite against your updated agent to confirm the regression
     is gone.
   </Card>
   <Card title="Works across your workspace" icon="fa-regular fa-layer-group">
-    Traces, threads, datasets, experiments, prompts — Ollie queries across all
+    Traces, threads, datasets, experiments, prompts — Opik Connect queries across all
     of them in a single conversation. No tab-switching, no manual stitching.
   </Card>
 </CardGroup>
 
 ## From debugging to improvement
 
-The real workflow — and the reason Ollie exists — is the full loop from *"something looks wrong"* to *"it's fixed and it won't regress."* Here's what that looks like in Opik:
+The real workflow — and the reason Opik Connect exists — is the full loop from *"something looks wrong"* to *"it's fixed and it won't regress."* Here's what that looks like in Opik:
 
 <Steps>
 
@@ -52,21 +52,21 @@ The real workflow — and the reason Ollie exists — is the full loop from *"so
 
 Start where every debugging session starts: a trace that looks wrong. Filter by error status, low feedback score, or latency spike.
 
-### Ask Ollie what went wrong
+### Ask Opik Connect what went wrong
 
-Open Ollie from the trace view. Describe what looks off — *"the model ignored the retrieved context"*, *"the tool call returned empty"* — and Ollie walks the span tree to find the cause.
+Open Opik Connect from the trace view. Describe what looks off — *"the model ignored the retrieved context"*, *"the tool call returned empty"* — and Opik Connect walks the span tree to find the cause.
 
 <Frame>
   <img src="/img/v2/ollie/step-2-ask-ollie.png" />
 </Frame>
 
-### Let Ollie read your code
+### Let Opik Connect read your code
 
-Once Ollie identifies *where* the bug lives, it asks to read the relevant source file. With `opik connect` running on your machine, it has secure access to the files in your project — and shows you exactly what it's looking at.
+Once Opik Connect identifies *where* the bug lives, it asks to read the relevant source file. With `opik connect` running on your machine, it has secure access to the files in your project — and shows you exactly what it's looking at.
 
 ### Approve the fix
 
-Ollie proposes a change. You see the diff, approve it, and the file is updated on your machine. Nothing happens without your click.
+Opik Connect proposes a change. You see the diff, approve it, and the file is updated on your machine. Nothing happens without your click.
 
 <Frame>
   <img src="/img/v2/ollie/step-4-suggested-fix.png" />
@@ -74,11 +74,11 @@ Ollie proposes a change. You see the diff, approve it, and the file is updated o
 
 ### Rerun the agent from Opik
 
-With the fix applied locally, Ollie reruns your agent through `opik connect` using the same inputs from the original failing trace. The new trace streams back into Opik in real time.
+With the fix applied locally, Opik Connect reruns your agent through `opik connect` using the same inputs from the original failing trace. The new trace streams back into Opik in real time.
 
 ### Verify with a test suite
 
-Ask Ollie to add the original trace to a test suite as a regression case, then run the suite against the updated agent. You get a pass/fail summary — and a test that will catch the bug if it ever comes back.
+Ask Opik Connect to add the original trace to a test suite as a regression case, then run the suite against the updated agent. You get a pass/fail summary — and a test that will catch the bug if it ever comes back.
 
 <Frame>
   <img src="/img/v2/ollie/step-6-eval-verification.png" />
@@ -86,7 +86,7 @@ Ask Ollie to add the original trace to a test suite as a regression case, then r
 
 </Steps>
 
-## Get started with Ollie
+## Get started with Opik Connect
 
 <Steps>
 
@@ -98,16 +98,16 @@ From the root of your agent project, run:
 opik connect --project <project-name>
 ```
 
-That's it. `opik connect` pairs your local project with Opik, and Ollie takes care of the rest — discovering your entrypoints, running your agent, and proposing code changes.
+That's it. `opik connect` pairs your local project with Opik, and Opik Connect takes care of the rest — discovering your entrypoints, running your agent, and proposing code changes.
 
-### Chat with Ollie
+### Chat with Opik Connect
 
-Open Ollie from anywhere in the Opik UI and start asking. Traces, code, reruns, evaluations — it's all one conversation from here.
+Open Opik Connect from anywhere in the Opik UI and start asking. Traces, code, reruns, evaluations — it's all one conversation from here.
 
 </Steps>
 
 <Tip>
-  `opik connect` is opt-in and scoped to the session it's launched in. Ollie
+  `opik connect` is opt-in and scoped to the session it's launched in. Opik Connect
   can only read and edit files in the project you connect, and every write
   operation requires your explicit approval.
 </Tip>
@@ -115,13 +115,13 @@ Open Ollie from anywhere in the Opik UI and start asking. Traces, code, reruns, 
 ## Next steps
 
 <CardGroup cols={3}>
-  <Card title="Debugging agents with Ollie" href="/tracing/debug-agents" icon="fa-regular fa-bug">
+  <Card title="Debugging agents with Opik Connect" href="/tracing/debug-agents" icon="fa-regular fa-bug">
     The tactical guide to the debug-fix-verify loop, with example prompts.
   </Card>
   <Card title="Agent sandbox" href="/development/agent-sandbox" icon="fa-regular fa-flask">
     Everything about `opik connect` — how it discovers and runs your agent.
   </Card>
   <Card title="Test suites" href="/evaluation/overview" icon="fa-regular fa-check-double">
-    Build the regression net Ollie will populate for you.
+    Build the regression net Opik Connect will populate for you.
   </Card>
 </CardGroup>

--- a/apps/opik-documentation/documentation/fern/docs-v2/quickstart.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/quickstart.mdx
@@ -65,7 +65,7 @@ Opik makes it easy to integrate with your existing LLM application, the best way
 
 ## Analyze your traces
 
-After running your application, you will start seeing your traces in Opik and you can use Ollie to analyze them and improve your agent.
+After running your application, you will start seeing your traces in Opik and you can use Opik Connect to analyze them and improve your agent.
 
 {/* [text](TODO: Update video) */}
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/self_improving_agents/ollie_and_your_codebase.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self_improving_agents/ollie_and_your_codebase.mdx
@@ -1,13 +1,13 @@
 ---
-headline: Ollie and Your Codebase | Opik Documentation
-og:description: How Ollie reads your source files, proposes code changes, reruns your
+headline: Opik Connect and Your Codebase | Opik Documentation
+og:description: How Opik Connect reads your source files, proposes code changes, reruns your
   agent, and verifies fixes — all through opik connect
 og:site_name: Opik Documentation
-og:title: Ollie and Your Codebase — Opik
-title: Ollie and your codebase
+og:title: Opik Connect and Your Codebase — Opik
+title: Opik Connect and your codebase
 ---
 
-Ollie is useful even without code access — it can analyze traces, search your workspace, and help you understand failures. But when you pair it with `opik connect`, it becomes something more: an AI that can read your source files, propose changes, rerun your agent, and verify fixes with test suites. All from the Opik UI.
+Opik Connect is useful even without code access — it can analyze traces, search your workspace, and help you understand failures. But when you pair it with `opik connect`, it becomes something more: an AI that can read your source files, propose changes, rerun your agent, and verify fixes with test suites. All from the Opik UI.
 
 ## Setting up opik connect
 
@@ -17,27 +17,27 @@ From the root of your agent project, run:
 opik connect --project <project-name>
 ```
 
-That's it. `opik connect` pairs your local project with your Opik workspace. Ollie discovers your source files and gains the ability to read and propose changes to them.
+That's it. `opik connect` pairs your local project with your Opik workspace. Opik Connect discovers your source files and gains the ability to read and propose changes to them.
 
 <Tip>
-  `opik connect` is opt-in and scoped to the session. Ollie can only access
+  `opik connect` is opt-in and scoped to the session. Opik Connect can only access
   files in the project you connect, and every write operation requires your
   explicit approval.
 </Tip>
 
-## What Ollie can do with your code
+## What Opik Connect can do with your code
 
 ### Read source files
 
-Once connected, Ollie can read any file in your project when investigating an issue. When a trace shows a failure in your retrieval step, Ollie doesn't just tell you *"the retrieval returned empty results"* — it reads the actual retrieval function, understands the logic, and identifies why it failed for that specific input.
+Once connected, Opik Connect can read any file in your project when investigating an issue. When a trace shows a failure in your retrieval step, Opik Connect doesn't just tell you *"the retrieval returned empty results"* — it reads the actual retrieval function, understands the logic, and identifies why it failed for that specific input.
 
 This bridges the gap between *what went wrong* (the trace) and *why it went wrong* (the code).
 
 ### Propose code changes
 
-After identifying a root cause, Ollie proposes a fix as a diff. You see exactly what will change before anything happens. Click approve, and the file is updated on your machine. Click reject, and nothing changes.
+After identifying a root cause, Opik Connect proposes a fix as a diff. You see exactly what will change before anything happens. Click approve, and the file is updated on your machine. Click reject, and nothing changes.
 
-Common fixes Ollie proposes:
+Common fixes Opik Connect proposes:
 - Adjusting prompt templates to handle edge cases
 - Adding guardrails to tool call outputs
 - Fixing retrieval query construction
@@ -45,7 +45,7 @@ Common fixes Ollie proposes:
 
 ### Rerun your agent
 
-With the fix applied locally, Ollie can rerun your agent through `opik connect` using the same inputs from the original failing trace. The new trace streams back into Opik in real time, so you can see immediately whether the fix worked.
+With the fix applied locally, Opik Connect can rerun your agent through `opik connect` using the same inputs from the original failing trace. The new trace streams back into Opik in real time, so you can see immediately whether the fix worked.
 
 This eliminates the manual cycle of:
 1. Fix code locally
@@ -57,7 +57,7 @@ Instead, it's one click — and the comparison is side-by-side in the Opik UI.
 
 ### Verify with test suites
 
-The final step: ask Ollie to run your test suite against the updated agent. This checks not just the trace you fixed, but every test case in the suite. You get a pass/fail summary and confidence that nothing regressed.
+The final step: ask Opik Connect to run your test suite against the updated agent. This checks not just the trace you fixed, but every test case in the suite. You get a pass/fail summary and confidence that nothing regressed.
 
 ```
 "Run the customer-support-qa suite against the updated agent"
@@ -73,21 +73,21 @@ Here's what the complete loop looks like with `opik connect` active:
 
 You see a trace in the dashboard where the agent hallucinated a step in a how-to response. The trace shows the LLM ignored the retrieved context.
 
-### Ask Ollie
+### Ask Opik Connect
 
-Open Ollie from the trace view:
+Open Opik Connect from the trace view:
 
 *"Why did the agent make up step 3 instead of using the context from the knowledge base?"*
 
-Ollie reads the span tree, identifies that the retrieval step returned the right document but the prompt template doesn't instruct the model to stay grounded in the context.
+Opik Connect reads the span tree, identifies that the retrieval step returned the right document but the prompt template doesn't instruct the model to stay grounded in the context.
 
-### Let Ollie read the code
+### Let Opik Connect read the code
 
-Ollie asks to read your prompt template file. With `opik connect` running, it reads the file and confirms the issue — the system prompt says "answer the user's question" but doesn't include an instruction to only use provided context.
+Opik Connect asks to read your prompt template file. With `opik connect` running, it reads the file and confirms the issue — the system prompt says "answer the user's question" but doesn't include an instruction to only use provided context.
 
 ### Approve the fix
 
-Ollie proposes adding a grounding instruction to the system prompt:
+Opik Connect proposes adding a grounding instruction to the system prompt:
 
 ```diff
 - You are a helpful customer support assistant.
@@ -100,19 +100,19 @@ You review the diff and click approve.
 
 ### Rerun and verify
 
-Ollie reruns the agent with the same input from the failing trace. The new trace shows the agent now correctly uses the context and doesn't hallucinate. Ollie then runs the full test suite to confirm nothing else broke.
+Opik Connect reruns the agent with the same input from the failing trace. The new trace shows the agent now correctly uses the context and doesn't hallucinate. Opik Connect then runs the full test suite to confirm nothing else broke.
 
 </Steps>
 
 ## Security and access control
 
 - **Scoped to your session**: `opik connect` only exposes files in the project directory you connect. It cannot access files outside that directory.
-- **Read requires connection**: Without `opik connect` running, Ollie has no access to your source files. It can still analyze traces and search your workspace.
-- **Writes require approval**: Every code change Ollie proposes requires explicit approval. The diff is shown before anything is written.
+- **Read requires connection**: Without `opik connect` running, Opik Connect has no access to your source files. It can still analyze traces and search your workspace.
+- **Writes require approval**: Every code change Opik Connect proposes requires explicit approval. The diff is shown before anything is written.
 - **Local execution**: Your agent runs on your machine. Code and data stay local — only traces and metadata are sent to Opik.
 
 ## Next steps
 
 - [Agent sandbox](/development/agent-sandbox) — Technical details on `opik connect` and `opik endpoint`
 - [The Flywheel](/self-improving-agents/the-flywheel) — The complete self-improvement cycle
-- [Debugging agents with Ollie](/tracing/debug-agents) — Example prompts for common debugging scenarios
+- [Debugging agents with Opik Connect](/tracing/debug-agents) — Example prompts for common debugging scenarios

--- a/apps/opik-documentation/documentation/fern/docs-v2/self_improving_agents/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self_improving_agents/overview.mdx
@@ -45,7 +45,7 @@ def my_agent(query: str) -> str:
 
 ### Analyze with Opik Connect agent
 
-When you spot a trace that looks wrong — a hallucinated answer, ignored context, a failed tool call — open [Opik Connect](/tracing/ollie) from the trace view. Describe what looks off, and Opik Connect walks the span tree to find the root cause.
+When you spot a trace that looks wrong — a hallucinated answer, ignored context, a failed tool call — open [Opik Connect](/opik-connect) from the trace view. Describe what looks off, and Opik Connect walks the span tree to find the root cause.
 
 Opik Connect doesn't just summarize the trace. It reads the full execution path, compares failing runs to successful ones, and identifies exactly which step went wrong and why.
 
@@ -86,7 +86,7 @@ With the root cause identified and a test case in place, fix the issue. This mig
 
 With [`opik connect`](/development/agent-sandbox) running, Opik Connect can read your source files and propose code changes directly. You see the diff, approve it, and the file is updated on your machine. Nothing changes without your click.
 
-This is the step where Opik Connect's full power shows — it has context from the trace (what went wrong), the test suite (what "correct" looks like), and your code (where to make the change). See [Opik Connect and your codebase](/self-improving-agents/ollie-and-your-codebase) for the full workflow.
+This is the step where Opik Connect's full power shows — it has context from the trace (what went wrong), the test suite (what "correct" looks like), and your code (where to make the change). See [Opik Connect and your codebase](/self-improving-agents/opik-connect-and-your-codebase) for the full workflow.
 
 **Where this happens in Opik:** The Opik Connect chat panel with `opik connect` active.
 
@@ -122,6 +122,6 @@ The flywheel isn't just a process — it's a compounding investment:
 
 ## Next steps
 
-- [Opik Connect and your codebase](/self-improving-agents/ollie-and-your-codebase) — How `opik connect` lets Opik Connect read and edit your code
+- [Opik Connect and your codebase](/self-improving-agents/opik-connect-and-your-codebase) — How `opik connect` lets Opik Connect read and edit your code
 - [Getting started with evaluation](/evaluation/getting-started) — Run your first test suite
 - [Debugging agents with Opik Connect](/tracing/debug-agents) — Example prompts and the full debug workflow

--- a/apps/opik-documentation/documentation/fern/docs-v2/self_improving_agents/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self_improving_agents/overview.mdx
@@ -1,7 +1,7 @@
 ---
 headline: Building Self-Improving Agents | Opik Documentation
 og:description: The Opik philosophy on building agents that get better over time —
-  from production logging to automated improvement with Ollie
+  from production logging to automated improvement with Opik Connect
 og:site_name: Opik Documentation
 og:title: Building Self-Improving Agents — Opik
 title: Building Self-Improving Agents
@@ -43,18 +43,18 @@ def my_agent(query: str) -> str:
 
 **Where this happens in Opik:** The [Traces dashboard](/tracing/overview) shows every request with filtering by status, latency, cost, and custom tags.
 
-### Analyze with Ollie agent
+### Analyze with Opik Connect agent
 
-When you spot a trace that looks wrong — a hallucinated answer, ignored context, a failed tool call — open [Ollie](/tracing/ollie) from the trace view. Describe what looks off, and Ollie walks the span tree to find the root cause.
+When you spot a trace that looks wrong — a hallucinated answer, ignored context, a failed tool call — open [Opik Connect](/tracing/ollie) from the trace view. Describe what looks off, and Opik Connect walks the span tree to find the root cause.
 
-Ollie doesn't just summarize the trace. It reads the full execution path, compares failing runs to successful ones, and identifies exactly which step went wrong and why.
+Opik Connect doesn't just summarize the trace. It reads the full execution path, compares failing runs to successful ones, and identifies exactly which step went wrong and why.
 
 Example prompts:
 - *"Why did the final answer ignore the retrieved context?"*
 - *"Which tool call caused this trace to fail?"*
 - *"Compare this to a recent successful trace for the same query type"*
 
-**Where this happens in Opik:** The [Ollie debug panel](/tracing/debug-agents) is available from any trace view.
+**Where this happens in Opik:** The [Opik Connect debug panel](/tracing/debug-agents) is available from any trace view.
 
 ### Add failed agent responses to test suites
 
@@ -65,7 +65,7 @@ Example assertions:
 - *"The tool call must return a non-empty result"*
 - *"The response must not contain information not present in the context"*
 
-You can add test cases through Ollie, the Opik UI, or the SDK:
+You can add test cases through Opik Connect, the Opik UI, or the SDK:
 
 ```python
 import opik
@@ -80,15 +80,15 @@ suite.add_test_case(
 
 **Where this happens in Opik:** [Test Suites](/evaluation/advanced/building-test-suites) in the Evaluation section.
 
-### Update your agent prompts and code with Ollie
+### Update your agent prompts and code with Opik Connect
 
 With the root cause identified and a test case in place, fix the issue. This might mean updating a prompt, adjusting tool definitions, or changing retrieval parameters.
 
-With [`opik connect`](/development/agent-sandbox) running, Ollie can read your source files and propose code changes directly. You see the diff, approve it, and the file is updated on your machine. Nothing changes without your click.
+With [`opik connect`](/development/agent-sandbox) running, Opik Connect can read your source files and propose code changes directly. You see the diff, approve it, and the file is updated on your machine. Nothing changes without your click.
 
-This is the step where Ollie's full power shows — it has context from the trace (what went wrong), the test suite (what "correct" looks like), and your code (where to make the change). See [Ollie and your codebase](/self-improving-agents/ollie-and-your-codebase) for the full workflow.
+This is the step where Opik Connect's full power shows — it has context from the trace (what went wrong), the test suite (what "correct" looks like), and your code (where to make the change). See [Opik Connect and your codebase](/self-improving-agents/ollie-and-your-codebase) for the full workflow.
 
-**Where this happens in Opik:** The Ollie chat panel with `opik connect` active.
+**Where this happens in Opik:** The Opik Connect chat panel with `opik connect` active.
 
 ### Validate changes with test suites
 
@@ -109,7 +109,7 @@ You get a pass/fail summary for every assertion. If something fails, you're back
 The flywheel isn't just a process — it's a compounding investment:
 
 - **Each turn adds a test case.** After 50 production failures caught and fixed, you have 50 regression tests that run automatically.
-- **Ollie gets more context.** The more traces and test cases in your workspace, the better Ollie can diagnose new issues by comparing to known patterns.
+- **Opik Connect gets more context.** The more traces and test cases in your workspace, the better Opik Connect can diagnose new issues by comparing to known patterns.
 - **Confidence grows.** With a comprehensive test suite, you can ship changes faster because you know regressions will be caught.
 - **Failure rate drops.** Each fix addresses a real production failure mode. Over time, the easy failures are eliminated and your agent handles edge cases that would have broken it before.
 
@@ -122,6 +122,6 @@ The flywheel isn't just a process — it's a compounding investment:
 
 ## Next steps
 
-- [Ollie and your codebase](/self-improving-agents/ollie-and-your-codebase) — How `opik connect` lets Ollie read and edit your code
+- [Opik Connect and your codebase](/self-improving-agents/ollie-and-your-codebase) — How `opik connect` lets Opik Connect read and edit your code
 - [Getting started with evaluation](/evaluation/getting-started) — Run your first test suite
-- [Debugging agents with Ollie](/tracing/debug-agents) — Example prompts and the full debug workflow
+- [Debugging agents with Opik Connect](/tracing/debug-agents) — Example prompts and the full debug workflow

--- a/apps/opik-documentation/documentation/fern/versions/latest.yml
+++ b/apps/opik-documentation/documentation/fern/versions/latest.yml
@@ -35,7 +35,7 @@ navigation:
             icon: fa-regular fa-bolt
           - page: Opik Connect
             path: ../docs-v2/ollie.mdx
-            slug: ollie
+            slug: opik-connect
             icon: fa-regular fa-sparkles
           - page: FAQ
             path: ../docs-v2/faq.mdx
@@ -860,7 +860,7 @@ navigation:
         slug: overview
       - page: Opik Connect and your codebase
         path: ../docs-v2/self_improving_agents/ollie_and_your_codebase.mdx
-        slug: ollie-and-your-codebase
+        slug: opik-connect-and-your-codebase
   - tab: self-host
     layout:
       - page: Overview

--- a/apps/opik-documentation/documentation/fern/versions/latest.yml
+++ b/apps/opik-documentation/documentation/fern/versions/latest.yml
@@ -33,7 +33,7 @@ navigation:
             path: ../docs-v2/quickstart.mdx
             slug: /quickstart
             icon: fa-regular fa-bolt
-          - page: Ollie Agent
+          - page: Opik Connect
             path: ../docs-v2/ollie.mdx
             slug: ollie
             icon: fa-regular fa-sparkles
@@ -57,7 +57,7 @@ navigation:
           - page: Concepts
             path: ../docs-v2/tracing/concepts.mdx
             slug: concepts
-          - page: Debugging agents with Ollie
+          - page: Debugging agents with Opik Connect
             path: ../docs-v2/observability/debug_agents.mdx
             slug: debug-agents
           - section: Advanced
@@ -858,7 +858,7 @@ navigation:
       - page: Overview
         path: ../docs-v2/self_improving_agents/overview.mdx
         slug: overview
-      - page: Ollie and your codebase
+      - page: Opik Connect and your codebase
         path: ../docs-v2/self_improving_agents/ollie_and_your_codebase.mdx
         slug: ollie-and-your-codebase
   - tab: self-host

--- a/apps/opik-frontend/src/plugins/comet/OllieLoader.tsx
+++ b/apps/opik-frontend/src/plugins/comet/OllieLoader.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 
 const MESSAGES = [
-  "Ollie is waking up\u2026",
+  "Opik Connect is waking up\u2026",
   "Loading traces\u2026",
   "Crunching evaluation data\u2026",
   "Almost ready\u2026",

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsActionsPanel.tsx
@@ -248,7 +248,7 @@ const TraceDetailsActionsPanel: React.FunctionComponent<
               }
             >
               <Sparkles className="size-3.5 shrink-0" />
-              <span className="ml-1.5">Improve with Ollie</span>
+              <span className="ml-1.5">Improve with Opik Connect</span>
             </Button>
           </TooltipWrapper>
         )}

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentSandboxFlowDiagram.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentSandboxFlowDiagram.tsx
@@ -104,7 +104,9 @@ const AgentSandboxFlowDiagram: React.FC = () => {
         <div className="rounded border border-primary bg-primary-foreground px-2 py-1.5">
           <div className="flex items-center gap-1.5">
             <OllieOwl className="size-3 shrink-0" />
-            <span className="text-[11px] font-medium">Improve with Ollie</span>
+            <span className="text-[11px] font-medium">
+              Improve with Opik Connect
+            </span>
           </div>
           <p className="mt-0.5 text-[10px] text-muted-slate">
             Analyze traces, suggest prompt tweaks

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
@@ -30,9 +30,9 @@ const ConnectToOllieTab: React.FC<ConnectToOllieTabProps> = ({ connected }) => {
   return (
     <div className="flex flex-col gap-4 px-1">
       <p className="comet-body-s text-muted-slate">
-        Ollie is Opik&apos;s AI coding assistant. When you connect your repo,
-        Ollie can inspect your code, help add Opik tracing, and guide you
-        through setup.
+        Opik Connect is Opik&apos;s AI coding assistant. When you connect your
+        repo, Opik Connect can inspect your code, help add Opik tracing, and
+        guide you through setup.
       </p>
       <div className="flex flex-col">
         <TimelineStep number={1}>
@@ -45,12 +45,12 @@ const ConnectToOllieTab: React.FC<ConnectToOllieTabProps> = ({ connected }) => {
         <TimelineStep number={2}>
           <div className="flex flex-col gap-2.5">
             <h4 className="comet-body-s-accented">
-              Connect your repo to Ollie
+              Connect your repo to Opik Connect
             </h4>
             <p className="comet-body-xs text-muted-slate">
-              Run this command in the repository you want Ollie to work in. This
-              creates a local connection between Opik and your machine so Ollie
-              can help with setup.
+              Run this command in the repository you want Opik Connect to work
+              in. This creates a local connection between Opik and your machine
+              so Opik Connect can help with setup.
             </p>
             <CodeSnippet title="Terminal" code={connectCommandText} />
           </div>
@@ -65,11 +65,11 @@ const ConnectToOllieTab: React.FC<ConnectToOllieTabProps> = ({ connected }) => {
             </h4>
             <p className="comet-body-xs text-muted-slate">
               {connected ? (
-                "Ollie can now inspect your code and help you set up tracing in Opik."
+                "Opik Connect can now inspect your code and help you set up tracing in Opik."
               ) : (
                 <>
-                  Run the command above in your repo. Once connected, Ollie can
-                  inspect your code and help finish setup.{" "}
+                  Run the command above in your repo. Once connected, Opik
+                  Connect can inspect your code and help finish setup.{" "}
                   <a
                     href={buildDocsUrl(
                       "/agents/local-runner",


### PR DESCRIPTION
## Details

Rebrand: the product formerly known as "Ollie" is now "Opik Connect". This PR replaces every user-visible occurrence across the frontend and fern documentation.

Scope was deliberately limited to rendered copy. The following are intentionally **out of scope** and untouched in this PR:

- File names (e.g. `ConnectToOllieTab.tsx`, `ollie.mdx`, `ollie-owl.svg`, `img/v2/ollie/*`)
- Backend endpoints (`/opik/ollie/compute`, `/v1/private/ollie/state`) and `openapi/opik.yaml`
- TypeScript identifiers, types, components, props, and imports (`OllieLoader`, `ConnectToOllieTab`, `OllieOwl`, `showOllieTab`, etc.)
- Tailwind animation class names (`ollie-breathe`, `ollie-blink`, `ollie-text-in`)
- PostHog variant strings (`"connect-to-ollie"`) — preserved to keep historical funnel analytics intact
- URL slugs in `latest.yml` (`ollie`, `ollie-and-your-codebase`) — preserved to avoid breaking inbound links
- Source-code comments referencing Ollie
- Image paths inside MDX (`/img/v2/ollie/...`)

Those can be handled in a follow-up if/when a broader rename is green-lit.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: Drafted the scoped rename plan, executed the find-and-replace edits across 15 files, and ran verification (grep sanity, `tsc --noEmit`, `eslint`).
- Human verification: Author reviewed the plan and confirmed the out-of-scope list before edits; final diff to be reviewed on this PR.

## Testing

- `npx tsc --noEmit` in `apps/opik-frontend` — clean.
- `npx eslint` on the four edited frontend files with `--max-warnings=0` — clean.
- Grep sanity: `Ollie` returns 0 hits in `apps/opik-documentation/documentation/fern/docs-v2/**/*.mdx` and in JSX-visible text in `apps/opik-frontend/src`. Remaining `Ollie` references are all in the explicitly-excluded categories above.
- Not run: browser walkthrough and `fern docs dev` preview — changes are pure string swaps with no logic changes, and identifier names were deliberately not touched so type-check coverage is sufficient. Reviewers should spot-check the onboarding modal "Connect to Opik Connect" tab, the "Improve with Opik Connect" buttons on the trace details panel and agent sandbox flow diagram, and the loader message.

## Documentation

This PR itself updates documentation. Files touched under `apps/opik-documentation/documentation/fern/`:

- `docs-v2/ollie.mdx` (body, title, headline, OG meta)
- `docs-v2/self_improving_agents/{overview,ollie_and_your_codebase}.mdx`
- `docs-v2/observability/{overview,getting-started,debug_agents,agent_sandbox}.mdx`
- `docs-v2/evaluation/{overview,building_evaluation_suites}.mdx`
- `docs-v2/quickstart.mdx`
- `versions/latest.yml` (three navigation page titles; slugs and paths unchanged)