### PR TITLE
[NA] [TESTS] stop testing opus 4.7 in online scoring

### DIFF
--- a/tests_end_to_end/typescript-tests/models_config.yaml
+++ b/tests_end_to_end/typescript-tests/models_config.yaml
@@ -59,7 +59,7 @@ providers:
         ui_selector: "Claude Opus 4.7"
         enabled: true
         test_playground: true
-        test_online_scoring: true
+        test_online_scoring: false
       - name: "Claude Opus 4.6"
         ui_selector: "Claude Opus 4.6"
         enabled: true


### PR DESCRIPTION
## Details
Opus 4.7 response times are unstable, removing from online scoring testing temporarily

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
NA

## AI-WATERMARK

AI-WATERMARK: no


## Testing

## Documentation
