### PR TITLE
[OPIK-6333] [FE] Confirm before leaving agent playground while a run is in progress

### DIFF
--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx
@@ -2,7 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AgentRunnerContent from "./AgentRunnerContent";
-import { RunnerConnectionStatus } from "@/types/agent-sandbox";
+import {
+  RunnerConnectionStatus,
+  SandboxJobStatus,
+} from "@/types/agent-sandbox";
+import useSandboxJobStatus from "@/api/agent-sandbox/useSandboxJobStatus";
 import type { PairingState } from "@/hooks/usePairingState";
 import { ReactNode } from "react";
 import { TooltipProvider } from "@/ui/tooltip";
@@ -28,6 +32,8 @@ vi.mock("@/api/agent-sandbox/useSandboxJobStatus", () => ({
   })),
 }));
 
+const mockUseSandboxJobStatus = vi.mocked(useSandboxJobStatus);
+
 vi.mock("./AgentRunnerEmptyState", () => {
   const MockEmptyState = () => <div data-testid="empty-state">Empty state</div>;
   MockEmptyState.displayName = "MockEmptyState";
@@ -46,8 +52,36 @@ vi.mock("./AgentRunnerResult", () => ({
   default: () => null,
 }));
 
+interface NavigationBlockerOptions {
+  condition: boolean;
+  title: string;
+  description: string;
+  confirmText: string;
+  cancelText: string;
+}
+
+const mockUseNavigationBlocker = vi.fn();
+
+vi.mock("@/hooks/useNavigationBlocker", () => ({
+  default: (options: NavigationBlockerOptions) =>
+    mockUseNavigationBlocker(options),
+}));
+
 describe("AgentRunnerContent", () => {
   let queryClient: QueryClient;
+
+  const setConnectedRunner = () => {
+    mockPairingState = {
+      ...mockPairingState,
+      status: RunnerConnectionStatus.CONNECTED,
+      runner: {
+        id: "runner-1",
+        project_id: "proj-1",
+        status: RunnerConnectionStatus.CONNECTED,
+        agents: [{ name: "test-agent" }],
+      },
+    };
+  };
 
   const createWrapper = (qc: QueryClient) => {
     const Wrapper = ({ children }: { children: ReactNode }) => (
@@ -72,6 +106,12 @@ describe("AgentRunnerContent", () => {
       runnerId: null,
       runner: null,
     };
+    mockUseNavigationBlocker.mockReturnValue({
+      DialogComponent: <div data-testid="navigation-blocker-dialog" />,
+    });
+    mockUseSandboxJobStatus.mockReturnValue({
+      data: null,
+    } as ReturnType<typeof useSandboxJobStatus>);
   });
 
   it("shows empty state when idle", () => {
@@ -112,5 +152,77 @@ describe("AgentRunnerContent", () => {
     });
 
     expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+  });
+
+  it("calls useNavigationBlocker with the agent-playground copy and a falsy condition when no job is active", () => {
+    setConnectedRunner();
+
+    render(<AgentRunnerContent projectId="proj-1" />, {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(mockUseNavigationBlocker).toHaveBeenCalledWith({
+      condition: false,
+      title: "Agent execution in progress",
+      description:
+        "Your agent is currently running. Leaving now will interrupt the execution and may result in an incomplete trace. Are you sure you want to leave?",
+      confirmText: "Leave anyway",
+      cancelText: "Stay and wait",
+    });
+  });
+
+  it("blocks navigation while the sandbox job is RUNNING", () => {
+    setConnectedRunner();
+    mockUseSandboxJobStatus.mockReturnValue({
+      data: { status: SandboxJobStatus.RUNNING },
+    } as ReturnType<typeof useSandboxJobStatus>);
+
+    render(<AgentRunnerContent projectId="proj-1" />, {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(mockUseNavigationBlocker).toHaveBeenCalledWith(
+      expect.objectContaining({ condition: true }),
+    );
+  });
+
+  it("blocks navigation while the sandbox job is PENDING", () => {
+    setConnectedRunner();
+    mockUseSandboxJobStatus.mockReturnValue({
+      data: { status: SandboxJobStatus.PENDING },
+    } as ReturnType<typeof useSandboxJobStatus>);
+
+    render(<AgentRunnerContent projectId="proj-1" />, {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(mockUseNavigationBlocker).toHaveBeenCalledWith(
+      expect.objectContaining({ condition: true }),
+    );
+  });
+
+  it("does not block navigation when the sandbox job has finished", () => {
+    setConnectedRunner();
+    mockUseSandboxJobStatus.mockReturnValue({
+      data: { status: SandboxJobStatus.COMPLETED },
+    } as ReturnType<typeof useSandboxJobStatus>);
+
+    render(<AgentRunnerContent projectId="proj-1" />, {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(mockUseNavigationBlocker).toHaveBeenCalledWith(
+      expect.objectContaining({ condition: false }),
+    );
+  });
+
+  it("renders the dialog returned by useNavigationBlocker", () => {
+    setConnectedRunner();
+
+    render(<AgentRunnerContent projectId="proj-1" />, {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(screen.getByTestId("navigation-blocker-dialog")).toBeInTheDocument();
   });
 });

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx
@@ -175,7 +175,7 @@ describe("AgentRunnerContent", () => {
     setConnectedRunner();
     mockUseSandboxJobStatus.mockReturnValue({
       data: { status: SandboxJobStatus.RUNNING },
-    } as ReturnType<typeof useSandboxJobStatus>);
+    } as unknown as ReturnType<typeof useSandboxJobStatus>);
 
     render(<AgentRunnerContent projectId="proj-1" />, {
       wrapper: createWrapper(queryClient),
@@ -190,7 +190,7 @@ describe("AgentRunnerContent", () => {
     setConnectedRunner();
     mockUseSandboxJobStatus.mockReturnValue({
       data: { status: SandboxJobStatus.PENDING },
-    } as ReturnType<typeof useSandboxJobStatus>);
+    } as unknown as ReturnType<typeof useSandboxJobStatus>);
 
     render(<AgentRunnerContent projectId="proj-1" />, {
       wrapper: createWrapper(queryClient),
@@ -205,7 +205,7 @@ describe("AgentRunnerContent", () => {
     setConnectedRunner();
     mockUseSandboxJobStatus.mockReturnValue({
       data: { status: SandboxJobStatus.COMPLETED },
-    } as ReturnType<typeof useSandboxJobStatus>);
+    } as unknown as ReturnType<typeof useSandboxJobStatus>);
 
     render(<AgentRunnerContent projectId="proj-1" />, {
       wrapper: createWrapper(queryClient),

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx
@@ -7,6 +7,7 @@ import {
   SandboxJobStatus,
 } from "@/types/agent-sandbox";
 import useSandboxJobStatus from "@/api/agent-sandbox/useSandboxJobStatus";
+import useSandboxCreateJobMutation from "@/api/agent-sandbox/useSandboxCreateJobMutation";
 import type { PairingState } from "@/hooks/usePairingState";
 import { ReactNode } from "react";
 import { TooltipProvider } from "@/ui/tooltip";
@@ -33,6 +34,7 @@ vi.mock("@/api/agent-sandbox/useSandboxJobStatus", () => ({
 }));
 
 const mockUseSandboxJobStatus = vi.mocked(useSandboxJobStatus);
+const mockUseSandboxCreateJobMutation = vi.mocked(useSandboxCreateJobMutation);
 
 vi.mock("./AgentRunnerEmptyState", () => {
   const MockEmptyState = () => <div data-testid="empty-state">Empty state</div>;
@@ -112,6 +114,10 @@ describe("AgentRunnerContent", () => {
     mockUseSandboxJobStatus.mockReturnValue({
       data: null,
     } as unknown as ReturnType<typeof useSandboxJobStatus>);
+    mockUseSandboxCreateJobMutation.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useSandboxCreateJobMutation>);
   });
 
   it("shows empty state when idle", () => {
@@ -191,6 +197,22 @@ describe("AgentRunnerContent", () => {
     mockUseSandboxJobStatus.mockReturnValue({
       data: { status: SandboxJobStatus.PENDING },
     } as unknown as ReturnType<typeof useSandboxJobStatus>);
+
+    render(<AgentRunnerContent projectId="proj-1" />, {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(mockUseNavigationBlocker).toHaveBeenCalledWith(
+      expect.objectContaining({ condition: true }),
+    );
+  });
+
+  it("blocks navigation while the create-job mutation is in flight (before jobData arrives)", () => {
+    setConnectedRunner();
+    mockUseSandboxCreateJobMutation.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: true,
+    } as unknown as ReturnType<typeof useSandboxCreateJobMutation>);
 
     render(<AgentRunnerContent projectId="proj-1" />, {
       wrapper: createWrapper(queryClient),

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx
@@ -111,7 +111,7 @@ describe("AgentRunnerContent", () => {
     });
     mockUseSandboxJobStatus.mockReturnValue({
       data: null,
-    } as ReturnType<typeof useSandboxJobStatus>);
+    } as unknown as ReturnType<typeof useSandboxJobStatus>);
   });
 
   it("shows empty state when idle", () => {

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
@@ -20,6 +20,7 @@ import useTraceById from "@/api/traces/useTraceById";
 import usePairingState from "@/hooks/usePairingState";
 import { usePermissions } from "@/contexts/PermissionsContext";
 import TraceDetailsPanel from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel";
+import useNavigationBlocker from "@/hooks/useNavigationBlocker";
 import AgentRunnerEmptyState from "./AgentRunnerEmptyState";
 import AgentRunnerConnectedState from "./AgentRunnerConnectedState";
 import AgentRunnerResult from "./AgentRunnerResult";
@@ -68,6 +69,15 @@ const AgentRunnerContent: React.FC<AgentRunnerContentProps> = ({
   const isJobRunning =
     jobData?.status === SandboxJobStatus.RUNNING ||
     jobData?.status === SandboxJobStatus.PENDING;
+
+  const { DialogComponent: navigationBlockerDialog } = useNavigationBlocker({
+    condition: isJobRunning,
+    title: "Agent execution in progress",
+    description:
+      "Your agent is currently running. Leaving now will interrupt the execution and may result in an incomplete trace. Are you sure you want to leave?",
+    confirmText: "Leave anyway",
+    cancelText: "Stay and wait",
+  });
 
   const { data: traceData } = useTraceById(
     { traceId, stripAttachments: true },
@@ -277,6 +287,7 @@ const AgentRunnerContent: React.FC<AgentRunnerContentProps> = ({
           refetchInterval={TRACE_POLL_INTERVAL}
         />
       )}
+      {navigationBlockerDialog}
     </div>
   );
 };

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
@@ -71,7 +71,7 @@ const AgentRunnerContent: React.FC<AgentRunnerContentProps> = ({
     jobData?.status === SandboxJobStatus.PENDING;
 
   const { DialogComponent: navigationBlockerDialog } = useNavigationBlocker({
-    condition: isJobRunning,
+    condition: isJobRunning || createJobMutation.isPending,
     title: "Agent execution in progress",
     description:
       "Your agent is currently running. Leaving now will interrupt the execution and may result in an incomplete trace. Are you sure you want to leave?",


### PR DESCRIPTION
## Details

Adds a navigate-away confirmation dialog to the Agent playground when a sandbox job is in progress, mirroring the existing behavior of the Prompt playground. Reuses the shared `useNavigationBlocker` hook — no new components, hooks, or backend work.

- [AgentRunnerContent.tsx](apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx) imports `useNavigationBlocker` and invokes it with `condition: isJobRunning` (true when `jobData?.status` is `RUNNING` or `PENDING`).
- The hook handles both in-app navigation (TanStack Router `useBlocker`) and tab close (`beforeunload`); the returned `DialogComponent` is rendered at the bottom of the JSX as `{navigationBlockerDialog}`.
- Reference call site for the same hook on the Prompt playground: [PlaygroundPage.tsx#L127](apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx#L127).
- UX copy (locked):
  - title: `Agent execution in progress`
  - description: `Your agent is currently running. Leaving now will interrupt the execution and may result in an incomplete trace. Are you sure you want to leave?`
  - confirm: `Leave anyway`
  - cancel: `Stay and wait`
- Out of scope by design: the in-page **Stop run**, **Reset**, and **Disconnect** buttons mutate local state, not the route — they continue to work without a confirmation. If product wants Disconnect to confirm during a run, that's a follow-up ticket.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6333

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: full implementation (plan, tests, hook wiring) under TDD with subagent-driven review (spec compliance + code quality reviews per task, then a final cumulative review)
- Human verification: PR owner reviews and runs the manual test plan below in a deployed environment

## Testing

Unit tests in [AgentRunnerContent.test.tsx](apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx) cover the four behavioral cases plus the dialog render:

- `useNavigationBlocker` is called with the locked copy and `condition: false` when no job is active.
- `condition: true` when the sandbox job status is `RUNNING`.
- `condition: true` when the sandbox job status is `PENDING`.
- `condition: false` when the sandbox job status is `COMPLETED`.
- The returned `DialogComponent` is rendered.

Run: `cd apps/opik-frontend && npx vitest run src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx` → 8/8 passing. `npx tsc --noEmit` and `npx eslint` clean for the changed files.

Manual test plan (please run in the deployed environment):
- [ ] Start a long-running agent run; click any sidebar link → dialog appears with the locked copy.
- [ ] Click **Stay and wait** → stay on page, run continues. Click the same link, then **Leave anyway** → navigation proceeds.
- [ ] While running, attempt tab close (Cmd+W) or refresh (Cmd+R) → browser native `beforeunload` confirm appears.
- [ ] Wait for the run to finish, then navigate → no dialog.
- [ ] In-page **Stop run**, **Reset**, and **Disconnect** still work without a dialog.
- [ ] Regression check: Prompt playground confirmation still works (shared hook).

## Documentation

N/A — UX-only change in an existing page; no public API or user-facing docs to update.