### PR TITLE
[OPIK-6149] [FE] perf: parallelize plugin module imports

### DIFF
--- a/apps/opik-frontend/src/store/PluginsStore.ts
+++ b/apps/opik-frontend/src/store/PluginsStore.ts
@@ -80,20 +80,22 @@ const usePluginsStore = create<PluginStore>((set) => ({
       return set({ WorkspacePreloader });
     }
 
-    for (const pluginName of PLUGIN_NAMES) {
-      try {
-        // dynamic import does not support alias
-        const plugin = await import(
-          `../plugins/${folderName}/${pluginName}.tsx`
-        );
+    await Promise.all(
+      PLUGIN_NAMES.map(async (pluginName) => {
+        try {
+          // dynamic import does not support alias
+          const plugin = await import(
+            `../plugins/${folderName}/${pluginName}.tsx`
+          );
 
-        if (plugin.default) {
-          set({ [pluginName]: plugin.default });
+          if (plugin.default) {
+            set({ [pluginName]: plugin.default });
+          }
+        } catch {
+          // plugin file is optional — swallow and continue
         }
-      } catch (error) {
-        continue;
-      }
-    }
+      }),
+    );
 
     // Ensure WorkspacePreloader is always set (fallback to default)
     if (!usePluginsStore.getState().WorkspacePreloader) {


### PR DESCRIPTION
## Details

`PluginsStore.setupPlugins()` awaited each dynamic plugin `import()` inside a `for` loop, serializing 17 module fetches that cost ~100–300 ms each. On fresh signups this phase accounted for ~4–9 s of LCP (the single largest contributor in the OPIK-6066 traces). Swap the loop for `Promise.all` so all plugins fetch in parallel, preserving the per-item `try/catch` so missing plugin files still short-circuit silently.

Side benefit: `init.tsx` (the plugin that triggers `config.js` + PostHog/Segment/FullStory/GTM/NewRelic init) used to load last in the sequence. It now fires concurrently with the other plugins, so third-party SDK init starts ~4 s earlier.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6149

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation + Chrome DevTools MCP measurement runs
- Human verification: code review, repeated fresh-signup measurement on test.dev.comet.com (5 pre-fix + 4 post-fix runs), manual smoke test of v2 workspace login

## Testing

Automated:
- `bash scripts/dev-runner.sh --lint-fe` — lint + typecheck + deps:validate pass
- `npm run build` — production bundle builds without warnings

Manual + measured (test.dev.comet.com, fresh signups, cold cache):

| Metric | Pre-fix median (5 runs) | Post-fix median (4 runs) | Delta |
|---|---|---|---|
| Plugin-import phase | 4,073 ms | **273 ms** | **−93%** |
| FCP | 4,372 ms | **1,614 ms** | **−63%** |
| `init.tsx` loaded at | 4,215 ms | **415 ms** | −3,800 ms |

All 17 plugin chunks fetch in a single parallel burst in every post-fix trace. Verified: `navigationCount: 1`, `cache: { "<workspace>": "v2" }` populates, `UserMenu` / `WorkspaceSelector` / `AssistantSidebar` / `PermissionsProvider` / `RetentionBanner` all render.

Not run: unit tests for PluginsStore — none exist, no reasonable way to unit-test a dynamic-import glob. Compensated by the measurement runs above.

## Documentation

N/A — internal bootstrap mechanism, no public surface changed.