### PR TITLE
[OPIK-6066] [FE] perf: improve first load time (cache + v2 default + lazy pages)

### DIFF
--- a/apps/opik-frontend/src/WorkspaceVersionGate.tsx
+++ b/apps/opik-frontend/src/WorkspaceVersionGate.tsx
@@ -17,11 +17,14 @@
  *   1. Workspace is now fully resolved (auth, access, header set)
  *   2. Fetch version via React Query (reuses existing providers)
  *   3. Write the resolved version to the localStorage cache
- *   4. If it disagrees with what the gate picked → update the store so this
- *      gate re-renders and Suspense lazy-swaps V1App ↔ V2App in place.
+ *   4. If it disagrees with what the gate picked → hard reload so the next
+ *      module load picks the correct App synchronously from the cache.
  *
- * The gate's guess is optimistic; the Resolver self-corrects with an
- * in-place subtree swap — no page reload, no Loader flash on first paint.
+ * Reload is required because each App instantiates its own TanStack Router
+ * at module scope. Swapping apps in place leaves the inactive router's URL
+ * state stale and causes the two WorkspacePreloaders to disagree on the
+ * active workspace. A full reload re-evaluates modules with the current
+ * browser URL and resets both routers to a consistent initial state.
  */
 import React, { Suspense } from "react";
 import useAppStore, { useWorkspaceVersion } from "@/store/AppStore";

--- a/apps/opik-frontend/src/WorkspaceVersionGate.tsx
+++ b/apps/opik-frontend/src/WorkspaceVersionGate.tsx
@@ -11,12 +11,15 @@
  *   1. Check localStorage override ("opik-version-override") → use immediately
  *   2. Else parse the workspace name from window.location
  *      (path segment for normal URLs, ?workspace= query for pair links)
- *   3. If found → fetch version from API with per-request Comet-Workspace header
- *   4. If not found (e.g. root "/") → default to v1 optimistically
+ *   3. If found → check the localStorage cache ("opik-workspace-versions");
+ *      on cache miss, fetch the version from the API with a per-request
+ *      Comet-Workspace header
+ *   4. If not found (e.g. root "/") → default to v2 optimistically
  *
- * Steps 1 and 4 are synchronous and run at module load, so the first paint
- * already knows which App to render — no Loader flash in the common cases.
- * Only step 3 (workspace in URL, version unknown) falls back to a Loader.
+ * Steps 1, 4, and the cache-hit branch of 3 are synchronous and run at module
+ * load, so the first paint already knows which App to render — no Loader
+ * flash in the common cases. Only step 3 with a cache miss falls back to a
+ * Loader while the API resolves.
  *
  * Level 2 — WorkspaceVersionResolver (INSIDE the router, after WorkspacePreloader):
  *   1. Workspace is now fully resolved (auth, access, header set)
@@ -33,6 +36,7 @@ import { fetchWorkspaceVersion } from "@/api/workspaces/useWorkspaceVersion";
 import {
   getWorkspaceNameFromUrl,
   resolveSyncWorkspaceVersion,
+  setCachedWorkspaceVersion,
 } from "@/lib/workspaceVersion";
 import Loader from "@/shared/Loader/Loader";
 
@@ -54,9 +58,9 @@ const WorkspaceVersionGate = () => {
 
     let cancelled = false;
     fetchWorkspaceVersion({ workspaceName }).then((resolved) => {
-      if (!cancelled) {
-        useAppStore.getState().setWorkspaceVersion(resolved);
-      }
+      if (cancelled) return;
+      useAppStore.getState().setWorkspaceVersion(resolved);
+      setCachedWorkspaceVersion(workspaceName, resolved);
     });
     return () => {
       cancelled = true;

--- a/apps/opik-frontend/src/WorkspaceVersionGate.tsx
+++ b/apps/opik-frontend/src/WorkspaceVersionGate.tsx
@@ -8,68 +8,33 @@
  * We break the circle with two levels of checks:
  *
  * Level 1 — WorkspaceVersionGate (this component, BEFORE the router):
- *   1. Check localStorage override ("opik-version-override") → use immediately
- *   2. Else parse the workspace name from window.location
- *      (path segment for normal URLs, ?workspace= query for pair links)
- *   3. If found → check the localStorage cache ("opik-workspace-versions");
- *      on cache miss, fetch the version from the API with a per-request
- *      Comet-Workspace header
- *   4. If not found (e.g. root "/") → default to v2 optimistically
- *
- * Steps 1, 4, and the cache-hit branch of 3 are synchronous and run at module
- * load, so the first paint already knows which App to render — no Loader
- * flash in the common cases. Only step 3 with a cache miss falls back to a
- * Loader while the API resolves.
+ *   resolveSyncWorkspaceVersion() always returns a version synchronously
+ *   from: override > per-workspace cache > DEFAULT_WORKSPACE_VERSION.
+ *   First paint renders the chosen App immediately — no Loader, no API
+ *   call at this stage.
  *
  * Level 2 — WorkspaceVersionResolver (INSIDE the router, after WorkspacePreloader):
  *   1. Workspace is now fully resolved (auth, access, header set)
  *   2. Fetch version via React Query (reuses existing providers)
- *   3. If version matches what the gate picked → continue
- *   4. If mismatch → hard reload (URL now contains workspace → Level 1 gets it right)
+ *   3. Write the resolved version to the localStorage cache
+ *   4. If it disagrees with what the gate picked → update the store so this
+ *      gate re-renders and Suspense lazy-swaps V1App ↔ V2App in place.
  *
- * This ensures the correct router loads on first paint when workspace is in
- * the URL, and self-corrects via reload in the rare optimistic-default case.
+ * The gate's guess is optimistic; the Resolver self-corrects with an
+ * in-place subtree swap — no page reload, no Loader flash on first paint.
  */
-import React, { Suspense, useEffect } from "react";
+import React, { Suspense } from "react";
 import useAppStore, { useWorkspaceVersion } from "@/store/AppStore";
-import { fetchWorkspaceVersion } from "@/api/workspaces/useWorkspaceVersion";
-import {
-  getWorkspaceNameFromUrl,
-  resolveSyncWorkspaceVersion,
-  setCachedWorkspaceVersion,
-} from "@/lib/workspaceVersion";
+import { resolveSyncWorkspaceVersion } from "@/lib/workspaceVersion";
 import Loader from "@/shared/Loader/Loader";
 
 const V1App = React.lazy(() => import("@/v1/App"));
 const V2App = React.lazy(() => import("@/v2/App"));
 
-const initialVersion = resolveSyncWorkspaceVersion();
-if (initialVersion) {
-  useAppStore.getState().setWorkspaceVersion(initialVersion);
-}
+useAppStore.getState().setWorkspaceVersion(resolveSyncWorkspaceVersion());
 
 const WorkspaceVersionGate = () => {
   const version = useWorkspaceVersion();
-
-  useEffect(() => {
-    if (useAppStore.getState().workspaceVersion) return;
-    const workspaceName = getWorkspaceNameFromUrl();
-    if (!workspaceName) return;
-
-    let cancelled = false;
-    fetchWorkspaceVersion({ workspaceName }).then((resolved) => {
-      if (cancelled) return;
-      useAppStore.getState().setWorkspaceVersion(resolved);
-      setCachedWorkspaceVersion(workspaceName, resolved);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  if (!version) {
-    return <Loader />;
-  }
 
   return (
     <Suspense fallback={<Loader />}>

--- a/apps/opik-frontend/src/lib/workspaceVersion.ts
+++ b/apps/opik-frontend/src/lib/workspaceVersion.ts
@@ -1,12 +1,45 @@
 import { WorkspaceVersion } from "@/store/AppStore";
 
-export const DEFAULT_WORKSPACE_VERSION: WorkspaceVersion = "v1";
+export const DEFAULT_WORKSPACE_VERSION: WorkspaceVersion = "v2";
 
 const OPIK_VERSION_OVERRIDE_KEY = "opik-version-override";
+const OPIK_WORKSPACE_VERSIONS_KEY = "opik-workspace-versions";
 
 export function getVersionOverride(): WorkspaceVersion | null {
   const override = localStorage.getItem(OPIK_VERSION_OVERRIDE_KEY);
   return override === "v1" || override === "v2" ? override : null;
+}
+
+function readVersionMap(): Record<string, WorkspaceVersion> {
+  try {
+    const raw = localStorage.getItem(OPIK_WORKSPACE_VERSIONS_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function getCachedWorkspaceVersion(
+  workspaceName: string,
+): WorkspaceVersion | null {
+  const v = readVersionMap()[workspaceName];
+  return v === "v1" || v === "v2" ? v : null;
+}
+
+export function setCachedWorkspaceVersion(
+  workspaceName: string,
+  version: WorkspaceVersion,
+): void {
+  try {
+    const map = readVersionMap();
+    if (map[workspaceName] === version) return;
+    map[workspaceName] = version;
+    localStorage.setItem(OPIK_WORKSPACE_VERSIONS_KEY, JSON.stringify(map));
+  } catch {
+    // localStorage unavailable (private mode, quota) — silently skip
+  }
 }
 
 function getRelativePathSegments(): string[] {
@@ -31,11 +64,12 @@ export function getWorkspaceNameFromUrl(): string | null {
   return segments[0] || null;
 }
 
-// Returns null only when the workspace is in the URL but needs an API fetch
-// to resolve its version — the one case that requires a Loader fallback.
+// Returns null only when the workspace is in the URL, has no cached version,
+// and needs an API fetch — the one case that requires a Loader fallback.
 export function resolveSyncWorkspaceVersion(): WorkspaceVersion | null {
   const override = getVersionOverride();
   if (override) return override;
-  if (!getWorkspaceNameFromUrl()) return DEFAULT_WORKSPACE_VERSION;
-  return null;
+  const workspaceName = getWorkspaceNameFromUrl();
+  if (!workspaceName) return DEFAULT_WORKSPACE_VERSION;
+  return getCachedWorkspaceVersion(workspaceName);
 }

--- a/apps/opik-frontend/src/lib/workspaceVersion.ts
+++ b/apps/opik-frontend/src/lib/workspaceVersion.ts
@@ -64,12 +64,13 @@ export function getWorkspaceNameFromUrl(): string | null {
   return segments[0] || null;
 }
 
-// Returns null only when the workspace is in the URL, has no cached version,
-// and needs an API fetch — the one case that requires a Loader fallback.
-export function resolveSyncWorkspaceVersion(): WorkspaceVersion | null {
+// Always returns a version synchronously: override > per-workspace cache >
+// default. WorkspaceVersionResolver verifies via API after mount and swaps
+// the App in place if the guess was wrong.
+export function resolveSyncWorkspaceVersion(): WorkspaceVersion {
   const override = getVersionOverride();
   if (override) return override;
   const workspaceName = getWorkspaceNameFromUrl();
   if (!workspaceName) return DEFAULT_WORKSPACE_VERSION;
-  return getCachedWorkspaceVersion(workspaceName);
+  return getCachedWorkspaceVersion(workspaceName) ?? DEFAULT_WORKSPACE_VERSION;
 }

--- a/apps/opik-frontend/src/shared/WorkspaceVersionResolver/PairRouteVersionGuard.tsx
+++ b/apps/opik-frontend/src/shared/WorkspaceVersionResolver/PairRouteVersionGuard.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect } from "react";
+import useAppStore, { useActiveWorkspaceName } from "@/store/AppStore";
+import { getWorkspaceNameFromUrl } from "@/lib/workspaceVersion";
+import WorkspaceVersionResolver from "@/shared/WorkspaceVersionResolver/WorkspaceVersionResolver";
+import Loader from "@/shared/Loader/Loader";
+
+/**
+ * Pair routes (/pair/v1 and the /opik/pair/v1 OSS alias) render outside
+ * WorkspaceGuard — they must work without a logged-in session. That means
+ * WorkspaceVersionResolver normally cannot mount on these routes, so a
+ * wrong gate guess (e.g. v2 default on a v1 workspace) would render the
+ * wrong pair page.
+ *
+ * This guard seeds activeWorkspaceName from the pair URL's ?workspace=
+ * query and mounts WorkspaceVersionResolver so the API-side check +
+ * reload-on-mismatch flow runs for pair routes too.
+ */
+const PairRouteVersionGuard: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const workspaceFromUrl = getWorkspaceNameFromUrl();
+  const active = useActiveWorkspaceName();
+
+  useEffect(() => {
+    if (workspaceFromUrl && workspaceFromUrl !== active) {
+      useAppStore.getState().setActiveWorkspaceName(workspaceFromUrl);
+    }
+  }, [workspaceFromUrl, active]);
+
+  // Resolver keys its query off useActiveWorkspaceName and early-returns
+  // while it is empty. Show a Loader until the store reflects the URL.
+  if (workspaceFromUrl && !active) return <Loader />;
+
+  return <WorkspaceVersionResolver>{children}</WorkspaceVersionResolver>;
+};
+
+export default PairRouteVersionGuard;

--- a/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
+++ b/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
@@ -4,7 +4,10 @@ import useAppStore, {
   useWorkspaceVersion,
 } from "@/store/AppStore";
 import useWorkspaceVersionQuery from "@/api/workspaces/useWorkspaceVersion";
-import { getVersionOverride } from "@/lib/workspaceVersion";
+import {
+  getVersionOverride,
+  setCachedWorkspaceVersion,
+} from "@/lib/workspaceVersion";
 import Loader from "@/shared/Loader/Loader";
 
 const VERSION_RELOAD_PREFIX = "opik-version-reload:";
@@ -28,6 +31,7 @@ const WorkspaceVersionResolver: React.FC<WorkspaceVersionResolverProps> = ({
     if (!resolvedVersion || !workspaceName) return;
 
     useAppStore.getState().setWorkspaceVersion(resolvedVersion);
+    setCachedWorkspaceVersion(workspaceName, resolvedVersion);
 
     const reloadKey = VERSION_RELOAD_PREFIX + workspaceName;
 

--- a/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
+++ b/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
@@ -10,9 +10,6 @@ import {
 } from "@/lib/workspaceVersion";
 import Loader from "@/shared/Loader/Loader";
 
-const VERSION_RELOAD_PREFIX = "opik-version-reload:";
-const MAX_RELOADS = 2;
-
 type WorkspaceVersionResolverProps = {
   children: React.ReactNode;
 };
@@ -29,20 +26,9 @@ const WorkspaceVersionResolver: React.FC<WorkspaceVersionResolverProps> = ({
 
   useEffect(() => {
     if (!resolvedVersion || !workspaceName) return;
-
-    useAppStore.getState().setWorkspaceVersion(resolvedVersion);
     setCachedWorkspaceVersion(workspaceName, resolvedVersion);
-
-    const reloadKey = VERSION_RELOAD_PREFIX + workspaceName;
-
-    if (gateVersion && resolvedVersion !== gateVersion) {
-      const reloadCount = Number(sessionStorage.getItem(reloadKey) || "0");
-      if (reloadCount < MAX_RELOADS) {
-        sessionStorage.setItem(reloadKey, String(reloadCount + 1));
-        window.location.reload();
-      }
-    } else {
-      sessionStorage.removeItem(reloadKey);
+    if (resolvedVersion !== gateVersion) {
+      useAppStore.getState().setWorkspaceVersion(resolvedVersion);
     }
   }, [resolvedVersion, gateVersion, workspaceName]);
 

--- a/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
+++ b/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
@@ -10,6 +10,9 @@ import {
 } from "@/lib/workspaceVersion";
 import Loader from "@/shared/Loader/Loader";
 
+const VERSION_RELOAD_PREFIX = "opik-version-reload:";
+const MAX_RELOADS = 2;
+
 type WorkspaceVersionResolverProps = {
   children: React.ReactNode;
 };
@@ -26,9 +29,20 @@ const WorkspaceVersionResolver: React.FC<WorkspaceVersionResolverProps> = ({
 
   useEffect(() => {
     if (!resolvedVersion || !workspaceName) return;
+
+    useAppStore.getState().setWorkspaceVersion(resolvedVersion);
     setCachedWorkspaceVersion(workspaceName, resolvedVersion);
-    if (resolvedVersion !== gateVersion) {
-      useAppStore.getState().setWorkspaceVersion(resolvedVersion);
+
+    const reloadKey = VERSION_RELOAD_PREFIX + workspaceName;
+
+    if (gateVersion && resolvedVersion !== gateVersion) {
+      const reloadCount = Number(sessionStorage.getItem(reloadKey) || "0");
+      if (reloadCount < MAX_RELOADS) {
+        sessionStorage.setItem(reloadKey, String(reloadCount + 1));
+        window.location.reload();
+      }
+    } else {
+      sessionStorage.removeItem(reloadKey);
     }
   }, [resolvedVersion, gateVersion, workspaceName]);
 

--- a/apps/opik-frontend/src/v1/router.tsx
+++ b/apps/opik-frontend/src/v1/router.tsx
@@ -55,6 +55,7 @@ import TestSuitesPage from "@/v1/pages/TestSuitesPage/TestSuitesPage";
 import TestSuitePage from "@/v1/pages/TestSuitePage/TestSuitePage";
 import TestSuiteItemsPage from "@/v1/pages/TestSuiteItemsPage/TestSuiteItemsPage";
 import PairV1Page from "@/v1/pages/PairV1Page/PairV1Page";
+import PairRouteVersionGuard from "@/shared/WorkspaceVersionResolver/PairRouteVersionGuard";
 
 const TanStackRouterDevtools =
   process.env.NODE_ENV === "production"
@@ -111,15 +112,20 @@ const workspaceGuardEmptyLayoutRoute = createRoute({
 // "/opik/" prefix isn't stripped and the router sees "/opik/pair/v1".
 // TODO: make the Python SDK build basepath-aware pairing URLs and drop
 // this alias once shipped CLI versions roll over.
+const PairRouteComponent = () => (
+  <PairRouteVersionGuard>
+    <PairV1Page />
+  </PairRouteVersionGuard>
+);
 const pairingRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/pair/v1",
-  component: PairV1Page,
+  component: PairRouteComponent,
 });
 const pairingRouteOssAlias = createRoute({
   getParentRoute: () => rootRoute,
   path: "/opik/pair/v1",
-  component: PairV1Page,
+  component: PairRouteComponent,
 });
 
 const baseRoute = createRoute({

--- a/apps/opik-frontend/src/v1/router.tsx
+++ b/apps/opik-frontend/src/v1/router.tsx
@@ -15,7 +15,9 @@ import DashboardsPageGuard from "@/v1/layout/DashboardsPageGuard";
 import PlaygroundPageGuard from "@/v1/layout/PlaygroundPageGuard";
 import SMEPageLayout from "@/v1/layout/SMEPageLayout/SMEPageLayout";
 import ExperimentsPage from "@/v1/pages/ExperimentsPage/ExperimentsPage";
-import CompareExperimentsPage from "@/v1/pages/CompareExperimentsPage/CompareExperimentsPage";
+const CompareExperimentsPage = lazy(
+  () => import("@/v1/pages/CompareExperimentsPage/CompareExperimentsPage"),
+);
 import HomePage from "@/v1/pages/HomePage/HomePage";
 import OldHomePage from "@/v1/pages/HomePage/OldHomePage";
 import PartialPageLayout from "@/v1/layout/PartialPageLayout/PartialPageLayout";
@@ -25,10 +27,12 @@ import ProjectsPage from "@/v1/pages/ProjectsPage/ProjectsPage";
 import TracesPage from "@/v1/pages/TracesPage/TracesPage";
 import WorkspacePage from "@/v1/pages/WorkspacePage/WorkspacePage";
 import PromptsPage from "@/v1/pages/PromptsPage/PromptsPage";
-import PromptPage from "@/v1/pages/PromptPage/PromptPage";
+const PromptPage = lazy(() => import("@/v1/pages/PromptPage/PromptPage"));
 import RedirectProjects from "@/v1/redirect/RedirectProjects";
 import RedirectDatasets from "@/v1/redirect/RedirectDatasets";
-import PlaygroundPage from "@/v1/pages/PlaygroundPage/PlaygroundPage";
+const PlaygroundPage = lazy(
+  () => import("@/v1/pages/PlaygroundPage/PlaygroundPage"),
+);
 import useAppStore from "@/store/AppStore";
 import ConfigurationPage from "@/v1/pages/ConfigurationPage/ConfigurationPage";
 import GetStartedPage from "@/v1/pages/GetStartedPage/GetStartedPage";
@@ -41,7 +45,9 @@ import OptimizationsNewPage from "@/v1/pages/OptimizationsPage/OptimizationsNewP
 import OptimizationPage from "@/v1/pages/OptimizationPage/OptimizationPage";
 import OptimizationCompareRedirect from "@/v1/pages/OptimizationPage/OptimizationCompareRedirect";
 import TrialPage from "@/v1/pages/TrialPage/TrialPage";
-import AlertsRouteWrapper from "@/v1/pages/AlertsPage/AlertsRouteWrapper";
+const AlertsRouteWrapper = lazy(
+  () => import("@/v1/pages/AlertsPage/AlertsRouteWrapper"),
+);
 import AlertEditPageGuard from "@/v1/layout/AlertEditPageGuard/AlertEditPageGuard";
 import DashboardPage from "@/v1/pages/DashboardPage/DashboardPage";
 import DashboardsPage from "@/v1/pages/DashboardsPage/DashboardsPage";

--- a/apps/opik-frontend/src/v2/router.tsx
+++ b/apps/opik-frontend/src/v2/router.tsx
@@ -15,7 +15,9 @@ import PlaygroundPageGuard from "@/v2/layout/PlaygroundPageGuard";
 import DatasetsPageGuard from "@/v2/layout/DatasetsPageGuard";
 import SMEPageLayout from "@/v2/layout/SMEPageLayout/SMEPageLayout";
 import ExperimentsPage from "@/v2/pages/ExperimentsPage/ExperimentsPage";
-import CompareExperimentsPage from "@/v2/pages/CompareExperimentsPage/CompareExperimentsPage";
+const CompareExperimentsPage = lazy(
+  () => import("@/v2/pages/CompareExperimentsPage/CompareExperimentsPage"),
+);
 import HomePage from "@/v2/pages/HomePage/HomePage";
 import PartialPageLayout from "@/v2/layout/PartialPageLayout/PartialPageLayout";
 import EmptyPageLayout from "@/v2/layout/EmptyPageLayout/EmptyPageLayout";
@@ -26,7 +28,9 @@ import WorkspacePage from "@/v2/pages/WorkspacePage/WorkspacePage";
 import RedirectProjects from "@/v2/redirect/RedirectProjects";
 import RedirectDatasets from "@/v2/redirect/RedirectDatasets";
 import { createV1RedirectRoutes } from "@/v2/redirect/v1RedirectConfig";
-import PlaygroundPage from "@/v2/pages/PlaygroundPage/PlaygroundPage";
+const PlaygroundPage = lazy(
+  () => import("@/v2/pages/PlaygroundPage/PlaygroundPage"),
+);
 import useAppStore from "@/store/AppStore";
 import ConfigurationPage from "@/v2/pages/ConfigurationPage/ConfigurationPage";
 import NewQuickstart from "@/v2/pages/GetStartedPage/NewQuickstart";
@@ -42,7 +46,9 @@ import OptimizationsNewPage from "@/v2/pages/OptimizationsPage/OptimizationsNewP
 import OptimizationPage from "@/v2/pages/OptimizationPage/OptimizationPage";
 import OptimizationCompareRedirect from "@/v2/pages/OptimizationPage/OptimizationCompareRedirect";
 import TrialPage from "@/v2/pages/TrialPage/TrialPage";
-import AlertsRouteWrapper from "@/v2/pages/AlertsPage/AlertsRouteWrapper";
+const AlertsRouteWrapper = lazy(
+  () => import("@/v2/pages/AlertsPage/AlertsRouteWrapper"),
+);
 import AlertEditPageGuard from "@/v2/layout/AlertEditPageGuard/AlertEditPageGuard";
 import DashboardPage from "@/v2/pages/DashboardPage/DashboardPage";
 import DashboardsPage from "@/v2/pages/DashboardsPage/DashboardsPage";

--- a/apps/opik-frontend/src/v2/router.tsx
+++ b/apps/opik-frontend/src/v2/router.tsx
@@ -41,6 +41,7 @@ import AnnotationQueuePage from "@/v2/pages/AnnotationQueuePage/AnnotationQueueP
 import AgentConfigurationPage from "@/v2/pages/AgentConfigurationPage/AgentConfigurationPage";
 import AgentRunnerPage from "@/v2/pages/AgentRunnerPage/AgentRunnerPage";
 import PairingPage from "@/v2/pages/PairingPage/PairingPage";
+import PairRouteVersionGuard from "@/shared/WorkspaceVersionResolver/PairRouteVersionGuard";
 import OptimizationsPage from "@/v2/pages/OptimizationsPage/OptimizationsPage";
 import OptimizationsNewPage from "@/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPage";
 import OptimizationPage from "@/v2/pages/OptimizationPage/OptimizationPage";
@@ -116,15 +117,20 @@ const workspaceGuardEmptyLayoutRoute = createRoute({
 // "/opik/" prefix isn't stripped and the router sees "/opik/pair/v1".
 // TODO: make the Python SDK build basepath-aware pairing URLs and drop
 // this alias once shipped CLI versions roll over.
+const PairRouteComponent = () => (
+  <PairRouteVersionGuard>
+    <PairingPage />
+  </PairRouteVersionGuard>
+);
 const pairingRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/pair/v1",
-  component: PairingPage,
+  component: PairRouteComponent,
 });
 const pairingRouteOssAlias = createRoute({
   getParentRoute: () => rootRoute,
   path: "/opik/pair/v1",
-  component: PairingPage,
+  component: PairRouteComponent,
 });
 
 // ----------- base redirect


### PR DESCRIPTION
## Details

Addresses the post-signup/post-login first-load slowness in Opik FE. Ships four low-risk, independently-revertable changes on top of `main` that together cut LCP on fresh-signup flow by ~20% on dev.comet.com (median 14.9s → 12.2s, measured across 6 signups).

- **Per-workspace version cache + v2 default** (`src/lib/workspaceVersion.ts`, `src/WorkspaceVersionGate.tsx`, `src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx`) — returning users land on the correct App synchronously from `localStorage["opik-workspace-versions"]`; fresh users fall back to `v2` instead of `v1` (aligned with product direction).
- **Drop the gate's API fetch and Loader branch** — `resolveSyncWorkspaceVersion` now always returns a version. The pre-render `/workspaces/versions` call is gone; `WorkspaceVersionResolver` remains the single source of truth for API verification.
- **Lazy-load heaviest non-critical pages** (`src/v1/router.tsx`, `src/v2/router.tsx`) — `PlaygroundPage`, `PromptPage`, `CompareExperimentsPage`, `AlertsRouteWrapper` (+ `TracesPage` for v1 only kept eager as it's on the critical path). V1 App chunk −131 KB, V2 App chunk −119 KB.
- **Kept the reload on version mismatch** — an earlier attempt to swap V1App ↔ V2App in place caused an infinite swap loop when switching between workspaces of different versions (stale TanStack Router URL state on module-scoped router instances). Reverted that change; reload path is unchanged from `main`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6066

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: investigation + implementation + measurement
- Human verification: code review + lint + typecheck + dependency-cruiser + manual dev.comet.com signup flow (6 accounts, before/after Chrome DevTools traces)

## Testing

- `bash scripts/dev-runner.sh --lint-fe` — ESLint, TypeScript, and dependency-cruiser all green
- `npm run build` (in `apps/opik-frontend`) — production build green; measured chunk sizes confirm V1App −131 KB / V2App −119 KB vs. pre-change baseline
- Manual dev.comet.com signup flow — 6 fresh signups in isolated Chrome contexts using Chrome DevTools MCP performance tracing:
  - Before: median LCP 14,947 ms (runs 1-3)
  - After: median LCP 12,193 ms (runs 4-6) → ~18-20% reduction
  - Verified `opik-workspace-versions` localStorage cache populates correctly on every run
  - Verified `/workspaces/versions` is no longer called pre-render
  - Verified no V1App chunk loads when the workspace is v2
- Not run: unit tests (no existing coverage for `workspaceVersion.ts` helpers; not introduced in this PR per scope)
- Rebased on latest `main` (`origin/main` at `272021b7aa`) — no conflicts

## Documentation

N/A — no user-facing docs changes. Investigation + measurement notes live in the associated Jira ticket (OPIK-6066) and its follow-ups (OPIK-6149, OPIK-6150, OPIK-6151, OPIK-6153).