### PR TITLE
[OPIK-4722] Optimization studio use permission

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/PermissionsProvider.tsx
+++ b/apps/opik-frontend/src/plugins/comet/PermissionsProvider.tsx
@@ -34,6 +34,7 @@ const PermissionsProvider: React.FC<{ children: ReactNode }> = ({
     canAnnotateTraceSpanThread,
     canTagTrace,
     canUsePlayground,
+    canUseOptimizationStudio,
     isPending,
   } = useUserPermission();
 
@@ -67,6 +68,7 @@ const PermissionsProvider: React.FC<{ children: ReactNode }> = ({
         canAnnotateTraceSpanThread,
         canTagTrace,
         canUsePlayground,
+        canUseOptimizationStudio,
       },
       isPending,
     }),
@@ -98,6 +100,7 @@ const PermissionsProvider: React.FC<{ children: ReactNode }> = ({
       canAnnotateTraceSpanThread,
       canTagTrace,
       canUsePlayground,
+      canUseOptimizationStudio,
       isPending,
     ],
   );

--- a/apps/opik-frontend/src/plugins/comet/types.ts
+++ b/apps/opik-frontend/src/plugins/comet/types.ts
@@ -88,6 +88,7 @@ export enum ManagementPermissionsNames {
   ONLINE_EVALUATION_RULE_UPDATE = "online_evaluation_rule_update",
   ALERT_UPDATE = "alert_update",
   PLAYGROUND_USE = "playground_use",
+  OPTIMIZATION_STUDIO_USE = "optimization_studio_use",
 }
 
 export interface UserPermission {

--- a/apps/opik-frontend/src/plugins/comet/useUserPermission.ts
+++ b/apps/opik-frontend/src/plugins/comet/useUserPermission.ts
@@ -234,6 +234,14 @@ const useUserPermission = (config?: { enabled?: boolean }) => {
     [checkNullablePermission],
   );
 
+  const canUseOptimizationStudio = useMemo(
+    () =>
+      checkNullablePermission(
+        ManagementPermissionsNames.OPTIMIZATION_STUDIO_USE,
+      ),
+    [checkNullablePermission],
+  );
+
   return {
     canInviteMembers,
     isWorkspaceOwner,
@@ -264,6 +272,7 @@ const useUserPermission = (config?: { enabled?: boolean }) => {
     canAnnotateTraceSpanThread,
     canTagTrace,
     canUsePlayground,
+    canUseOptimizationStudio,
     isPending: isEnabled && isPending,
   };
 };

--- a/apps/opik-frontend/src/types/permissions.ts
+++ b/apps/opik-frontend/src/types/permissions.ts
@@ -26,6 +26,7 @@ export interface Permissions {
   canAnnotateTraceSpanThread: boolean;
   canTagTrace: boolean;
   canUsePlayground: boolean;
+  canUseOptimizationStudio: boolean;
 }
 
 export interface PermissionsContextValue {
@@ -62,6 +63,7 @@ export const DEFAULT_PERMISSIONS: PermissionsContextValue = {
     canAnnotateTraceSpanThread: true,
     canTagTrace: true,
     canUsePlayground: true,
+    canUseOptimizationStudio: true,
   },
   isPending: false,
 };

--- a/apps/opik-frontend/src/v1/layout/OptimizationStudioPageGuard/index.tsx
+++ b/apps/opik-frontend/src/v1/layout/OptimizationStudioPageGuard/index.tsx
@@ -1,0 +1,17 @@
+import { usePermissions } from "@/contexts/PermissionsContext";
+import NoAccessPageGuard from "@/v1/layout/NoAccessPageGuard/NoAccessPageGuard";
+
+const OptimizationStudioPageGuard = () => {
+  const {
+    permissions: { canUseOptimizationStudio },
+  } = usePermissions();
+
+  return (
+    <NoAccessPageGuard
+      canViewPage={canUseOptimizationStudio}
+      message="You don't have permissions to start new optimization runs in this workspace."
+    />
+  );
+};
+
+export default OptimizationStudioPageGuard;

--- a/apps/opik-frontend/src/v1/pages/HomePage/OptimizationRunsSection.tsx
+++ b/apps/opik-frontend/src/v1/pages/HomePage/OptimizationRunsSection.tsx
@@ -16,6 +16,7 @@ import useOptimizationsList from "@/api/optimizations/useOptimizationsList";
 import Loader from "@/shared/Loader/Loader";
 import AddOptimizationDialog from "@/v1/pages/OptimizationsPage/AddOptimizationDialog/AddOptimizationDialog";
 import { Button } from "@/ui/button";
+import { usePermissions } from "@/contexts/PermissionsContext";
 import useAppStore from "@/store/AppStore";
 import { COLUMN_NAME_ID, COLUMN_SELECT_ID, COLUMN_TYPE } from "@/types/shared";
 import { RESOURCE_TYPE } from "@/shared/ResourceLink/ResourceLink";
@@ -114,6 +115,9 @@ export const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
 const OptimizationRunsSection: React.FunctionComponent = () => {
   const navigate = useNavigate();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const {
+    permissions: { canUseOptimizationStudio },
+  } = usePermissions();
 
   const resetDialogKeyRef = useRef(0);
   const [openDialog, setOpenDialog] = useState<boolean>(false);
@@ -182,9 +186,11 @@ const OptimizationRunsSection: React.FunctionComponent = () => {
         columnPinning={DEFAULT_COLUMN_PINNING}
         noData={
           <DataTableNoData title={noDataText}>
-            <Button variant="link" onClick={handleNewOptimizationClick}>
-              Create new optimization
-            </Button>
+            {canUseOptimizationStudio && (
+              <Button variant="link" onClick={handleNewOptimizationClick}>
+                Create new optimization
+              </Button>
+            )}
           </DataTableNoData>
         }
       />

--- a/apps/opik-frontend/src/v1/pages/OptimizationPage/OptimizationPage.tsx
+++ b/apps/opik-frontend/src/v1/pages/OptimizationPage/OptimizationPage.tsx
@@ -14,6 +14,7 @@ import OptimizationHeader from "./OptimizationHeader";
 import OptimizationTrialsControls from "./OptimizationTrialsControls";
 import OptimizationTrialsTable from "./OptimizationTrialsTable";
 import OptimizationKPICards from "./OptimizationKPICards";
+import { usePermissions } from "@/contexts/PermissionsContext";
 
 enum OPTIMIZATION_TAB {
   OVERVIEW = "overview",
@@ -22,6 +23,9 @@ enum OPTIMIZATION_TAB {
 
 const OptimizationPage: React.FC = () => {
   const navigate = useNavigate();
+  const {
+    permissions: { canUseOptimizationStudio },
+  } = usePermissions();
 
   const {
     workspaceName,
@@ -126,6 +130,7 @@ const OptimizationPage: React.FC = () => {
   }
 
   const canRerun =
+    canUseOptimizationStudio &&
     Boolean(optimization?.studio_config) &&
     Boolean(optimization?.id) &&
     optimization?.status &&

--- a/apps/opik-frontend/src/v1/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/v1/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -169,7 +169,11 @@ const OptimizationsPage: React.FunctionComponent = () => {
   );
 
   const {
-    permissions: { canViewDatasets, canDeleteOptimizationRuns },
+    permissions: {
+      canViewDatasets,
+      canDeleteOptimizationRuns,
+      canUseOptimizationStudio,
+    },
   } = usePermissions();
 
   const [search = "", setSearch] = useQueryParam("search", StringParam, {
@@ -324,7 +328,9 @@ const OptimizationsPage: React.FunctionComponent = () => {
       <ExplainerDescription
         {...EXPLAINERS_MAP[EXPLAINER_ID.whats_an_optimization_run]}
       />
-      {isOptimizationStudioEnabled && <StudioTemplates />}
+      {isOptimizationStudioEnabled && canUseOptimizationStudio && (
+        <StudioTemplates />
+      )}
       <div className="pt-6">
         <h2 className="comet-title-s sticky top-0 z-10 truncate break-words bg-soft-background pb-3 pt-2">
           Optimization runs
@@ -386,7 +392,7 @@ const OptimizationsPage: React.FunctionComponent = () => {
           }}
           noData={
             <DataTableNoData title={noDataText}>
-              {noData && (
+              {noData && canUseOptimizationStudio && (
                 <Button variant="link" onClick={handleNewOptimizationClick}>
                   Create new optimization
                 </Button>

--- a/apps/opik-frontend/src/v1/router.tsx
+++ b/apps/opik-frontend/src/v1/router.tsx
@@ -13,6 +13,7 @@ import ExperimentsPageGuard from "@/v1/layout/ExperimentsPageGuard";
 import DatasetsPageGuard from "@/v1/layout/DatasetsPageGuard";
 import DashboardsPageGuard from "@/v1/layout/DashboardsPageGuard";
 import PlaygroundPageGuard from "@/v1/layout/PlaygroundPageGuard";
+import OptimizationStudioPageGuard from "@/v1/layout/OptimizationStudioPageGuard";
 import SMEPageLayout from "@/v1/layout/SMEPageLayout/SMEPageLayout";
 import ExperimentsPage from "@/v1/pages/ExperimentsPage/ExperimentsPage";
 const CompareExperimentsPage = lazy(
@@ -286,11 +287,17 @@ const optimizationsListRoute = createRoute({
 const optimizationsNewRoute = createRoute({
   path: "/new",
   getParentRoute: () => optimizationsRoute,
-  component: OptimizationsNewPage,
+  component: OptimizationStudioPageGuard,
   staticData: {
     param: "optimizationsNew",
     paramValue: "new",
   },
+});
+
+const optimizationsNewIndexRoute = createRoute({
+  path: "/",
+  getParentRoute: () => optimizationsNewRoute,
+  component: OptimizationsNewPage,
 });
 
 const optimizationCompareRedirectRoute = createRoute({
@@ -591,7 +598,7 @@ const routeTree = rootRoute.addChildren([
       ]),
       optimizationsRoute.addChildren([
         optimizationsListRoute,
-        optimizationsNewRoute,
+        optimizationsNewRoute.addChildren([optimizationsNewIndexRoute]),
         optimizationCompareRedirectRoute,
         optimizationBaseRoute.addChildren([optimizationRoute, trialRoute]),
       ]),

--- a/apps/opik-frontend/src/v2/layout/OptimizationStudioPageGuard/index.tsx
+++ b/apps/opik-frontend/src/v2/layout/OptimizationStudioPageGuard/index.tsx
@@ -1,0 +1,17 @@
+import { usePermissions } from "@/contexts/PermissionsContext";
+import NoAccessPageGuard from "@/v2/layout/NoAccessPageGuard/NoAccessPageGuard";
+
+const OptimizationStudioPageGuard = () => {
+  const {
+    permissions: { canUseOptimizationStudio },
+  } = usePermissions();
+
+  return (
+    <NoAccessPageGuard
+      canViewPage={canUseOptimizationStudio}
+      message="You don't have permissions to start new optimization runs in this workspace."
+    />
+  );
+};
+
+export default OptimizationStudioPageGuard;

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationPage.tsx
@@ -15,6 +15,7 @@ import OptimizationHeader from "./OptimizationHeader";
 import OptimizationTrialsControls from "./OptimizationTrialsControls";
 import OptimizationTrialsTable from "./OptimizationTrialsTable";
 import OptimizationKPICards from "./OptimizationKPICards";
+import { usePermissions } from "@/contexts/PermissionsContext";
 
 enum OPTIMIZATION_TAB {
   OVERVIEW = "overview",
@@ -24,6 +25,9 @@ enum OPTIMIZATION_TAB {
 const OptimizationPage: React.FC = () => {
   const navigate = useNavigate();
   const activeProjectId = useActiveProjectId();
+  const {
+    permissions: { canUseOptimizationStudio },
+  } = usePermissions();
 
   const {
     workspaceName,
@@ -129,6 +133,7 @@ const OptimizationPage: React.FC = () => {
   }
 
   const canRerun =
+    canUseOptimizationStudio &&
     Boolean(optimization?.studio_config) &&
     Boolean(optimization?.id) &&
     optimization?.status &&

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -172,7 +172,11 @@ const OptimizationsPage: React.FunctionComponent = () => {
   );
 
   const {
-    permissions: { canViewDatasets, canDeleteOptimizationRuns },
+    permissions: {
+      canViewDatasets,
+      canDeleteOptimizationRuns,
+      canUseOptimizationStudio,
+    },
   } = usePermissions();
 
   const [search = "", setSearch] = useQueryParam("search", StringParam, {
@@ -337,15 +341,21 @@ const OptimizationsPage: React.FunctionComponent = () => {
           description={
             "Explore different prompt variations and see what performs best.\nOptimizations help you improve accuracy, consistency, and overall user experience."
           }
-          primaryActionLabel="Create optimization run"
-          onPrimaryAction={handleNewOptimizationClick}
+          primaryActionLabel={
+            canUseOptimizationStudio ? "Create optimization run" : undefined
+          }
+          onPrimaryAction={
+            canUseOptimizationStudio ? handleNewOptimizationClick : undefined
+          }
           docsUrl={buildDocsUrl(
             "/development/optimization-runs/optimization_studio",
           )}
         />
       ) : (
         <>
-          {isOptimizationStudioEnabled && <StudioTemplates />}
+          {isOptimizationStudioEnabled && canUseOptimizationStudio && (
+            <StudioTemplates />
+          )}
           <div className="pt-4">
             <h2 className="comet-title-s sticky top-0 z-10 truncate break-words bg-soft-background pb-3 pt-2">
               Optimization runs
@@ -407,7 +417,7 @@ const OptimizationsPage: React.FunctionComponent = () => {
               }}
               noData={
                 <DataTableNoData title={noDataText}>
-                  {noData && (
+                  {noData && canUseOptimizationStudio && (
                     <Button variant="link" onClick={handleNewOptimizationClick}>
                       Create optimization
                     </Button>

--- a/apps/opik-frontend/src/v2/router.tsx
+++ b/apps/opik-frontend/src/v2/router.tsx
@@ -12,6 +12,7 @@ import WorkspaceGuard from "@/v2/layout/WorkspaceGuard/WorkspaceGuard";
 import ExperimentsPageGuard from "@/v2/layout/ExperimentsPageGuard";
 import DashboardsPageGuard from "@/v2/layout/DashboardsPageGuard";
 import PlaygroundPageGuard from "@/v2/layout/PlaygroundPageGuard";
+import OptimizationStudioPageGuard from "@/v2/layout/OptimizationStudioPageGuard";
 import DatasetsPageGuard from "@/v2/layout/DatasetsPageGuard";
 import SMEPageLayout from "@/v2/layout/SMEPageLayout/SMEPageLayout";
 import ExperimentsPage from "@/v2/pages/ExperimentsPage/ExperimentsPage";
@@ -370,11 +371,17 @@ const optimizationsListRoute = createRoute({
 const optimizationsNewRoute = createRoute({
   path: "/new",
   getParentRoute: () => optimizationsRoute,
-  component: OptimizationsNewPage,
+  component: OptimizationStudioPageGuard,
   staticData: {
     param: "optimizationsNew",
     paramValue: "new",
   },
+});
+
+const optimizationsNewIndexRoute = createRoute({
+  path: "/",
+  getParentRoute: () => optimizationsNewRoute,
+  component: OptimizationsNewPage,
 });
 
 const optimizationCompareRedirectRoute = createRoute({
@@ -615,7 +622,7 @@ const routeTree = rootRoute.addChildren([
           playgroundRoute.addChildren([playgroundIndexRoute]),
           optimizationsRoute.addChildren([
             optimizationsListRoute,
-            optimizationsNewRoute,
+            optimizationsNewRoute.addChildren([optimizationsNewIndexRoute]),
             optimizationCompareRedirectRoute,
             optimizationBaseRoute.addChildren([optimizationRoute, trialRoute]),
           ]),


### PR DESCRIPTION
## Details

Adds a new `optimization_studio_use` permission and wires it up across the v1 and v2 frontends to gate entry points for starting new optimization runs.

**Permission plumbing**
- Introduces `OPTIMIZATION_STUDIO_USE` in `ManagementPermissionsNames` and exposes it via `useUserPermission` as `canUseOptimizationStudio`.
- Adds `canUseOptimizationStudio` to the `Permissions` type, `DEFAULT_PERMISSIONS`, and the `PermissionsProvider` context value.

**Route guarding (v1 & v2)**
- Adds `OptimizationStudioPageGuard` for both v1 and v2, built on top of `NoAccessPageGuard`, to block `/optimizations/new` when the permission is missing.
- Restructures the `/new` route so that the guard renders as the parent and the `OptimizationsNewPage` sits under an index child route.

**UI gating (v1 & v2)**
- `OptimizationsPage`: hides `StudioTemplates` and the "Create optimization" empty-state CTA when the user lacks the permission; in v2 also clears the empty-state primary action when gated.
- `OptimizationPage`: disables the "Rerun" action by ANDing `canUseOptimizationStudio` into `canRerun`.
- `OptimizationRunsSection` (v1 home page): hides the "Create new optimization" link in the empty state when gated.

## Change checklist

- [x] Add new `optimization_studio_use` permission and expose it through permissions context
- [x] Guard `/optimizations/new` route in v1 and v2
- [x] Hide "Create optimization" CTAs and studio templates when the user lacks the permission
- [x] Gate rerun action on the optimization detail page
- [x] Default permission value preserves existing (permissive) behavior for non-Comet deployments

## Testing

- [ ] With `optimization_studio_use` granted: can open `/optimizations/new`, see `StudioTemplates`, and trigger "Create optimization" / "Rerun"
- [ ] Without the permission: `/optimizations/new` shows the no-access guard, `StudioTemplates` is hidden, empty-state CTAs are hidden, and rerun is disabled on the optimization detail page
- [ ] Home page `OptimizationRunsSection` empty state hides the "Create new optimization" link when gated
- [ ] Verified in both v1 and v2 layouts
- [ ] Non-Comet / self-hosted deployments still see the feature (default permission `true`)

## Issues

- [OPIK-4722](https://comet-ml.atlassian.net/browse/OPIK-4722)

## Documentation

No user-facing documentation changes required — this wires a new RBAC permission into existing UI surfaces. Admin-side documentation for the `optimization_studio_use` permission is handled by the platform team.


[OPIK-4722]: https://comet-ml.atlassian.net/browse/OPIK-4722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ