### PR TITLE
[OPIK-5956] [BE] fix: time-range filter matches trace start_time, not UUIDv7 id time

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -166,6 +166,8 @@ public class TracesResource {
                 .stripAttachments(stripAttachments)
                 .uuidFromTime(instantToUUIDMapper.toLowerBound(startTime))
                 .uuidToTime(instantToUUIDMapper.toUpperBound(endTime))
+                .fromTime(startTime)
+                .toTime(endTime)
                 .exclude(ParamsValidator.get(exclude, Trace.TraceField.class, "exclude"))
                 .sortingFields(sortingFields)
                 .searchText(StringUtils.trimToNull(search))
@@ -422,6 +424,8 @@ public class TracesResource {
                 .searchText(StringUtils.trimToNull(search))
                 .uuidFromTime(instantToUUIDMapper.toLowerBound(startTime))
                 .uuidToTime(instantToUUIDMapper.toUpperBound(endTime))
+                .fromTime(startTime)
+                .toTime(endTime)
                 .build();
 
         String workspaceId = requestContext.get().getWorkspaceId();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -811,6 +811,8 @@ class TraceDAOImpl implements TraceDAO {
                 <if(last_received_id)> AND id \\< :last_received_id <endif>
                 <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
                 <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                <if(from_time)> AND start_time >= parseDateTime64BestEffort(:from_time, 9) <endif>
+                <if(to_time)> AND start_time \\<= parseDateTime64BestEffort(:to_time, 9) <endif>
                 <if(filters)> AND <filters> <endif>
                 <if(search_text)> AND <search_text> <endif>
             ), <endif><if(!exclude_feedback_scores)>feedback_scores_deduped AS (
@@ -1234,6 +1236,8 @@ class TraceDAOImpl implements TraceDAO {
                 AND project_id = :project_id
                 <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
                 <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                <if(from_time)> AND start_time >= parseDateTime64BestEffort(:from_time, 9) <endif>
+                <if(to_time)> AND start_time \\<= parseDateTime64BestEffort(:to_time, 9) <endif>
                 <if(last_received_id)> AND id \\< :last_received_id <endif>
                 <if(filters)> AND <filters> <endif>
                 <if(search_text)> AND <search_text> <endif>
@@ -1621,6 +1625,8 @@ class TraceDAOImpl implements TraceDAO {
                     AND workspace_id = :workspace_id
                     <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
                     <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                    <if(from_time)> AND start_time >= parseDateTime64BestEffort(:from_time, 9) <endif>
+                    <if(to_time)> AND start_time \\<= parseDateTime64BestEffort(:to_time, 9) <endif>
                     <if(filters)> AND <filters> <endif>
                     <if(search_text)> AND <search_text> <endif>
                     <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
@@ -2256,6 +2262,8 @@ class TraceDAOImpl implements TraceDAO {
                 AND project_id IN :project_ids
                 <if(uuid_from_time)>AND id >= :uuid_from_time<endif>
                 <if(uuid_to_time)>AND id \\<= :uuid_to_time<endif>
+                <if(from_time)> AND start_time >= parseDateTime64BestEffort(:from_time, 9) <endif>
+                <if(to_time)> AND start_time \\<= parseDateTime64BestEffort(:to_time, 9) <endif>
                 <if(filters)> AND <filters> <endif>
                 <if(search_text)> AND <search_text> <endif>
                 <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
@@ -3456,6 +3464,11 @@ class TraceDAOImpl implements TraceDAO {
 
         return asyncTemplate
                 .nonTransaction(connection -> {
+                    // This path bypasses newTraceThreadFindTemplate / bindTraceThreadSearchCriteria and wires
+                    // template attrs + R2DBC binds manually. If time-window filtering (from_time/to_time,
+                    // uuid_from_time/uuid_to_time) is ever added here, the placeholders in SELECT_TRACES_STATS
+                    // must have matching explicit binds below — otherwise the driver will fail with an
+                    // unbound-parameter error at runtime.
                     var template = getSTWithLogComment(SELECT_TRACES_STATS, "get_trace_stats_by_project_ids",
                             workspaceId, "", projectIds.size());
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceSearchCriteria.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceSearchCriteria.java
@@ -5,6 +5,7 @@ import com.comet.opik.api.filter.Filter;
 import com.comet.opik.api.sorting.SortingField;
 import lombok.Builder;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -21,5 +22,7 @@ public record TraceSearchCriteria(
         Set<Trace.TraceField> exclude,
         UUID uuidFromTime,
         UUID uuidToTime,
+        Instant fromTime,
+        Instant toTime,
         String searchText) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/FilterUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/FilterUtils.java
@@ -148,6 +148,14 @@ public class FilterUtils {
         Optional.ofNullable(traceSearchCriteria.uuidToTime())
                 .ifPresent(uuid_to_time -> template.add("uuid_to_time", uuid_to_time));
 
+        // start_time bounds: UUIDv7 id-time approximates start_time only for live tracing. Backfills
+        // and imports set historical start_time on freshly-generated ids, so id-based filtering alone
+        // admits rows whose actual event time is outside the window (OPIK-5956).
+        Optional.ofNullable(traceSearchCriteria.fromTime())
+                .ifPresent(from_time -> template.add("from_time", from_time.toString()));
+        Optional.ofNullable(traceSearchCriteria.toTime())
+                .ifPresent(to_time -> template.add("to_time", to_time.toString()));
+
         Optional.ofNullable(traceSearchCriteria.searchText())
                 .ifPresent(searchText -> template.add("search_text", searchClause));
         return template;
@@ -178,6 +186,11 @@ public class FilterUtils {
                 .ifPresent(uuid_from_time -> statement.bind("uuid_from_time", uuid_from_time));
         Optional.ofNullable(traceSearchCriteria.uuidToTime())
                 .ifPresent(uuid_to_time -> statement.bind("uuid_to_time", uuid_to_time));
+
+        Optional.ofNullable(traceSearchCriteria.fromTime())
+                .ifPresent(from_time -> statement.bind("from_time", from_time.toString()));
+        Optional.ofNullable(traceSearchCriteria.toTime())
+                .ifPresent(to_time -> statement.bind("to_time", to_time.toString()));
 
         Optional.ofNullable(traceSearchCriteria.searchText())
                 .ifPresent(searchText -> statement.bind("search_text", "%" + searchText + "%"));

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/GetTracesByProjectResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/GetTracesByProjectResourceTest.java
@@ -8,6 +8,7 @@ import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem.FeedbackScoreBatchItemBuilder;
 import com.comet.opik.api.Guardrail;
 import com.comet.opik.api.Project;
+import com.comet.opik.api.ProjectStats;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.Trace.TracePage;
@@ -5366,6 +5367,121 @@ class GetTracesByProjectResourceTest {
             assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
         }
 
+        // OPIK-5956: from_time must filter by start_time, not by UUIDv7 id creation time.
+        // Customers backfill traces by generating fresh ids at upload time while setting
+        // start_time to the historical event time. With id-based filtering, those traces
+        // leak through even when start_time is well before from_time.
+        @Test
+        @DisplayName("from_time filters by trace start_time, not UUIDv7 id creation time (OPIK-5956)")
+        void whenTraceStartTimeIsBeforeFromTime_butIdIsFresh_thenExcludeFromResults() {
+            var workspace = setupTestWorkspace();
+
+            Instant now = Instant.now();
+            Instant fromTime = now.minus(Duration.ofDays(3));
+
+            // Backfill scenario: fresh UUIDv7 id (id-time == now) but start_time 7 days ago.
+            Trace backfilledTrace = createTrace().toBuilder()
+                    .projectName(workspace.projectName())
+                    .id(idGenerator.generateId())
+                    .startTime(now.minus(Duration.ofDays(7)))
+                    .endTime(now.minus(Duration.ofDays(7)).plus(Duration.ofMillis(100)))
+                    .spanCount(0)
+                    .llmSpanCount(0)
+                    .guardrailsValidations(null)
+                    .feedbackScores(null)
+                    .spanFeedbackScores(null)
+                    .build();
+
+            // Live scenario: fresh id, recent start_time - should be included.
+            Trace liveTrace = createTrace().toBuilder()
+                    .projectName(workspace.projectName())
+                    .id(idGenerator.generateId())
+                    .startTime(now.minus(Duration.ofHours(1)))
+                    .endTime(now.minus(Duration.ofHours(1)).plus(Duration.ofMillis(100)))
+                    .spanCount(0)
+                    .llmSpanCount(0)
+                    .guardrailsValidations(null)
+                    .feedbackScores(null)
+                    .spanFeedbackScores(null)
+                    .build();
+
+            traceResourceClient.batchCreateTraces(
+                    List.of(backfilledTrace, liveTrace), workspace.apiKey(), workspace.workspaceName());
+
+            Map<String, String> queryParams = new HashMap<>();
+            queryParams.put("project_name", workspace.projectName());
+            queryParams.put("from_time", fromTime.toString());
+
+            var actualResponse = traceResourceClient.callGetTracesWithQueryParams(
+                    workspace.apiKey(), workspace.workspaceName(), queryParams);
+
+            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
+            var tracePage = actualResponse.readEntity(TracePage.class);
+
+            assertThat(tracePage.content())
+                    .as("backfilled trace with start_time=%s must be excluded by from_time=%s",
+                            backfilledTrace.startTime(), fromTime)
+                    .noneSatisfy(t -> assertThat(t.id()).isEqualTo(backfilledTrace.id()));
+
+            assertThat(tracePage.content())
+                    .as("live trace with start_time after from_time must be included")
+                    .anySatisfy(t -> assertThat(t.id()).isEqualTo(liveTrace.id()));
+        }
+
+        // OPIK-5956: /traces/stats must also filter by start_time, not id-time. The list endpoint
+        // and the stats endpoint share the same from_time/to_time contract on the UI.
+        @Test
+        @DisplayName("/traces/stats trace_count excludes backfilled traces whose start_time is before from_time (OPIK-5956)")
+        void whenStatsRequestedWithFromTime_thenBackfilledTraceIsNotCounted() {
+            var workspace = setupTestWorkspace();
+
+            Instant now = Instant.now();
+            Instant fromTime = now.minus(Duration.ofDays(3));
+
+            Trace backfilledTrace = createTrace().toBuilder()
+                    .projectName(workspace.projectName())
+                    .id(idGenerator.generateId())
+                    .startTime(now.minus(Duration.ofDays(7)))
+                    .endTime(now.minus(Duration.ofDays(7)).plus(Duration.ofMillis(100)))
+                    .spanCount(0)
+                    .llmSpanCount(0)
+                    .guardrailsValidations(null)
+                    .feedbackScores(null)
+                    .spanFeedbackScores(null)
+                    .build();
+
+            Trace liveTrace = createTrace().toBuilder()
+                    .projectName(workspace.projectName())
+                    .id(idGenerator.generateId())
+                    .startTime(now.minus(Duration.ofHours(1)))
+                    .endTime(now.minus(Duration.ofHours(1)).plus(Duration.ofMillis(100)))
+                    .spanCount(0)
+                    .llmSpanCount(0)
+                    .guardrailsValidations(null)
+                    .feedbackScores(null)
+                    .spanFeedbackScores(null)
+                    .build();
+
+            traceResourceClient.batchCreateTraces(
+                    List.of(backfilledTrace, liveTrace), workspace.apiKey(), workspace.workspaceName());
+
+            Map<String, String> queryParams = new HashMap<>();
+            queryParams.put("from_time", fromTime.toString());
+
+            var stats = traceResourceClient.getTraceStats(
+                    workspace.projectName(), null, workspace.apiKey(), workspace.workspaceName(), null, queryParams);
+
+            var traceCount = stats.stats().stream()
+                    .filter(s -> "trace_count".equals(s.getName()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("trace_count stat not found"));
+
+            assertThat(((ProjectStats.CountValueStat) traceCount).getValue())
+                    .as("trace_count must exclude backfilled trace (start_time=%s < from_time=%s)",
+                            backfilledTrace.startTime(), fromTime)
+                    .isEqualTo(1L);
+        }
+
         // Helper methods to reduce duplication
         private TestWorkspace setupTestWorkspace() {
             var workspaceName = RandomStringUtils.secure().nextAlphanumeric(10);
@@ -5382,6 +5498,8 @@ class GetTracesByProjectResourceTest {
             return createTrace().toBuilder()
                     .projectName(projectName)
                     .id(idGenerator.generateId(timestamp))
+                    .startTime(timestamp)
+                    .endTime(timestamp.plus(Duration.ofMillis(100)))
                     .spanCount(0)
                     .llmSpanCount(0)
                     .guardrailsValidations(null)


### PR DESCRIPTION
## Details

Time-range filters on the Traces UI (`from_time`/`to_time`) were translated into UUIDv7 bounds and filtered by `id >= :uuid_from_time`. UUIDv7 ids encode the SDK's **generation** timestamp, which approximates `start_time` for live tracing but diverges for **backfills/imports** — customers generate fresh ids at upload time while setting `start_time` to the historical event time. Those backfilled traces leaked through any "last N hours/days" filter.

Fix: add `start_time` predicates alongside the UUIDv7 bounds at the three user-facing trace query sites. UUIDv7 bounds stay as a cheap PK-prefix pre-filter (the traces table PK is `(workspace_id, project_id, id)`); `start_time` becomes the authoritative semantic filter.

- **`TraceSearchCriteria`** — carry the raw `Instant fromTime` / `toTime` through the data layer alongside the existing `uuidFromTime` / `uuidToTime`.
- **`TracesResource`** — `getTracesByProject` (list) and `getStats` now pass the parsed `startTime` / `endTime` into the criteria builder. `getThreadStats` is intentionally untouched — threads use a different DAO whose SQL has no `from_time` placeholder, and the reported bug is list+stats on the Traces page.
- **`FilterUtils`** — `newTraceThreadFindTemplate` adds `from_time`/`to_time` ST4 attributes (as ISO-8601 strings) when non-null; `bindTraceThreadSearchCriteria` binds them. Follows the same `Optional.ofNullable(...).ifPresent(...)` pattern as `uuidFromTime` / `lastReceivedId`, so callers that don't set the new fields produce byte-for-byte identical SQL.
- **`TraceDAO`** — adds `AND start_time >= parseDateTime64BestEffort(:from_time, 9)` / `<= :to_time` at four template sites gated by `<if(from_time)>` / `<if(to_time)>`:
  - `SELECT_BY_PROJECT_ID` → `trace_id_prefilter` CTE
  - `SELECT_BY_PROJECT_ID` → `traces_deduped` main WHERE
  - `COUNT_BY_PROJECT_ID` → inner `FROM traces` WHERE (drives page `total`)
  - `SELECT_TRACES_STATS` → main `FROM traces final` WHERE
- Added a maintenance comment in `TraceDAO.getStatsByProjectIds` flagging that the manual bind path must be kept in sync with `bindTraceThreadSearchCriteria` if time-window filtering is ever extended to it.

Feedback-score / span-feedback-score / annotation-queue sub-CTEs keep their existing `uuid_from_time` filters on joined `entity_id` / `trace_id` — those are performance pre-filters on auxiliary tables that don't have `start_time`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5956

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation (bug investigation via acli/Jira, TDD regression tests, DAO template edits, criteria/resource wiring)
- Human verification: code review + running the new regression tests against a Testcontainers ClickHouse instance

## Testing

Exact commands run from `apps/opik-backend`:

- `mvn spotless:apply`
- `mvn -Dtest='GetTracesByProjectResourceTest$GetTracesByProjectTimeFilteringTests' test` — **15/15 passing** (14 existing + 2 new OPIK-5956 regression tests).
- `mvn -Dtest='GetTracesByProjectResourceTest' test` — **1492/1492 passing** (full outer class covering list, stats, stream, filter, search).

Scenarios validated:

- **`whenTraceStartTimeIsBeforeFromTime_butIdIsFresh_thenExcludeFromResults`** (new, OPIK-5956) — creates a trace with a fresh UUIDv7 id but `start_time = now - 7 days`, queries `GET /traces?from_time=now-3d`, asserts the backfilled trace is excluded and a recent live trace is included. Fails on `main`; passes with the fix.
- **`whenStatsRequestedWithFromTime_thenBackfilledTraceIsNotCounted`** (new, OPIK-5956) — parallel test for `GET /traces/stats`; asserts `trace_count == 1` (only the live trace contributes).
- Existing parameterized time-filter tests (bounds-inclusive, ISO-8601 parsing, invalid parameter handling, `from_time` alone, `to_time` alone) continue to pass across `/traces`, `/traces/stats`, `/traces/stream`.
- Existing `FindTraces`, `FilterTest`, `SearchTraces` nested classes continue to pass, confirming no regression in unrelated code paths.

A minor helper tightening: `createTraceAtTimestamp` in the test file now sets `startTime(timestamp)` in addition to `id(idGenerator.generateId(timestamp))`. The previous helper left `startTime` as random podam data, which worked tautologically against the old UUID-based filter but couldn't catch the OPIK-5956 bug by construction. The new form reflects what live tracing actually produces (`id-time ≈ start_time`) and keeps existing parameterized tests asserting the correct behavior.

Environment: local Testcontainers-backed JUnit suite (ClickHouse + MySQL + Redis), Java 21, macOS.

## Documentation

N/A — behavioral fix; no public API or documented contract changed.