### PR TITLE
[NA] [BE][FE] chore: sync provider model definitions

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/OpenaiModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/OpenaiModelName.java
@@ -74,7 +74,8 @@ public enum OpenaiModelName implements StructuredOutputSupported {
     GPT_O3_MINI("o3-mini", false),
     GPT_O3_PRO("o3-pro", true),
     GPT_O4_MINI("o4-mini", true),
-    GPT_O4_MINI_DEEP_RESEARCH("o4-mini-deep-research", true);
+    GPT_O4_MINI_DEEP_RESEARCH("o4-mini-deep-research", true),
+    GPT_IMAGE_2("gpt-image-2", false);
 
     private static final String WARNING_UNKNOWN_MODEL = "could not find OpenaiModelName with value '{}'";
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
@@ -150,6 +150,7 @@ public enum OpenRouterModelName implements StructuredOutputSupported {
     INCEPTION_MERCURY("inception/mercury"),
     INCEPTION_MERCURY_2("inception/mercury-2"),
     INCEPTION_MERCURY_CODER("inception/mercury-coder"),
+    INCLUSIONAI_LING_2_6_FLASH_FREE("inclusionai/ling-2.6-flash:free"),
     INFLECTION_INFLECTION_3_PI("inflection/inflection-3-pi"),
     INFLECTION_INFLECTION_3_PRODUCTIVITY("inflection/inflection-3-productivity"),
     KWAIPILOT_KAT_CODER_PRO("kwaipilot/kat-coder-pro"),
@@ -319,6 +320,7 @@ public enum OpenRouterModelName implements StructuredOutputSupported {
     OPENAI_GPT_5_3_CHAT("openai/gpt-5.3-chat"),
     OPENAI_GPT_5_3_CODEX("openai/gpt-5.3-codex"),
     OPENAI_GPT_5_4("openai/gpt-5.4"),
+    OPENAI_GPT_5_4_IMAGE_2("openai/gpt-5.4-image-2"),
     OPENAI_GPT_5_4_MINI("openai/gpt-5.4-mini"),
     OPENAI_GPT_5_4_NANO("openai/gpt-5.4-nano"),
     OPENAI_GPT_5_4_PRO("openai/gpt-5.4-pro"),
@@ -347,6 +349,7 @@ public enum OpenRouterModelName implements StructuredOutputSupported {
     OPENROUTER_FREE("openrouter/free"),
     OPENROUTER_HEALER_ALPHA("openrouter/healer-alpha"),
     OPENROUTER_HUNTER_ALPHA("openrouter/hunter-alpha"),
+    OPENROUTER_PARETO_CODE("openrouter/pareto-code"),
     PERPLEXITY_SONAR("perplexity/sonar"),
     PERPLEXITY_SONAR_DEEP_RESEARCH("perplexity/sonar-deep-research"),
     PERPLEXITY_SONAR_PRO("perplexity/sonar-pro"),
@@ -472,7 +475,8 @@ public enum OpenRouterModelName implements StructuredOutputSupported {
     Z_AI_GLM_5("z-ai/glm-5"),
     Z_AI_GLM_5_TURBO("z-ai/glm-5-turbo"),
     Z_AI_GLM_5_1("z-ai/glm-5.1"),
-    Z_AI_GLM_5V_TURBO("z-ai/glm-5v-turbo");
+    Z_AI_GLM_5V_TURBO("z-ai/glm-5v-turbo"),
+    ~ANTHROPIC_CLAUDE_OPUS_LATEST("~anthropic/claude-opus-latest");
 
     private static final String WARNING_UNKNOWN_MODEL = "could not find OpenRouterModelName with value '{}'";
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
@@ -476,7 +476,7 @@ public enum OpenRouterModelName implements StructuredOutputSupported {
     Z_AI_GLM_5_TURBO("z-ai/glm-5-turbo"),
     Z_AI_GLM_5_1("z-ai/glm-5.1"),
     Z_AI_GLM_5V_TURBO("z-ai/glm-5v-turbo"),
-    ~ANTHROPIC_CLAUDE_OPUS_LATEST("~anthropic/claude-opus-latest");
+    ANTHROPIC_CLAUDE_OPUS_LATEST("~anthropic/claude-opus-latest");
 
     private static final String WARNING_UNKNOWN_MODEL = "could not find OpenRouterModelName with value '{}'";
 

--- a/apps/opik-backend/src/main/resources/llm-models-default.yaml
+++ b/apps/opik-backend/src/main/resources/llm-models-default.yaml
@@ -105,6 +105,7 @@ openai:
   - id: "o4-mini-deep-research"
     structuredOutput: true
     reasoning: true
+  - id: "gpt-image-2"
 anthropic:
   - id: "claude-3-7-sonnet-20250219"
   - id: "claude-haiku-4-5-20251001"
@@ -361,6 +362,7 @@ openrouter:
   - id: "inception/mercury"
   - id: "inception/mercury-2"
   - id: "inception/mercury-coder"
+  - id: "inclusionai/ling-2.6-flash:free"
   - id: "inflection/inflection-3-pi"
   - id: "inflection/inflection-3-productivity"
   - id: "kwaipilot/kat-coder-pro"
@@ -569,6 +571,7 @@ openrouter:
   - id: "openai/gpt-5.3-chat"
   - id: "openai/gpt-5.3-codex"
   - id: "openai/gpt-5.4"
+  - id: "openai/gpt-5.4-image-2"
   - id: "openai/gpt-5.4-mini"
   - id: "openai/gpt-5.4-nano"
   - id: "openai/gpt-5.4-pro"
@@ -614,6 +617,7 @@ openrouter:
     structuredOutput: true
   - id: "openrouter/healer-alpha"
   - id: "openrouter/hunter-alpha"
+  - id: "openrouter/pareto-code"
   - id: "perplexity/sonar"
   - id: "perplexity/sonar-deep-research"
   - id: "perplexity/sonar-pro"
@@ -755,3 +759,4 @@ openrouter:
   - id: "z-ai/glm-5-turbo"
   - id: "z-ai/glm-5.1"
   - id: "z-ai/glm-5v-turbo"
+  - id: "~anthropic/claude-opus-latest"

--- a/apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts
+++ b/apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts
@@ -1981,7 +1981,7 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       label: "z-ai/glm-5v-turbo",
     },
     {
-      value: PROVIDER_MODEL_TYPE.~ANTHROPIC_CLAUDE_OPUS_LATEST,
+      value: PROVIDER_MODEL_TYPE.ANTHROPIC_CLAUDE_OPUS_LATEST,
       label: "~anthropic/claude-opus-latest",
     },
   ],

--- a/apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts
+++ b/apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts
@@ -677,6 +677,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       label: "inception/mercury-coder",
     },
     {
+      value: PROVIDER_MODEL_TYPE.INCLUSIONAI_LING_2_6_FLASH_FREE,
+      label: "inclusionai/ling-2.6-flash:free",
+    },
+    {
       value: PROVIDER_MODEL_TYPE.INFLECTION_INFLECTION_3_PI,
       label: "inflection/inflection-3-pi",
     },
@@ -1353,6 +1357,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       label: "openai/gpt-5.4",
     },
     {
+      value: PROVIDER_MODEL_TYPE.OPENAI_GPT_5_4_IMAGE_2,
+      label: "openai/gpt-5.4-image-2",
+    },
+    {
       value: PROVIDER_MODEL_TYPE.OPENAI_GPT_5_4_MINI,
       label: "openai/gpt-5.4-mini",
     },
@@ -1463,6 +1471,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
     {
       value: PROVIDER_MODEL_TYPE.OPENROUTER_HUNTER_ALPHA,
       label: "openrouter/hunter-alpha",
+    },
+    {
+      value: PROVIDER_MODEL_TYPE.OPENROUTER_PARETO_CODE,
+      label: "openrouter/pareto-code",
     },
     {
       value: PROVIDER_MODEL_TYPE.PERPLEXITY_SONAR,
@@ -1967,6 +1979,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
     {
       value: PROVIDER_MODEL_TYPE.Z_AI_GLM_5V_TURBO,
       label: "z-ai/glm-5v-turbo",
+    },
+    {
+      value: PROVIDER_MODEL_TYPE.~ANTHROPIC_CLAUDE_OPUS_LATEST,
+      label: "~anthropic/claude-opus-latest",
     },
   ],
 

--- a/apps/opik-frontend/src/types/providers.ts
+++ b/apps/opik-frontend/src/types/providers.ts
@@ -564,7 +564,7 @@ export enum PROVIDER_MODEL_TYPE {
   Z_AI_GLM_5_TURBO = "z-ai/glm-5-turbo",
   Z_AI_GLM_5_1 = "z-ai/glm-5.1",
   Z_AI_GLM_5V_TURBO = "z-ai/glm-5v-turbo",
-  ~ANTHROPIC_CLAUDE_OPUS_LATEST = "~anthropic/claude-opus-latest",
+  ANTHROPIC_CLAUDE_OPUS_LATEST = "~anthropic/claude-opus-latest",
 
   //   <----- gemini
   AQA = "aqa",

--- a/apps/opik-frontend/src/types/providers.ts
+++ b/apps/opik-frontend/src/types/providers.ts
@@ -90,6 +90,7 @@ export enum PROVIDER_MODEL_TYPE {
   GPT_O3_PRO = "o3-pro",
   GPT_O4_MINI = "o4-mini",
   GPT_O4_MINI_DEEP_RESEARCH = "o4-mini-deep-research",
+  GPT_IMAGE_2 = "gpt-image-2",
 
   //  <----- anthropic
   CLAUDE_SONNET_3_7 = "claude-3-7-sonnet-20250219",
@@ -237,6 +238,7 @@ export enum PROVIDER_MODEL_TYPE {
   INCEPTION_MERCURY = "inception/mercury",
   INCEPTION_MERCURY_2 = "inception/mercury-2",
   INCEPTION_MERCURY_CODER = "inception/mercury-coder",
+  INCLUSIONAI_LING_2_6_FLASH_FREE = "inclusionai/ling-2.6-flash:free",
   INFLECTION_INFLECTION_3_PI = "inflection/inflection-3-pi",
   INFLECTION_INFLECTION_3_PRODUCTIVITY = "inflection/inflection-3-productivity",
   KWAIPILOT_KAT_CODER_PRO = "kwaipilot/kat-coder-pro",
@@ -406,6 +408,7 @@ export enum PROVIDER_MODEL_TYPE {
   OPENAI_GPT_5_3_CHAT = "openai/gpt-5.3-chat",
   OPENAI_GPT_5_3_CODEX = "openai/gpt-5.3-codex",
   OPENAI_GPT_5_4 = "openai/gpt-5.4",
+  OPENAI_GPT_5_4_IMAGE_2 = "openai/gpt-5.4-image-2",
   OPENAI_GPT_5_4_MINI = "openai/gpt-5.4-mini",
   OPENAI_GPT_5_4_NANO = "openai/gpt-5.4-nano",
   OPENAI_GPT_5_4_PRO = "openai/gpt-5.4-pro",
@@ -434,6 +437,7 @@ export enum PROVIDER_MODEL_TYPE {
   OPENROUTER_FREE = "openrouter/free",
   OPENROUTER_HEALER_ALPHA = "openrouter/healer-alpha",
   OPENROUTER_HUNTER_ALPHA = "openrouter/hunter-alpha",
+  OPENROUTER_PARETO_CODE = "openrouter/pareto-code",
   PERPLEXITY_SONAR = "perplexity/sonar",
   PERPLEXITY_SONAR_DEEP_RESEARCH = "perplexity/sonar-deep-research",
   PERPLEXITY_SONAR_PRO = "perplexity/sonar-pro",
@@ -560,6 +564,7 @@ export enum PROVIDER_MODEL_TYPE {
   Z_AI_GLM_5_TURBO = "z-ai/glm-5-turbo",
   Z_AI_GLM_5_1 = "z-ai/glm-5.1",
   Z_AI_GLM_5V_TURBO = "z-ai/glm-5v-turbo",
+  ~ANTHROPIC_CLAUDE_OPUS_LATEST = "~anthropic/claude-opus-latest",
 
   //   <----- gemini
   AQA = "aqa",

--- a/scripts/sync_provider_models.py
+++ b/scripts/sync_provider_models.py
@@ -294,6 +294,7 @@ def model_to_enum_name(model_str: str, provider: str) -> str:
         s = s.removeprefix("vertex_ai/")
     if provider == "openai" and re.match(r"^o\d", s):
         s = "GPT_" + s
+    s = s.lstrip("~")
     s = re.sub(r"[-.:\/]", "_", s)
     return s.upper()
 


### PR DESCRIPTION
## Details

Automated sync of LLM provider model definitions from source APIs and prices JSON.

**Sync summary:**
```
## Provider Model Sync

### Openrouter
- Added 4 model(s):
  + inclusionai/ling-2.6-flash:free
  + openai/gpt-5.4-image-2
  + openrouter/pareto-code
  + ~anthropic/claude-opus-latest
- Stale 113 model(s) (not in source, manual review needed):
  ? ai21/jamba-mini-1.7
  ? alibaba/tongyi-deepresearch-30b-a3b:free
  ? allenai/molmo-2-8b
  ? allenai/olmo-2-0325-32b-instruct
  ? allenai/olmo-3-7b-instruct
  ? allenai/olmo-3-7b-think
  ? allenai/olmo-3.1-32b-think
  ? anthropic/claude-3.5-sonnet
  ? arcee-ai/afm-4.5b
  ? arcee-ai/trinity-mini:free
  ? arliai/qwq-32b-arliai-rpr-v1
  ? arliai/qwq-32b-arliai-rpr-v1:free
  ? deepcogito/cogito-v2-preview-deepseek-671b
  ? deepcogito/cogito-v2-preview-llama-109b-moe
  ? deepcogito/cogito-v2-preview-llama-405b
  ? deepcogito/cogito-v2-preview-llama-70b
  ? deepseek/deepseek-chat-v3-0324:free
  ? deepseek/deepseek-prover-v2
  ? deepseek/deepseek-r1-0528-qwen3-8b
  ? deepseek/deepseek-r1-0528-qwen3-8b:free
  ? deepseek/deepseek-r1-0528:free
  ? deepseek/deepseek-r1-distill-llama-70b:free
  ? deepseek/deepseek-r1-distill-qwen-14b
  ? deepseek/deepseek-r1:free
  ? deepseek/deepseek-v3.1-terminus:exacto
  ? eleutherai/llemma_7b
  ? google/gemini-2.0-flash-exp:free
  ? google/gemini-2.5-flash-image-preview
  ? google/gemini-2.5-flash-preview-09-2025
  ? google/gemini-3-pro-preview
  ? google/gemma-2-9b-it
  ? inception/mercury
  ? inception/mercury-coder
  ? kwaipilot/kat-coder-pro
  ? kwaipilot/kat-coder-pro:free
  ? liquid/lfm-2.2-6b
  ? liquid/lfm2-8b-a1b
  ? meituan/longcat-flash-chat
  ? meituan/longcat-flash-chat:free
  ? meta-llama/llama-3.1-405b
  ? meta-llama/llama-3.1-405b-instruct
  ? meta-llama/llama-3.2-90b-vision-instruct
  ? meta-llama/llama-guard-2-8b
  ? meta-llama/llama-guard-4-12b:free
  ? microsoft/mai-ds-r1
  ? microsoft/mai-ds-r1:free
  ? microsoft/phi-3-medium-128k-instruct
  ? microsoft/phi-3-mini-128k-instruct
  ? microsoft/phi-3.5-mini-128k-instruct
  ? microsoft/phi-4-multimodal-instruct
  ? microsoft/phi-4-reasoning-plus
  ? mistralai/codestral-2501
  ? mistralai/devstral-small-2505
  ? mistralai/magistral-medium-2506
  ? mistralai/magistral-medium-2506:thinking
  ? mistralai/magistral-small-2506
  ? mistralai/ministral-3b
  ? mistralai/ministral-8b
  ? mistralai/mistral-7b-instruct
  ? mistralai/mistral-7b-instruct-v0.2
  ? mistralai/mistral-7b-instruct-v0.3
  ? mistralai/mistral-7b-instruct:free
  ? mistralai/mistral-nemo:free
  ? mistralai/mistral-small
  ? mistralai/mistral-small-24b-instruct-2501:free
  ? mistralai/mistral-small-3.1-24b-instruct:free
  ? mistralai/mistral-small-3.2-24b-instruct:free
  ? mistralai/mistral-tiny
  ? mistralai/pixtral-12b
  ? moonshotai/kimi-dev-72b
  ? moonshotai/kimi-k2-0905:exacto
  ? moonshotai/kimi-k2:free
  ? moonshotai/kimi-linear-48b-a3b-instruct
  ? neversleep/llama-3.1-lumimaid-8b
  ? neversleep/noromaid-20b
  ? nousresearch/deephermes-3-mistral-24b-preview
  ? nvidia/llama-3.1-nemotron-ultra-253b-v1
  ? openai/chatgpt-4o-latest
  ? openai/codex-mini
  ? openai/gpt-4o:extended
  ? openai/gpt-5.2-chat-latest
  ? openai/gpt-oss-120b:exacto
  ? opengvlab/internvl3-78b
  ? openrouter/elephant-alpha
  ? openrouter/healer-alpha
  ? openrouter/hunter-alpha
  ? perplexity/sonar-reasoning
  ? qwen/qwen-2.5-72b-instruct:free
  ? qwen/qwen-2.5-coder-32b-instruct:free
  ? qwen/qwen-2.5-vl-7b-instruct
  ? qwen/qwen2.5-coder-7b-instruct
  ? qwen/qwen2.5-vl-32b-instruct
  ? qwen/qwen2.5-vl-32b-instruct:free
  ? qwen/qwen3-14b:free
  ? qwen/qwen3-235b-a22b:free
  ? qwen/qwen3-30b-a3b:free
  ? qwen/qwen3-4b:free
  ? qwen/qwen3-coder:exacto
  ? qwen/qwen3.6-plus-preview:free
  ? qwen/qwen3.6-plus:free
  ? raifle/sorcererlm-8x22b
  ? reka/reka-edge
  ? stepfun-ai/step3
  ? stepfun/step-3.5-flash:free
  ? thedrummer/anubis-70b-v1.1
  ? thudm/glm-4.1v-9b-thinking
  ? tngtech/deepseek-r1t-chimera
  ? tngtech/deepseek-r1t-chimera:free
  ? tngtech/deepseek-r1t2-chimera:free
  ? x-ai/grok-4.1-fast:free
  ? x-ai/grok-4.20-beta
  ? x-ai/grok-4.20-multi-agent-beta
  ? z-ai/glm-4.6:exacto
- Total models: 459 (dropdown: 459)

### Openai
- Added 1 model(s):
  + gpt-image-2
- Stale 15 model(s) (not in source, manual review needed):
  ? chatgpt-4o-latest
  ? gpt-4-0125-preview
  ? gpt-4-0314
  ? gpt-4-1106-preview
  ? gpt-4-turbo-2024-04-09
  ? gpt-4-turbo-preview
  ? gpt-4o-2024-05-13
  ? gpt-4o-2024-08-06
  ? gpt-4o-2024-11-20
  ? gpt-4o-mini-2024-07-18
  ? o1-2024-12-17
  ? o1-mini
  ? o1-mini-2024-09-12
  ? o1-preview
  ? o1-preview-2024-09-12
- Deprecated 4 model(s) (past deprecation_date, excluded from dropdown):
  ✗ gpt-4-0125-preview
  ✗ gpt-4-0314
  ✗ gpt-4-0613
  ✗ gpt-4-1106-preview
- Total models: 63 (dropdown: 19)

### Anthropic
- Stale 2 model(s) (not in source, manual review needed):
  ? claude-3-7-sonnet-20250219
  ? claude-sonnet-4-5
- Deprecated 1 model(s) (past deprecation_date, excluded from dropdown):
  ✗ claude-3-7-sonnet-20250219
- Total models: 11 (dropdown: 9)

### Gemini
- Stale 6 model(s) (not in source, manual review needed):
  ? aqa
  ? gemini-1.0-pro
  ? gemini-1.5-flash-latest
  ? gemini-1.5-pro-latest
  ? gemini-pro-vision
  ? text-embedding-004
- Deprecated 2 model(s) (past deprecation_date, excluded from dropdown):
  ✗ gemini-3-pro-preview
  ✗ text-embedding-004
- Total models: 22 (dropdown: 11)

### Vertexai
- Stale 9 model(s) (not in source, manual review needed):
  ? vertex_ai/gemini-2.0-flash-001
  ? vertex_ai/gemini-2.0-flash-lite-001
  ? vertex_ai/gemini-2.5-flash
  ? vertex_ai/gemini-2.5-flash-lite-preview-06-17
  ? vertex_ai/gemini-2.5-flash-preview-04-17
  ? vertex_ai/gemini-2.5-pro
  ? vertex_ai/gemini-2.5-pro-exp-03-25
  ? vertex_ai/gemini-2.5-pro-preview-03-25
  ? vertex_ai/gemini-2.5-pro-preview-05-06
- Total models: 12 (dropdown: 7)

```

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: GitHub Actions (`sync_provider_models.yml`)
  - Model(s): N/A (scripted automation)
  - Scope: Automated model list sync
  - Human verification: Requires manual review before merge

## Testing

- Script dry-run passed in CI
- Changes are add-only; stale/deprecated models flagged for manual review

## Documentation

N/A