### PR TITLE
[OPIK-6207] [FE] Update optimization runs empty state and page title

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -964,9 +964,9 @@ serviceToggles:
   # Default: true
   # Description: Whether or not dataset export to CSV feature is enabled
   datasetExportEnabled: ${DATASET_EXPORT_ENABLED:-"false"}
-  # Default: true
+  # Default: false
   # Description: Whether or not Optimization Studio feature is enabled
-  optimizationStudioEnabled: ${TOGGLE_OPTIMIZATION_STUDIO_ENABLED:-"true"}
+  optimizationStudioEnabled: ${TOGGLE_OPTIMIZATION_STUDIO_ENABLED:-"false"}
   # Default: true
   # Description: Whether or not OpenAI provider is enabled
   openaiProviderEnabled: ${TOGGLE_OPENAI_PROVIDER_ENABLED:-"true"}

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -964,9 +964,9 @@ serviceToggles:
   # Default: true
   # Description: Whether or not dataset export to CSV feature is enabled
   datasetExportEnabled: ${DATASET_EXPORT_ENABLED:-"false"}
-  # Default: false
+  # Default: true
   # Description: Whether or not Optimization Studio feature is enabled
-  optimizationStudioEnabled: ${TOGGLE_OPTIMIZATION_STUDIO_ENABLED:-"false"}
+  optimizationStudioEnabled: ${TOGGLE_OPTIMIZATION_STUDIO_ENABLED:-"true"}
   # Default: true
   # Description: Whether or not OpenAI provider is enabled
   openaiProviderEnabled: ${TOGGLE_OPENAI_PROVIDER_ENABLED:-"true"}

--- a/apps/opik-frontend/src/api/datasets/useGetOrCreateDemoDataset.ts
+++ b/apps/opik-frontend/src/api/datasets/useGetOrCreateDemoDataset.ts
@@ -19,8 +19,13 @@ const useGetOrCreateDemoDataset = () => {
     async (
       template: OptimizationTemplate,
       workspaceName: string,
+      projectName?: string,
     ): Promise<Dataset | null> => {
-      const datasetName = template.studio_config?.dataset_name;
+      const baseDatasetName = template.studio_config?.dataset_name;
+      const datasetName =
+        baseDatasetName && projectName
+          ? `${baseDatasetName} (${projectName})`
+          : baseDatasetName;
       const datasetItems = template.dataset_items;
 
       if (!datasetName || !datasetItems?.length) {
@@ -33,7 +38,8 @@ const useGetOrCreateDemoDataset = () => {
         try {
           const { data } = await api.post(DATASETS_REST_ENDPOINT, {
             name: datasetName,
-            type: DATASET_TYPE.TEST_SUITE,
+            type: DATASET_TYPE.DATASET,
+            ...(projectName && { project_name: projectName }),
           });
           newDataset = data;
         } catch {

--- a/apps/opik-frontend/src/shared/PageEmptyState/PageEmptyState.tsx
+++ b/apps/opik-frontend/src/shared/PageEmptyState/PageEmptyState.tsx
@@ -31,7 +31,7 @@ const PageEmptyState: React.FC<PageEmptyStateProps> = ({
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-7 py-10">
       <img src={imageUrl} alt={title} />
-      <div className="flex flex-col items-center gap-1.5">
+      <div className="flex flex-col items-center gap-2">
         <h2 className="comet-title-s text-foreground">{title}</h2>
         <p className="comet-body-s max-w-[570px] whitespace-pre-line text-center text-muted-slate">
           {description}

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsEmptyState.tsx
@@ -36,8 +36,8 @@ const OptimizationsEmptyState: React.FC<OptimizationsEmptyStateProps> = ({
 
   return (
     <div className="flex min-h-full flex-1 items-center justify-center gap-16 px-6">
-      <div className="flex w-full max-w-lg flex-col gap-7">
-        <div className="flex flex-col gap-1.5">
+      <div className="flex w-full max-w-lg flex-col gap-6">
+        <div className="flex flex-col gap-2">
           <h2 className="comet-title-s text-foreground">
             No optimization runs yet
           </h2>

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsEmptyState.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { SquareDashedMousePointer, Bot, ExternalLink } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+
+import { Button } from "@/ui/button";
+import { buildDocsUrl } from "@/v2/lib/utils";
+import { useTheme } from "@/contexts/theme-provider";
+import { THEME_MODE } from "@/constants/theme";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
+import emptyOptStudioLightUrl from "/images/empty-optimization-studio-light.svg";
+import emptyOptStudioDarkUrl from "/images/empty-optimization-studio-dark.svg";
+
+type OptimizationsEmptyStateProps = {
+  onOptimizeClick: () => void;
+};
+
+const OptimizationsEmptyState: React.FC<OptimizationsEmptyStateProps> = ({
+  onOptimizeClick,
+}) => {
+  const { themeMode } = useTheme();
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
+  const navigate = useNavigate();
+  const imageUrl =
+    themeMode === THEME_MODE.DARK
+      ? emptyOptStudioDarkUrl
+      : emptyOptStudioLightUrl;
+
+  const handleDemoTemplateClick = () => {
+    navigate({
+      to: "/$workspaceName/projects/$projectId/optimizations/new",
+      params: { workspaceName, projectId: activeProjectId! },
+      search: { template: "opik-chatbot" },
+    });
+  };
+
+  return (
+    <div className="flex min-h-full flex-1 items-center justify-center gap-16 px-6">
+      <div className="flex w-full max-w-lg flex-col gap-7">
+        <div className="flex flex-col gap-1.5">
+          <h2 className="comet-title-s text-foreground">
+            No optimization runs yet
+          </h2>
+          <p className="comet-body-s text-muted-slate">
+            Try different prompt versions and see what performs best.
+            Optimization runs help you improve accuracy, consistency, and user
+            experience.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={onOptimizeClick}
+            className="flex items-start gap-3 rounded-md border p-4 text-left transition-colors hover:border-primary hover:bg-primary-100"
+          >
+            <SquareDashedMousePointer className="mt-0.5 size-5 shrink-0 text-chart-green" />
+            <div className="flex flex-col gap-0.5">
+              <span className="comet-body-s-accented text-foreground">
+                Optimize your prompt
+              </span>
+              <span className="comet-body-s text-muted-slate">
+                Start from scratch and configure your own optimization setting
+              </span>
+            </div>
+          </button>
+          <button
+            type="button"
+            onClick={handleDemoTemplateClick}
+            className="flex items-start gap-3 rounded-md border p-4 text-left transition-colors hover:border-primary hover:bg-primary-100"
+          >
+            <Bot className="mt-0.5 size-5 shrink-0 text-chart-burgundy" />
+            <div className="flex flex-col gap-0.5">
+              <span className="comet-body-s-accented text-foreground">
+                Try demo template
+              </span>
+              <span className="comet-body-s text-muted-slate">
+                Train a chatbot to answer questions about Opik and decline
+                off-topic requests.
+              </span>
+            </div>
+          </button>
+        </div>
+        <div>
+          <Button variant="outline" size="sm" asChild>
+            <a
+              href={buildDocsUrl(
+                "/development/optimization-runs/optimization_studio",
+              )}
+              target="_blank"
+              rel="noreferrer"
+            >
+              View docs
+              <ExternalLink className="ml-1.5 size-3.5" />
+            </a>
+          </Button>
+        </div>
+      </div>
+
+      <div className="hidden shrink-0 items-start xl:flex">
+        <img src={imageUrl} alt="No optimization runs yet" />
+      </div>
+    </div>
+  );
+};
+
+export default OptimizationsEmptyState;

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewConfigSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewConfigSidebar.tsx
@@ -58,7 +58,7 @@ const OptimizationsNewConfigSidebar: React.FC<
   getFirstMetricParamsError,
 }) => {
   return (
-    <div className="w-[500px] shrink-0 space-y-6">
+    <div className="w-full space-y-6 xl:w-[500px] xl:shrink-0">
       <FormField
         control={form.control}
         name="optimizerType"
@@ -107,7 +107,7 @@ const OptimizationsNewConfigSidebar: React.FC<
           render={({ field }) => (
             <FormItem>
               <FormLabel className="comet-body-s-accented flex items-center gap-1">
-                Test suite
+                Dataset
                 <ExplainerIcon
                   {...EXPLAINERS_MAP[EXPLAINER_ID.whats_the_test_suite_section]}
                 />
@@ -117,6 +117,7 @@ const OptimizationsNewConfigSidebar: React.FC<
                   value={field.value}
                   onValueChange={(id) => onDatasetChange(id)}
                   projectId={projectId}
+                  placeholder="Select a dataset"
                   className="h-10 w-full"
                 />
               </FormControl>

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPage.tsx
@@ -2,10 +2,11 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryParam, StringParam } from "use-query-params";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { OpikEvent, trackEvent } from "@/lib/analytics/tracking";
 import useGetOrCreateDemoDataset from "@/api/datasets/useGetOrCreateDemoDataset";
 import useOptimizationById from "@/api/optimizations/useOptimizationById";
+import useProjectById from "@/api/projects/useProjectById";
 import {
   OptimizationConfigFormType,
   OptimizationConfigSchema,
@@ -17,9 +18,14 @@ import Loader from "@/shared/Loader/Loader";
 
 const OptimizationsNewPage: React.FC = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
   const [templateId] = useQueryParam("template", StringParam);
   const [rerunId] = useQueryParam("rerun", StringParam);
   const { getOrCreateDataset } = useGetOrCreateDemoDataset();
+  const { data: project } = useProjectById(
+    { projectId: activeProjectId! },
+    { enabled: !!activeProjectId },
+  );
   const datasetCreationRef = useRef<string | null>(null);
   const [isPreparingDataset, setIsPreparingDataset] = useState(false);
 
@@ -78,7 +84,11 @@ const OptimizationsNewPage: React.FC = () => {
         setIsPreparingDataset(true);
 
         try {
-          const dataset = await getOrCreateDataset(templateData, workspaceName);
+          const dataset = await getOrCreateDataset(
+            templateData,
+            workspaceName,
+            project?.name,
+          );
           if (dataset?.id) {
             form.setValue("datasetId", dataset.id, { shouldValidate: true });
           }
@@ -89,7 +99,14 @@ const OptimizationsNewPage: React.FC = () => {
     };
 
     internalCreateOrGetDataset();
-  }, [rerunData, templateData, getOrCreateDataset, form, workspaceName]);
+  }, [
+    rerunData,
+    templateData,
+    getOrCreateDataset,
+    form,
+    workspaceName,
+    project?.name,
+  ]);
 
   if (Boolean(rerunId) && isRerunFetching) {
     return <Loader message="Loading optimization..." />;

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPageContent.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPageContent.tsx
@@ -46,7 +46,7 @@ const OptimizationsNewPageContent: React.FC = () => {
         onCancel={handleCancel}
       />
 
-      <div className="flex gap-6">
+      <div className="flex flex-col gap-6 xl:flex-row">
         <OptimizationsNewPromptSection
           form={form}
           projectId={activeProjectId!}

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPromptSection.tsx
@@ -116,7 +116,7 @@ const OptimizationsNewPromptSection: React.FC<
   );
 
   return (
-    <div className="flex-1 space-y-6">
+    <div className="min-w-0 flex-1 space-y-6">
       <FormField
         control={form.control}
         name="name"
@@ -137,8 +137,8 @@ const OptimizationsNewPromptSection: React.FC<
       />
 
       <div>
-        <div className="mb-2 flex h-8 items-center justify-between">
-          <div className="flex items-center gap-0.5">
+        <div className="mb-2 flex h-8 items-center justify-between gap-2">
+          <div className="flex shrink-0 items-center gap-0.5">
             <Label className="comet-body-s-accented">Prompt</Label>
             <BlueprintPromptsSelectBox
               projectId={projectId}
@@ -167,14 +167,14 @@ const OptimizationsNewPromptSection: React.FC<
               </TooltipWrapper>
             )}
           </div>
-          <div className="flex h-full items-center gap-1">
+          <div className="flex h-full min-w-0 items-center gap-1">
             <FormField
               control={form.control}
               name="modelName"
               render={({ field }) => (
-                <FormItem className="flex h-full flex-row items-center gap-1">
+                <FormItem className="flex h-full min-w-0 flex-row items-center gap-1">
                   <FormControl>
-                    <div className="h-full w-56">
+                    <div className="h-full min-w-0 max-w-56">
                       <OptimizationModelSelect
                         value={field.value as PROVIDER_MODEL_TYPE | ""}
                         onChange={onModelChange}

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -43,6 +43,7 @@ import {
   generateActionsColumDef,
   generateSelectColumDef,
 } from "@/shared/DataTable/utils";
+import OptimizationsEmptyState from "@/v2/pages/OptimizationsPage/OptimizationsEmptyState";
 import PageEmptyState from "@/shared/PageEmptyState/PageEmptyState";
 import { buildDocsUrl } from "@/v2/lib/utils";
 import emptyOptStudioLightUrl from "/images/empty-optimization-studio-light.svg";
@@ -330,27 +331,25 @@ const OptimizationsPage: React.FunctionComponent = () => {
     <div className="flex min-h-full flex-col pt-4">
       <div className="mb-1 flex min-h-7 items-center justify-between">
         <h1 className="comet-body-accented truncate break-words">
-          Optimization Studio
+          Optimization runs
         </h1>
       </div>
       {isEmpty ? (
-        <PageEmptyState
-          lightImageUrl={emptyOptStudioLightUrl}
-          darkImageUrl={emptyOptStudioDarkUrl}
-          title="No optimization runs yet"
-          description={
-            "Explore different prompt variations and see what performs best.\nOptimizations help you improve accuracy, consistency, and overall user experience."
-          }
-          primaryActionLabel={
-            canUseOptimizationStudio ? "Create optimization run" : undefined
-          }
-          onPrimaryAction={
-            canUseOptimizationStudio ? handleNewOptimizationClick : undefined
-          }
-          docsUrl={buildDocsUrl(
-            "/development/optimization-runs/optimization_studio",
-          )}
-        />
+        canUseOptimizationStudio ? (
+          <OptimizationsEmptyState
+            onOptimizeClick={handleNewOptimizationClick}
+          />
+        ) : (
+          <PageEmptyState
+            lightImageUrl={emptyOptStudioLightUrl}
+            darkImageUrl={emptyOptStudioDarkUrl}
+            title="No optimization runs yet"
+            description="Try different prompt versions and see what performs best. Optimization runs help you improve accuracy, consistency, and user experience."
+            docsUrl={buildDocsUrl(
+              "/development/optimization-runs/optimization_studio",
+            )}
+          />
+        )
       ) : (
         <>
           {isOptimizationStudioEnabled && canUseOptimizationStudio && (

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -335,7 +335,7 @@ const OptimizationsPage: React.FunctionComponent = () => {
         </h1>
       </div>
       {isEmpty ? (
-        canUseOptimizationStudio ? (
+        isOptimizationStudioEnabled && canUseOptimizationStudio ? (
           <OptimizationsEmptyState
             onOptimizeClick={handleNewOptimizationClick}
           />


### PR DESCRIPTION
## Details

Updates the V2 Optimization runs page with the following changes:

### Empty state & page title
- **Page title**: Renamed from "Optimization Studio" to "Optimization runs" to match sidebar navigation
- **Empty state**: New `OptimizationsEmptyState` component with two action cards:
  - "Optimize your prompt" — opens the AddOptimizationDialog side panel
  - "Try demo template" — navigates to `/optimizations/new?template=opik-chatbot`
  - "View docs" link to documentation
  - Dark/light mode illustration on the right (hidden on small screens)
- **Permission + feature flag gating**: Empty state and StudioTemplates both gated on `isOptimizationStudioEnabled && canUseOptimizationStudio`, with fallback to `PageEmptyState`

### Demo dataset preselection
- Demo dataset created as `DATASET` type (not `TEST_SUITE`) with project-scoped naming, e.g. "Demo - Opik Chatbot (my-project)"
- Uses `project_name` in the POST body to associate with the current project
- Dataset appears in the V2 project-scoped dropdown and gets preselected

### Responsive layout for /optimizations/new
- Sidebar stacks below prompt section on small screens (`flex-col xl:flex-row`)
- Model selector and prompt section shrink instead of causing horizontal overflow
- Added `min-w-0` to prevent flex child overflow

### Label updates
- "Test suite" label → "Dataset" in the new optimization form
- Placeholder updated to "Select a dataset"

### Config
- `optimizationStudioEnabled` default set to `true` in `config.yml` for local development

Design reference: [Figma](https://www.figma.com/design/eumAOxjM1i2tIBjKQzw7TG/Misc?node-id=431-30424&t=53L7BUL0qFWOCUIY-1)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-6207

## Testing
- Verified empty state renders with two action cards and illustration
- Verified "Optimize your prompt" opens the side panel dialog
- Verified "Try demo template" navigates to `/optimizations/new?template=opik-chatbot`
- Verified illustration hides on viewports below `xl` breakpoint
- Verified permission + feature flag fallback renders `PageEmptyState`
- Verified StudioTemplates shows in non-empty state when feature flag is on
- Verified demo dataset created as DATASET type with project name suffix
- Verified responsive layout stacks sidebar below on small screens
- Verified "Dataset" label and placeholder in optimization form
- TypeScript and ESLint checks pass

## Documentation
N/A