### PR TITLE
[OPIK-6201] [FE] fix: navigation sidebar styling pass

### DIFF
--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -25,7 +25,6 @@
     --tree-line: 213 16% 88%;
     --slate-300: 213 27% 84%;
     --border: 214 32% 92%;
-    --breadcrumb-last: 216 20% 40%;
     --secondary-foreground: 222.2 47.4% 11.2%;
     --primary-foreground: 210 40% 98%;
 
@@ -90,6 +89,8 @@
     --chart-pink: #ed4a7b;
     --chart-orange: #fb9341;
     --chart-teal: #12a4b4;
+    --chart-gray-light: #ebf2f5;
+    --chart-gray-dark: #45575f;
 
     /* Template icon colors */
     --template-icon-metrics: #5899da;
@@ -279,7 +280,6 @@
     --tree-line: 0 0% 30%;
     --slate-300: 213 27% 84%;
     --border: 0, 0%, 16%;
-    --breadcrumb-last: 214, 32%, 91%;
     --secondary-foreground: 0, 0%, 10%;
     --primary-foreground: 0, 0%, 11%;
 
@@ -385,6 +385,8 @@
     --chart-pink: #ed4a7b;
     --chart-orange: #fb9341;
     --chart-teal: #12a4b4;
+    --chart-gray-light: #2e2e2e;
+    --chart-gray-dark: #e2e8f0;
 
     /* Template icon colors - Dark Mode */
     --template-icon-metrics: #5899da;

--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -20,7 +20,7 @@
     --muted-gray: 218 11% 65%;
     --muted-disabled: 220 14% 96%;
 
-    --muted-slate: 215 16%, 47%;
+    --muted-slate: 215 16% 47%;
     --light-slate: 215 20% 65%;
     --tree-line: 213 16% 88%;
     --slate-300: 213 27% 84%;

--- a/apps/opik-frontend/src/plugins/comet/SidebarWorkspaceSelector.tsx
+++ b/apps/opik-frontend/src/plugins/comet/SidebarWorkspaceSelector.tsx
@@ -8,13 +8,11 @@ import {
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuPortal,
-  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu";
-import { Separator } from "@/ui/separator";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { calculateWorkspaceName, cn } from "@/lib/utils";
@@ -44,14 +42,12 @@ const SidebarWorkspaceSelector: React.FC<SidebarWorkspaceSelectorProps> = ({
     handleOpenChange,
     handleChangeWorkspace,
     handleChangeOrganization,
-    handleOrgSettingsClick,
 
     sortedWorkspaces,
     sortedOrganizations,
 
     shouldShowDropdown,
     hasMultipleOrganizations,
-    isOrgAdmin,
   } = useWorkspaceSelectorData();
 
   const displayName = calculateWorkspaceName(workspaceName);
@@ -68,16 +64,46 @@ const SidebarWorkspaceSelector: React.FC<SidebarWorkspaceSelectorProps> = ({
     );
   }
 
+  const initial = (displayName || workspaceName).charAt(0).toUpperCase();
+
+  const expandedThumb = (
+    <span className="comet-body-xs-accented flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-slate">
+      {initial}
+    </span>
+  );
+
+  const collapsedThumb = (
+    <span className="comet-body-xs-accented flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-[10.5px] leading-none text-muted-slate">
+      {initial}
+    </span>
+  );
+
   if (!user?.loggedIn || !currentOrganization || !shouldShowDropdown) {
     return expanded ? (
       <Link
         to="/$workspaceName/home"
         params={{ workspaceName }}
-        className="comet-body-s-accented truncate rounded-md px-2 py-1 text-foreground hover:bg-primary-foreground"
+        className="flex w-full items-center gap-1.5 rounded-md px-1 py-0.5 hover:bg-primary-foreground"
       >
-        {displayName}
+        {expandedThumb}
+        <div className="flex min-w-0 flex-1 flex-col items-stretch">
+          <span className="comet-body-xs-accented text-light-slate">
+            Workspace
+          </span>
+          <span className="comet-body-s-accented w-full truncate text-left text-foreground">
+            {displayName}
+          </span>
+        </div>
       </Link>
-    ) : null;
+    ) : (
+      <Link
+        to="/$workspaceName/home"
+        params={{ workspaceName }}
+        className="flex items-center justify-center"
+      >
+        {collapsedThumb}
+      </Link>
+    );
   }
 
   return (
@@ -86,120 +112,104 @@ const SidebarWorkspaceSelector: React.FC<SidebarWorkspaceSelectorProps> = ({
         {expanded ? (
           <button
             className={cn(
-              "flex w-full items-center gap-1 rounded-md px-2 py-1",
+              "flex w-full items-center gap-1.5 rounded-md px-1 py-0.5",
               isDropdownOpen
                 ? "bg-primary-foreground"
                 : "hover:bg-primary-foreground",
             )}
           >
-            <span className="comet-body-s-accented flex-1 truncate text-left text-foreground">
-              {displayName}
-            </span>
-            <span className="shrink-0 text-muted-slate">
-              {isDropdownOpen ? (
-                <ChevronUp className="size-3.5" />
-              ) : (
-                <ChevronDown className="size-3.5" />
-              )}
-            </span>
+            {expandedThumb}
+            <div className="flex min-w-0 flex-1 flex-col items-stretch">
+              <span className="flex items-end gap-0.5 text-light-slate">
+                <span className="comet-body-xs-accented">Workspace</span>
+                {isDropdownOpen ? (
+                  <ChevronUp className="size-3.5" />
+                ) : (
+                  <ChevronDown className="size-3.5" />
+                )}
+              </span>
+              <span className="comet-body-s-accented w-full truncate text-left text-foreground">
+                {displayName}
+              </span>
+            </div>
           </button>
         ) : (
           <button
-            className={cn(
-              "flex size-7 items-center justify-center rounded-md",
-              isDropdownOpen
-                ? "bg-primary-foreground"
-                : "hover:bg-primary-foreground",
-            )}
+            className="relative flex w-fit items-center justify-center self-center"
+            aria-label="Open workspace selector"
           >
-            {isDropdownOpen ? (
-              <ChevronUp className="size-3.5 text-foreground" />
-            ) : (
-              <ChevronDown className="size-3.5 text-foreground" />
-            )}
+            {collapsedThumb}
+            <Button
+              variant="outline"
+              size="icon-4xs"
+              asChild
+              className="pointer-events-none absolute -bottom-1 -right-1 text-foreground-secondary shadow-sm"
+            >
+              <span>{isDropdownOpen ? <ChevronUp /> : <ChevronDown />}</span>
+            </Button>
           </button>
         )}
       </DropdownMenuTrigger>
 
       <DropdownMenuContent
-        className="w-[240px] p-1"
+        className="w-[280px] p-1"
         side="top"
         align="start"
         sideOffset={4}
       >
-        <div className="flex items-center justify-between gap-2 px-3 py-2">
+        <div className="flex h-8 items-center gap-1 px-3">
           <TooltipWrapper content={currentOrganization.name}>
             <span className="comet-body-s-accented min-w-0 flex-1 truncate text-foreground">
               {currentOrganization.name}
             </span>
           </TooltipWrapper>
 
-          <div className="flex shrink-0 items-center gap-1">
-            {isOrgAdmin && (
-              <TooltipWrapper content="Organization settings">
-                <Button
-                  variant="minimal"
-                  size="icon-xs"
-                  onClick={handleOrgSettingsClick}
-                >
-                  <Settings2 className="size-3.5" />
-                </Button>
-              </TooltipWrapper>
-            )}
-
-            {isOrgAdmin && hasMultipleOrganizations && (
-              <Separator orientation="vertical" className="h-3.5" />
-            )}
-
-            {hasMultipleOrganizations && (
-              <DropdownMenuSub
-                open={isOrgSubmenuOpen}
-                onOpenChange={setIsOrgSubmenuOpen}
-              >
-                <DropdownMenuSubTrigger className="size-6 justify-center p-0 text-light-slate [&>svg]:ml-0" />
-                <DropdownMenuPortal>
-                  <DropdownMenuSubContent className="w-[244px] p-1">
-                    <div className="flex items-center gap-1 p-2 pl-8">
-                      <span className="comet-body-s-accented text-foreground">
-                        Switch organization
-                      </span>
-                    </div>
-                    <div className="max-h-[60vh] overflow-auto">
-                      {sortedOrganizations.length > 0 ? (
-                        sortedOrganizations.map((org) => (
-                          <DropdownMenuCheckboxItem
-                            key={org.id}
-                            checked={currentOrganization.id === org.id}
-                            onCheckedChange={() => {
-                              handleChangeOrganization(org);
-                              setIsOrgSubmenuOpen(false);
-                            }}
-                            onSelect={(e) => e.preventDefault()}
-                            className="h-10 cursor-pointer data-[state=checked]:bg-primary-foreground"
-                          >
-                            <TooltipWrapper content={org.name}>
-                              <span className="comet-body-s min-w-0 flex-1 truncate text-left">
-                                {org.name}
-                              </span>
-                            </TooltipWrapper>
-                          </DropdownMenuCheckboxItem>
-                        ))
-                      ) : (
-                        <div className="flex min-h-[120px] flex-col items-center justify-center px-4 py-2 text-center">
-                          <span className="comet-body-s text-muted-slate">
-                            No organizations found
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                  </DropdownMenuSubContent>
-                </DropdownMenuPortal>
-              </DropdownMenuSub>
-            )}
-          </div>
+          {hasMultipleOrganizations && (
+            <DropdownMenuSub
+              open={isOrgSubmenuOpen}
+              onOpenChange={setIsOrgSubmenuOpen}
+            >
+              <DropdownMenuSubTrigger className="size-6 shrink-0 justify-center p-0 text-light-slate [&>svg]:ml-0" />
+              <DropdownMenuPortal>
+                <DropdownMenuSubContent className="w-[280px] p-1">
+                  <div className="flex h-8 items-center px-3">
+                    <span className="comet-body-s-accented text-foreground">
+                      Switch organization
+                    </span>
+                  </div>
+                  <div className="max-h-[60vh] overflow-auto">
+                    {sortedOrganizations.length > 0 ? (
+                      sortedOrganizations.map((org) => (
+                        <DropdownMenuCheckboxItem
+                          key={org.id}
+                          checked={currentOrganization.id === org.id}
+                          onCheckedChange={() => {
+                            handleChangeOrganization(org);
+                            setIsOrgSubmenuOpen(false);
+                          }}
+                          onSelect={(e) => e.preventDefault()}
+                          className="h-8 cursor-pointer data-[state=checked]:bg-primary-100 data-[state=checked]:text-primary"
+                        >
+                          <TooltipWrapper content={org.name}>
+                            <span className="comet-body-s min-w-0 flex-1 truncate text-left">
+                              {org.name}
+                            </span>
+                          </TooltipWrapper>
+                        </DropdownMenuCheckboxItem>
+                      ))
+                    ) : (
+                      <div className="flex min-h-[120px] flex-col items-center justify-center px-4 py-2 text-center">
+                        <span className="comet-body-s text-muted-slate">
+                          No organizations found
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                </DropdownMenuSubContent>
+              </DropdownMenuPortal>
+            </DropdownMenuSub>
+          )}
         </div>
-
-        <DropdownMenuSeparator className="my-1" />
 
         <div className="px-1" onKeyDown={(e) => e.stopPropagation()}>
           <SearchInput
@@ -207,10 +217,9 @@ const SidebarWorkspaceSelector: React.FC<SidebarWorkspaceSelectorProps> = ({
             setSearchText={setSearch}
             placeholder="Search"
             variant="ghost"
+            size="sm"
           />
         </div>
-
-        <DropdownMenuSeparator className="my-1" />
 
         <div className="max-h-[50vh] overflow-auto">
           {sortedWorkspaces.length > 0 ? (
@@ -230,7 +239,7 @@ const SidebarWorkspaceSelector: React.FC<SidebarWorkspaceSelectorProps> = ({
                     setSearch("");
                   }}
                   onSelect={(e) => e.preventDefault()}
-                  className="h-10 cursor-pointer data-[state=checked]:bg-primary-foreground"
+                  className="h-8 cursor-pointer data-[state=checked]:bg-primary-100 data-[state=checked]:text-primary"
                 >
                   <TooltipWrapper content={wsDisplayName}>
                     <span className="comet-body-s min-w-0 flex-1 truncate text-left">
@@ -249,16 +258,15 @@ const SidebarWorkspaceSelector: React.FC<SidebarWorkspaceSelectorProps> = ({
           )}
         </div>
 
-        <DropdownMenuSeparator className="my-1" />
         <Button
           variant="ghost"
           size="sm"
-          className="w-full justify-start gap-1.5 text-primary"
+          className="comet-body-s h-8 w-full justify-start gap-2 px-3 font-normal text-foreground"
           asChild
         >
           <a href={buildUrl("account-settings/workspaces", workspaceName)}>
-            <Settings2 className="size-3.5" />
-            <span className="comet-body-s-accented">Manage workspaces</span>
+            <Settings2 className="size-3.5 text-light-slate" />
+            <span>Manage workspaces</span>
           </a>
         </Button>
       </DropdownMenuContent>

--- a/apps/opik-frontend/src/plugins/comet/SidebarWorkspaceSelector.tsx
+++ b/apps/opik-frontend/src/plugins/comet/SidebarWorkspaceSelector.tsx
@@ -1,23 +1,16 @@
 import React from "react";
 import { Link } from "@tanstack/react-router";
-import { ChevronDown, ChevronUp, Settings2 } from "lucide-react";
+import { ChevronDown, ChevronUp } from "lucide-react";
 
 import { Button } from "@/ui/button";
 import {
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuPortal,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu";
-import SearchInput from "@/shared/SearchInput/SearchInput";
-import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { calculateWorkspaceName, cn } from "@/lib/utils";
 import useWorkspaceSelectorData from "@/plugins/comet/useWorkspaceSelectorData";
-import { buildUrl } from "@/plugins/comet/utils";
+import WorkspaceMenuContent from "@/plugins/comet/WorkspaceMenuContent";
 
 interface SidebarWorkspaceSelectorProps {
   expanded?: boolean;
@@ -157,118 +150,20 @@ const SidebarWorkspaceSelector: React.FC<SidebarWorkspaceSelectorProps> = ({
         align="start"
         sideOffset={4}
       >
-        <div className="flex h-8 items-center gap-1 px-3">
-          <TooltipWrapper content={currentOrganization.name}>
-            <span className="comet-body-s-accented min-w-0 flex-1 truncate text-foreground">
-              {currentOrganization.name}
-            </span>
-          </TooltipWrapper>
-
-          {hasMultipleOrganizations && (
-            <DropdownMenuSub
-              open={isOrgSubmenuOpen}
-              onOpenChange={setIsOrgSubmenuOpen}
-            >
-              <DropdownMenuSubTrigger className="size-6 shrink-0 justify-center p-0 text-light-slate [&>svg]:ml-0" />
-              <DropdownMenuPortal>
-                <DropdownMenuSubContent className="w-[280px] p-1">
-                  <div className="flex h-8 items-center px-3">
-                    <span className="comet-body-s-accented text-foreground">
-                      Switch organization
-                    </span>
-                  </div>
-                  <div className="max-h-[60vh] overflow-auto">
-                    {sortedOrganizations.length > 0 ? (
-                      sortedOrganizations.map((org) => (
-                        <DropdownMenuCheckboxItem
-                          key={org.id}
-                          checked={currentOrganization.id === org.id}
-                          onCheckedChange={() => {
-                            handleChangeOrganization(org);
-                            setIsOrgSubmenuOpen(false);
-                          }}
-                          onSelect={(e) => e.preventDefault()}
-                          className="h-8 cursor-pointer data-[state=checked]:bg-primary-100 data-[state=checked]:text-primary"
-                        >
-                          <TooltipWrapper content={org.name}>
-                            <span className="comet-body-s min-w-0 flex-1 truncate text-left">
-                              {org.name}
-                            </span>
-                          </TooltipWrapper>
-                        </DropdownMenuCheckboxItem>
-                      ))
-                    ) : (
-                      <div className="flex min-h-[120px] flex-col items-center justify-center px-4 py-2 text-center">
-                        <span className="comet-body-s text-muted-slate">
-                          No organizations found
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                </DropdownMenuSubContent>
-              </DropdownMenuPortal>
-            </DropdownMenuSub>
-          )}
-        </div>
-
-        <div className="px-1" onKeyDown={(e) => e.stopPropagation()}>
-          <SearchInput
-            searchText={search}
-            setSearchText={setSearch}
-            placeholder="Search"
-            variant="ghost"
-            size="sm"
-          />
-        </div>
-
-        <div className="max-h-[50vh] overflow-auto">
-          {sortedWorkspaces.length > 0 ? (
-            sortedWorkspaces.map((workspace) => {
-              const wsDisplayName = calculateWorkspaceName(
-                workspace.workspaceName,
-              );
-              const isSelected = workspace.workspaceName === workspaceName;
-
-              return (
-                <DropdownMenuCheckboxItem
-                  key={workspace.workspaceName}
-                  checked={isSelected}
-                  onCheckedChange={() => {
-                    handleChangeWorkspace(workspace);
-                    setIsDropdownOpen(false);
-                    setSearch("");
-                  }}
-                  onSelect={(e) => e.preventDefault()}
-                  className="h-8 cursor-pointer data-[state=checked]:bg-primary-100 data-[state=checked]:text-primary"
-                >
-                  <TooltipWrapper content={wsDisplayName}>
-                    <span className="comet-body-s min-w-0 flex-1 truncate text-left">
-                      {wsDisplayName}
-                    </span>
-                  </TooltipWrapper>
-                </DropdownMenuCheckboxItem>
-              );
-            })
-          ) : (
-            <div className="flex min-h-[120px] flex-col items-center justify-center px-4 py-2 text-center">
-              <span className="comet-body-s text-muted-slate">
-                No workspaces found
-              </span>
-            </div>
-          )}
-        </div>
-
-        <Button
-          variant="ghost"
-          size="sm"
-          className="comet-body-s h-8 w-full justify-start gap-2 px-3 font-normal text-foreground"
-          asChild
-        >
-          <a href={buildUrl("account-settings/workspaces", workspaceName)}>
-            <Settings2 className="size-3.5 text-light-slate" />
-            <span>Manage workspaces</span>
-          </a>
-        </Button>
+        <WorkspaceMenuContent
+          workspaceName={workspaceName}
+          currentOrganization={currentOrganization}
+          sortedWorkspaces={sortedWorkspaces}
+          sortedOrganizations={sortedOrganizations}
+          hasMultipleOrganizations={hasMultipleOrganizations}
+          isOrgSubmenuOpen={isOrgSubmenuOpen}
+          setIsOrgSubmenuOpen={setIsOrgSubmenuOpen}
+          setIsDropdownOpen={setIsDropdownOpen}
+          handleChangeWorkspace={handleChangeWorkspace}
+          handleChangeOrganization={handleChangeOrganization}
+          search={search}
+          setSearch={setSearch}
+        />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/opik-frontend/src/plugins/comet/SidebarWorkspaceSelector.tsx
+++ b/apps/opik-frontend/src/plugins/comet/SidebarWorkspaceSelector.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu";
 import { calculateWorkspaceName, cn } from "@/lib/utils";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import useWorkspaceSelectorData from "@/plugins/comet/useWorkspaceSelectorData";
 import WorkspaceMenuContent from "@/plugins/comet/WorkspaceMenuContent";
 
@@ -101,8 +102,8 @@ const SidebarWorkspaceSelector: React.FC<SidebarWorkspaceSelectorProps> = ({
 
   return (
     <DropdownMenu open={isDropdownOpen} onOpenChange={handleOpenChange}>
-      <DropdownMenuTrigger asChild>
-        {expanded ? (
+      {expanded ? (
+        <DropdownMenuTrigger asChild>
           <button
             className={cn(
               "flex w-full items-center gap-1.5 rounded-md px-1 py-0.5",
@@ -113,7 +114,7 @@ const SidebarWorkspaceSelector: React.FC<SidebarWorkspaceSelectorProps> = ({
           >
             {expandedThumb}
             <div className="flex min-w-0 flex-1 flex-col items-stretch">
-              <span className="flex items-end gap-0.5 text-light-slate">
+              <span className="flex items-center gap-0.5 text-light-slate">
                 <span className="comet-body-xs-accented">Workspace</span>
                 {isDropdownOpen ? (
                   <ChevronUp className="size-3.5" />
@@ -126,23 +127,27 @@ const SidebarWorkspaceSelector: React.FC<SidebarWorkspaceSelectorProps> = ({
               </span>
             </div>
           </button>
-        ) : (
-          <button
-            className="relative flex w-fit items-center justify-center self-center"
-            aria-label="Open workspace selector"
-          >
-            {collapsedThumb}
-            <Button
-              variant="outline"
-              size="icon-4xs"
-              asChild
-              className="pointer-events-none absolute -bottom-1 -right-1 text-foreground-secondary shadow-sm"
+        </DropdownMenuTrigger>
+      ) : (
+        <TooltipWrapper content="Switch workspace" side="right">
+          <DropdownMenuTrigger asChild>
+            <button
+              className="relative flex w-fit items-center justify-center self-center"
+              aria-label="Open workspace selector"
             >
-              <span>{isDropdownOpen ? <ChevronUp /> : <ChevronDown />}</span>
-            </Button>
-          </button>
-        )}
-      </DropdownMenuTrigger>
+              {collapsedThumb}
+              <Button
+                variant="outline"
+                size="icon-4xs"
+                asChild
+                className="pointer-events-none absolute -bottom-1 -right-1 text-foreground-secondary shadow-sm"
+              >
+                <span>{isDropdownOpen ? <ChevronUp /> : <ChevronDown />}</span>
+              </Button>
+            </button>
+          </DropdownMenuTrigger>
+        </TooltipWrapper>
+      )}
 
       <DropdownMenuContent
         className="w-[280px] p-1"

--- a/apps/opik-frontend/src/plugins/comet/WorkspaceMenuContent.tsx
+++ b/apps/opik-frontend/src/plugins/comet/WorkspaceMenuContent.tsx
@@ -90,7 +90,8 @@ const WorkspaceMenuContent: React.FC<WorkspaceMenuContentProps> = ({
                       }}
                       className={cn(
                         "group h-8 cursor-pointer px-3 pr-1.5",
-                        isActive && "bg-primary-100 text-primary",
+                        isActive &&
+                          "bg-primary-100 text-primary focus:bg-secondary focus:text-primary",
                       )}
                     >
                       <TooltipWrapper content={org.name}>
@@ -160,7 +161,7 @@ const WorkspaceMenuContent: React.FC<WorkspaceMenuContentProps> = ({
 
     <DropdownMenuSeparator className="my-1" />
 
-    <div className="px-1" onKeyDown={(e) => e.stopPropagation()}>
+    <div className="px-0.5" onKeyDown={(e) => e.stopPropagation()}>
       <SearchInput
         searchText={search}
         setSearchText={setSearch}
@@ -189,7 +190,8 @@ const WorkspaceMenuContent: React.FC<WorkspaceMenuContentProps> = ({
               }}
               className={cn(
                 "h-8 cursor-pointer px-3",
-                isSelected && "bg-primary-100 text-primary",
+                isSelected &&
+                  "bg-primary-100 text-primary focus:bg-secondary focus:text-primary",
               )}
             >
               <TooltipWrapper content={wsDisplayName}>
@@ -211,17 +213,13 @@ const WorkspaceMenuContent: React.FC<WorkspaceMenuContentProps> = ({
 
     <DropdownMenuSeparator className="my-1" />
 
-    <Button
-      variant="ghost"
-      size="sm"
-      className="comet-body-s h-8 w-full justify-start gap-2 px-3 font-normal text-foreground"
-      asChild
+    <a
+      href={buildUrl("account-settings/workspaces", workspaceName)}
+      className="comet-body-s flex h-8 w-full items-center gap-2 rounded-md px-3 text-foreground hover:bg-primary-foreground"
     >
-      <a href={buildUrl("account-settings/workspaces", workspaceName)}>
-        <Settings2 className="size-3.5 text-light-slate" />
-        <span>Manage workspaces</span>
-      </a>
-    </Button>
+      <Settings2 className="size-3.5 text-light-slate" />
+      <span>Manage workspaces</span>
+    </a>
   </>
 );
 

--- a/apps/opik-frontend/src/plugins/comet/WorkspaceMenuContent.tsx
+++ b/apps/opik-frontend/src/plugins/comet/WorkspaceMenuContent.tsx
@@ -4,12 +4,14 @@ import { Settings2 } from "lucide-react";
 import { Button } from "@/ui/button";
 import {
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuPortal,
   DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
 } from "@/ui/dropdown-menu";
+import { ListAction } from "@/ui/list-action";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { calculateWorkspaceName, cn } from "@/lib/utils";
@@ -61,7 +63,11 @@ const WorkspaceMenuContent: React.FC<WorkspaceMenuContentProps> = ({
         open={isOrgSubmenuOpen}
         onOpenChange={setIsOrgSubmenuOpen}
       >
-        <DropdownMenuSubTrigger className="comet-body-s-accented h-8 cursor-pointer px-3 text-foreground data-[state=open]:bg-primary-foreground [&>svg]:size-3.5 [&>svg]:text-light-slate">
+        <DropdownMenuSubTrigger
+          variant="menu"
+          size="sm"
+          className="cursor-pointer"
+        >
           <TooltipWrapper content={currentOrganization.name}>
             <span className="min-w-0 flex-1 truncate text-left">
               {currentOrganization.name}
@@ -70,11 +76,7 @@ const WorkspaceMenuContent: React.FC<WorkspaceMenuContentProps> = ({
         </DropdownMenuSubTrigger>
         <DropdownMenuPortal>
           <DropdownMenuSubContent className="w-[280px] p-1" sideOffset={8}>
-            <div className="flex h-8 items-center px-3">
-              <span className="comet-body-s-accented text-foreground">
-                Organizations
-              </span>
-            </div>
+            <DropdownMenuLabel size="sm">Organizations</DropdownMenuLabel>
             <DropdownMenuSeparator className="my-1" />
             <div className="max-h-[60vh] overflow-auto">
               {sortedOrganizations.length > 0 ? (
@@ -83,16 +85,14 @@ const WorkspaceMenuContent: React.FC<WorkspaceMenuContentProps> = ({
                   return (
                     <DropdownMenuItem
                       key={org.id}
+                      size="sm"
+                      selected={isActive}
                       onSelect={(e) => {
                         e.preventDefault();
                         handleChangeOrganization(org);
                         setIsOrgSubmenuOpen(false);
                       }}
-                      className={cn(
-                        "group h-8 cursor-pointer px-3 pr-1.5",
-                        isActive &&
-                          "bg-primary-100 text-primary focus:bg-secondary focus:text-primary",
-                      )}
+                      className="group pr-1.5"
                     >
                       <TooltipWrapper content={org.name}>
                         <span className="comet-body-s min-w-0 flex-1 truncate text-left">
@@ -182,17 +182,14 @@ const WorkspaceMenuContent: React.FC<WorkspaceMenuContentProps> = ({
           return (
             <DropdownMenuItem
               key={workspace.workspaceName}
+              size="sm"
+              selected={isSelected}
               onSelect={(e) => {
                 e.preventDefault();
                 handleChangeWorkspace(workspace);
                 setIsDropdownOpen(false);
                 setSearch("");
               }}
-              className={cn(
-                "h-8 cursor-pointer px-3",
-                isSelected &&
-                  "bg-primary-100 text-primary focus:bg-secondary focus:text-primary",
-              )}
             >
               <TooltipWrapper content={wsDisplayName}>
                 <span className="comet-body-s min-w-0 flex-1 truncate text-left">
@@ -213,13 +210,12 @@ const WorkspaceMenuContent: React.FC<WorkspaceMenuContentProps> = ({
 
     <DropdownMenuSeparator className="my-1" />
 
-    <a
-      href={buildUrl("account-settings/workspaces", workspaceName)}
-      className="comet-body-s flex h-8 w-full items-center gap-2 rounded-md px-3 text-foreground hover:bg-primary-foreground"
-    >
-      <Settings2 className="size-3.5 text-light-slate" />
-      <span>Manage workspaces</span>
-    </a>
+    <ListAction variant="default" size="sm" asChild>
+      <a href={buildUrl("account-settings/workspaces", workspaceName)}>
+        <Settings2 className="size-3.5 text-light-slate" />
+        <span>Manage workspaces</span>
+      </a>
+    </ListAction>
   </>
 );
 

--- a/apps/opik-frontend/src/plugins/comet/WorkspaceMenuContent.tsx
+++ b/apps/opik-frontend/src/plugins/comet/WorkspaceMenuContent.tsx
@@ -1,0 +1,228 @@
+import React from "react";
+import { Settings2 } from "lucide-react";
+
+import { Button } from "@/ui/button";
+import {
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from "@/ui/dropdown-menu";
+import SearchInput from "@/shared/SearchInput/SearchInput";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import { calculateWorkspaceName, cn } from "@/lib/utils";
+import {
+  Organization,
+  ORGANIZATION_ROLE_TYPE,
+  Workspace,
+} from "@/plugins/comet/types";
+import { buildUrl } from "@/plugins/comet/utils";
+
+const canManageOrg = (org: Organization) =>
+  org.role === ORGANIZATION_ROLE_TYPE.admin;
+
+const orgSettingsUrl = (orgId: string, workspaceName: string) =>
+  buildUrl(`organizations/${orgId}`, workspaceName);
+
+interface WorkspaceMenuContentProps {
+  workspaceName: string;
+  currentOrganization: Organization;
+  sortedWorkspaces: Workspace[];
+  sortedOrganizations: Organization[];
+  hasMultipleOrganizations: boolean | undefined;
+  isOrgSubmenuOpen: boolean;
+  setIsOrgSubmenuOpen: (open: boolean) => void;
+  setIsDropdownOpen: (open: boolean) => void;
+  handleChangeWorkspace: (workspace: Workspace) => void;
+  handleChangeOrganization: (org: Organization) => void;
+  search: string;
+  setSearch: (value: string) => void;
+}
+
+const WorkspaceMenuContent: React.FC<WorkspaceMenuContentProps> = ({
+  workspaceName,
+  currentOrganization,
+  sortedWorkspaces,
+  sortedOrganizations,
+  hasMultipleOrganizations,
+  isOrgSubmenuOpen,
+  setIsOrgSubmenuOpen,
+  setIsDropdownOpen,
+  handleChangeWorkspace,
+  handleChangeOrganization,
+  search,
+  setSearch,
+}) => (
+  <>
+    {hasMultipleOrganizations ? (
+      <DropdownMenuSub
+        open={isOrgSubmenuOpen}
+        onOpenChange={setIsOrgSubmenuOpen}
+      >
+        <DropdownMenuSubTrigger className="comet-body-s-accented h-8 cursor-pointer px-3 text-foreground data-[state=open]:bg-primary-foreground [&>svg]:size-3.5 [&>svg]:text-light-slate">
+          <TooltipWrapper content={currentOrganization.name}>
+            <span className="min-w-0 flex-1 truncate text-left">
+              {currentOrganization.name}
+            </span>
+          </TooltipWrapper>
+        </DropdownMenuSubTrigger>
+        <DropdownMenuPortal>
+          <DropdownMenuSubContent className="w-[280px] p-1" sideOffset={8}>
+            <div className="flex h-8 items-center px-3">
+              <span className="comet-body-s-accented text-foreground">
+                Organizations
+              </span>
+            </div>
+            <DropdownMenuSeparator className="my-1" />
+            <div className="max-h-[60vh] overflow-auto">
+              {sortedOrganizations.length > 0 ? (
+                sortedOrganizations.map((org) => {
+                  const isActive = currentOrganization.id === org.id;
+                  return (
+                    <DropdownMenuItem
+                      key={org.id}
+                      onSelect={(e) => {
+                        e.preventDefault();
+                        handleChangeOrganization(org);
+                        setIsOrgSubmenuOpen(false);
+                      }}
+                      className={cn(
+                        "group h-8 cursor-pointer px-3 pr-1.5",
+                        isActive && "bg-primary-100 text-primary",
+                      )}
+                    >
+                      <TooltipWrapper content={org.name}>
+                        <span className="comet-body-s min-w-0 flex-1 truncate text-left">
+                          {org.name}
+                        </span>
+                      </TooltipWrapper>
+                      {canManageOrg(org) && (
+                        <Button
+                          variant="minimal"
+                          size="icon-2xs"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            window.location.href = orgSettingsUrl(
+                              org.id,
+                              workspaceName,
+                            );
+                          }}
+                          aria-label={`Open ${org.name} settings`}
+                          className={cn(
+                            "shrink-0 text-light-slate hover:text-foreground",
+                            !isActive && "invisible group-hover:visible",
+                          )}
+                        >
+                          <Settings2 className="size-3.5" />
+                        </Button>
+                      )}
+                    </DropdownMenuItem>
+                  );
+                })
+              ) : (
+                <div className="flex min-h-[120px] flex-col items-center justify-center px-4 py-2 text-center">
+                  <span className="comet-body-s text-muted-slate">
+                    No organizations found
+                  </span>
+                </div>
+              )}
+            </div>
+          </DropdownMenuSubContent>
+        </DropdownMenuPortal>
+      </DropdownMenuSub>
+    ) : (
+      <div className="flex h-8 items-center gap-1.5 px-3 pr-1.5">
+        <TooltipWrapper content={currentOrganization.name}>
+          <span className="comet-body-s-accented min-w-0 flex-1 truncate text-foreground">
+            {currentOrganization.name}
+          </span>
+        </TooltipWrapper>
+        {canManageOrg(currentOrganization) && (
+          <Button
+            variant="minimal"
+            size="icon-2xs"
+            onClick={() => {
+              window.location.href = orgSettingsUrl(
+                currentOrganization.id,
+                workspaceName,
+              );
+            }}
+            aria-label={`Open ${currentOrganization.name} settings`}
+            className="shrink-0 text-light-slate hover:text-foreground"
+          >
+            <Settings2 className="size-3.5" />
+          </Button>
+        )}
+      </div>
+    )}
+
+    <DropdownMenuSeparator className="my-1" />
+
+    <div className="px-1" onKeyDown={(e) => e.stopPropagation()}>
+      <SearchInput
+        searchText={search}
+        setSearchText={setSearch}
+        placeholder="Search"
+        variant="ghost"
+        size="sm"
+      />
+    </div>
+
+    <DropdownMenuSeparator className="my-1" />
+
+    <div className="max-h-[50vh] overflow-auto">
+      {sortedWorkspaces.length > 0 ? (
+        sortedWorkspaces.map((workspace) => {
+          const wsDisplayName = calculateWorkspaceName(workspace.workspaceName);
+          const isSelected = workspace.workspaceName === workspaceName;
+
+          return (
+            <DropdownMenuItem
+              key={workspace.workspaceName}
+              onSelect={(e) => {
+                e.preventDefault();
+                handleChangeWorkspace(workspace);
+                setIsDropdownOpen(false);
+                setSearch("");
+              }}
+              className={cn(
+                "h-8 cursor-pointer px-3",
+                isSelected && "bg-primary-100 text-primary",
+              )}
+            >
+              <TooltipWrapper content={wsDisplayName}>
+                <span className="comet-body-s min-w-0 flex-1 truncate text-left">
+                  {wsDisplayName}
+                </span>
+              </TooltipWrapper>
+            </DropdownMenuItem>
+          );
+        })
+      ) : (
+        <div className="flex min-h-[120px] flex-col items-center justify-center px-4 py-2 text-center">
+          <span className="comet-body-s text-muted-slate">
+            No workspaces found
+          </span>
+        </div>
+      )}
+    </div>
+
+    <DropdownMenuSeparator className="my-1" />
+
+    <Button
+      variant="ghost"
+      size="sm"
+      className="comet-body-s h-8 w-full justify-start gap-2 px-3 font-normal text-foreground"
+      asChild
+    >
+      <a href={buildUrl("account-settings/workspaces", workspaceName)}>
+        <Settings2 className="size-3.5 text-light-slate" />
+        <span>Manage workspaces</span>
+      </a>
+    </Button>
+  </>
+);
+
+export default WorkspaceMenuContent;

--- a/apps/opik-frontend/src/plugins/comet/WorkspaceSelector.tsx
+++ b/apps/opik-frontend/src/plugins/comet/WorkspaceSelector.tsx
@@ -1,53 +1,15 @@
 import React from "react";
 import { Link } from "@tanstack/react-router";
-import { ChevronDown, ChevronUp, Settings2 } from "lucide-react";
+import { ChevronDown, ChevronUp } from "lucide-react";
 
-import { Button } from "@/ui/button";
 import {
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuPortal,
-  DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu";
-import { ListAction } from "@/ui/list-action";
-import { Separator } from "@/ui/separator";
-import SearchInput from "@/shared/SearchInput/SearchInput";
-import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import { calculateWorkspaceName, cn } from "@/lib/utils";
+import { calculateWorkspaceName } from "@/lib/utils";
 import useWorkspaceSelectorData from "@/plugins/comet/useWorkspaceSelectorData";
-import { buildUrl } from "@/plugins/comet/utils";
-
-type WorkspaceLinkProps = {
-  workspaceName: string;
-  children?: React.ReactNode;
-  className?: string;
-};
-
-const WorkspaceLink: React.FC<WorkspaceLinkProps> = ({
-  workspaceName,
-  className,
-  children,
-}) => {
-  const displayName = calculateWorkspaceName(workspaceName);
-
-  return (
-    <div className={cn("flex h-8 items-center", className)}>
-      <Link
-        to="/$workspaceName/home"
-        params={{ workspaceName }}
-        className="comet-body-s min-w-0 flex-1 truncate text-left hover:underline"
-      >
-        {displayName}
-      </Link>
-      {children}
-    </div>
-  );
-};
+import WorkspaceMenuContent from "@/plugins/comet/WorkspaceMenuContent";
 
 const WorkspaceSelector: React.FC = () => {
   const {
@@ -66,15 +28,15 @@ const WorkspaceSelector: React.FC = () => {
     handleOpenChange,
     handleChangeWorkspace,
     handleChangeOrganization,
-    handleOrgSettingsClick,
 
     sortedWorkspaces,
     sortedOrganizations,
 
     shouldShowDropdown,
     hasMultipleOrganizations,
-    isOrgAdmin,
   } = useWorkspaceSelectorData();
+
+  const displayName = calculateWorkspaceName(workspaceName);
 
   if (isLoading) {
     return (
@@ -85,154 +47,52 @@ const WorkspaceSelector: React.FC = () => {
   }
 
   if (!user?.loggedIn || !currentOrganization || !shouldShowDropdown) {
-    return <WorkspaceLink workspaceName={workspaceName} />;
+    return (
+      <Link
+        to="/$workspaceName/home"
+        params={{ workspaceName }}
+        className="comet-body-xs truncate p-1.5 transition-colors hover:text-foreground"
+      >
+        {displayName}
+      </Link>
+    );
   }
 
   return (
-    <WorkspaceLink className="gap-0.5" workspaceName={workspaceName}>
-      <DropdownMenu open={isDropdownOpen} onOpenChange={handleOpenChange}>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon-2xs"
-            className="shrink-0 border border-transparent text-muted-slate hover:bg-primary-foreground hover:text-muted-slate focus-visible:ring-0 focus-visible:ring-offset-0"
-          >
-            {isDropdownOpen ? <ChevronUp /> : <ChevronDown />}
-          </Button>
-        </DropdownMenuTrigger>
-
-        <DropdownMenuContent className="w-[320px] p-1" align="start">
-          <div className="flex items-center justify-between gap-2 px-3 py-2">
-            <TooltipWrapper content={currentOrganization.name}>
-              <span className="comet-body-s-accented min-w-0 flex-1 truncate text-foreground">
-                {currentOrganization.name}
-              </span>
-            </TooltipWrapper>
-
-            <div className="flex shrink-0 items-center gap-1">
-              {isOrgAdmin && (
-                <TooltipWrapper content="Organization settings">
-                  <Button
-                    variant="minimal"
-                    size="icon-xs"
-                    onClick={handleOrgSettingsClick}
-                  >
-                    <Settings2 className="size-3.5" />
-                  </Button>
-                </TooltipWrapper>
-              )}
-
-              {isOrgAdmin && hasMultipleOrganizations && (
-                <Separator orientation="vertical" className="h-3.5" />
-              )}
-
-              {hasMultipleOrganizations && (
-                <DropdownMenuSub
-                  open={isOrgSubmenuOpen}
-                  onOpenChange={setIsOrgSubmenuOpen}
-                >
-                  <DropdownMenuSubTrigger className="size-6 justify-center p-0 text-light-slate [&>svg]:ml-0" />
-                  <DropdownMenuPortal>
-                    <DropdownMenuSubContent className="w-[244px] p-1">
-                      <div className="flex items-center gap-1 p-2 pl-8">
-                        <span className="comet-body-s-accented text-foreground">
-                          Switch organization
-                        </span>
-                      </div>
-                      <div className="max-h-[60vh] overflow-auto">
-                        {sortedOrganizations.length > 0 ? (
-                          sortedOrganizations.map((org) => (
-                            <DropdownMenuCheckboxItem
-                              key={org.id}
-                              checked={currentOrganization.id === org.id}
-                              onCheckedChange={() => {
-                                handleChangeOrganization(org);
-                                setIsOrgSubmenuOpen(false);
-                              }}
-                              onSelect={(e) => e.preventDefault()}
-                              className="h-10 cursor-pointer data-[state=checked]:bg-primary-foreground"
-                            >
-                              <TooltipWrapper content={org.name}>
-                                <span className="comet-body-s min-w-0 flex-1 truncate text-left">
-                                  {org.name}
-                                </span>
-                              </TooltipWrapper>
-                            </DropdownMenuCheckboxItem>
-                          ))
-                        ) : (
-                          <div className="flex min-h-[120px] flex-col items-center justify-center px-4 py-2 text-center">
-                            <span className="comet-body-s text-muted-slate">
-                              No organizations found
-                            </span>
-                          </div>
-                        )}
-                      </div>
-                    </DropdownMenuSubContent>
-                  </DropdownMenuPortal>
-                </DropdownMenuSub>
-              )}
-            </div>
-          </div>
-
-          <DropdownMenuSeparator className="my-1" />
-
-          <div className="px-1" onKeyDown={(e) => e.stopPropagation()}>
-            <SearchInput
-              searchText={search}
-              setSearchText={setSearch}
-              placeholder="Search"
-              variant="ghost"
-            />
-          </div>
-
-          <DropdownMenuSeparator className="my-1" />
-
-          <div className="max-h-[50vh] overflow-auto">
-            {sortedWorkspaces.length > 0 ? (
-              sortedWorkspaces.map((workspace) => {
-                const displayName = calculateWorkspaceName(
-                  workspace.workspaceName,
-                );
-                const isSelected = workspace.workspaceName === workspaceName;
-
-                return (
-                  <DropdownMenuCheckboxItem
-                    key={workspace.workspaceName}
-                    checked={isSelected}
-                    onCheckedChange={() => {
-                      handleChangeWorkspace(workspace);
-                      setIsDropdownOpen(false);
-                      setSearch("");
-                    }}
-                    onSelect={(e) => e.preventDefault()}
-                    className="h-10 cursor-pointer data-[state=checked]:bg-primary-foreground"
-                  >
-                    <TooltipWrapper content={displayName}>
-                      <span className="comet-body-s min-w-0 flex-1 truncate text-left">
-                        {displayName}
-                      </span>
-                    </TooltipWrapper>
-                  </DropdownMenuCheckboxItem>
-                );
-              })
+    <DropdownMenu open={isDropdownOpen} onOpenChange={handleOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="comet-body-xs flex items-center gap-1 truncate rounded p-1.5 text-muted-slate transition-colors hover:text-foreground data-[state=open]:text-foreground"
+        >
+          <span className="truncate">{displayName}</span>
+          <span className="shrink-0">
+            {isDropdownOpen ? (
+              <ChevronUp className="size-3.5" />
             ) : (
-              <div className="flex min-h-[120px] flex-col items-center justify-center px-4 py-2 text-center">
-                <span className="comet-body-s text-muted-slate">
-                  No workspaces found
-                </span>
-              </div>
+              <ChevronDown className="size-3.5" />
             )}
-          </div>
+          </span>
+        </button>
+      </DropdownMenuTrigger>
 
-          <DropdownMenuSeparator className="my-1" />
-          <ListAction asChild>
-            <a href={buildUrl("account-settings/workspaces", workspaceName)}>
-              Manage workspaces
-            </a>
-          </ListAction>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </WorkspaceLink>
+      <DropdownMenuContent className="w-[280px] p-1" align="start">
+        <WorkspaceMenuContent
+          workspaceName={workspaceName}
+          currentOrganization={currentOrganization}
+          sortedWorkspaces={sortedWorkspaces}
+          sortedOrganizations={sortedOrganizations}
+          hasMultipleOrganizations={hasMultipleOrganizations}
+          isOrgSubmenuOpen={isOrgSubmenuOpen}
+          setIsOrgSubmenuOpen={setIsOrgSubmenuOpen}
+          setIsDropdownOpen={setIsDropdownOpen}
+          handleChangeWorkspace={handleChangeWorkspace}
+          handleChangeOrganization={handleChangeOrganization}
+          search={search}
+          setSearch={setSearch}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };
 

--- a/apps/opik-frontend/src/shared/AudioPlayer/AudioPlayer.tsx
+++ b/apps/opik-frontend/src/shared/AudioPlayer/AudioPlayer.tsx
@@ -29,7 +29,7 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({ url, name, className }) => {
     >
       {/* Header: Filename and Duration */}
       <div className="mb-1 flex items-center justify-between">
-        <span className="truncate text-xs" style={{ color: "#45575F" }}>
+        <span className="truncate text-xs text-chart-gray-dark">
           {name || "Audio"}
         </span>
         {hasError ? (

--- a/apps/opik-frontend/src/shared/SearchInput/SearchInput.tsx
+++ b/apps/opik-frontend/src/shared/SearchInput/SearchInput.tsx
@@ -32,7 +32,7 @@ export const SearchInput = ({
   return (
     <div className={cn("relative w-full", className)}>
       <div className="absolute left-2.5 top-1/2 -translate-y-1/2">
-        <Search className="size-3.5 text-muted-slate" />
+        <Search className="size-3.5 text-light-slate" />
       </div>
       <DebounceInput
         className={cn("px-8", size === "sm" && "h-8")}

--- a/apps/opik-frontend/src/shared/attachments/AttachmentThumbnail/AttachmentThumbnail.tsx
+++ b/apps/opik-frontend/src/shared/attachments/AttachmentThumbnail/AttachmentThumbnail.tsx
@@ -52,7 +52,9 @@ const AttachmentThumbnail: React.FC<AttachmentThumbnailProps> = ({
     >
       <div className="absolute inset-x-0 top-0 flex h-8 items-center justify-between gap-2 truncate px-3 py-2">
         <TooltipWrapper content={name}>
-          <span className="comet-body-xs truncate text-[#45575F]">{name}</span>
+          <span className="comet-body-xs truncate text-chart-gray-dark">
+            {name}
+          </span>
         </TooltipWrapper>
         <div className="-mr-1 hidden shrink-0 items-center gap-1 group-hover:flex">
           {isExpandable && (

--- a/apps/opik-frontend/src/ui/breadcrumb.tsx
+++ b/apps/opik-frontend/src/ui/breadcrumb.tsx
@@ -19,7 +19,7 @@ const BreadcrumbList = React.forwardRef<
   <ol
     ref={ref}
     className={cn(
-      "comet-body-s flex items-center break-words text-muted-slate",
+      "comet-body-xs flex items-center break-words text-muted-slate",
       className,
     )}
     {...props}
@@ -34,7 +34,7 @@ const BreadcrumbItem = React.forwardRef<
   <li
     ref={ref}
     className={cn(
-      "inline-flex items-center gap-1.5 last:text-[hsl(var(--breadcrumb-last))] last:font-medium p-1.5 truncate",
+      "inline-flex items-center gap-1.5 truncate p-1.5 last:text-foreground",
       className,
     )}
     {...props}
@@ -54,7 +54,7 @@ const BreadcrumbLink = React.forwardRef<
     <Comp
       ref={ref}
       className={cn(
-        "transition-colors hover:underline truncate break-words",
+        "truncate break-words transition-colors hover:text-foreground",
         className,
       )}
       {...props}
@@ -86,7 +86,7 @@ const BreadcrumbSeparator = ({
   <li
     role="presentation"
     aria-hidden="true"
-    className={cn("text-muted-gray", className)}
+    className={cn("text-muted-slate", className)}
     {...props}
   >
     {children ?? "/"}

--- a/apps/opik-frontend/src/ui/button.tsx
+++ b/apps/opik-frontend/src/ui/button.tsx
@@ -42,6 +42,7 @@ const buttonVariants = cva(
         "icon-xs": "size-7 [&>svg]:size-3.5 [&>svg]:shrink-0",
         "icon-2xs": "size-6 [&>svg]:size-3 [&>svg]:shrink-0",
         "icon-3xs": "size-4 [&>svg]:size-3 [&>svg]:shrink-0",
+        "icon-4xs": "size-3.5 rounded [&>svg]:size-2.5 [&>svg]:shrink-0",
       },
     },
     defaultVariants: {

--- a/apps/opik-frontend/src/ui/dropdown-menu.tsx
+++ b/apps/opik-frontend/src/ui/dropdown-menu.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 import { usePortalContainer } from "@/lib/portal-container";
 
 const dropdownMenuItemVariants = cva(
-  "comet-body-s relative flex cursor-pointer select-none items-center outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:bg-muted-disabled data-[disabled]:text-muted-gray data-[selected]:bg-primary-100 data-[selected]:text-primary data-[selected]:focus:bg-secondary data-[selected]:focus:text-primary",
+  "comet-body-s relative flex cursor-pointer select-none items-center outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:bg-muted-disabled data-[selected]:bg-primary-100 data-[disabled]:text-muted-gray data-[selected]:text-primary data-[selected]:focus:bg-secondary data-[selected]:focus:text-primary",
   {
     variants: {
       variant: {

--- a/apps/opik-frontend/src/ui/dropdown-menu.tsx
+++ b/apps/opik-frontend/src/ui/dropdown-menu.tsx
@@ -1,10 +1,64 @@
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { cva, type VariantProps } from "class-variance-authority";
 import { Check, ChevronRight, Circle } from "lucide-react";
 
 import { Checkbox } from "@/ui/checkbox";
 import { cn } from "@/lib/utils";
 import { usePortalContainer } from "@/lib/portal-container";
+
+const dropdownMenuItemVariants = cva(
+  "comet-body-s relative flex cursor-pointer select-none items-center outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:bg-muted-disabled data-[disabled]:text-muted-gray data-[selected]:bg-primary-100 data-[selected]:text-primary data-[selected]:focus:bg-secondary data-[selected]:focus:text-primary",
+  {
+    variants: {
+      variant: {
+        default: "focus:bg-primary-foreground focus:text-foreground",
+        destructive:
+          "text-destructive focus:bg-destructive/10 focus:text-destructive",
+      },
+      size: {
+        default: "rounded-sm px-4 py-2",
+        sm: "h-8 rounded-md px-3",
+      },
+    },
+    defaultVariants: { variant: "default", size: "default" },
+  },
+);
+
+type DropdownMenuItemVariants = VariantProps<typeof dropdownMenuItemVariants>;
+
+const dropdownMenuLabelVariants = cva("comet-body-s-accented", {
+  variants: {
+    size: {
+      default: "min-h-10 px-4 py-2.5",
+      sm: "flex h-8 items-center px-3",
+    },
+  },
+  defaultVariants: { size: "default" },
+});
+
+type DropdownMenuLabelVariants = VariantProps<typeof dropdownMenuLabelVariants>;
+
+const dropdownMenuSubTriggerVariants = cva(
+  "flex cursor-default select-none items-center outline-none focus:bg-primary-foreground data-[state=open]:bg-primary-foreground",
+  {
+    variants: {
+      variant: {
+        default: "text-sm",
+        menu: "comet-body-s-accented text-foreground [&>svg]:size-3.5 [&>svg]:text-light-slate",
+      },
+      size: {
+        default: "rounded-sm px-4 py-2",
+        sm: "h-8 rounded-md px-3",
+      },
+    },
+    defaultVariants: { variant: "default", size: "default" },
+  },
+);
+
+type DropdownMenuSubTriggerVariants = VariantProps<
+  typeof dropdownMenuSubTriggerVariants
+>;
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 
@@ -29,14 +83,15 @@ const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
 const DropdownMenuSubTrigger = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-    inset?: boolean;
-  }
->(({ className, inset, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> &
+    DropdownMenuSubTriggerVariants & {
+      inset?: boolean;
+    }
+>(({ className, inset, variant, size, children, ...props }, ref) => (
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-4 py-2 text-sm outline-none focus:bg-primary-foreground data-[state=open]:bg-primary-foreground",
+      dropdownMenuSubTriggerVariants({ variant, size }),
       inset && "pl-8",
       className,
     )}
@@ -93,18 +148,17 @@ DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-    inset?: boolean;
-    variant?: "default" | "destructive";
-  }
->(({ className, inset, variant = "default", ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> &
+    DropdownMenuItemVariants & {
+      inset?: boolean;
+      selected?: boolean;
+    }
+>(({ className, inset, variant, size, selected, ...props }, ref) => (
   <DropdownMenuPrimitive.Item
     ref={ref}
+    data-selected={selected ? "" : undefined}
     className={cn(
-      "comet-body-s relative flex cursor-pointer select-none items-center rounded-sm px-4 py-2 outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:bg-muted-disabled data-[disabled]:text-muted-gray",
-      variant === "destructive"
-        ? "text-destructive focus:bg-destructive/10 focus:text-destructive"
-        : "focus:bg-primary-foreground focus:text-foreground",
+      dropdownMenuItemVariants({ variant, size }),
       inset && "pl-8",
       className,
     )}
@@ -183,14 +237,15 @@ DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
 
 const DropdownMenuLabel = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
-    inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> &
+    DropdownMenuLabelVariants & {
+      inset?: boolean;
+    }
+>(({ className, inset, size, ...props }, ref) => (
   <DropdownMenuPrimitive.Label
     ref={ref}
     className={cn(
-      "comet-body-s-accented min-h-10 px-4 py-2.5",
+      dropdownMenuLabelVariants({ size }),
       inset && "pl-8",
       className,
     )}

--- a/apps/opik-frontend/src/ui/list-action.tsx
+++ b/apps/opik-frontend/src/ui/list-action.tsx
@@ -1,23 +1,39 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
+const listActionVariants = cva(
+  "flex w-full cursor-pointer items-center gap-2 rounded transition-colors hover:bg-primary-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        primary: "comet-body-s-accented text-primary",
+        default: "comet-body-s text-foreground",
+      },
+      size: {
+        default: "h-10 px-4",
+        sm: "h-8 px-3",
+      },
+    },
+    defaultVariants: { variant: "primary", size: "default" },
+  },
+);
+
 interface ListActionProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof listActionVariants> {
   asChild?: boolean;
 }
 
 const ListAction = React.forwardRef<HTMLButtonElement, ListActionProps>(
-  ({ className, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
     return (
       <Comp
         ref={ref}
         type={asChild ? undefined : "button"}
-        className={cn(
-          "comet-body-s-accented flex h-10 w-full cursor-pointer items-center gap-2 rounded px-4 text-primary hover:bg-primary-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
-          className,
-        )}
+        className={cn(listActionVariants({ variant, size }), className)}
         {...props}
       />
     );
@@ -25,4 +41,4 @@ const ListAction = React.forwardRef<HTMLButtonElement, ListActionProps>(
 );
 ListAction.displayName = "ListAction";
 
-export { ListAction };
+export { ListAction, listActionVariants };

--- a/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
+++ b/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
@@ -112,7 +112,7 @@ const PageLayout = () => {
       style={
         {
           "--banner-height": `${bannerHeight}px`,
-          "--sidebar-width": expanded ? "240px" : "54px",
+          "--sidebar-width": expanded ? "240px" : "48px",
           "--assistant-sidebar-width": layoutAssistantWidth,
         } as React.CSSProperties
       }

--- a/apps/opik-frontend/src/v2/layout/SideBar/BackToProjectButton.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/BackToProjectButton.tsx
@@ -46,8 +46,8 @@ const BackToProjectButton: React.FC<BackToProjectButtonProps> = ({
   const button = expanded ? (
     <Button
       variant="outline"
-      size="xs"
-      className="w-full justify-start gap-1"
+      size="2xs"
+      className="comet-body-xs-accented w-fit max-w-full gap-1 rounded px-1.5"
       onClick={handleClick}
       disabled={!hasActiveProject}
     >
@@ -57,7 +57,8 @@ const BackToProjectButton: React.FC<BackToProjectButtonProps> = ({
   ) : (
     <Button
       variant="outline"
-      size="icon-xs"
+      size="icon-2xs"
+      className="rounded"
       onClick={handleClick}
       disabled={!hasActiveProject}
     >
@@ -73,7 +74,7 @@ const BackToProjectButton: React.FC<BackToProjectButtonProps> = ({
     <TooltipWrapper content={tooltipContent} side="right" delayDuration={0}>
       {/* span wrapper lets the tooltip receive hover events even when the
           button inside is disabled */}
-      <span className={expanded ? "block" : "inline-block"}>{button}</span>
+      <span className="inline-block max-w-full">{button}</span>
     </TooltipWrapper>
   );
 };

--- a/apps/opik-frontend/src/v2/layout/SideBar/GitHubStarListItem/GitHubStarListItem.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/GitHubStarListItem/GitHubStarListItem.tsx
@@ -41,7 +41,7 @@ const GitHubStarListItem: React.FC<GitHubStarListItemProps> = ({
           {expanded && (
             <>
               <span className="comet-body-xs-accented">Star</span>
-              <span className="rounded bg-[#EBF2F5] px-1 text-[10px] font-medium leading-4 text-[#45575F] dark:bg-secondary dark:text-foreground">
+              <span className="rounded bg-chart-gray-light px-1 text-[10px] font-medium leading-4 text-chart-gray-dark">
                 {starCount}
               </span>
             </>

--- a/apps/opik-frontend/src/v2/layout/SideBar/GitHubStarListItem/GitHubStarListItem.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/GitHubStarListItem/GitHubStarListItem.tsx
@@ -22,12 +22,12 @@ const GitHubStarListItem: React.FC<GitHubStarListItemProps> = ({
   }, [data?.stargazers_count]);
 
   const itemElement = (
-    <li className="mb-2">
+    <li className="mb-2 pl-0.5">
       <Button
         variant="outline"
         size="sm"
         className={cn(
-          expanded ? "ml-0.5 h-8 gap-1.5 px-2" : "size-8 p-0 max-w-full",
+          expanded ? "h-6 gap-1 pl-1.5 pr-1" : "size-6 p-0 max-w-full",
           "dark:bg-primary-foreground",
         )}
         asChild
@@ -37,11 +37,11 @@ const GitHubStarListItem: React.FC<GitHubStarListItemProps> = ({
           target="_blank"
           rel="noreferrer"
         >
-          <GitHubIcon className="size-3.5" />
+          <GitHubIcon className="size-3" />
           {expanded && (
             <>
-              <span className="comet-body-s">Star</span>
-              <span className="rounded-full bg-muted px-1.5 py-0.5 text-xs dark:bg-secondary">
+              <span className="comet-body-xs-accented">Star</span>
+              <span className="rounded bg-[#EBF2F5] px-1 text-[10px] font-medium leading-4 text-[#45575F] dark:bg-secondary dark:text-foreground">
                 {starCount}
               </span>
             </>

--- a/apps/opik-frontend/src/v2/layout/SideBar/MenuItem/SidebarMenuItem.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/MenuItem/SidebarMenuItem.tsx
@@ -51,15 +51,26 @@ const SidebarMenuItem: React.FunctionComponent<SidebarMenuItemProps> = ({
 
   const content = (
     <>
-      <item.icon className="size-3.5 shrink-0" />
+      <item.icon
+        className={cn(
+          "size-3.5 shrink-0 group-data-[status=active]:text-primary",
+          expanded
+            ? item.muted
+              ? "text-muted-slate"
+              : "text-light-slate"
+            : item.muted
+              ? "text-light-slate"
+              : "text-foreground",
+        )}
+      />
       {expanded && <div className="grow truncate">{item.label}</div>}
     </>
   );
 
   const linkClasses = cn(
-    "comet-body-s relative flex w-full items-center gap-2 rounded-md h-7 hover:bg-primary-foreground data-[status=active]:bg-primary-100 data-[status=active]:text-primary py-1",
+    "comet-body-s group relative flex items-center gap-2 rounded-md hover:bg-primary-foreground data-[status=active]:bg-primary-100 data-[status=active]:text-primary",
     item.muted ? "text-muted-slate" : "text-foreground",
-    expanded ? "px-2" : "w-7 justify-center",
+    expanded ? "h-7 w-full px-2 py-1" : "size-6 justify-center",
   );
 
   if (item.disabled) {

--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useRef, useState } from "react";
 import {
-  Check,
   ChevronDown,
   ChevronUp,
   MoreHorizontal,
@@ -12,7 +11,6 @@ import { Link, useNavigate, useRouter } from "@tanstack/react-router";
 
 import { cn } from "@/lib/utils";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
-import { Separator } from "@/ui/separator";
 import { Button } from "@/ui/button";
 import {
   DropdownMenu,
@@ -95,7 +93,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
 
   const renderExpandedLoading = () => (
     <PopoverTrigger asChild>
-      <button className="flex w-full items-center gap-2 rounded-md px-2 py-1.5">
+      <button className="flex w-full items-center gap-1.5 px-1 py-0.5">
         <Spinner size="xs" />
         <span className="comet-body-s flex-1 text-left text-muted-slate">
           Loading…
@@ -107,10 +105,10 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   const renderProjectLabel = () => (
     <PopoverTrigger asChild>
       <button
-        className="flex items-center gap-0.5 text-light-slate"
+        className="flex items-end gap-0.5 text-light-slate"
         aria-label="Open project selector"
       >
-        <span className="comet-body-s">Project</span>
+        <span className="comet-body-xs-accented">Project</span>
         {open ? (
           <ChevronUp className="size-3.5" />
         ) : (
@@ -124,14 +122,16 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
     <PopoverTrigger asChild>
       <button
         className={cn(
-          "flex w-full items-center gap-2 rounded-md px-2 py-1.5",
+          "flex w-full items-center gap-1.5 rounded-md px-1 py-0.5",
           open && "bg-primary-foreground",
         )}
       >
         <ProjectIcon index={activeIconIndex} size="lg" />
-        <div className="flex min-w-0 flex-1 flex-col items-start">
-          <div className="flex w-full items-center gap-0.5">
-            <span className="comet-body-s text-light-slate">Project</span>
+        <div className="flex min-w-0 flex-1 flex-col items-stretch">
+          <div className="flex items-end gap-0.5">
+            <span className="comet-body-xs-accented text-light-slate">
+              Project
+            </span>
             <span className="shrink-0 text-light-slate">
               {open ? (
                 <ChevronUp className="size-3.5" />
@@ -153,7 +153,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
     return (
       <div
         className={cn(
-          "flex w-full items-center gap-2 rounded-md px-2 py-1.5",
+          "flex w-full items-center gap-1.5 rounded-md px-1 py-0.5",
           open && "bg-primary-foreground",
         )}
       >
@@ -164,7 +164,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
         >
           <ProjectIcon index={activeIconIndex} size="lg" />
         </Link>
-        <div className="flex min-w-0 flex-1 flex-col items-start">
+        <div className="flex min-w-0 flex-1 flex-col items-stretch">
           {renderProjectLabel()}
           <Link
             to="/$workspaceName/projects/$projectId/home"
@@ -229,9 +229,9 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
       <PopoverTrigger asChild>
         <Button
           variant="outline"
-          size="icon-2xs"
+          size="icon-4xs"
           aria-label="Open project selector"
-          className="absolute -bottom-1 -left-1 size-3.5 rounded bg-background text-light-slate shadow-sm hover:text-foreground [&>svg]:size-3.5"
+          className="absolute -bottom-1 -right-1 text-foreground-secondary shadow-sm"
         >
           {open ? <ChevronUp /> : <ChevronDown />}
         </Button>
@@ -246,18 +246,17 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
         <PopoverContent
           align="start"
           side="bottom"
-          className="flex w-[320px] flex-col overflow-hidden p-1"
+          className="flex w-[280px] flex-col overflow-hidden p-1"
           sideOffset={4}
           style={{
             maxHeight: "var(--radix-popover-content-available-height)",
           }}
         >
-          <div className="px-3 py-2">
+          <div className="flex h-8 items-center px-3">
             <span className="comet-body-s-accented text-foreground">
               Projects
             </span>
           </div>
-          <Separator className="my-1" />
           <div className="px-1">
             <SearchInput
               searchText={search}
@@ -266,7 +265,6 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
               size="sm"
             />
           </div>
-          <Separator className="my-1" />
           <div className="min-h-0 flex-1 overflow-auto">
             {projectsData?.content?.map((project) => (
               <ProjectItem
@@ -291,21 +289,16 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
             ))}
           </div>
           {canCreateProjects && (
-            <>
-              <Separator className="my-1" />
-              <button
-                className="flex w-full items-center gap-2 rounded-md px-3 py-2 hover:bg-primary-foreground"
-                onClick={() => {
-                  setOpen(false);
-                  setOpenCreateDialog(true);
-                }}
-              >
-                <Plus className="size-3.5 shrink-0 text-foreground" />
-                <span className="comet-body-s text-foreground">
-                  New project
-                </span>
-              </button>
-            </>
+            <button
+              className="flex h-8 w-full items-center gap-2 rounded-md px-3 hover:bg-primary-foreground"
+              onClick={() => {
+                setOpen(false);
+                setOpenCreateDialog(true);
+              }}
+            >
+              <Plus className="size-3.5 shrink-0 text-light-slate" />
+              <span className="comet-body-s text-foreground">New project</span>
+            </button>
           )}
         </PopoverContent>
       </Popover>
@@ -375,7 +368,8 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
         className={cn(
           "group relative flex h-8 items-center gap-2 rounded-md px-3 hover:bg-primary-foreground",
           hasActions && "hover:pr-9",
-          isSelected && "bg-primary-100 text-primary",
+          hasActions && isSelected && "pr-9",
+          isSelected && "bg-primary-100 text-primary hover:bg-primary-100",
         )}
         onClick={(e) => {
           if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
@@ -385,32 +379,45 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
       >
         <ProjectIcon index={iconIndex} />
         <TooltipWrapper content={project.name}>
-          <span className="comet-body-s flex-1 truncate text-foreground">
+          <span
+            className={cn(
+              "comet-body-s flex-1 truncate",
+              isSelected ? "text-primary" : "text-foreground",
+            )}
+          >
             {project.name}
           </span>
         </TooltipWrapper>
-        {isSelected && <Check className="size-3.5 shrink-0 text-primary" />}
         {hasActions && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
               <Button
                 variant="minimal"
                 size="icon-2xs"
-                className="invisible absolute right-3 top-1/2 -translate-y-1/2 rounded pl-2 group-hover:visible"
+                className={cn(
+                  "absolute right-3 top-1/2 -translate-y-1/2 rounded pl-2",
+                  isSelected ? "visible" : "invisible group-hover:visible",
+                )}
               >
-                <MoreHorizontal className="size-3.5" />
+                <MoreHorizontal
+                  className={cn(
+                    "size-3.5",
+                    isSelected ? "text-primary" : "text-light-slate",
+                  )}
+                />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" className="w-40">
               {canCreateProjects && (
                 <DropdownMenuItem
+                  className="h-8 px-3 py-1.5"
                   onClick={(e) => {
                     e.stopPropagation();
                     setOpenDialog(2);
                     resetKeyRef.current += 1;
                   }}
                 >
-                  <Pencil className="mr-2 size-3.5" />
+                  <Pencil className="mr-1.5 size-3.5 text-light-slate" />
                   Edit
                 </DropdownMenuItem>
               )}
@@ -418,13 +425,14 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
               {canDelete && (
                 <DropdownMenuItem
                   variant="destructive"
+                  className="h-8 px-3 py-1.5"
                   onClick={(e) => {
                     e.stopPropagation();
                     setOpenDialog(1);
                     resetKeyRef.current += 1;
                   }}
                 >
-                  <Trash className="mr-2 size-3.5" />
+                  <Trash className="mr-1.5 size-3.5" />
                   Delete
                 </DropdownMenuItem>
               )}

--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
@@ -16,9 +16,11 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu";
+import { ListAction } from "@/ui/list-action";
 import { SearchInput } from "@/shared/SearchInput/SearchInput";
 import { setActiveProject } from "@/hooks/useActiveProjectInitializer";
 import useAppStore, { useActiveProjectId } from "@/store/AppStore";
@@ -105,7 +107,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   const renderProjectLabel = () => (
     <PopoverTrigger asChild>
       <button
-        className="flex items-end gap-0.5 text-light-slate"
+        className="flex items-center gap-0.5 text-light-slate"
         aria-label="Open project selector"
       >
         <span className="comet-body-xs-accented">Project</span>
@@ -128,7 +130,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
       >
         <ProjectIcon index={activeIconIndex} size="lg" />
         <div className="flex min-w-0 flex-1 flex-col items-stretch">
-          <div className="flex items-end gap-0.5">
+          <div className="flex items-center gap-0.5">
             <span className="comet-body-xs-accented text-light-slate">
               Project
             </span>
@@ -226,16 +228,18 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   const renderCollapsedTrigger = () => (
     <div className="relative w-fit self-center">
       {renderCollapsedIcon()}
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          size="icon-4xs"
-          aria-label="Open project selector"
-          className="absolute -bottom-1 -right-1 text-foreground-secondary shadow-sm"
-        >
-          {open ? <ChevronUp /> : <ChevronDown />}
-        </Button>
-      </PopoverTrigger>
+      <TooltipWrapper content="Switch project" side="right">
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            size="icon-4xs"
+            aria-label="Open project selector"
+            className="absolute -bottom-1 -right-1 text-foreground-secondary shadow-sm"
+          >
+            {open ? <ChevronUp /> : <ChevronDown />}
+          </Button>
+        </PopoverTrigger>
+      </TooltipWrapper>
     </div>
   );
 
@@ -252,12 +256,9 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
             maxHeight: "var(--radix-popover-content-available-height)",
           }}
         >
-          <div className="flex h-8 items-center px-3">
-            <span className="comet-body-s-accented text-foreground">
-              Projects
-            </span>
-          </div>
-          <div className="px-1">
+          <DropdownMenuLabel size="sm">Projects</DropdownMenuLabel>
+          <DropdownMenuSeparator className="my-1" />
+          <div className="px-0.5" onKeyDown={(e) => e.stopPropagation()}>
             <SearchInput
               searchText={search}
               setSearchText={setSearch}
@@ -265,6 +266,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
               size="sm"
             />
           </div>
+          <DropdownMenuSeparator className="my-1" />
           <div className="min-h-0 flex-1 overflow-auto">
             {projectsData?.content?.map((project) => (
               <ProjectItem
@@ -289,16 +291,20 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
             ))}
           </div>
           {canCreateProjects && (
-            <button
-              className="flex h-8 w-full items-center gap-2 rounded-md px-3 hover:bg-primary-foreground"
-              onClick={() => {
-                setOpen(false);
-                setOpenCreateDialog(true);
-              }}
-            >
-              <Plus className="size-3.5 shrink-0 text-light-slate" />
-              <span className="comet-body-s text-foreground">New project</span>
-            </button>
+            <>
+              <DropdownMenuSeparator className="my-1" />
+              <ListAction
+                variant="default"
+                size="sm"
+                onClick={() => {
+                  setOpen(false);
+                  setOpenCreateDialog(true);
+                }}
+              >
+                <Plus className="size-3.5 shrink-0 text-light-slate" />
+                <span>New project</span>
+              </ListAction>
+            </>
           )}
         </PopoverContent>
       </Popover>
@@ -366,10 +372,11 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
         to="/$workspaceName/projects/$projectId/home"
         params={{ workspaceName, projectId: project.id }}
         className={cn(
-          "group relative flex h-8 items-center gap-2 rounded-md px-3 hover:bg-primary-foreground",
+          "comet-body-s group relative flex h-8 cursor-pointer items-center gap-2 rounded-md px-3 outline-none transition-colors hover:bg-primary-foreground hover:text-foreground",
           hasActions && "hover:pr-9",
           hasActions && isSelected && "pr-9",
-          isSelected && "bg-primary-100 text-primary hover:bg-primary-100",
+          isSelected &&
+            "bg-primary-100 text-primary hover:bg-secondary hover:text-primary",
         )}
         onClick={(e) => {
           if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
@@ -395,22 +402,17 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
                 variant="minimal"
                 size="icon-2xs"
                 className={cn(
-                  "absolute right-3 top-1/2 -translate-y-1/2 rounded pl-2",
+                  "absolute right-3 top-1/2 -translate-y-1/2 rounded pl-2 text-light-slate hover:text-foreground",
                   isSelected ? "visible" : "invisible group-hover:visible",
                 )}
               >
-                <MoreHorizontal
-                  className={cn(
-                    "size-3.5",
-                    isSelected ? "text-primary" : "text-light-slate",
-                  )}
-                />
+                <MoreHorizontal className="size-3.5" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" className="w-40">
               {canCreateProjects && (
                 <DropdownMenuItem
-                  className="h-8 px-3 py-1.5"
+                  size="sm"
                   onClick={(e) => {
                     e.stopPropagation();
                     setOpenDialog(2);
@@ -425,7 +427,7 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
               {canDelete && (
                 <DropdownMenuItem
                   variant="destructive"
-                  className="h-8 px-3 py-1.5"
+                  size="sm"
                   onClick={(e) => {
                     e.stopPropagation();
                     setOpenDialog(1);

--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSidebarContent.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSidebarContent.tsx
@@ -21,7 +21,7 @@ const ProjectSidebarContent: React.FC<ProjectSidebarContentProps> = ({
   return (
     <>
       <ProjectSelector expanded={expanded} />
-      {expanded && <Separator className="my-2" />}
+      <Separator className="my-2" />
       <div className="flex min-h-0 flex-1 flex-col overflow-auto">
         <ul className="flex flex-col">
           <SideBarMenuItems expanded={expanded} />
@@ -29,7 +29,7 @@ const ProjectSidebarContent: React.FC<ProjectSidebarContentProps> = ({
       </div>
 
       <div className="shrink-0 pt-2">
-        <Separator className="mb-3" />
+        <Separator className={expanded ? "mb-3" : "mb-1"} />
         <ul className="flex flex-col">
           {workspaceItems.flatMap((group) =>
             group.items.map((item) => (

--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSidebarContent.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSidebarContent.tsx
@@ -6,6 +6,7 @@ import GitHubStarListItem from "@/v2/layout/SideBar/GitHubStarListItem/GitHubSta
 import SidebarMenuItem from "@/v2/layout/SideBar/MenuItem/SidebarMenuItem";
 import { getWorkspaceMenuItems } from "@/v2/layout/SideBar/helpers/getMenuItems";
 import { Separator } from "@/ui/separator";
+import { cn } from "@/lib/utils";
 
 interface ProjectSidebarContentProps {
   expanded: boolean;
@@ -21,23 +22,25 @@ const ProjectSidebarContent: React.FC<ProjectSidebarContentProps> = ({
   return (
     <>
       <ProjectSelector expanded={expanded} />
-      <Separator className="my-2" />
+      <Separator className={cn("my-2", !expanded && "w-auto mx-1")} />
       <div className="flex min-h-0 flex-1 flex-col overflow-auto">
-        <ul className="flex flex-col">
+        <ul className={cn("flex flex-col", !expanded && "gap-1")}>
           <SideBarMenuItems expanded={expanded} />
         </ul>
       </div>
 
       <div className="shrink-0 pt-2">
-        <Separator className={expanded ? "mb-3" : "mb-1"} />
-        <ul className="flex flex-col">
+        <Separator
+          className={cn(expanded ? "mb-3" : "mb-1", !expanded && "mx-1 w-auto")}
+        />
+        <ul className={cn("flex flex-col", !expanded && "gap-1")}>
           {workspaceItems.flatMap((group) =>
             group.items.map((item) => (
               <SidebarMenuItem key={item.id} item={item} expanded={expanded} />
             )),
           )}
         </ul>
-        <ul className="mt-2 flex flex-col">
+        <ul className={cn("mt-2 flex flex-col", !expanded && "gap-1")}>
           <GitHubStarListItem expanded={expanded} />
         </ul>
       </div>

--- a/apps/opik-frontend/src/v2/layout/SideBar/SideBar.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/SideBar.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { Link, useRouterState } from "@tanstack/react-router";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { PanelLeft } from "lucide-react";
 import { useActiveWorkspaceName } from "@/store/AppStore";
 import { Button } from "@/ui/button";
 import Logo from "@/shared/Logo/Logo";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { useActiveProjectInitializer } from "@/hooks/useActiveProjectInitializer";
 import ProjectSidebarContent from "@/v2/layout/SideBar/ProjectSidebarContent";
 import WorkspaceSidebarContent from "@/v2/layout/SideBar/WorkspaceSidebarContent";
@@ -32,27 +33,47 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
   const logo = <Logo expanded={expanded} />;
 
   return (
-    <aside className="comet-sidebar-width group h-[calc(100vh-var(--banner-height))] border-r transition-all">
-      <div className="comet-header-height relative flex w-full items-center justify-between gap-6 border-b">
+    <aside className="comet-sidebar-width relative h-[calc(100vh-var(--banner-height))] border-r transition-all">
+      <div className="comet-header-height relative flex w-full items-center justify-end border-b pr-2">
         <Link
           to={HOME_PATH}
-          className="absolute left-[18px] z-10 block"
+          className="absolute left-[15px] top-1/2 block -translate-y-1/2"
           params={{ workspaceName }}
         >
           {logo}
+          {canToggle && !expanded && (
+            <TooltipWrapper content="Expand sidebar" side="right">
+              <Button
+                variant="outline"
+                size="icon-4xs"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onToggle();
+                }}
+                className="absolute bottom-[-9px] right-[-9px] z-10 text-foreground-secondary shadow-sm"
+                aria-label="Expand sidebar"
+              >
+                <PanelLeft />
+              </Button>
+            </TooltipWrapper>
+          )}
         </Link>
+        {canToggle && expanded && (
+          <TooltipWrapper content="Collapse sidebar" side="right">
+            <Button
+              variant="minimal"
+              size="icon-xs"
+              onClick={onToggle}
+              className="text-light-slate duration-100 animate-in fade-in"
+              aria-label="Collapse sidebar"
+            >
+              <PanelLeft />
+            </Button>
+          </TooltipWrapper>
+        )}
       </div>
       <div className="relative flex h-[calc(100%-var(--header-height))]">
-        {canToggle && (
-          <Button
-            variant="outline"
-            size="icon-2xs"
-            onClick={onToggle}
-            className="absolute -right-3 top-2 z-50 hidden rounded-full max-lg:flex lg:group-hover:flex"
-          >
-            {expanded ? <ChevronLeft /> : <ChevronRight />}
-          </Button>
-        )}
         <div className="flex min-h-0 grow flex-col justify-between overflow-auto p-3">
           {isProjectRoute ? (
             <ProjectSidebarContent expanded={expanded} />

--- a/apps/opik-frontend/src/v2/layout/SideBar/SideBarMenuItems.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/SideBarMenuItems.tsx
@@ -51,7 +51,9 @@ const SideBarMenuItems: React.FC<SideBarMenuItemsProps> = ({ expanded }) => {
                 {menuGroup.label}
               </div>
             ) : (
-              <div className="py-1">{index > 0 && <Separator />}</div>
+              <div className="py-1">
+                {index > 0 && <Separator className="mx-1 w-auto" />}
+              </div>
             ))}
           <ul className="flex flex-col text-foreground">
             {renderItems(menuGroup.items)}

--- a/apps/opik-frontend/src/v2/layout/SideBar/SideBarMenuItems.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/SideBarMenuItems.tsx
@@ -44,16 +44,14 @@ const SideBarMenuItems: React.FC<SideBarMenuItemsProps> = ({ expanded }) => {
   return (
     <>
       {menuItems.map((menuGroup, index) => (
-        <li key={menuGroup.id} className="pb-3">
+        <li key={menuGroup.id} className={expanded ? "pb-3" : "pb-1"}>
           {menuGroup.label &&
             (expanded ? (
-              <div className="comet-body-xs truncate px-2 py-1 text-light-slate">
+              <div className="comet-body-xs-accented truncate px-2 py-1 text-light-slate">
                 {menuGroup.label}
               </div>
             ) : (
-              <div className="pb-[17px] pt-1.5">
-                {index > 0 && <Separator />}
-              </div>
+              <div className="py-1">{index > 0 && <Separator />}</div>
             ))}
           <ul className="flex flex-col text-foreground">
             {renderItems(menuGroup.items)}

--- a/apps/opik-frontend/src/v2/layout/SideBar/WorkspaceSidebarContent.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/WorkspaceSidebarContent.tsx
@@ -28,24 +28,36 @@ const WorkspaceSidebarContent: React.FC<WorkspaceSidebarContentProps> = ({
 
   const menuGroups = getWorkspaceSidebarMenuItems({ canViewDashboards });
 
+  const initial = (displayName || workspaceName).charAt(0).toUpperCase();
+
   const workspaceSelector = SidebarWorkspaceSelectorComponent ? (
     <SidebarWorkspaceSelectorComponent expanded={expanded} />
   ) : expanded ? (
-    <div className="comet-body-s-accented truncate rounded-md px-2 py-1 text-foreground">
-      {displayName}
+    <div className="flex items-center gap-2 px-2 py-1">
+      <span className="comet-body-xs-accented flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-slate">
+        {initial}
+      </span>
+      <div className="flex min-w-0 flex-col">
+        <span className="comet-body-xs-accented text-light-slate">
+          Workspace
+        </span>
+        <span className="comet-body-s-accented truncate text-foreground">
+          {displayName}
+        </span>
+      </div>
     </div>
-  ) : null;
+  ) : (
+    <span className="comet-body-xs-accented flex size-7 shrink-0 items-center justify-center self-center rounded-md bg-muted text-[10.5px] leading-none text-muted-slate">
+      {initial}
+    </span>
+  );
 
   return (
     <>
+      {workspaceSelector}
+      <Separator className="my-2" />
       <div className="flex min-h-0 flex-1 flex-col overflow-auto">
-        {expanded && (
-          <div className="comet-body-xs-accented truncate px-2 py-1 text-light-slate">
-            Workspace
-          </div>
-        )}
-        {workspaceSelector}
-        <ul className="mt-2 flex flex-col">
+        <ul className="flex flex-col">
           {menuGroups.flatMap((group) =>
             group.items.map((item) => (
               <SidebarMenuItem key={item.id} item={item} expanded={expanded} />
@@ -56,7 +68,7 @@ const WorkspaceSidebarContent: React.FC<WorkspaceSidebarContentProps> = ({
 
       <div className="shrink-0 pt-2">
         <BackToProjectButton expanded={expanded} />
-        <Separator className="my-4" />
+        <Separator className="my-2" />
         <ul className="flex flex-col">
           <GitHubStarListItem expanded={expanded} />
         </ul>

--- a/apps/opik-frontend/src/v2/layout/SideBar/WorkspaceSidebarContent.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/WorkspaceSidebarContent.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useActiveWorkspaceName } from "@/store/AppStore";
 import { Separator } from "@/ui/separator";
-import { calculateWorkspaceName } from "@/lib/utils";
+import { calculateWorkspaceName, cn } from "@/lib/utils";
 import usePluginsStore from "@/store/PluginsStore";
 import SidebarMenuItem from "@/v2/layout/SideBar/MenuItem/SidebarMenuItem";
 import GitHubStarListItem from "@/v2/layout/SideBar/GitHubStarListItem/GitHubStarListItem";
@@ -55,9 +55,9 @@ const WorkspaceSidebarContent: React.FC<WorkspaceSidebarContentProps> = ({
   return (
     <>
       {workspaceSelector}
-      <Separator className="my-2" />
+      <Separator className={cn("my-2", !expanded && "mx-1 w-auto")} />
       <div className="flex min-h-0 flex-1 flex-col overflow-auto">
-        <ul className="flex flex-col">
+        <ul className={cn("flex flex-col", !expanded && "gap-1")}>
           {menuGroups.flatMap((group) =>
             group.items.map((item) => (
               <SidebarMenuItem key={item.id} item={item} expanded={expanded} />
@@ -68,8 +68,8 @@ const WorkspaceSidebarContent: React.FC<WorkspaceSidebarContentProps> = ({
 
       <div className="shrink-0 pt-2">
         <BackToProjectButton expanded={expanded} />
-        <Separator className="my-2" />
-        <ul className="flex flex-col">
+        <Separator className={cn("my-2", !expanded && "mx-1 w-auto")} />
+        <ul className={cn("flex flex-col", !expanded && "gap-1")}>
           <GitHubStarListItem expanded={expanded} />
         </ul>
       </div>

--- a/apps/opik-frontend/tailwind.config.ts
+++ b/apps/opik-frontend/tailwind.config.ts
@@ -102,7 +102,6 @@ module.exports = {
         "diff-added-text": "var(--diff-added-text)",
         "upload-icon-bg": "hsl(var(--upload-icon-bg))",
         "code-block": "var(--code-block)",
-        "breadcrumb-last": "hsl(var(--breadcrumb-last))",
         "special-button": "var(--special-button)",
         "thread-active": "var(--thread-active)",
         "selection-bar": "hsl(var(--selection-bar))",
@@ -131,6 +130,8 @@ module.exports = {
         "chart-purple": "var(--chart-purple)",
         "chart-pink": "var(--chart-pink)",
         "chart-orange": "var(--chart-orange)",
+        "chart-gray-light": "var(--chart-gray-light)",
+        "chart-gray-dark": "var(--chart-gray-dark)",
 
         /* Template icon colors */
         "template-icon-metrics": "var(--template-icon-metrics)",


### PR DESCRIPTION
## Details

Two-commit polish of the v2 navigation against Figma's IA redesign (file `MHqvEwnuCHBLVvN9ilmhw8`).


https://github.com/user-attachments/assets/45a1baca-b360-409e-82d3-1b8e95c99954



- **`[OPIK-6201]` Sidebar styling pass** — full audit and rework of the v2 sidebar (project + workspace selectors, expanded + collapsed states, menu items, GH star, back-to-project, micro-buttons). Repaired a long-standing typo in `--muted-slate` that silently rendered ~270 sites as foreground for ~8 months. Added a new `icon-4xs` Button size and `chart-gray-light/dark` tokens to the design system; removed the orphaned `--breadcrumb-last` token.
- **`[OPIK-6165]` Breadcrumbs polish** — typography (12px, regular last item), hover state (foreground, no underline), single-trigger workspace pill, and full Figma-format workspace popover (Organizations submenu with per-org settings cog gated by admin role, separators between sections, no checkbox indicators, single-org settings access preserved). Extracted shared `WorkspaceMenuContent` component to deduplicate ~150 lines between the breadcrumb and sidebar workspace switchers.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6201
- OPIK-6165

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation, Figma extraction, refactor
- Human verification: code review + manual browser QA across expanded/collapsed states, project/workspace sidebars, popovers, breadcrumb hover/click

## Testing

- `cd apps/opik-frontend && npm run lint && npm run typecheck` — clean
- Manual browser QA on `http://localhost:5174/`:
  - Expanded project sidebar: 12px Project label, light-slate body icons, muted-slate Workspace/Configuration items, 24px GH star with restyled count tag
  - Project selector popover: 280px width, 32px rows, active state, hover ellipsis
  - Workspace sidebar (expanded): thumbnail (32×32 gray-square with initial), Workspace mini-label, hug-content Back button
  - Workspaces popover (breadcrumb + sidebar): single-trigger pill, three section separators, Organizations submenu with `sideOffset={8}`, per-org settings cog (always visible on active, hover-revealed on others, gated by admin role)
  - Single-org case: settings cog inline in title row (admin only)
  - Collapsed sidebars: 48px width, logo anchored at `left:15px` so it doesn't jump on toggle, collapse button fades in via `animate-in fade-in` after the width transition, plain `PanelLeft` icons (no chevron arrow) on both expand/collapse buttons
  - Collapsed menu items render as 24×24 squares; muted icons stay light-slate
  - Three micro-buttons (expand-near-logo, project chevron, workspace chevron) all share the new `icon-4xs` Button size
- Not run: backend tests (no backend changes), E2E suite

Video evidence: N/A — visual styling pass.

## Documentation

N/A — no user-facing docs or API reference changes. Internal Figma node references (`551-16239`, `551-16290`, `551-1963`, `551-2357`, `570-1453`, `570-1439`, `581-1580`, `583-3492`, `594-8702`, `595-9070`) are noted in commit messages for future reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OPIK-6201]: https://comet-ml.atlassian.net/browse/OPIK-6201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPIK-6165]: https://comet-ml.atlassian.net/browse/OPIK-6165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ