### PR TITLE
[OPIK-6173] [BE] Fix experiments with ZERO_UUID aggregate project_id not appearing in experiment list

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -628,7 +628,7 @@ public class ExperimentDAO {
                 SELECT
                     e.workspace_id as workspace_id,
                     e.dataset_id as dataset_id,
-                    if(empty(agg.project_ids), '', agg.project_ids[1]) as project_id,
+                    if(notEmpty(agg.project_ids), agg.project_ids[1], e.project_id) as project_id,
                     e.id as id,
                     e.name as name,
                     e.metadata as metadata,
@@ -658,7 +658,7 @@ public class ExperimentDAO {
                     if(agg.total_count = 0, NULL, agg.passed_count) AS passed_count,
                     if(agg.total_count = 0, NULL, agg.total_count) AS total_count,
                     agg.assertion_scores as assertion_scores,
-                    agg.project_ids as combined_project_ids
+                    multiIf(notEmpty(agg.project_ids), agg.project_ids, notEmpty(e.project_id), cast([e.project_id] AS Array(String)), cast([] AS Array(String))) as combined_project_ids
                 FROM experiments_resolved AS e
                 INNER JOIN experiments_from_aggregates_final AS agg ON e.id = agg.experiment_id
                 WHERE 1=1
@@ -675,10 +675,10 @@ public class ExperimentDAO {
                 AND (<experiment_scores_agg_empty_filters>)
                 <endif>
                 <if(project_id)>
-                AND has(agg.project_ids, :project_id)
+                AND (has(agg.project_ids, :project_id) OR (empty(agg.project_ids) AND e.project_id = :project_id))
                 <endif>
                 <if(project_deleted)>
-                AND (has(agg.project_ids, '') OR empty(agg.project_ids))
+                AND (has(agg.project_ids, '') OR (empty(agg.project_ids) AND empty(e.project_id)))
                 <endif>
                 <endif>
 
@@ -955,10 +955,10 @@ public class ExperimentDAO {
                 AND (<experiment_scores_agg_empty_filters>)
                 <endif>
                 <if(project_id)>
-                AND has(agg.project_ids, :project_id)
+                AND (has(agg.project_ids, :project_id) OR (empty(agg.project_ids) AND e.project_id = :project_id))
                 <endif>
                 <if(project_deleted)>
-                AND (has(agg.project_ids, '') OR empty(agg.project_ids))
+                AND (has(agg.project_ids, '') OR (empty(agg.project_ids) AND empty(e.project_id)))
                 <endif>
                 <endif>
 
@@ -1081,16 +1081,16 @@ public class ExperimentDAO {
                     ef.tags,
                     ef.prompt_ids,
                     ef.created_at,
-                    agg.project_ids as project_ids,
-                    if(empty(agg.project_ids), '', agg.project_ids[1]) as project_id
+                    multiIf(notEmpty(agg.project_ids), agg.project_ids, notEmpty(ef.experiment_project_id), cast([ef.experiment_project_id] AS Array(String)), cast([] AS Array(String))) as project_ids,
+                    if(notEmpty(agg.project_ids), agg.project_ids[1], ef.experiment_project_id) as project_id
                 FROM experiments_filtered ef
                 INNER JOIN experiments_from_aggregates_final agg ON ef.id = agg.experiment_id
                 WHERE 1=1
                 <if(project_id)>
-                AND has(agg.project_ids, :project_id)
+                AND (has(agg.project_ids, :project_id) OR (empty(agg.project_ids) AND ef.experiment_project_id = :project_id))
                 <endif>
                 <if(project_deleted)>
-                AND (has(agg.project_ids, '') OR empty(agg.project_ids))
+                AND (has(agg.project_ids, '') OR (empty(agg.project_ids) AND empty(ef.experiment_project_id)))
                 <endif>
                 <endif>
                 <if(has_aggregated)><if(has_raw)>UNION ALL<endif><endif>
@@ -1488,8 +1488,8 @@ public class ExperimentDAO {
                     agg.duration_values AS duration,
                     agg.total_estimated_cost_sum as total_estimated_cost,
                     agg.total_estimated_cost_avg as total_estimated_cost_avg,
-                    agg.project_ids as project_ids,
-                    if(empty(agg.project_ids), '', agg.project_ids[1]) as project_id,
+                    multiIf(notEmpty(agg.project_ids), agg.project_ids, notEmpty(e.experiment_project_id), cast([e.experiment_project_id] AS Array(String)), cast([] AS Array(String))) as project_ids,
+                    if(notEmpty(agg.project_ids), agg.project_ids[1], e.experiment_project_id) as project_id,
                     agg.pass_rate as pass_rate,
                     agg.passed_count as passed_count,
                     agg.total_count as total_count,
@@ -1498,10 +1498,10 @@ public class ExperimentDAO {
                 INNER JOIN experiments_from_aggregates_final AS agg ON e.id = agg.experiment_id
                 WHERE 1=1
                 <if(project_id)>
-                AND has(agg.project_ids, :project_id)
+                AND (has(agg.project_ids, :project_id) OR (empty(agg.project_ids) AND e.experiment_project_id = :project_id))
                 <endif>
                 <if(project_deleted)>
-                AND (has(agg.project_ids, '') OR empty(agg.project_ids))
+                AND (has(agg.project_ids, '') OR (empty(agg.project_ids) AND empty(e.experiment_project_id)))
                 <endif>
                 <endif>
                 <if(has_aggregated)><if(has_raw)>UNION ALL<endif><endif>

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
@@ -2465,4 +2465,85 @@ class ExperimentAggregatesIntegrationTest {
         assertDatasetItemsWithExperimentItems(expectedAfterDelete, afterDelete.content());
     }
 
+    @Test
+    @DisplayName("Experiments with ZERO_UUID aggregate project_id are visible when experiment has correct project_id")
+    void experimentsWithZeroUuidAggregateProjectIdAreVisibleViaFallback() {
+        var workspaceName = UUID.randomUUID().toString();
+        var apiKey = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var project = createProject(apiKey, workspaceName);
+        var dataset = createDataset(apiKey, workspaceName);
+
+        var experiment = experimentResourceClient.createPartialExperiment()
+                .datasetId(dataset.id())
+                .datasetName(dataset.name())
+                .projectName(project.name())
+                .build();
+        experimentResourceClient.create(experiment, apiKey, workspaceName);
+
+        // Populate aggregates BEFORE creating items/traces.
+        // This simulates the race condition: aggregate gets project_id = ZERO_UUID
+        // because getProjectId() finds no traces yet.
+        experimentAggregatesService.populateAggregations(experiment.id())
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+                .block();
+
+        // FIND: experiment should be found by project_id despite ZERO_UUID aggregate
+        var findCriteria = ExperimentSearchCriteria.builder()
+                .projectId(project.id())
+                .entityType(EntityType.TRACE)
+                .sortingFields(List.of())
+                .build();
+
+        var findResult = experimentService.find(1, 10, findCriteria)
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+                .block();
+
+        assertThat(findResult).isNotNull();
+        assertThat(findResult.content())
+                .as("FIND should return experiment with ZERO_UUID aggregate when experiment has correct project_id")
+                .extracting(Experiment::id)
+                .contains(experiment.id());
+
+        assertThat(findResult.total())
+                .as("FIND total count should include experiment with ZERO_UUID aggregate")
+                .isGreaterThanOrEqualTo(1);
+
+        // FIND_GROUPS: experiment should appear in grouped view
+        var groupCriteria = ExperimentGroupCriteria.builder()
+                .groups(List.of(GroupBy.builder().field(GroupingFactory.DATASET_ID).type(FieldType.STRING).build()))
+                .projectId(project.id())
+                .build();
+
+        var groupsResult = experimentService.findGroups(groupCriteria)
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+                .block();
+
+        assertThat(groupsResult).isNotNull();
+        assertThat(groupsResult.content())
+                .as("FIND_GROUPS should return groups containing experiment with ZERO_UUID aggregate")
+                .isNotEmpty();
+
+        // FIND_GROUPS_AGGREGATIONS: experiment should appear in aggregations
+        var groupAggResult = experimentService.findGroupsAggregations(groupCriteria)
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+                .block();
+
+        assertThat(groupAggResult).isNotNull();
+        assertThat(groupAggResult.content())
+                .as("FIND_GROUPS_AGGREGATIONS should return aggregations for experiment with ZERO_UUID aggregate")
+                .isNotEmpty();
+    }
+
 }


### PR DESCRIPTION
## Details

When the aggregation job (`populateExperimentAggregate`) runs before traces are ingested, it stores `project_id` as `00000000-0000-0000-0000-000000000000` (ZERO_UUID) in the `experiment_aggregates` table. The experiment list queries convert this to an empty array and filter it out via `has([], :project_id)`, making the experiment permanently invisible — even though the experiment record itself has the correct `project_id`.

**Root cause confirmed** with production data from the reporter's workspace: 35 of 41 regular experiments had ZERO_UUID aggregate project_ids and were invisible.

**Fix**: In the aggregated branch SELECTs of FIND, FIND_COUNT, FIND_GROUPS, and FIND_GROUPS_AGGREGATIONS, fall back to the experiment's own `project_id` when the aggregate's `project_ids` array is empty. No new joins needed — the experiment table is already joined in these SELECTs.

Changes:
- `project_id` (scalar): `if(notEmpty(agg.project_ids), agg.project_ids[1], e.project_id)`
- `project_ids` (array): `multiIf(notEmpty(agg.project_ids), agg.project_ids, notEmpty(e.project_id), cast([e.project_id] AS Array(String)), cast([] AS Array(String)))`
- WHERE filters: `has(agg.project_ids, :project_id) OR (empty(agg.project_ids) AND e.project_id = :project_id)`

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-6173

## Testing
- Added integration test `experimentsWithZeroUuidAggregateProjectIdAreVisibleViaFallback` that reproduces the exact bug: creates an experiment with `projectName`, populates aggregates before items/traces exist (aggregate gets ZERO_UUID), then verifies the experiment is found via FIND, FIND_GROUPS, and FIND_GROUPS_AGGREGATIONS when filtering by `project_id`.
- Verified locally by mutating an experiment aggregate's `project_id` to ZERO_UUID — experiment disappeared before fix, reappeared after.

## Documentation
N/A