### PR TITLE
[OPIK-6310] [BE] feat: auto-generate blueprint descriptions from config changes

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
@@ -23,6 +23,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
@@ -276,7 +277,7 @@ class AgentConfigServiceImpl implements AgentConfigService {
                 : generateNextBlueprintName(dao, workspaceId, projectId);
 
         String description = blueprint.description();
-        if ((description == null || description.isBlank()) && blueprint.type() != AgentBlueprint.BlueprintType.MASK) {
+        if (blueprint.type() == AgentBlueprint.BlueprintType.BLUEPRINT && StringUtils.isBlank(description)) {
             description = generateUpdateDescription(dao, workspaceId, projectId, blueprint.values());
         }
 
@@ -320,10 +321,10 @@ class AgentConfigServiceImpl implements AgentConfigService {
             if (prev == null) {
                 added.add(v.key());
             } else if (!Objects.equals(prev.value(), v.value())) {
-                boolean isNumeric = v.type() == AgentConfigValue.ValueType.INTEGER
+                boolean isPrimitive = v.type() == AgentConfigValue.ValueType.INTEGER
                         || v.type() == AgentConfigValue.ValueType.FLOAT
                         || v.type() == AgentConfigValue.ValueType.BOOLEAN;
-                if (isNumeric) {
+                if (isPrimitive) {
                     modified.add(v.key() + " to " + v.value());
                 } else {
                     modified.add(v.key());
@@ -335,22 +336,24 @@ class AgentConfigServiceImpl implements AgentConfigService {
             return null;
         }
 
-        List<String> parts = new ArrayList<>();
+        StringBuilder description = new StringBuilder();
         if (!added.isEmpty()) {
-            parts.add("Added " + String.join(", ", added));
+            description.append("Added ").append(String.join(", ", added));
         }
         if (!modified.isEmpty()) {
-            parts.add("Modified " + String.join(", ", modified));
+            if (!description.isEmpty()) description.append(". ");
+            description.append("Modified ").append(String.join(", ", modified));
         }
         if (!removed.isEmpty()) {
-            parts.add("Removed " + String.join(", ", removed));
+            if (!description.isEmpty()) description.append(". ");
+            description.append("Removed ").append(String.join(", ", removed));
         }
 
-        String description = String.join(". ", parts);
         if (description.length() > 255) {
-            description = description.substring(0, 252) + "...";
+            description.setLength(252);
+            description.append("...");
         }
-        return description;
+        return description.toString();
     }
 
     private UUID createBlueprintSnapshot(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
@@ -274,12 +274,78 @@ class AgentConfigServiceImpl implements AgentConfigService {
         String name = blueprint.type() == AgentBlueprint.BlueprintType.MASK
                 ? ""
                 : generateNextBlueprintName(dao, workspaceId, projectId);
+
+        String description = blueprint.description();
+        if ((description == null || description.isBlank()) && blueprint.type() != AgentBlueprint.BlueprintType.MASK) {
+            description = generateUpdateDescription(dao, workspaceId, projectId, blueprint.values());
+        }
+
+        blueprint = blueprint.toBuilder().description(description).build();
         UUID blueprintId = createBlueprintSnapshot(dao, workspaceId, projectId, configId, name, blueprint);
 
         return blueprint.toBuilder()
                 .id(blueprintId)
                 .name(name)
                 .build();
+    }
+
+    private String generateUpdateDescription(
+            AgentConfigDAO dao,
+            String workspaceId,
+            UUID projectId,
+            List<AgentConfigValue> newValues) {
+
+        if (newValues == null || newValues.isEmpty()) {
+            return null;
+        }
+
+        AgentBlueprint previous = dao.getLatestBlueprint(workspaceId, projectId,
+                AgentBlueprint.BlueprintType.BLUEPRINT);
+        Map<String, AgentConfigValue> previousByKey = previous != null && previous.values() != null
+                ? previous.values().stream().collect(Collectors.toMap(AgentConfigValue::key, v -> v))
+                : Map.of();
+
+        Set<String> newKeys = newValues.stream().map(AgentConfigValue::key).collect(Collectors.toSet());
+
+        List<String> removed = previousByKey.keySet().stream()
+                .filter(k -> !newKeys.contains(k))
+                .sorted()
+                .toList();
+
+        List<String> added = new ArrayList<>();
+        List<String> modified = new ArrayList<>();
+
+        for (AgentConfigValue v : newValues) {
+            AgentConfigValue prev = previousByKey.get(v.key());
+            if (prev == null) {
+                added.add(v.key());
+            } else if (!Objects.equals(prev.value(), v.value())) {
+                boolean isNumeric = v.type() == AgentConfigValue.ValueType.INTEGER
+                        || v.type() == AgentConfigValue.ValueType.FLOAT;
+                if (isNumeric) {
+                    modified.add(v.key() + " to " + v.value());
+                } else {
+                    modified.add(v.key());
+                }
+            }
+        }
+
+        if (added.isEmpty() && modified.isEmpty() && removed.isEmpty()) {
+            return null;
+        }
+
+        List<String> parts = new ArrayList<>();
+        if (!added.isEmpty()) {
+            parts.add("Added " + String.join(", ", added));
+        }
+        if (!modified.isEmpty()) {
+            parts.add("Modified " + String.join(", ", modified));
+        }
+        if (!removed.isEmpty()) {
+            parts.add("Removed " + String.join(", ", removed));
+        }
+
+        return String.join(". ", parts);
     }
 
     private UUID createBlueprintSnapshot(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
@@ -346,7 +346,11 @@ class AgentConfigServiceImpl implements AgentConfigService {
             parts.add("Removed " + String.join(", ", removed));
         }
 
-        return String.join(". ", parts);
+        String description = String.join(". ", parts);
+        if (description.length() > 255) {
+            description = description.substring(0, 252) + "...";
+        }
+        return description;
     }
 
     private UUID createBlueprintSnapshot(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
@@ -321,7 +321,8 @@ class AgentConfigServiceImpl implements AgentConfigService {
                 added.add(v.key());
             } else if (!Objects.equals(prev.value(), v.value())) {
                 boolean isNumeric = v.type() == AgentConfigValue.ValueType.INTEGER
-                        || v.type() == AgentConfigValue.ValueType.FLOAT;
+                        || v.type() == AgentConfigValue.ValueType.FLOAT
+                        || v.type() == AgentConfigValue.ValueType.BOOLEAN;
                 if (isNumeric) {
                     modified.add(v.key() + " to " + v.value());
                 } else {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResourceTest.java
@@ -564,6 +564,275 @@ class AgentConfigsResourceTest {
             assertThat(retrieved.description()).isEqualTo("Updated blueprint");
         }
 
+        @Test
+        @DisplayName("Success: auto-generates description listing added keys when none provided")
+        void updateAgentConfig__noDescription__addsKeys__thenAutoGeneratesDescription() {
+            var projectId = projectResourceClient.createProject(UUID.randomUUID().toString(), API_KEY, TEST_WORKSPACE);
+            var existingKey = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var newKey = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var existingValue = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var newValue = RandomStringUtils.insecure().nextNumeric(5);
+
+            agentConfigsResourceClient.createAgentConfig(
+                    AgentConfigCreate.builder()
+                            .projectId(projectId)
+                            .blueprint(AgentBlueprint.builder()
+                                    .type(BlueprintType.BLUEPRINT)
+                                    .description(RandomStringUtils.insecure().nextAlphanumeric(10))
+                                    .values(List.of(
+                                            AgentConfigValue.builder().key(existingKey).value(existingValue)
+                                                    .type(ValueType.STRING).build()))
+                                    .build())
+                            .build(),
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+
+            var blueprintId = agentConfigsResourceClient.updateAgentConfig(
+                    AgentConfigCreate.builder()
+                            .projectId(projectId)
+                            .blueprint(AgentBlueprint.builder()
+                                    .type(BlueprintType.BLUEPRINT)
+                                    .values(List.of(
+                                            AgentConfigValue.builder().key(existingKey).value(existingValue)
+                                                    .type(ValueType.STRING).build(),
+                                            AgentConfigValue.builder().key(newKey).value(newValue)
+                                                    .type(ValueType.FLOAT).build()))
+                                    .build())
+                            .build(),
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+
+            var retrieved = agentConfigsResourceClient.getBlueprintById(blueprintId, null, API_KEY,
+                    TEST_WORKSPACE, HttpStatus.SC_OK);
+            assertThat(retrieved.description()).isEqualTo("Added " + newKey);
+        }
+
+        Stream<Arguments> numericValueTypes() {
+            return Stream.of(
+                    arguments(ValueType.FLOAT),
+                    arguments(ValueType.INTEGER));
+        }
+
+        @ParameterizedTest
+        @MethodSource("numericValueTypes")
+        @DisplayName("Success: auto-generates description with new value when numeric key is modified")
+        void updateAgentConfig__noDescription__modifiesNumericKey__thenAutoGeneratesDescription(ValueType type) {
+            var projectId = projectResourceClient.createProject(UUID.randomUUID().toString(), API_KEY, TEST_WORKSPACE);
+            var key = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var oldValue = RandomStringUtils.insecure().nextNumeric(3);
+            var newValue = RandomStringUtils.insecure().nextNumeric(4);
+
+            agentConfigsResourceClient.createAgentConfig(
+                    AgentConfigCreate.builder()
+                            .projectId(projectId)
+                            .blueprint(AgentBlueprint.builder()
+                                    .type(BlueprintType.BLUEPRINT)
+                                    .description(RandomStringUtils.insecure().nextAlphanumeric(10))
+                                    .values(List.of(
+                                            AgentConfigValue.builder().key(key).value(oldValue)
+                                                    .type(type).build()))
+                                    .build())
+                            .build(),
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+
+            var blueprintId = agentConfigsResourceClient.updateAgentConfig(
+                    AgentConfigCreate.builder()
+                            .projectId(projectId)
+                            .blueprint(AgentBlueprint.builder()
+                                    .type(BlueprintType.BLUEPRINT)
+                                    .values(List.of(
+                                            AgentConfigValue.builder().key(key).value(newValue)
+                                                    .type(type).build()))
+                                    .build())
+                            .build(),
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+
+            var retrieved = agentConfigsResourceClient.getBlueprintById(blueprintId, null, API_KEY,
+                    TEST_WORKSPACE, HttpStatus.SC_OK);
+            assertThat(retrieved.description()).isEqualTo("Modified " + key + " to " + newValue);
+        }
+
+        Stream<Arguments> nonNumericValueTypes() {
+            return Stream.of(
+                    arguments(ValueType.STRING),
+                    arguments(ValueType.BOOLEAN),
+                    arguments(ValueType.PROMPT),
+                    arguments(ValueType.PROMPT_COMMIT));
+        }
+
+        @ParameterizedTest
+        @MethodSource("nonNumericValueTypes")
+        @DisplayName("Success: auto-generates description without value when non-numeric key is modified")
+        void updateAgentConfig__noDescription__modifiesNonNumericKey__thenAutoGeneratesDescriptionWithoutValue(
+                ValueType type) {
+            var projectId = projectResourceClient.createProject(UUID.randomUUID().toString(), API_KEY, TEST_WORKSPACE);
+            var key = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var oldValue = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var newValue = RandomStringUtils.insecure().nextAlphanumeric(10);
+
+            agentConfigsResourceClient.createAgentConfig(
+                    AgentConfigCreate.builder()
+                            .projectId(projectId)
+                            .blueprint(AgentBlueprint.builder()
+                                    .type(BlueprintType.BLUEPRINT)
+                                    .description(RandomStringUtils.insecure().nextAlphanumeric(10))
+                                    .values(List.of(
+                                            AgentConfigValue.builder().key(key).value(oldValue)
+                                                    .type(type).build()))
+                                    .build())
+                            .build(),
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+
+            var blueprintId = agentConfigsResourceClient.updateAgentConfig(
+                    AgentConfigCreate.builder()
+                            .projectId(projectId)
+                            .blueprint(AgentBlueprint.builder()
+                                    .type(BlueprintType.BLUEPRINT)
+                                    .values(List.of(
+                                            AgentConfigValue.builder().key(key).value(newValue)
+                                                    .type(type).build()))
+                                    .build())
+                            .build(),
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+
+            var retrieved = agentConfigsResourceClient.getBlueprintById(blueprintId, null, API_KEY,
+                    TEST_WORKSPACE, HttpStatus.SC_OK);
+            assertThat(retrieved.description()).isEqualTo("Modified " + key);
+        }
+
+        @Test
+        @DisplayName("Success: auto-generates description listing removed keys")
+        void updateAgentConfig__noDescription__removesKey__thenAutoGeneratesDescription() {
+            var projectId = projectResourceClient.createProject(UUID.randomUUID().toString(), API_KEY, TEST_WORKSPACE);
+            var keptKey = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var removedKey = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var keptValue = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var removedValue = RandomStringUtils.insecure().nextAlphanumeric(10);
+
+            agentConfigsResourceClient.createAgentConfig(
+                    AgentConfigCreate.builder()
+                            .projectId(projectId)
+                            .blueprint(AgentBlueprint.builder()
+                                    .type(BlueprintType.BLUEPRINT)
+                                    .description(RandomStringUtils.insecure().nextAlphanumeric(10))
+                                    .values(List.of(
+                                            AgentConfigValue.builder().key(keptKey).value(keptValue)
+                                                    .type(ValueType.STRING).build(),
+                                            AgentConfigValue.builder().key(removedKey).value(removedValue)
+                                                    .type(ValueType.STRING).build()))
+                                    .build())
+                            .build(),
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+
+            var blueprintId = agentConfigsResourceClient.updateAgentConfig(
+                    AgentConfigCreate.builder()
+                            .projectId(projectId)
+                            .blueprint(AgentBlueprint.builder()
+                                    .type(BlueprintType.BLUEPRINT)
+                                    .values(List.of(
+                                            AgentConfigValue.builder().key(keptKey).value(keptValue)
+                                                    .type(ValueType.STRING).build()))
+                                    .build())
+                            .build(),
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+
+            var retrieved = agentConfigsResourceClient.getBlueprintById(blueprintId, null, API_KEY,
+                    TEST_WORKSPACE, HttpStatus.SC_OK);
+            assertThat(retrieved.description()).isEqualTo("Removed " + removedKey);
+        }
+
+        @Test
+        @DisplayName("Success: explicit description overrides auto-generation")
+        void updateAgentConfig__withExplicitDescription__thenExplicitDescriptionIsUsed() {
+            var projectId = projectResourceClient.createProject(UUID.randomUUID().toString(), API_KEY, TEST_WORKSPACE);
+            var key = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var oldValue = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var newValue = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var explicitDescription = RandomStringUtils.insecure().nextAlphanumeric(20);
+
+            agentConfigsResourceClient.createAgentConfig(
+                    AgentConfigCreate.builder()
+                            .projectId(projectId)
+                            .blueprint(AgentBlueprint.builder()
+                                    .type(BlueprintType.BLUEPRINT)
+                                    .description(RandomStringUtils.insecure().nextAlphanumeric(10))
+                                    .values(List.of(
+                                            AgentConfigValue.builder().key(key).value(oldValue)
+                                                    .type(ValueType.STRING).build()))
+                                    .build())
+                            .build(),
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+
+            var blueprintId = agentConfigsResourceClient.updateAgentConfig(
+                    AgentConfigCreate.builder()
+                            .projectId(projectId)
+                            .blueprint(AgentBlueprint.builder()
+                                    .type(BlueprintType.BLUEPRINT)
+                                    .description(explicitDescription)
+                                    .values(List.of(
+                                            AgentConfigValue.builder().key(key).value(newValue)
+                                                    .type(ValueType.STRING).build()))
+                                    .build())
+                            .build(),
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+
+            var retrieved = agentConfigsResourceClient.getBlueprintById(blueprintId, null, API_KEY,
+                    TEST_WORKSPACE, HttpStatus.SC_OK);
+            assertThat(retrieved.description()).isEqualTo(explicitDescription);
+        }
+
+        @Test
+        @DisplayName("Success: auto-generates description combining added, modified, and removed keys")
+        void updateAgentConfig__noDescription__mixedChanges__thenAutoGeneratesDescription() {
+            var projectId = projectResourceClient.createProject(UUID.randomUUID().toString(), API_KEY, TEST_WORKSPACE);
+            var addedKey = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var modifiedKey = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var removedKey = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var unchangedKey = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var modifiedOldValue = RandomStringUtils.insecure().nextNumeric(3);
+            var modifiedNewValue = RandomStringUtils.insecure().nextNumeric(4);
+            var unchangedValue = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var addedValue = RandomStringUtils.insecure().nextAlphanumeric(10);
+            var removedValue = RandomStringUtils.insecure().nextAlphanumeric(10);
+
+            agentConfigsResourceClient.createAgentConfig(
+                    AgentConfigCreate.builder()
+                            .projectId(projectId)
+                            .blueprint(AgentBlueprint.builder()
+                                    .type(BlueprintType.BLUEPRINT)
+                                    .description(RandomStringUtils.insecure().nextAlphanumeric(10))
+                                    .values(List.of(
+                                            AgentConfigValue.builder().key(unchangedKey).value(unchangedValue)
+                                                    .type(ValueType.STRING).build(),
+                                            AgentConfigValue.builder().key(modifiedKey).value(modifiedOldValue)
+                                                    .type(ValueType.INTEGER).build(),
+                                            AgentConfigValue.builder().key(removedKey).value(removedValue)
+                                                    .type(ValueType.STRING).build()))
+                                    .build())
+                            .build(),
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+
+            var blueprintId = agentConfigsResourceClient.updateAgentConfig(
+                    AgentConfigCreate.builder()
+                            .projectId(projectId)
+                            .blueprint(AgentBlueprint.builder()
+                                    .type(BlueprintType.BLUEPRINT)
+                                    .values(List.of(
+                                            AgentConfigValue.builder().key(unchangedKey).value(unchangedValue)
+                                                    .type(ValueType.STRING).build(),
+                                            AgentConfigValue.builder().key(modifiedKey).value(modifiedNewValue)
+                                                    .type(ValueType.INTEGER).build(),
+                                            AgentConfigValue.builder().key(addedKey).value(addedValue)
+                                                    .type(ValueType.STRING).build()))
+                                    .build())
+                            .build(),
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+
+            var retrieved = agentConfigsResourceClient.getBlueprintById(blueprintId, null, API_KEY,
+                    TEST_WORKSPACE, HttpStatus.SC_OK);
+            assertThat(retrieved.description()).isEqualTo(
+                    "Added " + addedKey + ". Modified " + modifiedKey + " to " + modifiedNewValue
+                            + ". Removed " + removedKey);
+        }
+
     }
 
     @Nested

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResourceTest.java
@@ -608,20 +608,26 @@ class AgentConfigsResourceTest {
             assertThat(retrieved.description()).isEqualTo("Added " + newKey);
         }
 
-        Stream<Arguments> numericValueTypes() {
+        Stream<Arguments> modifiedKeyValueTypes() {
             return Stream.of(
                     arguments(ValueType.FLOAT, RandomStringUtils.insecure().nextNumeric(3),
-                            RandomStringUtils.insecure().nextNumeric(4)),
+                            RandomStringUtils.insecure().nextNumeric(4), true),
                     arguments(ValueType.INTEGER, RandomStringUtils.insecure().nextNumeric(3),
-                            RandomStringUtils.insecure().nextNumeric(4)),
-                    arguments(ValueType.BOOLEAN, "true", "false"));
+                            RandomStringUtils.insecure().nextNumeric(4), true),
+                    arguments(ValueType.BOOLEAN, "true", "false", true),
+                    arguments(ValueType.STRING, RandomStringUtils.insecure().nextAlphanumeric(10),
+                            RandomStringUtils.insecure().nextAlphanumeric(10), false),
+                    arguments(ValueType.PROMPT, RandomStringUtils.insecure().nextAlphanumeric(10),
+                            RandomStringUtils.insecure().nextAlphanumeric(10), false),
+                    arguments(ValueType.PROMPT_COMMIT, RandomStringUtils.insecure().nextAlphanumeric(10),
+                            RandomStringUtils.insecure().nextAlphanumeric(10), false));
         }
 
         @ParameterizedTest
-        @MethodSource("numericValueTypes")
-        @DisplayName("Success: auto-generates description with new value when numeric-like key is modified")
-        void updateAgentConfig__noDescription__modifiesNumericKey__thenAutoGeneratesDescription(ValueType type,
-                String oldValue, String newValue) {
+        @MethodSource("modifiedKeyValueTypes")
+        @DisplayName("Success: auto-generates description when a key is modified, including new value for primitives only")
+        void updateAgentConfig__noDescription__modifiesKey__thenAutoGeneratesDescription(ValueType type,
+                String oldValue, String newValue, boolean includeValueInDescription) {
             var projectId = projectResourceClient.createProject(UUID.randomUUID().toString(), API_KEY, TEST_WORKSPACE);
             var key = RandomStringUtils.insecure().nextAlphanumeric(10);
 
@@ -642,44 +648,10 @@ class AgentConfigsResourceTest {
 
             var retrieved = agentConfigsResourceClient.getBlueprintById(blueprintId, null, API_KEY,
                     TEST_WORKSPACE, HttpStatus.SC_OK);
-            assertThat(retrieved.description()).isEqualTo("Modified " + key + " to " + newValue);
-        }
-
-        Stream<Arguments> nonNumericValueTypes() {
-            return Stream.of(
-                    arguments(ValueType.STRING),
-                    arguments(ValueType.PROMPT),
-                    arguments(ValueType.PROMPT_COMMIT));
-        }
-
-        @ParameterizedTest
-        @MethodSource("nonNumericValueTypes")
-        @DisplayName("Success: auto-generates description without value when non-numeric key is modified")
-        void updateAgentConfig__noDescription__modifiesNonNumericKey__thenAutoGeneratesDescriptionWithoutValue(
-                ValueType type) {
-            var projectId = projectResourceClient.createProject(UUID.randomUUID().toString(), API_KEY, TEST_WORKSPACE);
-            var key = RandomStringUtils.insecure().nextAlphanumeric(10);
-            var oldValue = RandomStringUtils.insecure().nextAlphanumeric(10);
-            var newValue = RandomStringUtils.insecure().nextAlphanumeric(10);
-
-            createInitialBlueprint(projectId, List.of(
-                    AgentConfigValue.builder().key(key).value(oldValue).type(type).build()));
-
-            var blueprintId = agentConfigsResourceClient.updateAgentConfig(
-                    AgentConfigCreate.builder()
-                            .projectId(projectId)
-                            .blueprint(AgentBlueprint.builder()
-                                    .type(BlueprintType.BLUEPRINT)
-                                    .values(List.of(
-                                            AgentConfigValue.builder().key(key).value(newValue)
-                                                    .type(type).build()))
-                                    .build())
-                            .build(),
-                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
-
-            var retrieved = agentConfigsResourceClient.getBlueprintById(blueprintId, null, API_KEY,
-                    TEST_WORKSPACE, HttpStatus.SC_OK);
-            assertThat(retrieved.description()).isEqualTo("Modified " + key);
+            var expectedDescription = includeValueInDescription
+                    ? "Modified " + key + " to " + newValue
+                    : "Modified " + key;
+            assertThat(retrieved.description()).isEqualTo(expectedDescription);
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResourceTest.java
@@ -607,18 +607,20 @@ class AgentConfigsResourceTest {
 
         Stream<Arguments> numericValueTypes() {
             return Stream.of(
-                    arguments(ValueType.FLOAT),
-                    arguments(ValueType.INTEGER));
+                    arguments(ValueType.FLOAT, RandomStringUtils.insecure().nextNumeric(3),
+                            RandomStringUtils.insecure().nextNumeric(4)),
+                    arguments(ValueType.INTEGER, RandomStringUtils.insecure().nextNumeric(3),
+                            RandomStringUtils.insecure().nextNumeric(4)),
+                    arguments(ValueType.BOOLEAN, "true", "false"));
         }
 
         @ParameterizedTest
         @MethodSource("numericValueTypes")
-        @DisplayName("Success: auto-generates description with new value when numeric key is modified")
-        void updateAgentConfig__noDescription__modifiesNumericKey__thenAutoGeneratesDescription(ValueType type) {
+        @DisplayName("Success: auto-generates description with new value when numeric-like key is modified")
+        void updateAgentConfig__noDescription__modifiesNumericKey__thenAutoGeneratesDescription(ValueType type,
+                String oldValue, String newValue) {
             var projectId = projectResourceClient.createProject(UUID.randomUUID().toString(), API_KEY, TEST_WORKSPACE);
             var key = RandomStringUtils.insecure().nextAlphanumeric(10);
-            var oldValue = RandomStringUtils.insecure().nextNumeric(3);
-            var newValue = RandomStringUtils.insecure().nextNumeric(4);
 
             agentConfigsResourceClient.createAgentConfig(
                     AgentConfigCreate.builder()
@@ -653,7 +655,6 @@ class AgentConfigsResourceTest {
         Stream<Arguments> nonNumericValueTypes() {
             return Stream.of(
                     arguments(ValueType.STRING),
-                    arguments(ValueType.BOOLEAN),
                     arguments(ValueType.PROMPT),
                     arguments(ValueType.PROMPT_COMMIT));
         }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResourceTest.java
@@ -564,6 +564,19 @@ class AgentConfigsResourceTest {
             assertThat(retrieved.description()).isEqualTo("Updated blueprint");
         }
 
+        private void createInitialBlueprint(UUID projectId, List<AgentConfigValue> values) {
+            agentConfigsResourceClient.createAgentConfig(
+                    AgentConfigCreate.builder()
+                            .projectId(projectId)
+                            .blueprint(AgentBlueprint.builder()
+                                    .type(BlueprintType.BLUEPRINT)
+                                    .description(RandomStringUtils.insecure().nextAlphanumeric(10))
+                                    .values(values)
+                                    .build())
+                            .build(),
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+        }
+
         @Test
         @DisplayName("Success: auto-generates description listing added keys when none provided")
         void updateAgentConfig__noDescription__addsKeys__thenAutoGeneratesDescription() {
@@ -573,18 +586,8 @@ class AgentConfigsResourceTest {
             var existingValue = RandomStringUtils.insecure().nextAlphanumeric(10);
             var newValue = RandomStringUtils.insecure().nextNumeric(5);
 
-            agentConfigsResourceClient.createAgentConfig(
-                    AgentConfigCreate.builder()
-                            .projectId(projectId)
-                            .blueprint(AgentBlueprint.builder()
-                                    .type(BlueprintType.BLUEPRINT)
-                                    .description(RandomStringUtils.insecure().nextAlphanumeric(10))
-                                    .values(List.of(
-                                            AgentConfigValue.builder().key(existingKey).value(existingValue)
-                                                    .type(ValueType.STRING).build()))
-                                    .build())
-                            .build(),
-                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+            createInitialBlueprint(projectId, List.of(
+                    AgentConfigValue.builder().key(existingKey).value(existingValue).type(ValueType.STRING).build()));
 
             var blueprintId = agentConfigsResourceClient.updateAgentConfig(
                     AgentConfigCreate.builder()
@@ -622,18 +625,8 @@ class AgentConfigsResourceTest {
             var projectId = projectResourceClient.createProject(UUID.randomUUID().toString(), API_KEY, TEST_WORKSPACE);
             var key = RandomStringUtils.insecure().nextAlphanumeric(10);
 
-            agentConfigsResourceClient.createAgentConfig(
-                    AgentConfigCreate.builder()
-                            .projectId(projectId)
-                            .blueprint(AgentBlueprint.builder()
-                                    .type(BlueprintType.BLUEPRINT)
-                                    .description(RandomStringUtils.insecure().nextAlphanumeric(10))
-                                    .values(List.of(
-                                            AgentConfigValue.builder().key(key).value(oldValue)
-                                                    .type(type).build()))
-                                    .build())
-                            .build(),
-                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+            createInitialBlueprint(projectId, List.of(
+                    AgentConfigValue.builder().key(key).value(oldValue).type(type).build()));
 
             var blueprintId = agentConfigsResourceClient.updateAgentConfig(
                     AgentConfigCreate.builder()
@@ -669,18 +662,8 @@ class AgentConfigsResourceTest {
             var oldValue = RandomStringUtils.insecure().nextAlphanumeric(10);
             var newValue = RandomStringUtils.insecure().nextAlphanumeric(10);
 
-            agentConfigsResourceClient.createAgentConfig(
-                    AgentConfigCreate.builder()
-                            .projectId(projectId)
-                            .blueprint(AgentBlueprint.builder()
-                                    .type(BlueprintType.BLUEPRINT)
-                                    .description(RandomStringUtils.insecure().nextAlphanumeric(10))
-                                    .values(List.of(
-                                            AgentConfigValue.builder().key(key).value(oldValue)
-                                                    .type(type).build()))
-                                    .build())
-                            .build(),
-                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+            createInitialBlueprint(projectId, List.of(
+                    AgentConfigValue.builder().key(key).value(oldValue).type(type).build()));
 
             var blueprintId = agentConfigsResourceClient.updateAgentConfig(
                     AgentConfigCreate.builder()
@@ -708,20 +691,9 @@ class AgentConfigsResourceTest {
             var keptValue = RandomStringUtils.insecure().nextAlphanumeric(10);
             var removedValue = RandomStringUtils.insecure().nextAlphanumeric(10);
 
-            agentConfigsResourceClient.createAgentConfig(
-                    AgentConfigCreate.builder()
-                            .projectId(projectId)
-                            .blueprint(AgentBlueprint.builder()
-                                    .type(BlueprintType.BLUEPRINT)
-                                    .description(RandomStringUtils.insecure().nextAlphanumeric(10))
-                                    .values(List.of(
-                                            AgentConfigValue.builder().key(keptKey).value(keptValue)
-                                                    .type(ValueType.STRING).build(),
-                                            AgentConfigValue.builder().key(removedKey).value(removedValue)
-                                                    .type(ValueType.STRING).build()))
-                                    .build())
-                            .build(),
-                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+            createInitialBlueprint(projectId, List.of(
+                    AgentConfigValue.builder().key(keptKey).value(keptValue).type(ValueType.STRING).build(),
+                    AgentConfigValue.builder().key(removedKey).value(removedValue).type(ValueType.STRING).build()));
 
             var blueprintId = agentConfigsResourceClient.updateAgentConfig(
                     AgentConfigCreate.builder()
@@ -749,18 +721,8 @@ class AgentConfigsResourceTest {
             var newValue = RandomStringUtils.insecure().nextAlphanumeric(10);
             var explicitDescription = RandomStringUtils.insecure().nextAlphanumeric(20);
 
-            agentConfigsResourceClient.createAgentConfig(
-                    AgentConfigCreate.builder()
-                            .projectId(projectId)
-                            .blueprint(AgentBlueprint.builder()
-                                    .type(BlueprintType.BLUEPRINT)
-                                    .description(RandomStringUtils.insecure().nextAlphanumeric(10))
-                                    .values(List.of(
-                                            AgentConfigValue.builder().key(key).value(oldValue)
-                                                    .type(ValueType.STRING).build()))
-                                    .build())
-                            .build(),
-                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+            createInitialBlueprint(projectId, List.of(
+                    AgentConfigValue.builder().key(key).value(oldValue).type(ValueType.STRING).build()));
 
             var blueprintId = agentConfigsResourceClient.updateAgentConfig(
                     AgentConfigCreate.builder()
@@ -794,22 +756,10 @@ class AgentConfigsResourceTest {
             var addedValue = RandomStringUtils.insecure().nextAlphanumeric(10);
             var removedValue = RandomStringUtils.insecure().nextAlphanumeric(10);
 
-            agentConfigsResourceClient.createAgentConfig(
-                    AgentConfigCreate.builder()
-                            .projectId(projectId)
-                            .blueprint(AgentBlueprint.builder()
-                                    .type(BlueprintType.BLUEPRINT)
-                                    .description(RandomStringUtils.insecure().nextAlphanumeric(10))
-                                    .values(List.of(
-                                            AgentConfigValue.builder().key(unchangedKey).value(unchangedValue)
-                                                    .type(ValueType.STRING).build(),
-                                            AgentConfigValue.builder().key(modifiedKey).value(modifiedOldValue)
-                                                    .type(ValueType.INTEGER).build(),
-                                            AgentConfigValue.builder().key(removedKey).value(removedValue)
-                                                    .type(ValueType.STRING).build()))
-                                    .build())
-                            .build(),
-                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+            createInitialBlueprint(projectId, List.of(
+                    AgentConfigValue.builder().key(unchangedKey).value(unchangedValue).type(ValueType.STRING).build(),
+                    AgentConfigValue.builder().key(modifiedKey).value(modifiedOldValue).type(ValueType.INTEGER).build(),
+                    AgentConfigValue.builder().key(removedKey).value(removedValue).type(ValueType.STRING).build()));
 
             var blueprintId = agentConfigsResourceClient.updateAgentConfig(
                     AgentConfigCreate.builder()


### PR DESCRIPTION
## Details

When creating or updating an agent config blueprint without providing a description, the backend now automatically generates one by diffing the submitted values against the previous blueprint.

**Rules:**
- **Added keys** — keys present in the new blueprint but not in the previous one: `"Added key1, key2"`
- **Modified keys (STRING, PROMPT, PROMPT_COMMIT)** — changed values: `"Modified key3"` (no value exposed)
- **Modified keys (INTEGER, FLOAT, BOOLEAN)** — changed values: `"Modified key3 to 0.9"` / `"Modified enabled to false"` (new value included)
- **Removed keys** — keys present in the previous blueprint but absent from the new one, sorted alphabetically: `"Removed key4"`
- Sections are joined with `". "` when multiple apply: e.g. `"Added a. Modified b to 5. Removed c"`
- An explicitly provided description always takes precedence — auto-generation is skipped when description is non-blank

<img width="1161" height="557" alt="image" src="https://github.com/user-attachments/assets/eace7117-7b0b-4c83-87d1-06be772aed46" />

**Implementation:**
- Added `generateUpdateDescription()` private method in `AgentConfigServiceImpl`
- Called from `createBlueprint()` only when `description` is null/blank and blueprint type is not MASK
- The existing `removeConfigKeys` auto-description (`"Deleted configuration parameters: ..."`) is unchanged — it goes through a separate code path

## Change checklist

- [ ] I have added tests for my changes
- [x] I have updated the documentation (if applicable) — N/A, internal backend behaviour
- [ ] My changes generate no new warnings

## Issues

OPIK-6310

## AI-WATERMARK

AI-WATERMARK: yes
- Tools: Claude Code
- Model: Claude Sonnet 4.6
- Scope: full implementation
- Human verification: code review

## Testing

Integration tests added to `AgentConfigsResourceTest` covering:
- Auto-generated description when a key is **added** (no description provided)
- Auto-generated description when a **value-included key** (INTEGER, FLOAT, BOOLEAN) is modified — includes new value; parameterized over all three types
- Auto-generated description when a **value-hidden key** (STRING, PROMPT, PROMPT_COMMIT) is modified — no value shown; parameterized over all three types
- Auto-generated description when a key is **removed**
- Combined scenario: add + modify (numeric) + remove in a single update
- Explicit description **overrides** auto-generation

All values (keys, old/new values, descriptions) use `RandomStringUtils.insecure().nextAlphanumeric/nextNumeric`; boolean cases use the literals `"true"` / `"false"`.

## Documentation

N/A — no user-facing documentation changes required for this internal backend change.