### PR TITLE
[OPIK-6201] [FE] fix: 4px gap between collapsed sidebar menu items

### DIFF
--- a/apps/opik-frontend/src/v2/layout/SideBar/SideBarMenuItems.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/SideBarMenuItems.tsx
@@ -7,6 +7,7 @@ import SidebarMenuItem, {
 } from "@/v2/layout/SideBar/MenuItem/SidebarMenuItem";
 import getMenuItems from "@/v2/layout/SideBar/helpers/getMenuItems";
 import { usePermissions } from "@/contexts/PermissionsContext";
+import { cn } from "@/lib/utils";
 
 interface SideBarMenuItemsProps {
   expanded: boolean;
@@ -55,7 +56,12 @@ const SideBarMenuItems: React.FC<SideBarMenuItemsProps> = ({ expanded }) => {
                 {index > 0 && <Separator className="mx-1 w-auto" />}
               </div>
             ))}
-          <ul className="flex flex-col text-foreground">
+          <ul
+            className={cn(
+              "flex flex-col text-foreground",
+              !expanded && "gap-1",
+            )}
+          >
             {renderItems(menuGroup.items)}
           </ul>
         </li>


### PR DESCRIPTION
## Details

<img width="1665" height="928" alt="image" src="https://github.com/user-attachments/assets/383dc419-e3ed-4888-9e7b-b34474743294" />


Follow-up to #6495. The 4px gap between collapsed-sidebar items wasn't visible because `gap-1` was placed on the outer `<ul>` in `ProjectSidebarContent`, whose direct children are per-group `<li>` wrappers from `SideBarMenuItems` (with their own `pb-1`). Move `gap-1` (collapsed-only) onto the inner `<ul>` that actually renders the menu items so the gap takes effect between items, not between groups.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6201

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Opus 4.7
- Scope: assisted (root-cause analysis + 1-line patch)
- Human verification: code review + visual check on test env

## Testing

- `bash scripts/dev-runner.sh --lint-fe` (lint:fix + typecheck + deps:validate) — all pass
- Visual check pending on the redeployed test env

## Documentation

N/A