### PR TITLE
[OPIK-6164] [FE] fix: unify experiment items ID column label to "Item ID"

### DIFF
--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -88,13 +88,11 @@ const STORAGE_PREFIX = "compare-experiments";
 const DYNAMIC_COLUMNS_KEY = "compare-experiments-dynamic-columns";
 const EVAL_SUITE_ECHOED_OUTPUT_KEY = "input";
 
-function getFilterColumns(
-  isTestSuite: boolean,
-): ColumnData<ExperimentsCompare>[] {
+function getFilterColumns(): ColumnData<ExperimentsCompare>[] {
   return [
     {
       id: COLUMN_ID_ID,
-      label: isTestSuite ? "ID (Test suite item)" : "Dataset item ID",
+      label: "Item ID",
       type: COLUMN_TYPE.string,
     },
     {
@@ -250,7 +248,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
     return [
       {
         id: COLUMN_ID_ID,
-        label: "Dataset item ID",
+        label: "Item ID",
         type: COLUMN_TYPE.string,
         cell: IdCell as never,
         verticalAlignment: calculateVerticalAlignment(experimentsCount),
@@ -566,7 +564,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         label: `${label} (Output)`,
         type: COLUMN_TYPE.string,
       })),
-      ...getFilterColumns(!!isTestSuite),
+      ...getFilterColumns(),
     ];
   }, [dynamicDatasetColumns, visibleOutputColumns, isTestSuite]);
 


### PR DESCRIPTION
## Details

The ID column on the Compare Experiments → Items tab used different labels depending on the experiment source:

- **Dataset experiments** → `Dataset item ID` (visible header + filter)
- **Test-suite experiments** → `Dataset item ID` (visible header) and `ID (Test suite item)` (filter)

Per [OPIK-6164] the column name should be unified to **`Item ID`** for both cases so the experiment results page is consistent regardless of whether it points at a dataset or a test suite.

Touches one file (`apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx`):
- Filter-column label (was a `isTestSuite ? ... : ...` ternary) → static `"Item ID"`
- Visible header label in `datasetColumnsData` → `"Item ID"`
- Drop the now-unused `isTestSuite` parameter from `getFilterColumns`

The column **id** (`COLUMN_ID_ID === "id"`) is unchanged — only the user-visible label is touched, so filtering, sorting, and persisted column-state continue to work unchanged. Scope intentionally limited to v2 per the assignee's direction.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6164

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: codebase exploration, single-file edit, commit/PR authoring
- Human verification: author reviewed diff and ran typecheck + lint locally

## Testing

- `npm run typecheck` (in `apps/opik-frontend`) — clean
- `npx eslint src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx --max-warnings=0` — clean
- Manual verification still TODO by reviewer: open the Compare Experiments → Items tab on both a dataset-based and a test-suite-based experiment; confirm the ID column header reads `Item ID` and that the filter panel lists the same label. Apply a filter on the field to confirm filtering still works (column id is unchanged so behavior should be identical).

## Documentation

N/A — label-only UI fix; no public API or documented contract changed.

[OPIK-6164]: https://comet-ml.atlassian.net/browse/OPIK-6164