### PR TITLE
[OPIK-6337] [DOCS] Update permissions table to match Apr 24 revamp

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/administration/roles_and_permissions.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/administration/roles_and_permissions.mdx
@@ -58,11 +58,10 @@ The table below shows the default permissions for each role. Custom roles can co
 | --------------------- | ------------------------------- | ------ | ----- | -------- | ---- |
 | Admin                 | Invite users to workspace       | Yes    | Yes   | No       | No   |
 | Admin                 | Configure workspace settings    | Yes    | No    | No       | No   |
-| Admin                 | Delete workspaces               | Yes    | No    | No       | No   |
 | Admin                 | Define AI providers             | Yes    | Yes   | No       | No   |
 | Experiment management | Change project settings         | Yes    | No    | No       | No   |
 | Experiment management | Approve and manage models       | Yes    | No    | No       | No   |
-| Observability         | View project data               | Yes    | Yes   | Yes      | Yes  |
+| Observability         | View logs                       | Yes    | Yes   | Yes      | Yes  |
 | Observability         | Log trace, span, or thread      | Yes    | Yes   | No       | No   |
 | Observability         | Delete trace                    | Yes    | Yes   | No       | No   |
 | Observability         | Write comments                  | Yes    | Yes   | Yes      | No   |
@@ -73,7 +72,7 @@ The table below shows the default permissions for each role. Custom roles can co
 | Observability         | Create annotation queue         | Yes    | Yes   | No       | No   |
 | Dashboards            | View dashboard                  | Yes    | Yes   | No       | Yes  |
 | Experiments           | View experiments                | Yes    | Yes   | No       | Yes  |
-| Datasets              | View datasets                   | Yes    | Yes   | No       | Yes  |
+| Datasets              | View datasets and test suites   | Yes    | Yes   | No       | Yes  |
 | Annotation queues     | View annotation queues          | Yes    | Yes   | Yes      | Yes  |
 | Annotation queues     | Annotate trace, span, or thread | Yes    | Yes   | Yes      | Yes  |
 

--- a/apps/opik-documentation/documentation/fern/docs/administration/roles_and_permissions.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/roles_and_permissions.mdx
@@ -58,13 +58,12 @@ The table below shows the default permissions for each role. Custom roles can co
 | --------------------- | ------------------------------- | ------ | ----- | -------- | ---- |
 | Admin                 | Invite users to workspace       | Yes    | Yes   | No       | No   |
 | Admin                 | Configure workspace settings    | Yes    | No    | No       | No   |
-| Admin                 | Delete workspaces               | Yes    | No    | No       | No   |
 | Admin                 | Define AI providers             | Yes    | Yes   | No       | No   |
 | Experiment management | Change project settings         | Yes    | No    | No       | No   |
 | Experiment management | Approve and manage models       | Yes    | No    | No       | No   |
 | Observability         | Create projects                 | Yes    | Yes   | No       | No   |
 | Observability         | Delete projects                 | Yes    | Yes   | No       | No   |
-| Observability         | View project data               | Yes    | Yes   | Yes      | Yes  |
+| Observability         | View logs                       | Yes    | Yes   | Yes      | Yes  |
 | Observability         | Log trace, span, or thread      | Yes    | Yes   | No       | No   |
 | Observability         | Delete trace                    | Yes    | Yes   | No       | No   |
 | Observability         | Annotate trace, span, or thread | Yes    | Yes   | Yes      | No   |
@@ -76,11 +75,11 @@ The table below shows the default permissions for each role. Custom roles can co
 | Dashboards            | Create dashboards               | Yes    | Yes   | No       | No   |
 | Dashboards            | Delete dashboards               | Yes    | Yes   | No       | No   |
 | Experiments           | View experiments                | Yes    | Yes   | No       | Yes  |
-| Experiments           | Create experiment               | Yes    | Yes   | No       | No   |
-| Datasets              | View datasets                   | Yes    | Yes   | No       | Yes  |
-| Datasets              | Create datasets                 | Yes    | Yes   | No       | No   |
-| Datasets              | Edit datasets                   | Yes    | Yes   | No       | No   |
-| Datasets              | Delete datasets                 | Yes    | Yes   | No       | No   |
+| Experiments           | Create experiment ¹             | Yes    | Yes   | No       | No   |
+| Datasets              | View datasets and test suites   | Yes    | Yes   | No       | Yes  |
+| Datasets              | Create datasets and test suites | Yes    | Yes   | No       | No   |
+| Datasets              | Edit datasets and test suites   | Yes    | Yes   | No       | No   |
+| Datasets              | Delete datasets and test suites | Yes    | Yes   | No       | No   |
 | Annotation queues     | View annotation queues          | Yes    | Yes   | Yes      | Yes  |
 | Annotation queues     | Create annotation queue         | Yes    | Yes   | No       | No   |
 | Annotation queues     | Edit annotation queue           | Yes    | Yes   | No       | No   |
@@ -89,7 +88,11 @@ The table below shows the default permissions for each role. Custom roles can co
 | Playground            | Use playground                  | Yes    | Yes   | No       | No   |
 | Optimization          | View Optimization runs          | Yes    | Yes   | No       | Yes  |
 | Optimization          | Delete Optimization runs        | Yes    | Yes   | No       | No   |
-| Optimization          | Use optimization studio         | Yes    | Yes   | No       | No   |
+| Optimization          | Use optimization studio ²       | Yes    | Yes   | No       | No   |
+
+¹ Requires the `Log trace, span, or thread` permission.
+
+² Requires `Log trace, span, or thread`, `Annotate trace, span, or thread`, and `Create experiment` permissions.
 
 ### Custom roles
 


### PR DESCRIPTION
## Details

Aligns the workspace roles documentation with the FE label changes and BE permission removal merged for [OPIK-6337](https://comet-ml.atlassian.net/browse/OPIK-6337):

- Renames `View project data` → **View logs**
- Renames Datasets rows to **`... and test suites`** (View / Create / Edit / Delete)
- Drops the `Admin · Delete workspaces` row (permission removed; workspace deletion is now gated by `Workspace management` + the no-remaining-members check)
- Adds footnotes describing dependent permissions for **Create experiment** (¹) and **Use optimization studio** (²) — mirrors the new FE tooltips

Both `fern/docs/administration/roles_and_permissions.mdx` (v1) and `fern/docs-v2/administration/roles_and_permissions.mdx` updated; the v2 table is slimmer so only 3 of the 8 rows apply there.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6337
- Cross-reference: comet-ml/comet-react#7725 (FE label renames + tooltips)
- Cross-reference: comet-ml/comet-backend#5540 (BE removal of `workspace_delete` + migration `000024`)
- Source: [Apr 24 Permissions Revamp status update](https://www.notion.so/cometml/Status-update-April-24-34a7124010a3800183a9ef40dd661463)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: Doc-only edits to `roles_and_permissions.mdx` (v1 + v2) — table row renames, row removal, footnotes
- Human verification: Diffs reviewed locally; cross-referenced against merged FE/BE PRs and the Apr 24 status doc before opening

## Testing

Doc-only change. Verified locally:

- `git diff` on both edited `.mdx` files reviewed; only the intended table cells, the removed row, and the new footnote block changed
- Confirmed each renamed cell matches the FE display label set in `formatPermissions.ts` (comet-ml/comet-react#7725)
- Confirmed the removed `Delete workspaces` row matches the BE enum/role removal (comet-ml/comet-backend#5540)

Not run: docs site preview build (no local Fern setup); will rely on the standard docs CI / preview deploy on this PR.

## Documentation

This PR is the documentation update for OPIK-6337. No additional docs are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OPIK-6337]: https://comet-ml.atlassian.net/browse/OPIK-6337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ