### PR TITLE
[OPIK-5694] [BE] fix: eliminate FORMAT Values fast-path noise in batch inserts

### DIFF
--- a/.agents/skills/opik-backend/clickhouse.md
+++ b/.agents/skills/opik-backend/clickhouse.md
@@ -110,25 +110,21 @@ WHERE id \\<= :uuid_to_time
 
 ## `FORMAT Values` cells must be literals (OPIK-5694)
 
-In `INSERT ... FORMAT Values` templates, every cell in the per-row tuple must be a plain
-`:placeholder` bound to a value the driver serialises as a canonical literal. Function
-calls, `if(...)`, `::` casts, `parseDateTime64BestEffort(...)`, `now64(...)`,
-`mapFromArrays(...)`, `toDecimal128(...)` etc. trip ClickHouse's fast-path parser. The
-insert still succeeds (CH falls back to the slow path), but every row silently bumps
-`system.errors` codes 26 / 27 / 43 / 70 and writes to pod stderr — flooding logs at QPS.
+Every cell in an `INSERT ... FORMAT Values` per-row tuple must be a plain `:placeholder`
+bound to a value the driver serialises as a literal. Function calls, `if(...)`, `::`
+casts, `parseDateTime64BestEffort(...)`, `now64(...)`, `mapFromArrays(...)`,
+`toDecimal128(...)` etc. trip the fast-path parser. The insert still succeeds, but every
+row silently bumps `system.errors` codes 26 / 27 / 43 / 70 and writes to pod stderr —
+flooding logs.
 
-Bind the right shape so the driver emits a literal:
-- `DateTime64(P)` → `String` pre-formatted via `ClickHouseDateTimeFormat.formatNanos/formatMicros`
-  (UTC). Don't use `Instant.toString()` — its `T`/`Z` form trips the fast-path.
-- `Map(K,V)` → bind a Java `Map`. Don't compose `mapFromArrays(...)` in SQL.
-- `Decimal128(S)` → bind a `BigDecimal`. `.toString()` would emit a quoted string, which
-  Decimal cells also reject from the fast-path.
-- Non-nullable cell whose model value is null → substitute the column DEFAULT in Java
-  (e.g. `Instant.now()` for `now64()`, `'default'` for an Enum8 default), don't rely on
-  a SQL-side `if(:x IS NULL, ...)`.
-
-Single-row `INSERT ... SELECT` / `UPDATE` templates are not subject to this rule — the
-Values fast-path doesn't apply there, so the existing wrappers stay.
+Bind the right shape:
+- `DateTime64(P)` → `String` formatted via `ClickHouseDateTimeFormat.formatNanos/formatMicros`
+  (not `Instant.toString()` — its `T`/`Z` form trips the fast-path).
+- `Map(K,V)` → bind a Java `Map`.
+- `Decimal128(S)` → bind a `BigDecimal` (`.toString()` would emit a quoted string which
+  Decimal cells also reject).
+- Non-nullable cell, value null → substitute the column DEFAULT in Java (e.g.
+  `Instant.now()` for `now64()`, `'default'` for an Enum8 default).
 
 ## Numeric Gotchas
 

--- a/.agents/skills/opik-backend/clickhouse.md
+++ b/.agents/skills/opik-backend/clickhouse.md
@@ -108,6 +108,28 @@ WHERE id \\<= :uuid_to_time
 .bind("workspaceId", workspaceId)
 ```
 
+## `FORMAT Values` cells must be literals (OPIK-5694)
+
+In `INSERT ... FORMAT Values` templates, every cell in the per-row tuple must be a plain
+`:placeholder` bound to a value the driver serialises as a canonical literal. Function
+calls, `if(...)`, `::` casts, `parseDateTime64BestEffort(...)`, `now64(...)`,
+`mapFromArrays(...)`, `toDecimal128(...)` etc. trip ClickHouse's fast-path parser. The
+insert still succeeds (CH falls back to the slow path), but every row silently bumps
+`system.errors` codes 26 / 27 / 43 / 70 and writes to pod stderr — flooding logs at QPS.
+
+Bind the right shape so the driver emits a literal:
+- `DateTime64(P)` → `String` pre-formatted via `ClickHouseDateTimeFormat.formatNanos/formatMicros`
+  (UTC). Don't use `Instant.toString()` — its `T`/`Z` form trips the fast-path.
+- `Map(K,V)` → bind a Java `Map`. Don't compose `mapFromArrays(...)` in SQL.
+- `Decimal128(S)` → bind a `BigDecimal`. `.toString()` would emit a quoted string, which
+  Decimal cells also reject from the fast-path.
+- Non-nullable cell whose model value is null → substitute the column DEFAULT in Java
+  (e.g. `Instant.now()` for `now64()`, `'default'` for an Enum8 default), don't rely on
+  a SQL-side `if(:x IS NULL, ...)`.
+
+Single-row `INSERT ... SELECT` / `UPDATE` templates are not subject to this rule — the
+Values fast-path doesn't apply there, so the existing wrappers stay.
+
 ## Numeric Gotchas
 
 ### Handle NaN/Infinity

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -1558,7 +1558,15 @@ public class SpanDAO {
 
                 TruncationUtils.bindTruncationThreshold(statement, "truncation_threshold" + i, configuration);
 
-                bindCostForBulkInsert(span, statement, i);
+                // BULK_INSERT writes the cost cell directly into Decimal128(12) (no toDecimal128
+                // wrap), so the driver must emit an unquoted numeric literal — bind the
+                // BigDecimal itself rather than its String form. See OPIK-5694.
+                BigDecimal cost = span.totalEstimatedCost() != null ? span.totalEstimatedCost() : calculateCost(span);
+                statement.bind("total_estimated_cost" + i, cost);
+                statement.bind("total_estimated_cost_version" + i,
+                        span.totalEstimatedCost() == null && cost.compareTo(BigDecimal.ZERO) > 0
+                                ? ESTIMATED_COST_VERSION
+                                : "");
 
                 if (span.ttft() != null) {
                     statement.bind("ttft" + i, span.ttft());
@@ -2568,14 +2576,6 @@ public class SpanDAO {
                 spanUpdate.metadata()).compareTo(BigDecimal.ZERO) > 0;
     }
 
-    /**
-     * Cost binder for the single-row INSERT and UPDATE templates. Those SQL templates wrap the
-     * cell as {@code toDecimal128(:total_estimated_cost, 12)} — they expect a quoted string the
-     * driver wraps with {@code '...'}, so {@code toDecimal128('123.456', 12)} parses via the
-     * Decimal-aware string path and is lossless. Binding a {@link BigDecimal} here would let the
-     * driver emit an unquoted numeric, and {@code toDecimal128(123.456, 12)} would route through
-     * Float64 first (precision drift on 17+ significant-digit values).
-     */
     private void bindCost(Span span, Statement statement, String index) {
         if (span.totalEstimatedCost() != null) {
             // Cost is set manually by the user
@@ -2587,23 +2587,6 @@ public class SpanDAO {
             statement.bind("total_estimated_cost_version" + index,
                     estimatedCost.compareTo(BigDecimal.ZERO) > 0 ? ESTIMATED_COST_VERSION : "");
         }
-    }
-
-    /**
-     * Cost binder for {@link #BULK_INSERT}. The cell in that template is now a bare
-     * {@code :total_estimated_cost<idx>} placeholder (no {@code toDecimal128(...)} wrap), so the
-     * driver must emit an unquoted numeric literal — which means binding the value as a
-     * {@link BigDecimal}. CH parses the literal directly into the {@code Decimal128(12)} column
-     * without a Float64 detour, preserving precision and avoiding the FORMAT Values fast-path
-     * fallback that a quoted-decimal-into-Decimal128-cell would trip.
-     */
-    private void bindCostForBulkInsert(Span span, Statement statement, int index) {
-        BigDecimal cost = span.totalEstimatedCost() != null ? span.totalEstimatedCost() : calculateCost(span);
-        statement.bind("total_estimated_cost" + index, cost);
-        statement.bind("total_estimated_cost_version" + index,
-                span.totalEstimatedCost() != null
-                        ? ""
-                        : (cost.compareTo(BigDecimal.ZERO) > 0 ? ESTIMATED_COST_VERSION : ""));
     }
 
     @WithSpan

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -17,6 +17,7 @@ import com.comet.opik.domain.stats.StatsMapper;
 import com.comet.opik.domain.utils.DemoDataExclusionUtils;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.utils.ClickHouseDateTimeFormat;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.TruncationUtils;
 import com.comet.opik.utils.template.TemplateUtils;
@@ -128,8 +129,8 @@ public class SpanDAO {
                         :parent_span_id<item.index>,
                         :name<item.index>,
                         :type<item.index>,
-                        parseDateTime64BestEffort(:start_time<item.index>, 9),
-                        if(:end_time<item.index> IS NULL, NULL, parseDateTime64BestEffort(:end_time<item.index>, 9)),
+                        :start_time<item.index>,
+                        :end_time<item.index>,
                         :input<item.index>,
                         :output<item.index>,
                         :metadata<item.index>,
@@ -139,7 +140,7 @@ public class SpanDAO {
                         :total_estimated_cost_version<item.index>,
                         :tags<item.index>,
                         mapFromArrays(:usage_keys<item.index>, :usage_values<item.index>),
-                        if(:last_updated_at<item.index> IS NULL, now64(6), parseDateTime64BestEffort(:last_updated_at<item.index>, 6)),
+                        :last_updated_at<item.index>,
                         :error_info<item.index>,
                         :created_by<item.index>,
                         :last_updated_by<item.index>,
@@ -1520,7 +1521,7 @@ public class SpanDAO {
                         .bind("trace_id" + i, span.traceId())
                         .bind("name" + i, StringUtils.defaultIfBlank(span.name(), ""))
                         .bind("type" + i, Objects.toString(span.type(), SpanType.UNKNOWN_VALUE))
-                        .bind("start_time" + i, span.startTime().toString())
+                        .bind("start_time" + i, ClickHouseDateTimeFormat.formatNanos(span.startTime()))
                         .bind("parent_span_id" + i, span.parentSpanId() != null ? span.parentSpanId() : "")
                         .bind("input" + i, inputValue)
                         .bind("output" + i, outputValue)
@@ -1536,7 +1537,7 @@ public class SpanDAO {
                         .bind("output_slim" + i, TruncationUtils.createSlimJsonString(outputValue));
 
                 if (span.endTime() != null) {
-                    statement.bind("end_time" + i, span.endTime().toString());
+                    statement.bind("end_time" + i, ClickHouseDateTimeFormat.formatNanos(span.endTime()));
                 } else {
                     statement.bindNull("end_time" + i, String.class);
                 }
@@ -1559,11 +1560,12 @@ public class SpanDAO {
                     statement.bind("usage_values" + i, new Integer[]{});
                 }
 
-                if (span.lastUpdatedAt() != null) {
-                    statement.bind("last_updated_at" + i, span.lastUpdatedAt().toString());
-                } else {
-                    statement.bindNull("last_updated_at" + i, String.class);
-                }
+                // Format the timestamp client-side so the SQL contains a plain string literal in the
+                // last_updated_at cell. Fall back to "now" when the client did not provide a value —
+                // matches the column's DEFAULT now64(6) but avoids the function call in the tuple
+                // that would trip the FORMAT Values fast-path. See OPIK-5694.
+                statement.bind("last_updated_at" + i, ClickHouseDateTimeFormat.formatMicros(
+                        span.lastUpdatedAt() != null ? span.lastUpdatedAt() : Instant.now()));
 
                 TruncationUtils.bindTruncationThreshold(statement, "truncation_threshold" + i, configuration);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -306,7 +306,7 @@ public class SpanDAO {
                     :metadata as metadata,
                     :model as model,
                     :provider as provider,
-                    toDecimal128(:total_estimated_cost, 12) as total_estimated_cost,
+                    :total_estimated_cost as total_estimated_cost,
                     :total_estimated_cost_version as total_estimated_cost_version,
                     :tags as tags,
                     mapFromArrays(:usage_keys, :usage_values) as usage,
@@ -383,7 +383,7 @@ public class SpanDAO {
             	<if(metadata)> :metadata <else> metadata <endif> as metadata,
             	<if(model)> :model <else> model <endif> as model,
             	<if(provider)> :provider <else> provider <endif> as provider,
-            	<if(total_estimated_cost)> toDecimal128(:total_estimated_cost, 12) <else> total_estimated_cost <endif> as total_estimated_cost,
+            	<if(total_estimated_cost)> :total_estimated_cost <else> total_estimated_cost <endif> as total_estimated_cost,
             	<if(total_estimated_cost_version)> :total_estimated_cost_version <else> total_estimated_cost_version <endif> as total_estimated_cost_version,
             	<if(tags)> :tags <else> tags <endif> as tags,
             	<if(usage)> CAST((:usageKeys, :usageValues), 'Map(String, Int64)') <else> usage <endif> as usage,
@@ -553,7 +553,7 @@ public class SpanDAO {
                     <if(metadata)> :metadata <else> '' <endif> as metadata,
                     <if(model)> :model <else> '' <endif> as model,
                     <if(provider)> :provider <else> '' <endif> as provider,
-                    <if(total_estimated_cost)> toDecimal128(:total_estimated_cost, 12) <else> toDecimal128(0, 12) <endif> as total_estimated_cost,
+                    <if(total_estimated_cost)> :total_estimated_cost <else> 0 <endif> as total_estimated_cost,
                     <if(total_estimated_cost_version)> :total_estimated_cost_version <else> '' <endif> as total_estimated_cost_version,
                     <if(tags)> :tags <else> [] <endif> as tags,
                     <if(usage)> CAST((:usageKeys, :usageValues), 'Map(String, Int64)') <else>  mapFromArrays([], []) <endif> as usage,
@@ -1449,7 +1449,7 @@ public class SpanDAO {
                 <if(metadata)> :metadata <else> s.metadata <endif> as metadata,
                 <if(model)> :model <else> s.model <endif> as model,
                 <if(provider)> :provider <else> s.provider <endif> as provider,
-                <if(total_estimated_cost)> toDecimal128(:total_estimated_cost, 12) <else> s.total_estimated_cost <endif> as total_estimated_cost,
+                <if(total_estimated_cost)> :total_estimated_cost <else> s.total_estimated_cost <endif> as total_estimated_cost,
                 <if(total_estimated_cost_version)> :total_estimated_cost_version <else> s.total_estimated_cost_version <endif> as total_estimated_cost_version,
                 """
             + TagOperations.tagUpdateFragment("s.tags")
@@ -1562,15 +1562,7 @@ public class SpanDAO {
 
                 TruncationUtils.bindTruncationThreshold(statement, "truncation_threshold" + i, configuration);
 
-                // BULK_INSERT writes the cost cell directly into Decimal128(12) (no toDecimal128
-                // wrap), so the driver must emit an unquoted numeric literal — bind the
-                // BigDecimal itself rather than its String form. See OPIK-5694.
-                BigDecimal cost = span.totalEstimatedCost() != null ? span.totalEstimatedCost() : calculateCost(span);
-                statement.bind("total_estimated_cost" + i, cost);
-                statement.bind("total_estimated_cost_version" + i,
-                        span.totalEstimatedCost() == null && cost.compareTo(BigDecimal.ZERO) > 0
-                                ? ESTIMATED_COST_VERSION
-                                : "");
+                bindCost(span, statement, String.valueOf(i));
 
                 if (span.ttft() != null) {
                     statement.bind("ttft" + i, span.ttft());
@@ -2581,16 +2573,17 @@ public class SpanDAO {
     }
 
     private void bindCost(Span span, Statement statement, String index) {
-        if (span.totalEstimatedCost() != null) {
-            // Cost is set manually by the user
-            statement.bind("total_estimated_cost" + index, span.totalEstimatedCost().toString());
-            statement.bind("total_estimated_cost_version" + index, "");
-        } else {
-            BigDecimal estimatedCost = calculateCost(span);
-            statement.bind("total_estimated_cost" + index, estimatedCost.toString());
-            statement.bind("total_estimated_cost_version" + index,
-                    estimatedCost.compareTo(BigDecimal.ZERO) > 0 ? ESTIMATED_COST_VERSION : "");
-        }
+        // Bind BigDecimal directly so the driver emits an unquoted numeric literal. Every
+        // SQL site for this column writes straight into a Decimal128(12) cell without a
+        // toDecimal128(...) wrap, so CH parses the literal directly into the column type
+        // (no Float64 detour, no precision drift) and FORMAT Values stays on the streaming
+        // parser fast path. See OPIK-5694.
+        BigDecimal cost = span.totalEstimatedCost() != null ? span.totalEstimatedCost() : calculateCost(span);
+        statement.bind("total_estimated_cost" + index, cost);
+        statement.bind("total_estimated_cost_version" + index,
+                span.totalEstimatedCost() == null && cost.compareTo(BigDecimal.ZERO) > 0
+                        ? ESTIMATED_COST_VERSION
+                        : "");
     }
 
     @WithSpan

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -136,10 +136,10 @@ public class SpanDAO {
                         :metadata<item.index>,
                         :model<item.index>,
                         :provider<item.index>,
-                        toDecimal128(:total_estimated_cost<item.index>, 12),
+                        :total_estimated_cost<item.index>,
                         :total_estimated_cost_version<item.index>,
                         :tags<item.index>,
-                        mapFromArrays(:usage_keys<item.index>, :usage_values<item.index>),
+                        :usage<item.index>,
                         :last_updated_at<item.index>,
                         :error_info<item.index>,
                         :created_by<item.index>,
@@ -1542,23 +1542,12 @@ public class SpanDAO {
                     statement.bindNull("end_time" + i, String.class);
                 }
 
-                if (span.usage() != null) {
-                    Stream.Builder<String> keys = Stream.builder();
-                    Stream.Builder<Integer> values = Stream.builder();
-
-                    span.usage().forEach((key, value) -> {
-                        if (Objects.nonNull(value)) {
-                            keys.add(key);
-                            values.add(value);
-                        }
-                    });
-
-                    statement.bind("usage_keys" + i, keys.build().toArray(String[]::new));
-                    statement.bind("usage_values" + i, values.build().toArray(Integer[]::new));
-                } else {
-                    statement.bind("usage_keys" + i, new String[]{});
-                    statement.bind("usage_values" + i, new Integer[]{});
-                }
+                Map<String, Integer> usageMap = span.usage() == null
+                        ? Map.of()
+                        : span.usage().entrySet().stream()
+                                .filter(e -> e.getValue() != null)
+                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                statement.bind("usage" + i, usageMap);
 
                 // Format the timestamp client-side so the SQL contains a plain string literal in the
                 // last_updated_at cell. Fall back to "now" when the client did not provide a value —
@@ -2582,11 +2571,11 @@ public class SpanDAO {
     private void bindCost(Span span, Statement statement, String index) {
         if (span.totalEstimatedCost() != null) {
             // Cost is set manually by the user
-            statement.bind("total_estimated_cost" + index, span.totalEstimatedCost().toString());
+            statement.bind("total_estimated_cost" + index, span.totalEstimatedCost());
             statement.bind("total_estimated_cost_version" + index, "");
         } else {
             BigDecimal estimatedCost = calculateCost(span);
-            statement.bind("total_estimated_cost" + index, estimatedCost.toString());
+            statement.bind("total_estimated_cost" + index, estimatedCost);
             statement.bind("total_estimated_cost_version" + index,
                     estimatedCost.compareTo(BigDecimal.ZERO) > 0 ? ESTIMATED_COST_VERSION : "");
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -1511,6 +1511,10 @@ public class SpanDAO {
 
             Statement statement = connection.createStatement(template.render());
 
+            // Captured once per batch so every row whose client did not provide lastUpdatedAt gets
+            // the same timestamp — matches the prior server-side now64(6) semantics.
+            Instant nowForBatch = Instant.now();
+
             int i = 0;
             for (Span span : spans) {
                 String inputValue = TruncationUtils.toJsonString(span.input());
@@ -1554,7 +1558,7 @@ public class SpanDAO {
                 // matches the column's DEFAULT now64(6) but avoids the function call in the tuple
                 // that would trip the FORMAT Values fast-path. See OPIK-5694.
                 statement.bind("last_updated_at" + i, ClickHouseDateTimeFormat.formatMicros(
-                        span.lastUpdatedAt() != null ? span.lastUpdatedAt() : Instant.now()));
+                        span.lastUpdatedAt() != null ? span.lastUpdatedAt() : nowForBatch));
 
                 TruncationUtils.bindTruncationThreshold(statement, "truncation_threshold" + i, configuration);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -1558,7 +1558,7 @@ public class SpanDAO {
 
                 TruncationUtils.bindTruncationThreshold(statement, "truncation_threshold" + i, configuration);
 
-                bindCost(span, statement, String.valueOf(i));
+                bindCostForBulkInsert(span, statement, i);
 
                 if (span.ttft() != null) {
                     statement.bind("ttft" + i, span.ttft());
@@ -2568,17 +2568,42 @@ public class SpanDAO {
                 spanUpdate.metadata()).compareTo(BigDecimal.ZERO) > 0;
     }
 
+    /**
+     * Cost binder for the single-row INSERT and UPDATE templates. Those SQL templates wrap the
+     * cell as {@code toDecimal128(:total_estimated_cost, 12)} — they expect a quoted string the
+     * driver wraps with {@code '...'}, so {@code toDecimal128('123.456', 12)} parses via the
+     * Decimal-aware string path and is lossless. Binding a {@link BigDecimal} here would let the
+     * driver emit an unquoted numeric, and {@code toDecimal128(123.456, 12)} would route through
+     * Float64 first (precision drift on 17+ significant-digit values).
+     */
     private void bindCost(Span span, Statement statement, String index) {
         if (span.totalEstimatedCost() != null) {
             // Cost is set manually by the user
-            statement.bind("total_estimated_cost" + index, span.totalEstimatedCost());
+            statement.bind("total_estimated_cost" + index, span.totalEstimatedCost().toString());
             statement.bind("total_estimated_cost_version" + index, "");
         } else {
             BigDecimal estimatedCost = calculateCost(span);
-            statement.bind("total_estimated_cost" + index, estimatedCost);
+            statement.bind("total_estimated_cost" + index, estimatedCost.toString());
             statement.bind("total_estimated_cost_version" + index,
                     estimatedCost.compareTo(BigDecimal.ZERO) > 0 ? ESTIMATED_COST_VERSION : "");
         }
+    }
+
+    /**
+     * Cost binder for {@link #BULK_INSERT}. The cell in that template is now a bare
+     * {@code :total_estimated_cost<idx>} placeholder (no {@code toDecimal128(...)} wrap), so the
+     * driver must emit an unquoted numeric literal — which means binding the value as a
+     * {@link BigDecimal}. CH parses the literal directly into the {@code Decimal128(12)} column
+     * without a Float64 detour, preserving precision and avoiding the FORMAT Values fast-path
+     * fallback that a quoted-decimal-into-Decimal128-cell would trip.
+     */
+    private void bindCostForBulkInsert(Span span, Statement statement, int index) {
+        BigDecimal cost = span.totalEstimatedCost() != null ? span.totalEstimatedCost() : calculateCost(span);
+        statement.bind("total_estimated_cost" + index, cost);
+        statement.bind("total_estimated_cost_version" + index,
+                span.totalEstimatedCost() != null
+                        ? ""
+                        : (cost.compareTo(BigDecimal.ZERO) > 0 ? ESTIMATED_COST_VERSION : ""));
     }
 
     @WithSpan

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -306,7 +306,7 @@ public class SpanDAO {
                     :metadata as metadata,
                     :model as model,
                     :provider as provider,
-                    :total_estimated_cost as total_estimated_cost,
+                    toDecimal128(:total_estimated_cost, 12) as total_estimated_cost,
                     :total_estimated_cost_version as total_estimated_cost_version,
                     :tags as tags,
                     mapFromArrays(:usage_keys, :usage_values) as usage,
@@ -383,7 +383,7 @@ public class SpanDAO {
             	<if(metadata)> :metadata <else> metadata <endif> as metadata,
             	<if(model)> :model <else> model <endif> as model,
             	<if(provider)> :provider <else> provider <endif> as provider,
-            	<if(total_estimated_cost)> :total_estimated_cost <else> total_estimated_cost <endif> as total_estimated_cost,
+            	<if(total_estimated_cost)> toDecimal128(:total_estimated_cost, 12) <else> total_estimated_cost <endif> as total_estimated_cost,
             	<if(total_estimated_cost_version)> :total_estimated_cost_version <else> total_estimated_cost_version <endif> as total_estimated_cost_version,
             	<if(tags)> :tags <else> tags <endif> as tags,
             	<if(usage)> CAST((:usageKeys, :usageValues), 'Map(String, Int64)') <else> usage <endif> as usage,
@@ -553,7 +553,7 @@ public class SpanDAO {
                     <if(metadata)> :metadata <else> '' <endif> as metadata,
                     <if(model)> :model <else> '' <endif> as model,
                     <if(provider)> :provider <else> '' <endif> as provider,
-                    <if(total_estimated_cost)> :total_estimated_cost <else> 0 <endif> as total_estimated_cost,
+                    <if(total_estimated_cost)> toDecimal128(:total_estimated_cost, 12) <else> toDecimal128(0, 12) <endif> as total_estimated_cost,
                     <if(total_estimated_cost_version)> :total_estimated_cost_version <else> '' <endif> as total_estimated_cost_version,
                     <if(tags)> :tags <else> [] <endif> as tags,
                     <if(usage)> CAST((:usageKeys, :usageValues), 'Map(String, Int64)') <else>  mapFromArrays([], []) <endif> as usage,
@@ -1449,7 +1449,7 @@ public class SpanDAO {
                 <if(metadata)> :metadata <else> s.metadata <endif> as metadata,
                 <if(model)> :model <else> s.model <endif> as model,
                 <if(provider)> :provider <else> s.provider <endif> as provider,
-                <if(total_estimated_cost)> :total_estimated_cost <else> s.total_estimated_cost <endif> as total_estimated_cost,
+                <if(total_estimated_cost)> toDecimal128(:total_estimated_cost, 12) <else> s.total_estimated_cost <endif> as total_estimated_cost,
                 <if(total_estimated_cost_version)> :total_estimated_cost_version <else> s.total_estimated_cost_version <endif> as total_estimated_cost_version,
                 """
             + TagOperations.tagUpdateFragment("s.tags")
@@ -1562,7 +1562,15 @@ public class SpanDAO {
 
                 TruncationUtils.bindTruncationThreshold(statement, "truncation_threshold" + i, configuration);
 
-                bindCost(span, statement, String.valueOf(i));
+                // BULK_INSERT writes the cost cell directly into Decimal128(12) (no toDecimal128
+                // wrap), so the driver must emit an unquoted numeric literal — bind the
+                // BigDecimal itself rather than its String form. See OPIK-5694.
+                BigDecimal cost = span.totalEstimatedCost() != null ? span.totalEstimatedCost() : calculateCost(span);
+                statement.bind("total_estimated_cost" + i, cost);
+                statement.bind("total_estimated_cost_version" + i,
+                        span.totalEstimatedCost() == null && cost.compareTo(BigDecimal.ZERO) > 0
+                                ? ESTIMATED_COST_VERSION
+                                : "");
 
                 if (span.ttft() != null) {
                     statement.bind("ttft" + i, span.ttft());
@@ -2573,17 +2581,16 @@ public class SpanDAO {
     }
 
     private void bindCost(Span span, Statement statement, String index) {
-        // Bind BigDecimal directly so the driver emits an unquoted numeric literal. Every
-        // SQL site for this column writes straight into a Decimal128(12) cell without a
-        // toDecimal128(...) wrap, so CH parses the literal directly into the column type
-        // (no Float64 detour, no precision drift) and FORMAT Values stays on the streaming
-        // parser fast path. See OPIK-5694.
-        BigDecimal cost = span.totalEstimatedCost() != null ? span.totalEstimatedCost() : calculateCost(span);
-        statement.bind("total_estimated_cost" + index, cost);
-        statement.bind("total_estimated_cost_version" + index,
-                span.totalEstimatedCost() == null && cost.compareTo(BigDecimal.ZERO) > 0
-                        ? ESTIMATED_COST_VERSION
-                        : "");
+        if (span.totalEstimatedCost() != null) {
+            // Cost is set manually by the user
+            statement.bind("total_estimated_cost" + index, span.totalEstimatedCost().toString());
+            statement.bind("total_estimated_cost_version" + index, "");
+        } else {
+            BigDecimal estimatedCost = calculateCost(span);
+            statement.bind("total_estimated_cost" + index, estimatedCost.toString());
+            statement.bind("total_estimated_cost_version" + index,
+                    estimatedCost.compareTo(BigDecimal.ZERO) > 0 ? ESTIMATED_COST_VERSION : "");
+        }
     }
 
     @WithSpan

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -25,6 +25,7 @@ import com.comet.opik.domain.utils.DemoDataExclusionUtils;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
+import com.comet.opik.utils.ClickHouseDateTimeFormat;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.TruncationUtils;
 import com.comet.opik.utils.template.TemplateUtils;
@@ -218,18 +219,18 @@ class TraceDAOImpl implements TraceDAO {
                         :project_id<item.index>,
                         :workspace_id,
                         :name<item.index>,
-                        parseDateTime64BestEffort(:start_time<item.index>, 9),
-                        if(:end_time<item.index> IS NULL, NULL, parseDateTime64BestEffort(:end_time<item.index>, 9)),
+                        :start_time<item.index>,
+                        :end_time<item.index>,
                         :input<item.index>,
                         :output<item.index>,
                         :metadata<item.index>,
                         :tags<item.index>,
-                        if(:last_updated_at<item.index> IS NULL, now64(6), parseDateTime64BestEffort(:last_updated_at<item.index>, 6)),
+                        :last_updated_at<item.index>,
                         :error_info<item.index>,
                         :user_name,
                         :user_name,
                         :thread_id<item.index>,
-                        if(:visibility_mode<item.index> IS NULL, 'default', :visibility_mode<item.index>),
+                        :visibility_mode<item.index>,
                         :truncation_threshold<item.index>,
                         :input_slim<item.index>,
                         :output_slim<item.index>,
@@ -3262,7 +3263,7 @@ class TraceDAOImpl implements TraceDAO {
                 statement.bind("id" + i, trace.id())
                         .bind("project_id" + i, trace.projectId())
                         .bind("name" + i, StringUtils.defaultIfBlank(trace.name(), ""))
-                        .bind("start_time" + i, trace.startTime().toString())
+                        .bind("start_time" + i, ClickHouseDateTimeFormat.formatNanos(trace.startTime()))
                         .bind("tags" + i, trace.tags() != null ? trace.tags().toArray(String[]::new) : new String[]{})
                         .bind("error_info" + i,
                                 trace.errorInfo() != null ? JsonUtils.readTree(trace.errorInfo()).toString() : "")
@@ -3271,22 +3272,21 @@ class TraceDAOImpl implements TraceDAO {
                 bindInputOutputMetadataAndSlim(statement, trace, i);
 
                 if (trace.endTime() != null) {
-                    statement.bind("end_time" + i, trace.endTime().toString());
+                    statement.bind("end_time" + i, ClickHouseDateTimeFormat.formatNanos(trace.endTime()));
                 } else {
                     statement.bindNull("end_time" + i, String.class);
                 }
 
-                if (trace.lastUpdatedAt() != null) {
-                    statement.bind("last_updated_at" + i, trace.lastUpdatedAt().toString());
-                } else {
-                    statement.bindNull("last_updated_at" + i, String.class);
-                }
+                // Format the timestamp client-side so the SQL contains a plain string literal in the
+                // last_updated_at cell. Fall back to "now" when the client did not provide a value —
+                // matches the column's DEFAULT now64(6) but avoids the function call in the tuple
+                // that would trip the FORMAT Values fast-path. See OPIK-5694.
+                statement.bind("last_updated_at" + i, ClickHouseDateTimeFormat.formatMicros(
+                        trace.lastUpdatedAt() != null ? trace.lastUpdatedAt() : Instant.now()));
 
-                if (trace.visibilityMode() != null) {
-                    statement.bind("visibility_mode" + i, trace.visibilityMode().getValue());
-                } else {
-                    statement.bindNull("visibility_mode" + i, String.class);
-                }
+                statement.bind("visibility_mode" + i, trace.visibilityMode() != null
+                        ? trace.visibilityMode().getValue()
+                        : VisibilityMode.DEFAULT.getValue());
 
                 TruncationUtils.bindTruncationThreshold(statement, "truncation_threshold" + i, configuration);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -3258,6 +3258,12 @@ class TraceDAOImpl implements TraceDAO {
 
             Statement statement = connection.createStatement(template.render());
 
+            // Captured once per batch so every row whose client did not provide lastUpdatedAt gets
+            // the same timestamp — matches the prior server-side now64(6) semantics (CH evaluates
+            // it once per query) and avoids timing-sensitive ordering in downstream MAX(...)
+            // aggregations.
+            Instant nowForBatch = Instant.now();
+
             int i = 0;
             for (Trace trace : traces) {
                 statement.bind("id" + i, trace.id())
@@ -3282,7 +3288,7 @@ class TraceDAOImpl implements TraceDAO {
                 // matches the column's DEFAULT now64(6) but avoids the function call in the tuple
                 // that would trip the FORMAT Values fast-path. See OPIK-5694.
                 statement.bind("last_updated_at" + i, ClickHouseDateTimeFormat.formatMicros(
-                        trace.lastUpdatedAt() != null ? trace.lastUpdatedAt() : Instant.now()));
+                        trace.lastUpdatedAt() != null ? trace.lastUpdatedAt() : nowForBatch));
 
                 statement.bind("visibility_mode" + i, trace.visibilityMode() != null
                         ? trace.visibilityMode().getValue()

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadDAO.java
@@ -7,6 +7,7 @@ import com.comet.opik.api.events.ProjectWithPendingClosureTraceThreads;
 import com.comet.opik.domain.TagOperations;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils;
+import com.comet.opik.utils.ClickHouseDateTimeFormat;
 import com.comet.opik.utils.template.TemplateUtils;
 import com.google.common.base.Preconditions;
 import com.google.inject.ImplementedBy;
@@ -29,6 +30,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -90,10 +92,10 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
                          :status<item.index>,
                          :created_by<item.index>,
                          :last_updated_by<item.index>,
-                         parseDateTime64BestEffort(:created_at<item.index> , 9),
-                         parseDateTime64BestEffort(:last_updated_at<item.index> , 6),
+                         :created_at<item.index>,
+                         :last_updated_at<item.index>,
                          :tags<item.index>,
-                         mapFromArrays(:rule_ids<item.index>, :sampling<item.index>),
+                         :sampling_per_rule<item.index>,
                          :scored_at<item.index>,
                          :source<item.index>
                      )
@@ -317,8 +319,8 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
                 statement.bind("status" + i, item.status().getValue());
                 statement.bind("created_by" + i, item.createdBy());
                 statement.bind("last_updated_by" + i, userName);
-                statement.bind("created_at" + i, item.createdAt().toString());
-                statement.bind("last_updated_at" + i, item.lastUpdatedAt().toString());
+                statement.bind("created_at" + i, ClickHouseDateTimeFormat.formatNanos(item.createdAt()));
+                statement.bind("last_updated_at" + i, ClickHouseDateTimeFormat.formatMicros(item.lastUpdatedAt()));
 
                 if (item.tags() != null) {
                     statement.bind("tags" + i, item.tags().toArray(String[]::new));
@@ -326,15 +328,8 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
                     statement.bind("tags" + i, new String[]{});
                 }
 
-                if (item.sampling() != null) {
-                    UUID[] ruleIds = item.sampling().keySet().toArray(UUID[]::new);
-                    statement.bind("rule_ids" + i, ruleIds);
-                    statement.bind("sampling" + i,
-                            Arrays.stream(ruleIds).map(ruleId -> item.sampling().get(ruleId)).toArray(Boolean[]::new));
-                } else {
-                    statement.bind("rule_ids" + i, new UUID[]{});
-                    statement.bind("sampling" + i, new Boolean[]{});
-                }
+                statement.bind("sampling_per_rule" + i,
+                        item.sampling() != null ? item.sampling() : Map.of());
 
                 if (item.scoredAt() != null) {
                     statement.bind("scored_at" + i, item.scoredAt().toString());

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadDAO.java
@@ -332,9 +332,9 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
                         item.sampling() != null ? item.sampling() : Map.of());
 
                 if (item.scoredAt() != null) {
-                    statement.bind("scored_at" + i, item.scoredAt().toString());
+                    statement.bind("scored_at" + i, ClickHouseDateTimeFormat.formatNanos(item.scoredAt()));
                 } else {
-                    statement.bindNull("scored_at" + i, Instant.class);
+                    statement.bindNull("scored_at" + i, String.class);
                 }
 
                 if (item.source() != null) {
@@ -513,9 +513,9 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
                         : new String[]{});
 
                 if (traceThreadModel.scoredAt() != null) {
-                    statement.bind("scored_at" + i, traceThreadModel.scoredAt().toString());
+                    statement.bind("scored_at" + i, ClickHouseDateTimeFormat.formatNanos(traceThreadModel.scoredAt()));
                 } else {
-                    statement.bindNull("scored_at" + i, Instant.class);
+                    statement.bindNull("scored_at" + i, String.class);
                 }
 
                 if (traceThreadModel.source() != null) {
@@ -563,7 +563,7 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
             var statement = connection.createStatement(UPDATE_THREAD_SCORED_AT)
                     .bind("project_id", projectId)
                     .bind("thread_ids", threadIds)
-                    .bind("scored_at", scoredAt.toString());
+                    .bind("scored_at", ClickHouseDateTimeFormat.formatNanos(scoredAt));
 
             return makeMonoContextAware(bindUserNameAndWorkspaceContext(statement))
                     .flatMap(result -> Mono.from(result.getRowsUpdated()));

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/ClickHouseDateTimeFormat.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/ClickHouseDateTimeFormat.java
@@ -1,5 +1,6 @@
 package com.comet.opik.utils;
 
+import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 
 import java.time.Instant;
@@ -31,11 +32,11 @@ public class ClickHouseDateTimeFormat {
             .ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS")
             .withZone(ZoneOffset.UTC);
 
-    public static String formatNanos(Instant instant) {
+    public static String formatNanos(@NonNull Instant instant) {
         return NANOS.format(instant);
     }
 
-    public static String formatMicros(Instant instant) {
+    public static String formatMicros(@NonNull Instant instant) {
         return MICROS.format(instant);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/ClickHouseDateTimeFormat.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/ClickHouseDateTimeFormat.java
@@ -1,0 +1,41 @@
+package com.comet.opik.utils;
+
+import lombok.experimental.UtilityClass;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Canonical ClickHouse {@code DateTime64(<precision>)} text format, in UTC.
+ * <p>
+ * ClickHouse's {@code FORMAT Values} fast-path parser only recognises a literal in the canonical
+ * {@code 'yyyy-MM-dd HH:mm:ss.fff...'} form for {@code DateTime64} cells. Any function expression
+ * ({@code parseDateTime64BestEffort(...)}, {@code now64(...)}, {@code if(...)}, {@code ::} cast,
+ * etc.) trips the fast-path assertion and increments {@code system.errors} codes 26 / 27 / 43 — the
+ * silent counter pollution we observed in production (see OPIK-5694).
+ * <p>
+ * Use these formatters to produce the canonical text in Java <i>before</i> binding it to the SQL
+ * statement, so the rendered SQL contains a plain string literal.
+ */
+@UtilityClass
+public class ClickHouseDateTimeFormat {
+
+    /** Precision 9 — matches {@code DateTime64(9, 'UTC')} columns ({@code start_time}, {@code end_time}). */
+    public static final DateTimeFormatter NANOS = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS")
+            .withZone(ZoneOffset.UTC);
+
+    /** Precision 6 — matches {@code DateTime64(6, 'UTC')} columns ({@code last_updated_at}). */
+    public static final DateTimeFormatter MICROS = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS")
+            .withZone(ZoneOffset.UTC);
+
+    public static String formatNanos(Instant instant) {
+        return NANOS.format(instant);
+    }
+
+    public static String formatMicros(Instant instant) {
+        return MICROS.format(instant);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -2094,8 +2094,8 @@ class SpansResourceTest {
         }
 
         @Test
-        @DisplayName("when batch contains a span with null lastUpdatedAt, then no CANNOT_CONVERT_TYPE errors are emitted (OPIK-5694)")
-        void batch__whenSpanHasNullLastUpdatedAt__thenNoCannotConvertTypeErrors(
+        @DisplayName("when batch spans are inserted, no CANNOT_CONVERT_TYPE errors are emitted (OPIK-5694)")
+        void batch__whenSpansAreInserted__thenNoCannotConvertTypeErrors(
                 TransactionTemplateAsync templateAsync) {
             var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
             var workspaceId = UUID.randomUUID().toString();
@@ -2120,9 +2120,13 @@ class SpansResourceTest {
 
             long cannotConvertTypeAfter = readClickHouseErrorCount(templateAsync, 70);
 
+            // Code 70 (CANNOT_CONVERT_TYPE) is fully eliminated for spans by this PR. Codes 26 / 27 /
+            // 43 are NOT asserted here because spans BULK_INSERT still has function expressions in
+            // non-datetime cells (toDecimal128 for total_estimated_cost, mapFromArrays for usage)
+            // that trip the FORMAT Values fast-path. Datetime cells were the scope flagged on
+            // OPIK-5694 by Liya; the remaining contributors will need their own follow-up.
             assertThat(cannotConvertTypeAfter - cannotConvertTypeBefore)
-                    .as("batch insert must not emit CANNOT_CONVERT_TYPE errors (code 70) "
-                            + "into system.errors when spans have null lastUpdatedAt")
+                    .as("batch insert must not emit CANNOT_CONVERT_TYPE errors (code 70)")
                     .isZero();
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -2094,14 +2094,17 @@ class SpansResourceTest {
         }
 
         @Test
-        @DisplayName("when batch spans are inserted, no CANNOT_CONVERT_TYPE errors are emitted (OPIK-5694)")
-        void batch__whenSpansAreInserted__thenNoCannotConvertTypeErrors(
+        @DisplayName("when batch spans are inserted, no FORMAT Values fast-path errors are emitted (OPIK-5694)")
+        void batch__whenSpansAreInserted__thenNoFastPathErrorsEmitted(
                 TransactionTemplateAsync templateAsync) {
             var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
             var workspaceId = UUID.randomUUID().toString();
             AuthTestUtils.mockTargetWorkspace(wireMock.server(), API_KEY, workspaceName, workspaceId, USER);
 
-            long cannotConvertTypeBefore = readClickHouseErrorCount(templateAsync, 70);
+            long parseInputBefore = readClickHouseErrorCount(templateAsync, 27);
+            long convertTypeBefore = readClickHouseErrorCount(templateAsync, 70);
+            long illegalArgBefore = readClickHouseErrorCount(templateAsync, 43);
+            long parseQuotedBefore = readClickHouseErrorCount(templateAsync, 26);
 
             var spanWithNullLastUpdatedAt = podamFactory.manufacturePojo(Span.class).toBuilder()
                     .endTime(null)
@@ -2118,15 +2121,19 @@ class SpansResourceTest {
             spanResourceClient.batchCreateSpans(List.of(spanWithNullLastUpdatedAt, spanWithEndTime),
                     API_KEY, workspaceName);
 
-            long cannotConvertTypeAfter = readClickHouseErrorCount(templateAsync, 70);
-
-            // Code 70 (CANNOT_CONVERT_TYPE) is fully eliminated for spans by this PR. Codes 26 / 27 /
-            // 43 are NOT asserted here because spans BULK_INSERT still has function expressions in
-            // non-datetime cells (toDecimal128 for total_estimated_cost, mapFromArrays for usage)
-            // that trip the FORMAT Values fast-path. Datetime cells were the scope flagged on
-            // OPIK-5694 by Liya; the remaining contributors will need their own follow-up.
-            assertThat(cannotConvertTypeAfter - cannotConvertTypeBefore)
-                    .as("batch insert must not emit CANNOT_CONVERT_TYPE errors (code 70)")
+            // After the fix, the spans BULK_INSERT must not increment any of the FORMAT Values
+            // fast-path counters. See OPIK-5694.
+            assertThat(readClickHouseErrorCount(templateAsync, 70) - convertTypeBefore)
+                    .as("CANNOT_CONVERT_TYPE (70): NULL bound to non-nullable last_updated_at")
+                    .isZero();
+            assertThat(readClickHouseErrorCount(templateAsync, 27) - parseInputBefore)
+                    .as("CANNOT_PARSE_INPUT_ASSERTION_FAILED (27): function expressions in Values cells")
+                    .isZero();
+            assertThat(readClickHouseErrorCount(templateAsync, 43) - illegalArgBefore)
+                    .as("ILLEGAL_TYPE_OF_ARGUMENT (43): same fast-path fallback path")
+                    .isZero();
+            assertThat(readClickHouseErrorCount(templateAsync, 26) - parseQuotedBefore)
+                    .as("CANNOT_PARSE_QUOTED_STRING (26): same fast-path fallback path")
                     .isZero();
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -2106,20 +2106,26 @@ class SpansResourceTest {
             long illegalArgBefore = readClickHouseErrorCount(templateAsync, 43);
             long parseQuotedBefore = readClickHouseErrorCount(templateAsync, 26);
 
-            var spanWithNullLastUpdatedAt = podamFactory.manufacturePojo(Span.class).toBuilder()
+            // Cover every null/non-null branch of the fields this PR touches in BULK_INSERT:
+            // - endTime: null (row A) + non-null (row B)
+            // - lastUpdatedAt: null (row A) + non-null (row B)
+            // - usage: null (row A) + non-empty Map (row B)
+            // - totalEstimatedCost: null (row A, calculated path) + explicit BigDecimal (row B)
+            var rowA = podamFactory.manufacturePojo(Span.class).toBuilder()
                     .endTime(null)
                     .duration(null)
                     .lastUpdatedAt(null)
-                    .feedbackScores(null)
+                    .usage(null)
                     .totalEstimatedCost(null)
+                    .feedbackScores(null)
                     .build();
-            var spanWithEndTime = podamFactory.manufacturePojo(Span.class).toBuilder()
+            var rowB = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .usage(Map.of("prompt_tokens", 12, "completion_tokens", 7))
+                    .totalEstimatedCost(new java.math.BigDecimal("0.000123456789"))
                     .feedbackScores(null)
-                    .totalEstimatedCost(null)
                     .build();
 
-            spanResourceClient.batchCreateSpans(List.of(spanWithNullLastUpdatedAt, spanWithEndTime),
-                    API_KEY, workspaceName);
+            spanResourceClient.batchCreateSpans(List.of(rowA, rowB), API_KEY, workspaceName);
 
             // After the fix, the spans BULK_INSERT must not increment any of the FORMAT Values
             // fast-path counters. See OPIK-5694.

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -2957,8 +2957,8 @@ class TracesResourceTest {
         }
 
         @Test
-        @DisplayName("when batch contains a trace with null lastUpdatedAt, then no CANNOT_CONVERT_TYPE errors are emitted (OPIK-5694)")
-        void batch__whenTraceHasNullLastUpdatedAt__thenNoCannotConvertTypeErrors(
+        @DisplayName("when batch traces are inserted, no FORMAT Values fast-path errors are emitted (OPIK-5694)")
+        void batch__whenTracesAreInserted__thenNoFastPathErrorsEmitted(
                 TransactionTemplateAsync templateAsync) {
             var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
             var workspaceId = UUID.randomUUID().toString();
@@ -2966,7 +2966,10 @@ class TracesResourceTest {
 
             var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(16);
 
-            long cannotConvertTypeBefore = readClickHouseErrorCount(templateAsync, 70);
+            long parseInputBefore = readClickHouseErrorCount(templateAsync, 27);
+            long convertTypeBefore = readClickHouseErrorCount(templateAsync, 70);
+            long illegalArgBefore = readClickHouseErrorCount(templateAsync, 43);
+            long parseQuotedBefore = readClickHouseErrorCount(templateAsync, 26);
 
             var traceWithNullLastUpdatedAt = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectName(projectName)
@@ -2992,11 +2995,20 @@ class TracesResourceTest {
                 assertThat(retrieved.id()).isEqualTo(trace.id());
             }
 
-            long cannotConvertTypeAfter = readClickHouseErrorCount(templateAsync, 70);
-
-            assertThat(cannotConvertTypeAfter - cannotConvertTypeBefore)
-                    .as("batch insert must not emit CANNOT_CONVERT_TYPE errors (code 70) "
-                            + "into system.errors. Production sees ~30k of these per hour from this code path.")
+            // The trace BATCH_INSERT and the side-effect trace_threads INSERT must both stop
+            // tripping the FORMAT Values fast-path. These counters are silent in production (the
+            // inserts succeed) but pollute system.errors and pod stderr. See OPIK-5694.
+            assertThat(readClickHouseErrorCount(templateAsync, 70) - convertTypeBefore)
+                    .as("CANNOT_CONVERT_TYPE (70): NULL bound to non-nullable last_updated_at")
+                    .isZero();
+            assertThat(readClickHouseErrorCount(templateAsync, 27) - parseInputBefore)
+                    .as("CANNOT_PARSE_INPUT_ASSERTION_FAILED (27): function expressions in Values cells")
+                    .isZero();
+            assertThat(readClickHouseErrorCount(templateAsync, 43) - illegalArgBefore)
+                    .as("ILLEGAL_TYPE_OF_ARGUMENT (43): same fast-path fallback path")
+                    .isZero();
+            assertThat(readClickHouseErrorCount(templateAsync, 26) - parseQuotedBefore)
+                    .as("CANNOT_PARSE_QUOTED_STRING (26): same fast-path fallback path")
                     .isZero();
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -2971,21 +2971,33 @@ class TracesResourceTest {
             long illegalArgBefore = readClickHouseErrorCount(templateAsync, 43);
             long parseQuotedBefore = readClickHouseErrorCount(templateAsync, 26);
 
-            var traceWithNullLastUpdatedAt = factory.manufacturePojo(Trace.class).toBuilder()
+            // Cover every null/non-null branch of the fields this PR touches:
+            // - endTime: null (row A) + non-null (rows B / C)
+            // - lastUpdatedAt: null (row A) + non-null (rows B / C)
+            // - visibilityMode: null (row A) + DEFAULT (row B) + HIDDEN (row C)
+            var rowA = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectName(projectName)
                     .endTime(null)
                     .duration(null)
                     .lastUpdatedAt(null)
+                    .visibilityMode(null)
                     .usage(null)
                     .feedbackScores(null)
                     .build();
-            var traceWithEndTime = factory.manufacturePojo(Trace.class).toBuilder()
+            var rowB = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectName(projectName)
+                    .visibilityMode(VisibilityMode.DEFAULT)
+                    .usage(null)
+                    .feedbackScores(null)
+                    .build();
+            var rowC = factory.manufacturePojo(Trace.class).toBuilder()
+                    .projectName(projectName)
+                    .visibilityMode(VisibilityMode.HIDDEN)
                     .usage(null)
                     .feedbackScores(null)
                     .build();
 
-            var traces = List.of(traceWithNullLastUpdatedAt, traceWithEndTime);
+            var traces = List.of(rowA, rowB, rowC);
 
             traceResourceClient.batchCreateTraces(traces, API_KEY, workspaceName);
 


### PR DESCRIPTION
## Details

> "All involve `parseDateTime64BestEffort(...)` and `now64(...)` being literal-substituted into the SQL string by the query builder, rather than bound as parameters. […] Datetime fields are textually substituted into the SQL string *before* the row is sent."
(Liya Katz nailed the root cause on the ticket)

This PR is the empirical realisation of that diagnosis. After the previous code-70 fix landed, production ClickHouse was still logging a sustained stream of `CANNOT_PARSE_INPUT_ASSERTION_FAILED` (code 27), `ILLEGAL_TYPE_OF_ARGUMENT` (code 43), and `CANNOT_PARSE_QUOTED_STRING` (code 26) errors from the trace/span/thread batch ingestion paths. The inserts succeed, but every batch INSERT statement counts an error in `system.errors` and writes to pod stderr.

We empirically isolated this against ClickHouse `25.3.6.56` (test container) and `25.3.8` (production version): every column whose value in the per-row tuple is a function call instead of a recognised literal trips the Values fast-path and counts an assertion in `system.errors`. The Values fast path only recognises canonical literals — quoted strings, plain numbers, NULL, array literals `[...]`, map literals `{key : value}`. Anything else (`parseDateTime64BestEffort(...)`, `now64(...)`, `if(... IS NULL, ...)`, `toDecimal128(...)`, `mapFromArrays(...)`, `'...'::Type` casts) falls back to the slow path and increments the counter once per offending cell per statement.

### Fix

For every datetime/decimal/map cell in the three FORMAT Values templates affected, build the canonical literal in Java and bind it as a plain value, dropping every wrapping function from the SQL.

| Template | Cell | Before | After |
|---|---|---|---|
| `TraceDAO.BATCH_INSERT` | `start_time` | `parseDateTime64BestEffort(:start_time, 9)` | `:start_time` (canonical text via `ClickHouseDateTimeFormat.formatNanos`) |
| | `end_time` | `if(:end_time IS NULL, NULL, parseDateTime64BestEffort(...))` | `:end_time` (canonical text or `bindNull` → literal `NULL`) |
| | `last_updated_at` | `if(:last_updated_at IS NULL, now64(6), parseDateTime64BestEffort(...))` | `:last_updated_at` (canonical text; null → `Instant.now()` formatted) |
| | `visibility_mode` | `if(:visibility_mode IS NULL, 'default', :visibility_mode)` | `:visibility_mode` (binds `'default'` literal when null) |
| `SpanDAO.BULK_INSERT` | `start_time` / `end_time` / `last_updated_at` | same as above | same as above |
| | `total_estimated_cost` | `toDecimal128(:total_estimated_cost, 12)` | `:total_estimated_cost` (bind `BigDecimal` directly → driver emits plain numeric) |
| | `usage` | `mapFromArrays(:usage_keys, :usage_values)` | `:usage` (bind `Map<String, Integer>` directly → driver emits `{'k' : v}` literal) |
| `TraceThreadDAO.INSERT_THREADS_SQL` | `created_at` / `last_updated_at` | `parseDateTime64BestEffort(...)` | canonical text in Java |
| | `sampling_per_rule` | `mapFromArrays(:rule_ids, :sampling)` | `:sampling_per_rule` (bind `Map<UUID, Boolean>` directly) |

Other templates in the same files (single-row `INSERT … SELECT`, `UPDATE_SPAN_SQL`, `UPDATE_THREAD_SQL`) were audited and left alone — they don't use `FORMAT Values`, so the fast-path issue doesn't apply.

New util `ClickHouseDateTimeFormat` exposes `formatNanos` / `formatMicros` (UTC) for the two precision flavours used by the schema.

The ClickHouse skill (`.agents/skills/opik-backend/clickhouse.md`) gets a short section codifying the rule for future contributors: in `FORMAT Values` templates every cell must be a plain `:placeholder` bound to a value the driver serialises as a literal — function calls, casts, and `if(...)` wrappers in cells flood `system.errors` even when the insert succeeds.

Behaviour visible to API consumers is unchanged: `lastUpdatedAt` still defaults to "now" when omitted (the column DEFAULT was `now64(6)`, we now compute `Instant.now()` in Java and format it the same way), `visibilityMode` still defaults to `'default'`, costs and usage are still recorded with the same precision and shape.

The previous code-70 fix on this ticket (`if(... IS NULL, now64(6), parseDateTime64BestEffort(...))`) is now superseded — the canonical-literal approach eliminates the same NULL→non-nullable conversion failure from a different angle, plus codes 26/27/43.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-5694

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6 / 4.7
- Scope: assisted (empirical isolation against two ClickHouse builds via raw HTTP, fix design, regression tests, PR write-up). Liya Katz authored the root-cause analysis on the ticket; this PR realises it.
- Human verification: code review + side-by-side comparison of `system.errors` counters before/after the fix; targeted run of all 31 BatchInsert tests across `TracesResourceTest` and `SpansResourceTest`

## Testing

Commands run:

```
mvn -B compile -DskipTests
mvn -B spotless:check
mvn -B test -Dtest='TracesResourceTest$BatchInsert,SpansResourceTest$BatchInsert'
mvn -B test -Dtest='FindTraceThreadsResourceTest,TraceThreadListenerTest,TraceThreadsClosingJobTest'
```

Results:
- `TracesResourceTest$BatchInsert`: 19 tests pass.
- `SpansResourceTest$BatchInsert`: 12 tests pass.
- `FindTraceThreadsResourceTest` + `TraceThreadListenerTest` + `TraceThreadsClosingJobTest`: 407 tests pass (covers the modified `TraceThreadDAO.INSERT_THREADS_SQL` path).

Scenarios validated:
- Pre-fix tests `batch__whenTracesAreInserted__thenNoFastPathErrorsEmitted` and `batch__whenSpansAreInserted__thenNoFastPathErrorsEmitted` measure `system.errors` deltas for codes 26 / 27 / 43 / 70 across `batchCreateTraces` / `batchCreateSpans`. With the fix, all four counters' deltas are zero. Without the fix the same tests would fail on multiple counters at once.
- Persistence verified: each test calls `getById` for every inserted row to confirm rows are still present and the materialised `duration` column still computes correctly.
- Bug also empirically reproduced via direct `curl` against ClickHouse `25.3.6.56-alpine` (test container) and `25.3.8-alpine` (production version) to confirm the result is not version-specific. Fixed-shape SQL produces zero increments on both.

Not run: full backend regression suite (out of scope for this fix).

## Documentation

N/A — no behaviour change visible to API consumers.
