### PR TITLE
[OPIK-6257] [FE] Gate create experiment buttons on permission

### DIFF
--- a/apps/opik-frontend/src/v1/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
+++ b/apps/opik-frontend/src/v1/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
@@ -83,6 +83,7 @@ import GroupsButton from "@/shared/GroupsButton/GroupsButton";
 import useTablePageSize from "@/hooks/useTablePageSize";
 import TextCell from "@/shared/DataTableCells/TextCell";
 import DatasetVersionCell from "@/shared/DataTableCells/DatasetVersionCell";
+import { usePermissions } from "@/contexts/PermissionsContext";
 const PASS_RATE_LABEL = "Pass rate";
 
 const STORAGE_KEY_PREFIX = "experiments";
@@ -128,6 +129,10 @@ const GeneralDatasetsTab: React.FC = () => {
   const navigate = useNavigate();
   const resetDialogKeyRef = useRef(0);
   const [query] = useQueryParam("new", JsonParam);
+
+  const {
+    permissions: { canCreateExperiments },
+  } = usePermissions();
 
   const [openDialog, setOpenDialog] = useState<boolean>(
     Boolean(query?.experiment),
@@ -708,14 +713,16 @@ const GeneralDatasetsTab: React.FC = () => {
             onOrderChange={setColumnsOrder}
             sections={columnSections}
           ></ColumnsButton>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleNewExperimentClick}
-          >
-            <Info className="mr-1.5 size-3.5" />
-            Create new experiment
-          </Button>
+          {canCreateExperiments && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleNewExperimentClick}
+            >
+              <Info className="mr-1.5 size-3.5" />
+              Create new experiment
+            </Button>
+          )}
         </div>
       </PageBodyStickyContainer>
       <DataTable
@@ -738,7 +745,7 @@ const GeneralDatasetsTab: React.FC = () => {
         columnPinning={columnPinningConfig}
         noData={
           <DataTableNoData title={noDataText}>
-            {noData && (
+            {noData && canCreateExperiments && (
               <Button variant="link" onClick={handleNewExperimentClick}>
                 Create new experiment
               </Button>

--- a/apps/opik-frontend/src/v2/pages/ExperimentsPage/ExperimentsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ExperimentsPage/ExperimentsPage.tsx
@@ -11,6 +11,7 @@ import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodySt
 import GeneralDatasetsTab from "./GeneralDatasetsTab/GeneralDatasetsTab";
 import PageEmptyState from "@/shared/PageEmptyState/PageEmptyState";
 import { buildDocsUrl } from "@/v2/lib/utils";
+import { usePermissions } from "@/contexts/PermissionsContext";
 import useExperimentsList from "@/api/datasets/useExperimentsList";
 import emptyExperimentsLightUrl from "/images/empty-experiments-light.svg";
 import emptyExperimentsDarkUrl from "/images/empty-experiments-dark.svg";
@@ -22,6 +23,10 @@ const ExperimentsPage: React.FC = () => {
   const [openDialog, setOpenDialog] = useState<boolean>(
     Boolean(query?.experiment),
   );
+
+  const {
+    permissions: { canCreateExperiments },
+  } = usePermissions();
 
   const { data: existenceData, isPending: isExistencePending } =
     useExperimentsList(
@@ -52,14 +57,16 @@ const ExperimentsPage: React.FC = () => {
           <h1 className="comet-body-accented truncate break-words">
             Experiments
           </h1>
-          <Button
-            variant="default"
-            size="xs"
-            onClick={handleNewExperimentClick}
-          >
-            <Plus className="mr-1 size-4" />
-            Create experiment
-          </Button>
+          {canCreateExperiments && (
+            <Button
+              variant="default"
+              size="xs"
+              onClick={handleNewExperimentClick}
+            >
+              <Plus className="mr-1 size-4" />
+              Create experiment
+            </Button>
+          )}
         </PageBodyStickyContainer>
         {isEmpty ? (
           <PageEmptyState


### PR DESCRIPTION
## Details

Gates the "Create new experiment" / "Create experiment" buttons on the Experiments page behind the `canCreateExperiments` permission, so users without the permission no longer see entry points they cannot use.

- v2 `ExperimentsPage` header button is now hidden when the permission is denied.
- v1 `GeneralDatasetsTab` header button and the empty-state link are both hidden when the permission is denied.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Testing

- Verified in the browser with a user who has `canCreateExperiments` granted: both v1 and v2 buttons render and work as before.
- Verified with the permission denied: header button is hidden on v2; header button and empty-state "Create new experiment" link are hidden on v1.
- `npm run lint` / `npm run type-check` on `apps/opik-frontend`.

## Issues

- Resolves #
- OPIK-6257

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: Authoring assistance for the permission-gating change in `GeneralDatasetsTab.tsx` and `ExperimentsPage.tsx`, plus this PR description.
- Human verification: Author reviewed the diff and tested the UI locally.

## Documentation

No documentation changes required — this is a permission-driven UI visibility change with no public API/behavior shift for permitted users.