### PR TITLE
[NA] [DOCS] Lead observability getting-started with AI coding agent flow

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/getting-started.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/getting-started.mdx
@@ -7,8 +7,11 @@ og:title: Getting Started with Observability — Opik
 title: Getting started with Observability
 ---
 
-Opik makes it easy to add observability to your existing LLM application. You can get started
-using Opik Connect for AI-assisted setup, the Opik skill for automated integration, or manually add tracing using the SDK.
+Opik makes it easy to add observability to your existing LLM application. The fastest way is to let
+your coding agent do it — install the Opik skill in Claude Code, Cursor, Codex, or any other
+coding agent and it will instrument your code for you. If you'd rather stay inside Opik, use Opik
+Connect to have [Ollie](/tracing/ollie) set up tracing from the dashboard. You can also add
+tracing manually with the SDK.
 
 <video
   src="/img/v2/observability/getting-started.mp4"
@@ -24,9 +27,31 @@ using Opik Connect for AI-assisted setup, the Opik skill for automated integrati
 ## Adding observability to your code
 
 <Tabs>
+  <Tab title="AI coding agent">
+    The fastest way to add observability is to install the Opik skill in your coding agent and let
+    it instrument your code for you. The skill is compatible with Claude Code, Codex, Cursor,
+    OpenCode and any other agent that supports skills.
+
+    <Steps>
+      <Step title="Install the Opik skill">
+        ```bash
+        npx skills add comet-ml/opik-skills
+        ```
+      </Step>
+      <Step title="Run the integration">
+        Ask your coding agent to instrument your code:
+        ```
+        Instrument my agent with Opik using the /instrument command.
+        ```
+
+        The agent will read your code, pick the right Opik integration, and add tracing.
+      </Step>
+    </Steps>
+  </Tab>
   <Tab title="Opik Connect">
-    Opik Connect links your local repository to Opik so that [Ollie](/tracing/ollie), Opik's AI coding assistant,
-    can inspect your code, add tracing, and guide you through setup.
+    Opik Connect links your local repository to Opik so that [Ollie](/tracing/ollie), Opik's
+    built-in AI coding assistant, can inspect your code and add tracing from the dashboard — no
+    local agent setup required.
 
     <Steps>
       <Step title="Install Opik">
@@ -65,27 +90,8 @@ using Opik Connect for AI-assisted setup, the Opik skill for automated integrati
       </Step>
     </Steps>
 
-    Once connected, open Opik and Ollie will be able to help you instrument your code and
-    set up tracing. See the [Ollie documentation](/tracing/ollie) for more details.
-  </Tab>
-  <Tab title="AI Integration">
-    The simplest way to add observability is using the Opik Skills with your favorite coding agent:
-
-    <Steps>
-      <Step title="Install the Opik skill">
-        ```bash
-        npx skills add comet-ml/opik-skills
-        ```
-
-        This skill is compatible with all coding agents including Claude Code, Codex, Cursor, OpenCode and more.
-      </Step>
-      <Step title="Run the integration">
-        Once the skill is installed, you can add tracing using the following prompt:
-        ```
-        Instrument my agent with Opik using the /instrument command.
-        ```
-      </Step>
-    </Steps>
+    Once connected, open Opik and Ollie will help you instrument your code and set up tracing.
+    See the [Ollie documentation](/tracing/ollie) for more details.
   </Tab>
   <Tab title="Manual integration">
     Opik has integrations with all the popular Agent frameworks in both Python and TypeScript as well as


### PR DESCRIPTION
## Summary
- Reorder the integration tabs on `/tracing/getting-started` so the **AI coding agent** path (install Opik skill → run `/instrument` in Claude Code, Cursor, Codex, etc.) is first.
- Push **Opik Connect** to second — still documented prominently, but framed as "stay inside Opik" for users who'd rather not set up a local coding agent.
- Keep **Manual integration** third (unchanged content).
- Rewrite the page intro accordingly so the lead matches the first tab.

Rationale: most users already have a coding agent on their machine, so the skill is the fastest path to first trace.

## Test plan
- [ ] Visit `/tracing/getting-started` — first tab is "AI coding agent", second is "Opik Connect", third is "Manual integration".
- [ ] Intro paragraph leads with the skill flow.
- [ ] Tab content renders (steps, code blocks, tabs-in-tabs for Opik Cloud / Self-hosted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)