### PR TITLE
[OPIK-6101] [FE] fix: preserve workspace prefix in Ollie navigate with basepath collision

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -403,12 +403,26 @@ const AssistantSidebar: React.FC<AssistantSidebarProps> = ({
    * responsible for supplying values that match the destination route's
    * search schema. Structured values are single-stringified by the router so
    * `use-query-params`' `JsonParam` round-trips correctly.
+   *
+   * The workspace is injected via a `$workspaceName` template param rather
+   * than string concatenation. TanStack Router strips the basepath from `to`
+   * with an unbounded `^basepath` regex (see @tanstack/react-router path.js
+   * `resolvePath`/`removeBasepath`), so a literal `to: "/opik-demos/..."`
+   * with basepath `/opik` would be mangled to `/opik/-demos/...`. Keeping
+   * the workspace as a param defers substitution until after the strip runs.
    */
   const navigateRef = useLatestRef(
     (path: string, search?: Record<string, unknown>) => {
       const ws = contextRef.current.workspaceName;
-      const fullPath = ws ? `/${ws}${path}` : path;
-      router.navigate({ to: fullPath, search });
+      if (ws) {
+        router.navigate({
+          to: `/$workspaceName${path}`,
+          params: { workspaceName: ws },
+          search,
+        });
+      } else {
+        router.navigate({ to: path, search });
+      }
     },
   );
 


### PR DESCRIPTION
## Details

Ollie's bridge navigate callback in `AssistantSidebar.tsx` built the target URL as `/${workspaceName}${path}` and passed the result as `to:` to TanStack Router. `@tanstack/react-router` strips the router basepath from the start of `to` with an unbounded `^basepath` regex (see `path.js` `resolvePath` / `removeBasepath`) — no `/` boundary check.

With cloud basepath `/opik` and any workspace whose name starts with `opik` (e.g. `opik-demos`), the string `/opik-demos/...` matched the `^/opik` prefix and got mangled to `-demos/...`, producing the final URL `/opik/-demos/...` — a workspace the user has no access to, landing them on the "This is a private project" screen.

Workspaces whose names don't start with `opik` (e.g. `acme-corp`) were unaffected, which is why this wasn't caught earlier.

**Fix:** inject the workspace via a `$workspaceName` template param and pass it through `params` instead of concatenating into `to`. The basepath strip now runs against `/$workspaceName/...`, which doesn't match the basepath regex, and the workspace name is substituted by TanStack *after* the strip during segment interpolation. Matches the existing pattern in `NoAccessPageGuard.tsx` (both v1 and v2).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-6101

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: root-cause investigation (traced to TanStack Router `path.js` source), one-file fix, commit/PR authoring
- Human verification: author reproduced the bug on dev against `opik-demos` workspace (`https://dev.comet.com/opik/-demos/configuration`), applied the fix locally against `localhost:5175`, reverted and re-reproduced to confirm the fix was what flipped the behavior

## Testing

- Manually reproduced on dev: as user in `opik-demos` workspace, asked Ollie to navigate to the configuration page — landed on `/opik/-demos/configuration` (bug)
- Applied fix in a local worktree on `localhost:5175`, repeated the navigate flow — URL resolved correctly to `/opik/<workspace>/configuration` with no mangling
- Reverted the fix locally and re-reproduced the mangling to confirm the fix is what changed the behavior
- `npm run typecheck` — clean
- `npm run lint` (ESLint on `AssistantSidebar.tsx`) — clean

## Documentation

N/A — internal frontend bridge bug fix with no user-visible API change. The inline comment above `navigateRef` documents the subtlety for future maintainers.