### PR TITLE
[OPIK-6308] [BE] fix: make online evaluation score path non-blocking end-to-end

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -931,6 +931,12 @@ pythonEvaluator:
   # Default: 500ms
   # Description: Min delay between retry attempts
   minRetryDelay: ${PYTHON_EVALUATOR_MIN_RETRY_DELAY:-500ms}
+  # Default: 10s
+  # Description: Max wait for a Python evaluator response read per call.
+  readTimeout: ${PYTHON_EVALUATOR_READ_TIMEOUT:-10s}
+  # Default: 5s
+  # Description: Max wait for the TCP/TLS connection to the Python evaluator to be established.
+  connectTimeout: ${PYTHON_EVALUATOR_CONNECT_TIMEOUT:-5s}
 
 serviceToggles:
   # Default: true

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
@@ -32,9 +32,11 @@ import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
 import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItemThread;
 
 /**
- * This is the base online scorer, for all particular implementations to extend. It listens to a Redis stream for
- * Traces to be scored. Extending classes must provide a particular implementation for the score method.
- * This class extends BaseRedisSubscriber to reuse common Redis stream handling functionality.
+ * Base online scorer for all particular implementations to extend. It listens to a Redis stream for
+ * Traces/Spans/Threads to be scored. Subclasses provide a particular {@link #score(Object)} implementation that
+ * returns a {@link Mono} so the entire processing chain stays non-blocking from Redis read to feedback-score
+ * persistence. The Reactor pipeline owned by {@link BaseRedisSubscriber} schedules execution on the per-stream
+ * worker scheduler; subclasses should NOT call {@code .block()} from {@code score()}.
  */
 public abstract class OnlineScoringBaseScorer<M> extends BaseRedisSubscriber<M> {
 
@@ -66,51 +68,53 @@ public abstract class OnlineScoringBaseScorer<M> extends BaseRedisSubscriber<M> 
         this.type = type;
     }
 
+    /**
+     * Defers the subscription of {@link #score(Object)} so any synchronous work in implementations
+     * runs at subscription time on the per-stream worker scheduler.
+     */
     @Override
     protected Mono<Void> processEvent(M message) {
-        return Mono.fromRunnable(() -> score(message));
+        return Mono.defer(() -> score(message));
     }
 
     /**
-     * Provide a particular implementation to score the trace and store it as a FeedbackScore.
-     * @param message a Redis message with Trace to score, workspace and username.
+     * Scores the message and persists the resulting feedback scores. Implementations must compose
+     * reactive operators (no {@code .block()}); see {@link #storeScores}, {@link #storeSpanScores},
+     * {@link #storeThreadScores}.
      */
-    protected abstract void score(M message);
+    protected abstract Mono<Void> score(M message);
 
-    protected Map<String, List<BigDecimal>> storeScores(
+    protected Mono<Map<String, List<BigDecimal>>> storeScores(
             List<FeedbackScoreBatchItem> scores, Trace trace, String userName, String workspaceId) {
         log.info("Received '{}' scores for traceId '{}' in workspace '{}'. Storing them",
                 scores.size(), trace.id(), workspaceId);
-        feedbackScoreService.scoreBatchOfTraces(scores)
+        return feedbackScoreService.scoreBatchOfTraces(scores)
                 .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, userName)
                         .put(RequestContext.WORKSPACE_ID, workspaceId))
-                .block();
-        return scores.stream()
-                .collect(Collectors.groupingBy(FeedbackScoreItem::name,
-                        Collectors.mapping(FeedbackScoreItem::value, Collectors.toList())));
+                .thenReturn(groupScoresByName(scores));
     }
 
-    protected Map<String, List<BigDecimal>> storeSpanScores(
+    protected Mono<Map<String, List<BigDecimal>>> storeSpanScores(
             List<FeedbackScoreBatchItem> scores, com.comet.opik.api.Span span, String userName, String workspaceId) {
         log.info("Received '{}' scores for spanId '{}' in workspace '{}'. Storing them",
                 scores.size(), span.id(), workspaceId);
-        feedbackScoreService.scoreBatchOfSpans(scores)
+        return feedbackScoreService.scoreBatchOfSpans(scores)
                 .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, userName)
                         .put(RequestContext.WORKSPACE_ID, workspaceId))
-                .block();
-        return scores.stream()
-                .collect(Collectors.groupingBy(FeedbackScoreItem::name,
-                        Collectors.mapping(FeedbackScoreItem::value, Collectors.toList())));
+                .thenReturn(groupScoresByName(scores));
     }
 
-    protected Map<String, List<BigDecimal>> storeThreadScores(
+    protected Mono<Map<String, List<BigDecimal>>> storeThreadScores(
             List<FeedbackScoreBatchItemThread> scores, String threadId, String userName, String workspaceId) {
         log.info("Received '{}' scores for threadId '{}' in workspace '{}'. Storing them",
                 scores.size(), threadId, workspaceId);
-        feedbackScoreService.scoreBatchOfThreads(scores)
+        return feedbackScoreService.scoreBatchOfThreads(scores)
                 .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, userName)
                         .put(RequestContext.WORKSPACE_ID, workspaceId))
-                .block();
+                .thenReturn(groupScoresByName(scores));
+    }
+
+    private static <T extends FeedbackScoreItem> Map<String, List<BigDecimal>> groupScoresByName(List<T> scores) {
         return scores.stream()
                 .collect(Collectors.groupingBy(FeedbackScoreItem::name,
                         Collectors.mapping(FeedbackScoreItem::value, Collectors.toList())));

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -11,13 +11,13 @@ import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.response.ChatResponse;
 import jakarta.inject.Inject;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RedissonReactiveClient;
 import org.slf4j.Logger;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
 import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
@@ -29,6 +29,7 @@ import java.util.UUID;
 import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.Constants;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.LLM_AS_JUDGE;
+import static com.comet.opik.infrastructure.log.LogContextAware.withMdc;
 import static com.comet.opik.infrastructure.log.LogContextAware.wrapWithMdc;
 
 /**
@@ -80,18 +81,34 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
      * @param message a Redis message with the Trace to score with an Evaluator code, workspace and username.
      */
     @Override
-    protected void score(@NonNull TraceToScoreLlmAsJudge message) {
+    protected Mono<Void> score(@NonNull TraceToScoreLlmAsJudge message) {
         var trace = message.trace();
         log.info("Message received with traceId '{}', userName '{}', to be scored in '{}'",
                 trace.id(), message.userName(), message.llmAsJudgeCode().model().name());
 
-        // This is crucial for logging purposes to identify the rule and trace
-        try (var logContext = wrapWithMdc(Map.of(
+        var mdc = Map.of(
                 UserLog.MARKER, UserLog.AUTOMATION_RULE_EVALUATOR.name(),
                 UserLog.WORKSPACE_ID, message.workspaceId(),
                 UserLog.TRACE_ID, trace.id().toString(),
-                UserLog.RULE_ID, message.ruleId().toString()))) {
+                UserLog.RULE_ID, message.ruleId().toString());
 
+        return Mono.fromCallable(() -> evaluate(message, mdc))
+                .subscribeOn(Schedulers.boundedElastic())
+                .flatMap(scores -> storeScores(scores, trace, message.userName(), message.workspaceId()))
+                .doOnNext(withMdc(mdc, loggedScores -> userFacingLogger
+                        .info("Scores for traceId '{}' stored successfully:\n\n{}", trace.id(), loggedScores)))
+                .doOnError(withMdc(mdc, error -> userFacingLogger
+                        .error("Unexpected error while scoring traceId '{}' with rule '{}': \n\n{}",
+                                trace.id(), message.ruleName(),
+                                Optional.ofNullable(error.getCause()).map(Throwable::getMessage)
+                                        .orElse(error.getMessage()))))
+                .then();
+    }
+
+    private List<FeedbackScoreBatchItem> evaluate(TraceToScoreLlmAsJudge message, Map<String, String> mdc) {
+        var trace = message.trace();
+        // This is crucial for logging purposes to identify the rule and trace
+        try (var logContext = wrapWithMdc(mdc)) {
             userFacingLogger.info("Evaluating traceId '{}' sampled by rule '{}'", trace.id(), message.ruleName());
 
             ChatRequest scoreRequest;
@@ -109,44 +126,26 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
             userFacingLogger.info("Sending traceId '{}' to LLM using the following input:\n\n{}",
                     trace.id(), scoreRequest);
 
-            ChatResponse chatResponse;
-            try {
-                chatResponse = aiProxyService.scoreTrace(
-                        scoreRequest, message.llmAsJudgeCode().model(), message.workspaceId());
-                userFacingLogger.info("Received response for traceId '{}':\n\n{}", trace.id(), chatResponse);
-            } catch (Exception exception) {
-                String errorMessage = Optional.ofNullable(exception.getCause())
-                        .map(Throwable::getMessage)
-                        .orElse(exception.getMessage());
+            var chatResponse = aiProxyService.scoreTrace(
+                    scoreRequest, message.llmAsJudgeCode().model(), message.workspaceId());
+            userFacingLogger.info("Received response for traceId '{}':\n\n{}", trace.id(), chatResponse);
 
-                userFacingLogger.error("Unexpected error while scoring traceId '{}' with rule '{}': \n\n{}",
-                        trace.id(), message.ruleName(), errorMessage);
-                throw exception;
-            }
-
-            try {
-                // When scoreNameMapping is empty (regular online scoring), names pass through unchanged.
-                List<FeedbackScoreBatchItem> scores = OnlineScoringEngine.toFeedbackScores(chatResponse).stream()
-                        .map(item -> {
-                            String scoreName = item.name();
-                            if (message.scoreNameMapping().containsKey(scoreName)) {
-                                scoreName = message.scoreNameMapping().get(scoreName);
-                            }
-                            return (FeedbackScoreBatchItem) item.toBuilder()
-                                    .name(scoreName)
-                                    .categoryName(message.categoryName())
-                                    .id(trace.id())
-                                    .projectId(trace.projectId())
-                                    .projectName(trace.projectName())
-                                    .build();
-                        })
-                        .toList();
-                var loggedScores = storeScores(scores, trace, message.userName(), message.workspaceId());
-                userFacingLogger.info("Scores for traceId '{}' stored successfully:\n\n{}", trace.id(), loggedScores);
-            } catch (Exception exception) {
-                userFacingLogger.error("Unexpected error while storing scores for traceId '{}'", trace.id());
-                throw exception;
-            }
+            // When scoreNameMapping is empty (regular online scoring), names pass through unchanged.
+            return OnlineScoringEngine.toFeedbackScores(chatResponse).stream()
+                    .map(item -> {
+                        String scoreName = item.name();
+                        if (message.scoreNameMapping().containsKey(scoreName)) {
+                            scoreName = message.scoreNameMapping().get(scoreName);
+                        }
+                        return (FeedbackScoreBatchItem) item.toBuilder()
+                                .name(scoreName)
+                                .categoryName(message.categoryName())
+                                .id(trace.id())
+                                .projectId(trace.projectId())
+                                .projectName(trace.projectName())
+                                .build();
+                    })
+                    .toList();
         }
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
@@ -10,12 +10,13 @@ import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.response.ChatResponse;
 import jakarta.inject.Inject;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RedissonReactiveClient;
 import org.slf4j.Logger;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
 import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
@@ -26,6 +27,7 @@ import java.util.Optional;
 import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.Constants;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.SPAN_LLM_AS_JUDGE;
+import static com.comet.opik.infrastructure.log.LogContextAware.withMdc;
 import static com.comet.opik.infrastructure.log.LogContextAware.wrapWithMdc;
 
 /**
@@ -72,18 +74,34 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
      * @param message a Redis message with the Span to score with an Evaluator code, workspace and username.
      */
     @Override
-    protected void score(@NonNull SpanToScoreLlmAsJudge message) {
+    protected Mono<Void> score(@NonNull SpanToScoreLlmAsJudge message) {
         var span = message.span();
         log.info("Message received with spanId '{}', userName '{}', to be scored in '{}'",
                 span.id(), message.userName(), message.llmAsJudgeCode().model().name());
 
-        // This is crucial for logging purposes to identify the rule and span
-        try (var logContext = wrapWithMdc(Map.of(
+        var mdc = Map.of(
                 UserLog.MARKER, UserLog.AUTOMATION_RULE_EVALUATOR.name(),
                 UserLog.WORKSPACE_ID, message.workspaceId(),
                 UserLog.SPAN_ID, span.id().toString(),
-                UserLog.RULE_ID, message.ruleId().toString()))) {
+                UserLog.RULE_ID, message.ruleId().toString());
 
+        return Mono.fromCallable(() -> evaluate(message, mdc))
+                .subscribeOn(Schedulers.boundedElastic())
+                .flatMap(scores -> storeSpanScores(scores, span, message.userName(), message.workspaceId()))
+                .doOnNext(withMdc(mdc, loggedScores -> userFacingLogger
+                        .info("Scores for spanId '{}' stored successfully:\n\n{}", span.id(), loggedScores)))
+                .doOnError(withMdc(mdc, error -> userFacingLogger
+                        .error("Unexpected error while scoring spanId '{}' with rule '{}': \n\n{}",
+                                span.id(), message.ruleName(),
+                                Optional.ofNullable(error.getCause()).map(Throwable::getMessage)
+                                        .orElse(error.getMessage()))))
+                .then();
+    }
+
+    private List<FeedbackScoreBatchItem> evaluate(SpanToScoreLlmAsJudge message, Map<String, String> mdc) {
+        var span = message.span();
+        // This is crucial for logging purposes to identify the rule and span
+        try (var logContext = wrapWithMdc(mdc)) {
             userFacingLogger.info("Evaluating spanId '{}' sampled by rule '{}'", span.id(), message.ruleName());
 
             ChatRequest scoreRequest;
@@ -101,36 +119,17 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
             userFacingLogger.info("Sending spanId '{}' to LLM using the following input:\n\n{}",
                     span.id(), scoreRequest);
 
-            ChatResponse score;
-            try {
-                // Reuse scoreTrace method as it's generic enough - it just takes a ChatRequest and calls the LLM
-                score = aiProxyService.scoreTrace(
-                        scoreRequest, message.llmAsJudgeCode().model(), message.workspaceId());
-                userFacingLogger.info("Received response for spanId '{}':\n\n{}", span.id(), score);
-            } catch (Exception exception) {
-                String errorMessage = Optional.ofNullable(exception.getCause())
-                        .map(Throwable::getMessage)
-                        .orElse(exception.getMessage());
+            var score = aiProxyService.scoreTrace(
+                    scoreRequest, message.llmAsJudgeCode().model(), message.workspaceId());
+            userFacingLogger.info("Received response for spanId '{}':\n\n{}", span.id(), score);
 
-                userFacingLogger.error("Unexpected error while scoring spanId '{}' with rule '{}': \n\n{}",
-                        span.id(), message.ruleName(), errorMessage);
-                throw exception;
-            }
-
-            try {
-                List<FeedbackScoreBatchItem> scores = OnlineScoringEngine.toFeedbackScores(score).stream()
-                        .map(item -> (FeedbackScoreBatchItem) item.toBuilder()
-                                .id(span.id())
-                                .projectId(span.projectId())
-                                .projectName(span.projectName())
-                                .build())
-                        .toList();
-                var loggedScores = storeSpanScores(scores, span, message.userName(), message.workspaceId());
-                userFacingLogger.info("Scores for spanId '{}' stored successfully:\n\n{}", span.id(), loggedScores);
-            } catch (Exception exception) {
-                userFacingLogger.error("Unexpected error while storing scores for spanId '{}'", span.id());
-                throw exception;
-            }
+            return OnlineScoringEngine.toFeedbackScores(score).stream()
+                    .map(item -> (FeedbackScoreBatchItem) item.toBuilder()
+                            .id(span.id())
+                            .projectId(span.projectId())
+                            .projectName(span.projectName())
+                            .build())
+                    .toList();
         }
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorer.java
@@ -1,6 +1,7 @@
 package com.comet.opik.api.resources.v1.events;
 
 import com.comet.opik.api.ScoreSource;
+import com.comet.opik.api.Span;
 import com.comet.opik.api.events.SpanToScoreUserDefinedMetricPython;
 import com.comet.opik.domain.FeedbackScoreService;
 import com.comet.opik.domain.TraceService;
@@ -15,6 +16,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RedissonReactiveClient;
 import org.slf4j.Logger;
+import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
 import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
@@ -24,6 +26,7 @@ import java.util.Map;
 import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.Constants;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.SPAN_USER_DEFINED_METRIC_PYTHON;
+import static com.comet.opik.infrastructure.log.LogContextAware.withMdc;
 import static com.comet.opik.infrastructure.log.LogContextAware.wrapWithMdc;
 
 /**
@@ -66,60 +69,59 @@ public class OnlineScoringSpanUserDefinedMetricPythonScorer
     }
 
     @Override
-    protected void score(@NonNull SpanToScoreUserDefinedMetricPython message) {
+    protected Mono<Void> score(@NonNull SpanToScoreUserDefinedMetricPython message) {
         var span = message.span();
         log.info("Message received with spanId '{}', userName '{}'", span.id(), message.userName());
 
-        // This is crucial for logging purposes to identify the rule and span
-        try (var logContext = wrapWithMdc(Map.of(
+        var mdc = Map.of(
                 UserLog.MARKER, UserLog.AUTOMATION_RULE_EVALUATOR.name(),
                 UserLog.WORKSPACE_ID, message.workspaceId(),
                 UserLog.SPAN_ID, span.id().toString(),
-                UserLog.RULE_ID, message.ruleId().toString()))) {
+                UserLog.RULE_ID, message.ruleId().toString());
 
+        return Mono.fromCallable(() -> prepareData(message, mdc))
+                .flatMap(data -> pythonEvaluatorService.evaluate(message.code().metric(), data))
+                .doOnNext(withMdc(mdc, scoreResults -> userFacingLogger
+                        .info("Received response for spanId '{}':\n\n{}", span.id(), scoreResults)))
+                .flatMap(scoreResults -> storeSpanScores(toFeedbackScores(scoreResults, span), span,
+                        message.userName(), message.workspaceId()))
+                .doOnNext(withMdc(mdc, loggedScores -> userFacingLogger
+                        .info("Scores for spanId '{}' stored successfully:\n\n{}", span.id(), loggedScores)))
+                .doOnError(withMdc(mdc, error -> userFacingLogger
+                        .error("Unexpected error while scoring spanId '{}' with rule '{}': \n\n{}",
+                                span.id(), message.ruleName(), error.getMessage())))
+                .then();
+    }
+
+    private Map<String, String> prepareData(SpanToScoreUserDefinedMetricPython message, Map<String, String> mdc) {
+        var span = message.span();
+        // This is crucial for logging purposes to identify the rule and span
+        try (var logContext = wrapWithMdc(mdc)) {
             userFacingLogger.info("Evaluating spanId '{}' sampled by rule '{}'", span.id(), message.ruleName());
-
-            Map<String, String> data;
             try {
-                data = OnlineScoringEngine.toReplacements(message.code().arguments(), span);
+                var data = OnlineScoringEngine.toReplacements(message.code().arguments(), span);
+                userFacingLogger.info("Sending spanId '{}' to Python evaluator using the following input:\n\n{}",
+                        span.id(), data);
+                return data;
             } catch (Exception exception) {
                 userFacingLogger.error("Error preparing Python request for spanId '{}': \n\n{}",
                         span.id(), exception.getMessage());
                 throw exception;
             }
-
-            userFacingLogger.info("Sending spanId '{}' to Python evaluator using the following input:\n\n{}",
-                    span.id(), data);
-
-            List<PythonScoreResult> scoreResults;
-            try {
-                scoreResults = pythonEvaluatorService.evaluate(message.code().metric(), data);
-                userFacingLogger.info("Received response for spanId '{}':\n\n{}", span.id(), scoreResults);
-            } catch (Exception exception) {
-                userFacingLogger.error("Unexpected error while scoring spanId '{}' with rule '{}': \n\n{}",
-                        span.id(), message.ruleName(), exception.getMessage());
-                throw exception;
-            }
-
-            try {
-                List<FeedbackScoreBatchItem> scores = scoreResults.stream()
-                        .map(scoreResult -> (FeedbackScoreBatchItem) FeedbackScoreBatchItem.builder()
-                                .id(span.id())
-                                .projectName(span.projectName())
-                                .projectId(span.projectId())
-                                .name(scoreResult.name())
-                                .value(scoreResult.value())
-                                .reason(scoreResult.reason())
-                                .source(ScoreSource.ONLINE_SCORING)
-                                .build())
-                        .toList();
-
-                var loggedScores = storeSpanScores(scores, span, message.userName(), message.workspaceId());
-                userFacingLogger.info("Scores for spanId '{}' stored successfully:\n\n{}", span.id(), loggedScores);
-            } catch (Exception exception) {
-                userFacingLogger.error("Unexpected error while storing scores for spanId '{}'", span.id());
-                throw exception;
-            }
         }
+    }
+
+    private static List<FeedbackScoreBatchItem> toFeedbackScores(List<PythonScoreResult> scoreResults, Span span) {
+        return scoreResults.stream()
+                .map(scoreResult -> (FeedbackScoreBatchItem) FeedbackScoreBatchItem.builder()
+                        .id(span.id())
+                        .projectName(span.projectName())
+                        .projectId(span.projectId())
+                        .name(scoreResult.name())
+                        .value(scoreResult.value())
+                        .reason(scoreResult.reason())
+                        .source(ScoreSource.ONLINE_SCORING)
+                        .build())
+                .toList();
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -16,10 +16,8 @@ import com.comet.opik.domain.llm.LlmProviderFactory;
 import com.comet.opik.domain.threads.TraceThreadService;
 import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
-import com.comet.opik.infrastructure.log.LogContextAware;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.response.ChatResponse;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 import lombok.NonNull;
@@ -44,6 +42,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItemThread;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.Constants;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.TRACE_THREAD_LLM_AS_JUDGE;
+import static com.comet.opik.infrastructure.log.LogContextAware.withMdc;
+import static com.comet.opik.infrastructure.log.LogContextAware.wrapWithMdc;
 
 @EagerSingleton
 @Slf4j
@@ -83,112 +83,148 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
      * @param message a Redis message with the trace thread to score with an Evaluator code, workspace and username.
      */
     @Override
-    protected void score(@NonNull TraceThreadToScoreLlmAsJudge message) {
+    protected Mono<Void> score(@NonNull TraceThreadToScoreLlmAsJudge message) {
 
         log.info("Message received with projectId: '{}', ruleId: '{}', threadIds: '{}' for workspace '{}'",
                 message.projectId(), message.ruleId(), message.threadIds(), message.workspaceId());
 
-        Flux.fromIterable(message.threadIds())
+        return Flux.fromIterable(message.threadIds())
                 .flatMap(threadId -> processThreadScores(message, threadId))
                 .then(Mono.defer(
                         () -> traceThreadService.setScoredAt(message.projectId(), message.threadIds(), Instant.now())))
                 .contextWrite(context -> context.put(RequestContext.WORKSPACE_ID, message.workspaceId())
                         .put(RequestContext.USER_NAME, message.userName())
                         .put(RequestContext.VISIBILITY, Visibility.PRIVATE))
-                .thenReturn(message)
-                .subscribe(
-                        unused -> log.info("Processed trace threads for projectId '{}', ruleId '{}' for workspace '{}'",
-                                message.projectId(), message.ruleId(), message.workspaceId()),
-                        error -> log.error(
-                                "Error processing trace thread for projectId '{}', ruleId '{}' for workspace '{}'",
-                                message.projectId(), message.ruleId(), message.workspaceId(), error));
+                .doOnSuccess(unused -> log.info(
+                        "Processed trace threads for projectId '{}', ruleId '{}' for workspace '{}'",
+                        message.projectId(), message.ruleId(), message.workspaceId()))
+                .doOnError(error -> log.error(
+                        "Error processing trace thread for projectId '{}', ruleId '{}' for workspace '{}'",
+                        message.projectId(), message.ruleId(), message.workspaceId(), error))
+                .then();
     }
 
     private Mono<Void> processThreadScores(TraceThreadToScoreLlmAsJudge message, String currentThreadId) {
+        var mdc = Map.of(
+                UserLog.MARKER, UserLog.AUTOMATION_RULE_EVALUATOR.name(),
+                UserLog.WORKSPACE_ID, message.workspaceId(),
+                UserLog.RULE_ID, message.ruleId().toString());
         return retrieveFullThreadContext(currentThreadId, new AtomicReference<>(null), message.projectId())
                 .sort(Comparator.comparing(Trace::id))
                 .collectList()
-                .switchIfEmpty(Mono.defer(() -> {
-                    log.warn("No traces found for threadId '{}' in projectId '{}'. Skipping scoring.",
-                            currentThreadId, message.projectId());
-                    return Mono.empty();
-                }))
-                .flatMap(traces -> traceThreadService.getThreadModelId(message.projectId(), currentThreadId)
-                        .flatMap(threadModelId -> Mono.fromCallable(() -> {
-                            try (var logContext = LogContextAware.wrapWithMdc(Map.of(
-                                    UserLog.MARKER, UserLog.AUTOMATION_RULE_EVALUATOR.name(),
-                                    UserLog.WORKSPACE_ID, message.workspaceId(),
-                                    UserLog.THREAD_MODEL_ID, threadModelId.toString(),
-                                    UserLog.RULE_ID, message.ruleId().toString()))) {
-
-                                // Process python scoring for the thread
-                                processScoring(message, traces, threadModelId, currentThreadId);
-
-                                return threadModelId;
-                            }
-                        }).subscribeOn(Schedulers.boundedElastic())))
+                .flatMap(traces -> {
+                    if (traces.isEmpty()) {
+                        try (var logContext = wrapWithMdc(mdc)) {
+                            userFacingLogger.info(
+                                    "No traces found for threadId '{}' in projectId '{}'. Skipping scoring.",
+                                    currentThreadId, message.projectId());
+                        }
+                        return Mono.empty();
+                    }
+                    return traceThreadService.getThreadModelId(message.projectId(), currentThreadId)
+                            .switchIfEmpty(Mono.defer(() -> {
+                                try (var logContext = wrapWithMdc(mdc)) {
+                                    userFacingLogger.info(
+                                            "Thread model not found for threadId '{}' in projectId '{}'. Skipping scoring.",
+                                            currentThreadId, message.projectId());
+                                }
+                                return Mono.empty();
+                            }))
+                            .flatMap(threadModelId -> processScoring(message, traces, threadModelId,
+                                    currentThreadId));
+                })
                 .then();
     }
 
     /**
-     * Processes the scoring for a given thread using the Python evaluator.
-     *
-     * @param message the message containing project ID, rule ID, and other details
-     * @param traces the list of traces associated with the thread
-     * @param threadModelId the ID of the thread model
-     * @param threadId the ID of the thread
+     * Scores a single thread for a given rule and persists the resulting feedback scores.
      */
-    private void processScoring(TraceThreadToScoreLlmAsJudge message, List<Trace> traces,
+    private Mono<Void> processScoring(TraceThreadToScoreLlmAsJudge message, List<Trace> traces,
             UUID threadModelId, String threadId) {
+        var mdc = Map.of(
+                UserLog.MARKER, UserLog.AUTOMATION_RULE_EVALUATOR.name(),
+                UserLog.WORKSPACE_ID, message.workspaceId(),
+                UserLog.THREAD_MODEL_ID, threadModelId.toString(),
+                UserLog.RULE_ID, message.ruleId().toString());
+        return Mono.fromCallable(() -> findRule(message, threadId, mdc))
+                .subscribeOn(Schedulers.boundedElastic())
+                .doOnError(withMdc(mdc, error -> userFacingLogger
+                        .error("Unexpected error while looking up rule for threadId '{}': \n\n{}",
+                                threadId,
+                                Optional.ofNullable(error.getCause()).map(Throwable::getMessage)
+                                        .orElse(error.getMessage()))))
+                .flatMap(maybeRule -> maybeRule
+                        .map(rule -> scoreThread(message, traces, threadModelId, threadId, rule, mdc))
+                        .orElseGet(Mono::empty));
+    }
 
-        final AutomationRuleEvaluator<?, ?> rule;
-
-        try {
-            rule = automationRuleEvaluatorService.findById(message.ruleId(), Set.of(message.projectId()),
-                    message.workspaceId());
-        } catch (NotFoundException ex) {
-            log.warn(
-                    "Automation rule with ID '{}' not found in projectId '{}' for workspace '{}'. Skipping scoring for threadId '{}'.",
-                    message.ruleId(), message.projectId(), message.workspaceId(), threadId);
-            return;
+    /**
+     * Resolves the automation rule for this scoring run. Returns {@link Optional#empty()} if the rule
+     * has been deleted, signalling the caller to skip without throwing.
+     */
+    private Optional<AutomationRuleEvaluator<?, ?>> findRule(TraceThreadToScoreLlmAsJudge message, String threadId,
+            Map<String, String> mdc) {
+        try (var logContext = wrapWithMdc(mdc)) {
+            try {
+                var rule = automationRuleEvaluatorService.findById(message.ruleId(),
+                        Set.of(message.projectId()), message.workspaceId());
+                return Optional.of(rule);
+            } catch (NotFoundException ex) {
+                log.warn(
+                        "Automation rule with ID '{}' not found in projectId '{}' for workspace '{}'. Skipping scoring for threadId '{}'.",
+                        message.ruleId(), message.projectId(), message.workspaceId(), threadId);
+                return Optional.empty();
+            }
         }
+    }
 
-        // This is crucial for logging purposes to identify the rule and trace
-        userFacingLogger.info("Evaluating threadId: '{}' sampled by ruleName: '{}'", threadId, rule.getName());
-        log.info("Evaluating threadId: '{}' sampled by ruleName: '{}'", threadId, rule.getName());
+    /**
+     * Runs the scoring chain for a known rule and persists the resulting feedback scores. Caller
+     * guarantees {@code traces} is non-empty.
+     */
+    private Mono<Void> scoreThread(TraceThreadToScoreLlmAsJudge message, List<Trace> traces, UUID threadModelId,
+            String threadId, AutomationRuleEvaluator<?, ?> rule, Map<String, String> mdc) {
+        return Mono.fromCallable(() -> evaluate(message, traces, threadModelId, threadId, rule, mdc))
+                .flatMap(scores -> storeThreadScores(scores, threadId, message.userName(), message.workspaceId()))
+                .doOnNext(withMdc(mdc, loggedScores -> userFacingLogger
+                        .info("Scores for threadId '{}' stored successfully:\n\n{}", threadId, loggedScores)))
+                .doOnError(withMdc(mdc, error -> userFacingLogger
+                        .error("Unexpected error while scoring threadId '{}' with rule '{}': \n\n{}",
+                                threadId, rule.getName(),
+                                Optional.ofNullable(error.getCause()).map(Throwable::getMessage)
+                                        .orElse(error.getMessage()))))
+                .then();
+    }
 
-        Project project = projectService.get(message.projectId(), message.workspaceId());
+    /**
+     * Calls the LLM provider for the given thread and returns the resulting feedback scores. Caller
+     * guarantees {@code traces} is non-empty.
+     */
+    private List<FeedbackScoreBatchItemThread> evaluate(TraceThreadToScoreLlmAsJudge message, List<Trace> traces,
+            UUID threadModelId, String threadId, AutomationRuleEvaluator<?, ?> rule, Map<String, String> mdc) {
+        try (var logContext = wrapWithMdc(mdc)) {
+            userFacingLogger.info("Evaluating threadId '{}' sampled by rule '{}'", threadId, rule.getName());
 
-        ChatRequest scoreRequest;
-        try {
-            String modelName = message.code().model().name();
-            var strategy = llmProviderFactory.getStructuredOutputStrategy(modelName);
-            scoreRequest = OnlineScoringEngine.prepareThreadLlmRequest(message.code(), traces, strategy);
-        } catch (Exception exception) {
-            userFacingLogger.error("Error preparing LLM request for threadId: '{}': \n\n{}",
-                    threadId, exception.getMessage());
-            throw exception;
-        }
+            Project project = projectService.get(message.projectId(), message.workspaceId());
 
-        userFacingLogger.info("Sending threadId: '{}' to LLM using the following input:\n\n{}",
-                threadId, scoreRequest);
-        log.info("Sending threadId: '{}' to LLM using the following input:\n\n{}", threadId, scoreRequest);
+            ChatRequest scoreRequest;
+            try {
+                String modelName = message.code().model().name();
+                var strategy = llmProviderFactory.getStructuredOutputStrategy(modelName);
+                scoreRequest = OnlineScoringEngine.prepareThreadLlmRequest(message.code(), traces, strategy);
+            } catch (Exception exception) {
+                userFacingLogger.error("Error preparing LLM request for threadId '{}': \n\n{}",
+                        threadId, exception.getMessage());
+                throw exception;
+            }
 
-        ChatResponse chatResponse;
-        try {
-            chatResponse = aiProxyService.scoreTrace(
-                    scoreRequest, message.code().model(), message.workspaceId());
-            userFacingLogger.info("Received response for threadId: '{}':\n\n{}", threadId, chatResponse);
-        } catch (Exception exception) {
-            userFacingLogger.error("Unexpected error while scoring threadId: '{}' with ruleName: '{}': \n\n{}",
-                    threadId, rule.getName(), Optional.ofNullable(exception.getCause())
-                            .map(Throwable::getMessage)
-                            .orElse(exception.getMessage()));
-            throw exception;
-        }
+            userFacingLogger.info("Sending threadId '{}' to LLM using the following input:\n\n{}",
+                    threadId, scoreRequest);
 
-        try {
-            List<FeedbackScoreBatchItemThread> scores = OnlineScoringEngine.toFeedbackScores(chatResponse).stream()
+            var chatResponse = aiProxyService.scoreTrace(scoreRequest, message.code().model(), message.workspaceId());
+            userFacingLogger.info("Received response for threadId '{}':\n\n{}", threadId, chatResponse);
+
+            return OnlineScoringEngine.toFeedbackScores(chatResponse).stream()
                     .map(item -> FeedbackScoresMapper.INSTANCE.map(
                             item.toBuilder()
                                     .id(threadModelId)
@@ -198,13 +234,6 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                                     .build(),
                             threadId))
                     .toList();
-
-            var loggedScores = storeThreadScores(scores, threadId, message.userName(), message.workspaceId());
-            userFacingLogger.info("Scores for threadId '{}' stored successfully:\n\n{}", threadId, loggedScores);
-        } catch (Exception exception) {
-            userFacingLogger.error("Unexpected error while storing scores for threadId '{}' with ruleName '{}'",
-                    threadId, rule.getName());
-            throw exception;
         }
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
@@ -12,17 +12,16 @@ import com.comet.opik.domain.TraceService;
 import com.comet.opik.domain.evaluators.AutomationRuleEvaluatorService;
 import com.comet.opik.domain.evaluators.UserLog;
 import com.comet.opik.domain.evaluators.python.PythonEvaluatorService;
-import com.comet.opik.domain.evaluators.python.PythonScoreResult;
 import com.comet.opik.domain.threads.TraceThreadService;
 import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
-import com.comet.opik.infrastructure.log.LogContextAware;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.redisson.api.RedissonReactiveClient;
 import org.slf4j.Logger;
 import reactor.core.publisher.Flux;
@@ -31,10 +30,12 @@ import reactor.core.scheduler.Schedulers;
 import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
 import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -43,6 +44,8 @@ import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItemThread;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.Constants;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.TRACE_THREAD_USER_DEFINED_METRIC_PYTHON;
 import static com.comet.opik.domain.evaluators.python.TraceThreadPythonEvaluatorRequest.ChatMessage;
+import static com.comet.opik.infrastructure.log.LogContextAware.withMdc;
+import static com.comet.opik.infrastructure.log.LogContextAware.wrapWithMdc;
 
 @EagerSingleton
 @Slf4j
@@ -89,124 +92,166 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
     }
 
     @Override
-    protected void score(@NonNull TraceThreadToScoreUserDefinedMetricPython message) {
+    protected Mono<Void> score(@NonNull TraceThreadToScoreUserDefinedMetricPython message) {
 
         log.info("Message received with projectId '{}', ruleId '{}' for workspace '{}'",
                 message.projectId(), message.ruleId(), message.workspaceId());
 
-        Flux.fromIterable(message.threadIds())
+        return Flux.fromIterable(message.threadIds())
                 .flatMap(threadId -> processThreadScores(message, threadId))
                 .then(Mono.defer(
                         () -> traceThreadService.setScoredAt(message.projectId(), message.threadIds(), Instant.now())))
                 .contextWrite(context -> context.put(RequestContext.WORKSPACE_ID, message.workspaceId())
                         .put(RequestContext.USER_NAME, message.userName())
                         .put(RequestContext.VISIBILITY, Visibility.PRIVATE))
-                .thenReturn(message)
-                .subscribe(
-                        unused -> log.info("Processed trace threads for projectId '{}', ruleId '{}' for workspace '{}'",
-                                message.projectId(), message.ruleId(), message.workspaceId()),
-                        error -> {
-                            log.error(
-                                    "Error processing trace thread for projectId '{}', ruleId '{}' for workspace '{}': {}",
-                                    message.projectId(), message.ruleId(), message.workspaceId(), error.getMessage());
-                            log.error("Error processing trace thread scoring", error);
-                        });
+                .doOnSuccess(unused -> log.info(
+                        "Processed trace threads for projectId '{}', ruleId '{}' for workspace '{}'",
+                        message.projectId(), message.ruleId(), message.workspaceId()))
+                .doOnError(error -> log.error(
+                        "Error processing trace thread for projectId '{}', ruleId '{}' for workspace '{}': {}",
+                        message.projectId(), message.ruleId(), message.workspaceId(), error.getMessage(), error))
+                .then();
     }
 
-    private Mono<Void> processThreadScores(TraceThreadToScoreUserDefinedMetricPython message, String currentThreadId) {
+    private Mono<Void> processThreadScores(TraceThreadToScoreUserDefinedMetricPython message,
+            String currentThreadId) {
+        var mdc = Map.of(
+                UserLog.MARKER, UserLog.AUTOMATION_RULE_EVALUATOR.name(),
+                UserLog.WORKSPACE_ID, message.workspaceId(),
+                UserLog.RULE_ID, message.ruleId().toString());
         return retrieveFullThreadContext(currentThreadId, new AtomicReference<>(null), message.projectId())
                 .sort(Comparator.comparing(Trace::id))
                 .collectList()
-                .flatMap(traces -> traceThreadService.getThreadModelId(message.projectId(), currentThreadId)
-                        .flatMap(threadModelId -> Mono.fromCallable(() -> {
-                            try (var logContext = LogContextAware.wrapWithMdc(Map.of(
-                                    UserLog.MARKER, UserLog.AUTOMATION_RULE_EVALUATOR.name(),
-                                    UserLog.WORKSPACE_ID, message.workspaceId(),
-                                    UserLog.THREAD_MODEL_ID, threadModelId.toString(),
-                                    UserLog.RULE_ID, message.ruleId().toString()))) {
-
-                                // Process python scoring for the thread
-                                processScoring(message, traces, threadModelId, currentThreadId);
-
-                                return threadModelId;
-                            }
-                        }).subscribeOn(Schedulers.boundedElastic())))
+                .flatMap(traces -> {
+                    if (traces.isEmpty()) {
+                        try (var logContext = wrapWithMdc(mdc)) {
+                            userFacingLogger.info(
+                                    "No traces found for threadId '{}' in projectId '{}'. Skipping scoring.",
+                                    currentThreadId, message.projectId());
+                        }
+                        return Mono.empty();
+                    }
+                    return traceThreadService.getThreadModelId(message.projectId(), currentThreadId)
+                            .switchIfEmpty(Mono.defer(() -> {
+                                try (var logContext = wrapWithMdc(mdc)) {
+                                    userFacingLogger.info(
+                                            "Thread model not found for threadId '{}' in projectId '{}'. Skipping scoring.",
+                                            currentThreadId, message.projectId());
+                                }
+                                return Mono.empty();
+                            }))
+                            .flatMap(threadModelId -> processScoring(message, traces, threadModelId,
+                                    currentThreadId));
+                })
                 .then();
     }
 
     /**
-     * Processes the scoring for a given thread using the Python evaluator.
-     *
-     * @param message the message containing project ID, rule ID, and other details
-     * @param traces the list of traces associated with the thread
-     * @param threadModelId the ID of the thread model
-     * @param threadId the ID of the thread
+     * Scores a single thread for a given rule and persists the resulting feedback scores.
      */
-    private void processScoring(TraceThreadToScoreUserDefinedMetricPython message, List<Trace> traces,
+    private Mono<Void> processScoring(TraceThreadToScoreUserDefinedMetricPython message, List<Trace> traces,
             UUID threadModelId, String threadId) {
+        var mdc = Map.of(
+                UserLog.MARKER, UserLog.AUTOMATION_RULE_EVALUATOR.name(),
+                UserLog.WORKSPACE_ID, message.workspaceId(),
+                UserLog.THREAD_MODEL_ID, threadModelId.toString(),
+                UserLog.RULE_ID, message.ruleId().toString());
+        return Mono.fromCallable(() -> findRule(message, threadId, mdc))
+                .subscribeOn(Schedulers.boundedElastic())
+                .doOnError(withMdc(mdc, error -> userFacingLogger
+                        .error("Unexpected error while looking up rule for threadId '{}': \n\n{}",
+                                threadId,
+                                Optional.ofNullable(error.getCause()).map(Throwable::getMessage)
+                                        .orElse(error.getMessage()))))
+                .flatMap(maybeRule -> maybeRule
+                        .map(rule -> scoreThread(message, traces, threadModelId, threadId, rule, mdc))
+                        .orElseGet(Mono::empty));
+    }
 
-        final AutomationRuleEvaluator<?, ?> rule;
-
-        try {
-            rule = automationRuleEvaluatorService.findById(message.ruleId(), Set.of(message.projectId()),
-                    message.workspaceId());
-        } catch (NotFoundException ex) {
-            log.warn(
-                    "Automation rule with ID '{}' not found in projectId '{}' for workspace '{}'. Skipping scoring for threadId '{}'.",
-                    message.ruleId(), message.projectId(), message.workspaceId(), threadId);
-            return;
-        }
-
-        Project project = projectService.get(message.projectId(), message.workspaceId());
-
-        if (traces.isEmpty()) {
-            userFacingLogger.info(
-                    "No traces found for threadId: '{}' in projectId; '{}', ruleName: '{}' for workspace '{}'",
-                    threadId, message.projectId(), rule.getName(), message.workspaceId());
-            return;
-        }
-
-        List<ChatMessage> context;
-        try {
-            context = OnlineScoringEngine.fromTraceToThread(traces);
-        } catch (Exception exception) {
-            userFacingLogger.error("Error preparing Python request for threadId: '{}': \n\n{}",
-                    threadId, exception.getMessage());
-            throw exception;
-        }
-
-        userFacingLogger.info("Sending threadId: '{}' to Python evaluator using the following context:\n\n{}",
-                threadId, context);
-
-        List<PythonScoreResult> scoreResults;
-        try {
-            scoreResults = pythonEvaluatorService.evaluateThread(message.code().metric(), context);
-            userFacingLogger.info("Received response for threadId: '{}':\n\n{}", threadId, scoreResults);
-        } catch (Exception exception) {
-            userFacingLogger.error("Unexpected error while scoring traceId: '{}' with ruleName: '{}': \n\n{}",
-                    threadId, rule.getName(), exception.getMessage());
-            throw exception;
-        }
-
-        List<FeedbackScoreBatchItemThread> scores = scoreResults.stream()
-                .map(scoreResult -> FeedbackScoresMapper.INSTANCE.map(
-                        scoreResult,
-                        threadModelId,
-                        threadId,
-                        message.projectId(),
-                        project.name(),
-                        ScoreSource.ONLINE_SCORING))
-                .toList();
-
-        try {
-            var loggedScores = storeThreadScores(scores, threadId, message.userName(), message.workspaceId());
-            userFacingLogger.info("Scores for threadId: '{}' stored successfully:\n\n{}", threadId,
-                    loggedScores);
-        } catch (Exception exception) {
-            userFacingLogger.error("Unexpected error while storing scores for traceId: '{}' with ruleName: '{}'",
-                    threadId, rule.getName());
-            throw exception;
+    /**
+     * Resolves the automation rule for this scoring run. Returns {@link Optional#empty()} if the rule
+     * has been deleted, signalling the caller to skip without throwing.
+     */
+    private Optional<AutomationRuleEvaluator<?, ?>> findRule(
+            TraceThreadToScoreUserDefinedMetricPython message, String threadId, Map<String, String> mdc) {
+        try (var logContext = wrapWithMdc(mdc)) {
+            try {
+                var rule = automationRuleEvaluatorService.findById(message.ruleId(),
+                        Set.of(message.projectId()), message.workspaceId());
+                return Optional.of(rule);
+            } catch (NotFoundException ex) {
+                log.warn(
+                        "Automation rule with ID '{}' not found in projectId '{}' for workspace '{}'. Skipping scoring for threadId '{}'.",
+                        message.ruleId(), message.projectId(), message.workspaceId(), threadId);
+                return Optional.empty();
+            }
         }
     }
 
+    /**
+     * Runs the scoring chain for a known rule and persists the resulting feedback scores. Caller
+     * guarantees {@code traces} is non-empty.
+     */
+    private Mono<Void> scoreThread(TraceThreadToScoreUserDefinedMetricPython message, List<Trace> traces,
+            UUID threadModelId, String threadId, AutomationRuleEvaluator<?, ?> rule, Map<String, String> mdc) {
+        return Mono.fromCallable(() -> prepareScoring(message, traces, threadId, rule, mdc))
+                .flatMap(context -> evaluateAndStore(message, threadModelId, threadId, context, mdc))
+                .doOnError(withMdc(mdc, error -> userFacingLogger
+                        .error("Unexpected error while scoring threadId '{}' with rule '{}': \n\n{}",
+                                threadId, rule.getName(),
+                                Optional.ofNullable(error.getCause()).map(Throwable::getMessage)
+                                        .orElse(error.getMessage()))))
+                .then();
+    }
+
+    /**
+     * Builds the Python evaluator request (project + chat messages) for the given thread. Caller
+     * guarantees {@code traces} is non-empty.
+     */
+    private Pair<Project, List<ChatMessage>> prepareScoring(TraceThreadToScoreUserDefinedMetricPython message,
+            List<Trace> traces, String threadId, AutomationRuleEvaluator<?, ?> rule, Map<String, String> mdc) {
+        try (var logContext = wrapWithMdc(mdc)) {
+            userFacingLogger.info("Evaluating threadId '{}' sampled by rule '{}'", threadId, rule.getName());
+
+            Project project = projectService.get(message.projectId(), message.workspaceId());
+
+            List<ChatMessage> context;
+            try {
+                context = OnlineScoringEngine.fromTraceToThread(traces);
+            } catch (Exception exception) {
+                userFacingLogger.error("Error preparing Python request for threadId '{}': \n\n{}",
+                        threadId, exception.getMessage());
+                throw exception;
+            }
+
+            userFacingLogger.info("Sending threadId '{}' to Python evaluator using the following context:\n\n{}",
+                    threadId, context);
+
+            return Pair.of(project, context);
+        }
+    }
+
+    private Mono<Map<String, List<BigDecimal>>> evaluateAndStore(
+            TraceThreadToScoreUserDefinedMetricPython message, UUID threadModelId, String threadId,
+            Pair<Project, List<ChatMessage>> context, Map<String, String> mdc) {
+        var project = context.getLeft();
+        var chatMessages = context.getRight();
+        return pythonEvaluatorService.evaluateThread(message.code().metric(), chatMessages)
+                .doOnNext(withMdc(mdc, scoreResults -> userFacingLogger
+                        .info("Received response for threadId '{}':\n\n{}", threadId, scoreResults)))
+                .flatMap(scoreResults -> {
+                    List<FeedbackScoreBatchItemThread> scores = scoreResults.stream()
+                            .map(scoreResult -> FeedbackScoresMapper.INSTANCE.map(
+                                    scoreResult,
+                                    threadModelId,
+                                    threadId,
+                                    message.projectId(),
+                                    project.name(),
+                                    ScoreSource.ONLINE_SCORING))
+                            .toList();
+                    return storeThreadScores(scores, threadId, message.userName(), message.workspaceId());
+                })
+                .doOnNext(withMdc(mdc, loggedScores -> userFacingLogger
+                        .info("Scores for threadId '{}' stored successfully:\n\n{}", threadId, loggedScores)));
+    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
@@ -108,8 +108,8 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
                         "Processed trace threads for projectId '{}', ruleId '{}' for workspace '{}'",
                         message.projectId(), message.ruleId(), message.workspaceId()))
                 .doOnError(error -> log.error(
-                        "Error processing trace thread for projectId '{}', ruleId '{}' for workspace '{}': {}",
-                        message.projectId(), message.ruleId(), message.workspaceId(), error.getMessage(), error))
+                        "Error processing trace thread for projectId '{}', ruleId '{}' for workspace '{}'",
+                        message.projectId(), message.ruleId(), message.workspaceId(), error))
                 .then();
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorer.java
@@ -1,6 +1,7 @@
 package com.comet.opik.api.resources.v1.events;
 
 import com.comet.opik.api.ScoreSource;
+import com.comet.opik.api.Trace;
 import com.comet.opik.api.events.TraceToScoreUserDefinedMetricPython;
 import com.comet.opik.domain.FeedbackScoreService;
 import com.comet.opik.domain.TraceService;
@@ -15,6 +16,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RedissonReactiveClient;
 import org.slf4j.Logger;
+import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
 import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
@@ -24,6 +26,7 @@ import java.util.Map;
 import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.Constants;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.USER_DEFINED_METRIC_PYTHON;
+import static com.comet.opik.infrastructure.log.LogContextAware.withMdc;
 import static com.comet.opik.infrastructure.log.LogContextAware.wrapWithMdc;
 
 @EagerSingleton
@@ -60,60 +63,58 @@ public class OnlineScoringUserDefinedMetricPythonScorer
     }
 
     @Override
-    protected void score(@NonNull TraceToScoreUserDefinedMetricPython message) {
+    protected Mono<Void> score(@NonNull TraceToScoreUserDefinedMetricPython message) {
         var trace = message.trace();
         log.info("Message received with traceId '{}', userName '{}'", trace.id(), message.userName());
 
-        // This is crucial for logging purposes to identify the rule and trace
-        try (var logContext = wrapWithMdc(Map.of(
+        var mdc = Map.of(
                 UserLog.MARKER, UserLog.AUTOMATION_RULE_EVALUATOR.name(),
                 UserLog.WORKSPACE_ID, message.workspaceId(),
                 UserLog.TRACE_ID, trace.id().toString(),
-                UserLog.RULE_ID, message.ruleId().toString()))) {
+                UserLog.RULE_ID, message.ruleId().toString());
 
+        return Mono.fromCallable(() -> prepareData(message, mdc))
+                .flatMap(data -> pythonEvaluatorService.evaluate(message.code().metric(), data))
+                .doOnNext(withMdc(mdc, scoreResults -> userFacingLogger
+                        .info("Received response for traceId '{}':\n\n{}", trace.id(), scoreResults)))
+                .flatMap(scoreResults -> storeScores(toFeedbackScores(scoreResults, trace), trace,
+                        message.userName(), message.workspaceId()))
+                .doOnNext(withMdc(mdc, loggedScores -> userFacingLogger
+                        .info("Scores for traceId '{}' stored successfully:\n\n{}", trace.id(), loggedScores)))
+                .doOnError(withMdc(mdc, error -> userFacingLogger
+                        .error("Unexpected error while scoring traceId '{}' with rule '{}': \n\n{}",
+                                trace.id(), message.ruleName(), error.getMessage())))
+                .then();
+    }
+
+    private Map<String, String> prepareData(TraceToScoreUserDefinedMetricPython message, Map<String, String> mdc) {
+        var trace = message.trace();
+        try (var logContext = wrapWithMdc(mdc)) {
             userFacingLogger.info("Evaluating traceId '{}' sampled by rule '{}'", trace.id(), message.ruleName());
-
-            Map<String, String> data;
             try {
-                data = OnlineScoringEngine.toReplacements(message.code().arguments(), trace);
+                var data = OnlineScoringEngine.toReplacements(message.code().arguments(), trace);
+                userFacingLogger.info("Sending traceId '{}' to Python evaluator using the following input:\n\n{}",
+                        trace.id(), data);
+                return data;
             } catch (Exception exception) {
                 userFacingLogger.error("Error preparing Python request for traceId '{}': \n\n{}",
                         trace.id(), exception.getMessage());
                 throw exception;
             }
-
-            userFacingLogger.info("Sending traceId '{}' to Python evaluator using the following input:\n\n{}",
-                    trace.id(), data);
-
-            List<PythonScoreResult> scoreResults;
-            try {
-                scoreResults = pythonEvaluatorService.evaluate(message.code().metric(), data);
-                userFacingLogger.info("Received response for traceId '{}':\n\n{}", trace.id(), scoreResults);
-            } catch (Exception exception) {
-                userFacingLogger.error("Unexpected error while scoring traceId '{}' with rule '{}': \n\n{}",
-                        trace.id(), message.ruleName(), exception.getMessage());
-                throw exception;
-            }
-
-            try {
-                List<FeedbackScoreBatchItem> scores = scoreResults.stream()
-                        .map(scoreResult -> (FeedbackScoreBatchItem) FeedbackScoreBatchItem.builder()
-                                .id(trace.id())
-                                .projectName(trace.projectName())
-                                .projectId(trace.projectId())
-                                .name(scoreResult.name())
-                                .value(scoreResult.value())
-                                .reason(scoreResult.reason())
-                                .source(ScoreSource.ONLINE_SCORING)
-                                .build())
-                        .toList();
-
-                var loggedScores = storeScores(scores, trace, message.userName(), message.workspaceId());
-                userFacingLogger.info("Scores for traceId '{}' stored successfully:\n\n{}", trace.id(), loggedScores);
-            } catch (Exception exception) {
-                userFacingLogger.error("Unexpected error while storing scores for traceId '{}'", trace.id());
-                throw exception;
-            }
         }
+    }
+
+    private static List<FeedbackScoreBatchItem> toFeedbackScores(List<PythonScoreResult> scoreResults, Trace trace) {
+        return scoreResults.stream()
+                .map(scoreResult -> (FeedbackScoreBatchItem) FeedbackScoreBatchItem.builder()
+                        .id(trace.id())
+                        .projectName(trace.projectName())
+                        .projectId(trace.projectId())
+                        .name(scoreResult.name())
+                        .value(scoreResult.value())
+                        .reason(scoreResult.reason())
+                        .source(ScoreSource.ONLINE_SCORING)
+                        .build())
+                .toList();
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Map;
@@ -29,7 +30,7 @@ public class PythonEvaluatorService {
     private final @NonNull RetriableHttpClient client;
     private final @NonNull OpikConfiguration config;
 
-    public List<PythonScoreResult> evaluate(@NonNull String code, Map<String, String> data) {
+    public Mono<List<PythonScoreResult>> evaluate(@NonNull String code, Map<String, String> data) {
         Preconditions.checkArgument(MapUtils.isNotEmpty(data), "Argument 'data' must not be empty");
         var request = PythonEvaluatorRequest.builder()
                 .code(code)
@@ -39,7 +40,7 @@ public class PythonEvaluatorService {
         return executeWithRetry(Entity.json(request));
     }
 
-    public List<PythonScoreResult> evaluateThread(@NonNull String code, List<ChatMessage> context) {
+    public Mono<List<PythonScoreResult>> evaluateThread(@NonNull String code, List<ChatMessage> context) {
         Preconditions.checkArgument(CollectionUtils.isNotEmpty(context), "Argument 'context' must not be empty");
         TraceThreadPythonEvaluatorRequest request = TraceThreadPythonEvaluatorRequest.builder()
                 .code(code)
@@ -49,14 +50,19 @@ public class PythonEvaluatorService {
         return executeWithRetry(Entity.json(request));
     }
 
-    private List<PythonScoreResult> executeWithRetry(Entity<?> request) {
-        return RetriableHttpClient.newPost(c -> c.target(URL_TEMPLATE.formatted(config.getPythonEvaluator().getUrl())))
-                .withRetryPolicy(RetryUtils.handleHttpErrors(config.getPythonEvaluator().getMaxRetryAttempts(),
-                        config.getPythonEvaluator().getMinRetryDelay().toJavaDuration(),
-                        config.getPythonEvaluator().getMaxRetryDelay().toJavaDuration()))
-                .withRequestBody(request)
-                .withResponse(this::processResponse)
-                .execute(client);
+    private Mono<List<PythonScoreResult>> executeWithRetry(Entity<?> body) {
+        var pythonConfig = config.getPythonEvaluator();
+        var request = RetriableHttpClient.Request.<List<PythonScoreResult>>builder()
+                .requestFunction(client -> client.target(URL_TEMPLATE.formatted(pythonConfig.getUrl())))
+                .retryPolicy(RetryUtils.handleHttpErrors(pythonConfig.getMaxRetryAttempts(),
+                        pythonConfig.getMinRetryDelay().toJavaDuration(),
+                        pythonConfig.getMaxRetryDelay().toJavaDuration()))
+                .body(body)
+                .connectTimeout(pythonConfig.getConnectTimeout().toJavaDuration())
+                .readTimeout(pythonConfig.getReadTimeout().toJavaDuration())
+                .responseFunction(this::processResponse)
+                .build();
+        return client.executePostWithRetry(request);
     }
 
     private List<PythonScoreResult> processResponse(Response response) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/PythonEvaluatorConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/PythonEvaluatorConfig.java
@@ -6,9 +6,9 @@ import io.dropwizard.validation.MaxDuration;
 import io.dropwizard.validation.MinDuration;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 
 import java.util.concurrent.TimeUnit;
 
@@ -31,12 +31,12 @@ public class PythonEvaluatorConfig {
     private Duration minRetryDelay = Duration.milliseconds(500);
 
     @JsonProperty
-    @NonNull @MinDuration(value = 10, unit = TimeUnit.MILLISECONDS)
+    @NotNull @MinDuration(value = 10, unit = TimeUnit.MILLISECONDS)
     @MaxDuration(value = 60, unit = TimeUnit.SECONDS)
     private Duration readTimeout;
 
     @JsonProperty
-    @NonNull @MinDuration(value = 10, unit = TimeUnit.MILLISECONDS)
+    @NotNull @MinDuration(value = 10, unit = TimeUnit.MILLISECONDS)
     @MaxDuration(value = 60, unit = TimeUnit.SECONDS)
     private Duration connectTimeout;
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/PythonEvaluatorConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/PythonEvaluatorConfig.java
@@ -7,10 +7,13 @@ import io.dropwizard.validation.MinDuration;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 import java.util.concurrent.TimeUnit;
 
 @Data
+@NoArgsConstructor
 public class PythonEvaluatorConfig {
 
     @JsonProperty
@@ -26,4 +29,14 @@ public class PythonEvaluatorConfig {
     @JsonProperty
     @MaxDuration(value = 1, unit = TimeUnit.SECONDS)
     private Duration minRetryDelay = Duration.milliseconds(500);
+
+    @JsonProperty
+    @NonNull @MinDuration(value = 10, unit = TimeUnit.MILLISECONDS)
+    @MaxDuration(value = 60, unit = TimeUnit.SECONDS)
+    private Duration readTimeout;
+
+    @JsonProperty
+    @NonNull @MinDuration(value = 10, unit = TimeUnit.MILLISECONDS)
+    @MaxDuration(value = 60, unit = TimeUnit.SECONDS)
+    private Duration connectTimeout;
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/RetriableHttpClient.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/RetriableHttpClient.java
@@ -8,16 +8,25 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.InvocationCallback;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
+import lombok.Builder;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.glassfish.jersey.client.ClientProperties;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
-import reactor.util.function.Tuple2;
-import reactor.util.function.Tuples;
 import reactor.util.retry.Retry;
 
+import java.time.Duration;
 import java.util.function.Function;
 
+/**
+ * Reactive HTTP POST helper with retry semantics over a JAX-RS {@link Client}. Returns a cold
+ * {@link Mono} so callers compose into a non-blocking pipeline; safe to subscribe from any thread.
+ * <p>
+ * Subscribed on {@link Schedulers#boundedElastic()} so any incidental subscribe-side work
+ * is isolated from caller threads. This keeps the client
+ * encapsulated regardless of how callers invoke it.
+ */
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 public class RetriableHttpClient {
@@ -25,71 +34,27 @@ public class RetriableHttpClient {
     private final @NonNull Client client;
 
     /**
-     * Fluent interface for building and executing retryable HTTP POST requests.
+     * Immutable specification of an outbound POST. {@code connectTimeout} caps TCP/TLS handshake duration;
+     * {@code readTimeout} caps the response read. Both are optional but recommended.
      */
-    public interface RetryableHttpPost {
-
-        @NonNull Function<Client, WebTarget> callEndpoint();
-
-        static RetryableHttpPost of(@NonNull Function<Client, WebTarget> requestFunction) {
-            return () -> requestFunction;
-        }
-
-        default RetryableHttpCallContext withRetryPolicy(@NonNull Retry retryPolicy) {
-            return () -> Tuples.of(this, retryPolicy);
-        }
-
-    }
-
-    public interface RetryableHttpCallContext {
-        Tuple2<RetryableHttpPost, Retry> getRequestWithContext();
-
-        default RetryableHttpCallContextWithResponse withRequestBody(@NonNull Entity<?> requestEntity) {
-            return () -> Tuples.of(this, requestEntity);
-        }
-    }
-
-    public interface RetryableHttpCallContextWithResponse {
-        Tuple2<RetryableHttpCallContext, Entity<?>> getRequestWithContextAndFunction();
-
-        default <T> RetryableHttpExecutableContext<T> withResponse(@NonNull Function<Response, T> responseFunction) {
-            return () -> Tuples.of(this, responseFunction);
-        }
-    }
-
-    public interface RetryableHttpExecutableContext<T> {
-
-        Tuple2<RetryableHttpCallContextWithResponse, Function<Response, T>> getFullContext();
-
-        default T execute(@NonNull RetriableHttpClient httpClient) {
-            Function<Client, WebTarget> requestFunction = getFullContext().getT1().getRequestWithContextAndFunction()
-                    .getT1().getRequestWithContext().getT1().callEndpoint();
-            Retry retrySpec = getFullContext().getT1().getRequestWithContextAndFunction().getT1()
-                    .getRequestWithContext().getT2();
-            Entity<?> requestBody = getFullContext().getT1().getRequestWithContextAndFunction().getT2();
-            Function<Response, T> responseFunction = getFullContext().getT2();
-
-            return httpClient.executePostWithRetry(requestBody, retrySpec, requestFunction, responseFunction);
-        }
-
+    @Builder
+    public record Request<T>(
+            @NonNull Function<Client, WebTarget> requestFunction,
+            @NonNull Retry retryPolicy,
+            @NonNull Entity<?> body,
+            Duration connectTimeout,
+            Duration readTimeout,
+            @NonNull Function<Response, T> responseFunction) {
     }
 
     /**
-     * Initiates a new retryable HTTP POST request to the specified endpoint.
-     *
-     * @param requestFunction Function that takes a JAX-RS Client and returns a WebTarget for the desired endpoint.
-     * @return A RetryableHttpPost instance to further configure the request.
+     * Execute the request and return a cold {@link Mono} that emits the response value, retrying on
+     * 503/504 according to the supplied policy.
      */
-    public static RetryableHttpPost newPost(@NonNull Function<Client, WebTarget> requestFunction) {
-        return RetryableHttpPost.of(requestFunction);
-    }
-
-    private <T> T executePostWithRetry(Entity<?> request, Retry retrySpec, Function<Client, WebTarget> requestFunction,
-            Function<Response, T> responseFunction) {
-        return Mono.defer(() -> performHttpPost(request, requestFunction)
+    public <T> Mono<T> executePostWithRetry(@NonNull Request<T> request) {
+        return Mono.defer(() -> performHttpPost(request)
                 .flatMap(response -> {
                     int statusCode = response.getStatus();
-
                     if (isRetryableStatusCode(statusCode)) {
                         response.bufferEntity(); // Buffer the entity to allow multiple reads
                         String body = response.readEntity(String.class);
@@ -97,34 +62,38 @@ public class RetriableHttpClient {
                                 "Service temporarily unavailable (HTTP %s): %s".formatted(statusCode, body),
                                 statusCode));
                     }
-
                     return Mono.just(response);
                 })
-                .flatMap(value -> Mono.fromCallable(() -> responseFunction.apply(value))))
+                .flatMap(value -> Mono.fromCallable(() -> request.responseFunction().apply(value))))
                 .subscribeOn(Schedulers.boundedElastic())
-                .retryWhen(retrySpec)
-                .block();
+                .retryWhen(request.retryPolicy());
     }
 
     private boolean isRetryableStatusCode(int statusCode) {
         return statusCode == 503 || statusCode == 504;
     }
 
-    private Mono<Response> performHttpPost(Entity<?> request, Function<Client, WebTarget> requestFunction) {
-        return Mono.create(sink -> requestFunction.apply(client)
-                .request()
-                .async()
-                .post(request, new InvocationCallback<Response>() {
-                    @Override
-                    public void completed(Response response) {
-                        sink.success(response);
-                    }
+    private <T> Mono<Response> performHttpPost(Request<T> request) {
+        return Mono.create(sink -> {
+            var builder = request.requestFunction().apply(client)
+                    .request();
+            if (request.connectTimeout() != null) {
+                builder.property(ClientProperties.CONNECT_TIMEOUT, (int) request.connectTimeout().toMillis());
+            }
+            if (request.readTimeout() != null) {
+                builder.property(ClientProperties.READ_TIMEOUT, (int) request.readTimeout().toMillis());
+            }
+            builder.async().post(request.body(), new InvocationCallback<Response>() {
+                @Override
+                public void completed(Response response) {
+                    sink.success(response);
+                }
 
-                    @Override
-                    public void failed(Throwable throwable) {
-                        sink.error(throwable);
-                    }
-                }));
+                @Override
+                public void failed(Throwable throwable) {
+                    sink.error(throwable);
+                }
+            });
+        });
     }
-
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/log/LogContextAware.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/log/LogContextAware.java
@@ -1,6 +1,7 @@
 package com.comet.opik.infrastructure.log;
 
 import lombok.AccessLevel;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.UtilityClass;
 import org.slf4j.MDC;
@@ -62,5 +63,18 @@ public class LogContextAware {
                 .toList();
 
         return new Closable(context);
+    }
+
+    /**
+     * Wrap a {@link Consumer} so it executes with the supplied MDC context applied. Useful for
+     * {@code doOnNext}, {@code doOnError}, etc. in reactive pipelines where the executing thread is not
+     * guaranteed to carry the caller's MDC.
+     */
+    public static <T> Consumer<T> withMdc(@NonNull Map<String, String> contextMap, @NonNull Consumer<T> consumer) {
+        return task -> {
+            try (var logContext = wrapWithMdc(contextMap)) {
+                consumer.accept(task);
+            }
+        };
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorerTest.java
@@ -23,7 +23,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RStreamReactive;
 import org.redisson.api.RedissonReactiveClient;
+import org.redisson.api.options.PlainOptions;
+import org.slf4j.Logger;
+import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -71,7 +75,7 @@ class OnlineScoringSpanUserDefinedMetricPythonScorerTest {
         // Mock the static UserFacingLoggingFactory.getLogger method
         mockedFactory = mockStatic(UserFacingLoggingFactory.class);
         mockedFactory.when(() -> UserFacingLoggingFactory.getLogger(any(Class.class)))
-                .thenReturn(mock(org.slf4j.Logger.class));
+                .thenReturn(mock(Logger.class));
 
         // Mock OnlineScoringConfig to return stream configuration for span_user_defined_metric_python
         OnlineScoringConfig.StreamConfiguration streamConfig = new OnlineScoringConfig.StreamConfiguration();
@@ -121,10 +125,9 @@ class OnlineScoringSpanUserDefinedMetricPythonScorerTest {
             // Given
             when(serviceTogglesConfig.isSpanUserDefinedMetricPythonEnabled()).thenReturn(true);
             // Mock Redis stream to avoid NullPointerException
-            org.redisson.api.RStreamReactive<Object, Object> mockStream = mock(org.redisson.api.RStreamReactive.class);
-            lenient().when(redissonClient.getStream(any(org.redisson.api.options.PlainOptions.class)))
-                    .thenReturn(mockStream);
-            lenient().when(mockStream.createGroup(any())).thenReturn(reactor.core.publisher.Mono.empty());
+            RStreamReactive<Object, Object> mockStream = mock(RStreamReactive.class);
+            lenient().when(redissonClient.getStream(any(PlainOptions.class))).thenReturn(mockStream);
+            lenient().when(mockStream.createGroup(any())).thenReturn(Mono.empty());
 
             // When
             scorer.start();
@@ -147,7 +150,7 @@ class OnlineScoringSpanUserDefinedMetricPythonScorerTest {
             // If no exception is thrown, the scorer handled the disabled state gracefully
             // The actual behavior is that super.start() is not called
             // Verify Redis stream was never accessed
-            verify(redissonClient, never()).getStream(any(org.redisson.api.options.PlainOptions.class));
+            verify(redissonClient, never()).getStream(any(PlainOptions.class));
         }
     }
 
@@ -194,12 +197,12 @@ class OnlineScoringSpanUserDefinedMetricPythonScorerTest {
                     .build();
 
             when(pythonEvaluatorService.evaluate(any(String.class), any(Map.class)))
-                    .thenReturn(List.of(scoreResult));
+                    .thenReturn(Mono.just(List.of(scoreResult)));
             when(feedbackScoreService.scoreBatchOfSpans(any(List.class)))
-                    .thenReturn(reactor.core.publisher.Mono.empty());
+                    .thenReturn(Mono.empty());
 
             // When
-            scorer.score(message);
+            scorer.score(message).block();
 
             // Then
             @SuppressWarnings("unchecked")
@@ -258,12 +261,12 @@ class OnlineScoringSpanUserDefinedMetricPythonScorerTest {
                     .build();
 
             when(pythonEvaluatorService.evaluate(any(String.class), any(Map.class)))
-                    .thenReturn(List.of(scoreResult1, scoreResult2));
+                    .thenReturn(Mono.just(List.of(scoreResult1, scoreResult2)));
             when(feedbackScoreService.scoreBatchOfSpans(any(List.class)))
-                    .thenReturn(reactor.core.publisher.Mono.empty());
+                    .thenReturn(Mono.empty());
 
             // When
-            scorer.score(message);
+            scorer.score(message).block();
 
             // Then
             @SuppressWarnings("unchecked")
@@ -311,12 +314,12 @@ class OnlineScoringSpanUserDefinedMetricPythonScorerTest {
                     .build();
 
             when(pythonEvaluatorService.evaluate(any(String.class), any(Map.class)))
-                    .thenReturn(List.of());
+                    .thenReturn(Mono.just(List.of()));
             when(feedbackScoreService.scoreBatchOfSpans(any(List.class)))
-                    .thenReturn(reactor.core.publisher.Mono.empty());
+                    .thenReturn(Mono.empty());
 
             // When
-            scorer.score(message);
+            scorer.score(message).block();
 
             // Then
             @SuppressWarnings("unchecked")

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -1,0 +1,328 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.Project;
+import com.comet.opik.api.ScoreSource;
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadLlmAsJudge;
+import com.comet.opik.api.events.TraceThreadToScoreLlmAsJudge;
+import com.comet.opik.domain.FeedbackScoreService;
+import com.comet.opik.domain.ProjectService;
+import com.comet.opik.domain.TraceSearchCriteria;
+import com.comet.opik.domain.TraceService;
+import com.comet.opik.domain.evaluators.AutomationRuleEvaluatorService;
+import com.comet.opik.domain.llm.ChatCompletionService;
+import com.comet.opik.domain.llm.LlmProviderFactory;
+import com.comet.opik.domain.llm.structuredoutput.ToolCallingStrategy;
+import com.comet.opik.domain.threads.TraceThreadService;
+import com.comet.opik.infrastructure.OnlineScoringConfig;
+import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.comet.opik.utils.JsonUtils;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import io.dropwizard.util.Duration;
+import jakarta.ws.rs.NotFoundException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RedissonReactiveClient;
+import org.slf4j.Logger;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItemThread;
+import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadLlmAsJudge.TraceThreadLlmAsJudgeCode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
+
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+
+    @Mock
+    private OnlineScoringConfig onlineScoringConfig;
+    @Mock
+    private RedissonReactiveClient redissonClient;
+    @Mock
+    private FeedbackScoreService feedbackScoreService;
+    @Mock
+    private ChatCompletionService aiProxyService;
+    @Mock
+    private LlmProviderFactory llmProviderFactory;
+    @Mock
+    private TraceService traceService;
+    @Mock
+    private TraceThreadService traceThreadService;
+    @Mock
+    private ProjectService projectService;
+    @Mock
+    private AutomationRuleEvaluatorService automationRuleEvaluatorService;
+
+    private OnlineScoringTraceThreadLlmAsJudgeScorer scorer;
+    private MockedStatic<UserFacingLoggingFactory> mockedFactory;
+    private Logger userFacingLogger;
+
+    private UUID projectId;
+    private UUID ruleId;
+    private UUID threadModelId;
+    private String threadId;
+    private String workspaceId;
+    private String userName;
+    private String ruleName;
+
+    @BeforeEach
+    void setUp() {
+        userFacingLogger = mock(Logger.class);
+        mockedFactory = mockStatic(UserFacingLoggingFactory.class);
+        mockedFactory.when(() -> UserFacingLoggingFactory.getLogger(any(Class.class)))
+                .thenReturn(userFacingLogger);
+
+        var streamConfig = OnlineScoringConfig.StreamConfiguration.builder()
+                .scorer("trace_thread_llm_as_judge")
+                .streamName("stream_scoring_trace_thread_llm_as_judge")
+                .codec("java")
+                .poolingInterval(Duration.milliseconds(500))
+                .longPollingDuration(Duration.seconds(5))
+                .consumerBatchSize(10)
+                .claimIntervalRatio(10)
+                .pendingMessageDuration(Duration.minutes(10))
+                .maxRetries(3)
+                .build();
+
+        when(onlineScoringConfig.getStreams()).thenReturn(List.of(streamConfig));
+        when(onlineScoringConfig.getConsumerGroupName()).thenReturn("online_scoring");
+
+        scorer = new OnlineScoringTraceThreadLlmAsJudgeScorer(
+                onlineScoringConfig,
+                redissonClient,
+                feedbackScoreService,
+                aiProxyService,
+                llmProviderFactory,
+                traceService,
+                traceThreadService,
+                projectService,
+                automationRuleEvaluatorService);
+
+        projectId = UUID.randomUUID();
+        ruleId = UUID.randomUUID();
+        threadModelId = UUID.randomUUID();
+        threadId = "thread-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        workspaceId = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        userName = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        ruleName = "rule-" + RandomStringUtils.secure().nextAlphanumeric(32);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (mockedFactory != null) {
+            mockedFactory.close();
+        }
+    }
+
+    @Nested
+    class ScoringTests {
+
+        // Real evaluator code so prepareThreadLlmRequest renders against a valid schema.
+        private static final String EVALUATOR_JSON = """
+                {
+                  "model": { "name": "gpt-4o", "temperature": 0.3 },
+                  "messages": [
+                    { "role": "USER", "content": "Score the conversation: {{context}}" },
+                    { "role": "SYSTEM", "content": "You are a helpful AI." }
+                  ],
+                  "schema": [
+                    { "name": "Relevance",   "type": "INTEGER", "description": "Relevance of the answer" },
+                    { "name": "Conciseness", "type": "DOUBLE",  "description": "How concise the answer is" }
+                  ]
+                }
+                """;
+
+        // Matches the schema above; toFeedbackScores parses this into two FeedbackScoreBatchItem entries.
+        private static final String LLM_RESPONSE = """
+                {
+                  "Relevance":   { "score": 4,   "reason": "on-topic" },
+                  "Conciseness": { "score": 3.5, "reason": "could be tighter" }
+                }
+                """;
+
+        @Test
+        void scoresThreadAndPersistsScores() {
+            var code = JsonUtils.readValue(EVALUATOR_JSON, TraceThreadLlmAsJudgeCode.class);
+            var message = sampleMessage().toBuilder().code(code).build();
+            var trace = sampleTrace();
+            var project = Project.builder().id(projectId).name("test-project").build();
+            var rule = AutomationRuleEvaluatorTraceThreadLlmAsJudge.builder()
+                    .name(ruleName)
+                    .code(code)
+                    .build();
+
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class)))
+                    .thenReturn(Flux.just(trace), Flux.empty());
+            when(traceThreadService.getThreadModelId(projectId, threadId))
+                    .thenReturn(Mono.just(threadModelId));
+            when(automationRuleEvaluatorService.findById(ruleId, Set.of(projectId), workspaceId))
+                    .thenReturn(rule);
+            when(projectService.get(projectId, workspaceId)).thenReturn(project);
+            when(llmProviderFactory.getStructuredOutputStrategy("gpt-4o"))
+                    .thenReturn(new ToolCallingStrategy());
+            when(aiProxyService.scoreTrace(any(ChatRequest.class), eq(code.model()), eq(workspaceId)))
+                    .thenReturn(ChatResponse.builder().aiMessage(AiMessage.aiMessage(LLM_RESPONSE)).build());
+            when(feedbackScoreService.scoreBatchOfThreads(any())).thenReturn(Mono.empty());
+            when(traceThreadService.setScoredAt(eq(projectId), eq(List.of(threadId)), any()))
+                    .thenReturn(Mono.empty());
+
+            scorer.score(message).block();
+
+            var captor = ArgumentCaptor.forClass(List.class);
+            verify(feedbackScoreService).scoreBatchOfThreads(captor.capture());
+            verify(traceThreadService).setScoredAt(eq(projectId), eq(List.of(threadId)), any());
+
+            assertThat(captor.getValue()).usingRecursiveComparison().isEqualTo(List.of(
+                    threadScore("Relevance", BigDecimal.valueOf(4), "on-topic", project),
+                    threadScore("Conciseness", new BigDecimal("3.5"), "could be tighter", project)));
+        }
+
+        @Test
+        void skipsScoringWhenThreadHasNoTraces() {
+            var message = sampleMessage();
+
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class))).thenReturn(Flux.empty());
+            when(traceThreadService.setScoredAt(eq(projectId), eq(List.of(threadId)), any()))
+                    .thenReturn(Mono.empty());
+
+            scorer.score(message).block();
+
+            verify(traceThreadService, never()).getThreadModelId(any(), any());
+            verify(automationRuleEvaluatorService, never()).findById(any(), any(), any());
+            verify(projectService, never()).get(any(), any());
+            verify(aiProxyService, never()).scoreTrace(any(), any(), any());
+            verify(feedbackScoreService, never()).scoreBatchOfThreads(any());
+        }
+
+        @Test
+        void skipsScoringWhenThreadModelIsMissing() {
+            var message = sampleMessage();
+
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class)))
+                    .thenReturn(Flux.just(sampleTrace()), Flux.empty());
+            when(traceThreadService.getThreadModelId(projectId, threadId)).thenReturn(Mono.empty());
+            when(traceThreadService.setScoredAt(eq(projectId), eq(List.of(threadId)), any()))
+                    .thenReturn(Mono.empty());
+
+            scorer.score(message).block();
+
+            verify(automationRuleEvaluatorService, never()).findById(any(), any(), any());
+            verify(projectService, never()).get(any(), any());
+            verify(aiProxyService, never()).scoreTrace(any(), any(), any());
+            verify(feedbackScoreService, never()).scoreBatchOfThreads(any());
+        }
+
+        @Test
+        void skipsSilentlyWhenRuleHasBeenDeleted() {
+            var message = sampleMessage();
+
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class)))
+                    .thenReturn(Flux.just(sampleTrace()), Flux.empty());
+            when(traceThreadService.getThreadModelId(projectId, threadId)).thenReturn(Mono.just(threadModelId));
+            when(automationRuleEvaluatorService.findById(ruleId, Set.of(projectId), workspaceId))
+                    .thenThrow(new NotFoundException("rule not found"));
+            when(traceThreadService.setScoredAt(eq(projectId), eq(List.of(threadId)), any()))
+                    .thenReturn(Mono.empty());
+
+            scorer.score(message).block();
+
+            verify(projectService, never()).get(any(), any());
+            verify(aiProxyService, never()).scoreTrace(any(), any(), any());
+            verify(feedbackScoreService, never()).scoreBatchOfThreads(any());
+        }
+
+        static Stream<Arguments> errorCauseScenarios() {
+            return Stream.of(
+                    Arguments.of("without cause -> uses error message",
+                            new RuntimeException("DB unreachable"), "DB unreachable"),
+                    Arguments.of("with cause -> uses cause message",
+                            new RuntimeException("wrapper", new IllegalStateException("inner cause")), "inner cause"));
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("errorCauseScenarios")
+        void unwrapsCauseMessageWhenLoggingRuleLookupFailure(String name, RuntimeException error,
+                String loggedMessage) {
+            var message = sampleMessage();
+
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class)))
+                    .thenReturn(Flux.just(sampleTrace()), Flux.empty());
+            when(traceThreadService.getThreadModelId(projectId, threadId)).thenReturn(Mono.just(threadModelId));
+            when(automationRuleEvaluatorService.findById(ruleId, Set.of(projectId), workspaceId)).thenThrow(error);
+
+            assertThatThrownBy(() -> scorer.score(message).block()).isInstanceOf(RuntimeException.class);
+
+            verify(userFacingLogger).error(
+                    contains("Unexpected error while looking up rule for threadId"),
+                    eq(threadId),
+                    eq(loggedMessage));
+            verify(aiProxyService, never()).scoreTrace(any(), any(), any());
+            verify(feedbackScoreService, never()).scoreBatchOfThreads(any());
+        }
+    }
+
+    private TraceThreadToScoreLlmAsJudge sampleMessage() {
+        return podamFactory.manufacturePojo(TraceThreadToScoreLlmAsJudge.class).toBuilder()
+                .ruleId(ruleId)
+                .projectId(projectId)
+                .threadIds(List.of(threadId))
+                .code(new TraceThreadLlmAsJudgeCode(null, List.of(), List.of()))
+                .workspaceId(workspaceId)
+                .userName(userName)
+                .build();
+    }
+
+    private Trace sampleTrace() {
+        return podamFactory.manufacturePojo(Trace.class).toBuilder()
+                .id(UUID.randomUUID())
+                .projectId(projectId)
+                .threadId(threadId)
+                .build();
+    }
+
+    private FeedbackScoreBatchItemThread threadScore(String name, BigDecimal value, String reason, Project project) {
+        return FeedbackScoreBatchItemThread.builder()
+                .id(threadModelId)
+                .threadId(threadId)
+                .projectId(projectId)
+                .projectName(project.name())
+                .name(name)
+                .value(value)
+                .reason(reason)
+                .source(ScoreSource.ONLINE_SCORING)
+                .build();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
@@ -1,0 +1,355 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.Project;
+import com.comet.opik.api.ScoreSource;
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython;
+import com.comet.opik.api.events.TraceThreadToScoreUserDefinedMetricPython;
+import com.comet.opik.domain.FeedbackScoreService;
+import com.comet.opik.domain.ProjectService;
+import com.comet.opik.domain.TraceSearchCriteria;
+import com.comet.opik.domain.TraceService;
+import com.comet.opik.domain.evaluators.AutomationRuleEvaluatorService;
+import com.comet.opik.domain.evaluators.python.PythonEvaluatorService;
+import com.comet.opik.domain.evaluators.python.PythonScoreResult;
+import com.comet.opik.domain.threads.TraceThreadService;
+import com.comet.opik.infrastructure.OnlineScoringConfig;
+import com.comet.opik.infrastructure.ServiceTogglesConfig;
+import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
+import com.comet.opik.podam.PodamFactoryUtils;
+import io.dropwizard.util.Duration;
+import jakarta.ws.rs.NotFoundException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RStreamReactive;
+import org.redisson.api.RedissonReactiveClient;
+import org.redisson.api.options.PlainOptions;
+import org.slf4j.Logger;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItemThread;
+import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython.TraceThreadUserDefinedMetricPythonCode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
+
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+
+    @Mock
+    private OnlineScoringConfig onlineScoringConfig;
+    @Mock
+    private ServiceTogglesConfig serviceTogglesConfig;
+    @Mock
+    private RedissonReactiveClient redissonClient;
+    @Mock
+    private FeedbackScoreService feedbackScoreService;
+    @Mock
+    private PythonEvaluatorService pythonEvaluatorService;
+    @Mock
+    private TraceService traceService;
+    @Mock
+    private TraceThreadService traceThreadService;
+    @Mock
+    private ProjectService projectService;
+    @Mock
+    private AutomationRuleEvaluatorService automationRuleEvaluatorService;
+
+    private OnlineScoringTraceThreadUserDefinedMetricPythonScorer scorer;
+    private MockedStatic<UserFacingLoggingFactory> mockedFactory;
+    private Logger userFacingLogger;
+
+    private UUID projectId;
+    private UUID ruleId;
+    private UUID threadModelId;
+    private String threadId;
+    private String workspaceId;
+    private String userName;
+    private String ruleName;
+
+    @BeforeEach
+    void setUp() {
+        userFacingLogger = mock(Logger.class);
+        mockedFactory = mockStatic(UserFacingLoggingFactory.class);
+        mockedFactory.when(() -> UserFacingLoggingFactory.getLogger(any(Class.class)))
+                .thenReturn(userFacingLogger);
+
+        var streamConfig = OnlineScoringConfig.StreamConfiguration.builder()
+                .scorer("trace_thread_user_defined_metric_python")
+                .streamName("stream_scoring_trace_thread_user_defined_metric_python")
+                .codec("java")
+                .poolingInterval(Duration.milliseconds(500))
+                .longPollingDuration(Duration.seconds(5))
+                .consumerBatchSize(10)
+                .claimIntervalRatio(10)
+                .pendingMessageDuration(Duration.minutes(10))
+                .maxRetries(3)
+                .build();
+
+        when(onlineScoringConfig.getStreams()).thenReturn(List.of(streamConfig));
+        when(onlineScoringConfig.getConsumerGroupName()).thenReturn("online_scoring");
+
+        scorer = new OnlineScoringTraceThreadUserDefinedMetricPythonScorer(
+                onlineScoringConfig,
+                serviceTogglesConfig,
+                redissonClient,
+                feedbackScoreService,
+                pythonEvaluatorService,
+                traceService,
+                traceThreadService,
+                projectService,
+                automationRuleEvaluatorService);
+
+        projectId = UUID.randomUUID();
+        ruleId = UUID.randomUUID();
+        threadModelId = UUID.randomUUID();
+        threadId = "thread-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        workspaceId = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        userName = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        ruleName = "rule-" + RandomStringUtils.secure().nextAlphanumeric(32);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (mockedFactory != null) {
+            mockedFactory.close();
+        }
+    }
+
+    @Nested
+    class ServiceToggleTests {
+
+        @Test
+        void startsConsumerWhenToggleIsEnabled() {
+            when(serviceTogglesConfig.isTraceThreadPythonEvaluatorEnabled()).thenReturn(true);
+            RStreamReactive<Object, Object> stream = mock(RStreamReactive.class);
+            when(redissonClient.getStream(any(PlainOptions.class))).thenReturn(stream);
+            when(stream.createGroup(any())).thenReturn(Mono.empty());
+
+            scorer.start();
+        }
+
+        @Test
+        void skipsStartWhenToggleIsDisabled() {
+            when(serviceTogglesConfig.isTraceThreadPythonEvaluatorEnabled()).thenReturn(false);
+
+            scorer.start();
+
+            verify(redissonClient, never()).getStream(any(PlainOptions.class));
+        }
+    }
+
+    @Nested
+    class ScoringTests {
+
+        @Test
+        void scoresThreadAndPersistsScores() {
+            var message = sampleMessage();
+            var trace = sampleTrace();
+            var project = Project.builder().id(projectId).name("test-project").build();
+            var pythonScore = PythonScoreResult.builder()
+                    .name("test_score")
+                    .value(BigDecimal.valueOf(0.95))
+                    .reason("test reason")
+                    .build();
+
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class)))
+                    .thenReturn(Flux.just(trace), Flux.empty());
+            when(traceThreadService.getThreadModelId(projectId, threadId)).thenReturn(Mono.just(threadModelId));
+            when(automationRuleEvaluatorService.findById(ruleId, Set.of(projectId), workspaceId))
+                    .thenReturn(ruleFor(ruleName));
+            when(projectService.get(projectId, workspaceId)).thenReturn(project);
+            when(pythonEvaluatorService.evaluateThread(eq(message.code().metric()), any()))
+                    .thenReturn(Mono.just(List.of(pythonScore)));
+            when(feedbackScoreService.scoreBatchOfThreads(any())).thenReturn(Mono.empty());
+            when(traceThreadService.setScoredAt(eq(projectId), eq(List.of(threadId)), any()))
+                    .thenReturn(Mono.empty());
+
+            scorer.score(message).block();
+
+            var captor = ArgumentCaptor.forClass(List.class);
+            verify(feedbackScoreService).scoreBatchOfThreads(captor.capture());
+            verify(traceThreadService).setScoredAt(eq(projectId), eq(List.of(threadId)), any());
+
+            assertThat(captor.getValue()).usingRecursiveComparison().isEqualTo(List.of(
+                    threadScore("test_score", BigDecimal.valueOf(0.95), "test reason", project)));
+        }
+
+        @Test
+        void skipsScoringWhenThreadHasNoTraces() {
+            var message = sampleMessage();
+
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class))).thenReturn(Flux.empty());
+            when(traceThreadService.setScoredAt(eq(projectId), eq(List.of(threadId)), any()))
+                    .thenReturn(Mono.empty());
+
+            scorer.score(message).block();
+
+            verify(traceThreadService, never()).getThreadModelId(any(), any());
+            verify(automationRuleEvaluatorService, never()).findById(any(), any(), any());
+            verify(projectService, never()).get(any(), any());
+            verify(pythonEvaluatorService, never()).evaluateThread(any(), any());
+            verify(feedbackScoreService, never()).scoreBatchOfThreads(any());
+        }
+
+        @Test
+        void skipsScoringWhenThreadModelIsMissing() {
+            var message = sampleMessage();
+
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class)))
+                    .thenReturn(Flux.just(sampleTrace()), Flux.empty());
+            when(traceThreadService.getThreadModelId(projectId, threadId)).thenReturn(Mono.empty());
+            when(traceThreadService.setScoredAt(eq(projectId), eq(List.of(threadId)), any()))
+                    .thenReturn(Mono.empty());
+
+            scorer.score(message).block();
+
+            verify(automationRuleEvaluatorService, never()).findById(any(), any(), any());
+            verify(projectService, never()).get(any(), any());
+            verify(pythonEvaluatorService, never()).evaluateThread(any(), any());
+            verify(feedbackScoreService, never()).scoreBatchOfThreads(any());
+        }
+
+        @Test
+        void skipsSilentlyWhenRuleHasBeenDeleted() {
+            var message = sampleMessage();
+
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class)))
+                    .thenReturn(Flux.just(sampleTrace()), Flux.empty());
+            when(traceThreadService.getThreadModelId(projectId, threadId)).thenReturn(Mono.just(threadModelId));
+            when(automationRuleEvaluatorService.findById(ruleId, Set.of(projectId), workspaceId))
+                    .thenThrow(new NotFoundException("rule not found"));
+            when(traceThreadService.setScoredAt(eq(projectId), eq(List.of(threadId)), any()))
+                    .thenReturn(Mono.empty());
+
+            scorer.score(message).block();
+
+            verify(projectService, never()).get(any(), any());
+            verify(pythonEvaluatorService, never()).evaluateThread(any(), any());
+            verify(feedbackScoreService, never()).scoreBatchOfThreads(any());
+        }
+
+        static Stream<Arguments> errorCauseScenarios() {
+            return Stream.of(
+                    Arguments.of("without cause -> uses error message",
+                            new RuntimeException("DB unreachable"), "DB unreachable"),
+                    Arguments.of("with cause -> uses cause message",
+                            new RuntimeException("wrapper", new IllegalStateException("inner cause")), "inner cause"));
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("errorCauseScenarios")
+        void unwrapsCauseMessageWhenLoggingRuleLookupFailure(String name, RuntimeException error,
+                String loggedMessage) {
+            var message = sampleMessage();
+
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class)))
+                    .thenReturn(Flux.just(sampleTrace()), Flux.empty());
+            when(traceThreadService.getThreadModelId(projectId, threadId)).thenReturn(Mono.just(threadModelId));
+            when(automationRuleEvaluatorService.findById(ruleId, Set.of(projectId), workspaceId)).thenThrow(error);
+
+            assertThatThrownBy(() -> scorer.score(message).block()).isInstanceOf(RuntimeException.class);
+
+            verify(userFacingLogger).error(
+                    contains("Unexpected error while looking up rule for threadId"),
+                    eq(threadId),
+                    eq(loggedMessage));
+            verify(pythonEvaluatorService, never()).evaluateThread(any(), any());
+            verify(feedbackScoreService, never()).scoreBatchOfThreads(any());
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("errorCauseScenarios")
+        void unwrapsCauseMessageWhenLoggingEvaluatorFailure(String name, RuntimeException error,
+                String loggedMessage) {
+            var message = sampleMessage();
+
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class)))
+                    .thenReturn(Flux.just(sampleTrace()), Flux.empty());
+            when(traceThreadService.getThreadModelId(projectId, threadId)).thenReturn(Mono.just(threadModelId));
+            when(automationRuleEvaluatorService.findById(ruleId, Set.of(projectId), workspaceId))
+                    .thenReturn(ruleFor(ruleName));
+            when(projectService.get(projectId, workspaceId))
+                    .thenReturn(Project.builder().id(projectId).name("test-project").build());
+            when(pythonEvaluatorService.evaluateThread(eq(message.code().metric()), any()))
+                    .thenReturn(Mono.error(error));
+
+            assertThatThrownBy(() -> scorer.score(message).block()).isInstanceOf(RuntimeException.class);
+
+            verify(userFacingLogger).error(
+                    contains("Unexpected error while scoring threadId"),
+                    eq(threadId),
+                    eq(ruleName),
+                    eq(loggedMessage));
+            verify(feedbackScoreService, never()).scoreBatchOfThreads(any());
+        }
+    }
+
+    private TraceThreadToScoreUserDefinedMetricPython sampleMessage() {
+        return podamFactory.manufacturePojo(TraceThreadToScoreUserDefinedMetricPython.class).toBuilder()
+                .ruleId(ruleId)
+                .projectId(projectId)
+                .threadIds(List.of(threadId))
+                .code(new TraceThreadUserDefinedMetricPythonCode("def score(context): return []"))
+                .workspaceId(workspaceId)
+                .userName(userName)
+                .build();
+    }
+
+    private Trace sampleTrace() {
+        return podamFactory.manufacturePojo(Trace.class).toBuilder()
+                .id(UUID.randomUUID())
+                .projectId(projectId)
+                .threadId(threadId)
+                .build();
+    }
+
+    private static AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython ruleFor(String name) {
+        return AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython.builder()
+                .name(name)
+                .code(new TraceThreadUserDefinedMetricPythonCode("def score(context): return []"))
+                .build();
+    }
+
+    private FeedbackScoreBatchItemThread threadScore(String name, BigDecimal value, String reason, Project project) {
+        return FeedbackScoreBatchItemThread.builder()
+                .id(threadModelId)
+                .threadId(threadId)
+                .projectId(projectId)
+                .projectName(project.name())
+                .name(name)
+                .value(value)
+                .reason(reason)
+                .source(ScoreSource.ONLINE_SCORING)
+                .build();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorerTest.java
@@ -1,0 +1,219 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.ScoreSource;
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.events.TraceToScoreUserDefinedMetricPython;
+import com.comet.opik.domain.FeedbackScoreService;
+import com.comet.opik.domain.TraceService;
+import com.comet.opik.domain.evaluators.python.PythonEvaluatorService;
+import com.comet.opik.domain.evaluators.python.PythonScoreResult;
+import com.comet.opik.infrastructure.OnlineScoringConfig;
+import com.comet.opik.infrastructure.ServiceTogglesConfig;
+import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
+import com.comet.opik.podam.PodamFactoryUtils;
+import io.dropwizard.util.Duration;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RStreamReactive;
+import org.redisson.api.RedissonReactiveClient;
+import org.redisson.api.options.PlainOptions;
+import org.slf4j.Logger;
+import reactor.core.publisher.Mono;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
+import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorUserDefinedMetricPython.UserDefinedMetricPythonCode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OnlineScoringUserDefinedMetricPythonScorerTest {
+
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+
+    @Mock
+    private OnlineScoringConfig onlineScoringConfig;
+    @Mock
+    private ServiceTogglesConfig serviceTogglesConfig;
+    @Mock
+    private RedissonReactiveClient redissonClient;
+    @Mock
+    private FeedbackScoreService feedbackScoreService;
+    @Mock
+    private TraceService traceService;
+    @Mock
+    private PythonEvaluatorService pythonEvaluatorService;
+
+    private OnlineScoringUserDefinedMetricPythonScorer scorer;
+    private MockedStatic<UserFacingLoggingFactory> mockedFactory;
+    private Logger userFacingLogger;
+
+    private UUID projectId;
+    private UUID traceId;
+    private UUID ruleId;
+    private String workspaceId;
+    private String userName;
+    private String ruleName;
+
+    @BeforeEach
+    void setUp() {
+        userFacingLogger = mock(Logger.class);
+        mockedFactory = mockStatic(UserFacingLoggingFactory.class);
+        mockedFactory.when(() -> UserFacingLoggingFactory.getLogger(any(Class.class)))
+                .thenReturn(userFacingLogger);
+
+        var streamConfig = OnlineScoringConfig.StreamConfiguration.builder()
+                .scorer("user_defined_metric_python")
+                .streamName("stream_scoring_user_defined_metric_python")
+                .codec("java")
+                .poolingInterval(Duration.milliseconds(500))
+                .longPollingDuration(Duration.seconds(5))
+                .consumerBatchSize(10)
+                .claimIntervalRatio(10)
+                .pendingMessageDuration(Duration.minutes(10))
+                .maxRetries(3)
+                .build();
+
+        when(onlineScoringConfig.getStreams()).thenReturn(List.of(streamConfig));
+        when(onlineScoringConfig.getConsumerGroupName()).thenReturn("online_scoring");
+
+        scorer = new OnlineScoringUserDefinedMetricPythonScorer(
+                onlineScoringConfig,
+                serviceTogglesConfig,
+                redissonClient,
+                feedbackScoreService,
+                traceService,
+                pythonEvaluatorService);
+
+        projectId = UUID.randomUUID();
+        traceId = UUID.randomUUID();
+        ruleId = UUID.randomUUID();
+        workspaceId = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        userName = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        ruleName = "rule-" + RandomStringUtils.secure().nextAlphanumeric(32);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (mockedFactory != null) {
+            mockedFactory.close();
+        }
+    }
+
+    @Nested
+    class ServiceToggleTests {
+
+        @Test
+        void startsConsumerWhenToggleIsEnabled() {
+            when(serviceTogglesConfig.isPythonEvaluatorEnabled()).thenReturn(true);
+            RStreamReactive<Object, Object> stream = mock(RStreamReactive.class);
+            when(redissonClient.getStream(any(PlainOptions.class))).thenReturn(stream);
+            when(stream.createGroup(any())).thenReturn(Mono.empty());
+
+            scorer.start();
+        }
+
+        @Test
+        void skipsStartWhenToggleIsDisabled() {
+            when(serviceTogglesConfig.isPythonEvaluatorEnabled()).thenReturn(false);
+
+            scorer.start();
+
+            verify(redissonClient, never()).getStream(any(PlainOptions.class));
+        }
+    }
+
+    @Nested
+    class ScoringTests {
+
+        @Test
+        void scoresTraceAndPersistsScores() {
+            var message = sampleMessage();
+            var pythonScore = PythonScoreResult.builder()
+                    .name("test_score")
+                    .value(BigDecimal.valueOf(0.95))
+                    .reason("test reason")
+                    .build();
+
+            when(pythonEvaluatorService.evaluate(eq(message.code().metric()), any()))
+                    .thenReturn(Mono.just(List.of(pythonScore)));
+            when(feedbackScoreService.scoreBatchOfTraces(any())).thenReturn(Mono.empty());
+
+            scorer.score(message).block();
+
+            var captor = ArgumentCaptor.forClass(List.class);
+            verify(feedbackScoreService).scoreBatchOfTraces(captor.capture());
+
+            assertThat(captor.getValue()).usingRecursiveComparison().isEqualTo(List.of(
+                    traceScore("test_score", BigDecimal.valueOf(0.95), "test reason", message.trace())));
+        }
+
+        @Test
+        void propagatesEvaluatorErrorAndLogsMessage() {
+            var message = sampleMessage();
+            var error = new RuntimeException("Python BE timeout");
+
+            when(pythonEvaluatorService.evaluate(eq(message.code().metric()), any()))
+                    .thenReturn(Mono.error(error));
+
+            assertThatThrownBy(() -> scorer.score(message).block()).isInstanceOf(RuntimeException.class);
+
+            verify(userFacingLogger).error(
+                    contains("Unexpected error while scoring traceId"),
+                    eq(traceId),
+                    eq(ruleName),
+                    eq("Python BE timeout"));
+            verify(feedbackScoreService, never()).scoreBatchOfTraces(any());
+        }
+    }
+
+    private TraceToScoreUserDefinedMetricPython sampleMessage() {
+        var trace = podamFactory.manufacturePojo(Trace.class).toBuilder()
+                .id(traceId)
+                .projectId(projectId)
+                .build();
+        return podamFactory.manufacturePojo(TraceToScoreUserDefinedMetricPython.class).toBuilder()
+                .trace(trace)
+                .ruleId(ruleId)
+                .ruleName(ruleName)
+                .code(new UserDefinedMetricPythonCode(
+                        "def score(input, output): return []",
+                        Map.of("input", "input.question", "output", "output.answer")))
+                .workspaceId(workspaceId)
+                .userName(userName)
+                .build();
+    }
+
+    private FeedbackScoreBatchItem traceScore(String name, BigDecimal value, String reason, Trace trace) {
+        return FeedbackScoreBatchItem.builder()
+                .id(trace.id())
+                .projectId(trace.projectId())
+                .projectName(trace.projectName())
+                .name(name)
+                .value(value)
+                .reason(reason)
+                .source(ScoreSource.ONLINE_SCORING)
+                .build();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
@@ -75,6 +75,8 @@ class PythonEvaluatorServiceTest {
         pythonEvaluatorConfig.setMaxRetryAttempts(4);
         pythonEvaluatorConfig.setMinRetryDelay(Duration.milliseconds(100));
         pythonEvaluatorConfig.setMaxRetryDelay(Duration.milliseconds(100));
+        pythonEvaluatorConfig.setConnectTimeout(Duration.seconds(1));
+        pythonEvaluatorConfig.setReadTimeout(Duration.seconds(5));
 
         config = new OpikConfiguration();
         config.setPythonEvaluator(pythonEvaluatorConfig);
@@ -116,7 +118,7 @@ class PythonEvaluatorServiceTest {
             }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
 
             // When
-            var actualScores = pythonEvaluatorService.evaluate(code, data);
+            var actualScores = pythonEvaluatorService.evaluate(code, data).block();
 
             // Then
             assertThat(actualScores).isEqualTo(expectedScores);
@@ -168,7 +170,7 @@ class PythonEvaluatorServiceTest {
             }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
 
             // When
-            var actualScores = pythonEvaluatorService.evaluate(code, data);
+            var actualScores = pythonEvaluatorService.evaluate(code, data).block();
 
             // Then
             assertThat(actualScores).isEqualTo(expectedScores);
@@ -203,7 +205,7 @@ class PythonEvaluatorServiceTest {
             }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
 
             // When
-            var actualScores = pythonEvaluatorService.evaluate(code, data);
+            var actualScores = pythonEvaluatorService.evaluate(code, data).block();
 
             // Then
             assertThat(actualScores).isEqualTo(expectedScores);
@@ -239,7 +241,7 @@ class PythonEvaluatorServiceTest {
             }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
 
             // When
-            var actualScores = pythonEvaluatorService.evaluate(code, data);
+            var actualScores = pythonEvaluatorService.evaluate(code, data).block();
 
             // Then
             assertThat(actualScores).isEqualTo(expectedScores);
@@ -265,7 +267,7 @@ class PythonEvaluatorServiceTest {
             }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
 
             // When & Then
-            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data))
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
                     .isInstanceOf(RuntimeException.class);
 
             // Should retry 4 times + initial attempt = 5 total calls
@@ -294,7 +296,7 @@ class PythonEvaluatorServiceTest {
             }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
 
             // When & Then
-            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data))
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
                     .isInstanceOf(BadRequestException.class)
                     .hasMessageContaining("Invalid Python code");
 
@@ -320,7 +322,7 @@ class PythonEvaluatorServiceTest {
             }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
 
             // When & Then
-            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data))
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
                     .isInstanceOf(ProcessingException.class)
                     .hasMessageContaining("Connection refused");
 
@@ -359,7 +361,7 @@ class PythonEvaluatorServiceTest {
             }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
 
             // When
-            var actualScores = pythonEvaluatorService.evaluateThread(code, context);
+            var actualScores = pythonEvaluatorService.evaluateThread(code, context).block();
 
             // Then
             assertThat(actualScores).isEqualTo(expectedScores);
@@ -406,7 +408,7 @@ class PythonEvaluatorServiceTest {
             }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
 
             // When
-            var actualScores = pythonEvaluatorService.evaluateThread(code, context);
+            var actualScores = pythonEvaluatorService.evaluateThread(code, context).block();
 
             // Then
             assertThat(actualScores).isEqualTo(expectedScores);
@@ -432,7 +434,7 @@ class PythonEvaluatorServiceTest {
             }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
 
             // When & Then
-            assertThatThrownBy(() -> pythonEvaluatorService.evaluateThread(code, context))
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluateThread(code, context).block())
                     .isInstanceOf(RuntimeException.class);
 
             // Should retry 4 times + initial attempt = 5 total calls
@@ -471,7 +473,7 @@ class PythonEvaluatorServiceTest {
             }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
 
             // When & Then
-            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data))
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
                     .isInstanceOf(BadRequestException.class)
                     .hasMessageContaining("Custom error message");
         }
@@ -504,7 +506,7 @@ class PythonEvaluatorServiceTest {
             }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
 
             // When & Then
-            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data))
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
                     .isInstanceOf(InternalServerErrorException.class)
                     .hasMessageContaining(
                             "Python evaluation failed (HTTP 500): Unknown error during Python evaluation");

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -492,6 +492,12 @@ pythonEvaluator:
   # Default: http://localhost:8000
   # Description: URL of the Python evaluator service, generally the opik-python-backend service
   url: ${PYTHON_EVALUATOR_URL:-http://localhost:8000}
+  # Default: 10s
+  # Description: Max wait for a Python evaluator response read per call.
+  readTimeout: 10s
+  # Default: 5s
+  # Description: Max wait for the TCP/TLS connection to the Python evaluator to be established.
+  connectTimeout: 5s
 
 serviceToggles:
   # Default: false for testing. It should be enabled for test scenarios when it's relevant.


### PR DESCRIPTION
## Details

Production metrics showed JVM threads piling up in WAITING state on `Mono.block()` calls in the online evaluation path during a span ingestion spike that coincided with a spike of Online Evaluation requests for Python custom metrics. Per call, the Java backend was holding a `workersScheduler` thread, a global `Schedulers.boundedElastic()` thread, and a Jersey `ClientExecutor` thread for the entire upstream wait — even when the upstream was just slow, not failing.

This change makes the score path non-blocking end-to-end:
- `OnlineScoringBaseScorer.score(M)` now returns `Mono<Void>` and is subscribed via `Mono.defer` in `processEvent`; `storeScores` / `storeSpanScores` / `storeThreadScores` return `Mono<Map>` instead of blocking.
- All seven concrete scorers (trace/span/thread × Python/LLM) lifted to reactive composition. LLM scorers wrap the synchronous langchain4j call with `Mono.fromCallable(...).subscribeOn(Schedulers.boundedElastic())` so the consumer thread is released immediately.
- `RetriableHttpClient` rewritten as a reactive helper (returns `Mono<T>`) with retry on 503/504, configurable connect/read timeouts, and `@NonNull` validation on `Request` fields. Now used by `PythonEvaluatorService` (`evaluate` / `evaluateThread` return `Mono`).
- Trace-thread scorers (Python + LLM) restructured for correctness: empty-traces fail-fast, `switchIfEmpty` on missing thread-model, extracted `findRule()` helper, outer `processScoring.doOnError` for rule-lookup failures, inner `scoreThread.doOnError` for evaluator failures — both with cause-chain unwrap (`Optional.ofNullable(error.getCause()).map(Throwable::getMessage).orElse(error.getMessage())`).
- New `PythonEvaluatorConfig` fields `connectTimeout` and `readTimeout` (`@NonNull`, bounds `[10ms, 60s]`); `LogContextAware.withMdc(map, consumer)` helper for reactive MDC propagation.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6308

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation (production refactor + tests) and iterative review
- Human verification: code review, manual production-incident analysis, full unit-test sweep (172/172 green), inspection of integration-test coverage paths

## Testing

Commands run:
- `mvn test -Dtest='OnlineScoring*Test,PythonEvaluator*Test'` → **172/172 passing**
- `mvn spotless:apply` → clean

Scenarios validated by unit + integration tests on the affected paths:
- Reactive lift: every `score(M)` returns `Mono<Void>` and is exercised via `.block()` in 4 dedicated scorer test classes (trace Python, span Python, trace-thread Python, trace-thread LLM) — 25 unit tests total.
- Cause-chain unwrap (the actual production hot-path bug): 4 parameterized scenarios across the two thread scorers (rule-lookup failure + evaluator failure × cause present / cause absent), plus the existing e2e `OnlineScoringEngineTest.testUserFacingLogErrorWhenAIProviderFails` for the non-thread LLM scorer.
- Trace-thread restructure: empty-traces fail-fast, missing thread-model `switchIfEmpty`, `findRule` `Optional.empty()` silent skip, happy path with score persistence and `setScoredAt` invocation.
- Trace-thread LLM happy path: drives real `OnlineScoringEngine.prepareThreadLlmRequest` + real `ToolCallingStrategy` + real `toFeedbackScores`; only `aiProxyService.scoreTrace` is stubbed with deterministic JSON.
- `PythonEvaluatorService` reactive: 14 WireMock-based tests covering 503/504/timeout retry, max-retries-exhausted, 400 non-retryable, `ProcessingException`, error-body parsing fallbacks for both `evaluate` and `evaluateThread`. New `connectTimeout` + `readTimeout` `@NonNull` fields are regression-locked through the test setUp.
- `RetriableHttpClient` is exercised end-to-end through the 14 `PythonEvaluatorServiceTest` cases.
- LLM scorers without dedicated unit tests (non-thread LLM, span LLM) retain their pre-existing e2e coverage: `OnlineScoringEngineTest.testRedisProducerAndConsumerBaseFlow` (happy + cause-chain unwrap on AI provider failure) and `OnlineScoringSpanSamplerIntegrationTest.redisProducerAndConsumerBaseFlowForSpans` (happy path via Redis container).

Tests not run locally: full repo-wide suite — CI will run it. Integration tests using Testcontainers run via the e2e classes referenced above and are expected to pass on CI.

Environment/context: local process mode, JDK 21, Maven.

## Documentation

N/A — internal refactor of the online-evaluation worker path. No public API changes; `connectTimeout` / `readTimeout` config fields are documented in `apps/opik-backend/config.yml`.