### PR TITLE
[OPIK-6226] [FE] fix: agent configuration show more button issues

### DIFF
--- a/apps/opik-frontend/src/shared/SingleLineExpandableText/SingleLineExpandableText.tsx
+++ b/apps/opik-frontend/src/shared/SingleLineExpandableText/SingleLineExpandableText.tsx
@@ -1,0 +1,80 @@
+import React, { ReactNode, useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+type SingleLineExpandableTextProps = {
+  children: ReactNode;
+  showMoreLabel?: string;
+  showLessLabel?: string;
+  className?: string;
+  buttonClassName?: string;
+};
+
+const SingleLineExpandableText: React.FC<SingleLineExpandableTextProps> = ({
+  children,
+  showMoreLabel = "Show more",
+  showLessLabel = "Show less",
+  className,
+  buttonClassName,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const measureRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = measureRef.current;
+    if (!el) return;
+
+    const measure = () => {
+      setIsOverflowing(el.scrollWidth > el.clientWidth);
+    };
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [children]);
+
+  const toggle = () => setIsExpanded((prev) => !prev);
+
+  return (
+    <div className={cn("relative min-w-0 flex-1", className)}>
+      <div
+        ref={measureRef}
+        aria-hidden="true"
+        className="pointer-events-none invisible absolute inset-x-0 top-0 truncate"
+      >
+        {children}
+      </div>
+
+      {isExpanded ? (
+        <div className="min-w-0 break-words">
+          {children}
+          {isOverflowing && (
+            <button
+              type="button"
+              className={cn("ml-1 underline", buttonClassName)}
+              onClick={toggle}
+            >
+              {showLessLabel}
+            </button>
+          )}
+        </div>
+      ) : (
+        <div className="flex min-w-0 items-baseline gap-1">
+          <div className="min-w-0 flex-1 truncate">{children}</div>
+          {isOverflowing && (
+            <button
+              type="button"
+              className={cn("shrink-0 underline", buttonClassName)}
+              onClick={toggle}
+            >
+              {showMoreLabel}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SingleLineExpandableText;

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationDetailView.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationDetailView.tsx
@@ -4,7 +4,6 @@ import { Clock, FilePen, Pencil, User } from "lucide-react";
 import { ConfigHistoryItem } from "@/types/agent-configs";
 import { formatDate, getTimeFromNow } from "@/lib/date";
 import Loader from "@/shared/Loader/Loader";
-import { cn } from "@/lib/utils";
 import { Card } from "@/ui/card";
 import DeployToPopover from "./DeployToPopover";
 import BlueprintValuesList from "@/v2/pages-shared/traces/ConfigurationTab/BlueprintValuesList";
@@ -19,14 +18,13 @@ import { COLUMN_TYPE } from "@/types/shared";
 import { Separator } from "@/ui/separator";
 import DiffVersionPopover from "./DiffVersionPopover";
 import AgentConfigTagList from "./AgentConfigTagList";
+import SingleLineExpandableText from "@/shared/SingleLineExpandableText/SingleLineExpandableText";
 import ExpandAllToggle from "@/v2/pages-shared/agent-configuration/fields/ExpandAllToggle";
 import { useFieldsCollapse } from "@/v2/pages-shared/agent-configuration/fields/useFieldsCollapse";
 import {
   collectMultiLineKeys,
   hasAnyExpandableField,
 } from "@/v2/pages-shared/agent-configuration/fields/blueprintFieldLayout";
-
-const DESCRIPTION_TRUNCATE_LENGTH = 80;
 
 type AgentConfigurationDetailViewProps = {
   item: ConfigHistoryItem;
@@ -69,7 +67,6 @@ const AgentConfigurationDetailView: React.FC<
     label: string;
     blueprintId: string;
   } | null>(null);
-  const [notesExpanded, setNotesExpanded] = useState(false);
 
   const handleSelectDiffVersion = (versionItem: ConfigHistoryItem) => {
     setComparedVersion({
@@ -82,9 +79,6 @@ const AgentConfigurationDetailView: React.FC<
   const isLatestVersion = versions[0]?.id === item.id;
 
   const description = item.description;
-
-  const descriptionIsLong =
-    (description?.length ?? 0) > DESCRIPTION_TRUNCATE_LENGTH;
 
   const collapsibleKeys = useMemo(
     () => collectMultiLineKeys(agentConfig?.values ?? []),
@@ -162,30 +156,9 @@ const AgentConfigurationDetailView: React.FC<
         {description && (
           <div className="comet-body-s flex w-full min-w-0 items-start gap-1 text-light-slate">
             <FilePen className="mt-1 size-3 shrink-0" />
-            <div
-              className={cn(
-                "flex min-w-0 flex-1 items-baseline gap-1",
-                notesExpanded && "flex-wrap",
-              )}
-            >
-              <span
-                className={cn(
-                  "min-w-0",
-                  notesExpanded ? "break-words" : "truncate",
-                )}
-              >
-                {description}
-              </span>
-              {descriptionIsLong && (
-                <button
-                  type="button"
-                  className="shrink-0 text-light-slate underline"
-                  onClick={() => setNotesExpanded((v) => !v)}
-                >
-                  {notesExpanded ? "Show less" : "Show more"}
-                </button>
-              )}
-            </div>
+            <SingleLineExpandableText key={item.id}>
+              {description}
+            </SingleLineExpandableText>
           </div>
         )}
         <div className="comet-body-s mt-1 flex items-center gap-1 text-light-slate">


### PR DESCRIPTION
## Details

Fixes three issues with the Show more / Show less toggle on the agent configuration version description:
- Expanded state was leaking across versions — now reset per version via component remount.
- "Show less" no longer occupies a separate line — it now appears inline at the end of the description.
- "Show more" / "Show less" only render when the description actually overflows the available width, and reactively appear/disappear when the panel is resized.

Introduces a small `SingleLineExpandableText` component in `shared/` that owns single-line truncation, real overflow detection (`ResizeObserver` on a hidden full-width measurement element using `truncate`), and the inline toggle button.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6226

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.7 (1M context)
  - Scope: full implementation
  - Human verification: code review + manual testing in the agent configuration page

## Testing

- `bash scripts/dev-runner.sh --lint-fe` (eslint, stylelint, tsc, dependency-cruiser) — all pass
- Manual verification in the Agent configuration tab:
  - Long description → "Show more" appears inline next to truncated text; click expands to full text with "Show less" inline at end of last line.
  - Switching versions while expanded → new version starts collapsed (per-version state).
  - Resizing the side panel narrower → button appears as soon as the description no longer fits.
  - Resizing wider while expanded → "Show less" disappears the moment the description fits in one line.
  - Short description → no button rendered.

## Documentation

N/A