### PR TITLE
[OPIK-6146] [BE] fix: add 3 more demo dataset names to DemoData exclusion list

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DemoData.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DemoData.java
@@ -21,7 +21,8 @@ public class DemoData {
 
     /** MySQL (utf8mb4_unicode_ci) — matching is case-insensitive, no need for case variants. */
     public static final List<String> DATASETS = List.of("Demo dataset", "Opik Demo Questions",
-            "Demo - Opik Chatbot", "Demo - Jailbreak Password", "Demo - Customer Message Classifier");
+            "Demo - Opik Chatbot", "Demo - Jailbreak Password", "Demo - Customer Message Classifier",
+            "Opik Demo Chatbot Training", "Opik Demo Text to SQL", "Opik Demo Structured Output");
 
     /** ClickHouse — matching is case-sensitive, list every known casing explicitly. */
     public static final List<String> EXPERIMENTS = List.of(


### PR DESCRIPTION
## Details
Preemptively add 3 demo dataset names to `DemoData.DATASETS` that exist in older demo generation code but have no production data at the moment: `Opik Demo Chatbot Training`, `Opik Demo Text to SQL`, `Opik Demo Structured Output`. This prevents them from blocking V2 workspace promotion in other installations.

Follow-up to #6419 and #6420.

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- OPIK-6146

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review

## Testing

- `mvn compile -pl .` — clean compilation
- No new test needed — existing `WorkspaceVersionResourceTest` already covers the `DemoData.DATASETS` exclusion path, and MySQL collation is case-insensitive

## Documentation

N/A