### PR TITLE
[NA] [FE] Add "New Opik experience" toggle in v1 user menu

### DIFF
--- a/apps/opik-frontend/src/lib/workspaceVersion.ts
+++ b/apps/opik-frontend/src/lib/workspaceVersion.ts
@@ -52,6 +52,14 @@ export function getWorkspaceNameFromUrl(): string | null {
   return segments[0] || null;
 }
 
+// URL routes differ between v1 and v2, so after switching versions we can't
+// keep the user on the current path — send them to the workspace root and
+// let the active app re-route them to its home page.
+export function getWorkspaceHomeUrl(workspaceName: string): string {
+  const basePath = (import.meta.env.VITE_BASE_URL || "/").replace(/\/$/, "");
+  return `${basePath}/${workspaceName}`;
+}
+
 // Returns null only when the workspace is in the URL but needs an API fetch
 // to resolve its version — the one case that requires a Loader fallback.
 export function resolveSyncWorkspaceVersion(): WorkspaceVersion | null {

--- a/apps/opik-frontend/src/lib/workspaceVersion.ts
+++ b/apps/opik-frontend/src/lib/workspaceVersion.ts
@@ -13,6 +13,10 @@ export function setVersionOverride(version: WorkspaceVersion): void {
   localStorage.setItem(OPIK_VERSION_OVERRIDE_KEY, version);
 }
 
+export function clearVersionOverride(): void {
+  localStorage.removeItem(OPIK_VERSION_OVERRIDE_KEY);
+}
+
 function getRelativePathSegments(): string[] {
   const basePath = (import.meta.env.VITE_BASE_URL || "/").replace(/\/$/, "");
   const pathname = window.location.pathname;

--- a/apps/opik-frontend/src/lib/workspaceVersion.ts
+++ b/apps/opik-frontend/src/lib/workspaceVersion.ts
@@ -9,6 +9,10 @@ export function getVersionOverride(): WorkspaceVersion | null {
   return override === "v1" || override === "v2" ? override : null;
 }
 
+export function setVersionOverride(version: WorkspaceVersion): void {
+  localStorage.setItem(OPIK_VERSION_OVERRIDE_KEY, version);
+}
+
 function getRelativePathSegments(): string[] {
   const basePath = (import.meta.env.VITE_BASE_URL || "/").replace(/\/$/, "");
   const pathname = window.location.pathname;

--- a/apps/opik-frontend/src/lib/workspaceVersion.ts
+++ b/apps/opik-frontend/src/lib/workspaceVersion.ts
@@ -3,6 +3,7 @@ import { WorkspaceVersion } from "@/store/AppStore";
 export const DEFAULT_WORKSPACE_VERSION: WorkspaceVersion = "v1";
 
 const OPIK_VERSION_OVERRIDE_KEY = "opik-version-override";
+const OPIK_NEW_EXPERIENCE_OPT_IN_KEY = "opik-new-experience-opt-in";
 
 export function getVersionOverride(): WorkspaceVersion | null {
   const override = localStorage.getItem(OPIK_VERSION_OVERRIDE_KEY);
@@ -15,6 +16,18 @@ export function setVersionOverride(version: WorkspaceVersion): void {
 
 export function clearVersionOverride(): void {
   localStorage.removeItem(OPIK_VERSION_OVERRIDE_KEY);
+}
+
+export function getNewExperienceOptIn(): boolean {
+  return localStorage.getItem(OPIK_NEW_EXPERIENCE_OPT_IN_KEY) === "true";
+}
+
+export function setNewExperienceOptIn(optIn: boolean): void {
+  if (optIn) {
+    localStorage.setItem(OPIK_NEW_EXPERIENCE_OPT_IN_KEY, "true");
+  } else {
+    localStorage.removeItem(OPIK_NEW_EXPERIENCE_OPT_IN_KEY);
+  }
 }
 
 function getRelativePathSegments(): string[] {
@@ -44,6 +57,7 @@ export function getWorkspaceNameFromUrl(): string | null {
 export function resolveSyncWorkspaceVersion(): WorkspaceVersion | null {
   const override = getVersionOverride();
   if (override) return override;
+  if (getNewExperienceOptIn()) return "v2";
   if (!getWorkspaceNameFromUrl()) return DEFAULT_WORKSPACE_VERSION;
   return null;
 }

--- a/apps/opik-frontend/src/lib/workspaceVersion.ts
+++ b/apps/opik-frontend/src/lib/workspaceVersion.ts
@@ -52,14 +52,6 @@ export function getWorkspaceNameFromUrl(): string | null {
   return segments[0] || null;
 }
 
-// URL routes differ between v1 and v2, so after switching versions we can't
-// keep the user on the current path — send them to the workspace root and
-// let the active app re-route them to its home page.
-export function getWorkspaceHomeUrl(workspaceName: string): string {
-  const basePath = (import.meta.env.VITE_BASE_URL || "/").replace(/\/$/, "");
-  return `${basePath}/${workspaceName}`;
-}
-
 // Returns null only when the workspace is in the URL but needs an API fetch
 // to resolve its version — the one case that requires a Loader fallback.
 export function resolveSyncWorkspaceVersion(): WorkspaceVersion | null {

--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -9,12 +9,14 @@ import {
   Settings,
   Settings2,
   Shield,
+  Sparkles,
   UserPlus,
 } from "lucide-react";
 
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import SupportHubSubMenu from "@/shared/SupportHub/SupportHubSubMenu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/ui/avatar";
+import { Switch } from "@/ui/switch";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -34,7 +36,8 @@ import { ADMIN_DASHBOARD_LABEL } from "@/constants/labels";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
 import { cn, maskAPIKey } from "@/lib/utils";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useWorkspaceVersion } from "@/store/AppStore";
+import { setVersionOverride } from "@/lib/workspaceVersion";
 import api from "./api";
 import { ORGANIZATION_ROLE_TYPE } from "./types";
 import useOrganizations from "./useOrganizations";
@@ -52,6 +55,7 @@ const UserMenu = () => {
   const { theme, themeOptions, CurrentIcon, handleThemeSelect } =
     useThemeOptions();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const workspaceVersion = useWorkspaceVersion();
 
   const { data: user } = useUser();
   const { data: organizations, isLoading } = useOrganizations({
@@ -277,6 +281,24 @@ const UserMenu = () => {
                 </DropdownMenuSubContent>
               </DropdownMenuPortal>
             </DropdownMenuSub>
+            {workspaceVersion === "v1" && (
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onSelect={(e) => {
+                  e.preventDefault();
+                  setVersionOverride("v2");
+                  window.location.reload();
+                }}
+              >
+                <Sparkles className="mr-2 size-4" />
+                <span>New Opik experience</span>
+                <Switch
+                  checked={false}
+                  className="ml-auto pointer-events-none"
+                  size="sm"
+                />
+              </DropdownMenuItem>
+            )}
           </DropdownMenuGroup>
           {!isLLMOnlyOrganization && (
             <>

--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -35,13 +35,12 @@ import { APP_VERSION } from "@/constants/app";
 import { ADMIN_DASHBOARD_LABEL } from "@/constants/labels";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
-import { cn, maskAPIKey } from "@/lib/utils";
+import { buildFullBaseUrl, cn, maskAPIKey } from "@/lib/utils";
 import useAppStore from "@/store/AppStore";
 import useWorkspaceVersionQuery from "@/api/workspaces/useWorkspaceVersion";
 import {
   getNewExperienceOptIn,
   getVersionOverride,
-  getWorkspaceHomeUrl,
   setNewExperienceOptIn,
 } from "@/lib/workspaceVersion";
 import api from "./api";
@@ -295,7 +294,7 @@ const UserMenu = () => {
                 onSelect={(e) => {
                   e.preventDefault();
                   setNewExperienceOptIn(!hasOptedIn);
-                  window.location.href = getWorkspaceHomeUrl(workspaceName);
+                  window.location.href = buildFullBaseUrl() + workspaceName;
                 }}
               >
                 <Sparkles className="mr-2 size-4" />

--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -36,8 +36,13 @@ import { ADMIN_DASHBOARD_LABEL } from "@/constants/labels";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
 import { cn, maskAPIKey } from "@/lib/utils";
-import useAppStore, { useWorkspaceVersion } from "@/store/AppStore";
-import { setVersionOverride } from "@/lib/workspaceVersion";
+import useAppStore from "@/store/AppStore";
+import useWorkspaceVersionQuery from "@/api/workspaces/useWorkspaceVersion";
+import {
+  clearVersionOverride,
+  getVersionOverride,
+  setVersionOverride,
+} from "@/lib/workspaceVersion";
 import api from "./api";
 import { ORGANIZATION_ROLE_TYPE } from "./types";
 import useOrganizations from "./useOrganizations";
@@ -55,7 +60,8 @@ const UserMenu = () => {
   const { theme, themeOptions, CurrentIcon, handleThemeSelect } =
     useThemeOptions();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
-  const workspaceVersion = useWorkspaceVersion();
+  const { data: backendWorkspaceVersion } = useWorkspaceVersionQuery();
+  const isOverriddenToV2 = getVersionOverride() === "v2";
 
   const { data: user } = useUser();
   const { data: organizations, isLoading } = useOrganizations({
@@ -281,19 +287,23 @@ const UserMenu = () => {
                 </DropdownMenuSubContent>
               </DropdownMenuPortal>
             </DropdownMenuSub>
-            {workspaceVersion === "v1" && (
+            {backendWorkspaceVersion === "v1" && (
               <DropdownMenuItem
                 className="cursor-pointer"
                 onSelect={(e) => {
                   e.preventDefault();
-                  setVersionOverride("v2");
+                  if (isOverriddenToV2) {
+                    clearVersionOverride();
+                  } else {
+                    setVersionOverride("v2");
+                  }
                   window.location.reload();
                 }}
               >
                 <Sparkles className="mr-2 size-4" />
                 <span>New Opik experience</span>
                 <Switch
-                  checked={false}
+                  checked={isOverriddenToV2}
                   className="pointer-events-none ml-auto"
                   size="sm"
                 />

--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -41,6 +41,7 @@ import useWorkspaceVersionQuery from "@/api/workspaces/useWorkspaceVersion";
 import {
   getNewExperienceOptIn,
   getVersionOverride,
+  getWorkspaceHomeUrl,
   setNewExperienceOptIn,
 } from "@/lib/workspaceVersion";
 import api from "./api";
@@ -294,7 +295,7 @@ const UserMenu = () => {
                 onSelect={(e) => {
                   e.preventDefault();
                   setNewExperienceOptIn(!hasOptedIn);
-                  window.location.reload();
+                  window.location.href = getWorkspaceHomeUrl(workspaceName);
                 }}
               >
                 <Sparkles className="mr-2 size-4" />

--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -294,7 +294,7 @@ const UserMenu = () => {
                 <span>New Opik experience</span>
                 <Switch
                   checked={false}
-                  className="ml-auto pointer-events-none"
+                  className="pointer-events-none ml-auto"
                   size="sm"
                 />
               </DropdownMenuItem>

--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -39,9 +39,9 @@ import { cn, maskAPIKey } from "@/lib/utils";
 import useAppStore from "@/store/AppStore";
 import useWorkspaceVersionQuery from "@/api/workspaces/useWorkspaceVersion";
 import {
-  clearVersionOverride,
+  getNewExperienceOptIn,
   getVersionOverride,
-  setVersionOverride,
+  setNewExperienceOptIn,
 } from "@/lib/workspaceVersion";
 import api from "./api";
 import { ORGANIZATION_ROLE_TYPE } from "./types";
@@ -61,7 +61,8 @@ const UserMenu = () => {
     useThemeOptions();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const { data: backendWorkspaceVersion } = useWorkspaceVersionQuery();
-  const isOverriddenToV2 = getVersionOverride() === "v2";
+  const hasVersionOverride = getVersionOverride() !== null;
+  const hasOptedIn = getNewExperienceOptIn();
 
   const { data: user } = useUser();
   const { data: organizations, isLoading } = useOrganizations({
@@ -287,23 +288,19 @@ const UserMenu = () => {
                 </DropdownMenuSubContent>
               </DropdownMenuPortal>
             </DropdownMenuSub>
-            {backendWorkspaceVersion === "v1" && (
+            {backendWorkspaceVersion === "v1" && !hasVersionOverride && (
               <DropdownMenuItem
                 className="cursor-pointer"
                 onSelect={(e) => {
                   e.preventDefault();
-                  if (isOverriddenToV2) {
-                    clearVersionOverride();
-                  } else {
-                    setVersionOverride("v2");
-                  }
+                  setNewExperienceOptIn(!hasOptedIn);
                   window.location.reload();
                 }}
               >
                 <Sparkles className="mr-2 size-4" />
                 <span>New Opik experience</span>
                 <Switch
-                  checked={isOverriddenToV2}
+                  checked={hasOptedIn}
                   className="pointer-events-none ml-auto"
                   size="sm"
                 />

--- a/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
+++ b/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
@@ -8,9 +8,9 @@ import {
   clearVersionOverride,
   getNewExperienceOptIn,
   getVersionOverride,
-  getWorkspaceHomeUrl,
   setNewExperienceOptIn,
 } from "@/lib/workspaceVersion";
+import { buildFullBaseUrl } from "@/lib/utils";
 import Loader from "@/shared/Loader/Loader";
 
 const VERSION_RELOAD_PREFIX = "opik-version-reload:";
@@ -59,7 +59,7 @@ const WorkspaceVersionResolver: React.FC<WorkspaceVersionResolverProps> = ({
         sessionStorage.setItem(reloadKey, String(reloadCount + 1));
         // URL structure differs between v1 and v2, so redirect to workspace
         // home instead of reloading the current path.
-        window.location.href = getWorkspaceHomeUrl(workspaceName);
+        window.location.href = buildFullBaseUrl() + workspaceName;
       }
     } else {
       sessionStorage.removeItem(reloadKey);

--- a/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
+++ b/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
@@ -4,7 +4,10 @@ import useAppStore, {
   useWorkspaceVersion,
 } from "@/store/AppStore";
 import useWorkspaceVersionQuery from "@/api/workspaces/useWorkspaceVersion";
-import { getVersionOverride } from "@/lib/workspaceVersion";
+import {
+  clearVersionOverride,
+  getVersionOverride,
+} from "@/lib/workspaceVersion";
 import Loader from "@/shared/Loader/Loader";
 
 const VERSION_RELOAD_PREFIX = "opik-version-reload:";
@@ -22,10 +25,17 @@ const WorkspaceVersionResolver: React.FC<WorkspaceVersionResolverProps> = ({
   const workspaceName = useActiveWorkspaceName();
 
   const { data: apiVersion, isLoading } = useWorkspaceVersionQuery();
-  const resolvedVersion = override ?? apiVersion;
+  // The override is only honored when the backend says v1. Once a workspace is
+  // migrated to v2 on the backend, v2 is always rendered and any stale override
+  // is cleared.
+  const resolvedVersion = apiVersion === "v2" ? "v2" : override ?? apiVersion;
 
   useEffect(() => {
     if (!resolvedVersion || !workspaceName) return;
+
+    if (apiVersion === "v2" && override) {
+      clearVersionOverride();
+    }
 
     useAppStore.getState().setWorkspaceVersion(resolvedVersion);
 
@@ -40,7 +50,7 @@ const WorkspaceVersionResolver: React.FC<WorkspaceVersionResolverProps> = ({
     } else {
       sessionStorage.removeItem(reloadKey);
     }
-  }, [resolvedVersion, gateVersion, workspaceName]);
+  }, [apiVersion, override, resolvedVersion, gateVersion, workspaceName]);
 
   if (!override && isLoading) {
     return <Loader />;

--- a/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
+++ b/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
@@ -8,6 +8,7 @@ import {
   clearVersionOverride,
   getNewExperienceOptIn,
   getVersionOverride,
+  getWorkspaceHomeUrl,
   setNewExperienceOptIn,
 } from "@/lib/workspaceVersion";
 import Loader from "@/shared/Loader/Loader";
@@ -56,7 +57,9 @@ const WorkspaceVersionResolver: React.FC<WorkspaceVersionResolverProps> = ({
       const reloadCount = Number(sessionStorage.getItem(reloadKey) || "0");
       if (reloadCount < MAX_RELOADS) {
         sessionStorage.setItem(reloadKey, String(reloadCount + 1));
-        window.location.reload();
+        // URL structure differs between v1 and v2, so redirect to workspace
+        // home instead of reloading the current path.
+        window.location.href = getWorkspaceHomeUrl(workspaceName);
       }
     } else {
       sessionStorage.removeItem(reloadKey);

--- a/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
+++ b/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
@@ -6,7 +6,9 @@ import useAppStore, {
 import useWorkspaceVersionQuery from "@/api/workspaces/useWorkspaceVersion";
 import {
   clearVersionOverride,
+  getNewExperienceOptIn,
   getVersionOverride,
+  setNewExperienceOptIn,
 } from "@/lib/workspaceVersion";
 import Loader from "@/shared/Loader/Loader";
 
@@ -21,20 +23,29 @@ const WorkspaceVersionResolver: React.FC<WorkspaceVersionResolverProps> = ({
   children,
 }) => {
   const override = getVersionOverride();
+  const optIn = getNewExperienceOptIn();
   const gateVersion = useWorkspaceVersion();
   const workspaceName = useActiveWorkspaceName();
 
   const { data: apiVersion, isLoading } = useWorkspaceVersionQuery();
-  // The override is only honored when the backend says v1. Once a workspace is
-  // migrated to v2 on the backend, v2 is always rendered and any stale override
-  // is cleared.
-  const resolvedVersion = apiVersion === "v2" ? "v2" : override ?? apiVersion;
+  // Priority: explicit override wins; once the backend reports v2 the workspace
+  // is fully migrated and v2 always renders; otherwise the user's opt-in to the
+  // new experience upgrades a v1 workspace to v2; default to whatever the
+  // backend returned.
+  const resolvedVersion = override
+    ? override
+    : apiVersion === "v2"
+      ? "v2"
+      : optIn
+        ? "v2"
+        : apiVersion;
 
   useEffect(() => {
     if (!resolvedVersion || !workspaceName) return;
 
-    if (apiVersion === "v2" && override) {
-      clearVersionOverride();
+    if (apiVersion === "v2") {
+      if (override) clearVersionOverride();
+      if (optIn) setNewExperienceOptIn(false);
     }
 
     useAppStore.getState().setWorkspaceVersion(resolvedVersion);
@@ -50,9 +61,16 @@ const WorkspaceVersionResolver: React.FC<WorkspaceVersionResolverProps> = ({
     } else {
       sessionStorage.removeItem(reloadKey);
     }
-  }, [apiVersion, override, resolvedVersion, gateVersion, workspaceName]);
+  }, [
+    apiVersion,
+    override,
+    optIn,
+    resolvedVersion,
+    gateVersion,
+    workspaceName,
+  ]);
 
-  if (!override && isLoading) {
+  if (!override && !optIn && isLoading) {
     return <Loader />;
   }
 


### PR DESCRIPTION
## Details
Adds a new "New Opik experience" dropdown entry to the Comet `UserMenu`, gated to only render when the active workspace is currently showing the v1 UI (`useWorkspaceVersion() === "v1"`). Selecting it writes `"v2"` to the `opik-version-override` localStorage key via a new `setVersionOverride()` helper in `lib/workspaceVersion.ts`, then reloads the page. On reload, `WorkspaceVersionGate` reads the override synchronously at module load and mounts `<V2App />` on first paint — no loader flash.

The toggle replaces the manual `localStorage.setItem("opik-version-override","v2"); location.reload()` flow that's been used for testing, making it a user-facing opt-in.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- NA

## Testing
- `npm run lint` — clean
- `npm run typecheck` — clean
- Menu item is gated behind `workspaceVersion === "v1"`, so it's invisible to users already on v2.
- Full rendering path requires Comet cloud auth (four API hooks must resolve) and so can't be exercised in the OSS dev server; visual verification will happen on a Comet preview env.

## Documentation
N/A