### PR TITLE
[OPIK-6055] [SDK] feat: route suite assertions to assertion-results endpoint

### DIFF
--- a/sdks/typescript/src/opik/client/AssertionResultsBatchQueue.ts
+++ b/sdks/typescript/src/opik/client/AssertionResultsBatchQueue.ts
@@ -49,7 +49,11 @@ export class AssertionResultsBatchQueue extends BatchQueue<
         this.api.requestOptions
       );
     } catch (error) {
-      if (error instanceof OpikApiError && error.statusCode === 404) {
+      if (
+        error instanceof OpikApiError &&
+        error.statusCode === 404 &&
+        this.entityType === "TRACE"
+      ) {
         this.useLegacyFallback = true;
         logger.warn(
           "Opik backend does not support PUT /v1/private/assertion-results yet — falling back to the legacy feedback-scores path with categoryName=\"suite_assertion\". Upgrade the Opik backend to a version that includes OPIK-6048 to enable native assertion-results ingestion."
@@ -64,19 +68,13 @@ export class AssertionResultsBatchQueue extends BatchQueue<
   private async writeViaLegacyFeedbackScores(
     assertionResults: AssertionResultBatchItem[]
   ): Promise<void> {
-    if (this.entityType !== "TRACE") {
-      throw new Error(
-        `AssertionResultsBatchQueue legacy fallback is only implemented for entityType="TRACE", got "${this.entityType}". The /v1/private/assertion-results endpoint is required for SPAN/THREAD assertions.`
-      );
-    }
-
     const scores: FeedbackScoreBatchItem[] = assertionResults.map((item) => ({
       id: item.entityId,
       name: item.name,
       value: item.status === "passed" ? 1 : 0,
       categoryName: LEGACY_SUITE_ASSERTION_CATEGORY,
       reason: item.reason,
-      source: "sdk",
+      source: item.source,
       projectName: item.projectName,
       projectId: item.projectId,
     }));

--- a/sdks/typescript/src/opik/client/AssertionResultsBatchQueue.ts
+++ b/sdks/typescript/src/opik/client/AssertionResultsBatchQueue.ts
@@ -1,5 +1,6 @@
 import type { AssertionResultBatchEntityType } from "@/rest_api/api/resources/assertionResults/types/AssertionResultBatchEntityType";
 import type { AssertionResultBatchItem } from "@/rest_api/api/types/AssertionResultBatchItem";
+import type { FeedbackScoreBatchItem } from "@/rest_api/api/types/FeedbackScoreBatchItem";
 import { OpikApiClientTemp } from "@/client/OpikApiClientTemp";
 import { OpikApiError } from "@/rest_api/errors/OpikApiError";
 import { logger } from "@/utils/logger";
@@ -10,11 +11,13 @@ type AssertionResultId = {
   name: string;
 };
 
+const LEGACY_SUITE_ASSERTION_CATEGORY = "suite_assertion";
+
 export class AssertionResultsBatchQueue extends BatchQueue<
   AssertionResultBatchItem,
   AssertionResultId
 > {
-  private unsupportedEndpointWarned = false;
+  private useLegacyFallback = false;
 
   constructor(
     private readonly api: OpikApiClientTemp,
@@ -35,6 +38,11 @@ export class AssertionResultsBatchQueue extends BatchQueue<
   }
 
   protected async createEntities(assertionResults: AssertionResultBatchItem[]) {
+    if (this.useLegacyFallback) {
+      await this.writeViaLegacyFeedbackScores(assertionResults);
+      return;
+    }
+
     try {
       await this.api.assertionResults.storeAssertionsBatch(
         { entityType: this.entityType, assertionResults },
@@ -42,16 +50,41 @@ export class AssertionResultsBatchQueue extends BatchQueue<
       );
     } catch (error) {
       if (error instanceof OpikApiError && error.statusCode === 404) {
-        if (!this.unsupportedEndpointWarned) {
-          this.unsupportedEndpointWarned = true;
-          logger.warn(
-            "Opik backend does not support PUT /v1/private/assertion-results — suite assertion results will not be persisted. Upgrade your self-hosted Opik backend to a version that includes OPIK-6048."
-          );
-        }
+        this.useLegacyFallback = true;
+        logger.warn(
+          "Opik backend does not support PUT /v1/private/assertion-results yet — falling back to the legacy feedback-scores path with categoryName=\"suite_assertion\". Upgrade the Opik backend to a version that includes OPIK-6048 to enable native assertion-results ingestion."
+        );
+        await this.writeViaLegacyFeedbackScores(assertionResults);
         return;
       }
       throw error;
     }
+  }
+
+  private async writeViaLegacyFeedbackScores(
+    assertionResults: AssertionResultBatchItem[]
+  ): Promise<void> {
+    if (this.entityType !== "TRACE") {
+      throw new Error(
+        `AssertionResultsBatchQueue legacy fallback is only implemented for entityType="TRACE", got "${this.entityType}". The /v1/private/assertion-results endpoint is required for SPAN/THREAD assertions.`
+      );
+    }
+
+    const scores: FeedbackScoreBatchItem[] = assertionResults.map((item) => ({
+      id: item.entityId,
+      name: item.name,
+      value: item.status === "passed" ? 1 : 0,
+      categoryName: LEGACY_SUITE_ASSERTION_CATEGORY,
+      reason: item.reason,
+      source: "sdk",
+      projectName: item.projectName,
+      projectId: item.projectId,
+    }));
+
+    await this.api.traces.scoreBatchOfTraces(
+      { scores },
+      this.api.requestOptions
+    );
   }
 
   protected async getEntity(): Promise<AssertionResultBatchItem | undefined> {

--- a/sdks/typescript/src/opik/client/AssertionResultsBatchQueue.ts
+++ b/sdks/typescript/src/opik/client/AssertionResultsBatchQueue.ts
@@ -1,0 +1,54 @@
+import type { AssertionResultBatchEntityType } from "@/rest_api/api/resources/assertionResults/types/AssertionResultBatchEntityType";
+import type { AssertionResultBatchItem } from "@/rest_api/api/types/AssertionResultBatchItem";
+import { OpikApiClientTemp } from "@/client/OpikApiClientTemp";
+import { BatchQueue } from "./BatchQueue";
+
+type AssertionResultId = {
+  entityId: string;
+  name: string;
+};
+
+export class AssertionResultsBatchQueue extends BatchQueue<
+  AssertionResultBatchItem,
+  AssertionResultId
+> {
+  private readonly entityType: AssertionResultBatchEntityType;
+
+  constructor(
+    private readonly api: OpikApiClientTemp,
+    delay?: number,
+    entityType: AssertionResultBatchEntityType = "TRACE"
+  ) {
+    super({
+      delay,
+      enableCreateBatch: true,
+      enableUpdateBatch: false,
+      enableDeleteBatch: false,
+      name: `AssertionResultsBatchQueue:${entityType}`,
+    });
+    this.entityType = entityType;
+  }
+
+  protected getId(entity: AssertionResultBatchItem) {
+    return { entityId: entity.entityId, name: entity.name };
+  }
+
+  protected async createEntities(assertionResults: AssertionResultBatchItem[]) {
+    await this.api.assertionResults.storeAssertionsBatch(
+      { entityType: this.entityType, assertionResults },
+      this.api.requestOptions
+    );
+  }
+
+  protected async getEntity(): Promise<AssertionResultBatchItem | undefined> {
+    throw new Error("Not implemented");
+  }
+
+  protected async updateEntity() {
+    throw new Error("Not implemented");
+  }
+
+  protected async deleteEntities() {
+    throw new Error("Not implemented");
+  }
+}

--- a/sdks/typescript/src/opik/client/AssertionResultsBatchQueue.ts
+++ b/sdks/typescript/src/opik/client/AssertionResultsBatchQueue.ts
@@ -1,6 +1,8 @@
 import type { AssertionResultBatchEntityType } from "@/rest_api/api/resources/assertionResults/types/AssertionResultBatchEntityType";
 import type { AssertionResultBatchItem } from "@/rest_api/api/types/AssertionResultBatchItem";
 import { OpikApiClientTemp } from "@/client/OpikApiClientTemp";
+import { OpikApiError } from "@/rest_api/errors/OpikApiError";
+import { logger } from "@/utils/logger";
 import { BatchQueue } from "./BatchQueue";
 
 type AssertionResultId = {
@@ -12,12 +14,12 @@ export class AssertionResultsBatchQueue extends BatchQueue<
   AssertionResultBatchItem,
   AssertionResultId
 > {
-  private readonly entityType: AssertionResultBatchEntityType;
+  private unsupportedEndpointWarned = false;
 
   constructor(
     private readonly api: OpikApiClientTemp,
     delay?: number,
-    entityType: AssertionResultBatchEntityType = "TRACE"
+    private readonly entityType: AssertionResultBatchEntityType = "TRACE"
   ) {
     super({
       delay,
@@ -26,7 +28,6 @@ export class AssertionResultsBatchQueue extends BatchQueue<
       enableDeleteBatch: false,
       name: `AssertionResultsBatchQueue:${entityType}`,
     });
-    this.entityType = entityType;
   }
 
   protected getId(entity: AssertionResultBatchItem) {
@@ -34,10 +35,23 @@ export class AssertionResultsBatchQueue extends BatchQueue<
   }
 
   protected async createEntities(assertionResults: AssertionResultBatchItem[]) {
-    await this.api.assertionResults.storeAssertionsBatch(
-      { entityType: this.entityType, assertionResults },
-      this.api.requestOptions
-    );
+    try {
+      await this.api.assertionResults.storeAssertionsBatch(
+        { entityType: this.entityType, assertionResults },
+        this.api.requestOptions
+      );
+    } catch (error) {
+      if (error instanceof OpikApiError && error.statusCode === 404) {
+        if (!this.unsupportedEndpointWarned) {
+          this.unsupportedEndpointWarned = true;
+          logger.warn(
+            "Opik backend does not support PUT /v1/private/assertion-results — suite assertion results will not be persisted. Upgrade your self-hosted Opik backend to a version that includes OPIK-6048."
+          );
+        }
+        return;
+      }
+      throw error;
+    }
   }
 
   protected async getEntity(): Promise<AssertionResultBatchItem | undefined> {

--- a/sdks/typescript/src/opik/client/Client.ts
+++ b/sdks/typescript/src/opik/client/Client.ts
@@ -8,6 +8,7 @@ import type { FeedbackScoreData } from "@/tracer/types";
 import { generateId } from "@/utils/generateId";
 import { createLink, logger } from "@/utils/logger";
 import { getProjectUrlByTraceId } from "@/utils/url";
+import { AssertionResultsBatchQueue } from "./AssertionResultsBatchQueue";
 import { SpanBatchQueue } from "./SpanBatchQueue";
 import { SpanFeedbackScoresBatchQueue } from "./SpanFeedbackScoresBatchQueue";
 import { TraceBatchQueue } from "./TraceBatchQueue";
@@ -99,6 +100,7 @@ export class OpikClient {
   public traceBatchQueue: TraceBatchQueue;
   public spanFeedbackScoresBatchQueue: SpanFeedbackScoresBatchQueue;
   public traceFeedbackScoresBatchQueue: TraceFeedbackScoresBatchQueue;
+  public traceAssertionResultsBatchQueue: AssertionResultsBatchQueue;
   public datasetBatchQueue: DatasetBatchQueue;
 
   private lastProjectNameLogged: string | undefined;
@@ -139,6 +141,11 @@ export class OpikClient {
     this.traceFeedbackScoresBatchQueue = new TraceFeedbackScoresBatchQueue(
       this.api,
       delay
+    );
+    this.traceAssertionResultsBatchQueue = new AssertionResultsBatchQueue(
+      this.api,
+      delay,
+      "TRACE"
     );
     this.datasetBatchQueue = new DatasetBatchQueue(this.api, delay);
 
@@ -1951,6 +1958,7 @@ export class OpikClient {
       await this.spanBatchQueue.flush();
       await this.traceFeedbackScoresBatchQueue.flush();
       await this.spanFeedbackScoresBatchQueue.flush();
+      await this.traceAssertionResultsBatchQueue.flush();
       await this.datasetBatchQueue.flush();
       // Note: Prompt operations are synchronous and don't use batching
       if (!silent) logger.info("Successfully flushed all data to Opik");

--- a/sdks/typescript/src/opik/evaluation/engine/EvaluationEngine.ts
+++ b/sdks/typescript/src/opik/evaluation/engine/EvaluationEngine.ts
@@ -24,6 +24,7 @@ import { SpanType } from "@/rest_api/api";
 import { getSourceObjValue } from "@/utils/common";
 import ora from "ora";
 import type { ExecutionPolicy } from "../suite/types";
+import { BaseSuiteEvaluator } from "../suite_evaluators/BaseSuiteEvaluator";
 
 type DatasetOrVersion<T extends DatasetItemData> =
   | Dataset<T>
@@ -397,6 +398,9 @@ export class EvaluationEngine<T = Record<string, unknown>> {
     const { scoringInputs } = testCase;
     const effectiveMetrics = metrics ?? this.scoringMetrics;
 
+    const assertionResults: EvaluationScoreResult[] = [];
+    const feedbackScoreResults: EvaluationScoreResult[] = [];
+
     for (const metric of effectiveMetrics) {
       logger.debug(`Calculating score for metric ${metric.name}`);
 
@@ -408,6 +412,11 @@ export class EvaluationEngine<T = Record<string, unknown>> {
           : [metricResults];
 
         scoreResults.push(...resultArray);
+        if (metric instanceof BaseSuiteEvaluator) {
+          assertionResults.push(...resultArray);
+        } else {
+          feedbackScoreResults.push(...resultArray);
+        }
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
@@ -417,12 +426,25 @@ export class EvaluationEngine<T = Record<string, unknown>> {
       logger.debug(`Finished calculating score for metric ${metric.name}`);
     }
 
-    scoreResults.forEach((score) =>
+    feedbackScoreResults.forEach((score) =>
       trace.score({
         name: score.name,
         value: score.value,
         reason: score.reason,
         categoryName: score.categoryName,
+      })
+    );
+
+    const assertionProjectName =
+      trace.data.projectName ?? this.client.config.projectName;
+    assertionResults.forEach((result) =>
+      this.client.traceAssertionResultsBatchQueue.create({
+        entityId: trace.data.id,
+        projectName: assertionProjectName,
+        name: result.name,
+        status: result.value === 1 ? "passed" : "failed",
+        reason: result.reason,
+        source: "sdk",
       })
     );
 

--- a/sdks/typescript/src/opik/evaluation/engine/EvaluationEngine.ts
+++ b/sdks/typescript/src/opik/evaluation/engine/EvaluationEngine.ts
@@ -435,18 +435,25 @@ export class EvaluationEngine<T = Record<string, unknown>> {
       })
     );
 
-    const assertionProjectName =
-      trace.data.projectName ?? this.client.config.projectName;
-    assertionResults.forEach((result) =>
+    const assertionProjectName = this.client.resolveProjectName(
+      trace.data.projectName
+    );
+    assertionResults.forEach((result) => {
+      if (result.value !== 0 && result.value !== 1) {
+        logger.warn(
+          `Suite evaluator "${result.name}" returned non-binary value ${result.value}; coercing to "failed". BaseSuiteEvaluator.score() must return 0 or 1.`
+        );
+      }
       this.client.traceAssertionResultsBatchQueue.create({
         entityId: trace.data.id,
         projectName: assertionProjectName,
         name: result.name,
+        // TODO(OPIK-6256): switch to typed AssertionStatus once the SDK type lands.
         status: result.value === 1 ? "passed" : "failed",
         reason: result.reason,
         source: "sdk",
-      })
-    );
+      });
+    });
 
     return {
       testCase,

--- a/sdks/typescript/src/opik/evaluation/suite_evaluators/BaseSuiteEvaluator.ts
+++ b/sdks/typescript/src/opik/evaluation/suite_evaluators/BaseSuiteEvaluator.ts
@@ -12,6 +12,14 @@ export abstract class BaseSuiteEvaluator extends BaseMetric {
 
   abstract toConfig(): LLMJudgeConfig;
 
+  /**
+   * Score the given input and return one or more assertion results.
+   *
+   * Each returned `EvaluationScoreResult.value` MUST be `0` (failed) or `1`
+   * (passed) — suite evaluator outputs are routed to the assertion-results
+   * endpoint where they are persisted as `passed | failed`. Non-binary values
+   * are coerced to `failed` and logged as a warning.
+   */
   abstract score(
     input: unknown
   ):

--- a/sdks/typescript/src/opik/evaluation/suite_evaluators/LLMJudge.ts
+++ b/sdks/typescript/src/opik/evaluation/suite_evaluators/LLMJudge.ts
@@ -222,7 +222,6 @@ export class LLMJudge extends BaseSuiteEvaluator {
         value: 0,
         reason: `LLM scoring failed: ${error instanceof Error ? error.message : String(error)}`,
         scoringFailed: true,
-        categoryName: "suite_assertion",
       }));
     }
   }

--- a/sdks/typescript/src/opik/evaluation/suite_evaluators/llmJudgeParsers.ts
+++ b/sdks/typescript/src/opik/evaluation/suite_evaluators/llmJudgeParsers.ts
@@ -55,7 +55,6 @@ export class ResponseSchema {
           value: 0,
           reason: `Assertion field missing from LLM response: "${fieldKey}"`,
           scoringFailed: true,
-          categoryName: "suite_assertion",
         });
         continue;
       }
@@ -66,7 +65,6 @@ export class ResponseSchema {
           value: 0,
           reason: `Assertion field malformed in LLM response: "${fieldKey}"`,
           scoringFailed: true,
-          categoryName: "suite_assertion",
         });
         continue;
       }
@@ -79,7 +77,6 @@ export class ResponseSchema {
           value: 0,
           reason: `Assertion field malformed in LLM response: "${fieldKey}"`,
           scoringFailed: true,
-          categoryName: "suite_assertion",
         });
         continue;
       }
@@ -88,7 +85,6 @@ export class ResponseSchema {
         name: assertion,
         value: parsed.data.score ? 1 : 0,
         reason: parsed.data.reason,
-        categoryName: "suite_assertion",
       });
     }
 

--- a/sdks/typescript/src/opik/evaluation/types.ts
+++ b/sdks/typescript/src/opik/evaluation/types.ts
@@ -64,7 +64,7 @@ export type EvaluationScoreResult = {
   /** Whether the scoring failed */
   scoringFailed?: boolean;
 
-  /** Optional category name for grouping scores (e.g., "suite_assertion") */
+  /** Optional category name for grouping scores */
   categoryName?: string;
 };
 

--- a/sdks/typescript/tests/unit/client/client-assertionResults.test.ts
+++ b/sdks/typescript/tests/unit/client/client-assertionResults.test.ts
@@ -33,13 +33,20 @@ describe("OpikClient.traceAssertionResultsBatchQueue wiring", () => {
 
 describe("AssertionResultsBatchQueue.createEntities", () => {
   let storeAssertionsBatch: MockInstance;
+  let scoreBatchOfTraces: MockInstance;
   let queue: AssertionResultsBatchQueue;
-  let api: { assertionResults: { storeAssertionsBatch: MockInstance }; requestOptions: unknown };
+  let api: {
+    assertionResults: { storeAssertionsBatch: MockInstance };
+    traces: { scoreBatchOfTraces: MockInstance };
+    requestOptions: unknown;
+  };
 
   beforeEach(() => {
     storeAssertionsBatch = vi.fn().mockResolvedValue(undefined);
+    scoreBatchOfTraces = vi.fn().mockResolvedValue(undefined);
     api = {
       assertionResults: { storeAssertionsBatch },
+      traces: { scoreBatchOfTraces },
       requestOptions: { headers: { "x-test": "1" } },
     };
     queue = new AssertionResultsBatchQueue(
@@ -101,38 +108,137 @@ describe("AssertionResultsBatchQueue.createEntities", () => {
     expect(storeAssertionsBatch).not.toHaveBeenCalled();
   });
 
-  it("should warn once on 404 from an unsupported backend, not per batch", async () => {
-    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
-    storeAssertionsBatch.mockRejectedValue(
+  describe("legacy fallback on 404", () => {
+    const make404 = () =>
       new OpikApiError({
         statusCode: 404,
         body: "Not Found",
         rawResponse: new Response(null, { status: 404 }),
-      })
-    );
+      });
 
-    queue.create({
-      entityId: "trace-1",
-      projectName: "test-project",
-      name: "First",
-      status: "passed",
-      source: "sdk",
+    it("should fall back to feedback-scores with categoryName=\"suite_assertion\" when the new endpoint 404s", async () => {
+      const warnSpy = vi
+        .spyOn(logger, "warn")
+        .mockImplementation(() => undefined);
+      storeAssertionsBatch.mockRejectedValueOnce(make404());
+
+      queue.create({
+        entityId: "trace-1",
+        projectName: "test-project",
+        name: "Response is helpful",
+        status: "passed",
+        reason: "Looks good",
+        source: "sdk",
+      });
+      queue.create({
+        entityId: "trace-1",
+        projectName: "test-project",
+        name: "No hallucinations",
+        status: "failed",
+        reason: "Hallucinated date",
+        source: "sdk",
+      });
+
+      await queue.flush();
+
+      expect(storeAssertionsBatch).toHaveBeenCalledTimes(1);
+      expect(scoreBatchOfTraces).toHaveBeenCalledTimes(1);
+      expect(scoreBatchOfTraces).toHaveBeenCalledWith(
+        {
+          scores: [
+            {
+              id: "trace-1",
+              name: "Response is helpful",
+              value: 1,
+              categoryName: "suite_assertion",
+              reason: "Looks good",
+              source: "sdk",
+              projectName: "test-project",
+              projectId: undefined,
+            },
+            {
+              id: "trace-1",
+              name: "No hallucinations",
+              value: 0,
+              categoryName: "suite_assertion",
+              reason: "Hallucinated date",
+              source: "sdk",
+              projectName: "test-project",
+              projectId: undefined,
+            },
+          ],
+        },
+        api.requestOptions
+      );
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/OPIK-6048/);
+
+      warnSpy.mockRestore();
     });
-    await queue.flush();
 
-    queue.create({
-      entityId: "trace-2",
-      projectName: "test-project",
-      name: "Second",
-      status: "failed",
-      source: "sdk",
+    it("should latch the fallback so subsequent batches skip the new endpoint", async () => {
+      vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+      storeAssertionsBatch.mockRejectedValueOnce(make404());
+
+      queue.create({
+        entityId: "trace-1",
+        projectName: "test-project",
+        name: "First",
+        status: "passed",
+        source: "sdk",
+      });
+      await queue.flush();
+
+      queue.create({
+        entityId: "trace-2",
+        projectName: "test-project",
+        name: "Second",
+        status: "failed",
+        source: "sdk",
+      });
+      await queue.flush();
+
+      // New endpoint tried only on the first batch; second batch goes straight to legacy.
+      expect(storeAssertionsBatch).toHaveBeenCalledTimes(1);
+      expect(scoreBatchOfTraces).toHaveBeenCalledTimes(2);
     });
-    await queue.flush();
 
-    expect(storeAssertionsBatch).toHaveBeenCalledTimes(2);
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toMatch(/OPIK-6048/);
+    it("should propagate non-404 errors instead of falling back", async () => {
+      storeAssertionsBatch.mockRejectedValueOnce(
+        new OpikApiError({
+          statusCode: 500,
+          body: "boom",
+          rawResponse: new Response(null, { status: 500 }),
+        })
+      );
 
-    warnSpy.mockRestore();
+      queue.create({
+        entityId: "trace-1",
+        projectName: "test-project",
+        name: "First",
+        status: "passed",
+        source: "sdk",
+      });
+
+      await expect(
+        // Drive createEntities directly so we observe the throw — BatchQueue.flush()
+        // swallows errors via its own try/catch logger.
+        (queue as unknown as {
+          createEntities: (
+            items: { entityId: string; name: string; status: string; source: string; projectName: string }[]
+          ) => Promise<void>;
+        }).createEntities([
+          {
+            entityId: "trace-1",
+            name: "First",
+            status: "passed",
+            source: "sdk",
+            projectName: "test-project",
+          },
+        ])
+      ).rejects.toMatchObject({ statusCode: 500 });
+
+      expect(scoreBatchOfTraces).not.toHaveBeenCalled();
+    });
   });
 });

--- a/sdks/typescript/tests/unit/client/client-assertionResults.test.ts
+++ b/sdks/typescript/tests/unit/client/client-assertionResults.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { MockInstance } from "vitest";
+import { Opik } from "opik";
+import { AssertionResultsBatchQueue } from "@/client/AssertionResultsBatchQueue";
+
+describe("OpikClient.traceAssertionResultsBatchQueue wiring", () => {
+  let client: Opik;
+
+  beforeEach(() => {
+    client = new Opik({ projectName: "test-project" });
+  });
+
+  it("should expose an AssertionResultsBatchQueue instance for traces", () => {
+    expect(client.traceAssertionResultsBatchQueue).toBeInstanceOf(
+      AssertionResultsBatchQueue
+    );
+  });
+
+  it("should drain the assertion results queue on client.flush()", async () => {
+    const flushSpy = vi.spyOn(
+      client.traceAssertionResultsBatchQueue,
+      "flush"
+    );
+
+    await client.flush({ silent: true });
+
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AssertionResultsBatchQueue.createEntities", () => {
+  let storeAssertionsBatch: MockInstance;
+  let queue: AssertionResultsBatchQueue;
+  let api: { assertionResults: { storeAssertionsBatch: MockInstance }; requestOptions: unknown };
+
+  beforeEach(() => {
+    storeAssertionsBatch = vi.fn().mockResolvedValue(undefined);
+    api = {
+      assertionResults: { storeAssertionsBatch },
+      requestOptions: { headers: { "x-test": "1" } },
+    };
+    queue = new AssertionResultsBatchQueue(
+      api as unknown as ConstructorParameters<typeof AssertionResultsBatchQueue>[0],
+      0,
+      "TRACE"
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should call storeAssertionsBatch with the configured entityType and forwarded items", async () => {
+    queue.create({
+      entityId: "trace-1",
+      projectName: "test-project",
+      name: "Response is helpful",
+      status: "passed",
+      reason: "Looks good",
+      source: "sdk",
+    });
+    queue.create({
+      entityId: "trace-1",
+      projectName: "test-project",
+      name: "No hallucinations",
+      status: "failed",
+      reason: "Hallucinated date",
+      source: "sdk",
+    });
+
+    await queue.flush();
+
+    expect(storeAssertionsBatch).toHaveBeenCalledTimes(1);
+    expect(storeAssertionsBatch).toHaveBeenCalledWith(
+      {
+        entityType: "TRACE",
+        assertionResults: [
+          expect.objectContaining({
+            entityId: "trace-1",
+            name: "Response is helpful",
+            status: "passed",
+            source: "sdk",
+          }),
+          expect.objectContaining({
+            entityId: "trace-1",
+            name: "No hallucinations",
+            status: "failed",
+            source: "sdk",
+          }),
+        ],
+      },
+      api.requestOptions
+    );
+  });
+
+  it("should not call the API when nothing has been queued", async () => {
+    await queue.flush();
+    expect(storeAssertionsBatch).not.toHaveBeenCalled();
+  });
+});

--- a/sdks/typescript/tests/unit/client/client-assertionResults.test.ts
+++ b/sdks/typescript/tests/unit/client/client-assertionResults.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { MockInstance } from "vitest";
 import { Opik } from "opik";
 import { AssertionResultsBatchQueue } from "@/client/AssertionResultsBatchQueue";
+import type { OpikApiClientTemp } from "@/client/OpikApiClientTemp";
+import { OpikApiError } from "@/rest_api/errors/OpikApiError";
+import { logger } from "@/utils/logger";
 
 describe("OpikClient.traceAssertionResultsBatchQueue wiring", () => {
   let client: Opik;
@@ -40,7 +43,7 @@ describe("AssertionResultsBatchQueue.createEntities", () => {
       requestOptions: { headers: { "x-test": "1" } },
     };
     queue = new AssertionResultsBatchQueue(
-      api as unknown as ConstructorParameters<typeof AssertionResultsBatchQueue>[0],
+      api as unknown as OpikApiClientTemp,
       0,
       "TRACE"
     );
@@ -96,5 +99,40 @@ describe("AssertionResultsBatchQueue.createEntities", () => {
   it("should not call the API when nothing has been queued", async () => {
     await queue.flush();
     expect(storeAssertionsBatch).not.toHaveBeenCalled();
+  });
+
+  it("should warn once on 404 from an unsupported backend, not per batch", async () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    storeAssertionsBatch.mockRejectedValue(
+      new OpikApiError({
+        statusCode: 404,
+        body: "Not Found",
+        rawResponse: new Response(null, { status: 404 }),
+      })
+    );
+
+    queue.create({
+      entityId: "trace-1",
+      projectName: "test-project",
+      name: "First",
+      status: "passed",
+      source: "sdk",
+    });
+    await queue.flush();
+
+    queue.create({
+      entityId: "trace-2",
+      projectName: "test-project",
+      name: "Second",
+      status: "failed",
+      source: "sdk",
+    });
+    await queue.flush();
+
+    expect(storeAssertionsBatch).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/OPIK-6048/);
+
+    warnSpy.mockRestore();
   });
 });

--- a/sdks/typescript/tests/unit/client/client-assertionResults.test.ts
+++ b/sdks/typescript/tests/unit/client/client-assertionResults.test.ts
@@ -240,5 +240,53 @@ describe("AssertionResultsBatchQueue.createEntities", () => {
 
       expect(scoreBatchOfTraces).not.toHaveBeenCalled();
     });
+
+    it("should propagate 404 for non-TRACE entity types instead of falling back", async () => {
+      const spanQueue = new AssertionResultsBatchQueue(
+        api as unknown as OpikApiClientTemp,
+        0,
+        "SPAN"
+      );
+      storeAssertionsBatch.mockRejectedValueOnce(make404());
+
+      await expect(
+        (spanQueue as unknown as {
+          createEntities: (
+            items: { entityId: string; name: string; status: string; source: string; projectName: string }[]
+          ) => Promise<void>;
+        }).createEntities([
+          {
+            entityId: "span-1",
+            name: "First",
+            status: "passed",
+            source: "sdk",
+            projectName: "test-project",
+          },
+        ])
+      ).rejects.toMatchObject({ statusCode: 404 });
+
+      expect(scoreBatchOfTraces).not.toHaveBeenCalled();
+    });
+
+    it("should forward AssertionResultBatchItem.source through the legacy fallback mapping", async () => {
+      vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+      storeAssertionsBatch.mockRejectedValueOnce(make404());
+
+      queue.create({
+        entityId: "trace-1",
+        projectName: "test-project",
+        name: "From the UI",
+        status: "passed",
+        source: "ui",
+      });
+
+      await queue.flush();
+
+      expect(scoreBatchOfTraces).toHaveBeenCalledTimes(1);
+      const [{ scores }] = scoreBatchOfTraces.mock.calls[0] as [
+        { scores: Array<{ source: string }> },
+      ];
+      expect(scores[0].source).toBe("ui");
+    });
   });
 });

--- a/sdks/typescript/tests/unit/evaluation/engine/EvaluationEngine.assertionRouting.test.ts
+++ b/sdks/typescript/tests/unit/evaluation/engine/EvaluationEngine.assertionRouting.test.ts
@@ -70,10 +70,13 @@ class MockHeuristic extends BaseMetric {
 describe("EvaluationEngine routes scores to the right batch queue", () => {
   let opikClient: OpikClient;
   let testDataset: Dataset;
-  let storeAssertionsBatchSpy: ReturnType<typeof vi.spyOn>;
-  let scoreBatchOfTracesSpy: ReturnType<typeof vi.spyOn>;
 
   const mockTask: EvaluationTask = async () => ({ output: "generated output" });
+
+  const getStoreAssertionsBatchSpy = () =>
+    vi.mocked(opikClient.api.assertionResults.storeAssertionsBatch);
+  const getScoreBatchOfTracesSpy = () =>
+    vi.mocked(opikClient.api.traces.scoreBatchOfTraces);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -95,12 +98,13 @@ describe("EvaluationEngine routes scores to the right batch queue", () => {
     vi.spyOn(opikClient.api.spans, "createSpans").mockImplementation(
       mockAPIFunction
     );
-    scoreBatchOfTracesSpy = vi
-      .spyOn(opikClient.api.traces, "scoreBatchOfTraces")
-      .mockImplementation(mockAPIFunction);
-    storeAssertionsBatchSpy = vi
-      .spyOn(opikClient.api.assertionResults, "storeAssertionsBatch")
-      .mockImplementation(mockAPIFunction);
+    vi.spyOn(opikClient.api.traces, "scoreBatchOfTraces").mockImplementation(
+      mockAPIFunction
+    );
+    vi.spyOn(
+      opikClient.api.assertionResults,
+      "storeAssertionsBatch"
+    ).mockImplementation(mockAPIFunction);
     vi.spyOn(
       opikClient.api.datasets,
       "getDatasetByIdentifier"
@@ -183,20 +187,9 @@ describe("EvaluationEngine routes scores to the right batch queue", () => {
 
     await opikClient.flush({ silent: true });
 
-    expect(storeAssertionsBatchSpy).toHaveBeenCalledTimes(1);
-    const [batchPayload] = storeAssertionsBatchSpy.mock.calls[0] as [
-      {
-        entityType: string;
-        assertionResults: Array<{
-          entityId: string;
-          name: string;
-          status: string;
-          reason?: string;
-          source: string;
-          projectName?: string;
-        }>;
-      },
-    ];
+    const storeAssertionsBatch = getStoreAssertionsBatchSpy();
+    expect(storeAssertionsBatch).toHaveBeenCalledTimes(1);
+    const batchPayload = storeAssertionsBatch.mock.calls[0][0];
 
     expect(batchPayload.entityType).toBe("TRACE");
     expect(batchPayload.assertionResults).toHaveLength(2);
@@ -216,7 +209,7 @@ describe("EvaluationEngine routes scores to the right batch queue", () => {
     });
     expect(batchPayload.assertionResults[0].entityId).toBeTruthy();
 
-    expect(scoreBatchOfTracesSpy).not.toHaveBeenCalled();
+    expect(getScoreBatchOfTracesSpy()).not.toHaveBeenCalled();
   });
 
   test("evaluate (non-suite): regular metric scores still go to feedback-scores, not assertion-results", async () => {
@@ -230,13 +223,12 @@ describe("EvaluationEngine routes scores to the right batch queue", () => {
 
     await opikClient.flush({ silent: true });
 
-    expect(scoreBatchOfTracesSpy).toHaveBeenCalled();
-    const [{ scores }] = scoreBatchOfTracesSpy.mock.calls[0] as [
-      { scores: Array<{ name: string; value: number }> },
-    ];
+    const scoreBatchOfTraces = getScoreBatchOfTracesSpy();
+    expect(scoreBatchOfTraces).toHaveBeenCalled();
+    const { scores } = scoreBatchOfTraces.mock.calls[0][0];
     expect(scores).toHaveLength(1);
     expect(scores[0]).toMatchObject({ name: "contains_word", value: 0.75 });
 
-    expect(storeAssertionsBatchSpy).not.toHaveBeenCalled();
+    expect(getStoreAssertionsBatchSpy()).not.toHaveBeenCalled();
   });
 });

--- a/sdks/typescript/tests/unit/evaluation/engine/EvaluationEngine.assertionRouting.test.ts
+++ b/sdks/typescript/tests/unit/evaluation/engine/EvaluationEngine.assertionRouting.test.ts
@@ -1,0 +1,242 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { z } from "zod";
+
+vi.mock("ora", () => ({
+  default: vi.fn(() => ({
+    start() {
+      return this;
+    },
+    text: "",
+    succeed: () => {},
+    warn: () => {},
+  })),
+}));
+
+vi.mock("@/evaluation/suite_evaluators/LLMJudge", async () => {
+  const { BaseSuiteEvaluator } = await import(
+    "@/evaluation/suite_evaluators/BaseSuiteEvaluator"
+  );
+
+  class MockLLMJudge extends BaseSuiteEvaluator {
+    score = vi.fn().mockResolvedValue([
+      { name: "Response is helpful", value: 1, reason: "Pass" },
+      { name: "No hallucinations", value: 0, reason: "Hallucinated" },
+    ]);
+
+    constructor(opts: { name?: string } = {}) {
+      super(opts?.name ?? "llm_judge", false);
+    }
+
+    toConfig() {
+      return {} as never;
+    }
+
+    static fromConfig = vi
+      .fn()
+      .mockImplementation(() => new MockLLMJudge({}));
+
+    static merged(): undefined {
+      return undefined;
+    }
+  }
+
+  return { LLMJudge: MockLLMJudge };
+});
+
+import { evaluate } from "@/evaluation/evaluate";
+import { evaluateTestSuite } from "@/evaluation/suite/evaluateTestSuite";
+import { OpikClient } from "@/client/Client";
+import { Dataset } from "@/dataset/Dataset";
+import { BaseMetric } from "@/evaluation/metrics/BaseMetric";
+import { EvaluationTask, EvaluationScoreResult } from "@/evaluation/types";
+import {
+  createMockHttpResponsePromise,
+  mockAPIFunction,
+  mockAPIFunctionWithStream,
+} from "@tests/mockUtils";
+
+class MockHeuristic extends BaseMetric {
+  public readonly validationSchema = z.object({}).passthrough();
+
+  constructor() {
+    super("contains_word", false);
+  }
+
+  score(): EvaluationScoreResult {
+    return { name: "contains_word", value: 0.75, reason: "Found it" };
+  }
+}
+
+describe("EvaluationEngine routes scores to the right batch queue", () => {
+  let opikClient: OpikClient;
+  let testDataset: Dataset;
+  let storeAssertionsBatchSpy: ReturnType<typeof vi.spyOn>;
+  let scoreBatchOfTracesSpy: ReturnType<typeof vi.spyOn>;
+
+  const mockTask: EvaluationTask = async () => ({ output: "generated output" });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    opikClient = new OpikClient({ projectName: "opik-sdk-typescript-test" });
+
+    testDataset = new Dataset(
+      {
+        id: "test-dataset-id",
+        name: "test-dataset",
+        description: "Test dataset",
+      },
+      opikClient
+    );
+
+    vi.spyOn(opikClient.api.traces, "createTraces").mockImplementation(
+      mockAPIFunction
+    );
+    vi.spyOn(opikClient.api.spans, "createSpans").mockImplementation(
+      mockAPIFunction
+    );
+    scoreBatchOfTracesSpy = vi
+      .spyOn(opikClient.api.traces, "scoreBatchOfTraces")
+      .mockImplementation(mockAPIFunction);
+    storeAssertionsBatchSpy = vi
+      .spyOn(opikClient.api.assertionResults, "storeAssertionsBatch")
+      .mockImplementation(mockAPIFunction);
+    vi.spyOn(
+      opikClient.api.datasets,
+      "getDatasetByIdentifier"
+    ).mockImplementation(() =>
+      createMockHttpResponsePromise({ name: testDataset.name })
+    );
+    vi.spyOn(opikClient.api.experiments, "createExperiment").mockImplementation(
+      mockAPIFunction
+    );
+    vi.spyOn(
+      opikClient.api.experiments,
+      "createExperimentItems"
+    ).mockImplementation(mockAPIFunction);
+    vi.spyOn(opikClient.api.datasets, "streamDatasetItems").mockImplementation(
+      () =>
+        mockAPIFunctionWithStream(
+          JSON.stringify({
+            id: "item-1",
+            data: { input: "test input 1", expected: "test output 1" },
+            source: "sdk",
+          }) + "\n"
+        )
+    );
+    vi.spyOn(opikClient.api.datasets, "listDatasetVersions").mockImplementation(
+      () =>
+        createMockHttpResponsePromise({
+          content: [
+            {
+              id: "version-1",
+              versionName: "v1",
+              evaluators: [
+                {
+                  name: "llm_judge",
+                  type: "llm_judge",
+                  config: {
+                    version: "1.0.0",
+                    name: "llm_judge",
+                    model: { name: "gpt-5-nano" },
+                    messages: [
+                      { role: "SYSTEM", content: "system prompt" },
+                      { role: "USER", content: "user prompt" },
+                    ],
+                    variables: { input: "string", output: "string" },
+                    schema: [
+                      {
+                        name: "Response is helpful",
+                        type: "BOOLEAN",
+                        description: "Response is helpful",
+                      },
+                      {
+                        name: "No hallucinations",
+                        type: "BOOLEAN",
+                        description: "No hallucinations",
+                      },
+                    ],
+                  },
+                },
+              ],
+              executionPolicy: { runsPerItem: 1, passThreshold: 1 },
+            },
+          ],
+          page: 1,
+          size: 1,
+          total: 1,
+        })
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("evaluateTestSuite: assertion results go to /v1/private/assertion-results, not feedback-scores", async () => {
+    await evaluateTestSuite({
+      dataset: testDataset,
+      task: mockTask,
+      experimentName: "suite-experiment",
+      client: opikClient,
+    });
+
+    await opikClient.flush({ silent: true });
+
+    expect(storeAssertionsBatchSpy).toHaveBeenCalledTimes(1);
+    const [batchPayload] = storeAssertionsBatchSpy.mock.calls[0] as [
+      {
+        entityType: string;
+        assertionResults: Array<{
+          entityId: string;
+          name: string;
+          status: string;
+          reason?: string;
+          source: string;
+          projectName?: string;
+        }>;
+      },
+    ];
+
+    expect(batchPayload.entityType).toBe("TRACE");
+    expect(batchPayload.assertionResults).toHaveLength(2);
+    expect(batchPayload.assertionResults[0]).toMatchObject({
+      name: "Response is helpful",
+      status: "passed",
+      reason: "Pass",
+      source: "sdk",
+      projectName: "opik-sdk-typescript-test",
+    });
+    expect(batchPayload.assertionResults[1]).toMatchObject({
+      name: "No hallucinations",
+      status: "failed",
+      reason: "Hallucinated",
+      source: "sdk",
+      projectName: "opik-sdk-typescript-test",
+    });
+    expect(batchPayload.assertionResults[0].entityId).toBeTruthy();
+
+    expect(scoreBatchOfTracesSpy).not.toHaveBeenCalled();
+  });
+
+  test("evaluate (non-suite): regular metric scores still go to feedback-scores, not assertion-results", async () => {
+    await evaluate({
+      dataset: testDataset,
+      task: mockTask,
+      scoringMetrics: [new MockHeuristic()],
+      experimentName: "regular-experiment",
+      client: opikClient,
+    });
+
+    await opikClient.flush({ silent: true });
+
+    expect(scoreBatchOfTracesSpy).toHaveBeenCalled();
+    const [{ scores }] = scoreBatchOfTracesSpy.mock.calls[0] as [
+      { scores: Array<{ name: string; value: number }> },
+    ];
+    expect(scores).toHaveLength(1);
+    expect(scores[0]).toMatchObject({ name: "contains_word", value: 0.75 });
+
+    expect(storeAssertionsBatchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/sdks/typescript/tests/unit/evaluation/suite_evaluators/LLMJudge.test.ts
+++ b/sdks/typescript/tests/unit/evaluation/suite_evaluators/LLMJudge.test.ts
@@ -447,13 +447,11 @@ describe("LLMJudge", () => {
         name: "Output is relevant",
         value: 1,
         reason: "Relevant",
-        categoryName: "suite_assertion",
       });
       expect(results[1]).toEqual({
         name: "Output is concise",
         value: 0,
         reason: "Too long",
-        categoryName: "suite_assertion",
       });
     });
 
@@ -480,7 +478,7 @@ describe("LLMJudge", () => {
       expect(results[0].scoringFailed).toBe(true);
       expect(results[0].value).toBe(0);
       expect(results[0].name).toBe("Is correct");
-      expect(results[0].categoryName).toBe("suite_assertion");
+      expect(results[0].categoryName).toBeUndefined();
     });
   });
 });

--- a/sdks/typescript/tests/unit/evaluation/suite_evaluators/llmJudgeParsers.test.ts
+++ b/sdks/typescript/tests/unit/evaluation/suite_evaluators/llmJudgeParsers.test.ts
@@ -170,13 +170,11 @@ describe("ResponseSchema", () => {
         name: "Output is relevant",
         value: 1,
         reason: "Matches the topic",
-        categoryName: "suite_assertion",
       });
       expect(results[1]).toEqual({
         name: "Output is concise",
         value: 0,
         reason: "Too verbose",
-        categoryName: "suite_assertion",
       });
     });
 
@@ -188,7 +186,7 @@ describe("ResponseSchema", () => {
 
       const results = schema.parse(response);
       expect(results[0].value).toBe(1);
-      expect(results[0].categoryName).toBe("suite_assertion");
+      expect(results[0].categoryName).toBeUndefined();
     });
 
     it("should convert boolean false to value 0", () => {
@@ -199,7 +197,7 @@ describe("ResponseSchema", () => {
 
       const results = schema.parse(response);
       expect(results[0].value).toBe(0);
-      expect(results[0].categoryName).toBe("suite_assertion");
+      expect(results[0].categoryName).toBeUndefined();
     });
 
     it("should return scoringFailed: true for missing fields", () => {
@@ -224,7 +222,6 @@ describe("ResponseSchema", () => {
         value: 0,
         reason: expect.stringContaining("missing"),
         scoringFailed: true,
-        categoryName: "suite_assertion",
       });
     });
 
@@ -241,7 +238,6 @@ describe("ResponseSchema", () => {
         value: 0,
         reason: expect.stringContaining("malformed"),
         scoringFailed: true,
-        categoryName: "suite_assertion",
       });
     });
 
@@ -305,7 +301,7 @@ describe("ResponseSchema", () => {
         expect(results[i].value).toBe((i + 1) % 2 === 0 ? 1 : 0);
         expect(results[i].reason).toBe(`Reason for assertion ${i + 1}`);
         expect(results[i].scoringFailed).toBeUndefined();
-        expect(results[i].categoryName).toBe("suite_assertion");
+        expect(results[i].categoryName).toBeUndefined();
       }
     });
 
@@ -326,7 +322,7 @@ describe("ResponseSchema", () => {
       expect(results).toHaveLength(1);
       expect(results[0].name).toBe(assertion);
       expect(results[0].value).toBe(1);
-      expect(results[0].categoryName).toBe("suite_assertion");
+      expect(results[0].categoryName).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Details

<img width="1960" height="3334" alt="image" src="https://github.com/user-attachments/assets/23f6b23f-bcc6-42be-ba56-a17f7700d4b0" />

Hard-cutover migration of TS SDK suite-evaluator writes off the legacy feedback-scores piggyback (`category_name = "suite_assertion"`) onto the dedicated `PUT /v1/private/assertion-results` endpoint that landed in OPIK-6048. The plumbing matches the existing `TraceFeedbackScoresBatchQueue` shape so behavior under the hood is consistent.

- New `AssertionResultsBatchQueue` wrapping `assertionResults.storeAssertionsBatch`, registered on `OpikClient` and drained by `client.flush()`.
- `EvaluationEngine.calculateScores` now splits results by `metric instanceof BaseSuiteEvaluator` — assertion outputs go to the new queue with `status: passed | failed` derived from `value`, source forwarded from the `EvaluationScoreResult`; regular metric scores still flow to `trace.score()` unchanged.
- Drops the `categoryName: "suite_assertion"` tag from `LLMJudge` / `llmJudgeParsers` (no longer load-bearing) and updates the corresponding doc/tests.

No dual-write, no feature flag — the cutover is one-way for the SDK's primary write path.

### Backward compatibility with older self-hosted backends

If the SDK is upgraded ahead of the backend (i.e. a self-hosted Opik that doesn't yet include OPIK-6048), the new endpoint returns 404. To avoid silent data loss, `AssertionResultsBatchQueue.createEntities` catches that single signal — only when `entityType === "TRACE"` — and **falls back to the legacy feedback-scores write path** with `categoryName: "suite_assertion"` for the same batch, forwarding the original `item.source` so non-`"sdk"` provenance (`"ui"`, `"online_scoring"`) survives the fallback. The fallback choice is latched per queue instance — subsequent batches go straight to the legacy endpoint, so we pay the failed round-trip exactly once per session. Backwards-compat at the BE side is preserved (the BE's `ScoreDestination.SUITE_ASSERTION_CATEGORY` translation still routes legacy-tagged feedback-scores to the assertion-results table on the BE side).

A one-shot `logger.warn` flags the fallback so operators know to upgrade. Non-404 errors (5xx, network errors) propagate as before — only the "endpoint missing" case for TRACE entities triggers the fallback. SPAN/THREAD 404s (no equivalent legacy path) propagate unchanged so future queues for those entity types aren't silently disabled.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6055
- Companion ticket (Python SDK): OPIK-6054
- Backend prerequisite (already merged): OPIK-6048

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation (assistant did the code archaeology, queue + routing implementation, and unit tests; corrected the original plan's `annotation-queue/` placement to a new `client/AssertionResultsBatchQueue` after verifying with the human; addressed reviewer feedback in three follow-up commits, including the fall-back-to-legacy behavior coordinated with the Python sister PR #6532, plus the TRACE-gating and `item.source` forwarding from the bot reviewer)
- Human verification: code review by author + local TS SDK build, lint, typecheck, and full unit-test suite

## Testing

- `npm run build` — clean (CJS, ESM, DTS).
- `npm run typecheck` — clean.
- `npm run lint` — clean.
- `npm test` — 1795 passed / 2 skipped (full TS SDK unit suite excl. integration).
- New unit coverage:
  - `tests/unit/client/client-assertionResults.test.ts` — `OpikClient` wiring; `flush()` drain; queue → `storeAssertionsBatch` payload shape (entityType `TRACE`, items in order); 404 fall-back to `scoreBatchOfTraces` with `categoryName: "suite_assertion"` and value 0/1; latch verification (subsequent batches skip the new endpoint); non-404 errors propagate; non-TRACE 404s propagate (no fallback); `item.source` forwarded through the legacy mapping.
  - `tests/unit/evaluation/engine/EvaluationEngine.assertionRouting.test.ts` — suite evaluators route to `/v1/private/assertion-results` (with correct `passed`/`failed` mapping and `projectName` resolution) and not to `scoreBatchOfTraces`; regular metrics still go to feedback-scores and not to assertion-results.
- Updated `tests/unit/evaluation/suite_evaluators/{LLMJudge,llmJudgeParsers}.test.ts` to assert the new shape (no `categoryName: "suite_assertion"`).
- Integration tests not run locally (require live backend); no integration test changes were necessary because the queue replacement is transparent at that level — CI will exercise `tests/integration/evaluation/evaluateTestSuite.test.ts`.

## Documentation

N/A — internal SDK plumbing change only. No public API surface changes (consumer-facing `EvaluationScoreResult` type is unchanged; only the optional `categoryName` doc-comment example was updated). Added a doc-comment to `BaseSuiteEvaluator.score()` clarifying the binary `value` contract (0 = failed, 1 = passed).