### PR TITLE
[OPIK-6289] [FE] feat: add Back button to onboarding agent name step

### DIFF
--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/AgentNameStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/AgentNameStep.tsx
@@ -96,7 +96,7 @@ const AgentNameStep: React.FC = () => {
             variant="outline"
             size="sm"
             onClick={() =>
-              goToStep(AGENT_ONBOARDING_STEPS.SELECT_INTENT, { agentName: "" })
+              goToStep(AGENT_ONBOARDING_STEPS.SELECT_INTENT, { agentName: trimmedName })
             }
           >
             Back

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/AgentNameStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/AgentNameStep.tsx
@@ -92,6 +92,16 @@ const AgentNameStep: React.FC = () => {
             <p className="comet-body-xs mr-auto text-destructive">{error}</p>
           )}
           <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              goToStep(AGENT_ONBOARDING_STEPS.SELECT_INTENT, { agentName: "" })
+            }
+          >
+            Back
+          </Button>
+          <Button
             type="submit"
             size="sm"
             disabled={!isValid || isPending || !!error}

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/AgentNameStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/AgentNameStep.tsx
@@ -96,7 +96,9 @@ const AgentNameStep: React.FC = () => {
             variant="outline"
             size="sm"
             onClick={() =>
-              goToStep(AGENT_ONBOARDING_STEPS.SELECT_INTENT, { agentName: trimmedName })
+              goToStep(AGENT_ONBOARDING_STEPS.SELECT_INTENT, {
+                agentName: trimmedName,
+              })
             }
           >
             Back


### PR DESCRIPTION
## Details
Add a "Back" button on the onboarding agent name step (`#agent-name`) that navigates the user back to the intent selection step (`#select-intent`).
This allows users to change their choice of whether they have an agent or not, instead of being stuck on the name input screen.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6289

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full implementation
  - Human verification: Yes — reviewed and tested locally

## Testing

- Navigate to the onboarding flow (`/default/get-started`) with `DEFAULT_ONBOARDING_FLOW` temporarily set to `"control"`
- Select "I have an AI agent or LLM app" to reach the agent name step
- Verify the "Back" button appears next to "Continue"
- Click "Back" and verify it returns to the intent selection screen
- Verify selecting an option again works correctly after going back

## Documentation
