### PR TITLE
[NA] [BE] Seed test suite, prompt, agent configs, and experiments in demo data

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/demo_data.py
+++ b/apps/opik-python-backend/src/opik_backend/demo_data.py
@@ -4972,405 +4972,7 @@ demo_spans = [
             "openai"
         ]
     },
-    {
-        "id": "0198eca8-73a1-7788-836c-a69098b05a3e",
-        "trace_id": "0198eca8-732b-7c7e-94d6-3e2d431f4e22",
-        "parent_span_id": "0198eca8-73a2-7915-a2fb-7416e66bba9b",
-        "name": "chat_completion_create",
-        "type": "llm",
-        "start_time": datetime.datetime(2025, 8, 27, 17, 10, 59, 960398),
-        "end_time": datetime.datetime(2025, 8, 27, 17, 11, 2, 598677),
-        "input": {
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "\nYou are a CRM assistant. A backend tool returned the following raw output:\n\nThe next contact with Jessica Lau should focus on following up on the proposal sent and addressing her interest in predictive maintenance features. Given that she has decision authority but is awaiting CFO sign-off, it may also be beneficial to offer additional resources or insights that could help facilitate that discussion. A suggested approach could be to schedule a call or meeting to discuss any questions she may have and to reinforce the value of the solution in relation to her implementation timeline for Q3.\n\nYour job is to rephrase this nicely for the user, based on their question:\n\nWhat should our next contact with her be?\n\nReturn a clear and helpful response.\n"
-                }
-            ]
-        },
-        "output": {
-            "choices": [
-                {
-                    "finish_reason": "stop",
-                    "index": 0,
-                    "logprobs": None,
-                    "message": {
-                        "content": "For your next contact with Jessica Lau, I recommend focusing on following up regarding the proposal you sent her. It's important to address her interest in predictive maintenance features as well. Since she has decision-making authority but is currently waiting for CFO approval, it might be helpful to offer additional resources or insights that could assist her in that discussion. A good approach would be to schedule a call or meeting to discuss any questions she may have and to reinforce the value of your solution, particularly in relation to her implementation timeline for Q3.",
-                        "refusal": None,
-                        "role": "assistant",
-                        "annotations": [],
-                        "audio": None,
-                        "function_call": None,
-                        "tool_calls": None
-                    }
-                }
-            ]
-        },
-        "metadata": {
-            "model": "gpt-4o-mini-2024-07-18",
-            "temperature": 0.5,
-            "created_from": "openai",
-            "type": "openai_chat",
-            "id": "chatcmpl-C9DxkI3z2ZCgpcTJW7KMNhX0NQqGN",
-            "created": 1756314660,
-            "object": "chat.completion",
-            "service_tier": "default",
-            "system_fingerprint": "fp_560af6e559",
-            "usage": {
-                "completion_tokens": 104,
-                "prompt_tokens": 147,
-                "total_tokens": 251,
-                "original_usage.completion_tokens": 104,
-                "original_usage.prompt_tokens": 147,
-                "original_usage.total_tokens": 251,
-                "original_usage.completion_tokens_details.accepted_prediction_tokens": 0,
-                "original_usage.completion_tokens_details.audio_tokens": 0,
-                "original_usage.completion_tokens_details.reasoning_tokens": 0,
-                "original_usage.completion_tokens_details.rejected_prediction_tokens": 0,
-                "original_usage.prompt_tokens_details.audio_tokens": 0,
-                "original_usage.prompt_tokens_details.cached_tokens": 0
-            }
-        },
-        "usage": {
-            "completion_tokens": 104,
-            "prompt_tokens": 147,
-            "total_tokens": 251,
-            "original_usage.completion_tokens": 104,
-            "original_usage.prompt_tokens": 147,
-            "original_usage.total_tokens": 251,
-            "original_usage.original_usage.completion_tokens": 104,
-            "original_usage.original_usage.prompt_tokens": 147,
-            "original_usage.original_usage.total_tokens": 251,
-            "original_usage.original_usage.completion_tokens_details.accepted_prediction_tokens": 0,
-            "original_usage.original_usage.completion_tokens_details.audio_tokens": 0,
-            "original_usage.original_usage.completion_tokens_details.reasoning_tokens": 0,
-            "original_usage.original_usage.completion_tokens_details.rejected_prediction_tokens": 0,
-            "original_usage.original_usage.prompt_tokens_details.audio_tokens": 0,
-            "original_usage.original_usage.prompt_tokens_details.cached_tokens": 0
-        },
-        "model": "gpt-4o-mini-2024-07-18",
-        "provider": "openai",
-        "tags": [
-            "openai"
-        ]
-    },
-    {
-        "id": "0198eca8-73a2-7915-a2fb-7416e66bba9b",
-        "trace_id": "0198eca8-732b-7c7e-94d6-3e2d431f4e22",
-        "parent_span_id": "0198eca8-73a8-7d26-86c3-6ebba4905482",
-        "name": "format_response",
-        "type": "general",
-        "start_time": datetime.datetime(2025, 8, 27, 17, 10, 59, 960334),
-        "end_time": datetime.datetime(2025, 8, 27, 17, 11, 2, 598936),
-        "input": {
-            "user_query": "What should our next contact with her be?",
-            "raw_tool_output": "The next contact with Jessica Lau should focus on following up on the proposal sent and addressing her interest in predictive maintenance features. Given that she has decision authority but is awaiting CFO sign-off, it may also be beneficial to offer additional resources or insights that could help facilitate that discussion. A suggested approach could be to schedule a call or meeting to discuss any questions she may have and to reinforce the value of the solution in relation to her implementation timeline for Q3.",
-            "model": "gpt-4o-mini",
-            "temperature": 0.5
-        },
-        "output": {
-            "output": "For your next contact with Jessica Lau, I recommend focusing on following up regarding the proposal you sent her. It's important to address her interest in predictive maintenance features as well. Since she has decision-making authority but is currently waiting for CFO approval, it might be helpful to offer additional resources or insights that could assist her in that discussion. A good approach would be to schedule a call or meeting to discuss any questions she may have and to reinforce the value of your solution, particularly in relation to her implementation timeline for Q3."
-        },
-        "tags": []
-    },
-    {
-        "id": "0198eca8-73a3-7977-ab30-2bd6df188f79",
-        "trace_id": "0198eca8-732b-7c7e-94d6-3e2d431f4e22",
-        "parent_span_id": "0198eca8-73a5-7301-8bff-1223b15aded8",
-        "name": "chat_completion_create",
-        "type": "llm",
-        "start_time": datetime.datetime(2025, 8, 27, 17, 10, 58, 182175),
-        "end_time": datetime.datetime(2025, 8, 27, 17, 10, 59, 959841),
-        "input": {
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "Who is our main contact at greenleaf tech?"
-                },
-                {
-                    "role": "assistant",
-                    "content": "Your main contact at Greenleaf Tech is Jessica Lau, the Head of IT Procurement. You can reach her at jessica.lau@greenleaftech.com."
-                },
-                {
-                    "role": "user",
-                    "content": "How many emails has she opened in the last year?"
-                },
-                {
-                    "role": "assistant",
-                    "content": "Jessica Lau has opened a total of 6 emails in the past year."
-                },
-                {
-                    "role": "user",
-                    "content": "What should our next contact with her be?"
-                },
-                {
-                    "role": "user",
-                    "content": "\nYou are a CRM contact tool and need to simulate a response to a query using realistic but invented data.\nThe goal is to return raw insights related to the query, don't add anything to the response that is not related to the query.\n\nQuery: \"What should our next contact with her be?\"\n\nContext: {\n    \"customer\": {\n        \"contact\": {\n            \"name\": \"Jessica Lau\",\n            \"title\": \"Head of IT Procurement\",\n            \"email\": \"jessica.lau@greenleaftech.com\",\n            \"status\": \"High-value prospect\"\n        },\n        \"company\": \"Greenleaf Tech\",\n        \"industry\": \"Renewable Energy Tech\",\n        \"deal_stage\": \"Proposal Sent\",\n        \"deal_size_estimate\": 85000,\n        \"lead_source\": \"Webinar sign-up\",\n        \"lead_source_date\": \"2025-03-15\",\n        \"last_contacted\": \"2025-05-12\",\n        \"engagement\": {\n            \"emails_opened\": 6,\n            \"emails_sent\": 7,\n            \"average_email_open_time_hours\": 2,\n            \"outreach_responses\": 3,\n            \"outreach_sent\": 5,\n            \"demos_attended\": [\n                \"2025-04-04\",\n                \"2025-05-09\"\n            ],\n            \"downloads\": [\n                {\n                    \"title\": \"Energy Grid Optimization\",\n                    \"date\": \"2025-04-17\"\n                }\n            ]\n        },\n        \"internal_notes\": [\n            \"Interested in predictive maintenance features\",\n            \"Has decision authority but awaiting CFO sign-off\",\n            \"Expressed need to implement Q3 (starting July)\"\n        ]\n    }\n}\n"
-                }
-            ]
-        },
-        "output": {
-            "choices": [
-                {
-                    "finish_reason": "stop",
-                    "index": 0,
-                    "logprobs": None,
-                    "message": {
-                        "content": "The next contact with Jessica Lau should focus on following up on the proposal sent and addressing her interest in predictive maintenance features. Given that she has decision authority but is awaiting CFO sign-off, it may also be beneficial to offer additional resources or insights that could help facilitate that discussion. A suggested approach could be to schedule a call or meeting to discuss any questions she may have and to reinforce the value of the solution in relation to her implementation timeline for Q3.",
-                        "refusal": None,
-                        "role": "assistant",
-                        "annotations": [],
-                        "audio": None,
-                        "function_call": None,
-                        "tool_calls": None
-                    }
-                }
-            ]
-        },
-        "metadata": {
-            "model": "gpt-4o-mini-2024-07-18",
-            "temperature": 0.5,
-            "created_from": "openai",
-            "type": "openai_chat",
-            "id": "chatcmpl-C9DxiO7R3Rp8NuqV7RQGCZLvoiIrU",
-            "created": 1756314658,
-            "object": "chat.completion",
-            "service_tier": "default",
-            "system_fingerprint": "fp_560af6e559",
-            "usage": {
-                "completion_tokens": 91,
-                "prompt_tokens": 459,
-                "total_tokens": 550,
-                "original_usage.completion_tokens": 91,
-                "original_usage.prompt_tokens": 459,
-                "original_usage.total_tokens": 550,
-                "original_usage.completion_tokens_details.accepted_prediction_tokens": 0,
-                "original_usage.completion_tokens_details.audio_tokens": 0,
-                "original_usage.completion_tokens_details.reasoning_tokens": 0,
-                "original_usage.completion_tokens_details.rejected_prediction_tokens": 0,
-                "original_usage.prompt_tokens_details.audio_tokens": 0,
-                "original_usage.prompt_tokens_details.cached_tokens": 0
-            }
-        },
-        "usage": {
-            "completion_tokens": 91,
-            "prompt_tokens": 459,
-            "total_tokens": 550,
-            "original_usage.completion_tokens": 91,
-            "original_usage.prompt_tokens": 459,
-            "original_usage.total_tokens": 550,
-            "original_usage.original_usage.completion_tokens": 91,
-            "original_usage.original_usage.prompt_tokens": 459,
-            "original_usage.original_usage.total_tokens": 550,
-            "original_usage.original_usage.completion_tokens_details.accepted_prediction_tokens": 0,
-            "original_usage.original_usage.completion_tokens_details.audio_tokens": 0,
-            "original_usage.original_usage.completion_tokens_details.reasoning_tokens": 0,
-            "original_usage.original_usage.completion_tokens_details.rejected_prediction_tokens": 0,
-            "original_usage.original_usage.prompt_tokens_details.audio_tokens": 0,
-            "original_usage.original_usage.prompt_tokens_details.cached_tokens": 0
-        },
-        "model": "gpt-4o-mini-2024-07-18",
-        "provider": "openai",
-        "tags": [
-            "openai"
-        ]
-    },
-    {
-        "id": "0198eca8-73a4-7137-9550-48f864937d7b",
-        "trace_id": "0198eca8-732b-7c7e-94d6-3e2d431f4e22",
-        "parent_span_id": "0198eca8-73a5-7301-8bff-1223b15aded8",
-        "name": "retrieve_documents_rag",
-        "type": "general",
-        "start_time": datetime.datetime(2025, 8, 27, 17, 10, 58, 182092),
-        "end_time": datetime.datetime(2025, 8, 27, 17, 10, 58, 182136),
-        "input": {
-            "category": "contact"
-        },
-        "output": {
-            "output": '{\n    "customer": {\n        "contact": {\n            "name": "Jessica Lau",\n            "title": "Head of IT Procurement",\n            "email": "jessica.lau@greenleaftech.com",\n            "status": "High-value prospect"\n        },\n        "company": "Greenleaf Tech",\n        "industry": "Renewable Energy Tech",\n        "deal_stage": "Proposal Sent",\n        "deal_size_estimate": 85000,\n        "lead_source": "Webinar sign-up",\n        "lead_source_date": "2025-03-15",\n        "last_contacted": "2025-05-12",\n        "engagement": {\n            "emails_opened": 6,\n            "emails_sent": 7,\n            "average_email_open_time_hours": 2,\n            "outreach_responses": 3,\n            "outreach_sent": 5,\n            "demos_attended": [\n                "2025-04-04",\n                "2025-05-09"\n            ],\n            "downloads": [\n                {\n                    "title": "Energy Grid Optimization",\n                    "date": "2025-04-17"\n                }\n            ]\n        },\n        "internal_notes": [\n            "Interested in predictive maintenance features",\n            "Has decision authority but awaiting CFO sign-off",\n            "Expressed need to implement Q3 (starting July)"\n        ]\n    }\n}'
-        },
-        "tags": []
-    },
-    {
-        "id": "0198eca8-73a5-7301-8bff-1223b15aded8",
-        "trace_id": "0198eca8-732b-7c7e-94d6-3e2d431f4e22",
-        "parent_span_id": "0198eca8-73a8-7d26-86c3-6ebba4905482",
-        "name": "contact_insight_tool",
-        "type": "tool",
-        "start_time": datetime.datetime(2025, 8, 27, 17, 10, 58, 182035),
-        "end_time": datetime.datetime(2025, 8, 27, 17, 10, 59, 960060),
-        "input": {
-            "query": "What should our next contact with her be?",
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "Who is our main contact at greenleaf tech?"
-                },
-                {
-                    "role": "assistant",
-                    "content": "Your main contact at Greenleaf Tech is Jessica Lau, the Head of IT Procurement. You can reach her at jessica.lau@greenleaftech.com."
-                },
-                {
-                    "role": "user",
-                    "content": "How many emails has she opened in the last year?"
-                },
-                {
-                    "role": "assistant",
-                    "content": "Jessica Lau has opened a total of 6 emails in the past year."
-                },
-                {
-                    "role": "user",
-                    "content": "What should our next contact with her be?"
-                }
-            ],
-            "model": "gpt-4o-mini",
-            "temperature": 0.5
-        },
-        "output": {
-            "output": "The next contact with Jessica Lau should focus on following up on the proposal sent and addressing her interest in predictive maintenance features. Given that she has decision authority but is awaiting CFO sign-off, it may also be beneficial to offer additional resources or insights that could help facilitate that discussion. A suggested approach could be to schedule a call or meeting to discuss any questions she may have and to reinforce the value of the solution in relation to her implementation timeline for Q3."
-        },
-        "tags": []
-    },
-    {
-        "id": "0198eca8-73a6-734a-80b0-014edc8e4279",
-        "trace_id": "0198eca8-732b-7c7e-94d6-3e2d431f4e22",
-        "parent_span_id": "0198eca8-73a7-7d1b-9f11-920f9bf6c33e",
-        "name": "chat_completion_create",
-        "type": "llm",
-        "start_time": datetime.datetime(2025, 8, 27, 17, 10, 57, 832500),
-        "end_time": datetime.datetime(2025, 8, 27, 17, 10, 58, 181786),
-        "input": {
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "\nYou are a routing assistant. Classify the following CRM query into one of:\n\n- \"contact\" for information about people, accounts, contact information or engagement\n- \"sales\" for information about forecasts, KPIs, Deals, pipeline or performance\n- \"other\" for anything else\n\nRespond with only one word: contact, sales or other.\n\nQuery: What should our next contact with her be?\nCategory:"
-                }
-            ]
-        },
-        "output": {
-            "choices": [
-                {
-                    "finish_reason": "stop",
-                    "index": 0,
-                    "logprobs": None,
-                    "message": {
-                        "content": "contact",
-                        "refusal": None,
-                        "role": "assistant",
-                        "annotations": [],
-                        "audio": None,
-                        "function_call": None,
-                        "tool_calls": None
-                    }
-                }
-            ]
-        },
-        "metadata": {
-            "model": "gpt-4o-mini-2024-07-18",
-            "temperature": 0,
-            "created_from": "openai",
-            "type": "openai_chat",
-            "id": "chatcmpl-C9DxiATf9x05zNL7VqhHVqf0swnPC",
-            "created": 1756314658,
-            "object": "chat.completion",
-            "service_tier": "default",
-            "system_fingerprint": "fp_560af6e559",
-            "usage": {
-                "completion_tokens": 1,
-                "prompt_tokens": 91,
-                "total_tokens": 92,
-                "original_usage.completion_tokens": 1,
-                "original_usage.prompt_tokens": 91,
-                "original_usage.total_tokens": 92,
-                "original_usage.completion_tokens_details.accepted_prediction_tokens": 0,
-                "original_usage.completion_tokens_details.audio_tokens": 0,
-                "original_usage.completion_tokens_details.reasoning_tokens": 0,
-                "original_usage.completion_tokens_details.rejected_prediction_tokens": 0,
-                "original_usage.prompt_tokens_details.audio_tokens": 0,
-                "original_usage.prompt_tokens_details.cached_tokens": 0
-            }
-        },
-        "usage": {
-            "completion_tokens": 1,
-            "prompt_tokens": 91,
-            "total_tokens": 92,
-            "original_usage.completion_tokens": 1,
-            "original_usage.prompt_tokens": 91,
-            "original_usage.total_tokens": 92,
-            "original_usage.original_usage.completion_tokens": 1,
-            "original_usage.original_usage.prompt_tokens": 91,
-            "original_usage.original_usage.total_tokens": 92,
-            "original_usage.original_usage.completion_tokens_details.accepted_prediction_tokens": 0,
-            "original_usage.original_usage.completion_tokens_details.audio_tokens": 0,
-            "original_usage.original_usage.completion_tokens_details.reasoning_tokens": 0,
-            "original_usage.original_usage.completion_tokens_details.rejected_prediction_tokens": 0,
-            "original_usage.original_usage.prompt_tokens_details.audio_tokens": 0,
-            "original_usage.original_usage.prompt_tokens_details.cached_tokens": 0
-        },
-        "model": "gpt-4o-mini-2024-07-18",
-        "provider": "openai",
-        "tags": [
-            "openai"
-        ]
-    },
-    {
-        "id": "0198eca8-73a7-7d1b-9f11-920f9bf6c33e",
-        "trace_id": "0198eca8-732b-7c7e-94d6-3e2d431f4e22",
-        "parent_span_id": "0198eca8-73a8-7d26-86c3-6ebba4905482",
-        "name": "classify_query",
-        "type": "general",
-        "start_time": datetime.datetime(2025, 8, 27, 17, 10, 57, 832451),
-        "end_time": datetime.datetime(2025, 8, 27, 17, 10, 58, 181898),
-        "input": {
-            "query": "What should our next contact with her be?",
-            "model": "gpt-4o-mini"
-        },
-        "output": {
-            "output": "contact"
-        },
-        "tags": []
-    },
-    {
-        "id": "0198eca8-73a8-7d26-86c3-6ebba4905482",
-        "trace_id": "0198eca8-732b-7c7e-94d6-3e2d431f4e22",
-        "name": "handle_query",
-        "type": "general",
-        "start_time": datetime.datetime(2025, 8, 27, 17, 10, 57, 832386),
-        "end_time": datetime.datetime(2025, 8, 27, 17, 11, 2, 598984),
-        "input": {
-            "thread_id": "653280c1-0f2b-42a1-bb8d-7f4023a35752",
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "Who is our main contact at greenleaf tech?"
-                },
-                {
-                    "role": "assistant",
-                    "content": "Your main contact at Greenleaf Tech is Jessica Lau, the Head of IT Procurement. You can reach her at jessica.lau@greenleaftech.com."
-                },
-                {
-                    "role": "user",
-                    "content": "How many emails has she opened in the last year?"
-                },
-                {
-                    "role": "assistant",
-                    "content": "Jessica Lau has opened a total of 6 emails in the past year."
-                },
-                {
-                    "role": "user",
-                    "content": "What should our next contact with her be?"
-                }
-            ],
-            "query": "What should our next contact with her be?"
-        },
-        "output": {
-            "tool": "contact",
-            "tool_response": "The next contact with Jessica Lau should focus on following up on the proposal sent and addressing her interest in predictive maintenance features. Given that she has decision authority but is awaiting CFO sign-off, it may also be beneficial to offer additional resources or insights that could help facilitate that discussion. A suggested approach could be to schedule a call or meeting to discuss any questions she may have and to reinforce the value of the solution in relation to her implementation timeline for Q3.",
-            "response": "For your next contact with Jessica Lau, I recommend focusing on following up regarding the proposal you sent her. It's important to address her interest in predictive maintenance features as well. Since she has decision-making authority but is currently waiting for CFO approval, it might be helpful to offer additional resources or insights that could assist her in that discussion. A good approach would be to schedule a call or meeting to discuss any questions she may have and to reinforce the value of your solution, particularly in relation to her implementation timeline for Q3."
-        },
-        "tags": []
-    },
-    {
+                                    {
         "id": "0198ecb0-4b6f-7286-ad89-18efdbfdc0d3",
         "trace_id": "0198ecb0-4aed-7cff-8e33-cfaf0711abec",
         "parent_span_id": "0198ecb0-4b70-7934-9b3d-f6f0840051aa",
@@ -52563,3 +52165,451 @@ demo_thread_feedback_scores = {
     ]
 }
 
+
+# ---------------------------------------------------------------------------
+# Test suite + agent config + experiments demo data
+# ---------------------------------------------------------------------------
+
+demo_test_suite_global_assertion = "Response is written in clear English"
+
+# 20 items. `assertions` holds per-item assertions (1-3 each). `pass_mask_prod`
+# is a parallel list of booleans shaping the prod experiment pass rate: 16 items
+# pass all assertions, 4 items have a single False → 80% pass rate. Staging uses
+# an implicit all-pass mask (no failures).
+demo_test_suite_items = [
+    {
+        "id": "0199a000-0001-7000-8000-000000000001",
+        "question": "How do I create a project in Opik?",
+        "answer_staging": (
+            "Two paths work:\n\n"
+            "- UI: open the sidebar, click 'Projects', then 'New project' and give it a name.\n"
+            "- SDK: instantiate a client with the project name, e.g. "
+            "`opik.Opik(project_name='my-project')` — Opik creates the project on first write if it doesn't exist.\n\n"
+            "Both are equivalent; pick whichever fits your workflow."
+        ),
+        "answer_prod": "From the UI click Projects in the side nav and hit 'New project', or call `opik.Opik(project_name='...')` from the SDK — both create the project.",
+        "assertions": [
+            "Mentions either the UI path or the SDK",
+            "Is helpful and actionable",
+        ],
+        "pass_mask_prod": [True, True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000002",
+        "question": "What is a trace in Opik?",
+        "answer_staging": (
+            "A trace represents a single top-level interaction with your agent — usually one request from a user. "
+            "Inside each trace, individual operations (LLM calls, tool calls, retrieval, etc.) are recorded as spans, "
+            "which can be nested to mirror the structure of your agent's control flow. "
+            "Traces are the unit you filter, score, and compare in Opik."
+        ),
+        "answer_prod": "A trace is the top-level record of one interaction with your agent. It groups together all the spans that represent the individual steps inside that interaction.",
+        "assertions": [
+            "Defines what a trace represents",
+            "Mentions that traces group spans",
+        ],
+        "pass_mask_prod": [True, True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000003",
+        "question": "How do I log a trace from Python?",
+        # staging uses the richer prompt and returns a full example.
+        "answer_staging": (
+            "In Python you have two options:\n\n"
+            "1. Decorate a function with `@opik.track` — every call is automatically logged as a trace.\n"
+            "2. Call `client.trace(...)` directly on an `opik.Opik()` instance when you want to build the trace manually.\n\n"
+            "Example:\n"
+            "```python\n"
+            "import opik\n\n"
+            "@opik.track\n"
+            "def answer(question: str) -> str:\n"
+            "    return chat(question)\n"
+            "```"
+        ),
+        # prod (simpler prompt, cheaper model) — names the APIs but skips the example.
+        "answer_prod": "Use the `@opik.track` decorator on a function, or create an `opik.Opik()` client and call `client.trace(...)`.",
+        "assertions": [
+            "Mentions @opik.track or client.trace",
+            "Is specific to Python",
+            "Provides a working example",
+        ],
+        "pass_mask_prod": [True, True, False],
+        "fail_reasons_prod": {
+            2: "The response lists the two entry points (decorator and client.trace) but stops short of providing a complete, runnable code snippet the user can copy-paste.",
+        },
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000004",
+        "question": "What's the difference between a trace and a span?",
+        "answer_staging": (
+            "Think of it as two levels of detail: a **trace** is the full interaction (one request "
+            "end-to-end), while **spans** are the individual steps inside that interaction "
+            "— an LLM call, a tool invocation, a retrieval query, a guardrail check. "
+            "Spans can have child spans, so the whole trace forms a nested tree that mirrors how the agent actually executed."
+        ),
+        "answer_prod": "A trace is the full interaction from start to finish. Spans are the individual steps inside that interaction and can be nested under each other.",
+        "assertions": [
+            "Contrasts trace and span",
+            "Mentions that spans can be nested",
+        ],
+        "pass_mask_prod": [True, True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000005",
+        "question": "How do I add feedback scores to a trace?",
+        "answer_staging": (
+            "You have two options. From the SDK call `client.log_traces_feedback_scores([{id: trace_id, name: 'helpfulness', value: 1}])` "
+            "to batch-log scores for one or many traces. From the UI, open the trace detail panel and add a score on the "
+            "Feedback tab — useful for manual review."
+        ),
+        "answer_prod": "Use the SDK method `client.log_traces_feedback_scores([...])`, or open a trace in the UI and add a score on the Feedback tab.",
+        "assertions": [
+            "Mentions the SDK or UI",
+            "Is concrete about the method name",
+        ],
+        "pass_mask_prod": [True, True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000006",
+        "question": "Does Opik support self-hosting?",
+        "answer_staging": (
+            "Yes. Opik is open source and can run entirely on your own infrastructure. "
+            "For local or small setups, use the Docker Compose stack (`./opik.sh` from "
+            "`deployment/docker-compose`). For production, there's a Helm chart for "
+            "Kubernetes in `deployment/helm_chart/opik`."
+        ),
+        "answer_prod": "Yes — you can self-host Opik with Docker Compose for local setups or the Helm chart for Kubernetes in production.",
+        "assertions": [
+            "Answers yes/no clearly",
+            "Mentions Docker or Kubernetes",
+        ],
+        "pass_mask_prod": [True, True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000007",
+        "question": "How do I filter traces by tag?",
+        "answer_staging": (
+            "In the Traces view, open the filter panel above the table, add a filter on the 'Tags' "
+            "column, and pick the tag value(s) you want. The filter combines with any other "
+            "active filters, so you can narrow by tag *and* date *and* feedback score in one query."
+        ),
+        "answer_prod": "Open the Traces view, click the filter panel, pick the Tags column, and select the tag values you want.",
+        "assertions": [
+            "Mentions the filter UI",
+        ],
+        "pass_mask_prod": [True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000008",
+        "question": "Can Opik track token usage and cost?",
+        "answer_staging": (
+            "Yes. When your LLM spans include `usage` fields (prompt/completion/total tokens), "
+            "Opik aggregates those into per-trace totals and rolls them up into per-project cost estimates "
+            "using provider price tables. Official integrations (OpenAI, Anthropic, LiteLLM, …) populate these fields automatically."
+        ),
+        "answer_prod": "Yes — Opik aggregates token usage from spans into per-trace totals and estimates cost at the trace and project level.",
+        "assertions": [
+            "Confirms usage/cost tracking",
+            "Mentions aggregation or per-trace view",
+        ],
+        "pass_mask_prod": [True, True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000009",
+        "question": "What LLM integrations does Opik support?",
+        # staging links to the integrations docs URL (grounded prompt).
+        "answer_staging": (
+            "Opik supports OpenAI, Anthropic, Google Gemini, AWS Bedrock, LangChain, "
+            "LlamaIndex, LiteLLM, Ollama, DSPy, CrewAI, AutoGen, and more. "
+            "Full catalog with setup snippets: https://www.comet.com/docs/opik/integrations/overview"
+        ),
+        # prod — lists providers but mentions docs only by name (no URL).
+        "answer_prod": "OpenAI, Anthropic, LangChain, LlamaIndex, LiteLLM, Ollama, Bedrock, and more — see the integrations docs.",
+        "assertions": [
+            "Lists multiple providers",
+            "Points to the integrations docs",
+        ],
+        "pass_mask_prod": [True, False],
+        "fail_reasons_prod": {
+            1: "The response mentions the integrations docs generically but does not include a link or a concrete docs URL, which the assertion asks for.",
+        },
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000010",
+        "question": "How do I create a dataset?",
+        "answer_staging": (
+            "Two steps. First, get or create the dataset: "
+            "`ds = client.get_or_create_dataset(name='my-dataset')`. Then add items with "
+            "`ds.insert([{'input': '...', 'expected_output': '...'}, ...])`. "
+            "`get_or_create_dataset` is idempotent, so re-running the same script won't duplicate the dataset."
+        ),
+        "answer_prod": "Call `client.get_or_create_dataset(name='...')` to get or create the dataset, then `dataset.insert([{...}, {...}])` to add items.",
+        "assertions": [
+            "Mentions get_or_create_dataset",
+            "Mentions how to insert items",
+        ],
+        "pass_mask_prod": [True, True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000011",
+        "question": "What is a test suite in Opik?",
+        "answer_staging": (
+            "A test suite is the regression-testing construct in Opik. It's a specialized dataset "
+            "where each item carries a set of natural-language assertions. When you run the suite "
+            "against a task (a function that takes an item and returns an output), Opik scores every "
+            "assertion with an LLM judge and reports pass/fail per item plus a rolled-up pass rate — "
+            "so you know immediately whether a prompt or model change broke anything."
+        ),
+        "answer_prod": "A test suite is a regression test set: a dataset of inputs plus assertions. You run it against a task, and Opik scores each item and reports pass/fail results.",
+        "assertions": [
+            "Explains regression testing",
+            "Mentions assertions",
+            "Mentions pass/fail results",
+        ],
+        "pass_mask_prod": [True, True, True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000012",
+        "question": "How do I run a test suite?",
+        "answer_staging": (
+            "Call `opik.run_tests(test_suite=suite, task=my_task_fn)`. Your `task` callable receives "
+            "each dataset item's data dict and returns either a string or a dict with `input`/`output` keys. "
+            "Opik invokes the task for every item, records a trace, and automatically scores each assertion "
+            "with the configured LLM judge."
+        ),
+        "answer_prod": "Use `opik.run_tests(test_suite=suite, task=my_fn)`. Your task callback runs on each item and Opik scores the assertions automatically.",
+        "assertions": [
+            "Names the run_tests function",
+            "Describes the task callback",
+        ],
+        "pass_mask_prod": [True, True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000013",
+        "question": "What does an experiment group together?",
+        "answer_staging": (
+            "An experiment is the record of one evaluation run against a specific dataset version. "
+            "It owns a set of traces (one per dataset item), links each trace back to its dataset item, "
+            "and stores the resulting feedback and assertion scores. That shape is exactly what lets you "
+            "compare two experiments side-by-side across dataset items and metrics."
+        ),
+        "answer_prod": "An experiment groups the traces produced by one evaluation run against a dataset, so you can compare results across versions of your app.",
+        "assertions": [
+            "Mentions traces and dataset",
+            "Mentions comparison between runs",
+        ],
+        "pass_mask_prod": [True, True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000014",
+        "question": "How do I tag an experiment?",
+        "answer_staging": (
+            "Pass the `tags` argument when you create it: "
+            "`client.create_experiment(name='...', dataset_name='...', tags=['prod', 'v2.1'])`. "
+            "Tags are free-form strings and can be used later to filter the Experiments list or "
+            "group experiments in comparison views."
+        ),
+        "answer_prod": "Pass `tags=['prod']` (or any list of strings) when calling `client.create_experiment(...)`.",
+        "assertions": [
+            "Mentions the tags parameter",
+        ],
+        "pass_mask_prod": [True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000015",
+        "question": "What is an agent configuration blueprint?",
+        "answer_staging": (
+            "A blueprint is an immutable, versioned snapshot of your agent's configuration — "
+            "model name, temperature, system prompt, tool settings, feature flags, anything you "
+            "want to pin. Each blueprint has a version name (v1, v2, …) and can be tagged with "
+            "an environment like `prod` or `staging`, which lets you point 'the prod agent' at a "
+            "specific blueprint and flip environments without redeploying code."
+        ),
+        "answer_prod": "A blueprint is a versioned snapshot of your agent's config (model, temperature, prompts, flags). You can tag a blueprint with an environment like prod or staging.",
+        "assertions": [
+            "Describes versioned config values",
+            "Mentions environments",
+        ],
+        "pass_mask_prod": [True, True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000016",
+        "question": "How do I roll back an agent config?",
+        "answer_staging": (
+            "Environments are just labels on blueprint versions, so a rollback is one call: "
+            "`client.set_config_env(version='v1', env='prod')`. That re-tags the older "
+            "`v1` blueprint with the `prod` environment; next time your agent reads its config "
+            "it will pick up `v1` instead of whatever was previously tagged. No redeploy, no downtime."
+        ),
+        "answer_prod": "Use `client.set_config_env(version='v1', env='prod')` to retag the previous version with the prod environment name — the env pointer moves back to that version.",
+        "assertions": [
+            "Explains retagging",
+            "Names set_config_env",
+            "Mentions the version argument",
+        ],
+        "pass_mask_prod": [True, True, True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000017",
+        "question": "Can I compare two experiments side by side?",
+        # staging calls out outputs and scores explicitly.
+        "answer_staging": (
+            "Yes. From the Experiments view select two experiments and click "
+            "'Compare' to open the side-by-side diff — it lines up each dataset "
+            "item's outputs, feedback scores, and assertion results so you can "
+            "see exactly where the runs differ."
+        ),
+        # prod — confirms compare exists but omits what is actually displayed.
+        "answer_prod": "Yes — from the Experiments view you can select two experiments and click 'Compare' to open a side-by-side view.",
+        "assertions": [
+            "Confirms side-by-side comparison",
+            "Mentions outputs or scores",
+        ],
+        "pass_mask_prod": [True, False],
+        "fail_reasons_prod": {
+            1: "The reply confirms the 'Compare' action but does not say what data is shown (outputs, scores, or the per-item diff), which is what the assertion asks for.",
+        },
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000018",
+        "question": "Where are assertion results stored?",
+        "answer_staging": (
+            "Regular feedback scores live in the `feedback_scores` table, but "
+            "test-suite assertions are routed to a dedicated `assertion_results` table in ClickHouse. "
+            "That separation keeps ad-hoc feedback distinct from regression signals, and the backend "
+            "reads from `assertion_results` to compute each experiment's pass rate and per-assertion averages."
+        ),
+        "answer_prod": "Test-suite assertions land in a dedicated `assertion_results` table, separate from regular feedback scores, and drive the experiment's pass rate aggregation.",
+        "assertions": [
+            "Mentions a dedicated table",
+            "Mentions pass rate aggregation",
+        ],
+        "pass_mask_prod": [True, True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000019",
+        "question": "How do I run Opik locally for development?",
+        "answer_staging": (
+            "Easiest path: clone the repo and from `deployment/docker-compose` run `./opik.sh`. "
+            "That spins up the full stack — frontend, Java backend, Python backend, ClickHouse, MySQL, Redis, "
+            "MinIO — in containers. For iterating on just the backend or frontend while keeping the "
+            "infra dockerized, use `./scripts/dev-runner.sh --start` instead."
+        ),
+        "answer_prod": "Clone the repo, then from `deployment/docker-compose` run `./opik.sh` — that brings up the whole stack with docker compose.",
+        "assertions": [
+            "Mentions the opik.sh script or docker compose",
+            "Is concrete about the path",
+        ],
+        "pass_mask_prod": [True, True],
+    },
+    {
+        "id": "0199a000-0001-7000-8000-000000000020",
+        "question": "How do I evaluate prompt changes without affecting prod?",
+        # staging answer spells out the staging environment explicitly.
+        "answer_staging": (
+            "Publish the candidate prompt as a new blueprint version and tag "
+            "that version as `staging`. Run your test suite against the staging "
+            "blueprint; once the assertions pass at the bar you want, retag the "
+            "same version as `prod` to ship it."
+        ),
+        # prod answer talks about 'a new version' without naming staging.
+        "answer_prod": "Publish a new blueprint version, run your test suite against it, and when the results look good retag that version as prod.",
+        "assertions": [
+            "Mentions staging env",
+            "Describes the retag-to-prod flow",
+        ],
+        "pass_mask_prod": [False, True],
+        "fail_reasons_prod": {
+            0: "The reply refers to 'new blueprint version' and 'retag it as prod' but never names the staging environment explicitly, which is what the assertion requires.",
+        },
+    },
+]
+
+
+# Shared system prompt used by the demo support agent. The generator creates
+# two commits on the same prompt — v1 is pinned by the prod blueprint, v2 is
+# pinned by staging — to mirror a real "prompt under evaluation" workflow.
+demo_agent_prompt_name = "support-agent-system"
+
+demo_agent_prompt_v1 = (
+    "You are a helpful Opik support agent.\n"
+    "Answer user questions about Opik — the LLM observability and evaluation "
+    "platform — in clear, plain English.\n"
+    "Be concise: three sentences or fewer unless the user asks for more detail.\n"
+    "If you do not know the answer, say so rather than guessing."
+)
+
+demo_agent_prompt_v2 = (
+    "You are an expert Opik support agent.\n"
+    "You have access to a document retrieval tool. Always call it before "
+    "answering and ground your reply in the documentation it returns.\n"
+    "When the retrieved passages support your answer, quote the most relevant "
+    "snippet verbatim and cite its title.\n"
+    "Respond in plain English and keep answers under 120 words.\n"
+    "If the retrieved context does not contain the answer, say so explicitly "
+    "and point the user to the official docs or community Slack instead of "
+    "guessing."
+)
+
+
+# Two blueprints tagged prod/staging. Each sets the same keys but with
+# different values so the UI shows a meaningful diff. The `system_prompt`
+# entry has type "prompt" and stores the prompt commit — the backend resolves
+# it to the full prompt version on read.
+demo_agent_config_blueprints = [
+    {
+        "env": "prod",
+        "description": "Production config — stable, cheap, deterministic.",
+        "prompt_version": "v1",
+        "values": [
+            {"key": "model", "value": "gpt-4o-mini", "type": "string",
+             "description": "LLM used for user-facing answers"},
+            {"key": "temperature", "value": "0.2", "type": "float",
+             "description": "Lower temperature for stable outputs"},
+            {"key": "top_p", "value": "0.9", "type": "float",
+             "description": "Nucleus sampling threshold"},
+            {"key": "max_tokens", "value": "512", "type": "integer",
+             "description": "Response length cap"},
+            {"key": "enable_fallback", "value": "true", "type": "boolean",
+             "description": "Fall back to secondary provider on timeout"},
+            # system_prompt value is appended at seed time with the v1 commit.
+        ],
+    },
+    {
+        "env": "staging",
+        "description": "Staging config — experimenting with a stronger model and context-grounded prompt.",
+        "prompt_version": "v2",
+        "values": [
+            {"key": "model", "value": "gpt-4o", "type": "string",
+             "description": "Stronger model under evaluation"},
+            {"key": "temperature", "value": "0.5", "type": "float",
+             "description": "Higher temperature for variety"},
+            {"key": "top_p", "value": "0.95", "type": "float",
+             "description": "Nucleus sampling threshold"},
+            {"key": "max_tokens", "value": "1024", "type": "integer",
+             "description": "Longer responses allowed"},
+            {"key": "enable_fallback", "value": "true", "type": "boolean",
+             "description": "Fall back to secondary provider on timeout"},
+            # system_prompt value is appended at seed time with the v2 commit.
+        ],
+    },
+]
+
+
+# Experiment definitions. `tag` is the env tag for the experiment (also the
+# env tag on the blueprint the experiment is linked to). `pass_mode` drives
+# how per-item assertions are scored: "prod" uses the item's pass_mask_prod,
+# "all_pass" scores every assertion as passing. Global assertion is always
+# scored using the same mode.
+demo_test_suite_experiments = [
+    {
+        "name": "Support agent — prod candidate",
+        "tag": "prod",
+        "pass_mode": "prod",
+    },
+    {
+        "name": "Support agent — staging candidate",
+        "tag": "staging",
+        "pass_mode": "all_pass",
+    },
+]

--- a/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
+++ b/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
@@ -11,7 +11,20 @@ import random
 import opik.rest_api
 from opik.rest_api.types.trace_write import TraceWrite
 from opik.rest_api.types.span_write import SpanWrite
-from opik_backend.demo_data import demo_traces, demo_spans, demo_thread_feedback_scores
+from opik.rest_api.types.feedback_score_batch_item import FeedbackScoreBatchItem
+from opik.api_objects.experiment.experiment_item import ExperimentItemReferences
+from opik_backend.demo_data import (
+    demo_traces,
+    demo_spans,
+    demo_thread_feedback_scores,
+    demo_test_suite_items,
+    demo_test_suite_global_assertion,
+    demo_agent_config_blueprints,
+    demo_test_suite_experiments,
+    demo_agent_prompt_name,
+    demo_agent_prompt_v1,
+    demo_agent_prompt_v2,
+)
 from opentelemetry import trace
 from dataclasses import dataclass, field
 
@@ -480,15 +493,432 @@ def create_demo_chatbot_project(context: DemoDataContext, base_url: str, workspa
                 client.flush()
                 client.end()
 
+def retrieve_project_id_by_name(base_url, workspace_name, comet_api_key, project_name):
+    request = {
+        "url": "/v1/private/projects/retrieve",
+        "method": "POST",
+        "payload": {"name": project_name},
+    }
+    data, status_code = make_http_request(base_url, request, workspace_name, comet_api_key)
+    if status_code == 200 and data and "id" in data:
+        return data["id"]
+    return None
+
+
+def create_agent_config_blueprint(base_url, workspace_name, comet_api_key, project_id, blueprint_values, description):
+    """Create or patch an agent config blueprint and return its id+name.
+
+    Checks GET /latest to decide between POST (no config yet) and PATCH
+    (adding another blueprint to existing config). POST fails with 409 when
+    a config already exists, which is why we dispatch explicitly instead of
+    always using POST.
+
+    The POST response uses the Write JsonView which omits the auto-generated
+    name, and PATCH returns no body at all. We fetch via GET /latest
+    afterwards (Public view) to obtain the name.
+    """
+    latest_request = {
+        "url": f"/v1/private/agent-configs/blueprints/latest/projects/{project_id}",
+        "method": "GET",
+    }
+    _, latest_status = make_http_request(base_url, latest_request, workspace_name, comet_api_key)
+    method = "POST" if latest_status == 404 else "PATCH"
+    create_request = {
+        "url": "/v1/private/agent-configs/blueprints",
+        "method": method,
+        "payload": {
+            "project_id": project_id,
+            "blueprint": {
+                "type": "blueprint",
+                "description": description,
+                "values": blueprint_values,
+            },
+        },
+    }
+    data, status_code = make_http_request(base_url, create_request, workspace_name, comet_api_key)
+    if status_code not in (200, 201):
+        logger.error("Failed to create blueprint: status=%s, data=%s", status_code, data)
+        return None, None
+
+    # Response omits name (Write view). Re-fetch as Public view to get the name.
+    latest_request = {
+        "url": f"/v1/private/agent-configs/blueprints/latest/projects/{project_id}",
+        "method": "GET",
+    }
+    latest_data, latest_status = make_http_request(base_url, latest_request, workspace_name, comet_api_key)
+    if latest_status != 200 or not latest_data:
+        logger.error("Failed to fetch latest blueprint after create: status=%s", latest_status)
+        return None, None
+    return latest_data.get("id"), latest_data.get("name")
+
+
+def tag_agent_config_env(base_url, workspace_name, comet_api_key, project_id, env_name, blueprint_name):
+    request = {
+        "url": f"/v1/private/agent-configs/blueprints/environments/{env_name}/projects/{project_id}",
+        "method": "PUT",
+        "payload": {"blueprint_name": blueprint_name},
+    }
+    _, status_code = make_http_request(base_url, request, workspace_name, comet_api_key)
+    if status_code != 204:
+        logger.error("Failed to tag env '%s' → '%s': status=%s", env_name, blueprint_name, status_code)
+
+
+def _build_suite_span_tree(trace_id, question, answer, trace_start, trace_end,
+                           project_name, model, env):
+    """Build an 8-span agent tree mirroring the existing chatbot demo structure.
+
+    Structure:
+      handle_query (root, general)
+      ├── classify_query (general)
+      │   └── chat_completion_create (llm)
+      ├── contact_insight_tool (tool)
+      │   ├── retrieve_documents_rag (general)
+      │   └── chat_completion_create (llm)
+      └── format_response (general)
+          └── chat_completion_create (llm)
+    """
+    total = (trace_end - trace_start).total_seconds()
+    # Divide the trace into 6 sequential segments (3 main stages × 2 sub-stages).
+    seg = datetime.timedelta(seconds=total / 6.0)
+
+    s0, s1, s2, s3, s4, s5, s6 = [trace_start + i * seg for i in range(7)]
+    # s0..s1: classify_query | s1..s3: contact_insight_tool | s3..s5: format_response
+
+    root_id = str(uuid6.uuid7())
+    classify_id = str(uuid6.uuid7())
+    classify_llm_id = str(uuid6.uuid7())
+    tool_id = str(uuid6.uuid7())
+    retrieve_id = str(uuid6.uuid7())
+    tool_llm_id = str(uuid6.uuid7())
+    format_id = str(uuid6.uuid7())
+    format_llm_id = str(uuid6.uuid7())
+
+    def llm_span(span_id, parent_id, start, end, user_prompt, assistant_output,
+                 prompt_tokens, completion_tokens):
+        return SpanWrite(
+            id=span_id, trace_id=trace_id, parent_span_id=parent_id,
+            project_name=project_name, name="chat_completion_create", type="llm",
+            start_time=start, end_time=end,
+            input={"messages": [
+                {"role": "system", "content": "You are a helpful support agent."},
+                {"role": "user", "content": user_prompt},
+            ]},
+            output={"choices": [
+                {"index": 0, "finish_reason": "stop",
+                 "message": {"role": "assistant", "content": assistant_output}}
+            ]},
+            model=model, provider="openai",
+            usage={
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
+            },
+            tags=[env],
+            source="experiment",
+        )
+
+    return [
+        SpanWrite(
+            id=root_id, trace_id=trace_id, parent_span_id=None,
+            project_name=project_name, name="handle_query", type="general",
+            start_time=trace_start, end_time=trace_end,
+            input={"question": question},
+            output={"answer": answer},
+            tags=[env],
+            source="experiment",
+        ),
+        SpanWrite(
+            id=classify_id, trace_id=trace_id, parent_span_id=root_id,
+            project_name=project_name, name="classify_query", type="general",
+            start_time=s0, end_time=s1,
+            input={"query": question, "model": model},
+            output={"category": "support"},
+            tags=[env],
+            source="experiment",
+        ),
+        llm_span(classify_llm_id, classify_id, s0, s1,
+                 user_prompt=f"Classify the following user query into a support category: {question}",
+                 assistant_output="support",
+                 prompt_tokens=65, completion_tokens=3),
+        SpanWrite(
+            id=tool_id, trace_id=trace_id, parent_span_id=root_id,
+            project_name=project_name, name="contact_insight_tool", type="tool",
+            start_time=s1, end_time=s3,
+            input={"query": question, "model": model},
+            output={"documents_found": 3, "context_preview": answer[:120]},
+            tags=[env],
+            source="experiment",
+        ),
+        SpanWrite(
+            id=retrieve_id, trace_id=trace_id, parent_span_id=tool_id,
+            project_name=project_name, name="retrieve_documents_rag", type="general",
+            start_time=s1, end_time=s2,
+            input={"category": "support"},
+            output={"documents": [{"title": "Opik docs excerpt", "snippet": answer[:160]}]},
+            tags=[env],
+            source="experiment",
+        ),
+        llm_span(tool_llm_id, tool_id, s2, s3,
+                 user_prompt=(f"Given the retrieved context about Opik, answer the user's question: "
+                              f"{question}"),
+                 assistant_output=answer,
+                 prompt_tokens=180, completion_tokens=max(32, len(answer.split()) * 2)),
+        SpanWrite(
+            id=format_id, trace_id=trace_id, parent_span_id=root_id,
+            project_name=project_name, name="format_response", type="general",
+            start_time=s3, end_time=s5,
+            input={"user_query": question, "raw_tool_output": answer, "model": model},
+            output={"answer": answer},
+            tags=[env],
+            source="experiment",
+        ),
+        llm_span(format_llm_id, format_id, s3, s5,
+                 user_prompt=(f"Format the following answer as a clear, concise reply: {answer}"),
+                 assistant_output=answer,
+                 prompt_tokens=120, completion_tokens=max(24, len(answer.split()) * 2)),
+    ]
+
+
+def create_demo_test_suite_and_experiments(base_url: str, workspace_name, comet_api_key, project_name):
+    """Seed a test suite, agent-config blueprints, and two experiments.
+
+    Assumes the demo project was just created. Uses the existing feedback-score
+    batch endpoint with category_name='suite_assertion' to route scores to the
+    assertion_results table (ScoreDestination.ASSERTION_RESULTS).
+    """
+    with tracer.start_as_current_span("create_demo_test_suite_and_experiments"):
+        client: opik.Opik = None
+        try:
+            project_id = retrieve_project_id_by_name(base_url, workspace_name, comet_api_key, project_name)
+            if project_id is None:
+                logger.error("Demo project '%s' not found, skipping test suite creation", project_name)
+                return
+
+            client = opik.Opik(
+                project_name=project_name,
+                workspace=workspace_name,
+                host=base_url,
+                api_key=comet_api_key,
+                _use_batching=True,
+            )
+
+            # Step 1 — evaluation suite (renamed to "test suite" on main, but this
+            # codepath uses the 1.10.56 SDK naming for evaluation suites).
+            suite_name = "Customer support regression suite"
+            suite = client.get_or_create_evaluation_suite(
+                name=suite_name,
+                description="Demo regression tests for the support agent.",
+                assertions=[demo_test_suite_global_assertion],
+                project_name=project_name,
+            )
+            if suite.get_items():
+                logger.info("Evaluation suite '%s' already populated, skipping", suite_name)
+                return
+
+            suite.add_items([
+                {
+                    "data": {"question": template["question"]},
+                    "assertions": template["assertions"],
+                }
+                for template in demo_test_suite_items
+            ])
+            client.flush()
+
+            # After insert, map back: question text → backend-assigned item id.
+            inserted_items = suite.get_items()
+            item_id_by_question = {item["data"]["question"]: item["id"] for item in inserted_items}
+            logger.info("Inserted %d evaluation suite items for workspace %s",
+                        len(inserted_items), workspace_name)
+
+            # Step 2a — create the support agent system prompt with two commits.
+            # Each blueprint pins the `system_prompt` key to the commit matching
+            # its prompt_version so the UI shows a real prompt link, not a raw string.
+            prompt_v1 = client.create_prompt(
+                name=demo_agent_prompt_name,
+                prompt=demo_agent_prompt_v1,
+                description="Support agent system prompt used by the demo project.",
+                project_name=project_name,
+            )
+            prompt_v2 = client.create_prompt(
+                name=demo_agent_prompt_name,
+                prompt=demo_agent_prompt_v2,
+                change_description="Ground answers in retrieved context and enforce 120-word cap.",
+                project_name=project_name,
+            )
+            prompt_commit_by_version = {"v1": prompt_v1.commit, "v2": prompt_v2.commit}
+            logger.info("Created prompt '%s' with commits v1=%s v2=%s",
+                        demo_agent_prompt_name, prompt_v1.commit, prompt_v2.commit)
+
+            # Step 2b — agent config blueprints. The helper auto-detects POST vs PATCH.
+            blueprint_by_env = {}
+            for bp in demo_agent_config_blueprints:
+                values_with_prompt = list(bp["values"]) + [{
+                    "key": "system_prompt",
+                    "type": "prompt",
+                    "value": prompt_commit_by_version[bp["prompt_version"]],
+                    "description": f"System prompt pinned to {bp['prompt_version']}",
+                }]
+                bp_id, bp_name = create_agent_config_blueprint(
+                    base_url, workspace_name, comet_api_key, project_id,
+                    values_with_prompt, bp["description"],
+                )
+                if bp_id is None:
+                    logger.error("Aborting test suite seed — blueprint creation failed for env %s", bp["env"])
+                    return
+                blueprint_by_env[bp["env"]] = {"id": bp_id, "name": bp_name}
+                tag_agent_config_env(base_url, workspace_name, comet_api_key, project_id, bp["env"], bp_name)
+
+            # Step 3 — experiments + traces + scores.
+            suite_dataset_name = suite.dataset.name
+            now = datetime.datetime.now()
+
+            for exp_cfg in demo_test_suite_experiments:
+                env = exp_cfg["tag"]
+                blueprint = blueprint_by_env[env]
+                # Resolve the model value from the blueprint for realistic LLM span metadata.
+                model_value = next(
+                    (v["value"] for v in next(
+                        bp["values"] for bp in demo_agent_config_blueprints if bp["env"] == env
+                    ) if v["key"] == "model"),
+                    "gpt-4o-mini",
+                )
+
+                experiment = client.create_experiment(
+                    name=exp_cfg["name"],
+                    dataset_name=suite_dataset_name,
+                    evaluation_method="evaluation_suite",
+                    tags=[env],
+                    project_name=project_name,
+                    experiment_config={
+                        "agent_configuration": {
+                            "_blueprint_id": blueprint["id"],
+                            "blueprint_version": blueprint["name"],
+                        }
+                    },
+                )
+
+                # For each suite item: one trace (with full span tree), one experiment_item,
+                # per-item + global assertion scores.
+                traces_to_create = []
+                spans_to_create = []
+                experiment_refs = []
+                score_items = []
+
+                for i, template in enumerate(demo_test_suite_items):
+                    trace_id = str(uuid6.uuid7())
+                    dataset_item_id = item_id_by_question[template["question"]]
+
+                    # Per-env answer: prod may have a weaker variant that legitimately
+                    # fails the assertions marked False in pass_mask_prod; staging
+                    # always uses the "good" answer that satisfies every assertion.
+                    # Items without an answer_prod override use the same answer in both.
+                    if env == "prod":
+                        answer = template.get("answer_prod") or template["answer_staging"]
+                    else:
+                        answer = template["answer_staging"]
+
+                    # Spread traces across the last ~30 minutes in reverse order.
+                    start = now - datetime.timedelta(minutes=len(demo_test_suite_items) - i)
+                    end = start + datetime.timedelta(seconds=random.randint(4, 12))
+
+                    traces_to_create.append(TraceWrite(
+                        id=trace_id,
+                        name="handle_query",
+                        project_name=project_name,
+                        start_time=start,
+                        end_time=end,
+                        input={"question": template["question"]},
+                        output={"answer": answer},
+                        tags=[env],
+                        source="experiment",
+                    ))
+
+                    spans_to_create.extend(_build_suite_span_tree(
+                        trace_id=trace_id,
+                        question=template["question"],
+                        answer=answer,
+                        trace_start=start,
+                        trace_end=end,
+                        project_name=project_name,
+                        model=model_value,
+                        env=env,
+                    ))
+
+                    experiment_refs.append(ExperimentItemReferences(
+                        dataset_item_id=dataset_item_id,
+                        trace_id=trace_id,
+                    ))
+
+                    # Assertion scores. Pass mode drives fail patterns. Name = full
+                    # assertion text (matching real LLM-judge output after
+                    # scoreNameMapping), reason = why it passed or failed.
+                    pass_mode = exp_cfg["pass_mode"]
+                    assertions = template["assertions"]
+                    mask = (template["pass_mask_prod"]
+                            if pass_mode == "prod"
+                            else [True] * len(assertions))
+                    fail_reasons = (template.get("fail_reasons_prod") or {}) if pass_mode == "prod" else {}
+
+                    # Global suite-level assertion — always passes in the demo.
+                    score_items.append(FeedbackScoreBatchItem(
+                        id=trace_id,
+                        project_name=project_name,
+                        name=demo_test_suite_global_assertion,
+                        category_name="suite_assertion",
+                        value=1.0,
+                        reason="The response is written entirely in clear, fluent English.",
+                        source="online_scoring",
+                    ))
+
+                    for idx, (assertion_text, passed) in enumerate(zip(assertions, mask)):
+                        if passed:
+                            reason = (f"The response satisfies the assertion: "
+                                      f"it clearly {assertion_text[0].lower() + assertion_text[1:]}.")
+                        else:
+                            reason = fail_reasons.get(
+                                idx,
+                                f"The response does not satisfy the assertion: "
+                                f"it fails to {assertion_text[0].lower() + assertion_text[1:]}.",
+                            )
+                        score_items.append(FeedbackScoreBatchItem(
+                            id=trace_id,
+                            project_name=project_name,
+                            name=assertion_text,
+                            category_name="suite_assertion",
+                            value=1.0 if passed else 0.0,
+                            reason=reason,
+                            source="online_scoring",
+                        ))
+
+                client.rest_client.traces.create_traces(traces=traces_to_create)
+                client.rest_client.spans.create_spans(spans=spans_to_create)
+                experiment.insert(experiment_refs)
+                client.flush()
+                client.rest_client.traces.score_batch_of_traces(scores=score_items)
+
+                logger.info("Seeded experiment '%s' with %d traces / %d spans / %d assertion scores",
+                            exp_cfg["name"], len(traces_to_create), len(spans_to_create), len(score_items))
+
+        except Exception as e:
+            logger.error("Error creating demo test suite for workspace %s: %s",
+                         workspace_name, e, exc_info=True)
+        finally:
+            if client:
+                client.flush()
+                client.end()
+
+
 def create_demo_data(base_url: str, workspace_name, comet_api_key):
     with tracer.start_as_current_span("create_demo_data"):
         # Create a fresh context for this invocation to prevent race conditions
         # when multiple users sign up concurrently
         context = DemoDataContext()
-        
+        project_name = "Opik Demo Agent Observability"
+
         try:
             create_demo_chatbot_project(context, base_url, workspace_name, comet_api_key)
             create_feedback_scores_definition(base_url, workspace_name, comet_api_key)
+            create_demo_test_suite_and_experiments(base_url, workspace_name, comet_api_key, project_name)
             logger.info("Demo data created successfully")
         except Exception as e:
             logger.error(e)

--- a/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
+++ b/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
@@ -366,6 +366,8 @@ def get_new_uuid_by_time(context: DemoDataContext, old_id, datetime):
     return new_id
 
 def create_demo_chatbot_project(context: DemoDataContext, base_url: str, workspace_name, comet_api_key):
+    """Seed the demo chatbot project. Returns True when fresh data was written,
+    False when the project already existed (409) and the seed was skipped."""
     with tracer.start_as_current_span("create_demo_chatbot_project"):
         client: opik.Opik = None
 
@@ -387,12 +389,12 @@ def create_demo_chatbot_project(context: DemoDataContext, base_url: str, workspa
                     break
                 if attempt == max_retries - 1:
                     logger.error("Failed to create project %s for workspace %s after %d retries (last status=%s), aborting demo data creation", project_name, workspace_name, max_retries, status_code)
-                    return
+                    return False
                 time.sleep(2 ** attempt)
 
             if status_code == 409:
                 logger.info("%s project already exists for workspace %s, skipping demo data creation", project_name, workspace_name)
-                return
+                return False
 
             client = opik.Opik(
                 project_name=project_name,
@@ -485,8 +487,11 @@ def create_demo_chatbot_project(context: DemoDataContext, base_url: str, workspa
                         time.sleep(0.5)
                 if not done:
                     logger.error("Failed to score batch of threads for workspace %s after %d attempts", workspace_name, max_attempts)
+
+            return True
         except Exception as e:
             logger.error("Error creating demo chatbot project for workspace %s: %s", workspace_name, e, exc_info=True)
+            return False
         finally:
             # Close the client
             if client:
@@ -916,9 +921,14 @@ def create_demo_data(base_url: str, workspace_name, comet_api_key):
         project_name = "Opik Demo Agent Observability"
 
         try:
-            create_demo_chatbot_project(context, base_url, workspace_name, comet_api_key)
+            chatbot_seeded = create_demo_chatbot_project(context, base_url, workspace_name, comet_api_key)
             create_feedback_scores_definition(base_url, workspace_name, comet_api_key)
-            create_demo_test_suite_and_experiments(base_url, workspace_name, comet_api_key, project_name)
+            # Only run the test-suite seed when the chatbot project was freshly created.
+            # If the chatbot flow short-circuited on 409 (project already exists), the
+            # suite/prompt/blueprints/experiments were seeded on the prior run too —
+            # a second pass must be a no-op to stay idempotent under signup retries.
+            if chatbot_seeded:
+                create_demo_test_suite_and_experiments(base_url, workspace_name, comet_api_key, project_name)
             logger.info("Demo data created successfully")
         except Exception as e:
             logger.error(e)


### PR DESCRIPTION
## Details

Extends the post-signup demo-data generator so the demo workspace showcases the full regression-testing + agent-config story end-to-end. New users now land with an evaluation suite, two environment-tagged blueprints, a versioned system prompt, and two fully-scored experiments — not just a few chatbot traces.

Also fixes a pre-existing bug: 8 orphan spans in `demo_data.py` referenced a trace that was never created, producing 404s when opening those spans in the UI.

- Creates `"Customer support regression suite"` evaluation suite — 20 items, 1 global assertion (`Response is written in clear English`), 1–3 per-item assertions
- Creates `"support-agent-system"` opik.Prompt with two versioned commits (v1 concise, v2 grounded-with-RAG)
- Creates two agent-config blueprints on the demo project: `v1` tagged env `prod` (gpt-4o-mini, temp 0.2, pinned to prompt v1) and `v2` tagged env `staging` (gpt-4o, temp 0.5, pinned to prompt v2). Each blueprint stores the system prompt as an `AgentConfigValue` of type `prompt`
- Runs two experiments (`Support agent — prod candidate`, `Support agent — staging candidate`) linked to the suite via `evaluation_method="evaluation_suite"` and `experiment_config.agent_configuration._blueprint_id` pointing at the respective blueprint
- Each experiment item has an 8-span agent tree (`handle_query` → `classify_query`/`contact_insight_tool`/`format_response`, each with an LLM call) mirroring the existing chatbot demo structure, with the blueprint's model value on every `chat_completion_create` span and `source="experiment"` on every trace and span
- Each of the 20 suite items has distinct `answer_prod` + `answer_staging` strings so the two experiments never return byte-identical outputs. 4 items have a deliberately-weaker `answer_prod` that legitimately fails the assertion flagged in `pass_mask_prod` (e.g. prod answer to "How do I log a trace from Python?" omits the code example; staging's includes one). Pass rates: prod 0.8 (16/20), staging 1.0 (20/20)
- Assertion scores are posted with `category_name="suite_assertion"` (routes to `assertion_results` table via `ScoreDestination.fromCategoryName`). Name = full assertion text (matching real LLM-judge output after `scoreNameMapping`), reason = specific pass/fail explanation (pre-authored for the 4 documented failures, templated for passes)
- Removes 8 orphan spans from `demo_data.py` whose parent trace `0198eca8-732b-7c7e-94d6-3e2d431f4e22` was missing from `demo_traces`

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: Implementation of demo-data extension (planning, code generation, verification); authored the 20 suite items, prompt templates, and assertion reason strings
- Human verification: Owner reviewed the plan before implementation, steered the iterative fixes (orphan span removal, span tree shape, prompt wording, per-env answer variation, assertion names + reasons, trace source), and confirmed UI rendering end-to-end against a local stack

## Testing

Local stack brought up with `./scripts/dev-runner.sh --start` (port offset 10 to avoid a port conflict), python-backend rebuilt and recreated, suite + project state cleaned between runs.

- Triggered end-to-end: `curl -X POST http://localhost:8000/v1/private/post_user_signup -d '{"workspace":"default","apiKey":"1234"}'`
- Verified via REST + ClickHouse:
  - 20 evaluation suite items created with correct per-item + global assertions
  - Prompt `support-agent-system` has 2 versions; v1 commit pinned in prod blueprint, v2 in staging blueprint (`system_prompt` value, type `prompt`)
  - Environment tags: `prod → v1`, `staging → v2`
  - Both experiments have 20 traces, 160 spans each (20 × 8-span tree), 61 assertion scores each (20 × avg 2 per-item + 20 global + 1)
  - Pass rates: prod `0.8` (16/20), staging `1.0` (20/20)
  - Assertion scores use full assertion text as `name` and carry a `reason` — verified on 4 items the specific fail reasons surface
  - Per-env outputs differ on every suite item (sampled 3 non-failing + 4 failing)
  - All suite traces + all 320 suite spans have `source="experiment"`
  - No orphan spans after the fix: `SELECT count(DISTINCT trace_id) FROM spans WHERE trace_id NOT IN (SELECT id FROM traces)` returns 0 (was 1)
  - Idempotency: re-running the signup hook against a populated workspace is a no-op (suite guarded by `get_or_create_evaluation_suite` + `get_items()` check; blueprints auto-detect POST vs PATCH via `GET /latest`)
- UI verified: Test suite, Experiments (prod 80%, staging 100%), Opik Connect (two blueprints, prompt link on `system_prompt`), trace detail shows the full waterfall, assertion names + reasons render.
- No backend/Java or frontend changes — all required surfaces already wired.

## Documentation

No documentation updates required — this is purely demo-data seeding and uses existing public APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)