### PR TITLE
[OPIK-6274][P SDK] Enable OTEL integration test

### DIFF
--- a/sdks/python/tests/e2e_library_integration/opentelemetry/test_otel_distributed_trace.py
+++ b/sdks/python/tests/e2e_library_integration/opentelemetry/test_otel_distributed_trace.py
@@ -10,7 +10,6 @@ These tests verify the full roundtrip through the Opik backend:
 
 import urllib.parse
 
-import pytest
 
 import opik
 from opik import opik_context, config as opik_config, synchronization
@@ -56,7 +55,6 @@ def _create_otel_tracer(config: opik_config.OpikConfig):
     return provider.get_tracer("e2e-otel-test-tracer"), provider
 
 
-@pytest.mark.skip(reason="enable after backend is ready for this test in the next PR")
 def test_otel_distributed_trace_roundtrip__happyflow(opik_client: opik.Opik):
     """
     Full E2E roundtrip through the Opik backend:


### PR DESCRIPTION
## Details
Enabled integration test for OpenTelemetry distribution headers support

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6274

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
Added integration test

## Documentation
NA