### PR TITLE
[OPIK-6174]: Fix members search

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/CollaboratorsTab.tsx
+++ b/apps/opik-frontend/src/plugins/comet/CollaboratorsTab.tsx
@@ -210,7 +210,7 @@ const CollaboratorsTab = () => {
       ? mappedMembers.filter((member) => {
           return (
             member.userName?.toLowerCase().includes(searchLower) ||
-            member.email.toLowerCase().includes(searchLower) ||
+            member.email?.toLowerCase().includes(searchLower) ||
             member.role?.toLowerCase().includes(searchLower)
           );
         })


### PR DESCRIPTION
## Details

Fix a crash in the Collaborators tab when searching for members. If any member in the list had an undefined `email` field, calling `member.email.toLowerCase()` threw a `TypeError` and broke the entire member list rendering. Added optional chaining (`member.email?.toLowerCase()`) to match the handling already used for `userName` and `role` in the same filter.

## Change checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- Navigate to a workspace's Collaborators tab that includes a member without an email populated.
- Type any query into the search input.
- Confirm the member list filters without throwing an error in the console and that results match matches against `userName`, `email`, or `role`.

## Issues

Resolves [OPIK-6174](https://comet-ml.atlassian.net/browse/OPIK-6174).

## Documentation

No documentation changes required.


[OPIK-6174]: https://comet-ml.atlassian.net/browse/OPIK-6174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ