### PR TITLE
[OPIK-6209] [CI] perf: reduce SDK E2E matrix to min+max on BE-only PRs

### DIFF
--- a/.github/actions/select-e2e-matrix/action.yml
+++ b/.github/actions/select-e2e-matrix/action.yml
@@ -1,0 +1,53 @@
+name: Select E2E version matrix
+description: >
+  Emits the full version array or a reduced [min, max] array depending on whether
+  the event's changed files match the given SDK-touching regex. Full matrix on
+  workflow_dispatch and when any changed file matches the regex; min+max otherwise.
+
+inputs:
+  all-versions:
+    required: true
+    description: JSON array of all supported versions (e.g. '["3.10","3.14"]').
+  match-regex:
+    required: true
+    description: POSIX extended regex; any changed file matching it forces the full matrix.
+  github-token:
+    required: true
+    description: Token used to list PR/commit files via the GitHub API.
+
+outputs:
+  versions:
+    description: JSON array of versions the caller should feed into its strategy matrix.
+    value: ${{ steps.pick.outputs.versions }}
+
+runs:
+  using: composite
+  steps:
+    - id: pick
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        ALL: ${{ inputs.all-versions }}
+        REGEX: ${{ inputs.match-regex }}
+        REPO: ${{ github.repository }}
+        EVENT: ${{ github.event_name }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        SHA: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+        if [ "$EVENT" = "workflow_dispatch" ]; then
+            echo "versions=$ALL" >> "$GITHUB_OUTPUT"
+            exit 0
+        fi
+        if [ "$EVENT" = "pull_request" ]; then
+            FILES=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
+        else
+            FILES=$(gh api "repos/$REPO/commits/$SHA" --jq '.files[].filename')
+        fi
+        # Default to full matrix on empty file list so a degenerate API response
+        # never silently under-tests.
+        if [ -z "$FILES" ] || echo "$FILES" | grep -Eq "$REGEX"; then
+            echo "versions=$ALL" >> "$GITHUB_OUTPUT"
+        else
+            echo "versions=$(echo "$ALL" | jq -c '[.[0], .[-1]]')" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/select-e2e-matrix/action.yml
+++ b/.github/actions/select-e2e-matrix/action.yml
@@ -32,6 +32,7 @@ runs:
         REPO: ${{ github.repository }}
         EVENT: ${{ github.event_name }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
+        BEFORE: ${{ github.event.before }}
         SHA: ${{ github.sha }}
       run: |
         set -euo pipefail
@@ -41,7 +42,12 @@ runs:
         fi
         if [ "$EVENT" = "pull_request" ]; then
             FILES=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
+        elif [ -n "$BEFORE" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ]; then
+            # Aggregate across the full push range so multi-commit pushes (rebase-merge, direct pushes)
+            # don't miss SDK-touching files landed in non-tip commits.
+            FILES=$(gh api "repos/$REPO/compare/$BEFORE...$SHA" --jq '.files[].filename')
         else
+            # Branch creation / force-push: before is zero or missing; fall back to tip.
             FILES=$(gh api "repos/$REPO/commits/$SHA" --jq '.files[].filename')
         fi
         # Default to full matrix on empty file list so a degenerate API response

--- a/.github/workflows/guardrails_e2e_tests.yml
+++ b/.github/workflows/guardrails_e2e_tests.yml
@@ -49,7 +49,7 @@ jobs:
         id: pick
         with:
           all-versions: ${{ vars.PYTHON_VERSIONS }}
-          match-regex: '^apps/opik-guardrails-backend/|^sdks/python/src/opik/guardrails/|^sdks/python/tests/e2e/test_guardrails\.py$'
+          match-regex: '^apps/opik-guardrails-backend/|^sdks/python/src/opik/guardrails/|^sdks/python/tests/e2e/test_guardrails\.py$|^\.github/workflows/guardrails_e2e_tests\.yml$'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   e2e-tests:

--- a/.github/workflows/guardrails_e2e_tests.yml
+++ b/.github/workflows/guardrails_e2e_tests.yml
@@ -45,6 +45,9 @@ jobs:
       python_versions: ${{ steps.pick.outputs.versions }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions/select-e2e-matrix
+          sparse-checkout-cone-mode: false
       - uses: ./.github/actions/select-e2e-matrix
         id: pick
         with:

--- a/.github/workflows/guardrails_e2e_tests.yml
+++ b/.github/workflows/guardrails_e2e_tests.yml
@@ -49,7 +49,7 @@ jobs:
         id: pick
         with:
           all-versions: ${{ vars.PYTHON_VERSIONS }}
-          match-regex: '^apps/opik-guardrails-backend/|^sdks/python/src/opik/guardrails/|^sdks/python/tests/e2e/test_guardrails\.py$|^\.github/workflows/guardrails_e2e_tests\.yml$'
+          match-regex: '^apps/opik-guardrails-backend/|^sdks/python/src/opik/guardrails/|^sdks/python/tests/e2e/test_guardrails\.py$'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   e2e-tests:

--- a/.github/workflows/guardrails_e2e_tests.yml
+++ b/.github/workflows/guardrails_e2e_tests.yml
@@ -37,14 +37,30 @@ env:
   OPIK_CONSOLE_LOGGING_LEVEL: DEBUG
 
 jobs:
+  select-matrix:
+    name: Select Python version matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      python_versions: ${{ steps.pick.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/select-e2e-matrix
+        id: pick
+        with:
+          all-versions: ${{ vars.PYTHON_VERSIONS }}
+          match-regex: '^apps/opik-guardrails-backend/|^sdks/python/src/opik/guardrails/|^sdks/python/tests/e2e/test_guardrails\.py$|^\.github/workflows/guardrails_e2e_tests\.yml$'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
   e2e-tests:
+    needs: select-matrix
     name: Guardrails E2E Tests ${{matrix.python_version}}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        python_version: ${{ fromJSON(vars.PYTHON_VERSIONS) }}
+        python_version: ${{ fromJSON(needs.select-matrix.outputs.python_versions) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
@@ -30,14 +30,30 @@ env:
   OPIK_URL_OVERRIDE: http://localhost:8080
   OPIK_CONSOLE_LOGGING_LEVEL: DEBUG
 jobs:
+    select-matrix:
+        name: Select Python version matrix
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        outputs:
+            python_versions: ${{ steps.pick.outputs.versions }}
+        steps:
+            - uses: actions/checkout@v6
+            - uses: ./.github/actions/select-e2e-matrix
+              id: pick
+              with:
+                  all-versions: ${{ vars.PYTHON_VERSIONS }}
+                  match-regex: '^sdks/python/|^\.github/workflows/python_sdk_compatibility_v1_e2e_tests\.yml$'
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
     run-compatibility-v1-e2e:
+        needs: select-matrix
         name: Python SDK Compatibility V1.x E2E Tests ${{matrix.python_version}}
         runs-on: ubuntu-latest
         timeout-minutes: 30
         strategy:
             fail-fast: false
             matrix:
-                python_version: ${{ fromJSON(vars.PYTHON_VERSIONS) }}
+                python_version: ${{ fromJSON(needs.select-matrix.outputs.python_versions) }}
 
         steps:
         - name: Checkout

--- a/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
@@ -42,7 +42,7 @@ jobs:
               id: pick
               with:
                   all-versions: ${{ vars.PYTHON_VERSIONS }}
-                  match-regex: '^sdks/python/|^\.github/workflows/python_sdk_compatibility_v1_e2e_tests\.yml$'
+                  match-regex: '^sdks/python/'
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
     run-compatibility-v1-e2e:

--- a/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
@@ -42,7 +42,7 @@ jobs:
               id: pick
               with:
                   all-versions: ${{ vars.PYTHON_VERSIONS }}
-                  match-regex: '^sdks/python/'
+                  match-regex: '^sdks/python/|^\.github/workflows/python_sdk_compatibility_v1_e2e_tests\.yml$'
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
     run-compatibility-v1-e2e:

--- a/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
@@ -38,6 +38,9 @@ jobs:
             python_versions: ${{ steps.pick.outputs.versions }}
         steps:
             - uses: actions/checkout@v6
+              with:
+                  sparse-checkout: .github/actions/select-e2e-matrix
+                  sparse-checkout-cone-mode: false
             - uses: ./.github/actions/select-e2e-matrix
               id: pick
               with:

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -42,7 +42,7 @@ jobs:
               id: pick
               with:
                   all-versions: ${{ vars.PYTHON_VERSIONS }}
-                  match-regex: '^sdks/python/'
+                  match-regex: '^sdks/python/|^\.github/workflows/python_sdk_e2e_tests\.yml$'
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
     run-e2e:

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -42,7 +42,7 @@ jobs:
               id: pick
               with:
                   all-versions: ${{ vars.PYTHON_VERSIONS }}
-                  match-regex: '^sdks/python/|^\.github/workflows/python_sdk_e2e_tests\.yml$'
+                  match-regex: '^sdks/python/'
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
     run-e2e:

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -38,6 +38,9 @@ jobs:
             python_versions: ${{ steps.pick.outputs.versions }}
         steps:
             - uses: actions/checkout@v6
+              with:
+                  sparse-checkout: .github/actions/select-e2e-matrix
+                  sparse-checkout-cone-mode: false
             - uses: ./.github/actions/select-e2e-matrix
               id: pick
               with:

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -30,14 +30,30 @@ env:
   OPIK_URL_OVERRIDE: http://localhost:8080
   OPIK_CONSOLE_LOGGING_LEVEL: DEBUG
 jobs:
+    select-matrix:
+        name: Select Python version matrix
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        outputs:
+            python_versions: ${{ steps.pick.outputs.versions }}
+        steps:
+            - uses: actions/checkout@v6
+            - uses: ./.github/actions/select-e2e-matrix
+              id: pick
+              with:
+                  all-versions: ${{ vars.PYTHON_VERSIONS }}
+                  match-regex: '^sdks/python/|^\.github/workflows/python_sdk_e2e_tests\.yml$'
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
     run-e2e:
+        needs: select-matrix
         name: Python SDK E2E Tests ${{matrix.python_version}}
         runs-on: ubuntu-latest
-        timeout-minutes: 30   
+        timeout-minutes: 30
         strategy:
             fail-fast: false
             matrix:
-                python_version: ${{ fromJSON(vars.PYTHON_VERSIONS) }}
+                python_version: ${{ fromJSON(needs.select-matrix.outputs.python_versions) }}
 
         steps:
         - name: Checkout

--- a/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
@@ -40,7 +40,7 @@ jobs:
         id: pick
         with:
           all-versions: ${{ vars.NODE_VERSIONS }}
-          match-regex: '^sdks/typescript/|^\.github/workflows/typescript_sdk_compatibility_v1_e2e_tests\.yml$'
+          match-regex: '^sdks/typescript/'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   run-compatibility-v1-e2e:

--- a/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
@@ -28,14 +28,30 @@ env:
   OPIK_URL_OVERRIDE: http://localhost:8080
   OPIK_CONSOLE_LOGGING_LEVEL: DEBUG
 jobs:
+  select-matrix:
+    name: Select Node version matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      node_versions: ${{ steps.pick.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/select-e2e-matrix
+        id: pick
+        with:
+          all-versions: ${{ vars.NODE_VERSIONS }}
+          match-regex: '^sdks/typescript/|^\.github/workflows/typescript_sdk_compatibility_v1_e2e_tests\.yml$'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
   run-compatibility-v1-e2e:
+    needs: select-matrix
     name: TypeScript SDK Compatibility V1.x E2E Tests Node ${{matrix.node_version}}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        node_version: ${{ fromJSON(vars.NODE_VERSIONS) }}
+        node_version: ${{ fromJSON(needs.select-matrix.outputs.node_versions) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
@@ -40,7 +40,7 @@ jobs:
         id: pick
         with:
           all-versions: ${{ vars.NODE_VERSIONS }}
-          match-regex: '^sdks/typescript/'
+          match-regex: '^sdks/typescript/|^\.github/workflows/typescript_sdk_compatibility_v1_e2e_tests\.yml$'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   run-compatibility-v1-e2e:

--- a/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
@@ -36,6 +36,9 @@ jobs:
       node_versions: ${{ steps.pick.outputs.versions }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions/select-e2e-matrix
+          sparse-checkout-cone-mode: false
       - uses: ./.github/actions/select-e2e-matrix
         id: pick
         with:

--- a/.github/workflows/typescript_sdk_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_e2e_tests.yml
@@ -27,7 +27,26 @@ env:
   OPIK_URL_OVERRIDE: http://localhost:8080
   OPIK_CONSOLE_LOGGING_LEVEL: DEBUG
 jobs:
+  select-matrix:
+    name: Select Node version matrix
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      node_versions: ${{ steps.pick.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/select-e2e-matrix
+        id: pick
+        with:
+          all-versions: ${{ vars.NODE_VERSIONS }}
+          match-regex: '^sdks/typescript/|^\.github/workflows/typescript_sdk_e2e_tests\.yml$'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
   run-e2e:
+    needs: select-matrix
     name: TypeScript SDK E2E Tests Node ${{matrix.node_version}}
     permissions:
       contents: read
@@ -38,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ${{ fromJSON(vars.NODE_VERSIONS) }}
+        node_version: ${{ fromJSON(needs.select-matrix.outputs.node_versions) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/typescript_sdk_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_e2e_tests.yml
@@ -42,7 +42,7 @@ jobs:
         id: pick
         with:
           all-versions: ${{ vars.NODE_VERSIONS }}
-          match-regex: '^sdks/typescript/|^\.github/workflows/typescript_sdk_e2e_tests\.yml$'
+          match-regex: '^sdks/typescript/'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   run-e2e:

--- a/.github/workflows/typescript_sdk_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_e2e_tests.yml
@@ -38,6 +38,9 @@ jobs:
       node_versions: ${{ steps.pick.outputs.versions }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions/select-e2e-matrix
+          sparse-checkout-cone-mode: false
       - uses: ./.github/actions/select-e2e-matrix
         id: pick
         with:

--- a/.github/workflows/typescript_sdk_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_e2e_tests.yml
@@ -42,7 +42,7 @@ jobs:
         id: pick
         with:
           all-versions: ${{ vars.NODE_VERSIONS }}
-          match-regex: '^sdks/typescript/'
+          match-regex: '^sdks/typescript/|^\.github/workflows/typescript_sdk_e2e_tests\.yml$'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   run-e2e:


### PR DESCRIPTION
## Details

<img width="1920" height="2638" alt="image" src="https://github.com/user-attachments/assets/801d6646-11f7-485f-b4c9-2c1c63cef9ee" />

https://github.com/user-attachments/assets/6c6b00ce-26b2-44fa-b160-2a13b0fbd933

Escalation of [OPIK-6019](https://comet-ml.atlassian.net/browse/OPIK-6019). When a PR only touches `apps/opik-backend/**` and does not change the SDKs, the SDK E2E workflows today still run the full Python/Node version matrix (5 Python × 2 workflows + 3 Node × 2 workflows + 5 Python for Guardrails = 21 matrix runners per BE-only PR). That coverage is overkill — min+max is enough for catching API-contract regressions. This PR shrinks the matrix to 2 versions on BE-only changes, both on PR and on post-merge to `main`, while keeping the full matrix for SDK-touching changes and for manual `workflow_dispatch` runs.

- New composite action `.github/actions/select-e2e-matrix` queries PR files (`gh api --paginate .../pulls/N/files`) or commit files (`gh api .../commits/SHA`) and emits either the full `vars.PYTHON_VERSIONS` / `vars.NODE_VERSIONS` array or `[first, last]` via `jq -c '[.[0], .[-1]]'`.
- Each of the 5 SDK E2E workflows adds a `select-matrix` pre-job that calls the composite action with a per-workflow SDK-touching regex, and the existing matrix job consumes `fromJSON(needs.select-matrix.outputs.*)`.
- Empty-`FILES` response defaults to the full matrix so a degenerate API reply never silently under-tests.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6209
- Relates: OPIK-6019, OPIK-6028

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation, assisted
- Human verification: code review + branch-protection/rulesets check + YAML + actionlint validation; runtime matrix behavior to be confirmed on this PR's own CI runs

## Testing

- `python3 -c yaml.safe_load` on all 5 workflow files and the new composite action — OK.
- `actionlint` on all 5 workflow files — exit 0.
- `pre-commit run --files <changed>` — language-specific hooks correctly skipped (no Java/FE/Python-SDK files touched).
- Runtime matrix behavior can only be validated on a real PR. This PR itself is BE-only (well, CI-only) → expected matrix = `[3.10, 3.14]` for Python SDK E2E workflows and `[18, 22]` for TypeScript SDK E2E workflows. The Guardrails E2E workflow does not trigger on this PR (its `pull_request` path filter is guardrails-only).
- Will follow up with a deliberate SDK-touching test PR post-merge to confirm the full-matrix path still fires.

## Documentation

N/A — internal CI change, no user-facing or SDK-facing surface affected.

[OPIK-6019]: https://comet-ml.atlassian.net/browse/OPIK-6019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ