### PR TITLE
[OPIK-6146] [BE] fix: add demo data exclusion to OptimizationDAO.hasVersion1Optimizations

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DemoData.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DemoData.java
@@ -25,4 +25,6 @@ public class DemoData {
             "Demo-flat_bulb_3765",
             "Demo-horizontal_shrimp_833",
             "Demo-continuous_milk_2919");
+
+    public static final List<String> OPTIMIZATIONS = List.of("ivory_berm_3833");
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
@@ -71,7 +71,7 @@ public interface OptimizationDAO {
 
     Flux<OptimizationSummary> findOptimizationSummaryByDatasetIds(Set<UUID> datasetIds);
 
-    Mono<Boolean> hasVersion1Optimizations(String workspaceId);
+    Mono<Boolean> hasVersion1Optimizations(String workspaceId, List<String> demoOptimizationNames);
 }
 
 @Singleton
@@ -82,6 +82,7 @@ class OptimizationDAOImpl implements OptimizationDAO {
     private static final String HAS_VERSION1_OPTIMIZATIONS = """
             SELECT 1 FROM optimizations
             WHERE workspace_id = :workspace_id AND project_id = ''
+            AND name NOT IN :demo_optimization_names
             LIMIT 1
             SETTINGS log_comment = '<log_comment>'""";
 
@@ -874,12 +875,14 @@ class OptimizationDAOImpl implements OptimizationDAO {
     }
 
     @Override
-    public Mono<Boolean> hasVersion1Optimizations(@NonNull String workspaceId) {
+    public Mono<Boolean> hasVersion1Optimizations(
+            @NonNull String workspaceId, @NonNull List<String> demoOptimizationNames) {
         var template = FilterUtils.getSTWithLogComment(HAS_VERSION1_OPTIMIZATIONS,
-                "has_version1_optimizations", workspaceId, "", "");
+                "has_version1_optimizations", workspaceId, "", demoOptimizationNames);
         return Mono.from(connectionFactory.create())
                 .flatMapMany(connection -> Flux.from(connection.createStatement(template.render())
                         .bind("workspace_id", workspaceId)
+                        .bind("demo_optimization_names", demoOptimizationNames.toArray(String[]::new))
                         .execute())
                         .flatMap(result -> Flux.from(result.map((row, metadata) -> true))))
                 .hasElements();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
@@ -171,7 +171,7 @@ abstract class AbstractWorkspaceVersionService implements WorkspaceVersionServic
         return Flux.concat(
                 Mono.fromCallable(() -> hasStateDbVersion1Entities(workspaceId))
                         .subscribeOn(Schedulers.boundedElastic()),
-                optimizationDAO.hasVersion1Optimizations(workspaceId),
+                optimizationDAO.hasVersion1Optimizations(workspaceId, DemoData.OPTIMIZATIONS),
                 experimentDAO.hasVersion1Experiments(workspaceId, DemoData.EXPERIMENTS))
                 .any(found -> found)
                 .map(found -> {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/WorkspaceVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/WorkspaceVersionResourceTest.java
@@ -449,8 +449,15 @@ class WorkspaceVersionResourceTest {
                     .build();
             datasetClient.createDataset(dataset, API_KEY, workspaceName);
             assertThat(workspaceClient.getWorkspaceVersion(API_KEY, workspaceName)).isEqualTo(V2_WORKSPACE_VERSION);
+            // Demo optimization without project does not trigger V1
+            optimizationClient.create(optimizationClient.createPartialOptimization()
+                    .name("ivory_berm_3833")
+                    .datasetName(dataset.name())
+                    .build(),
+                    API_KEY, workspaceName);
+            assertThat(workspaceClient.getWorkspaceVersion(API_KEY, workspaceName)).isEqualTo(V2_WORKSPACE_VERSION);
 
-            // Workspace level optimization triggers V1
+            // Non-demo workspace level optimization triggers V1
             optimizationClient.create(optimizationClient.createPartialOptimization()
                     .datasetName(dataset.name())
                     .build(),


### PR DESCRIPTION
## Details
`OptimizationDAO.hasVersion1Optimizations` had no demo data exclusion, unlike `ExperimentDAO` and `DatasetDAO`. This caused workspaces whose only orphaned optimization was the demo `ivory_berm_3833` (created by the now-removed `create_demo_optimizer_project()` during Aug 2025–Apr 2026) to be incorrectly blocked from V2 promotion.

- Added `OPTIMIZATIONS` constant to `DemoData.java` with `ivory_berm_3833`
- Updated `hasVersion1Optimizations` query to exclude demo names via `AND name NOT IN :demo_optimization_names`
- Updated `WorkspaceVersionService` caller to pass `DemoData.OPTIMIZATIONS`
- Extended existing workspace version test to verify demo optimization exclusion

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- OPIK-6146

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review + CI tests

## Testing

- `mvn compile -pl .` — clean compilation
- `mvn test -Dtest="WorkspaceVersionResourceTest$EntityWorkspaceVersionTest#workspaceVersion__whenOptimizationWithoutProject__returnsVersion1"` — passes, validates:
  - Demo optimization (`ivory_berm_3833`) without project does NOT trigger V1
  - Non-demo optimization without project DOES trigger V1

## Documentation

N/A