### PR TITLE
[OPIK-6069] [FE] Animate refresh buttons (shared RefreshButton)

### DIFF
--- a/apps/opik-frontend/src/shared/RefreshButton/RefreshButton.tsx
+++ b/apps/opik-frontend/src/shared/RefreshButton/RefreshButton.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import { RotateCw } from "lucide-react";
+import { Button, ButtonProps } from "@/ui/button";
+import { cn } from "@/lib/utils";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+
+interface RefreshButtonProps {
+  onRefresh: () => void;
+  isFetching?: boolean;
+  tooltip: string;
+  label?: string;
+  variant?: ButtonProps["variant"];
+  size?: ButtonProps["size"];
+  className?: string;
+}
+
+const RefreshButton: React.FC<RefreshButtonProps> = ({
+  onRefresh,
+  isFetching = false,
+  tooltip,
+  label,
+  variant = "outline",
+  size = "icon-sm",
+  className,
+}) => {
+  const [spin, setSpin] = useState(false);
+  const isSpinning = spin || isFetching;
+  return (
+    <TooltipWrapper content={tooltip}>
+      <Button
+        variant={variant}
+        size={size}
+        className={cn("shrink-0", className)}
+        onClick={() => {
+          setSpin(true);
+          onRefresh();
+        }}
+        disabled={isSpinning}
+      >
+        <RotateCw
+          className={cn(
+            label && "mr-1.5 size-3.5",
+            isSpinning && "animate-spin",
+          )}
+          onAnimationIteration={() => {
+            if (!isFetching) setSpin(false);
+          }}
+        />
+        {label}
+      </Button>
+    </TooltipWrapper>
+  );
+};
+
+export default RefreshButton;

--- a/apps/opik-frontend/src/shared/RefreshButton/RefreshButton.tsx
+++ b/apps/opik-frontend/src/shared/RefreshButton/RefreshButton.tsx
@@ -38,18 +38,15 @@ const RefreshButton: React.FC<RefreshButtonProps> = ({
         }}
         disabled={isSpinning}
       >
-        <span
+        <RotateCw
           className={cn(
-            "inline-flex shrink-0",
-            label && "mr-1.5",
+            label && "mr-1.5 size-3.5",
             isSpinning && "animate-spin",
           )}
           onAnimationIteration={() => {
             if (!isFetching) setSpin(false);
           }}
-        >
-          <RotateCw className="size-3.5" />
-        </span>
+        />
         {label}
       </Button>
     </TooltipWrapper>

--- a/apps/opik-frontend/src/shared/RefreshButton/RefreshButton.tsx
+++ b/apps/opik-frontend/src/shared/RefreshButton/RefreshButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
 import { RotateCw } from "lucide-react";
 import { Button, ButtonProps } from "@/ui/button";
 import { cn } from "@/lib/utils";
@@ -14,10 +14,6 @@ interface RefreshButtonProps {
   className?: string;
 }
 
-// Fallback in case `animationiteration` never fires (e.g. animations
-// suppressed) so the button can't stay disabled forever.
-const SPIN_FALLBACK_MS = 1200;
-
 const RefreshButton: React.FC<RefreshButtonProps> = ({
   onRefresh,
   isFetching = false,
@@ -28,22 +24,7 @@ const RefreshButton: React.FC<RefreshButtonProps> = ({
   className,
 }) => {
   const [spin, setSpin] = useState(false);
-  const fallbackRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isSpinning = spin || isFetching;
-
-  useEffect(
-    () => () => {
-      if (fallbackRef.current) clearTimeout(fallbackRef.current);
-    },
-    [],
-  );
-
-  const handleClick = () => {
-    setSpin(true);
-    if (fallbackRef.current) clearTimeout(fallbackRef.current);
-    fallbackRef.current = setTimeout(() => setSpin(false), SPIN_FALLBACK_MS);
-    onRefresh();
-  };
 
   return (
     <TooltipWrapper content={tooltip}>
@@ -51,7 +32,10 @@ const RefreshButton: React.FC<RefreshButtonProps> = ({
         variant={variant}
         size={size}
         className={cn("shrink-0", className)}
-        onClick={handleClick}
+        onClick={() => {
+          setSpin(true);
+          onRefresh();
+        }}
         disabled={isSpinning}
       >
         <span

--- a/apps/opik-frontend/src/shared/RefreshButton/RefreshButton.tsx
+++ b/apps/opik-frontend/src/shared/RefreshButton/RefreshButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { RotateCw } from "lucide-react";
 import { Button, ButtonProps } from "@/ui/button";
 import { cn } from "@/lib/utils";
@@ -14,6 +14,10 @@ interface RefreshButtonProps {
   className?: string;
 }
 
+// Fallback in case `animationiteration` never fires (e.g. animations
+// suppressed) so the button can't stay disabled forever.
+const SPIN_FALLBACK_MS = 1200;
+
 const RefreshButton: React.FC<RefreshButtonProps> = ({
   onRefresh,
   isFetching = false,
@@ -24,28 +28,44 @@ const RefreshButton: React.FC<RefreshButtonProps> = ({
   className,
 }) => {
   const [spin, setSpin] = useState(false);
+  const fallbackRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isSpinning = spin || isFetching;
+
+  useEffect(
+    () => () => {
+      if (fallbackRef.current) clearTimeout(fallbackRef.current);
+    },
+    [],
+  );
+
+  const handleClick = () => {
+    setSpin(true);
+    if (fallbackRef.current) clearTimeout(fallbackRef.current);
+    fallbackRef.current = setTimeout(() => setSpin(false), SPIN_FALLBACK_MS);
+    onRefresh();
+  };
+
   return (
     <TooltipWrapper content={tooltip}>
       <Button
         variant={variant}
         size={size}
         className={cn("shrink-0", className)}
-        onClick={() => {
-          setSpin(true);
-          onRefresh();
-        }}
+        onClick={handleClick}
         disabled={isSpinning}
       >
-        <RotateCw
+        <span
           className={cn(
-            label && "mr-1.5 size-3.5",
+            "inline-flex shrink-0",
+            label && "mr-1.5",
             isSpinning && "animate-spin",
           )}
           onAnimationIteration={() => {
             if (!isFetching) setSpin(false);
           }}
-        />
+        >
+          <RotateCw className="size-3.5" />
+        </span>
         {label}
       </Button>
     </TooltipWrapper>

--- a/apps/opik-frontend/src/v2/pages-shared/optimizations/OptimizationLogs/OptimizationLogs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/optimizations/OptimizationLogs/OptimizationLogs.tsx
@@ -5,13 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import {
-  ArrowDownToLine,
-  Clock,
-  ListEnd,
-  Maximize2,
-  RotateCw,
-} from "lucide-react";
+import { ArrowDownToLine, Clock, ListEnd, Maximize2 } from "lucide-react";
 import { Card, CardContent } from "@/ui/card";
 import { Button } from "@/ui/button";
 import { Optimization } from "@/types/optimizations";
@@ -19,6 +13,7 @@ import useOptimizationStudioLogs from "@/api/optimizations/useOptimizationStudio
 import Loader from "@/shared/Loader/Loader";
 import { Spinner } from "@/ui/spinner";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import RefreshButton from "@/shared/RefreshButton/RefreshButton";
 import { cn } from "@/lib/utils";
 import {
   IN_PROGRESS_OPTIMIZATION_STATUSES,
@@ -204,18 +199,13 @@ const OptimizationLogs: React.FC<OptimizationLogsProps> = ({
                 </Button>
               </TooltipWrapper>
             )}
-            <TooltipWrapper content="Refresh logs">
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                onClick={() => refetch()}
-                disabled={isPending}
-              >
-                <RotateCw
-                  className={cn("size-3.5", isPending && "animate-spin")}
-                />
-              </Button>
-            </TooltipWrapper>
+            <RefreshButton
+              tooltip="Refresh logs"
+              variant="ghost"
+              size="icon-xs"
+              isFetching={isPending}
+              onRefresh={() => refetch()}
+            />
             {logContent && (
               <TooltipWrapper content="Fullscreen">
                 <Button variant="ghost" size="icon-xs" onClick={openFullscreen}>

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
@@ -11,7 +11,7 @@ import {
   ColumnSort,
   RowSelectionState,
 } from "@tanstack/react-table";
-import { RotateCw, Undo2, X } from "lucide-react";
+import { Undo2, X } from "lucide-react";
 import findIndex from "lodash/findIndex";
 import isObject from "lodash/isObject";
 import isNumber from "lodash/isNumber";
@@ -57,6 +57,7 @@ import { Button } from "@/ui/button";
 import { Sheet, SheetContent, SheetTitle } from "@/ui/sheet";
 import DataTableRowHeightSelector from "@/shared/DataTableRowHeightSelector/DataTableRowHeightSelector";
 import ColumnsButton from "@/shared/ColumnsButton/ColumnsButton";
+import RefreshButton from "@/shared/RefreshButton/RefreshButton";
 import DataTable from "@/shared/DataTable/DataTable";
 import DataTableNoData from "@/shared/DataTableNoData/DataTableNoData";
 import DataTablePagination from "@/shared/DataTablePagination/DataTablePagination";
@@ -76,7 +77,6 @@ import CommentsCell from "@/shared/DataTableCells/CommentsCell";
 import FeedbackScoreHeader from "@/shared/DataTableHeaders/FeedbackScoreHeader";
 import { formatScoreDisplay } from "@/lib/feedback-scores";
 import DataTableStateHandler from "@/shared/DataTableStateHandler/DataTableStateHandler";
-import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import TraceDetailsPanel from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel";
 import TracesOrSpansPathsAutocomplete from "@/v2/pages-shared/traces/TracesOrSpansPathsAutocomplete/TracesOrSpansPathsAutocomplete";
 import TracesOrSpansFeedbackScoresSelect from "@/v2/pages-shared/traces/TracesOrSpansFeedbackScoresSelect/TracesOrSpansFeedbackScoresSelect";
@@ -986,19 +986,14 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
                 minDate={minDate}
                 maxDate={maxDate}
               />
-              <TooltipWrapper content="Refresh traces list">
-                <Button
-                  variant="outline"
-                  size="icon-sm"
-                  className="shrink-0"
-                  onClick={() => {
-                    refetch();
-                    refetchStatistic();
-                  }}
-                >
-                  <RotateCw />
-                </Button>
-              </TooltipWrapper>
+              <RefreshButton
+                tooltip="Refresh traces list"
+                isFetching={isFetching}
+                onRefresh={() => {
+                  refetch();
+                  refetchStatistic();
+                }}
+              />
               <DataTableRowHeightSelector
                 type={height as ROW_HEIGHT}
                 setType={setHeight}

--- a/apps/opik-frontend/src/v2/pages/AutomationLogsPage/AutomationLogsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AutomationLogsPage/AutomationLogsPage.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from "react";
 import { useSearch } from "@tanstack/react-router";
 import { flatMap, get, uniq } from "lodash";
 import md5 from "md5";
-import { FoldVertical, RotateCw, UnfoldVertical } from "lucide-react";
+import { FoldVertical, UnfoldVertical } from "lucide-react";
 
 import useRulesLogsList from "@/api/automations/useRulesLogsList";
 import NoData from "@/shared/NoData/NoData";
@@ -14,6 +14,7 @@ import PageBodyStickyTableWrapper from "@/v2/layout/PageBodyStickyTableWrapper/P
 import DataTable from "@/shared/DataTable/DataTable";
 import DataTableNoData from "@/shared/DataTableNoData/DataTableNoData";
 import ExpandableTextCell from "@/shared/DataTableCells/ExpandableTextCell";
+import RefreshButton from "@/shared/RefreshButton/RefreshButton";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { COLUMN_TYPE, ColumnData } from "@/types/shared";
 import {
@@ -180,18 +181,11 @@ const AutomationLogsPage = () => {
         >
           <h1 className="comet-title-xs truncate break-words">Logs</h1>
           <div className="flex items-center gap-2">
-            <TooltipWrapper content="Refresh logs list">
-              <Button
-                variant="outline"
-                size="icon-sm"
-                className="shrink-0"
-                onClick={() => {
-                  refetch();
-                }}
-              >
-                <RotateCw />
-              </Button>
-            </TooltipWrapper>
+            <RefreshButton
+              tooltip="Refresh logs list"
+              isFetching={isFetching}
+              onRefresh={() => refetch()}
+            />
             <TooltipWrapper
               content={allExpanded ? "Collapse all" : "Expand all"}
             >

--- a/apps/opik-frontend/src/v2/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { ChartLine, RotateCw } from "lucide-react";
+import { ChartLine } from "lucide-react";
 import {
   CellContext,
   ColumnSort,
@@ -57,7 +57,7 @@ import ExperimentsActionsPanel from "@/v2/pages-shared/experiments/ExperimentsAc
 import ExperimentRowActionsCell from "@/v2/pages/ExperimentsPage/ExperimentRowActionsCell";
 import FeedbackScoresChartsWrapper from "@/v2/pages-shared/experiments/FeedbackScoresChartsWrapper/FeedbackScoresChartsWrapper";
 import SearchInput from "@/shared/SearchInput/SearchInput";
-import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import RefreshButton from "@/shared/RefreshButton/RefreshButton";
 import { Button } from "@/ui/button";
 import { Separator } from "@/ui/separator";
 import { Card } from "@/ui/card";
@@ -699,16 +699,11 @@ const GeneralDatasetsTab: React.FC<GeneralDatasetsTabProps> = ({
             }}
           />
           <Separator orientation="vertical" className="mx-2 h-4" />
-          <TooltipWrapper content="Refresh experiments list">
-            <Button
-              variant="outline"
-              size="icon-sm"
-              className="shrink-0"
-              onClick={() => refetch()}
-            >
-              <RotateCw />
-            </Button>
-          </TooltipWrapper>
+          <RefreshButton
+            tooltip="Refresh experiments list"
+            isFetching={isFetching}
+            onRefresh={() => refetch()}
+          />
           <ColumnsButton
             columns={availableColumns}
             selectedColumns={selectedColumns}

--- a/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
@@ -40,6 +40,7 @@ import {
   injectColumnCallback,
   migrateSelectedColumns,
 } from "@/lib/table";
+import { cn } from "@/lib/utils";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import { generateSelectColumDef } from "@/shared/DataTable/utils";
 import DataTableEmptyContent from "@/shared/DataTableNoData/DataTableEmptyContent";
@@ -382,6 +383,8 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [isTableDataEnabled, setIsTableDataEnabled] = useState(false);
+
+  const [refreshSpin, setRefreshSpin] = useState(false);
 
   // Enable table data loading after initial render to allow users to change the date filter
   React.useEffect(() => {
@@ -766,10 +769,20 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
                   size="sm"
                   className="shrink-0"
                   onClick={() => {
+                    setRefreshSpin(true);
                     refetch();
                   }}
+                  disabled={refreshSpin || isFetching}
                 >
-                  <RotateCw className="mr-1.5 size-3.5" />
+                  <RotateCw
+                    className={cn(
+                      "mr-1.5 size-3.5",
+                      (refreshSpin || isFetching) && "animate-spin",
+                    )}
+                    onAnimationIteration={() => {
+                      if (!isFetching) setRefreshSpin(false);
+                    }}
+                  />
                   Refresh
                 </Button>
               </TooltipWrapper>

--- a/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
@@ -12,7 +12,7 @@ import {
   ColumnSort,
   RowSelectionState,
 } from "@tanstack/react-table";
-import { ExternalLink, RotateCw } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import findIndex from "lodash/findIndex";
 import isNumber from "lodash/isNumber";
 import get from "lodash/get";
@@ -40,7 +40,6 @@ import {
   injectColumnCallback,
   migrateSelectedColumns,
 } from "@/lib/table";
-import { cn } from "@/lib/utils";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import { generateSelectColumDef } from "@/shared/DataTable/utils";
 import DataTableEmptyContent from "@/shared/DataTableNoData/DataTableEmptyContent";
@@ -50,7 +49,6 @@ import emptyLogsLightUrl from "/images/empty-logs-light.svg";
 import emptyLogsDarkUrl from "/images/empty-logs-dark.svg";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";
-import { Button } from "@/ui/button";
 import { Separator } from "@/ui/separator";
 import DataTableRowHeightSelector from "@/shared/DataTableRowHeightSelector/DataTableRowHeightSelector";
 import ColumnsButton from "@/shared/ColumnsButton/ColumnsButton";
@@ -61,7 +59,7 @@ import IdCell from "@/shared/DataTableCells/IdCell";
 import DurationCell from "@/shared/DataTableCells/DurationCell";
 import PrettyCell from "@/shared/DataTableCells/PrettyCell";
 import CostCell from "@/shared/DataTableCells/CostCell";
-import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import RefreshButton from "@/shared/RefreshButton/RefreshButton";
 import ThreadDetailsPanel from "@/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel";
 import TraceDetailsPanel from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
@@ -383,8 +381,6 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [isTableDataEnabled, setIsTableDataEnabled] = useState(false);
-
-  const [refreshSpin, setRefreshSpin] = useState(false);
 
   // Enable table data loading after initial render to allow users to change the date filter
   React.useEffect(() => {
@@ -763,29 +759,13 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
                 layout="labeled"
               />
               <Separator orientation="vertical" className="mx-1 h-6" />
-              <TooltipWrapper content="Refresh threads list">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="shrink-0"
-                  onClick={() => {
-                    setRefreshSpin(true);
-                    refetch();
-                  }}
-                  disabled={refreshSpin || isFetching}
-                >
-                  <RotateCw
-                    className={cn(
-                      "mr-1.5 size-3.5",
-                      (refreshSpin || isFetching) && "animate-spin",
-                    )}
-                    onAnimationIteration={() => {
-                      if (!isFetching) setRefreshSpin(false);
-                    }}
-                  />
-                  Refresh
-                </Button>
-              </TooltipWrapper>
+              <RefreshButton
+                tooltip="Refresh threads list"
+                size="sm"
+                label="Refresh"
+                isFetching={isFetching}
+                onRefresh={() => refetch()}
+              />
             </div>
           </div>
         </PageBodyStickyContainer>

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -11,7 +11,7 @@ import {
   ColumnSort,
   RowSelectionState,
 } from "@tanstack/react-table";
-import { ExternalLink, RotateCw } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import findIndex from "lodash/findIndex";
 import isObject from "lodash/isObject";
 import isNumber from "lodash/isNumber";
@@ -52,7 +52,7 @@ import {
 } from "@/lib/metadata";
 import { BaseTraceData, Span, Trace, LOGS_SOURCE } from "@/types/traces";
 import { convertColumnDataToColumn, migrateSelectedColumns } from "@/lib/table";
-import { cn, getJSONPaths } from "@/lib/utils";
+import { getJSONPaths } from "@/lib/utils";
 import { buildDocsUrl } from "@/v2/lib/utils";
 import { generateSelectColumDef } from "@/shared/DataTable/utils";
 import DataTableEmptyContent from "@/shared/DataTableNoData/DataTableEmptyContent";
@@ -62,7 +62,6 @@ import emptyLogsDarkUrl from "/images/empty-logs-dark.svg";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";
 import TracesActionsPanel from "@/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel";
-import { Button } from "@/ui/button";
 import { Separator } from "@/ui/separator";
 import DataTableRowHeightSelector from "@/shared/DataTableRowHeightSelector/DataTableRowHeightSelector";
 import ColumnsButton from "@/shared/ColumnsButton/ColumnsButton";
@@ -86,7 +85,7 @@ import ConfigurationVersionCell from "@/shared/DataTableCells/ConfigurationVersi
 import FeedbackScoreHeader from "@/shared/DataTableHeaders/FeedbackScoreHeader";
 import { formatScoreDisplay } from "@/lib/feedback-scores";
 import DataTableStateHandler from "@/shared/DataTableStateHandler/DataTableStateHandler";
-import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import RefreshButton from "@/shared/RefreshButton/RefreshButton";
 import ThreadDetailsPanel from "@/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel";
 import TraceDetailsPanel from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
@@ -533,8 +532,6 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   const [isTableDataEnabled, setIsTableDataEnabled] = useState(false);
-
-  const [refreshSpin, setRefreshSpin] = useState(false);
 
   // Declare selectedColumns early so it can be used in excludeFields computation
   const [selectedColumns, setSelectedColumns] = useLocalStorageState<string[]>(
@@ -1349,34 +1346,18 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
                 }
               />
               <Separator orientation="vertical" className="mx-1 h-6" />
-              <TooltipWrapper
-                content={`Refresh ${
+              <RefreshButton
+                tooltip={`Refresh ${
                   type === TRACE_DATA_TYPE.traces ? "traces" : "spans"
                 } list`}
-              >
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="shrink-0"
-                  onClick={() => {
-                    setRefreshSpin(true);
-                    refetch();
-                    refetchStatistic();
-                  }}
-                  disabled={refreshSpin || isFetching}
-                >
-                  <RotateCw
-                    className={cn(
-                      "mr-1.5 size-3.5",
-                      (refreshSpin || isFetching) && "animate-spin",
-                    )}
-                    onAnimationIteration={() => {
-                      if (!isFetching) setRefreshSpin(false);
-                    }}
-                  />
-                  Refresh
-                </Button>
-              </TooltipWrapper>
+                size="sm"
+                label="Refresh"
+                isFetching={isFetching}
+                onRefresh={() => {
+                  refetch();
+                  refetchStatistic();
+                }}
+              />
             </div>
           </div>
         </PageBodyStickyContainer>

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -52,7 +52,7 @@ import {
 } from "@/lib/metadata";
 import { BaseTraceData, Span, Trace, LOGS_SOURCE } from "@/types/traces";
 import { convertColumnDataToColumn, migrateSelectedColumns } from "@/lib/table";
-import { getJSONPaths } from "@/lib/utils";
+import { cn, getJSONPaths } from "@/lib/utils";
 import { buildDocsUrl } from "@/v2/lib/utils";
 import { generateSelectColumDef } from "@/shared/DataTable/utils";
 import DataTableEmptyContent from "@/shared/DataTableNoData/DataTableEmptyContent";
@@ -533,6 +533,8 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   const [isTableDataEnabled, setIsTableDataEnabled] = useState(false);
+
+  const [refreshSpin, setRefreshSpin] = useState(false);
 
   // Declare selectedColumns early so it can be used in excludeFields computation
   const [selectedColumns, setSelectedColumns] = useLocalStorageState<string[]>(
@@ -1357,11 +1359,21 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
                   size="sm"
                   className="shrink-0"
                   onClick={() => {
+                    setRefreshSpin(true);
                     refetch();
                     refetchStatistic();
                   }}
+                  disabled={refreshSpin || isFetching}
                 >
-                  <RotateCw className="mr-1.5 size-3.5" />
+                  <RotateCw
+                    className={cn(
+                      "mr-1.5 size-3.5",
+                      (refreshSpin || isFetching) && "animate-spin",
+                    )}
+                    onAnimationIteration={() => {
+                      if (!isFetching) setRefreshSpin(false);
+                    }}
+                  />
                   Refresh
                 </Button>
               </TooltipWrapper>

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationPage.tsx
@@ -221,6 +221,7 @@ const OptimizationPage: React.FC = () => {
           <div className="flex shrink-0 items-center justify-end pb-4">
             <OptimizationTrialsControls
               onRefresh={handleRefresh}
+              isFetching={isExperimentsFetching}
               rowHeight={height}
               onRowHeightChange={setHeight}
               columnsDef={columnsDef}

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationTrialsControls.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationTrialsControls.tsx
@@ -1,14 +1,13 @@
 import React from "react";
-import { RotateCw } from "lucide-react";
-import { Button } from "@/ui/button";
 import { ColumnData, ROW_HEIGHT } from "@/types/shared";
-import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import DataTableRowHeightSelector from "@/shared/DataTableRowHeightSelector/DataTableRowHeightSelector";
 import ColumnsButton from "@/shared/ColumnsButton/ColumnsButton";
+import RefreshButton from "@/shared/RefreshButton/RefreshButton";
 import { AggregatedCandidate } from "@/types/optimizations";
 
 interface OptimizationTrialsControlsProps {
   onRefresh: () => void;
+  isFetching?: boolean;
   rowHeight: ROW_HEIGHT;
   onRowHeightChange: (height: ROW_HEIGHT) => void;
   columnsDef: ColumnData<AggregatedCandidate>[];
@@ -20,6 +19,7 @@ interface OptimizationTrialsControlsProps {
 
 const OptimizationTrialsControls: React.FC<OptimizationTrialsControlsProps> = ({
   onRefresh,
+  isFetching,
   rowHeight,
   onRowHeightChange,
   columnsDef,
@@ -30,16 +30,11 @@ const OptimizationTrialsControls: React.FC<OptimizationTrialsControlsProps> = ({
 }) => {
   return (
     <div className="flex items-center gap-2">
-      <TooltipWrapper content="Refresh trials list">
-        <Button
-          variant="outline"
-          size="icon-sm"
-          className="shrink-0"
-          onClick={onRefresh}
-        >
-          <RotateCw />
-        </Button>
-      </TooltipWrapper>
+      <RefreshButton
+        tooltip="Refresh trials list"
+        isFetching={isFetching}
+        onRefresh={onRefresh}
+      />
       <DataTableRowHeightSelector
         type={rowHeight}
         setType={onRowHeightChange}

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { RotateCw } from "lucide-react";
 import useLocalStorageState from "use-local-storage-state";
 import { RowSelectionState } from "@tanstack/react-table";
 import { useNavigate } from "@tanstack/react-router";
@@ -36,7 +35,7 @@ import DatasetSelectBox from "@/v2/pages-shared/experiments/DatasetSelectBox/Dat
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";
 import OptimizationRowActionsCell from "@/v2/pages/OptimizationsPage/OptimizationRowActionsCell";
 import SearchInput from "@/shared/SearchInput/SearchInput";
-import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import RefreshButton from "@/shared/RefreshButton/RefreshButton";
 import { Button } from "@/ui/button";
 import { Separator } from "@/ui/separator";
 import {
@@ -386,16 +385,11 @@ const OptimizationsPage: React.FunctionComponent = () => {
                     <Separator orientation="vertical" className="mx-2 h-4" />
                   </>
                 )}
-                <TooltipWrapper content="Refresh optimizations list">
-                  <Button
-                    variant="outline"
-                    size="icon-sm"
-                    className="shrink-0"
-                    onClick={() => refetch()}
-                  >
-                    <RotateCw />
-                  </Button>
-                </TooltipWrapper>
+                <RefreshButton
+                  tooltip="Refresh optimizations list"
+                  isFetching={isFetching}
+                  onRefresh={() => refetch()}
+                />
                 <ColumnsButton
                   columns={visibleColumns}
                   selectedColumns={selectedColumns}


### PR DESCRIPTION
## Details

Refresh buttons across the v2 frontend gave no visible feedback on click. On the **Logs** page in particular (Traces/Spans + Threads tabs), responses can be ~100–300ms and identical to the previous data, so a click looked like nothing happened (OPIK-6069).

This PR adds a shared `RefreshButton` component (`src/shared/RefreshButton/RefreshButton.tsx`) that:

- spins the `RotateCw` icon while a request is in flight (`isFetching`),
- guarantees a minimum of one full rotation per click by latching a local flag and clearing it on the native CSS `animationiteration` event only after `isFetching` is false,
- disables the button for the entire spin duration so rapid clicks can't stack requests.

Then replaces the ad-hoc refresh button JSX on the v2 pages that already had a refetch handler available:

- `LogsPage/TracesSpansTab` and `LogsPage/ThreadsTab` (the original ticket target)
- `pages-shared/traces/TraceLogsSidebar`
- `pages-shared/optimizations/OptimizationLogs`
- `AutomationLogsPage`, `OptimizationsPage`, `ExperimentsPage/GeneralDatasetsTab`
- `OptimizationPage/OptimizationTrialsControls` (with `isFetching` threaded from the parent)

No `setTimeout` / `Promise` hacks — timing comes from the CSS `animate-spin` keyframes and the native `animationiteration` event.

v1 surfaces are intentionally left untouched per scope.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-6069

## Testing

- `npm run typecheck` (opik-frontend) — pass
- `npx eslint <all touched files> --max-warnings=0` — pass
- Manual: on Logs (Traces/Spans + Threads), TraceLogsSidebar, AutomationLogsPage, OptimizationLogs, OptimizationTrials, Optimizations, and Experiments/Datasets pages — click Refresh on a busy project (icon spins continuously while fetching, button disabled, settles after fetch + next animation cycle) and on an idle project (icon still completes a full rotation even though row count is unchanged); spam-click → only one network request fires per cycle.

## Documentation

N/A