### PR TITLE
fix(fe): pass time range to trace list query in ThreadDetailsPanel

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
@@ -191,9 +191,11 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
       page: 1,
       size: 1000,
       truncate: false,
+      fromTime: thread?.start_time,
+      toTime: thread?.end_time,
     },
     {
-      enabled: Boolean(threadId),
+      enabled: Boolean(threadId) && !isThreadPending,
     },
   );
 


### PR DESCRIPTION
## Summary

Fixes #6148

`ThreadDetailsPanel` queries traces by `thread_id` without passing `fromTime`/`toTime` parameters, preventing ClickHouse from using index pruning on the time-based UUID `id` column. On large datasets (~4.7M traces), this causes query timeouts (HTTP 500).

## Changes

- Pass `thread.start_time` and `thread.end_time` as `fromTime`/`toTime` to the `useTracesList` hook call in `ThreadDetailsPanel`
- Defer the traces query until thread data is loaded (`enabled: Boolean(threadId) && !isThreadPending`) to ensure time range is available

## Testing

- Verified that `useTracesList` hook already supports `fromTime` and `toTime` parameters
- The `Thread` type includes `start_time` and `end_time` fields from the API
- The change is minimal and scoped to the query parameters only

## Related Issues

Fixes #6148 — ThreadDetailsPanel does not pass time range to trace list query, causing slow loading

---

> This PR was authored with AI assistance. All changes have been reviewed for correctness.