### PR TITLE
[OPIK-6296] [DOCS] feat: auto-refresh PR description on git push to prevent drift

### DIFF
--- a/.agents/commands/comet/_pr-description-sync.md
+++ b/.agents/commands/comet/_pr-description-sync.md
@@ -17,17 +17,24 @@ This sub-skill:
 ## Inputs
 
 - `branch` (required): branch name to look up the PR against. Caller passes `git rev-parse --abbrev-ref HEAD`.
-- `pr_number` (optional): if the caller already located the PR (e.g., `/comet:address-github-pr-comments`), pass it to skip the lookup.
+- `pr_number` (optional): if the caller already located the PR (e.g., `/comet:address-github-pr-comments`), pass it as a hint. The sub-skill **always validates** that the PR's `headRefName` matches `branch` before any read or write — never trust `pr_number` blindly.
 - `repo` (optional, defaults to `comet-ml/opik`): the GitHub repo to operate against.
 
 ## Steps
 
-### 1. No-op gates (silent return)
+### 1. Locate and validate the PR (no-op gates)
 
-Return without prompting or making any API call when any of these are true:
+Return without prompting or making any API call when any of the failure conditions below are reached.
 
-- **No open PR for the branch.** If `pr_number` was not passed, run `gh pr list --repo {repo} --head {branch} --state open --json number,url --jq '.[0]'`. If empty, return silently.
-- **Mute memory says "never for this repo".** Read the per-user memory file (see "Memory entry" below). If the normalized remote URL is in the `never` list, return silently.
+**1a. PR resolution.** Determine which PR to operate on:
+
+- **If `pr_number` was passed**: run `gh pr view {pr_number} --repo {repo} --json number,headRefName,headRefOid,state`. Verify `state == "OPEN"` and `headRefName == branch`. If either check fails, discard the hint and fall through to the branch lookup below — never edit the passed PR on mismatch.
+- **Branch lookup**: run `gh pr list --repo {repo} --head {branch} --state open --json number,url,headRefName,headRefOid`. Filter to PRs whose `headRefOid` matches the local `git rev-parse HEAD`.
+  - **0 matches**: no open PR for this exact HEAD — return silently.
+  - **Exactly 1 match**: use it.
+  - **More than 1 match** (e.g., multiple forks share the same head branch name): log `PR description sync skipped: {N} open PRs match branch={branch} and HEAD={oid}; refusing to guess` and return silently. Don't edit any of them.
+
+**1b. Mute memory check.** Read the per-user memory file (see "Memory entry" below). If the normalized remote URL is in the `never` list, return silently.
 
 ### 2. Fetch current state
 

--- a/.agents/commands/comet/_pr-description-sync.md
+++ b/.agents/commands/comet/_pr-description-sync.md
@@ -10,9 +10,9 @@ This sub-skill:
 
 - Reads the canonical structure from `.github/pull_request_template.md` and the validation rules from `.github/workflows/pr-lint.yml`.
 - Regenerates the description from the current `git diff origin/main...HEAD` and commit history using the same logic as `/comet:create-pr` Step 6/7.
-- Preserves all media (images, GIFs, video links, Loom embeds) and any hand-edits the user added that don't conflict with regenerated content.
+- Preserves all media (images, GIFs, video links, Loom embeds) verbatim, and uses a hidden section-hash marker to detect which `##` sections the user has hand-edited so those sections are kept as-is rather than overwritten.
 - Confirms the proposed update with the user via `AskUserQuestion`, with per-repo `Always` / `Never` mute options persisted to local memory.
-- Is a no-op when the branch has no open PR or when the regenerated body equals the current body (idempotence).
+- Is a no-op when the branch has no open PR, when no PR matches the local HEAD, or when the regenerated body is semantically identical to the current body (sha1 of body excluding the marker).
 
 ## Inputs
 
@@ -28,7 +28,7 @@ Return without prompting or making any API call when any of the failure conditio
 
 **1a. PR resolution.** Determine which PR to operate on:
 
-- **If `pr_number` was passed**: run `gh pr view {pr_number} --repo {repo} --json number,headRefName,headRefOid,state`. Verify `state == "OPEN"` and `headRefName == branch`. If either check fails, discard the hint and fall through to the branch lookup below — never edit the passed PR on mismatch.
+- **If `pr_number` was passed**: run `gh pr view {pr_number} --repo {repo} --json number,headRefName,headRefOid,state`. Verify `state == "OPEN"` and `headRefName == branch`. If either check fails, **fail closed**: log `PR description sync skipped: pr_number={N} does not match branch={branch} (headRefName={X}, state={S}); refusing to switch PRs silently` and return. Do not fall through to the branch lookup — a caller passing a mismatching `pr_number` is a bug or stale state, not a request to switch PRs.
 - **Branch lookup**: run `gh pr list --repo {repo} --head {branch} --state open --json number,url,headRefName,headRefOid`. Filter to PRs whose `headRefOid` matches the local `git rev-parse HEAD`.
   - **0 matches**: no open PR for this exact HEAD — return silently.
   - **Exactly 1 match**: use it.
@@ -38,12 +38,17 @@ Return without prompting or making any API call when any of the failure conditio
 
 ### 2. Fetch current state
 
+Use the PR number resolved in Step 1 (whether from the validated `pr_number` hint or the branch lookup).
+
 ```bash
-gh pr view {pr_number} --repo {repo} --json body,title,headRefOid > /tmp/pr-current.json
+TMP=$(mktemp)
+gh pr view {resolved_pr_number} --repo {repo} --json body,title,headRefOid > "$TMP"
 git diff origin/main...HEAD
 git log origin/main..HEAD --pretty=format:'%h %s'
 cat .github/pull_request_template.md
 ```
+
+Clean up `$TMP` on exit.
 
 ### 3. Regenerate the description
 
@@ -59,26 +64,53 @@ Apply the same logic as `/comet:create-pr` Step 6 (Extract Change Information) a
 
 Apply the same secrecy rules as `/comet:create-pr` Step 7: never include customer/client names, internal hostnames, internal URLs, IPs, bucket names, or credentials.
 
-### 4. Preserve media and hand-edits
+### 4. Detect user edits via the section-hash marker
 
-Parse the *current* PR body. For each of the following, lift the matching content verbatim from the current body and reinsert it into the regenerated body under the same `##` section:
+The sub-skill stores a hidden HTML comment at the bottom of every body it writes:
+
+```html
+<!-- pr-sync: {"Details":"<sha1>","Change checklist":"<sha1>","Issues":"<sha1>","AI-WATERMARK":"<sha1>","Testing":"<sha1>","Documentation":"<sha1>"} -->
+```
+
+Each value is `sha1(<section content with leading/trailing whitespace trimmed>)`. The marker lets the next run distinguish *agent-generated content the user hasn't touched* from *content the user has edited*.
+
+**Marker present:** for each `## <Section>` heading defined in `.github/pull_request_template.md`:
+
+1. Compute `sha1(current section content)`.
+2. If it equals the stored hash → section is *unmodified since the last refresh* → safe to overwrite with the regenerated content.
+3. If it differs → *user has edited this section* → keep the current section content verbatim in the regenerated body; do not regenerate it.
+
+This per-section decision is the merge algorithm. There is no "fuzzy match" or "append on conflict" — the marker is the source of truth.
+
+**Marker absent** (first run on a PR that pre-dates this skill, or a PR whose body was edited externally to strip the marker): regenerate every section per Step 3 — we have no way to know which sections the user touched, so the user reviews the full diff in Step 7 and decides. Their confirmation in Step 7 is the act of adopting managed mode; on `Update` / `Always`, Step 8 installs the marker, and subsequent runs use the per-section logic above.
+
+This means the **first refresh of a managed-mode PR will be the most disruptive** — it proposes overwriting everything. After that, the marker tracks state and refreshes are surgical. The user can always decline the first prompt to opt out (one-shot `Skip` or per-repo `Never`).
+
+### 4b. Preserve media (always, regardless of marker state)
+
+Independent of the marker check, scan the *current* body for media and lift it verbatim into whatever the regenerated body becomes:
 
 - **Markdown images**: any `![…](…)` line.
 - **HTML img tags**: any `<img …>` element (single-line or multi-line).
 - **Video / embed links**: any URL matching `user-images.githubusercontent.com`, `github.com/.../assets/`, `*.loom.com/share/`, `youtube.com/watch`, `youtu.be/`, `vimeo.com/`.
-- **Hand-edited free-text under a known `##` section**: text the user added that does not match the regenerated content for that section. Append it under the same heading rather than overwriting.
 
-Inside `## Testing`, treat the `Video evidence:` sub-section as a preservation island — keep its content as-is.
+Reinsert each piece of media into the regenerated body at the same position relative to its surrounding `##` heading.
 
-If the user adds an entirely new top-level `##` section that isn't in the template (e.g., `## Migration plan`), keep it intact at the bottom of the body.
+If the user adds an entirely new top-level `##` section that isn't in the template (e.g., `## Migration plan`), keep it intact at the bottom of the regenerated body, *above* the `<!-- pr-sync: ... -->` marker.
 
-### 5. Idempotence check
+### 5. Idempotence check (semantic, not byte-equal)
 
-If the regenerated body, after preservation, is byte-equal to the current body (after trimming trailing whitespace on each line), return silently. Do not prompt, do not call `gh pr edit`.
+After Steps 3, 4, and 4b produce the regenerated body, compute `sha1(regenerated body without the marker)`. Compare against `sha1(current body without the marker)`. If equal → no semantic change → return silently. Do not prompt, do not call `gh pr edit`.
+
+This handles the "every push regenerates Testing, but nothing meaningful changed" case: if user-touched sections are preserved verbatim (because their hashes still match the marker) and agent-owned sections regenerate to the same content as before, the body hashes match.
+
+The check applies in both marker-present and marker-absent modes, so a PR whose regenerated body happens to match the current body byte-for-byte (excluding the marker) is a no-op even on first run.
 
 ### 6. Validate against pr-lint
 
-Run the same checks as `/comet:create-pr` Step 8 against the regenerated body — title regex (unchanged here, body only), required `##` sections present, `## Details` non-empty, `## Issues` references a ticket, no leftover `<!-- REPLACE ME` placeholders. If any check fails, auto-fix and re-validate. Never push a body that would fail pr-lint.
+Run the same checks as `/comet:create-pr` Step 8 against the regenerated body — title regex (unchanged here, body only), required `##` sections present, `## Details` non-empty, `## Issues` references a ticket, no leftover template placeholders. If any check fails, auto-fix and re-validate. Never push a body that would fail pr-lint.
+
+**Placeholder check details**: a "leftover template placeholder" means the literal HTML comment block from `.github/pull_request_template.md` appearing as the *only* content of a section (i.e., the user replaced nothing). Match the comment text from the template, not arbitrary `<!-- REPLACE ME` substrings — bodies that legitimately quote the placeholder string while documenting the skill itself must pass.
 
 ### 7. Confirm with user (unless silent mode is active)
 
@@ -102,8 +134,19 @@ Do not show the reminder when there's no media — avoid noise.
 
 ### 8. Apply
 
-- On `Update` or under silent `Always` mode: `gh pr edit {pr_number} --repo {repo} --body-file <tmpfile>`.
-- On `Skip`: return.
+Before writing, **append (or replace) the marker** at the bottom of the regenerated body:
+
+```html
+
+<!-- pr-sync: {"<Section>":"<sha1 of regenerated section content>", ...} -->
+```
+
+The marker is computed from the *final* body that will be written (post Step 4 user-section preservation, post Step 4b media reinsertion). One marker per body; if a previous marker exists, replace it.
+
+Then:
+
+- On `Update` or under silent `Always` mode: write the body to a `mktemp` file, then `gh pr edit {pr_number} --repo {repo} --body-file <tmpfile>`.
+- On `Skip`: return without writing.
 - On `Always for this repo`: write the normalized remote URL into the `always` list of the memory file (Step 9), then apply.
 - On `Never for this repo`: write the normalized remote URL into the `never` list of the memory file, return without applying.
 
@@ -111,9 +154,12 @@ After applying, log: `PR description refreshed in sync with HEAD ({headRefOid}).
 
 ### 9. Memory entry — `feedback_pr_description_auto_refresh.md`
 
-Persist `Always` / `Never` choices to a single user-memory file alongside the user's other feedback memories.
+Persist `Always` / `Never` choices to a single memory file alongside the project's other feedback memories.
 
-**Path**: `{user-memory-dir}/feedback_pr_description_auto_refresh.md`
+**Path resolution** (in order, first hit wins):
+
+1. The directory containing the project's existing `MEMORY.md` index, if one exists. Discover by walking up from `cwd` looking for `**/memory/MEMORY.md` under `~/.claude/projects/<project-id>/`. If found, write next to it: `<that-dir>/feedback_pr_description_auto_refresh.md`.
+2. If no project `MEMORY.md` exists, fall back to `~/.claude/memory/feedback_pr_description_auto_refresh.md` (user-global). Note this in the log so the user knows the choice will apply across all projects until a project memory dir is established.
 
 **Format**:
 

--- a/.agents/commands/comet/_pr-description-sync.md
+++ b/.agents/commands/comet/_pr-description-sync.md
@@ -86,17 +86,19 @@ This per-section decision is the merge algorithm. There is no "fuzzy match" or "
 
 This means the **first refresh of a managed-mode PR will be the most disruptive** — it proposes overwriting everything. After that, the marker tracks state and refreshes are surgical. The user can always decline the first prompt to opt out (one-shot `Skip` or per-repo `Never`).
 
-### 4b. Preserve media (always, regardless of marker state)
+### 4b. Preserve media (template-managed sections only)
 
-Independent of the marker check, scan the *current* body for media and lift it verbatim into whatever the regenerated body becomes:
+Scope: media extraction and reinsertion apply **only to template-managed sections** — the `##` headings defined in `.github/pull_request_template.md`. Media inside custom (non-template) `##` sections is preserved verbatim as part of the section's intact appended block (see below) and is **never** lifted out, scanned, or independently reinserted. This prevents duplicate-write and reorder hazards when a custom section contains the same image syntax that the scanner would otherwise pick up.
+
+For each template-managed `##` section in the *current* body, scan it for media and lift it verbatim into the regenerated version of the same section:
 
 - **Markdown images**: any `![…](…)` line.
 - **HTML img tags**: any `<img …>` element (single-line or multi-line).
 - **Video / embed links**: any URL matching `user-images.githubusercontent.com`, `github.com/.../assets/`, `*.loom.com/share/`, `youtube.com/watch`, `youtu.be/`, `vimeo.com/`.
 
-Reinsert each piece of media into the regenerated body at the same position relative to its surrounding `##` heading.
+Reinsert each piece of media at the same relative position within its template-managed section. Sections preserved verbatim under the marker check (Step 4) carry their media along automatically — no separate lift step is needed for them.
 
-If the user adds an entirely new top-level `##` section that isn't in the template (e.g., `## Migration plan`), keep it intact at the bottom of the regenerated body, *above* the `<!-- pr-sync: ... -->` marker.
+**Custom (non-template) sections**: if the user adds an entirely new top-level `##` section that isn't in the template (e.g., `## Migration plan`), keep it intact — content, media, and all — and append it at the bottom of the regenerated body, *above* the `<!-- pr-sync: ... -->` marker. The media scan above must not touch it.
 
 ### 5. Idempotence check (semantic, not byte-equal)
 

--- a/.agents/commands/comet/_pr-description-sync.md
+++ b/.agents/commands/comet/_pr-description-sync.md
@@ -11,7 +11,7 @@ This sub-skill:
 - Reads the canonical structure from `.github/pull_request_template.md` and the validation rules from `.github/workflows/pr-lint.yml`.
 - Regenerates the description from the current `git diff origin/main...HEAD` and commit history using the same logic as `/comet:create-pr` Step 6/7.
 - Preserves all media (images, GIFs, video links, Loom embeds) verbatim, and uses a hidden section-hash marker to detect which `##` sections the user has hand-edited so those sections are kept as-is rather than overwritten.
-- Confirms the proposed update with the user via `AskUserQuestion`, with per-repo `Always` / `Never` mute options persisted to local memory.
+- Auto-applies by default — if the regenerated body differs and passes pr-lint, the sub-skill updates the PR description without prompting. Users can opt out per-repo via a one-line memory entry; opted-out repos are skipped silently.
 - Is a no-op when the branch has no open PR, when no PR matches the local HEAD, or when the regenerated body is semantically identical to the current body (sha1 of body excluding the marker).
 
 ## Inputs
@@ -82,9 +82,9 @@ Each value is `sha1(<section content with leading/trailing whitespace trimmed>)`
 
 This per-section decision is the merge algorithm. There is no "fuzzy match" or "append on conflict" — the marker is the source of truth.
 
-**Marker absent** (first run on a PR that pre-dates this skill, or a PR whose body was edited externally to strip the marker): regenerate every section per Step 3 — we have no way to know which sections the user touched, so the user reviews the full diff in Step 7 and decides. Their confirmation in Step 7 is the act of adopting managed mode; on `Update` / `Always`, Step 8 installs the marker, and subsequent runs use the per-section logic above.
+**Marker absent** (first run on a PR that pre-dates this skill, or a PR whose body was edited externally to strip the marker): regenerate every section per Step 3 — we have no way to know which sections the user touched, so the auto-apply in Step 7 will install the marker on this run and adopt managed mode. Subsequent runs use the per-section logic above. Users who don't want this implicit adoption can opt the repo out before the next push (see Step 8).
 
-This means the **first refresh of a managed-mode PR will be the most disruptive** — it proposes overwriting everything. After that, the marker tracks state and refreshes are surgical. The user can always decline the first prompt to opt out (one-shot `Skip` or per-repo `Never`).
+This means the **first refresh of a managed-mode PR is the most invasive** — it overwrites every section since none are flagged as user-edited yet. After that, the marker tracks state and refreshes are surgical: only sections whose hash still matches get regenerated. Users who don't want the first-run overwrite can opt the repo out by adding it to the `never` list before the next push.
 
 ### 4b. Preserve media (template-managed sections only)
 
@@ -114,27 +114,9 @@ Run the same checks as `/comet:create-pr` Step 8 against the regenerated body �
 
 **Placeholder check details**: a "leftover template placeholder" means the literal HTML comment block from `.github/pull_request_template.md` appearing as the *only* content of a section (i.e., the user replaced nothing). Match the comment text from the template, not arbitrary `<!-- REPLACE ME` substrings — bodies that legitimately quote the placeholder string while documenting the skill itself must pass.
 
-### 7. Confirm with user (unless silent mode is active)
+### 7. Apply (auto, no prompt)
 
-**Silent mode**: the per-repo mute memory says `always` for this repo's normalized remote URL. Skip the prompt and apply directly.
-
-**Otherwise**: emit an `AskUserQuestion` with:
-
-- **Question header**: `Refresh PR description?`
-- **Question body**: a unified diff (`diff -u`) between current and regenerated bodies, capped at ~80 lines (truncate the middle with `... [N lines elided] ...` if longer).
-- **Options**:
-  - `Update` — apply the change to this PR only.
-  - `Skip` — do nothing this time.
-  - `Always for this repo` — apply now, and silently apply on every future push to any PR in this repo.
-  - `Never for this repo` — do nothing now, and skip the prompt entirely on future pushes in this repo.
-
-**Media-stale reminder (conditional)**: if the *current* body contains at least one match from the media patterns in Step 4, append a one-line preface to the question body:
-
-> Heads up — this PR has screenshots/videos. Verify they still match the current behavior; you may need to re-record after this update.
-
-Do not show the reminder when there's no media — avoid noise.
-
-### 8. Apply
+The default is **silent auto-apply** — refreshing the PR description is a routine bookkeeping action, not a decision that needs user confirmation each time. By the time we reach this step, the body has already passed pr-lint (Step 6), preservation rules have already protected user edits (Step 4), and idempotence has already filtered out no-op cases (Step 5).
 
 Before writing, **append (or replace) the marker** at the bottom of the regenerated body:
 
@@ -145,18 +127,24 @@ Before writing, **append (or replace) the marker** at the bottom of the regenera
 
 The marker is computed from the *final* body that will be written (post Step 4 user-section preservation, post Step 4b media reinsertion). One marker per body; if a previous marker exists, replace it.
 
-Then:
+Then write the body to a `mktemp` file and:
 
-- On `Update` or under silent `Always` mode: write the body to a `mktemp` file, then `gh pr edit {pr_number} --repo {repo} --body-file <tmpfile>`.
-- On `Skip`: return without writing.
-- On `Always for this repo`: write the normalized remote URL into the `always` list of the memory file (Step 9), then apply.
-- On `Never for this repo`: write the normalized remote URL into the `never` list of the memory file, return without applying.
+```bash
+gh pr edit {pr_number} --repo {repo} --body-file <tmpfile>
+```
 
-After applying, log: `PR description refreshed in sync with HEAD ({headRefOid}).`
+After applying, log:
 
-### 9. Memory entry — `feedback_pr_description_auto_refresh.md`
+- `PR description refreshed in sync with HEAD ({headRefOid}).`
+- If the body contains any media (image / video / Loom embed), append: `Note: this PR has screenshots/videos — verify they still match the current behavior; you may need to re-record.` This is informational only; the apply has already happened.
 
-Persist `Always` / `Never` choices to a single memory file alongside the project's other feedback memories.
+**Opt-out**: if the user has previously added this repo to the `never` list of the memory file (Step 8), skip the apply silently. There is no `Always` list because auto-apply is the default — `Always` is the only mode.
+
+**Manual override**: a user who wants to inspect the proposed body before it lands can set the repo to `never` and run the diff manually, or revert via GitHub UI / `gh pr edit` after the auto-apply if a refresh produced something they don't want.
+
+### 8. Memory entry — `feedback_pr_description_auto_refresh.md`
+
+Per-repo opt-out is stored in a single memory file alongside the project's other feedback memories. The sub-skill only ever *reads* this file; users edit it (or ask the agent to) when they want to disable auto-refresh for a specific repo.
 
 **Path resolution** (in order, first hit wins):
 
@@ -168,18 +156,15 @@ Persist `Always` / `Never` choices to a single memory file alongside the project
 ```markdown
 ---
 name: PR description auto-refresh per-repo preference
-description: Per-repo opt-in/opt-out for the post-push PR-description sync prompt
+description: Per-repo opt-out list for the post-push PR-description sync
 type: feedback
 ---
 
-When the post-push PR description sync prompt fires, the user has chosen the following per-repo behaviors. Apply these without prompting on future pushes in those repos.
+The PR description sync auto-applies by default. Repos listed below have been opted out — the sub-skill returns silently without refreshing the PR description on those repos.
 
-**How to apply**: before invoking the sync prompt, normalize the current repo's `git config --get remote.origin.url` to `host/owner/repo` (lowercase, strip `git@`, `https://`, trailing `.git`). Look it up below.
+**How to apply**: before invoking the sub-skill's main flow, normalize the current repo's `git config --get remote.origin.url` to `host/owner/repo` (lowercase, strip `git@`, `https://`, trailing `.git`). If it appears in the list below, skip; otherwise auto-apply per Step 7.
 
-## Always (silent refresh, no prompt)
-- {host/owner/repo}
-
-## Never (skip entirely, no prompt)
+## Never (auto-refresh disabled)
 - {host/owner/repo}
 ```
 
@@ -190,7 +175,7 @@ Also add (or update) a one-line entry in the user's `MEMORY.md` index pointing a
 - `git@github.com:comet-ml/opik.git` → `github.com/comet-ml/opik`
 - `https://github.com/comet-ml/opik.git` → `github.com/comet-ml/opik`
 
-A repo can appear in `Always` *or* `Never`, never both. If the user picks the opposite later, move it.
+**Adding a repo to the list**: the sub-skill itself does not write to this file. To opt out, the user edits the file directly (or asks the agent to). This keeps the sub-skill side-effect-light: it only ever reads the list, never adds to it.
 
 ## Caller contract
 
@@ -200,8 +185,8 @@ Each caller invokes this sub-skill at the moment immediately after a successful 
 
 - **`gh` unavailable**: log `PR description sync skipped: gh CLI unavailable` and return. Do not attempt MCP fallback — refresh is a quality-of-life feature, not a correctness gate.
 - **PR description fetch fails (404, network)**: log the error and return. Don't block the caller.
-- **`gh pr edit` fails after user confirmation**: surface the error and prompt the user whether to retry. On retry-no, return without changing memory entries.
-- **Memory file write fails**: surface the error but still apply the description update if the user said `Update` / `Always`.
+- **`gh pr edit` fails**: surface the error in the log; the caller continues normally. The next push will re-attempt the sync.
+- **Memory file read fails**: treat as no opt-out and proceed with auto-apply. Don't block on a read error to a config-style file.
 
 ---
 

--- a/.agents/commands/comet/_pr-description-sync.md
+++ b/.agents/commands/comet/_pr-description-sync.md
@@ -11,7 +11,7 @@ This sub-skill:
 - Reads the canonical structure from `.github/pull_request_template.md` and the validation rules from `.github/workflows/pr-lint.yml`.
 - Regenerates the description from the current `git diff origin/main...HEAD` and commit history using the same logic as `/comet:create-pr` Step 6/7.
 - Preserves all media (images, GIFs, video links, Loom embeds) verbatim, and uses a hidden section-hash marker to detect which `##` sections the user has hand-edited so those sections are kept as-is rather than overwritten.
-- Auto-applies by default — if the regenerated body differs and passes pr-lint, the sub-skill updates the PR description without prompting. Users can opt out per-repo via a one-line memory entry; opted-out repos are skipped silently.
+- Auto-applies by default — if the regenerated body differs and passes pr-lint, the sub-skill updates the PR description without prompting. There is no opt-out flag; if a refresh ever produces unwanted content, the user edits the body in the GitHub UI or via `gh pr edit`, and the marker check (Step 4) leaves those edits alone on subsequent runs.
 - Is a no-op when the branch has no open PR, when no PR matches the local HEAD, or when the regenerated body is semantically identical to the current body (sha1 of body excluding the marker).
 
 ## Inputs
@@ -24,17 +24,13 @@ This sub-skill:
 
 ### 1. Locate and validate the PR (no-op gates)
 
-Return without prompting or making any API call when any of the failure conditions below are reached.
-
-**1a. PR resolution.** Determine which PR to operate on:
+Return without prompting or making any API call when any of the failure conditions below are reached. Determine which PR to operate on:
 
 - **If `pr_number` was passed**: run `gh pr view {pr_number} --repo {repo} --json number,headRefName,headRefOid,state`. Verify `state == "OPEN"` and `headRefName == branch`. If either check fails, **fail closed**: log `PR description sync skipped: pr_number={N} does not match branch={branch} (headRefName={X}, state={S}); refusing to switch PRs silently` and return. Do not fall through to the branch lookup — a caller passing a mismatching `pr_number` is a bug or stale state, not a request to switch PRs.
 - **Branch lookup**: run `gh pr list --repo {repo} --head {branch} --state open --json number,url,headRefName,headRefOid`. Filter to PRs whose `headRefOid` matches the local `git rev-parse HEAD`.
   - **0 matches**: no open PR for this exact HEAD — return silently.
   - **Exactly 1 match**: use it.
   - **More than 1 match** (e.g., multiple forks share the same head branch name): log `PR description sync skipped: {N} open PRs match branch={branch} and HEAD={oid}; refusing to guess` and return silently. Don't edit any of them.
-
-**1b. Mute memory check.** Read the per-user memory file (see "Memory entry" below). If the normalized remote URL is in the `never` list, return silently.
 
 ### 2. Fetch current state
 
@@ -82,9 +78,9 @@ Each value is `sha1(<section content with leading/trailing whitespace trimmed>)`
 
 This per-section decision is the merge algorithm. There is no "fuzzy match" or "append on conflict" — the marker is the source of truth.
 
-**Marker absent** (first run on a PR that pre-dates this skill, or a PR whose body was edited externally to strip the marker): regenerate every section per Step 3 — we have no way to know which sections the user touched, so the auto-apply in Step 7 will install the marker on this run and adopt managed mode. Subsequent runs use the per-section logic above. Users who don't want this implicit adoption can opt the repo out before the next push (see Step 8).
+**Marker absent** (first run on a PR that pre-dates this skill, or a PR whose body was edited externally to strip the marker): regenerate every section per Step 3 — we have no way to know which sections the user touched, so the auto-apply in Step 7 will install the marker on this run and adopt managed mode. Subsequent runs use the per-section logic above. Users who want specific sections preserved through that first overwrite can edit the body in the GitHub UI ahead of the next push; the post-edit content becomes the new baseline once the marker is reinstalled.
 
-This means the **first refresh of a managed-mode PR is the most invasive** — it overwrites every section since none are flagged as user-edited yet. After that, the marker tracks state and refreshes are surgical: only sections whose hash still matches get regenerated. Users who don't want the first-run overwrite can opt the repo out by adding it to the `never` list before the next push.
+This means the **first refresh of a managed-mode PR is the most invasive** — it overwrites every section since none are flagged as user-edited yet. After that, the marker tracks state and refreshes are surgical: only sections whose hash still matches get regenerated. Users who want to lock in specific content before the first auto-refresh can edit the body in the GitHub UI; the marker check leaves user-edited sections alone on subsequent runs.
 
 ### 4b. Preserve media (template-managed sections only)
 
@@ -138,44 +134,7 @@ After applying, log:
 - `PR description refreshed in sync with HEAD ({headRefOid}).`
 - If the body contains any media (image / video / Loom embed), append: `Note: this PR has screenshots/videos — verify they still match the current behavior; you may need to re-record.` This is informational only; the apply has already happened.
 
-**Opt-out**: if the user has previously added this repo to the `never` list of the memory file (Step 8), skip the apply silently. There is no `Always` list because auto-apply is the default — `Always` is the only mode.
-
-**Manual override**: a user who wants to inspect the proposed body before it lands can set the repo to `never` and run the diff manually, or revert via GitHub UI / `gh pr edit` after the auto-apply if a refresh produced something they don't want.
-
-### 8. Memory entry — `feedback_pr_description_auto_refresh.md`
-
-Per-repo opt-out is stored in a single memory file alongside the project's other feedback memories. The sub-skill only ever *reads* this file; users edit it (or ask the agent to) when they want to disable auto-refresh for a specific repo.
-
-**Path resolution** (in order, first hit wins):
-
-1. The directory containing the project's existing `MEMORY.md` index, if one exists. Discover by walking up from `cwd` looking for `**/memory/MEMORY.md` under `~/.claude/projects/<project-id>/`. If found, write next to it: `<that-dir>/feedback_pr_description_auto_refresh.md`.
-2. If no project `MEMORY.md` exists, fall back to `~/.claude/memory/feedback_pr_description_auto_refresh.md` (user-global). Note this in the log so the user knows the choice will apply across all projects until a project memory dir is established.
-
-**Format**:
-
-```markdown
----
-name: PR description auto-refresh per-repo preference
-description: Per-repo opt-out list for the post-push PR-description sync
-type: feedback
----
-
-The PR description sync auto-applies by default. Repos listed below have been opted out — the sub-skill returns silently without refreshing the PR description on those repos.
-
-**How to apply**: before invoking the sub-skill's main flow, normalize the current repo's `git config --get remote.origin.url` to `host/owner/repo` (lowercase, strip `git@`, `https://`, trailing `.git`). If it appears in the list below, skip; otherwise auto-apply per Step 7.
-
-## Never (auto-refresh disabled)
-- {host/owner/repo}
-```
-
-Also add (or update) a one-line entry in the user's `MEMORY.md` index pointing at this file.
-
-**Normalization rule** (applied identically when reading and writing): take the URL from `git config --get remote.origin.url`, strip `git@` / `https://` prefix, strip trailing `.git`, replace `:` with `/`, lowercase. Examples:
-
-- `git@github.com:comet-ml/opik.git` → `github.com/comet-ml/opik`
-- `https://github.com/comet-ml/opik.git` → `github.com/comet-ml/opik`
-
-**Adding a repo to the list**: the sub-skill itself does not write to this file. To opt out, the user edits the file directly (or asks the agent to). This keeps the sub-skill side-effect-light: it only ever reads the list, never adds to it.
+**Recovery**: if a refresh produces something the user didn't want, the body can be edited in the GitHub UI or via `gh pr edit`. The marker check in Step 4 then treats those edits as user-owned on subsequent runs and leaves them alone — no permanent opt-out is required.
 
 ## Caller contract
 
@@ -186,7 +145,6 @@ Each caller invokes this sub-skill at the moment immediately after a successful 
 - **`gh` unavailable**: log `PR description sync skipped: gh CLI unavailable` and return. Do not attempt MCP fallback — refresh is a quality-of-life feature, not a correctness gate.
 - **PR description fetch fails (404, network)**: log the error and return. Don't block the caller.
 - **`gh pr edit` fails**: surface the error in the log; the caller continues normally. The next push will re-attempt the sync.
-- **Memory file read fails**: treat as no opt-out and proceed with auto-apply. Don't block on a read error to a config-style file.
 
 ---
 

--- a/.agents/commands/comet/_pr-description-sync.md
+++ b/.agents/commands/comet/_pr-description-sync.md
@@ -1,0 +1,153 @@
+# PR Description Sync (shared sub-skill)
+
+**Command**: not user-invocable. Called by `/comet:create-pr`, `/comet:work-on-jira-ticket`, and `/comet:address-github-pr-comments` after a `git push` succeeds against a branch with an open PR.
+
+## Overview
+
+Keep the GitHub PR description in sync with what was actually pushed, so reviewers don't read stale claims about endpoint paths, method names, emitted events, or other implementation details that the review cycle reshaped after the description was first written.
+
+This sub-skill:
+
+- Reads the canonical structure from `.github/pull_request_template.md` and the validation rules from `.github/workflows/pr-lint.yml`.
+- Regenerates the description from the current `git diff origin/main...HEAD` and commit history using the same logic as `/comet:create-pr` Step 6/7.
+- Preserves all media (images, GIFs, video links, Loom embeds) and any hand-edits the user added that don't conflict with regenerated content.
+- Confirms the proposed update with the user via `AskUserQuestion`, with per-repo `Always` / `Never` mute options persisted to local memory.
+- Is a no-op when the branch has no open PR or when the regenerated body equals the current body (idempotence).
+
+## Inputs
+
+- `branch` (required): branch name to look up the PR against. Caller passes `git rev-parse --abbrev-ref HEAD`.
+- `pr_number` (optional): if the caller already located the PR (e.g., `/comet:address-github-pr-comments`), pass it to skip the lookup.
+- `repo` (optional, defaults to `comet-ml/opik`): the GitHub repo to operate against.
+
+## Steps
+
+### 1. No-op gates (silent return)
+
+Return without prompting or making any API call when any of these are true:
+
+- **No open PR for the branch.** If `pr_number` was not passed, run `gh pr list --repo {repo} --head {branch} --state open --json number,url --jq '.[0]'`. If empty, return silently.
+- **Mute memory says "never for this repo".** Read the per-user memory file (see "Memory entry" below). If the normalized remote URL is in the `never` list, return silently.
+
+### 2. Fetch current state
+
+```bash
+gh pr view {pr_number} --repo {repo} --json body,title,headRefOid > /tmp/pr-current.json
+git diff origin/main...HEAD
+git log origin/main..HEAD --pretty=format:'%h %s'
+cat .github/pull_request_template.md
+```
+
+### 3. Regenerate the description
+
+Apply the same logic as `/comet:create-pr` Step 6 (Extract Change Information) and Step 7 (Pre-fill PR Template). In particular:
+
+- Fill every `##` section defined in `.github/pull_request_template.md`. Sections not applicable to this PR get `N/A`, never get removed.
+- Re-derive the **Details** summary from the diff and commit messages.
+- Re-derive the **Change checklist** from the file types changed (e.g., user-facing checked when UI files changed; documentation checked when `*.md` / `*.mdx` changed).
+- Keep the existing **Issues** ticket reference if present (e.g., `OPIK-6296`); if missing, infer from branch name.
+- Keep the existing **AI-WATERMARK** answers verbatim — never silently flip `yes`↔`no`.
+- Re-derive **Testing** from commit messages and test files changed.
+- Re-derive **Documentation** from docs files changed.
+
+Apply the same secrecy rules as `/comet:create-pr` Step 7: never include customer/client names, internal hostnames, internal URLs, IPs, bucket names, or credentials.
+
+### 4. Preserve media and hand-edits
+
+Parse the *current* PR body. For each of the following, lift the matching content verbatim from the current body and reinsert it into the regenerated body under the same `##` section:
+
+- **Markdown images**: any `![…](…)` line.
+- **HTML img tags**: any `<img …>` element (single-line or multi-line).
+- **Video / embed links**: any URL matching `user-images.githubusercontent.com`, `github.com/.../assets/`, `*.loom.com/share/`, `youtube.com/watch`, `youtu.be/`, `vimeo.com/`.
+- **Hand-edited free-text under a known `##` section**: text the user added that does not match the regenerated content for that section. Append it under the same heading rather than overwriting.
+
+Inside `## Testing`, treat the `Video evidence:` sub-section as a preservation island — keep its content as-is.
+
+If the user adds an entirely new top-level `##` section that isn't in the template (e.g., `## Migration plan`), keep it intact at the bottom of the body.
+
+### 5. Idempotence check
+
+If the regenerated body, after preservation, is byte-equal to the current body (after trimming trailing whitespace on each line), return silently. Do not prompt, do not call `gh pr edit`.
+
+### 6. Validate against pr-lint
+
+Run the same checks as `/comet:create-pr` Step 8 against the regenerated body — title regex (unchanged here, body only), required `##` sections present, `## Details` non-empty, `## Issues` references a ticket, no leftover `<!-- REPLACE ME` placeholders. If any check fails, auto-fix and re-validate. Never push a body that would fail pr-lint.
+
+### 7. Confirm with user (unless silent mode is active)
+
+**Silent mode**: the per-repo mute memory says `always` for this repo's normalized remote URL. Skip the prompt and apply directly.
+
+**Otherwise**: emit an `AskUserQuestion` with:
+
+- **Question header**: `Refresh PR description?`
+- **Question body**: a unified diff (`diff -u`) between current and regenerated bodies, capped at ~80 lines (truncate the middle with `... [N lines elided] ...` if longer).
+- **Options**:
+  - `Update` — apply the change to this PR only.
+  - `Skip` — do nothing this time.
+  - `Always for this repo` — apply now, and silently apply on every future push to any PR in this repo.
+  - `Never for this repo` — do nothing now, and skip the prompt entirely on future pushes in this repo.
+
+**Media-stale reminder (conditional)**: if the *current* body contains at least one match from the media patterns in Step 4, append a one-line preface to the question body:
+
+> Heads up — this PR has screenshots/videos. Verify they still match the current behavior; you may need to re-record after this update.
+
+Do not show the reminder when there's no media — avoid noise.
+
+### 8. Apply
+
+- On `Update` or under silent `Always` mode: `gh pr edit {pr_number} --repo {repo} --body-file <tmpfile>`.
+- On `Skip`: return.
+- On `Always for this repo`: write the normalized remote URL into the `always` list of the memory file (Step 9), then apply.
+- On `Never for this repo`: write the normalized remote URL into the `never` list of the memory file, return without applying.
+
+After applying, log: `PR description refreshed in sync with HEAD ({headRefOid}).`
+
+### 9. Memory entry — `feedback_pr_description_auto_refresh.md`
+
+Persist `Always` / `Never` choices to a single user-memory file alongside the user's other feedback memories.
+
+**Path**: `{user-memory-dir}/feedback_pr_description_auto_refresh.md`
+
+**Format**:
+
+```markdown
+---
+name: PR description auto-refresh per-repo preference
+description: Per-repo opt-in/opt-out for the post-push PR-description sync prompt
+type: feedback
+---
+
+When the post-push PR description sync prompt fires, the user has chosen the following per-repo behaviors. Apply these without prompting on future pushes in those repos.
+
+**How to apply**: before invoking the sync prompt, normalize the current repo's `git config --get remote.origin.url` to `host/owner/repo` (lowercase, strip `git@`, `https://`, trailing `.git`). Look it up below.
+
+## Always (silent refresh, no prompt)
+- {host/owner/repo}
+
+## Never (skip entirely, no prompt)
+- {host/owner/repo}
+```
+
+Also add (or update) a one-line entry in the user's `MEMORY.md` index pointing at this file.
+
+**Normalization rule** (applied identically when reading and writing): take the URL from `git config --get remote.origin.url`, strip `git@` / `https://` prefix, strip trailing `.git`, replace `:` with `/`, lowercase. Examples:
+
+- `git@github.com:comet-ml/opik.git` → `github.com/comet-ml/opik`
+- `https://github.com/comet-ml/opik.git` → `github.com/comet-ml/opik`
+
+A repo can appear in `Always` *or* `Never`, never both. If the user picks the opposite later, move it.
+
+## Caller contract
+
+Each caller invokes this sub-skill at the moment immediately after a successful `git push` (or `git push --force-with-lease`). Callers pass `branch = git rev-parse --abbrev-ref HEAD` and, if known, `pr_number`. The sub-skill itself never pushes and never modifies code — only the PR description on GitHub.
+
+## Failure modes
+
+- **`gh` unavailable**: log `PR description sync skipped: gh CLI unavailable` and return. Do not attempt MCP fallback — refresh is a quality-of-life feature, not a correctness gate.
+- **PR description fetch fails (404, network)**: log the error and return. Don't block the caller.
+- **`gh pr edit` fails after user confirmation**: surface the error and prompt the user whether to retry. On retry-no, return without changing memory entries.
+- **Memory file write fails**: surface the error but still apply the description update if the user said `Update` / `Always`.
+
+---
+
+**End sub-skill**

--- a/.agents/commands/comet/address-github-pr-comments.md
+++ b/.agents/commands/comet/address-github-pr-comments.md
@@ -132,7 +132,8 @@ When the user opts to fix a comment, **defer the reply** until the fix is pushed
 1. Track comments that need deferred replies (comment ID + description of fix)
 2. After all fixes are applied, prompt the user to commit and push
 3. Once `git push` completes, capture the commit SHA from the push output
-4. Post deferred replies referencing the commit:
+4. **Sync PR description**: invoke the `_pr-description-sync` sub-skill (`.agents/commands/comet/_pr-description-sync.md`) with `branch = git rev-parse --abbrev-ref HEAD` and `pr_number = {pr_number}` from Step 2. This is the highest-drift moment in the PR lifecycle: review feedback often reshapes the API, method names, or events after the description was first written. The sub-skill is a no-op when the description is already in sync or when the user has opted out of refreshes for this repo.
+5. Post deferred replies referencing the commit:
 
 ```
 Fixed in <commit_sha> — <brief description of what was changed>

--- a/.agents/commands/comet/create-pr.md
+++ b/.agents/commands/comet/create-pr.md
@@ -110,7 +110,7 @@ This workflow will:
 - **Search existing PRs**: Use GitHub CLI when available (for example `gh pr list --head <branch> --state open`); if CLI is unavailable, use GitHub MCP fallback.
 - **If PR exists**: Show existing PR and ask:
   > "PR already exists for this branch: <PR_URL>. Continue with the flow (quality checks, Jira status, progress comment)? (y/n)"
-  - **If yes**: Continue with Steps 5–11. The PR description was already refreshed by the `_pr-description-sync` sub-skill at the end of Step 3, so it is in sync with the latest push.
+  - **If yes**: Continue with Steps 5–11. The `_pr-description-sync` sub-skill ran at the end of Step 3 — it refreshed the description if needed (no-op when the body was already in sync, the user opted out for this repo, or `gh` was unavailable). Either way, do not attempt a second refresh here.
   - **If no**: Stop the flow
 - **If no PR exists**: Continue to PR creation
 

--- a/.agents/commands/comet/create-pr.md
+++ b/.agents/commands/comet/create-pr.md
@@ -101,6 +101,7 @@ This workflow will:
     ```bash
     git push --force-with-lease   # after rebase
     ```
+  - **Post-push: sync PR description.** If an open PR exists for this branch, invoke the `_pr-description-sync` sub-skill (`.agents/commands/comet/_pr-description-sync.md`) with `branch = git rev-parse --abbrev-ref HEAD`. The sub-skill is a no-op when no PR exists, when the description is already in sync, or when the user has opted out of refreshes for this repo.
 
 ---
 
@@ -108,8 +109,8 @@ This workflow will:
 
 - **Search existing PRs**: Use GitHub CLI when available (for example `gh pr list --head <branch> --state open`); if CLI is unavailable, use GitHub MCP fallback.
 - **If PR exists**: Show existing PR and ask:
-  > "PR already exists for this branch: <PR_URL>. Do you want to update the PR description and continue with the flow (quality checks, Jira status, progress comment)? (y/n)"
-  - **If yes**: Update PR description using the pre-filled template (Step 7 output), then continue with Steps 5–11 as usual
+  > "PR already exists for this branch: <PR_URL>. Continue with the flow (quality checks, Jira status, progress comment)? (y/n)"
+  - **If yes**: Continue with Steps 5–11. The PR description was already refreshed by the `_pr-description-sync` sub-skill at the end of Step 3, so it is in sync with the latest push.
   - **If no**: Stop the flow
 - **If no PR exists**: Continue to PR creation
 

--- a/.agents/commands/comet/work-on-jira-ticket.md
+++ b/.agents/commands/comet/work-on-jira-ticket.md
@@ -205,6 +205,7 @@ If the `EnterWorktree` tool is not available (e.g., running in Cursor or another
   - Apply code changes according to the plan
   - Run quality checks and tests
   - Commit changes with proper ticket number prefix
+- **Post-push PR description sync**: Whenever this skill (or any follow-up step the user runs from this conversation) invokes `git push` or `git push --force-with-lease` to a branch with an open PR in `comet-ml/opik`, invoke the `_pr-description-sync` sub-skill (`.agents/commands/comet/_pr-description-sync.md`) immediately after the push completes. The sub-skill is a no-op when no PR exists, when the description is already in sync, or when the user has opted out of refreshes for this repo. This keeps the PR description aligned with what was actually shipped instead of what was claimed when the PR was opened.
 - **If user declined**: Provide manual implementation guidance and stop
 
 ---


### PR DESCRIPTION
## Details

<img width="1920" height="2680" alt="image" src="https://github.com/user-attachments/assets/c0767147-ddd9-4d1f-87be-bc6a2318c38c" />

Adds a shared post-push routine that keeps GitHub PR descriptions in sync with what was actually pushed, so reviewers don't read stale claims about endpoint paths, method names, or emitted events that the review cycle reshaped after the description was first written.

The new `_pr-description-sync` sub-skill is invoked by the three skills that already run `git push` during a ticket's lifecycle:

- `/comet:create-pr` — after the post-rebase `git push --force-with-lease`. The "PR exists" branch in Step 4 no longer duplicates description-refresh logic; Step 4's wording explicitly notes the sub-skill is a no-op when the body is already in sync or when `gh` is unavailable.
- `/comet:work-on-jira-ticket` — Step 10 declares an explicit post-push contract so any push during the implementation phase triggers the refresh.
- `/comet:address-github-pr-comments` — Step 6 deferred replies sync the description after the fix push and before posting the "Fixed in `<sha>`" replies. This is the highest-drift moment in the PR lifecycle.

The sub-skill regenerates from `.github/pull_request_template.md`, scopes media preservation to template-managed `##` sections (so embeds inside custom user-added sections are never lifted or reordered), and uses a hidden section-hash marker (`<!-- pr-sync: {"<Section>":"<sha1>"} -->`) to decide which `##` sections the user has hand-edited so those sections are kept verbatim rather than overwritten.

Step 1 of the sub-skill performs PR resolution with explicit safety guards: when callers pass `pr_number` it is validated against the PR's `headRefName` and `state`; on mismatch, the sub-skill **fails closed** and returns rather than silently switching to another PR. When falling back to a branch lookup, candidates are disambiguated by matching `headRefOid` against the local `git rev-parse HEAD` so wrong-fork same-branch-name PRs cannot be edited (0 matches → silent no-op, 1 → use it, >1 → log and skip).

Idempotence is semantic, not byte-equal: the sub-skill compares `sha1(body without marker)` between the current and regenerated bodies. This handles the "every push regenerates Testing, but nothing meaningful changed" case — only meaningful drift triggers a refresh.

**Step 7 auto-applies without prompting** — refreshing the PR description is a routine bookkeeping action, not a decision the user needs to confirm each time. By the time apply runs, the body has already passed pr-lint, the marker check has already protected user edits, and idempotence has already filtered out no-op cases. There is no opt-out flag; if a refresh ever produces unwanted content, the user edits the body in the GitHub UI or via `gh pr edit`, and the marker check leaves those edits alone on subsequent runs.

Drift example that motivated this: PR #6391 (review #4187352979 / discussion r3152894063) shipped with three claims that didn't match what merged — endpoint paths `PUT /v1/private/traces/assertion-results` and `PUT /v1/private/spans/assertion-results`, service methods `saveBatchOfTraces` / `saveBatchOfSpans`, and an extra emitted `FeedbackScoresCreated` event. None of those existed in the merged code. A reviewer had to flag it manually.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6296

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Opus 4.7 (1M context)
  - Scope: full implementation
  - Human verification: code review + manual walk-through of the three integration points against the canonical skill files; manual exercise of the sub-skill against this PR's own description across multiple refreshes

## Testing

How tested:

- `git diff origin/main...HEAD` shows only the four expected `.md` files under `.agents/commands/comet/` (one new sub-skill + three modified callers) — no Java, FE, or SDK changes, so the project's quality checks (Maven, lint/typecheck, `make precommit-sdks`) have nothing to run.
- Pre-commit hook ran on each of the seven local commits (`f718568b6d`, `671b589f9a`, `e8aba7fc28`, `940ca91adb`, `4123ff4e70`, `8c06574a57`, `e60669c30b`) and reported "No Java/frontend/SDK/Optimizer/Guardrails files changed. Skipping." for every domain check.
- Manually walked the three integration points against the canonical skill files at `.agents/commands/comet/{create-pr,work-on-jira-ticket,address-github-pr-comments}.md` and confirmed each reference into `_pr-description-sync.md` lands at the correct push moment.
- Validated the generated PR title and body against `.github/workflows/pr-lint.yml` rules (title regex, all 5 required `##` sections present, `## Details` non-empty, `## Issues` references `OPIK-6296`, no leftover template HTML-comment placeholders) before each submission.
- Manually walked Baz's three review scenarios against the post-fix Step 1 wording: stale `pr_number` hint → fail closed and return; multiple forks with same head branch → `headRefOid` filter resolves to one; >1 same-OID matches → log and skip rather than guess.
- Manually exercised the full sub-skill flow against this PR's own description across multiple refreshes (`e8aba7fc28`, `940ca91adb`, `8c06574a57`). Verified: image preservation across refreshes, AI-WATERMARK answers stayed verbatim across regenerations, idempotence-passing behavior, and the section-hash marker correctly distinguishing user-edited from agent-owned sections.
- Walked Step 4b's media-scope hazard: a custom `## Migration plan` section with `<img>` syntax inside no longer gets double-written or reordered, because the media scan is now restricted to template-managed sections only.

Scenarios for reviewers to validate end-to-end on a follow-up branch:

- After a normal `git push` to a branch with an open PR, the description is auto-refreshed if the regenerated body differs from the current body and passes pr-lint — no prompt fires.
- All embedded images/GIFs/videos/Loom links present in template-managed sections survive a refresh; media inside custom user-added sections is preserved verbatim with its surrounding section.
- All template sections defined in `.github/pull_request_template.md` remain present and pass pr-lint after a refresh.
- After the marker is installed, hand-edited sections are kept verbatim on subsequent refreshes (per-section sha1 detection); only sections whose hash still matches get regenerated.
- Pushing to a branch with no open PR is a silent no-op.
- Running the sync twice in a row with no intervening commits proposes no change (semantic idempotence via marker-stripped sha1).
- A caller passing a `pr_number` that doesn't match the current branch causes the sub-skill to fail closed and return, rather than editing the wrong PR.
- A user who doesn't want a refresh that already landed can revert via `gh pr edit` or the GitHub UI; subsequent refreshes leave the user-edited sections alone.

Video evidence:
- N/A — change is markdown skill files only, no UI or runtime behavior to capture.

## Documentation

This PR *is* the documentation update — it changes four agent-skill markdown files under `.agents/commands/comet/`. No other docs (README, mintlify, swagger) need updating.

<!-- pr-sync: {"Details":"58d32a3f2c","Change checklist":"2b0c321698","Issues":"322fd4e267","AI-WATERMARK":"4e9ffb6ab2","Testing":"f2e1277172","Documentation":"8a238ca77d"} -->
