### PR TITLE
[OPIK-6360] [INFRA] fix: emit labels for every dropdown entry in regenerated YAML and fix path in job

### DIFF
--- a/.github/workflows/sync_provider_models.yml
+++ b/.github/workflows/sync_provider_models.yml
@@ -84,7 +84,7 @@ jobs:
           git config --local user.name "Github Actions (${{ github.actor }})"
           git add apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/
           git add apps/opik-frontend/src/types/providers.ts
-          git add apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts
+          git add apps/opik-frontend/src/constants/providerModels.ts
           git add apps/opik-backend/src/main/resources/llm-models-default.yaml
           git commit -m "[NA] [BE][FE] chore: sync provider model definitions"
 

--- a/scripts/sync_provider_models.py
+++ b/scripts/sync_provider_models.py
@@ -1012,11 +1012,15 @@ def regenerate_llm_models_yaml(
                 model_id = entry.value
                 lines.append(f'  - id: "{model_id}"')
 
-            # Emit label only for dropdown-visible entries and only when it
-            # differs from the id — saves bytes on OpenRouter and matches the
-            # FE fallback (`label ?? id`).
+            # Emit a label for every dropdown-visible entry, even when it
+            # equals the id. The FE filter uses label-presence as the
+            # "is this dropdown-visible?" signal, so dropping labels for
+            # OpenRouter (where label == id by convention) made every
+            # OpenRouter model invisible in the picker (OPIK-6360). The
+            # extra ~30KB on the cold-cached YAML is a non-issue compared
+            # to the correctness fragility of the omit-when-equal rule.
             is_dropdown_entry = entry.value in dropdown_values
-            if is_dropdown_entry and entry.label and entry.label != model_id:
+            if is_dropdown_entry and entry.label:
                 escaped_label = entry.label.replace('"', '\\"')
                 lines.append(f'    label: "{escaped_label}"')
 


### PR DESCRIPTION
## Details

Fixes [OPIK-6360](https://comet-ml.atlassian.net/browse/OPIK-6360): OpenRouter dropdown empty in production after the CDN-driven model registry rollout. Two related fixes in the sync infrastructure.

The sync script's `regenerate_llm_models_yaml` had a skip-emit optimization — when a model's `label` was equal to its `id`, the YAML omitted the `label:` line to save bytes. The intent was OpenRouter, where every label is exactly its id (`label: "ai21/jamba-large-1.7"` for `value: "ai21/jamba-large-1.7"`).

That played badly with the FE's `transformFetched` filter, which uses **label presence** as the "is this entry dropdown-visible?" signal. For OpenAI/Anthropic/Gemini the filter works as designed (curated entries carry labels, dated snapshots don't). For OpenRouter, the YAML had stripped every label, so the FE filtered the entire provider's list out of the dropdown.

The previous static `PROVIDER_MODELS` constant explicitly carried `label: "ai21/jamba-large-1.7"` for every OpenRouter entry, so the bug only manifested once the CDN-served YAML became the runtime source of truth.

## Fix

Drop the `entry.label != model_id` check in `regenerate_llm_models_yaml`. Every dropdown-visible entry now gets its `label:` line emitted, even when it equals the id.


## Second fix — sync workflow `git add` path

While investigating, also noticed that `.github/workflows/sync_provider_models.yml`'s `Commit files` step still hardcoded the pre-OPIK-5021 location of `PROVIDER_MODELS` (`apps/opik-frontend/src/hooks/useLLMProviderModelsData.ts`). That constant moved to `apps/opik-frontend/src/constants/providerModels.ts` during OPIK-5021.

Symptoms:
- Sync runs that produced real changes to the constant left the new file unstaged. `peter-evans/create-pull-request`'s "Uncommitted changes found. Adding a commit." fallback caught it on the action side, but this split one logical change across two commits in the resulting PR and would lose the change entirely if anyone disabled that fallback.
- Visible in PR #6576 which closed with 0 changed files — the explicitly-staged set was already redundant against main, and the unstaged `providerModels.ts` changes were the only meaningful diff that could have prevented the no-op.

One-line path swap, same domain as the script fix above.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6360
- Regression introduced by OPIK-5021

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: Root cause analysis from the production payload, fix proposal, decision to relocate the fix from the FE filter into the sync script after operator pushback on the optimization rationale.
- Human verification: Reviewed the production `/v1/private/llm/models` response that exposed the bug, ran the regeneration locally to confirm the fix produces a YAML with labels on every dropdown entry (~536 label lines vs the prior ~50), and confirmed `LlmModelRegistryServiceTest` + `LlmProviderFactoryTest` (639 BE tests) still pass against a regenerated fixture.

## Testing

```bash
cd apps/opik-backend && mvn test -Dtest='LlmModelRegistryServiceTest,LlmProviderFactoryTest'
# 639 BE tests pass against a regenerated YAML carrying OpenRouter labels.
```

To sanity-check the script change locally without committing the regenerated YAML:

```bash
python3 - <<'PY'
import sys; sys.path.insert(0, "scripts")
import sync_provider_models as s
# (the same one-off driver used in OPIK-5021 to invoke regenerate_llm_models_yaml directly)
PY
```

The regenerated `llm-models-default.yaml` should grow from ~700 to ~1340 lines and contain `label: "ai21/jamba-large-1.7"`-style entries for every OpenRouter model.

## Documentation

N/A — sync-script behavior change. The self-host docs page describing the YAML schema is unchanged (it always documented `label` as an optional field that "falls back to id when omitted" — the FE fallback still works in the air-gapped path; this PR fixes the CDN-served path).

[OPIK-6360]: https://comet-ml.atlassian.net/browse/OPIK-6360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
