### PR TITLE
[OPIK-6011] [FE] fix: treat config history 404 as empty state and poll until data arrives

### DIFF
--- a/apps/opik-frontend/src/api/agent-configs/useConfigHistoryListInfinite.ts
+++ b/apps/opik-frontend/src/api/agent-configs/useConfigHistoryListInfinite.ts
@@ -61,9 +61,7 @@ export default function useConfigHistoryListInfinite({
     initialPageParam: 1,
     refetchInterval: (query) => {
       if (query.state.status !== "success" || !query.state.data) return false;
-      const isEmpty = !query.state.data.pages.some(
-        (p) => p.content.length > 0,
-      );
+      const isEmpty = !query.state.data.pages.some((p) => p.content.length > 0);
       return isEmpty ? 5000 : false;
     },
   });

--- a/apps/opik-frontend/src/api/agent-configs/useConfigHistoryListInfinite.ts
+++ b/apps/opik-frontend/src/api/agent-configs/useConfigHistoryListInfinite.ts
@@ -1,4 +1,5 @@
 import { QueryFunctionContext, useInfiniteQuery } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 
 import api, { AGENT_CONFIGS_KEY, AGENT_CONFIGS_REST_ENDPOINT } from "@/api/api";
 import { ConfigHistoryItem } from "@/types/agent-configs";
@@ -12,24 +13,38 @@ type UseConfigHistoryListInfiniteResponse = {
   total: number;
 };
 
+const EMPTY_RESPONSE: UseConfigHistoryListInfiniteResponse = {
+  content: [],
+  page: 1,
+  size: PAGE_SIZE,
+  total: 0,
+};
+
 const getConfigHistoryList = async (
   { signal }: QueryFunctionContext,
   { projectId, page }: { projectId: string; page: number },
 ): Promise<UseConfigHistoryListInfiniteResponse> => {
-  const { data } = await api.get(
-    `${AGENT_CONFIGS_REST_ENDPOINT}blueprints/history/projects/${projectId}`,
-    { signal, params: { page, size: PAGE_SIZE } },
-  );
+  try {
+    const { data } = await api.get(
+      `${AGENT_CONFIGS_REST_ENDPOINT}blueprints/history/projects/${projectId}`,
+      { signal, params: { page, size: PAGE_SIZE } },
+    );
 
-  return {
-    ...data,
-    content: data.content.map(
-      (item: { envs?: string[] } & Omit<ConfigHistoryItem, "tags">) => ({
-        ...item,
-        tags: item.envs ?? [],
-      }),
-    ),
-  };
+    return {
+      ...data,
+      content: data.content.map(
+        (item: { envs?: string[] } & Omit<ConfigHistoryItem, "tags">) => ({
+          ...item,
+          tags: item.envs ?? [],
+        }),
+      ),
+    };
+  } catch (error) {
+    if (error instanceof AxiosError && error.response?.status === 404) {
+      return EMPTY_RESPONSE;
+    }
+    throw error;
+  }
 };
 
 export default function useConfigHistoryListInfinite({
@@ -37,12 +52,20 @@ export default function useConfigHistoryListInfinite({
 }: {
   projectId: string;
 }) {
-  return useInfiniteQuery<UseConfigHistoryListInfiniteResponse>({
+  const query = useInfiniteQuery<UseConfigHistoryListInfiniteResponse>({
     queryKey: [AGENT_CONFIGS_KEY, "history", { projectId }],
     queryFn: (ctx) =>
       getConfigHistoryList(ctx, { projectId, page: ctx.pageParam as number }),
     getNextPageParam: ({ page, size, total }) =>
       page * size < total ? page + 1 : undefined,
     initialPageParam: 1,
+    refetchInterval: (query) => {
+      const isEmpty = !query.state.data?.pages?.some(
+        (p) => p.content.length > 0,
+      );
+      return isEmpty ? 5000 : false;
+    },
   });
+
+  return query;
 }

--- a/apps/opik-frontend/src/api/agent-configs/useConfigHistoryListInfinite.ts
+++ b/apps/opik-frontend/src/api/agent-configs/useConfigHistoryListInfinite.ts
@@ -60,7 +60,8 @@ export default function useConfigHistoryListInfinite({
       page * size < total ? page + 1 : undefined,
     initialPageParam: 1,
     refetchInterval: (query) => {
-      const isEmpty = !query.state.data?.pages?.some(
+      if (query.state.status !== "success" || !query.state.data) return false;
+      const isEmpty = !query.state.data.pages.some(
         (p) => p.content.length > 0,
       );
       return isEmpty ? 5000 : false;

--- a/apps/opik-frontend/src/hooks/useProjectOnboardingStats.ts
+++ b/apps/opik-frontend/src/hooks/useProjectOnboardingStats.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 import api, {
   TRACES_KEY,
   TRACES_REST_ENDPOINT,
@@ -24,11 +25,18 @@ function useOnboardingCountQuery(
   return useQuery({
     queryKey: [key, "onboarding-count", endpoint, params],
     queryFn: async ({ signal }) => {
-      const { data } = await api.get(endpoint, {
-        signal,
-        params: { size: 1, page: 1, ...params },
-      });
-      return (data.total as number) ?? 0;
+      try {
+        const { data } = await api.get(endpoint, {
+          signal,
+          params: { size: 1, page: 1, ...params },
+        });
+        return (data.total as number) ?? 0;
+      } catch (error) {
+        if (error instanceof AxiosError && error.response?.status === 404) {
+          return 0;
+        }
+        throw error;
+      }
     },
     enabled,
     staleTime: 1_000,


### PR DESCRIPTION
## Details
When the Agent Sandbox page loads before any agent config exists, the backend returns 404 for the config history endpoint. React Query (with `retry: false`) caches this as an error and never retries, leaving the Configuration tab stuck on "No agent configuration found" even after the agent creates its config.

This fix:
- Catches 404 responses in `useConfigHistoryListInfinite` and returns an empty result instead of letting the error propagate, so React Query treats it as successful empty data
- Adds polling (`refetchInterval: 5s`) while the data is empty, stopping once config data arrives — handles the race condition where the agent creates config after the initial query
- Applies the same 404-to-zero treatment in `useProjectOnboardingStats` so the Ollie sidebar's blueprint count doesn't get stuck on error either

https://github.com/user-attachments/assets/d4a80c18-1171-4f2d-bb50-c5545f2b650f



## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6011

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6, Claude Sonnet 4.6
- Scope: full implementation
- Human verification: code review + manual testing

## Testing

- `npx tsc --noEmit` — passes with no errors
- `npx eslint` on both changed files — passes
- Manual testing: open Agent Sandbox before agent connects, verify config tab shows empty state (not error), then connect agent and confirm config appears within ~5s without hard refresh

## Documentation
N/A