### PR TITLE
[OPIK-6057] [BE] fix: skip online-scoring feedback rows when judge returns null

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -530,11 +530,15 @@ public class OnlineScoringEngine {
                         log.info("No score found for '{}' score in {}", scoreName, scoreNested);
                         return null;
                     }
+                    var actualScore = scoreNested.path(SCORE_FIELD_NAME);
+                    if (actualScore.isNull()) {
+                        log.info("Skipping '{}' score because the judge returned a null value", scoreName);
+                        return null;
+                    }
                     var resultBuilder = FeedbackScoreBatchItem.builder()
                             .name(scoreName)
                             .reason(scoreNested.path(REASON_FIELD_NAME).asText())
                             .source(ScoreSource.ONLINE_SCORING);
-                    var actualScore = scoreNested.path(SCORE_FIELD_NAME);
                     if (actualScore.isBoolean()) {
                         resultBuilder.value(actualScore.asBoolean() ? BigDecimal.ONE : BigDecimal.ZERO);
                     } else {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -37,8 +37,8 @@ import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -507,48 +507,52 @@ public class OnlineScoringEngine {
                 .toList();
     }
 
-    public static List<FeedbackScoreBatchItem> toFeedbackScores(@NotNull ChatResponse chatResponse) {
+    public record ParsedFeedbackScores(List<FeedbackScoreBatchItem> scores, List<String> nullScoreNames) {
+        public static ParsedFeedbackScores empty() {
+            return new ParsedFeedbackScores(List.of(), List.of());
+        }
+    }
+
+    public static ParsedFeedbackScores toFeedbackScores(@NotNull ChatResponse chatResponse) {
         var content = extractJson(chatResponse.aiMessage().text());
         JsonNode structuredResponse;
         try {
             structuredResponse = OBJECT_MAPPER.readTree(content);
             if (!structuredResponse.isObject()) {
                 log.info("ChatResponse content returned into an empty JSON result");
-                return Collections.emptyList();
+                return ParsedFeedbackScores.empty();
             }
         } catch (JsonProcessingException e) {
             log.error("parsing LLM response into a JSON: {}", content, e);
-            return Collections.emptyList();
+            return ParsedFeedbackScores.empty();
         }
-        var spliterator = Spliterators.spliteratorUnknownSize(
-                structuredResponse.properties().iterator(), Spliterator.ORDERED | Spliterator.NONNULL);
-        List<FeedbackScoreBatchItem> results = StreamSupport.stream(spliterator, false)
-                .map(scoreMetric -> {
-                    var scoreName = scoreMetric.getKey();
-                    var scoreNested = scoreMetric.getValue();
-                    if (scoreNested == null || scoreNested.isMissingNode() || !scoreNested.has(SCORE_FIELD_NAME)) {
-                        log.info("No score found for '{}' score in {}", scoreName, scoreNested);
-                        return null;
-                    }
-                    var actualScore = scoreNested.path(SCORE_FIELD_NAME);
-                    if (actualScore.isNull()) {
-                        log.info("Skipping '{}' score because the judge returned a null value", scoreName);
-                        return null;
-                    }
-                    var resultBuilder = FeedbackScoreBatchItem.builder()
-                            .name(scoreName)
-                            .reason(scoreNested.path(REASON_FIELD_NAME).asText())
-                            .source(ScoreSource.ONLINE_SCORING);
-                    if (actualScore.isBoolean()) {
-                        resultBuilder.value(actualScore.asBoolean() ? BigDecimal.ONE : BigDecimal.ZERO);
-                    } else {
-                        resultBuilder.value(actualScore.decimalValue());
-                    }
-                    return resultBuilder.build();
-                })
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-        if (results.isEmpty()) {
+        List<FeedbackScoreBatchItem> results = new ArrayList<>();
+        List<String> nullScoreNames = new ArrayList<>();
+        structuredResponse.properties().forEach(scoreMetric -> {
+            var scoreName = scoreMetric.getKey();
+            var scoreNested = scoreMetric.getValue();
+            if (scoreNested == null || scoreNested.isMissingNode() || !scoreNested.has(SCORE_FIELD_NAME)) {
+                log.info("No score found for '{}' score in {}", scoreName, scoreNested);
+                return;
+            }
+            var actualScore = scoreNested.path(SCORE_FIELD_NAME);
+            if (actualScore.isNull()) {
+                log.info("Skipping '{}' score because the judge returned a null value", scoreName);
+                nullScoreNames.add(scoreName);
+                return;
+            }
+            var resultBuilder = FeedbackScoreBatchItem.builder()
+                    .name(scoreName)
+                    .reason(scoreNested.path(REASON_FIELD_NAME).asText())
+                    .source(ScoreSource.ONLINE_SCORING);
+            if (actualScore.isBoolean()) {
+                resultBuilder.value(actualScore.asBoolean() ? BigDecimal.ONE : BigDecimal.ZERO);
+            } else {
+                resultBuilder.value(actualScore.decimalValue());
+            }
+            results.add(resultBuilder.build());
+        });
+        if (results.isEmpty() && nullScoreNames.isEmpty()) {
             var topLevelKeys = StreamSupport.stream(
                     Spliterators.spliteratorUnknownSize(structuredResponse.fieldNames(),
                             Spliterator.ORDERED | Spliterator.NONNULL),
@@ -559,7 +563,7 @@ public class OnlineScoringEngine {
                     "Invalid LLM output format for feedback scores. Expected structure: { '<scoreName>': { 'score': <number|boolean>, 'reason': <string> } }. Top-level keys: '{}'. Raw response (truncated): '{}'",
                     topLevelKeys, truncated);
         }
-        return results;
+        return new ParsedFeedbackScores(results, nullScoreNames);
     }
 
     private static String extractJson(String response) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -34,6 +34,7 @@ import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
+import org.slf4j.Logger;
 
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
@@ -513,6 +514,13 @@ public class OnlineScoringEngine {
         }
     }
 
+    public static void logSkippedNullScores(
+            Logger userFacingLogger, ParsedFeedbackScores parsed, String entityType, Object entityId) {
+        parsed.nullScoreNames().forEach(name -> userFacingLogger.info(
+                "Skipped score '{}' for {} '{}' because the judge returned a null value (treated as not applicable)",
+                name, entityType, entityId));
+    }
+
     public static ParsedFeedbackScores toFeedbackScores(@NotNull ChatResponse chatResponse) {
         var content = extractJson(chatResponse.aiMessage().text());
         JsonNode structuredResponse;
@@ -532,12 +540,12 @@ public class OnlineScoringEngine {
             var scoreName = scoreMetric.getKey();
             var scoreNested = scoreMetric.getValue();
             if (scoreNested == null || scoreNested.isMissingNode() || !scoreNested.has(SCORE_FIELD_NAME)) {
-                log.info("No score found for '{}' score in {}", scoreName, scoreNested);
+                log.debug("No score found for '{}' score in {}", scoreName, scoreNested);
                 return;
             }
             var actualScore = scoreNested.path(SCORE_FIELD_NAME);
             if (actualScore.isNull()) {
-                log.info("Skipping '{}' score because the judge returned a null value", scoreName);
+                log.debug("Skipping '{}' score because the judge returned a null value", scoreName);
                 nullScoreNames.add(scoreName);
                 return;
             }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -132,9 +132,7 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
 
             // When scoreNameMapping is empty (regular online scoring), names pass through unchanged.
             var parsed = OnlineScoringEngine.toFeedbackScores(chatResponse);
-            parsed.nullScoreNames().forEach(name -> userFacingLogger.info(
-                    "Skipped score '{}' for traceId '{}' because the judge returned a null value (treated as not applicable)",
-                    name, trace.id()));
+            OnlineScoringEngine.logSkippedNullScores(userFacingLogger, parsed, "traceId", trace.id());
             return parsed.scores().stream()
                     .map(item -> {
                         String scoreName = item.name();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -131,7 +131,11 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
             userFacingLogger.info("Received response for traceId '{}':\n\n{}", trace.id(), chatResponse);
 
             // When scoreNameMapping is empty (regular online scoring), names pass through unchanged.
-            return OnlineScoringEngine.toFeedbackScores(chatResponse).stream()
+            var parsed = OnlineScoringEngine.toFeedbackScores(chatResponse);
+            parsed.nullScoreNames().forEach(name -> userFacingLogger.info(
+                    "Skipped score '{}' for traceId '{}' because the judge returned a null value (treated as not applicable)",
+                    name, trace.id()));
+            return parsed.scores().stream()
                     .map(item -> {
                         String scoreName = item.name();
                         if (message.scoreNameMapping().containsKey(scoreName)) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
@@ -123,7 +123,11 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
                     scoreRequest, message.llmAsJudgeCode().model(), message.workspaceId());
             userFacingLogger.info("Received response for spanId '{}':\n\n{}", span.id(), score);
 
-            return OnlineScoringEngine.toFeedbackScores(score).stream()
+            var parsed = OnlineScoringEngine.toFeedbackScores(score);
+            parsed.nullScoreNames().forEach(name -> userFacingLogger.info(
+                    "Skipped score '{}' for spanId '{}' because the judge returned a null value (treated as not applicable)",
+                    name, span.id()));
+            return parsed.scores().stream()
                     .map(item -> (FeedbackScoreBatchItem) item.toBuilder()
                             .id(span.id())
                             .projectId(span.projectId())

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
@@ -124,9 +124,7 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
             userFacingLogger.info("Received response for spanId '{}':\n\n{}", span.id(), score);
 
             var parsed = OnlineScoringEngine.toFeedbackScores(score);
-            parsed.nullScoreNames().forEach(name -> userFacingLogger.info(
-                    "Skipped score '{}' for spanId '{}' because the judge returned a null value (treated as not applicable)",
-                    name, span.id()));
+            OnlineScoringEngine.logSkippedNullScores(userFacingLogger, parsed, "spanId", span.id());
             return parsed.scores().stream()
                     .map(item -> (FeedbackScoreBatchItem) item.toBuilder()
                             .id(span.id())

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -225,9 +225,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             userFacingLogger.info("Received response for threadId '{}':\n\n{}", threadId, chatResponse);
 
             var parsed = OnlineScoringEngine.toFeedbackScores(chatResponse);
-            parsed.nullScoreNames().forEach(name -> userFacingLogger.info(
-                    "Skipped score '{}' for threadId '{}' because the judge returned a null value (treated as not applicable)",
-                    name, threadId));
+            OnlineScoringEngine.logSkippedNullScores(userFacingLogger, parsed, "threadId", threadId);
             return parsed.scores().stream()
                     .map(item -> FeedbackScoresMapper.INSTANCE.map(
                             item.toBuilder()

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -224,7 +224,11 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             var chatResponse = aiProxyService.scoreTrace(scoreRequest, message.code().model(), message.workspaceId());
             userFacingLogger.info("Received response for threadId '{}':\n\n{}", threadId, chatResponse);
 
-            return OnlineScoringEngine.toFeedbackScores(chatResponse).stream()
+            var parsed = OnlineScoringEngine.toFeedbackScores(chatResponse);
+            parsed.nullScoreNames().forEach(name -> userFacingLogger.info(
+                    "Skipped score '{}' for threadId '{}' because the judge returned a null value (treated as not applicable)",
+                    name, threadId));
+            return parsed.scores().stream()
                     .map(item -> FeedbackScoresMapper.INSTANCE.map(
                             item.toBuilder()
                                     .id(threadModelId)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
@@ -1083,6 +1083,25 @@ class OnlineScoringEngineTest {
         }
     }
 
+    @Test
+    @DisplayName("skip feedback scores whose value is null in the AI response")
+    void testToFeedbackScores__whenScoreValueIsNull__thenSkipsThatScore() {
+        var aiMessage = "{\"Relevance\":{\"score\":5,\"reason\":\"applies\"},"
+                + "\"Conciseness\":{\"score\":null,\"reason\":\"not applicable to this turn\"},"
+                + "\"Technical Accuracy\":{\"score\":4.0,\"reason\":\"good\"}}";
+        var chatResponse = ChatResponse.builder()
+                .aiMessage(AiMessage.aiMessage(aiMessage))
+                .build();
+
+        var feedbackScores = OnlineScoringEngine.toFeedbackScores(chatResponse);
+
+        assertThat(feedbackScores).hasSize(2);
+        assertThat(feedbackScores).extracting(FeedbackScoreBatchItem::name)
+                .containsExactlyInAnyOrder("Relevance", "Technical Accuracy");
+        assertThat(feedbackScores).extracting(FeedbackScoreBatchItem::name)
+                .doesNotContain("Conciseness");
+    }
+
     private JsonObjectSchema createTestSchema() {
         return JsonObjectSchema.builder()
                 .addProperty("Relevance", JsonObjectSchema.builder()

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
@@ -1061,7 +1061,7 @@ class OnlineScoringEngineTest {
                 .aiMessage(AiMessage.aiMessage(aiMessage))
                 .build();
 
-        var feedbackScores = OnlineScoringEngine.toFeedbackScores(chatResponse);
+        var feedbackScores = OnlineScoringEngine.toFeedbackScores(chatResponse).scores();
 
         assertThat(feedbackScores).hasSize(expectedSize);
 
@@ -1085,7 +1085,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("skip feedback scores whose value is null in the AI response")
-    void testToFeedbackScores__whenScoreValueIsNull__thenSkipsThatScore() {
+    void whenScoreValueIsNull_thenSkipsThatScoreAndReportsItAsSkipped() {
         var aiMessage = "{\"Relevance\":{\"score\":5,\"reason\":\"applies\"},"
                 + "\"Conciseness\":{\"score\":null,\"reason\":\"not applicable to this turn\"},"
                 + "\"Technical Accuracy\":{\"score\":4.0,\"reason\":\"good\"}}";
@@ -1093,13 +1093,12 @@ class OnlineScoringEngineTest {
                 .aiMessage(AiMessage.aiMessage(aiMessage))
                 .build();
 
-        var feedbackScores = OnlineScoringEngine.toFeedbackScores(chatResponse);
+        var parsed = OnlineScoringEngine.toFeedbackScores(chatResponse);
 
-        assertThat(feedbackScores).hasSize(2);
-        assertThat(feedbackScores).extracting(FeedbackScoreBatchItem::name)
+        assertThat(parsed.scores()).hasSize(2);
+        assertThat(parsed.scores()).extracting(FeedbackScoreBatchItem::name)
                 .containsExactlyInAnyOrder("Relevance", "Technical Accuracy");
-        assertThat(feedbackScores).extracting(FeedbackScoreBatchItem::name)
-                .doesNotContain("Conciseness");
+        assertThat(parsed.nullScoreNames()).containsExactly("Conciseness");
     }
 
     private JsonObjectSchema createTestSchema() {


### PR DESCRIPTION
## Details

When an LLM-as-judge rubric returned `{"metric_x": {"score": null, "reason": "..."}}`, online scoring was persisting it as `0.0` instead of skipping it. The existing guard in `OnlineScoringEngine.toFeedbackScores` only checked whether the `score` key was absent — not whether its value was `null`. The path then reached `actualScore.decimalValue()` on a Jackson `NullNode`, which silently returns `BigDecimal.ZERO`, and the 0 row was indistinguishable from a real low score in metric averages.

The likely original-author intent was to be defensive about malformed judge output, but `NullNode.decimalValue() → ZERO` was a quiet edge case rather than a deliberate default. The fix adds an explicit `actualScore.isNull()` check that returns `null` from the map (filtered out by the existing `.filter(Objects::nonNull)`), mirroring the offline `evaluate(...)` flow's behavior — no row is written, so ClickHouse `avg()` over the `LEFT JOIN` excludes the value from both numerator and denominator.

Wrote a reproducing test first (a 3-metric judge response with the middle score `null` asserts only 2 feedback rows are returned), confirmed it failed before the fix, then applied the fix.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6057

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: implementation
- Human verification: code review, requested more confirmations and better testing, local test run

## Testing

- `mvn test -Dtest='OnlineScoringEngineTest#testToFeedbackScores*'` — 6/6 pass (5 existing + 1 new null-score test)
- `mvn test -Dtest='OnlineScoringEngineTest'` — 80/80 pass
- `mvn spotless:check` — clean
- New test `testToFeedbackScores__whenScoreValueIsNull__thenSkipsThatScore` was confirmed to fail against the unfixed `OnlineScoringEngine` (returned 3 rows instead of 2) and passes after the fix.

## Documentation

N/A — internal fix to online-scoring response parsing; no public API or docs change.