### PR TITLE
[OPIK-6168][BE] Add support for distributed headers to OPIK OTEL endpoint

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -3,6 +3,7 @@ package com.comet.opik.domain;
 import com.comet.opik.api.Source;
 import com.comet.opik.api.Span.SpanBuilder;
 import com.comet.opik.domain.mapping.OpenTelemetryMappingRuleFactory;
+import com.comet.opik.domain.mapping.otel.GeneralMappingRules;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.opentelemetry.proto.common.v1.KeyValue;
@@ -55,14 +56,30 @@ public class OpenTelemetryMapper {
         var otelSpanId = otelSpan.getSpanId();
         var opikSpanId = convertOtelIdToUUIDv7(otelSpanId.toByteArray(), traceTimestamp);
 
-        var otelParentSpanId = otelSpan.getParentSpanId();
-        var opikParentSpanId = otelParentSpanId.isEmpty()
-                ? null
-                : convertOtelIdToUUIDv7(otelParentSpanId.toByteArray(), traceTimestamp);
+        // Check for opik.trace_id and opik.parent_span_id override attributes.
+        // When present, these connect the span to an existing OPIK trace/span as-is (no ID conversion).
+        var opikTraceIdOverride = extractOpikTraceId(otelSpan);
+        var opikParentSpanIdOverride = extractOpikParentSpanId(otelSpan);
+
+        UUID effectiveTraceId;
+        UUID opikParentSpanId;
+
+        if (opikTraceIdOverride.isPresent()) {
+            effectiveTraceId = opikTraceIdOverride.get();
+            // When opik.trace_id is set, use opik.parent_span_id if available, otherwise null
+            // (span connects directly to the trace as a root span)
+            opikParentSpanId = opikParentSpanIdOverride.orElse(null);
+        } else {
+            effectiveTraceId = opikTraceId;
+            var otelParentSpanId = otelSpan.getParentSpanId();
+            opikParentSpanId = otelParentSpanId.isEmpty()
+                    ? null
+                    : convertOtelIdToUUIDv7(otelParentSpanId.toByteArray(), traceTimestamp);
+        }
 
         var spanBuilder = com.comet.opik.api.Span.builder()
                 .id(opikSpanId)
-                .traceId(opikTraceId)
+                .traceId(effectiveTraceId)
                 .parentSpanId(opikParentSpanId)
                 .name(otelSpan.getName())
                 .type(SpanType.general)
@@ -236,5 +253,53 @@ public class OpenTelemetryMapper {
      */
     private long extractTimestampFromUUIDv7(UUID uuid) {
         return IdGenerator.extractTimestampFromUUIDv7(uuid).toEpochMilli();
+    }
+
+    /**
+     * Extracts the opik.trace_id attribute from an OTEL span, if present.
+     * This attribute allows connecting an OTEL span to an existing OPIK trace.
+     *
+     * @param otelSpan the OTEL span to extract from
+     * @return the OPIK trace UUID if the attribute is present and valid
+     */
+    public static Optional<UUID> extractOpikTraceId(Span otelSpan) {
+        return extractStringAttribute(otelSpan, GeneralMappingRules.OPIK_TRACE_ID_ATTR)
+                .flatMap(value -> parseUUIDv7(value, GeneralMappingRules.OPIK_TRACE_ID_ATTR));
+    }
+
+    /**
+     * Extracts the opik.parent_span_id attribute from an OTEL span, if present.
+     * This attribute allows connecting an OTEL span to an existing OPIK span as its parent.
+     * Only meaningful when opik.trace_id is also present.
+     *
+     * @param otelSpan the OTEL span to extract from
+     * @return the OPIK parent span UUID if the attribute is present and valid
+     */
+    public static Optional<UUID> extractOpikParentSpanId(Span otelSpan) {
+        return extractStringAttribute(otelSpan, GeneralMappingRules.OPIK_PARENT_SPAN_ID_ATTR)
+                .flatMap(value -> parseUUIDv7(value, GeneralMappingRules.OPIK_PARENT_SPAN_ID_ATTR));
+    }
+
+    private static Optional<String> extractStringAttribute(Span otelSpan, String key) {
+        return otelSpan.getAttributesList().stream()
+                .filter(attr -> key.equals(attr.getKey()))
+                .map(attr -> attr.getValue().getStringValue())
+                .filter(StringUtils::isNotBlank)
+                .findFirst();
+    }
+
+    private static Optional<UUID> parseUUIDv7(String value, String attributeName) {
+        try {
+            var uuid = UUID.fromString(value);
+            if (uuid.version() != 7) {
+                log.warn("Attribute '{}' value '{}' is not a UUIDv7 (version {}), ignoring",
+                        attributeName, value, uuid.version());
+                return Optional.empty();
+            }
+            return Optional.of(uuid);
+        } catch (IllegalArgumentException e) {
+            log.warn("Attribute '{}' value '{}' is not a valid UUIDv7, ignoring", attributeName, value);
+            return Optional.empty();
+        }
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -70,6 +70,11 @@ public class OpenTelemetryMapper {
             // (span connects directly to the trace as a root span)
             opikParentSpanId = opikParentSpanIdOverride.orElse(null);
         } else {
+            if (opikParentSpanIdOverride.isPresent()) {
+                log.warn("Span '{}' has '{}' without '{}', ignoring parent span ID override",
+                        otelSpan.getName(), GeneralMappingRules.OPIK_PARENT_SPAN_ID_ATTR,
+                        GeneralMappingRules.OPIK_TRACE_ID_ATTR);
+            }
             effectiveTraceId = opikTraceId;
             var otelParentSpanId = otelSpan.getParentSpanId();
             opikParentSpanId = otelParentSpanId.isEmpty()

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryService.java
@@ -25,8 +25,10 @@ import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
 import java.time.Duration;
 import java.util.Base64;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -105,12 +107,19 @@ class OpenTelemetryServiceImpl implements OpenTelemetryService {
     private Mono<Long> doStoreSpans(List<Span> otelSpans, Map<String, UUID> traceIdMapper, String projectName,
             String integrationName) {
 
+        // Track trace IDs that came from opik.trace_id attribute overrides.
+        // These spans connect to existing OPIK traces, so we must not create new traces for them.
+        Set<UUID> overriddenTraceIds = new HashSet<>();
+
         // converts otel spans into opik spans, using the mapped opik trace id
         var opikSpans = otelSpans.stream()
                 .map(otelSpan -> {
                     var otelTraceIdBase64 = base64OtelId(otelSpan.getTraceId());
 
                     var opikTraceId = traceIdMapper.get(otelTraceIdBase64);
+
+                    OpenTelemetryMapper.extractOpikTraceId(otelSpan)
+                            .ifPresent(overriddenTraceIds::add);
 
                     return OpenTelemetryMapper.toOpikSpan(otelSpan, opikTraceId, integrationName);
                 })
@@ -141,7 +150,10 @@ class OpenTelemetryServiceImpl implements OpenTelemetryService {
                         .toList();
 
         // check if there spans without parentId: we will use them as a Trace too
-        return Flux.fromStream(dedupedSpans.stream().filter(span -> span.parentSpanId() == null))
+        // Skip spans with opik.trace_id override as they connect to existing traces
+        return Flux.fromStream(dedupedSpans.stream()
+                .filter(span -> span.parentSpanId() == null)
+                .filter(span -> !overriddenTraceIds.contains(span.traceId())))
                 .flatMap(rootSpan -> {
                     // Extract thread_id from root span metadata if present
                     String threadId = null;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/GeneralMappingRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/GeneralMappingRules.java
@@ -13,6 +13,9 @@ public final class GeneralMappingRules {
 
     public static final String SOURCE = "General";
 
+    public static final String OPIK_TRACE_ID_ATTR = "opik.trace_id";
+    public static final String OPIK_PARENT_SPAN_ID_ATTR = "opik.parent_span_id";
+
     private static final List<OpenTelemetryMappingRule> RULES = List.of(
             OpenTelemetryMappingRule.builder()
                     .rule("input").isPrefix(true).source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.INPUT)
@@ -26,7 +29,16 @@ public final class GeneralMappingRules {
                     .rule("opik.tags").source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.TAGS).build(),
             OpenTelemetryMappingRule.builder()
                     .rule("opik.metadata").isPrefix(true).source(SOURCE)
-                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build());
+                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build(),
+            // These attributes are consumed by OpenTelemetryMapper.toOpikSpan() to connect
+            // OTEL spans to existing OPIK traces/spans. They are dropped here to prevent them
+            // from leaking into input/output/metadata as regular span attributes.
+            OpenTelemetryMappingRule.builder()
+                    .rule(OPIK_TRACE_ID_ATTR).source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.DROP)
+                    .build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule(OPIK_PARENT_SPAN_ID_ATTR).source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.DROP)
+                    .build());
 
     public static List<OpenTelemetryMappingRule> getRules() {
         return RULES;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
@@ -20,6 +20,8 @@ import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.protobuf.ByteString;
 import com.redis.testcontainers.RedisContainer;
@@ -98,6 +100,7 @@ class OpenTelemetryResourceTest {
     private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
     private final ClickHouseContainer CLICK_HOUSE_CONTAINER = ClickHouseContainerUtils
             .newClickHouseContainer(ZOOKEEPER_CONTAINER);
+    private final TimeBasedEpochGenerator UUID_V7_GENERATOR = Generators.timeBasedEpochGenerator();
     private final WireMockUtils.WireMockRuntime wireMock;
 
     @RegisterApp
@@ -132,14 +135,15 @@ class OpenTelemetryResourceTest {
 
         ClientSupportUtils.config(client);
 
-        mockTargetWorkspace(API_KEY, TEST_WORKSPACE, WORKSPACE_ID);
+        mockTargetWorkspace(API_KEY, TEST_WORKSPACE);
 
         this.traceResourceClient = new TraceResourceClient(this.client, baseURI);
         this.spanResourceClient = new SpanResourceClient(this.client, baseURI);
     }
 
-    private void mockTargetWorkspace(String apiKey, String workspaceName, String workspaceId) {
-        AuthTestUtils.mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, USER);
+    private void mockTargetWorkspace(String apiKey, String workspaceName) {
+        AuthTestUtils.mockTargetWorkspace(wireMock.server(), apiKey, workspaceName,
+                OpenTelemetryResourceTest.WORKSPACE_ID, USER);
     }
 
     @AfterAll
@@ -182,7 +186,7 @@ class OpenTelemetryResourceTest {
                 io.dropwizard.jersey.errors.ErrorMessage errorMessage) {
 
             String workspaceName = UUID.randomUUID().toString();
-            mockTargetWorkspace(okApikey, workspaceName, WORKSPACE_ID);
+            mockTargetWorkspace(okApikey, workspaceName);
 
             var otelTraceId = UUID.randomUUID().toString().getBytes(); // otel uses 128-bit, but it doesnt matter
             var parentSpanId = UUID.randomUUID().toString().getBytes();// otel uses  64-bit, but it doesnt matter
@@ -268,7 +272,7 @@ class OpenTelemetryResourceTest {
             String payload2 = "{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"my-service\"}}]},\"scopeSpans\":[{\"spans\":[{\"traceId\":\"%s\",\"spanId\":\"%s\",\"name\":\"example-span\",\"kind\":\"SPAN_KIND_SERVER\",\"startTimeUnixNano\":\"%d\",\"endTimeUnixNano\":\"1623456790000000000\"}]}]}]}";
 
             String workspaceName = UUID.randomUUID().toString();
-            mockTargetWorkspace(okApikey, workspaceName, WORKSPACE_ID);
+            mockTargetWorkspace(okApikey, workspaceName);
 
             String otelTraceId = Base64.getEncoder().encodeToString(UUID.randomUUID().toString().getBytes());
             String spanId = Base64.getEncoder().encodeToString(UUID.randomUUID().toString().getBytes());
@@ -413,7 +417,7 @@ class OpenTelemetryResourceTest {
         @DisplayName("test thread_id support in OpenTelemetry")
         void testThreadIdSupport() {
             String workspaceName = UUID.randomUUID().toString();
-            mockTargetWorkspace(okApikey, workspaceName, WORKSPACE_ID);
+            mockTargetWorkspace(okApikey, workspaceName);
 
             var otelTraceId = UUID.randomUUID().toString().getBytes();
             var parentSpanId = UUID.randomUUID().toString().getBytes();
@@ -474,7 +478,7 @@ class OpenTelemetryResourceTest {
         @DisplayName("test gen_ai.conversation.id maps to threadId in OpenTelemetry")
         void testGenAiConversationIdSupport() {
             String workspaceName = UUID.randomUUID().toString();
-            mockTargetWorkspace(okApikey, workspaceName, WORKSPACE_ID);
+            mockTargetWorkspace(okApikey, workspaceName);
 
             var otelTraceId = UUID.randomUUID().toString().getBytes();
             var parentSpanId = UUID.randomUUID().toString().getBytes();
@@ -535,7 +539,7 @@ class OpenTelemetryResourceTest {
         @DisplayName("test integer thread_id is properly stored in OpenTelemetry traces")
         void testIntegerThreadIdSupport() {
             String workspaceName = UUID.randomUUID().toString();
-            mockTargetWorkspace(okApikey, workspaceName, WORKSPACE_ID);
+            mockTargetWorkspace(okApikey, workspaceName);
 
             var otelTraceId = UUID.randomUUID().toString().getBytes();
             var parentSpanId = UUID.randomUUID().toString().getBytes();
@@ -596,7 +600,7 @@ class OpenTelemetryResourceTest {
         @DisplayName("test token deduplication when parent and child both have usage (PydanticAI/Logfire pattern)")
         void testTokenDeduplicationWhenParentAndChildBothHaveUsage() {
             String workspaceName = UUID.randomUUID().toString();
-            mockTargetWorkspace(okApikey, workspaceName, WORKSPACE_ID);
+            mockTargetWorkspace(okApikey, workspaceName);
 
             var otelTraceId = UUID.randomUUID().toString().getBytes();
             var parentSpanId = UUID.randomUUID().toString().getBytes();
@@ -670,7 +674,7 @@ class OpenTelemetryResourceTest {
         @DisplayName("test no token deduplication when only parent has usage (no child usage)")
         void testNoTokenDeduplicationWhenOnlyParentHasUsage() {
             String workspaceName = UUID.randomUUID().toString();
-            mockTargetWorkspace(okApikey, workspaceName, WORKSPACE_ID);
+            mockTargetWorkspace(okApikey, workspaceName);
 
             var otelTraceId = UUID.randomUUID().toString().getBytes();
             var parentSpanId = UUID.randomUUID().toString().getBytes();
@@ -735,7 +739,7 @@ class OpenTelemetryResourceTest {
         @DisplayName("test token deduplication with multiple children having usage")
         void testTokenDeduplicationWithMultipleChildrenHavingUsage() {
             String workspaceName = UUID.randomUUID().toString();
-            mockTargetWorkspace(okApikey, workspaceName, WORKSPACE_ID);
+            mockTargetWorkspace(okApikey, workspaceName);
 
             var otelTraceId = UUID.randomUUID().toString().getBytes();
             var parentSpanId = UUID.randomUUID().toString().getBytes();
@@ -820,5 +824,200 @@ class OpenTelemetryResourceTest {
             childSpans.forEach(span -> assertThat(span.usage()).isNotNull());
         }
 
+        @Test
+        @DisplayName("test opik.trace_id connects OTEL span to existing OPIK trace without creating a new trace")
+        void testOpikTraceIdConnectsToExistingTrace() {
+            String workspaceName = UUID.randomUUID().toString();
+            mockTargetWorkspace(okApikey, workspaceName);
+
+            String projectName = "Test Project " + UUID.randomUUID();
+
+            // First, create an existing OPIK trace via the Trace API (must be UUIDv7)
+            var existingTraceId = UUID_V7_GENERATOR.generate();
+            var existingTrace = Trace.builder()
+                    .id(existingTraceId)
+                    .name("existing trace")
+                    .projectName(projectName)
+                    .startTime(Instant.now().minus(Duration.ofSeconds(5)))
+                    .build();
+            traceResourceClient.createTrace(existingTrace, okApikey, workspaceName);
+
+            // Now send an OTEL span with opik.trace_id pointing to the existing trace
+            var otelTraceId = UUID.randomUUID().toString().getBytes();
+            var otelSpanId = UUID.randomUUID().toString().getBytes();
+
+            var otelSpan = Span.newBuilder()
+                    .setName("attached otel span")
+                    .setTraceId(ByteString.copyFrom(otelTraceId))
+                    .setSpanId(ByteString.copyFrom(otelSpanId))
+                    .setStartTimeUnixNano((System.currentTimeMillis() - 1_000) * 1_000_000L)
+                    .setEndTimeUnixNano(System.currentTimeMillis() * 1_000_000L)
+                    .addAttributes(KeyValue.newBuilder()
+                            .setKey("opik.trace_id")
+                            .setValue(AnyValue.newBuilder().setStringValue(existingTraceId.toString()))
+                            .build())
+                    .build();
+
+            sendProtobufTraces(List.of(otelSpan), projectName, workspaceName, okApikey, true, null);
+
+            // Verify the span is connected to the existing trace
+            var spanPage = spanResourceClient.getByTraceIdAndProject(existingTraceId,
+                    projectName, workspaceName, okApikey);
+            assertThat(spanPage.size()).isEqualTo(1);
+
+            var attachedSpan = spanPage.content().getFirst();
+            assertThat(attachedSpan.traceId()).isEqualTo(existingTraceId);
+            assertThat(attachedSpan.parentSpanId()).isNull();
+            assertThat(attachedSpan.name()).isEqualTo("attached otel span");
+
+            // Verify opik.trace_id is not leaked into span attributes
+            if (attachedSpan.input() != null) {
+                assertThat(attachedSpan.input().has("opik.trace_id")).isFalse();
+            }
+            if (attachedSpan.metadata() != null) {
+                assertThat(attachedSpan.metadata().has("opik.trace_id")).isFalse();
+            }
+        }
+
+        @Test
+        @DisplayName("test opik.trace_id and opik.parent_span_id connect OTEL span to existing OPIK span")
+        void testOpikTraceIdAndParentSpanIdConnectToExistingSpan() {
+            String workspaceName = UUID.randomUUID().toString();
+            mockTargetWorkspace(okApikey, workspaceName);
+
+            String projectName = "Test Project " + UUID.randomUUID();
+
+            // Create an existing OPIK trace and span via the APIs (must be UUIDv7)
+            var existingTraceId = UUID_V7_GENERATOR.generate();
+            var existingTrace = Trace.builder()
+                    .id(existingTraceId)
+                    .name("existing trace")
+                    .projectName(projectName)
+                    .startTime(Instant.now().minus(Duration.ofSeconds(5)))
+                    .build();
+            traceResourceClient.createTrace(existingTrace, okApikey, workspaceName);
+
+            var existingParentSpanId = UUID_V7_GENERATOR.generate();
+            var existingSpan = com.comet.opik.api.Span.builder()
+                    .id(existingParentSpanId)
+                    .traceId(existingTraceId)
+                    .name("existing parent span")
+                    .projectName(projectName)
+                    .startTime(Instant.now().minus(Duration.ofSeconds(4)))
+                    .build();
+            spanResourceClient.createSpan(existingSpan, okApikey, workspaceName);
+
+            // Send OTEL span with both opik.trace_id and opik.parent_span_id
+            var otelTraceId = UUID.randomUUID().toString().getBytes();
+            var otelSpanId = UUID.randomUUID().toString().getBytes();
+
+            var otelSpan = Span.newBuilder()
+                    .setName("child otel span")
+                    .setTraceId(ByteString.copyFrom(otelTraceId))
+                    .setSpanId(ByteString.copyFrom(otelSpanId))
+                    .setStartTimeUnixNano((System.currentTimeMillis() - 1_000) * 1_000_000L)
+                    .setEndTimeUnixNano(System.currentTimeMillis() * 1_000_000L)
+                    .addAttributes(KeyValue.newBuilder()
+                            .setKey("opik.trace_id")
+                            .setValue(AnyValue.newBuilder().setStringValue(existingTraceId.toString()))
+                            .build())
+                    .addAttributes(KeyValue.newBuilder()
+                            .setKey("opik.parent_span_id")
+                            .setValue(AnyValue.newBuilder().setStringValue(existingParentSpanId.toString()))
+                            .build())
+                    .build();
+
+            sendProtobufTraces(List.of(otelSpan), projectName, workspaceName, okApikey, true, null);
+
+            // Verify the span is connected to the existing trace with the correct parent
+            var spanPage = spanResourceClient.getByTraceIdAndProject(existingTraceId,
+                    projectName, workspaceName, okApikey);
+
+            // Should have 2 spans: the existing parent and the new child
+            assertThat(spanPage.size()).isEqualTo(2);
+
+            var childSpan = spanPage.content().stream()
+                    .filter(s -> "child otel span".equals(s.name()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(childSpan.traceId()).isEqualTo(existingTraceId);
+            assertThat(childSpan.parentSpanId()).isEqualTo(existingParentSpanId);
+
+            // Verify opik attributes are not leaked
+            if (childSpan.input() != null) {
+                assertThat(childSpan.input().has("opik.trace_id")).isFalse();
+                assertThat(childSpan.input().has("opik.parent_span_id")).isFalse();
+            }
+            if (childSpan.metadata() != null) {
+                assertThat(childSpan.metadata().has("opik.trace_id")).isFalse();
+                assertThat(childSpan.metadata().has("opik.parent_span_id")).isFalse();
+            }
+        }
+
+        @Test
+        @DisplayName("test mixed batch: spans with and without opik.trace_id override")
+        void testMixedBatchWithAndWithoutOpikTraceIdOverride() {
+            String workspaceName = UUID.randomUUID().toString();
+            mockTargetWorkspace(okApikey, workspaceName);
+
+            String projectName = "Test Project " + UUID.randomUUID();
+
+            // Create an existing OPIK trace to attach to (must be UUIDv7)
+            var existingTraceId = UUID_V7_GENERATOR.generate();
+            var existingTrace = Trace.builder()
+                    .id(existingTraceId)
+                    .name("existing trace")
+                    .projectName(projectName)
+                    .startTime(Instant.now().minus(Duration.ofSeconds(5)))
+                    .build();
+            traceResourceClient.createTrace(existingTrace, okApikey, workspaceName);
+
+            // Create a batch with: one normal OTEL root span + one span with opik.trace_id override
+            var otelTraceId = UUID.randomUUID().toString().getBytes();
+            var normalRootSpanId = UUID.randomUUID().toString().getBytes();
+            var overrideSpanId = UUID.randomUUID().toString().getBytes();
+
+            // Normal root span (should create a new trace)
+            var normalRootSpan = Span.newBuilder()
+                    .setName("normal root span")
+                    .setTraceId(ByteString.copyFrom(otelTraceId))
+                    .setSpanId(ByteString.copyFrom(normalRootSpanId))
+                    .setStartTimeUnixNano((System.currentTimeMillis() - 1_000) * 1_000_000L)
+                    .setEndTimeUnixNano(System.currentTimeMillis() * 1_000_000L)
+                    .build();
+
+            // Span with opik.trace_id override (should attach to existing trace, no new trace)
+            var overrideSpan = Span.newBuilder()
+                    .setName("override span")
+                    .setTraceId(ByteString.copyFrom(otelTraceId))
+                    .setSpanId(ByteString.copyFrom(overrideSpanId))
+                    .setStartTimeUnixNano((System.currentTimeMillis() - 500) * 1_000_000L)
+                    .setEndTimeUnixNano(System.currentTimeMillis() * 1_000_000L)
+                    .addAttributes(KeyValue.newBuilder()
+                            .setKey("opik.trace_id")
+                            .setValue(AnyValue.newBuilder().setStringValue(existingTraceId.toString()))
+                            .build())
+                    .build();
+
+            var otelSpans = List.of(normalRootSpan, overrideSpan);
+
+            var minTimestamp = otelSpans.stream().map(Span::getStartTimeUnixNano).min(Long::compareTo).orElseThrow();
+            var minTimestampMs = Duration.ofNanos(minTimestamp).toMillis();
+            var expectedNewTraceId = OpenTelemetryMapper.convertOtelIdToUUIDv7(otelTraceId, minTimestampMs);
+
+            sendProtobufTraces(otelSpans, projectName, workspaceName, okApikey, true, null);
+
+            // Verify the normal root span created a new trace
+            Trace newTrace = traceResourceClient.getById(expectedNewTraceId, workspaceName, okApikey);
+            assertThat(newTrace.id()).isEqualTo(expectedNewTraceId);
+            assertThat(newTrace.name()).isEqualTo("normal root span");
+
+            // Verify the override span is attached to the existing trace
+            var existingTraceSpans = spanResourceClient.getByTraceIdAndProject(existingTraceId,
+                    projectName, workspaceName, okApikey);
+            assertThat(existingTraceSpans.size()).isEqualTo(1);
+            assertThat(existingTraceSpans.content().getFirst().name()).isEqualTo("override span");
+            assertThat(existingTraceSpans.content().getFirst().traceId()).isEqualTo(existingTraceId);
+        }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1,8 +1,12 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.Span;
+import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
+import com.google.protobuf.ByteString;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -532,5 +536,287 @@ class OpenTelemetryMapperTest {
 
         assertThat(span.usage()).isNotNull();
         assertThat(span.usage().containsKey("total_tokens")).isFalse();
+    }
+
+    @Nested
+    class OpikTraceIdAndParentSpanIdOverride {
+
+        private final TimeBasedEpochGenerator uuidV7Generator = Generators.timeBasedEpochGenerator();
+
+        private io.opentelemetry.proto.trace.v1.Span buildOtelSpan(byte[] traceId, byte[] spanId,
+                byte[] parentSpanId, List<KeyValue> attributes) {
+            var builder = io.opentelemetry.proto.trace.v1.Span.newBuilder()
+                    .setName("test span")
+                    .setTraceId(ByteString.copyFrom(traceId))
+                    .setSpanId(ByteString.copyFrom(spanId))
+                    .setStartTimeUnixNano((System.currentTimeMillis() - 1_000) * 1_000_000L)
+                    .setEndTimeUnixNano(System.currentTimeMillis() * 1_000_000L);
+            if (parentSpanId != null) {
+                builder.setParentSpanId(ByteString.copyFrom(parentSpanId));
+            }
+            attributes.forEach(builder::addAttributes);
+            return builder.build();
+        }
+
+        @Test
+        void toOpikSpan_withOpikTraceIdOnly_usesOverrideTraceIdAndNullParent() {
+            var otelTraceId = UUID.randomUUID().toString().getBytes();
+            var otelSpanId = UUID.randomUUID().toString().getBytes();
+            var otelParentSpanId = UUID.randomUUID().toString().getBytes();
+
+            var overrideTraceId = uuidV7Generator.generate();
+
+            var otelSpan = buildOtelSpan(otelTraceId, otelSpanId, otelParentSpanId, List.of(
+                    KeyValue.newBuilder()
+                            .setKey("opik.trace_id")
+                            .setValue(AnyValue.newBuilder().setStringValue(overrideTraceId.toString()))
+                            .build()));
+
+            var mappedTraceId = OpenTelemetryMapper.convertOtelIdToUUIDv7(otelTraceId,
+                    System.currentTimeMillis());
+
+            var opikSpan = OpenTelemetryMapper.toOpikSpan(otelSpan, mappedTraceId, null);
+
+            // trace ID should be the override, not the mapped one
+            assertThat(opikSpan.traceId()).isEqualTo(overrideTraceId);
+            // parent span ID should be null (no opik.parent_span_id provided)
+            assertThat(opikSpan.parentSpanId()).isNull();
+        }
+
+        @Test
+        void toOpikSpan_withBothOpikTraceIdAndParentSpanId_usesBothOverrides() {
+            var otelTraceId = UUID.randomUUID().toString().getBytes();
+            var otelSpanId = UUID.randomUUID().toString().getBytes();
+
+            var overrideTraceId = uuidV7Generator.generate();
+            var overrideParentSpanId = uuidV7Generator.generate();
+
+            var otelSpan = buildOtelSpan(otelTraceId, otelSpanId, null, List.of(
+                    KeyValue.newBuilder()
+                            .setKey("opik.trace_id")
+                            .setValue(AnyValue.newBuilder().setStringValue(overrideTraceId.toString()))
+                            .build(),
+                    KeyValue.newBuilder()
+                            .setKey("opik.parent_span_id")
+                            .setValue(AnyValue.newBuilder().setStringValue(overrideParentSpanId.toString()))
+                            .build()));
+
+            var mappedTraceId = OpenTelemetryMapper.convertOtelIdToUUIDv7(otelTraceId,
+                    System.currentTimeMillis());
+
+            var opikSpan = OpenTelemetryMapper.toOpikSpan(otelSpan, mappedTraceId, null);
+
+            assertThat(opikSpan.traceId()).isEqualTo(overrideTraceId);
+            assertThat(opikSpan.parentSpanId()).isEqualTo(overrideParentSpanId);
+        }
+
+        @Test
+        void toOpikSpan_withoutOverrides_usesNormalMappingBehavior() {
+            var otelTraceId = UUID.randomUUID().toString().getBytes();
+            var otelSpanId = UUID.randomUUID().toString().getBytes();
+            var otelParentSpanId = UUID.randomUUID().toString().getBytes();
+
+            var otelSpan = buildOtelSpan(otelTraceId, otelSpanId, otelParentSpanId, List.of());
+
+            var mappedTraceId = OpenTelemetryMapper.convertOtelIdToUUIDv7(otelTraceId,
+                    System.currentTimeMillis());
+
+            var opikSpan = OpenTelemetryMapper.toOpikSpan(otelSpan, mappedTraceId, null);
+
+            // should use the mapped trace ID (not overridden)
+            assertThat(opikSpan.traceId()).isEqualTo(mappedTraceId);
+            // should have a converted parent span ID (not null)
+            assertThat(opikSpan.parentSpanId()).isNotNull();
+        }
+
+        @Test
+        void toOpikSpan_withoutOverrides_rootSpanHasNullParent() {
+            var otelTraceId = UUID.randomUUID().toString().getBytes();
+            var otelSpanId = UUID.randomUUID().toString().getBytes();
+
+            var otelSpan = buildOtelSpan(otelTraceId, otelSpanId, null, List.of());
+
+            var mappedTraceId = OpenTelemetryMapper.convertOtelIdToUUIDv7(otelTraceId,
+                    System.currentTimeMillis());
+
+            var opikSpan = OpenTelemetryMapper.toOpikSpan(otelSpan, mappedTraceId, null);
+
+            assertThat(opikSpan.traceId()).isEqualTo(mappedTraceId);
+            assertThat(opikSpan.parentSpanId()).isNull();
+        }
+
+        @Test
+        void toOpikSpan_opikTraceIdAndParentSpanId_areDroppedFromAttributes() {
+            var otelTraceId = UUID.randomUUID().toString().getBytes();
+            var otelSpanId = UUID.randomUUID().toString().getBytes();
+
+            var overrideTraceId = uuidV7Generator.generate();
+            var overrideParentSpanId = uuidV7Generator.generate();
+
+            var otelSpan = buildOtelSpan(otelTraceId, otelSpanId, null, List.of(
+                    KeyValue.newBuilder()
+                            .setKey("opik.trace_id")
+                            .setValue(AnyValue.newBuilder().setStringValue(overrideTraceId.toString()))
+                            .build(),
+                    KeyValue.newBuilder()
+                            .setKey("opik.parent_span_id")
+                            .setValue(AnyValue.newBuilder().setStringValue(overrideParentSpanId.toString()))
+                            .build(),
+                    KeyValue.newBuilder()
+                            .setKey("gen_ai.request.model")
+                            .setValue(AnyValue.newBuilder().setStringValue("gpt-4"))
+                            .build()));
+
+            var mappedTraceId = OpenTelemetryMapper.convertOtelIdToUUIDv7(otelTraceId,
+                    System.currentTimeMillis());
+
+            var opikSpan = OpenTelemetryMapper.toOpikSpan(otelSpan, mappedTraceId, null);
+
+            // opik.trace_id and opik.parent_span_id should NOT appear in input, output, or metadata
+            if (opikSpan.input() != null) {
+                assertThat(opikSpan.input().has("opik.trace_id")).isFalse();
+                assertThat(opikSpan.input().has("opik.parent_span_id")).isFalse();
+            }
+            if (opikSpan.output() != null) {
+                assertThat(opikSpan.output().has("opik.trace_id")).isFalse();
+                assertThat(opikSpan.output().has("opik.parent_span_id")).isFalse();
+            }
+            if (opikSpan.metadata() != null) {
+                assertThat(opikSpan.metadata().has("opik.trace_id")).isFalse();
+                assertThat(opikSpan.metadata().has("opik.parent_span_id")).isFalse();
+            }
+            // other attributes should still be processed normally
+            assertThat(opikSpan.model()).isEqualTo("gpt-4");
+        }
+
+        @Test
+        void extractOpikTraceId_returnsUUID_whenAttributePresent() {
+            var expectedId = uuidV7Generator.generate();
+            var otelSpan = buildOtelSpan(
+                    UUID.randomUUID().toString().getBytes(),
+                    UUID.randomUUID().toString().getBytes(),
+                    null,
+                    List.of(KeyValue.newBuilder()
+                            .setKey("opik.trace_id")
+                            .setValue(AnyValue.newBuilder().setStringValue(expectedId.toString()))
+                            .build()));
+
+            var result = OpenTelemetryMapper.extractOpikTraceId(otelSpan);
+            assertThat(result).isPresent().contains(expectedId);
+        }
+
+        @Test
+        void extractOpikTraceId_returnsEmpty_whenAttributeAbsent() {
+            var otelSpan = buildOtelSpan(
+                    UUID.randomUUID().toString().getBytes(),
+                    UUID.randomUUID().toString().getBytes(),
+                    null,
+                    List.of());
+
+            var result = OpenTelemetryMapper.extractOpikTraceId(otelSpan);
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void extractOpikParentSpanId_returnsUUID_whenAttributePresent() {
+            var expectedId = uuidV7Generator.generate();
+            var otelSpan = buildOtelSpan(
+                    UUID.randomUUID().toString().getBytes(),
+                    UUID.randomUUID().toString().getBytes(),
+                    null,
+                    List.of(KeyValue.newBuilder()
+                            .setKey("opik.parent_span_id")
+                            .setValue(AnyValue.newBuilder().setStringValue(expectedId.toString()))
+                            .build()));
+
+            var result = OpenTelemetryMapper.extractOpikParentSpanId(otelSpan);
+            assertThat(result).isPresent().contains(expectedId);
+        }
+
+        @Test
+        void extractOpikParentSpanId_returnsEmpty_whenAttributeAbsent() {
+            var otelSpan = buildOtelSpan(
+                    UUID.randomUUID().toString().getBytes(),
+                    UUID.randomUUID().toString().getBytes(),
+                    null,
+                    List.of());
+
+            var result = OpenTelemetryMapper.extractOpikParentSpanId(otelSpan);
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void extractOpikTraceId_returnsEmpty_whenNotUUIDv7() {
+            // UUID v4 should be rejected
+            var v4Uuid = UUID.randomUUID();
+            var otelSpan = buildOtelSpan(
+                    UUID.randomUUID().toString().getBytes(),
+                    UUID.randomUUID().toString().getBytes(),
+                    null,
+                    List.of(KeyValue.newBuilder()
+                            .setKey("opik.trace_id")
+                            .setValue(AnyValue.newBuilder().setStringValue(v4Uuid.toString()))
+                            .build()));
+
+            var result = OpenTelemetryMapper.extractOpikTraceId(otelSpan);
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void extractOpikTraceId_returnsEmpty_whenInvalidUUIDString() {
+            var otelSpan = buildOtelSpan(
+                    UUID.randomUUID().toString().getBytes(),
+                    UUID.randomUUID().toString().getBytes(),
+                    null,
+                    List.of(KeyValue.newBuilder()
+                            .setKey("opik.trace_id")
+                            .setValue(AnyValue.newBuilder().setStringValue("not-a-uuid"))
+                            .build()));
+
+            var result = OpenTelemetryMapper.extractOpikTraceId(otelSpan);
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void extractOpikTraceId_returnsEmpty_whenAttributeBlank() {
+            var otelSpan = buildOtelSpan(
+                    UUID.randomUUID().toString().getBytes(),
+                    UUID.randomUUID().toString().getBytes(),
+                    null,
+                    List.of(KeyValue.newBuilder()
+                            .setKey("opik.trace_id")
+                            .setValue(AnyValue.newBuilder().setStringValue(""))
+                            .build()));
+
+            var result = OpenTelemetryMapper.extractOpikTraceId(otelSpan);
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void toOpikSpan_opikParentSpanIdWithoutTraceId_isIgnored() {
+            // opik.parent_span_id without opik.trace_id should be ignored (normal flow)
+            var otelTraceId = UUID.randomUUID().toString().getBytes();
+            var otelSpanId = UUID.randomUUID().toString().getBytes();
+            var otelParentSpanId = UUID.randomUUID().toString().getBytes();
+
+            var overrideParentSpanId = uuidV7Generator.generate();
+
+            var otelSpan = buildOtelSpan(otelTraceId, otelSpanId, otelParentSpanId, List.of(
+                    KeyValue.newBuilder()
+                            .setKey("opik.parent_span_id")
+                            .setValue(AnyValue.newBuilder().setStringValue(overrideParentSpanId.toString()))
+                            .build()));
+
+            var mappedTraceId = OpenTelemetryMapper.convertOtelIdToUUIDv7(otelTraceId,
+                    System.currentTimeMillis());
+
+            var opikSpan = OpenTelemetryMapper.toOpikSpan(otelSpan, mappedTraceId, null);
+
+            // trace ID should use normal mapping (no override)
+            assertThat(opikSpan.traceId()).isEqualTo(mappedTraceId);
+            // parent span ID should use normal OTEL conversion (override ignored)
+            assertThat(opikSpan.parentSpanId()).isNotNull();
+            assertThat(opikSpan.parentSpanId()).isNotEqualTo(overrideParentSpanId);
+        }
     }
 }


### PR DESCRIPTION
## Details
Today there is no supported way to make a batch of OTel spans land inside an existing Opik trace. Opik's OTLP endpoint converts every incoming otel_trace_id / span_id into a freshly-derived UUIDv7 (timestamp_ms + SHA-256(otel_id)[:10]). 

That derivation is one-way, so a client that already holds an Opik trace UUID (e.g. the one created by opik.evaluation.evaluate() on each dataset item) cannot hand that UUID to an external OTel-emitting service and have its spans appear under the same trace in Opik.

This is a common distributed-tracing pattern for anyone running a polyglot agent stack — Python/Node.js/Java eval harness calling out to services that already speak OTel and don't want an Opik SDK in the critical path.
We want a supported, documented mechanism that lets callers say: "this batch of OTel spans belongs to Opik trace X, rooted under Opik span Y".

## Summary

Adds support for two new OTEL span attributes (`opik.trace_id` and `opik.parent_span_id`) that allow connecting incoming OTEL spans to existing OPIK traces and spans. When present, these attributes are used as-is (UUIDv7, no conversion) instead of the normal OTEL trace ID mapping. Spans with `opik.trace_id` skip automatic trace creation since they attach to pre-existing traces.

## Changes by Component

### Backend
- **`GeneralMappingRules.java`** - Added `OPIK_TRACE_ID_ATTR` and `OPIK_PARENT_SPAN_ID_ATTR` constants. Added DROP mapping rules so these attributes are not leaked into span input/output/metadata during attribute processing.
- **`OpenTelemetryMapper.java`** - Added `extractOpikTraceId()` and `extractOpikParentSpanId()` methods that extract and validate (must be UUIDv7) the override attributes from OTEL spans. Modified `toOpikSpan()` to use these overrides: when `opik.trace_id` is present, it replaces the mapped trace ID; when `opik.parent_span_id` is also present, it replaces the converted parent span ID; when only `opik.trace_id` is set, parent span ID is null (direct child of trace). Invalid or non-v7 UUIDs are logged and ignored.
- **`OpenTelemetryService.java`** - Modified `doStoreSpans()` to track trace IDs from `opik.trace_id` overrides and exclude those spans from automatic trace creation (since they connect to existing traces).
- **`OpenTelemetryResourceTest.java`** - Added 3 integration tests: (1) `opik.trace_id` connects span to existing trace without creating a new one; (2) both `opik.trace_id` and `opik.parent_span_id` connect span to existing trace and parent span; (3) mixed batch with overridden and normal spans processed correctly.
- **`OpenTelemetryMapperTest.java`** - Added 13 unit tests covering: override with trace ID only, both overrides, no overrides (normal behavior), attributes dropped from span data, extraction helpers for present/absent/blank/non-v7/invalid UUID values, and `opik.parent_span_id` without `opik.trace_id` being ignored.

## Files Changed

```
 .../com/comet/opik/domain/OpenTelemetryMapper.java |  75 +++++-
 .../comet/opik/domain/OpenTelemetryService.java    |  14 +-
 .../domain/mapping/otel/GeneralMappingRules.java   |  14 +-
 .../v1/priv/OpenTelemetryResourceTest.java         | 221 +++++++++++++++-
 .../comet/opik/domain/OpenTelemetryMapperTest.java | 286 +++++++++++++++++++++
 5 files changed, 592 insertions(+), 18 deletions(-)
```

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6168

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code v2.1.108
  - Model(s): Opus 4.6 (1M context)
  - Scope: Implementation and tests
  - Human verification: Verified by human

## Testing
Implemented unit and integration tests.

## Documentation
Nothing added