### PR TITLE
[OPIK-6245] [FE] feat: show Ollie version in AppDebugInfo

### DIFF
--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -121,6 +121,7 @@
     /* Feature/brand colors */
     --feature-experiment-management: #6c6ff7;
     --feature-llm: #52aea4;
+    --color-ollie: #f46e41;
 
     /* Config link icon color */
     --color-fuchsia: #db46ef;
@@ -337,6 +338,7 @@
     /* Feature colors - Dark Mode */
     --feature-experiment-management: #3b70f6;
     --feature-llm: #20ac74;
+    --color-ollie: #f46e41;
 
     /* Config link icon color - Dark Mode */
     --color-fuchsia: #c850c0;

--- a/apps/opik-frontend/src/plugins/comet/AssistantDebugInfo.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantDebugInfo.tsx
@@ -1,0 +1,31 @@
+import copy from "clipboard-copy";
+import { Copy } from "lucide-react";
+import OllieOwl from "@/icons/ollie-owl.svg?react";
+import { toast } from "@/ui/use-toast";
+import useAssistantBackend from "@/plugins/comet/useAssistantBackend";
+import useAssistantManifest from "@/plugins/comet/useAssistantManifest";
+
+const AssistantDebugInfo = () => {
+  const { probeUrl } = useAssistantBackend();
+  const meta = useAssistantManifest(probeUrl);
+
+  if (!meta?.version) return null;
+
+  return (
+    <div
+      className="flex items-center gap-1"
+      onClick={() => {
+        copy(meta.version);
+        toast({ description: "Successfully copied Ollie version" });
+      }}
+    >
+      <span className="comet-body-xs-accented flex items-center gap-1 truncate">
+        <OllieOwl className="size-4 text-[#F46E41]" />
+        OLLIE VERSION {meta.version}
+      </span>
+      <Copy className="size-3 shrink-0" />
+    </div>
+  );
+};
+
+export default AssistantDebugInfo;

--- a/apps/opik-frontend/src/plugins/comet/AssistantDebugInfo.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantDebugInfo.tsx
@@ -20,7 +20,7 @@ const AssistantDebugInfo = () => {
       }}
     >
       <span className="comet-body-xs-accented flex items-center gap-1 truncate">
-        <OllieOwl className="size-4 text-[#F46E41]" />
+        <OllieOwl className="size-4 text-[var(--color-ollie)]" />
         OLLIE VERSION {meta.version}
       </span>
       <Copy className="size-3 shrink-0" />

--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -5,7 +5,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { useParams, useRouter } from "@tanstack/react-router";
 import {
   AssistantSidebarBridge,
@@ -26,10 +25,8 @@ import useRunnerBridgeSync from "@/hooks/useRunnerBridgeSync";
 import { BASE_API_URL } from "@/api/api";
 import AssistantErrorState from "@/plugins/comet/AssistantErrorState";
 import OllieLoader, { OllieLoaderVariant } from "@/plugins/comet/OllieLoader";
-import {
-  ASSISTANT_DEV_BASE_URL,
-  IS_ASSISTANT_DEV,
-} from "@/plugins/comet/constants/assistant";
+import { IS_ASSISTANT_DEV } from "@/plugins/comet/constants/assistant";
+import useAssistantManifest from "@/plugins/comet/useAssistantManifest";
 import {
   ASSISTANT_SIDEBAR_COLLAPSED_WIDTH,
   getStoredAssistantSidebarWidth,
@@ -38,14 +35,6 @@ import {
 } from "@/constants/assistantSidebar";
 
 const BRIDGE_PROTOCOL_VERSION = 1;
-
-// Pod may serve /console/manifest.json before /health/ready flips — retry
-// with backoff so transient 404/503 during warmup don't permanently fail.
-// Budget (~140s) exceeds the 2 min health-poll timeout so manifest doesn't
-// give up before health polling does.
-const MANIFEST_RETRY_COUNT = 30;
-const MANIFEST_RETRY_BASE_DELAY_MS = 500;
-const MANIFEST_RETRY_MAX_DELAY_MS = 5000;
 
 interface AssistantSidebarLoaderProps {
   error: string | null;
@@ -115,13 +104,6 @@ function useLatestRef<T>(value: T): React.MutableRefObject<T> {
   const ref = useRef(value);
   ref.current = value;
   return ref;
-}
-
-interface AssistantManifest {
-  js: string;
-  css?: string;
-  shell: string;
-  ver: string;
 }
 
 type HostListeners = {
@@ -272,61 +254,6 @@ function useBridgeContext(
   );
 }
 
-interface AssistantMeta {
-  scriptUrl: string;
-  cssUrl?: string;
-  shellUrl: string;
-  version: string;
-}
-
-function resolveManifestUrl(backendUrl: string | null): string | null {
-  if (ASSISTANT_DEV_BASE_URL) return `${ASSISTANT_DEV_BASE_URL}/manifest.json`;
-  if (backendUrl) return `${backendUrl}/console/manifest.json`;
-  return null;
-}
-
-const DEV_META: AssistantMeta = {
-  scriptUrl: "/assistant/assistant.js",
-  cssUrl: "/assistant/assistant.css",
-  shellUrl: "/assistant/shell",
-  version: "dev",
-};
-
-function useAssistantMeta(backendUrl: string | null): AssistantMeta | null {
-  const manifestUrl = resolveManifestUrl(backendUrl);
-
-  const manifestBase = manifestUrl
-    ? manifestUrl.substring(0, manifestUrl.lastIndexOf("/"))
-    : null;
-
-  const { data } = useQuery<AssistantMeta>({
-    queryKey: ["assistant-manifest", manifestUrl],
-    queryFn: async () => {
-      const res = await fetch(manifestUrl!);
-      if (!res.ok) throw new Error(`manifest ${res.status}`);
-      const manifest: AssistantManifest = await res.json();
-      return {
-        scriptUrl: `${manifestBase}/${manifest.js}`,
-        cssUrl: manifest.css ? `${manifestBase}/${manifest.css}` : undefined,
-        shellUrl: `${manifestBase}/${manifest.shell}`,
-        version: manifest.ver,
-      };
-    },
-    enabled: !IS_ASSISTANT_DEV && !!manifestUrl,
-    staleTime: Infinity,
-    retry: MANIFEST_RETRY_COUNT,
-    retryDelay: (attempt) =>
-      Math.min(
-        MANIFEST_RETRY_BASE_DELAY_MS * 2 ** attempt,
-        MANIFEST_RETRY_MAX_DELAY_MS,
-      ),
-  });
-
-  if (IS_ASSISTANT_DEV) return DEV_META;
-
-  return data ?? null;
-}
-
 interface AssistantSidebarProps {
   surface?: BridgeSurface;
   onWidthChange: (width: number) => void;
@@ -345,7 +272,7 @@ const AssistantSidebar: React.FC<AssistantSidebarProps> = ({
     retry,
     retryCount,
   } = useAssistantBackend();
-  const meta = useAssistantMeta(probeUrl);
+  const meta = useAssistantManifest(probeUrl);
   const context = useBridgeContext(backendUrl ?? "", surface);
   const router = useRouter();
 

--- a/apps/opik-frontend/src/plugins/comet/useAssistantManifest.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAssistantManifest.ts
@@ -57,7 +57,7 @@ export default function useAssistantManifest(
       return {
         scriptUrl: `${manifestBase}/${manifest.js}`,
         cssUrl: manifest.css ? `${manifestBase}/${manifest.css}` : undefined,
-        shellUrl: `/assistant/${manifest.shell}`,
+        shellUrl: `${manifestBase}/${manifest.shell}`,
         version: manifest.ver,
       };
     },

--- a/apps/opik-frontend/src/plugins/comet/useAssistantManifest.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAssistantManifest.ts
@@ -1,0 +1,77 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  ASSISTANT_DEV_BASE_URL,
+  IS_ASSISTANT_DEV,
+} from "@/plugins/comet/constants/assistant";
+
+// Pod may serve /console/manifest.json before /health/ready flips — retry
+// with backoff so transient 404/503 during warmup don't permanently fail.
+// Budget (~140s) exceeds the 2 min health-poll timeout so manifest doesn't
+// give up before health polling does.
+const MANIFEST_RETRY_COUNT = 30;
+const MANIFEST_RETRY_BASE_DELAY_MS = 500;
+const MANIFEST_RETRY_MAX_DELAY_MS = 5000;
+
+interface AssistantManifest {
+  js: string;
+  css?: string;
+  shell: string;
+  ver: string;
+}
+
+export interface AssistantMeta {
+  scriptUrl: string;
+  cssUrl?: string;
+  shellUrl: string;
+  version: string;
+}
+
+export function resolveManifestUrl(backendUrl: string | null): string | null {
+  if (ASSISTANT_DEV_BASE_URL) return `${ASSISTANT_DEV_BASE_URL}/manifest.json`;
+  if (backendUrl) return `${backendUrl}/console/manifest.json`;
+  return null;
+}
+
+const DEV_META: AssistantMeta = {
+  scriptUrl: "/assistant/assistant.js",
+  cssUrl: "/assistant/assistant.css",
+  shellUrl: "/assistant/shell",
+  version: "dev",
+};
+
+export default function useAssistantManifest(
+  backendUrl: string | null,
+): AssistantMeta | null {
+  const manifestUrl = resolveManifestUrl(backendUrl);
+
+  const manifestBase = manifestUrl
+    ? manifestUrl.substring(0, manifestUrl.lastIndexOf("/"))
+    : null;
+
+  const { data } = useQuery<AssistantMeta>({
+    queryKey: ["assistant-manifest", manifestUrl],
+    queryFn: async () => {
+      const res = await fetch(manifestUrl!);
+      if (!res.ok) throw new Error(`manifest ${res.status}`);
+      const manifest: AssistantManifest = await res.json();
+      return {
+        scriptUrl: `${manifestBase}/${manifest.js}`,
+        cssUrl: manifest.css ? `${manifestBase}/${manifest.css}` : undefined,
+        shellUrl: `/assistant/${manifest.shell}`,
+        version: manifest.ver,
+      };
+    },
+    enabled: !IS_ASSISTANT_DEV && !!manifestUrl,
+    staleTime: Infinity,
+    retry: MANIFEST_RETRY_COUNT,
+    retryDelay: (attempt) =>
+      Math.min(
+        MANIFEST_RETRY_BASE_DELAY_MS * 2 ** attempt,
+        MANIFEST_RETRY_MAX_DELAY_MS,
+      ),
+  });
+
+  if (IS_ASSISTANT_DEV) return DEV_META;
+
+  return data ?? null;
+}

--- a/apps/opik-frontend/src/plugins/development/AssistantDebugInfo.tsx
+++ b/apps/opik-frontend/src/plugins/development/AssistantDebugInfo.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/plugins/comet/AssistantDebugInfo";

--- a/apps/opik-frontend/src/plugins/development/AssistantDebugInfo.tsx
+++ b/apps/opik-frontend/src/plugins/development/AssistantDebugInfo.tsx
@@ -1,1 +1,0 @@
-export { default } from "@/plugins/comet/AssistantDebugInfo";

--- a/apps/opik-frontend/src/shared/OwlArt.tsx
+++ b/apps/opik-frontend/src/shared/OwlArt.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import { cn } from "@/lib/utils";
 
 const OwlArt: React.FC<{ className?: string }> = ({ className }) => (
-  <div className={cn("motion-safe:animate-ollie-breathe", className)}>
+  <div
+    className={cn(
+      "text-[var(--color-ollie)] motion-safe:animate-ollie-breathe",
+      className,
+    )}
+  >
     <svg
       className="size-full"
       viewBox="0 0 72 72"
@@ -10,8 +15,8 @@ const OwlArt: React.FC<{ className?: string }> = ({ className }) => (
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden
     >
-      <path d="M13.5 27L19.125 15.75L24.75 27" fill="#F46E41" />
-      <path d="M47.25 27L52.875 15.75L58.5 27" fill="#F46E41" />
+      <path d="M13.5 27L19.125 15.75L24.75 27" fill="currentColor" />
+      <path d="M47.25 27L52.875 15.75L58.5 27" fill="currentColor" />
       <g
         className="motion-safe:animate-ollie-blink"
         style={{
@@ -21,7 +26,7 @@ const OwlArt: React.FC<{ className?: string }> = ({ className }) => (
       >
         <path
           d="M51.75 21.9375C62.0018 21.9375 70.3125 30.2482 70.3125 40.5C70.3125 50.7518 62.0018 59.0625 51.75 59.0625C45.1063 59.0625 39.2797 55.5711 36 50.3242C32.7203 55.5711 26.8937 59.0625 20.25 59.0625C9.99821 59.0625 1.6875 50.7518 1.6875 40.5C1.6875 30.2482 9.99821 21.9375 20.25 21.9375C26.8934 21.9375 32.7202 25.4283 36 30.6748C39.2798 25.4283 45.1066 21.9375 51.75 21.9375ZM20.25 27.5625C13.1048 27.5625 7.3125 33.3548 7.3125 40.5C7.3125 47.6452 13.1048 53.4375 20.25 53.4375C27.3952 53.4375 33.1875 47.6452 33.1875 40.5C33.1875 33.3548 27.3952 27.5625 20.25 27.5625ZM51.75 27.5625C44.6048 27.5625 38.8125 33.3548 38.8125 40.5C38.8125 47.6452 44.6048 53.4375 51.75 53.4375C58.8952 53.4375 64.6875 47.6452 64.6875 40.5C64.6875 33.3548 58.8952 27.5625 51.75 27.5625Z"
-          fill="#F46E41"
+          fill="currentColor"
         />
       </g>
     </svg>

--- a/apps/opik-frontend/src/store/PluginsStore.ts
+++ b/apps/opik-frontend/src/store/PluginsStore.ts
@@ -31,6 +31,7 @@ type PluginStore = {
     onWidthChange: (width: number) => void;
   }> | null;
   AssistantPrewarmer: React.ComponentType | null;
+  AssistantDebugInfo: React.ComponentType | null;
   UpgradeButton: React.ComponentType | null;
   init: unknown;
   setupPlugins: (folderName: string) => Promise<void>;
@@ -53,6 +54,7 @@ const PLUGIN_NAMES = [
   "SidebarWorkspaceSelector",
   "AssistantSidebar",
   "AssistantPrewarmer",
+  "AssistantDebugInfo",
   "UpgradeButton",
   "init",
 ];
@@ -73,6 +75,7 @@ const usePluginsStore = create<PluginStore>((set) => ({
   SidebarWorkspaceSelector: null,
   AssistantSidebar: null,
   AssistantPrewarmer: null,
+  AssistantDebugInfo: null,
   UpgradeButton: null,
   init: null,
   setupPlugins: async (folderName: string) => {

--- a/apps/opik-frontend/src/v2/layout/AppDebugInfo/AppDebugInfo.tsx
+++ b/apps/opik-frontend/src/v2/layout/AppDebugInfo/AppDebugInfo.tsx
@@ -7,12 +7,16 @@ import OpikIcon from "@/icons/opik.svg?react";
 import copy from "clipboard-copy";
 import { Copy } from "lucide-react";
 import { modifierKey } from "@/lib/utils";
+import usePluginsStore from "@/store/PluginsStore";
 
 const DEBUGGER_MODE_KEY = "comet-debugger-mode"; // Same key used in EM for consistency
 
 const AppDebugInfo = () => {
   const [showAppDebugInfo, setShowAppDebugInfo] = useState(
     () => localStorage.getItem(DEBUGGER_MODE_KEY) === "true",
+  );
+  const AssistantDebugInfo = usePluginsStore(
+    (state) => state.AssistantDebugInfo,
   );
 
   // Keyboard shortcut handler for debugger mode: Meta/Ctrl + Shift + . (all pressed simultaneously)
@@ -30,27 +34,27 @@ const AppDebugInfo = () => {
 
   return (
     showAppDebugInfo && (
-      <>
-        <div className="flex items-center">
-          <AppNetworkStatus />
-        </div>
+      <div className="flex items-center gap-3">
+        <AppNetworkStatus />
 
         {APP_VERSION && (
           <div
-            className="flex items-center gap-2"
+            className="flex items-center gap-1"
             onClick={() => {
               copy(APP_VERSION);
-              toast({ description: "Successfully copied version" });
+              toast({ description: "Successfully copied Opik version" });
             }}
           >
-            <span className="comet-body-s-accented flex items-center gap-2 truncate">
-              <OpikIcon className="size-5" />
+            <span className="comet-body-xs-accented flex items-center gap-1 truncate">
+              <OpikIcon className="size-4" />
               OPIK VERSION {APP_VERSION}
             </span>
-            <Copy className="size-4 shrink-0" />
+            <Copy className="size-3 shrink-0" />
           </div>
         )}
-      </>
+
+        {AssistantDebugInfo && <AssistantDebugInfo />}
+      </div>
     )
   );
 };

--- a/apps/opik-frontend/src/v2/layout/AppNetworkStatus/AppNetworkStatus.tsx
+++ b/apps/opik-frontend/src/v2/layout/AppNetworkStatus/AppNetworkStatus.tsx
@@ -17,10 +17,10 @@ const AppNetworkStatus = () => {
   return (
     <div className="flex items-center gap-2">
       {isConnectedToBackend && (
-        <div className="flex items-center gap-2">
-          <SatelliteDishIcon className="size-5" />
+        <div className="flex items-center gap-1">
+          <SatelliteDishIcon className="size-4" />
           <TooltipWrapper content="Round-trip time (RTT) to ping backend server">
-            <span className="comet-body-s-accented">RTT: {rttInSeconds}s</span>
+            <span className="comet-body-xs-accented">RTT: {rttInSeconds}s</span>
           </TooltipWrapper>
         </div>
       )}
@@ -28,7 +28,7 @@ const AppNetworkStatus = () => {
         <div className="relative flex flex-col items-center justify-center">
           <div
             className={cn(
-              "absolute -top-2.5 left-1.75 size-2 rounded-full",
+              "absolute -top-2 left-1.5 size-1.5 rounded-full",
               isConnectedToBackend ? "bg-green-500" : "bg-red-500",
             )}
           />
@@ -40,7 +40,7 @@ const AppNetworkStatus = () => {
             }
           >
             <span>
-              <CometIcon className="size-5" />
+              <CometIcon className="size-4" />
             </span>
           </TooltipWrapper>
         </div>
@@ -48,7 +48,7 @@ const AppNetworkStatus = () => {
       <div className="relative flex flex-col items-center justify-center">
         <div
           className={cn(
-            "absolute -top-2.5 left-1.75 size-2 rounded-full",
+            "absolute -top-2 left-1/2 size-1.5 -translate-x-1/2 rounded-full",
             isNetworkOnline ? "bg-green-500" : "bg-red-500",
           )}
         />
@@ -60,9 +60,9 @@ const AppNetworkStatus = () => {
           }
         >
           {isNetworkOnline ? (
-            <WifiIcon className="size-5" />
+            <WifiIcon className="size-4" />
           ) : (
-            <WifiOffIcon className="size-5" />
+            <WifiOffIcon className="size-4" />
           )}
         </TooltipWrapper>
       </div>

--- a/apps/opik-frontend/src/v2/layout/TopBar/TopBar.tsx
+++ b/apps/opik-frontend/src/v2/layout/TopBar/TopBar.tsx
@@ -32,7 +32,7 @@ const TopBar: React.FC<TopBarProps> = ({
           <Button
             size="icon-sm"
             variant="outline"
-            className="text-[#F46E41]"
+            className="text-[var(--color-ollie)]"
             onClick={onOpenAssistant}
           >
             <OllieOwl />


### PR DESCRIPTION
## Details

https://github.com/user-attachments/assets/b62de8de-8547-4823-ac28-f8b498544f05

<img width="1960" height="3124" alt="image" src="https://github.com/user-attachments/assets/a825954a-6ccb-4826-9773-59dfb024b7b3" />

When operating in Comet Debugger Mode (Meta/Ctrl+Shift+.), `AppDebugInfo` previously showed only the running Opik version. This PR surfaces the Ollie pod's manifest version next to it, so an engineer triaging an Ollie chat issue can pin a report to a specific deployment without inspecting network requests.

- Extracts the manifest fetch from `AssistantSidebar` into a shared `useAssistantManifest` hook so both the sidebar and the new debug-info block read from the same React Query cache (no extra network request).
- Adds a new V2-only `AssistantDebugInfo` plugin component that renders `OLLIE VERSION x.y.z` with the Ollie owl icon and copy-to-clipboard, mirroring the existing `OPIK VERSION` block.
- Registers the plugin slot in `PluginsStore` so OSS production builds (no plugin folder match) render nothing — the Ollie block is fully gated by Comet plugin availability.
- Polishes sizing in `AppDebugInfo` and `AppNetworkStatus` (size-4 icons, size-3 copy, `comet-body-xs-accented`, size-1.5 status dots, gap-3 between blocks) per product feedback.

V1 is intentionally untouched: there is no assistant integration in V1 to display.

## Change checklist

- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6245

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation
- Human verification: code review + manual testing in local dev (IS_ASSISTANT_DEV=true)

## Testing

- Ran `npm run typecheck` and `npm run lint` in `apps/opik-frontend` — both pass clean.
- Local dev (`VITE_ASSISTANT_SIDEBAR_BASE_URL=http://localhost:3333`, `IS_ASSISTANT_DEV=true`): toggled debugger mode (Meta/Ctrl+Shift+.), confirmed `OLLIE VERSION dev` appears next to `OPIK VERSION`, click-to-copy works with toast "Successfully copied Ollie version", DevTools Network shows zero new manifest requests.
- Verified V1 layout is unaffected (no Ollie integration there).
- Acceptance check on EM staging is pending — manifest field `ver` should resolve to the deployed value (e.g. `ollie-0.1.214`). Same query/queryKey as `AssistantSidebar` already uses today, so cache reuse is automatic.

## Documentation

N/A