### PR TITLE
[NA]: Update titles and slugs for prompt and agent playgrounds

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/development/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/development/overview.mdx
@@ -41,7 +41,7 @@ When you're happy with a configuration, use the **Deploy to** button in the Agen
 ## More tools
 
 <CardGroup cols={2}>
-  <Card title="Prompt Playground" href="/development/playground" icon="fa-regular fa-terminal">
+  <Card title="Prompt Playground" href="/development/prompt-playground" icon="fa-regular fa-terminal">
     Test and compare prompt variants side-by-side across models. Run against datasets for systematic evaluation.
   </Card>
   <Card title="Optimization Runs" href="/development/optimization-runs/overview" icon="fa-regular fa-chart-line">

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/debug_agents.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/debug_agents.mdx
@@ -101,5 +101,5 @@ debugging scenarios:
 ## Next steps
 
 - [Ollie overview](/ollie) — Full introduction to Ollie's capabilities and setup
-- [Agent playground](/development/agent-sandbox) — How `opik connect` discovers and runs your agent
+- [Agent playground](/development/agent-playground) — How `opik connect` discovers and runs your agent
 - [Evaluation overview](/evaluation/overview) — Build the regression net Ollie populates for you

--- a/apps/opik-documentation/documentation/fern/docs-v2/ollie.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/ollie.mdx
@@ -118,7 +118,7 @@ Open Ollie from anywhere in the Opik UI and start asking. Traces, code, reruns, 
   <Card title="Debugging agents with Ollie" href="/tracing/debug-agents" icon="fa-regular fa-bug">
     The tactical guide to the debug-fix-verify loop, with example prompts.
   </Card>
-  <Card title="Agent playground" href="/development/agent-sandbox" icon="fa-regular fa-flask">
+  <Card title="Agent playground" href="/development/agent-playground" icon="fa-regular fa-flask">
     Everything about `opik connect` — how it discovers and runs your agent.
   </Card>
   <Card title="Test suites" href="/evaluation/overview" icon="fa-regular fa-check-double">

--- a/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/advanced/playground.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/advanced/playground.mdx
@@ -1,10 +1,10 @@
 ---
-headline: Playground | Opik Documentation
+headline: Prompt Playground | Opik Documentation
 og:description: Test and compare prompt variants across models, then validate them
   against test suites — all without writing code
 og:site_name: Opik Documentation
-og:title: Playground — Opik
-title: Playground
+og:title: Prompt Playground — Opik
+title: Prompt Playground
 ---
 
 The Playground lets you test prompt changes and compare models without writing code. Create

--- a/apps/opik-documentation/documentation/fern/docs-v2/self_improving_agents/ollie_and_your_codebase.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self_improving_agents/ollie_and_your_codebase.mdx
@@ -113,6 +113,6 @@ Ollie reruns the agent with the same input from the failing trace. The new trace
 
 ## Next steps
 
-- [Agent playground](/development/agent-sandbox) — Technical details on `opik connect` and `opik endpoint`
+- [Agent playground](/development/agent-playground) — Technical details on `opik connect` and `opik endpoint`
 - [The Flywheel](/self-improving-agents/the-flywheel) — The complete self-improvement cycle
 - [Debugging agents with Ollie](/tracing/debug-agents) — Example prompts for common debugging scenarios

--- a/apps/opik-documentation/documentation/fern/versions/latest.yml
+++ b/apps/opik-documentation/documentation/fern/versions/latest.yml
@@ -110,7 +110,7 @@ navigation:
             slug: overview
           - page: Agent playground
             path: ../docs-v2/observability/agent_sandbox.mdx
-            slug: agent-sandbox
+            slug: agent-playground
           - page: Prompt playground
             path: ../docs-v2/prompt_engineering/advanced/playground.mdx
             slug: playground

--- a/apps/opik-documentation/documentation/fern/versions/latest.yml
+++ b/apps/opik-documentation/documentation/fern/versions/latest.yml
@@ -113,7 +113,7 @@ navigation:
             slug: agent-playground
           - page: Prompt playground
             path: ../docs-v2/prompt_engineering/advanced/playground.mdx
-            slug: playground
+            slug: prompt-playground
           - section: Agent configuration
             slug: /agent-configuration
             contents:


### PR DESCRIPTION
## Details
Make prompt and agent playground tabs more discoverable for their key words but updating titles, headings and slugs.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
<!--
REPLACE ME WITH:

How you tested

Include:
- Exact commands run (for example: `mvn test`, `npm run lint && npm run test`, `pytest ...`)
- Scenarios validated (happy path, edge cases, regressions)
- Environment/context used (local process mode vs Docker, OS/browser when relevant)
- Any tests not run, with reason
- Relevant logs/artifacts links if available

Video evidence:
- External contributors: include a short recording for all contributions where possible.
- Internal contributors: include a short recording for complex changes where possible.
-->

## Documentation
