### PR TITLE
[OPIK-6037] [FE] fix: vertically center empty state on Datasets and Test Suites

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetListPage/DatasetListPage.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetListPage/DatasetListPage.tsx
@@ -423,7 +423,7 @@ const DatasetListPage: React.FunctionComponent<DatasetListPageProps> = ({
   }
 
   return (
-    <div className="pt-4">
+    <div className="flex min-h-full flex-col pt-4">
       <div className="mb-4 flex min-h-7 items-center justify-between">
         <h1 className="comet-body-accented truncate break-words">
           {config.title}


### PR DESCRIPTION
## Details
Fixes the empty-state vertical alignment on the Datasets and Test Suites (Evaluation suites) pages per [OPIK-6037](https://comet-ml.atlassian.net/browse/OPIK-6037) and the Figma design.

The root container in `DatasetListPage.tsx` was a plain `<div className="pt-4">`, so `PageEmptyState`'s `flex-1 justify-center` had no flex parent and no vertical space to grow into — leaving the empty state top-aligned. Added `flex min-h-full flex-col` to match the pattern already used by `ExperimentsPage` and `PromptsPage`. One change fixes both pages since `DatasetsPage` and `TestSuitesPage` are thin wrappers around the shared `DatasetListPage`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6037

## Testing

- Verified locally: illustration, text, and buttons now render vertically centered on both Datasets and Test Suites empty states
- Verified table view still renders correctly when data is present (toolbar, table, pagination stack normally)
- Typecheck passes (`tsc --noEmit`)

## Documentation

N/A — purely a CSS/layout fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OPIK-6037]: https://comet-ml.atlassian.net/browse/OPIK-6037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ