### PR TITLE
[issue-6421] [FE] fix: truncate v1 SME threads list and surface items load errors

### DIFF
--- a/apps/opik-frontend/src/v1/pages/SMEFlowPage/NoDataView.tsx
+++ b/apps/opik-frontend/src/v1/pages/SMEFlowPage/NoDataView.tsx
@@ -1,19 +1,24 @@
 import React from "react";
-import { AlertCircle, FileText } from "lucide-react";
+import { AlertCircle, FileText, RefreshCw } from "lucide-react";
 import { Card } from "@/ui/card";
 import { Alert, AlertDescription } from "@/ui/alert";
+import { Button } from "@/ui/button";
 import SMEFlowLayout from "./SMEFlowLayout";
 
+type NoDataViewVariant = "no-queue" | "queue-error" | "items-error";
+
 interface NoDataViewProps {
-  hasQueueId: boolean;
+  variant: NoDataViewVariant;
+  onRetry?: () => void;
 }
 
 const NoDataView: React.FunctionComponent<NoDataViewProps> = ({
-  hasQueueId,
+  variant,
+  onRetry,
 }) => {
   return (
     <SMEFlowLayout header={<h1 className="comet-title-xl">Error</h1>}>
-      {hasQueueId ? (
+      {variant === "queue-error" && (
         <div className="space-y-6">
           <Alert variant="destructive">
             <AlertCircle className="size-4" />
@@ -32,7 +37,36 @@ const NoDataView: React.FunctionComponent<NoDataViewProps> = ({
             </p>
           </Card>
         </div>
-      ) : (
+      )}
+
+      {variant === "items-error" && (
+        <div className="space-y-6">
+          <Alert variant="destructive">
+            <AlertCircle className="size-4" />
+            <AlertDescription>
+              Unable to load items in this annotation queue. This is usually a
+              temporary issue.
+            </AlertDescription>
+          </Alert>
+
+          <Card className="p-8 text-center">
+            <FileText className="mx-auto mb-4 size-12 text-muted-slate" />
+            <h3 className="comet-title-m mb-2">Items failed to load</h3>
+            <p className="comet-body-s mb-6 text-muted-slate">
+              Please try again. If the problem persists, contact your
+              administrator.
+            </p>
+            {onRetry && (
+              <Button onClick={onRetry} variant="outline">
+                <RefreshCw className="mr-2 size-4" />
+                Retry
+              </Button>
+            )}
+          </Card>
+        </div>
+      )}
+
+      {variant === "no-queue" && (
         <Card className="p-8 text-center">
           <FileText className="mx-auto mb-4 size-12 text-muted-slate" />
           <h3 className="comet-title-m mb-2">No annotation queue selected</h3>

--- a/apps/opik-frontend/src/v1/pages/SMEFlowPage/SMEFlowContext.tsx
+++ b/apps/opik-frontend/src/v1/pages/SMEFlowPage/SMEFlowContext.tsx
@@ -247,6 +247,7 @@ interface SMEFlowContextValue {
   isLoading: boolean;
   isError: boolean;
   isItemsLoading: boolean;
+  isItemsError: boolean;
 }
 
 const SMEFlowContext = createContext<SMEFlowContextValue | null>(null);
@@ -319,7 +320,11 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
     [annotationQueue?.id],
   );
 
-  const { data: tracesData, isLoading: isTracesLoading } = useTracesList(
+  const {
+    data: tracesData,
+    isLoading: isTracesLoading,
+    isError: isTracesError,
+  } = useTracesList(
     {
       projectId: annotationQueue?.project_id || "",
       page: 1,
@@ -338,7 +343,11 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
     },
   );
 
-  const { data: threadsData, isLoading: isThreadsLoading } = useThreadsList(
+  const {
+    data: threadsData,
+    isLoading: isThreadsLoading,
+    isError: isThreadsError,
+  } = useThreadsList(
     {
       projectId: annotationQueue?.project_id || "",
       page: 1,
@@ -346,6 +355,7 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
       sorting: [],
       filters: annotationQueueFilter,
       search: "",
+      truncate: true,
     },
     {
       enabled:
@@ -355,6 +365,13 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
       placeholderData: keepPreviousData,
     },
   );
+
+  const isItemsError =
+    annotationQueue?.scope === ANNOTATION_QUEUE_SCOPE.TRACE
+      ? isTracesError
+      : annotationQueue?.scope === ANNOTATION_QUEUE_SCOPE.THREAD
+        ? isThreadsError
+        : false;
 
   const queueItems = useMemo(() => {
     return (
@@ -818,6 +835,7 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
     isLoading,
     isError,
     isItemsLoading,
+    isItemsError,
   };
 
   return (

--- a/apps/opik-frontend/src/v1/pages/SMEFlowPage/SMEFlowPage.tsx
+++ b/apps/opik-frontend/src/v1/pages/SMEFlowPage/SMEFlowPage.tsx
@@ -17,6 +17,7 @@ const SMEFlowContent: React.FunctionComponent = () => {
     isLoading,
     isItemsLoading,
     isError,
+    isItemsError,
   } = useSMEFlow();
 
   if (isLoading || isItemsLoading) {
@@ -28,8 +29,21 @@ const SMEFlowContent: React.FunctionComponent = () => {
     );
   }
 
-  if (!annotationQueue || isError) {
-    return <NoDataView hasQueueId={!!annotationQueue} />;
+  if (isError) {
+    return <NoDataView variant="queue-error" />;
+  }
+
+  if (!annotationQueue) {
+    return <NoDataView variant="no-queue" />;
+  }
+
+  if (isItemsError) {
+    return (
+      <NoDataView
+        variant="items-error"
+        onRetry={() => window.location.reload()}
+      />
+    );
   }
 
   switch (currentView) {


### PR DESCRIPTION
## Details

Apply the same fix already shipped in v2 (PR #6425) to the v1 SME annotation flow. Production reporter is on v1, so v2-only fix did not unblock them.

The root cause is a backend `500 Internal Server Error` (`Premature end of chunk coded message body`) on `GET /v1/private/traces/threads` when filtered by `annotation_queue_ids`. The SME flow's threads list query was missing `truncate=true`, so heavy threads (hundreds of messages each) produced responses large enough to exceed ClickHouse streaming/buffer limits and the connection was closed mid-stream. The frontend silently treated the empty error response as "all items processed" and showed a misleading destructive alert.

- **`v1/.../SMEFlowContext.tsx`** — Pass `truncate=true` to `useThreadsList`, mirroring the existing `useTracesList` pattern. Detail views (`TraceDataViewer`, `ThreadDataViewer`) already fetch full untruncated content on demand, so this is functionally safe.
- **`v1/.../SMEFlowContext.tsx`** — Capture `isError` from both list hooks and expose `isItemsError` on the context, scoped to the queue's active scope (TRACE vs THREAD).
- **`v1/.../SMEFlowPage.tsx`** — Split the previously combined `!annotationQueue || isError` branch into three explicit cases: `queue-error`, `no-queue`, and `items-error` (with retry).
- **`v1/.../NoDataView.tsx`** — Replace the `hasQueueId` boolean with a `variant` discriminator and add a dedicated `items-error` state including a retry action.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #6421

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: Port the v2 fix from PR #6425 to v1
- Human verification: `bash scripts/dev-runner.sh --lint-fe` (eslint + tsc + dependency-cruiser) passes; v2 equivalent was already verified end-to-end on prod by imitating the affected user, so this PR is a 1:1 port to v1.

## Testing

- `bash scripts/dev-runner.sh --lint-fe` — all green (lint:fix + typecheck + deps:validate).
- The same fix was already verified in v2 (PR #6425): all three error variants (`queue-error`, `no-queue`, `items-error`) and the success path were tested locally with simulated 500s on `getAnnotationQueueById`, `getTracesByProject`, and `getTraceThreads`. Detail views still load full untruncated content. v1 implementation mirrors v2 line-for-line, so no separate behavioral retest is required.

## Documentation

N/A — internal behavior fix; no public docs or APIs changed.