### PR TITLE
[OPIK-5694] [BE] fix: stop emitting NULL into non-nullable last_updated_at on batch insert

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -139,7 +139,7 @@ public class SpanDAO {
                         :total_estimated_cost_version<item.index>,
                         :tags<item.index>,
                         mapFromArrays(:usage_keys<item.index>, :usage_values<item.index>),
-                        if(:last_updated_at<item.index> IS NULL, NULL, parseDateTime64BestEffort(:last_updated_at<item.index>, 6)),
+                        if(:last_updated_at<item.index> IS NULL, now64(6), parseDateTime64BestEffort(:last_updated_at<item.index>, 6)),
                         :error_info<item.index>,
                         :created_by<item.index>,
                         :last_updated_by<item.index>,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -224,7 +224,7 @@ class TraceDAOImpl implements TraceDAO {
                         :output<item.index>,
                         :metadata<item.index>,
                         :tags<item.index>,
-                        if(:last_updated_at<item.index> IS NULL, NULL, parseDateTime64BestEffort(:last_updated_at<item.index>, 6)),
+                        if(:last_updated_at<item.index> IS NULL, now64(6), parseDateTime64BestEffort(:last_updated_at<item.index>, 6)),
                         :error_info<item.index>,
                         :user_name,
                         :user_name,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -49,6 +49,7 @@ import com.comet.opik.domain.cost.CostService;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.auth.WorkspaceUserPermission;
+import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.infrastructure.usagelimit.Quota;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.AttachmentPayloadUtilsTest;
@@ -2090,6 +2091,53 @@ class SpansResourceTest {
                     assertThat(actualResponse.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
                 }
             }
+        }
+
+        @Test
+        @DisplayName("when batch contains a span with null lastUpdatedAt, then no CANNOT_CONVERT_TYPE errors are emitted (OPIK-5694)")
+        void batch__whenSpanHasNullLastUpdatedAt__thenNoCannotConvertTypeErrors(
+                TransactionTemplateAsync templateAsync) {
+            var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var workspaceId = UUID.randomUUID().toString();
+            AuthTestUtils.mockTargetWorkspace(wireMock.server(), API_KEY, workspaceName, workspaceId, USER);
+
+            long cannotConvertTypeBefore = readClickHouseErrorCount(templateAsync, 70);
+
+            var spanWithNullLastUpdatedAt = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .endTime(null)
+                    .duration(null)
+                    .lastUpdatedAt(null)
+                    .feedbackScores(null)
+                    .totalEstimatedCost(null)
+                    .build();
+            var spanWithEndTime = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .feedbackScores(null)
+                    .totalEstimatedCost(null)
+                    .build();
+
+            spanResourceClient.batchCreateSpans(List.of(spanWithNullLastUpdatedAt, spanWithEndTime),
+                    API_KEY, workspaceName);
+
+            long cannotConvertTypeAfter = readClickHouseErrorCount(templateAsync, 70);
+
+            assertThat(cannotConvertTypeAfter - cannotConvertTypeBefore)
+                    .as("batch insert must not emit CANNOT_CONVERT_TYPE errors (code 70) "
+                            + "into system.errors when spans have null lastUpdatedAt")
+                    .isZero();
+        }
+
+        private long readClickHouseErrorCount(TransactionTemplateAsync templateAsync, int errorCode) {
+            return templateAsync.nonTransaction(connection -> {
+                var statement = connection.createStatement(
+                        "SELECT value FROM system.errors WHERE code = :code");
+                statement.bind("code", errorCode);
+                return Mono.from(statement.execute())
+                        .flatMap(result -> Mono.from(result.map((row, meta) -> {
+                            Long value = row.get("value", Long.class);
+                            return value != null ? value : 0L;
+                        })))
+                        .defaultIfEmpty(0L);
+            }).block();
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -2955,6 +2955,64 @@ class TracesResourceTest {
                 }
             }
         }
+
+        @Test
+        @DisplayName("when batch contains a trace with null lastUpdatedAt, then no CANNOT_CONVERT_TYPE errors are emitted (OPIK-5694)")
+        void batch__whenTraceHasNullLastUpdatedAt__thenNoCannotConvertTypeErrors(
+                TransactionTemplateAsync templateAsync) {
+            var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(API_KEY, workspaceName, workspaceId);
+
+            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(16);
+
+            long cannotConvertTypeBefore = readClickHouseErrorCount(templateAsync, 70);
+
+            var traceWithNullLastUpdatedAt = factory.manufacturePojo(Trace.class).toBuilder()
+                    .projectName(projectName)
+                    .endTime(null)
+                    .duration(null)
+                    .lastUpdatedAt(null)
+                    .usage(null)
+                    .feedbackScores(null)
+                    .build();
+            var traceWithEndTime = factory.manufacturePojo(Trace.class).toBuilder()
+                    .projectName(projectName)
+                    .usage(null)
+                    .feedbackScores(null)
+                    .build();
+
+            var traces = List.of(traceWithNullLastUpdatedAt, traceWithEndTime);
+
+            traceResourceClient.batchCreateTraces(traces, API_KEY, workspaceName);
+
+            for (var trace : traces) {
+                Trace retrieved = traceResourceClient.getById(trace.id(), workspaceName, API_KEY);
+                assertThat(retrieved).as("trace %s should be persisted", trace.id()).isNotNull();
+                assertThat(retrieved.id()).isEqualTo(trace.id());
+            }
+
+            long cannotConvertTypeAfter = readClickHouseErrorCount(templateAsync, 70);
+
+            assertThat(cannotConvertTypeAfter - cannotConvertTypeBefore)
+                    .as("batch insert must not emit CANNOT_CONVERT_TYPE errors (code 70) "
+                            + "into system.errors. Production sees ~30k of these per hour from this code path.")
+                    .isZero();
+        }
+
+        private long readClickHouseErrorCount(TransactionTemplateAsync templateAsync, int errorCode) {
+            return templateAsync.nonTransaction(connection -> {
+                var statement = connection.createStatement(
+                        "SELECT value FROM system.errors WHERE code = :code");
+                statement.bind("code", errorCode);
+                return Mono.from(statement.execute())
+                        .flatMap(result -> Mono.from(result.map((row, meta) -> {
+                            Long value = row.get("value", Long.class);
+                            return value != null ? value : 0L;
+                        })))
+                        .defaultIfEmpty(0L);
+            }).block();
+        }
     }
 
     private Stream<Arguments> getProjectNameModifierArgs() {


### PR DESCRIPTION
## Details

Production ClickHouse logs a sustained, high-volume stream of `CANNOT_CONVERT_TYPE` (code 70) errors from the trace/span batch ingestion path. The inserts succeed (rows land via the column `DEFAULT`), but every null `lastUpdatedAt` row counts an error in `system.errors` and pollutes pod stderr.

We reproduced the symptom in a Java integration test before touching production code: it queries `system.errors` for code 70 before and after `batchCreateTraces` / `batchCreateSpans` with one row having `lastUpdatedAt=null`, and asserts the counter does not grow. Without the fix it fails with `expected: 0L but was: 1L`, matching the production signal exactly. The bug also reproduces via direct `curl` against ClickHouse `25.3.6.56` (test container) and `25.3.8` (production version), so it is not version-specific.

Root cause: `TraceDAO.BATCH_INSERT` and `SpanDAO.BULK_INSERT` emitted

```sql
if(:last_updated_at<idx> IS NULL, NULL, parseDateTime64BestEffort(:last_updated_at<idx>, 6))
```

When the client did not provide `lastUpdatedAt`, the driver substituted literal `NULL`, the `if` evaluated to `NULL`, and ClickHouse could not convert that to the non-nullable `DateTime64(6)` column (`last_updated_at` is the `ReplacingMergeTree` version column, so it cannot be Nullable). CH counted the type-check failure, then fell back to the column DEFAULT.

Fix: emit `now64(6)` in the else-branch instead of `NULL`. Behaviour is identical for clients (null input → current time, exactly what the column `DEFAULT now64(6)` produces), but no NULL ever reaches the non-nullable column, so no type-conversion error is logged. The original code most likely assumed the DEFAULT clause would handle NULL silently — it does, but only after the failure is counted. `OptimizationDAO`, `TraceThreadDAO`, and the single-row `INSERT`/`UPDATE` templates were audited and are already safe: they either omit `last_updated_at` from the column list (letting DEFAULT take over) or use a `COALESCE(parseDateTime64BestEffortOrNull(...), now64(6))` pattern that never lets NULL reach the column.

**Scope: code 27 not addressed here.** The same code path also generates `CANNOT_PARSE_INPUT_ASSERTION_FAILED` (code 27) errors at a higher rate than code 70. We empirically isolated this and confirmed it is **not** the same bug — every `FORMAT Values` insert increments code 27 by +2 to +3 regardless of payload, including a control insert with all non-null literal values and no function calls. We also tried two narrower workarounds suggested for this counter — swapping the strict `parseDateTime64BestEffort` to `parseDateTime64BestEffortOrNull` on `end_time` (with and without the `if(... IS NULL, NULL, ...)` wrap) — and neither reduced the counter, because the `if` wrap already short-circuits the strict-variant call. Real reductions require either per-row conditional StringTemplate templating (medium effort, partial drop expected) or switching the batch wire format off `FORMAT Values` to `RowBinary` / `Native` (high effort, near-total drop). Both will be tackled in a follow-up PR with their own ticket.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5694

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6 / 4.7
- Scope: assisted (empirical reproduction, root-cause isolation via direct CH HTTP probes, fix, regression tests)
- Human verification: code review + manual reproduction of the failing test before/after the fix; targeted run of all 31 BatchInsert tests across `TracesResourceTest` and `SpansResourceTest`

## Testing

Commands run:

```
mvn -B compile -DskipTests
mvn -B spotless:check
mvn -B test -Dtest='TracesResourceTest$BatchInsert,SpansResourceTest$BatchInsert'
```

Results: `Tests run: 31, Failures: 0, Errors: 0` (19 traces + 12 spans).

Scenarios validated:
- Pre-fix: new tests `batch__whenTraceHasNullLastUpdatedAt__thenNoCannotConvertTypeErrors` and `batch__whenSpanHasNullLastUpdatedAt__thenNoCannotConvertTypeErrors` fail with `system.errors` code-70 delta == 1, matching the production signal.
- Post-fix: same tests pass with delta == 0.
- All other existing batch insert tests continue to pass — no regression.
- Bug also empirically reproduced via direct `curl` against both ClickHouse `25.3.6.56-alpine` (test container) and `25.3.8-alpine` (production version) to confirm the bug is not a CH-version issue.
- Counter behaviour for code 27 across five SQL variants tested side-by-side (strict vs `OrNull`, with vs without `if`-wrap, literal NULL, function-free) to justify the scope split documented in Details.

Not run: full backend regression suite (out of scope for this fix; targeted classes covered).

## Documentation

N/A — no behaviour change visible to API consumers; `lastUpdatedAt` continues to default to "now" when omitted, matching prior observable behaviour.