### PR TITLE
[OPIK-6291] [DOCS] feat: surface PR-level review bodies in /address-github-pr-comments

### DIFF
--- a/.agents/commands/comet/address-github-pr-comments.md
+++ b/.agents/commands/comet/address-github-pr-comments.md
@@ -13,10 +13,10 @@ This workflow will:
 - Validate branch name and extract the Opik ticket number
 - Verify GitHub MCP availability (stop if not available)
 - Find the existing open PR for the branch (stop if none)
-- Fetch pending/unaddressed comments or review threads
+- Fetch pending/unaddressed feedback across **three categories**: inline review comments, issue thread comments, and PR-level review bodies (including reviews with no inline comments)
 - Summarize findings and propose solutions or next actions
 - Ask for confirmation before proceeding with fixes, skipping, or replying
-- Post threaded replies on the PR using `gh api` (immediate for skips, deferred for fixes)
+- Post replies on the PR using `gh api` (immediate for skips, deferred for fixes): threaded replies for inline comments, quote-replies on the issue thread for PR-level review bodies
 
 ---
 
@@ -49,25 +49,48 @@ This workflow will:
 
 ### 3. Collect Pending Comments
 
-- **Fetch review comments**: Use GitHub MCP to retrieve PR review comments and/or discussion threads. When using `gh api` for any list endpoint, **always** use `--paginate` to ensure all results are fetched:
+There are **three distinct categories** of feedback to collect — missing any one of them silently drops reviewer comments on the floor:
+
+1. **Inline review comments** — code-line-anchored comments (`pulls/{N}/comments`)
+2. **Issue thread comments** — general PR comments not tied to code (`issues/{N}/comments`)
+3. **PR-level review bodies** — top-level review submissions with feedback in the review `body` (`pulls/{N}/reviews`), including reviews with **zero inline comments**
+
+> **Why category 3 matters**: A reviewer can submit `state=CHANGES_REQUESTED` (or `COMMENTED`) with all their feedback in the review body and no inline comments. Such reviews do **not** appear in the GraphQL `reviewThreads` query (which only surfaces reviews containing inline comments) and they do **not** appear in `pulls/{N}/comments` or `issues/{N}/comments`. They are only visible via `pulls/{N}/reviews`. Past incident: PR #6507 had a `CHANGES_REQUESTED` review whose body asked us to investigate a regression; it was missed on re-runs of this skill because the body wasn't surfaced.
+
+- **Fetch all three sources**: Use GitHub MCP / `gh api` for each. When using `gh api` for any list endpoint, **always** use `--paginate` to ensure all results are fetched:
   ```bash
-  # Review comments (inline code comments)
+  # 1. Inline review comments (code-line-anchored)
   gh api repos/comet-ml/opik/pulls/{pr_number}/comments --paginate
 
-  # Issue comments (general PR comments)
+  # 2. Issue thread comments (general PR comments)
   gh api repos/comet-ml/opik/issues/{pr_number}/comments --paginate
 
-  # PR reviews
+  # 3. PR-level reviews (includes review BODY text — required for category 3)
   gh api repos/comet-ml/opik/pulls/{pr_number}/reviews --paginate
   ```
   > **Why pagination is required**: GitHub API returns 30 items per page by default. Opik PRs regularly exceed this — 17 CI test group comments + deployment bot comments + reviewer comments can push past 30 total. Without `--paginate`, the agent silently gets only the first page and may miss real review feedback.
-- **Fetch PR reviews**: Get all reviews to understand the review context (use `--paginate` as shown above)
-- **Determine pending/unaddressed items**:
-  - Prefer unresolved review threads when available
+- **Determine pending/unaddressed items** — evaluate each category separately:
+
+  **Category 1 — Inline review comments** (`pulls/{N}/comments`):
+  - Prefer unresolved review threads when available (via GraphQL `reviewThreads`)
   - Otherwise, treat comments as pending if they are not from the latest code line (not "outdated") or explicitly unresolved, and have no author follow-up confirmation
-  - **Include AI-posted review comments**: Comments containing AI markers (e.g., `🤖 *Review posted via /review-github-pr*`) are external review feedback even if posted from the same GitHub account. Never skip them based on the commenter's identity — only skip if the comment already has a threaded "Fixed" or "Skipping" reply with the `/address-github-pr-comments` marker.
-  - Group by file and topic
-- **If none pending**: Print: "No pending PR comments to address." and stop
+  - Skip if the comment already has a threaded "Fixed" or "Skipping" reply with the `/address-github-pr-comments` marker
+
+  **Category 2 — Issue thread comments** (`issues/{N}/comments`):
+  - Treat as pending if from a reviewer (not the PR author) and there's no follow-up author response addressing the point
+  - Skip the skill's own auto-posted replies (those carrying the `/address-github-pr-comments` marker)
+
+  **Category 3 — PR-level review bodies** (`pulls/{N}/reviews`):
+  - A review is pending when it has a non-empty `body` AND meets one of:
+    - `state=CHANGES_REQUESTED`, AND not later dismissed (no `dismissed_at` or `state=DISMISSED`), AND no superseding review from the same reviewer that supersedes the request (e.g., `APPROVED`)
+    - `state=COMMENTED` with non-empty `body` AND no inline comments attached to that review AND no follow-up addressing it (no later quote-reply on the issue thread carrying the `/address-github-pr-comments` marker that quotes this review body)
+  - Note: these reviews do **not** appear in GraphQL `reviewThreads`, so they must be sourced from `pulls/{N}/reviews` directly
+  - Idempotency on re-runs: a PR-level review body has been "addressed" if there exists an issue-thread comment carrying the `/address-github-pr-comments` AI marker that quotes the review body (see Step 6, "PR-level review replies")
+
+  **All categories**:
+  - **Include AI-posted review comments**: Comments/reviews containing AI markers (e.g., `🤖 *Review posted via /review-github-pr*`) are external review feedback even if posted from the same GitHub account. Never skip them based on the commenter's identity — only skip if the item already has the matching `/address-github-pr-comments` reply marker.
+  - Group by file and topic for inline; group PR-level reviews under their reviewer
+- **If none pending across all three categories**: Print: "No pending PR comments to address." and stop
 
 ---
 
@@ -97,15 +120,35 @@ This workflow will:
 
 ### 6. Post Replies to PR
 
-Reply to PR review comments using `gh api` with threaded replies via `in_reply_to`.
+Replies are posted differently depending on the feedback category. Inline review comments use threaded replies via `in_reply_to`; PR-level review bodies (which have no thread to attach to) use a quote-reply on the issue thread.
 
-#### Reply Command Format
+#### Inline Review Comments — Threaded Reply
 
 ```bash
 gh api repos/comet-ml/opik/pulls/{pr_number}/comments \
   -f body="<reply text>" \
   -F in_reply_to={comment_id}
 ```
+
+#### PR-level Review Replies — Quote Reply on Issue Thread
+
+PR-level review bodies (Category 3) have no thread to attach to (`in_reply_to` is not applicable). Acknowledge them by posting a **quote-reply** on the issue thread. The quoted body provides explicit linkage back to the review and makes the response visible in the conversation timeline; reviewer is notified via the standard PR-comment notification.
+
+```bash
+gh api repos/comet-ml/opik/issues/{pr_number}/comments \
+  -f body="$(cat <<'EOF'
+> @<reviewer-login> wrote in their review (<review-state>):
+>
+> <quoted review body — preserve line breaks; truncate with `…` if very long>
+
+<response: "Fixed in <sha> — ..." or "Skipping — ...">
+
+🤖 *Reply posted via /address-github-pr-comments*
+EOF
+)"
+```
+
+The quoted body is what makes re-runs idempotent: on the next invocation, Step 3's "addressed" check looks for an issue-thread comment carrying the `/address-github-pr-comments` marker that quotes this review's body. Always include the quote — it's the matching key.
 
 #### AI Marker
 
@@ -117,7 +160,7 @@ All auto-posted replies **must** include a footer marker to distinguish them fro
 
 #### Immediate Replies ("Skipping")
 
-When the user opts to skip a comment, post the reply immediately:
+When the user opts to skip an item, post the reply immediately. The body format is the same for inline and PR-level; only the endpoint differs (per the sections above):
 
 ```
 Skipping — <brief rationale why this is not being addressed>
@@ -125,28 +168,44 @@ Skipping — <brief rationale why this is not being addressed>
 🤖 *Reply posted via /address-github-pr-comments*
 ```
 
+For a PR-level review, wrap with the quote prefix shown in "PR-level Review Replies".
+
 #### Deferred Replies ("Fixed")
 
-When the user opts to fix a comment, **defer the reply** until the fix is pushed to the remote:
+When the user opts to fix an item, **defer the reply** until the fix is pushed to the remote. This applies to both inline and PR-level items:
 
-1. Track comments that need deferred replies (comment ID + description of fix)
+1. Track items that need deferred replies. For inline: comment ID + description. For PR-level: reviewer login + review id + review body (for the quote) + description of fix.
 2. After all fixes are applied, prompt the user to commit and push
 3. Once `git push` completes, capture the commit SHA from the push output
 4. Post deferred replies referencing the commit:
 
-```
-Fixed in <commit_sha> — <brief description of what was changed>
+   For inline (threaded):
+   ```
+   Fixed in <commit_sha> — <brief description of what was changed>
 
-🤖 *Reply posted via /address-github-pr-comments*
-```
+   🤖 *Reply posted via /address-github-pr-comments*
+   ```
 
-If the user declines to push immediately, remind them which comments still need deferred replies and provide the reply commands they can run manually later.
+   For PR-level (quote-reply on issue thread, using the format above):
+   ```
+   > @<reviewer-login> wrote in their review (<review-state>):
+   >
+   > <quoted review body>
+
+   Fixed in <commit_sha> — <brief description of what was changed>
+
+   🤖 *Reply posted via /address-github-pr-comments*
+   ```
+
+If the user declines to push immediately, remind them which items still need deferred replies and provide the reply commands they can run manually later.
 
 ---
 
 ### 7. Resolve Addressed Review Threads (Optional)
 
 After all replies are posted, offer to resolve the GitHub review threads that were addressed in this run.
+
+> **Scope**: This step applies only to **inline review comments** (Category 1). PR-level review bodies (Category 3) have no review thread to resolve — their acknowledgement is the quote-reply posted in Step 6, and they are not included here.
 
 - **Ask**: "Would you like to resolve all addressed review threads?"
 - **If no**: Skip and finish
@@ -232,19 +291,21 @@ The command is successful when:
 1. ✅ GitHub MCP is available and accessible
 2. ✅ Feature branch is validated with Opik ticket number
 3. ✅ An open PR for the branch is found (or we clearly stop if not)
-4. ✅ Pending/unaddressed comments are listed (or we clearly state none)
+4. ✅ Pending/unaddressed feedback is listed across **all three categories** — inline review comments, issue thread comments, and PR-level review bodies — or we clearly state none
 5. ✅ Proposed solutions are provided per item
-6. ✅ User can choose actions (fix, skip, reply) per comment
-7. ✅ "Skipping" replies posted immediately with AI marker
-8. ✅ "Fixed" replies posted after push with commit SHA and AI marker
-9. ✅ Addressed review threads resolved (if user opted in)
+6. ✅ User can choose actions (fix, skip, reply) per item
+7. ✅ "Skipping" replies posted immediately with AI marker (threaded for inline; quote-reply on issue thread for PR-level review bodies)
+8. ✅ "Fixed" replies posted after push with commit SHA and AI marker (same per-category posting)
+9. ✅ Addressed inline review threads resolved (if user opted in); PR-level review bodies are not part of thread resolution
 
 ---
 
 ## Notes
 
 - **Repository**: Always targets `comet-ml/opik`
-- **Replies via gh CLI**: Uses `gh api` with `in_reply_to` to post threaded replies on PR review comments. GitHub MCP is used for reading; `gh` CLI is used for posting replies.
+- **Three feedback sources**: Always fetch from `pulls/{N}/comments` (inline), `issues/{N}/comments` (issue thread), AND `pulls/{N}/reviews` (PR-level review bodies). Skipping any source silently drops feedback.
+- **Replies via gh CLI**: Uses `gh api` for posting. Inline comments → threaded reply via `in_reply_to` on `pulls/{N}/comments`. PR-level review bodies → quote-reply on `issues/{N}/comments` (no thread exists to attach to). GitHub MCP is used for reading; `gh` CLI is used for posting.
+- **Quote-reply quoting**: For PR-level review replies, the reviewer's body must be quoted in the reply — it's how re-runs detect that the review has already been addressed (idempotency).
 - **AI marker required**: Every auto-posted reply must include the `🤖 *Reply posted via /address-github-pr-comments*` footer — never omit it
 - **Deferred replies**: "Fixed" replies are only posted after the fix commit is pushed to remote. Never post a "Fixed" reply before the code is on the remote.
 - **Heuristics**: If unresolved review thread flags are not available via MCP, use best-effort heuristics (latest commit context, lack of author confirmation, not marked as outdated) and clearly label them

--- a/.agents/commands/comet/address-github-pr-comments.md
+++ b/.agents/commands/comet/address-github-pr-comments.md
@@ -81,11 +81,13 @@ There are **three distinct categories** of feedback to collect — missing any o
   - Skip the skill's own auto-posted replies (those carrying the `/address-github-pr-comments` marker)
 
   **Category 3 — PR-level review bodies** (`pulls/{N}/reviews`):
-  - A review is pending when it has a non-empty `body` AND meets one of:
-    - `state=CHANGES_REQUESTED`, AND not later dismissed (no `dismissed_at` or `state=DISMISSED`), AND no superseding review from the same reviewer that supersedes the request (e.g., `APPROVED`)
-    - `state=COMMENTED` with non-empty `body` AND no inline comments attached to that review AND no follow-up addressing it (no later quote-reply on the issue thread carrying the `/address-github-pr-comments` marker that quotes this review body)
+  - **Per-reviewer latest-review selection (required)**: First, sort all reviews by `submitted_at` descending and group by `user.login`. For each reviewer, keep **only the newest review** as the authoritative one — older reviews from the same reviewer are always considered superseded and are never pending, regardless of state. All checks below evaluate against this latest-per-reviewer set only.
+  - **Inline-comment association gate (required for COMMENTED)**: Build a map from `pull_request_review_id` (present on each item in `pulls/{N}/comments`) to the count of inline comments. A `COMMENTED` review whose id has any associated inline comments is **not** Category 3 — its feedback lives in Category 1 (those inline comments) and is handled there. Apply this gate before evaluating pending status, so a review body is never double-counted.
+  - A reviewer's **latest** review is pending when it has a non-empty `body` AND meets one of:
+    - `state=CHANGES_REQUESTED`, AND not later dismissed (no `dismissed_at` or `state=DISMISSED`). Per-reviewer dedup already handles supersession (e.g., a later `APPROVED` from the same reviewer wins because it's the newest).
+    - `state=COMMENTED` with non-empty `body`, AND the inline-comment association gate above shows zero inline comments for this `review.id`, AND no follow-up addressing it (no later quote-reply on the issue thread carrying the `/address-github-pr-comments` marker that quotes this review body — see "Idempotency on re-runs" below)
   - Note: these reviews do **not** appear in GraphQL `reviewThreads`, so they must be sourced from `pulls/{N}/reviews` directly
-  - Idempotency on re-runs: a PR-level review body has been "addressed" if there exists an issue-thread comment carrying the `/address-github-pr-comments` AI marker that quotes the review body (see Step 6, "PR-level review replies")
+  - Idempotency on re-runs: a PR-level review body has been "addressed" if there exists an issue-thread comment carrying the `/address-github-pr-comments` AI marker whose quote block, normalized per the "Quote-body normalization" rule in Step 6, matches the same normalized form of this review body. Both quote generation and the addressed check **must** use the identical normalization function — otherwise a long body's truncated quote on first run won't match the full body on re-run, causing duplicate replies.
 
   **All categories**:
   - **Include AI-posted review comments**: Comments/reviews containing AI markers (e.g., `🤖 *Review posted via /review-github-pr*`) are external review feedback even if posted from the same GitHub account. Never skip them based on the commenter's identity — only skip if the item already has the matching `/address-github-pr-comments` reply marker.
@@ -134,12 +136,29 @@ gh api repos/comet-ml/opik/pulls/{pr_number}/comments \
 
 PR-level review bodies (Category 3) have no thread to attach to (`in_reply_to` is not applicable). Acknowledge them by posting a **quote-reply** on the issue thread. The quoted body provides explicit linkage back to the review and makes the response visible in the conversation timeline; reviewer is notified via the standard PR-comment notification.
 
+##### Quote-body normalization (shared rule)
+
+Both quote generation here AND the addressed-check in Step 3 (Category 3 idempotency) MUST use this exact same `normalize(body)` function — otherwise a long body's truncated quote on first run won't match the full body on a re-run and the skill will post duplicate "Fixed"/"Skipping" replies.
+
+`normalize(body)`:
+1. Trim leading/trailing whitespace from the whole body
+2. Strip any leading `>` quote markers and one optional space (so previously quoted text inside the body doesn't double-prefix on re-quoting)
+3. Collapse runs of internal whitespace to a single space within each line; preserve line breaks between lines
+4. If the resulting string is longer than **280 characters**, truncate at 280 chars and append `…` (single Unicode horizontal ellipsis, U+2026)
+5. Return the normalized string
+
+For the **on-the-wire quote block** in the comment body, prefix each line of the normalized string with `> ` (greater-than + single space). For the **addressed-check**, extract candidate quote blocks from existing issue-thread comments by stripping that same `> ` prefix per line, then compare the resulting string to `normalize(<review body>)` — exact equality.
+
+The 280-char limit is a hard contract, not a heuristic: changing it without updating both call sites silently breaks idempotency for previously-addressed long reviews.
+
+##### Reply template
+
 ```bash
 gh api repos/comet-ml/opik/issues/{pr_number}/comments \
   -f body="$(cat <<'EOF'
 > @<reviewer-login> wrote in their review (<review-state>):
 >
-> <quoted review body — preserve line breaks; truncate with `…` if very long>
+<each line of normalize(<review body>) prefixed with "> ">
 
 <response: "Fixed in <sha> — ..." or "Skipping — ...">
 
@@ -148,7 +167,7 @@ EOF
 )"
 ```
 
-The quoted body is what makes re-runs idempotent: on the next invocation, Step 3's "addressed" check looks for an issue-thread comment carrying the `/address-github-pr-comments` marker that quotes this review's body. Always include the quote — it's the matching key.
+The quoted, normalized body is the idempotency key for re-runs: on the next invocation, Step 3's Category 3 "addressed" check looks for an issue-thread comment carrying the `/address-github-pr-comments` marker whose extracted quote block equals `normalize(<review body>)`. Always include the quote — it's the matching key.
 
 #### AI Marker
 
@@ -174,7 +193,7 @@ For a PR-level review, wrap with the quote prefix shown in "PR-level Review Repl
 
 When the user opts to fix an item, **defer the reply** until the fix is pushed to the remote. This applies to both inline and PR-level items:
 
-1. Track items that need deferred replies. For inline: comment ID + description. For PR-level: reviewer login + review id + review body (for the quote) + description of fix.
+1. Track items that need deferred replies. For inline: comment ID + description. For PR-level: reviewer login + review id + raw review body (the quote is regenerated at post time via `normalize(body)` from the "Quote-body normalization" rule above) + description of fix.
 2. After all fixes are applied, prompt the user to commit and push
 3. Once `git push` completes, capture the commit SHA from the push output
 4. Post deferred replies referencing the commit:
@@ -186,11 +205,11 @@ When the user opts to fix an item, **defer the reply** until the fix is pushed t
    🤖 *Reply posted via /address-github-pr-comments*
    ```
 
-   For PR-level (quote-reply on issue thread, using the format above):
+   For PR-level (quote-reply on issue thread, using the "Quote-body normalization" rule and reply template above):
    ```
    > @<reviewer-login> wrote in their review (<review-state>):
    >
-   > <quoted review body>
+   <each line of normalize(<review body>) prefixed with "> ">
 
    Fixed in <commit_sha> — <brief description of what was changed>
 


### PR DESCRIPTION
## Details

<img width="1920" height="2358" alt="image" src="https://github.com/user-attachments/assets/1986f9a5-7ff4-4f31-be1e-ce1184580ad2" />

Update the `/comet:address-github-pr-comments` skill so it stops silently dropping PR-level reviews where feedback lives only in the review `body` (e.g., a `CHANGES_REQUESTED` review submitted with no inline comments — these don't appear in GraphQL `reviewThreads` or in `pulls/{N}/comments` / `issues/{N}/comments`). Triggered by missed feedback on PR #6507.

**Step 3 (Collect Pending Comments)** now enumerates **three** feedback categories — inline review comments, issue thread comments, and PR-level review bodies — with explicit pending criteria for each:
- **Per-reviewer latest-review selection**: sort `pulls/{N}/reviews` by `submitted_at` desc, group by `user.login`, evaluate only the newest review per reviewer (so older reviews can't stay pending after a superseding one).
- **`pull_request_review_id` association gate**: a `COMMENTED` review whose id is referenced by any inline comment isn't a Category 3 item — its feedback already lives in Category 1, so it's not double-counted.
- Pending criteria: `state=CHANGES_REQUESTED` not later dismissed; or `state=COMMENTED` with non-empty `body`, zero attached inline comments, and no prior addressed-marker reply.

**Step 6 (Post Replies)** introduces a new "PR-level Review Replies — Quote Reply on Issue Thread" section. Since these reviews have no thread to attach to (`in_reply_to` is N/A), the skill posts a quote-reply on `issues/{N}/comments`. Both quote generation **and** the Step 3 idempotency check call the same `normalize(body)` function (whitespace collapse, leading-`>` strip, 280-char truncation, U+2026 ellipsis) — preventing duplicate replies on re-runs of long bodies.

**Step 7 (Resolve Threads)** scope clarified — applies only to inline comments (Category 1). PR-level review bodies have no review thread to resolve; their acknowledgement is the quote-reply from Step 6.

Doc-only edit: `.agents/commands/comet/address-github-pr-comments.md` (canonical source; `.claude/commands/...` is gitignored, regenerated locally). No regression to inline-only flow.

Commits on this branch:
- `d2e310c80c` — initial three-category restructure + quote-reply flow
- `c2a3f2d4ee` — tighten Category 3 dedup and shared quote normalization (addresses inline review feedback on this PR)

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6291

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation (skill doc edits)
- Human verification: code review + manual diff review against ticket acceptance criteria; PR review feedback addressed in follow-up commit

## Testing

No automated tests — this is a skill spec / prompt-doc change with no executable code.

Manual verification plan:
- Re-run `/comet:address-github-pr-comments` against a PR that has a `CHANGES_REQUESTED` review with no inline comments (e.g., revisit PR #6507) and confirm the review body is surfaced as a pending item.
- Confirm an inline-only PR still flows through Steps 3 → 7 unchanged (no regression in threaded reply or `resolveReviewThread`).
- Confirm an empty-body `COMMENTED` review is **not** surfaced as Category 3 (already verified on this PR — `pulls/6536/reviews` returned one `COMMENTED` with `body=""` and the new spec correctly filters it).

## Documentation

N/A — this PR itself is the documentation change (skill spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)