### PR TITLE
[OPIK-6184] [BE] feat: experiment project migration job (V1 -> V2 auto-inference)

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1310,6 +1310,37 @@ datasetVersioningMigration:
   # Should be long enough to complete the entire migration process
   itemsTotalJobTimeoutSeconds: ${DATASET_VERSION_ITEMS_TOTAL_MIGRATION_JOB_TIMEOUT_SECONDS:-3600}
 
+# Experiment Project Migration configuration
+# Assigns project_id to orphan experiments (V1 → V2 workspace migration).
+# Runs as a recurring job, processing workspaces in batches.
+experimentProjectMigration:
+  # Master switch — disabled by default, enable for staged rollout
+  enabled: ${EXPERIMENT_PROJECT_MIGRATION_ENABLED:-false}
+  # Number of workspaces to process per job run (smallest first)
+  workspacesPerRun: ${EXPERIMENT_PROJECT_MIGRATION_WORKSPACES_PER_RUN:-20}
+  # Number of experiments to update per ClickHouse INSERT batch
+  experimentBatchSize: ${EXPERIMENT_PROJECT_MIGRATION_BATCH_SIZE:-1000}
+  # Interval between recurring job runs
+  interval: ${EXPERIMENT_PROJECT_MIGRATION_INTERVAL:-30s}
+  # Delay before first run after app startup
+  startupDelay: ${EXPERIMENT_PROJECT_MIGRATION_STARTUP_DELAY:-30s}
+  # Distributed lock timeout — prevents overlap across replicas.
+  # Intentionally shorter than jobTimeout: the lock covers typical cycle duration (minutes) and
+  # prevents redundant scheduling across replicas. Cycles that exceed lockTimeout tolerate replica
+  # overlap because the migration is idempotent (WHERE project_id = '' skips already-migrated rows).
+  lockTimeout: ${EXPERIMENT_PROJECT_MIGRATION_LOCK_TIMEOUT:-5m}
+  # Max time to wait for the distributed lock when another replica holds it. Kept brief so a held
+  # lock doesn't block this fire — the next scheduled tick will try again.
+  lockWaitTime: ${EXPERIMENT_PROJECT_MIGRATION_LOCK_WAIT_TIME:-100ms}
+  # Per-cycle timeout — safety net for stuck cycles, not normal completion
+  jobTimeout: ${EXPERIMENT_PROJECT_MIGRATION_JOB_TIMEOUT:-1h}
+
+# Shared configuration for V1 → V2 entity project migration jobs
+# Centralised so all migration jobs (experiments, datasets, etc.) share the same exclusion list
+migration:
+  # Comma-separated workspace IDs to exclude (e.g. internal Comet workspaces)
+  excludedWorkspaceIds: ${MIGRATION_EXCLUDED_WORKSPACE_IDS:-}
+
 llmModelRegistry:
   defaultResource: ${LLM_MODEL_REGISTRY_DEFAULT_RESOURCE:-llm-models-default.yaml}
   localOverridePath: ${LLM_MODEL_REGISTRY_LOCAL_OVERRIDE_PATH:-}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ExperimentAggregateEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ExperimentAggregateEventListener.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
 @Slf4j
 public class ExperimentAggregateEventListener {
 
-    private static final Set<ExperimentStatus> FINISHED_STATUSES = Set.of(
+    public static final Set<ExperimentStatus> FINISHED_STATUSES = Set.of(
             ExperimentStatus.COMPLETED, ExperimentStatus.CANCELLED);
 
     private final ExperimentItemService experimentItemService;

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/ExperimentProjectMigrationJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/ExperimentProjectMigrationJob.java
@@ -1,0 +1,126 @@
+package com.comet.opik.api.resources.v1.jobs;
+
+import com.comet.opik.domain.ExperimentProjectMigrationService;
+import com.comet.opik.infrastructure.ExperimentProjectMigrationConfig;
+import com.comet.opik.infrastructure.lock.LockService;
+import io.dropwizard.jobs.Job;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongHistogram;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.InterruptableJob;
+import org.quartz.JobExecutionContext;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.comet.opik.domain.ExperimentProjectMigrationService.METRIC_NAMESPACE;
+import static com.comet.opik.domain.ExperimentProjectMigrationService.RESULT_ERROR;
+import static com.comet.opik.domain.ExperimentProjectMigrationService.RESULT_KEY;
+import static com.comet.opik.infrastructure.lock.LockService.Lock;
+
+@Singleton
+@Slf4j
+@DisallowConcurrentExecution
+public class ExperimentProjectMigrationJob extends Job implements InterruptableJob {
+
+    private static final Lock JOB_LOCK = new Lock("opik_job", ExperimentProjectMigrationJob.class.getSimpleName());
+
+    private static final Attributes RESULT_SUCCESS = Attributes.of(RESULT_KEY, "success");
+    private static final Attributes RESULT_LOCK_SKIPPED = Attributes.of(RESULT_KEY, "lock_skipped");
+
+    private final ExperimentProjectMigrationService migrationService;
+    private final ExperimentProjectMigrationConfig config;
+    private final LockService lockService;
+
+    private final AtomicBoolean interrupted = new AtomicBoolean(false);
+    private final AtomicReference<Disposable> currentExecution = new AtomicReference<>();
+
+    private final LongHistogram cycleDuration;
+
+    @Inject
+    public ExperimentProjectMigrationJob(
+            @NonNull ExperimentProjectMigrationService migrationService,
+            @NonNull @Config("experimentProjectMigration") ExperimentProjectMigrationConfig config,
+            @NonNull LockService lockService) {
+        this.migrationService = migrationService;
+        this.config = config;
+        this.lockService = lockService;
+
+        var meter = GlobalOpenTelemetry.get().getMeter(METRIC_NAMESPACE);
+        this.cycleDuration = meter
+                .histogramBuilder("%s.cycle.duration".formatted(METRIC_NAMESPACE))
+                .setDescription(
+                        "Duration of an experiment project migration cycle, tagged by result")
+                .setUnit("ms")
+                .ofLongs()
+                .build();
+    }
+
+    @Override
+    public void doJob(JobExecutionContext context) {
+        if (!config.enabled()) {
+            log.debug("Experiment project migration job is disabled, skipping");
+            return;
+        }
+        if (interrupted.get()) {
+            log.info("Experiment project migration job was interrupted before execution, skipping");
+            return;
+        }
+        log.info("Starting experiment project migration job");
+        var startMillis = System.currentTimeMillis();
+        var subscription = lockService.bestEffortLock(
+                JOB_LOCK,
+                Mono.defer(() -> {
+                    if (interrupted.get()) {
+                        log.info("Experiment project migration was interrupted before processing, skipping");
+                        return Mono.empty();
+                    }
+                    return migrationService.runMigrationCycle()
+                            .timeout(config.jobTimeout().toJavaDuration())
+                            .doOnSuccess(unused -> cycleDuration.record(
+                                    System.currentTimeMillis() - startMillis, RESULT_SUCCESS));
+                }),
+                Mono.defer(() -> {
+                    log.info("Could not acquire lock, another instance is already running");
+                    cycleDuration.record(System.currentTimeMillis() - startMillis, RESULT_LOCK_SKIPPED);
+                    return Mono.empty();
+                }),
+                config.lockTimeout().toJavaDuration(),
+                config.lockWaitTime().toJavaDuration(),
+                true)
+                // Resume on errors so the recurring job stays alive
+                .onErrorResume(throwable -> {
+                    cycleDuration.record(System.currentTimeMillis() - startMillis, RESULT_ERROR);
+                    if (interrupted.get()) {
+                        log.warn("Experiment project migration was interrupted", throwable);
+                    } else {
+                        log.error("Experiment project migration failed", throwable);
+                    }
+                    return Mono.empty();
+                })
+                .doFinally(signal -> currentExecution.set(null))
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe();
+        currentExecution.set(subscription);
+    }
+
+    @Override
+    public void interrupt() {
+        log.info("Interrupting experiment project migration job");
+        interrupted.set(true);
+        var execution = currentExecution.get();
+        if (execution != null && !execution.isDisposed()) {
+            execution.dispose();
+            log.info("Experiment project migration job interrupted successfully");
+        }
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EligibleWorkspace.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EligibleWorkspace.java
@@ -1,0 +1,8 @@
+package com.comet.opik.domain;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder(toBuilder = true)
+public record EligibleWorkspace(@NonNull String workspaceId, long experimentsCount) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -27,6 +27,7 @@ import com.comet.opik.domain.filter.FilterQueryBuilder;
 import com.comet.opik.domain.filter.FilterStrategy;
 import com.comet.opik.domain.sorting.SortingQueryBuilder;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.RowUtils;
 import com.comet.opik.utils.template.TemplateUtils;
@@ -68,6 +69,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static com.comet.opik.domain.AsyncContextUtils.bindUserNameAndWorkspaceContextToStream;
 import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToFlux;
 import static com.comet.opik.domain.CommentResultMapper.parseCommentsFromJson;
 import static com.comet.opik.infrastructure.FilterUtils.getSTWithLogComment;
@@ -152,10 +154,19 @@ public class ExperimentDAO {
             FilterStrategy.EXPERIMENT_SCORES_AGGREGATED,
             FilterStrategy.EXPERIMENT_SCORES_AGGREGATED_IS_EMPTY);
 
+    /**
+     * Per-workspace check: does any non-demo experiment have {@code project_id = ''} on its
+     * latest row? GROUP BY id with {@code argMax(project_id, last_updated_at)} in HAVING dedups
+     * the {@code ReplacingMergeTree}; we avoid {@code FINAL} because ClickHouse pushes outer
+     * WHERE predicates into the FINAL scan and would mask post-migration rows.
+     */
     private static final String HAS_VERSION1_EXPERIMENTS = """
-            SELECT 1 FROM experiments
-            WHERE workspace_id = :workspace_id AND project_id = ''
+            SELECT 1
+            FROM experiments
+            WHERE workspace_id = :workspace_id
             AND name NOT IN :demo_experiment_names
+            GROUP BY id
+            HAVING argMax(project_id, last_updated_at) = ''
             LIMIT 1
             SETTINGS log_comment = '<log_comment>'""";
 
@@ -1688,7 +1699,94 @@ public class ExperimentDAO {
             SETTINGS log_comment = '<log_comment>', short_circuit_function_evaluation = 'force_enable';
             """;
 
+    /**
+     * Returns workspaces with at least one eligible orphan experiment, ordered by smallest
+     * count first. An experiment is eligible when its latest row has {@code project_id = ''}
+     * (checked via {@code argMax} in HAVING — see {@link #HAS_VERSION1_EXPERIMENTS}) and all
+     * its linked traces resolve to a single non-empty project.
+     */
+    private static final String FIND_ELIGIBLE_EXPERIMENT_WORKSPACES = """
+            SELECT
+                workspace_id,
+                count(DISTINCT id) AS experiments_count
+            FROM (
+                SELECT
+                    e.workspace_id AS workspace_id,
+                    e.id AS id
+                FROM experiments e
+                INNER JOIN experiment_items ei
+                    ON e.workspace_id = ei.workspace_id AND e.id = ei.experiment_id
+                INNER JOIN traces t
+                    ON ei.workspace_id = t.workspace_id AND ei.trace_id = t.id
+                WHERE e.name NOT IN :demo_experiment_names
+                AND t.project_id != ''
+                <if(excluded_workspace_ids)>
+                AND e.workspace_id NOT IN :excluded_workspace_ids
+                <endif>
+                GROUP BY e.workspace_id, e.id
+                HAVING count(DISTINCT t.project_id) = 1
+                AND argMax(e.project_id, e.last_updated_at) = ''
+            )
+            GROUP BY workspace_id
+            ORDER BY experiments_count ASC
+            LIMIT :limit
+            SETTINGS log_comment = '<log_comment>'
+            """;
+
+    /**
+     * For one workspace, returns each eligible experiment id and the (single) trace project_id
+     * to migrate it to. Same dedup pattern as {@link #FIND_ELIGIBLE_EXPERIMENT_WORKSPACES}.
+     */
+    private static final String COMPUTE_EXPERIMENT_PROJECT_MAPPING = """
+            SELECT
+                e.id AS experiment_id,
+                any(t.project_id) AS project_id
+            FROM experiments e
+            INNER JOIN experiment_items ei
+                ON e.workspace_id = ei.workspace_id AND e.id = ei.experiment_id
+            INNER JOIN traces t
+                ON ei.workspace_id = t.workspace_id AND ei.trace_id = t.id
+            WHERE e.workspace_id = :workspace_id
+            AND e.name NOT IN :demo_experiment_names
+            AND t.project_id != ''
+            GROUP BY e.id
+            HAVING count(DISTINCT t.project_id) = 1
+            AND argMax(e.project_id, e.last_updated_at) = ''
+            SETTINGS log_comment = '<log_comment>'
+            """;
+
+    /**
+     * Re-INSERT the latest row per id with overridden {@code project_id}, {@code last_updated_by}
+     * and {@code last_updated_at}. Uses {@code SELECT * REPLACE} so any future column added to
+     * {@code experiments} is automatically copied without a schema-drift fix to this query —
+     * the alternative (explicit column list) would silently lose new columns by writing their
+     * defaults instead of preserving the source row's values.
+     *
+     * <p>Assumption: {@code experiments} has no {@code MATERIALIZED} or {@code ALIAS} columns.
+     * Adding one would require updating this query (the INSERT would fail loudly at execution
+     * time, surfacing the issue rather than corrupting data silently).
+     */
+    private static final String BATCH_SET_PROJECT_ID = """
+            INSERT INTO experiments
+            SELECT * REPLACE (
+                :user_name AS last_updated_by,
+                now64(9) AS last_updated_at,
+                :project_id AS project_id
+            )
+            FROM (
+                SELECT *
+                FROM experiments
+                WHERE workspace_id = :workspace_id
+                AND id IN :experiment_ids
+                ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
+                LIMIT 1 BY id
+            )
+            WHERE project_id = ''
+            SETTINGS log_comment = '<log_comment>'
+            """;
+
     private final @NonNull ConnectionFactory connectionFactory;
+    private final @NonNull TransactionTemplateAsync asyncTemplate;
     private final @NonNull SortingQueryBuilder sortingQueryBuilder;
     private final @NonNull ExperimentSortingFactory sortingFactory;
     private final @NonNull FilterQueryBuilder filterQueryBuilder;
@@ -2710,4 +2808,57 @@ public class ExperimentDAO {
         }
     }
 
+    Flux<EligibleWorkspace> findEligibleExperimentWorkspaces(Set<String> excludedWorkspaceIds, int limit) {
+        var excludedWorkspacesCount = CollectionUtils.size(excludedWorkspaceIds);
+        return asyncTemplate.stream(connection -> makeFluxContextAware((userName, workspaceId) -> {
+            var details = "excludedWorkspacesCount=%d, limit=%d, ".formatted(excludedWorkspacesCount, limit);
+            var template = getSTWithLogComment(FIND_ELIGIBLE_EXPERIMENT_WORKSPACES,
+                    "find_eligible_experiment_workspaces", workspaceId, userName, details);
+            if (excludedWorkspacesCount > 0) {
+                template.add("excluded_workspace_ids", true);
+            }
+            var statement = connection.createStatement(template.render())
+                    .bind("demo_experiment_names", DemoData.EXPERIMENTS)
+                    .bind("limit", limit);
+            if (excludedWorkspacesCount > 0) {
+                statement.bind("excluded_workspace_ids", excludedWorkspaceIds);
+            }
+            return Flux.from(statement.execute())
+                    .flatMap(result -> result.map((row, metadata) -> EligibleWorkspace.builder()
+                            .workspaceId(row.get("workspace_id", String.class))
+                            .experimentsCount(row.get("experiments_count", Long.class))
+                            .build()));
+        }));
+    }
+
+    Flux<ExperimentProjectMapping> computeExperimentProjectMapping() {
+        return asyncTemplate.stream(connection -> makeFluxContextAware((userName, workspaceId) -> {
+            var template = getSTWithLogComment(COMPUTE_EXPERIMENT_PROJECT_MAPPING,
+                    "compute_certain_experiment_project_mapping", workspaceId, userName, "");
+            var statement = connection.createStatement(template.render())
+                    .bind("demo_experiment_names", DemoData.EXPERIMENTS);
+            return makeFluxContextAware(bindWorkspaceIdToFlux(statement));
+        }))
+                .flatMap(result -> result.map((row, metadata) -> ExperimentProjectMapping.builder()
+                        .experimentId(UUID.fromString(row.get("experiment_id", String.class)))
+                        .projectId(UUID.fromString(row.get("project_id", String.class)))
+                        .build()));
+    }
+
+    Mono<Long> batchSetProjectId(Set<UUID> experimentIds, @NonNull UUID projectId) {
+        if (CollectionUtils.isEmpty(experimentIds)) {
+            return Mono.just(0L);
+        }
+        return asyncTemplate.stream(connection -> makeFluxContextAware((userName, workspaceId) -> {
+            var details = "experimentCount=%d, projectId=%s".formatted(experimentIds.size(), projectId);
+            var template = getSTWithLogComment(
+                    BATCH_SET_PROJECT_ID, "batch_set_project_id", workspaceId, userName, details);
+            var statement = connection.createStatement(template.render())
+                    .bind("experiment_ids", experimentIds)
+                    .bind("project_id", projectId);
+            return makeFluxContextAware(bindUserNameAndWorkspaceContextToStream(statement));
+        }))
+                .flatMap(Result::getRowsUpdated)
+                .reduce(0L, Long::sum);
+    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -2837,7 +2837,7 @@ public class ExperimentDAO {
                     "compute_certain_experiment_project_mapping", workspaceId, userName, "");
             var statement = connection.createStatement(template.render())
                     .bind("demo_experiment_names", DemoData.EXPERIMENTS);
-            return makeFluxContextAware(bindWorkspaceIdToFlux(statement));
+            return bindWorkspaceIdToFlux(statement).subscriberContext(userName, workspaceId);
         }))
                 .flatMap(result -> result.map((row, metadata) -> ExperimentProjectMapping.builder()
                         .experimentId(UUID.fromString(row.get("experiment_id", String.class)))
@@ -2856,7 +2856,7 @@ public class ExperimentDAO {
             var statement = connection.createStatement(template.render())
                     .bind("experiment_ids", experimentIds)
                     .bind("project_id", projectId);
-            return makeFluxContextAware(bindUserNameAndWorkspaceContextToStream(statement));
+            return bindUserNameAndWorkspaceContextToStream(statement).subscriberContext(userName, workspaceId);
         }))
                 .flatMap(Result::getRowsUpdated)
                 .reduce(0L, Long::sum);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMapping.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMapping.java
@@ -1,0 +1,10 @@
+package com.comet.opik.domain;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+import java.util.UUID;
+
+@Builder(toBuilder = true)
+public record ExperimentProjectMapping(@NonNull UUID experimentId, @NonNull UUID projectId) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMigrationService.java
@@ -1,0 +1,251 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Project;
+import com.comet.opik.domain.experiments.aggregations.ExperimentAggregationPublisher;
+import com.comet.opik.domain.workspaces.WorkspaceVersionService;
+import com.comet.opik.infrastructure.ExperimentProjectMigrationConfig;
+import com.comet.opik.infrastructure.MigrationConfig;
+import com.google.common.collect.Lists;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongGauge;
+import io.opentelemetry.api.metrics.LongHistogram;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.comet.opik.infrastructure.auth.RequestContext.SYSTEM_USER;
+import static com.comet.opik.utils.AsyncUtils.setRequestContext;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+@Slf4j
+@Singleton
+public class ExperimentProjectMigrationService {
+
+    public static final String METRIC_NAMESPACE = "opik.migration.experiment_project";
+
+    public static final AttributeKey<String> RESULT_KEY = stringKey("result");
+
+    public static final Attributes RESULT_ERROR = Attributes.of(RESULT_KEY, "error");
+
+    private static final Attributes RESULT_MIGRATED = Attributes.of(RESULT_KEY, "migrated");
+    private static final Attributes RESULT_NO_CERTAIN = Attributes.of(RESULT_KEY, "no_certain_experiments");
+    private static final Attributes RESULT_ALL_SKIPPED = Attributes.of(RESULT_KEY, "all_skipped_deleted_project");
+    private static final Attributes SKIP_REASON_DELETED_PROJECT = Attributes.of(stringKey("reason"), "deleted_project");
+
+    /**
+     * Process-local set of workspaces whose only certain experiments point to deleted projects.
+     * Without this, every cycle would re-attempt the same workspaces and run an expensive
+     * 3-table JOIN for nothing. The set is reset on JVM restart, so a redeployed process retries
+     * each previously-trapped workspace once before re-trapping it. Operators can permanently ban
+     * a workspace via the {@code migration.excludedWorkspaceIds} config.
+     */
+    private static final Set<String> TRAPPED_WORKSPACE_IDS = ConcurrentHashMap.newKeySet();
+
+    private final @NonNull ExperimentDAO experimentDAO;
+    private final @NonNull ProjectService projectService;
+    private final @NonNull ExperimentAggregationPublisher experimentAggregationPublisher;
+    private final @NonNull WorkspaceVersionService workspaceVersionService;
+    private final @NonNull ExperimentProjectMigrationConfig config;
+    private final @NonNull MigrationConfig migrationConfig;
+
+    private final LongHistogram cycleEligibleWorkspaces;
+    private final LongGauge cycleTrappedWorkspaces;
+    private final LongHistogram workspaceDuration;
+    private final LongCounter experimentsSkipped;
+    private final LongHistogram batchSize;
+
+    @Inject
+    public ExperimentProjectMigrationService(
+            @NonNull ExperimentDAO experimentDAO,
+            @NonNull ProjectService projectService,
+            @NonNull ExperimentAggregationPublisher experimentAggregationPublisher,
+            @NonNull WorkspaceVersionService workspaceVersionService,
+            @NonNull @Config("experimentProjectMigration") ExperimentProjectMigrationConfig config,
+            @NonNull @Config("migration") MigrationConfig migrationConfig) {
+        this.experimentDAO = experimentDAO;
+        this.projectService = projectService;
+        this.experimentAggregationPublisher = experimentAggregationPublisher;
+        this.workspaceVersionService = workspaceVersionService;
+        this.config = config;
+        this.migrationConfig = migrationConfig;
+
+        var meter = GlobalOpenTelemetry.get().getMeter(METRIC_NAMESPACE);
+        this.cycleEligibleWorkspaces = meter
+                .histogramBuilder("%s.cycle.eligible_workspaces".formatted(METRIC_NAMESPACE))
+                .setDescription("Number of workspaces with eligible experiments found per cycle")
+                .ofLongs()
+                .build();
+        this.cycleTrappedWorkspaces = meter
+                .gaugeBuilder("%s.cycle.trapped_workspaces".formatted(METRIC_NAMESPACE))
+                .setDescription(
+                        "Number of workspaces locally skipped because all their certain experiments point to deleted projects")
+                .ofLongs()
+                .build();
+        this.workspaceDuration = meter
+                .histogramBuilder("%s.workspace.duration".formatted(METRIC_NAMESPACE))
+                .setDescription("Duration of a single workspace migration, tagged by result")
+                .setUnit("ms")
+                .ofLongs()
+                .build();
+        this.experimentsSkipped = meter
+                .counterBuilder("%s.experiments.skipped".formatted(METRIC_NAMESPACE))
+                .setDescription("Total number of experiments skipped during migration, tagged by reason")
+                .build();
+        this.batchSize = meter
+                .histogramBuilder("%s.batch.size".formatted(METRIC_NAMESPACE))
+                .setDescription("Size of each successful ClickHouse INSERT batch")
+                .ofLongs()
+                .build();
+    }
+
+    public Mono<Void> runMigrationCycle() {
+        cycleTrappedWorkspaces.set(TRAPPED_WORKSPACE_IDS.size());
+        log.info(
+                "Starting experiment project migration cycle, workspacesPerRun='{}', batchSize='{}', trappedWorkspaces='{}'",
+                config.workspacesPerRun(), config.experimentBatchSize(), TRAPPED_WORKSPACE_IDS.size());
+        var excludedWorkspaceIds = Stream.concat(
+                migrationConfig.getExcludedWorkspaceIds().stream(),
+                TRAPPED_WORKSPACE_IDS.stream())
+                .collect(Collectors.toUnmodifiableSet());
+        return experimentDAO.findEligibleExperimentWorkspaces(excludedWorkspaceIds, config.workspacesPerRun())
+                .contextWrite(ctx -> setRequestContext(ctx, SYSTEM_USER, ""))
+                .collectList()
+                .flatMapMany(eligibleWorkspaces -> {
+                    cycleEligibleWorkspaces.record(eligibleWorkspaces.size());
+                    if (CollectionUtils.isEmpty(eligibleWorkspaces)) {
+                        log.info("No workspaces with eligible experiments found, consider disabling the job");
+                        return Flux.empty();
+                    }
+                    log.info("Found workspaces with eligible experiments, count='{}'", eligibleWorkspaces.size());
+                    return Flux.fromIterable(eligibleWorkspaces)
+                            .concatMap(workspace -> migrateWorkspace(
+                                    workspace.workspaceId(),
+                                    workspace.experimentsCount(),
+                                    config.experimentBatchSize()));
+                })
+                .then();
+    }
+
+    private Mono<Boolean> migrateWorkspace(String workspaceId, long experimentsCount, int batchSize) {
+        log.info("Starting workspace migration, workspaceId='{}', experimentsCount='{}'",
+                workspaceId, experimentsCount);
+        var workspaceStartMillis = System.currentTimeMillis();
+        return experimentDAO.computeExperimentProjectMapping()
+                .contextWrite(ctx -> setRequestContext(ctx, SYSTEM_USER, workspaceId))
+                .collectList()
+                .flatMap(mappings -> {
+                    if (CollectionUtils.isEmpty(mappings)) {
+                        log.info("No certain experiments to migrate, workspaceId='{}'", workspaceId);
+                        recordWorkspaceDuration(RESULT_NO_CERTAIN, workspaceStartMillis);
+                        return Mono.empty();
+                    }
+                    return migrateValidatedMappings(workspaceId, mappings, batchSize, workspaceStartMillis);
+                })
+                .onErrorResume(throwable -> {
+                    log.error("Workspace migration failed, will retry next cycle, workspaceId='{}'",
+                            workspaceId, throwable);
+                    recordWorkspaceDuration(RESULT_ERROR, workspaceStartMillis);
+                    return Mono.empty();
+                });
+    }
+
+    private Mono<Boolean> migrateValidatedMappings(
+            String workspaceId, List<ExperimentProjectMapping> mappings, int batchSize, long workspaceStartMillis) {
+        var inferredProjectIds = mappings.stream()
+                .map(ExperimentProjectMapping::projectId)
+                .collect(Collectors.toUnmodifiableSet());
+        return Mono.fromCallable(() -> projectService.findByIds(workspaceId, inferredProjectIds))
+                .subscribeOn(Schedulers.boundedElastic())
+                .flatMap(existingProjects -> {
+                    var validProjectIds = existingProjects.stream()
+                            .map(Project::id)
+                            .collect(Collectors.toUnmodifiableSet());
+                    var validated = mappings.stream()
+                            .filter(mapping -> validProjectIds.contains(mapping.projectId()))
+                            .toList();
+                    var skippedDeleted = mappings.size() - validated.size();
+                    if (skippedDeleted > 0) {
+                        log.info("Skipping experiments with deleted project, workspaceId='{}', count='{}'",
+                                workspaceId, skippedDeleted);
+                        experimentsSkipped.add(skippedDeleted, SKIP_REASON_DELETED_PROJECT);
+                    }
+                    if (CollectionUtils.isEmpty(validated)) {
+                        log.info(
+                                "All certain experiments point to deleted projects, marking workspace as trapped, workspaceId='{}'",
+                                workspaceId);
+                        TRAPPED_WORKSPACE_IDS.add(workspaceId);
+                        recordWorkspaceDuration(RESULT_ALL_SKIPPED, workspaceStartMillis);
+                        return Mono.empty();
+                    }
+                    var byProject = validated.stream()
+                            .collect(Collectors.groupingBy(ExperimentProjectMapping::projectId));
+                    return Flux.fromIterable(byProject.entrySet())
+                            .concatMap(entry -> batchUpdateProjectId(
+                                    workspaceId, entry.getKey(), entry.getValue(), batchSize))
+                            .then(triggerReaggregation(workspaceId, validated))
+                            .then(evictWorkspaceVersionCache(workspaceId))
+                            .doOnSuccess(__ -> {
+                                log.info(
+                                        "Workspace migration completed, workspaceId='{}', migrated='{}', skippedDeletedProject='{}'",
+                                        workspaceId, validated.size(), skippedDeleted);
+                                recordWorkspaceDuration(RESULT_MIGRATED, workspaceStartMillis);
+                            });
+                });
+    }
+
+    private void recordWorkspaceDuration(Attributes resultAttributes, long startMillis) {
+        workspaceDuration.record(System.currentTimeMillis() - startMillis, resultAttributes);
+    }
+
+    private Mono<Long> batchUpdateProjectId(
+            String workspaceId, UUID projectId, List<ExperimentProjectMapping> experiments, int maxBatchSize) {
+        return Flux.fromIterable(Lists.partition(experiments, maxBatchSize))
+                .concatMap(batch -> {
+                    var experimentIds = batch.stream()
+                            .map(ExperimentProjectMapping::experimentId)
+                            .collect(Collectors.toUnmodifiableSet());
+                    log.debug("Updating experiment batch, workspaceId='{}', projectId='{}', count='{}'",
+                            workspaceId, projectId, experimentIds.size());
+                    return experimentDAO.batchSetProjectId(experimentIds, projectId)
+                            .contextWrite(ctx -> setRequestContext(ctx, SYSTEM_USER, workspaceId))
+                            .doOnSuccess(rowsUpdated -> batchSize.record(experimentIds.size()));
+                })
+                .reduce(0L, Long::sum);
+    }
+
+    private Mono<Void> triggerReaggregation(String workspaceId, List<ExperimentProjectMapping> migrated) {
+        var experimentIds = migrated.stream()
+                .map(ExperimentProjectMapping::experimentId)
+                .collect(Collectors.toUnmodifiableSet());
+        return experimentAggregationPublisher.publish(experimentIds, workspaceId, SYSTEM_USER)
+                .onErrorResume(throwable -> {
+                    log.warn("Failed to trigger experiment reaggregation, workspaceId='{}', experimentIds.size='{}'",
+                            workspaceId, experimentIds.size(), throwable);
+                    return Mono.empty();
+                });
+    }
+
+    private Mono<Boolean> evictWorkspaceVersionCache(String workspaceId) {
+        return workspaceVersionService.evictCache(workspaceId)
+                .onErrorResume(throwable -> {
+                    log.warn("Failed to evict workspace version cache, workspaceId='{}'", workspaceId, throwable);
+                    return Mono.just(false);
+                });
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMigrationService.java
@@ -3,6 +3,7 @@ package com.comet.opik.domain;
 import com.comet.opik.api.Project;
 import com.comet.opik.domain.experiments.aggregations.ExperimentAggregationPublisher;
 import com.comet.opik.domain.workspaces.WorkspaceVersionService;
+import com.comet.opik.infrastructure.ExperimentDenormalizationConfig;
 import com.comet.opik.infrastructure.ExperimentProjectMigrationConfig;
 import com.comet.opik.infrastructure.MigrationConfig;
 import com.google.common.collect.Lists;
@@ -29,6 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.comet.opik.api.resources.v1.events.ExperimentAggregateEventListener.FINISHED_STATUSES;
 import static com.comet.opik.infrastructure.auth.RequestContext.SYSTEM_USER;
 import static com.comet.opik.utils.AsyncUtils.setRequestContext;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
@@ -58,11 +60,13 @@ public class ExperimentProjectMigrationService {
     private static final Set<String> TRAPPED_WORKSPACE_IDS = ConcurrentHashMap.newKeySet();
 
     private final @NonNull ExperimentDAO experimentDAO;
+    private final @NonNull ExperimentItemService experimentItemService;
     private final @NonNull ProjectService projectService;
     private final @NonNull ExperimentAggregationPublisher experimentAggregationPublisher;
     private final @NonNull WorkspaceVersionService workspaceVersionService;
     private final @NonNull ExperimentProjectMigrationConfig config;
     private final @NonNull MigrationConfig migrationConfig;
+    private final @NonNull ExperimentDenormalizationConfig denormalizationConfig;
 
     private final LongHistogram cycleEligibleWorkspaces;
     private final LongGauge cycleTrappedWorkspaces;
@@ -73,17 +77,21 @@ public class ExperimentProjectMigrationService {
     @Inject
     public ExperimentProjectMigrationService(
             @NonNull ExperimentDAO experimentDAO,
+            @NonNull ExperimentItemService experimentItemService,
             @NonNull ProjectService projectService,
             @NonNull ExperimentAggregationPublisher experimentAggregationPublisher,
             @NonNull WorkspaceVersionService workspaceVersionService,
             @NonNull @Config("experimentProjectMigration") ExperimentProjectMigrationConfig config,
-            @NonNull @Config("migration") MigrationConfig migrationConfig) {
+            @NonNull @Config("migration") MigrationConfig migrationConfig,
+            @NonNull @Config("experimentDenormalization") ExperimentDenormalizationConfig denormalizationConfig) {
         this.experimentDAO = experimentDAO;
+        this.experimentItemService = experimentItemService;
         this.projectService = projectService;
         this.experimentAggregationPublisher = experimentAggregationPublisher;
         this.workspaceVersionService = workspaceVersionService;
         this.config = config;
         this.migrationConfig = migrationConfig;
+        this.denormalizationConfig = denormalizationConfig;
 
         var meter = GlobalOpenTelemetry.get().getMeter(METRIC_NAMESPACE);
         this.cycleEligibleWorkspaces = meter
@@ -230,10 +238,24 @@ public class ExperimentProjectMigrationService {
     }
 
     private Mono<Void> triggerReaggregation(String workspaceId, List<ExperimentProjectMapping> migrated) {
+        if (!denormalizationConfig.isEnabled()) {
+            log.debug("Skipping reaggregation: experiment denormalization disabled, workspaceId='{}'", workspaceId);
+            return Mono.empty();
+        }
         var experimentIds = migrated.stream()
                 .map(ExperimentProjectMapping::experimentId)
                 .collect(Collectors.toUnmodifiableSet());
-        return experimentAggregationPublisher.publish(experimentIds, workspaceId, SYSTEM_USER)
+        return experimentItemService.filterExperimentIdsByStatus(experimentIds, FINISHED_STATUSES)
+                .collect(Collectors.toUnmodifiableSet())
+                .flatMap(finished -> {
+                    if (finished.isEmpty()) {
+                        log.info("No finished experiments to reaggregate, workspaceId='{}', candidateCount='{}'",
+                                workspaceId, experimentIds.size());
+                        return Mono.empty();
+                    }
+                    return experimentAggregationPublisher.publish(finished, workspaceId, SYSTEM_USER);
+                })
+                .contextWrite(ctx -> setRequestContext(ctx, SYSTEM_USER, workspaceId))
                 .onErrorResume(throwable -> {
                     log.warn("Failed to trigger experiment reaggregation, workspaceId='{}', experimentIds.size='{}'",
                             workspaceId, experimentIds.size(), throwable);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
@@ -80,6 +80,8 @@ import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONL
  */
 public interface WorkspaceVersionService {
     Mono<WorkspaceVersion> getWorkspaceVersion(String workspaceId, OpikVersion authSuggestedVersion);
+
+    Mono<Boolean> evictCache(String workspaceId);
 }
 
 /**
@@ -233,5 +235,10 @@ abstract class AbstractWorkspaceVersionService implements WorkspaceVersionServic
 
     private WorkspaceVersion buildResponse(OpikVersion version) {
         return WorkspaceVersion.builder().opikVersion(version).build();
+    }
+
+    @Override
+    public Mono<Boolean> evictCache(@NonNull String workspaceId) {
+        return cacheManager.evict(cacheKey(workspaceId), false);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ExperimentProjectMigrationConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ExperimentProjectMigrationConfig.java
@@ -1,0 +1,30 @@
+package com.comet.opik.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.dropwizard.util.Duration;
+import io.dropwizard.validation.MaxDuration;
+import io.dropwizard.validation.MinDuration;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.util.concurrent.TimeUnit;
+
+@Builder(toBuilder = true)
+public record ExperimentProjectMigrationConfig(
+        boolean enabled,
+        @Min(1) @Max(100) int workspacesPerRun,
+        @Min(100) @Max(1000) int experimentBatchSize,
+        @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 1, unit = TimeUnit.HOURS) Duration interval,
+        @NotNull @MinDuration(value = 0, unit = TimeUnit.SECONDS) @MaxDuration(value = 10, unit = TimeUnit.MINUTES) Duration startupDelay,
+        @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 30, unit = TimeUnit.MINUTES) Duration lockTimeout,
+        @NotNull @MinDuration(value = 50, unit = TimeUnit.MILLISECONDS) @MaxDuration(value = 5, unit = TimeUnit.SECONDS) Duration lockWaitTime,
+        @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 1, unit = TimeUnit.HOURS) Duration jobTimeout) {
+
+    @JsonIgnore
+    @AssertTrue(message = "lockTimeout must be shorter than jobTimeout") public boolean isLockTimeoutShorterThanJobTimeout() {
+        return lockTimeout.toJavaDuration().compareTo(jobTimeout.toJavaDuration()) < 0;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/MigrationConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/MigrationConfig.java
@@ -1,0 +1,37 @@
+package com.comet.opik.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Shared configuration for V1 → V2 entity project migration jobs (experiments, datasets,
+ * optimizations, etc.). Centralised so all migration jobs share the same excluded workspaces.
+ */
+@Data
+public class MigrationConfig {
+
+    private @NotNull Set<@NotBlank String> excludedWorkspaceIds = Set.of();
+
+    @JsonSetter
+    public void setExcludedWorkspaceIds(String excludedWorkspaceIds) {
+        this.excludedWorkspaceIds = Optional.ofNullable(excludedWorkspaceIds)
+                .filter(StringUtils::isNotBlank)
+                .map(commaSeparated -> Arrays.stream(commaSeparated.split(","))
+                        .map(String::strip)
+                        .filter(StringUtils::isNotBlank)
+                        .collect(Collectors.collectingAndThen(
+                                Collectors.toCollection(LinkedHashSet::new),
+                                Collections::unmodifiableSet)))
+                .orElse(Set.of());
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
@@ -120,6 +120,13 @@ public class OpikConfiguration extends JobConfiguration {
     private DatasetVersioningMigrationConfig datasetVersioningMigration = new DatasetVersioningMigrationConfig();
 
     @Valid @NotNull @JsonProperty
+    private MigrationConfig migration = new MigrationConfig();
+
+    @Valid @NotNull @JsonProperty
+    private ExperimentProjectMigrationConfig experimentProjectMigration = ExperimentProjectMigrationConfig.builder()
+            .build();
+
+    @Valid @NotNull @JsonProperty
     private LocalRunnerConfig localRunner = new LocalRunnerConfig();
 
     @Valid @NotNull @JsonProperty

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListener.java
@@ -2,6 +2,7 @@ package com.comet.opik.infrastructure.bi;
 
 import com.comet.opik.api.resources.v1.jobs.DatasetVersionItemsTotalMigrationJob;
 import com.comet.opik.api.resources.v1.jobs.ExperimentDenormalizationJob;
+import com.comet.opik.api.resources.v1.jobs.ExperimentProjectMigrationJob;
 import com.comet.opik.api.resources.v1.jobs.LocalRunnerReaperJob;
 import com.comet.opik.api.resources.v1.jobs.MetricsAlertJob;
 import com.comet.opik.api.resources.v1.jobs.RetentionCatchUpJob;
@@ -57,6 +58,7 @@ public class OpikGuiceyLifecycleEventListener implements GuiceyLifecycleListener
                 setRetentionJobs();
                 setLlmModelRegistryRefreshJob();
                 scheduleDatasetVersionItemsTotalMigrationJobIfEnabled();
+                scheduleExperimentProjectMigrationJobIfEnabled();
             }
 
             case GuiceyLifecycle.ApplicationShutdown -> shutdownJobManagerScheduler();
@@ -306,5 +308,16 @@ public class OpikGuiceyLifecycleEventListener implements GuiceyLifecycleListener
         } catch (Exception e) {
             log.error("Unexpected error setting up dataset version items_total migration job", e);
         }
+    }
+
+    private void scheduleExperimentProjectMigrationJobIfEnabled() {
+        var config = injector.get().getInstance(OpikConfiguration.class).getExperimentProjectMigration();
+        if (config == null || !config.enabled()) {
+            log.info("Experiment project migration job is disabled");
+            return;
+        }
+        scheduleRepeatingJob(ExperimentProjectMigrationJob.class,
+                config.interval().toJavaDuration(),
+                config.startupDelay().toJavaDuration());
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ExperimentTestAssertions.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ExperimentTestAssertions.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api.resources.utils.resources;
 
+import com.comet.opik.api.Experiment;
 import com.comet.opik.api.ExperimentItem;
 import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.resources.utils.CommentAssertionUtils;
@@ -17,6 +18,36 @@ public class ExperimentTestAssertions {
             "feedbackScores.createdAt", "feedbackScores.lastUpdatedAt", "comments.createdAt", "comments.lastUpdatedAt",
             "feedbackScores.valueByAuthor", "projectName"
     };
+
+    public static final String[] EXPERIMENT_IGNORED_FIELDS = new String[]{
+            "id", "datasetId", "name", "feedbackScores", "assertionScores", "traceCount", "createdAt",
+            "lastUpdatedAt", "createdBy", "lastUpdatedBy", "comments", "projectName", "datasetItemCount"};
+
+    /**
+     * Asserts that {@code actual} matches {@code expected} via recursive comparison ignoring
+     * {@link #EXPERIMENT_IGNORED_FIELDS}, plus per-field equality on every ignored scalar
+     * <em>except</em> {@code lastUpdatedAt} and the async-aggregation fields. {@code lastUpdatedAt}
+     * is left to the caller because its expected semantic is scenario-specific ({@code ==} for an
+     * untouched experiment, {@code isAfter} for one re-written by a job). Aggregation fields
+     * ({@code feedbackScores}/{@code traceCount}/etc.) are also async and out of this helper's
+     * scope. Fields that <em>aren't</em> in {@code EXPERIMENT_IGNORED_FIELDS} (notably
+     * {@code projectId}) are covered by the recursive comparison, so no explicit re-assertion is
+     * needed for them here.
+     */
+    public static void assertExperimentEqual(Experiment actual, Experiment expected) {
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .ignoringFields(EXPERIMENT_IGNORED_FIELDS)
+                .isEqualTo(expected);
+
+        assertThat(actual.id()).isEqualTo(expected.id());
+        assertThat(actual.datasetId()).isEqualTo(expected.datasetId());
+        assertThat(actual.name()).isEqualTo(expected.name());
+        assertThat(actual.createdAt()).isEqualTo(expected.createdAt());
+        assertThat(actual.createdBy()).isEqualTo(expected.createdBy());
+        assertThat(actual.lastUpdatedBy()).isEqualTo(expected.lastUpdatedBy());
+        assertThat(actual.projectName()).isEqualTo(expected.projectName());
+    }
 
     public static void assertExperimentResultsIgnoringFields(List<ExperimentItem> actual, List<ExperimentItem> expected,
             String[] ignoringFields) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ProjectResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ProjectResourceClient.java
@@ -61,6 +61,16 @@ public class ProjectResourceClient {
         }
     }
 
+    public void deleteProject(UUID projectId, String apiKey, String workspaceName) {
+        try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/" + projectId)
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(RequestContext.WORKSPACE_HEADER, workspaceName)
+                .delete()) {
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+        }
+    }
+
     public Project getProject(UUID projectId, String apiKey, String workspaceName) {
 
         try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/" + projectId)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceFindProjectExperimentsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceFindProjectExperimentsTest.java
@@ -83,6 +83,7 @@ import static com.comet.opik.api.FeedbackScoreBatchContainer.FeedbackScoreBatch;
 import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
 import static com.comet.opik.api.resources.utils.ExperimentsTestUtils.getQuantities;
 import static com.comet.opik.api.resources.utils.TestUtils.toURLEncodedQueryParam;
+import static com.comet.opik.api.resources.utils.resources.ExperimentTestAssertions.EXPERIMENT_IGNORED_FIELDS;
 import static com.comet.opik.utils.ValidationUtils.SCALE;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
@@ -102,10 +103,6 @@ class ExperimentsResourceFindProjectExperimentsTest {
     private static final String USER = "user-" + RandomStringUtils.secure().nextAlphanumeric(36);
 
     private static final String URL_TEMPLATE = "%s/v1/private/experiments";
-
-    private static final String[] EXPERIMENT_IGNORED_FIELDS = new String[]{
-            "id", "datasetId", "name", "feedbackScores", "assertionScores", "traceCount", "createdAt",
-            "lastUpdatedAt", "createdBy", "lastUpdatedBy", "comments", "projectName", "datasetItemCount"};
 
     private final TestContainersSetup setup = new TestContainersSetup(Mockito.mock(EventBus.class));
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -168,6 +168,7 @@ import static com.comet.opik.api.resources.utils.TestHttpClientUtils.NO_API_KEY_
 import static com.comet.opik.api.resources.utils.TestHttpClientUtils.UNAUTHORIZED_RESPONSE;
 import static com.comet.opik.api.resources.utils.TestUtils.getIdFromLocation;
 import static com.comet.opik.api.resources.utils.TestUtils.toURLEncodedQueryParam;
+import static com.comet.opik.api.resources.utils.resources.ExperimentTestAssertions.EXPERIMENT_IGNORED_FIELDS;
 import static com.comet.opik.infrastructure.auth.RequestContext.SESSION_COOKIE;
 import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER;
 import static com.comet.opik.utils.ValidationUtils.SCALE;
@@ -199,10 +200,6 @@ class ExperimentsResourceTest {
     private static final String ITEMS_PATH = "/items";
 
     private static final String API_KEY = UUID.randomUUID().toString();
-
-    private static final String[] EXPERIMENT_IGNORED_FIELDS = new String[]{
-            "id", "datasetId", "name", "feedbackScores", "assertionScores", "traceCount", "createdAt",
-            "lastUpdatedAt", "createdBy", "lastUpdatedBy", "comments", "projectName", "datasetItemCount"};
 
     private static final String WORKSPACE_ID = UUID.randomUUID().toString();
     private static final String USER = "user-" + RandomStringUtils.secure().nextAlphanumeric(36);

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationJobTest.java
@@ -1,0 +1,412 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Dataset;
+import com.comet.opik.api.Experiment;
+import com.comet.opik.api.ExperimentItem;
+import com.comet.opik.api.OpikVersion;
+import com.comet.opik.api.Project;
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.DatasetResourceClient;
+import com.comet.opik.api.resources.utils.resources.ExperimentResourceClient;
+import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
+import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
+import com.comet.opik.api.resources.utils.resources.WorkspaceResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.redis.testcontainers.RedisContainer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.comet.opik.api.resources.utils.AuthTestUtils.mockTargetWorkspace;
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.api.resources.utils.resources.ExperimentTestAssertions.assertExperimentEqual;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class ExperimentProjectMigrationJobTest {
+
+    private static final String EXCLUDED_WORKSPACE_ID_1 = UUID.randomUUID().toString();
+    private static final String EXCLUDED_WORKSPACE_ID_2 = UUID.randomUUID().toString();
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE_CONTAINER = ClickHouseContainerUtils
+            .newClickHouseContainer(ZOOKEEPER_CONTAINER);
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(REDIS, CLICKHOUSE_CONTAINER, MYSQL, ZOOKEEPER_CONTAINER).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils
+                .newDatabaseAnalyticsFactory(CLICKHOUSE_CONTAINER, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE_CONTAINER);
+
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .redisUrl(REDIS.getRedisURI())
+                        .customConfigs(List.of(
+                                new CustomConfig("experimentProjectMigration.enabled", "true"),
+                                // Buffer so the first cycle fires after the initial seed+prime.
+                                new CustomConfig("experimentProjectMigration.startupDelay", "3s"),
+                                new CustomConfig("migration.excludedWorkspaceIds",
+                                        "%s,%s".formatted(EXCLUDED_WORKSPACE_ID_1, EXCLUDED_WORKSPACE_ID_2)),
+                                // Cache enabled with the production TTL so only the migration's
+                                // evictCache can flip a cached V1 to V2 within the test windows.
+                                new CustomConfig("cacheManager.enabled", "true"),
+                                new CustomConfig("cacheManager.caches.workspace_version", "PT5M")))
+                        .build());
+    }
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    private ProjectResourceClient projectResourceClient;
+    private DatasetResourceClient datasetResourceClient;
+    private ExperimentResourceClient experimentResourceClient;
+    private TraceResourceClient traceResourceClient;
+    private WorkspaceResourceClient workspaceResourceClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport clientSupport) {
+        var baseUrl = TestUtils.getBaseUrl(clientSupport);
+
+        projectResourceClient = new ProjectResourceClient(clientSupport, baseUrl, factory);
+        datasetResourceClient = new DatasetResourceClient(clientSupport, baseUrl);
+        experimentResourceClient = new ExperimentResourceClient(clientSupport, baseUrl, factory);
+        traceResourceClient = new TraceResourceClient(clientSupport, baseUrl);
+        workspaceResourceClient = new WorkspaceResourceClient(clientSupport, baseUrl, factory);
+    }
+
+    @Test
+    void migrateEligibleExperimentsAcrossWorkspaces() {
+        // Workspace A: one eligible experiment (smallest first per FIND_ELIGIBLE ordering).
+        var apiKeyA = randomName("api-key");
+        var workspaceNameA = randomName("workspace");
+        var workspaceIdA = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKeyA, workspaceNameA, workspaceIdA, randomName("user"));
+        var projectNameA = randomName("project");
+        var seededA = seedCertainExperiment(apiKeyA, workspaceNameA, projectNameA);
+        var experimentIdA = seededA.getLeft();
+        var projectIdA = seededA.getRight();
+        var beforeA = experimentResourceClient.getExperiment(experimentIdA, apiKeyA, workspaceNameA);
+
+        // Workspace B: two eligible experiments in the same project (multi-experiment per workspace).
+        var apiKeyB = randomName("api-key");
+        var workspaceNameB = randomName("workspace");
+        var workspaceIdB = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKeyB, workspaceNameB, workspaceIdB, randomName("user"));
+        var projectNameB = randomName("project");
+        var projectIdB = createProject(apiKeyB, workspaceNameB, projectNameB);
+        var datasetNameB = randomName("dataset");
+        createDatasetWithProject(apiKeyB, workspaceNameB, datasetNameB, projectIdB);
+        var experimentIdsB = new ArrayList<UUID>();
+        for (int i = 0; i < 2; i++) {
+            var traceId = createTrace(apiKeyB, workspaceNameB, projectNameB);
+            var experimentId = createOrphanExperiment(apiKeyB, workspaceNameB, datasetNameB);
+            linkExperimentToTraces(apiKeyB, workspaceNameB, experimentId, traceId);
+            experimentIdsB.add(experimentId);
+        }
+        var beforesB = new ArrayList<Experiment>();
+        for (var id : experimentIdsB) {
+            beforesB.add(experimentResourceClient.getExperiment(id, apiKeyB, workspaceNameB));
+        }
+
+        // Prime the workspace_version cache to V1 before the first migration cycle fires.
+        // This forces the post-migration V2 read to depend on evictWorkspaceVersionCache
+        // actually clearing the cached V1, exercising the evictCache path end-to-end.
+        assertWorkspaceVersion(apiKeyA, workspaceNameA, OpikVersion.VERSION_1);
+        assertWorkspaceVersion(apiKeyB, workspaceNameB, OpikVersion.VERSION_1);
+
+        // A single cycle picks up both workspaces (workspacesPerRun=20 default) and
+        // FIND_ELIGIBLE_EXPERIMENT_WORKSPACES orders smallest-first; both should reach V2.
+        assertWorkspaceVersion2(apiKeyA, workspaceNameA);
+        assertWorkspaceVersion2(apiKeyB, workspaceNameB);
+
+        assertExperimentMigrated(apiKeyA, workspaceNameA, experimentIdA, beforeA, projectIdA, projectNameA);
+        for (int i = 0; i < experimentIdsB.size(); i++) {
+            assertExperimentMigrated(apiKeyB, workspaceNameB, experimentIdsB.get(i),
+                    beforesB.get(i), projectIdB, projectNameB);
+        }
+    }
+
+    /**
+     * Single workspace covering all non-eligible filter points in one cycle:
+     * <ul>
+     *   <li>"ambiguous" experiment is filtered at {@code COMPUTE_MAPPING}
+     *       ({@code HAVING count(DISTINCT t.project_id) = 1}).</li>
+     *   <li>"deleted-project" experiment reaches {@code COMPUTE_MAPPING} but is filtered at
+     *       {@code projectService.findByIds} ({@code skippedDeleted > 0} branch in
+     *       {@code migrateValidatedMappings}).</li>
+     *   <li>"demo" experiment is eligible-shaped (one trace in a single live project) but
+     *       filtered by {@code WHERE e.name NOT IN :demo_experiment_names} in both
+     *       {@code FIND_ELIGIBLE} and {@code COMPUTE_MAPPING}. Demo data is invisible to the
+     *       workspace V1 entity check, so this gap can only be detected at the experiment level.</li>
+     * </ul>
+     * Workspace stays V1 because the ambiguous and deleted-project orphans keep it V1; the
+     * eligible one migrates to its inferred project; the demo experiment's empty project_id is
+     * preserved.
+     */
+    @Test
+    void mixedWorkspaceMigratesEligibleAndKeepsNonEligibleAsV1() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        // Eligible: one trace in a single alive project => migrates.
+        var eligibleProjectName = randomName("project");
+        var eligibleProjectId = createProject(apiKey, workspaceName, eligibleProjectName);
+        var datasetName = randomName("dataset");
+        createDatasetWithProject(apiKey, workspaceName, datasetName, eligibleProjectId);
+        var eligibleTraceId = createTrace(apiKey, workspaceName, eligibleProjectName);
+        var eligibleExperimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+        linkExperimentToTraces(apiKey, workspaceName, eligibleExperimentId, eligibleTraceId);
+
+        // Ambiguous: two traces in two different projects => filtered at COMPUTE_MAPPING.
+        var ambiguousProjectName1 = randomName("project");
+        var ambiguousProjectName2 = randomName("project");
+        createProject(apiKey, workspaceName, ambiguousProjectName1);
+        createProject(apiKey, workspaceName, ambiguousProjectName2);
+        var ambiguousTrace1Id = createTrace(apiKey, workspaceName, ambiguousProjectName1);
+        var ambiguousTrace2Id = createTrace(apiKey, workspaceName, ambiguousProjectName2);
+        var ambiguousExperimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+        linkExperimentToTraces(apiKey, workspaceName, ambiguousExperimentId,
+                ambiguousTrace1Id, ambiguousTrace2Id);
+
+        // Deleted-project: one trace in a single project that gets deleted in MySQL after seeding.
+        // Reaches COMPUTE_MAPPING (single project), gets filtered at projectService.findByIds.
+        var deletedProjectName = randomName("project");
+        var deletedProjectId = createProject(apiKey, workspaceName, deletedProjectName);
+        var deletedTraceId = createTrace(apiKey, workspaceName, deletedProjectName);
+        var deletedExperimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+        linkExperimentToTraces(apiKey, workspaceName, deletedExperimentId, deletedTraceId);
+        projectResourceClient.deleteProject(deletedProjectId, apiKey, workspaceName);
+
+        // Demo: eligible-shaped (single trace in the live eligible project) but filtered by
+        // demo-name exclusion in both FIND_ELIGIBLE and COMPUTE_MAPPING.
+        var demoTraceId = createTrace(apiKey, workspaceName, eligibleProjectName);
+        var demoExperimentId = experimentResourceClient.create(
+                experimentResourceClient.createPartialExperiment()
+                        .id(null)
+                        .name(DemoData.EXPERIMENTS.getFirst())
+                        .datasetName(datasetName)
+                        .build(),
+                apiKey, workspaceName);
+        linkExperimentToTraces(apiKey, workspaceName, demoExperimentId, demoTraceId);
+
+        var eligibleBefore = experimentResourceClient.getExperiment(eligibleExperimentId, apiKey, workspaceName);
+        var ambiguousBefore = experimentResourceClient.getExperiment(ambiguousExperimentId, apiKey, workspaceName);
+        var deletedBefore = experimentResourceClient.getExperiment(deletedExperimentId, apiKey, workspaceName);
+        var demoBefore = experimentResourceClient.getExperiment(demoExperimentId, apiKey, workspaceName);
+
+        assertWorkspaceVersion1(apiKey, workspaceName);
+
+        assertExperimentMigrated(apiKey, workspaceName, eligibleExperimentId, eligibleBefore,
+                eligibleProjectId, eligibleProjectName);
+        assertExperimentUnchanged(apiKey, workspaceName, ambiguousExperimentId, ambiguousBefore);
+        assertExperimentUnchanged(apiKey, workspaceName, deletedExperimentId, deletedBefore);
+        assertExperimentUnchanged(apiKey, workspaceName, demoExperimentId, demoBefore);
+    }
+
+    @Test
+    void skipExperimentWhenInferredProjectWasDeleted() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var projectName = randomName("project");
+        var projectId = createProject(apiKey, workspaceName, projectName);
+        var datasetName = randomName("dataset");
+        createDatasetWithProject(apiKey, workspaceName, datasetName, projectId);
+        var traceId = createTrace(apiKey, workspaceName, projectName);
+        var experimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+        linkExperimentToTraces(apiKey, workspaceName, experimentId, traceId);
+
+        projectResourceClient.deleteProject(projectId, apiKey, workspaceName);
+
+        var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+
+        assertWorkspaceVersion1(apiKey, workspaceName);
+
+        assertExperimentUnchanged(apiKey, workspaceName, experimentId, beforeMigration);
+    }
+
+    @Test
+    void skipExperimentWithNoTraceLinks() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var projectName = randomName("project");
+        var projectId = createProject(apiKey, workspaceName, projectName);
+        var datasetName = randomName("dataset");
+        createDatasetWithProject(apiKey, workspaceName, datasetName, projectId);
+        var experimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+
+        var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+
+        assertWorkspaceVersion1(apiKey, workspaceName);
+
+        assertExperimentUnchanged(apiKey, workspaceName, experimentId, beforeMigration);
+    }
+
+    @Test
+    void skipExcludedWorkspaces() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, EXCLUDED_WORKSPACE_ID_1, randomName("user"));
+
+        var projectName = randomName("project");
+        var seeded = seedCertainExperiment(apiKey, workspaceName, projectName);
+        var experimentId = seeded.getLeft();
+        var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+
+        assertWorkspaceVersion1(apiKey, workspaceName);
+
+        assertExperimentUnchanged(apiKey, workspaceName, experimentId, beforeMigration);
+    }
+
+    private Pair<UUID, UUID> seedCertainExperiment(String apiKey, String workspaceName, String projectName) {
+        var projectId = createProject(apiKey, workspaceName, projectName);
+        var datasetName = randomName("dataset");
+        createDatasetWithProject(apiKey, workspaceName, datasetName, projectId);
+        var traceId = createTrace(apiKey, workspaceName, projectName);
+        var experimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+        linkExperimentToTraces(apiKey, workspaceName, experimentId, traceId);
+        return Pair.of(experimentId, projectId);
+    }
+
+    private String randomName(String prefix) {
+        return "%s-%s".formatted(prefix, RandomStringUtils.secure().nextAlphanumeric(32));
+    }
+
+    private UUID createProject(String apiKey, String workspaceName, String projectName) {
+        return projectResourceClient.createProject(
+                factory.manufacturePojo(Project.class).toBuilder().name(projectName).build(),
+                apiKey, workspaceName);
+    }
+
+    private void createDatasetWithProject(String apiKey, String workspaceName, String datasetName, UUID projectId) {
+        datasetResourceClient.createDataset(
+                factory.manufacturePojo(Dataset.class).toBuilder()
+                        .name(datasetName)
+                        .projectId(projectId)
+                        .projectName(null)
+                        .build(),
+                apiKey, workspaceName);
+    }
+
+    private UUID createTrace(String apiKey, String workspaceName, String projectName) {
+        return traceResourceClient.createTrace(
+                factory.manufacturePojo(Trace.class).toBuilder()
+                        .id(null)
+                        .projectName(projectName)
+                        .projectId(null)
+                        .startTime(Instant.now())
+                        .feedbackScores(null)
+                        .usage(null)
+                        .build(),
+                apiKey, workspaceName);
+    }
+
+    private UUID createOrphanExperiment(String apiKey, String workspaceName, String datasetName) {
+        return experimentResourceClient.create(
+                experimentResourceClient.createPartialExperiment()
+                        .id(null)
+                        .datasetName(datasetName)
+                        .build(),
+                apiKey, workspaceName);
+    }
+
+    private void linkExperimentToTraces(String apiKey, String workspaceName, UUID experimentId, UUID... traceIds) {
+        var items = Arrays.stream(traceIds)
+                .map(traceId -> factory.manufacturePojo(ExperimentItem.class).toBuilder()
+                        .experimentId(experimentId)
+                        .traceId(traceId)
+                        .feedbackScores(null)
+                        .build())
+                .collect(Collectors.toUnmodifiableSet());
+        experimentResourceClient.createExperimentItem(items, apiKey, workspaceName);
+    }
+
+    private void assertWorkspaceVersion(String apiKey, String workspaceName, OpikVersion expected) {
+        assertThat(workspaceResourceClient.getWorkspaceVersion(apiKey, workspaceName).opikVersion())
+                .isEqualTo(expected);
+    }
+
+    private void assertWorkspaceVersion2(String apiKey, String workspaceName) {
+        Awaitility.await().atMost(30, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS).untilAsserted(
+                        () -> assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_2));
+    }
+
+    private void assertWorkspaceVersion1(String apiKey, String workspaceName) {
+        Awaitility.await().atMost(15, TimeUnit.SECONDS).during(12, TimeUnit.SECONDS).untilAsserted(
+                () -> assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_1));
+    }
+
+    private void assertExperimentMigrated(
+            String apiKey, String workspaceName, UUID experimentId,
+            Experiment beforeMigration, UUID expectedProjectId, String expectedProjectName) {
+        var actual = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+        var expected = beforeMigration.toBuilder()
+                .projectId(expectedProjectId)
+                .projectName(expectedProjectName)
+                .lastUpdatedBy(RequestContext.SYSTEM_USER)
+                .build();
+        assertExperimentEqual(actual, expected);
+        assertThat(actual.lastUpdatedAt()).isAfter(beforeMigration.lastUpdatedAt());
+    }
+
+    private void assertExperimentUnchanged(
+            String apiKey, String workspaceName, UUID experimentId, Experiment beforeMigration) {
+        var actual = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+        assertExperimentEqual(actual, beforeMigration);
+        assertThat(actual.lastUpdatedAt()).isEqualTo(beforeMigration.lastUpdatedAt());
+    }
+}

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -670,6 +670,34 @@ datasetVersioningMigration:
   # Should be long enough to complete the entire migration process
   itemsTotalJobTimeoutSeconds: 3600
 
+# Experiment Project Migration configuration
+# Assigns project_id to orphan experiments (V1 → V2 workspace migration).
+# Runs as a recurring job, processing workspaces in batches.
+experimentProjectMigration:
+  # Master switch — disabled in tests by default
+  enabled: false
+  # Number of workspaces to process per job run (smallest first)
+  workspacesPerRun: 20
+  # Number of experiments to update per ClickHouse INSERT batch
+  experimentBatchSize: 1000
+  # Interval between recurring job runs
+  interval: 5s
+  # Delay before first run after app startup
+  startupDelay: 0s
+  # Distributed lock timeout — prevents overlap across replicas. Must stay < jobTimeout.
+  # Short in tests so the lock releases between cycles and Awaitility windows can stay brief.
+  lockTimeout: 5s
+  # Max time to wait for the distributed lock when another replica holds it
+  lockWaitTime: 100ms
+  # Per-cycle timeout — short for tests so hangs fail fast
+  jobTimeout: 30s
+
+# Shared configuration for V1 → V2 entity project migration jobs
+# Centralised so all migration jobs (experiments, datasets, etc.) share the same exclusion list
+migration:
+  # Comma-separated workspace IDs to exclude (e.g. internal Comet workspaces)
+  excludedWorkspaceIds:
+
 # Job timeout configuration
 jobTimeout:
   # Default: 30s


### PR DESCRIPTION
## Details

Adds a recurring backend job that migrates orphan (V1) experiments to their inferred project (V2) when their linked traces unambiguously resolve to a single live project, then evicts the cached workspace version so the workspace promotes to V2 on the next read. Ships behind a master switch with a Redisson distributed lock, configurable batching, schema-drift-safe ClickHouse `INSERT … SELECT * REPLACE`, and OpenTelemetry metrics.

- Filters demo experiments by name in both `FIND_ELIGIBLE_EXPERIMENT_WORKSPACES` and `COMPUTE_EXPERIMENT_PROJECT_MAPPING` so demo data is never silently mutated.
- Validates inferred projects against MySQL before the ClickHouse update; workspaces whose certain experiments all point to deleted projects are trapped in-process to skip future cycles.
- `lockTimeout < jobTimeout` enforced via `@AssertTrue` so misconfiguration fails on startup.

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- OPIK-6184

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: implementation, tests, configuration, code review iterations
- Human verification: design reviewed iteratively; integration tests run locally; SQL execution plans reviewed before code changes

## Testing

- `mvn test -Dtest=ExperimentProjectMigrationJobTest` — all 5 tests pass (~90s with Testcontainers).
- Scenarios validated:
  - Eligible orphans across multiple workspaces migrate to inferred project.
  - Mixed-workspace test covers all non-eligible filter points in one cycle (ambiguous traces, deleted inferred project, demo-name exclusion).
  - Inferred-project deleted before migration → experiment unchanged, workspace stays V1.
  - Orphans with no trace links → not eligible, workspace stays V1.
  - Excluded workspace IDs → migration skipped, workspace stays V1.
  - Cached workspace version is evicted after migration so V2 surfaces immediately (production TTL `PT5M`).
- Environment: local Maven, Testcontainers (ClickHouse + MySQL + Redis + Zookeeper), darwin/arm64.
- Tests not run: full backend suite — relying on CI.

## Documentation