### PR TITLE
[OPIK-5637] [FE] fix: match agent sandbox empty state avatar to active project

### DIFF
--- a/apps/opik-frontend/src/shared/ProjectIcon/ProjectAvatar.tsx
+++ b/apps/opik-frontend/src/shared/ProjectIcon/ProjectAvatar.tsx
@@ -1,0 +1,16 @@
+import ProjectIcon from "@/shared/ProjectIcon/ProjectIcon";
+import useProjectIconIndices from "@/hooks/useProjectIconIndex";
+
+interface ProjectAvatarProps {
+  projectId?: string | null;
+  size?: "sm" | "md" | "lg";
+}
+
+const ProjectAvatar = ({ projectId, size = "sm" }: ProjectAvatarProps) => {
+  const iconIndices = useProjectIconIndices();
+  const index = projectId ? iconIndices.get(projectId) ?? 0 : 0;
+
+  return <ProjectIcon index={index} size={size} />;
+};
+
+export default ProjectAvatar;

--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/ProjectSelector.tsx
@@ -33,8 +33,7 @@ import { DEFAULT_PROJECT_NAME, Project } from "@/types/projects";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import AddEditProjectDialog from "@/v2/pages/ProjectsPage/AddEditProjectDialog";
-import ProjectIcon from "@/shared/ProjectIcon/ProjectIcon";
-import useProjectIconIndices from "@/hooks/useProjectIconIndex";
+import ProjectAvatar from "@/shared/ProjectIcon/ProjectAvatar";
 import { resolveProjectSwitchTarget } from "./resolveProjectSwitchTarget";
 
 interface ProjectSelectorProps {
@@ -62,11 +61,6 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   );
 
   const isLoading = !!activeProjectId && isProjectPending;
-
-  const iconIndices = useProjectIconIndices();
-  const activeIconIndex = activeProjectId
-    ? iconIndices.get(activeProjectId) ?? 0
-    : 0;
 
   const { data: projectsData } = useProjectsList(
     {
@@ -128,7 +122,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
           open && "bg-primary-foreground",
         )}
       >
-        <ProjectIcon index={activeIconIndex} size="lg" />
+        <ProjectAvatar projectId={activeProjectId} size="lg" />
         <div className="flex min-w-0 flex-1 flex-col items-stretch">
           <div className="flex items-center gap-0.5">
             <span className="comet-body-xs-accented text-light-slate">
@@ -164,7 +158,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
           params={{ workspaceName, projectId: activeProject.id }}
           className="shrink-0"
         >
-          <ProjectIcon index={activeIconIndex} size="lg" />
+          <ProjectAvatar projectId={activeProjectId} size="lg" />
         </Link>
         <div className="flex min-w-0 flex-1 flex-col items-stretch">
           {renderProjectLabel()}
@@ -194,7 +188,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
     const iconContent = isLoading ? (
       <Spinner size="xs" />
     ) : (
-      <ProjectIcon index={activeIconIndex} size="md" />
+      <ProjectAvatar projectId={activeProjectId} size="md" />
     );
 
     if (!activeProject) {
@@ -272,7 +266,6 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
               <ProjectItem
                 key={project.id}
                 project={project}
-                iconIndex={iconIndices.get(project.id) ?? 0}
                 isSelected={project.id === activeProjectId}
                 workspaceName={workspaceName}
                 onSelect={handleSelect}
@@ -318,7 +311,6 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
 
 interface ProjectItemProps {
   project: Project;
-  iconIndex: number;
   isSelected: boolean;
   workspaceName: string;
   onSelect: (projectId: string) => void;
@@ -327,7 +319,6 @@ interface ProjectItemProps {
 
 const ProjectItem: React.FC<ProjectItemProps> = ({
   project,
-  iconIndex,
   isSelected,
   workspaceName,
   onSelect,
@@ -384,7 +375,7 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
           onSelect(project.id);
         }}
       >
-        <ProjectIcon index={iconIndex} />
+        <ProjectAvatar projectId={project.id} />
         <TooltipWrapper content={project.name}>
           <span
             className={cn(

--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/resolveProjectSwitchTarget.test.ts
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/resolveProjectSwitchTarget.test.ts
@@ -156,6 +156,20 @@ describe("resolveProjectSwitchTarget", () => {
     expect(result.search).toBeUndefined();
   });
 
+  it("stays on /agent-playground (empty allowlist) with empty search", () => {
+    const result = resolveProjectSwitchTarget(
+      [...projectChain, match(`${CUR}/agent-playground`)],
+      { anything: "x" },
+      WS,
+      NEW_PROJECT,
+    );
+    expect(result).toEqual({
+      to: "/$workspaceName/projects/$projectId/agent-playground",
+      params: { workspaceName: WS, projectId: NEW_PROJECT },
+      search: {},
+    });
+  });
+
   it("stays on /home with empty search (search dropped)", () => {
     const result = resolveProjectSwitchTarget(
       [...projectChain, match(`${CUR}/home`)],

--- a/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/resolveProjectSwitchTarget.ts
+++ b/apps/opik-frontend/src/v2/layout/SideBar/ProjectSelector/resolveProjectSwitchTarget.ts
@@ -23,7 +23,7 @@ const PORTABLE_SEARCH_PARAMS: Record<string, readonly string[]> = {
   playground: [],
   optimizations: [...COMMON_UI_STATE],
   "agent-configuration": [],
-  "agent-runner": [],
+  "agent-playground": [],
   "online-evaluation": [...COMMON_UI_STATE],
   "annotation-queues": [...COMMON_UI_STATE],
   alerts: [...COMMON_UI_STATE],

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerEmptyState.tsx
@@ -5,8 +5,9 @@ import { buildDocsUrl } from "@/v2/lib/utils";
 import TimelineStep from "@/shared/TimelineStep/TimelineStep";
 import CodeSnippet from "@/shared/CodeSnippet/CodeSnippet";
 import AgentSandboxFlowDiagram from "./AgentSandboxFlowDiagram";
-import ProjectIcon from "@/shared/ProjectIcon/ProjectIcon";
+import ProjectAvatar from "@/shared/ProjectIcon/ProjectAvatar";
 import useActiveProjectName from "@/hooks/useActiveProjectName";
+import { useActiveProjectId } from "@/store/AppStore";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/ui/tabs";
 
 const ENTRYPOINT_SNIPPET_PYTHON = `import opik
@@ -32,13 +33,14 @@ const myAgent = track(
 
 const AgentRunnerEmptyState: React.FC = () => {
   const projectName = useActiveProjectName();
+  const activeProjectId = useActiveProjectId();
   const command = `opik endpoint --project "${projectName}" -- <your app start command>`;
 
   return (
     <div className="flex flex-1 justify-center gap-16 px-10 pt-16">
       <div className="w-full max-w-lg">
         <div className="mb-1 flex items-center gap-2">
-          <ProjectIcon index={0} size="lg" />
+          <ProjectAvatar projectId={activeProjectId} size="lg" />
           <h2 className="comet-title-m">Connect your agent</h2>
         </div>
         <p className="comet-body-s mb-8 text-muted-slate">

--- a/apps/opik-frontend/src/v2/pages/ProjectsPage/ProjectNameCell.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectsPage/ProjectNameCell.tsx
@@ -1,23 +1,21 @@
 import { CellContext } from "@tanstack/react-table";
 import { ProjectWithStatistic } from "@/types/projects";
 import CellWrapper from "@/shared/DataTableCells/CellWrapper";
-import ProjectIcon from "@/shared/ProjectIcon/ProjectIcon";
+import ProjectAvatar from "@/shared/ProjectIcon/ProjectAvatar";
 import LinkifyText from "@/shared/LinkifyText/LinkifyText";
-import useProjectIconIndices from "@/hooks/useProjectIconIndex";
 
 const ProjectNameCell = (
   context: CellContext<ProjectWithStatistic, string>,
 ) => {
   const value = context.getValue();
   const projectId = context.row.original.id;
-  const iconIndices = useProjectIconIndices();
 
   return (
     <CellWrapper
       metadata={context.column.columnDef.meta}
       tableMetadata={context.table.options.meta}
     >
-      <ProjectIcon index={iconIndices.get(projectId) ?? 0} />
+      <ProjectAvatar projectId={projectId} />
       <span className="ml-2 truncate">
         <LinkifyText>{value}</LinkifyText>
       </span>


### PR DESCRIPTION
## Details


https://github.com/user-attachments/assets/84140175-cdfc-4a0a-9e12-3705585a06ab



The agent sandbox empty state always rendered the blue (index 0) project avatar, which was confusing because it didn't match the user's active project. While fixing this I noticed (a) the same project-icon-by-id pattern was duplicated across 5 call sites, and (b) switching projects from the agent playground always redirected to `/home` instead of staying on `/agent-playground`.

- Introduce `ProjectAvatar` (`shared/ProjectIcon/ProjectAvatar.tsx`) that wraps `ProjectIcon` + `useProjectIconIndices` so callers just pass `projectId`. Replace 5 inline `iconIndices.get(projectId) ?? 0` sites: `AgentRunnerEmptyState` (the original bug), `ProjectNameCell`, and three in `ProjectSelector` (also dropped the `iconIndex` prop drilled through `ProjectItem`).
- Fix project-switch redirect: `resolveProjectSwitchTarget.ts` had a stale `"agent-runner"` key in `PORTABLE_SEARCH_PARAMS`, but the actual URL section is `agent-playground`. Lookup fell through and returned `homeTarget`. Renamed the key and added a regression test.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-5637

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation
- Human verification: code review + manual testing

## Testing

- `bash scripts/dev-runner.sh --lint-fe` → lint:fix, typecheck, deps:validate all green
- `npx vitest run src/v2/layout/SideBar/ProjectSelector/resolveProjectSwitchTarget.test.ts src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx` → 17/17 passing (includes new `/agent-playground` regression test)
- Manual: verified the empty state avatar now matches the active project's owl, and that switching projects from the agent playground keeps you on `/agent-playground` for the new project instead of redirecting to `/home`

## Documentation

N/A