### PR TITLE
[OPIK-6161] [FE] feat: add "New Opik experience" toggle for v1 users

### DIFF
--- a/apps/opik-frontend/src/lib/workspaceVersion.ts
+++ b/apps/opik-frontend/src/lib/workspaceVersion.ts
@@ -12,14 +12,22 @@ export function getVersionOverride(): WorkspaceVersion | null {
 }
 
 export function getNewExperienceOptIn(): boolean {
-  return localStorage.getItem(OPIK_NEW_EXPERIENCE_OPT_IN_KEY) === "true";
+  try {
+    return localStorage.getItem(OPIK_NEW_EXPERIENCE_OPT_IN_KEY) === "true";
+  } catch {
+    return false;
+  }
 }
 
 export function setNewExperienceOptIn(optIn: boolean): void {
-  if (optIn) {
-    localStorage.setItem(OPIK_NEW_EXPERIENCE_OPT_IN_KEY, "true");
-  } else {
-    localStorage.removeItem(OPIK_NEW_EXPERIENCE_OPT_IN_KEY);
+  try {
+    if (optIn) {
+      localStorage.setItem(OPIK_NEW_EXPERIENCE_OPT_IN_KEY, "true");
+    } else {
+      localStorage.removeItem(OPIK_NEW_EXPERIENCE_OPT_IN_KEY);
+    }
+  } catch {
+    // localStorage unavailable (private mode, quota) — silently skip
   }
 }
 

--- a/apps/opik-frontend/src/lib/workspaceVersion.ts
+++ b/apps/opik-frontend/src/lib/workspaceVersion.ts
@@ -4,10 +4,23 @@ export const DEFAULT_WORKSPACE_VERSION: WorkspaceVersion = "v2";
 
 const OPIK_VERSION_OVERRIDE_KEY = "opik-version-override";
 const OPIK_WORKSPACE_VERSIONS_KEY = "opik-workspace-versions";
+const OPIK_NEW_EXPERIENCE_OPT_IN_KEY = "opik-new-experience-opt-in";
 
 export function getVersionOverride(): WorkspaceVersion | null {
   const override = localStorage.getItem(OPIK_VERSION_OVERRIDE_KEY);
   return override === "v1" || override === "v2" ? override : null;
+}
+
+export function getNewExperienceOptIn(): boolean {
+  return localStorage.getItem(OPIK_NEW_EXPERIENCE_OPT_IN_KEY) === "true";
+}
+
+export function setNewExperienceOptIn(optIn: boolean): void {
+  if (optIn) {
+    localStorage.setItem(OPIK_NEW_EXPERIENCE_OPT_IN_KEY, "true");
+  } else {
+    localStorage.removeItem(OPIK_NEW_EXPERIENCE_OPT_IN_KEY);
+  }
 }
 
 function readVersionMap(): Record<string, WorkspaceVersion> {
@@ -70,6 +83,7 @@ export function getWorkspaceNameFromUrl(): string | null {
 export function resolveSyncWorkspaceVersion(): WorkspaceVersion {
   const override = getVersionOverride();
   if (override) return override;
+  if (getNewExperienceOptIn()) return "v2";
   const workspaceName = getWorkspaceNameFromUrl();
   if (!workspaceName) return DEFAULT_WORKSPACE_VERSION;
   return getCachedWorkspaceVersion(workspaceName) ?? DEFAULT_WORKSPACE_VERSION;

--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -9,12 +9,14 @@ import {
   Settings,
   Settings2,
   Shield,
+  Sparkles,
   UserPlus,
 } from "lucide-react";
 
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import SupportHubSubMenu from "@/shared/SupportHub/SupportHubSubMenu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/ui/avatar";
+import { Switch } from "@/ui/switch";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -33,8 +35,13 @@ import { APP_VERSION } from "@/constants/app";
 import { ADMIN_DASHBOARD_LABEL } from "@/constants/labels";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
-import { cn, maskAPIKey } from "@/lib/utils";
-import useAppStore from "@/store/AppStore";
+import { buildFullBaseUrl, cn, maskAPIKey } from "@/lib/utils";
+import useAppStore, { useDetectedWorkspaceVersion } from "@/store/AppStore";
+import {
+  getNewExperienceOptIn,
+  getVersionOverride,
+  setNewExperienceOptIn,
+} from "@/lib/workspaceVersion";
 import api from "./api";
 import { ORGANIZATION_ROLE_TYPE } from "./types";
 import useOrganizations from "./useOrganizations";
@@ -52,6 +59,10 @@ const UserMenu = () => {
   const { theme, themeOptions, CurrentIcon, handleThemeSelect } =
     useThemeOptions();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const detectedWorkspaceVersion = useDetectedWorkspaceVersion();
+  const hasOptedIn = getNewExperienceOptIn();
+  const showNewExperienceToggle =
+    detectedWorkspaceVersion === "v1" && getVersionOverride() === null;
 
   const { data: user } = useUser();
   const { data: organizations, isLoading } = useOrganizations({
@@ -277,6 +288,24 @@ const UserMenu = () => {
                 </DropdownMenuSubContent>
               </DropdownMenuPortal>
             </DropdownMenuSub>
+            {showNewExperienceToggle && (
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onSelect={(e) => {
+                  e.preventDefault();
+                  setNewExperienceOptIn(!hasOptedIn);
+                  window.location.href = buildFullBaseUrl() + workspaceName;
+                }}
+              >
+                <Sparkles className="mr-2 size-4" />
+                <span>New Opik experience</span>
+                <Switch
+                  checked={hasOptedIn}
+                  className="pointer-events-none ml-auto"
+                  size="sm"
+                />
+              </DropdownMenuItem>
+            )}
           </DropdownMenuGroup>
           {!isLLMOnlyOrganization && (
             <>

--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -294,7 +294,9 @@ const UserMenu = () => {
                 onSelect={(e) => {
                   e.preventDefault();
                   setNewExperienceOptIn(!hasOptedIn);
-                  window.location.href = buildFullBaseUrl() + workspaceName;
+                  const base = buildFullBaseUrl();
+                  const normalizedBase = base.endsWith("/") ? base : `${base}/`;
+                  window.location.href = normalizedBase + workspaceName;
                 }}
               >
                 <Sparkles className="mr-2 size-4" />

--- a/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
+++ b/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
@@ -34,8 +34,10 @@ const WorkspaceVersionResolver: React.FC<WorkspaceVersionResolverProps> = ({
 
     const store = useAppStore.getState();
     store.setWorkspaceVersion(resolvedVersion);
-    if (apiVersion) store.setDetectedWorkspaceVersion(apiVersion);
-    setCachedWorkspaceVersion(workspaceName, resolvedVersion);
+    if (apiVersion) {
+      store.setDetectedWorkspaceVersion(apiVersion);
+      setCachedWorkspaceVersion(workspaceName, apiVersion);
+    }
 
     const reloadKey = VERSION_RELOAD_PREFIX + workspaceName;
 

--- a/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
+++ b/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
@@ -5,6 +5,7 @@ import useAppStore, {
 } from "@/store/AppStore";
 import useWorkspaceVersionQuery from "@/api/workspaces/useWorkspaceVersion";
 import {
+  getNewExperienceOptIn,
   getVersionOverride,
   setCachedWorkspaceVersion,
 } from "@/lib/workspaceVersion";
@@ -21,16 +22,19 @@ const WorkspaceVersionResolver: React.FC<WorkspaceVersionResolverProps> = ({
   children,
 }) => {
   const override = getVersionOverride();
+  const optIn = getNewExperienceOptIn();
   const gateVersion = useWorkspaceVersion();
   const workspaceName = useActiveWorkspaceName();
 
   const { data: apiVersion, isLoading } = useWorkspaceVersionQuery();
-  const resolvedVersion = override ?? apiVersion;
+  const resolvedVersion = override ?? (optIn ? "v2" : apiVersion);
 
   useEffect(() => {
     if (!resolvedVersion || !workspaceName) return;
 
-    useAppStore.getState().setWorkspaceVersion(resolvedVersion);
+    const store = useAppStore.getState();
+    store.setWorkspaceVersion(resolvedVersion);
+    if (apiVersion) store.setDetectedWorkspaceVersion(apiVersion);
     setCachedWorkspaceVersion(workspaceName, resolvedVersion);
 
     const reloadKey = VERSION_RELOAD_PREFIX + workspaceName;
@@ -44,9 +48,9 @@ const WorkspaceVersionResolver: React.FC<WorkspaceVersionResolverProps> = ({
     } else {
       sessionStorage.removeItem(reloadKey);
     }
-  }, [resolvedVersion, gateVersion, workspaceName]);
+  }, [apiVersion, resolvedVersion, gateVersion, workspaceName]);
 
-  if (!override && isLoading) {
+  if (!override && !optIn && isLoading) {
     return <Loader />;
   }
 

--- a/apps/opik-frontend/src/store/AppStore.ts
+++ b/apps/opik-frontend/src/store/AppStore.ts
@@ -19,6 +19,8 @@ type AppStore = {
   setIsProjectLoading: (loading: boolean) => void;
   workspaceVersion: WorkspaceVersion | null;
   setWorkspaceVersion: (version: WorkspaceVersion) => void;
+  detectedWorkspaceVersion: WorkspaceVersion | null;
+  setDetectedWorkspaceVersion: (version: WorkspaceVersion | null) => void;
 };
 
 const useAppStore = create<AppStore>((set) => ({
@@ -43,6 +45,9 @@ const useAppStore = create<AppStore>((set) => ({
   workspaceVersion: null,
   setWorkspaceVersion: (version: WorkspaceVersion) =>
     set({ workspaceVersion: version }),
+  detectedWorkspaceVersion: null,
+  setDetectedWorkspaceVersion: (version: WorkspaceVersion | null) =>
+    set({ detectedWorkspaceVersion: version }),
 }));
 
 export const useActiveWorkspaceName = () =>
@@ -56,6 +61,9 @@ export const useIsProjectLoading = () =>
 
 export const useWorkspaceVersion = () =>
   useAppStore((state) => state.workspaceVersion);
+
+export const useDetectedWorkspaceVersion = () =>
+  useAppStore((state) => state.detectedWorkspaceVersion);
 
 const getResolvedUserName = (userName: string, defaultUserName?: string) => {
   return isDefaultUser(userName) ? defaultUserName : userName;


### PR DESCRIPTION
## Details


https://github.com/user-attachments/assets/735307ad-875a-4e08-8e86-ea98ac7d1f05



Adds a "New Opik experience" toggle to the Comet UserMenu for users whose workspace is currently on v1. Flipping it writes a global `opik-new-experience-opt-in` localStorage flag and redirects to the workspace home so v2 renders on next paint. The menu item is hidden on v2 workspaces and when the debug version override is active.

- Sync resolver priority: debug override > user opt-in > per-workspace cache > default. Opt-in is intentionally global — "I want the new Opik experience" is a user preference, not a per-workspace setting, so it applies to every v1 workspace the user opens.
- `WorkspaceVersionResolver` mirrors the backend-reported version into a new `detectedWorkspaceVersion` store field; `UserMenu` reads from it instead of standing up its own `useWorkspaceVersionQuery` subscription.
- `opik-workspace-versions` cache now stores the backend-reported version rather than the resolved version — keeps cache semantics clean (backend truth only), so opting out doesn't trigger extra reloads on previously-visited workspaces.
- Known limitation (per ticket): users lose datasets/experiments not linked to projects on switch; they can toggle off to get back to v1.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6161

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation (minimal rewrite of earlier PR #6424 by Jacques Verre + cache-semantic follow-up fix)
- Human verification: code review + `scripts/dev-runner.sh --lint-fe` (eslint + tsc + depcruise)

## Testing

- `scripts/dev-runner.sh --lint-fe` — lint:fix + typecheck + deps:validate all green
- Manual verification checklist (to run on Comet dev env since OSS server can't exercise the full rendering path — four API hooks must resolve):
  - v1 workspace: menu item appears with Switch; click flips `opik-new-experience-opt-in`, redirects to workspace home, v2 UI renders.
  - Toggle off again: key cleared, v1 UI renders.
  - v2 workspace: menu item not rendered.
  - `localStorage['opik-version-override']` manually set: menu item hidden (avoids no-op click state).
  - Cross-workspace: opt in on v1 workspace A, open v1 workspace B → B also renders v2 (intended global behavior).

## Documentation

N/A