### PR TITLE
[OPIK-6239] [BE] feat: add P4-P6 workspace permissions and annotate endpoints

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResource.java
@@ -182,6 +182,7 @@ public class AnnotationQueuesResource {
             @ApiResponse(responseCode = "204", description = "No Content"),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))
     })
+    @RequiredPermissions(WorkspaceUserPermission.ANNOTATION_QUEUE_EDIT)
     @RateLimited
     public Response updateAnnotationQueue(
             @PathParam("id") UUID id,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DashboardsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DashboardsResource.java
@@ -71,6 +71,7 @@ public class DashboardsResource {
             @ApiResponse(responseCode = "201", description = "Created", headers = {
                     @Header(name = "Location", required = true, example = "${basePath}/v1/private/dashboards/{dashboardId}", schema = @Schema(implementation = String.class))}, content = @Content(schema = @Schema(implementation = Dashboard.class)))
     })
+    @RequiredPermissions(WorkspaceUserPermission.DASHBOARD_CREATE)
     @JsonView(Dashboard.View.Public.class)
     @RateLimited
     public Response createDashboard(
@@ -144,6 +145,7 @@ public class DashboardsResource {
             @ApiResponse(responseCode = "404", description = "Dashboard not found"),
             @ApiResponse(responseCode = "409", description = "Conflict - dashboard with this name already exists")
     })
+    @RequiredPermissions(WorkspaceUserPermission.DASHBOARD_EDIT)
     @JsonView(Dashboard.View.Public.class)
     @RateLimited
     public Response updateDashboard(
@@ -166,6 +168,7 @@ public class DashboardsResource {
     @Operation(operationId = "deleteDashboard", summary = "Delete dashboard", description = "Delete dashboard by id", responses = {
             @ApiResponse(responseCode = "204", description = "No content")
     })
+    @RequiredPermissions(WorkspaceUserPermission.DASHBOARD_DELETE)
     public Response deleteDashboard(@PathParam("dashboardId") UUID id) {
 
         String workspaceId = requestContext.get().getWorkspaceId();
@@ -182,6 +185,7 @@ public class DashboardsResource {
     @Operation(operationId = "deleteDashboardsBatch", summary = "Delete dashboards", description = "Delete dashboards batch", responses = {
             @ApiResponse(responseCode = "204", description = "No content"),
     })
+    @RequiredPermissions(WorkspaceUserPermission.DASHBOARD_DELETE)
     public Response deleteDashboardsBatch(
             @NotNull @RequestBody(content = @Content(schema = @Schema(implementation = BatchDelete.class))) @Valid BatchDelete batchDelete) {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -190,6 +190,7 @@ public class DatasetsResource {
                     @Header(name = "Location", required = true, example = "${basePath}/api/v1/private/datasets/{id}", schema = @Schema(implementation = String.class))
             })
     })
+    @RequiredPermissions(WorkspaceUserPermission.DATASET_CREATE)
     @RateLimited
     public Response createDataset(
             @RequestBody(content = @Content(schema = @Schema(implementation = Dataset.class))) @JsonView(Dataset.View.Write.class) @NotNull @Valid Dataset dataset,
@@ -219,6 +220,7 @@ public class DatasetsResource {
     @Operation(operationId = "updateDataset", summary = "Update dataset by id", description = "Update dataset by id", responses = {
             @ApiResponse(responseCode = "204", description = "No content"),
     })
+    @RequiredPermissions(WorkspaceUserPermission.DATASET_EDIT)
     @RateLimited
     public Response updateDataset(@PathParam("id") UUID id,
             @RequestBody(content = @Content(schema = @Schema(implementation = DatasetUpdate.class))) @NotNull @Valid DatasetUpdate datasetUpdate) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -292,6 +292,7 @@ public class ExperimentsResource {
     @Operation(operationId = "createExperiment", summary = "Create experiment", description = "Create experiment", responses = {
             @ApiResponse(responseCode = "201", description = "Created", headers = {
                     @Header(name = "Location", required = true, example = "${basePath}/v1/private/experiments/{id}", schema = @Schema(implementation = String.class))})})
+    @RequiredPermissions(WorkspaceUserPermission.EXPERIMENT_CREATE)
     @RateLimited
     public Response create(
             @RequestBody(content = @Content(schema = @Schema(implementation = Experiment.class))) @JsonView(Experiment.View.Write.class) @NotNull @Valid Experiment experiment,

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/WorkspaceUserPermission.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/WorkspaceUserPermission.java
@@ -8,26 +8,43 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum WorkspaceUserPermission {
 
-    DASHBOARD_VIEW("dashboard_view"),
-    EXPERIMENT_VIEW("experiment_view"),
-    DATASET_VIEW("dataset_view"),
-    ANNOTATION_QUEUE_VIEW("annotation_queue_view"),
-    TRACE_SPAN_THREAD_LOG("trace_span_thread_log"),
-    PROJECT_DELETE("project_delete"),
-    TRACE_DELETE("trace_delete"),
-    DATASET_DELETE("dataset_delete"),
-    ANNOTATION_QUEUE_DELETE("annotation_queue_delete"),
-    PROMPT_DELETE("prompt_delete"),
-    OPTIMIZATION_RUN_DELETE("optimization_run_delete"),
     WORKSPACE_SETTINGS_CONFIGURE("workspace_settings_configure"),
     AI_PROVIDER_UPDATE("ai_provider_update"),
-    ANNOTATION_QUEUE_ANNOTATE("annotation_queue_annotate"),
+
     PROJECT_CREATE("project_create"),
     PROJECT_DATA_VIEW("project_data_view"),
+    PROJECT_DELETE("project_delete"),
+
+    TRACE_SPAN_THREAD_LOG("trace_span_thread_log"),
     TRACE_SPAN_THREAD_ANNOTATE("trace_span_thread_annotate"),
+    TRACE_DELETE("trace_delete"),
+
     ONLINE_EVALUATION_RULE_UPDATE("online_evaluation_rule_update"),
     ALERT_UPDATE("alert_update"),
-    ANNOTATION_QUEUE_CREATE("annotation_queue_create");
+
+    DASHBOARD_VIEW("dashboard_view"),
+    DASHBOARD_CREATE("dashboard_create"),
+    DASHBOARD_EDIT("dashboard_edit"),
+    DASHBOARD_DELETE("dashboard_delete"),
+
+    EXPERIMENT_VIEW("experiment_view"),
+    EXPERIMENT_CREATE("experiment_create"),
+
+    DATASET_VIEW("dataset_view"),
+    DATASET_CREATE("dataset_create"),
+    DATASET_EDIT("dataset_edit"),
+    DATASET_DELETE("dataset_delete"),
+
+    ANNOTATION_QUEUE_VIEW("annotation_queue_view"),
+    ANNOTATION_QUEUE_CREATE("annotation_queue_create"),
+    ANNOTATION_QUEUE_ANNOTATE("annotation_queue_annotate"),
+    ANNOTATION_QUEUE_EDIT("annotation_queue_edit"),
+    ANNOTATION_QUEUE_DELETE("annotation_queue_delete"),
+    ANNOTATION_QUEUE_RESULTS_EXPORT("annotation_queue_results_export"),
+
+    PROMPT_DELETE("prompt_delete"),
+
+    OPTIMIZATION_RUN_DELETE("optimization_run_delete");
 
     @JsonValue
     private final String value;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AnnotationQueuesResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AnnotationQueuesResourceClient.java
@@ -176,15 +176,19 @@ public class AnnotationQueuesResourceClient {
 
     public void updateAnnotationQueue(UUID queueId, AnnotationQueueUpdate updateRequest, String apiKey,
             String workspaceName, int expectedStatus) {
-        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
+        try (var response = callUpdateAnnotationQueue(queueId, updateRequest, apiKey, workspaceName)) {
+            assertThat(response.getStatus()).isEqualTo(expectedStatus);
+        }
+    }
+
+    public Response callUpdateAnnotationQueue(UUID queueId, AnnotationQueueUpdate updateRequest, String apiKey,
+            String workspaceName) {
+        return client.target(RESOURCE_PATH.formatted(baseURI))
                 .path(queueId.toString())
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, apiKey)
                 .header(RequestContext.WORKSPACE_HEADER, workspaceName)
-                .method("PATCH", Entity.json(updateRequest))) {
-
-            assertThat(response.getStatus()).isEqualTo(expectedStatus);
-        }
+                .method("PATCH", Entity.json(updateRequest));
     }
 
     public AnnotationQueue.AnnotationQueuePage findAnnotationQueues(int page, int size, String name,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/DashboardResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/DashboardResourceClient.java
@@ -201,17 +201,21 @@ public class DashboardResourceClient {
     }
 
     public void batchDelete(Set<UUID> ids, String apiKey, String workspaceName, int expectedStatus) {
+        try (var response = callBatchDelete(ids, apiKey, workspaceName)) {
+            assertThat(response.getStatus()).isEqualTo(expectedStatus);
+        }
+    }
+
+    public Response callBatchDelete(Set<UUID> ids, String apiKey, String workspaceName) {
         var batchDelete = com.comet.opik.api.BatchDelete.builder()
                 .ids(ids)
                 .build();
-        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
+        return client.target(RESOURCE_PATH.formatted(baseURI))
                 .path("delete-batch")
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, apiKey)
                 .header(WORKSPACE_HEADER, workspaceName)
-                .post(Entity.json(batchDelete))) {
-            assertThat(response.getStatus()).isEqualTo(expectedStatus);
-        }
+                .post(Entity.json(batchDelete));
     }
 
     public Dashboard.DashboardBuilder createPartialDashboard() {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/DatasetResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/DatasetResourceClient.java
@@ -10,6 +10,7 @@ import com.comet.opik.api.DatasetItemBatch;
 import com.comet.opik.api.DatasetItemChanges;
 import com.comet.opik.api.DatasetItemStreamRequest;
 import com.comet.opik.api.DatasetItemsDelete;
+import com.comet.opik.api.DatasetUpdate;
 import com.comet.opik.api.DatasetVersion;
 import com.comet.opik.api.DatasetVersionDiff;
 import com.comet.opik.api.DatasetVersionRetrieveRequest;
@@ -90,6 +91,16 @@ public class DatasetResourceClient {
                 .header(HttpHeaders.AUTHORIZATION, apiKey)
                 .header(WORKSPACE_HEADER, workspaceName)
                 .post(Entity.json(dataset));
+    }
+
+    public Response callUpdateDataset(UUID datasetId, DatasetUpdate update, String apiKey, String workspaceName) {
+        return client.target(RESOURCE_PATH.formatted(baseURI))
+                .path(datasetId.toString())
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .put(Entity.json(update));
     }
 
     public UUID createDataset(Dataset dataset, String apiKey, String workspaceName) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResourceTest.java
@@ -320,6 +320,51 @@ class AnnotationQueuesResourceTest {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN);
             }
         }
+
+        @Test
+        @DisplayName("Update annotation queue passes required permissions to auth endpoint")
+        void updateAnnotationQueuePassesRequiredPermissionsToAuthEndpoint() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var project = factory.manufacturePojo(Project.class);
+            var projectId = projectResourceClient.createProject(project, apiKey, workspaceName);
+
+            var annotationQueue = factory.manufacturePojo(AnnotationQueue.class)
+                    .toBuilder()
+                    .id(null)
+                    .projectId(projectId)
+                    .build();
+
+            var queueId = annotationQueuesResourceClient.createAnnotationQueue(annotationQueue, apiKey, workspaceName,
+                    HttpStatus.SC_CREATED);
+
+            wireMock.server().resetRequests();
+            annotationQueuesResourceClient.callUpdateAnnotationQueue(queueId,
+                    factory.manufacturePojo(AnnotationQueueUpdate.class), apiKey, workspaceName).close();
+
+            wireMock.server().verify(
+                    postRequestedFor(urlPathEqualTo("/opik/auth"))
+                            .withRequestBody(matchingJsonPath("$.requiredPermissions[0]",
+                                    equalTo(WorkspaceUserPermission.ANNOTATION_QUEUE_EDIT.getValue()))));
+        }
+
+        @Test
+        @DisplayName("Update annotation queue returns 403 when permission is denied")
+        void updateAnnotationQueueReturnsForbiddenWhenPermissionDenied() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+
+            AuthTestUtils.mockTargetWorkspaceDenyPermission(wireMock.server(), apiKey, workspaceName,
+                    WorkspaceUserPermission.ANNOTATION_QUEUE_EDIT.getValue());
+
+            try (var response = annotationQueuesResourceClient.callUpdateAnnotationQueue(UUID.randomUUID(),
+                    factory.manufacturePojo(AnnotationQueueUpdate.class), apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN);
+            }
+        }
     }
 
     @Nested

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DashboardsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DashboardsResourceTest.java
@@ -145,6 +145,148 @@ class DashboardsResourceTest {
     }
 
     @Nested
+    @DisplayName("Required permissions")
+    class RequiredPermissionsTest {
+
+        @Test
+        @DisplayName("Create dashboard passes required permissions to auth endpoint")
+        void createDashboardPassesRequiredPermissionsToAuthEndpoint() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var dashboard = dashboardResourceClient.createPartialDashboard().build();
+
+            wireMock.server().resetRequests();
+            dashboardResourceClient.callCreate(dashboard, apiKey, workspaceName).close();
+
+            wireMock.server().verify(
+                    postRequestedFor(urlPathEqualTo("/opik/auth"))
+                            .withRequestBody(matchingJsonPath("$.requiredPermissions[0]",
+                                    equalTo(WorkspaceUserPermission.DASHBOARD_CREATE.getValue()))));
+        }
+
+        @Test
+        @DisplayName("Create dashboard returns 403 when permission is denied")
+        void createDashboardReturnsForbiddenWhenPermissionDenied() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+
+            AuthTestUtils.mockTargetWorkspaceDenyPermission(wireMock.server(), apiKey, workspaceName,
+                    WorkspaceUserPermission.DASHBOARD_CREATE.getValue());
+
+            var dashboard = dashboardResourceClient.createPartialDashboard().build();
+
+            try (var response = dashboardResourceClient.callCreate(dashboard, apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN);
+            }
+        }
+
+        @Test
+        @DisplayName("Update dashboard passes required permissions to auth endpoint")
+        void updateDashboardPassesRequiredPermissionsToAuthEndpoint() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var id = dashboardResourceClient.create(apiKey, workspaceName);
+
+            wireMock.server().resetRequests();
+            dashboardResourceClient.callUpdate(id, DashboardUpdate.builder().description("updated").build(), apiKey,
+                    workspaceName).close();
+
+            wireMock.server().verify(
+                    postRequestedFor(urlPathEqualTo("/opik/auth"))
+                            .withRequestBody(matchingJsonPath("$.requiredPermissions[0]",
+                                    equalTo(WorkspaceUserPermission.DASHBOARD_EDIT.getValue()))));
+        }
+
+        @Test
+        @DisplayName("Update dashboard returns 403 when permission is denied")
+        void updateDashboardReturnsForbiddenWhenPermissionDenied() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+
+            AuthTestUtils.mockTargetWorkspaceDenyPermission(wireMock.server(), apiKey, workspaceName,
+                    WorkspaceUserPermission.DASHBOARD_EDIT.getValue());
+
+            try (var response = dashboardResourceClient.callUpdate(UUID.randomUUID(),
+                    DashboardUpdate.builder().description("updated").build(), apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN);
+            }
+        }
+
+        @Test
+        @DisplayName("Delete dashboard passes required permissions to auth endpoint")
+        void deleteDashboardPassesRequiredPermissionsToAuthEndpoint() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var id = dashboardResourceClient.create(apiKey, workspaceName);
+
+            wireMock.server().resetRequests();
+            dashboardResourceClient.callDelete(id, apiKey, workspaceName).close();
+
+            wireMock.server().verify(
+                    postRequestedFor(urlPathEqualTo("/opik/auth"))
+                            .withRequestBody(matchingJsonPath("$.requiredPermissions[0]",
+                                    equalTo(WorkspaceUserPermission.DASHBOARD_DELETE.getValue()))));
+        }
+
+        @Test
+        @DisplayName("Delete dashboard returns 403 when permission is denied")
+        void deleteDashboardReturnsForbiddenWhenPermissionDenied() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+
+            AuthTestUtils.mockTargetWorkspaceDenyPermission(wireMock.server(), apiKey, workspaceName,
+                    WorkspaceUserPermission.DASHBOARD_DELETE.getValue());
+
+            try (var response = dashboardResourceClient.callDelete(UUID.randomUUID(), apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN);
+            }
+        }
+
+        @Test
+        @DisplayName("Delete dashboards batch passes required permissions to auth endpoint")
+        void deleteDashboardsBatchPassesRequiredPermissionsToAuthEndpoint() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var id = dashboardResourceClient.create(apiKey, workspaceName);
+
+            wireMock.server().resetRequests();
+            dashboardResourceClient.callBatchDelete(Set.of(id), apiKey, workspaceName).close();
+
+            wireMock.server().verify(
+                    postRequestedFor(urlPathEqualTo("/opik/auth"))
+                            .withRequestBody(matchingJsonPath("$.requiredPermissions[0]",
+                                    equalTo(WorkspaceUserPermission.DASHBOARD_DELETE.getValue()))));
+        }
+
+        @Test
+        @DisplayName("Delete dashboards batch returns 403 when permission is denied")
+        void deleteDashboardsBatchReturnsForbiddenWhenPermissionDenied() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+
+            AuthTestUtils.mockTargetWorkspaceDenyPermission(wireMock.server(), apiKey, workspaceName,
+                    WorkspaceUserPermission.DASHBOARD_DELETE.getValue());
+
+            try (var response = dashboardResourceClient.callBatchDelete(Set.of(UUID.randomUUID()), apiKey,
+                    workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN);
+            }
+        }
+    }
+
+    @Nested
     @DisplayName("Create dashboard")
     class CreateDashboard {
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -434,6 +434,72 @@ class DatasetsResourceTest {
                             .withRequestBody(matchingJsonPath("$.requiredPermissions[0]",
                                     equalTo(WorkspaceUserPermission.DATASET_DELETE.getValue()))));
         }
+
+        @Test
+        @DisplayName("Create dataset passes required permissions to auth endpoint")
+        void createDatasetPassesRequiredPermissionsToAuthEndpoint() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            wireMock.server().resetRequests();
+            datasetResourceClient.callCreateDataset(buildDataset(), apiKey, workspaceName).close();
+
+            wireMock.server().verify(
+                    postRequestedFor(urlPathEqualTo("/opik/auth"))
+                            .withRequestBody(matchingJsonPath("$.requiredPermissions[0]",
+                                    equalTo(WorkspaceUserPermission.DATASET_CREATE.getValue()))));
+        }
+
+        @Test
+        @DisplayName("Create dataset returns 403 when permission is denied")
+        void createDatasetReturnsForbiddenWhenPermissionDenied() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+
+            AuthTestUtils.mockTargetWorkspaceDenyPermission(wireMock.server(), apiKey, workspaceName,
+                    WorkspaceUserPermission.DATASET_CREATE.getValue());
+
+            try (var response = datasetResourceClient.callCreateDataset(buildDataset(), apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN);
+            }
+        }
+
+        @Test
+        @DisplayName("Update dataset passes required permissions to auth endpoint")
+        void updateDatasetPassesRequiredPermissionsToAuthEndpoint() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var id = datasetResourceClient.createDataset(buildDataset(), apiKey, workspaceName);
+
+            wireMock.server().resetRequests();
+            datasetResourceClient.callUpdateDataset(id, factory.manufacturePojo(DatasetUpdate.class), apiKey,
+                    workspaceName).close();
+
+            wireMock.server().verify(
+                    postRequestedFor(urlPathEqualTo("/opik/auth"))
+                            .withRequestBody(matchingJsonPath("$.requiredPermissions[0]",
+                                    equalTo(WorkspaceUserPermission.DATASET_EDIT.getValue()))));
+        }
+
+        @Test
+        @DisplayName("Update dataset returns 403 when permission is denied")
+        void updateDatasetReturnsForbiddenWhenPermissionDenied() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+
+            AuthTestUtils.mockTargetWorkspaceDenyPermission(wireMock.server(), apiKey, workspaceName,
+                    WorkspaceUserPermission.DATASET_EDIT.getValue());
+
+            try (var response = datasetResourceClient.callUpdateDataset(UUID.randomUUID(),
+                    factory.manufacturePojo(DatasetUpdate.class), apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN);
+            }
+        }
     }
 
     @Nested

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -336,6 +336,41 @@ class ExperimentsResourceTest {
                             .withRequestBody(matchingJsonPath("$.requiredPermissions[0]",
                                     equalTo(WorkspaceUserPermission.EXPERIMENT_VIEW.getValue()))));
         }
+
+        @Test
+        @DisplayName("Create experiment passes required permissions to auth endpoint")
+        void createExperimentPassesRequiredPermissionsToAuthEndpoint() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var experiment = experimentResourceClient.createPartialExperiment().build();
+
+            wireMock.server().resetRequests();
+            experimentResourceClient.callCreate(experiment, apiKey, workspaceName).close();
+
+            wireMock.server().verify(
+                    postRequestedFor(urlPathEqualTo("/opik/auth"))
+                            .withRequestBody(matchingJsonPath("$.requiredPermissions[0]",
+                                    equalTo(WorkspaceUserPermission.EXPERIMENT_CREATE.getValue()))));
+        }
+
+        @Test
+        @DisplayName("Create experiment returns 403 when permission is denied")
+        void createExperimentReturnsForbiddenWhenPermissionDenied() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+
+            AuthTestUtils.mockTargetWorkspaceDenyPermission(wireMock.server(), apiKey, workspaceName,
+                    WorkspaceUserPermission.EXPERIMENT_CREATE.getValue());
+
+            var experiment = experimentResourceClient.createPartialExperiment().build();
+
+            try (var response = experimentResourceClient.callCreate(experiment, apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN);
+            }
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Details
Add P4-P6 workspace permissions from the [permissions spec](https://www.notion.so/cometml/Workspace-permissions-and-user-roles-management-2b77124010a380f8b526e7ecb235c419) to the `WorkspaceUserPermission` enum and annotate the matching endpoints with `@RequiredPermissions`. The enum is reorganized so permissions are grouped by entity (admin, project, trace, dashboards, experiments, datasets, annotation queues, prompts, optimization).

- New permissions: `DASHBOARD_CREATE`/`DASHBOARD_EDIT`/`DASHBOARD_DELETE` (P4), `EXPERIMENT_CREATE` (P5), `DATASET_CREATE`/`DATASET_EDIT` (P5), `ANNOTATION_QUEUE_EDIT`/`ANNOTATION_QUEUE_RESULTS_EXPORT` (P6).
- Annotated endpoints: `DashboardsResource` (create/update/delete/delete-batch), `ExperimentsResource` (create), `DatasetsResource` (create/update), `AnnotationQueuesResource` (update). `ANNOTATION_QUEUE_RESULTS_EXPORT` is enum-only — no export endpoint exists yet (same pattern as `USER_ROLE_UPDATE` in OPIK-5044).
- Adds `RequiredPermissionsTest` coverage (permission-passes-to-auth and 403-when-denied) for every new annotation, plus `call*` response-returning helpers in the affected resource clients.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6239

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: Enum additions, endpoint annotations, test code, and resource client helpers
- Human verification: Author reviewed all diffs, ran `mvn compile`, `mvn test-compile`, and the four affected `RequiredPermissionsTest` classes locally before pushing

## Testing
Local commands run on `apps/opik-backend`:

- `mvn compile -DskipTests` — BUILD SUCCESS
- `mvn test-compile -DskipTests` — BUILD SUCCESS
- `mvn test -Dtest='DashboardsResourceTest$RequiredPermissionsTest'` — 8/8 pass
- `mvn test -Dtest='DatasetsResourceTest$RequiredPermissionsTest'` — 8/8 pass (4 pre-existing + 4 new)
- `mvn test -Dtest='AnnotationQueuesResourceTest$RequiredPermissionsTest'` — 10/10 pass (8 pre-existing + 2 new)
- `mvn test -Dtest='ExperimentsResourceTest$RequiredPermissions#createExperimentReturnsForbiddenWhenPermissionDenied+createExperimentPassesRequiredPermissionsToAuthEndpoint'` — 2/2 pass

Scenarios covered: each newly annotated endpoint has both a "permission name passes through to /opik/auth" assertion and a "endpoint returns 403 when auth service denies the permission" assertion. `ANNOTATION_QUEUE_RESULTS_EXPORT` has no test because no endpoint uses it yet.

## Documentation
N/A — no user-facing or API surface change beyond enum values consumed by the auth service.