### PR TITLE
[OPIK-6159] [FE] fix: UX polish for assertions UI across suite dialogs

### DIFF
--- a/apps/opik-frontend/src/constants/explainers.ts
+++ b/apps/opik-frontend/src/constants/explainers.ts
@@ -175,7 +175,7 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
   [EXPLAINER_ID.why_would_i_want_to_add_traces_to_an_test_suite]: {
     id: EXPLAINER_ID.why_would_i_want_to_add_traces_to_an_test_suite,
     description:
-      "Add traces to a test suite to evaluate and benchmark LLM outputs using real production data. You can then use these test suites in experiments to track how your LLM app's performance evolves over time.",
+      "Add traces to a test suite to evaluate your agent's performance using real production data.",
   },
   [EXPLAINER_ID.hows_the_cost_estimated]: {
     id: EXPLAINER_ID.hows_the_cost_estimated,

--- a/apps/opik-frontend/src/shared/AssertionField/AssertionsField.tsx
+++ b/apps/opik-frontend/src/shared/AssertionField/AssertionsField.tsx
@@ -22,7 +22,7 @@ const VARIANT_CONFIG: Record<
 
 interface AssertionsFieldProps {
   variant: AssertionsVariant;
-  headerContent?: React.ReactNode;
+  footerContent?: React.ReactNode;
   readOnlyAssertions?: string[];
   editableAssertions: string[];
   onChangeEditable: (index: number, value: string) => void;
@@ -33,7 +33,7 @@ interface AssertionsFieldProps {
 
 const AssertionsField: React.FC<AssertionsFieldProps> = ({
   variant,
-  headerContent,
+  footerContent,
   readOnlyAssertions = [],
   editableAssertions,
   onChangeEditable,
@@ -42,9 +42,12 @@ const AssertionsField: React.FC<AssertionsFieldProps> = ({
   placeholder = "e.g. Response should be factually accurate",
 }) => {
   const prevCountRef = useRef(editableAssertions.length);
-  const shouldAutoFocusLast = editableAssertions.length > prevCountRef.current;
+  const firstFieldRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
+    if (editableAssertions.length > prevCountRef.current) {
+      firstFieldRef.current?.focus();
+    }
     prevCountRef.current = editableAssertions.length;
   }, [editableAssertions.length]);
 
@@ -68,7 +71,6 @@ const AssertionsField: React.FC<AssertionsFieldProps> = ({
               Assertion
             </button>
           )}
-          {headerContent}
         </div>
       </div>
 
@@ -77,13 +79,11 @@ const AssertionsField: React.FC<AssertionsFieldProps> = ({
           <button
             type="button"
             onClick={onAdd}
-            className="flex flex-col items-center justify-center gap-1.5 rounded-md border bg-muted/50 p-4"
+            className="flex flex-col items-center justify-center gap-1.5 rounded-lg border border-primary/40 bg-primary/5 p-4"
           >
-            <div className="flex size-6 items-center justify-center rounded-full border">
-              <CheckCheck className="size-3 text-muted-slate" />
-            </div>
+            <CheckCheck className="size-4 text-muted-slate" />
             <span className="comet-body-xs text-muted-slate">
-              No custom assertions added yet
+              No assertions added yet
             </span>
             <span className="comet-body-xs-accented inline-flex items-center text-primary">
               <Plus className="mr-0.5 size-3" />
@@ -97,9 +97,7 @@ const AssertionsField: React.FC<AssertionsFieldProps> = ({
             {editableAssertions.map((assertion, index) => (
               <AssertionField
                 key={index}
-                autoFocus={
-                  shouldAutoFocusLast && index === editableAssertions.length - 1
-                }
+                ref={index === 0 ? firstFieldRef : undefined}
                 placeholder={placeholder}
                 value={assertion}
                 onChange={(e) => onChangeEditable(index, e.target.value)}
@@ -120,6 +118,7 @@ const AssertionsField: React.FC<AssertionsFieldProps> = ({
             ))}
           </div>
         )}
+        {footerContent}
       </div>
     </div>
   );

--- a/apps/opik-frontend/src/shared/EvaluationCriteriaSection/EvaluationCriteriaSection.tsx
+++ b/apps/opik-frontend/src/shared/EvaluationCriteriaSection/EvaluationCriteriaSection.tsx
@@ -26,6 +26,8 @@ export interface EvaluationCriteriaSectionProps {
   useGlobalPolicy: boolean;
   onRevertToDefaults: () => void;
   onOpenSettings?: () => void;
+  defaultRunsPerItem: number;
+  defaultPassThreshold: number;
 }
 
 const EvaluationCriteriaSection: React.FunctionComponent<
@@ -43,6 +45,8 @@ const EvaluationCriteriaSection: React.FunctionComponent<
   useGlobalPolicy,
   onRevertToDefaults,
   onOpenSettings,
+  defaultRunsPerItem,
+  defaultPassThreshold,
 }) => {
   const runsInput = useClampedIntegerInput({
     value: runsPerItem,
@@ -64,7 +68,7 @@ const EvaluationCriteriaSection: React.FunctionComponent<
   const manageSettingsButton = onOpenSettings ? (
     <button
       type="button"
-      className="comet-body-xs inline-flex shrink-0 items-center gap-1 border-b border-foreground text-foreground"
+      className="comet-body-xs inline-flex shrink-0 items-center gap-1 text-foreground underline"
       onClick={onOpenSettings}
     >
       <Settings2 className="size-3.5 shrink-0" />
@@ -76,7 +80,7 @@ const EvaluationCriteriaSection: React.FunctionComponent<
     <div>
       <AssertionsField
         variant="item"
-        headerContent={manageSettingsButton}
+        footerContent={manageSettingsButton}
         readOnlyAssertions={suiteAssertions}
         editableAssertions={editableAssertions}
         onChangeEditable={onChangeAssertion}
@@ -136,7 +140,7 @@ const EvaluationCriteriaSection: React.FunctionComponent<
           content={
             useGlobalPolicy
               ? "Already using the suite's defaults"
-              : "Revert to the default values for this test suite"
+              : `Revert to suite defaults (runs: ${defaultRunsPerItem}, threshold: ${defaultPassThreshold})`
           }
         >
           <button

--- a/apps/opik-frontend/src/v1/pages/TestSuiteItemsPage/TestSuiteItemPanel/TestSuiteItemForm.tsx
+++ b/apps/opik-frontend/src/v1/pages/TestSuiteItemsPage/TestSuiteItemPanel/TestSuiteItemForm.tsx
@@ -209,10 +209,10 @@ const EvaluationCriteriaSection: React.FC<EvaluationCriteriaSectionProps> = ({
 
       <AssertionsField
         variant="item"
-        headerContent={
+        footerContent={
           <button
             type="button"
-            className="comet-body-xs inline-flex shrink-0 items-center gap-1 border-b border-foreground text-foreground"
+            className="comet-body-xs inline-flex shrink-0 items-center gap-1 text-foreground underline"
             onClick={onOpenSettings}
           >
             <Settings2 className="size-3.5 shrink-0" />

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/EditTestSuiteSettingsDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/EditTestSuiteSettingsDialog.tsx
@@ -64,7 +64,7 @@ const SettingsForm: React.FC<SettingsFormProps> = ({
     mode: "onChange",
   });
 
-  const { fields, append, remove, update } = useFieldArray({
+  const { fields, prepend, remove, update } = useFieldArray({
     control: form.control,
     name: "assertions",
   });
@@ -99,70 +99,76 @@ const SettingsForm: React.FC<SettingsFormProps> = ({
         </DialogHeader>
         <DialogAutoScrollBody>
           <div className="flex flex-col">
-            <div className="mb-4">
-              <AssertionsField
-                variant="global"
-                editableAssertions={fields.map((f) => f.value)}
-                onChangeEditable={(index, value) => update(index, { value })}
-                onRemoveEditable={(index) => remove(index)}
-                onAdd={() => append({ value: "" })}
-                placeholder="e.g. Response should be factually accurate and cite sources"
-              />
-            </div>
+            <AssertionsField
+              variant="global"
+              editableAssertions={fields.map((f) => f.value)}
+              onChangeEditable={(index, value) => update(index, { value })}
+              onRemoveEditable={(index) => remove(index)}
+              onAdd={() => prepend({ value: "" })}
+              placeholder="e.g. Response should be factually accurate and cite sources"
+            />
 
-            <div className="mb-4">
-              <h3 className="comet-body-s-accented">{PASS_CRITERIA_TITLE}</h3>
-              <p className="comet-body-xs text-light-slate">
-                {PASS_CRITERIA_DESCRIPTION}
-              </p>
-            </div>
+            <h3 className="comet-body-s-accented mb-1 mt-6">
+              {PASS_CRITERIA_TITLE}
+            </h3>
+            <p className="comet-body-xs mb-4 text-light-slate">
+              {PASS_CRITERIA_DESCRIPTION}
+            </p>
 
-            <div className="mb-4 flex gap-4">
-              <div className="flex flex-1 flex-col gap-1">
-                <Label
-                  htmlFor="runs-per-item"
-                  className="comet-body-xs-accented"
-                >
-                  Default runs per item
-                </Label>
-                <Input
-                  id="runs-per-item"
-                  dimension="sm"
-                  className={cn({
-                    "border-destructive": runsInput.isInvalid,
-                  })}
-                  type="number"
-                  min={1}
-                  max={MAX_RUNS_PER_ITEM}
-                  value={runsInput.displayValue}
-                  onChange={runsInput.onChange}
-                  onFocus={runsInput.onFocus}
-                  onBlur={runsInput.onBlur}
-                  onKeyDown={runsInput.onKeyDown}
-                />
-              </div>
-              <div className="flex flex-1 flex-col gap-1">
-                <Label
-                  htmlFor="pass-threshold"
-                  className="comet-body-xs-accented"
-                >
-                  Default pass threshold
-                </Label>
-                <Input
-                  id="pass-threshold"
-                  dimension="sm"
-                  className={cn({
-                    "border-destructive": thresholdInput.isInvalid,
-                  })}
-                  type="number"
-                  min={1}
-                  max={runsPerItem}
-                  value={thresholdInput.displayValue}
-                  onChange={thresholdInput.onChange}
-                  onFocus={thresholdInput.onFocus}
-                  onBlur={thresholdInput.onBlur}
-                  onKeyDown={thresholdInput.onKeyDown}
-                />
+            <div className="mb-4 overflow-hidden rounded-md border p-3">
+              <div className="flex gap-4">
+                <div className="flex flex-1 flex-col gap-1">
+                  <Label
+                    htmlFor="runs-per-item"
+                    className="comet-body-xs-accented"
+                  >
+                    Default runs per item
+                  </Label>
+                  <Input
+                    id="runs-per-item"
+                    dimension="sm"
+                    className={cn({
+                      "border-destructive": runsInput.isInvalid,
+                    })}
+                    type="number"
+                    min={1}
+                    max={MAX_RUNS_PER_ITEM}
+                    value={runsInput.displayValue}
+                    onChange={runsInput.onChange}
+                    onFocus={runsInput.onFocus}
+                    onBlur={runsInput.onBlur}
+                    onKeyDown={runsInput.onKeyDown}
+                  />
+                  <span className="comet-body-xs text-light-slate">
+                    Sets how many times each item runs.
+                  </span>
+                </div>
+                <div className="flex flex-1 flex-col gap-1">
+                  <Label
+                    htmlFor="pass-threshold"
+                    className="comet-body-xs-accented"
+                  >
+                    Default pass threshold
+                  </Label>
+                  <Input
+                    id="pass-threshold"
+                    dimension="sm"
+                    className={cn({
+                      "border-destructive": thresholdInput.isInvalid,
+                    })}
+                    type="number"
+                    min={1}
+                    max={runsPerItem}
+                    value={thresholdInput.displayValue}
+                    onChange={thresholdInput.onChange}
+                    onFocus={thresholdInput.onFocus}
+                    onBlur={thresholdInput.onBlur}
+                    onKeyDown={thresholdInput.onKeyDown}
+                  />
+                  <span className="comet-body-xs text-light-slate">
+                    Define how many runs must succeed.
+                  </span>
+                </div>
               </div>
             </div>
           </div>

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/TestSuiteItemForm.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/TestSuiteItemForm.tsx
@@ -115,7 +115,7 @@ const FormEvaluationCriteriaSection: React.FC<
   FormEvaluationCriteriaSectionProps
 > = ({ suiteAssertions, suitePolicy, onOpenSettings }) => {
   const form = useFormContext<TestSuiteItemFormValues>();
-  const { fields, append, remove, update } = useFieldArray({
+  const { fields, prepend, remove, update } = useFieldArray({
     control: form.control,
     name: "assertions",
   });
@@ -163,7 +163,7 @@ const FormEvaluationCriteriaSection: React.FC<
       editableAssertions={fields.map((f) => f.value)}
       onChangeAssertion={(index, value) => update(index, { value })}
       onRemoveAssertion={(index) => remove(index)}
-      onAddAssertion={() => append({ value: "" })}
+      onAddAssertion={() => prepend({ value: "" })}
       runsPerItem={runsPerItem}
       passThreshold={passThreshold}
       onRunsPerItemChange={handleRunsChange}
@@ -171,6 +171,8 @@ const FormEvaluationCriteriaSection: React.FC<
       useGlobalPolicy={useGlobalPolicy}
       onRevertToDefaults={handleRevertPolicy}
       onOpenSettings={onOpenSettings}
+      defaultRunsPerItem={suitePolicy.runs_per_item}
+      defaultPassThreshold={suitePolicy.pass_threshold}
     />
   );
 };

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.tsx
@@ -258,7 +258,7 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
   }, []);
 
   const handleAssertionAdd = useCallback(() => {
-    setAssertions((prev) => [...prev, ""]);
+    setAssertions((prev) => ["", ...prev]);
   }, []);
 
   const handleRunsPerItemChange = useCallback(
@@ -503,7 +503,7 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
   return (
     <>
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-lg sm:max-w-[560px]">
+        <DialogContent className="max-w-lg sm:max-w-screen-sm">
           <DialogHeader>
             <DialogTitle>Add to {entityName}</DialogTitle>
           </DialogHeader>
@@ -522,7 +522,26 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
                 value={selectedDataset?.id ?? ""}
                 onChange={handleDatasetSelect}
                 options={datasetOptions}
-                placeholder={`Select a ${entityName}`}
+                placeholder={
+                  <div className="flex items-center gap-2">
+                    {isTestSuiteMode ? (
+                      <ListChecks className="size-4 shrink-0 text-muted-slate" />
+                    ) : (
+                      <Database className="size-4 shrink-0 text-muted-slate" />
+                    )}
+                    <span>Select a {entityName}</span>
+                  </div>
+                }
+                renderTitle={(option: DropdownOption<string>) => (
+                  <div className="flex items-center gap-2 truncate">
+                    {isTestSuiteMode ? (
+                      <ListChecks className="size-4 shrink-0 text-muted-slate" />
+                    ) : (
+                      <Database className="size-4 shrink-0 text-muted-slate" />
+                    )}
+                    <span className="truncate">{option.label}</span>
+                  </div>
+                )}
                 searchPlaceholder={`Search ${entityName}s`}
                 isLoading={isPending}
                 disabled={noValidRows}
@@ -553,7 +572,7 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
               </div>
             )}
             {isTestSuiteMode && selectedDataset && (
-              <div ref={configSectionRef} className="mt-4">
+              <div ref={configSectionRef} className="mt-6">
                 <EvaluationCriteriaSection
                   suiteAssertions={suiteAssertions}
                   editableAssertions={assertions}
@@ -566,6 +585,8 @@ const AddToDatasetDialog: React.FunctionComponent<AddToDatasetDialogProps> = ({
                   onPassThresholdChange={handlePassThresholdChange}
                   useGlobalPolicy={useGlobalPolicy}
                   onRevertToDefaults={handleRevertToDefaults}
+                  defaultRunsPerItem={suiteExecutionPolicy.runs_per_item}
+                  defaultPassThreshold={suiteExecutionPolicy.pass_threshold}
                 />
               </div>
             )}


### PR DESCRIPTION
## Details
UX polish for assertions UI across test suite dialogs per designer feedback (OPIK-6159):
- Widen "Add to test suite/dataset" dialog to 640px, add entity icon to select trigger
- Rework assertions empty state with blue-tinted styling, move "Manage global assertions" below the list
- Auto-focus new assertion field on prepend, consistent 1.5rem section spacing
- Add border wrapper and descriptions to pass criteria inputs in test settings dialog
- Show actual default values in revert tooltip (runs/threshold)
- Shorten test suite explainer text

## Issues
https://comet-ml.atlassian.net/browse/OPIK-6159

## Testing
- Open "Add to test suite" dialog — verify wider width, icon in select trigger, shortened explainer
- Open "Add to dataset" dialog — verify DB icon in select trigger
- Verify assertions empty state has blue-tinted border/background
- Add assertion via "+ Assertion" — verify it appears at top and is auto-focused
- Open test settings dialog — verify consistent 1.5rem spacing between sections, border around pass criteria
- Open item panel — verify "Manage global assertions" appears below global assertions
- Verify revert tooltip shows actual default values
- Check v1 item panel — verify footerContent styling matches v2

## Change checklist
- [x] I have reviewed my own code
- [x] Frontend only — no backend changes

## Documentation
No documentation changes needed.