### PR TITLE
[NA] [BE] Exclude demo eval suite from opik_eval_suite_created / _run BI events

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -37,6 +37,7 @@ import com.comet.opik.domain.DatasetItemSearchCriteria;
 import com.comet.opik.domain.DatasetItemService;
 import com.comet.opik.domain.DatasetService;
 import com.comet.opik.domain.DatasetVersionService;
+import com.comet.opik.domain.DemoData;
 import com.comet.opik.domain.EntityType;
 import com.comet.opik.domain.IdGenerator;
 import com.comet.opik.domain.Streamer;
@@ -201,7 +202,8 @@ public class DatasetsResource {
         log.info("Created dataset with name '{}', id '{}', on workspace_id '{}'", savedDataset.name(),
                 savedDataset.id(), workspaceId);
 
-        if (savedDataset.type() == DatasetType.TEST_SUITE) {
+        if (savedDataset.type() == DatasetType.TEST_SUITE
+                && !DemoData.DATASETS.contains(savedDataset.name())) {
             analyticsService.trackEvent("opik_eval_suite_created", Map.of(
                     "eval_suite_id", savedDataset.id().toString(),
                     "eval_suite_name", savedDataset.name(),

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DemoData.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DemoData.java
@@ -22,7 +22,8 @@ public class DemoData {
     /** MySQL (utf8mb4_unicode_ci) — matching is case-insensitive, no need for case variants. */
     public static final List<String> DATASETS = List.of("Demo dataset", "Opik Demo Questions",
             "Demo - Opik Chatbot", "Demo - Jailbreak Password", "Demo - Customer Message Classifier",
-            "Opik Demo Chatbot Training", "Opik Demo Text to SQL", "Opik Demo Structured Output");
+            "Opik Demo Chatbot Training", "Opik Demo Text to SQL", "Opik Demo Structured Output",
+            "Customer support regression suite");
 
     /** ClickHouse — matching is case-sensitive, list every known casing explicitly. */
     public static final List<String> EXPERIMENTS = List.of(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentService.java
@@ -702,6 +702,7 @@ public class ExperimentService {
             try {
                 datasetService.getById(experiment.datasetId(), workspaceId)
                         .filter(dataset -> dataset.type() == DatasetType.TEST_SUITE)
+                        .filter(dataset -> !DemoData.DATASETS.contains(dataset.name()))
                         .ifPresent(dataset -> analyticsService.trackEvent("opik_eval_suite_run", Map.of(
                                 "eval_suite_id", dataset.id().toString(),
                                 "experiment_id", experiment.id().toString(),


### PR DESCRIPTION
## Details

Two BI events fire today for the demo eval suite seeded by the post-signup hook, polluting the funnel for real user suite creation:

- `opik_eval_suite_created` — [`DatasetsResource.createDataset`](apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java), fires once when the suite dataset is created.
- `opik_eval_suite_run` — [`ExperimentService.trackEvalSuiteRunIfApplicable`](apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentService.java), fires for each experiment run against a `TEST_SUITE` dataset (×2 per demo seed).

Follows the existing `DemoData` name-list pattern already used for V1 entity exclusion and [`DatasetService.getDatasetsBIInformation`](apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetService.java):
1. Append the demo suite name `"Customer support regression suite"` to `DemoData.DATASETS`.
2. Guard both `analyticsService.trackEvent(...)` calls with `!DemoData.DATASETS.contains(dataset.name())`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: Spotted the two uninstrumented `analyticsService.trackEvent` call sites for `TEST_SUITE` events, authored the name-list guards, verified the backend still compiles.
- Human verification: Owner pointed at the problem, reviewed the fix pattern, and approved the scope before I raised the PR.

## Testing

- `mvn compile -T 4` on `apps/opik-backend` — `BUILD SUCCESS`, no new warnings in touched files.
- Manual trace of the guarded code paths:
  - `DatasetsResource.createDataset` — only name is compared against the list, no extra DB lookups.
  - `ExperimentService.trackEvalSuiteRunIfApplicable` — guard added as a `.filter` on the existing `Optional`, preserving the original null-safety + exception-wrapping.

Functional testing is via the existing demo-data flow: trigger a signup, confirm the seeded suite `"Customer support regression suite"` no longer produces `opik_eval_suite_created` / `opik_eval_suite_run` entries in the analytics pipeline. Suites created by real users (any other name) are unaffected.

## Documentation

No documentation updates required — internal BI instrumentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)