### PR TITLE
[OPIK-6084] [FE] feat: unify select-all pattern in menus

### DIFF
--- a/apps/opik-frontend/src/lib/utils.test.ts
+++ b/apps/opik-frontend/src/lib/utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { isStringMarkdown, removeUndefinedKeys, isLooseEqual } from "./utils";
+import {
+  getSelectAllCheckedState,
+  isStringMarkdown,
+  removeUndefinedKeys,
+  isLooseEqual,
+} from "./utils";
 
 describe("isStringMarkdown", () => {
   // Test non-string inputs
@@ -380,5 +385,27 @@ describe("isLooseEqual", () => {
     const a = { x: 1 };
     const b = { x: 1, y: 2 };
     expect(isLooseEqual(a, b)).toBe(false);
+  });
+});
+
+describe("getSelectAllCheckedState", () => {
+  it("returns false when there is nothing to select (totalCount === 0)", () => {
+    expect(getSelectAllCheckedState(0, 0)).toBe(false);
+  });
+
+  it("returns false when nothing is selected", () => {
+    expect(getSelectAllCheckedState(0, 5)).toBe(false);
+  });
+
+  it("returns true when all items are selected", () => {
+    expect(getSelectAllCheckedState(5, 5)).toBe(true);
+  });
+
+  it('returns "indeterminate" when only some items are selected', () => {
+    expect(getSelectAllCheckedState(2, 5)).toBe("indeterminate");
+  });
+
+  it("returns true when selectedCount exceeds totalCount", () => {
+    expect(getSelectAllCheckedState(7, 5)).toBe(true);
   });
 });

--- a/apps/opik-frontend/src/lib/utils.ts
+++ b/apps/opik-frontend/src/lib/utils.ts
@@ -329,3 +329,13 @@ export const escapeJsString = (value: string): string => {
     }
   });
 };
+
+export const getSelectAllCheckedState = (
+  selectedCount: number,
+  totalCount: number,
+): boolean | "indeterminate" => {
+  if (totalCount === 0) return false;
+  if (selectedCount >= totalCount) return true;
+  if (selectedCount > 0) return "indeterminate";
+  return false;
+};

--- a/apps/opik-frontend/src/shared/ColumnsContent/ColumnsContent.tsx
+++ b/apps/opik-frontend/src/shared/ColumnsContent/ColumnsContent.tsx
@@ -13,6 +13,7 @@ import { ColumnData } from "@/types/shared";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import type { ColumnsContentVariant } from "./SortableMenuItem";
 import { useColumnsCount } from "./useColumnsCount";
+import { getSelectAllCheckedState } from "@/lib/utils";
 
 type ColumnsContentShared<TColumnData> = {
   columns: ColumnData<TColumnData>[];
@@ -115,12 +116,14 @@ const ColumnsContent = <TColumnData,>({
     );
   };
 
+  const checkedState = getSelectAllCheckedState(selectedCount, totalCount);
+
   const renderSelectAll = () => {
     if (isMenu) {
       return (
         <DropdownMenuCustomCheckboxItem
-          checked={allColumnsSelected}
-          onCheckedChange={toggleColumns}
+          checked={checkedState}
+          onCheckedChange={() => toggleColumns(!allColumnsSelected)}
           onSelect={(event) => event.preventDefault()}
         >
           <div className="w-full break-words py-2">
@@ -135,16 +138,7 @@ const ColumnsContent = <TColumnData,>({
         onClick={() => toggleColumns(!allColumnsSelected)}
       >
         <span className="absolute left-2 flex size-8 items-center justify-center">
-          <Checkbox
-            checked={
-              allColumnsSelected
-                ? true
-                : selectedCount > 0
-                  ? "indeterminate"
-                  : false
-            }
-            tabIndex={-1}
-          />
+          <Checkbox checked={checkedState} tabIndex={-1} />
         </span>
         <div className="w-full break-words py-2">
           {selectedCount} of {totalCount} selected

--- a/apps/opik-frontend/src/shared/LoadableSelectBox/LoadableSelectBox.tsx
+++ b/apps/opik-frontend/src/shared/LoadableSelectBox/LoadableSelectBox.tsx
@@ -111,13 +111,18 @@ export const LoadableSelectBox = ({
     return multiselect && isArray(value) ? value : [];
   }, [multiselect, value]);
 
+  const selectedValuesSet = useMemo(
+    () => new Set(selectedValues),
+    [selectedValues],
+  );
+
   const isSelected = useCallback(
     (optionValue: string) => {
       return multiselect
-        ? selectedValues.includes(optionValue)
+        ? selectedValuesSet.has(optionValue)
         : value === optionValue;
     },
-    [multiselect, selectedValues, value],
+    [multiselect, selectedValuesSet, value],
   );
 
   const selectedOptions = useMemo(
@@ -168,7 +173,7 @@ export const LoadableSelectBox = ({
   }, [options, search]);
 
   const filteredSelectedCount = multiselect
-    ? filteredOptions.filter((option) => selectedValues.includes(option.value))
+    ? filteredOptions.filter((option) => selectedValuesSet.has(option.value))
         .length
     : 0;
 
@@ -185,9 +190,9 @@ export const LoadableSelectBox = ({
     if (!multiselect) return;
 
     if (allFilteredSelected) {
-      const filteredValues = filteredOptions.map((o) => o.value);
+      const filteredValuesSet = new Set(filteredOptions.map((o) => o.value));
       const newSelectedValues = selectedValues.filter(
-        (v) => !filteredValues.includes(v),
+        (v) => !filteredValuesSet.has(v),
       );
       onChange && (onChange as (value: string[]) => void)(newSelectedValues);
     } else {

--- a/apps/opik-frontend/src/shared/LoadableSelectBox/LoadableSelectBox.tsx
+++ b/apps/opik-frontend/src/shared/LoadableSelectBox/LoadableSelectBox.tsx
@@ -10,7 +10,7 @@ import { Button, ButtonProps } from "@/ui/button";
 import { Spinner } from "@/ui/spinner";
 import { Separator } from "@/ui/separator";
 import { Checkbox } from "@/ui/checkbox";
-import { cn } from "@/lib/utils";
+import { cn, getSelectAllCheckedState } from "@/lib/utils";
 import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
 import { DropdownOption } from "@/types/shared";
 import NoOptions from "./NoOptions";
@@ -167,12 +167,19 @@ export const LoadableSelectBox = ({
     return options.filter((o) => toLower(o.label).includes(toLower(search)));
   }, [options, search]);
 
-  const allFilteredSelected = useMemo(() => {
-    if (!multiselect || !filteredOptions.length) return false;
-    return filteredOptions.every((option) =>
-      selectedValues.includes(option.value),
-    );
-  }, [multiselect, filteredOptions, selectedValues]);
+  const filteredSelectedCount = multiselect
+    ? filteredOptions.filter((option) => selectedValues.includes(option.value))
+        .length
+    : 0;
+
+  const allFilteredSelected =
+    filteredOptions.length > 0 &&
+    filteredSelectedCount === filteredOptions.length;
+
+  const selectAllCheckedState = getSelectAllCheckedState(
+    filteredSelectedCount,
+    filteredOptions.length,
+  );
 
   const handleSelectAll = useCallback(() => {
     if (!multiselect) return;
@@ -425,11 +432,15 @@ export const LoadableSelectBox = ({
                   onClick={handleSelectAll}
                 >
                   <Checkbox
-                    checked={allFilteredSelected}
+                    checked={selectAllCheckedState}
                     className="shrink-0"
+                    tabIndex={-1}
                   />
                   <div className="min-w-0 flex-1">
-                    <div className="comet-body-s truncate">Select all</div>
+                    <div className="comet-body-s truncate">
+                      {filteredSelectedCount} of {filteredOptions.length}{" "}
+                      selected
+                    </div>
                   </div>
                 </div>
               </>

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/GeneratedSamplesDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/GeneratedSamplesDialog.tsx
@@ -23,6 +23,7 @@ import { DatasetItem } from "@/types/datasets";
 import SyntaxHighlighter from "@/shared/SyntaxHighlighter/SyntaxHighlighter";
 import { Alert, AlertDescription, AlertTitle } from "@/ui/alert";
 import { extractOpikMetadata } from "@/lib/dataset-item-utils";
+import { getSelectAllCheckedState } from "@/lib/utils";
 import { OPIK_GENERATION_MODEL_FIELD } from "@/constants/datasets";
 
 function DiversityTag({ score }: { score: number }): React.ReactElement {
@@ -257,8 +258,11 @@ const GeneratedSamplesDialog: React.FunctionComponent<
     setOpen(false);
   }, [samples, selectedSamples, onAddItems, setOpen]);
 
-  const allSelected = selectedSamples.size === samples.length;
   const noneSelected = selectedSamples.size === 0;
+  const selectAllCheckedState = getSelectAllCheckedState(
+    selectedSamples.size,
+    samples.length,
+  );
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -322,31 +326,27 @@ const GeneratedSamplesDialog: React.FunctionComponent<
 
             {/* Selection Controls */}
             <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  checked={allSelected}
-                  onCheckedChange={handleSelectAll}
-                />
+              <div
+                className="flex cursor-pointer items-center gap-2"
+                onClick={() => handleSelectAll()}
+              >
+                <Checkbox checked={selectAllCheckedState} tabIndex={-1} />
                 <span className="text-sm">
-                  {allSelected ? "Deselect all" : "Select all"}
+                  {selectedSamples.size} of {samples.length} selected
                 </span>
-                {samples.length > 20 && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setShowAllSamples(!showAllSamples)}
-                    className="ml-4"
-                  >
-                    <Eye className="mr-1 size-4" />
-                    {showAllSamples
-                      ? `Show sample (${displaySamples.length})`
-                      : `Show all (${samples.length})`}
-                  </Button>
-                )}
               </div>
-              <Tag variant="gray">
-                {selectedSamples.size} of {samples.length} selected
-              </Tag>
+              {samples.length > 20 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setShowAllSamples(!showAllSamples)}
+                >
+                  <Eye className="mr-1 size-4" />
+                  {showAllSamples
+                    ? `Show sample (${displaySamples.length})`
+                    : `Show all (${samples.length})`}
+                </Button>
+              )}
             </div>
 
             {/* Compact Sample List */}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceTreeViewer/SpanDetailsButton.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceTreeViewer/SpanDetailsButton.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from "react";
-import { Eye, EyeOff, MoreVertical } from "lucide-react";
+import { MoreVertical } from "lucide-react";
 
 import { DropdownOption, OnChangeFn } from "@/types/shared";
 import { Button } from "@/ui/button";
@@ -7,7 +7,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuCustomCheckboxItem,
-  DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu";
@@ -18,6 +17,7 @@ import {
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import { getSelectAllCheckedState } from "@/lib/utils";
 
 const OPTIONS: DropdownOption<TREE_DATABLOCK_TYPE>[] = [
   { label: "Duration", value: TREE_DATABLOCK_TYPE.DURATION },
@@ -68,6 +68,13 @@ const SpanDetailsButton: React.FC<SpanDetailsButtonProps> = ({
     [onConfigChange, options],
   );
 
+  const totalCount = options.length + 1;
+  const selectedCount =
+    options.filter(({ value }) => config[value]).length +
+    (config[TREE_DATABLOCK_TYPE.DURATION_TIMELINE] ? 1 : 0);
+  const allSelected = selectedCount === totalCount;
+  const checkedState = getSelectAllCheckedState(selectedCount, totalCount);
+
   return (
     <DropdownMenu>
       <TooltipWrapper content="More options">
@@ -108,16 +115,17 @@ const SpanDetailsButton: React.FC<SpanDetailsButtonProps> = ({
           >
             Timeline
           </DropdownMenuCustomCheckboxItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => toggleColumns(true)}>
-            <Eye className="mr-2 size-4" />
-            Show all
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => toggleColumns(false)}>
-            <EyeOff className="mr-2 size-4" />
-            Hide all
-          </DropdownMenuItem>
         </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuCustomCheckboxItem
+          checked={checkedState}
+          onSelect={(event) => event.preventDefault()}
+          onCheckedChange={() => toggleColumns(!allSelected)}
+        >
+          <div className="w-full break-words py-2">
+            {selectedCount} of {totalCount} selected
+          </div>
+        </DropdownMenuCustomCheckboxItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/ExperimentDataset.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/ExperimentDataset.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuCustomCheckboxItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu";
 import uniq from "lodash/uniq";
@@ -21,6 +22,7 @@ import { RESOURCE_TYPE } from "@/shared/ResourceLink/ResourceLink";
 import { useDatasetIdFromCompareExperimentsURL } from "@/v2/pages/CompareExperimentsPage/useDatasetIdFromCompareExperimentsURL";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
+import { getSelectAllCheckedState } from "@/lib/utils";
 
 const COLLAPSE_KEYS_BUTTON_WIDTH = 340;
 
@@ -73,6 +75,26 @@ const ExperimentDataset = ({ data, datasetItemId }: ExperimentDatasetProps) => {
 
       return [...(selectedKeys || []), key];
     });
+  };
+
+  const visibleSelectedCount = dataKeys.filter(
+    (key) => selectedKeys?.includes(key),
+  ).length;
+  const allKeysSelected =
+    dataKeys.length > 0 && visibleSelectedCount === dataKeys.length;
+  const selectAllCheckedState = getSelectAllCheckedState(
+    visibleSelectedCount,
+    dataKeys.length,
+  );
+
+  const handleToggleAll = () => {
+    if (allKeysSelected) {
+      setSelectedKeys((current) =>
+        (current ?? []).filter((key) => !dataKeys.includes(key)),
+      );
+    } else {
+      setSelectedKeys((current) => union(current ?? [], dataKeys));
+    }
   };
 
   useEffect(() => {
@@ -135,6 +157,20 @@ const ExperimentDataset = ({ data, datasetItemId }: ExperimentDatasetProps) => {
                   {key}
                 </DropdownMenuCustomCheckboxItem>
               ))}
+              {dataKeys.length > 0 && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuCustomCheckboxItem
+                    checked={selectAllCheckedState}
+                    onSelect={(event) => event.preventDefault()}
+                    onCheckedChange={handleToggleAll}
+                  >
+                    <div className="w-full break-words py-2">
+                      {visibleSelectedCount} of {dataKeys.length} selected
+                    </div>
+                  </DropdownMenuCustomCheckboxItem>
+                </>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/MetricSelector.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/MetricSelector.tsx
@@ -14,11 +14,11 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
 import { ListAction } from "@/ui/list-action";
 import { Separator } from "@/ui/separator";
 import { Checkbox } from "@/ui/checkbox";
+import { cn, getSelectAllCheckedState } from "@/lib/utils";
 import { EvaluatorsRule } from "@/types/automations";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import toLower from "lodash/toLower";
-import { cn } from "@/lib/utils";
 import { usePermissions } from "@/contexts/PermissionsContext";
 
 const MAX_VISIBLE_TAGS = 3;
@@ -52,7 +52,17 @@ const MetricSelector: React.FC<MetricSelectorProps> = ({
   } = usePermissions();
 
   const isAllSelected =
-    selectedRuleIds === null || selectedRuleIds.length === rules.length;
+    rules.length > 0 &&
+    (selectedRuleIds === null || selectedRuleIds.length === rules.length);
+
+  const selectedCount = isAllSelected
+    ? rules.length
+    : selectedRuleIds?.length ?? 0;
+
+  const selectAllCheckedState = getSelectAllCheckedState(
+    selectedCount,
+    rules.length,
+  );
 
   const selectedRuleIdsSet = useMemo(
     () => new Set(selectedRuleIds ?? []),
@@ -96,27 +106,9 @@ const MetricSelector: React.FC<MetricSelectorProps> = ({
     [selectedRuleIds, selectedRuleIdsSet, rules, onSelectionChange],
   );
 
-  const handleSelectAll = useCallback(
-    (checked?: boolean | "indeterminate") => {
-      // Toggle between all selected (null) and none selected ([])
-      if (checked !== undefined && checked !== "indeterminate") {
-        // Called from checkbox onCheckedChange - checked is the NEW desired state
-        // true = check = select all (null), false = uncheck = deselect all ([])
-        onSelectionChange(checked ? null : []);
-      } else {
-        // Called from div onClick or indeterminate state - toggle based on current state
-        const allSelected =
-          selectedRuleIds === null ||
-          (Array.isArray(selectedRuleIds) &&
-            selectedRuleIds.length === rules.length &&
-            rules.length > 0);
-
-        // Toggle: if all selected, deselect; if not all selected, select all
-        onSelectionChange(allSelected ? [] : null);
-      }
-    },
-    [onSelectionChange, selectedRuleIds, rules.length],
-  );
+  const handleSelectAll = useCallback(() => {
+    onSelectionChange(isAllSelected ? [] : null);
+  }, [onSelectionChange, isAllSelected]);
 
   const openChangeHandler = useCallback((newOpen: boolean) => {
     if (deletingRef.current) {
@@ -291,15 +283,17 @@ const MetricSelector: React.FC<MetricSelectorProps> = ({
               <Separator className="my-1" />
               <div
                 className="flex h-10 cursor-pointer items-center gap-2 rounded-md px-4 hover:bg-primary-foreground"
-                onClick={() => handleSelectAll()}
+                onClick={handleSelectAll}
               >
                 <Checkbox
-                  checked={isAllSelected}
+                  checked={selectAllCheckedState}
                   className="shrink-0"
-                  onCheckedChange={(checked) => handleSelectAll(checked)}
+                  tabIndex={-1}
                 />
                 <div className="min-w-0 flex-1">
-                  <div className="comet-body-s truncate">Select all</div>
+                  <div className="comet-body-s truncate">
+                    {selectedCount} of {rules.length} selected
+                  </div>
                 </div>
               </div>
             </>

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/MetricSelector.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/MetricSelector.tsx
@@ -51,19 +51,6 @@ const MetricSelector: React.FC<MetricSelectorProps> = ({
     permissions: { canUpdateOnlineEvaluationRules },
   } = usePermissions();
 
-  const isAllSelected =
-    rules.length > 0 &&
-    (selectedRuleIds === null || selectedRuleIds.length === rules.length);
-
-  const selectedCount = isAllSelected
-    ? rules.length
-    : selectedRuleIds?.length ?? 0;
-
-  const selectAllCheckedState = getSelectAllCheckedState(
-    selectedCount,
-    rules.length,
-  );
-
   const selectedRuleIdsSet = useMemo(
     () => new Set(selectedRuleIds ?? []),
     [selectedRuleIds],
@@ -73,6 +60,13 @@ const MetricSelector: React.FC<MetricSelectorProps> = ({
     if (!selectedRuleIds) return rules;
     return rules.filter((rule) => selectedRuleIdsSet.has(rule.id));
   }, [rules, selectedRuleIds, selectedRuleIdsSet]);
+
+  const selectedCount = selectedRules.length;
+  const isAllSelected = rules.length > 0 && selectedCount === rules.length;
+  const selectAllCheckedState = getSelectAllCheckedState(
+    selectedCount,
+    rules.length,
+  );
 
   const filteredRules = useMemo(() => {
     if (!search) return rules;


### PR DESCRIPTION
## Details


https://github.com/user-attachments/assets/0f8e43de-dc3e-4ddb-b553-789ac72bb9b7



Replace the legacy "Show all / Hide all" two-item pattern and the mixed "Select all / Deselect all" + count-tag controls with a single unified row showing `N of N selected` plus a checkbox that supports the indeterminate state when only some items are selected. Adds a small `getSelectAllCheckedState` helper in `lib/utils.ts` so all six call sites share the same `(selectedCount, totalCount) → boolean | "indeterminate"` mapping.

- `shared/ColumnsContent` (menu variant): pass indeterminate state to the bottom select-all row — cascades to every `ColumnsButton` + `WorkspaceMenuContent` menu across v2.
- `shared/LoadableSelectBox`: replace `Select all` label with the unified count + indeterminate state — cascades to every v2 caller using `showSelectAll`.
- `v2/.../SpanDetailsButton`: drop the separate Show all / Hide all items in favor of the unified row.
- `v2/.../GeneratedSamplesDialog`: collapse the select-all text + count Tag into a single unified row.
- `v2/.../MetricSelector`: render unified count with indeterminate state on top of the existing tristate (`null` / `[]` / `[ids]`) selection semantics.
- `v2/.../ExperimentDataset`: add the unified select-all row to the Keys dropdown (it had none before).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6084

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.7
  - Scope: full implementation, helper extraction, simplification pass
  - Human verification: code review + manual visual verification of every affected menu in the dev server

## Testing

- `bash scripts/dev-runner.sh --lint-fe` (runs `lint:fix` + `typecheck` + `deps:validate`) — all green
- Manual visual verification in the dev server of every affected menu:
  - Columns dropdown across v2 table pages — bottom row toggles unchecked → indeterminate (—) → checked correctly
  - TraceTreeViewer "More options" `⋮` menu — old Show all / Hide all gone, single unified row works for the 9 toggleable keys (8 options + Timeline)
  - Generated Samples dialog — single unified row, separate `Show all (N)` button still works
  - LoadableSelectBox-backed multiselects (Project Metrics widget editor "Metrics" / "All percentiles" / "All usage metrics", Experiments Feedback Scores widget editor, Annotation Queue create/edit dialog feedback definitions) — count + indeterminate state correct, search filtering works
  - Playground → Metric Selector — unified count + indeterminate, tristate semantics preserved
  - Compare Experiments → Keys dropdown — newly added select-all row toggles correctly

## Documentation

N/A — UI behavior change only, no documentation updates required.