### PR TITLE
[OPIK-6246] [SDK] feat: add 'opik copy dataset' CLI command

### DIFF
--- a/sdks/python/src/opik/cli/_group_helpers.py
+++ b/sdks/python/src/opik/cli/_group_helpers.py
@@ -1,0 +1,43 @@
+"""Shared helpers for the top-level Click groups (``export``, ``import``, ``copy``).
+
+These groups all present their subcommands as data-type "Items" (datasets,
+experiments, etc.) rather than the default Click "Commands" header. Keeping
+the formatter in one place avoids drift across the three groups.
+"""
+
+from typing import Callable
+
+import click
+
+
+def items_format_commands(
+    self: click.Group, ctx: click.Context, formatter: click.HelpFormatter
+) -> None:
+    """Click ``format_commands`` override that renders subcommands under ``Items``.
+
+    Bound onto a group via :func:`bind_items_format_commands` so ``--help``
+    output reads ``Items: dataset …`` instead of ``Commands: dataset …``.
+    """
+    commands = []
+    for subcommand in self.list_commands(ctx):
+        cmd = self.get_command(ctx, subcommand)
+        if cmd is None or cmd.hidden:
+            continue
+        commands.append((subcommand, cmd))
+
+    if len(commands):
+        limit = formatter.width - 6 - max(len(cmd[0]) for cmd in commands)
+        rows = []
+        for subcommand, cmd in commands:
+            help_text = cmd.get_short_help_str(limit)
+            rows.append((subcommand, help_text))
+
+        if rows:
+            with formatter.section("Items"):
+                formatter.write_dl(rows)
+
+
+def bind_items_format_commands(group: click.Group) -> None:
+    """Install :func:`items_format_commands` as ``group.format_commands``."""
+    bound: Callable[..., None] = items_format_commands.__get__(group, type(group))
+    setattr(group, "format_commands", bound)

--- a/sdks/python/src/opik/cli/copy/__init__.py
+++ b/sdks/python/src/opik/cli/copy/__init__.py
@@ -18,6 +18,7 @@ from typing import Optional
 import click
 from rich.logging import RichHandler
 
+from .._group_helpers import bind_items_format_commands
 from .dataset import copy_dataset_command
 
 COPY_CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
@@ -126,35 +127,7 @@ def copy_group(ctx: click.Context, workspace: str, api_key: Optional[str]) -> No
 
 copy_group.subcommand_metavar = "ITEM [ARGS]..."
 
-
-def format_commands(
-    self: click.Group, ctx: click.Context, formatter: click.HelpFormatter
-) -> None:
-    """Override to change 'Commands' heading to 'Items'."""
-    commands = []
-    for subcommand in self.list_commands(ctx):
-        cmd = self.get_command(ctx, subcommand)
-        if cmd is None or cmd.hidden:
-            continue
-        commands.append((subcommand, cmd))
-
-    if len(commands):
-        limit = formatter.width - 6 - max(len(cmd[0]) for cmd in commands)
-        rows = []
-        for subcommand, cmd in commands:
-            help = cmd.get_short_help_str(limit)
-            rows.append((subcommand, help))
-
-        if rows:
-            with formatter.section("Items"):
-                formatter.write_dl(rows)
-
-
-setattr(
-    copy_group,
-    "format_commands",
-    format_commands.__get__(copy_group, type(copy_group)),
-)
+bind_items_format_commands(copy_group)
 
 
 copy_group.add_command(copy_dataset_command)

--- a/sdks/python/src/opik/cli/copy/__init__.py
+++ b/sdks/python/src/opik/cli/copy/__init__.py
@@ -1,0 +1,160 @@
+"""Copy command for Opik CLI.
+
+The ``opik copy`` group orchestrates a same-instance copy of one asset (and
+its related entities) from a source location into a destination project.
+v1 ships ``copy dataset`` only; ``copy prompt`` / ``copy experiment`` slot in
+later behind the same group.
+
+Under the hood, each subcommand:
+1. Exports the asset (and its related entities) into a persistent run dir
+   under ``~/.opik/copy-runs/`` using the existing ``opik export`` machinery.
+2. Imports it back via ``opik import``, threading a ``destination_project``
+   override through so all entities land in the chosen project.
+"""
+
+import logging
+from typing import Optional
+
+import click
+from rich.logging import RichHandler
+
+from .dataset import copy_dataset_command
+
+COPY_CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+@click.group(
+    name="copy", context_settings=COPY_CONTEXT_SETTINGS, invoke_without_command=True
+)
+@click.argument("workspace", type=str)
+@click.option(
+    "--api-key",
+    type=str,
+    help="Opik API key. If not provided, will use OPIK_API_KEY environment variable or configuration.",
+)
+@click.pass_context
+def copy_group(ctx: click.Context, workspace: str, api_key: Optional[str]) -> None:
+    """Copy assets between projects on the same Opik instance.
+
+    Copies an asset (and its related entities) from a source location into
+    a destination project on the same Opik instance, in a single command.
+
+    \b
+    General Usage:
+        opik copy WORKSPACE ITEM NAME --destination-project NAME [OPTIONS]
+
+    \b
+    Data Types (ITEM):
+        dataset      Copy a dataset (and its experiments + traces + spans by
+                     default) into a destination project.
+
+    \b
+    Common Options:
+        --destination-project   Required. Project name to copy into. The
+                                backend auto-creates the project if it does
+                                not yet exist.
+        --source-project        Optional. Scopes which experiments tag along.
+                                Omit to pull every experiment that references
+                                the source dataset across the workspace.
+        --exclude-experiments   Copy only the dataset definition + items.
+        --dry-run               Preview the export pass without writing to
+                                the destination.
+        --debug                 Show detailed information; keep the run dir
+                                on success for inspection.
+
+    \b
+    Examples:
+        # Copy a workspace-level dataset into Project B (with experiments + traces).
+        opik copy my-workspace dataset "MyDataset" --destination-project "Project B"
+
+        # Copy from one project into another, only the dataset definition + items.
+        opik copy my-workspace dataset "MyDataset" \\
+            --source-project "Project A" \\
+            --destination-project "Project B" \\
+            --exclude-experiments
+    """
+    ctx.ensure_object(dict)
+    ctx.obj["workspace"] = workspace
+    ctx.obj["api_key"] = api_key or (
+        ctx.parent.obj.get("api_key") if ctx.parent and ctx.parent.obj else None
+    )
+
+    # Mirror the export group's logger swap so SDK deprecation messages don't
+    # corrupt the Rich progress bars during the export → import passes.
+    from ..exports.utils import console as _console
+
+    _opik_logger = logging.getLogger("opik")
+    _original_handlers = list(_opik_logger.handlers)
+
+    def _restore_opik_handlers() -> None:
+        for _h in list(_opik_logger.handlers):
+            _opik_logger.removeHandler(_h)
+        for _h in _original_handlers:
+            _opik_logger.addHandler(_h)
+
+    ctx.call_on_close(_restore_opik_handlers)
+
+    for _h in list(_opik_logger.handlers):
+        if isinstance(_h, RichHandler):
+            if getattr(_h, "console", None) is not _console:
+                _opik_logger.removeHandler(_h)
+        elif isinstance(_h, logging.StreamHandler):
+            _opik_logger.removeHandler(_h)
+    if not any(isinstance(h, RichHandler) for h in _opik_logger.handlers):
+        _rich_handler = RichHandler(
+            console=_console,
+            show_time=False,
+            show_path=False,
+            markup=False,
+        )
+        _rich_handler.setLevel(logging.ERROR)
+        _opik_logger.addHandler(_rich_handler)
+
+    if ctx.invoked_subcommand is None:
+        available_items = ", ".join(sorted(["dataset"]))
+        click.echo(
+            f"Error: Missing ITEM.\n\n"
+            f"Available items: {available_items}\n\n"
+            f"Usage: opik copy {workspace} ITEM NAME --destination-project NAME [OPTIONS]\n\n"
+            f"Examples:\n"
+            f'  opik copy {workspace} dataset "MyDataset" --destination-project "Project B"\n\n'
+            f"Run 'opik copy {workspace} --help' for more information.",
+            err=True,
+        )
+        ctx.exit(2)
+
+
+copy_group.subcommand_metavar = "ITEM [ARGS]..."
+
+
+def format_commands(
+    self: click.Group, ctx: click.Context, formatter: click.HelpFormatter
+) -> None:
+    """Override to change 'Commands' heading to 'Items'."""
+    commands = []
+    for subcommand in self.list_commands(ctx):
+        cmd = self.get_command(ctx, subcommand)
+        if cmd is None or cmd.hidden:
+            continue
+        commands.append((subcommand, cmd))
+
+    if len(commands):
+        limit = formatter.width - 6 - max(len(cmd[0]) for cmd in commands)
+        rows = []
+        for subcommand, cmd in commands:
+            help = cmd.get_short_help_str(limit)
+            rows.append((subcommand, help))
+
+        if rows:
+            with formatter.section("Items"):
+                formatter.write_dl(rows)
+
+
+setattr(
+    copy_group,
+    "format_commands",
+    format_commands.__get__(copy_group, type(copy_group)),
+)
+
+
+copy_group.add_command(copy_dataset_command)

--- a/sdks/python/src/opik/cli/copy/dataset.py
+++ b/sdks/python/src/opik/cli/copy/dataset.py
@@ -33,6 +33,13 @@ console = Console()
 
 COPY_RUNS_DIR = Path.home() / ".opik" / "copy-runs"
 
+# Upper bound on the number of experiments we try to enumerate per dataset.
+# ``client.get_dataset_experiments`` is a hard cap, not a paginator, so this
+# is the same number used for both the source listing and the destination
+# verification. If a real workspace ever exceeds this we saturate visibly
+# (the user sees a warning) rather than silently passing a partial check.
+EXPERIMENT_LIST_CAP = 10_000
+
 
 def _run_dir_key(
     workspace: str,
@@ -292,7 +299,7 @@ def _verify_destination_counts(
             client.get_dataset_experiments(
                 dataset_name=dataset_name,
                 project_name=destination_project,
-                max_results=10_000,
+                max_results=EXPERIMENT_LIST_CAP,
             )
         )
         exp_match = actual_experiments == expected["experiments"]
@@ -303,6 +310,18 @@ def _verify_destination_counts(
             str(actual_experiments),
             "✓" if exp_match else "✗",
         )
+        # Loudly flag the bound: if either side reaches the cap we cannot
+        # honestly say "the counts match", because the API may have
+        # truncated. The export side uses the same cap so this is symmetric.
+        if (
+            actual_experiments >= EXPERIMENT_LIST_CAP
+            or expected["experiments"] >= EXPERIMENT_LIST_CAP
+        ):
+            console.print(
+                f"[yellow]Warning: experiment count reached the {EXPERIMENT_LIST_CAP:,} "
+                f"enumeration cap; the verification result is best-effort. "
+                f"File a follow-up if you have a workspace this large.[/yellow]"
+            )
 
     console.print(table)
     return matched
@@ -443,7 +462,7 @@ def copy_dataset_command(
         experiments_to_export = client.get_dataset_experiments(
             dataset_name=name,
             project_name=source_project,
-            max_results=10_000,
+            max_results=EXPERIMENT_LIST_CAP,
         )
         if not experiments_to_export:
             # No experiments tag along → fall back to dataset-only export.

--- a/sdks/python/src/opik/cli/copy/dataset.py
+++ b/sdks/python/src/opik/cli/copy/dataset.py
@@ -9,9 +9,9 @@ overrides every ``project_name`` it would otherwise infer with
 ``--destination-project``.
 """
 
+import hashlib
 import shutil
 import sys
-from datetime import datetime
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -34,16 +34,58 @@ console = Console()
 COPY_RUNS_DIR = Path.home() / ".opik" / "copy-runs"
 
 
-def _make_run_dir(workspace: str, dataset_name: str) -> Path:
-    """Return a persistent, per-run directory under ~/.opik/copy-runs/.
+def _run_dir_key(
+    workspace: str,
+    dataset_name: str,
+    destination_project: str,
+    source_project: Optional[str],
+    exclude_experiments: bool,
+) -> str:
+    """Stable identifier for a copy job, independent of when it ran.
 
-    Persistent (not /tmp) so an interrupted copy can be resumed by re-running
-    the same command — the ``MigrationManifest`` lives inside.
+    Two invocations with the same arguments produce the same key, so an
+    interrupted run can be resumed by reusing its ``MigrationManifest``.
+    The hash is purely a fingerprint — there are no security implications,
+    so SHA-1 is fine and short.
+    """
+    fingerprint = "|".join(
+        [
+            workspace,
+            dataset_name,
+            destination_project,
+            source_project or "",
+            "no-experiments" if exclude_experiments else "with-experiments",
+        ]
+    )
+    return hashlib.sha1(fingerprint.encode()).hexdigest()[:12]
+
+
+def _make_run_dir(
+    workspace: str,
+    dataset_name: str,
+    destination_project: str,
+    source_project: Optional[str] = None,
+    exclude_experiments: bool = False,
+) -> Path:
+    """Return a persistent, resumable run directory under ``~/.opik/copy-runs/``.
+
+    The directory is keyed off the copy-job fingerprint
+    (``workspace + dataset + destination + source + exclude_experiments``)
+    so re-running the same command finds the prior run dir and its
+    ``MigrationManifest``. Two genuinely different copies (e.g. different
+    destination projects) get distinct directories so their manifests don't
+    collide.
     """
     safe_workspace = "".join(c if c.isalnum() or c in "-_" else "_" for c in workspace)
     safe_dataset = "".join(c if c.isalnum() or c in "-_" else "_" for c in dataset_name)
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    run_dir = COPY_RUNS_DIR / f"{safe_workspace}-{safe_dataset}-{timestamp}"
+    key = _run_dir_key(
+        workspace,
+        dataset_name,
+        destination_project,
+        source_project,
+        exclude_experiments,
+    )
+    run_dir = COPY_RUNS_DIR / f"{safe_workspace}-{safe_dataset}-{key}"
     run_dir.mkdir(parents=True, exist_ok=True)
     return run_dir
 
@@ -118,49 +160,84 @@ def _print_preflight_summary(
     console.print(table)
 
 
+def _build_trace_to_project_index(projects_dir: Path) -> Dict[str, str]:
+    """Map every exported ``trace_id`` to the project directory it lives in.
+
+    The trace exporter writes ``projects/<project_name>/trace_<trace_id>.json``,
+    so a single directory walk is enough — no JSON parsing required.
+    """
+    index: Dict[str, str] = {}
+    if not projects_dir.exists():
+        return index
+    for project_dir in projects_dir.iterdir():
+        if not project_dir.is_dir():
+            continue
+        for trace_file in project_dir.glob("trace_*.json"):
+            trace_id = trace_file.stem[len("trace_") :]
+            if trace_id:
+                index[trace_id] = project_dir.name
+    return index
+
+
+def _resolve_experiment_project(
+    experiment_file: Path, trace_to_project: Dict[str, str]
+) -> Optional[str]:
+    """Best-effort project lookup for an exported experiment.
+
+    Order of attempts:
+    1. ``experiment.metadata.project_name`` from the JSON.
+    2. Any item's ``trace_id`` mapped via the trace→project index.
+
+    Returns ``None`` when neither attempt resolves the project — callers must
+    treat this as "unknown" and **not** assume mismatch.
+    """
+    import json
+
+    try:
+        with open(experiment_file) as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    exp_project = (data.get("experiment", {}).get("metadata") or {}).get("project_name")
+    if exp_project:
+        return exp_project
+
+    for item in data.get("items") or []:
+        trace_id = item.get("trace_id")
+        if trace_id and trace_id in trace_to_project:
+            return trace_to_project[trace_id]
+    return None
+
+
 def _filter_experiments_by_source_project(
     workspace_root: Path, source_project: str
 ) -> int:
     """Drop exported experiment + trace artefacts whose project doesn't match.
 
     The export pass pulls every experiment that references the source dataset.
-    When ``--source-project`` is given, prune anything outside that project so
-    the import pass only recreates the matching subset.
+    When ``--source-project`` is given, prune anything that *resolves* to a
+    different project. Experiments whose project we cannot resolve are
+    **kept** — never silently deleted — so users don't lose data when
+    metadata is missing.
 
     Returns the number of experiment files retained.
     """
-    import json
-
     experiments_dir = workspace_root / "experiments"
     projects_dir = workspace_root / "projects"
     retained = 0
 
+    trace_to_project = _build_trace_to_project_index(projects_dir)
+
     if experiments_dir.exists():
         for exp_file in list(experiments_dir.glob("experiment_*.json")):
-            try:
-                with open(exp_file) as fh:
-                    data = json.load(fh)
-                exp_project = (data.get("experiment", {}).get("metadata") or {}).get(
-                    "project_name"
-                )
-                # Fall back to inferring from the trace project dirs if metadata is missing.
-                if exp_project is None and projects_dir.exists():
-                    items = data.get("items") or []
-                    if items:
-                        first_trace_id = items[0].get("trace_id")
-                        if first_trace_id:
-                            for project_dir in projects_dir.iterdir():
-                                if (
-                                    project_dir / f"trace_{first_trace_id}.json"
-                                ).exists():
-                                    exp_project = project_dir.name
-                                    break
-                if exp_project != source_project:
-                    exp_file.unlink()
-                else:
-                    retained += 1
-            except (OSError, json.JSONDecodeError):
-                continue
+            exp_project = _resolve_experiment_project(exp_file, trace_to_project)
+            # Only delete when we resolved the project AND it doesn't match.
+            # An unresolved (None) project is kept defensively.
+            if exp_project is not None and exp_project != source_project:
+                exp_file.unlink()
+            else:
+                retained += 1
 
     # Drop trace project directories that don't belong to the source project.
     if projects_dir.exists():
@@ -178,22 +255,16 @@ def _verify_destination_counts(
     expected: Dict[str, int],
     exclude_experiments: bool,
 ) -> bool:
-    """Best-effort post-copy count diff against the destination.
+    """Post-copy count diff against the destination.
 
-    Returns True when the actual destination counts match what was exported.
-    Logs a warning and returns False on any mismatch — the caller decides
-    whether to exit non-zero.
+    Returns True when the actual destination counts match what was exported,
+    False when any count is short. SDK errors (auth, network, missing
+    permissions, etc.) propagate to the caller unchanged — the previous
+    behaviour of swallowing them into a generic "counts didn't match" exit
+    code obscured the real failure mode.
     """
-    try:
-        dest_dataset = client.get_dataset(
-            dataset_name, project_name=destination_project
-        )
-        actual_items = len(dest_dataset.get_items())
-    except Exception as e:
-        console.print(
-            f"[yellow]Could not verify destination dataset items: {e}[/yellow]"
-        )
-        return False
+    dest_dataset = client.get_dataset(dataset_name, project_name=destination_project)
+    actual_items = len(dest_dataset.get_items())
 
     table = Table(
         title="Post-copy verification",
@@ -217,27 +288,20 @@ def _verify_destination_counts(
     )
 
     if not exclude_experiments:
-        try:
-            actual_experiments = len(
-                client.get_dataset_experiments(
-                    dataset_name=dataset_name,
-                    project_name=destination_project,
-                    max_results=10_000,
-                )
+        actual_experiments = len(
+            client.get_dataset_experiments(
+                dataset_name=dataset_name,
+                project_name=destination_project,
+                max_results=10_000,
             )
-        except Exception as e:
-            console.print(
-                f"[yellow]Could not verify destination experiments: {e}[/yellow]"
-            )
-            actual_experiments = -1
-
+        )
         exp_match = actual_experiments == expected["experiments"]
         matched = matched and exp_match
         table.add_row(
             "Experiments",
             str(expected["experiments"]),
-            str(actual_experiments) if actual_experiments >= 0 else "?",
-            "✓" if exp_match else "?" if actual_experiments < 0 else "✗",
+            str(actual_experiments),
+            "✓" if exp_match else "✗",
         )
 
     console.print(table)
@@ -340,11 +404,16 @@ def copy_dataset_command(
             + "[/red]"
         )
         sys.exit(1)
-    except Exception as e:
-        console.print(f"[red]Could not look up source dataset '{name}': {e}[/red]")
-        sys.exit(1)
+    # Other SDK errors (auth, network, permissions) propagate as themselves —
+    # the original SDK exception type is the most useful signal for the user.
 
-    run_dir = _make_run_dir(workspace, name)
+    run_dir = _make_run_dir(
+        workspace=workspace,
+        dataset_name=name,
+        destination_project=destination_project,
+        source_project=source_project,
+        exclude_experiments=exclude_experiments,
+    )
     workspace_root = run_dir / workspace
 
     if debug:

--- a/sdks/python/src/opik/cli/copy/dataset.py
+++ b/sdks/python/src/opik/cli/copy/dataset.py
@@ -1,0 +1,516 @@
+"""``opik copy dataset`` — copy a dataset (and its experiments + traces +
+spans by default) from a source location into a destination project on the
+same Opik instance.
+
+Implementation: thin orchestration over the existing ``opik export`` and
+``opik import`` flows. The export pass writes to a persistent run directory
+under ``~/.opik/copy-runs/``; the import pass reads from that directory and
+overrides every ``project_name`` it would otherwise infer with
+``--destination-project``.
+"""
+
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+import opik
+from opik import exceptions
+
+from ..exports.dataset import export_dataset_by_name
+from ..exports.experiment import export_experiment_by_name_or_id
+from ..imports.dataset import import_datasets_from_directory
+from ..imports.experiment import import_experiments_from_directory
+from ..migration_manifest import MigrationManifest
+
+console = Console()
+
+
+COPY_RUNS_DIR = Path.home() / ".opik" / "copy-runs"
+
+
+def _make_run_dir(workspace: str, dataset_name: str) -> Path:
+    """Return a persistent, per-run directory under ~/.opik/copy-runs/.
+
+    Persistent (not /tmp) so an interrupted copy can be resumed by re-running
+    the same command — the ``MigrationManifest`` lives inside.
+    """
+    safe_workspace = "".join(c if c.isalnum() or c in "-_" else "_" for c in workspace)
+    safe_dataset = "".join(c if c.isalnum() or c in "-_" else "_" for c in dataset_name)
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    run_dir = COPY_RUNS_DIR / f"{safe_workspace}-{safe_dataset}-{timestamp}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
+def _scan_run_dir(run_dir: Path, workspace: str) -> Dict[str, int]:
+    """Count exported entities on disk so the pre-flight summary can show them."""
+    workspace_root = run_dir / workspace
+    counts = {
+        "datasets": 0,
+        "dataset_items": 0,
+        "experiments": 0,
+        "traces": 0,
+        "spans": 0,
+    }
+
+    datasets_dir = workspace_root / "datasets"
+    if datasets_dir.exists():
+        import json
+
+        for f in datasets_dir.glob("dataset_*.json"):
+            counts["datasets"] += 1
+            try:
+                with open(f) as fh:
+                    counts["dataset_items"] += len(json.load(fh).get("items", []))
+            except (OSError, json.JSONDecodeError):
+                pass
+
+    experiments_dir = workspace_root / "experiments"
+    if experiments_dir.exists():
+        counts["experiments"] = len(list(experiments_dir.glob("experiment_*.json")))
+
+    projects_dir = workspace_root / "projects"
+    if projects_dir.exists():
+        import json
+
+        for project_dir in projects_dir.iterdir():
+            if not project_dir.is_dir():
+                continue
+            for trace_file in project_dir.glob("trace_*.json"):
+                counts["traces"] += 1
+                try:
+                    with open(trace_file) as fh:
+                        counts["spans"] += len(json.load(fh).get("spans", []))
+                except (OSError, json.JSONDecodeError):
+                    pass
+
+    return counts
+
+
+def _print_preflight_summary(
+    counts: Dict[str, int],
+    dataset_name: str,
+    destination_project: str,
+    exclude_experiments: bool,
+) -> None:
+    """Render a Rich table with what's about to be copied."""
+    table = Table(
+        title=f"About to copy '{dataset_name}' → '{destination_project}'",
+        show_header=False,
+        box=None,
+        pad_edge=False,
+    )
+    table.add_column("Asset", style="bold")
+    table.add_column("Count", justify="right", style="cyan")
+
+    table.add_row("Dataset", "1")
+    table.add_row("Dataset items", str(counts["dataset_items"]))
+    if not exclude_experiments:
+        table.add_row("Experiments", str(counts["experiments"]))
+        table.add_row("Traces", str(counts["traces"]))
+        table.add_row("Spans", str(counts["spans"]))
+    console.print(table)
+
+
+def _filter_experiments_by_source_project(
+    workspace_root: Path, source_project: str
+) -> int:
+    """Drop exported experiment + trace artefacts whose project doesn't match.
+
+    The export pass pulls every experiment that references the source dataset.
+    When ``--source-project`` is given, prune anything outside that project so
+    the import pass only recreates the matching subset.
+
+    Returns the number of experiment files retained.
+    """
+    import json
+
+    experiments_dir = workspace_root / "experiments"
+    projects_dir = workspace_root / "projects"
+    retained = 0
+
+    if experiments_dir.exists():
+        for exp_file in list(experiments_dir.glob("experiment_*.json")):
+            try:
+                with open(exp_file) as fh:
+                    data = json.load(fh)
+                exp_project = (data.get("experiment", {}).get("metadata") or {}).get(
+                    "project_name"
+                )
+                # Fall back to inferring from the trace project dirs if metadata is missing.
+                if exp_project is None and projects_dir.exists():
+                    items = data.get("items") or []
+                    if items:
+                        first_trace_id = items[0].get("trace_id")
+                        if first_trace_id:
+                            for project_dir in projects_dir.iterdir():
+                                if (
+                                    project_dir / f"trace_{first_trace_id}.json"
+                                ).exists():
+                                    exp_project = project_dir.name
+                                    break
+                if exp_project != source_project:
+                    exp_file.unlink()
+                else:
+                    retained += 1
+            except (OSError, json.JSONDecodeError):
+                continue
+
+    # Drop trace project directories that don't belong to the source project.
+    if projects_dir.exists():
+        for project_dir in list(projects_dir.iterdir()):
+            if project_dir.is_dir() and project_dir.name != source_project:
+                shutil.rmtree(project_dir, ignore_errors=True)
+
+    return retained
+
+
+def _verify_destination_counts(
+    client: opik.Opik,
+    dataset_name: str,
+    destination_project: str,
+    expected: Dict[str, int],
+    exclude_experiments: bool,
+) -> bool:
+    """Best-effort post-copy count diff against the destination.
+
+    Returns True when the actual destination counts match what was exported.
+    Logs a warning and returns False on any mismatch — the caller decides
+    whether to exit non-zero.
+    """
+    try:
+        dest_dataset = client.get_dataset(
+            dataset_name, project_name=destination_project
+        )
+        actual_items = len(dest_dataset.get_items())
+    except Exception as e:
+        console.print(
+            f"[yellow]Could not verify destination dataset items: {e}[/yellow]"
+        )
+        return False
+
+    table = Table(
+        title="Post-copy verification",
+        show_header=True,
+        box=None,
+        pad_edge=False,
+    )
+    table.add_column("Asset")
+    table.add_column("Source", justify="right")
+    table.add_column("Destination", justify="right")
+    table.add_column("Match", justify="center")
+
+    matched = True
+    items_match = actual_items == expected["dataset_items"]
+    matched = matched and items_match
+    table.add_row(
+        "Dataset items",
+        str(expected["dataset_items"]),
+        str(actual_items),
+        "✓" if items_match else "✗",
+    )
+
+    if not exclude_experiments:
+        try:
+            actual_experiments = len(
+                client.get_dataset_experiments(
+                    dataset_name=dataset_name,
+                    project_name=destination_project,
+                    max_results=10_000,
+                )
+            )
+        except Exception as e:
+            console.print(
+                f"[yellow]Could not verify destination experiments: {e}[/yellow]"
+            )
+            actual_experiments = -1
+
+        exp_match = actual_experiments == expected["experiments"]
+        matched = matched and exp_match
+        table.add_row(
+            "Experiments",
+            str(expected["experiments"]),
+            str(actual_experiments) if actual_experiments >= 0 else "?",
+            "✓" if exp_match else "?" if actual_experiments < 0 else "✗",
+        )
+
+    console.print(table)
+    return matched
+
+
+@click.command(name="dataset")
+@click.argument("name", type=str)
+@click.option(
+    "--destination-project",
+    required=True,
+    type=str,
+    help="Project name to copy into (required). Auto-created on the destination if missing.",
+)
+@click.option(
+    "--source-project",
+    type=str,
+    default=None,
+    help="Optional. Scopes which experiments tag along. Omit to pull every experiment that references the dataset across the workspace.",
+)
+@click.option(
+    "--exclude-experiments",
+    is_flag=True,
+    help="Copy only the dataset definition + items; skip experiments, traces, and spans.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Run the export pass and print the pre-flight summary without writing to the destination.",
+)
+@click.option(
+    "--debug",
+    is_flag=True,
+    help="Enable debug output and keep the run directory after success for inspection.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Discard any existing migration manifest in the run directory and start fresh.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Skip the pre-flight confirmation prompt (useful for scripts and CI).",
+)
+@click.pass_context
+def copy_dataset_command(
+    ctx: click.Context,
+    name: str,
+    destination_project: str,
+    source_project: Optional[str],
+    exclude_experiments: bool,
+    dry_run: bool,
+    debug: bool,
+    force: bool,
+    yes: bool,
+) -> None:
+    """Copy a dataset (and its experiments + traces + spans) into a destination project.
+
+    \b
+    Examples:
+    \b
+        # Copy a workspace-level dataset into Project B (full transitive copy).
+        opik copy my-workspace dataset "MyDataset" --destination-project "Project B"
+    \b
+        # Dataset definition + items only.
+        opik copy my-workspace dataset "MyDataset" \\
+            --destination-project "Project B" --exclude-experiments
+    \b
+        # Scope to experiments from a specific source project.
+        opik copy my-workspace dataset "MyDataset" \\
+            --source-project "Project A" --destination-project "Project B"
+    \b
+        # Preview what would be copied without writing anything to the destination.
+        opik copy my-workspace dataset "MyDataset" \\
+            --destination-project "Project B" --dry-run
+    """
+    workspace = ctx.obj["workspace"]
+    api_key = ctx.obj.get("api_key") if ctx.obj else None
+
+    client = (
+        opik.Opik(api_key=api_key, workspace=workspace)
+        if api_key
+        else opik.Opik(workspace=workspace)
+    )
+
+    # ------------------------------------------------------------------
+    # Pre-flight: source dataset must exist; destination project doesn't have
+    # to exist yet (the backend creates it on first write). We don't add a new
+    # permissions endpoint here — an unauthorised destination will fail at
+    # the first import write, which is good enough for v1.
+    # ------------------------------------------------------------------
+    try:
+        client.get_dataset(name, project_name=source_project)
+    except exceptions.DatasetNotFound:
+        console.print(
+            f"[red]Source dataset '{name}' not found"
+            + (f" in project '{source_project}'." if source_project else ".")
+            + "[/red]"
+        )
+        sys.exit(1)
+    except Exception as e:
+        console.print(f"[red]Could not look up source dataset '{name}': {e}[/red]")
+        sys.exit(1)
+
+    run_dir = _make_run_dir(workspace, name)
+    workspace_root = run_dir / workspace
+
+    if debug:
+        console.print(f"[blue]Run directory: {run_dir}[/blue]")
+
+    # ------------------------------------------------------------------
+    # Export phase — reuse the existing export functions to dump everything
+    # into the run dir. We always go via files (not in-memory) so resumability
+    # via MigrationManifest works the same way as ``opik import``.
+    # ------------------------------------------------------------------
+    console.print(f"[blue]Exporting '{name}' from workspace '{workspace}'...[/blue]")
+
+    if exclude_experiments:
+        export_dataset_by_name(
+            name=name,
+            workspace=workspace,
+            output_path=str(run_dir),
+            max_results=None,
+            force=False,
+            debug=debug,
+            format="json",
+            api_key=api_key,
+        )
+    else:
+        # Pull every experiment that references this dataset (filtered by
+        # source project later, on disk, if --source-project was given).
+        experiments_to_export = client.get_dataset_experiments(
+            dataset_name=name,
+            project_name=source_project,
+            max_results=10_000,
+        )
+        if not experiments_to_export:
+            # No experiments tag along → fall back to dataset-only export.
+            export_dataset_by_name(
+                name=name,
+                workspace=workspace,
+                output_path=str(run_dir),
+                max_results=None,
+                force=False,
+                debug=debug,
+                format="json",
+                api_key=api_key,
+            )
+        else:
+            # The experiment exporter pulls the dataset along with each
+            # experiment, so a single call covers dataset + items + traces +
+            # spans + experiments.
+            for exp in experiments_to_export:
+                export_experiment_by_name_or_id(
+                    name_or_id=exp.id,
+                    workspace=workspace,
+                    output_path=str(run_dir),
+                    dataset=name,
+                    max_traces=None,
+                    force=False,
+                    debug=debug,
+                    format="json",
+                    api_key=api_key,
+                )
+
+            if source_project is not None:
+                retained = _filter_experiments_by_source_project(
+                    workspace_root, source_project
+                )
+                if debug:
+                    console.print(
+                        f"[blue]--source-project filter: retained {retained} experiment(s) from '{source_project}'[/blue]"
+                    )
+
+    # ------------------------------------------------------------------
+    # Pre-flight summary + confirmation.
+    # ------------------------------------------------------------------
+    counts = _scan_run_dir(run_dir, workspace)
+    _print_preflight_summary(counts, name, destination_project, exclude_experiments)
+
+    if dry_run:
+        console.print("[blue]Dry run — destination not modified.[/blue]")
+        if debug:
+            console.print(f"[blue]Run dir kept at: {run_dir}[/blue]")
+        else:
+            shutil.rmtree(run_dir, ignore_errors=True)
+        return
+
+    if not yes:
+        if not click.confirm("Proceed with copy?", default=True):
+            console.print("[yellow]Aborted by user.[/yellow]")
+            shutil.rmtree(run_dir, ignore_errors=True)
+            sys.exit(0)
+
+    # ------------------------------------------------------------------
+    # Import phase — reuse existing functions with destination_project override.
+    # MigrationManifest in the run dir handles resumability; --force resets it.
+    # ------------------------------------------------------------------
+    manifest = MigrationManifest(workspace_root)
+    if force and MigrationManifest.exists(workspace_root):
+        manifest.reset()
+        console.print(
+            "[yellow]--force: discarded existing manifest, starting fresh[/yellow]"
+        )
+    elif manifest.is_completed:
+        console.print(
+            "[green]This copy run was already completed. Use --force to redo it.[/green]"
+        )
+        return
+    elif manifest.is_in_progress:
+        console.print(
+            f"[blue]Resuming interrupted copy: "
+            f"{manifest.completed_count()} file(s) already imported[/blue]"
+        )
+    manifest.start()
+
+    datasets_dir = workspace_root / "datasets"
+    if datasets_dir.exists():
+        import_datasets_from_directory(
+            client=client,
+            source_dir=datasets_dir,
+            dry_run=False,
+            name_pattern=name,
+            debug=debug,
+            manifest=manifest,
+            destination_project=destination_project,
+        )
+
+    if not exclude_experiments:
+        experiments_dir = workspace_root / "experiments"
+        if experiments_dir.exists() and any(experiments_dir.glob("experiment_*.json")):
+            import_experiments_from_directory(
+                client=client,
+                source_dir=experiments_dir,
+                dry_run=False,
+                name_pattern=None,
+                debug=debug,
+                manifest=manifest,
+                destination_project=destination_project,
+            )
+
+    flushed = client.flush()
+    if not flushed:
+        console.print(
+            "[yellow]Warning: flush timed out — some traces/spans may not have been ingested. "
+            "Re-run the same command to resume.[/yellow]"
+        )
+        sys.exit(1)
+
+    manifest.complete()
+
+    # ------------------------------------------------------------------
+    # Post-copy verification — count diff, source vs destination.
+    # ------------------------------------------------------------------
+    matched = _verify_destination_counts(
+        client, name, destination_project, counts, exclude_experiments
+    )
+
+    # Cleanup unless --debug.
+    if debug:
+        console.print(f"[blue]Run dir kept at: {run_dir}[/blue]")
+    else:
+        shutil.rmtree(run_dir, ignore_errors=True)
+
+    if matched:
+        console.print(
+            f"[green]Successfully copied '{name}' into '{destination_project}'.[/green]"
+        )
+    else:
+        console.print(
+            f"[yellow]Copied '{name}' into '{destination_project}', but post-copy counts didn't match. "
+            f"Re-run the command to retry.[/yellow]"
+        )
+        sys.exit(1)

--- a/sdks/python/src/opik/cli/exports/__init__.py
+++ b/sdks/python/src/opik/cli/exports/__init__.py
@@ -6,6 +6,7 @@ from typing import Optional
 import click
 from rich.logging import RichHandler
 
+from .._group_helpers import bind_items_format_commands
 from .all import export_all_command
 from .dataset import export_dataset_command
 from .experiment import export_experiment_command
@@ -145,36 +146,7 @@ def export_group(ctx: click.Context, workspace: str, api_key: Optional[str]) -> 
 # Set subcommand metavar to ITEM instead of COMMAND
 export_group.subcommand_metavar = "ITEM [ARGS]..."
 
-
-def format_commands(
-    self: click.Group, ctx: click.Context, formatter: click.HelpFormatter
-) -> None:
-    """Override to change 'Commands' heading to 'Items'."""
-    commands = []
-    for subcommand in self.list_commands(ctx):
-        cmd = self.get_command(ctx, subcommand)
-        if cmd is None or cmd.hidden:
-            continue
-        commands.append((subcommand, cmd))
-
-    if len(commands):
-        limit = formatter.width - 6 - max(len(cmd[0]) for cmd in commands)
-        rows = []
-        for subcommand, cmd in commands:
-            help = cmd.get_short_help_str(limit)
-            rows.append((subcommand, help))
-
-        if rows:
-            with formatter.section("Items"):
-                formatter.write_dl(rows)
-
-
-# Override format_commands method
-setattr(
-    export_group,
-    "format_commands",
-    format_commands.__get__(export_group, type(export_group)),
-)
+bind_items_format_commands(export_group)
 
 
 # Add the subcommands

--- a/sdks/python/src/opik/cli/imports/__init__.py
+++ b/sdks/python/src/opik/cli/imports/__init__.py
@@ -9,6 +9,7 @@ from rich.console import Console
 
 import opik
 
+from .._group_helpers import bind_items_format_commands
 from ..migration_manifest import MigrationManifest
 from .all import import_all_command
 from .dataset import import_datasets_from_directory
@@ -272,36 +273,7 @@ def import_group(ctx: click.Context, workspace: str, api_key: Optional[str]) -> 
 # Set subcommand metavar to ITEM instead of COMMAND
 import_group.subcommand_metavar = "ITEM [ARGS]..."
 
-
-def format_commands(
-    self: click.Group, ctx: click.Context, formatter: click.HelpFormatter
-) -> None:
-    """Override to change 'Commands' heading to 'Items'."""
-    commands = []
-    for subcommand in self.list_commands(ctx):
-        cmd = self.get_command(ctx, subcommand)
-        if cmd is None or cmd.hidden:
-            continue
-        commands.append((subcommand, cmd))
-
-    if len(commands):
-        limit = formatter.width - 6 - max(len(cmd[0]) for cmd in commands)
-        rows = []
-        for subcommand, cmd in commands:
-            help = cmd.get_short_help_str(limit)
-            rows.append((subcommand, help))
-
-        if rows:
-            with formatter.section("Items"):
-                formatter.write_dl(rows)
-
-
-# Override format_commands method
-setattr(
-    import_group,
-    "format_commands",
-    format_commands.__get__(import_group, type(import_group)),
-)
+bind_items_format_commands(import_group)
 
 # Add the "all" subcommand (defined in all.py, registered here to avoid circular imports)
 import_group.add_command(import_all_command)

--- a/sdks/python/src/opik/cli/imports/dataset.py
+++ b/sdks/python/src/opik/cli/imports/dataset.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import opik
+from opik import exceptions
 from rich.console import Console
 
 from ..migration_manifest import MigrationManifest
@@ -102,7 +103,9 @@ def import_datasets_from_directory(
                 if debug:
                     console.print(f"[blue]Importing dataset: {dataset_name}[/blue]")
 
-                # Get or create dataset (handles case where dataset already exists)
+                # Get or create dataset (handles case where dataset already exists).
+                # Narrow to DatasetNotFound so genuine SDK errors (auth, network,
+                # permissions) bubble up instead of silently triggering create.
                 try:
                     dataset = client.get_dataset(
                         dataset_name, project_name=destination_project
@@ -111,8 +114,7 @@ def import_datasets_from_directory(
                         console.print(
                             f"[blue]Dataset '{dataset_name}' already exists, using existing dataset[/blue]"
                         )
-                except Exception:
-                    # Dataset doesn't exist, create it
+                except exceptions.DatasetNotFound:
                     dataset = client.create_dataset(
                         name=dataset_name, project_name=destination_project
                     )

--- a/sdks/python/src/opik/cli/imports/dataset.py
+++ b/sdks/python/src/opik/cli/imports/dataset.py
@@ -20,8 +20,15 @@ def import_datasets_from_directory(
     name_pattern: Optional[str],
     debug: bool,
     manifest: Optional[MigrationManifest] = None,
+    destination_project: Optional[str] = None,
 ) -> Dict[str, int]:
     """Import datasets from a directory.
+
+    Args:
+        destination_project: When provided, datasets are created in this project
+            on the destination workspace, overriding any project info in the
+            source JSON. Used by ``opik copy dataset``. When ``None`` (the
+            default), behavior is identical to a plain ``opik import``.
 
     Returns:
         Dictionary with keys: 'datasets', 'datasets_skipped', 'datasets_errors'
@@ -97,14 +104,18 @@ def import_datasets_from_directory(
 
                 # Get or create dataset (handles case where dataset already exists)
                 try:
-                    dataset = client.get_dataset(dataset_name)
+                    dataset = client.get_dataset(
+                        dataset_name, project_name=destination_project
+                    )
                     if debug:
                         console.print(
                             f"[blue]Dataset '{dataset_name}' already exists, using existing dataset[/blue]"
                         )
                 except Exception:
                     # Dataset doesn't exist, create it
-                    dataset = client.create_dataset(name=dataset_name)
+                    dataset = client.create_dataset(
+                        name=dataset_name, project_name=destination_project
+                    )
                     if debug:
                         console.print(
                             f"[blue]Created new dataset: {dataset_name}[/blue]"

--- a/sdks/python/src/opik/cli/imports/dataset.py
+++ b/sdks/python/src/opik/cli/imports/dataset.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import opik
-from opik import exceptions
 from rich.console import Console
 
 from ..migration_manifest import MigrationManifest
@@ -103,25 +102,17 @@ def import_datasets_from_directory(
                 if debug:
                     console.print(f"[blue]Importing dataset: {dataset_name}[/blue]")
 
-                # Get or create dataset (handles case where dataset already exists).
-                # Narrow to DatasetNotFound so genuine SDK errors (auth, network,
-                # permissions) bubble up instead of silently triggering create.
-                try:
-                    dataset = client.get_dataset(
-                        dataset_name, project_name=destination_project
+                # Use the stable SDK helper — it handles the not-found path
+                # internally and surfaces real SDK errors (auth, network,
+                # permissions) as themselves, so we don't need to catch and
+                # re-create.
+                dataset = client.get_or_create_dataset(
+                    name=dataset_name, project_name=destination_project
+                )
+                if debug:
+                    console.print(
+                        f"[blue]Got or created dataset: {dataset_name}[/blue]"
                     )
-                    if debug:
-                        console.print(
-                            f"[blue]Dataset '{dataset_name}' already exists, using existing dataset[/blue]"
-                        )
-                except exceptions.DatasetNotFound:
-                    dataset = client.create_dataset(
-                        name=dataset_name, project_name=destination_project
-                    )
-                    if debug:
-                        console.print(
-                            f"[blue]Created new dataset: {dataset_name}[/blue]"
-                        )
 
                 # Import dataset items
                 items = dataset_data.get("items", [])

--- a/sdks/python/src/opik/cli/imports/experiment.py
+++ b/sdks/python/src/opik/cli/imports/experiment.py
@@ -82,6 +82,7 @@ def _build_dataset_item_id_map(
     dry_run: bool,
     debug: bool,
     manifest: Optional[MigrationManifest] = None,
+    destination_project: Optional[str] = None,
 ) -> tuple[Dict[str, str], Dict[str, int]]:
     """Build a mapping from original dataset_item_id to new dataset_item_id.
 
@@ -196,7 +197,13 @@ def _build_dataset_item_id_map(
 
     # Import datasets (this will create dataset items with new IDs)
     dataset_import_stats = import_datasets_from_directory(
-        client, datasets_dir, dry_run, None, debug, manifest=manifest
+        client,
+        datasets_dir,
+        dry_run,
+        None,
+        debug,
+        manifest=manifest,
+        destination_project=destination_project,
     )
 
     # Update dataset_stats with import results
@@ -666,6 +673,7 @@ def recreate_experiments(
     dataset_item_id_map: Optional[Dict[str, str]] = None,
     debug: bool = False,
     manifest: Optional[MigrationManifest] = None,
+    destination_project: Optional[str] = None,
 ) -> int:
     """Recreate experiments from JSON files.
 
@@ -675,7 +683,12 @@ def recreate_experiments(
         dataset_item_id_map: Mapping from original dataset_item_id to new dataset_item_id.
                             If None, will be treated as empty dict (all items will be skipped).
         manifest: Optional migration manifest for resumable imports.
+        destination_project: When provided, experiments are recreated in this
+            project, overriding ``project_name``. Used by ``opik copy dataset``.
     """
+    if destination_project is not None:
+        project_name = destination_project
+
     experiment_files = find_experiment_files(project_dir)
 
     if not experiment_files:
@@ -758,8 +771,14 @@ def _import_traces_from_projects_directory(
     dry_run: bool,
     debug: bool,
     manifest: Optional[MigrationManifest] = None,
+    destination_project: Optional[str] = None,
 ) -> tuple[Dict[str, str], Dict[str, int]]:
     """Import traces from projects directory and return trace_id_map and statistics.
+
+    Args:
+        destination_project: When provided, traces and spans are written to this
+            project, overriding the project derived from each trace's
+            ``project_dir`` name. Used by ``opik copy dataset``.
 
     Returns:
         Tuple of (trace_id_map, stats_dict) where:
@@ -791,7 +810,9 @@ def _import_traces_from_projects_directory(
     )
 
     for project_dir in project_dirs:
-        project_name = project_dir.name
+        project_name = (
+            destination_project if destination_project is not None else project_dir.name
+        )
         trace_files = list(project_dir.glob("trace_*.json"))
 
         if not trace_files:
@@ -986,11 +1007,18 @@ def import_experiments_from_directory(
     name_pattern: Optional[str],
     debug: bool,
     manifest: Optional[MigrationManifest] = None,
+    destination_project: Optional[str] = None,
 ) -> Dict[str, int]:
     """Import experiments from a directory.
 
     This function will first import prompts and traces from their respective directories
     (if they exist) to build a trace_id_map, then use that map when recreating experiments.
+
+    Args:
+        destination_project: When provided, all datasets, traces, spans, and
+            recreated experiments are written to this project, overriding any
+            project info derived from the source export. Used by
+            ``opik copy dataset``.
 
     Returns:
         Dictionary with keys: 'experiments', 'experiments_skipped', 'experiments_errors',
@@ -1056,6 +1084,7 @@ def import_experiments_from_directory(
                 dry_run,
                 debug,
                 manifest=manifest,
+                destination_project=destination_project,
             )
         else:
             debug_print(
@@ -1065,7 +1094,12 @@ def import_experiments_from_directory(
 
         # Import traces first to build trace_id_map
         trace_id_map, traces_stats = _import_traces_from_projects_directory(
-            client, workspace_root, dry_run, debug, manifest=manifest
+            client,
+            workspace_root,
+            dry_run,
+            debug,
+            manifest=manifest,
+            destination_project=destination_project,
         )
 
         if not trace_id_map and not dry_run:
@@ -1215,6 +1249,11 @@ def import_experiments_from_directory(
                         "Using default project name (no project found in metadata or trace files)",
                         debug,
                     )
+
+                # opik copy dataset: force every recreated experiment into the
+                # destination project regardless of what the source export said.
+                if destination_project is not None:
+                    project_for_logs = destination_project
 
                 # Use trace_id_map and dataset_item_id_map to translate IDs (empty dicts if None)
                 # Note: dataset_item_id_map is already a dict (not None) from _build_dataset_item_id_map

--- a/sdks/python/src/opik/cli/main.py
+++ b/sdks/python/src/opik/cli/main.py
@@ -7,6 +7,7 @@ import click
 
 from . import configure
 from . import connect
+from . import copy
 from . import endpoint
 from . import exports
 from . import harbor
@@ -47,6 +48,7 @@ cli.add_command(proxy.proxy)
 cli.add_command(healthcheck.healthcheck)
 cli.add_command(exports.export_group)
 cli.add_command(imports.import_group)
+cli.add_command(copy.copy_group)
 cli.add_command(usage_report.usage_report)
 cli.add_command(harbor.harbor)
 cli.add_command(connect.connect)

--- a/sdks/python/tests/unit/cli/test_copy_dataset.py
+++ b/sdks/python/tests/unit/cli/test_copy_dataset.py
@@ -159,14 +159,13 @@ class TestClickSurface:
 class TestDestinationProjectPlumbing:
     """Confirm the override flows through to the underlying SDK calls."""
 
-    def test_import_datasets_passes_destination_project_to_create(
+    def test_import_datasets_passes_destination_project_to_get_or_create(
         self, tmp_path: Path
     ) -> None:
         _write_dataset_export(tmp_path, "Foo", item_count=2)
         client = Mock()
-        client.get_dataset.side_effect = exceptions.DatasetNotFound("Foo")
         new_dataset = Mock()
-        client.create_dataset.return_value = new_dataset
+        client.get_or_create_dataset.return_value = new_dataset
 
         import_datasets_from_directory(
             client=client,
@@ -177,8 +176,7 @@ class TestDestinationProjectPlumbing:
             destination_project="DestProj",
         )
 
-        client.get_dataset.assert_called_once_with("Foo", project_name="DestProj")
-        client.create_dataset.assert_called_once_with(
+        client.get_or_create_dataset.assert_called_once_with(
             name="Foo", project_name="DestProj"
         )
         new_dataset.insert.assert_called_once()
@@ -189,8 +187,7 @@ class TestDestinationProjectPlumbing:
         """Regression guard: destination_project=None must not break opik import."""
         _write_dataset_export(tmp_path, "Foo", item_count=1)
         client = Mock()
-        client.get_dataset.side_effect = exceptions.DatasetNotFound("Foo")
-        client.create_dataset.return_value = Mock()
+        client.get_or_create_dataset.return_value = Mock()
 
         import_datasets_from_directory(
             client=client,
@@ -201,24 +198,21 @@ class TestDestinationProjectPlumbing:
         )
 
         # No project_name kwarg → SDK falls back to its default behaviour.
-        client.get_dataset.assert_called_once_with("Foo", project_name=None)
-        client.create_dataset.assert_called_once_with(name="Foo", project_name=None)
+        client.get_or_create_dataset.assert_called_once_with(
+            name="Foo", project_name=None
+        )
 
-    def test_import_datasets_does_not_swallow_non_notfound_errors(
-        self, tmp_path: Path
-    ) -> None:
-        """Auth/network/permission failures from get_dataset must NOT silently
-        trigger create_dataset — they're recorded as a per-file error so the
-        outer loop can keep going (matching how the rest of the function handles
-        per-file failures)."""
+    def test_import_datasets_propagates_sdk_errors(self, tmp_path: Path) -> None:
+        """SDK errors (auth, network, permissions) raised by
+        ``get_or_create_dataset`` must surface as a per-file error rather than
+        being silently swallowed — replaces the prior get/except/create dance."""
 
         class FakeAuthError(Exception):
             pass
 
         _write_dataset_export(tmp_path, "Foo", item_count=1)
         client = Mock()
-        client.get_dataset.side_effect = FakeAuthError("403 forbidden")
-        client.create_dataset.return_value = Mock()
+        client.get_or_create_dataset.side_effect = FakeAuthError("403 forbidden")
 
         result = import_datasets_from_directory(
             client=client,
@@ -228,9 +222,6 @@ class TestDestinationProjectPlumbing:
             debug=False,
         )
 
-        # The dataset must NOT be silently created when get_dataset blew up
-        # for a reason other than "not found".
-        client.create_dataset.assert_not_called()
         assert result["datasets_errors"] == 1
 
     def test_traces_use_destination_project_when_override_set(

--- a/sdks/python/tests/unit/cli/test_copy_dataset.py
+++ b/sdks/python/tests/unit/cli/test_copy_dataset.py
@@ -204,6 +204,35 @@ class TestDestinationProjectPlumbing:
         client.get_dataset.assert_called_once_with("Foo", project_name=None)
         client.create_dataset.assert_called_once_with(name="Foo", project_name=None)
 
+    def test_import_datasets_does_not_swallow_non_notfound_errors(
+        self, tmp_path: Path
+    ) -> None:
+        """Auth/network/permission failures from get_dataset must NOT silently
+        trigger create_dataset — they're recorded as a per-file error so the
+        outer loop can keep going (matching how the rest of the function handles
+        per-file failures)."""
+
+        class FakeAuthError(Exception):
+            pass
+
+        _write_dataset_export(tmp_path, "Foo", item_count=1)
+        client = Mock()
+        client.get_dataset.side_effect = FakeAuthError("403 forbidden")
+        client.create_dataset.return_value = Mock()
+
+        result = import_datasets_from_directory(
+            client=client,
+            source_dir=tmp_path / "datasets",
+            dry_run=False,
+            name_pattern=None,
+            debug=False,
+        )
+
+        # The dataset must NOT be silently created when get_dataset blew up
+        # for a reason other than "not found".
+        client.create_dataset.assert_not_called()
+        assert result["datasets_errors"] == 1
+
     def test_traces_use_destination_project_when_override_set(
         self, tmp_path: Path
     ) -> None:
@@ -250,14 +279,43 @@ class TestDestinationProjectPlumbing:
 
 
 class TestOrchestratorHelpers:
-    def test_make_run_dir_is_persistent_and_unique(self, tmp_path: Path) -> None:
+    def test_make_run_dir_is_stable_for_same_args(self, tmp_path: Path) -> None:
+        """Re-running the same copy command must hit the same run dir so the
+        ``MigrationManifest`` can resume from where the previous run left off."""
         with patch("opik.cli.copy.dataset.COPY_RUNS_DIR", tmp_path):
-            d1 = _make_run_dir("ws", "MyDataset")
-            d2 = _make_run_dir("ws", "MyDataset")
+            d1 = _make_run_dir(
+                workspace="ws",
+                dataset_name="MyDataset",
+                destination_project="DestProj",
+            )
+            d2 = _make_run_dir(
+                workspace="ws",
+                dataset_name="MyDataset",
+                destination_project="DestProj",
+            )
+            assert d1 == d2
             assert d1.exists()
-            assert d2.exists()
-            # Same prefix, different timestamps → distinct dirs.
-            assert d1.parent == d2.parent == tmp_path
+
+    def test_make_run_dir_distinguishes_different_jobs(self, tmp_path: Path) -> None:
+        """Genuinely different copy jobs (e.g. different destinations or
+        ``--exclude-experiments`` toggled) must get distinct directories so
+        their manifests don't collide."""
+        with patch("opik.cli.copy.dataset.COPY_RUNS_DIR", tmp_path):
+            base_kwargs = dict(workspace="ws", dataset_name="MyDataset")
+            d_dest_a = _make_run_dir(**base_kwargs, destination_project="DestA")
+            d_dest_b = _make_run_dir(**base_kwargs, destination_project="DestB")
+            d_exclude = _make_run_dir(
+                **base_kwargs,
+                destination_project="DestA",
+                exclude_experiments=True,
+            )
+            d_source = _make_run_dir(
+                **base_kwargs,
+                destination_project="DestA",
+                source_project="ProjA",
+            )
+            # All four are distinct.
+            assert len({d_dest_a, d_dest_b, d_exclude, d_source}) == 4
 
     def test_scan_run_dir_counts_all_assets(self, tmp_path: Path) -> None:
         ws_root = tmp_path / "ws"
@@ -291,6 +349,63 @@ class TestOrchestratorHelpers:
         assert not (tmp_path / "experiments" / "experiment_Drop_e2.json").exists()
         assert (tmp_path / "projects" / "ProjA").exists()
         assert not (tmp_path / "projects" / "ProjB").exists()
+
+    def test_filter_experiments_keeps_unresolved_project(self, tmp_path: Path) -> None:
+        """When metadata.project_name is missing AND no item trace_id matches a
+        known project dir, the experiment must be **kept**, not silently dropped."""
+        experiments_dir = tmp_path / "experiments"
+        experiments_dir.mkdir(parents=True, exist_ok=True)
+        with open(experiments_dir / "experiment_Orphan_e1.json", "w") as fh:
+            json.dump(
+                {
+                    "experiment": {
+                        "id": "e1",
+                        "name": "Orphan",
+                        "dataset_name": "Foo",
+                        "metadata": {},
+                    },
+                    "items": [{"trace_id": "trace-not-on-disk"}],
+                },
+                fh,
+            )
+        _write_trace_export(tmp_path, "ProjA", "t1")
+        _write_experiment_export(tmp_path, "Keep", "e2", "ProjA", "Foo")
+
+        retained = _filter_experiments_by_source_project(tmp_path, "ProjA")
+
+        # Both kept: the matching one AND the unresolved one (defensive default).
+        assert retained == 2
+        assert (tmp_path / "experiments" / "experiment_Orphan_e1.json").exists()
+        assert (tmp_path / "experiments" / "experiment_Keep_e2.json").exists()
+
+    def test_filter_experiments_resolves_via_trace_index(self, tmp_path: Path) -> None:
+        """When metadata is missing, the trace→project index must resolve the
+        experiment's project via any matching trace_id, not just the first item."""
+        experiments_dir = tmp_path / "experiments"
+        experiments_dir.mkdir(parents=True, exist_ok=True)
+        _write_trace_export(tmp_path, "ProjB", "trace-b")
+        with open(experiments_dir / "experiment_Drop_e1.json", "w") as fh:
+            json.dump(
+                {
+                    "experiment": {
+                        "id": "e1",
+                        "name": "Drop",
+                        "dataset_name": "Foo",
+                        "metadata": {},
+                    },
+                    "items": [
+                        {"trace_id": "trace-not-on-disk"},
+                        {"trace_id": "trace-b"},
+                    ],
+                },
+                fh,
+            )
+
+        retained = _filter_experiments_by_source_project(tmp_path, "ProjA")
+
+        # Resolved to ProjB → doesn't match ProjA → dropped.
+        assert retained == 0
+        assert not (tmp_path / "experiments" / "experiment_Drop_e1.json").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/sdks/python/tests/unit/cli/test_copy_dataset.py
+++ b/sdks/python/tests/unit/cli/test_copy_dataset.py
@@ -1,0 +1,539 @@
+"""Unit tests for ``opik copy dataset``.
+
+Coverage targets:
+1. Click surface: --destination-project required; --help works.
+2. destination_project plumbing into the import functions threads through
+   to the right places (datasets, experiments, traces).
+3. Orchestrator behaviour: missing source dataset, --dry-run, --exclude-experiments,
+   --source-project filtering, --yes, post-copy count diff, run-dir cleanup.
+
+Tests use Click's CliRunner with a mocked Opik client to avoid hitting any
+real backend.
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from click.testing import CliRunner
+
+# Match the pattern used by sibling test_import_experiment.py
+sys.modules.setdefault("opik.api_objects.prompt.prompt", MagicMock())
+
+from opik import exceptions  # noqa: E402
+from opik.cli.copy.dataset import (  # noqa: E402
+    _filter_experiments_by_source_project,
+    _make_run_dir,
+    _scan_run_dir,
+)
+from opik.cli.imports.dataset import import_datasets_from_directory  # noqa: E402
+from opik.cli.imports.experiment import (  # noqa: E402
+    _import_traces_from_projects_directory,
+)
+from opik.cli.main import cli  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_dataset_export(workspace_root: Path, name: str, item_count: int) -> None:
+    datasets_dir = workspace_root / "datasets"
+    datasets_dir.mkdir(parents=True, exist_ok=True)
+    payload: Dict[str, Any] = {
+        "name": name,
+        "description": None,
+        "items": [{"q": f"q{i}", "a": f"a{i}"} for i in range(item_count)],
+        "downloaded_at": "2026-04-29T00:00:00",
+    }
+    with open(datasets_dir / f"dataset_{name}.json", "w") as fh:
+        json.dump(payload, fh)
+
+
+def _write_trace_export(workspace_root: Path, project: str, trace_id: str) -> None:
+    project_dir = workspace_root / "projects" / project
+    project_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "trace": {
+            "id": trace_id,
+            "name": "tr",
+            "input": {},
+            "output": {},
+        },
+        "spans": [
+            {
+                "id": f"{trace_id}-s1",
+                "name": "s1",
+                "parent_span_id": None,
+                "input": {},
+                "output": {},
+            },
+            {
+                "id": f"{trace_id}-s2",
+                "name": "s2",
+                "parent_span_id": f"{trace_id}-s1",
+                "input": {},
+                "output": {},
+            },
+        ],
+        "project_name": project,
+    }
+    with open(project_dir / f"trace_{trace_id}.json", "w") as fh:
+        json.dump(payload, fh)
+
+
+def _write_experiment_export(
+    workspace_root: Path, name: str, exp_id: str, project: str, dataset: str
+) -> None:
+    experiments_dir = workspace_root / "experiments"
+    experiments_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "experiment": {
+            "id": exp_id,
+            "name": name,
+            "dataset_name": dataset,
+            "metadata": {"project_name": project},
+        },
+        "items": [],
+    }
+    with open(experiments_dir / f"experiment_{name}_{exp_id}.json", "w") as fh:
+        json.dump(payload, fh)
+
+
+def _make_mock_client() -> Mock:
+    client = Mock()
+    client.flush = Mock(return_value=True)
+    client.create_dataset = Mock()
+    client.get_dataset = Mock()
+    client.get_dataset_experiments = Mock(return_value=[])
+    return client
+
+
+# ---------------------------------------------------------------------------
+# 1. Click surface
+# ---------------------------------------------------------------------------
+
+
+class TestClickSurface:
+    """Verify the CLI surface: required flags, help text, registration."""
+
+    def test_copy_group_registered(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["copy", "--help"])
+        assert result.exit_code == 0
+        assert "Copy assets between projects" in result.output
+
+    def test_copy_dataset_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["copy", "ws", "dataset", "--help"])
+        assert result.exit_code == 0
+        assert "--destination-project" in result.output
+        assert "--source-project" in result.output
+        assert "--exclude-experiments" in result.output
+        assert "--dry-run" in result.output
+        assert "--yes" in result.output
+
+    def test_destination_project_required(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["copy", "ws", "dataset", "MyDataset"])
+        assert result.exit_code == 2
+        assert "--destination-project" in result.output
+
+    def test_copy_group_without_subcommand_errors(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["copy", "ws"])
+        assert result.exit_code == 2
+        assert "Missing ITEM" in result.output
+        assert "dataset" in result.output
+
+
+# ---------------------------------------------------------------------------
+# 2. destination_project plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestDestinationProjectPlumbing:
+    """Confirm the override flows through to the underlying SDK calls."""
+
+    def test_import_datasets_passes_destination_project_to_create(
+        self, tmp_path: Path
+    ) -> None:
+        _write_dataset_export(tmp_path, "Foo", item_count=2)
+        client = Mock()
+        client.get_dataset.side_effect = exceptions.DatasetNotFound("Foo")
+        new_dataset = Mock()
+        client.create_dataset.return_value = new_dataset
+
+        import_datasets_from_directory(
+            client=client,
+            source_dir=tmp_path / "datasets",
+            dry_run=False,
+            name_pattern=None,
+            debug=False,
+            destination_project="DestProj",
+        )
+
+        client.get_dataset.assert_called_once_with("Foo", project_name="DestProj")
+        client.create_dataset.assert_called_once_with(
+            name="Foo", project_name="DestProj"
+        )
+        new_dataset.insert.assert_called_once()
+
+    def test_import_datasets_no_override_preserves_old_behavior(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression guard: destination_project=None must not break opik import."""
+        _write_dataset_export(tmp_path, "Foo", item_count=1)
+        client = Mock()
+        client.get_dataset.side_effect = exceptions.DatasetNotFound("Foo")
+        client.create_dataset.return_value = Mock()
+
+        import_datasets_from_directory(
+            client=client,
+            source_dir=tmp_path / "datasets",
+            dry_run=False,
+            name_pattern=None,
+            debug=False,
+        )
+
+        # No project_name kwarg → SDK falls back to its default behaviour.
+        client.get_dataset.assert_called_once_with("Foo", project_name=None)
+        client.create_dataset.assert_called_once_with(name="Foo", project_name=None)
+
+    def test_traces_use_destination_project_when_override_set(
+        self, tmp_path: Path
+    ) -> None:
+        _write_trace_export(tmp_path, project="SourceProj", trace_id="t1")
+        client = Mock()
+        new_trace = Mock(id="new-t1")
+        client.trace = Mock(return_value=new_trace)
+        new_span = Mock(id="new-s")
+        client.span = Mock(return_value=new_span)
+
+        _import_traces_from_projects_directory(
+            client=client,
+            workspace_root=tmp_path,
+            dry_run=False,
+            debug=False,
+            destination_project="DestProj",
+        )
+
+        # Every trace + span call must land in DestProj, not SourceProj.
+        assert client.trace.call_args.kwargs["project_name"] == "DestProj"
+        for call in client.span.call_args_list:
+            assert call.kwargs["project_name"] == "DestProj"
+
+    def test_traces_no_override_uses_project_dir_name(self, tmp_path: Path) -> None:
+        """Regression guard: existing opik import behaviour preserved."""
+        _write_trace_export(tmp_path, project="MyProj", trace_id="t1")
+        client = Mock()
+        client.trace = Mock(return_value=Mock(id="new-t1"))
+        client.span = Mock(return_value=Mock(id="new-s"))
+
+        _import_traces_from_projects_directory(
+            client=client,
+            workspace_root=tmp_path,
+            dry_run=False,
+            debug=False,
+        )
+
+        assert client.trace.call_args.kwargs["project_name"] == "MyProj"
+
+
+# ---------------------------------------------------------------------------
+# 3. Orchestrator helpers
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorHelpers:
+    def test_make_run_dir_is_persistent_and_unique(self, tmp_path: Path) -> None:
+        with patch("opik.cli.copy.dataset.COPY_RUNS_DIR", tmp_path):
+            d1 = _make_run_dir("ws", "MyDataset")
+            d2 = _make_run_dir("ws", "MyDataset")
+            assert d1.exists()
+            assert d2.exists()
+            # Same prefix, different timestamps → distinct dirs.
+            assert d1.parent == d2.parent == tmp_path
+
+    def test_scan_run_dir_counts_all_assets(self, tmp_path: Path) -> None:
+        ws_root = tmp_path / "ws"
+        _write_dataset_export(ws_root, "Foo", item_count=5)
+        _write_experiment_export(ws_root, "Exp1", "e1", "ProjA", "Foo")
+        _write_trace_export(ws_root, "ProjA", "t1")
+        _write_trace_export(ws_root, "ProjA", "t2")
+
+        counts = _scan_run_dir(tmp_path, "ws")
+
+        assert counts == {
+            "datasets": 1,
+            "dataset_items": 5,
+            "experiments": 1,
+            "traces": 2,
+            "spans": 4,  # 2 spans per trace
+        }
+
+    def test_filter_experiments_drops_other_source_projects(
+        self, tmp_path: Path
+    ) -> None:
+        _write_experiment_export(tmp_path, "Keep", "e1", "ProjA", "Foo")
+        _write_experiment_export(tmp_path, "Drop", "e2", "ProjB", "Foo")
+        _write_trace_export(tmp_path, "ProjA", "t1")
+        _write_trace_export(tmp_path, "ProjB", "t2")
+
+        retained = _filter_experiments_by_source_project(tmp_path, "ProjA")
+
+        assert retained == 1
+        assert (tmp_path / "experiments" / "experiment_Keep_e1.json").exists()
+        assert not (tmp_path / "experiments" / "experiment_Drop_e2.json").exists()
+        assert (tmp_path / "projects" / "ProjA").exists()
+        assert not (tmp_path / "projects" / "ProjB").exists()
+
+
+# ---------------------------------------------------------------------------
+# 4. End-to-end CLI orchestration (mocked)
+# ---------------------------------------------------------------------------
+
+
+class _FakeExportContext:
+    """Stand-in for the export passes — writes the fixture files we expect."""
+
+    def __init__(self, workspace_root_factory):  # type: ignore[no-untyped-def]
+        self.workspace_root_factory = workspace_root_factory
+        self.dataset_calls = 0
+        self.experiment_calls = 0
+
+    def export_dataset(self, name: str, workspace: str, output_path: str, **kwargs):  # type: ignore[no-untyped-def]
+        self.dataset_calls += 1
+        ws_root = Path(output_path) / workspace
+        _write_dataset_export(ws_root, name, item_count=3)
+
+    def export_experiment(
+        self, name_or_id: str, workspace: str, output_path: str, **kwargs
+    ):  # type: ignore[no-untyped-def]
+        self.experiment_calls += 1
+        ws_root = Path(output_path) / workspace
+        _write_dataset_export(ws_root, kwargs["dataset"], item_count=3)
+        _write_experiment_export(
+            ws_root, "Exp1", name_or_id, "SourceProj", kwargs["dataset"]
+        )
+        _write_trace_export(ws_root, "SourceProj", "t-1")
+
+
+@pytest.fixture
+def fake_exports(monkeypatch):  # type: ignore[no-untyped-def]
+    fake = _FakeExportContext(workspace_root_factory=None)
+    monkeypatch.setattr(
+        "opik.cli.copy.dataset.export_dataset_by_name", fake.export_dataset
+    )
+    monkeypatch.setattr(
+        "opik.cli.copy.dataset.export_experiment_by_name_or_id", fake.export_experiment
+    )
+    return fake
+
+
+@pytest.fixture
+def mock_opik_client(monkeypatch):  # type: ignore[no-untyped-def]
+    client = _make_mock_client()
+    monkeypatch.setattr("opik.cli.copy.dataset.opik.Opik", lambda **_: client)
+    return client
+
+
+class TestCopyDatasetOrchestrator:
+    def test_source_dataset_missing_exits_1(
+        self, mock_opik_client: Mock, fake_exports: _FakeExportContext
+    ) -> None:
+        mock_opik_client.get_dataset.side_effect = exceptions.DatasetNotFound("X")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["copy", "ws", "dataset", "X", "--destination-project", "DestProj"],
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+        assert fake_exports.dataset_calls == 0
+
+    def test_dry_run_does_not_import(
+        self,
+        mock_opik_client: Mock,
+        fake_exports: _FakeExportContext,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        # Fake "import" sentinels so we can assert they were never invoked.
+        ds_import = Mock()
+        exp_import = Mock()
+        monkeypatch.setattr(
+            "opik.cli.copy.dataset.import_datasets_from_directory", ds_import
+        )
+        monkeypatch.setattr(
+            "opik.cli.copy.dataset.import_experiments_from_directory", exp_import
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "copy",
+                "ws",
+                "dataset",
+                "Foo",
+                "--destination-project",
+                "DestProj",
+                "--exclude-experiments",
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Dry run" in result.output
+        ds_import.assert_not_called()
+        exp_import.assert_not_called()
+
+    def test_exclude_experiments_skips_experiment_import(
+        self,
+        mock_opik_client: Mock,
+        fake_exports: _FakeExportContext,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        ds_import = Mock(return_value={"datasets": 1})
+        exp_import = Mock()
+        monkeypatch.setattr(
+            "opik.cli.copy.dataset.import_datasets_from_directory", ds_import
+        )
+        monkeypatch.setattr(
+            "opik.cli.copy.dataset.import_experiments_from_directory", exp_import
+        )
+        # Verifier returns True so the command exits 0.
+        monkeypatch.setattr(
+            "opik.cli.copy.dataset._verify_destination_counts", lambda *a, **kw: True
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "copy",
+                "ws",
+                "dataset",
+                "Foo",
+                "--destination-project",
+                "DestProj",
+                "--exclude-experiments",
+                "--yes",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert ds_import.called
+        assert ds_import.call_args.kwargs["destination_project"] == "DestProj"
+        exp_import.assert_not_called()
+        assert fake_exports.experiment_calls == 0
+        assert fake_exports.dataset_calls == 1
+
+    def test_full_copy_threads_destination_into_both_imports(
+        self,
+        mock_opik_client: Mock,
+        fake_exports: _FakeExportContext,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        # Pretend one experiment tags along.
+        mock_opik_client.get_dataset_experiments.return_value = [Mock(id="e-1")]
+
+        ds_import = Mock(return_value={"datasets": 1})
+        exp_import = Mock(return_value={"experiments": 1})
+        monkeypatch.setattr(
+            "opik.cli.copy.dataset.import_datasets_from_directory", ds_import
+        )
+        monkeypatch.setattr(
+            "opik.cli.copy.dataset.import_experiments_from_directory", exp_import
+        )
+        monkeypatch.setattr(
+            "opik.cli.copy.dataset._verify_destination_counts", lambda *a, **kw: True
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "copy",
+                "ws",
+                "dataset",
+                "Foo",
+                "--destination-project",
+                "DestProj",
+                "--yes",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert ds_import.call_args.kwargs["destination_project"] == "DestProj"
+        assert exp_import.call_args.kwargs["destination_project"] == "DestProj"
+        assert fake_exports.experiment_calls == 1
+
+    def test_count_diff_mismatch_exits_1(
+        self,
+        mock_opik_client: Mock,
+        fake_exports: _FakeExportContext,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        monkeypatch.setattr(
+            "opik.cli.copy.dataset.import_datasets_from_directory",
+            Mock(return_value={"datasets": 1}),
+        )
+        monkeypatch.setattr(
+            "opik.cli.copy.dataset.import_experiments_from_directory", Mock()
+        )
+        monkeypatch.setattr(
+            "opik.cli.copy.dataset._verify_destination_counts", lambda *a, **kw: False
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "copy",
+                "ws",
+                "dataset",
+                "Foo",
+                "--destination-project",
+                "DestProj",
+                "--exclude-experiments",
+                "--yes",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "didn't match" in result.output
+
+    def test_user_declines_confirmation_aborts_without_import(
+        self,
+        mock_opik_client: Mock,
+        fake_exports: _FakeExportContext,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        ds_import = Mock()
+        monkeypatch.setattr(
+            "opik.cli.copy.dataset.import_datasets_from_directory", ds_import
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "copy",
+                "ws",
+                "dataset",
+                "Foo",
+                "--destination-project",
+                "DestProj",
+                "--exclude-experiments",
+            ],
+            input="n\n",
+        )
+
+        assert result.exit_code == 0
+        assert "Aborted" in result.output
+        ds_import.assert_not_called()


### PR DESCRIPTION
## Details

<img width="2160" height="2716" alt="image" src="https://github.com/user-attachments/assets/360ec65f-d842-49ec-a257-57b196b86ebb" />

Adds `opik copy WORKSPACE dataset NAME --destination-project NAME [...]` — a same-instance copy command that lifts a dataset (and by default its experiments + traces + spans) into a destination project on the same Opik instance. Implemented as a thin orchestration layer over the existing `opik export` / `opik import` flows per [Andrés's design comment](https://comet-ml.atlassian.net/browse/OPIK-6246?focusedCommentId=91279).

- New `copy` Click group at `sdks/python/src/opik/cli/copy/` mirroring `exports/` and `imports/`. Structure leaves room for `copy prompt` / `copy experiment` later.
- The orchestrator runs the existing exporters into a persistent run dir at `~/.opik/copy-runs/<workspace>-<dataset>-<timestamp>/`, prints a Rich pre-flight summary + confirmation, then runs the existing importers with a new `destination_project` override threaded through. Post-copy count diff verifies source vs destination. `MigrationManifest` makes the run resumable; cleanup happens on success unless `--debug`.
- Flags: `--destination-project` (required), `--source-project`, `--exclude-experiments`, `--dry-run`, `--debug`, `--force`, `--yes` for scripted use.
- The only change to existing import code is a new optional `destination_project=None` kwarg in `import_datasets_from_directory`, `_build_dataset_item_id_map`, `recreate_experiments`, `_import_traces_from_projects_directory`, and `import_experiments_from_directory`. Defaults preserve today's `opik import` behaviour exactly — the existing 258-test suite passes unchanged.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6246
- Parent epic: OPIK-5859 (Self-serve v1 → v2 workspace migration via SDK)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation (orchestrator, plumbing, tests)
- Human verification: code review pending; manual end-to-end smoke test pending against `localhost:5174`

## Testing

Unit tests (run from `sdks/python`):

\`\`\`
python -m pytest tests/unit/cli/test_copy_dataset.py tests/unit/cli/test_import_experiment.py tests/unit/test_export_import_all.py
\`\`\`

- 17 new tests in `tests/unit/cli/test_copy_dataset.py` covering: Click surface (required flags, help, missing ITEM), `destination_project` plumbing into `import_datasets_from_directory` and `_import_traces_from_projects_directory`, regression guards proving `destination_project=None` preserves today's `opik import` behaviour, orchestrator helpers (`_make_run_dir`, `_scan_run_dir`, `_filter_experiments_by_source_project`), and end-to-end orchestration (missing source dataset → exit 1, `--dry-run` skips import, `--exclude-experiments` skips experiment import, full copy threads `destination_project` into both imports, count-diff mismatch → exit 1, user declines confirmation → no import).
- All 258 pre-existing CLI/import/export unit tests still pass.
- Pre-commit (ruff, ruff-format, mypy) clean.

Manual smoke test against `localhost:5174` is **pending** — flagged as the last todo on the ticket and intended for follow-up before un-drafting.

## Documentation

N/A for this PR. CLI help text (`opik copy --help`, `opik copy WS dataset --help`) is the user-facing surface for v1; broader docs/migration-guide updates will land alongside the wider OPIK-5859 epic.