### PR TITLE
[OPIK-6306] [FE] Load assistant shell from manifestBase

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -308,7 +308,7 @@ function useAssistantMeta(backendUrl: string | null): AssistantMeta | null {
       return {
         scriptUrl: `${manifestBase}/${manifest.js}`,
         cssUrl: manifest.css ? `${manifestBase}/${manifest.css}` : undefined,
-        shellUrl: `/assistant/${manifest.shell}`,
+        shellUrl: `${manifestBase}/${manifest.shell}`,
         version: manifest.ver,
       };
     },


### PR DESCRIPTION
## Details

`useAssistantMeta` resolves the assistant manifest from `${backendUrl}/console/manifest.json` and uses its directory (`manifestBase`) to build the `scriptUrl` and `cssUrl` for the JS and CSS bundles. The `shellUrl` was the odd one out — it was constructed as `/assistant/${manifest.shell}`, relying on the FE host serving the shell HTML at that path instead of pulling it from the same origin as the rest of the bundle.

This PR aligns the shell with the other two artifacts:

```diff
-        shellUrl: `/assistant/${manifest.shell}`,
+        shellUrl: `${manifestBase}/${manifest.shell}`,
```

Now in production all three URLs resolve relative to wherever the manifest came from. Dev mode is unchanged — `IS_ASSISTANT_DEV` short-circuits to `DEV_META`, which keeps `/assistant/shell` for the local Vite proxy (`vite.config.ts` rewrites `/assistant/*`).

The shell is loaded as the `src` of the assistant iframe (`AssistantSidebar.tsx:530`), so the only behavioral change is the iframe origin in production.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-6306

## Testing

- `npm run typecheck` (opik-frontend) — pass
- `npx eslint apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx --max-warnings=0` — pass

## Documentation

N/A