### PR TITLE
[OPIK-6072] [FE] feat: add connection steps to agent runner empty state

### DIFF
--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerEmptyState.tsx
@@ -7,13 +7,35 @@ import CodeSnippet from "@/shared/CodeSnippet/CodeSnippet";
 import AgentSandboxFlowDiagram from "./AgentSandboxFlowDiagram";
 import ProjectIcon from "@/shared/ProjectIcon/ProjectIcon";
 import useActiveProjectName from "@/hooks/useActiveProjectName";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/ui/tabs";
+
+const ENTRYPOINT_SNIPPET_PYTHON = `import opik
+
+@opik.track(entrypoint=True, project_name="my-agent")
+def my_agent(query: str) -> str:
+    # Your agent logic here
+    return result`;
+
+const ENTRYPOINT_SNIPPET_TYPESCRIPT = `import { track } from "opik";
+
+const myAgent = track(
+  {
+    entrypoint: true,
+    name: "my-agent",
+    params: [{ name: "query", type: "string" }],
+  },
+  async (query: string): Promise<string> => {
+    // Your agent logic here
+    return result;
+  }
+);`;
 
 const AgentRunnerEmptyState: React.FC = () => {
   const projectName = useActiveProjectName();
   const command = `opik endpoint --project "${projectName}" -- <your app start command>`;
 
   return (
-    <div className="flex flex-1 justify-center gap-16 px-10 pt-[15.69rem]">
+    <div className="flex flex-1 justify-center gap-16 px-10 pt-16">
       <div className="w-full max-w-lg">
         <div className="mb-1 flex items-center gap-2">
           <ProjectIcon index={0} size="lg" />
@@ -26,6 +48,32 @@ const AgentRunnerEmptyState: React.FC = () => {
 
         <div className="flex flex-col">
           <TimelineStep number={1}>
+            <div className="flex flex-col gap-2.5">
+              <h4 className="comet-body-s-accented">
+                Mark your agent as an entrypoint
+              </h4>
+              <p className="comet-body-xs text-muted-slate">
+                Add <code className="font-code">@opik.track(entrypoint=True)</code> to
+                your agent&apos;s main function so Opik can detect and register it.
+                You can also run <code className="font-code">/instrument</code> in the
+                Ollie sidebar to auto-instrument your agent.
+              </p>
+              <Tabs defaultValue="python">
+                <TabsList variant="underline">
+                  <TabsTrigger value="python" variant="underline">Python</TabsTrigger>
+                  <TabsTrigger value="typescript" variant="underline">TypeScript</TabsTrigger>
+                </TabsList>
+                <TabsContent value="python">
+                  <CodeSnippet title="Python" code={ENTRYPOINT_SNIPPET_PYTHON} />
+                </TabsContent>
+                <TabsContent value="typescript">
+                  <CodeSnippet title="TypeScript" code={ENTRYPOINT_SNIPPET_TYPESCRIPT} />
+                </TabsContent>
+              </Tabs>
+            </div>
+          </TimelineStep>
+
+          <TimelineStep number={2}>
             <div className="flex flex-col gap-2.5">
               <h4 className="comet-body-s-accented">
                 Run the connection command
@@ -50,7 +98,7 @@ const AgentRunnerEmptyState: React.FC = () => {
               <p className="comet-body-xs text-muted-slate">
                 Trouble connecting?{" "}
                 <a
-                  href={buildDocsUrl("/faq", "#troubleshooting")}
+                  href={buildDocsUrl("/development/agent-playground", "#troubleshooting")}
                   target="_blank"
                   rel="noreferrer"
                   className="inline-flex items-center gap-1 underline hover:text-foreground"

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerEmptyState.tsx
@@ -53,21 +53,33 @@ const AgentRunnerEmptyState: React.FC = () => {
                 Mark your agent as an entrypoint
               </h4>
               <p className="comet-body-xs text-muted-slate">
-                Add <code className="font-code">@opik.track(entrypoint=True)</code> to
-                your agent&apos;s main function so Opik can detect and register it.
-                You can also run <code className="font-code">/instrument</code> in the
-                Ollie sidebar to auto-instrument your agent.
+                Add{" "}
+                <code className="font-code">@opik.track(entrypoint=True)</code>{" "}
+                to your agent&apos;s main function so Opik can detect and
+                register it. You can also run{" "}
+                <code className="font-code">/instrument</code> in the Ollie
+                sidebar to auto-instrument your agent.
               </p>
               <Tabs defaultValue="python">
                 <TabsList variant="underline">
-                  <TabsTrigger value="python" variant="underline">Python</TabsTrigger>
-                  <TabsTrigger value="typescript" variant="underline">TypeScript</TabsTrigger>
+                  <TabsTrigger value="python" variant="underline">
+                    Python
+                  </TabsTrigger>
+                  <TabsTrigger value="typescript" variant="underline">
+                    TypeScript
+                  </TabsTrigger>
                 </TabsList>
                 <TabsContent value="python">
-                  <CodeSnippet title="Python" code={ENTRYPOINT_SNIPPET_PYTHON} />
+                  <CodeSnippet
+                    title="Python"
+                    code={ENTRYPOINT_SNIPPET_PYTHON}
+                  />
                 </TabsContent>
                 <TabsContent value="typescript">
-                  <CodeSnippet title="TypeScript" code={ENTRYPOINT_SNIPPET_TYPESCRIPT} />
+                  <CodeSnippet
+                    title="TypeScript"
+                    code={ENTRYPOINT_SNIPPET_TYPESCRIPT}
+                  />
                 </TabsContent>
               </Tabs>
             </div>
@@ -98,7 +110,10 @@ const AgentRunnerEmptyState: React.FC = () => {
               <p className="comet-body-xs text-muted-slate">
                 Trouble connecting?{" "}
                 <a
-                  href={buildDocsUrl("/development/agent-playground", "#troubleshooting")}
+                  href={buildDocsUrl(
+                    "/development/agent-playground",
+                    "#troubleshooting",
+                  )}
                   target="_blank"
                   rel="noreferrer"
                   className="inline-flex items-center gap-1 underline hover:text-foreground"


### PR DESCRIPTION
## Details
Adds a 3-step setup flow to the `AgentRunnerPage` empty state to guide users through connecting their agent:

1. **Mark your agent as an entrypoint** — tabbed Python/TypeScript code snippet showing `@opik.track(entrypoint=True)`, with a note that `/instrument` in the Ollie sidebar can auto-instrument the agent.
2. **Run the connection command** — the `opik endpoint` terminal command (unchanged).
3. **Waiting for connection** — animated spinner step (unchanged).

Steps taken from the [docs](https://www.comet.com/docs/opik/development/agent-playground#getting-started).

Also reduces the top padding from `15.69rem` to `4rem` to remove excessive empty space above the instructions, and fixes the troubleshooting link to point to `/development/agent-playground#troubleshooting`.

<img width="1514" height="820" alt="image" src="https://github.com/user-attachments/assets/9c910317-783c-4977-9dde-cf3f8d1171b2" />


## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6072

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: full implementation
- Human verification: code review + manual visual testing in browser

## Testing

- `npm run lint && npm run typecheck` — both pass
- Visually verified in browser: 3-step flow renders correctly, Python/TypeScript tabs switch properly, padding is reduced, troubleshooting link points to correct docs URL
- Confirmed "Waiting for connection" spinner step is preserved as last step

## Documentation

N/A — the feature is self-documenting via the UI steps and links to existing `/development/agent-playground` docs.