### PR TITLE
[OPIK-6311] [BE] perf: push Top-N filter into dataset_items_aggr_resolved CTE

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -34,6 +34,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.reactivestreams.Publisher;
 import org.stringtemplate.v4.ST;
 import reactor.core.publisher.Flux;
@@ -983,6 +984,17 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                   AND entity_id IN (SELECT trace_id FROM experiment_items_final)
                 GROUP BY entity_id
             )
+            <if(push_top_limit && !push_top_needs_div)>
+            , top_dataset_items AS (
+                SELECT eia_t.dataset_item_id
+                FROM experiment_item_aggregates AS eia_t FINAL
+                WHERE eia_t.workspace_id = :workspace_id
+                AND eia_t.experiment_id IN (SELECT id FROM experiment_aggregated_scope_ids)
+                GROUP BY eia_t.dataset_item_id
+                ORDER BY <if(top_sorting)><top_sorting><else>eia_t.dataset_item_id DESC<endif>
+                LIMIT :top_limit OFFSET :top_offset
+            )
+            <endif>
             , dataset_items_aggr_resolved AS (
                 SELECT
                     div_dedup.dataset_item_id AS id,
@@ -1006,19 +1018,20 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     WHERE workspace_id = :workspace_id
                     AND dataset_id  = :datasetId
                     AND dataset_version_id IN (SELECT resolved_dataset_version_id FROM experiment_aggregated_scope_ids)
+                    <if(push_top_limit && !push_top_needs_div)>
+                    AND dataset_item_id IN (SELECT dataset_item_id FROM top_dataset_items)
+                    <endif>
                     ORDER BY (workspace_id, dataset_id, dataset_version_id, id) DESC, last_updated_at DESC
                     LIMIT 1 BY id
                 ) AS div_dedup
             )
-            <if(push_top_limit)>
+            <if(push_top_limit && push_top_needs_div)>
             , top_dataset_items AS (
                 SELECT eia_t.dataset_item_id
                 FROM experiment_item_aggregates AS eia_t FINAL
-                <if(push_top_needs_div)>
                 INNER JOIN experiment_aggregated_scope_ids eas_t ON eas_t.id = eia_t.experiment_id
                 LEFT JOIN dataset_items_aggr_resolved AS di_t ON (di_t.id = eia_t.dataset_item_id OR di_t.row_id = eia_t.dataset_item_id)
                     AND di_t.dataset_version_id = eas_t.resolved_dataset_version_id
-                <endif>
                 WHERE eia_t.workspace_id = :workspace_id
                 AND eia_t.experiment_id IN (SELECT id FROM experiment_aggregated_scope_ids)
                 GROUP BY eia_t.dataset_item_id
@@ -2404,16 +2417,27 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                             template.add("has_aggregated", hasAggregated);
                             template.add("has_raw", hasRaw);
 
-                            // Push-top-limit: only when all experiments are aggregated (single branch)
+                            // Push-top-limit: only when all experiments are aggregated (single branch).
+                            // Two cases:
+                            //  - explicit sort: top-N driven by user-supplied sort, requires SortingFactory support.
+                            //  - default sort (no sortingFields, no filters, no search): outer query orders by
+                            //    dataset_item_id DESC, so the same expression can drive a Top-N pre-filter that
+                            //    also activates skip indexes on dataset_item_id (OPT3).
+                            boolean hasSortingFields = CollectionUtils.isNotEmpty(criteria.sortingFields());
+                            boolean hasFilters = CollectionUtils.isNotEmpty(criteria.filters());
+                            boolean hasSearch = StringUtils.isNotBlank(criteria.search());
                             boolean pushTopLimit = hasAggregated && !hasRaw
-                                    && CollectionUtils.isNotEmpty(criteria.sortingFields())
-                                    && sortingFactory.supportsPushTopLimit(criteria.sortingFields());
+                                    && ((hasSortingFields
+                                            && sortingFactory.supportsPushTopLimit(criteria.sortingFields()))
+                                            || (!hasSortingFields && !hasFilters && !hasSearch));
 
                             if (pushTopLimit) {
                                 template.add("push_top_limit", true);
-                                template.add("top_sorting", buildTopItemsSorting(criteria.sortingFields()));
-                                if (sortingFactory.pushTopLimitNeedsDivJoin(criteria.sortingFields())) {
-                                    template.add("push_top_needs_div", true);
+                                if (hasSortingFields) {
+                                    template.add("top_sorting", buildTopItemsSorting(criteria.sortingFields()));
+                                    if (sortingFactory.pushTopLimitNeedsDivJoin(criteria.sortingFields())) {
+                                        template.add("push_top_needs_div", true);
+                                    }
                                 }
                             }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -2417,19 +2417,17 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                             template.add("has_aggregated", hasAggregated);
                             template.add("has_raw", hasRaw);
 
-                            // Push-top-limit: only when all experiments are aggregated (single branch).
-                            // Two cases:
-                            //  - explicit sort: top-N driven by user-supplied sort, requires SortingFactory support.
-                            //  - default sort (no sortingFields, no filters, no search): outer query orders by
-                            //    dataset_item_id DESC, so the same expression can drive a Top-N pre-filter that
-                            //    also activates skip indexes on dataset_item_id (OPT3).
+                            // Push-top-limit: only when all experiments are aggregated (single branch),
+                            // and only when no filters/search are present. The Top-N CTE selects items by
+                            // sort BEFORE filters are applied; with filters/search active the outer query
+                            // would strip items from the top-N and silently return short pages.
                             boolean hasSortingFields = CollectionUtils.isNotEmpty(criteria.sortingFields());
                             boolean hasFilters = CollectionUtils.isNotEmpty(criteria.filters());
                             boolean hasSearch = StringUtils.isNotBlank(criteria.search());
                             boolean pushTopLimit = hasAggregated && !hasRaw
-                                    && ((hasSortingFields
-                                            && sortingFactory.supportsPushTopLimit(criteria.sortingFields()))
-                                            || (!hasSortingFields && !hasFilters && !hasSearch));
+                                    && !hasFilters && !hasSearch
+                                    && (!hasSortingFields
+                                            || sortingFactory.supportsPushTopLimit(criteria.sortingFields()));
 
                             if (pushTopLimit) {
                                 template.add("push_top_limit", true);

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
@@ -2546,4 +2546,48 @@ class ExperimentAggregatesIntegrationTest {
                 .isNotEmpty();
     }
 
+    @Test
+    @DisplayName("DatasetItemVersionDAO has_aggregated branch: explicit sort + filter consistent before/after aggregation")
+    void explicitSortAndFilterConsistentBeforeAndAfterAggregates() {
+        var workspaceName = UUID.randomUUID().toString();
+        var apiKey = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var project = createProject(apiKey, workspaceName);
+        var dataset = createDataset(apiKey, workspaceName);
+        var experiment = createExperiment(dataset, apiKey, workspaceName);
+
+        List<String> feedbackScoreNames = PodamFactoryUtils.manufacturePojoList(factory, String.class);
+        createExperimentItemWithData(experiment.id(), dataset.id(), project.name(), feedbackScoreNames, apiKey,
+                workspaceName);
+
+        var experimentIds = List.of(experiment.id());
+        var sorting = List.of(new com.comet.opik.api.sorting.SortingField("duration",
+                com.comet.opik.api.sorting.Direction.ASC));
+        var filters = List.of(new ExperimentsComparisonFilter("duration", FieldType.NUMBER,
+                Operator.GREATER_THAN, null, "30000"));
+        int pageSize = 2;
+
+        var beforeAggregation = datasetResourceClient.getDatasetItemsWithExperimentItems(
+                dataset.id(), experimentIds, null, filters, sorting, 1, pageSize, apiKey, workspaceName);
+
+        assertPageNotEmpty(beforeAggregation);
+
+        experimentAggregatesService.populateAggregations(experiment.id())
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+                .block();
+
+        var afterAggregation = datasetResourceClient.getDatasetItemsWithExperimentItems(
+                dataset.id(), experimentIds, null, filters, sorting, 1, pageSize, apiKey, workspaceName);
+
+        assertThat(afterAggregation.total())
+                .as("Filtered+sorted total should match before/after aggregation")
+                .isEqualTo(beforeAggregation.total());
+        assertDatasetItemsWithExperimentItems(beforeAggregation.content(), afterAggregation.content());
+    }
+
 }


### PR DESCRIPTION
## Details

Extends `push_top_limit` in `DatasetItemVersionDAO` so the Top-N pre-filter also activates for the default-sort case used by the experiment comparison page (no `sortingFields`, no filters, no search). In that case `top_dataset_items` is now defined **before** `dataset_items_aggr_resolved`, and `dataset_item_id IN (top_dataset_items)` is pushed into the dedup CTE.

- Activates the existing `bloom_filter` / `minmax` skip indexes on `dataset_item_versions` and `experiment_item_aggregates` (previously paid for but never exercised by the default-load path).
- When sorting requires the DI join (`push_top_needs_div=true`), keeps the prior CTE order to avoid forward references — pushdown into DI is skipped in that branch.
- Outer `ORDER BY id DESC LIMIT N` semantics are preserved: the Top-N CTE orders by `eia_t.dataset_item_id DESC` so the same N IDs are selected.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6311

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: assisted (analysis via EXPLAIN indexes, query rewrite, Java template wiring)
- Human verification: code review + EXPLAIN comparison + targeted backend test runs

## Testing

Targeted nested suites in `DatasetsResourceTest` (the comparison endpoint family `/v1/private/datasets/{id}/items/experiments/items[…]`):

```
mvn test -Dtest='DatasetsResourceTest$FindDatasetItemsWithExperimentItemsSortingTest,\
DatasetsResourceTest$FindDatasetItemsWithExperimentItems,\
DatasetsResourceTest$ExperimentItemsSortingAndFiltering,\
DatasetsResourceTest$FindDatasetItemsWithExperimentItemsAssertionResults,\
DatasetsResourceTest$GetExperimentItemsOutputColumnsTest,\
DatasetsResourceTest$GetDatasetExperimentItemsStats'
```

Result: **117 tests passed, 0 failures, 0 errors**.

| Suite | tests |
|---|---|
| FindDatasetItemsWithExperimentItemsSortingTest | 30 |
| FindDatasetItemsWithExperimentItems | 56 |
| ExperimentItemsSortingAndFiltering | 3 |
| FindDatasetItemsWithExperimentItemsAssertionResults | 6 |
| GetExperimentItemsOutputColumnsTest | 3 |
| GetDatasetExperimentItemsStats | 19 |

`mvn spotless:check` passes. `mvn -DskipTests compile` passes.

EXPLAIN comparison against a large experiment (~2.4M items):
- Before: `dataset_item_versions` reads 404/55984 granules; `experiment_item_aggregates` reads 341/3152 granules. No skip indexes activate (PrimaryKey only).
- After (rendered SQL with `dataset_item_id IN (top_dataset_items)`): the existing bloom_filter on `dataset_item_versions` and minmax on `experiment_item_aggregates.dataset_item_id` become eligible — expected order-of-magnitude granule reduction for default-sorted comparison page loads.

## Documentation

N/A — internal query-pipeline change, no public API or schema change.