### PR TITLE
[OPIK-6251] [DOCS] Add missing P0-P3 permissions to docs table

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/administration/roles_and_permissions.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/roles_and_permissions.mdx
@@ -62,20 +62,24 @@ The table below shows the default permissions for each role. Custom roles can co
 | Admin                 | Define AI providers             | Yes    | Yes   | No       | No   |
 | Experiment management | Change project settings         | Yes    | No    | No       | No   |
 | Experiment management | Approve and manage models       | Yes    | No    | No       | No   |
+| Observability         | Create projects                 | Yes    | Yes   | No       | No   |
+| Observability         | Delete projects                 | Yes    | Yes   | No       | No   |
 | Observability         | View project data               | Yes    | Yes   | Yes      | Yes  |
 | Observability         | Log trace, span, or thread      | Yes    | Yes   | No       | No   |
 | Observability         | Delete trace                    | Yes    | Yes   | No       | No   |
-| Observability         | Write comments                  | Yes    | Yes   | Yes      | No   |
 | Observability         | Annotate trace, span, or thread | Yes    | Yes   | Yes      | No   |
-| Observability         | Tag trace                       | Yes    | Yes   | Yes      | No   |
 | Observability         | Define online evaluation rule   | Yes    | Yes   | No       | No   |
 | Observability         | Define alert                    | Yes    | Yes   | No       | No   |
 | Observability         | Create annotation queue         | Yes    | Yes   | No       | No   |
-| Dashboards            | View dashboard                  | Yes    | Yes   | No       | Yes  |
+| Dashboards            | View dashboards                 | Yes    | Yes   | No       | Yes  |
 | Experiments           | View experiments                | Yes    | Yes   | No       | Yes  |
 | Datasets              | View datasets                   | Yes    | Yes   | No       | Yes  |
+| Datasets              | Delete datasets                 | Yes    | Yes   | No       | No   |
 | Annotation queues     | View annotation queues          | Yes    | Yes   | Yes      | Yes  |
+| Annotation queues     | Create annotation queue         | Yes    | Yes   | No       | No   |
 | Annotation queues     | Annotate trace, span, or thread | Yes    | Yes   | Yes      | Yes  |
+| Annotation queues     | Delete annotation queue         | Yes    | Yes   | No       | No   |
+| Optimization          | Delete Optimization runs        | Yes    | Yes   | No       | No   |
 
 ### Custom roles
 

--- a/apps/opik-documentation/documentation/fern/docs/administration/roles_and_permissions.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/roles_and_permissions.mdx
@@ -77,7 +77,6 @@ The table below shows the default permissions for each role. Custom roles can co
 | Datasets              | Delete datasets                 | Yes    | Yes   | No       | No   |
 | Annotation queues     | View annotation queues          | Yes    | Yes   | Yes      | Yes  |
 | Annotation queues     | Create annotation queue         | Yes    | Yes   | No       | No   |
-| Annotation queues     | Annotate trace, span, or thread | Yes    | Yes   | Yes      | Yes  |
 | Annotation queues     | Delete annotation queue         | Yes    | Yes   | No       | No   |
 | Optimization          | Delete Optimization runs        | Yes    | Yes   | No       | No   |
 


### PR DESCRIPTION
## Details

Adds previously undocumented P0–P3 permission entries to the roles and permissions reference table. The table was missing several permissions that already exist in the product (project create/delete, dataset delete, annotation queue create/delete, optimization run delete) and contained a few stale rows that no longer reflect current behavior.

- Add rows for: Create projects, Delete projects, Delete datasets, Create annotation queue, Delete annotation queue, Delete Optimization runs
- Remove stale rows: standalone "Write comments" and "Tag trace" entries
- Fix label typo: "View dashboard" → "View dashboards"

## Change checklist
- [ ] User facing
- [x] Documentation update

## Testing

Documentation-only change. Verified by:
- Reviewing the rendered diff of `roles_and_permissions.mdx` to confirm table formatting is intact (column count and alignment preserved on every modified row).
- Cross-checking the new/removed rows against the current permission set defined in the backend role configuration.

No code paths changed; no automated tests run.

## Issues

- Resolves #
- OPIK-6251

## Documentation

This PR _is_ the documentation update. No additional docs required.
