### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -11713,6 +11713,7 @@ components:
           minimum: 1
           type: integer
           format: int32
+      readOnly: true
     Dataset:
       required:
       - name
@@ -12103,6 +12104,8 @@ components:
         description:
           type: string
           readOnly: true
+        execution_policy:
+          $ref: "#/components/schemas/ExecutionPolicy"
         assertion_results:
           type: array
           readOnly: true
@@ -12737,6 +12740,7 @@ components:
           minimum: 1
           type: integer
           format: int32
+      readOnly: true
     ExperimentItem_Compare:
       required:
       - dataset_item_id
@@ -12811,6 +12815,8 @@ components:
         description:
           type: string
           readOnly: true
+        execution_policy:
+          $ref: "#/components/schemas/ExecutionPolicy_Compare"
         assertion_results:
           type: array
           readOnly: true

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -11713,6 +11713,7 @@ components:
           minimum: 1
           type: integer
           format: int32
+      readOnly: true
     Dataset:
       required:
       - name
@@ -12103,6 +12104,8 @@ components:
         description:
           type: string
           readOnly: true
+        execution_policy:
+          $ref: "#/components/schemas/ExecutionPolicy"
         assertion_results:
           type: array
           readOnly: true
@@ -12737,6 +12740,7 @@ components:
           minimum: 1
           type: integer
           format: int32
+      readOnly: true
     ExperimentItem_Compare:
       required:
       - dataset_item_id
@@ -12811,6 +12815,8 @@ components:
         description:
           type: string
           readOnly: true
+        execution_policy:
+          $ref: "#/components/schemas/ExecutionPolicy_Compare"
         assertion_results:
           type: array
           readOnly: true

--- a/sdks/python/src/opik/rest_api/types/experiment_item.py
+++ b/sdks/python/src/opik/rest_api/types/experiment_item.py
@@ -7,6 +7,7 @@ import pydantic
 from ..core.pydantic_utilities import IS_PYDANTIC_V2, UniversalBaseModel
 from .assertion_result import AssertionResult
 from .comment import Comment
+from .execution_policy import ExecutionPolicy
 from .experiment_item_status import ExperimentItemStatus
 from .experiment_item_trace_visibility_mode import ExperimentItemTraceVisibilityMode
 from .feedback_score import FeedbackScore
@@ -33,6 +34,7 @@ class ExperimentItem(UniversalBaseModel):
     last_updated_by: typing.Optional[str] = None
     trace_visibility_mode: typing.Optional[ExperimentItemTraceVisibilityMode] = None
     description: typing.Optional[str] = None
+    execution_policy: typing.Optional[ExecutionPolicy] = None
     assertion_results: typing.Optional[typing.List[AssertionResult]] = None
     status: typing.Optional[ExperimentItemStatus] = None
 

--- a/sdks/python/src/opik/rest_api/types/experiment_item_compare.py
+++ b/sdks/python/src/opik/rest_api/types/experiment_item_compare.py
@@ -7,6 +7,7 @@ import pydantic
 from ..core.pydantic_utilities import IS_PYDANTIC_V2, UniversalBaseModel
 from .assertion_result_compare import AssertionResultCompare
 from .comment_compare import CommentCompare
+from .execution_policy_compare import ExecutionPolicyCompare
 from .experiment_item_compare_status import ExperimentItemCompareStatus
 from .experiment_item_compare_trace_visibility_mode import ExperimentItemCompareTraceVisibilityMode
 from .feedback_score_compare import FeedbackScoreCompare
@@ -32,6 +33,7 @@ class ExperimentItemCompare(UniversalBaseModel):
     last_updated_by: typing.Optional[str] = None
     trace_visibility_mode: typing.Optional[ExperimentItemCompareTraceVisibilityMode] = None
     description: typing.Optional[str] = None
+    execution_policy: typing.Optional[ExecutionPolicyCompare] = None
     assertion_results: typing.Optional[typing.List[AssertionResultCompare]] = None
     status: typing.Optional[ExperimentItemCompareStatus] = None
 

--- a/sdks/typescript/src/opik/rest_api/api/types/ExperimentItem.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/ExperimentItem.ts
@@ -22,6 +22,7 @@ export interface ExperimentItem {
     lastUpdatedBy?: string;
     traceVisibilityMode?: OpikApi.ExperimentItemTraceVisibilityMode;
     description?: string;
+    executionPolicy?: OpikApi.ExecutionPolicy;
     assertionResults?: OpikApi.AssertionResult[];
     status?: OpikApi.ExperimentItemStatus;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/ExperimentItemCompare.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/ExperimentItemCompare.ts
@@ -21,6 +21,7 @@ export interface ExperimentItemCompare {
     lastUpdatedBy?: string;
     traceVisibilityMode?: OpikApi.ExperimentItemCompareTraceVisibilityMode;
     description?: string;
+    executionPolicy?: OpikApi.ExecutionPolicyCompare;
     assertionResults?: OpikApi.AssertionResultCompare[];
     status?: OpikApi.ExperimentItemCompareStatus;
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/ExperimentItem.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/ExperimentItem.ts
@@ -5,6 +5,7 @@ import * as core from "../../core/index.js";
 import type * as serializers from "../index.js";
 import { AssertionResult } from "./AssertionResult.js";
 import { Comment } from "./Comment.js";
+import { ExecutionPolicy } from "./ExecutionPolicy.js";
 import { ExperimentItemStatus } from "./ExperimentItemStatus.js";
 import { ExperimentItemTraceVisibilityMode } from "./ExperimentItemTraceVisibilityMode.js";
 import { FeedbackScore } from "./FeedbackScore.js";
@@ -37,6 +38,7 @@ export const ExperimentItem: core.serialization.ObjectSchema<serializers.Experim
             ExperimentItemTraceVisibilityMode.optional(),
         ),
         description: core.serialization.string().optional(),
+        executionPolicy: core.serialization.property("execution_policy", ExecutionPolicy.optional()),
         assertionResults: core.serialization.property(
             "assertion_results",
             core.serialization.list(AssertionResult).optional(),
@@ -65,6 +67,7 @@ export declare namespace ExperimentItem {
         last_updated_by?: string | null;
         trace_visibility_mode?: ExperimentItemTraceVisibilityMode.Raw | null;
         description?: string | null;
+        execution_policy?: ExecutionPolicy.Raw | null;
         assertion_results?: AssertionResult.Raw[] | null;
         status?: ExperimentItemStatus.Raw | null;
     }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/ExperimentItemCompare.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/ExperimentItemCompare.ts
@@ -5,6 +5,7 @@ import * as core from "../../core/index.js";
 import type * as serializers from "../index.js";
 import { AssertionResultCompare } from "./AssertionResultCompare.js";
 import { CommentCompare } from "./CommentCompare.js";
+import { ExecutionPolicyCompare } from "./ExecutionPolicyCompare.js";
 import { ExperimentItemCompareStatus } from "./ExperimentItemCompareStatus.js";
 import { ExperimentItemCompareTraceVisibilityMode } from "./ExperimentItemCompareTraceVisibilityMode.js";
 import { FeedbackScoreCompare } from "./FeedbackScoreCompare.js";
@@ -38,6 +39,7 @@ export const ExperimentItemCompare: core.serialization.ObjectSchema<
         ExperimentItemCompareTraceVisibilityMode.optional(),
     ),
     description: core.serialization.string().optional(),
+    executionPolicy: core.serialization.property("execution_policy", ExecutionPolicyCompare.optional()),
     assertionResults: core.serialization.property(
         "assertion_results",
         core.serialization.list(AssertionResultCompare).optional(),
@@ -65,6 +67,7 @@ export declare namespace ExperimentItemCompare {
         last_updated_by?: string | null;
         trace_visibility_mode?: ExperimentItemCompareTraceVisibilityMode.Raw | null;
         description?: string | null;
+        execution_policy?: ExecutionPolicyCompare.Raw | null;
         assertion_results?: AssertionResultCompare.Raw[] | null;
         status?: ExperimentItemCompareStatus.Raw | null;
     }


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

**Triggered by BE merge:** https://github.com/comet-ml/opik/pull/6361

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate