### PR TITLE
[OPIK-6295] [DOCS] refactor: rename create-initiative-ticket to create-initiative-epic

### DIFF
--- a/.agents/commands/comet/create-initiative-epic.md
+++ b/.agents/commands/comet/create-initiative-epic.md
@@ -1,4 +1,4 @@
-# Create Initiative Ticket
+# Create Initiative Epic
 
 Create a quarterly pillar Epic in Jira for a strategic initiative, synthesizing information from Notion PRDs and Figma designs.
 


### PR DESCRIPTION
## Details

<img width="1920" height="1908" alt="image" src="https://github.com/user-attachments/assets/807448e1-41d8-4953-9a20-f10a766e690f" />

Renames the `/comet:create-initiative-ticket` slash command to `/comet:create-initiative-epic` so the artifact word in the command name matches what the command actually creates (a Jira Epic, not a generic ticket). This disambiguates it from `/comet:create-jira-ticket`, which is the generic execution-layer ticket creator that produces variable issue types (Story / Task / Bug / Epic).

- Renames `.agents/commands/comet/create-initiative-ticket.md` → `.agents/commands/comet/create-initiative-epic.md` via `git mv`
- Updates the H1 inside the file from "Create Initiative Ticket" to "Create Initiative Epic"
- No backward-compatibility shim (no symlink, no stub) — single source of truth
- Verified zero references to the old name elsewhere in the repo

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6295

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation
- Human verification: code review + manual rename verification (`grep` for references, file content review)

## Testing

- `grep -r "create-initiative-ticket" .` returns zero matches in the worktree
- `git status` confirms only the rename + H1 edit are staged
- No code paths affected; no Java, frontend, or SDK files changed, so no lint / typecheck / unit tests are applicable
- Manual review of the renamed file: H1 updated, body unchanged

## Documentation

- The renamed file is itself a slash-command instruction document. H1 updated. No additional docs require changes.
- Team will receive a one-time Slack heads-up after merge so anyone with muscle-memory for the old command name learns the new one.