### PR TITLE
[OPIK-6314] [DOCS] docs: branch worktrees off origin/main automatically

### DIFF
--- a/.agents/commands/comet/work-on-jira-ticket.md
+++ b/.agents/commands/comet/work-on-jira-ticket.md
@@ -106,10 +106,14 @@ If the `EnterWorktree` tool is not available (e.g., running in Cursor or another
 #### 6b. Worktree Path (if using worktree)
 
 1. Slugify `{TICKET-SUMMARY}` for the worktree name: replace any character not in `[A-Za-z0-9._-]` with `-`, collapse consecutive `-` into one, and trim leading/trailing `-`. Then call `EnterWorktree` with name `{USERNAME}-OPIK-{TICKET-NUMBER}-{SLUGIFIED-SUMMARY}`.
-2. Inside the worktree, create the properly named branch (using the same slugified summary):
+2. Inside the worktree, fetch the latest remote state and create the properly named branch based on `origin/main` (using the same slugified summary):
    ```bash
-   git checkout -b {USERNAME}/OPIK-{TICKET-NUMBER}-{SLUGIFIED-SUMMARY}
+   git fetch origin
+   git checkout -b {USERNAME}/OPIK-{TICKET-NUMBER}-{SLUGIFIED-SUMMARY} origin/main
    ```
+   The worktree intentionally branches off `origin/main` regardless of the parent checkout's current branch or local `main` state, and skips the rebase-strategy prompt — isolation is the whole point of the worktree.
+
+   Do not inspect or prompt about the parent checkout's working tree (staged, unstaged, or untracked files; current branch). Worktrees are physically isolated, so parent state has no effect on the worktree and is not the agent's concern in this path.
 3. Continue with implementation in the worktree directory.
 
 #### 6c. Normal Path (if not using worktree)


### PR DESCRIPTION
## Details

<img width="1760" height="1920" alt="image" src="https://github.com/user-attachments/assets/fb11f77e-5741-48d0-8013-ebbb921b09e2" />

Update Step 6b of `/comet:work-on-jira-ticket` so the worktree path runs `git fetch origin` and creates the new branch from `origin/main`, instead of inheriting whatever the parent checkout's HEAD currently is.

- Worktrees exist to isolate work; basing them on the parent's state defeats the point and can mix in unrelated WIP.
- Step 6b now also explicitly tells the agent not to inspect or prompt about the parent checkout's working tree (staged/unstaged/untracked files, current branch).
- Step 6c (non-worktree path) is unchanged — it still asks the user about WIP and rebase strategy.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6314

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7 (1M context)
- Scope: full implementation (skill doc edit + commit)
- Human verification: dogfooded — the worktree for this very ticket was created using the new flow, validating the behavior end-to-end before commit

## Testing

Self-validating change: the worktree used to author this commit was created via the new Step 6b flow.

- Ran `git fetch origin` then `git worktree add -b danield/OPIK-6314-... <path> origin/main` from a parent checkout that had unrelated WIP on a different feature branch (OPIK-6246).
- Verified the new worktree branched off `origin/main` (commit `03508b3350`), tracked `origin/main`, and that the parent checkout's staged/unstaged/untracked files were untouched.
- No code paths exercised; this is a documentation-only change to `.agents/commands/comet/work-on-jira-ticket.md`. No unit/integration tests apply.

## Documentation

- Updated: `.agents/commands/comet/work-on-jira-ticket.md` (Step 6b — worktree path)
- No product docs (Fern, README) affected.
