### PR TITLE
[OPIK-5987][FE] Agent sandbox URL uses "/agent-runner" instead of "/agent-playground"

### DIFF
--- a/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
+++ b/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
@@ -68,7 +68,7 @@ const getMenuItems = ({
       items: [
         {
           id: "agent_runner",
-          path: projectPath("/agent-runner"),
+          path: projectPath("/agent-playground"),
           type: MENU_ITEM_TYPE.router,
           icon: GitBranch,
           label: "Agent playground",

--- a/apps/opik-frontend/src/v2/router.tsx
+++ b/apps/opik-frontend/src/v2/router.tsx
@@ -401,7 +401,7 @@ const agentConfigurationRoute = createRoute({
 
 // ----------- agent runner (project-scoped)
 const agentRunnerRoute = createRoute({
-  path: "/agent-runner",
+  path: "/agent-playground",
   getParentRoute: () => projectScopedRoute,
   staticData: {
     title: "Agent playground",


### PR DESCRIPTION
## Details
The agent sandbox page URL path is /agent-runner but it should be /agent-playground for consistency with the feature's naming across the product.

## Summary

Renamed the agent sandbox URL path from `/agent-runner` to `/agent-playground` in the frontend route definition and sidebar menu link.

## Changes by Component

### Frontend
- Changed route path from `/agent-runner` to `/agent-playground` in `router.tsx`
- Updated sidebar menu link from `/agent-runner` to `/agent-playground` in `getMenuItems.ts`

## Files Changed

```
 apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts | 2 +-
 apps/opik-frontend/src/v2/router.tsx                             | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```

## After applying fix
<img width="1271" height="1234" alt="Screenshot 2026-04-21 at 16 25 26" src="https://github.com/user-attachments/assets/d7840dd5-99f9-4299-b7f7-b8088128d9f7" />

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-5987

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
Manual testing

## Documentation
NA