### PR TITLE
[OPIK-3662] [INFRA] feat: add actionlint workflow validation

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,40 @@
+name: ':octocat: Lint Workflows'
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install actionlint
+        run: |
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          sudo mv actionlint /usr/local/bin/
+          actionlint --version
+
+      - name: Run actionlint on changed workflow files
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          # Suppress info-level shellcheck noise (SC2086 backlog tracked in OPIK-6323).
+          # Real issues at warning+ severity still gate.
+          SHELLCHECK_OPTS: --severity=warning
+        run: |
+          mapfile -t CHANGED < <(git diff --name-only --diff-filter=d "origin/${BASE_REF}...HEAD" -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
+          if [ ${#CHANGED[@]} -eq 0 ]; then
+            echo "No workflow files changed."
+            exit 0
+          fi
+          printf 'Changed workflow files:\n'
+          printf '  %s\n' "${CHANGED[@]}"
+          echo
+          actionlint -- "${CHANGED[@]}"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,4 +1,4 @@
-name: ':octocat: Lint Workflows'
+name: '🐙 Lint Workflows'
 
 on:
   pull_request:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,9 +17,23 @@ jobs:
           fetch-depth: 0
 
       - name: Install actionlint
+        # Download the latest actionlint release directly from the upstream repo and
+        # verify its GitHub artifact attestation (Sigstore-signed by rhysd's release CI).
+        # Per https://github.com/rhysd/actionlint/blob/main/docs/install.md this is the
+        # upstream-recommended secure install path. Verifies provenance, not just
+        # bytes — strictly stronger than a hardcoded SHA256. `gh` is preinstalled on
+        # GitHub-hosted runners.
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          LATEST_TAG=$(gh release view --repo rhysd/actionlint --json tagName --jq .tagName)
+          echo "Installing actionlint ${LATEST_TAG}"
+          ASSET="actionlint_${LATEST_TAG#v}_linux_amd64.tar.gz"
+          gh release download "${LATEST_TAG}" --repo rhysd/actionlint --pattern "${ASSET}"
+          gh attestation verify "${ASSET}" --repo rhysd/actionlint
+          tar -xzf "${ASSET}" actionlint
           sudo mv actionlint /usr/local/bin/
+          rm -f "${ASSET}"
           actionlint --version
 
       - name: Run actionlint on changed workflow files

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/**'
+      - '.github/actions/**'
 
 permissions:
   contents: read
@@ -36,19 +37,42 @@ jobs:
           rm -f "${ASSET}"
           actionlint --version
 
-      - name: Run actionlint on changed workflow files
+      - name: Run actionlint
         env:
           BASE_REF: ${{ github.base_ref }}
           # Suppress info-level shellcheck noise (SC2086 backlog tracked in OPIK-6323).
           # Real issues at warning+ severity still gate.
           SHELLCHECK_OPTS: --severity=warning
         run: |
-          mapfile -t CHANGED < <(git diff --name-only --diff-filter=d "origin/${BASE_REF}...HEAD" -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
-          if [ ${#CHANGED[@]} -eq 0 ]; then
-            echo "No workflow files changed."
+          mapfile -t CHANGED_WORKFLOWS < <(git diff --name-only --diff-filter=d "origin/${BASE_REF}...HEAD" -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
+          mapfile -t CHANGED_ACTIONS < <(git diff --name-only --diff-filter=d "origin/${BASE_REF}...HEAD" -- '.github/actions/**')
+
+          if [ ${#CHANGED_WORKFLOWS[@]} -eq 0 ] && [ ${#CHANGED_ACTIONS[@]} -eq 0 ]; then
+            echo "No workflow or composite-action files changed."
             exit 0
           fi
-          printf 'Changed workflow files:\n'
-          printf '  %s\n' "${CHANGED[@]}"
+
+          # actionlint cannot lint composite action.yml files directly — they're
+          # validated transitively when a workflow that uses them is linted.
+          # For each changed composite action, find workflows that reference it
+          # via `uses: ./.github/actions/<name>` and add them to the lint set.
+          declare -A TO_LINT_SET=()
+          for f in "${CHANGED_WORKFLOWS[@]}"; do TO_LINT_SET["$f"]=1; done
+          for action_file in "${CHANGED_ACTIONS[@]}"; do
+            action_dir=$(dirname "$action_file")
+            while IFS= read -r caller; do
+              [ -n "$caller" ] && TO_LINT_SET["$caller"]=1
+            done < <(grep -lE "uses:\s*\.?/?${action_dir}/?(\s|$)" .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null || true)
+          done
+
+          if [ ${#TO_LINT_SET[@]} -eq 0 ]; then
+            echo "Composite action(s) changed but no workflow references them. Nothing to lint."
+            printf '  %s\n' "${CHANGED_ACTIONS[@]}"
+            exit 0
+          fi
+
+          mapfile -t TO_LINT < <(printf '%s\n' "${!TO_LINT_SET[@]}" | sort)
+          echo "Linting:"
+          printf '  %s\n' "${TO_LINT[@]}"
           echo
-          actionlint -- "${CHANGED[@]}"
+          actionlint -- "${TO_LINT[@]}"

--- a/.github/workflows/build_and_publish_sdk.yaml
+++ b/.github/workflows/build_and_publish_sdk.yaml
@@ -19,7 +19,6 @@ on:
           type: string
           required: true
           description: Version
-          default: ""
         is_release:
           type: boolean
           required: false
@@ -51,7 +50,7 @@ jobs:
             fetch-tags: true
 
         - name: Set up Python 3.10
-          uses: actions/setup-python@v3
+          uses: actions/setup-python@v5
           with:
                 python-version: "3.10"
 

--- a/.github/workflows/documentation_cookbook_tests.yml
+++ b/.github/workflows/documentation_cookbook_tests.yml
@@ -37,15 +37,15 @@ jobs:
       OPIK_SENTRY_ENABLE: False
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
       - name: pip cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ matrix.os }}-${{ matrix.python-version }}-pip
@@ -67,7 +67,7 @@ jobs:
       - name: Test notebook
         run: |
           cd "$TEST_DIRECTORY" || exit
-          python -X faulthandler $(which ipython) "$TEST_NOTEBOOK"
+          python -X faulthandler "$(which ipython)" "$TEST_NOTEBOOK"
         env:
           OPENAI_API_KEY: ${{ secrets.DOCS_OPENAI_API_KEY }}
           OPIK_API_KEY: ${{ secrets.COMET_API_KEY }}

--- a/.github/workflows/frontend_linter.yml
+++ b/.github/workflows/frontend_linter.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
 

--- a/.github/workflows/opik-optimizer-publish.yml
+++ b/.github/workflows/opik-optimizer-publish.yml
@@ -20,7 +20,7 @@ jobs:
           uses: actions/checkout@v6
 
         - name: Set up Python 3.9
-          uses: actions/setup-python@v3
+          uses: actions/setup-python@v5
           with:
                 python-version: 3.9
 

--- a/.github/workflows/publish_cursor_extension.yml
+++ b/.github/workflows/publish_cursor_extension.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '22'
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 5
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml

--- a/.github/workflows/test_docs_links.yml
+++ b/.github/workflows/test_docs_links.yml
@@ -10,6 +10,11 @@ on:
   schedule:
     - cron: '0 12 * * *'  # Run daily at noon UTC
   workflow_dispatch:
+    inputs:
+      ALLURE_JOB_RUN_ID:
+        description: Allure run ID to attach test results to
+        required: false
+        type: string
 
 jobs:
   check-links:
@@ -20,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
         
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
       

--- a/.github/workflows/trigger_test_env_on_label.yaml
+++ b/.github/workflows/trigger_test_env_on_label.yaml
@@ -61,19 +61,24 @@ jobs:
 
       - name: Comment on PR - Deployment Started
         uses: actions/github-script@v7
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_VERSION: ${{ steps.get-tag.outputs.version }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const headRef = process.env.HEAD_REF;
+            const baseVersion = process.env.BASE_VERSION;
             await github.rest.issues.createComment({
               issue_number: Number('${{ github.event.number }}'),
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `🔄 **Test environment deployment process has started**
-              
-              **Phase 1**: Deploying base version \`${{ steps.get-tag.outputs.version }}\` (from main branch) if environment doesn't exist
-              **Phase 2**: Building new images from PR branch \`${{ github.event.pull_request.head.ref }}\`
+
+              **Phase 1**: Deploying base version \`${baseVersion}\` (from main branch) if environment doesn't exist
+              **Phase 2**: Building new images from PR branch \`${headRef}\`
               **Phase 3**: Will deploy newly built version after build completes
-              
+
               You can monitor the progress [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).`
             });
 

--- a/.github/workflows/trigger_test_env_on_label.yaml
+++ b/.github/workflows/trigger_test_env_on_label.yaml
@@ -61,22 +61,23 @@ jobs:
 
       - name: Comment on PR - Deployment Started
         uses: actions/github-script@v7
+        # HEAD_REF must be passed via env: — interpolating `${{ github.event.pull_request.head.ref }}`
+        # directly into the script body would let a crafted branch name break out of the string
+        # context. See: https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           BASE_VERSION: ${{ steps.get-tag.outputs.version }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const headRef = process.env.HEAD_REF;
-            const baseVersion = process.env.BASE_VERSION;
             await github.rest.issues.createComment({
               issue_number: Number('${{ github.event.number }}'),
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `🔄 **Test environment deployment process has started**
 
-              **Phase 1**: Deploying base version \`${baseVersion}\` (from main branch) if environment doesn't exist
-              **Phase 2**: Building new images from PR branch \`${headRef}\`
+              **Phase 1**: Deploying base version \`${process.env.BASE_VERSION}\` (from main branch) if environment doesn't exist
+              **Phase 2**: Building new images from PR branch \`${process.env.HEAD_REF}\`
               **Phase 3**: Will deploy newly built version after build completes
 
               You can monitor the progress [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).`

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -77,3 +77,19 @@ fi
 run_precommit_scope "Python SDK" '^sdks/python/' 'sdks/python/.pre-commit-config.yaml'
 run_precommit_scope "Optimizer SDK" '^sdks/opik_optimizer/' 'sdks/opik_optimizer/.pre-commit-config.yaml'
 run_precommit_scope "Guardrails backend" '^apps/opik-guardrails-backend/' 'apps/opik-guardrails-backend/.pre-commit-config.yaml'
+
+# Workflow files: validate staged ones with actionlint when available
+workflow_files=$(staged_files | grep -E '^\.github/workflows/.+\.(yml|yaml)$' || true)
+if [ -z "$workflow_files" ]; then
+  echo "No workflow files changed. Skipping actionlint."
+elif ! command -v actionlint >/dev/null 2>&1; then
+  echo "Workflow files changed but actionlint is not installed. Skipping local validation."
+  echo "Install: brew install actionlint  (or see https://github.com/rhysd/actionlint#installation)"
+else
+  echo "Workflow files have been changed. Running actionlint..."
+  # Match CI: suppress info-level shellcheck noise (SC2086 backlog tracked in OPIK-6323).
+  if ! printf '%s\n' "$workflow_files" | SHELLCHECK_OPTS="--severity=warning" xargs actionlint --; then
+    echo "actionlint found issues. Please fix them before committing."
+    exit 1
+  fi
+fi

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -78,18 +78,39 @@ run_precommit_scope "Python SDK" '^sdks/python/' 'sdks/python/.pre-commit-config
 run_precommit_scope "Optimizer SDK" '^sdks/opik_optimizer/' 'sdks/opik_optimizer/.pre-commit-config.yaml'
 run_precommit_scope "Guardrails backend" '^apps/opik-guardrails-backend/' 'apps/opik-guardrails-backend/.pre-commit-config.yaml'
 
-# Workflow files: validate staged ones with actionlint when available
-workflow_files=$(staged_files | grep -E '^\.github/workflows/.+\.(yml|yaml)$' || true)
-if [ -z "$workflow_files" ]; then
-  echo "No workflow files changed. Skipping actionlint."
+# Workflows / composite actions: validate with actionlint when available.
+# Composite actions (`.github/actions/*/action.yml`) cannot be linted directly —
+# they're validated transitively when a workflow that uses them is linted. For
+# each staged composite action, find workflows that reference it and lint those.
+staged_workflows=$(staged_files | grep -E '^\.github/workflows/.+\.(yml|yaml)$' || true)
+staged_actions=$(staged_files | grep -E '^\.github/actions/.+\.(yml|yaml)$' || true)
+
+if [ -z "$staged_workflows" ] && [ -z "$staged_actions" ]; then
+  echo "No workflow or composite-action files changed. Skipping actionlint."
 elif ! command -v actionlint >/dev/null 2>&1; then
-  echo "Workflow files changed but actionlint is not installed. Skipping local validation."
+  echo "Workflow/composite-action files changed but actionlint is not installed. Skipping local validation."
   echo "Install: brew install actionlint  (or see https://github.com/rhysd/actionlint#installation)"
 else
-  echo "Workflow files have been changed. Running actionlint..."
-  # Match CI: suppress info-level shellcheck noise (SC2086 backlog tracked in OPIK-6323).
-  if ! printf '%s\n' "$workflow_files" | SHELLCHECK_OPTS="--severity=warning" xargs actionlint --; then
-    echo "actionlint found issues. Please fix them before committing."
-    exit 1
+  files_to_lint="$staged_workflows"
+  if [ -n "$staged_actions" ]; then
+    callers=""
+    for action_file in $staged_actions; do
+      action_dir=$(dirname "$action_file")
+      found=$(grep -lE "uses:\s*\.?/?${action_dir}/?(\s|$)" .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null || true)
+      callers="${callers}${found}
+"
+    done
+    files_to_lint=$(printf '%s\n%s\n' "$files_to_lint" "$callers" | sed '/^$/d' | sort -u)
+  fi
+
+  if [ -z "$files_to_lint" ]; then
+    echo "Composite action(s) staged but no workflow references them. Skipping actionlint."
+  else
+    echo "Workflow/composite-action files have been changed. Running actionlint..."
+    # Match CI: suppress info-level shellcheck noise (SC2086 backlog tracked in OPIK-6323).
+    if ! printf '%s\n' "$files_to_lint" | SHELLCHECK_OPTS="--severity=warning" xargs actionlint --; then
+      echo "actionlint found issues. Please fix them before committing."
+      exit 1
+    fi
   fi
 fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,11 @@ Please review the CLA before contributing:
 5. Open a draft PR with GitHub CLI: `gh pr create --draft`.
 6. Fill `.github/pull_request_template.md` completely.
 
+## GitHub Actions workflows
+Workflow files in `.github/workflows/` are validated with [actionlint](https://github.com/rhysd/actionlint).
+- CI: `.github/workflows/actionlint.yml` runs on PRs that touch workflow files and lints only the changed ones.
+- Local: `.hooks/pre-commit` runs actionlint against staged workflow files when the binary is available; install with `brew install actionlint` (macOS) or via the [official install guide](https://github.com/rhysd/actionlint#installation). Without it the hook prints a hint and skips.
+
 ## Generated files (do not edit manually)
 - `apps/opik-backend/src/main/resources/model_prices_and_context_window.json`
 - `apps/opik-frontend/src/data/model_prices_and_context_window.json`


### PR DESCRIPTION
## Details

<img width="2160" height="2858" alt="image" src="https://github.com/user-attachments/assets/5b13163f-5422-4251-9a02-b1a852454443" />

Adds [actionlint](https://github.com/rhysd/actionlint) as a CI gate for changed GitHub Actions workflow files plus a matching pre-commit hook with graceful local degradation. Both run with `SHELLCHECK_OPTS=--severity=warning` so the pre-existing SC2086 backlog (deferred to OPIK-6323) does not gate PRs while real warning+ findings still do. This is the second attempt — the [previous one (#4594)](https://github.com/comet-ml/opik/pull/4594) was closed because it surfaced 207 pre-existing findings; this PR ships the linter alongside only the genuine safety/correctness fixes and splits the cosmetic backlog into OPIK-6323.

- Enables actionlint via new `.github/workflows/actionlint.yml`, updates `.hooks/pre-commit`, adds `CONTRIBUTING.md` section.
- Bumps 9 outdated action versions (`setup-python@v3/v4`, `setup-node@v3`, `cache@v3`, `checkout@v2`, `release-drafter@v5`) to versions matching repo conventions.
- ⚠️ **Security fix**: `trigger_test_env_on_label.yaml` was interpolating `pull_request.head.ref` directly into an `actions/github-script` body — a malicious branch name could inject JS into the workflow runtime. Rewrites the step to pass `head.ref` via `env:` and read `process.env.HEAD_REF` per the [official mitigation](https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks).
- Other small fixes: deprecated `set-output` → `$GITHUB_OUTPUT`, SC2046 unquoted `$(which ipython)`, dead `default: ""` on a `required: true` input, undeclared `ALLURE_JOB_RUN_ID` workflow_dispatch input.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-3662
- Follow-up: OPIK-6323 (linked as blocked-by)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: Triage of actionlint findings on current `origin/main`, drafting of `actionlint.yml` workflow and pre-commit hook addition, the script-injection rewrite in `trigger_test_env_on_label.yaml`, the action version bumps, and authoring of this PR description.
- Human verification: Daniel reviewed the triage breakdown before scope decisions; chose the split between this PR and OPIK-6323; reviewed the script-injection fix approach (env-var pattern) before it was applied; ran actionlint locally and confirmed the gate passes on the changed files.

## Testing

- Ran `SHELLCHECK_OPTS=--severity=warning xargs actionlint -- < changed-files.txt` locally on all 9 modified workflow files (the 7 listed above + `actionlint.yml` + the new file itself). Exit code 0.
- Without the severity gate, baseline still surfaces the deferred 168 SC2086 + minor info/style findings — confirming the warning-level gate is the operative control and that real warning+ findings would block.
- Verified `actionlint --version` resolves to v1.7.12 (latest at time of writing) via the workflow's official download script.
- Pre-commit hook: traced through the new section — `staged_files | grep -E '^\.github/workflows/.+\.(yml|yaml)$'` correctly scopes; if `actionlint` is not on PATH, prints install hint and skips (verified locally with `PATH=/usr/bin:/bin`); when present, runs the same `SHELLCHECK_OPTS` gate as CI.
- Action version bumps: cross-referenced existing usage in the repo (`grep -rh 'uses: actions/setup-python@'` etc.) to pick versions matching repo conventions (`setup-python@v5`, `setup-node@v4`, `checkout@v6`) rather than absolute latest.
- Script-injection rewrite: confirmed the rendered comment body still produces the same Markdown output by inspection (only the substitution mechanism changed, not the user-visible content).
- **Not yet run**: end-to-end smoke through GitHub-side CI on this PR — that's what this PR will exercise. Watch for the `:octocat: Lint Workflows` check status once CI runs.

Video evidence: not applicable — infrastructure-only change with no UI surface.

## Documentation

- New section in `CONTRIBUTING.md` ("GitHub Actions workflows") explaining the CI check, the local pre-commit hook, and how to install actionlint (`brew install actionlint` on macOS, link to the official install guide otherwise).