### PR TITLE
[OPIK-5623][FE]: align quickstart and onboarding;

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationsTabs/InstallWithAITab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationsTabs/InstallWithAITab.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useAgentOnboarding } from "./AgentOnboardingContext";
 import { useUserApiKey, useActiveWorkspaceName } from "@/store/AppStore";
 import { buildDocsUrl } from "@/lib/utils";
 import TimelineStep from "@/shared/TimelineStep/TimelineStep";
@@ -10,17 +9,21 @@ import cursorLogo from "/images/integrations/cursor.svg";
 import { INSTALL_OPIK_SKILLS_COMMAND } from "@/constants/shared";
 
 interface InstallWithAITabProps {
-  traceReceived: boolean;
+  agentName: string;
+  traceReceived?: boolean;
+  showWaitingStep?: boolean;
 }
 
 const InstallWithAITab: React.FC<InstallWithAITabProps> = ({
-  traceReceived,
+  agentName,
+  traceReceived = false,
+  showWaitingStep = true,
 }) => {
-  const { agentName } = useAgentOnboarding();
   const apiKey = useUserApiKey();
   const workspaceName = useActiveWorkspaceName();
 
-  const promptText = `Instrument my agent with Opik using the /instrument command. Make sure you use workspace "${workspaceName}", project name "${agentName}"${
+  const projectPart = agentName ? `, project name "${agentName}"` : "";
+  const promptText = `Instrument my agent with Opik using the /instrument command. Make sure you use workspace "${workspaceName}"${projectPart}${
     apiKey ? ` and API key "${apiKey}"` : ""
   }. Once you are ready with the instrumentation of your agent, run it with a couple of interactions so that we make sure that the observability is correctly instrumented and the right traces are flowing to the Opik dashboard.`;
 
@@ -55,7 +58,7 @@ const InstallWithAITab: React.FC<InstallWithAITabProps> = ({
           </div>
         </TimelineStep>
 
-        <TimelineStep number={2}>
+        <TimelineStep number={2} isLast={!showWaitingStep}>
           <div className="flex flex-col gap-2.5">
             <h4 className="comet-body-s-accented">
               Open your coding agent and paste this prompt
@@ -68,33 +71,35 @@ const InstallWithAITab: React.FC<InstallWithAITabProps> = ({
           </div>
         </TimelineStep>
 
-        <TimelineStep isLast completed={traceReceived}>
-          <div className="flex flex-col gap-1">
-            <h4 className="comet-body-s-accented text-primary">
-              {traceReceived
-                ? "First trace received! You're all set."
-                : "Waiting for first trace\u2026"}
-            </h4>
-            <p className="comet-body-xs text-muted-slate">
-              {traceReceived ? (
-                "Traces are flowing. You can now debug, evaluate, and optimize."
-              ) : (
-                <>
-                  Connect your agent to Opik for observability, evaluation and
-                  optimization.{" "}
-                  <a
-                    href={buildDocsUrl("/faq", "#troubleshooting")}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline hover:text-foreground"
-                  >
-                    Why isn&apos;t my trace showing?
-                  </a>
-                </>
-              )}
-            </p>
-          </div>
-        </TimelineStep>
+        {showWaitingStep && (
+          <TimelineStep isLast completed={traceReceived}>
+            <div className="flex flex-col gap-1">
+              <h4 className="comet-body-s-accented text-primary">
+                {traceReceived
+                  ? "First trace received! You're all set."
+                  : "Waiting for first trace\u2026"}
+              </h4>
+              <p className="comet-body-xs text-muted-slate">
+                {traceReceived ? (
+                  "Traces are flowing. You can now debug, evaluate, and optimize."
+                ) : (
+                  <>
+                    Connect your agent to Opik for observability, evaluation and
+                    optimization.{" "}
+                    <a
+                      href={buildDocsUrl("/faq", "#troubleshooting")}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline hover:text-foreground"
+                    >
+                      Why isn&apos;t my trace showing?
+                    </a>
+                  </>
+                )}
+              </p>
+            </div>
+          </TimelineStep>
+        )}
       </div>
     </div>
   );

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationsTabs/ManualIntegrationDetail.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationsTabs/ManualIntegrationDetail.tsx
@@ -6,16 +6,16 @@ import useAppStore, { useUserApiKey } from "@/store/AppStore";
 import { putConfigInCode } from "@/lib/formatCodeSnippets";
 import { Integration } from "@/constants/integrations";
 import { INSTALL_OPIK_SECTION_TITLE } from "@/constants/shared";
-import { useAgentOnboarding } from "./AgentOnboardingContext";
 
 type ManualIntegrationDetailProps = {
   integration: Integration;
+  agentName: string;
 };
 
 const ManualIntegrationDetail: React.FC<ManualIntegrationDetailProps> = ({
   integration,
+  agentName,
 }) => {
-  const { agentName } = useAgentOnboarding();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const apiKey = useUserApiKey();
 

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationsTabs/ManualIntegrationList.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationsTabs/ManualIntegrationList.tsx
@@ -5,7 +5,6 @@ import { THEME_MODE } from "@/constants/theme";
 import { ToggleGroup, ToggleGroupItem } from "@/ui/toggle-group";
 import IntegrationCard from "@/v2/pages-shared/onboarding/IntegrationExplorer/components/IntegrationCard";
 import CopyButton from "@/shared/CopyButton/CopyButton";
-import { useAgentOnboarding } from "./AgentOnboardingContext";
 import { useUserApiKey } from "@/store/AppStore";
 import { maskAPIKey } from "@/lib/utils";
 import {
@@ -18,9 +17,11 @@ import InstallWithAITab from "./InstallWithAITab";
 const INSTALL_WITH_AI = "install-with-ai";
 
 type ManualIntegrationListProps = {
+  agentName: string;
   onSelectIntegration: (id: string) => void;
   showInstallWithAI?: boolean;
   traceReceived?: boolean;
+  showWaitingStep?: boolean;
   activeCategory?: string | null;
   onCategoryChange?: (category: string) => void;
 };
@@ -35,13 +36,14 @@ const CATEGORY_TABS = [
 ] as const;
 
 const ManualIntegrationList: React.FC<ManualIntegrationListProps> = ({
+  agentName,
   onSelectIntegration,
   showInstallWithAI = false,
   traceReceived = false,
+  showWaitingStep = true,
   activeCategory: controlledCategory,
   onCategoryChange,
 }) => {
-  const { agentName } = useAgentOnboarding();
   const apiKey = useUserApiKey();
   const { themeMode } = useTheme();
 
@@ -61,21 +63,23 @@ const ManualIntegrationList: React.FC<ManualIntegrationListProps> = ({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex gap-3">
-        <div className="flex flex-1 flex-col gap-1">
-          <span className="comet-body-s-accented px-0.5 pb-0.5">
-            Project name
-          </span>
-          <div className="flex h-8 items-center gap-1 rounded border bg-primary-foreground px-2.5">
-            <code className="comet-body-s text-muted-slate">{agentName}</code>
-            <CopyButton
-              text={agentName}
-              message="Project name copied"
-              tooltipText="Copy project name"
-              size="icon-3xs"
-              className="ml-auto"
-            />
+        {agentName && (
+          <div className="flex flex-1 flex-col gap-1">
+            <span className="comet-body-s-accented px-0.5 pb-0.5">
+              Project name
+            </span>
+            <div className="flex h-8 items-center gap-1 rounded border bg-primary-foreground px-2.5">
+              <code className="comet-body-s text-muted-slate">{agentName}</code>
+              <CopyButton
+                text={agentName}
+                message="Project name copied"
+                tooltipText="Copy project name"
+                size="icon-3xs"
+                className="ml-auto"
+              />
+            </div>
           </div>
-        </div>
+        )}
         {apiKey && (
           <div className="flex flex-1 flex-col gap-1">
             <span className="comet-body-s-accented px-0.5 pb-0.5">API key</span>
@@ -124,7 +128,11 @@ const ManualIntegrationList: React.FC<ManualIntegrationListProps> = ({
         </ToggleGroup>
 
         {activeCategory === INSTALL_WITH_AI ? (
-          <InstallWithAITab traceReceived={traceReceived} />
+          <InstallWithAITab
+            agentName={agentName}
+            traceReceived={traceReceived}
+            showWaitingStep={showWaitingStep}
+          />
         ) : (
           <div className="grid grid-cols-4 gap-2">
             {integrations.map((integration) => (

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/QuickstartDialog/QuickstartDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/QuickstartDialog/QuickstartDialog.tsx
@@ -1,47 +1,112 @@
-import SideDialog from "@/shared/SideDialog/SideDialog";
-import React from "react";
-import { SheetTitle } from "@/ui/sheet";
-import { IntegrationExplorer } from "@/v2/pages-shared/onboarding/IntegrationExplorer";
+import React, { useState } from "react";
+import { Undo2 } from "lucide-react";
+
+import {
+  Dialog,
+  DialogAutoScrollBody,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/ui/dialog";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/ui/tabs";
+import { Button } from "@/ui/button";
 import { useLayoutDialog } from "@/hooks/useLayoutDialog";
+import { useActiveProjectId } from "@/store/AppStore";
+import useProjectById from "@/api/projects/useProjectById";
+import { INTEGRATIONS } from "@/constants/integrations";
+import InstallWithAITab from "@/v2/pages-shared/onboarding/IntegrationsTabs/InstallWithAITab";
+import ManualIntegrationList from "@/v2/pages-shared/onboarding/IntegrationsTabs/ManualIntegrationList";
+import ManualIntegrationDetail from "@/v2/pages-shared/onboarding/IntegrationsTabs/ManualIntegrationDetail";
+
+const AI_ASSISTED_TAB = "ai-assisted";
+const MANUAL_TAB = "manual";
 
 const useOpenQuickStartDialog = () => useLayoutDialog("quickstart");
+
+const QuickstartContent: React.FC = () => {
+  const projectId = useActiveProjectId();
+  const { data: project } = useProjectById(
+    { projectId: projectId ?? "" },
+    { enabled: !!projectId },
+  );
+  const agentName = project?.name ?? "";
+
+  const [activeTab, setActiveTab] = useState(AI_ASSISTED_TAB);
+  const [manualCategory, setManualCategory] = useState<string | null>(null);
+  const [selectedIntegrationId, setSelectedIntegrationId] = useState<
+    string | null
+  >(null);
+
+  const selectedIntegration = selectedIntegrationId
+    ? INTEGRATIONS.find((i) => i.id === selectedIntegrationId)
+    : undefined;
+
+  const handleTabChange = (value: string) => {
+    setActiveTab(value);
+    setSelectedIntegrationId(null);
+  };
+
+  if (selectedIntegration) {
+    return (
+      <div className="flex flex-col gap-5">
+        <Button
+          variant="outline"
+          size="xs"
+          onClick={() => setSelectedIntegrationId(null)}
+          className="w-fit"
+          id="quickstart-integration-back"
+          data-fs-element="QuickstartIntegrationBack"
+        >
+          <Undo2 className="mr-1 size-3" />
+          Back to integrations
+        </Button>
+        <ManualIntegrationDetail
+          integration={selectedIntegration}
+          agentName={agentName}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <Tabs value={activeTab} onValueChange={handleTabChange}>
+      <TabsList variant="underline">
+        <TabsTrigger value={AI_ASSISTED_TAB} variant="underline">
+          AI-assisted setup
+        </TabsTrigger>
+        <TabsTrigger value={MANUAL_TAB} variant="underline">
+          Manual setup
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value={AI_ASSISTED_TAB}>
+        <InstallWithAITab agentName={agentName} showWaitingStep={false} />
+      </TabsContent>
+      <TabsContent value={MANUAL_TAB}>
+        <ManualIntegrationList
+          agentName={agentName}
+          onSelectIntegration={setSelectedIntegrationId}
+          activeCategory={manualCategory}
+          onCategoryChange={setManualCategory}
+        />
+      </TabsContent>
+    </Tabs>
+  );
+};
 
 const QuickstartDialog: React.FC = () => {
   const { isOpen, setOpen } = useOpenQuickStartDialog();
 
   return (
-    <SideDialog open={isOpen} setOpen={setOpen}>
-      <div className="flex w-full min-w-fit flex-col px-20 pb-20">
-        <SheetTitle className="comet-title-xl my-3 text-left">
-          Quickstart guide
-        </SheetTitle>
-        <div className="comet-body-s mb-10 text-muted-slate">
-          Opik helps you improve your LLM features by tracking what happens
-          behind the scenes. Integrate Opik to unlock evaluations, experiments,
-          and debugging.
-        </div>
-
-        <IntegrationExplorer source="quickstart-dialog">
-          <div className="mb-8 flex items-center justify-between gap-6">
-            <IntegrationExplorer.Search />
-
-            <div className="flex items-center gap-3">
-              <IntegrationExplorer.CopyApiKey />
-              <IntegrationExplorer.GetHelp />
-            </div>
-          </div>
-
-          <div className="mb-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
-            <IntegrationExplorer.QuickInstall />
-            <IntegrationExplorer.TypeScriptSDK />
-          </div>
-
-          <IntegrationExplorer.Tabs>
-            <IntegrationExplorer.Grid />
-          </IntegrationExplorer.Tabs>
-        </IntegrationExplorer>
-      </div>
-    </SideDialog>
+    <Dialog open={isOpen} onOpenChange={setOpen}>
+      <DialogContent className="max-w-[720px] gap-2">
+        <DialogHeader>
+          <DialogTitle>Quickstart guide</DialogTitle>
+        </DialogHeader>
+        <DialogAutoScrollBody>
+          <QuickstartContent />
+        </DialogAutoScrollBody>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import useLocalStorageState from "use-local-storage-state";
 import { ArrowRight, MonitorPlay, Undo2 } from "lucide-react";
 import { useFeatureFlagVariantKey } from "posthog-js/react";
@@ -12,6 +12,10 @@ import useTracesList from "@/api/traces/useTracesList";
 import useSandboxConnectionStatus from "@/api/agent-sandbox/useSandboxConnectionStatus";
 import { RunnerConnectionStatus } from "@/types/agent-sandbox";
 import { OpikEvent, trackEvent } from "@/lib/analytics/tracking";
+import { INTEGRATIONS } from "@/constants/integrations";
+import InstallWithAITab from "@/v2/pages-shared/onboarding/IntegrationsTabs/InstallWithAITab";
+import ManualIntegrationList from "@/v2/pages-shared/onboarding/IntegrationsTabs/ManualIntegrationList";
+import ManualIntegrationDetail from "@/v2/pages-shared/onboarding/IntegrationsTabs/ManualIntegrationDetail";
 import {
   useAgentOnboarding,
   AGENT_ONBOARDING_STEPS,
@@ -20,11 +24,7 @@ import {
 } from "./AgentOnboardingContext";
 import AgentOnboardingCard from "./AgentOnboardingCard";
 import ConnectToOllieTab from "./ConnectToOllieTab";
-import InstallWithAITab from "./InstallWithAITab";
-import ManualIntegrationList from "./ManualIntegrationList";
-import ManualIntegrationDetail from "./ManualIntegrationDetail";
 import ShowDemoProjectButton from "./ShowDemoProjectButton";
-import { INTEGRATIONS } from "@/constants/integrations";
 import {
   SLACK_LINK,
   VIDEO_TUTORIAL_LINK,
@@ -33,26 +33,40 @@ import {
 const TRACE_POLL_INTERVAL = 5000;
 const FIRST_TRACE_TRACKED_KEY = "agent-onboarding-first-trace-tracked";
 
+const MANUAL_TAB = "manual-integration";
+const INSTALL_WITH_AI_TAB = "install-with-ai";
+const CONNECT_TO_OLLIE_TAB = "connect-to-ollie";
+
 const ConnectAgentStep: React.FC = () => {
   const { goToStep, agentName } = useAgentOnboarding();
   const InviteDevButton = usePluginsStore((state) => state.InviteDevButton);
   const apiKey = useUserApiKey();
-  // Variants: "control" = AI-assisted tab shows "Install with AI" (Opik skills prompt); "connect-to-ollie" = AI-assisted tab shows "Connect to Ollie"; "manual" = bypasses this modal entirely and renders the full integrations page (handled in NewQuickstart). Undefined falls back to "control" to preserve the Opik skills tab as default.
-  const aiAssistedOpikSkillsVariant =
+  const variant =
     useFeatureFlagVariantKey(AI_ASSISTED_OPIK_SKILLS_FEATURE_FLAG_KEY) ??
     "control";
 
-  const aiAssistedUsesOpikSkills = aiAssistedOpikSkillsVariant === "control";
-  const showOllieTab = !!apiKey && !aiAssistedUsesOpikSkills;
+  const showAiAssistedTab = variant !== "manual";
+  const showOllieTab = !!apiKey && variant !== "control";
 
-  const [activeTab, setActiveTab] = useState(
-    showOllieTab ? "connect-to-ollie" : "install-with-ai",
-  );
-
+  const [activeTab, setActiveTab] = useState(() => {
+    if (!showAiAssistedTab) return MANUAL_TAB;
+    return showOllieTab ? CONNECT_TO_OLLIE_TAB : INSTALL_WITH_AI_TAB;
+  });
   const [manualCategory, setManualCategory] = useState<string | null>(null);
   const [selectedIntegrationId, setSelectedIntegrationId] = useState<
     string | null
   >(null);
+
+  useEffect(() => {
+    setActiveTab((current) => {
+      if (!showAiAssistedTab && current !== MANUAL_TAB) return MANUAL_TAB;
+      if (showOllieTab && current === INSTALL_WITH_AI_TAB)
+        return CONNECT_TO_OLLIE_TAB;
+      if (!showOllieTab && current === CONNECT_TO_OLLIE_TAB)
+        return INSTALL_WITH_AI_TAB;
+      return current;
+    });
+  }, [showAiAssistedTab, showOllieTab]);
 
   const { data: project } = useProjectByName(
     { projectName: agentName },
@@ -82,18 +96,6 @@ const ConnectAgentStep: React.FC = () => {
   >(FIRST_TRACE_TRACKED_KEY, { defaultValue: null });
 
   useEffect(() => {
-    setActiveTab((current) => {
-      if (showOllieTab && current === "install-with-ai") {
-        return "connect-to-ollie";
-      }
-      if (!showOllieTab && current === "connect-to-ollie") {
-        return "install-with-ai";
-      }
-      return current;
-    });
-  }, [showOllieTab]);
-
-  useEffect(() => {
     if (firstTraceId && firstTraceId !== trackedTraceId) {
       trackEvent(OpikEvent.ONBOARDING_FIRST_TRACE_RECEIVED, {
         agent_name: agentName,
@@ -103,13 +105,14 @@ const ConnectAgentStep: React.FC = () => {
     }
   }, [firstTraceId, trackedTraceId, agentName, setTrackedTraceId]);
 
+  const isOllieTab = activeTab === CONNECT_TO_OLLIE_TAB;
+
   const { data: runner } = useSandboxConnectionStatus(
     { projectId: projectId ?? "", runnerType: "connect" },
-    { enabled: !!projectId && activeTab === "connect-to-ollie" },
+    { enabled: !!projectId && isOllieTab },
   );
   const connected = runner?.status === RunnerConnectionStatus.CONNECTED;
 
-  const isOllieTab = activeTab === "connect-to-ollie";
   const primaryReady = isOllieTab ? connected : traceReceived;
 
   const handleViewTraces = () => {
@@ -123,40 +126,55 @@ const ConnectAgentStep: React.FC = () => {
     ? INTEGRATIONS.find((i) => i.id === selectedIntegrationId)
     : undefined;
 
-  const handleTabChange = (value: string) => {
+  const handleTabChange = useCallback((value: string) => {
     setActiveTab(value);
     setSelectedIntegrationId(null);
-  };
+  }, []);
 
-  const tabs = useMemo(
-    () => [
-      showOllieTab
-        ? {
-            value: "connect-to-ollie",
-            label: "AI-assisted setup",
-            content: <ConnectToOllieTab connected={connected} />,
-          }
-        : {
-            value: "install-with-ai",
-            label: "AI-assisted setup",
-            content: <InstallWithAITab traceReceived={traceReceived} />,
-          },
-      {
-        value: "manual-integration",
-        label: "Manual setup",
-        content: (
-          <ManualIntegrationList
-            onSelectIntegration={setSelectedIntegrationId}
-            showInstallWithAI={showOllieTab}
-            traceReceived={traceReceived}
-            activeCategory={manualCategory}
-            onCategoryChange={setManualCategory}
-          />
-        ),
-      },
-    ],
-    [showOllieTab, connected, traceReceived, manualCategory],
-  );
+  const tabs = useMemo(() => {
+    const aiAssistedTab = showOllieTab
+      ? {
+          value: CONNECT_TO_OLLIE_TAB,
+          label: "AI-assisted setup",
+          content: (
+            <ConnectToOllieTab agentName={agentName} connected={connected} />
+          ),
+        }
+      : {
+          value: INSTALL_WITH_AI_TAB,
+          label: "AI-assisted setup",
+          content: (
+            <InstallWithAITab
+              agentName={agentName}
+              traceReceived={traceReceived}
+            />
+          ),
+        };
+
+    const manualTab = {
+      value: MANUAL_TAB,
+      label: "Manual setup",
+      content: (
+        <ManualIntegrationList
+          agentName={agentName}
+          onSelectIntegration={setSelectedIntegrationId}
+          showInstallWithAI={showOllieTab}
+          traceReceived={traceReceived}
+          activeCategory={manualCategory}
+          onCategoryChange={setManualCategory}
+        />
+      ),
+    };
+
+    return showAiAssistedTab ? [aiAssistedTab, manualTab] : [manualTab];
+  }, [
+    showAiAssistedTab,
+    showOllieTab,
+    agentName,
+    connected,
+    traceReceived,
+    manualCategory,
+  ]);
 
   if (selectedIntegration) {
     return (
@@ -221,7 +239,10 @@ const ConnectAgentStep: React.FC = () => {
           </div>
         }
       >
-        <ManualIntegrationDetail integration={selectedIntegration} />
+        <ManualIntegrationDetail
+          integration={selectedIntegration}
+          agentName={agentName}
+        />
       </AgentOnboardingCard>
     );
   }

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectToOllieTab.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useAgentOnboarding } from "./AgentOnboardingContext";
 import { useUserApiKey, useActiveWorkspaceName } from "@/store/AppStore";
 import { buildDocsUrl } from "@/lib/utils";
 import { BASE_API_URL } from "@/api/api";
@@ -9,20 +8,26 @@ import CodeSnippet from "@/shared/CodeSnippet/CodeSnippet";
 const INSTALL_COMMAND = "pip install opik";
 
 interface ConnectToOllieTabProps {
-  connected: boolean;
+  agentName: string;
+  connected?: boolean;
+  showWaitingStep?: boolean;
 }
 
-const ConnectToOllieTab: React.FC<ConnectToOllieTabProps> = ({ connected }) => {
-  const { agentName } = useAgentOnboarding();
+const ConnectToOllieTab: React.FC<ConnectToOllieTabProps> = ({
+  agentName,
+  connected = false,
+  showWaitingStep = true,
+}) => {
   const apiKey = useUserApiKey();
   const workspaceName = useActiveWorkspaceName();
 
   const buildConnectCommand = () => {
+    const projectArg = agentName ? ` --project "${agentName}"` : "";
     if (apiKey) {
-      return `opik connect --project "${agentName}" --workspace "${workspaceName}" --api-key "${apiKey}"`;
+      return `opik connect${projectArg} --workspace "${workspaceName}" --api-key "${apiKey}"`;
     }
     const url = new URL(BASE_API_URL, window.location.origin).toString();
-    return `OPIK_URL_OVERRIDE="${url}" opik connect --project "${agentName}"`;
+    return `OPIK_URL_OVERRIDE="${url}" opik connect${projectArg}`;
   };
 
   const connectCommandText = buildConnectCommand();
@@ -42,7 +47,7 @@ const ConnectToOllieTab: React.FC<ConnectToOllieTabProps> = ({ connected }) => {
           </div>
         </TimelineStep>
 
-        <TimelineStep number={2}>
+        <TimelineStep number={2} isLast={!showWaitingStep}>
           <div className="flex flex-col gap-2.5">
             <h4 className="comet-body-s-accented">
               Connect your repo to Ollie
@@ -56,36 +61,38 @@ const ConnectToOllieTab: React.FC<ConnectToOllieTabProps> = ({ connected }) => {
           </div>
         </TimelineStep>
 
-        <TimelineStep isLast completed={connected}>
-          <div className="flex flex-col gap-1">
-            <h4 className="comet-body-s-accented text-primary">
-              {connected
-                ? "Repo connected"
-                : "Waiting for your repo to connect\u2026"}
-            </h4>
-            <p className="comet-body-xs text-muted-slate">
-              {connected ? (
-                "Ollie can now inspect your code and help you set up tracing in Opik."
-              ) : (
-                <>
-                  Run the command above in your repo. Once connected, Ollie can
-                  inspect your code and help finish setup.{" "}
-                  <a
-                    href={buildDocsUrl(
-                      "/agents/local-runner",
-                      "#troubleshooting",
-                    )}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline hover:text-foreground"
-                  >
-                    Connect troubleshooting
-                  </a>
-                </>
-              )}
-            </p>
-          </div>
-        </TimelineStep>
+        {showWaitingStep && (
+          <TimelineStep isLast completed={connected}>
+            <div className="flex flex-col gap-1">
+              <h4 className="comet-body-s-accented text-primary">
+                {connected
+                  ? "Repo connected"
+                  : "Waiting for your repo to connect\u2026"}
+              </h4>
+              <p className="comet-body-xs text-muted-slate">
+                {connected ? (
+                  "Ollie can now inspect your code and help you set up tracing in Opik."
+                ) : (
+                  <>
+                    Run the command above in your repo. Once connected, Ollie
+                    can inspect your code and help finish setup.{" "}
+                    <a
+                      href={buildDocsUrl(
+                        "/agents/local-runner",
+                        "#troubleshooting",
+                      )}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline hover:text-foreground"
+                    >
+                      Connect troubleshooting
+                    </a>
+                  </>
+                )}
+              </p>
+            </div>
+          </TimelineStep>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Details
### Product description

Previously, the Quickstart guide (accessible from the nav) used a different, less focused UI than the Agent Onboarding flow — it opened a wide side sheet with a generic integration explorer. This change aligns both surfaces so users get the same clean "AI-assisted setup" / "Manual setup" tab experience everywhere they try to connect an agent to Opik. The Quickstart dialog is now a compact modal that pre-fills the active project name, making it faster to get instrumented without switching context.

### Summary

- **Extracted shared tab components** (`InstallWithAITab`, `ManualIntegrationList`, `ManualIntegrationDetail`) from `AgentOnboarding/` into `pages-shared/onboarding/IntegrationsTabs/` so they can be reused across flows.
- **Decoupled from context** — components previously pulled `agentName` from `useAgentOnboarding()` context; it is now passed as an explicit prop, making them standalone and composable.
- **Redesigned `QuickstartDialog`** — replaced the `SideDialog`/`IntegrationExplorer` layout with a standard `Dialog` containing the same "AI-assisted setup" / "Manual setup" tabs as the onboarding flow. The dialog now fetches the active project name to pre-fill connection commands.
- **Optional waiting step** — `InstallWithAITab` and `ConnectToOllieTab` gained a `showWaitingStep` prop (default `true`) so the "Waiting for first trace…" step can be hidden in contexts like `QuickstartDialog` where polling is not relevant.
- **Optional project name** — when `agentName` is empty the project name field is hidden and CLI commands/prompts omit the project argument.
- **`ConnectAgentStep` cleanup** — extracted tab name constants, unified the `useEffect` for all variant-driven tab changes, and added `agentName` to `useMemo` deps.

<img width="1463" height="728" alt="image" src="https://github.com/user-attachments/assets/ebde3b7d-122f-4908-a6e5-ff1878a8bb24" />


## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-5623
- OPIK-6080

## AI-WATERMARK

AI-WATERMARK: [yes|no]
  - Tools: Claude Code
  - Model(s): Opus 4.7
  - Scope: Full project
  - Human verification: Yes

## Testing
- manually in a local env, and in test
- `npm run lint`
- `npm run typecheck`

## Documentation
NA