### PR TITLE
[OPIK-6099] [SDK] fix: infer provider from LitellmModel prefix in OpikTracingProcessor

### DIFF
--- a/.github/workflows/lib-openai-tests.yml
+++ b/.github/workflows/lib-openai-tests.yml
@@ -9,6 +9,10 @@ permissions:
 env:
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
   OPENAI_ORG_ID:  ${{ secrets.OPENAI_ORG_ID }}
+  GCP_CREDENTIALS_JSON: ${{ secrets.GCP_CREDENTIALS_JSON }}
+  GOOGLE_CLOUD_LOCATION: us-east1
+  GOOGLE_CLOUD_PROJECT: opik-sdk-tests
+  GOOGLE_GENAI_USE_VERTEXAI: TRUE
   OPIK_ENABLE_LITELLM_MODELS_MONITORING: False
   OPIK_SENTRY_ENABLE: False
   OPIK_TEST_EXPENSIVE: ${{ inputs.run_expensive_tests }}
@@ -57,6 +61,11 @@ jobs:
           cd ./tests
           pip install --no-cache-dir --disable-pip-version-check -r library_integration/openai/requirements.txt
           pip list
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
 
       - name: Run tests
         run: |

--- a/sdks/python/src/opik/integrations/litellm/litellm_completion_decorator.py
+++ b/sdks/python/src/opik/integrations/litellm/litellm_completion_decorator.py
@@ -14,6 +14,7 @@ import opik.dict_utils as dict_utils
 import opik.llm_usage as llm_usage
 from opik.api_objects import span
 from opik.decorator import arguments_helpers, base_track_decorator
+from opik.llm_usage import litellm_provider_mapping
 from opik.types import LLMProvider
 
 import litellm
@@ -59,18 +60,6 @@ SENSITIVE_PARAMS_TO_EXCLUDE: List[str] = [
     "openrouter_api_key",
 ]
 
-PROVIDER_MAPPING: Dict[str, LLMProvider] = {
-    "openai": LLMProvider.OPENAI,
-    "vertex_ai": LLMProvider.GOOGLE_VERTEXAI,
-    "vertex_ai-language-models": LLMProvider.GOOGLE_VERTEXAI,
-    "gemini": LLMProvider.GOOGLE_AI,
-    "anthropic": LLMProvider.ANTHROPIC,
-    "vertex_ai-anthropic_models": LLMProvider.ANTHROPIC_VERTEXAI,
-    "bedrock": LLMProvider.BEDROCK,
-    "bedrock_converse": LLMProvider.BEDROCK,
-    "groq": LLMProvider.GROQ,
-}
-
 
 def _extract_provider_from_model(model_name: str) -> Optional[LLMProvider]:
     try:
@@ -78,7 +67,9 @@ def _extract_provider_from_model(model_name: str) -> Optional[LLMProvider]:
         provider_name = provider_info[1] if len(provider_info) > 1 else None
         if provider_name is None:
             return None
-        return PROVIDER_MAPPING.get(provider_name, None)
+        return litellm_provider_mapping.LITELLM_PROVIDER_MAPPING.get(
+            provider_name, None
+        )
     except Exception:
         return None
 

--- a/sdks/python/src/opik/integrations/openai/agents/span_data_parsers.py
+++ b/sdks/python/src/opik/integrations/openai/agents/span_data_parsers.py
@@ -1,9 +1,10 @@
 import dataclasses
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 import logging
 
 from agents import tracing
 
+from opik.llm_usage import litellm_provider_mapping
 from opik.types import SpanType, LLMProvider
 import opik.dict_utils as dict_utils
 import opik.llm_usage as llm_usage
@@ -52,7 +53,7 @@ class ParsedSpanData:
     metadata: Optional[Dict[str, Any]] = None
     usage: Optional[llm_usage.OpikUsage] = None
     model: Optional[str] = None
-    provider: Optional[LLMProvider] = None
+    provider: Optional[Union[LLMProvider, str]] = None
 
 
 def parse_spandata(openai_span_data: tracing.SpanData) -> ParsedSpanData:
@@ -76,9 +77,7 @@ def parse_spandata(openai_span_data: tracing.SpanData) -> ParsedSpanData:
         del content["input"], content["output"]
 
     elif openai_span_data.type == "generation":
-        input_data = openai_span_data.input
-        output_data = openai_span_data.output
-        del content["input"], content["output"]
+        return _parse_generation_span_content(openai_span_data)
 
     elif openai_span_data.type == "response":
         return _parse_response_span_content(openai_span_data)
@@ -121,6 +120,53 @@ def parse_spandata(openai_span_data: tracing.SpanData) -> ParsedSpanData:
     )
 
 
+def _parse_generation_span_content(
+    span_data: tracing.GenerationSpanData,
+) -> ParsedSpanData:
+    # openai-agents 0.14+ routes `LitellmModel` through `generation_span`, so the model
+    # string here carries the LiteLLM "<provider>/<model>" prefix. Usage is recorded in
+    # OpenAI Responses-API shape (input_tokens/output_tokens) regardless of the underlying
+    # provider, so the usage parser stays pinned to OPENAI; only the provider attribution
+    # on the span needs to follow the prefix.
+    model = span_data.model
+    inferred_provider = (
+        litellm_provider_mapping.infer_provider_from_litellm_model_prefix(model)
+        or LLMProvider.OPENAI
+    )
+
+    if span_data.usage is not None:
+        opik_usage = llm_usage.try_build_opik_usage_or_log_error(
+            provider=LLMProvider.OPENAI,
+            usage=span_data.usage,
+            logger=LOGGER,
+            error_message="Failed to log usage in openai agent generation span",
+        )
+    else:
+        opik_usage = None
+
+    input_data = span_data.input
+    output_data = span_data.output
+    if input_data is not None and not isinstance(input_data, dict):
+        input_data = {"input": input_data}
+    if output_data is not None and not isinstance(output_data, dict):
+        output_data = {"output": output_data}
+
+    metadata = span_data.export()
+    for key in ("input", "output", "usage", "model"):
+        metadata.pop(key, None)
+
+    return ParsedSpanData(
+        name="Generation",
+        input=input_data,
+        output=output_data,
+        usage=opik_usage,
+        type="llm",
+        metadata=metadata,
+        model=model,
+        provider=inferred_provider,
+    )
+
+
 def _parse_response_span_content(span_data: tracing.ResponseSpanData) -> ParsedSpanData:
     response = span_data.response
 
@@ -137,6 +183,18 @@ def _parse_response_span_content(span_data: tracing.ResponseSpanData) -> ParsedS
     _, metadata = dict_utils.split_dict_by_keys(
         input_dict=response_dict,
         keys=["input", "output"],
+    )
+
+    # When `LitellmModel` routes requests through a non-OpenAI provider, `response.model`
+    # carries a LiteLLM-style "<provider>/<model>" prefix (e.g. "gemini/gemini-3.1-flash").
+    # The usage payload on `response.usage` is still OpenAI-shaped — the openai-agents SDK
+    # adapts LiteLLM responses to OpenAI's `Response` type — so we keep OPENAI for usage
+    # parsing but attribute the span to the real provider for backend cost lookup.
+    inferred_provider = (
+        litellm_provider_mapping.infer_provider_from_litellm_model_prefix(
+            response.model
+        )
+        or LLMProvider.OPENAI
     )
 
     if response.usage is not None:
@@ -157,5 +215,5 @@ def _parse_response_span_content(span_data: tracing.ResponseSpanData) -> ParsedS
         type="llm",
         metadata=metadata,
         model=response.model,
-        provider=LLMProvider.OPENAI,
+        provider=inferred_provider,
     )

--- a/sdks/python/src/opik/integrations/openai/agents/span_data_parsers.py
+++ b/sdks/python/src/opik/integrations/openai/agents/span_data_parsers.py
@@ -120,100 +120,79 @@ def parse_spandata(openai_span_data: tracing.SpanData) -> ParsedSpanData:
     )
 
 
-def _parse_generation_span_content(
-    span_data: tracing.GenerationSpanData,
-) -> ParsedSpanData:
-    # openai-agents 0.14+ routes `LitellmModel` through `generation_span`, so the model
-    # string here carries the LiteLLM "<provider>/<model>" prefix. Usage is recorded in
-    # OpenAI Responses-API shape (input_tokens/output_tokens) regardless of the underlying
-    # provider, so the usage parser stays pinned to OPENAI; only the provider attribution
-    # on the span needs to follow the prefix.
-    model = span_data.model
-    inferred_provider = (
+def _infer_provider(model: Optional[str]) -> Union[LLMProvider, str]:
+    """Map a model string to a provider, defaulting to OpenAI for un-prefixed models."""
+    return (
         litellm_provider_mapping.infer_provider_from_litellm_model_prefix(model)
         or LLMProvider.OPENAI
     )
 
-    if span_data.usage is not None:
-        opik_usage = llm_usage.try_build_opik_usage_or_log_error(
-            provider=LLMProvider.OPENAI,
-            usage=span_data.usage,
-            logger=LOGGER,
-            error_message="Failed to log usage in openai agent generation span",
-        )
-    else:
-        opik_usage = None
 
-    input_data = span_data.input
-    output_data = span_data.output
-    if input_data is not None and not isinstance(input_data, dict):
-        input_data = {"input": input_data}
-    if output_data is not None and not isinstance(output_data, dict):
-        output_data = {"output": output_data}
+def _wrap_as_dict(value: Any, key: str) -> Optional[Dict[str, Any]]:
+    if value is None or isinstance(value, dict):
+        return value
+    return {key: value}
 
-    metadata = span_data.export()
-    for key in ("input", "output", "usage", "model"):
-        metadata.pop(key, None)
 
+def _build_opik_usage(
+    usage: Optional[Dict[str, Any]], error_message: str
+) -> Optional[llm_usage.OpikUsage]:
+    # openai-agents always emits usage in the OpenAI Responses shape, even for
+    # LiteLLM-routed calls, so the OpenAI parser handles every provider here.
+    if usage is None:
+        return None
+    return llm_usage.try_build_opik_usage_or_log_error(
+        provider=LLMProvider.OPENAI,
+        usage=usage,
+        logger=LOGGER,
+        error_message=error_message,
+    )
+
+
+_GENERATION_SPAN_HANDLED_KEYS = {"input", "output", "usage", "model"}
+
+
+def _parse_generation_span_content(
+    span_data: tracing.GenerationSpanData,
+) -> ParsedSpanData:
+    metadata = {
+        key: value
+        for key, value in span_data.export().items()
+        if key not in _GENERATION_SPAN_HANDLED_KEYS
+    }
     return ParsedSpanData(
         name="Generation",
-        input=input_data,
-        output=output_data,
-        usage=opik_usage,
         type="llm",
+        input=_wrap_as_dict(span_data.input, "input"),
+        output=_wrap_as_dict(span_data.output, "output"),
+        usage=_build_opik_usage(
+            span_data.usage,
+            "Failed to log usage in openai agent generation span",
+        ),
         metadata=metadata,
-        model=model,
-        provider=inferred_provider,
+        model=span_data.model,
+        provider=_infer_provider(span_data.model),
     )
 
 
 def _parse_response_span_content(span_data: tracing.ResponseSpanData) -> ParsedSpanData:
     response = span_data.response
-
     if response is None:
-        return ParsedSpanData(
-            name="Response",
-            type="llm",
-        )
-
-    response_dict = span_data.response.model_dump()
-    input = {"input": span_data.input}
-    output = {"output": response.output}
+        return ParsedSpanData(name="Response", type="llm")
 
     _, metadata = dict_utils.split_dict_by_keys(
-        input_dict=response_dict,
+        input_dict=response.model_dump(),
         keys=["input", "output"],
     )
-
-    # When `LitellmModel` routes requests through a non-OpenAI provider, `response.model`
-    # carries a LiteLLM-style "<provider>/<model>" prefix (e.g. "gemini/gemini-3.1-flash").
-    # The usage payload on `response.usage` is still OpenAI-shaped — the openai-agents SDK
-    # adapts LiteLLM responses to OpenAI's `Response` type — so we keep OPENAI for usage
-    # parsing but attribute the span to the real provider for backend cost lookup.
-    inferred_provider = (
-        litellm_provider_mapping.infer_provider_from_litellm_model_prefix(
-            response.model
-        )
-        or LLMProvider.OPENAI
-    )
-
-    if response.usage is not None:
-        opik_usage = llm_usage.try_build_opik_usage_or_log_error(
-            provider=LLMProvider.OPENAI,
-            usage=response.usage.model_dump(),
-            logger=LOGGER,
-            error_message="Failed to log usage in openai agent run",
-        )
-    else:
-        opik_usage = None
+    usage = response.usage.model_dump() if response.usage is not None else None
 
     return ParsedSpanData(
         name="Response",
-        input=input,
-        output=output,
-        usage=opik_usage,
         type="llm",
+        input={"input": span_data.input},
+        output={"output": response.output},
+        usage=_build_opik_usage(usage, "Failed to log usage in openai agent run"),
         metadata=metadata,
         model=response.model,
-        provider=inferred_provider,
+        provider=_infer_provider(response.model),
     )

--- a/sdks/python/src/opik/llm_usage/litellm_provider_mapping.py
+++ b/sdks/python/src/opik/llm_usage/litellm_provider_mapping.py
@@ -1,0 +1,37 @@
+from typing import Dict, Optional, Union
+
+from opik.types import LLMProvider
+
+LITELLM_PROVIDER_MAPPING: Dict[str, LLMProvider] = {
+    "openai": LLMProvider.OPENAI,
+    "vertex_ai": LLMProvider.GOOGLE_VERTEXAI,
+    "vertex_ai-language-models": LLMProvider.GOOGLE_VERTEXAI,
+    "vertex_ai-anthropic_models": LLMProvider.ANTHROPIC_VERTEXAI,
+    "gemini": LLMProvider.GOOGLE_AI,
+    "anthropic": LLMProvider.ANTHROPIC,
+    "bedrock": LLMProvider.BEDROCK,
+    "bedrock_converse": LLMProvider.BEDROCK,
+    "groq": LLMProvider.GROQ,
+}
+
+
+def infer_provider_from_litellm_model_prefix(
+    model: Optional[str],
+) -> Optional[Union[LLMProvider, str]]:
+    """Infer a provider from a LiteLLM-style "<provider>/<model>" string.
+
+    Returns:
+    - an `LLMProvider` enum value when the prefix is in the known mapping,
+    - the raw prefix string when a prefix is present but not mapped (callers can
+      forward it to the backend; unsupported providers resolve to zero cost
+      gracefully, and this preserves the original attribution for future
+      catalog updates),
+    - `None` when the input is empty or has no prefix (callers typically fall
+      back to `LLMProvider.OPENAI` for the native-OpenAI path).
+
+    Unlike `litellm.get_llm_provider`, this does not require the `litellm` package.
+    """
+    if not model or "/" not in model:
+        return None
+    prefix = model.split("/", 1)[0]
+    return LITELLM_PROVIDER_MAPPING.get(prefix, prefix)

--- a/sdks/python/src/opik/llm_usage/litellm_provider_mapping.py
+++ b/sdks/python/src/opik/llm_usage/litellm_provider_mapping.py
@@ -18,18 +18,11 @@ LITELLM_PROVIDER_MAPPING: Dict[str, LLMProvider] = {
 def infer_provider_from_litellm_model_prefix(
     model: Optional[str],
 ) -> Optional[Union[LLMProvider, str]]:
-    """Infer a provider from a LiteLLM-style "<provider>/<model>" string.
+    """Resolve the provider for a LiteLLM-style ``"<provider>/<model>"`` string.
 
-    Returns:
-    - an `LLMProvider` enum value when the prefix is in the known mapping,
-    - the raw prefix string when a prefix is present but not mapped (callers can
-      forward it to the backend; unsupported providers resolve to zero cost
-      gracefully, and this preserves the original attribution for future
-      catalog updates),
-    - `None` when the input is empty or has no prefix (callers typically fall
-      back to `LLMProvider.OPENAI` for the native-OpenAI path).
-
-    Unlike `litellm.get_llm_provider`, this does not require the `litellm` package.
+    Returns the mapped :class:`LLMProvider` for known prefixes, the raw prefix
+    string for unknown ones (so the backend can still attempt a lookup), or
+    ``None`` when the model has no prefix.
     """
     if not model or "/" not in model:
         return None

--- a/sdks/python/tests/library_integration/openai/agents_tests/test_opik_tracing_processor.py
+++ b/sdks/python/tests/library_integration/openai/agents_tests/test_opik_tracing_processor.py
@@ -890,3 +890,53 @@ def test_opik_tracing_processor__agent_called_in_another_tracked_function__agent
     trace_tree = fake_backend.trace_trees[0]
 
     assert_equal(expected=EXPECTED_TRACE_TREE, actual=trace_tree)
+
+
+def test_opik_tracing_processor__litellm_gemini_model__provider_is_google_ai(
+    fake_backend,
+):
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    input_message = "Write a haiku about recursion in programming."
+    project_name = "opik-test-openai-agents"
+    gemini_model_id = "gemini/gemini-2.5-flash"
+
+    set_trace_processors(processors=[OpikTracingProcessor(project_name)])
+
+    agent = Agent(
+        name="Assistant",
+        instructions="You are a helpful assistant",
+        model=LitellmModel(model=gemini_model_id),
+    )
+
+    Runner.run_sync(agent, input_message)
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+    trace_tree = fake_backend.trace_trees[0]
+
+    # openai-agents emits a `Generation` span for `LitellmModel` calls (vs the `Response`
+    # span used by native OpenAI models). The LLM call is the innermost of the
+    # Task → Assistant → Turn → Generation hierarchy.
+    llm_spans = [span for span in _iter_spans(trace_tree.spans) if span.type == "llm"]
+    assert len(llm_spans) == 1, f"Expected exactly one LLM span, found {len(llm_spans)}"
+    llm_span = llm_spans[0]
+
+    assert llm_span.provider == LLMProvider.GOOGLE_AI
+    assert llm_span.model.startswith(gemini_model_id)
+    # LiteLLM-routed Gemini still reports usage via OpenAI Responses-API shape
+    # (input_tokens/output_tokens), which Opik normalizes to prompt_tokens/completion_tokens.
+    assert llm_span.usage is not None
+    for required_key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        assert required_key in llm_span.usage, (
+            f"Usage missing key '{required_key}': {llm_span.usage}"
+        )
+        assert llm_span.usage[required_key] > 0
+
+
+def _iter_spans(spans):
+    for span in spans:
+        yield span
+        if span.spans:
+            yield from _iter_spans(span.spans)

--- a/sdks/python/tests/library_integration/openai/agents_tests/test_opik_tracing_processor.py
+++ b/sdks/python/tests/library_integration/openai/agents_tests/test_opik_tracing_processor.py
@@ -892,21 +892,21 @@ def test_opik_tracing_processor__agent_called_in_another_tracked_function__agent
     assert_equal(expected=EXPECTED_TRACE_TREE, actual=trace_tree)
 
 
-def test_opik_tracing_processor__litellm_gemini_model__provider_is_google_ai(
+def test_opik_tracing_processor__litellm_vertex_ai_model__provider_is_google_vertexai(
     fake_backend,
 ):
     from agents.extensions.models.litellm_model import LitellmModel
 
     input_message = "Write a haiku about recursion in programming."
     project_name = "opik-test-openai-agents"
-    gemini_model_id = "gemini/gemini-2.5-flash"
+    litellm_model_id = "vertex_ai/gemini-2.0-flash"
 
     set_trace_processors(processors=[OpikTracingProcessor(project_name)])
 
     agent = Agent(
         name="Assistant",
         instructions="You are a helpful assistant",
-        model=LitellmModel(model=gemini_model_id),
+        model=LitellmModel(model=litellm_model_id),
     )
 
     Runner.run_sync(agent, input_message)
@@ -923,9 +923,9 @@ def test_opik_tracing_processor__litellm_gemini_model__provider_is_google_ai(
     assert len(llm_spans) == 1, f"Expected exactly one LLM span, found {len(llm_spans)}"
     llm_span = llm_spans[0]
 
-    assert llm_span.provider == LLMProvider.GOOGLE_AI
-    assert llm_span.model.startswith(gemini_model_id)
-    # LiteLLM-routed Gemini still reports usage via OpenAI Responses-API shape
+    assert llm_span.provider == LLMProvider.GOOGLE_VERTEXAI
+    assert llm_span.model.startswith(litellm_model_id)
+    # LiteLLM-routed calls report usage via OpenAI Responses-API shape
     # (input_tokens/output_tokens), which Opik normalizes to prompt_tokens/completion_tokens.
     assert llm_span.usage is not None
     for required_key in ("prompt_tokens", "completion_tokens", "total_tokens"):

--- a/sdks/python/tests/library_integration/openai/requirements.txt
+++ b/sdks/python/tests/library_integration/openai/requirements.txt
@@ -1,2 +1,3 @@
 openai
 openai-agents
+litellm[google]

--- a/sdks/python/tests/unit/llm_usage/test_litellm_provider_mapping.py
+++ b/sdks/python/tests/unit/llm_usage/test_litellm_provider_mapping.py
@@ -1,0 +1,64 @@
+import pytest
+
+from opik.llm_usage import litellm_provider_mapping
+from opik.types import LLMProvider
+
+
+@pytest.mark.parametrize(
+    "model,expected_provider",
+    [
+        ("gemini/gemini-3.1-flash-lite-preview", LLMProvider.GOOGLE_AI),
+        ("vertex_ai/gemini-2.5-pro", LLMProvider.GOOGLE_VERTEXAI),
+        ("vertex_ai-language-models/gemini-1.5-pro", LLMProvider.GOOGLE_VERTEXAI),
+        (
+            "vertex_ai-anthropic_models/claude-3-5-sonnet",
+            LLMProvider.ANTHROPIC_VERTEXAI,
+        ),
+        ("anthropic/claude-3-5-sonnet", LLMProvider.ANTHROPIC),
+        ("bedrock/anthropic.claude-3-haiku", LLMProvider.BEDROCK),
+        ("bedrock_converse/anthropic.claude-3-haiku", LLMProvider.BEDROCK),
+        ("groq/llama-3.1-70b-versatile", LLMProvider.GROQ),
+        ("openai/gpt-4o", LLMProvider.OPENAI),
+    ],
+)
+def test_infer_provider_from_litellm_model_prefix__known_prefix__returns_provider_enum(
+    model, expected_provider
+):
+    assert (
+        litellm_provider_mapping.infer_provider_from_litellm_model_prefix(model)
+        == expected_provider
+    )
+
+
+@pytest.mark.parametrize(
+    "model,expected_raw_prefix",
+    [
+        ("cohere/command-r", "cohere"),
+        ("mistralai/mixtral-8x7b", "mistralai"),
+        ("perplexity/sonar-medium-online", "perplexity"),
+        ("unknown_provider/some-model", "unknown_provider"),
+    ],
+)
+def test_infer_provider_from_litellm_model_prefix__unknown_prefix__returns_raw_prefix_string(
+    model, expected_raw_prefix
+):
+    assert (
+        litellm_provider_mapping.infer_provider_from_litellm_model_prefix(model)
+        == expected_raw_prefix
+    )
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        None,
+        "",
+        "gpt-4o",
+        "claude-3-5-sonnet",
+        "some-standalone-model-name",
+    ],
+)
+def test_infer_provider_from_litellm_model_prefix__no_prefix__returns_none(model):
+    assert (
+        litellm_provider_mapping.infer_provider_from_litellm_model_prefix(model) is None
+    )


### PR DESCRIPTION
## Details

When the OpenAI Agents SDK routes calls through `LitellmModel` to a non-OpenAI provider, `response.model` arrives in LiteLLM form (e.g. `gemini/gemini-2.5-flash`) but `OpikTracingProcessor` hardcoded `provider=LLMProvider.OPENAI` on every span. The backend cost lookup then used the wrong `(model, provider)` key and returned `DEFAULT_COST = 0`, so traces showed zero cost for Gemini/Anthropic/Bedrock/VertexAI/Groq calls even when the pricing data was present.

While verifying the fix end-to-end against Gemini, a second (bigger) issue surfaced: in `openai-agents 0.14+`, `LitellmModel` emits `GenerationSpanData` rather than `ResponseSpanData`, and the existing `generation` branch in `span_data_parsers.py` dropped model / provider / usage entirely — meaning non-OpenAI calls through openai-agents were losing all LLM metadata, not just provider attribution.

- Both the `response` and `generation` paths now extract model/usage and infer the provider from the LiteLLM prefix (falling back to `OPENAI` when no prefix is present, preserving current native-OpenAI behavior).
- LiteLLM prefix → `LLMProvider` mapping extracted to `opik.llm_usage.litellm_provider_mapping` and reused by the LiteLLM decorator to remove duplication.
- Unknown prefixes pass through as raw strings so the backend can still attempt a lookup and future catalog additions start working without another SDK release.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6099

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation
- Human verification: code review + manual testing (real Gemini call via `LitellmModel`, asserted provider/model/usage on emitted span)

## Testing

- Unit tests for the shared LiteLLM provider mapping (18 cases covering known/unknown prefixes and no-prefix fallback):
  - `pytest sdks/python/tests/unit/llm_usage/test_litellm_provider_mapping.py`
- End-to-end regression against a real Gemini call through `LitellmModel` (asserts `provider == GOOGLE_AI`, model string preserved, usage non-zero):
  - `pytest sdks/python/tests/library_integration/openai/agents_tests/test_opik_tracing_processor.py::test_opik_tracing_processor__litellm_gemini_model__provider_is_google_ai`
- Existing native-OpenAI happy-flow test still passes (regression guard for `gpt-4o-mini` → `OPENAI` attribution):
  - `pytest sdks/python/tests/library_integration/openai/agents_tests/test_opik_tracing_processor.py::test_opik_tracing_processor__happy_flow`
- Quality gates: `make precommit-sdks` (ruff, ruff-format, mypy) and `pre-commit run --all-files` in `sdks/python` — all green.
- Environment: macOS, Python 3.13, `openai-agents==0.14.4`, `litellm==1.82.x`.

## Documentation

N/A — no documentation changes; public API of `OpikTracingProcessor` is unchanged.
