### PR TITLE
[NA] [BE] Fix silently-dropped demo experiment items in prod

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
+++ b/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
@@ -853,6 +853,12 @@ def create_demo_test_suite_and_experiments(base_url: str, workspace_name, comet_
                         experiment_id=experiment.id,
                         dataset_item_id=dataset_item_id,
                         trace_id=trace_id,
+                        # Pin project_name so the backend resolves project_id
+                        # deterministically via projectService.retrieveByNamesOrCreate
+                        # instead of falling back to a trace lookup — that lookup
+                        # races with ClickHouse ingestion of the traces we just
+                        # POSTed and can return null in prod.
+                        project_name=project_name,
                     ))
 
                     # Assertion scores. Pass mode drives fail patterns. Name = full

--- a/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
+++ b/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
@@ -12,7 +12,7 @@ import opik.rest_api
 from opik.rest_api.types.trace_write import TraceWrite
 from opik.rest_api.types.span_write import SpanWrite
 from opik.rest_api.types.feedback_score_batch_item import FeedbackScoreBatchItem
-from opik.api_objects.experiment.experiment_item import ExperimentItemReferences
+from opik.rest_api.types.experiment_item import ExperimentItem as RestExperimentItem
 from opik_backend.demo_data import (
     demo_traces,
     demo_spans,
@@ -849,7 +849,8 @@ def create_demo_test_suite_and_experiments(base_url: str, workspace_name, comet_
                         env=env,
                     ))
 
-                    experiment_refs.append(ExperimentItemReferences(
+                    experiment_refs.append(RestExperimentItem(
+                        experiment_id=experiment.id,
                         dataset_item_id=dataset_item_id,
                         trace_id=trace_id,
                     ))
@@ -895,14 +896,23 @@ def create_demo_test_suite_and_experiments(base_url: str, workspace_name, comet_
                             source="online_scoring",
                         ))
 
+                # Use synchronous REST for every write. The SDK's async streamer
+                # (experiment.insert / client.flush) silently drops messages on
+                # timeout in production — client.flush() returns True even when
+                # it couldn't drain the queue before the signup handler exits,
+                # which leaves the experiment with zero items in the UI even
+                # though the "Seeded experiment" log fires. Posting directly to
+                # the REST endpoint guarantees a 2xx-or-raise before we log.
                 client.rest_client.traces.create_traces(traces=traces_to_create)
                 client.rest_client.spans.create_spans(spans=spans_to_create)
-                experiment.insert(experiment_refs)
-                client.flush()
+                client.rest_client.experiments.create_experiment_items(
+                    experiment_items=experiment_refs,
+                )
                 client.rest_client.traces.score_batch_of_traces(scores=score_items)
 
-                logger.info("Seeded experiment '%s' with %d traces / %d spans / %d assertion scores",
-                            exp_cfg["name"], len(traces_to_create), len(spans_to_create), len(score_items))
+                logger.info("Seeded experiment '%s' with %d traces / %d spans / %d items / %d assertion scores",
+                            exp_cfg["name"], len(traces_to_create), len(spans_to_create),
+                            len(experiment_refs), len(score_items))
 
         except Exception as e:
             logger.error("Error creating demo test suite for workspace %s: %s",


### PR DESCRIPTION
## Details

Follow-up to #6426. In production, demo experiments show up with zero items because `experiment.insert(ExperimentItemReferences(...))` in the Opik 1.10.56 SDK enqueues to an **async streamer queue** — the actual HTTP POST only happens on `client.flush()`, which returns `True` even when it couldn't drain the queue before the signup handler exits. The "Seeded experiment" success log fires regardless, so the drop is invisible in the logs.

Verified against workspace `jacques-24042` in prod: project, suite (with versions + 20 items), prompt, blueprints, experiments, 40 traces (`source=experiment`), and 320 spans all land via sync REST calls — only `experiment_items` returns **0 rows** in ClickHouse, which is exactly what the UI displays as "experiment has no items".

Switch to the direct synchronous REST endpoint `client.rest_client.experiments.create_experiment_items(...)` (same pattern used for traces/spans/scores): blocks until the backend returns, raises `ApiError` on non-2xx, so either the items land or the `except Exception` branch logs `Error creating demo test suite for workspace <ws>` in Loki.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: Diagnosed the silent-streamer-drop against prod ClickHouse for workspace `jacques-24042`, authored the sync-REST switch, verified locally end-to-end.
- Human verification: Owner reported the prod symptom (experiments with 0 items), shared Loki log snippets confirming the `Seeded experiment` info line fires, pointed me to the prod DB access scripts to triangulate, and reviewed the diagnosis before approving the fix.

## Testing

Local stack via `./scripts/dev-runner.sh --start` (port offset 10), python-backend rebuilt with the fix, suite/project state cleaned between runs.

- `pytest tests/test_demo_data_generator.py` — both tests still pass (`test_create_demo_data_structure`, `test_create_demo_data_idempotence`)
- Triggered end-to-end: `curl -X POST http://localhost:8000/v1/private/post_user_signup -d '{"workspace":"default","apiKey":"1234"}'`
- Verified via ClickHouse: `SELECT experiment_id, count() FROM opik.experiment_items FINAL GROUP BY experiment_id` returns **20** for every seeded experiment (previously dependent on streamer flush timing)
- Pass rates and all other demo data unchanged: prod 0.8 (16/20), staging 1.0 (20/20)
- Success log now includes explicit `/ N items /` segment so a 0-items log is impossible — any drop would raise before logging

## Documentation

No documentation updates required — purely an internal demo-data fix that uses existing public Opik REST endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)