### PR TITLE
[OPIK-6150] [FE] fix: preserve deep-link URL on workspace version mismatch

### DIFF
--- a/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.test.tsx
+++ b/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import WorkspaceVersionResolver from "./WorkspaceVersionResolver";
+
+const mocks = vi.hoisted(() => {
+  return {
+    setWorkspaceVersion: vi.fn(),
+    setDetectedWorkspaceVersion: vi.fn(),
+    setCachedWorkspaceVersion: vi.fn(),
+    state: {
+      activeWorkspaceName: "ws-1" as string | null,
+      gateVersion: "v2" as "v1" | "v2" | null,
+      apiVersion: undefined as "v1" | "v2" | undefined,
+      override: null as "v1" | "v2" | null,
+      optIn: false,
+    },
+  };
+});
+
+vi.mock("@/store/AppStore", () => ({
+  default: {
+    getState: () => ({
+      setWorkspaceVersion: mocks.setWorkspaceVersion,
+      setDetectedWorkspaceVersion: mocks.setDetectedWorkspaceVersion,
+    }),
+  },
+  useActiveWorkspaceName: () => mocks.state.activeWorkspaceName,
+  useWorkspaceVersion: () => mocks.state.gateVersion,
+}));
+
+vi.mock("@/api/workspaces/useWorkspaceVersion", () => ({
+  default: () => ({ data: mocks.state.apiVersion }),
+}));
+
+vi.mock("@/lib/workspaceVersion", () => ({
+  getVersionOverride: () => mocks.state.override,
+  getNewExperienceOptIn: () => mocks.state.optIn,
+  setCachedWorkspaceVersion: mocks.setCachedWorkspaceVersion,
+}));
+
+const setLocation = (href: string) => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      href,
+      replace: vi.fn(),
+    },
+  });
+};
+
+describe("WorkspaceVersionResolver", () => {
+  beforeEach(() => {
+    mocks.setWorkspaceVersion.mockClear();
+    mocks.setDetectedWorkspaceVersion.mockClear();
+    mocks.setCachedWorkspaceVersion.mockClear();
+    sessionStorage.clear();
+    mocks.state.activeWorkspaceName = "ws-1";
+    mocks.state.gateVersion = "v2";
+    mocks.state.apiVersion = undefined;
+    mocks.state.override = null;
+    mocks.state.optIn = false;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders children immediately (no blocking Loader)", () => {
+    setLocation("http://localhost/opik/ws-1");
+    const { getByTestId } = render(
+      <WorkspaceVersionResolver>
+        <div data-testid="child" />
+      </WorkspaceVersionResolver>,
+    );
+    expect(getByTestId("child")).toBeTruthy();
+  });
+
+  it("no reload when api version matches gate version", () => {
+    setLocation("http://localhost/opik/ws-1");
+    mocks.state.gateVersion = "v2";
+    mocks.state.apiVersion = "v2";
+
+    render(
+      <WorkspaceVersionResolver>
+        <div />
+      </WorkspaceVersionResolver>,
+    );
+
+    expect(window.location.replace).not.toHaveBeenCalled();
+  });
+
+  it("on mismatch, reloads to the URL captured at first render — not the current URL", () => {
+    const originalUrl = "http://localhost/opik/ws-1/experiments/exp-42/compare";
+    setLocation(originalUrl);
+    mocks.state.gateVersion = "v2";
+    mocks.state.apiVersion = "v1";
+
+    const { rerender } = render(
+      <WorkspaceVersionResolver>
+        <div />
+      </WorkspaceVersionResolver>,
+    );
+
+    // Simulate a child redirect component mutating the URL BEFORE the
+    // resolver's effect runs on the next commit.
+    const replaceFn = window.location.replace as ReturnType<typeof vi.fn>;
+    setLocation("http://localhost/opik/ws-1/projects/proj-1/experiments");
+    // Carry the spy across the location reset so we can still assert on it.
+    (window.location as { replace: unknown }).replace = replaceFn;
+
+    rerender(
+      <WorkspaceVersionResolver>
+        <div />
+      </WorkspaceVersionResolver>,
+    );
+
+    expect(window.location.replace).toHaveBeenCalledWith(originalUrl);
+  });
+
+  it("caches detected version on every resolve", () => {
+    setLocation("http://localhost/opik/ws-1");
+    mocks.state.apiVersion = "v2";
+
+    render(
+      <WorkspaceVersionResolver>
+        <div />
+      </WorkspaceVersionResolver>,
+    );
+
+    expect(mocks.setCachedWorkspaceVersion).toHaveBeenCalledWith("ws-1", "v2");
+    expect(mocks.setDetectedWorkspaceVersion).toHaveBeenCalledWith("v2");
+  });
+
+  it("stops reloading after MAX_RELOADS to avoid infinite loops", () => {
+    setLocation("http://localhost/opik/ws-1/experiments/exp-42");
+    mocks.state.gateVersion = "v2";
+    mocks.state.apiVersion = "v1";
+    sessionStorage.setItem("opik-version-reload:ws-1", "2");
+
+    render(
+      <WorkspaceVersionResolver>
+        <div />
+      </WorkspaceVersionResolver>,
+    );
+
+    expect(window.location.replace).not.toHaveBeenCalled();
+  });
+
+  it("clears reload counter when no mismatch", () => {
+    setLocation("http://localhost/opik/ws-1");
+    mocks.state.gateVersion = "v2";
+    mocks.state.apiVersion = "v2";
+    sessionStorage.setItem("opik-version-reload:ws-1", "1");
+
+    render(
+      <WorkspaceVersionResolver>
+        <div />
+      </WorkspaceVersionResolver>,
+    );
+
+    expect(sessionStorage.getItem("opik-version-reload:ws-1")).toBeNull();
+  });
+
+  it("after a successful verification, a later mismatch reloads to the then-current URL (stale capture cleared)", () => {
+    // 1. First render on ws-1 with a correct version → URL captured & cleared.
+    const firstUrl = "http://localhost/opik/ws-1";
+    setLocation(firstUrl);
+    mocks.state.gateVersion = "v2";
+    mocks.state.apiVersion = "v2";
+
+    const { rerender } = render(
+      <WorkspaceVersionResolver>
+        <div />
+      </WorkspaceVersionResolver>,
+    );
+
+    // 2. Simulate a new optimistic mount later: user navigates to a deep link
+    // within ws-1, then a fresh mismatch fires (e.g. the admin flipped the
+    // workspace's version server-side). The resolver should reload to the
+    // CURRENT URL — not the stale `firstUrl` captured on the first mount.
+    const freshUrl = "http://localhost/opik/ws-1/experiments/exp-99/compare";
+    const replaceFn = window.location.replace as ReturnType<typeof vi.fn>;
+    setLocation(freshUrl);
+    (window.location as { replace: unknown }).replace = replaceFn;
+    mocks.state.apiVersion = "v1";
+
+    rerender(
+      <WorkspaceVersionResolver>
+        <div />
+      </WorkspaceVersionResolver>,
+    );
+
+    expect(window.location.replace).toHaveBeenCalledWith(freshUrl);
+    expect(window.location.replace).not.toHaveBeenCalledWith(firstUrl);
+  });
+
+  it("keeps per-workspace captures independent — ws-B mismatch does not reload to ws-A's URL", () => {
+    // Render once on ws-A (verifying) — ws-A URL gets captured.
+    const wsAUrl = "http://localhost/opik/ws-A/experiments/exp-1";
+    setLocation(wsAUrl);
+    mocks.state.activeWorkspaceName = "ws-A";
+    mocks.state.gateVersion = "v2";
+    mocks.state.apiVersion = undefined;
+
+    const { rerender } = render(
+      <WorkspaceVersionResolver>
+        <div />
+      </WorkspaceVersionResolver>,
+    );
+
+    // Switch to ws-B before ws-A verification ever resolved; fire mismatch
+    // on ws-B. Reload target must be ws-B's URL, not the stale ws-A capture.
+    const wsBUrl = "http://localhost/opik/ws-B/projects";
+    const replaceFn = window.location.replace as ReturnType<typeof vi.fn>;
+    setLocation(wsBUrl);
+    (window.location as { replace: unknown }).replace = replaceFn;
+    mocks.state.activeWorkspaceName = "ws-B";
+    mocks.state.apiVersion = "v1";
+
+    rerender(
+      <WorkspaceVersionResolver>
+        <div />
+      </WorkspaceVersionResolver>,
+    );
+
+    expect(window.location.replace).toHaveBeenCalledWith(wsBUrl);
+    expect(window.location.replace).not.toHaveBeenCalledWith(wsAUrl);
+  });
+});

--- a/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
+++ b/apps/opik-frontend/src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import useAppStore, {
   useActiveWorkspaceName,
   useWorkspaceVersion,
@@ -7,7 +7,6 @@ import useWorkspaceVersionQuery from "@/api/workspaces/useWorkspaceVersion";
 import {
   getNewExperienceOptIn,
   getVersionOverride,
-  navigateToWorkspaceRoot,
   setCachedWorkspaceVersion,
 } from "@/lib/workspaceVersion";
 
@@ -21,17 +20,26 @@ type WorkspaceVersionResolverProps = {
 /**
  * Renders children immediately using the Gate's optimistic version guess
  * (override > opt-in > per-workspace cache > default v2) and verifies
- * against `/workspaces/versions` asynchronously. On mismatch, the
- * `useEffect` below reloads so the Gate picks the correct App next time
- * (bounded by MAX_RELOADS).
+ * against `/workspaces/versions` asynchronously. On mismatch, reloads to
+ * the URL the user originally landed on so the Gate mounts the correct
+ * App with the original deep-link intact (bounded by MAX_RELOADS).
  *
  * We deliberately do NOT gate rendering on `isLoading`. Doing so used to
  * hide the whole tree behind a Loader for 600-2000ms on every load, which
- * sat on the LCP critical path. The mismatch window is the same either
- * way — today's Loader vs. tomorrow's brief wrong-version render — so
- * we'd rather pay that cost only when mismatch actually happens (rare:
- * cache is correct for ~95% of returning users, and new signups default
- * to v2 which is the only version new workspaces get). See OPIK-6150.
+ * sat on the LCP critical path. See OPIK-6150.
+ *
+ * Why `window.location.replace(originalUrl)` and not `reload()`:
+ * the wrong-version App mounted under us can contain redirect components
+ * (e.g. V1CompatRedirect) whose useEffects `navigate({ replace: true })`
+ * to a version-specific path before `/versions` returns. A plain
+ * `reload()` would rehydrate that mutated URL; replacing with the URL we
+ * captured on first render restores the user's original deep-link.
+ *
+ * Capture is in render (not useEffect) because child-component effects
+ * fire after the parent renders — so at capture time no redirect has run.
+ * The captured URL is keyed by workspace (so switching workspaces doesn't
+ * leak stale URLs) and cleared once verification succeeds (so a later
+ * mismatch re-captures fresh rather than reloading to an outdated URL).
  */
 const WorkspaceVersionResolver: React.FC<WorkspaceVersionResolverProps> = ({
   children,
@@ -40,6 +48,14 @@ const WorkspaceVersionResolver: React.FC<WorkspaceVersionResolverProps> = ({
   const optIn = getNewExperienceOptIn();
   const gateVersion = useWorkspaceVersion();
   const workspaceName = useActiveWorkspaceName();
+
+  const originalUrlByWorkspaceRef = useRef<Record<string, string>>({});
+  if (
+    workspaceName &&
+    originalUrlByWorkspaceRef.current[workspaceName] === undefined
+  ) {
+    originalUrlByWorkspaceRef.current[workspaceName] = window.location.href;
+  }
 
   const { data: apiVersion } = useWorkspaceVersionQuery();
   const resolvedVersion = override ?? (optIn ? "v2" : apiVersion);
@@ -60,14 +76,14 @@ const WorkspaceVersionResolver: React.FC<WorkspaceVersionResolverProps> = ({
       const reloadCount = Number(sessionStorage.getItem(reloadKey) || "0");
       if (reloadCount < MAX_RELOADS) {
         sessionStorage.setItem(reloadKey, String(reloadCount + 1));
-        // Navigate to the workspace root rather than reloading the current
-        // URL: the other App's router may have already rewritten the URL to
-        // something that only makes sense in its version. Landing on the
-        // workspace root lets the correct version's router route to home.
-        navigateToWorkspaceRoot(workspaceName);
+        const target =
+          originalUrlByWorkspaceRef.current[workspaceName] ??
+          window.location.href;
+        window.location.replace(target);
       }
     } else {
       sessionStorage.removeItem(reloadKey);
+      delete originalUrlByWorkspaceRef.current[workspaceName];
     }
   }, [apiVersion, resolvedVersion, gateVersion, workspaceName]);
 


### PR DESCRIPTION
## Details

Follow-up fix for [OPIK-6150](https://comet-ml.atlassian.net/browse/OPIK-6150). The non-blocking workspace version verify shipped in #6452 broke v1 deep-link preservation: when a v1 URL like `/opik/<ws>/experiments/<id>/compare` lands on a browser whose optimistic cache guess is v2, V2App mounts and its route subtree contains `V1CompatRedirect`-style components whose `useEffect` calls `navigate({ replace: true })` to a v2-specific path *before* `/versions` returns. By the time the resolver saw the mismatch, the URL had already been rewritten and the previous recovery path (`navigateToWorkspaceRoot`) dropped the user's original deep-link, breaking v1 E2E tests.

- `WorkspaceVersionResolver` now captures `window.location.href` in its render body (before any child effect can fire) and, on mismatch, `window.location.replace()`s that captured URL.
- Capture is keyed by workspace (so switching workspaces doesn't leak a stale URL) and cleared on successful verification (so a later mismatch re-captures fresh).
- `navigateToWorkspaceRoot` helper stays — still used by `UserMenu` for the intentional workspace-switch case.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6150

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation
- Human verification: code review + unit tests

## Testing

Automated:
- `npx vitest run src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.test.tsx` — 8 tests, all pass.
- `npx vitest run src/shared/WorkspaceVersionResolver src/v2/redirect` — 32 tests, all pass (Resolver + V1CompatRedirect + TracesTabRedirect — no regressions).
- `bash scripts/dev-runner.sh --lint-fe` — lint, typecheck, dependency-cruiser all green.

Scenarios covered by the new test suite:
- Children render immediately (no blocking Loader regression).
- No reload when API version matches gate version.
- On mismatch, reload target is the URL captured on first render — not the URL mutated by a child redirect effect.
- Successful verification clears the capture; a later mismatch re-captures the then-current URL rather than reloading to a stale one.
- Per-workspace isolation: a mismatch on workspace B never reloads to workspace A's URL.
- MAX_RELOADS cap stops the reload loop; counter is cleared on match.

Manual validation recommended on PR test env:
- Run the full v1-targeting E2E suite — failures caused by the previous `navigateToWorkspaceRoot` redirect should be gone.
- Smoke: with `opik-workspace-versions` cache cleared, deep-link to a v1-only path (e.g. a v1 workspace's `/experiments/…`). URL should survive the verify-and-reload.

## Documentation

N/A — internal plumbing change, no user-facing docs affected.

[OPIK-6150]: https://comet-ml.atlassian.net/browse/OPIK-6150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ