### PR TITLE
[OPIK-5640] [FE] feat: make MetricsSummary cards and chart responsive

### DIFF
--- a/apps/opik-frontend/src/shared/Charts/BarChart/BarChart.tsx
+++ b/apps/opik-frontend/src/shared/Charts/BarChart/BarChart.tsx
@@ -36,6 +36,9 @@ interface BarChartProps {
   data: ChartDataPoint[];
   xAxisKey?: string;
   xTickFormatter?: (value: string) => string;
+  xTickInterval?: number | "preserveStart" | "preserveEnd" | "preserveStartEnd";
+  hideXAxis?: boolean;
+  hideYAxis?: boolean;
   customYTickFormatter?: (value: number, maxDecimalLength?: number) => string;
   renderTooltipValue?: (data: { value: ValueType }) => ValueType;
   renderTooltipHeader?: (
@@ -55,6 +58,9 @@ const BarChart: React.FunctionComponent<BarChartProps> = ({
   data,
   xAxisKey = "time",
   xTickFormatter,
+  xTickInterval,
+  hideXAxis = false,
+  hideYAxis = false,
   customYTickFormatter,
   renderTooltipValue = defaultRenderTooltipValue,
   renderTooltipHeader,
@@ -111,24 +117,29 @@ const BarChart: React.FunctionComponent<BarChartProps> = ({
       >
         <CartesianGrid vertical={false} {...DEFAULT_CHART_GRID_PROPS} />
 
-        <XAxis
-          dataKey={xAxisKey}
-          axisLine={false}
-          tickLine={false}
-          dy={10}
-          tick={DEFAULT_CHART_TICK}
-          tickFormatter={xTickFormatter}
-        />
-        <YAxis
-          width={yTickWidth}
-          axisLine={false}
-          tickLine={false}
-          tick={DEFAULT_CHART_TICK}
-          interval={yTickInterval}
-          ticks={ticks}
-          tickFormatter={yTickFormatter}
-          domain={domain}
-        />
+        {!hideXAxis && (
+          <XAxis
+            dataKey={xAxisKey}
+            axisLine={false}
+            tickLine={false}
+            dy={10}
+            tick={DEFAULT_CHART_TICK}
+            tickFormatter={xTickFormatter}
+            interval={xTickInterval}
+          />
+        )}
+        {!hideYAxis && (
+          <YAxis
+            width={yTickWidth}
+            axisLine={false}
+            tickLine={false}
+            tick={DEFAULT_CHART_TICK}
+            interval={yTickInterval}
+            ticks={ticks}
+            tickFormatter={yTickFormatter}
+            domain={domain}
+          />
+        )}
         {showLegend && (
           <ChartLegend
             content={

--- a/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/MetricChart/MetricBarChart.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/MetricChart/MetricBarChart.tsx
@@ -18,6 +18,7 @@ interface MetricBarChartProps {
   interval: INTERVAL_TYPE;
   renderValue?: (data: { value: ValueType }) => ValueType;
   customYTickFormatter?: (value: number, maxDecimalLength?: number) => string;
+  customXTickFormatter?: (value: string) => string;
   chartId: string;
   data: TransformedData[];
   isPending: boolean;
@@ -26,6 +27,9 @@ interface MetricBarChartProps {
   showLegend?: boolean;
   tooltipPosition?: { x?: number; y?: number };
   targetTickCount?: number;
+  xTickInterval?: number | "preserveStart" | "preserveEnd" | "preserveStartEnd";
+  hideXAxis?: boolean;
+  hideYAxis?: boolean;
 }
 
 const MetricBarChart: React.FunctionComponent<MetricBarChartProps> = ({
@@ -33,6 +37,7 @@ const MetricBarChart: React.FunctionComponent<MetricBarChartProps> = ({
   interval,
   renderValue = renderTooltipValue,
   customYTickFormatter,
+  customXTickFormatter,
   chartId,
   isPending,
   data,
@@ -41,6 +46,9 @@ const MetricBarChart: React.FunctionComponent<MetricBarChartProps> = ({
   showLegend = true,
   tooltipPosition,
   targetTickCount,
+  xTickInterval,
+  hideXAxis = false,
+  hideYAxis = false,
 }) => {
   const renderChartTooltipHeader = useCallback(
     ({ payload }: ChartTooltipRenderHeaderArguments) => {
@@ -85,7 +93,10 @@ const MetricBarChart: React.FunctionComponent<MetricBarChartProps> = ({
       config={config}
       data={data}
       xAxisKey="time"
-      xTickFormatter={xTickFormatter}
+      xTickFormatter={customXTickFormatter ?? xTickFormatter}
+      xTickInterval={xTickInterval}
+      hideXAxis={hideXAxis}
+      hideYAxis={hideYAxis}
       customYTickFormatter={customYTickFormatter}
       renderTooltipValue={renderValue}
       renderTooltipHeader={renderChartTooltipHeader}

--- a/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/MetricChart/MetricChartContainer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/MetricChart/MetricChartContainer.tsx
@@ -64,6 +64,10 @@ interface MetricContainerChartProps {
   colorMap?: Record<string, string>;
   tooltipPosition?: { x?: number; y?: number };
   targetTickCount?: number;
+  customXTickFormatter?: (value: string) => string;
+  xTickInterval?: number | "preserveStart" | "preserveEnd" | "preserveStartEnd";
+  hideXAxis?: boolean;
+  hideYAxis?: boolean;
 }
 
 const customColorMap = {
@@ -111,6 +115,10 @@ const MetricContainerChart = ({
   colorMap,
   tooltipPosition,
   targetTickCount,
+  customXTickFormatter,
+  xTickInterval,
+  hideXAxis,
+  hideYAxis,
 }: MetricContainerChartProps) => {
   const { data: response, isPending } = useProjectMetric(
     {
@@ -226,6 +234,7 @@ const MetricContainerChart = ({
         interval={interval}
         renderValue={renderValue}
         customYTickFormatter={customYTickFormatter}
+        customXTickFormatter={customXTickFormatter}
         chartId={chartId}
         isPending={isPending}
         data={data}
@@ -234,6 +243,9 @@ const MetricContainerChart = ({
         showLegend={showLegend}
         tooltipPosition={tooltipPosition}
         targetTickCount={targetTickCount}
+        xTickInterval={xTickInterval}
+        hideXAxis={hideXAxis}
+        hideYAxis={hideYAxis}
       />
     );
   };

--- a/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/MetricChart/MetricLineChart.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/MetricChart/MetricLineChart.tsx
@@ -18,12 +18,18 @@ interface MetricLineChartProps {
   interval: INTERVAL_TYPE;
   renderValue?: (data: { value: ValueType }) => ValueType;
   customYTickFormatter?: (value: number, maxDecimalLength?: number) => string;
+  customXTickFormatter?: (value: string) => string;
   chartId: string;
   data: TransformedData[];
   isPending: boolean;
   labelActions?: Record<string, LegendLabelAction>;
   isAggregateTotal?: boolean;
   showLegend?: boolean;
+  tooltipPosition?: { x?: number; y?: number };
+  targetTickCount?: number;
+  xTickInterval?: number | "preserveStart" | "preserveEnd" | "preserveStartEnd";
+  hideXAxis?: boolean;
+  hideYAxis?: boolean;
 }
 
 const MetricLineChart: React.FunctionComponent<MetricLineChartProps> = ({

--- a/apps/opik-frontend/src/v2/pages-shared/traces/MetricsSummary/MetricCard.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/MetricsSummary/MetricCard.tsx
@@ -25,6 +25,9 @@ export type MetricCardProps = {
   selected?: boolean;
   onClick?: () => void;
   className?: string;
+  hideDelta?: boolean;
+  hideLabel?: boolean;
+  hideValue?: boolean;
 };
 
 const MetricCard: React.FC<MetricCardProps> = ({
@@ -37,6 +40,9 @@ const MetricCard: React.FC<MetricCardProps> = ({
   selected = false,
   onClick,
   className,
+  hideDelta = false,
+  hideLabel = false,
+  hideValue = false,
 }) => {
   const percentage = computePercentageChange(
     currentRaw ?? null,
@@ -70,37 +76,51 @@ const MetricCard: React.FC<MetricCardProps> = ({
     );
   };
 
+  const iconOnly = hideLabel && hideValue && hideDelta;
+
   return (
     <div
       className={cn(
-        "flex h-11 cursor-pointer items-center justify-between border px-4 transition-colors [&:not(:last-child)]:-mr-px",
+        "flex h-11 cursor-pointer items-center border px-4 transition-colors [&:not(:last-child)]:-mr-px",
+        iconOnly ? "justify-center" : "justify-between",
         selected ? "bg-background" : "bg-soft-background hover:bg-background",
         className,
       )}
       onClick={onClick}
     >
-      <div className="flex items-center gap-3">
+      <div
+        className={cn(
+          "flex min-w-0 items-center",
+          iconOnly ? "gap-0" : "gap-3",
+        )}
+      >
         <Icon className="size-4 shrink-0 text-muted-slate" />
-        <div className="flex items-center gap-2">
-          <span
-            className={cn(
-              "comet-body-s",
-              selected ? "text-foreground" : "text-muted-slate",
+        {!iconOnly && (
+          <div className="flex min-w-0 items-center gap-2">
+            {!hideLabel && (
+              <span
+                className={cn(
+                  "comet-body-s min-w-0 truncate",
+                  selected ? "text-foreground" : "text-muted-slate",
+                )}
+              >
+                {label}
+              </span>
             )}
-          >
-            {label}
-          </span>
-          <span
-            className={cn(
-              "comet-body-s",
-              selected ? "text-foreground" : "text-muted-slate",
-              value === "N/A" && "comet-body-xs text-light-slate",
+            {!hideValue && (
+              <span
+                className={cn(
+                  "comet-body-s min-w-0 truncate",
+                  selected ? "text-foreground" : "text-muted-slate",
+                  value === "N/A" && "comet-body-xs text-light-slate",
+                )}
+              >
+                {value}
+              </span>
             )}
-          >
-            {value}
-          </span>
-          {renderChange()}
-        </div>
+            {!hideDelta && renderChange()}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/opik-frontend/src/v2/pages-shared/traces/MetricsSummary/MetricsSummary.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/MetricsSummary/MetricsSummary.tsx
@@ -6,6 +6,7 @@ import { ValueType } from "recharts/types/component/DefaultTooltipContent";
 import { cn } from "@/lib/utils";
 import { formatDuration } from "@/lib/date";
 import { formatCost } from "@/lib/money";
+import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
 import MetricCard from "./MetricCard";
 import useProjectKpiCards, {
   KpiEntityType,
@@ -16,7 +17,10 @@ import { Filters } from "@/types/filters";
 import { LOGS_SOURCE } from "@/types/traces";
 import { PercentageTrendType } from "@/shared/PercentageTrend/PercentageTrend";
 import MetricContainerChart from "@/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/MetricChart/MetricChartContainer";
-import { METRIC_NAME_TYPE } from "@/api/projects/useProjectMetric";
+import {
+  INTERVAL_TYPE,
+  METRIC_NAME_TYPE,
+} from "@/api/projects/useProjectMetric";
 import { CHART_TYPE } from "@/constants/chart";
 import {
   durationYTickFormatter,
@@ -157,11 +161,11 @@ const SKELETON_BAR_HEIGHTS = Array.from(
 );
 
 const ChartPlaceholderBars: React.FC = () => (
-  <div className="flex h-[var(--chart-height)] min-h-[80px] items-end gap-[3px]">
+  <div className="flex h-[var(--chart-height)] min-h-[80px] min-w-0 items-end gap-[3px] overflow-hidden">
     {SKELETON_BAR_HEIGHTS.map((height, i) => (
       <div
         key={i}
-        className="flex-1 rounded-t-sm bg-[hsl(var(--muted))]"
+        className="min-w-0 flex-1 rounded-t-sm bg-[hsl(var(--muted))]"
         style={{ height }}
       />
     ))}
@@ -180,6 +184,19 @@ const ChartEmptyState: React.FC = () => (
 );
 
 const REFETCH_INTERVAL = 30000;
+
+type CardMode = "full" | "no-delta" | "no-label" | "icon-only";
+
+const PER_CARD_WIDTH_FULL = 240;
+const PER_CARD_WIDTH_NO_DELTA = 160;
+const PER_CARD_WIDTH_NO_LABEL = 80;
+
+const getCardMode = (perCardWidth: number): CardMode => {
+  if (perCardWidth >= PER_CARD_WIDTH_FULL) return "full";
+  if (perCardWidth >= PER_CARD_WIDTH_NO_DELTA) return "no-delta";
+  if (perCardWidth >= PER_CARD_WIDTH_NO_LABEL) return "no-label";
+  return "icon-only";
+};
 
 export type MetricsSummaryProps = {
   projectId: string;
@@ -266,10 +283,41 @@ const MetricsSummary: React.FC<MetricsSummaryProps> = ({
     [],
   );
 
+  const [containerWidth, setContainerWidth] = useState(0);
+  const handleResize = useCallback((node: HTMLDivElement) => {
+    setContainerWidth(node.getBoundingClientRect().width);
+  }, []);
+  const { ref: containerRef } =
+    useObserveResizeNode<HTMLDivElement>(handleResize);
+
+  const cardMode = useMemo<CardMode>(() => {
+    if (containerWidth === 0) return "full";
+    return getCardMode(containerWidth / filteredCards.length);
+  }, [containerWidth, filteredCards.length]);
+
+  const chartResponsive = useMemo(() => {
+    const isHourly = chartIntervalConfig.interval === INTERVAL_TYPE.HOURLY;
+    switch (cardMode) {
+      case "full":
+        return {};
+      case "no-delta":
+        return { xTickInterval: 1 as const };
+      case "no-label":
+        return {
+          customXTickFormatter: (val: string) =>
+            isHourly
+              ? dayjs(val).utc().format("HH")
+              : dayjs(val).utc().format("D"),
+        };
+      case "icon-only":
+        return { hideXAxis: true, hideYAxis: true };
+    }
+  }, [cardMode, chartIntervalConfig.interval]);
+
   const showData = !isPending && !allZero;
 
   return (
-    <div>
+    <div ref={containerRef}>
       <div
         className="grid"
         style={{
@@ -299,6 +347,9 @@ const MetricsSummary: React.FC<MetricsSummaryProps> = ({
                 isFirst && "rounded-tl-md",
                 isLast && "rounded-tr-md",
               )}
+              hideDelta={cardMode !== "full"}
+              hideLabel={cardMode === "no-label" || cardMode === "icon-only"}
+              hideValue={cardMode === "icon-only"}
             />
           );
         })}
@@ -330,6 +381,7 @@ const MetricsSummary: React.FC<MetricsSummaryProps> = ({
             logsSource={logsSource}
             tooltipPosition={{ y: 0 }}
             targetTickCount={2}
+            {...chartResponsive}
             {...chartFilters}
           />
         ) : (


### PR DESCRIPTION
## Details


https://github.com/user-attachments/assets/34838191-ebe6-4538-b1fc-6f3757b3a61f



Adapt the Logs page MetricsSummary block (KPI cards + bar chart) to narrow container widths via a width-based mode derived from per-card width: `full` (≥240px) → `no-delta` (≥160px) → `no-label` (≥80px) → `icon-only`. Cards progressively hide delta, label, and value; the chart thins X-axis ticks, switches to a denser day/hour formatter, then hides both axes at the narrowest breakpoint to match the Figma "Responsive behavior" frame linked from the ticket.

- Cards stop overlapping or wrapping at narrow widths, including with the right-side panel open.
- Chart adapts continuously and stays readable down to ~200px.
- Dashboard widget consumers are unaffected — new chart props are optional with safe defaults.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-5640

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.7
  - Scope: assisted (planning, implementation, lint pass)
  - Human verification: code review pending; manual browser resize verification pending

## Testing

- `bash scripts/dev-runner.sh --lint-fe` — passes (eslint with `--max-warnings=0`, `tsc --noEmit`, `depcruise`).
- Pending manual verification on the Logs page: resize browser across ~1280 / 800 / 510 / 200 px on Traces, Spans, and Threads tabs and compare against the four Figma variants. Threads has 3 cards instead of 4, so the same per-card thresholds apply at smaller container widths.
- No automated tests added; behavior is purely visual responsiveness driven by `ResizeObserver`.

## Documentation

N/A