### PR TITLE
[OPIK-6263] [BE] feat: seed default environments for workspaces

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000066_seed_default_environments.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000066_seed_default_environments.sql
@@ -11,4 +11,5 @@ CROSS JOIN (
     UNION ALL SELECT 'production', '#19A979', 2
 ) n;
 
---rollback DELETE FROM environments WHERE name IN ('development', 'staging', 'production');
+-- Backfilled defaults are indistinguishable from environments seeded for new workspaces; rollback is a no-op to avoid deleting user-visible data.
+--rollback empty

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000066_seed_default_environments.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000066_seed_default_environments.sql
@@ -1,0 +1,14 @@
+--liquibase formatted sql
+--changeset boryst:000066_seed_default_environments
+--comment: Backfill default environments (development, staging, production) for every existing workspace.
+
+INSERT IGNORE INTO environments (id, workspace_id, name, color, position)
+SELECT UUID(), p.workspace_id, n.name, n.color, n.position
+FROM (SELECT DISTINCT workspace_id FROM projects) p
+CROSS JOIN (
+    SELECT 'development' AS name, '#EF6868' AS color, 0 AS position
+    UNION ALL SELECT 'staging', '#F4B400', 1
+    UNION ALL SELECT 'production', '#19A979', 2
+) n;
+
+--rollback DELETE FROM environments WHERE name IN ('development', 'staging', 'production');

--- a/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
+++ b/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
@@ -109,6 +109,21 @@ def create_feedback_scores_definition(base_url, workspace_name, comet_api_key):
     make_http_request(base_url, request, workspace_name, comet_api_key)
 
 
+def create_default_environments(base_url, workspace_name, comet_api_key):
+    defaults = [
+        {"name": "development", "position": 0, "color": "#EF6868"},
+        {"name": "staging", "position": 1, "color": "#F4B400"},
+        {"name": "production", "position": 2, "color": "#19A979"},
+    ]
+    for payload in defaults:
+        request = {
+            "url": "/v1/private/environments",
+            "method": "POST",
+            "payload": payload,
+        }
+        make_http_request(base_url, request, workspace_name, comet_api_key)
+
+
 def create_project(base_url, workspace_name, comet_api_key, project_name):
     request = {
         "url": "/v1/private/projects",
@@ -939,6 +954,7 @@ def create_demo_data(base_url: str, workspace_name, comet_api_key):
         try:
             chatbot_seeded = create_demo_chatbot_project(context, base_url, workspace_name, comet_api_key)
             create_feedback_scores_definition(base_url, workspace_name, comet_api_key)
+            create_default_environments(base_url, workspace_name, comet_api_key)
             # Only run the test-suite seed when the chatbot project was freshly created.
             # If the chatbot flow short-circuited on 409 (project already exists), the
             # suite/prompt/blueprints/experiments were seeded on the prior run too —

--- a/apps/opik-python-backend/tests/test_demo_data_generator.py
+++ b/apps/opik-python-backend/tests/test_demo_data_generator.py
@@ -28,6 +28,8 @@ def test_create_demo_data_structure(httpserver):
     })
     httpserver.expect_request("/v1/private/feedback-definitions", method="POST").respond_with_data(status=201)
 
+    httpserver.expect_request("/v1/private/environments", method="POST").respond_with_data(status=201)
+
     httpserver.expect_request("/v1/private/prompts", method="POST").respond_with_data(status=201)
     httpserver.expect_request("/v1/private/datasets", method="POST").respond_with_data(status=201)
     httpserver.expect_request("/v1/private/datasets/retrieve", method="POST").respond_with_json({
@@ -127,6 +129,8 @@ def test_create_demo_data_idempotence(httpserver):
         "total": 1
     })
     httpserver.expect_request("/v1/private/feedback-definitions", method="POST").respond_with_data(status=409)
+
+    httpserver.expect_request("/v1/private/environments", method="POST").respond_with_data(status=409)
 
     httpserver.expect_request("/v1/private/prompts", method="POST").respond_with_handler(fail_on_request)
     httpserver.expect_request("/v1/private/datasets", method="POST").respond_with_handler(fail_on_request)


### PR DESCRIPTION
## Details
- Adds a Liquibase migration (`000066_seed_default_environments.sql`) that backfills three default environments — `development`, `staging`, `production` — for every existing workspace, with predefined colors and positions. Uses `INSERT IGNORE` so re-runs are safe.
- Updates the Python demo data generator to call `POST /v1/private/environments` for the same three defaults when seeding a fresh demo workspace, keeping new workspaces aligned with the migration's backfill.
- Extends `test_demo_data_generator` to mock the new endpoint in both the structure and idempotence test paths.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-6263

## Testing
- `test_create_demo_data_structure` — verifies the new `POST /v1/private/environments` call is part of the demo seed flow.
- `test_create_demo_data_idempotence` — verifies the seed flow tolerates `409 Conflict` on the environments endpoint (existing workspaces).
- Liquibase migration applied locally against an existing app-state DB; default environments inserted exactly once per workspace.

## Documentation
N/A
