### PR TITLE
[OPIK-6360] [INFRA] feat: add force_regen toggle to provider model sync

### DIFF
--- a/.github/workflows/sync_provider_models.yml
+++ b/.github/workflows/sync_provider_models.yml
@@ -3,7 +3,13 @@ name: Sync Provider Models Daily
 on:
   schedule:
     - cron: '30 0 * * 1-5' # 30 min after model prices sync, Monday to Friday
-  workflow_dispatch: # Allows manual trigger
+  workflow_dispatch:
+    inputs:
+      force_regen:
+        description: 'Regenerate and re-upload YAML even if no new models were found'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: write
@@ -38,9 +44,10 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          FORCE_REGEN_FLAG: ${{ inputs.force_regen == true && '--force-regen' || '' }}
         run: |
           set +e -o pipefail
-          python scripts/sync_provider_models.py 2>sync_stderr.txt | tee sync_summary.txt
+          python scripts/sync_provider_models.py $FORCE_REGEN_FLAG 2>sync_stderr.txt | tee sync_summary.txt
           EXIT_CODE=${PIPESTATUS[0]}
           set -e
           echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT

--- a/scripts/sync_provider_models.py
+++ b/scripts/sync_provider_models.py
@@ -1086,6 +1086,7 @@ def _get_vertexai_models_from_prices(prices: dict) -> list[tuple[str, bool]]:
 def main():
     parser = argparse.ArgumentParser(description="Sync LLM provider model definitions")
     parser.add_argument("--dry-run", action="store_true", help="Preview changes without writing")
+    parser.add_argument("--force-regen", action="store_true", help="Regenerate and write files even when no new models were found")
     args = parser.parse_args()
 
     print("## Provider Model Sync\n")
@@ -1261,12 +1262,15 @@ def main():
             print(f"- Total models: {len(entries)} (dropdown: {len(dropdown)})")
         print()
 
-    if total_added == 0:
+    if total_added == 0 and not args.force_regen:
         if total_stale > 0:
             print(f"No new models found. {total_stale} stale model(s) flagged for manual review.")
         else:
             print("No changes found.")
         sys.exit(1)
+
+    if total_added == 0 and args.force_regen:
+        print("No new models found, but --force-regen set: regenerating files anyway.")
 
     if args.dry_run:
         print(f"\n**Dry run**: {total_added} added. No files written.")


### PR DESCRIPTION
## Details

Adds a `force_regen` boolean input to the `Sync Provider Models Daily` workflow's `workflow_dispatch` trigger. When set to `true`, the script regenerates files and the workflow re-uploads the YAML to S3 + invalidates CloudFront, even if no new upstream provider models were found.

This unblocks republishing the CDN YAML when the sync logic itself changes (e.g. the OPIK-6360 fix that emits labels for every dropdown entry) but there are no upstream deltas to trigger the daily run.

**Changes:**
- `scripts/sync_provider_models.py`: new `--force-regen` flag; when set with `total_added == 0`, falls through to the file-writing path instead of `sys.exit(1)`.
- `.github/workflows/sync_provider_models.yml`: new `workflow_dispatch.inputs.force_regen` boolean (default `false`); flag is appended to the script invocation only when the input is `true`.

Existing scheduled runs and manual runs without the toggle behave identically to before.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6360

## Testing

- Verified `--force-regen` flag is registered in argparse.
- After merge, will run the workflow manually with `force_regen=true` to publish the labels-for-all-dropdown-entries YAML to the CDN.

## Documentation

N/A