### PR TITLE
[OPIK-6248] [FE] feat: trace details main content area – skeleton loader + tag colors

### DIFF
--- a/apps/opik-frontend/src/constants/traces.ts
+++ b/apps/opik-frontend/src/constants/traces.ts
@@ -1,4 +1,5 @@
 import { BASE_TRACE_DATA_TYPE, SPAN_TYPE } from "@/types/traces";
+import { TagProps } from "@/ui/tag";
 
 export const TRACE_TYPE_FOR_TREE = "trace";
 
@@ -78,6 +79,17 @@ export const TRACE_TYPE_COLORS_MAP: Record<
     color: "var(--type-llm-assistant)",
     bg: "var(--type-llm-assistant-bg)",
   },
+};
+
+export const TAG_VARIANT_BY_TRACE_TYPE: Record<
+  BASE_TRACE_DATA_TYPE,
+  TagProps["variant"]
+> = {
+  [TRACE_TYPE_FOR_TREE]: "purple",
+  [SPAN_TYPE.llm]: "blue",
+  [SPAN_TYPE.general]: "green",
+  [SPAN_TYPE.tool]: "burgundy",
+  [SPAN_TYPE.guardrail]: "orange",
 };
 
 export const SPAN_TYPE_LABELS_MAP: Record<SPAN_TYPE, string> = {

--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -42,6 +42,7 @@
 
     --muted: 210 40% 96.1%;
     --muted-foreground: 215.4 16.3% 46.9%;
+    --skeleton-shimmer-highlight: hsl(0 0% 100% / 0.6);
 
     --accent: 210 40% 96.1%;
     --accent-foreground: 222.2 47.4% 11.2%;
@@ -350,6 +351,7 @@
 
     /* Muted colors - Dark Mode */
     --muted: 0, 0%, 11%;
+    --skeleton-shimmer-highlight: hsl(0 0% 100% / 0.06);
 
     /* Toggle colors - Dark Mode */
     --toggle-outline-active: #2c3c56;

--- a/apps/opik-frontend/src/ui/skeleton.tsx
+++ b/apps/opik-frontend/src/ui/skeleton.tsx
@@ -6,7 +6,10 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-muted", className)}
+      className={cn(
+        "animate-shimmer rounded-md bg-muted bg-[linear-gradient(90deg,hsl(var(--muted))_0%,hsl(var(--muted))_40%,var(--skeleton-shimmer-highlight)_50%,hsl(var(--muted))_60%,hsl(var(--muted))_100%)] bg-[length:200%_100%]",
+        className,
+      )}
       {...props}
     />
   );

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -3,9 +3,15 @@ import get from "lodash/get";
 import { StringParam, useQueryParam } from "use-query-params";
 import { Brain, Calendar, MessageSquareMore, PenLine } from "lucide-react";
 
-import { AgentGraphData, Span, Trace } from "@/types/traces";
+import {
+  AgentGraphData,
+  BASE_TRACE_DATA_TYPE,
+  Span,
+  Trace,
+} from "@/types/traces";
 import {
   METADATA_AGENT_GRAPH_KEY,
+  TAG_VARIANT_BY_TRACE_TYPE,
   TRACE_TYPE_FOR_TREE,
 } from "@/constants/traces";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
@@ -246,7 +252,9 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
             traceId={traceId}
             spanId={spanId}
             className="pl-1"
-            tagVariant="gray"
+            tagVariant={
+              TAG_VARIANT_BY_TRACE_TYPE[type as BASE_TRACE_DATA_TYPE] ?? "gray"
+            }
           />
         </div>
 

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
@@ -16,7 +16,7 @@ import {
   ResizablePanelGroup,
 } from "@/ui/resizable";
 import useTraceById from "@/api/traces/useTraceById";
-import Loader from "@/shared/Loader/Loader";
+import { Skeleton } from "@/ui/skeleton";
 import TraceDataViewer from "./TraceDataViewer/TraceDataViewer";
 import TraceTreeViewer from "./TraceTreeViewer/TraceTreeViewer";
 import TraceAIViewer from "./TraceAIViewer/TraceAIViewer";
@@ -50,6 +50,43 @@ import { usePermissions } from "@/contexts/PermissionsContext";
 
 const MAX_SPANS_LOAD_SIZE = 15000;
 const EMPTY_FILTERS: unknown[] = [];
+
+const TREE_ROW_INDENTS = [
+  0, 20, 20, 40, 20, 40, 60, 20, 40, 20, 40, 60,
+] as const;
+
+const TraceTreeSkeleton: React.FC = () => (
+  <div className="flex size-full flex-col gap-2 overflow-hidden p-4">
+    {TREE_ROW_INDENTS.map((indent, i) => (
+      <div
+        key={i}
+        className="flex items-center gap-1"
+        style={{ paddingLeft: indent }}
+      >
+        <Skeleton className="size-4 shrink-0" />
+        <Skeleton className="h-4 flex-1" />
+      </div>
+    ))}
+  </div>
+);
+
+const TraceDataSkeleton: React.FC = () => (
+  <div className="flex flex-col gap-4 p-4">
+    <div className="flex flex-col gap-2">
+      <Skeleton className="h-6 w-full max-w-screen-sm" />
+      <div className="flex gap-2">
+        <Skeleton className="h-6 w-[72px]" />
+        <Skeleton className="h-6 w-[72px]" />
+        <Skeleton className="h-6 w-[72px]" />
+      </div>
+    </div>
+    <div className="flex flex-col gap-2">
+      <Skeleton className="h-9 w-full" />
+      <Skeleton className="h-40 w-full" />
+      <Skeleton className="h-60 w-full" />
+    </div>
+  </div>
+);
 
 type TraceDetailsPanelProps = {
   projectId?: string;
@@ -219,30 +256,33 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
   }, [hasPreviousRow, hasNextRow, onRowChange, onClose]);
 
   const renderContent = () => {
-    if (isTracePending || isSpansPending) {
-      return <Loader />;
-    }
+    const isLoading = isTracePending || isSpansPending;
 
-    if (!dataToView || !trace) {
+    if (!isLoading && (!dataToView || !trace)) {
       return <NoData />;
     }
 
-    const treeViewer = (
-      <TraceTreeViewer
-        trace={trace}
-        spans={spansData?.content}
-        rowId={spanId || traceId}
-        onSelectRow={handleRowSelect}
-        search={search}
-        filters={filters}
-        config={treeConfig}
-      />
-    );
+    const treeViewer =
+      isLoading || !trace ? (
+        <TraceTreeSkeleton />
+      ) : (
+        <TraceTreeViewer
+          trace={trace}
+          spans={spansData?.content}
+          rowId={spanId || traceId}
+          onSelectRow={handleRowSelect}
+          search={search}
+          filters={filters}
+          config={treeConfig}
+        />
+      );
 
     const isAnnotating =
       activeSection === DetailsActionSection.Annotate ||
       activeSection === DetailsActionSection.Annotations ||
       activeSection === DetailsActionSection.Comments;
+
+    const showAgentGraph = !isLoading && Boolean(agentGraphData);
 
     return (
       <div className="relative size-full">
@@ -255,12 +295,12 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
                 setSearch={setSearch}
                 filters={filters}
                 setFilters={setFilters}
-                isSpansLazyLoading={isSpansLazyLoading}
+                isSpansLazyLoading={isSpansLazyLoading || isLoading}
                 treeData={treeData}
                 config={treeConfig}
                 setConfig={setTreeConfig}
               />
-              {agentGraphData && !isGraphCollapsed ? (
+              {showAgentGraph && !isGraphCollapsed ? (
                 <ResizablePanelGroup
                   direction="vertical"
                   autoSaveId="trace-tree-graph"
@@ -299,7 +339,7 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
                   <div className="relative flex-auto overflow-hidden">
                     {treeViewer}
                   </div>
-                  {agentGraphData && (
+                  {showAgentGraph && (
                     <AgentGraphHeader
                       isCollapsed
                       onToggleCollapse={() => setIsGraphCollapsed(false)}
@@ -317,21 +357,27 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
               <TraceDataToolbar
                 dataToView={dataToView}
                 setActiveSection={setActiveSection}
+                isLoading={isLoading}
               />
               <div className="relative flex-auto overflow-hidden">
-                <TraceDataViewer
-                  data={dataToView}
-                  projectId={projectId}
-                  spanId={spanId}
-                  traceId={traceId}
-                  setActiveSection={setActiveSection}
-                  isSpansLazyLoading={isSpansLazyLoading}
-                  search={search}
-                />
+                {isLoading || !dataToView ? (
+                  <TraceDataSkeleton />
+                ) : (
+                  <TraceDataViewer
+                    data={dataToView}
+                    projectId={projectId}
+                    spanId={spanId}
+                    traceId={traceId}
+                    setActiveSection={setActiveSection}
+                    isSpansLazyLoading={isSpansLazyLoading}
+                    search={search}
+                  />
+                )}
               </div>
             </div>
           </ResizablePanel>
-          {Boolean(activeSection) &&
+          {!isLoading &&
+            Boolean(activeSection) &&
             (canAnnotateTraceSpanThread || !isAnnotating) && (
               <>
                 <ResizableHandle />
@@ -340,7 +386,7 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
                   defaultSize={40}
                   minSize={30}
                 >
-                  {isAnnotating && (
+                  {isAnnotating && dataToView && (
                     <AnnotatePanel
                       data={dataToView}
                       traceId={traceId}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsToolbar.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsToolbar.tsx
@@ -23,6 +23,7 @@ import BaseTraceDataTypeIcon from "@/shared/BaseTraceDataTypeIcon/BaseTraceDataT
 import ExpandableSearchInput from "@/shared/ExpandableSearchInput/ExpandableSearchInput";
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";
 import SelectBox, { SelectBoxProps } from "@/shared/SelectBox/SelectBox";
+import { Skeleton } from "@/ui/skeleton";
 import SpanDetailsButton from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceTreeViewer/SpanDetailsButton";
 import useTreeDetailsStore, {
   TreeNodeConfig,
@@ -247,13 +248,15 @@ export const TraceTreeToolbar: React.FC<TraceTreeToolbarProps> = ({
 
 // Right toolbar — sits above the data panel
 type TraceDataToolbarProps = {
-  dataToView: Trace | Span;
+  dataToView: Trace | Span | undefined;
   setActiveSection: (v: DetailsActionSectionValue) => void;
+  isLoading?: boolean;
 };
 
 export const TraceDataToolbar: React.FC<TraceDataToolbarProps> = ({
   dataToView,
   setActiveSection,
+  isLoading = false,
 }) => {
   const {
     permissions: { canAnnotateTraceSpanThread },
@@ -271,7 +274,7 @@ export const TraceDataToolbar: React.FC<TraceDataToolbarProps> = ({
 
   const rows = useMemo(() => (dataToView ? [dataToView] : []), [dataToView]);
 
-  const isSpan = isObjectSpan(dataToView);
+  const isSpan = dataToView ? isObjectSpan(dataToView) : false;
   const dataType = isSpan ? "spans" : "traces";
   const inspectType: BASE_TRACE_DATA_TYPE = isSpan
     ? (dataToView as Span).type
@@ -282,10 +285,16 @@ export const TraceDataToolbar: React.FC<TraceDataToolbarProps> = ({
       <span className="comet-body-xs-accented whitespace-nowrap text-foreground">
         Inspect:
       </span>
-      <BaseTraceDataTypeIcon type={inspectType} />
-      <span className="comet-body-xs-accented truncate">
-        {dataToView?.name}
-      </span>
+      {isLoading || !dataToView ? (
+        <Skeleton className="h-4 w-32" />
+      ) : (
+        <>
+          <BaseTraceDataTypeIcon type={inspectType} />
+          <span className="comet-body-xs-accented truncate">
+            {dataToView?.name}
+          </span>
+        </>
+      )}
 
       <div className="flex-auto" />
 
@@ -295,6 +304,7 @@ export const TraceDataToolbar: React.FC<TraceDataToolbarProps> = ({
         dataType={dataType}
         buttonVariant="ghost"
         buttonSize="2xs"
+        disabled={isLoading || !dataToView}
       />
       {canAnnotateTraceSpanThread && (
         <DetailsActionSectionToggle
@@ -305,6 +315,7 @@ export const TraceDataToolbar: React.FC<TraceDataToolbarProps> = ({
           variant="ghost"
           buttonSize="2xs"
           hotkey="A"
+          disabled={isLoading || !dataToView}
         />
       )}
     </div>

--- a/apps/opik-frontend/tailwind.config.ts
+++ b/apps/opik-frontend/tailwind.config.ts
@@ -166,6 +166,10 @@ module.exports = {
           from: { opacity: "0", transform: "translateY(4px)" },
           to: { opacity: "1", transform: "translateY(0)" },
         },
+        shimmer: {
+          "0%": { backgroundPosition: "200% 0" },
+          "100%": { backgroundPosition: "-200% 0" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
@@ -173,6 +177,7 @@ module.exports = {
         "ollie-breathe": "ollie-breathe 3.2s ease-in-out infinite",
         "ollie-blink": "ollie-blink 5.4s ease-in-out infinite",
         "ollie-text-in": "ollie-text-in 300ms ease-out",
+        shimmer: "shimmer 1.8s ease-in-out infinite",
       },
       boxShadow: {
         "action-card": "var(--action-card-shadow)",


### PR DESCRIPTION
## Details

First two sub-tasks of [OPIK-6248](https://comet-ml.atlassian.net/browse/OPIK-6248) — updating the v2 Trace Details main content area per the redesign in [Figma 457:81128](https://www.figma.com/design/eumAOxjM1i2tIBjKQzw7TG/Misc?node-id=457-81128) / [457:82978](https://www.figma.com/design/eumAOxjM1i2tIBjKQzw7TG/Misc?node-id=457-82978).

### 1. Skeleton loader (replaces the centered spinner)

- Both toolbars stay mounted during loading; only the inner viewers swap to `TraceTreeSkeleton` / `TraceDataSkeleton`, so the layout doesn't jump on resolve.
- `TraceDataToolbar` accepts an `isLoading` prop and renders an inline `<Skeleton>` placeholder for the inspect icon + name; `AddToDropdown` and the annotate toggle are disabled while loading.
- Adds a CSS-only shimmer animation to the existing shadcn `<Skeleton>` primitive (`animate-shimmer` keyframe + `--skeleton-shimmer-highlight` CSS variable defined in both `:root` and `.dark`), so the new effect applies app-wide without a dark-mode regression.
- No new dependency, no per-view skeleton component sprawl.

### 2. Tag colors follow the active section

- The user-defined `<TagList>` below the title now picks up the color of the currently active span/trace in the tree, instead of being hardcoded gray.
- New `TAG_VARIANT_BY_TRACE_TYPE` map in `constants/traces.ts`: trace→purple, llm→blue, general→green, tool→burgundy, guardrail→orange. Falls back to gray for unknown types.
- Reuses the existing named-variant tokens (`--tag-blue-*`, `--tag-burgundy-*`, etc.) — no new CSS, no `<Tag>` primitive changes.

v1 paths are untouched. The `constants/traces.ts` change is purely additive (no existing exports modified).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6248

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.7
  - Scope: assisted (planning, implementation, code review pass)
  - Human verification: code review + manual browser verification pending

## Testing

- `npm run typecheck` (opik-frontend) — pass
- `npm run lint` (opik-frontend) — pass
- Manual browser verification on the Trace Details panel:
  - **Skeleton loader**: flashes briefly on open, mirrors the loaded layout (tree-on-left / data-on-right), swap to real content is jump-free, dark-mode shimmer is subtle.
  - **Tag colors**: user tags below the title cycle through purple → blue → green → burgundy → orange when clicking trace root → llm → general → tool → guardrail spans. Entities with no tags render nothing (no regression).
  - Spot-check other `<Skeleton>` consumers (e.g. `TraceChatMessage`, `DataTableSkeletonBody`, `DatasetExpansionDialog`) — shimmer applies uniformly with no regressions.

## Documentation

N/A — UI behavior change only, no documentation updates required.

[OPIK-6248]: https://comet-ml.atlassian.net/browse/OPIK-6248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ