### PR TITLE
[OPIK-6214] [FE] fix: clear stale experiment results on version/dataset switch

### DIFF
--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -113,6 +113,17 @@ const PlaygroundPage = () => {
     resetPlayground,
   ]);
 
+  const prevDatasetIdRef = useRef(datasetId);
+  useEffect(() => {
+    if (
+      prevDatasetIdRef.current !== null &&
+      prevDatasetIdRef.current !== datasetId
+    ) {
+      clearCreatedExperiments();
+    }
+    prevDatasetIdRef.current = datasetId;
+  }, [datasetId, clearCreatedExperiments]);
+
   const { DialogComponent } = useNavigationBlocker({
     condition: isRunning,
     title: datasetId

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -115,10 +115,7 @@ const PlaygroundPage = () => {
 
   const prevDatasetIdRef = useRef(datasetId);
   useEffect(() => {
-    if (
-      prevDatasetIdRef.current !== null &&
-      prevDatasetIdRef.current !== datasetId
-    ) {
+    if (prevDatasetIdRef.current !== datasetId) {
       clearCreatedExperiments();
     }
     prevDatasetIdRef.current = datasetId;

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -115,7 +115,10 @@ const PlaygroundPage = () => {
 
   const prevDatasetIdRef = useRef(datasetId);
   useEffect(() => {
-    if (prevDatasetIdRef.current !== datasetId) {
+    if (
+      prevDatasetIdRef.current !== null &&
+      prevDatasetIdRef.current !== datasetId
+    ) {
       clearCreatedExperiments();
     }
     prevDatasetIdRef.current = datasetId;


### PR DESCRIPTION
## Details
Clears old experiment results when switching dataset versions or datasets in the playground test suite page. Previously, stale results from a prior version/dataset would linger in the UI after switching, causing confusion.

When the `datasetId` changes in the playground, `clearCreatedExperiments()` is now called to reset experiment state. Uses a ref to track the previous `datasetId` and only clears on actual changes (not on initial mount).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6214

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Implementation and PR creation
  - Human verification: Manual testing in browser

## Testing

- Ran `cd apps/opik-frontend && npm run lint && npm run test` — all pass
- Manual testing:
  1. Open playground, select test suite with multiple versions
  2. Run experiment on one version
  3. Switch to different version → old results cleared ✅
  4. Switch datasets → old results cleared ✅
  5. Initial page load does NOT trigger a clear ✅

## Documentation
No documentation changes needed — this is a bug fix with no new user-facing features or API changes.