### PR TITLE
[OPIK-6211] [BE] fix: item assertions fetched from wrong test suite version

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TestSuiteAssertionSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TestSuiteAssertionSampler.java
@@ -207,13 +207,15 @@ public class TestSuiteAssertionSampler {
         var itemId = itemIdOpt.get();
 
         return datasetEvaluatorsMono
-                .flatMap(result -> fetchItemEvaluators(itemId, result.versionId(), modelName)
-                        .map(itemEvals -> {
-                            var allEvaluators = new ArrayList<>(
-                                    evaluatorMapper.prepareEvaluators(result.evaluators(), modelName));
-                            allEvaluators.addAll(itemEvals);
-                            return allEvaluators;
-                        }))
+                .flatMap(result -> {
+                    var datasetEvals = evaluatorMapper.prepareEvaluators(result.evaluators(), modelName);
+                    return fetchItemEvaluators(itemId, result.versionId(), modelName)
+                            .map(itemEvals -> {
+                                var allEvaluators = new ArrayList<>(datasetEvals);
+                                allEvaluators.addAll(itemEvals);
+                                return allEvaluators;
+                            });
+                })
                 .flatMap(allEvaluators -> {
                     if (allEvaluators.isEmpty()) {
                         log.debug("No evaluators found for trace '{}', dataset item '{}'",

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TestSuiteAssertionSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TestSuiteAssertionSampler.java
@@ -135,7 +135,7 @@ public class TestSuiteAssertionSampler {
             return;
         }
 
-        Map<String, Mono<List<PreparedEvaluator>>> datasetEvaluatorsCache = new HashMap<>();
+        Map<String, Mono<DatasetEvaluatorsResult>> datasetEvaluatorsCache = new HashMap<>();
 
         decrementIncomplete
                 .thenMany(Flux.fromIterable(completeTraces)
@@ -156,7 +156,7 @@ public class TestSuiteAssertionSampler {
 
     private Mono<List<TraceToScoreLlmAsJudge>> processTrace(
             Trace trace, TracesCreated tracesBatch,
-            Map<String, Mono<List<PreparedEvaluator>>> datasetEvaluatorsCache,
+            Map<String, Mono<DatasetEvaluatorsResult>> datasetEvaluatorsCache,
             String modelName, Duration fetchTimeout) {
 
         var experimentId = getMetadataString(trace, TestSuiteMetadataKeys.EXPERIMENT_ID)
@@ -188,7 +188,6 @@ public class TestSuiteAssertionSampler {
                     datasetId, versionHash != null ? versionHash : "latest");
             return fetchDatasetEvaluators(datasetId, versionHash)
                     .timeout(fetchTimeout)
-                    .map(result -> evaluatorMapper.prepareEvaluators(result.evaluators(), modelName))
                     .cache();
         });
 
@@ -208,9 +207,10 @@ public class TestSuiteAssertionSampler {
         var itemId = itemIdOpt.get();
 
         return datasetEvaluatorsMono
-                .flatMap(datasetEvals -> fetchItemEvaluators(itemId, modelName)
+                .flatMap(result -> fetchItemEvaluators(itemId, result.versionId(), modelName)
                         .map(itemEvals -> {
-                            var allEvaluators = new ArrayList<PreparedEvaluator>(datasetEvals);
+                            var allEvaluators = new ArrayList<>(
+                                    evaluatorMapper.prepareEvaluators(result.evaluators(), modelName));
                             allEvaluators.addAll(itemEvals);
                             return allEvaluators;
                         }))
@@ -275,8 +275,8 @@ public class TestSuiteAssertionSampler {
         });
     }
 
-    private Mono<List<PreparedEvaluator>> fetchItemEvaluators(UUID itemId, String modelName) {
-        return datasetItemService.get(itemId)
+    private Mono<List<PreparedEvaluator>> fetchItemEvaluators(UUID itemId, UUID versionId, String modelName) {
+        return datasetItemService.get(itemId, versionId)
                 .timeout(Duration.ofSeconds(testSuiteConfig.getFetchTimeoutSeconds()))
                 .map(item -> Optional.ofNullable(item.evaluators())
                         .filter(evaluators -> !evaluators.isEmpty())

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -79,6 +79,8 @@ public interface DatasetItemService {
 
     Mono<DatasetItem> get(UUID id);
 
+    Mono<DatasetItem> get(UUID id, UUID datasetVersionId);
+
     Mono<Void> patch(UUID id, DatasetItem item);
 
     Mono<Void> batchUpdate(DatasetItemBatchUpdate batchUpdate);
@@ -350,27 +352,26 @@ class DatasetItemServiceImpl implements DatasetItemService {
     @WithSpan
     public Mono<DatasetItem> get(@NonNull UUID id) {
         if (featureFlags.isDatasetVersioningEnabled()) {
-            // When versioning is enabled, only query the versioned table
-            return versionDao.getItemById(id)
-                    .flatMap(item -> Mono.deferContextual(ctx -> {
-                        String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
-                        Visibility visibility = ctx.get(RequestContext.VISIBILITY);
-                        // Verify dataset visibility
-                        datasetService.findById(item.datasetId(), workspaceId, visibility);
-
-                        return Mono.just(item);
-                    }))
-                    .switchIfEmpty(Mono.defer(() -> Mono.error(failWithNotFound("Dataset item not found"))));
+            return authorizeItem(versionDao.getItemById(id));
         }
+        return authorizeItem(dao.get(id));
+    }
 
-        // Legacy mode: only query the draft table
-        return dao.get(id)
+    @Override
+    @WithSpan
+    public Mono<DatasetItem> get(@NonNull UUID id, UUID datasetVersionId) {
+        if (featureFlags.isDatasetVersioningEnabled()) {
+            return authorizeItem(versionDao.getItemById(id, datasetVersionId));
+        }
+        return authorizeItem(dao.get(id));
+    }
+
+    private Mono<DatasetItem> authorizeItem(Mono<DatasetItem> itemMono) {
+        return itemMono
                 .flatMap(item -> Mono.deferContextual(ctx -> {
                     String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
                     Visibility visibility = ctx.get(RequestContext.VISIBILITY);
-                    // Verify dataset visibility
                     datasetService.findById(item.datasetId(), workspaceId, visibility);
-
                     return Mono.just(item);
                 }))
                 .switchIfEmpty(Mono.defer(() -> Mono.error(failWithNotFound("Dataset item not found"))));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -226,6 +226,8 @@ public interface DatasetItemVersionDAO {
      */
     Mono<DatasetItem> getItemById(UUID id);
 
+    Mono<DatasetItem> getItemById(UUID id, UUID datasetVersionId);
+
     /**
      * Gets workspace IDs for stable dataset item IDs (dataset_item_id field from dataset_item_versions).
      * Used for validating that dataset items belong to the correct workspace.
@@ -1688,6 +1690,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             FROM dataset_item_versions
             WHERE workspace_id = :workspace_id
             AND dataset_item_id = :id
+            <if(dataset_version_id)>AND dataset_version_id = :dataset_version_id<endif>
             ORDER BY last_updated_at DESC
             LIMIT 1
             """;
@@ -3433,11 +3436,27 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
     @Override
     @WithSpan
     public Mono<DatasetItem> getItemById(@NonNull UUID id) {
-        log.debug("Getting item by ID '{}'", id);
+        return getItemById(id, null);
+    }
+
+    @Override
+    @WithSpan
+    public Mono<DatasetItem> getItemById(@NonNull UUID id, UUID datasetVersionId) {
+        log.debug("Getting item by ID '{}', version '{}'", id, datasetVersionId);
+
+        var template = TemplateUtils.newST(SELECT_ITEM_BY_ID);
+        if (datasetVersionId != null) {
+            template.add("dataset_version_id", true);
+        }
+        var query = template.render();
 
         return asyncTemplate.nonTransaction(connection -> {
-            var statement = connection.createStatement(SELECT_ITEM_BY_ID)
+            var statement = connection.createStatement(query)
                     .bind("id", id.toString());
+
+            if (datasetVersionId != null) {
+                statement.bind("dataset_version_id", datasetVersionId.toString());
+            }
 
             Segment segment = startSegment(DATASET_ITEM_VERSIONS, CLICKHOUSE, "get_item_by_id");
 
@@ -3450,9 +3469,9 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                         .next()
                         .doOnSuccess(item -> {
                             if (item != null) {
-                                log.debug("Found item by ID '{}'", id);
+                                log.debug("Found item by ID '{}', version '{}'", id, datasetVersionId);
                             } else {
-                                log.debug("Item not found by ID '{}'", id);
+                                log.debug("Item not found by ID '{}', version '{}'", id, datasetVersionId);
                             }
                         })
                         .doFinally(signalType -> endSegment(segment));

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestSuiteAssertionSamplerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestSuiteAssertionSamplerTest.java
@@ -110,7 +110,7 @@ class TestSuiteAssertionSamplerTest {
                     .thenReturn(versionId);
             when(datasetVersionService.getVersionById(workspaceId, datasetId, versionId))
                     .thenReturn(datasetVersion);
-            when(datasetItemService.get(any(UUID.class)))
+            when(datasetItemService.get(any(UUID.class), eq(versionId)))
                     .thenReturn(Mono.just(DatasetItem.builder().id(UUID.randomUUID()).build()));
 
             var datasetItemId = Generators.timeBasedEpochGenerator().generate();
@@ -176,7 +176,7 @@ class TestSuiteAssertionSamplerTest {
                     .thenReturn(versionId);
             when(datasetVersionService.getVersionById(workspaceId, datasetId, versionId))
                     .thenReturn(datasetVersion);
-            when(datasetItemService.get(datasetItemId))
+            when(datasetItemService.get(datasetItemId, versionId))
                     .thenReturn(Mono.just(DatasetItem.builder()
                             .id(datasetItemId)
                             .evaluators(List.of(itemEvaluator))
@@ -276,7 +276,7 @@ class TestSuiteAssertionSamplerTest {
                     .thenReturn(versionId);
             when(datasetVersionService.getVersionById(workspaceId, datasetId, versionId))
                     .thenReturn(datasetVersion);
-            when(datasetItemService.get(datasetItemId))
+            when(datasetItemService.get(datasetItemId, versionId))
                     .thenReturn(Mono.just(DatasetItem.builder()
                             .id(datasetItemId)
                             .evaluators(List.of(itemEvaluator))
@@ -396,7 +396,7 @@ class TestSuiteAssertionSamplerTest {
             sampler.onTracesCreated(event);
 
             verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
-            verify(datasetItemService, never()).get(any(UUID.class));
+            verify(datasetItemService, never()).get(any(UUID.class), any());
         }
 
         @Test
@@ -468,7 +468,7 @@ class TestSuiteAssertionSamplerTest {
                     .thenReturn(versionId);
             when(datasetVersionService.getVersionById(workspaceId, datasetId, versionId))
                     .thenReturn(datasetVersion);
-            when(datasetItemService.get(itemId1))
+            when(datasetItemService.get(itemId1, versionId))
                     .thenReturn(Mono.just(DatasetItem.builder()
                             .id(itemId1)
                             .evaluators(List.of(EvaluatorItem.builder()
@@ -478,7 +478,7 @@ class TestSuiteAssertionSamplerTest {
                                             JsonUtils.writeValueAsString(item1EvalConfig)))
                                     .build()))
                             .build()));
-            when(datasetItemService.get(itemId2))
+            when(datasetItemService.get(itemId2, versionId))
                     .thenReturn(Mono.just(DatasetItem.builder()
                             .id(itemId2)
                             .evaluators(List.of(EvaluatorItem.builder()
@@ -597,9 +597,9 @@ class TestSuiteAssertionSamplerTest {
             when(datasetVersionService.getVersionById(workspaceId, datasetId, versionId))
                     .thenReturn(datasetVersion);
             // Items with no evaluators
-            when(datasetItemService.get(itemId1))
+            when(datasetItemService.get(itemId1, versionId))
                     .thenReturn(Mono.just(DatasetItem.builder().id(itemId1).build()));
-            when(datasetItemService.get(itemId2))
+            when(datasetItemService.get(itemId2, versionId))
                     .thenReturn(Mono.just(DatasetItem.builder().id(itemId2).build()));
             when(idGenerator.generateId()).thenReturn(ruleId);
 
@@ -630,6 +630,91 @@ class TestSuiteAssertionSamplerTest {
                 assertThat(assertions).contains("relevance");
                 assertThat(assertions).contains("accuracy");
             }
+        }
+
+        @Test
+        @DisplayName("fetches item evaluators from requested version, not latest")
+        void fetchesItemEvaluatorsFromRequestedVersionNotLatest() {
+            UUID datasetId = Generators.timeBasedEpochGenerator().generate();
+            UUID v2VersionId = Generators.timeBasedEpochGenerator().generate();
+            UUID datasetItemId = Generators.timeBasedEpochGenerator().generate();
+            UUID ruleId = Generators.timeBasedEpochGenerator().generate();
+            String workspaceId = "test-workspace";
+            String userName = "test-user";
+            String v2VersionHash = "version2hash";
+
+            var evaluatorConfig = new LlmAsJudgeCode(
+                    LlmAsJudgeModelParameters.builder().name("gpt-5-nano").build(),
+                    List.of(LlmAsJudgeMessage.builder()
+                            .role(ChatMessageType.USER)
+                            .content("Evaluate {input}")
+                            .build()),
+                    Map.of("input", "input"),
+                    List.of(LlmAsJudgeOutputSchema.builder()
+                            .name("v2_check")
+                            .type(LlmAsJudgeOutputSchemaType.BOOLEAN)
+                            .description("V2 assertion")
+                            .build()));
+
+            var v2Evaluator = EvaluatorItem.builder()
+                    .name("v2-evaluator")
+                    .type(EvaluatorType.LLM_JUDGE)
+                    .config(JsonUtils.getJsonNodeFromString(JsonUtils.writeValueAsString(evaluatorConfig)))
+                    .build();
+
+            var v2Version = DatasetVersion.builder()
+                    .id(v2VersionId)
+                    .datasetId(datasetId)
+                    .versionHash(v2VersionHash)
+                    .evaluators(List.of())
+                    .build();
+
+            when(datasetVersionService.resolveVersionId(workspaceId, datasetId, v2VersionHash))
+                    .thenReturn(v2VersionId);
+            when(datasetVersionService.getVersionById(workspaceId, datasetId, v2VersionId))
+                    .thenReturn(v2Version);
+
+            // Mock only the two-arg call with v2VersionId — if the code calls
+            // the single-arg get() or passes the wrong versionId, the mock won't
+            // match and the test will fail (Mono.empty → no messages enqueued).
+            when(datasetItemService.get(datasetItemId, v2VersionId))
+                    .thenReturn(Mono.just(DatasetItem.builder()
+                            .id(datasetItemId)
+                            .evaluators(List.of(v2Evaluator))
+                            .build()));
+            when(idGenerator.generateId()).thenReturn(ruleId);
+
+            var metadata = JsonUtils.getJsonNodeFromString(
+                    "{\"test_suite_dataset_id\": \"%s\", \"test_suite_dataset_version_hash\": \"%s\", \"test_suite_dataset_item_id\": \"%s\"}"
+                            .formatted(datasetId, v2VersionHash, datasetItemId));
+
+            var trace = Trace.builder()
+                    .id(Generators.timeBasedEpochGenerator().generate())
+                    .projectId(Generators.timeBasedEpochGenerator().generate())
+                    .name("test-trace")
+                    .startTime(Instant.now())
+                    .endTime(Instant.now())
+                    .input(JsonUtils.getJsonNodeFromString("{\"messages\": [\"hello\"]}"))
+                    .output(JsonUtils.getJsonNodeFromString("{\"output\": \"world\"}"))
+                    .metadata(metadata)
+                    .build();
+
+            var event = new TracesCreated(List.of(trace), workspaceId, userName);
+            sampler.onTracesCreated(event);
+
+            // Verify the version-aware get was called with the correct versionId
+            verify(datasetItemService).get(datasetItemId, v2VersionId);
+            verify(datasetItemService, never()).get(any(UUID.class));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<TraceToScoreLlmAsJudge>> captor = ArgumentCaptor.forClass(List.class);
+            verify(onlineScorePublisher).enqueueMessage(captor.capture(),
+                    eq(AutomationRuleEvaluatorType.LLM_AS_JUDGE));
+
+            List<TraceToScoreLlmAsJudge> messages = captor.getValue();
+            assertThat(messages).hasSize(1);
+            assertThat(messages.getFirst().ruleName()).isEqualTo("v2-evaluator");
+            assertThat(messages.getFirst().scoreNameMapping()).containsEntry("assertion_1", "v2_check");
         }
 
         private Trace buildTrace(UUID datasetId, String versionHash, UUID datasetItemId) {
@@ -688,7 +773,7 @@ class TestSuiteAssertionSamplerTest {
                     .thenReturn(versionId);
             when(datasetVersionService.getVersionById(workspaceId, datasetId, versionId))
                     .thenReturn(datasetVersion);
-            when(datasetItemService.get(datasetItemId))
+            when(datasetItemService.get(datasetItemId, versionId))
                     .thenReturn(Mono.just(DatasetItem.builder().id(datasetItemId).build()));
             when(idGenerator.generateId()).thenReturn(ruleId);
             when(testSuiteAssertionCounterService.decrementAndFinishIfComplete(any(), any()))
@@ -779,7 +864,7 @@ class TestSuiteAssertionSamplerTest {
                     .thenReturn(versionId);
             when(datasetVersionService.getVersionById(workspaceId, datasetId, versionId))
                     .thenReturn(datasetVersion);
-            when(datasetItemService.get(datasetItemId))
+            when(datasetItemService.get(datasetItemId, versionId))
                     .thenReturn(Mono.just(DatasetItem.builder().id(datasetItemId).build()));
             when(idGenerator.generateId()).thenReturn(ruleId);
             when(testSuiteAssertionCounterService.decrementAndFinishIfComplete(any(), any()))
@@ -859,7 +944,7 @@ class TestSuiteAssertionSamplerTest {
 
             when(datasetVersionService.getLatestVersion(datasetId, workspaceId))
                     .thenReturn(Optional.of(datasetVersion));
-            when(datasetItemService.get(datasetItemId))
+            when(datasetItemService.get(datasetItemId, versionId))
                     .thenReturn(Mono.just(DatasetItem.builder().id(datasetItemId).build()));
             when(idGenerator.generateId()).thenReturn(ruleId);
 
@@ -937,7 +1022,7 @@ class TestSuiteAssertionSamplerTest {
                     .thenReturn(versionId);
             when(datasetVersionService.getVersionById(workspaceId, datasetId, versionId))
                     .thenReturn(datasetVersion);
-            when(datasetItemService.get(datasetItemId))
+            when(datasetItemService.get(datasetItemId, versionId))
                     .thenReturn(Mono.just(DatasetItem.builder().id(datasetItemId).build()));
             when(idGenerator.generateId()).thenReturn(ruleId);
 


### PR DESCRIPTION
## Details

When a playground experiment runs on a non-latest version of a test suite, item-level assertions are fetched from the latest version instead of the selected one. This happens because `fetchItemEvaluators()` in `TestSuiteAssertionSampler` calls `datasetItemService.get(itemId)` without passing the dataset version ID, and `DatasetItemVersionDAO.getItemById()` always returns the latest version (`ORDER BY last_updated_at DESC LIMIT 1`) with no version filter.

**Fix:** Thread the resolved `versionId` from `fetchDatasetEvaluators` through to `fetchItemEvaluators`, add a version-aware `get(id, versionId)` overload to `DatasetItemService`, and add a conditional `dataset_version_id` filter to the DAO query.

- `DatasetItemVersionDAO`: add conditional `<if(dataset_version_id)>` clause to `SELECT_ITEM_BY_ID`; single parameterized method, no-arg overload delegates with `null`
- `DatasetItemService`: add `get(UUID, UUID)` overload; extract shared `authorizeItem()` private method for DRY
- `TestSuiteAssertionSampler`: cache raw `DatasetEvaluatorsResult` (not prepared evaluators), move `prepareEvaluators` downstream, pass `result.versionId()` into `fetchItemEvaluators`

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6211

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code (CLI)
  - Model(s): Claude Opus 4.6
  - Scope: Implementation of version-aware item fetching across DAO, Service, and Sampler
  - Human verification: Manual testing of playground experiments on non-latest test suite versions

## Testing

- Local dev environment via `scripts/dev-runner.sh --restart`
- Created test suite with item-level assertions on specific versions
- Ran playground experiment on non-latest version, verified assertions match the selected version
- Verified latest version experiments still work correctly

## Documentation
No documentation changes needed.