### PR TITLE
[OPIK-6264] [BE] feat: add environments CRUD API

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -748,6 +748,11 @@ optimizationLogs:
   # Description: Maximum number of concurrent S3 uploads during sync
   syncConcurrency: ${OPTIMIZATION_LOGS_SYNC_CONCURRENCY:-5}
 
+# Environment CRUD configuration
+environment:
+  # Maximum number of environments allowed per workspace.
+  maxPerWorkspace: ${OPIK_ENVIRONMENT_MAX_PER_WORKSPACE:-20}
+
 # Data retention policy enforcement
 # The job splits the workspace UUID space into N=executionsPerDay fractions and processes one fraction per tick.
 # Use a value that divides 1440 evenly for consistent interval spacing (e.g., 1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24, 30, 32, 36, 48, 60, 80, 96, 120, 144, 160, 180, 240, 288).

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Environment.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Environment.java
@@ -1,0 +1,62 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record Environment(
+        @JsonView( {
+                Environment.View.Public.class, Environment.View.Write.class}) UUID id,
+        @JsonView({Environment.View.Public.class,
+                Environment.View.Write.class}) @NotBlank @Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") String name,
+        @JsonView({Environment.View.Public.class,
+                Environment.View.Write.class}) @Size(max = 500, message = "cannot exceed 500 characters") String description,
+        @JsonView({Environment.View.Public.class,
+                Environment.View.Write.class}) @Size(max = 20, message = "cannot exceed 20 characters") String color,
+        @JsonView({Environment.View.Public.class, Environment.View.Write.class}) Integer position,
+        @JsonView({Environment.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant createdAt,
+        @JsonView({Environment.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,
+        @JsonView({
+                Environment.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
+        @JsonView({
+                Environment.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy){
+
+    public static final String NAME_PATTERN = "^[A-Za-z0-9_-]+$";
+    public static final String NAME_PATTERN_MESSAGE = "must match '" + NAME_PATTERN + "'";
+
+    public static class View {
+        public static class Write {
+        }
+
+        public static class Public {
+        }
+    }
+
+    public record EnvironmentPage(
+            @JsonView( {
+                    Environment.View.Public.class}) int page,
+            @JsonView({Environment.View.Public.class}) int size,
+            @JsonView({Environment.View.Public.class}) long total,
+            @JsonView({Environment.View.Public.class}) List<Environment> content,
+            @JsonView({Environment.View.Public.class}) List<String> sortableBy)
+            implements
+                com.comet.opik.api.Page<Environment>{
+
+        public static EnvironmentPage empty() {
+            return new EnvironmentPage(1, 0, 0, List.of(), List.of("created_at"));
+        }
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/EnvironmentUpdate.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/EnvironmentUpdate.java
@@ -1,0 +1,18 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record EnvironmentUpdate(
+        @Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") String name,
+        @Size(max = 500, message = "cannot exceed 500 characters") String description,
+        @Size(max = 20, message = "cannot exceed 20 characters") String color,
+        Integer position) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/EnvironmentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/EnvironmentsResource.java
@@ -1,0 +1,140 @@
+package com.comet.opik.api.resources.v1.priv;
+
+import com.codahale.metrics.annotation.Timed;
+import com.comet.opik.api.BatchDelete;
+import com.comet.opik.api.Environment;
+import com.comet.opik.api.EnvironmentUpdate;
+import com.comet.opik.domain.EnvironmentService;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.ratelimit.RateLimited;
+import com.fasterxml.jackson.annotation.JsonView;
+import io.dropwizard.jersey.errors.ErrorMessage;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.UUID;
+
+@Path("/v1/private/environments")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Timed
+@Slf4j
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+@Tag(name = "Environments", description = "Environment related resources")
+public class EnvironmentsResource {
+
+    private final @NonNull EnvironmentService service;
+    private final @NonNull Provider<RequestContext> requestContext;
+
+    @GET
+    @Operation(operationId = "findEnvironments", summary = "Find environments", description = "Find environments for the workspace. Capped at the workspace limit (default 20).", responses = {
+            @ApiResponse(responseCode = "200", description = "Environments page", content = @Content(schema = @Schema(implementation = Environment.EnvironmentPage.class)))
+    })
+    @JsonView({Environment.View.Public.class})
+    public Response find() {
+        String workspaceId = requestContext.get().getWorkspaceId();
+        log.info("Finding environments on workspaceId '{}'", workspaceId);
+        Environment.EnvironmentPage page = service.find();
+        log.info("Found '{}' environments on workspaceId '{}'", page.total(), workspaceId);
+
+        return Response.ok().entity(page).build();
+    }
+
+    @GET
+    @Path("{id}")
+    @Operation(operationId = "getEnvironmentById", summary = "Get environment by id", description = "Get environment by id", responses = {
+            @ApiResponse(responseCode = "200", description = "Environment", content = @Content(schema = @Schema(implementation = Environment.class))),
+            @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))
+    })
+    @JsonView({Environment.View.Public.class})
+    public Response getById(@PathParam("id") @NotNull UUID id) {
+        String workspaceId = requestContext.get().getWorkspaceId();
+        log.info("Getting environment by id '{}' on workspaceId '{}'", id, workspaceId);
+        Environment environment = service.get(id);
+        log.info("Got environment by id '{}' on workspaceId '{}'", id, workspaceId);
+
+        return Response.ok().entity(environment).build();
+    }
+
+    @POST
+    @Operation(operationId = "createEnvironment", summary = "Create environment", description = "Create environment", responses = {
+            @ApiResponse(responseCode = "201", description = "Created", headers = {
+                    @Header(name = "Location", required = true, example = "${basePath}/v1/private/environments/{environmentId}", schema = @Schema(implementation = String.class))}),
+            @ApiResponse(responseCode = "409", description = "Conflict", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))
+    })
+    @RateLimited
+    public Response create(
+            @RequestBody(content = @Content(schema = @Schema(implementation = Environment.class))) @JsonView({
+                    Environment.View.Write.class}) @NotNull @Valid Environment environment,
+            @Context UriInfo uriInfo) {
+
+        String workspaceId = requestContext.get().getWorkspaceId();
+        log.info("Creating environment with name '{}' on workspaceId '{}'", environment.name(), workspaceId);
+        Environment created = service.create(environment);
+        log.info("Created environment with id '{}', name '{}' on workspaceId '{}'", created.id(), created.name(),
+                workspaceId);
+
+        var uri = uriInfo.getAbsolutePathBuilder().path("/%s".formatted(created.id())).build();
+
+        return Response.created(uri).build();
+    }
+
+    @PATCH
+    @Path("{id}")
+    @Operation(operationId = "updateEnvironment", summary = "Update environment by id", description = "Update environment by id", responses = {
+            @ApiResponse(responseCode = "204", description = "No Content"),
+            @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
+            @ApiResponse(responseCode = "409", description = "Conflict", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))
+    })
+    @RateLimited
+    public Response update(@PathParam("id") @NotNull UUID id,
+            @RequestBody(content = @Content(schema = @Schema(implementation = EnvironmentUpdate.class))) @NotNull @Valid EnvironmentUpdate environmentUpdate) {
+
+        String workspaceId = requestContext.get().getWorkspaceId();
+        log.info("Updating environment with id '{}' on workspaceId '{}'", id, workspaceId);
+        service.update(id, environmentUpdate);
+        log.info("Updated environment with id '{}' on workspaceId '{}'", id, workspaceId);
+
+        return Response.noContent().build();
+    }
+
+    @POST
+    @Path("/delete")
+    @Operation(operationId = "deleteEnvironmentsBatch", summary = "Delete environments", description = "Delete environments batch. Idempotent — missing ids are silently ignored.", responses = {
+            @ApiResponse(responseCode = "204", description = "No Content")
+    })
+    public Response deleteEnvironmentsBatch(
+            @NotNull @RequestBody(content = @Content(schema = @Schema(implementation = BatchDelete.class))) @Valid BatchDelete batchDelete) {
+
+        String workspaceId = requestContext.get().getWorkspaceId();
+        log.info("Deleting environments by ids, count '{}', on workspaceId '{}'", batchDelete.ids().size(),
+                workspaceId);
+        service.delete(batchDelete.ids());
+        log.info("Deleted environments by ids, count '{}', on workspaceId '{}'", batchDelete.ids().size(), workspaceId);
+
+        return Response.noContent().build();
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
@@ -1,0 +1,57 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Environment;
+import com.comet.opik.infrastructure.db.UUIDArgumentFactory;
+import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindList;
+import org.jdbi.v3.sqlobject.customizer.BindMethods;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+@RegisterConstructorMapper(Environment.class)
+@RegisterArgumentFactory(UUIDArgumentFactory.class)
+interface EnvironmentDAO {
+
+    @SqlUpdate("INSERT INTO environments (id, workspace_id, name, description, color, position, created_by, last_updated_by) "
+            +
+            "VALUES (:bean.id, :workspaceId, :bean.name, :bean.description, COALESCE(:bean.color, 'default'), COALESCE(:bean.position, 0), :bean.createdBy, :bean.lastUpdatedBy)")
+    void save(@Bind("workspaceId") String workspaceId, @BindMethods("bean") Environment environment);
+
+    @SqlUpdate("UPDATE environments SET " +
+            "name = COALESCE(:name, name), " +
+            "description = COALESCE(:description, description), " +
+            "color = COALESCE(:color, color), " +
+            "position = COALESCE(:position, position), " +
+            "last_updated_by = :lastUpdatedBy " +
+            "WHERE id = :id AND workspace_id = :workspaceId")
+    void update(@Bind("id") UUID id,
+            @Bind("workspaceId") String workspaceId,
+            @Bind("name") String name,
+            @Bind("description") String description,
+            @Bind("color") String color,
+            @Bind("position") Integer position,
+            @Bind("lastUpdatedBy") String lastUpdatedBy);
+
+    @SqlUpdate("DELETE FROM environments WHERE id IN (<ids>) AND workspace_id = :workspaceId")
+    void delete(@BindList("ids") Set<UUID> ids, @Bind("workspaceId") String workspaceId);
+
+    @SqlQuery("SELECT * FROM environments WHERE id = :id AND workspace_id = :workspaceId")
+    Environment findById(@Bind("id") UUID id, @Bind("workspaceId") String workspaceId);
+
+    @SqlQuery("SELECT * FROM environments WHERE workspace_id = :workspaceId ORDER BY created_at ASC")
+    List<Environment> findAll(@Bind("workspaceId") String workspaceId);
+
+    @SqlQuery("SELECT COUNT(*) FROM environments WHERE workspace_id = :workspaceId")
+    long countByWorkspace(@Bind("workspaceId") String workspaceId);
+
+    default Optional<Environment> fetch(UUID id, String workspaceId) {
+        return Optional.ofNullable(findById(id, workspaceId));
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
@@ -1,0 +1,225 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Environment;
+import com.comet.opik.api.Environment.EnvironmentPage;
+import com.comet.opik.api.EnvironmentUpdate;
+import com.comet.opik.api.error.EntityAlreadyExistsException;
+import com.comet.opik.api.error.ErrorMessage;
+import com.comet.opik.infrastructure.EnvironmentConfig;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
+import com.comet.opik.infrastructure.lock.LockService;
+import com.google.inject.ImplementedBy;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
+import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
+
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
+import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
+
+@ImplementedBy(EnvironmentServiceImpl.class)
+public interface EnvironmentService {
+
+    Environment create(Environment environment);
+
+    Environment update(UUID id, EnvironmentUpdate environmentUpdate);
+
+    Environment get(UUID id);
+
+    EnvironmentPage find();
+
+    void delete(Set<UUID> ids);
+}
+
+@Slf4j
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+class EnvironmentServiceImpl implements EnvironmentService {
+
+    private static final String ENVIRONMENT_NAME_CONFLICT_TEMPLATE = "Environment with name '%s' already exists in the workspace";
+    private static final String ENVIRONMENT_LIMIT_REACHED_TEMPLATE = "Workspace already has the maximum of %d environments";
+    private static final String ENVIRONMENT_CREATE_LOCK = "environment_create";
+
+    private final @NonNull TransactionTemplate template;
+    private final @NonNull IdGenerator idGenerator;
+    private final @NonNull Provider<RequestContext> requestContext;
+    private final @NonNull AnalyticsService analyticsService;
+    private final @NonNull LockService lockService;
+    private final @NonNull @Config("environment") EnvironmentConfig environmentConfig;
+
+    @Override
+    public Environment create(@NonNull Environment environment) {
+        UUID id = Objects.requireNonNullElseGet(environment.id(), idGenerator::generateId);
+        IdGenerator.validateVersion(id, "environment");
+
+        String userName = requestContext.get().getUserName();
+        String workspaceId = requestContext.get().getWorkspaceId();
+
+        var newEnvironment = environment.toBuilder()
+                .id(id)
+                .createdBy(userName)
+                .lastUpdatedBy(userName)
+                .build();
+
+        Environment saved = lockService.executeWithLock(
+                new LockService.Lock(workspaceId, ENVIRONMENT_CREATE_LOCK),
+                Mono.fromCallable(() -> {
+                    try {
+                        return template.inTransaction(WRITE, handle -> {
+                            var repository = handle.attach(EnvironmentDAO.class);
+
+                            long count = repository.countByWorkspace(workspaceId);
+                            if (count >= environmentConfig.getMaxPerWorkspace()) {
+                                throw newLimitReached();
+                            }
+
+                            repository.save(workspaceId, newEnvironment);
+                            return newEnvironment;
+                        });
+                    } catch (UnableToExecuteStatementException e) {
+                        if (e.getCause() instanceof SQLIntegrityConstraintViolationException) {
+                            throw newNameConflict(newEnvironment.name());
+                        }
+                        throw e;
+                    }
+                }).subscribeOn(Schedulers.boundedElastic()))
+                .block();
+
+        analyticsService.trackEvent("environment_created", Map.of(
+                "environment_id", saved.id().toString(),
+                "environment_name", saved.name(),
+                "workspace_id", workspaceId,
+                "user_name", userName,
+                "date", Instant.now().toString()));
+
+        return get(saved.id(), workspaceId);
+    }
+
+    @Override
+    public Environment update(@NonNull UUID id, @NonNull EnvironmentUpdate update) {
+        String userName = requestContext.get().getUserName();
+        String workspaceId = requestContext.get().getWorkspaceId();
+
+        try {
+            template.inTransaction(WRITE, handle -> {
+                var repository = handle.attach(EnvironmentDAO.class);
+
+                Environment existing = repository.fetch(id, workspaceId)
+                        .orElseThrow(this::createNotFoundError);
+
+                repository.update(existing.id(),
+                        workspaceId,
+                        update.name(),
+                        update.description(),
+                        update.color(),
+                        update.position(),
+                        userName);
+
+                return null;
+            });
+
+            analyticsService.trackEvent("environment_updated", Map.of(
+                    "environment_id", id.toString(),
+                    "workspace_id", workspaceId,
+                    "user_name", userName,
+                    "date", Instant.now().toString()));
+
+            return get(id, workspaceId);
+        } catch (UnableToExecuteStatementException e) {
+            if (e.getCause() instanceof SQLIntegrityConstraintViolationException) {
+                throw newNameConflict(update.name());
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public Environment get(@NonNull UUID id) {
+        return get(id, requestContext.get().getWorkspaceId());
+    }
+
+    private Environment get(UUID id, String workspaceId) {
+        return template.inTransaction(READ_ONLY, handle -> {
+            var repository = handle.attach(EnvironmentDAO.class);
+            return repository.fetch(id, workspaceId).orElseThrow(this::createNotFoundError);
+        });
+    }
+
+    @Override
+    public EnvironmentPage find() {
+        String workspaceId = requestContext.get().getWorkspaceId();
+
+        List<Environment> environments = template.inTransaction(READ_ONLY,
+                handle -> handle.attach(EnvironmentDAO.class).findAll(workspaceId));
+
+        if (environments.isEmpty()) {
+            return EnvironmentPage.empty();
+        }
+
+        return new EnvironmentPage(1, environments.size(), environments.size(), environments,
+                List.of("created_at"));
+    }
+
+    @Override
+    public void delete(@NonNull Set<UUID> ids) {
+        if (ids.isEmpty()) {
+            log.info("ids list is empty, returning");
+            return;
+        }
+
+        String workspaceId = requestContext.get().getWorkspaceId();
+        String userName = requestContext.get().getUserName();
+
+        template.inTransaction(WRITE, handle -> {
+            handle.attach(EnvironmentDAO.class).delete(ids, workspaceId);
+            return null;
+        });
+
+        analyticsService.trackEvent("environment_deleted", Map.of(
+                "environment_ids", ids.stream().map(UUID::toString).toList().toString(),
+                "workspace_id", workspaceId,
+                "user_name", userName,
+                "date", Instant.now().toString()));
+    }
+
+    private NotFoundException createNotFoundError() {
+        String message = "Environment not found";
+        log.info(message);
+        return new NotFoundException(message,
+                Response.status(Response.Status.NOT_FOUND).entity(new ErrorMessage(List.of(message))).build());
+    }
+
+    private EntityAlreadyExistsException newNameConflict(String name) {
+        String message = ENVIRONMENT_NAME_CONFLICT_TEMPLATE.formatted(name);
+        log.info(message);
+        return new EntityAlreadyExistsException(new ErrorMessage(List.of(message)));
+    }
+
+    private ClientErrorException newLimitReached() {
+        String message = ENVIRONMENT_LIMIT_REACHED_TEMPLATE.formatted(environmentConfig.getMaxPerWorkspace());
+        log.info(message);
+        return new ClientErrorException(
+                Response.status(Response.Status.CONFLICT)
+                        .entity(new ErrorMessage(List.of(message)))
+                        .build());
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
@@ -181,13 +181,13 @@ class EnvironmentServiceImpl implements EnvironmentService {
 
     @Override
     public void delete(@NonNull Set<UUID> ids) {
-        if (ids.isEmpty()) {
-            log.info("ids list is empty, returning");
-            return;
-        }
-
         String workspaceId = requestContext.get().getWorkspaceId();
         String userName = requestContext.get().getUserName();
+
+        if (ids.isEmpty()) {
+            log.info("ids list is empty for environments delete, on workspace_id '{}'", workspaceId);
+            return;
+        }
 
         template.inTransaction(WRITE, handle -> {
             handle.attach(EnvironmentDAO.class).delete(ids, workspaceId);

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/EnvironmentConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/EnvironmentConfig.java
@@ -1,0 +1,13 @@
+package com.comet.opik.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Data;
+
+@Data
+public class EnvironmentConfig {
+
+    @JsonProperty
+    @Min(1) @Max(1000) private int maxPerWorkspace = 20;
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
@@ -142,4 +142,7 @@ public class OpikConfiguration extends JobConfiguration {
 
     @Valid @NotNull @JsonProperty
     private AgentConfigConfiguration agentConfig = new AgentConfigConfiguration();
+
+    @Valid @NotNull @JsonProperty
+    private EnvironmentConfig environment = new EnvironmentConfig();
 }

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000065_create_environments_table.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000065_create_environments_table.sql
@@ -1,0 +1,21 @@
+--liquibase formatted sql
+--changeset boryst:000065_create_environments_table
+--comment: Create environments table for workspace-scoped environment CRUD
+
+CREATE TABLE environments (
+    id                  CHAR(36)        NOT NULL,
+    workspace_id        VARCHAR(150)    NOT NULL,
+    name                VARCHAR(150)    NOT NULL,
+    description         VARCHAR(500)    DEFAULT NULL,
+    color               VARCHAR(20)     NOT NULL DEFAULT 'default',
+    position            INT             NOT NULL DEFAULT 0,
+    created_at          TIMESTAMP(6)    NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    created_by          VARCHAR(100)    NOT NULL DEFAULT 'admin',
+    last_updated_at     TIMESTAMP(6)    NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    last_updated_by     VARCHAR(100)    NOT NULL DEFAULT 'admin',
+
+    CONSTRAINT environments_pk PRIMARY KEY (id),
+    CONSTRAINT environments_workspace_name_uk UNIQUE (workspace_id, name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--rollback DROP TABLE environments;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/EnvironmentsResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/EnvironmentsResourceClient.java
@@ -1,0 +1,88 @@
+package com.comet.opik.api.resources.utils.resources;
+
+import com.comet.opik.api.BatchDelete;
+import com.comet.opik.api.Environment;
+import com.comet.opik.api.EnvironmentUpdate;
+import com.comet.opik.api.resources.utils.TestUtils;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import lombok.RequiredArgsConstructor;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER;
+
+@RequiredArgsConstructor
+public class EnvironmentsResourceClient {
+
+    private static final String URL_TEMPLATE = "%s/v1/private/environments";
+
+    private final ClientSupport client;
+    private final String baseURI;
+
+    public UUID createEnvironment(Environment environment, String apiKey, String workspaceName) {
+        try (var response = callCreate(environment, apiKey, workspaceName)) {
+            if (response.getStatusInfo().getStatusCode() != 201) {
+                throw new IllegalStateException(
+                        "Unexpected status creating environment: " + response.getStatusInfo().getStatusCode());
+            }
+            return TestUtils.getIdFromLocation(response.getLocation());
+        }
+    }
+
+    public Response callCreate(Environment environment, String apiKey, String workspaceName) {
+        return client.target(URL_TEMPLATE.formatted(baseURI))
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(environment));
+    }
+
+    public Response callGet(UUID id, String apiKey, String workspaceName) {
+        return client.target(URL_TEMPLATE.formatted(baseURI))
+                .path(id.toString())
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .get();
+    }
+
+    public Response callFind(String apiKey, String workspaceName) {
+        return client.target(URL_TEMPLATE.formatted(baseURI))
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .get();
+    }
+
+    public Response callUpdate(UUID id, EnvironmentUpdate update, String apiKey, String workspaceName) {
+        return client.target(URL_TEMPLATE.formatted(baseURI))
+                .path(id.toString())
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .method("PATCH", Entity.json(update));
+    }
+
+    public Response callBatchDelete(Set<UUID> ids, String apiKey, String workspaceName) {
+        return callBatchDelete(new BatchDelete(ids), apiKey, workspaceName);
+    }
+
+    public Response callBatchDelete(BatchDelete batchDelete, String apiKey, String workspaceName) {
+        return client.target(URL_TEMPLATE.formatted(baseURI))
+                .path("delete")
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(batchDelete));
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/EnvironmentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/EnvironmentsResourceTest.java
@@ -1,0 +1,506 @@
+package com.comet.opik.api.resources.v1.priv;
+
+import com.comet.opik.api.BatchDelete;
+import com.comet.opik.api.Environment;
+import com.comet.opik.api.EnvironmentUpdate;
+import com.comet.opik.api.resources.utils.AuthTestUtils;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.EnvironmentsResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
+import com.redis.testcontainers.RedisContainer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hc.core5.http.HttpStatus;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Environments Resource Test")
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class EnvironmentsResourceTest {
+
+    private static final String[] ENVIRONMENT_IGNORED_FIELDS = new String[]{
+            "id", "createdAt", "lastUpdatedAt", "createdBy", "lastUpdatedBy"};
+
+    private static final String USER = UUID.randomUUID().toString();
+    private static final String API_KEY = UUID.randomUUID().toString();
+    private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+    private static final String WORKSPACE_NAME = UUID.randomUUID().toString();
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    @RegisterApp
+    private final TestDropwizardAppExtension APP;
+
+    {
+        Startables.deepStart(REDIS, MYSQL).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+
+        APP = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(MYSQL.getJdbcUrl(), null,
+                wireMock.runtimeInfo(), REDIS.getRedisURI());
+    }
+
+    private final TimeBasedEpochGenerator idGenerator = Generators.timeBasedEpochGenerator();
+
+    private String baseURI;
+    private EnvironmentsResourceClient environmentsClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport client) {
+        this.baseURI = TestUtils.getBaseUrl(client);
+
+        ClientSupportUtils.config(client);
+
+        environmentsClient = new EnvironmentsResourceClient(client, baseURI);
+
+        AuthTestUtils.mockTargetWorkspace(wireMock.server(), API_KEY, WORKSPACE_NAME, WORKSPACE_ID, USER);
+    }
+
+    @AfterAll
+    void tearDownAll() {
+        wireMock.server().stop();
+    }
+
+    private static String randomEnvName() {
+        return "env-" + RandomStringUtils.secure().nextAlphanumeric(12);
+    }
+
+    private static Environment buildEnvironment() {
+        return Environment.builder()
+                .name(randomEnvName())
+                .description("desc-" + RandomStringUtils.secure().nextAlphanumeric(8))
+                .color("default")
+                .position(0)
+                .build();
+    }
+
+    private void mockIsolatedWorkspace(String apiKey, String workspaceName, String workspaceId) {
+        AuthTestUtils.mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId,
+                "user-" + RandomStringUtils.secure().nextAlphanumeric(8));
+    }
+
+    private void assertCreatedMatches(Environment actual, Environment expected) {
+        assertThat(actual)
+                .usingRecursiveComparison(RecursiveComparisonConfiguration.builder()
+                        .withIgnoredFields(ENVIRONMENT_IGNORED_FIELDS)
+                        .build())
+                .isEqualTo(expected);
+        assertThat(actual.id()).isNotNull();
+        assertThat(actual.createdBy()).isEqualTo(USER);
+        assertThat(actual.lastUpdatedBy()).isEqualTo(USER);
+        assertThat(actual.createdAt()).isNotNull().isInstanceOf(Instant.class);
+        assertThat(actual.lastUpdatedAt()).isNotNull().isInstanceOf(Instant.class);
+    }
+
+    @Nested
+    @DisplayName("Create:")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class Create {
+
+        @Test
+        @DisplayName("create with all fields succeeds and returns 201 with Location header")
+        void createSucceeds() {
+            var input = Environment.builder()
+                    .name(randomEnvName())
+                    .description("staging traffic")
+                    .color("yellow")
+                    .position(3)
+                    .build();
+
+            try (var response = environmentsClient.callCreate(input, API_KEY, WORKSPACE_NAME)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_CREATED);
+                assertThat(response.getLocation()).isNotNull();
+
+                UUID id = TestUtils.getIdFromLocation(response.getLocation());
+
+                try (var getResponse = environmentsClient.callGet(id, API_KEY, WORKSPACE_NAME)) {
+                    assertThat(getResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
+                    var fetched = getResponse.readEntity(Environment.class);
+
+                    assertCreatedMatches(fetched, input);
+                    assertThat(fetched.id()).isEqualTo(id);
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("create with only name uses defaults: color='default', position=0, description=null")
+        void createWithDefaults() {
+            var input = Environment.builder().name(randomEnvName()).build();
+            var expected = input.toBuilder().color("default").position(0).build();
+
+            UUID id = environmentsClient.createEnvironment(input, API_KEY, WORKSPACE_NAME);
+
+            try (var response = environmentsClient.callGet(id, API_KEY, WORKSPACE_NAME)) {
+                var fetched = response.readEntity(Environment.class);
+                assertCreatedMatches(fetched, expected);
+            }
+        }
+
+        @Test
+        @DisplayName("create with client-provided id reuses that id")
+        void createReusesProvidedId() {
+            UUID providedId = idGenerator.generate();
+            var input = buildEnvironment().toBuilder().id(providedId).build();
+
+            UUID returnedId = environmentsClient.createEnvironment(input, API_KEY, WORKSPACE_NAME);
+
+            assertThat(returnedId).isEqualTo(providedId);
+
+            try (var response = environmentsClient.callGet(providedId, API_KEY, WORKSPACE_NAME)) {
+                var fetched = response.readEntity(Environment.class);
+                assertCreatedMatches(fetched, input);
+                assertThat(fetched.id()).isEqualTo(providedId);
+            }
+        }
+
+        @Test
+        @DisplayName("create with duplicate name in same workspace returns 409")
+        void createDuplicateNameConflicts() {
+            var first = buildEnvironment();
+            environmentsClient.createEnvironment(first, API_KEY, WORKSPACE_NAME);
+
+            var duplicate = Environment.builder().name(first.name()).build();
+            try (var response = environmentsClient.callCreate(duplicate, API_KEY, WORKSPACE_NAME)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_CONFLICT);
+            }
+        }
+
+        @Test
+        @DisplayName("create with same name in different workspace succeeds (workspace isolation)")
+        void createSameNameInDifferentWorkspace() {
+            String otherApiKey = UUID.randomUUID().toString();
+            String otherWorkspaceName = UUID.randomUUID().toString();
+            String otherWorkspaceId = UUID.randomUUID().toString();
+            mockIsolatedWorkspace(otherApiKey, otherWorkspaceName, otherWorkspaceId);
+
+            var first = buildEnvironment();
+            environmentsClient.createEnvironment(first, API_KEY, WORKSPACE_NAME);
+
+            var sameNameDifferentWorkspace = Environment.builder().name(first.name()).build();
+            try (var response = environmentsClient.callCreate(sameNameDifferentWorkspace, otherApiKey,
+                    otherWorkspaceName)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_CREATED);
+            }
+        }
+
+        Stream<Arguments> invalidCreatePayloads() {
+            return Stream.of(
+                    arguments("name with disallowed characters",
+                            Environment.builder().name("has spaces").build()),
+                    arguments("blank name",
+                            Environment.builder().name("").build()),
+                    arguments("name longer than 150 characters",
+                            Environment.builder().name(RandomStringUtils.secure().nextAlphanumeric(151)).build()),
+                    arguments("description longer than 500 characters",
+                            buildEnvironment().toBuilder()
+                                    .description(RandomStringUtils.secure().nextAlphanumeric(501))
+                                    .build()),
+                    arguments("color longer than 20 characters",
+                            buildEnvironment().toBuilder()
+                                    .color(RandomStringUtils.secure().nextAlphanumeric(21))
+                                    .build()));
+        }
+
+        @ParameterizedTest(name = "create with {0} returns 422")
+        @MethodSource("invalidCreatePayloads")
+        void createValidationRejected(String description, Environment input) {
+            try (var response = environmentsClient.callCreate(input, API_KEY, WORKSPACE_NAME)) {
+                assertThat(response.getStatusInfo().getStatusCode())
+                        .isEqualTo(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+            }
+        }
+
+        @Test
+        @DisplayName("create when workspace already has the configured maximum returns 409")
+        void createBeyondMaxReturnsConflict() {
+            String capApiKey = UUID.randomUUID().toString();
+            String capWorkspaceName = UUID.randomUUID().toString();
+            String capWorkspaceId = UUID.randomUUID().toString();
+            mockIsolatedWorkspace(capApiKey, capWorkspaceName, capWorkspaceId);
+
+            // default max is 20 — fill the workspace then attempt one more
+            IntStream.range(0, 20).forEach(i -> environmentsClient.createEnvironment(
+                    buildEnvironment(), capApiKey, capWorkspaceName));
+
+            try (var response = environmentsClient.callCreate(buildEnvironment(), capApiKey, capWorkspaceName)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_CONFLICT);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Get by id:")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class GetById {
+
+        @Test
+        @DisplayName("get unknown id returns 404")
+        void getUnknownReturnsNotFound() {
+            try (var response = environmentsClient.callGet(UUID.randomUUID(), API_KEY, WORKSPACE_NAME)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+            }
+        }
+
+        @Test
+        @DisplayName("get from a different workspace returns 404")
+        void getCrossWorkspaceReturnsNotFound() {
+            String otherApiKey = UUID.randomUUID().toString();
+            String otherWorkspaceName = UUID.randomUUID().toString();
+            String otherWorkspaceId = UUID.randomUUID().toString();
+            mockIsolatedWorkspace(otherApiKey, otherWorkspaceName, otherWorkspaceId);
+
+            UUID id = environmentsClient.createEnvironment(buildEnvironment(), API_KEY, WORKSPACE_NAME);
+
+            try (var response = environmentsClient.callGet(id, otherApiKey, otherWorkspaceName)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Find:")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class Find {
+
+        @Test
+        @DisplayName("find on empty workspace returns empty page")
+        void findEmpty() {
+            String emptyApiKey = UUID.randomUUID().toString();
+            String emptyWorkspaceName = UUID.randomUUID().toString();
+            String emptyWorkspaceId = UUID.randomUUID().toString();
+            mockIsolatedWorkspace(emptyApiKey, emptyWorkspaceName, emptyWorkspaceId);
+
+            try (var response = environmentsClient.callFind(emptyApiKey, emptyWorkspaceName)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
+                var page = response.readEntity(Environment.EnvironmentPage.class);
+
+                assertThat(page).isEqualTo(Environment.EnvironmentPage.empty());
+            }
+        }
+
+        @Test
+        @DisplayName("find returns all environments scoped to the workspace")
+        void findReturnsWorkspaceEnvironments() {
+            String findApiKey = UUID.randomUUID().toString();
+            String findWorkspaceName = UUID.randomUUID().toString();
+            String findWorkspaceId = UUID.randomUUID().toString();
+            mockIsolatedWorkspace(findApiKey, findWorkspaceName, findWorkspaceId);
+
+            String otherApiKey = UUID.randomUUID().toString();
+            String otherWorkspaceName = UUID.randomUUID().toString();
+            String otherWorkspaceId = UUID.randomUUID().toString();
+            mockIsolatedWorkspace(otherApiKey, otherWorkspaceName, otherWorkspaceId);
+
+            List<UUID> mine = IntStream.range(0, 3)
+                    .mapToObj(i -> environmentsClient.createEnvironment(
+                            buildEnvironment(), findApiKey, findWorkspaceName))
+                    .toList();
+
+            // pollute another workspace — must not appear in find
+            environmentsClient.createEnvironment(buildEnvironment(), otherApiKey, otherWorkspaceName);
+
+            try (var response = environmentsClient.callFind(findApiKey, findWorkspaceName)) {
+                var page = response.readEntity(Environment.EnvironmentPage.class);
+
+                assertThat(page.page()).isEqualTo(1);
+                assertThat(page.size()).isEqualTo(3);
+                assertThat(page.total()).isEqualTo(3);
+                assertThat(page.content()).extracting(Environment::id)
+                        .containsExactlyInAnyOrderElementsOf(mine);
+                assertThat(page.sortableBy()).contains("created_at");
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Update:")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class Update {
+
+        @Test
+        @DisplayName("update partial fields returns 204 and persists changes")
+        void updatePartial() {
+            var input = buildEnvironment();
+            UUID id = environmentsClient.createEnvironment(input, API_KEY, WORKSPACE_NAME);
+
+            var update = EnvironmentUpdate.builder()
+                    .description("updated desc")
+                    .color("green")
+                    .build();
+
+            try (var response = environmentsClient.callUpdate(id, update, API_KEY, WORKSPACE_NAME)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+            }
+
+            var expected = input.toBuilder()
+                    .description("updated desc")
+                    .color("green")
+                    .build();
+
+            try (var response = environmentsClient.callGet(id, API_KEY, WORKSPACE_NAME)) {
+                var fetched = response.readEntity(Environment.class);
+                assertThat(fetched)
+                        .usingRecursiveComparison(RecursiveComparisonConfiguration.builder()
+                                .withIgnoredFields(ENVIRONMENT_IGNORED_FIELDS)
+                                .build())
+                        .isEqualTo(expected);
+                assertThat(fetched.id()).isEqualTo(id);
+            }
+        }
+
+        @Test
+        @DisplayName("update unknown id returns 404")
+        void updateUnknown() {
+            var update = EnvironmentUpdate.builder().description("x").build();
+
+            try (var response = environmentsClient.callUpdate(UUID.randomUUID(), update, API_KEY, WORKSPACE_NAME)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+            }
+        }
+
+        @Test
+        @DisplayName("update name to a value already taken by another env returns 409")
+        void updateNameConflict() {
+            UUID firstId = environmentsClient.createEnvironment(buildEnvironment(), API_KEY, WORKSPACE_NAME);
+            var second = buildEnvironment();
+            environmentsClient.createEnvironment(second, API_KEY, WORKSPACE_NAME);
+
+            var update = EnvironmentUpdate.builder().name(second.name()).build();
+
+            try (var response = environmentsClient.callUpdate(firstId, update, API_KEY, WORKSPACE_NAME)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_CONFLICT);
+            }
+        }
+
+        @Test
+        @DisplayName("update with invalid name characters returns 422")
+        void updateInvalidNameRejected() {
+            UUID id = environmentsClient.createEnvironment(buildEnvironment(), API_KEY, WORKSPACE_NAME);
+            var update = EnvironmentUpdate.builder().name("has spaces").build();
+
+            try (var response = environmentsClient.callUpdate(id, update, API_KEY, WORKSPACE_NAME)) {
+                assertThat(response.getStatusInfo().getStatusCode())
+                        .isEqualTo(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+            }
+        }
+
+        @Test
+        @DisplayName("update from a different workspace returns 404")
+        void updateCrossWorkspaceReturnsNotFound() {
+            String otherApiKey = UUID.randomUUID().toString();
+            String otherWorkspaceName = UUID.randomUUID().toString();
+            String otherWorkspaceId = UUID.randomUUID().toString();
+            mockIsolatedWorkspace(otherApiKey, otherWorkspaceName, otherWorkspaceId);
+
+            UUID id = environmentsClient.createEnvironment(buildEnvironment(), API_KEY, WORKSPACE_NAME);
+
+            try (var response = environmentsClient.callUpdate(id,
+                    EnvironmentUpdate.builder().description("x").build(), otherApiKey, otherWorkspaceName)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Batch delete:")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class BatchDeletion {
+
+        @Test
+        @DisplayName("batch delete returns 204 and removes the environments")
+        void deleteBatch() {
+            UUID a = environmentsClient.createEnvironment(buildEnvironment(), API_KEY, WORKSPACE_NAME);
+            UUID b = environmentsClient.createEnvironment(buildEnvironment(), API_KEY, WORKSPACE_NAME);
+
+            try (var response = environmentsClient.callBatchDelete(Set.of(a, b), API_KEY, WORKSPACE_NAME)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+            }
+
+            try (var response = environmentsClient.callGet(a, API_KEY, WORKSPACE_NAME)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+            }
+            try (var response = environmentsClient.callGet(b, API_KEY, WORKSPACE_NAME)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+            }
+        }
+
+        @Test
+        @DisplayName("batch delete is idempotent — missing ids are silently ignored")
+        void deleteBatchIdempotent() {
+            UUID existing = environmentsClient.createEnvironment(buildEnvironment(), API_KEY, WORKSPACE_NAME);
+            UUID missing = UUID.randomUUID();
+
+            try (var response = environmentsClient.callBatchDelete(Set.of(existing, missing), API_KEY,
+                    WORKSPACE_NAME)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+            }
+        }
+
+        @Test
+        @DisplayName("batch delete with empty ids returns 422")
+        void deleteBatchEmptyRejected() {
+            try (var response = environmentsClient.callBatchDelete(new BatchDelete(new HashSet<>()), API_KEY,
+                    WORKSPACE_NAME)) {
+                assertThat(response.getStatusInfo().getStatusCode())
+                        .isEqualTo(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+            }
+        }
+
+        @Test
+        @DisplayName("batch delete from another workspace does not affect this workspace's environments")
+        void deleteBatchWorkspaceIsolation() {
+            String otherApiKey = UUID.randomUUID().toString();
+            String otherWorkspaceName = UUID.randomUUID().toString();
+            String otherWorkspaceId = UUID.randomUUID().toString();
+            mockIsolatedWorkspace(otherApiKey, otherWorkspaceName, otherWorkspaceId);
+
+            UUID id = environmentsClient.createEnvironment(buildEnvironment(), API_KEY, WORKSPACE_NAME);
+
+            try (var response = environmentsClient.callBatchDelete(Set.of(id), otherApiKey, otherWorkspaceName)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+            }
+
+            try (var response = environmentsClient.callGet(id, API_KEY, WORKSPACE_NAME)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Details
Adds a workspace-scoped Environments CRUD module to the backend so users can manage named environments (with description, color, position) via the private API. Introduces the `environments` MySQL table, JDBI DAO, transactional service, and Dropwizard resource, plus a configurable per-workspace cap (default 20) and the same audit/analytics/locking patterns used by other workspace entities.

- New endpoints under `/v1/private/environments`: `GET /` (list, capped), `GET /{id}`, `POST /` (create, rate-limited), `PATCH /{id}` (partial update, rate-limited), `POST /delete` (idempotent batch delete).
- New API records [Environment.java](apps/opik-backend/src/main/java/com/comet/opik/api/Environment.java) and [EnvironmentUpdate.java](apps/opik-backend/src/main/java/com/comet/opik/api/EnvironmentUpdate.java) with JSON views (`Public` / `Write`), snake_case naming, and validation (name regex `^[A-Za-z0-9_-]+$`, length caps 150/500/20).
- [EnvironmentService.java](apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java) enforces the workspace limit under a `LockService` mutex, maps unique-constraint violations to `409 Conflict`, emits an `environment_created` analytics event, and uses `READ_ONLY` / `WRITE` transaction templates.
- [EnvironmentDAO.java](apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java) uses `COALESCE` for partial PATCH updates and scopes every query by `workspace_id`.
- New Liquibase migration [000065_create_environments_table.sql](apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000065_create_environments_table.sql) creates `environments` with a `(workspace_id, name)` unique constraint.
- New [EnvironmentConfig.java](apps/opik-backend/src/main/java/com/comet/opik/infrastructure/EnvironmentConfig.java) wired into [OpikConfiguration.java](apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java); exposes `OPIK_ENVIRONMENT_MAX_PER_WORKSPACE` (default 20) in [config.yml](apps/opik-backend/config.yml).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves #
- OPIK-6264

## AI-WATERMARK

AI-WATERMARK: no

## Testing
- New integration suite [EnvironmentsResourceTest.java](apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/EnvironmentsResourceTest.java) (~506 lines) covers create/get/list/update/batch-delete happy paths, workspace isolation, name uniqueness (`409`), workspace cap (`409`), validation errors (`400`), missing-id (`404`), and PATCH partial semantics.
- Test client helper [EnvironmentsResourceClient.java](apps/opik-backend/src/test/java/com/comet/opik/api/resources/EnvironmentsResourceClient.java) added for reuse.
- Run: `cd apps/opik-backend && mvn test -Dtest=EnvironmentsResourceTest`.

## Documentation
N/A — OpenAPI annotations on the resource cover the new endpoints; no separate docs added.
