### PR TITLE
[OPIK-6074] [FE] Add Ollie button in mobile header instead of collapsed sidebar

### DIFF
--- a/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
+++ b/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
@@ -17,6 +17,7 @@ import {
   ASSISTANT_SIDEBAR_COLLAPSED_WIDTH,
   getStoredAssistantSidebarWidth,
   isAssistantSidebarOpen,
+  setAssistantSidebarOpen,
 } from "@/constants/assistantSidebar";
 import DemoProjectBanner from "@/v2/layout/DemoProjectBanner/DemoProjectBanner";
 
@@ -61,14 +62,16 @@ const PageLayout = () => {
 
   const isAssistantOpen =
     assistantSidebarWidth > ASSISTANT_SIDEBAR_COLLAPSED_WIDTH;
-  // On phones when the assistant is open, render it as a fixed overlay so it
-  // doesn't consume flex-row width and collapse main content. The layout var
-  // stays 0px so `.comet-content-inset`'s calc resolves correctly.
-  const isPhoneAssistantOverlay = isPhone && isAssistantOpen;
+  // On phones the assistant renders as a fixed overlay when open and is
+  // fully unmounted when collapsed. The layout var stays 0px so
+  // `.comet-content-inset`'s calc resolves correctly.
   const layoutAssistantWidth =
-    showAssistantSidebar && !isPhoneAssistantOverlay
-      ? `${assistantSidebarWidth}px`
-      : "0px";
+    showAssistantSidebar && !isPhone ? `${assistantSidebarWidth}px` : "0px";
+
+  const handleOpenAssistant = useCallback(() => {
+    setAssistantSidebarOpen(true);
+    setAssistantSidebarWidth(getStoredAssistantSidebarWidth());
+  }, []);
 
   const expanded = isPhone
     ? false
@@ -131,7 +134,12 @@ const PageLayout = () => {
               onToggle={toggleExpanded}
             />
             <main className="comet-content-inset absolute bottom-0 right-0 top-[var(--banner-height)] flex transition-all">
-              <TopBar />
+              <TopBar
+                showOllieToggle={
+                  isPhone && showAssistantSidebar && !isAssistantOpen
+                }
+                onOpenAssistant={handleOpenAssistant}
+              />
               <section className="comet-header-inset absolute inset-x-0 bottom-0 overflow-auto bg-soft-background px-6">
                 <Outlet />
               </section>
@@ -146,17 +154,13 @@ const PageLayout = () => {
           </div>
         </PortalContainerProvider>
 
-        {showAssistantSidebar ? (
+        {showAssistantSidebar && (!isPhone || isAssistantOpen) ? (
           <div
             className={
-              isPhoneAssistantOverlay
-                ? "fixed inset-0 z-40"
-                : "relative z-[1] shrink-0"
+              isPhone ? "fixed inset-0 z-40" : "relative z-[1] shrink-0"
             }
             style={
-              isPhoneAssistantOverlay
-                ? undefined
-                : { width: `${assistantSidebarWidth}px` }
+              isPhone ? undefined : { width: `${assistantSidebarWidth}px` }
             }
           >
             <SilentErrorBoundary>

--- a/apps/opik-frontend/src/v2/layout/TopBar/TopBar.tsx
+++ b/apps/opik-frontend/src/v2/layout/TopBar/TopBar.tsx
@@ -3,8 +3,18 @@ import Breadcrumbs from "@/v2/layout/Breadcrumbs/Breadcrumbs";
 import usePluginsStore from "@/store/PluginsStore";
 import AppDebugInfo from "@/v2/layout/AppDebugInfo/AppDebugInfo";
 import SettingsMenu from "../SettingsMenu/SettingsMenu";
+import { Button } from "@/ui/button";
+import OllieOwl from "@/icons/ollie-owl.svg?react";
 
-const TopBar: React.FC = () => {
+type TopBarProps = {
+  showOllieToggle?: boolean;
+  onOpenAssistant?: () => void;
+};
+
+const TopBar: React.FC<TopBarProps> = ({
+  showOllieToggle,
+  onOpenAssistant,
+}) => {
   const UserMenu = usePluginsStore((state) => state.UserMenu);
   const UpgradeButton = usePluginsStore((state) => state.UpgradeButton);
 
@@ -18,6 +28,16 @@ const TopBar: React.FC = () => {
         <AppDebugInfo />
         {UpgradeButton && <UpgradeButton />}
         {UserMenu ? <UserMenu /> : <SettingsMenu />}
+        {showOllieToggle && (
+          <Button
+            size="icon-sm"
+            variant="outline"
+            className="text-[#F46E41]"
+            onClick={onOpenAssistant}
+          >
+            <OllieOwl />
+          </Button>
+        )}
       </div>
     </nav>
   );


### PR DESCRIPTION
## Details

On mobile, the collapsed Ollie assistant sidebar (33px wide) wastes horizontal space without being interactive. This PR:

- **Hides the collapsed assistant sidebar entirely on mobile** — saves 33px of screen width
- **Adds an Ollie owl button in the top bar** (orange icon, outline variant) that opens the assistant as a full-screen overlay
- **Simplifies PageLayout conditions** — removes `isPhoneAssistantOverlay` / `isPhoneAssistantCollapsed` intermediaries in favor of direct `isPhone` / `isAssistantOpen` checks

### Changed files
- `PageLayout.tsx` — mobile assistant sidebar logic: unmount when collapsed, overlay when open, Ollie button wiring
- `TopBar.tsx` — accepts `showOllieToggle` / `onOpenAssistant` props, renders Ollie button using existing `ollie-owl.svg`

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-6074

## Testing
1. Open the app on a mobile viewport (or use Chrome DevTools responsive mode with touch simulation)
2. Verify the collapsed assistant sidebar is no longer visible
3. Verify an orange Ollie owl button appears at the right end of the top bar
4. Tap the button — assistant sidebar should open as a full-screen overlay
5. On desktop, verify no Ollie button appears and the assistant sidebar behaves as before

## Documentation
N/A