### PR TITLE
[OPIK-5792] [FE] fix: Playground UI regressions

### DIFF
--- a/apps/opik-frontend/src/shared/DataTablePagination/DataTablePagination.tsx
+++ b/apps/opik-frontend/src/shared/DataTablePagination/DataTablePagination.tsx
@@ -106,7 +106,7 @@ const DataTablePagination = ({
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
-              variant="outline"
+              variant={isMinimal ? "ghost" : "outline"}
               size="sm"
               className={`min-w-4 px-2 ${
                 isMinimal
@@ -116,7 +116,7 @@ const DataTablePagination = ({
               disabled={disabledSizeChange}
             >
               {size}
-              <ChevronDown className="ml-1 size-3.5" />
+              {!isMinimal && <ChevronDown className="ml-1 size-3.5" />}
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">

--- a/apps/opik-frontend/src/ui/hotkey-display.tsx
+++ b/apps/opik-frontend/src/ui/hotkey-display.tsx
@@ -8,7 +8,7 @@ const hotkeyDisplayVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-[#FFFFFF33] dark:bg-[#FFFFFF80]",
+        default: "bg-white/20 dark:bg-white/25",
         outline:
           "border border-input bg-background dark:border-border dark:bg-input dark:text-foreground-secondary dark:group-disabled:text-muted-gray",
       },

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundExperimentOutputActions.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundExperimentOutputActions.tsx
@@ -55,7 +55,7 @@ const PlaygroundExperimentOutputActions = ({
           <PlaygroundProgressIndicator />
         </div>
       ) : (
-        <div className="flex items-center justify-between bg-gray-100 px-4 py-3">
+        <div className="flex items-center justify-between bg-gray-100 py-3 pl-2 pr-4">
           {hasExperiments ? (
             <Button
               variant="ghost"


### PR DESCRIPTION
## Details

Three small styling regressions in the v2 Playground page:

- **Dark-mode shortcut chip opacity** — the `⇧`/`⏎` chips on the Run experiment button were too light, washing out the white glyphs. Halved the dark-mode background opacity (50% → 25%) on `HotkeyDisplay`'s `default` variant, switching from raw hex (`bg-[#FFFFFF80]`) to the `bg-white/N` token used by the `ghostInverted` Button variant. Light mode unchanged.
- **"Experiment results" alignment** — the label in the gray bar above the experiment table sat ~8px to the right of the first column header. The table's first `<th>` (`ui/table.tsx`) overrides the inner `HeaderWrapper`'s `px-3` with `pl-5` (20px), so the column header text actually starts at 20px. Added `pl-2` to the gray-bar wrapper so both the ghost Button (`size="sm"` → `px-3`) and the plain span (`pl-3`) land at 20px and align with the column header.
- **Borderless page-size selector** — in `DataTablePagination`'s `minimal` variant, the page-size dropdown trigger now uses `variant="ghost"` (no border) and hides the `ChevronDown` icon. The dropdown menu still opens normally. Default (non-`minimal`) callers — every other table — are unchanged.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5792

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: assisted (root-cause tracing for the alignment fix + 3 small patches + this PR description)
- Human verification: visual check on local dev (comet mode) + author review

## Testing

- `npx tsc --noEmit` and `npx eslint` on the three changed files — clean.
- Local dev (`npm start -- --mode comet`) verified:
  - Dark theme: Run experiment button chips visibly readable; light theme unchanged.
  - Experiment mode: "Experiment results" left-edge aligns with the first column header (`content`) below it, in both the no-experiments span branch and the post-run ghost Button branch.
  - Experiment-mode page-size selector: borderless, no chevron, dropdown still opens with `[10, 50, 100, 200, 500, 1000]`.
- Regression sweep: any non-Playground table (Traces / Datasets / Experiments / Projects) — page-size selector still has border + chevron (default `DataTablePagination` variant). v1 Playground inherits Fix #3 automatically since it also uses `variant="minimal"`.

## Documentation

N/A — styling-only fixes, no API or behavior change.