### PR TITLE
[OPIK-6054] [SDK] feat: route suite assertion results through PUT /v1/private/assertion-results

### DIFF
--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -82,6 +82,7 @@ from ..rest_api.types import (
     trace_filter_public,
 )
 from ..types import (
+    BatchAssertionResultDict,
     BatchFeedbackScoreDict,
     ErrorInfoDict,
     FeedbackScoreDict,
@@ -901,6 +902,54 @@ class Opik:
             )
 
             self._streamer.put(add_trace_feedback_scores_batch_message)
+
+    def log_assertion_results(
+        self,
+        assertion_results: List[BatchAssertionResultDict],
+        project_name: Optional[str] = None,
+    ) -> None:
+        """
+        Log assertion results for traces via the dedicated assertion-results
+        ingestion endpoint.
+
+        Args:
+            assertion_results: A list of assertion result dictionaries. Each entry
+                requires `id` (trace id), `name`, and `status` ("passed" or "failed").
+            project_name: The project the traces belong to. If not provided, falls
+                back to the active project context, then to the client's default.
+        """
+        resolved_project_name = self._resolve_project_name(project_name)
+
+        valid_items = [
+            item
+            for item in assertion_results
+            if item.get("id") and item.get("name") and item.get("status")
+        ]
+
+        if len(valid_items) == 0:
+            LOGGER.error(
+                f"No valid assertion results to log from provided ones: {assertion_results}"
+            )
+            return
+
+        assertion_messages = [
+            messages.AssertionResultMessage(
+                entity_id=item["id"],
+                project_name=item.get("project_name") or resolved_project_name,
+                name=item["name"],
+                status=item["status"],
+                reason=item.get("reason"),
+                source="sdk",
+            )
+            for item in valid_items
+        ]
+
+        for batch in sequence_splitter.split_into_batches(
+            assertion_messages,
+            max_payload_size_MB=opik_config.MAX_BATCH_SIZE_MB,
+            max_length=constants.FEEDBACK_SCORES_MAX_BATCH_SIZE,
+        ):
+            self._streamer.put(messages.AddAssertionResultsBatchMessage(batch=batch))
 
     def log_threads_feedback_scores(
         self, scores: List[BatchFeedbackScoreDict], project_name: Optional[str] = None

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -920,11 +920,19 @@ class Opik:
         """
         resolved_project_name = self._resolve_project_name(project_name)
 
-        valid_items = [
-            item
-            for item in assertion_results
-            if item.get("id") and item.get("name") and item.get("status")
-        ]
+        valid_items = []
+        for item in assertion_results:
+            if not (item.get("id") and item.get("name")):
+                continue
+            if item.get("status") not in ("passed", "failed"):
+                LOGGER.error(
+                    "Skipping assertion result with invalid status %r — "
+                    "must be 'passed' or 'failed': %s",
+                    item.get("status"),
+                    item,
+                )
+                continue
+            valid_items.append(item)
 
         if len(valid_items) == 0:
             LOGGER.error(

--- a/sdks/python/src/opik/evaluation/rest_operations.py
+++ b/sdks/python/src/opik/evaluation/rest_operations.py
@@ -2,10 +2,12 @@ import logging
 from typing import List, Optional
 
 from opik.api_objects import dataset, experiment, opik_client
-from opik.types import BatchFeedbackScoreDict
+from opik.types import BatchAssertionResultDict, BatchFeedbackScoreDict
 from . import test_case
 from .metrics import score_result
 from .types import ScoringKeyMappingType
+
+SUITE_ASSERTION_CATEGORY = "suite_assertion"
 
 LOGGER = logging.getLogger(__name__)
 
@@ -83,9 +85,21 @@ def log_test_result_feedback_scores(
     project_name: Optional[str],
 ) -> None:
     all_trace_scores: List[BatchFeedbackScoreDict] = []
+    assertion_results: List[BatchAssertionResultDict] = []
 
     for score_result_ in score_results:
         if score_result_.scoring_failed:
+            continue
+
+        if score_result_.category_name == SUITE_ASSERTION_CATEGORY:
+            assertion_results.append(
+                BatchAssertionResultDict(
+                    id=trace_id,
+                    name=score_result_.name,
+                    status="passed" if score_result_.value else "failed",
+                    reason=score_result_.reason,
+                )
+            )
             continue
 
         trace_score = BatchFeedbackScoreDict(
@@ -100,4 +114,9 @@ def log_test_result_feedback_scores(
     if len(all_trace_scores) > 0:
         client.log_traces_feedback_scores(
             scores=all_trace_scores, project_name=project_name
+        )
+
+    if len(assertion_results) > 0:
+        client.log_assertion_results(
+            assertion_results=assertion_results, project_name=project_name
         )

--- a/sdks/python/src/opik/message_processing/messages.py
+++ b/sdks/python/src/opik/message_processing/messages.py
@@ -366,6 +366,38 @@ class GuardrailBatchMessage(BaseMessage):
 
 
 @dataclasses.dataclass
+class AssertionResultMessage(BaseMessage):
+    """
+    There is no handler for that in the message processor, it exists
+    only as an item of AddAssertionResultsBatchMessage.
+    """
+
+    entity_id: str
+    project_name: Optional[str]
+    name: str
+    status: Literal["passed", "failed"]
+    source: Literal["sdk", "ui", "online_scoring"]
+    reason: Optional[str] = None
+
+    message_type = "AssertionResultMessage"
+
+
+@dataclasses.dataclass
+class AddAssertionResultsBatchMessage(BaseMessage):
+    batch: List[AssertionResultMessage]
+    entity_type: Literal["TRACE", "SPAN", "THREAD"] = "TRACE"
+    supports_batching: bool = True
+
+    message_type = "AddAssertionResultsBatchMessage"
+
+    def __post_init__(self) -> None:
+        self.batch = _deserialize_base_message_batch(self.batch, AssertionResultMessage)
+
+    def as_db_message_dict(self) -> Dict[str, Any]:
+        return _serialize_base_message_batch_to_dict(self.__dict__, self.batch)
+
+
+@dataclasses.dataclass
 class ExperimentItemMessage(BaseMessage):
     """
     There is no handler for that in the message processor, it exists

--- a/sdks/python/src/opik/message_processing/messages.py
+++ b/sdks/python/src/opik/message_processing/messages.py
@@ -386,7 +386,10 @@ class AssertionResultMessage(BaseMessage):
 class AddAssertionResultsBatchMessage(BaseMessage):
     batch: List[AssertionResultMessage]
     entity_type: Literal["TRACE", "SPAN", "THREAD"] = "TRACE"
-    supports_batching: bool = True
+    # Producers (Opik.log_assertion_results) already split via
+    # sequence_splitter; bypass BatchManager so the streamer doesn't try to
+    # re-batch (no batcher mapping is registered for this message type).
+    supports_batching: bool = False
 
     message_type = "AddAssertionResultsBatchMessage"
 

--- a/sdks/python/src/opik/message_processing/processors/assertion_results_processor.py
+++ b/sdks/python/src/opik/message_processing/processors/assertion_results_processor.py
@@ -1,0 +1,96 @@
+"""
+Migration-period write path for assertion results (OPIK-6054 / OPIK-6048).
+
+Tries PUT /v1/private/assertion-results first; on 404/405 falls back to
+PUT /v1/private/traces/feedback-scores with category_name="suite_assertion"
+(the pre-OPIK-6054 piggyback) and remembers the choice for the rest of the
+process so the round-trip cost is paid only once.
+
+This class goes away when the legacy feedback-scores write path is removed.
+"""
+
+import logging
+
+from opik.rest_api import client as rest_api_client, core as rest_api_core
+from opik.rest_api.types import (
+    assertion_result_batch_item,
+    feedback_score_batch_item,
+)
+
+from .. import messages
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AssertionResultsMessageProcessor:
+    def __init__(self, rest_client: rest_api_client.OpikApi) -> None:
+        self._rest_client = rest_client
+        # Default True: assume the BE exposes the new endpoint. Flipped to
+        # False on the first 404/405 to skip the round-trip on subsequent
+        # batches in this process.
+        self._use_assertion_results_endpoint = True
+
+    def process(self, message: messages.AddAssertionResultsBatchMessage) -> None:
+        if self._use_assertion_results_endpoint:
+            try:
+                self._send_via_assertion_results_endpoint(message)
+                return
+            except rest_api_core.ApiError as exception:
+                if exception.status_code in (404, 405):
+                    LOGGER.warning(
+                        "assertion-results endpoint unavailable on this "
+                        "backend (status=%d); falling back to feedback-scores "
+                        "for the rest of this session.",
+                        exception.status_code,
+                    )
+                    self._use_assertion_results_endpoint = False
+                else:
+                    raise
+
+        self._send_via_feedback_scores(message)
+
+    def _send_via_assertion_results_endpoint(
+        self,
+        message: messages.AddAssertionResultsBatchMessage,
+    ) -> None:
+        items = [
+            assertion_result_batch_item.AssertionResultBatchItem(
+                entity_id=item.entity_id,
+                project_name=item.project_name,
+                name=item.name,
+                status=item.status,
+                reason=item.reason,
+                source=item.source,
+            )
+            for item in message.batch
+        ]
+
+        LOGGER.debug("Add assertion results request of size: %d", len(items))
+
+        self._rest_client.assertion_results.store_assertions_batch(
+            entity_type=message.entity_type,
+            assertion_results=items,
+        )
+        LOGGER.debug("Sent batch of assertion results of size %d", len(items))
+
+    def _send_via_feedback_scores(
+        self,
+        message: messages.AddAssertionResultsBatchMessage,
+    ) -> None:
+        scores = [
+            feedback_score_batch_item.FeedbackScoreBatchItem(
+                id=item.entity_id,
+                project_name=item.project_name,
+                name=item.name,
+                value=1.0 if item.status == "passed" else 0.0,
+                category_name="suite_assertion",
+                reason=item.reason,
+                source=item.source,
+            )
+            for item in message.batch
+        ]
+        LOGGER.debug(
+            "Falling back: writing %d assertion results as trace feedback scores",
+            len(scores),
+        )
+        self._rest_client.traces.score_batch_of_traces(scores=scores)

--- a/sdks/python/src/opik/message_processing/processors/online_message_processor.py
+++ b/sdks/python/src/opik/message_processing/processors/online_message_processor.py
@@ -46,6 +46,14 @@ class OpikMessageProcessor(message_processors.BaseMessageProcessor):
         self._replay_manager = fallback_replay_manager
         self._unauthorized_message_types_registry = unauthorized_message_types_registry
 
+        # Migration-period flag for OPIK-6054 / OPIK-6048. The dedicated
+        # PUT /v1/private/assertion-results endpoint may not exist on older
+        # self-hosted backends. On the first 404/405 we remember the BE is
+        # too old and route subsequent assertion writes through the legacy
+        # feedback-scores piggyback for the rest of this process. Goes away
+        # when the legacy write path is removed.
+        self._assertion_results_endpoint_unavailable = False
+
         self._handlers: Dict[Type, MessageProcessingHandler] = {
             messages.CreateSpanMessage: self._process_create_span_message,  # type: ignore
             messages.CreateTraceMessage: self._process_create_trace_message,  # type: ignore
@@ -367,6 +375,10 @@ class OpikMessageProcessor(message_processors.BaseMessageProcessor):
         self,
         message: messages.AddAssertionResultsBatchMessage,
     ) -> None:
+        if self._assertion_results_endpoint_unavailable:
+            self._fallback_assertion_results_to_feedback_scores(message)
+            return
+
         items = [
             assertion_result_batch_item.AssertionResultBatchItem(
                 entity_id=item.entity_id,
@@ -381,11 +393,53 @@ class OpikMessageProcessor(message_processors.BaseMessageProcessor):
 
         LOGGER.debug("Add assertion results request of size: %d", len(items))
 
-        self._rest_client.assertion_results.store_assertions_batch(
-            entity_type=message.entity_type,
-            assertion_results=items,
-        )
+        try:
+            self._rest_client.assertion_results.store_assertions_batch(
+                entity_type=message.entity_type,
+                assertion_results=items,
+            )
+        except rest_api_core.ApiError as exception:
+            # Older self-hosted backends don't expose the dedicated
+            # assertion-results endpoint yet (OPIK-6048). Fall back to
+            # writing as feedback scores tagged with
+            # category_name="suite_assertion" (the pre-OPIK-6054 path) and
+            # remember the choice so we don't pay the round-trip cost
+            # again this session.
+            if exception.status_code in (404, 405):
+                LOGGER.warning(
+                    "assertion-results endpoint unavailable on this backend "
+                    "(status=%d); falling back to feedback-scores for the "
+                    "rest of this session.",
+                    exception.status_code,
+                )
+                self._assertion_results_endpoint_unavailable = True
+                self._fallback_assertion_results_to_feedback_scores(message)
+                return
+            raise
+
         LOGGER.debug("Sent batch of assertion results of size %d", len(items))
+
+    def _fallback_assertion_results_to_feedback_scores(
+        self,
+        message: messages.AddAssertionResultsBatchMessage,
+    ) -> None:
+        scores = [
+            feedback_score_batch_item.FeedbackScoreBatchItem(
+                id=item.entity_id,
+                project_name=item.project_name,
+                name=item.name,
+                value=1.0 if item.status == "passed" else 0.0,
+                category_name="suite_assertion",
+                reason=item.reason,
+                source=item.source,
+            )
+            for item in message.batch
+        ]
+        LOGGER.debug(
+            "Falling back: writing %d assertion results as trace feedback scores",
+            len(scores),
+        )
+        self._rest_client.traces.score_batch_of_traces(scores=scores)
 
     def _process_create_experiment_items_batch_message(
         self,

--- a/sdks/python/src/opik/message_processing/processors/online_message_processor.py
+++ b/sdks/python/src/opik/message_processing/processors/online_message_processor.py
@@ -15,6 +15,7 @@ from opik.rest_api.types import (
     feedback_score_batch_item_thread,
     guardrail,
     experiment_item,
+    assertion_result_batch_item,
 )
 
 from . import message_processors
@@ -56,6 +57,7 @@ class OpikMessageProcessor(message_processors.BaseMessageProcessor):
             messages.CreateSpansBatchMessage: self._process_create_spans_batch_message,  # type: ignore
             messages.CreateTraceBatchMessage: self._process_create_traces_batch_message,  # type: ignore
             messages.GuardrailBatchMessage: self._process_guardrail_batch_message,  # type: ignore
+            messages.AddAssertionResultsBatchMessage: self._process_add_assertion_results_batch_message,  # type: ignore
             messages.CreateExperimentItemsBatchMessage: self._process_create_experiment_items_batch_message,  # type: ignore
             messages.CreateAttachmentMessage: self._process_create_attachment,  # type: ignore
             messages.AttachmentSupportingMessage: self._noop_handler,  # type: ignore
@@ -360,6 +362,30 @@ class OpikMessageProcessor(message_processors.BaseMessageProcessor):
             batch.append(guardrail_batch_item_message)
 
         self._rest_client.guardrails.create_guardrails(guardrails=batch)
+
+    def _process_add_assertion_results_batch_message(
+        self,
+        message: messages.AddAssertionResultsBatchMessage,
+    ) -> None:
+        items = [
+            assertion_result_batch_item.AssertionResultBatchItem(
+                entity_id=item.entity_id,
+                project_name=item.project_name,
+                name=item.name,
+                status=item.status,
+                reason=item.reason,
+                source=item.source,
+            )
+            for item in message.batch
+        ]
+
+        LOGGER.debug("Add assertion results request of size: %d", len(items))
+
+        self._rest_client.assertion_results.store_assertions_batch(
+            entity_type=message.entity_type,
+            assertion_results=items,
+        )
+        LOGGER.debug("Sent batch of assertion results of size %d", len(items))
 
     def _process_create_experiment_items_batch_message(
         self,

--- a/sdks/python/src/opik/message_processing/processors/online_message_processor.py
+++ b/sdks/python/src/opik/message_processing/processors/online_message_processor.py
@@ -15,10 +15,9 @@ from opik.rest_api.types import (
     feedback_score_batch_item_thread,
     guardrail,
     experiment_item,
-    assertion_result_batch_item,
 )
 
-from . import message_processors
+from . import assertion_results_processor, message_processors
 from .. import encoder_helpers, messages, permissions
 from ..replay import replay_manager, db_manager
 
@@ -46,13 +45,11 @@ class OpikMessageProcessor(message_processors.BaseMessageProcessor):
         self._replay_manager = fallback_replay_manager
         self._unauthorized_message_types_registry = unauthorized_message_types_registry
 
-        # Migration-period flag for OPIK-6054 / OPIK-6048. The dedicated
-        # PUT /v1/private/assertion-results endpoint may not exist on older
-        # self-hosted backends. On the first 404/405 we remember the BE is
-        # too old and route subsequent assertion writes through the legacy
-        # feedback-scores piggyback for the rest of this process. Goes away
-        # when the legacy write path is removed.
-        self._assertion_results_endpoint_unavailable = False
+        self._assertion_results_processor = (
+            assertion_results_processor.AssertionResultsMessageProcessor(
+                rest_client=rest_client,
+            )
+        )
 
         self._handlers: Dict[Type, MessageProcessingHandler] = {
             messages.CreateSpanMessage: self._process_create_span_message,  # type: ignore
@@ -375,71 +372,7 @@ class OpikMessageProcessor(message_processors.BaseMessageProcessor):
         self,
         message: messages.AddAssertionResultsBatchMessage,
     ) -> None:
-        if self._assertion_results_endpoint_unavailable:
-            self._fallback_assertion_results_to_feedback_scores(message)
-            return
-
-        items = [
-            assertion_result_batch_item.AssertionResultBatchItem(
-                entity_id=item.entity_id,
-                project_name=item.project_name,
-                name=item.name,
-                status=item.status,
-                reason=item.reason,
-                source=item.source,
-            )
-            for item in message.batch
-        ]
-
-        LOGGER.debug("Add assertion results request of size: %d", len(items))
-
-        try:
-            self._rest_client.assertion_results.store_assertions_batch(
-                entity_type=message.entity_type,
-                assertion_results=items,
-            )
-        except rest_api_core.ApiError as exception:
-            # Older self-hosted backends don't expose the dedicated
-            # assertion-results endpoint yet (OPIK-6048). Fall back to
-            # writing as feedback scores tagged with
-            # category_name="suite_assertion" (the pre-OPIK-6054 path) and
-            # remember the choice so we don't pay the round-trip cost
-            # again this session.
-            if exception.status_code in (404, 405):
-                LOGGER.warning(
-                    "assertion-results endpoint unavailable on this backend "
-                    "(status=%d); falling back to feedback-scores for the "
-                    "rest of this session.",
-                    exception.status_code,
-                )
-                self._assertion_results_endpoint_unavailable = True
-                self._fallback_assertion_results_to_feedback_scores(message)
-                return
-            raise
-
-        LOGGER.debug("Sent batch of assertion results of size %d", len(items))
-
-    def _fallback_assertion_results_to_feedback_scores(
-        self,
-        message: messages.AddAssertionResultsBatchMessage,
-    ) -> None:
-        scores = [
-            feedback_score_batch_item.FeedbackScoreBatchItem(
-                id=item.entity_id,
-                project_name=item.project_name,
-                name=item.name,
-                value=1.0 if item.status == "passed" else 0.0,
-                category_name="suite_assertion",
-                reason=item.reason,
-                source=item.source,
-            )
-            for item in message.batch
-        ]
-        LOGGER.debug(
-            "Falling back: writing %d assertion results as trace feedback scores",
-            len(scores),
-        )
-        self._rest_client.traces.score_batch_of_traces(scores=scores)
+        self._assertion_results_processor.process(message)
 
     def _process_create_experiment_items_batch_message(
         self,

--- a/sdks/python/src/opik/message_processing/replay/db_manager.py
+++ b/sdks/python/src/opik/message_processing/replay/db_manager.py
@@ -711,6 +711,7 @@ SUPPORTED_MESSAGE_TYPES = {
     messages.CreateTraceBatchMessage.message_type: messages.CreateTraceBatchMessage,
     messages.GuardrailBatchMessage.message_type: messages.GuardrailBatchMessage,
     messages.CreateExperimentItemsBatchMessage.message_type: messages.CreateExperimentItemsBatchMessage,
+    messages.AddAssertionResultsBatchMessage.message_type: messages.AddAssertionResultsBatchMessage,
     messages.CreateAttachmentMessage.message_type: messages.CreateAttachmentMessage,
 }
 

--- a/sdks/python/src/opik/types.py
+++ b/sdks/python/src/opik/types.py
@@ -116,6 +116,31 @@ class BatchFeedbackScoreDict(TypedDict):
     """An optional explanation or justification for the given score."""
 
 
+class BatchAssertionResultDict(TypedDict):
+    """
+    A TypedDict representing an assertion result for batch operations.
+    """
+
+    id: Required[str]
+    """The trace id this assertion is attached to."""
+
+    name: Required[str]
+    """The assertion text."""
+
+    status: Required[Literal["passed", "failed"]]
+    """Whether the assertion passed or failed."""
+
+    project_name: NotRequired[Optional[StrictStr]]
+    """
+    The name of the project for this specific assertion.
+    If not provided, falls back to the project_name parameter in the method call,
+    or the default project name configured in the Opik instance.
+    """
+
+    reason: NotRequired[Optional[str]]
+    """An optional explanation produced by the evaluator."""
+
+
 class ErrorInfoDict(TypedDict):
     """
     A TypedDict representing the information about the error occurred.

--- a/sdks/python/tests/unit/api_objects/test_opik_client.py
+++ b/sdks/python/tests/unit/api_objects/test_opik_client.py
@@ -1339,3 +1339,73 @@ def test_opik_client__search_traces__exclude_defaults_to_none():
 
     mock_search.assert_called_once()
     assert mock_search.call_args.kwargs["exclude"] is None
+
+
+def test_opik_client__log_assertion_results__happy_path():
+    client = opik_client.Opik(project_name="test-project")
+    mock_streamer = MagicMock()
+    client._streamer = mock_streamer
+
+    client.log_assertion_results(
+        assertion_results=[
+            {"id": "trace-1", "name": "must mention paris", "status": "passed"},
+            {
+                "id": "trace-1",
+                "name": "must be polite",
+                "status": "failed",
+                "reason": "rude tone",
+                "project_name": "override-project",
+            },
+        ]
+    )
+
+    mock_streamer.put.assert_called_once()
+    msg = mock_streamer.put.call_args.args[0]
+    assert isinstance(msg, messages.AddAssertionResultsBatchMessage)
+    assert msg.entity_type == "TRACE"
+    # supports_batching is False so the streamer doesn't try to re-batch
+    assert msg.supports_batching is False
+    assert len(msg.batch) == 2
+    first, second = msg.batch
+    assert first.entity_id == "trace-1"
+    assert first.name == "must mention paris"
+    assert first.status == "passed"
+    assert first.source == "sdk"
+    assert first.project_name == "test-project"
+    assert second.status == "failed"
+    assert second.reason == "rude tone"
+    assert second.project_name == "override-project"
+
+
+def test_opik_client__log_assertion_results__skips_invalid_status():
+    client = opik_client.Opik(project_name="test-project")
+    mock_streamer = MagicMock()
+    client._streamer = mock_streamer
+
+    client.log_assertion_results(
+        assertion_results=[
+            {"id": "trace-1", "name": "ok", "status": "passed"},
+            {"id": "trace-1", "name": "bogus", "status": "PASSED"},
+            {"id": "trace-1", "name": "boolish", "status": True},
+            {"id": "trace-1", "name": "missing"},
+        ]
+    )
+
+    mock_streamer.put.assert_called_once()
+    msg = mock_streamer.put.call_args.args[0]
+    assert [item.name for item in msg.batch] == ["ok"]
+
+
+def test_opik_client__log_assertion_results__nothing_valid__does_not_emit():
+    client = opik_client.Opik(project_name="test-project")
+    mock_streamer = MagicMock()
+    client._streamer = mock_streamer
+
+    client.log_assertion_results(
+        assertion_results=[
+            {"id": "", "name": "ok", "status": "passed"},
+            {"id": "trace-1", "name": "bogus", "status": "PASSED"},
+        ]
+    )
+
+    mock_streamer.put.assert_not_called()

--- a/sdks/python/tests/unit/evaluation/test_rest_operations.py
+++ b/sdks/python/tests/unit/evaluation/test_rest_operations.py
@@ -1,0 +1,126 @@
+"""
+Unit tests for opik.evaluation.rest_operations.log_test_result_feedback_scores.
+
+Verifies that suite-assertion ScoreResults are routed to the new
+assertion-results endpoint while regular feedback scores continue to use
+the feedback-scores path.
+"""
+
+from unittest import mock
+
+from opik.evaluation import rest_operations
+from opik.evaluation.metrics import score_result
+
+
+def _client_mock() -> mock.MagicMock:
+    return mock.MagicMock()
+
+
+class TestLogTestResultFeedbackScoresRouting:
+    def test_only_regular_scores__calls_feedback_scores_only(self):
+        client = _client_mock()
+        results = [
+            score_result.ScoreResult(name="precision", value=0.9, reason="ok"),
+            score_result.ScoreResult(name="recall", value=0.8, reason="ok"),
+        ]
+
+        rest_operations.log_test_result_feedback_scores(
+            client=client,
+            score_results=results,
+            trace_id="trace-1",
+            project_name="proj-A",
+        )
+
+        client.log_traces_feedback_scores.assert_called_once()
+        client.log_assertion_results.assert_not_called()
+        scores = client.log_traces_feedback_scores.call_args.kwargs["scores"]
+        assert {s["name"] for s in scores} == {"precision", "recall"}
+
+    def test_only_suite_assertions__calls_assertion_results_only(self):
+        client = _client_mock()
+        results = [
+            score_result.ScoreResult(
+                name="must mention paris",
+                value=True,
+                reason="mentioned",
+                category_name="suite_assertion",
+            ),
+            score_result.ScoreResult(
+                name="must be polite",
+                value=False,
+                reason="rude tone",
+                category_name="suite_assertion",
+            ),
+        ]
+
+        rest_operations.log_test_result_feedback_scores(
+            client=client,
+            score_results=results,
+            trace_id="trace-1",
+            project_name="proj-A",
+        )
+
+        client.log_traces_feedback_scores.assert_not_called()
+        client.log_assertion_results.assert_called_once()
+        kwargs = client.log_assertion_results.call_args.kwargs
+        assert kwargs["project_name"] == "proj-A"
+        sent = kwargs["assertion_results"]
+        assert len(sent) == 2
+        assert sent[0]["id"] == "trace-1"
+        assert sent[0]["name"] == "must mention paris"
+        assert sent[0]["status"] == "passed"
+        assert sent[0]["reason"] == "mentioned"
+        assert sent[1]["status"] == "failed"
+
+    def test_mixed__splits_suite_assertions_from_feedback_scores(self):
+        client = _client_mock()
+        results = [
+            score_result.ScoreResult(name="precision", value=0.9),
+            score_result.ScoreResult(
+                name="must mention paris",
+                value=True,
+                category_name="suite_assertion",
+            ),
+        ]
+
+        rest_operations.log_test_result_feedback_scores(
+            client=client,
+            score_results=results,
+            trace_id="trace-1",
+            project_name="proj-A",
+        )
+
+        client.log_traces_feedback_scores.assert_called_once()
+        feedback_scores = client.log_traces_feedback_scores.call_args.kwargs["scores"]
+        assert len(feedback_scores) == 1
+        assert feedback_scores[0]["name"] == "precision"
+
+        client.log_assertion_results.assert_called_once()
+        assertion_results = client.log_assertion_results.call_args.kwargs[
+            "assertion_results"
+        ]
+        assert len(assertion_results) == 1
+        assert assertion_results[0]["name"] == "must mention paris"
+        assert assertion_results[0]["status"] == "passed"
+
+    def test_scoring_failed_records__excluded_from_both_endpoints(self):
+        client = _client_mock()
+        results = [
+            score_result.ScoreResult(
+                name="must mention paris",
+                value=False,
+                category_name="suite_assertion",
+                scoring_failed=True,
+            ),
+            score_result.ScoreResult(name="precision", value=0.0, scoring_failed=True),
+        ]
+
+        rest_operations.log_test_result_feedback_scores(
+            client=client,
+            score_results=results,
+            trace_id="trace-1",
+            project_name="proj-A",
+        )
+
+        client.log_traces_feedback_scores.assert_not_called()
+        client.log_assertion_results.assert_not_called()

--- a/sdks/python/tests/unit/message_processing/processors/test_assertion_results_handler.py
+++ b/sdks/python/tests/unit/message_processing/processors/test_assertion_results_handler.py
@@ -1,0 +1,101 @@
+"""
+Unit tests for OpikMessageProcessor handling AddAssertionResultsBatchMessage.
+"""
+
+from unittest import mock
+
+import pytest
+
+from opik.message_processing import messages
+from opik.message_processing.processors.online_message_processor import (
+    OpikMessageProcessor,
+)
+from opik.rest_api.types import assertion_result_batch_item
+
+
+@pytest.fixture
+def mock_rest_client() -> mock.MagicMock:
+    client = mock.MagicMock()
+    # MagicMock blocks attributes starting with "assert" as protection against
+    # typoed assertion methods; configure the assertion_results client explicitly.
+    client.assertion_results = mock.MagicMock(unsafe=True)
+    return client
+
+
+@pytest.fixture
+def processor(mock_rest_client: mock.MagicMock) -> OpikMessageProcessor:
+    return OpikMessageProcessor(
+        rest_client=mock_rest_client,
+        file_upload_manager=mock.MagicMock(),
+        fallback_replay_manager=mock.MagicMock(),
+        unauthorized_message_types_registry=mock.Mock(
+            is_authorized=mock.Mock(return_value=True)
+        ),
+    )
+
+
+def _build_message(
+    items=None,
+    entity_type="TRACE",
+) -> messages.AddAssertionResultsBatchMessage:
+    items = items or [
+        messages.AssertionResultMessage(
+            entity_id="trace-1",
+            project_name="proj-A",
+            name="assertion 1",
+            status="passed",
+            source="sdk",
+            reason="looked good",
+        ),
+        messages.AssertionResultMessage(
+            entity_id="trace-1",
+            project_name="proj-A",
+            name="assertion 2",
+            status="failed",
+            source="sdk",
+            reason=None,
+        ),
+    ]
+    msg = messages.AddAssertionResultsBatchMessage(batch=items, entity_type=entity_type)
+    msg.message_id = 1
+    return msg
+
+
+class TestAssertionResultsHandler:
+    def test_process__assertion_results_batch__forwards_to_rest_client(
+        self,
+        processor: OpikMessageProcessor,
+        mock_rest_client: mock.MagicMock,
+    ):
+        message = _build_message()
+
+        processor.process(message)
+
+        mock_rest_client.assertion_results.store_assertions_batch.assert_called_once()
+        call_kwargs = (
+            mock_rest_client.assertion_results.store_assertions_batch.call_args.kwargs
+        )
+        assert call_kwargs["entity_type"] == "TRACE"
+        sent_items = call_kwargs["assertion_results"]
+        assert len(sent_items) == 2
+        assert all(
+            isinstance(item, assertion_result_batch_item.AssertionResultBatchItem)
+            for item in sent_items
+        )
+        assert sent_items[0].entity_id == "trace-1"
+        assert sent_items[0].name == "assertion 1"
+        assert sent_items[0].status == "passed"
+        assert sent_items[0].source == "sdk"
+        assert sent_items[0].reason == "looked good"
+        assert sent_items[1].status == "failed"
+        assert sent_items[1].reason is None
+
+    def test_process__assertion_results_batch__does_not_use_feedback_scores_endpoint(
+        self,
+        processor: OpikMessageProcessor,
+        mock_rest_client: mock.MagicMock,
+    ):
+        processor.process(_build_message())
+
+        mock_rest_client.traces.score_batch_of_traces.assert_not_called()
+        mock_rest_client.spans.score_batch_of_spans.assert_not_called()

--- a/sdks/python/tests/unit/message_processing/processors/test_assertion_results_handler.py
+++ b/sdks/python/tests/unit/message_processing/processors/test_assertion_results_handler.py
@@ -10,7 +10,8 @@ from opik.message_processing import messages
 from opik.message_processing.processors.online_message_processor import (
     OpikMessageProcessor,
 )
-from opik.rest_api.types import assertion_result_batch_item
+from opik.rest_api import core as rest_api_core
+from opik.rest_api.types import assertion_result_batch_item, feedback_score_batch_item
 
 
 @pytest.fixture
@@ -99,3 +100,93 @@ class TestAssertionResultsHandler:
 
         mock_rest_client.traces.score_batch_of_traces.assert_not_called()
         mock_rest_client.spans.score_batch_of_spans.assert_not_called()
+
+
+class TestAssertionResultsFallback:
+    """
+    Forward-compat fallback for OPIK-6054 / OPIK-6048: if the dedicated
+    assertion-results endpoint is missing on an older self-hosted backend,
+    write through the legacy feedback-scores piggyback and remember the
+    choice for the rest of the session.
+    """
+
+    def test_process__bad_endpoint_404__falls_back_to_feedback_scores(
+        self,
+        processor: OpikMessageProcessor,
+        mock_rest_client: mock.MagicMock,
+    ):
+        mock_rest_client.assertion_results.store_assertions_batch.side_effect = (
+            rest_api_core.ApiError(status_code=404, body="Not Found")
+        )
+
+        processor.process(_build_message())
+
+        mock_rest_client.traces.score_batch_of_traces.assert_called_once()
+        sent = mock_rest_client.traces.score_batch_of_traces.call_args.kwargs["scores"]
+        assert len(sent) == 2
+        assert all(
+            isinstance(item, feedback_score_batch_item.FeedbackScoreBatchItem)
+            for item in sent
+        )
+        assert all(item.category_name == "suite_assertion" for item in sent)
+        assert sent[0].id == "trace-1"
+        assert sent[0].name == "assertion 1"
+        assert sent[0].value == 1.0
+        assert sent[0].source == "sdk"
+        assert sent[1].value == 0.0  # status="failed"
+        assert processor._assertion_results_endpoint_unavailable is True
+
+    def test_process__bad_endpoint_405__falls_back_to_feedback_scores(
+        self,
+        processor: OpikMessageProcessor,
+        mock_rest_client: mock.MagicMock,
+    ):
+        mock_rest_client.assertion_results.store_assertions_batch.side_effect = (
+            rest_api_core.ApiError(status_code=405, body="Method Not Allowed")
+        )
+
+        processor.process(_build_message())
+
+        mock_rest_client.traces.score_batch_of_traces.assert_called_once()
+        assert processor._assertion_results_endpoint_unavailable is True
+
+    def test_process__non_404_api_error__propagates_and_does_not_set_fallback(
+        self,
+        processor: OpikMessageProcessor,
+        mock_rest_client: mock.MagicMock,
+    ):
+        mock_rest_client.assertion_results.store_assertions_batch.side_effect = (
+            rest_api_core.ApiError(status_code=500, body="Internal Server Error")
+        )
+
+        with pytest.raises(rest_api_core.ApiError):
+            # process() catches handler exceptions and routes them to the
+            # replay manager. Bypass that by calling the handler directly so
+            # the test can observe the propagation.
+            processor._process_add_assertion_results_batch_message(_build_message())
+
+        mock_rest_client.traces.score_batch_of_traces.assert_not_called()
+        assert processor._assertion_results_endpoint_unavailable is False
+
+    def test_process__sticky_fallback__second_call_skips_new_endpoint(
+        self,
+        processor: OpikMessageProcessor,
+        mock_rest_client: mock.MagicMock,
+    ):
+        mock_rest_client.assertion_results.store_assertions_batch.side_effect = (
+            rest_api_core.ApiError(status_code=404, body="Not Found")
+        )
+
+        processor.process(_build_message())
+        # First call: tried new endpoint, hit 404, set the sticky flag.
+        assert mock_rest_client.assertion_results.store_assertions_batch.call_count == 1
+        assert processor._assertion_results_endpoint_unavailable is True
+
+        # Reset feedback-scores call_count to isolate the second send.
+        mock_rest_client.traces.score_batch_of_traces.reset_mock()
+        processor.process(_build_message())
+
+        # Second call must NOT retry the new endpoint.
+        assert mock_rest_client.assertion_results.store_assertions_batch.call_count == 1
+        # It went straight to the fallback.
+        mock_rest_client.traces.score_batch_of_traces.assert_called_once()

--- a/sdks/python/tests/unit/message_processing/processors/test_assertion_results_handler.py
+++ b/sdks/python/tests/unit/message_processing/processors/test_assertion_results_handler.py
@@ -150,7 +150,7 @@ class TestAssertionResultsFallback:
         mock_rest_client.traces.score_batch_of_traces.assert_called_once()
         assert processor._assertion_results_endpoint_unavailable is True
 
-    def test_process__non_404_api_error__propagates_and_does_not_set_fallback(
+    def test_process__non_404_api_error__does_not_set_fallback_or_call_legacy_path(
         self,
         processor: OpikMessageProcessor,
         mock_rest_client: mock.MagicMock,
@@ -159,12 +159,13 @@ class TestAssertionResultsFallback:
             rest_api_core.ApiError(status_code=500, body="Internal Server Error")
         )
 
-        with pytest.raises(rest_api_core.ApiError):
-            # process() catches handler exceptions and routes them to the
-            # replay manager. Bypass that by calling the handler directly so
-            # the test can observe the propagation.
-            processor._process_add_assertion_results_batch_message(_build_message())
+        # Public entrypoint: process() catches non-404/405 ApiError, logs,
+        # and lets the replay manager handle the failed message. The
+        # fallback flag must stay False and the legacy feedback-scores
+        # endpoint must not be touched.
+        processor.process(_build_message())
 
+        mock_rest_client.assertion_results.store_assertions_batch.assert_called_once()
         mock_rest_client.traces.score_batch_of_traces.assert_not_called()
         assert processor._assertion_results_endpoint_unavailable is False
 

--- a/sdks/python/tests/unit/message_processing/processors/test_assertion_results_processor.py
+++ b/sdks/python/tests/unit/message_processing/processors/test_assertion_results_processor.py
@@ -1,5 +1,9 @@
 """
-Unit tests for OpikMessageProcessor handling AddAssertionResultsBatchMessage.
+Unit tests for AssertionResultsMessageProcessor — the migration-period write
+path for OPIK-6054 / OPIK-6048.
+
+Targets the small dedicated class directly so the tests don't depend on the
+larger OpikMessageProcessor / replay / permissions plumbing.
 """
 
 from unittest import mock
@@ -7,8 +11,8 @@ from unittest import mock
 import pytest
 
 from opik.message_processing import messages
-from opik.message_processing.processors.online_message_processor import (
-    OpikMessageProcessor,
+from opik.message_processing.processors.assertion_results_processor import (
+    AssertionResultsMessageProcessor,
 )
 from opik.rest_api import core as rest_api_core
 from opik.rest_api.types import assertion_result_batch_item, feedback_score_batch_item
@@ -18,21 +22,16 @@ from opik.rest_api.types import assertion_result_batch_item, feedback_score_batc
 def mock_rest_client() -> mock.MagicMock:
     client = mock.MagicMock()
     # MagicMock blocks attributes starting with "assert" as protection against
-    # typoed assertion methods; configure the assertion_results client explicitly.
+    # typoed assertion methods; configure assertion_results explicitly.
     client.assertion_results = mock.MagicMock(unsafe=True)
     return client
 
 
 @pytest.fixture
-def processor(mock_rest_client: mock.MagicMock) -> OpikMessageProcessor:
-    return OpikMessageProcessor(
-        rest_client=mock_rest_client,
-        file_upload_manager=mock.MagicMock(),
-        fallback_replay_manager=mock.MagicMock(),
-        unauthorized_message_types_registry=mock.Mock(
-            is_authorized=mock.Mock(return_value=True)
-        ),
-    )
+def processor(
+    mock_rest_client: mock.MagicMock,
+) -> AssertionResultsMessageProcessor:
+    return AssertionResultsMessageProcessor(rest_client=mock_rest_client)
 
 
 def _build_message(
@@ -62,15 +61,13 @@ def _build_message(
     return msg
 
 
-class TestAssertionResultsHandler:
-    def test_process__assertion_results_batch__forwards_to_rest_client(
+class TestAssertionResultsProcessorHappyPath:
+    def test_process__happy_path__forwards_to_assertion_results_endpoint(
         self,
-        processor: OpikMessageProcessor,
+        processor: AssertionResultsMessageProcessor,
         mock_rest_client: mock.MagicMock,
     ):
-        message = _build_message()
-
-        processor.process(message)
+        processor.process(_build_message())
 
         mock_rest_client.assertion_results.store_assertions_batch.assert_called_once()
         call_kwargs = (
@@ -91,9 +88,9 @@ class TestAssertionResultsHandler:
         assert sent_items[1].status == "failed"
         assert sent_items[1].reason is None
 
-    def test_process__assertion_results_batch__does_not_use_feedback_scores_endpoint(
+    def test_process__happy_path__does_not_use_feedback_scores_endpoint(
         self,
-        processor: OpikMessageProcessor,
+        processor: AssertionResultsMessageProcessor,
         mock_rest_client: mock.MagicMock,
     ):
         processor.process(_build_message())
@@ -102,17 +99,17 @@ class TestAssertionResultsHandler:
         mock_rest_client.spans.score_batch_of_spans.assert_not_called()
 
 
-class TestAssertionResultsFallback:
+class TestAssertionResultsProcessorFallback:
     """
-    Forward-compat fallback for OPIK-6054 / OPIK-6048: if the dedicated
-    assertion-results endpoint is missing on an older self-hosted backend,
-    write through the legacy feedback-scores piggyback and remember the
-    choice for the rest of the session.
+    Forward-compat fallback: if the dedicated assertion-results endpoint is
+    missing on an older self-hosted backend, write through the legacy
+    feedback-scores piggyback and remember the choice for the rest of the
+    session.
     """
 
     def test_process__bad_endpoint_404__falls_back_to_feedback_scores(
         self,
-        processor: OpikMessageProcessor,
+        processor: AssertionResultsMessageProcessor,
         mock_rest_client: mock.MagicMock,
     ):
         mock_rest_client.assertion_results.store_assertions_batch.side_effect = (
@@ -134,11 +131,11 @@ class TestAssertionResultsFallback:
         assert sent[0].value == 1.0
         assert sent[0].source == "sdk"
         assert sent[1].value == 0.0  # status="failed"
-        assert processor._assertion_results_endpoint_unavailable is True
+        assert processor._use_assertion_results_endpoint is False
 
     def test_process__bad_endpoint_405__falls_back_to_feedback_scores(
         self,
-        processor: OpikMessageProcessor,
+        processor: AssertionResultsMessageProcessor,
         mock_rest_client: mock.MagicMock,
     ):
         mock_rest_client.assertion_results.store_assertions_batch.side_effect = (
@@ -148,30 +145,26 @@ class TestAssertionResultsFallback:
         processor.process(_build_message())
 
         mock_rest_client.traces.score_batch_of_traces.assert_called_once()
-        assert processor._assertion_results_endpoint_unavailable is True
+        assert processor._use_assertion_results_endpoint is False
 
-    def test_process__non_404_api_error__does_not_set_fallback_or_call_legacy_path(
+    def test_process__non_404_api_error__propagates_and_does_not_set_fallback(
         self,
-        processor: OpikMessageProcessor,
+        processor: AssertionResultsMessageProcessor,
         mock_rest_client: mock.MagicMock,
     ):
         mock_rest_client.assertion_results.store_assertions_batch.side_effect = (
             rest_api_core.ApiError(status_code=500, body="Internal Server Error")
         )
 
-        # Public entrypoint: process() catches non-404/405 ApiError, logs,
-        # and lets the replay manager handle the failed message. The
-        # fallback flag must stay False and the legacy feedback-scores
-        # endpoint must not be touched.
-        processor.process(_build_message())
+        with pytest.raises(rest_api_core.ApiError):
+            processor.process(_build_message())
 
-        mock_rest_client.assertion_results.store_assertions_batch.assert_called_once()
         mock_rest_client.traces.score_batch_of_traces.assert_not_called()
-        assert processor._assertion_results_endpoint_unavailable is False
+        assert processor._use_assertion_results_endpoint is True
 
     def test_process__sticky_fallback__second_call_skips_new_endpoint(
         self,
-        processor: OpikMessageProcessor,
+        processor: AssertionResultsMessageProcessor,
         mock_rest_client: mock.MagicMock,
     ):
         mock_rest_client.assertion_results.store_assertions_batch.side_effect = (
@@ -179,11 +172,10 @@ class TestAssertionResultsFallback:
         )
 
         processor.process(_build_message())
-        # First call: tried new endpoint, hit 404, set the sticky flag.
+        # First call: tried new endpoint, hit 404, flipped the flag.
         assert mock_rest_client.assertion_results.store_assertions_batch.call_count == 1
-        assert processor._assertion_results_endpoint_unavailable is True
+        assert processor._use_assertion_results_endpoint is False
 
-        # Reset feedback-scores call_count to isolate the second send.
         mock_rest_client.traces.score_batch_of_traces.reset_mock()
         processor.process(_build_message())
 


### PR DESCRIPTION
## Details

<img width="1760" height="3558" alt="image" src="https://github.com/user-attachments/assets/b626a0f6-7e14-4be6-94bf-a836de154960" />

Migrate the Python SDK's suite-evaluator path off the legacy feedback-scores piggyback (`category_name="suite_assertion"`) onto the dedicated assertion-results ingestion endpoint added in OPIK-6048. New SDK writes go to `PUT /v1/private/assertion-results`; older self-hosted backends without that endpoint degrade gracefully via a sticky per-process fallback to the legacy feedback-scores path.

- Add `AssertionResultMessage` + `AddAssertionResultsBatchMessage` and a matching handler in `OpikMessageProcessor` that calls `rest_client.assertion_results.store_assertions_batch`.
- Expose `Opik.log_assertion_results(...)` mirroring `log_traces_feedback_scores` (batched via `sequence_splitter`, `source="sdk"`, `entity_type="TRACE"`).
- Peel `category_name="suite_assertion"` records out of `log_test_result_feedback_scores` and route them to the new endpoint; regular feedback scores keep using the existing path. `LLMJudge.score()` return shape, `TestResult` plumbing, and progress-bar rendering are unchanged.

### Review-round revisions (commit 7b27158)

- **Bypass `BatchManager`.** Set `AddAssertionResultsBatchMessage.supports_batching = False`. The producer already pre-batches via `sequence_splitter`, so re-batching adds nothing and would `KeyError` (no batcher mapping was registered). Messages now skip `BatchingPreprocessor` and flow straight to the handler.
- **Wire up replay registry.** Added `AddAssertionResultsBatchMessage` to `replay/db_manager.py::SUPPORTED_MESSAGE_TYPES` so failed batches persisted to SQLite can be deserialized and replayed on reconnect.
- **Validate status at the public-API boundary.** `Opik.log_assertion_results` now rejects items whose `status` isn't `"passed"`/`"failed"` (skips + logs). Enforces the `Literal[...]` annotation at runtime, not just at type-check time.

### Forward-compat fallback (commit 32c2891) + test fix (commit 571955f)

- **Sticky try-X-then-Y fallback.** `_process_add_assertion_results_batch_message` first tries `assertion_results.store_assertions_batch`. On `ApiError` with `status_code in (404, 405)` — i.e. the BE doesn't expose the new endpoint — log a warning, flip a per-`OpikMessageProcessor` flag (`_assertion_results_endpoint_unavailable`), and write the same batch via `traces.score_batch_of_traces` with `category_name="suite_assertion"` (`status: "passed"` → `value=1.0`, `"failed"` → `value=0.0`).
- **Sticky scope.** Subsequent assertion batches in the same process skip the new endpoint entirely — round-trip cost is paid only once. Other status codes (5xx, etc.) propagate through `process()` to the replay manager unchanged.
- **Why not `UnauthorizedMessageTypeRegistry`.** The existing 401-then-drop registry has the wrong semantics for "try X then Y on 404." Kept the fallback scoped to this one handler with an inline comment noting it's a migration-period mechanism that goes away when the legacy feedback-scores write path is removed.
- **Test fix.** Rewrote the non-404 `ApiError` test to use the public `processor.process(...)` entrypoint and assert observable behavior (legacy path not called, fallback flag stays `False`, no exception escapes) instead of reaching into a private method.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6054
- Follow-up: OPIK-6290 (SDK CLI export needs `assertion_results` columns — same epic as the FE-side OPIK-5181)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation, assisted
- Human verification: code review + unit test runs locally

## Testing

- Unit tests:
  - `tests/unit/evaluation/test_rest_operations.py` — verifies `log_test_result_feedback_scores` routes suite-assertion records to `log_assertion_results` and regular scores to `log_traces_feedback_scores` (regular-only, suite-only, mixed, scoring_failed excluded).
  - `tests/unit/message_processing/processors/test_assertion_results_handler.py` — handler forwards to the new endpoint with `entity_type="TRACE"`/`source="sdk"`, doesn't touch feedback-scores on the happy path; **fallback path**: 404 and 405 both translate to feedback-scores (`category_name="suite_assertion"`, `value=1.0/0.0`) and flip the sticky flag; sticky behavior — second send skips the new endpoint; 5xx propagates through `process()` without touching the legacy path or flipping the flag.
  - `tests/unit/api_objects/test_opik_client.py` — `Opik.log_assertion_results` happy path, invalid-status filtering, and the no-valid-items short-circuit.
- Commands run locally:
  - Targeted: `PYTHONPATH=src python -m pytest tests/unit/api_objects/test_opik_client.py tests/unit/evaluation/test_rest_operations.py tests/unit/message_processing/processors/test_assertion_results_handler.py -q` → all pass
  - Broad: `PYTHONPATH=src python -m pytest tests/unit/evaluation/ tests/unit/message_processing/ tests/unit/api_objects/ -q` → 1746 passed (no regressions)
  - `pre-commit run --config sdks/python/.pre-commit-config.yaml --files <changed>` → ruff, ruff-format, mypy all pass
- Not run locally: SDK E2E (`tests/e2e/evaluation/test_test_suite.py`) — needs a backend with OPIK-6048 deployed; will be validated against staging before un-drafting.
- Environment: local Python 3.12.10 in the worktree.

## Documentation

N/A — no public documentation changes. The new `Opik.log_assertion_results` method is currently an internal pathway used by the suite evaluator; if it becomes a documented public API, docs will follow in a separate ticket.