### PR TITLE
docs: fix grammar, typos, and cleanup across docs and TS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </h1>
 <h2 align="center" style="border-bottom: none">Open-source AI Observability, Evaluation, and Optimization</h2>
 <p align="center">
-Opik helps you build, test, and optimize generative AI application that run better, from prototype to production.  From RAG chatbots to code assistants to complex agentic systems, Opik provides comprehensive tracing, evaluation, and automatic prompt and tool optimization to take the guesswork out of AI development.
+Opik helps you build, test, and optimize generative AI applications that run better, from prototype to production.  From RAG chatbots to code assistants to complex agentic systems, Opik provides comprehensive tracing, evaluation, and automatic prompt and tool optimization to take the guesswork out of AI development.
 </p>
 
 <div align="center">

--- a/apps/opik-documentation/documentation/fern/docs/tracing/cost_tracking.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/cost_tracking.mdx
@@ -23,7 +23,7 @@ Individual spans show the computed costs (in USD) for each LLM spans of your tra
 
 ### Trace-Level Costs
 
-If you are using one of Opik's integrations, we automatically aggregates costs from all spans within a trace to compute total trace costs:
+If you are using one of Opik's integrations, we automatically aggregate costs from all spans within a trace to compute total trace costs:
 
 <Frame>
   <img src="/img/tracing/cost_tracking_trace_view.png" />
@@ -74,7 +74,7 @@ print(trace.total_estimated_cost)
 
 ## Manually setting the provider and model name
 
-If you are not using one of Opik's integration, Opik can still compute the cost. For you will need to ensure the
+If you are not using one of Opik's integrations, Opik can still compute the cost. To do this, you will need to ensure the
 span type is `llm` and you will need to pass:
 
 1. `provider`: The name of the provider, typically `openai`, `anthropic` or `google_ai` for example (the most recent providers list can be found in `opik.LLMProvider` enum object)

--- a/apps/opik-documentation/documentation/fern/docs/tracing/log_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/log_traces.mdx
@@ -21,7 +21,7 @@ Opik's tracing functionality allows you to track not just all the LLM calls made
   <img src="/img/tracing/introduction.png" />
 </Frame>
 
-Opik supports agent observability using our [Typescript SDK](/reference/typescript-sdk/overview),
+Opik supports agent observability using our [TypeScript SDK](/reference/typescript-sdk/overview),
 [Python SDK](/reference/python-sdk/overview), [first class OpenTelemetry support](/v1/integrations/opentelemetry)
 and our [REST API](/reference/rest-api/overview).
 
@@ -41,7 +41,7 @@ Before adding observability to your application, you will first need to install 
 Opik SDK.
 
 <Tabs>
-    <Tab value="Typescript SDK" title="Typescript SDK" language="typescript">
+    <Tab value="TypeScript SDK" title="TypeScript SDK" language="typescript">
 
     ```bash
     npm install opik
@@ -421,12 +421,12 @@ input parameters and function output for that function. If we detect that a deco
 is being called within another decorated function, we will create a nested span for the inner
 function.
 
-While decorators are most popular in Python, we also support them in our Typescript SDK:
+While decorators are most popular in Python, we also support them in our TypeScript SDK:
 
 <Tabs>
-    <Tab title="Typescript" value="typescript" language="typescript">
-        TypeScript started supporting decorators from version 5 but it's use is still not widespread.
-        The Opik typescript SDK also supports decorators but it's currently considered experimental.
+    <Tab title="TypeScript" value="typescript" language="typescript">
+        TypeScript started supporting decorators from version 5 but its use is still not widespread.
+        The Opik TypeScript SDK also supports decorators but it's currently considered experimental.
 
         ```typescript maxLines=100
         import { track } from "opik";

--- a/sdks/typescript/src/opik/config/Config.ts
+++ b/sdks/typescript/src/opik/config/Config.ts
@@ -16,7 +16,6 @@ export interface OpikConfig {
   holdUntilFlush?: boolean;
 }
 
-// ALEX
 export interface ConstructorOpikConfig extends OpikConfig {
   headers?: Record<string, string>;
 }


### PR DESCRIPTION
## Summary

Fix several grammar errors, typos, and cleanup issues across documentation and the TypeScript SDK.

## Changes

- **README.md**: Fix subject-verb agreement ("application that run" → "applications that run")
- **cost_tracking.mdx**: Fix subject-verb agreement ("we automatically aggregates" → "we automatically aggregate") and sentence fragment ("For you will need" → "To do this, you will need"), fix singular/plural ("integration" → "integrations")
- **log_traces.mdx**: Fix possessive/contraction confusion ("it's use" → "its use"), standardize "Typescript" → "TypeScript" (official capitalization) in tab titles and body text
- **Config.ts** (TypeScript SDK): Remove stray debug comment `// ALEX` above `ConstructorOpikConfig` interface

## Testing

- Documentation-only and comment-removal changes; no behavioral impact
- Verified all changes are purely textual corrections

## Related Issues

None (discovered during code review)

---

> This PR was authored with AI assistance. All changes have been reviewed for correctness.