### PR TITLE
[OPIK-6341] [SDK] feat: add --destination-project + --exclude-experiments to opik import dataset

### DIFF
--- a/sdks/python/src/opik/cli/imports/__init__.py
+++ b/sdks/python/src/opik/cli/imports/__init__.py
@@ -33,6 +33,8 @@ def _import_by_type(
     api_key: Optional[str] = None,
     force: bool = False,
     include_attachments: bool = True,
+    destination_project: Optional[str] = None,
+    exclude_experiments: bool = False,
 ) -> None:
     """
     Import data by type (dataset, project, experiment) with pattern matching.
@@ -46,6 +48,11 @@ def _import_by_type(
         debug: Enable debug output
         recreate_experiments: Whether to recreate experiments after importing
         force: Discard any existing manifest and restart from scratch
+        destination_project: When set, override every project_name in the import
+            with this project. Currently wired only on ``import dataset``.
+        exclude_experiments: When True, skip the experiments/traces/spans
+            branch even if an ``experiments/`` directory is present alongside
+            ``datasets/``. Only meaningful with ``destination_project``.
     """
     try:
         debug_print(f"DEBUG: Starting {import_type} import from {path}", debug)
@@ -111,8 +118,48 @@ def _import_by_type(
 
         if import_type == "dataset":
             stats = import_datasets_from_directory(
-                client, source_dir, dry_run, name_pattern, debug, manifest=manifest
+                client,
+                source_dir,
+                dry_run,
+                name_pattern,
+                debug,
+                manifest=manifest,
+                destination_project=destination_project,
             )
+
+            # Same-workspace v1 → v2 migration story: when the user is
+            # redirecting the dataset into a destination project, also pull
+            # any sibling experiments (with the same project override) so a
+            # single ``opik import dataset`` invocation matches the
+            # transitive scope of ``opik copy dataset``. Suppressed by
+            # ``--exclude-experiments`` and a no-op when the export dir
+            # carries no ``experiments/`` (the typical
+            # ``opik export dataset`` layout).
+            if destination_project is not None and not exclude_experiments:
+                experiments_dir = base_path / "experiments"
+                if experiments_dir.exists() and any(
+                    experiments_dir.glob("experiment_*.json")
+                ):
+                    debug_print(
+                        f"Found experiments directory at {experiments_dir}, importing with destination_project={destination_project!r}",
+                        debug,
+                    )
+                    experiments_stats = import_experiments_from_directory(
+                        client,
+                        experiments_dir,
+                        dry_run,
+                        None,
+                        debug,
+                        manifest=manifest,
+                        destination_project=destination_project,
+                    )
+                    # Merge experiment-import stats into the dataset stats so
+                    # the summary surfaces both. ``import_experiments_from_directory``
+                    # already returns the dataset keys it touched, so prefer
+                    # the larger of the two when keys overlap rather than
+                    # silently overwriting dataset counts with zero.
+                    for key, value in experiments_stats.items():
+                        stats[key] = max(stats.get(key, 0), value)
         elif import_type == "project":
             stats = import_projects_from_directory(
                 client,
@@ -317,6 +364,17 @@ import_group.add_command(import_all_command)
     help="Directory containing exported data. Defaults to opik_exports.",
 )
 @click.option(
+    "--destination-project",
+    type=str,
+    default=None,
+    help="Target a specific project on the destination workspace (auto-created if missing). When set, any sibling experiments/ directory is also imported into this project unless --exclude-experiments is passed.",
+)
+@click.option(
+    "--exclude-experiments",
+    is_flag=True,
+    help="Skip experiment/trace/span import even when an experiments/ directory is present. Only meaningful with --destination-project.",
+)
+@click.option(
     "--dry-run",
     is_flag=True,
     help="Show what would be imported without actually importing.",
@@ -336,6 +394,8 @@ def import_dataset(
     ctx: click.Context,
     name: str,
     path: str,
+    destination_project: Optional[str],
+    exclude_experiments: bool,
     dry_run: bool,
     force: bool,
     debug: bool,
@@ -359,11 +419,26 @@ def import_dataset(
     \b
         # Import from a custom path
         opik import my-workspace dataset "my-dataset" --path ./custom-exports/
+    \b
+        # Import into a specific destination project (also pulls sibling experiments/)
+        opik import my-workspace dataset "my-dataset" --destination-project "Project B"
+    \b
+        # Import only the dataset definition + items, skip experiments
+        opik import my-workspace dataset "my-dataset" --destination-project "Project B" --exclude-experiments
     """
     workspace = ctx.obj["workspace"]
     api_key = ctx.obj.get("api_key") if ctx.obj else None
     _import_by_type(
-        "dataset", path, workspace, dry_run, name, debug, api_key=api_key, force=force
+        "dataset",
+        path,
+        workspace,
+        dry_run,
+        name,
+        debug,
+        api_key=api_key,
+        force=force,
+        destination_project=destination_project,
+        exclude_experiments=exclude_experiments,
     )
 
 

--- a/sdks/python/src/opik/cli/imports/dataset.py
+++ b/sdks/python/src/opik/cli/imports/dataset.py
@@ -20,8 +20,15 @@ def import_datasets_from_directory(
     name_pattern: Optional[str],
     debug: bool,
     manifest: Optional[MigrationManifest] = None,
+    destination_project: Optional[str] = None,
 ) -> Dict[str, int]:
     """Import datasets from a directory.
+
+    Args:
+        destination_project: When provided, datasets are created in this project
+            on the destination workspace, overriding any project info in the
+            source JSON. When ``None`` (the default), behavior is identical to
+            a plain ``opik import``.
 
     Returns:
         Dictionary with keys: 'datasets', 'datasets_skipped', 'datasets_errors'
@@ -97,14 +104,18 @@ def import_datasets_from_directory(
 
                 # Get or create dataset (handles case where dataset already exists)
                 try:
-                    dataset = client.get_dataset(dataset_name)
+                    dataset = client.get_dataset(
+                        dataset_name, project_name=destination_project
+                    )
                     if debug:
                         console.print(
                             f"[blue]Dataset '{dataset_name}' already exists, using existing dataset[/blue]"
                         )
                 except Exception:
                     # Dataset doesn't exist, create it
-                    dataset = client.create_dataset(name=dataset_name)
+                    dataset = client.create_dataset(
+                        name=dataset_name, project_name=destination_project
+                    )
                     if debug:
                         console.print(
                             f"[blue]Created new dataset: {dataset_name}[/blue]"

--- a/sdks/python/src/opik/cli/imports/experiment.py
+++ b/sdks/python/src/opik/cli/imports/experiment.py
@@ -82,6 +82,7 @@ def _build_dataset_item_id_map(
     dry_run: bool,
     debug: bool,
     manifest: Optional[MigrationManifest] = None,
+    destination_project: Optional[str] = None,
 ) -> tuple[Dict[str, str], Dict[str, int]]:
     """Build a mapping from original dataset_item_id to new dataset_item_id.
 
@@ -196,7 +197,13 @@ def _build_dataset_item_id_map(
 
     # Import datasets (this will create dataset items with new IDs)
     dataset_import_stats = import_datasets_from_directory(
-        client, datasets_dir, dry_run, None, debug, manifest=manifest
+        client,
+        datasets_dir,
+        dry_run,
+        None,
+        debug,
+        manifest=manifest,
+        destination_project=destination_project,
     )
 
     # Update dataset_stats with import results
@@ -257,7 +264,9 @@ def _build_dataset_item_id_map(
 
             # Get the imported dataset
             try:
-                dataset = client.get_dataset(dataset_name)
+                dataset = client.get_dataset(
+                    dataset_name, project_name=destination_project
+                )
             except Exception:
                 debug_print(
                     f"Warning: Could not get dataset '{dataset_name}' after import",
@@ -666,6 +675,7 @@ def recreate_experiments(
     dataset_item_id_map: Optional[Dict[str, str]] = None,
     debug: bool = False,
     manifest: Optional[MigrationManifest] = None,
+    destination_project: Optional[str] = None,
 ) -> int:
     """Recreate experiments from JSON files.
 
@@ -675,7 +685,12 @@ def recreate_experiments(
         dataset_item_id_map: Mapping from original dataset_item_id to new dataset_item_id.
                             If None, will be treated as empty dict (all items will be skipped).
         manifest: Optional migration manifest for resumable imports.
+        destination_project: When provided, experiments are recreated in this
+            project, overriding ``project_name``.
     """
+    if destination_project is not None:
+        project_name = destination_project
+
     experiment_files = find_experiment_files(project_dir)
 
     if not experiment_files:
@@ -758,8 +773,14 @@ def _import_traces_from_projects_directory(
     dry_run: bool,
     debug: bool,
     manifest: Optional[MigrationManifest] = None,
+    destination_project: Optional[str] = None,
 ) -> tuple[Dict[str, str], Dict[str, int]]:
     """Import traces from projects directory and return trace_id_map and statistics.
+
+    Args:
+        destination_project: When provided, traces and spans are written to this
+            project, overriding the project derived from each trace's
+            ``project_dir`` name.
 
     Returns:
         Tuple of (trace_id_map, stats_dict) where:
@@ -791,7 +812,9 @@ def _import_traces_from_projects_directory(
     )
 
     for project_dir in project_dirs:
-        project_name = project_dir.name
+        project_name = (
+            destination_project if destination_project is not None else project_dir.name
+        )
         trace_files = list(project_dir.glob("trace_*.json"))
 
         if not trace_files:
@@ -986,11 +1009,17 @@ def import_experiments_from_directory(
     name_pattern: Optional[str],
     debug: bool,
     manifest: Optional[MigrationManifest] = None,
+    destination_project: Optional[str] = None,
 ) -> Dict[str, int]:
     """Import experiments from a directory.
 
     This function will first import prompts and traces from their respective directories
     (if they exist) to build a trace_id_map, then use that map when recreating experiments.
+
+    Args:
+        destination_project: When provided, all datasets, traces, spans, and
+            recreated experiments are written to this project, overriding any
+            project info derived from the source export.
 
     Returns:
         Dictionary with keys: 'experiments', 'experiments_skipped', 'experiments_errors',
@@ -1056,6 +1085,7 @@ def import_experiments_from_directory(
                 dry_run,
                 debug,
                 manifest=manifest,
+                destination_project=destination_project,
             )
         else:
             debug_print(
@@ -1065,7 +1095,12 @@ def import_experiments_from_directory(
 
         # Import traces first to build trace_id_map
         trace_id_map, traces_stats = _import_traces_from_projects_directory(
-            client, workspace_root, dry_run, debug, manifest=manifest
+            client,
+            workspace_root,
+            dry_run,
+            debug,
+            manifest=manifest,
+            destination_project=destination_project,
         )
 
         if not trace_id_map and not dry_run:
@@ -1215,6 +1250,11 @@ def import_experiments_from_directory(
                         "Using default project name (no project found in metadata or trace files)",
                         debug,
                     )
+
+                # Force every recreated experiment into the destination project
+                # regardless of what the source export said.
+                if destination_project is not None:
+                    project_for_logs = destination_project
 
                 # Use trace_id_map and dataset_item_id_map to translate IDs (empty dicts if None)
                 # Note: dataset_item_id_map is already a dict (not None) from _build_dataset_item_id_map

--- a/sdks/python/tests/unit/cli/test_import_dataset.py
+++ b/sdks/python/tests/unit/cli/test_import_dataset.py
@@ -1,0 +1,483 @@
+"""Unit tests for ``opik import dataset`` flags and plumbing.
+
+Covers:
+1. Click surface: ``--destination-project`` and ``--exclude-experiments`` are
+   accepted and threaded through to ``_import_by_type``.
+2. ``destination_project`` plumbing into the underlying SDK calls
+   (``client.get_dataset``, ``client.create_dataset``, ``client.trace``,
+   ``client.span``) so dataset items, traces, and spans land in the
+   destination project rather than wherever the source export said.
+3. The new sibling-experiments branch: when ``--destination-project`` is set
+   and a sibling ``experiments/`` directory exists, the dataset import path
+   *also* invokes ``import_experiments_from_directory`` with the same
+   override (gated off by ``--exclude-experiments``).
+4. Regression guards: with no flags, behavior is identical to today
+   (no project override, no experiments call).
+
+Tests use Click's CliRunner with a mocked Opik client to avoid hitting any
+real backend.
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock, Mock, patch
+
+from click.testing import CliRunner
+
+# Match the pattern used by sibling test_import_experiment.py.
+sys.modules.setdefault("opik.api_objects.prompt.prompt", MagicMock())
+
+from opik.cli.imports.dataset import import_datasets_from_directory  # noqa: E402
+from opik.cli.imports.experiment import (  # noqa: E402
+    _import_traces_from_projects_directory,
+    recreate_experiments,
+)
+from opik.cli.main import cli  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_dataset_export(workspace_root: Path, name: str, item_count: int) -> None:
+    datasets_dir = workspace_root / "datasets"
+    datasets_dir.mkdir(parents=True, exist_ok=True)
+    payload: Dict[str, Any] = {
+        "name": name,
+        "description": None,
+        "items": [{"q": f"q{i}", "a": f"a{i}"} for i in range(item_count)],
+        "downloaded_at": "2026-04-30T00:00:00",
+    }
+    with open(datasets_dir / f"dataset_{name}.json", "w") as fh:
+        json.dump(payload, fh)
+
+
+def _write_trace_export(workspace_root: Path, project: str, trace_id: str) -> None:
+    project_dir = workspace_root / "projects" / project
+    project_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "trace": {
+            "id": trace_id,
+            "name": "tr",
+            "input": {},
+            "output": {},
+        },
+        "spans": [
+            {
+                "id": f"{trace_id}-s1",
+                "name": "s1",
+                "parent_span_id": None,
+                "input": {},
+                "output": {},
+            },
+        ],
+        "project_name": project,
+    }
+    with open(project_dir / f"trace_{trace_id}.json", "w") as fh:
+        json.dump(payload, fh)
+
+
+def _write_experiment_export(
+    workspace_root: Path, name: str, exp_id: str, project: str, dataset: str
+) -> None:
+    experiments_dir = workspace_root / "experiments"
+    experiments_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "experiment": {
+            "id": exp_id,
+            "name": name,
+            "dataset_name": dataset,
+            "metadata": {"project_name": project},
+        },
+        "items": [],
+    }
+    with open(experiments_dir / f"experiment_{name}_{exp_id}.json", "w") as fh:
+        json.dump(payload, fh)
+
+
+# ---------------------------------------------------------------------------
+# 1. Click surface
+# ---------------------------------------------------------------------------
+
+
+class TestClickSurface:
+    def test_help_lists_new_flags(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", "ws", "dataset", "--help"])
+        assert result.exit_code == 0
+        assert "--destination-project" in result.output
+        assert "--exclude-experiments" in result.output
+
+    def test_destination_project_threaded_into_import_by_type(
+        self, tmp_path: Path
+    ) -> None:
+        runner = CliRunner()
+        with patch("opik.cli.imports._import_by_type") as mocked:
+            result = runner.invoke(
+                cli,
+                [
+                    "import",
+                    "ws",
+                    "dataset",
+                    "MyDataset",
+                    "--path",
+                    str(tmp_path),
+                    "--destination-project",
+                    "DestProj",
+                ],
+            )
+        assert result.exit_code == 0
+        mocked.assert_called_once()
+        kwargs = mocked.call_args.kwargs
+        assert kwargs["destination_project"] == "DestProj"
+        assert kwargs["exclude_experiments"] is False
+
+    def test_exclude_experiments_threaded_into_import_by_type(
+        self, tmp_path: Path
+    ) -> None:
+        runner = CliRunner()
+        with patch("opik.cli.imports._import_by_type") as mocked:
+            result = runner.invoke(
+                cli,
+                [
+                    "import",
+                    "ws",
+                    "dataset",
+                    "MyDataset",
+                    "--path",
+                    str(tmp_path),
+                    "--destination-project",
+                    "DestProj",
+                    "--exclude-experiments",
+                ],
+            )
+        assert result.exit_code == 0
+        kwargs = mocked.call_args.kwargs
+        assert kwargs["exclude_experiments"] is True
+
+    def test_no_flags_preserves_old_invocation(self, tmp_path: Path) -> None:
+        """Regression guard: no flags → destination_project=None,
+        exclude_experiments=False (today's behaviour exactly)."""
+        runner = CliRunner()
+        with patch("opik.cli.imports._import_by_type") as mocked:
+            result = runner.invoke(
+                cli,
+                [
+                    "import",
+                    "ws",
+                    "dataset",
+                    "MyDataset",
+                    "--path",
+                    str(tmp_path),
+                ],
+            )
+        assert result.exit_code == 0
+        kwargs = mocked.call_args.kwargs
+        assert kwargs["destination_project"] is None
+        assert kwargs["exclude_experiments"] is False
+
+
+# ---------------------------------------------------------------------------
+# 2. destination_project plumbing into the importers
+# ---------------------------------------------------------------------------
+
+
+class TestDestinationProjectPlumbing:
+    def test_dataset_import_passes_destination_project(self, tmp_path: Path) -> None:
+        _write_dataset_export(tmp_path, "Foo", item_count=2)
+        client = Mock()
+        # First lookup raises (dataset doesn't exist) so create_dataset fires.
+        client.get_dataset.side_effect = Exception("not found")
+        client.create_dataset.return_value = Mock()
+
+        import_datasets_from_directory(
+            client=client,
+            source_dir=tmp_path / "datasets",
+            dry_run=False,
+            name_pattern=None,
+            debug=False,
+            destination_project="DestProj",
+        )
+
+        client.get_dataset.assert_called_once_with("Foo", project_name="DestProj")
+        client.create_dataset.assert_called_once_with(
+            name="Foo", project_name="DestProj"
+        )
+
+    def test_dataset_import_no_override_preserves_old_behavior(
+        self, tmp_path: Path
+    ) -> None:
+        _write_dataset_export(tmp_path, "Foo", item_count=1)
+        client = Mock()
+        client.get_dataset.side_effect = Exception("not found")
+        client.create_dataset.return_value = Mock()
+
+        import_datasets_from_directory(
+            client=client,
+            source_dir=tmp_path / "datasets",
+            dry_run=False,
+            name_pattern=None,
+            debug=False,
+        )
+
+        client.get_dataset.assert_called_once_with("Foo", project_name=None)
+        client.create_dataset.assert_called_once_with(name="Foo", project_name=None)
+
+    def test_traces_use_destination_project_when_override_set(
+        self, tmp_path: Path
+    ) -> None:
+        _write_trace_export(tmp_path, project="SourceProj", trace_id="t1")
+        client = Mock()
+        client.trace.return_value = Mock(id="new-t1")
+        client.span.return_value = Mock(id="new-s1")
+
+        _import_traces_from_projects_directory(
+            client=client,
+            workspace_root=tmp_path,
+            dry_run=False,
+            debug=False,
+            destination_project="DestProj",
+        )
+
+        assert client.trace.call_args.kwargs["project_name"] == "DestProj"
+        for call in client.span.call_args_list:
+            assert call.kwargs["project_name"] == "DestProj"
+
+    def test_traces_no_override_uses_project_dir_name(self, tmp_path: Path) -> None:
+        _write_trace_export(tmp_path, project="MyProj", trace_id="t1")
+        client = Mock()
+        client.trace.return_value = Mock(id="new-t1")
+        client.span.return_value = Mock(id="new-s1")
+
+        _import_traces_from_projects_directory(
+            client=client,
+            workspace_root=tmp_path,
+            dry_run=False,
+            debug=False,
+        )
+
+        assert client.trace.call_args.kwargs["project_name"] == "MyProj"
+
+    def test_recreate_experiments_destination_overrides_project_name(
+        self, tmp_path: Path
+    ) -> None:
+        _write_experiment_export(tmp_path, "Exp1", "e1", "MyProj", "Foo")
+        client = Mock()
+        with patch(
+            "opik.cli.imports.experiment.recreate_experiment", return_value=True
+        ) as recreate_mock:
+            recreate_experiments(
+                client=client,
+                project_dir=tmp_path / "experiments",
+                project_name="OriginalProj",
+                destination_project="DestProj",
+            )
+        assert recreate_mock.call_args.args[2] == "DestProj"
+
+
+# ---------------------------------------------------------------------------
+# 3. Sibling experiments-import branch in `opik import dataset`
+# ---------------------------------------------------------------------------
+
+
+class TestSiblingExperimentsBranch:
+    """When ``--destination-project`` is set and ``experiments/`` is present
+    alongside ``datasets/``, ``opik import dataset`` should also run the
+    experiments importer with the same project override.
+    """
+
+    def test_destination_project_triggers_experiments_import(
+        self, tmp_path: Path
+    ) -> None:
+        _write_dataset_export(tmp_path, "Foo", item_count=1)
+        _write_experiment_export(tmp_path, "Exp1", "e1", "ProjA", "Foo")
+        _write_trace_export(tmp_path, "ProjA", "t1")
+
+        runner = CliRunner()
+        with (
+            patch(
+                "opik.cli.imports.import_datasets_from_directory",
+                return_value={
+                    "datasets": 1,
+                    "datasets_skipped": 0,
+                    "datasets_errors": 0,
+                },
+            ) as ds_mock,
+            patch(
+                "opik.cli.imports.import_experiments_from_directory",
+                return_value={
+                    "experiments": 1,
+                    "experiments_skipped": 0,
+                    "experiments_errors": 0,
+                    "datasets": 0,
+                    "datasets_skipped": 0,
+                    "datasets_errors": 0,
+                    "prompts": 0,
+                    "prompts_skipped": 0,
+                    "prompts_errors": 0,
+                    "traces": 0,
+                    "traces_errors": 0,
+                },
+            ) as exp_mock,
+            patch("opik.cli.imports.opik.Opik") as opik_mock,
+        ):
+            client = Mock()
+            client.flush.return_value = True
+            client.__internal_api__failed_uploads__ = Mock(return_value=0)
+            opik_mock.return_value = client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "import",
+                    "ws",
+                    "dataset",
+                    "Foo",
+                    "--path",
+                    str(tmp_path),
+                    "--destination-project",
+                    "DestProj",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        ds_mock.assert_called_once()
+        assert ds_mock.call_args.kwargs["destination_project"] == "DestProj"
+        exp_mock.assert_called_once()
+        assert exp_mock.call_args.kwargs["destination_project"] == "DestProj"
+
+    def test_exclude_experiments_skips_experiments_call(self, tmp_path: Path) -> None:
+        _write_dataset_export(tmp_path, "Foo", item_count=1)
+        _write_experiment_export(tmp_path, "Exp1", "e1", "ProjA", "Foo")
+        _write_trace_export(tmp_path, "ProjA", "t1")
+
+        runner = CliRunner()
+        with (
+            patch(
+                "opik.cli.imports.import_datasets_from_directory",
+                return_value={
+                    "datasets": 1,
+                    "datasets_skipped": 0,
+                    "datasets_errors": 0,
+                },
+            ) as ds_mock,
+            patch("opik.cli.imports.import_experiments_from_directory") as exp_mock,
+            patch("opik.cli.imports.opik.Opik") as opik_mock,
+        ):
+            client = Mock()
+            client.flush.return_value = True
+            client.__internal_api__failed_uploads__ = Mock(return_value=0)
+            opik_mock.return_value = client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "import",
+                    "ws",
+                    "dataset",
+                    "Foo",
+                    "--path",
+                    str(tmp_path),
+                    "--destination-project",
+                    "DestProj",
+                    "--exclude-experiments",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        ds_mock.assert_called_once()
+        exp_mock.assert_not_called()
+
+    def test_no_destination_project_skips_experiments_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression guard: today's plain ``opik import dataset`` must not
+        suddenly import experiments just because they happen to sit alongside
+        the datasets directory. The experiments-import branch only fires when
+        ``--destination-project`` is set."""
+        _write_dataset_export(tmp_path, "Foo", item_count=1)
+        _write_experiment_export(tmp_path, "Exp1", "e1", "ProjA", "Foo")
+        _write_trace_export(tmp_path, "ProjA", "t1")
+
+        runner = CliRunner()
+        with (
+            patch(
+                "opik.cli.imports.import_datasets_from_directory",
+                return_value={
+                    "datasets": 1,
+                    "datasets_skipped": 0,
+                    "datasets_errors": 0,
+                },
+            ) as ds_mock,
+            patch("opik.cli.imports.import_experiments_from_directory") as exp_mock,
+            patch("opik.cli.imports.opik.Opik") as opik_mock,
+        ):
+            client = Mock()
+            client.flush.return_value = True
+            client.__internal_api__failed_uploads__ = Mock(return_value=0)
+            opik_mock.return_value = client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "import",
+                    "ws",
+                    "dataset",
+                    "Foo",
+                    "--path",
+                    str(tmp_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        ds_mock.assert_called_once()
+        # No destination_project kwarg → no override threaded through.
+        assert ds_mock.call_args.kwargs["destination_project"] is None
+        exp_mock.assert_not_called()
+
+    def test_destination_project_no_experiments_dir_skips_experiments_call(
+        self, tmp_path: Path
+    ) -> None:
+        """No-op when ``experiments/`` is absent — the typical
+        ``opik export dataset`` layout. Cross-instance migration path
+        should not be perturbed."""
+        _write_dataset_export(tmp_path, "Foo", item_count=1)
+        # Note: no experiments/ dir written.
+
+        runner = CliRunner()
+        with (
+            patch(
+                "opik.cli.imports.import_datasets_from_directory",
+                return_value={
+                    "datasets": 1,
+                    "datasets_skipped": 0,
+                    "datasets_errors": 0,
+                },
+            ),
+            patch("opik.cli.imports.import_experiments_from_directory") as exp_mock,
+            patch("opik.cli.imports.opik.Opik") as opik_mock,
+        ):
+            client = Mock()
+            client.flush.return_value = True
+            client.__internal_api__failed_uploads__ = Mock(return_value=0)
+            opik_mock.return_value = client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "import",
+                    "ws",
+                    "dataset",
+                    "Foo",
+                    "--path",
+                    str(tmp_path),
+                    "--destination-project",
+                    "DestProj",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        exp_mock.assert_not_called()


### PR DESCRIPTION
## Details

First half of OPIK-6341 — adds `--destination-project NAME` and `--exclude-experiments` to `opik import dataset`, and threads `destination_project` through the dataset / experiment importers (transplants the plumbing from parked PR #6555 so it can land independently). With `--destination-project` set, the dataset import path now also runs `import_experiments_from_directory` against any sibling `experiments/` dir using the same project override (gated by `--exclude-experiments`). Defaults preserve today's `opik import` behaviour exactly: cross-instance migrations and no-flag invocations are unchanged.

- The same-workspace **suffix-rename workaround** (the part that makes self-hosted v1→v2 same-workspace migration actually work despite the `(workspace_id, name)` uniqueness constraint) is **not** in this commit. Keeping it as a separate follow-up commit so the rename design (`<source>__<sanitized_project>`, `_001`/`_002` fallback, `opik-auto-copy` tag, provenance description) can be reviewed in isolation. Still thinking through edge cases — e.g. how to interact with the planned cleanup-sweep ticket, whether the tag should live on the dataset or as metadata, how to size the `get_datasets()` collision-detection cap.
- Until Commit 2 lands, **same-workspace migration still 409s with a clear error** rather than working. Cross-instance migration is fully unblocked.
- Implementation note: kept the existing `try get_dataset / except → create_dataset` shape rather than switching to `get_or_create_dataset` (as PR #6555 does) to minimize behaviour change in this commit. Commit 2 will likely revisit that choice in the rename branch.

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6341
- Parent epic: OPIK-5859 (Self-serve v1 → v2 workspace migration via SDK)
- Builds toward: OPIK-6246 (`opik copy dataset`, parked PR #6555 — becomes a thin wrapper once Commit 2 lands)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation (plumbing transplant, Click flags, sibling-experiments wiring, tests)
- Human verification: code review pending; manual end-to-end smoke test pending against `localhost:5174` (will be done before un-drafting alongside Commit 2)

## Testing

Unit tests (run from `sdks/python`):

- 13 new tests in `tests/unit/cli/test_import_dataset.py` covering:
  - Click surface: `--destination-project` / `--exclude-experiments` parsed and threaded into `_import_by_type`; `--help` lists them; no-flags invocation preserves old kwargs (regression guard).
  - `destination_project` plumbing: `client.get_dataset` / `client.create_dataset` / `client.trace` / `client.span` all receive the override; `recreate_experiments` rewrites `project_name`; no-override path unchanged.
  - Sibling-experiments branch: fires when `--destination-project` set + `experiments/` dir present; suppressed by `--exclude-experiments`; no-op when `experiments/` absent (typical `opik export dataset` layout); does NOT fire without `--destination-project`.
- 211 pre-existing `tests/unit/cli/` tests still pass — no regressions.

```
PYTHONPATH="$(pwd)/src" python -m pytest tests/unit/cli/ -q
# 211 passed
```

Pre-commit (ruff, ruff-format, mypy) clean via `sdks/python/.pre-commit-config.yaml`.

Manual smoke test against `localhost:5174` is **pending** and will be done before un-drafting alongside Commit 2.

## Documentation

N/A for this PR. CLI help text is the user-facing surface for v1; broader docs / migration-guide updates will land alongside the wider OPIK-5859 epic.