### PR TITLE
[OPIK-6227] [TESTS] chore: refresh playground models_config tested models

### DIFF
--- a/tests_end_to_end/typescript-tests/models_config.yaml
+++ b/tests_end_to_end/typescript-tests/models_config.yaml
@@ -2,55 +2,32 @@
 # Model Configuration for End-to-End Playground Tests
 # This file defines models that will be tested in playground tests
 # To add a new model: just add it to the appropriate provider section below
+# `ui_selector` must match the model option label rendered by the playground
+# model picker (see PROVIDER_MODELS in apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts).
 
 providers:
   openai:
     display_name: "OpenAI"
     api_key_env_var: "OPENAI_API_KEY"
     models:
-      - name: "GPT 5.2"
-        ui_selector: "GPT 5.2"
+      - name: "GPT 5.4"
+        ui_selector: "GPT 5.4"
         enabled: true
         test_playground: true
         test_online_scoring: true
-      - name: "GPT 5.1"
-        ui_selector: "GPT 5.1"
+      - name: "GPT 5.4 Mini"
+        ui_selector: "GPT 5.4 Mini"
         enabled: true
         test_playground: true
         test_online_scoring: true
-      - name: "GPT 5"
-        ui_selector: "GPT 5"
+      - name: "GPT 5.4 Nano"
+        ui_selector: "GPT 5.4 Nano"
         enabled: true
         test_playground: true
         test_online_scoring: true
-      - name: "GPT 5 Mini"
-        ui_selector: "GPT 5 Mini"
-        enabled: true
-        test_playground: true
-        test_online_scoring: true
-      - name: "GPT 5 Nano"
-        ui_selector: "GPT 5 Nano"
-        enabled: true
-        test_playground: true
-        test_online_scoring: true
-      - name: "GPT 4o"
-        ui_selector: "GPT 4o"
-        enabled: false
-        test_playground: false
-        test_online_scoring: false
       - name: "GPT 4o Mini"
         ui_selector: "GPT 4o Mini"
         enabled: true
-        test_playground: false
-        test_online_scoring: false
-      - name: "GPT 4.1"
-        ui_selector: "GPT 4.1"
-        enabled: false
-        test_playground: false
-        test_online_scoring: false
-      - name: "GPT 4.1 Mini"
-        ui_selector: "GPT 4.1 Mini"
-        enabled: false
         test_playground: false
         test_online_scoring: false
 
@@ -58,8 +35,18 @@ providers:
     display_name: "Gemini"
     api_key_env_var: "GEMINI_API_KEY"
     models:
-      - name: "Gemini 3 Pro"
-        ui_selector: "Gemini 3 Pro"
+      - name: "Gemini 3.1 Pro Preview"
+        ui_selector: "Gemini 3.1 Pro Preview"
+        enabled: true
+        test_playground: true
+        test_online_scoring: true
+      - name: "Gemini 2.5 Pro"
+        ui_selector: "Gemini 2.5 Pro"
+        enabled: true
+        test_playground: true
+        test_online_scoring: true
+      - name: "Gemini 2.5 Flash"
+        ui_selector: "Gemini 2.5 Flash"
         enabled: true
         test_playground: true
         test_online_scoring: true
@@ -68,6 +55,11 @@ providers:
     display_name: "Anthropic"
     api_key_env_var: "ANTHROPIC_API_KEY"
     models:
+      - name: "Claude Opus 4.7"
+        ui_selector: "Claude Opus 4.7"
+        enabled: true
+        test_playground: true
+        test_online_scoring: true
       - name: "Claude Opus 4.6"
         ui_selector: "Claude Opus 4.6"
         enabled: true


### PR DESCRIPTION
## Details

Refresh the playground/online-scoring E2E test model list in `tests_end_to_end/typescript-tests/models_config.yaml` so it tests current models and stops referencing sunsetted ones. Also fix a Gemini entry whose `ui_selector` did not match any rendered option in the playground model picker.

- **OpenAI**: dropped sunsetted/older entries (GPT 5, GPT 5 Mini/Nano, GPT 5.1, GPT 5.2, plus stale GPT 4o / GPT 4.1 / GPT 4.1 Mini that were already disabled). Added the GPT 5.4 family (GPT 5.4, GPT 5.4 Mini, GPT 5.4 Nano), which is the playground's current default. Kept GPT 4o Mini as a stable fallback (enabled, not actively tested).
- **Anthropic**: added Claude Opus 4.7. Kept Claude Opus 4.6, Sonnet 4.6, and Haiku 4.5.
- **Gemini**: replaced the broken `"Gemini 3 Pro"` entry — which had no matching label in the Gemini provider's picker — with `"Gemini 3.1 Pro Preview"`, `"Gemini 2.5 Pro"`, and `"Gemini 2.5 Flash"`, which match the labels in `PROVIDER_MODELS[GEMINI]` (`apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts`).
- Added a header comment pointing future maintainers at that frontend file as the source of truth for `ui_selector` strings.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6227

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation (config edit only)
- Human verification: cross-checked `ui_selector` strings against `PROVIDER_MODELS` in `apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts` and `selectModel` matching logic in `tests_end_to_end/typescript-tests/page-objects/playground.page.ts`

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('tests_end_to_end/typescript-tests/models_config.yaml'))"` — passes.
- Schema sanity check: confirmed every model entry has `name`, `ui_selector`, `enabled`, `test_playground`, `test_online_scoring`.
- Verified each `ui_selector` value exists as a `label` in `PROVIDER_MODELS` for the matching provider in `apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts`.
- Did not run the playwright suite locally — that requires a live Opik stack with provider API keys. The next scheduled CUJ run will exercise this.

## Documentation

N/A — config-only change. Header comment added in the YAML pointing maintainers at the frontend source of truth for `ui_selector` strings.