### PR TITLE
[OPIK-6202] [FE] [DOCS] fix: explainer docs anchors and wrapper re-exports

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/annotation_queues.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/annotation_queues.mdx
@@ -398,4 +398,4 @@ for (const queue of threadsQueues) {
 You can learn more about Opik's annotation and evaluation features in:
 
 1. [Evaluation overview](/evaluation/overview)
-2. [Feedback definitions](../configuration/configuration/feedback_definitions)
+2. [Feedback definitions](/administration/workspace-settings/feedback_definitions)

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/annotation_queues.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/annotation_queues.mdx
@@ -398,4 +398,4 @@ for (const queue of threadsQueues) {
 You can learn more about Opik's annotation and evaluation features in:
 
 1. [Evaluation overview](/v1/evaluation/overview)
-2. [Feedback definitions](../configuration/configuration/feedback_definitions)
+2. [Feedback definitions](/v1/administration/workspace-settings/feedback_definitions)

--- a/apps/opik-frontend/src/constants/explainers.ts
+++ b/apps/opik-frontend/src/constants/explainers.ts
@@ -27,7 +27,7 @@ export enum EXPLAINER_ID {
   whats_the_experiment_configuration = "whats_the_experiment_configuration",
   what_does_it_mean_to_compare_my_experiments = "what_does_it_mean_to_compare_my_experiments",
   whats_the_test_suite_item = "whats_the_test_suite_item",
-  whats_an_test_suite = "whats_an_test_suite",
+  whats_a_test_suite = "whats_a_test_suite",
   why_do_i_need_multiple_test_suites = "why_do_i_need_multiple_test_suites",
   what_format_is_this_to_add_my_test_suite_item = "what_format_is_this_to_add_my_test_suite_item",
   what_format_is_this_to_add_my_dataset_item = "what_format_is_this_to_add_my_dataset_item",
@@ -260,8 +260,8 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
       "Test suite items are individual input samples in an experiment, each representing a test case your LLM app processes and evaluates.",
     type: "help",
   },
-  [EXPLAINER_ID.whats_an_test_suite]: {
-    id: EXPLAINER_ID.whats_an_test_suite,
+  [EXPLAINER_ID.whats_a_test_suite]: {
+    id: EXPLAINER_ID.whats_a_test_suite,
     description:
       "A test suite is a collection of input-output examples used to evaluate your LLM application's performance.",
   },

--- a/apps/opik-frontend/src/v1/constants/explainers.ts
+++ b/apps/opik-frontend/src/v1/constants/explainers.ts
@@ -89,9 +89,9 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
     ...BASE_EXPLAINERS[EXPLAINER_ID.whats_the_test_suite_item],
     docLink: buildDocsUrl("/evaluation/concepts", "#experiments"),
   },
-  [EXPLAINER_ID.whats_an_test_suite]: {
-    ...BASE_EXPLAINERS[EXPLAINER_ID.whats_an_test_suite],
-    docLink: buildDocsUrl("/evaluation/concepts", "#test-suites"),
+  [EXPLAINER_ID.whats_a_test_suite]: {
+    ...BASE_EXPLAINERS[EXPLAINER_ID.whats_a_test_suite],
+    docLink: buildDocsUrl("/evaluation/concepts", "#experiments"),
   },
   [EXPLAINER_ID.whats_the_prompt_library]: {
     ...BASE_EXPLAINERS[EXPLAINER_ID.whats_the_prompt_library],
@@ -207,11 +207,11 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
   },
   [EXPLAINER_ID.prompt_generation_learn_more]: {
     ...BASE_EXPLAINERS[EXPLAINER_ID.prompt_generation_learn_more],
-    docLink: buildDocsUrl("/prompt_engineering/improve", "#generate"),
+    docLink: buildDocsUrl("/prompt_engineering/improve", "#prompt-generator"),
   },
   [EXPLAINER_ID.prompt_improvement_learn_more]: {
     ...BASE_EXPLAINERS[EXPLAINER_ID.prompt_improvement_learn_more],
-    docLink: buildDocsUrl("/prompt_engineering/improve", "#improve"),
+    docLink: buildDocsUrl("/prompt_engineering/improve", "#prompt-improver"),
   },
   [EXPLAINER_ID.prompt_improvement_optimizer]: {
     ...BASE_EXPLAINERS[EXPLAINER_ID.prompt_improvement_optimizer],

--- a/apps/opik-frontend/src/v1/lib/utils.ts
+++ b/apps/opik-frontend/src/v1/lib/utils.ts
@@ -3,8 +3,6 @@ import {
   buildDocsMarkdownUrl as buildDocsMarkdownUrlBase,
 } from "@/lib/utils";
 
-export * from "@/lib/utils";
-
 export const buildDocsUrl = (path: string = "", hash: string = "") =>
   buildDocsUrlBase(`/v1${path}`, hash);
 

--- a/apps/opik-frontend/src/v2/constants/explainers.ts
+++ b/apps/opik-frontend/src/v2/constants/explainers.ts
@@ -27,11 +27,11 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
   },
   [EXPLAINER_ID.i_added_traces_to_an_test_suite_now_what]: {
     ...BASE_EXPLAINERS[EXPLAINER_ID.i_added_traces_to_an_test_suite_now_what],
-    docLink: buildDocsUrl("/evaluation/overview", "#running-an-evaluation"),
+    docLink: buildDocsUrl("/evaluation/overview", "#the-evaluation-loop"),
   },
   [EXPLAINER_ID.i_added_items_to_a_dataset_now_what]: {
     ...BASE_EXPLAINERS[EXPLAINER_ID.i_added_items_to_a_dataset_now_what],
-    docLink: buildDocsUrl("/evaluation/overview", "#running-an-evaluation"),
+    docLink: buildDocsUrl("/evaluation/overview", "#the-evaluation-loop"),
   },
   [EXPLAINER_ID.hows_the_cost_estimated]: {
     ...BASE_EXPLAINERS[EXPLAINER_ID.hows_the_cost_estimated],
@@ -69,7 +69,10 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
   },
   [EXPLAINER_ID.whats_the_experiment_configuration]: {
     ...BASE_EXPLAINERS[EXPLAINER_ID.whats_the_experiment_configuration],
-    docLink: buildDocsUrl("/evaluation/concepts", "#experiment-configuration"),
+    docLink: buildDocsUrl(
+      "/evaluation/overview",
+      "#two-approaches-to-evaluation",
+    ),
   },
   [EXPLAINER_ID.what_does_it_mean_to_compare_my_experiments]: {
     ...BASE_EXPLAINERS[
@@ -82,11 +85,17 @@ export const EXPLAINERS_MAP: Record<EXPLAINER_ID, Explainer> = {
   },
   [EXPLAINER_ID.whats_the_test_suite_item]: {
     ...BASE_EXPLAINERS[EXPLAINER_ID.whats_the_test_suite_item],
-    docLink: buildDocsUrl("/evaluation/concepts", "#experiments"),
+    docLink: buildDocsUrl(
+      "/evaluation/concepts",
+      "#test-suites-assertion-based-testing",
+    ),
   },
-  [EXPLAINER_ID.whats_an_test_suite]: {
-    ...BASE_EXPLAINERS[EXPLAINER_ID.whats_an_test_suite],
-    docLink: buildDocsUrl("/evaluation/concepts", "#test-suites"),
+  [EXPLAINER_ID.whats_a_test_suite]: {
+    ...BASE_EXPLAINERS[EXPLAINER_ID.whats_a_test_suite],
+    docLink: buildDocsUrl(
+      "/evaluation/concepts",
+      "#test-suites-assertion-based-testing",
+    ),
   },
   [EXPLAINER_ID.whats_the_prompt_library]: {
     ...BASE_EXPLAINERS[EXPLAINER_ID.whats_the_prompt_library],

--- a/apps/opik-frontend/src/v2/lib/utils.ts
+++ b/apps/opik-frontend/src/v2/lib/utils.ts
@@ -3,8 +3,6 @@ import {
   buildDocsMarkdownUrl as buildDocsMarkdownUrlBase,
 } from "@/lib/utils";
 
-export * from "@/lib/utils";
-
 export const buildDocsUrl = (path: string = "", hash: string = "") =>
   buildDocsUrlBase(path, hash);
 


### PR DESCRIPTION
## Details

<img width="1920" height="2534" alt="image" src="https://github.com/user-attachments/assets/cb6438fc-13a1-4a0a-a65b-840ef88cea37" />

Follow-up to [OPIK-5856 / #6456](https://github.com/comet-ml/opik/pull/6456). Addresses the 8 hash-anchor mismatches flagged by @andriidudar in [their review](https://github.com/comet-ml/opik/pull/6456#pullrequestreview-4163587917) — base pages return HTTP 200 but the `#anchor` fragments pointed to headings that had been renamed or removed in Fern docs. Curl-based URL validation doesn't catch these, which is why they slipped through the prior PR.

- Mapped each broken anchor to the closest real heading verified against Fern MDX sources (`docs/` and `docs-v2/`). 5 are reviewer-suggested exact replacements; 3 were "removed/renamed" cases requiring judgment — picked `/evaluation/overview#two-approaches-to-evaluation`, `#test-suites-assertion-based-testing`, and v1 `#experiments` as the nearest-matching live sections.
- Renamed `EXPLAINER_ID.whats_an_test_suite` → `whats_a_test_suite` (grammar fix, carried across base + v1 + v2 explainer maps).
- Dropped `export * from "@/lib/utils"` from both `src/v1/lib/utils.ts` and `src/v2/lib/utils.ts` (second non-blocking note from the review). Verified all 56 wrapper importers only take `buildDocsUrl` / `buildDocsMarkdownUrl`; no file was relying on the wildcard re-export. Aligns with repo convention (no wildcard re-exports elsewhere).
- Piggybacked a 2-line MDX fix surfaced by the docs preview link checker: `evaluation/annotation_queues.mdx` and `evaluation/advanced/annotation_queues.mdx` had a relative path that Fern resolved into a doubled `configuration/configuration/` segment (404). Switched both to absolute canonical paths pointing at `/administration/workspace-settings/feedback_definitions`.
- Deferred (flagged in the ticket for record): the v2 wrapper's pure pass-through is kept as symmetry / future-proofing — removing it would churn 33 files for zero functional change today.

Follow-up filed: [OPIK-6205](https://comet-ml.atlassian.net/browse/OPIK-6205) — add a CI check that validates `buildDocsUrl` anchors against real page HTML, so future anchor rot is caught automatically.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6202

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation, including Fern source research for anchor mappings and reviewer-note verification
- Human verification: code review in PR, pre-commit hooks (lint + typecheck + dep-validation), manual spot-check of changed anchor URLs against live docs

## Testing

- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `pre-commit` hook on commit — frontend lint, typecheck, and dependency-cruiser all passed
- Manual curl sweep of the 4 base docs URLs I touched — all return HTTP 200
- Cross-checked all 8 anchor replacements against the Fern MDX source (`apps/opik-documentation/documentation/fern/docs{,-v2}/`) to confirm the target heading exists
- Not run automatically: in-browser scroll-to-anchor verification. The em-dash slug `#test-suites-assertion-based-testing` (from `## Test Suites — assertion-based testing`) is trusted from OPIK-5856 review context; reviewer may want to spot-check in the Fern preview

## Documentation

- Fern MDX link fix in two `annotation_queues.mdx` files (see Details section)
- No user-facing docs pages added or removed

[OPIK-6205]: https://comet-ml.atlassian.net/browse/OPIK-6205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ