### PR TITLE
[OPIK-6206] [FE] fix: thread sidebar scrolling

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
@@ -476,25 +476,29 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
             </div>
           </MediaProvider>
         </TabsContent>
-        <TabsContent value="feedback_scores" className="px-4">
-          <ConfigurableFeedbackScoreTable
-            onDeleteFeedbackScore={
-              canAnnotateTraceSpanThread ? handleDeleteFeedbackScore : undefined
-            }
-            feedbackScores={threadFeedbackScores}
-            onAddHumanReview={() =>
-              setActiveSection(DetailsActionSection.Annotate)
-            }
-            entityType="thread"
-          />
-          {canAnnotateTraceSpanThread && (
-            <ThreadFeedbackScoresInfo
+        <TabsContent value="feedback_scores">
+          <div style={bodyStyle} className="overflow-y-auto px-4">
+            <ConfigurableFeedbackScoreTable
+              onDeleteFeedbackScore={
+                canAnnotateTraceSpanThread
+                  ? handleDeleteFeedbackScore
+                  : undefined
+              }
               feedbackScores={threadFeedbackScores}
               onAddHumanReview={() =>
                 setActiveSection(DetailsActionSection.Annotate)
               }
+              entityType="thread"
             />
-          )}
+            {canAnnotateTraceSpanThread && (
+              <ThreadFeedbackScoresInfo
+                feedbackScores={threadFeedbackScores}
+                onAddHumanReview={() =>
+                  setActiveSection(DetailsActionSection.Annotate)
+                }
+              />
+            )}
+          </div>
         </TabsContent>
       </Tabs>
     );
@@ -536,7 +540,7 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
                   hotkey="A"
                 />
               </div>
-              <div ref={ref} className="relative flex-auto">
+              <div ref={ref} className="relative min-h-0 flex-auto">
                 <div className="px-4 pb-6 pt-4" data-panel-header="true">
                   {renderHeader()}
                 </div>


### PR DESCRIPTION
## Details

The Thread sidebar body could not scroll: both the Messages tab (long conversations) and the Feedback scores tab (long score lists) overflowed the panel instead of scrolling internally. Root cause was a flexbox sizing regression introduced in OPIK-6065 and a pre-existing gap where the Feedback scores tab had no fixed-height scroll container.

- Add `min-h-0` to the `flex-auto` container that wraps the resize-observed region. Without it, the default `min-height: auto` prevented the flex child from shrinking below its content, inflating `clientHeight` and feeding a bogus height into the body size calculation.
- Wrap the Feedback scores tab content in a fixed-height `overflow-y-auto` container using the same `bodyStyle` height as the Messages tab, so long score lists scroll inside the panel instead of overflowing it.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6206

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation (diagnosis, fix, verification)
- Human verification: code review + manual browser testing (Messages and Feedback scores tabs)

## Testing

- `scripts/dev-runner.sh --lint-fe` — eslint, tsc typecheck, dependency-cruiser all pass.
- Manual browser verification against the local dev stack (`http://localhost:5174`):
  - Opened a thread with 8 messages; measured Messages scroll container: `clientHeight=567px`, `scrollHeight=1348px`; programmatic scroll 0 → 400 works.
  - Switched to Feedback scores tab; confirmed the new wrapper resolves to `clientHeight=567px` with `overflow-y: auto` and `padding: 0 16px`; injected a 1500px probe element to force overflow and confirmed scroll 0 → 400 works.
  - Verified Previous/Next thread navigation, tag row, header metadata, and the actions dropdown still render correctly.
- No tests added — change is a CSS-only layout fix; no existing unit tests cover this panel's scroll behavior.

## Documentation

N/A