### PR TITLE
[OPIK-5964] [FE] fix: highlight added/removed prompts in agent config diff

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/BlueprintDiffDialog/BlueprintDiffCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/BlueprintDiffDialog/BlueprintDiffCell.tsx
@@ -76,8 +76,23 @@ export const PromptDiffPair: React.FC<{
     diffTemplate ?? diffPrompt?.requested_version?.template ?? "";
   const changed = baseText !== diffText;
   const commitsChanged = baseCommit !== diffCommit;
+  const hasBase = !!baseCommit || !!baseTemplate;
+  const hasDiff = !!diffCommit || !!diffTemplate;
 
   const renderDiffContent = (text: string, isBase: boolean) => {
+    if (isBase ? !hasDiff : !hasBase) {
+      return (
+        <div
+          className={cn(
+            "comet-code max-h-48 overflow-y-auto whitespace-pre-wrap break-words rounded-md border p-2 text-sm",
+            isBase ? SIDE_STYLES.base : SIDE_STYLES.diff,
+          )}
+        >
+          {text || "(empty)"}
+        </div>
+      );
+    }
+
     if (!changed) {
       return (
         <div className="comet-code max-h-48 overflow-y-auto whitespace-pre-wrap break-words rounded-md border bg-primary-foreground p-2 text-sm text-muted-foreground">
@@ -92,9 +107,6 @@ export const PromptDiffPair: React.FC<{
       </div>
     );
   };
-
-  const hasBase = !!baseCommit || !!baseTemplate;
-  const hasDiff = !!diffCommit || !!diffTemplate;
 
   return (
     <>

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/BlueprintDiffDialog/BlueprintDiffCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/BlueprintDiffDialog/BlueprintDiffCell.tsx
@@ -76,8 +76,8 @@ export const PromptDiffPair: React.FC<{
     diffTemplate ?? diffPrompt?.requested_version?.template ?? "";
   const changed = baseText !== diffText;
   const commitsChanged = baseCommit !== diffCommit;
-  const hasBase = !!baseCommit || !!baseTemplate;
-  const hasDiff = !!diffCommit || !!diffTemplate;
+  const hasBase = !!baseCommit || baseTemplate !== undefined;
+  const hasDiff = !!diffCommit || diffTemplate !== undefined;
 
   const renderDiffContent = (text: string, isBase: boolean) => {
     if (isBase ? !hasDiff : !hasBase) {

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/BlueprintDiffDialog/BlueprintDiffRow.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/BlueprintDiffDialog/BlueprintDiffRow.tsx
@@ -35,6 +35,11 @@ const BlueprintDiffRow: React.FC<{ pair: DiffPair }> = ({ pair }) => {
     diffPromptTemplate,
   } = pair;
   const isPrompt = type === BlueprintValueType.PROMPT;
+  const hasPromptContent =
+    !!baseValue?.value ||
+    !!diffValue?.value ||
+    !!basePromptTemplate ||
+    !!diffPromptTemplate;
 
   const baseText = baseValue ? formatBlueprintValue(baseValue) : undefined;
   const diffText = diffValue ? formatBlueprintValue(diffValue) : undefined;
@@ -63,11 +68,7 @@ const BlueprintDiffRow: React.FC<{ pair: DiffPair }> = ({ pair }) => {
           <p className="comet-body-xs mt-1 text-light-slate">{description}</p>
         )}
       </TableCell>
-      {isPrompt &&
-      (baseValue?.value ||
-        diffValue?.value ||
-        basePromptTemplate ||
-        diffPromptTemplate) ? (
+      {isPrompt && hasPromptContent ? (
         <PromptDiffPair
           baseCommit={baseValue?.value ?? ""}
           diffCommit={diffValue?.value ?? ""}

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/BlueprintDiffDialog/BlueprintDiffCell.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/BlueprintDiffDialog/BlueprintDiffCell.tsx
@@ -76,8 +76,23 @@ export const PromptDiffPair: React.FC<{
     diffTemplate ?? diffPrompt?.requested_version?.template ?? "";
   const changed = baseText !== diffText;
   const commitsChanged = baseCommit !== diffCommit;
+  const hasBase = !!baseCommit || !!baseTemplate;
+  const hasDiff = !!diffCommit || !!diffTemplate;
 
   const renderDiffContent = (text: string, isBase: boolean) => {
+    if (isBase ? !hasDiff : !hasBase) {
+      return (
+        <div
+          className={cn(
+            "comet-code max-h-48 overflow-y-auto whitespace-pre-wrap break-words rounded-md border p-2 text-sm",
+            isBase ? SIDE_STYLES.base : SIDE_STYLES.diff,
+          )}
+        >
+          {text || "(empty)"}
+        </div>
+      );
+    }
+
     if (!changed) {
       return (
         <div className="comet-code max-h-48 overflow-y-auto whitespace-pre-wrap break-words rounded-md border bg-primary-foreground p-2 text-sm text-muted-foreground">
@@ -96,21 +111,23 @@ export const PromptDiffPair: React.FC<{
   return (
     <>
       <TableCell className="w-1/2 py-3 pr-2 align-top">
-        {baseCommit ? (
+        {hasBase ? (
           <div className="flex flex-col gap-1">
-            <Tag
-              className={cn(
-                "flex w-fit items-center gap-1",
-                commitsChanged &&
-                  "border-[var(--diff-removed-border)] bg-[var(--diff-removed-bg)] text-[var(--diff-removed-text)]",
-              )}
-              variant="gray"
-              size="sm"
-              title={baseCommit}
-            >
-              <GitCommitVertical className="size-3.5 shrink-0" />
-              {baseCommit.slice(0, 8)}
-            </Tag>
+            {baseCommit && (
+              <Tag
+                className={cn(
+                  "flex w-fit items-center gap-1",
+                  commitsChanged &&
+                    "border-[var(--diff-removed-border)] bg-[var(--diff-removed-bg)] text-[var(--diff-removed-text)]",
+                )}
+                variant="gray"
+                size="sm"
+                title={baseCommit}
+              >
+                <GitCommitVertical className="size-3.5 shrink-0" />
+                {baseCommit.slice(0, 8)}
+              </Tag>
+            )}
             {renderDiffContent(baseText, true)}
           </div>
         ) : (
@@ -118,21 +135,23 @@ export const PromptDiffPair: React.FC<{
         )}
       </TableCell>
       <TableCell className="w-1/2 py-3 pl-2 align-top">
-        {diffCommit ? (
+        {hasDiff ? (
           <div className="flex flex-col gap-1">
-            <Tag
-              className={cn(
-                "flex w-fit items-center gap-1",
-                commitsChanged &&
-                  "border-[var(--diff-added-border)] bg-[var(--diff-added-bg)] text-[var(--diff-added-text)]",
-              )}
-              variant="gray"
-              size="sm"
-              title={diffCommit}
-            >
-              <GitCommitVertical className="size-3.5 shrink-0" />
-              {diffCommit.slice(0, 8)}
-            </Tag>
+            {diffCommit && (
+              <Tag
+                className={cn(
+                  "flex w-fit items-center gap-1",
+                  commitsChanged &&
+                    "border-[var(--diff-added-border)] bg-[var(--diff-added-bg)] text-[var(--diff-added-text)]",
+                )}
+                variant="gray"
+                size="sm"
+                title={diffCommit}
+              >
+                <GitCommitVertical className="size-3.5 shrink-0" />
+                {diffCommit.slice(0, 8)}
+              </Tag>
+            )}
             {renderDiffContent(diffText, false)}
           </div>
         ) : (

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/BlueprintDiffDialog/BlueprintDiffCell.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/BlueprintDiffDialog/BlueprintDiffCell.tsx
@@ -76,8 +76,8 @@ export const PromptDiffPair: React.FC<{
     diffTemplate ?? diffPrompt?.requested_version?.template ?? "";
   const changed = baseText !== diffText;
   const commitsChanged = baseCommit !== diffCommit;
-  const hasBase = !!baseCommit || !!baseTemplate;
-  const hasDiff = !!diffCommit || !!diffTemplate;
+  const hasBase = !!baseCommit || baseTemplate !== undefined;
+  const hasDiff = !!diffCommit || diffTemplate !== undefined;
 
   const renderDiffContent = (text: string, isBase: boolean) => {
     if (isBase ? !hasDiff : !hasBase) {

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/BlueprintDiffDialog/BlueprintDiffRow.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/BlueprintDiffDialog/BlueprintDiffRow.tsx
@@ -35,6 +35,11 @@ const BlueprintDiffRow: React.FC<{ pair: DiffPair }> = ({ pair }) => {
     diffPromptTemplate,
   } = pair;
   const isPrompt = type === BlueprintValueType.PROMPT;
+  const hasPromptContent =
+    !!baseValue?.value ||
+    !!diffValue?.value ||
+    !!basePromptTemplate ||
+    !!diffPromptTemplate;
 
   const baseText = baseValue ? formatBlueprintValue(baseValue) : undefined;
   const diffText = diffValue ? formatBlueprintValue(diffValue) : undefined;
@@ -63,10 +68,10 @@ const BlueprintDiffRow: React.FC<{ pair: DiffPair }> = ({ pair }) => {
           <p className="comet-body-xs mt-1 text-light-slate">{description}</p>
         )}
       </TableCell>
-      {isPrompt && baseValue?.value && diffValue?.value ? (
+      {isPrompt && hasPromptContent ? (
         <PromptDiffPair
-          baseCommit={baseValue.value}
-          diffCommit={diffValue.value}
+          baseCommit={baseValue?.value ?? ""}
+          diffCommit={diffValue?.value ?? ""}
           baseTemplate={basePromptTemplate}
           diffTemplate={diffPromptTemplate}
         />


### PR DESCRIPTION
## Details
Prompt rows in the agent configuration `BlueprintDiffDialog` now render with the same red/green add/remove highlighting used for primitive values when a prompt is only present on one side of the diff.

- `BlueprintDiffRow`: stop gating the `PromptDiffPair` on both sides having a value — render whenever any commit or template is present on either side, so additions/deletions surface instead of being hidden.
- `BlueprintDiffCell` (`PromptDiffPair`): when one side is empty, render the populated side with its `SIDE_STYLES` add/remove background instead of the neutral "(no changes)" style. Commit tag is only rendered when a commit value exists, while template content still renders in the colored container.
- Mirrored changes in both `pages-shared/agent-configuration/BlueprintDiffDialog` and `pages/AgentConfigurationPage/AgentConfigurationTab/BlueprintDiffDialog` so the shared and page-local copies stay in sync.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-5964

## Testing
Manual verification in the agent configuration diff dialog:
- Prompt added on the diff side → row renders with green "added" styling on the right and an empty placeholder on the left.
- Prompt removed from the diff side → row renders with red "removed" styling on the left and an empty placeholder on the right.
- Prompt present on both sides with template/commit changes → existing diff rendering unchanged.
- Prompt with no value on either side → row continues to render the neutral state.

## Documentation
N/A
