### PR TITLE
[OPIK-6302] [SDK] fix: render hallucination few-shot examples correctly

### DIFF
--- a/sdks/python/src/opik/evaluation/metrics/llm_judges/hallucination/template.py
+++ b/sdks/python/src/opik/evaluation/metrics/llm_judges/hallucination/template.py
@@ -83,8 +83,7 @@ def _format_examples(
     for example in few_shot_examples:
         if include_context:
             header = (
-                f"<example>\nInput: {example['input']}\n"
-                f"Context: {example['context']}\n"
+                f"<example>\nInput: {example['input']}\nContext: {example['context']}\n"
             )
         else:
             header = f"<example>\nInput: {example['input']}\n"

--- a/sdks/python/src/opik/evaluation/metrics/llm_judges/hallucination/template.py
+++ b/sdks/python/src/opik/evaluation/metrics/llm_judges/hallucination/template.py
@@ -79,18 +79,22 @@ def _format_examples(
 ) -> str:
     if not few_shot_examples:
         return ""
-    rendered = "\n\nEXAMPLES:\n\n".join(
-        [
-            f"<example>\nInput: {example['input']}\nContext: {example['context']}\n"
-            if include_context
-            else ""
+    rendered_examples = []
+    for example in few_shot_examples:
+        if include_context:
+            header = (
+                f"<example>\nInput: {example['input']}\n"
+                f"Context: {example['context']}\n"
+            )
+        else:
+            header = f"<example>\nInput: {example['input']}\n"
+        body = (
             f"Output: {example['output']}\n\n"
             f'{{"score": "{example["score"]}", "reason": "{example["reason"]}"}}\n'
             f"</example>"
-            for example in few_shot_examples
-        ]
-    )
-    return f"\n\n{rendered}"
+        )
+        rendered_examples.append(header + body)
+    return "\n\nEXAMPLES:\n\n" + "\n\n".join(rendered_examples)
 
 
 def build_messages(

--- a/sdks/python/tests/unit/evaluation/metrics/llm_judges/hallucination/test_template.py
+++ b/sdks/python/tests/unit/evaluation/metrics/llm_judges/hallucination/test_template.py
@@ -1,0 +1,80 @@
+from opik.evaluation.metrics.llm_judges.hallucination.template import (
+    FewShotExampleHallucination,
+    build_messages,
+)
+
+
+_EXAMPLE: FewShotExampleHallucination = {
+    "title": "ex1",
+    "input": "What is the capital of France?",
+    "context": ["France is a country in Europe."],
+    "output": "Paris is the capital of France.",
+    "score": 0.0,
+    "reason": "factual",
+}
+
+
+def _system_content(messages):
+    assert messages[0]["role"] == "system"
+    return messages[0]["content"]
+
+
+def test_few_shot_with_context_renders_full_example():
+    messages = build_messages(
+        input="q",
+        output="a",
+        context=["c"],
+        few_shot_examples=[_EXAMPLE],
+    )
+    system = _system_content(messages)
+
+    assert "<example>" in system
+    assert "Input: What is the capital of France?" in system
+    assert "Context: ['France is a country in Europe.']" in system
+    assert "Output: Paris is the capital of France." in system
+    assert '"score": "0.0"' in system
+    assert '"reason": "factual"' in system
+    assert "</example>" in system
+
+
+def test_few_shot_without_context_renders_full_example():
+    messages = build_messages(
+        input="q",
+        output="a",
+        context=None,
+        few_shot_examples=[_EXAMPLE],
+    )
+    system = _system_content(messages)
+
+    assert "<example>" in system
+    assert "Input: What is the capital of France?" in system
+    assert "Output: Paris is the capital of France." in system
+    assert '"score": "0.0"' in system
+    assert '"reason": "factual"' in system
+    assert "</example>" in system
+
+
+def test_multiple_few_shot_examples_separated():
+    second: FewShotExampleHallucination = {
+        "title": "ex2",
+        "input": "Who wrote Hamlet?",
+        "context": ["Shakespeare authored many plays."],
+        "output": "Shakespeare wrote Hamlet.",
+        "score": 0.0,
+        "reason": "correct",
+    }
+
+    messages = build_messages(
+        input="q",
+        output="a",
+        context=["c"],
+        few_shot_examples=[_EXAMPLE, second],
+    )
+    system = _system_content(messages)
+
+    assert system.count("<example>") == 2
+    assert system.count("</example>") == 2
+    assert system.count("EXAMPLES:") == 1
+    assert system.index("EXAMPLES:") < system.index("<example>")
+    assert "Who wrote Hamlet?" in system
+    assert "Shakespeare wrote Hamlet." in system


### PR DESCRIPTION
## Details

The hallucination judge's `_format_examples` used an inline `A if cond else B` mixed with implicit f-string concatenation, which Python silently bound as `A if cond else (B1 B2 B3 B4)`. As a result every rendered few-shot example was missing roughly half of its content — either its premise or its verdict — and the model never saw both halves of any example.

- When `context is not None` the rendered example was reduced to `<example>\nInput: ...\nContext: ...\n` — no `Output:`, no JSON verdict, no closing `</example>`.
- When `context is None` it was reduced to `Output: ...\n\n{"score": ..., "reason": ...}\n</example>` — no `<example>` opener, no `Input:`.
- Multiple few-shot examples produced unbalanced `<example>` / `</example>` counts and bled into each other.
- The `EXAMPLES:` header was used as the join separator, so it appeared *between* examples instead of once above them.

The fix replaces the ternary trick with an explicit `header + body` assembly per example so both halves are always emitted, with `Context:` only included when context is provided, and emits a single `EXAMPLES:` header above the list.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6302

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: Bug diagnosis, regression tests, fix
- Human verification: Tests verified to fail before the fix and pass after; diff reviewed locally

## Testing

- Added `sdks/python/tests/unit/evaluation/metrics/llm_judges/hallucination/test_template.py` with three regression tests covering the with-context, without-context, and multi-example cases (the latter also asserts the `EXAMPLES:` header appears exactly once, before the first `<example>`).
- Verified each test fails on the buggy version and passes after the fix:
  `OPIK_CONFIG_PATH=/dev/null python -m pytest sdks/python/tests/unit/evaluation/metrics/llm_judges/hallucination/ -v` — 4 passed.
- pre-commit hooks (trim-whitespace, end-of-file, ruff, ruff-format, mypy) all green on the changed files.

## Documentation

N/A