### PR TITLE
[OPIK-6153] [OPIK-6151] [FE] perf: landing-route fast path for PermissionsGuard and WorkspacePreloader

### DIFF
--- a/apps/opik-frontend/src/lib/landingRoutes.test.ts
+++ b/apps/opik-frontend/src/lib/landingRoutes.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { isLandingRoute } from "./landingRoutes";
+
+describe("isLandingRoute", () => {
+  it("matches cloud path", () => {
+    expect(isLandingRoute("/opik/my-ws/get-started")).toBe(true);
+  });
+
+  it("matches OSS path", () => {
+    expect(isLandingRoute("/my-ws/get-started")).toBe(true);
+  });
+
+  it("ignores trailing slash", () => {
+    expect(isLandingRoute("/opik/my-ws/get-started/")).toBe(true);
+  });
+
+  it("ignores hash fragment on the caller's side (pathname only)", () => {
+    // pathname excludes hash/search; hash = "#manual" never reaches here
+    expect(isLandingRoute("/opik/my-ws/get-started")).toBe(true);
+  });
+
+  it("does not match /home (intentionally excluded)", () => {
+    expect(isLandingRoute("/opik/my-ws/home")).toBe(false);
+  });
+
+  it("does not match other routes", () => {
+    expect(isLandingRoute("/opik/my-ws/projects")).toBe(false);
+    expect(isLandingRoute("/opik/my-ws/datasets")).toBe(false);
+    expect(isLandingRoute("/opik/my-ws")).toBe(false);
+    expect(isLandingRoute("/")).toBe(false);
+  });
+
+  it("does not match substrings that only contain the suffix elsewhere", () => {
+    expect(isLandingRoute("/opik/my-ws/projects/get-started-guide")).toBe(
+      false,
+    );
+  });
+});

--- a/apps/opik-frontend/src/lib/landingRoutes.ts
+++ b/apps/opik-frontend/src/lib/landingRoutes.ts
@@ -1,0 +1,6 @@
+const LANDING_ROUTE_SUFFIXES = ["/get-started"];
+
+export function isLandingRoute(pathname: string): boolean {
+  const normalized = pathname.replace(/\/+$/, "");
+  return LANDING_ROUTE_SUFFIXES.some((suffix) => normalized.endsWith(suffix));
+}

--- a/apps/opik-frontend/src/plugins/comet/WorkspacePreloader.tsx
+++ b/apps/opik-frontend/src/plugins/comet/WorkspacePreloader.tsx
@@ -1,6 +1,7 @@
 import {
   Link,
   Navigate,
+  useLocation,
   useMatchRoute,
   useParams,
 } from "@tanstack/react-router";
@@ -10,6 +11,7 @@ import React, { useEffect } from "react";
 import Loader from "@/shared/Loader/Loader";
 import { Button } from "@/ui/button";
 import { DEFAULT_WORKSPACE_NAME } from "@/constants/user";
+import { isLandingRoute } from "@/lib/landingRoutes";
 import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
 import useAppStore, { useSetAppUser } from "@/store/AppStore";
 import { usePostHog } from "posthog-js/react";
@@ -59,6 +61,7 @@ const WorkspacePreloader: React.FunctionComponent<WorkspacePreloaderProps> = ({
     strict: false,
     select: (params) => params["workspaceName"],
   });
+  const { pathname } = useLocation();
   const isRootPath = matchRoute({ to: "/" });
 
   useSegment(user?.userName);
@@ -129,6 +132,16 @@ const WorkspacePreloader: React.FunctionComponent<WorkspacePreloaderProps> = ({
         ? buildUrl("login")
         : buildUrl("login", workspaceNameFromURL);
     return null;
+  }
+
+  if (
+    isLandingRoute(pathname) &&
+    workspaceNameFromURL &&
+    user.defaultWorkspace === workspaceNameFromURL &&
+    !user.suspended
+  ) {
+    useAppStore.getState().setActiveWorkspaceName(workspaceNameFromURL);
+    return children;
   }
 
   if (!allWorkspaces) {

--- a/apps/opik-frontend/src/v2/layout/PermissionsGuard/PermissionsGuard.tsx
+++ b/apps/opik-frontend/src/v2/layout/PermissionsGuard/PermissionsGuard.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { useLocation } from "@tanstack/react-router";
 import { usePermissions } from "@/contexts/PermissionsContext";
+import { isLandingRoute } from "@/lib/landingRoutes";
 import Loader from "@/shared/Loader/Loader";
 
 interface PermissionsGuardProps {
@@ -8,8 +10,9 @@ interface PermissionsGuardProps {
 
 const PermissionsGuard: React.FC<PermissionsGuardProps> = ({ children }) => {
   const { isPending } = usePermissions();
+  const { pathname } = useLocation();
 
-  if (isPending) {
+  if (isPending && !isLandingRoute(pathname)) {
     return <Loader />;
   }
 


### PR DESCRIPTION
## Details

Post-signup cold boot on `/get-started` today has two network-blocking `<Loader />` screens in the v2 provider chain — `WorkspacePreloader` waits on `/workspaces` (line 158), and `PermissionsGuard` waits on `/permissions/organization/.../user/...` (line 19). Together they add ~2-3 s to LCP on every cold boot per the post-OPIK-6066 measurements.

Investigation on OPIK-6151 (comment 90326) confirmed `/auth/test` already returns everything `/get-started` needs to paint: `defaultWorkspace` (non-optional), `loggedIn`, `suspended`. `/workspaces` and `/organizations` only feed the workspace switcher and access-gated UI that lives off `/get-started`.

**Two commits, one shared mechanism:**

- **Commit 1 — OPIK-6153**: adds `src/lib/landingRoutes.ts` with `isLandingRoute(pathname)` whitelisting only `/get-started` (`/home` intentionally excluded). Updates v2 `PermissionsGuard.tsx` to consult the helper via `useLocation()`. On the landing route, children render immediately; the permissions query still runs in the background and `checkNullablePermission` defaults `can*` flags to `true` while pending. Admins already skip permissions entirely (`useUserPermissions` has `enabled: !isAdmin`), so this specifically targets non-admin users. v1 `PermissionsGuard` is intentionally not touched.
- **Commit 2 — OPIK-6151**: `WorkspacePreloader.tsx` adds a fast-path right after the logged-in redirect check, guarded by `isLandingRoute(pathname) && workspaceNameFromURL && user.defaultWorkspace === workspaceNameFromURL && !user.suspended`. When matched, sets `activeWorkspaceName` from the URL param and returns children immediately — skipping the `/workspaces` and `/organizations` blocking waits. Both queries still fire (same `enabled: !!user?.loggedIn` gating), so the switcher populates after first paint. Off landing routes, today's full waterfall behavior is unchanged.

**Other blocking loaders in the v2 cold-boot chain — verified, no changes needed:**
- `FeatureTogglesProvider` uses `useState(DEFAULT_STATE)` — non-blocking
- `ServerSyncProvider` uses `config: config ?? null` — non-blocking
- `WorkspaceVersionResolver` — non-blocking (OPIK-6150 already shipped)
- `WorkspaceGuard` top-level Loader — plugin-load only, not network

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6153
- OPIK-6151

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation (plan + code + tests)
- Human verification: code review + plan approval + manual testing + post-deploy measurement on test env

## Testing

### Automated
- `bash scripts/dev-runner.sh --lint-fe` — eslint, typecheck, dependency-cruiser all green.
- 7 new unit tests in `src/lib/landingRoutes.test.ts` — all pass. Cover cloud path, OSS path, trailing slash, hash fragment (not in pathname), `/home` rejection (intentionally excluded), other routes, and substring false-positive protection.

### Manual smoke plan (on test env after deploy)
1. Fresh signup in Incognito → land on `/opik/<new-ws>/get-started`.
2. DevTools Network waterfall: `/workspaces`, `/organizations`, `/permissions/organization/.../user/...` land **after** first paint (not before). No `<Loader />` flash.
3. Navigate to `/projects` from sidebar → `<Loader />` reappears (non-landing route still guarded). Workspace switcher populated from the background fetches.
4. Edge case: manually navigate to `/opik/<some-other-ws-I-have-access-to>/get-started` → fast path falls through (`defaultWorkspace !== workspaceNameFromURL`), full waterfall runs. Confirms safety guard.
5. Edge case: suspended user — falls through via `!user.suspended`.

### Measurement protocol
- 3 fresh-signup runs with `performance_start_trace` per `~/dev/issues/performance-optimization/HOW-TO-MEASURE.md`.
- Baseline on test.dev.comet.com post-OPIK-6150: median LCP **6,680 ms** (captured in `load-measurements.md § OPIK-6150 verification`).
- Gate: ≥1 s median LCP reduction. Expected saving is 1.5–3 s per the combined ticket estimates.
- Record results in `load-measurements.md` under a new "OPIK-6153 + OPIK-6151 verification" section.

## Documentation

N/A — internal plumbing change, no user-facing docs affected.