### PR TITLE
[OPIK-5968] [FE] fix: disable Run button and show tooltip when required sandbox inputs are empty

### DIFF
--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerConnectedState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerConnectedState.tsx
@@ -34,6 +34,7 @@ type AgentRunnerConnectedStateProps = {
   ) => void;
   isRunning: boolean;
   resetKey: number;
+  onValidityChange?: (hasAllRequired: boolean) => void;
 };
 
 const AgentRunnerConnectedState: React.FC<AgentRunnerConnectedStateProps> = ({
@@ -42,6 +43,7 @@ const AgentRunnerConnectedState: React.FC<AgentRunnerConnectedStateProps> = ({
   onRun,
   isRunning,
   resetKey,
+  onValidityChange,
 }) => {
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -199,6 +201,7 @@ const AgentRunnerConnectedState: React.FC<AgentRunnerConnectedStateProps> = ({
               fields={inputFields}
               onSubmit={handleRun}
               isRunning={isRunning}
+              onValidityChange={onValidityChange}
             />
           ) : (
             <AgentRunnerLoading runnerId={runner.id} />

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
@@ -35,7 +35,7 @@ const AgentRunnerContent: React.FC<AgentRunnerContentProps> = ({
 }) => {
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [traceOpen, setTraceOpen] = useState(false);
-  const [hasAllRequiredParams, setHasAllRequiredParams] = useState(true);
+  const [hasAllRequiredParams, setHasAllRequiredParams] = useState(false);
   const [tracePanelSpanId, setTracePanelSpanId] = useState<
     string | null | undefined
   >("");

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
@@ -35,6 +35,7 @@ const AgentRunnerContent: React.FC<AgentRunnerContentProps> = ({
 }) => {
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [traceOpen, setTraceOpen] = useState(false);
+  const [hasAllRequiredParams, setHasAllRequiredParams] = useState(true);
   const [tracePanelSpanId, setTracePanelSpanId] = useState<
     string | null | undefined
   >("");
@@ -170,16 +171,30 @@ const AgentRunnerContent: React.FC<AgentRunnerContentProps> = ({
                   Stop run
                 </Button>
               ) : (
-                <Button
-                  size="2xs"
-                  onClick={handleSubmitForm}
-                  disabled={createJobMutation.isPending || !isReady}
+                <TooltipWrapper
+                  content={
+                    !hasAllRequiredParams
+                      ? "Some required parameters are missing"
+                      : undefined
+                  }
                 >
-                  <Play className="mr-1 size-3.5" />
-                  Run
-                  <HotkeyDisplay hotkey="⇧" size="2xs" className="ml-1.5" />
-                  <HotkeyDisplay hotkey="⏎" size="2xs" className="ml-1" />
-                </Button>
+                  <span>
+                    <Button
+                      size="2xs"
+                      onClick={handleSubmitForm}
+                      disabled={
+                        createJobMutation.isPending ||
+                        !isReady ||
+                        !hasAllRequiredParams
+                      }
+                    >
+                      <Play className="mr-1 size-3.5" />
+                      Run
+                      <HotkeyDisplay hotkey="⇧" size="2xs" className="ml-1.5" />
+                      <HotkeyDisplay hotkey="⏎" size="2xs" className="ml-1" />
+                    </Button>
+                  </span>
+                </TooltipWrapper>
               )}
               <Button variant="ghost" size="2xs" onClick={handleReset}>
                 <RotateCcw className="mr-1 size-3.5" />
@@ -225,6 +240,7 @@ const AgentRunnerContent: React.FC<AgentRunnerContentProps> = ({
               onRun={handleRun}
               isRunning={createJobMutation.isPending}
               resetKey={resetKey}
+              onValidityChange={setHasAllRequiredParams}
             />
           </ResizablePanel>
 

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerInputForm.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerInputForm.tsx
@@ -16,31 +16,45 @@ type AgentParam = {
   presence?: ParamPresence;
 };
 
-const NUMERIC_TYPES = new Set(["int", "integer", "float", "double", "number"]);
+type NormalizedType =
+  | "boolean"
+  | "numeric-int"
+  | "numeric-float"
+  | "object"
+  | "text";
+
 const BOOL_TYPES = new Set(["bool", "boolean"]);
+const INT_TYPES = new Set(["int", "integer"]);
+const FLOAT_TYPES = new Set(["float", "double", "number"]);
 const OBJECT_TYPES = new Set(["dict", "object", "json", "list"]);
 
-const coerceValue = (value: string, type: string): unknown => {
+const normalizeType = (type: string): NormalizedType => {
   const lower = type.toLowerCase();
+  if (BOOL_TYPES.has(lower)) return "boolean";
+  if (INT_TYPES.has(lower)) return "numeric-int";
+  if (FLOAT_TYPES.has(lower)) return "numeric-float";
+  if (OBJECT_TYPES.has(lower)) return "object";
+  return "text";
+};
 
-  if (BOOL_TYPES.has(lower)) {
-    return value === "true";
-  }
-
-  if (NUMERIC_TYPES.has(lower)) {
-    const num = Number(value);
-    return isNaN(num) ? value : num;
-  }
-
-  if (OBJECT_TYPES.has(lower)) {
-    try {
-      return JSON.parse(value);
-    } catch {
-      return value;
+const coerceValue = (value: string, type: string): unknown => {
+  switch (normalizeType(type)) {
+    case "boolean":
+      return value === "true";
+    case "numeric-int":
+    case "numeric-float": {
+      const num = Number(value);
+      return isNaN(num) ? value : num;
     }
+    case "object":
+      try {
+        return JSON.parse(value);
+      } catch {
+        return value;
+      }
+    default:
+      return value;
   }
-
-  return value;
 };
 
 type AgentRunnerInputFormProps = {
@@ -57,18 +71,13 @@ const isFieldRequired = (field: AgentParam): boolean => {
 const buildSchema = (fields: AgentParam[]) => {
   const shape: Record<string, z.ZodTypeAny> = {};
   for (const field of fields) {
-    const lower = field.type.toLowerCase();
     // Boolean fields are always valid (Switch is always "true"/"false")
-    if (BOOL_TYPES.has(lower)) {
+    if (normalizeType(field.type) === "boolean" || !isFieldRequired(field)) {
       shape[field.name] = z.string();
-    } else if (isFieldRequired(field)) {
-      shape[field.name] = z
-        .string()
-        .refine((v) => v.trim().length > 0, {
-          message: "This field is required",
-        });
     } else {
-      shape[field.name] = z.string();
+      shape[field.name] = z.string().refine((v) => v.trim().length > 0, {
+        message: "This field is required",
+      });
     }
   }
   return z.object(shape);
@@ -124,57 +133,60 @@ const AgentRunnerInputForm: React.FC<AgentRunnerInputFormProps> = ({
         </div>
       ) : (
         <div className="flex flex-col gap-4">
-          {fields.map((field) => (
-            <div key={field.name} className="flex flex-col gap-1.5">
-              <Label className="comet-body-xs-accented">
-                {field.name}
-                <span className="ml-1 font-normal text-light-slate">
-                  {field.type}
-                </span>
-                {!isFieldRequired(field) && (
-                  <span className="ml-1 font-normal text-muted-slate">
-                    (optional)
+          {fields.map((field) => {
+            const normalized = normalizeType(field.type);
+            return (
+              <div key={field.name} className="flex flex-col gap-1.5">
+                <Label className="comet-body-xs-accented">
+                  {field.name}
+                  <span className="ml-1 font-normal text-light-slate">
+                    {field.type}
+                  </span>
+                  {!isFieldRequired(field) && (
+                    <span className="ml-1 font-normal text-muted-slate">
+                      (optional)
+                    </span>
+                  )}
+                </Label>
+
+                {normalized === "boolean" ? (
+                  <Switch
+                    checked={watch(field.name) === "true"}
+                    onCheckedChange={(checked) =>
+                      setValue(field.name, String(checked))
+                    }
+                    disabled={isRunning}
+                  />
+                ) : normalized === "object" ? (
+                  <Textarea
+                    {...register(field.name)}
+                    placeholder={`Enter ${field.name}...`}
+                    rows={4}
+                    disabled={isRunning}
+                  />
+                ) : (
+                  <Input
+                    {...register(field.name)}
+                    placeholder={`Enter ${field.name}...`}
+                    inputMode={
+                      normalized === "numeric-int"
+                        ? "numeric"
+                        : normalized === "numeric-float"
+                          ? "decimal"
+                          : "text"
+                    }
+                    disabled={isRunning}
+                  />
+                )}
+
+                {errors[field.name] && (
+                  <span className="comet-body-xs text-destructive">
+                    {errors[field.name]?.message as string}
                   </span>
                 )}
-              </Label>
-
-              {field.type === "boolean" ? (
-                <Switch
-                  checked={watch(field.name) === "true"}
-                  onCheckedChange={(checked) =>
-                    setValue(field.name, String(checked))
-                  }
-                  disabled={isRunning}
-                />
-              ) : field.type === "object" || field.type === "json" ? (
-                <Textarea
-                  {...register(field.name)}
-                  placeholder={`Enter ${field.name}...`}
-                  rows={4}
-                  disabled={isRunning}
-                />
-              ) : (
-                <Input
-                  {...register(field.name)}
-                  placeholder={`Enter ${field.name}...`}
-                  inputMode={
-                    field.type === "integer" || field.type === "int"
-                      ? "numeric"
-                      : field.type === "float" || field.type === "double"
-                        ? "decimal"
-                        : "text"
-                  }
-                  disabled={isRunning}
-                />
-              )}
-
-              {errors[field.name] && (
-                <span className="comet-body-xs text-destructive">
-                  {errors[field.name]?.message as string}
-                </span>
-              )}
-            </div>
-          ))}
+              </div>
+            );
+          })}
         </div>
       )}
     </form>

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerInputForm.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerInputForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useForm } from "react-hook-form";
 
 import { Input } from "@/ui/input";
@@ -45,6 +45,7 @@ type AgentRunnerInputFormProps = {
   fields: AgentParam[];
   onSubmit: (inputs: Record<string, unknown>, maskId?: string) => void;
   isRunning: boolean;
+  onValidityChange?: (hasAllRequired: boolean) => void;
 };
 
 const isFieldRequired = (field: AgentParam): boolean => {
@@ -55,6 +56,7 @@ const AgentRunnerInputForm: React.FC<AgentRunnerInputFormProps> = ({
   fields,
   onSubmit,
   isRunning,
+  onValidityChange,
 }) => {
   const {
     register,
@@ -71,6 +73,18 @@ const AgentRunnerInputForm: React.FC<AgentRunnerInputFormProps> = ({
       {} as Record<string, string>,
     ),
   });
+
+  const requiredFields = fields.filter(isFieldRequired);
+  const allValues = watch();
+
+  useEffect(() => {
+    if (!onValidityChange) return;
+    const allFilled = requiredFields.every((field) => {
+      const value = allValues[field.name];
+      return typeof value === "string" && value.trim().length > 0;
+    });
+    onValidityChange(allFilled);
+  }, [allValues, requiredFields, onValidityChange]);
 
   const onFormSubmit = handleSubmit((data) => {
     const inputs: Record<string, unknown> = {};

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerInputForm.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerInputForm.tsx
@@ -1,5 +1,7 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
 
 import { Input } from "@/ui/input";
 import { Textarea } from "@/ui/textarea";
@@ -52,19 +54,40 @@ const isFieldRequired = (field: AgentParam): boolean => {
   return field.presence !== "optional";
 };
 
+const buildSchema = (fields: AgentParam[]) => {
+  const shape: Record<string, z.ZodTypeAny> = {};
+  for (const field of fields) {
+    const lower = field.type.toLowerCase();
+    // Boolean fields are always valid (Switch is always "true"/"false")
+    if (BOOL_TYPES.has(lower)) {
+      shape[field.name] = z.string();
+    } else if (isFieldRequired(field)) {
+      shape[field.name] = z
+        .string()
+        .refine((v) => v.trim().length > 0, { message: "This field is required" });
+    } else {
+      shape[field.name] = z.string();
+    }
+  }
+  return z.object(shape);
+};
+
 const AgentRunnerInputForm: React.FC<AgentRunnerInputFormProps> = ({
   fields,
   onSubmit,
   isRunning,
   onValidityChange,
 }) => {
+  const schema = useMemo(() => buildSchema(fields), [fields]);
+
   const {
     register,
     handleSubmit,
     setValue,
     watch,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm({
+    resolver: zodResolver(schema),
     defaultValues: fields.reduce(
       (acc, field) => {
         acc[field.name] = "";
@@ -72,19 +95,12 @@ const AgentRunnerInputForm: React.FC<AgentRunnerInputFormProps> = ({
       },
       {} as Record<string, string>,
     ),
+    mode: "onChange",
   });
 
-  const requiredFields = fields.filter(isFieldRequired);
-  const allValues = watch();
-
   useEffect(() => {
-    if (!onValidityChange) return;
-    const allFilled = requiredFields.every((field) => {
-      const value = allValues[field.name];
-      return typeof value === "string" && value.trim().length > 0;
-    });
-    onValidityChange(allFilled);
-  }, [allValues, requiredFields, onValidityChange]);
+    onValidityChange?.(isValid);
+  }, [isValid, onValidityChange]);
 
   const onFormSubmit = handleSubmit((data) => {
     const inputs: Record<string, unknown> = {};
@@ -130,24 +146,14 @@ const AgentRunnerInputForm: React.FC<AgentRunnerInputFormProps> = ({
                 />
               ) : field.type === "object" || field.type === "json" ? (
                 <Textarea
-                  {...register(field.name, {
-                    ...(isFieldRequired(field) && {
-                      validate: (v: string) =>
-                        v.trim().length > 0 || "This field is required",
-                    }),
-                  })}
+                  {...register(field.name)}
                   placeholder={`Enter ${field.name}...`}
                   rows={4}
                   disabled={isRunning}
                 />
               ) : (
                 <Input
-                  {...register(field.name, {
-                    ...(isFieldRequired(field) && {
-                      validate: (v: string) =>
-                        v.trim().length > 0 || "This field is required",
-                    }),
-                  })}
+                  {...register(field.name)}
                   placeholder={`Enter ${field.name}...`}
                   inputMode={
                     field.type === "integer" || field.type === "int"

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerInputForm.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerInputForm.tsx
@@ -64,7 +64,9 @@ const buildSchema = (fields: AgentParam[]) => {
     } else if (isFieldRequired(field)) {
       shape[field.name] = z
         .string()
-        .refine((v) => v.trim().length > 0, { message: "This field is required" });
+        .refine((v) => v.trim().length > 0, {
+          message: "This field is required",
+        });
     } else {
       shape[field.name] = z.string();
     }


### PR DESCRIPTION
## Details

When the agent runner form has required parameters that are not yet filled in, the Run button is now disabled and shows a tooltip: "Some required parameters are missing". This prevents users from submitting the form with missing required inputs and provides clear feedback about what is blocking the run.

- `AgentRunnerInputForm` watches all form values and calls an `onValidityChange` callback whenever required fields change
- `AgentRunnerConnectedState` forwards the callback down to the form
- `AgentRunnerContent` tracks form validity state and disables the Run button accordingly; the button is wrapped in a `<span>` so the tooltip fires even while disabled

https://github.com/user-attachments/assets/a136609f-e96f-4ed4-a3e3-5e8ee486a4bc


## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5968

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-sonnet-4-6
  - Scope: full implementation
  - Human verification: code review

## Testing

- `npm run lint && npm run typecheck` — both pass
- Manual: connected an agent with required input fields, verified the Run button is disabled and tooltip appears until all required fields are filled; verified button becomes active once all required fields are populated; verified optional fields do not block the Run button

## Documentation

N/A