### PR TITLE
[OPIK-6311] [BE] feat: support comments sort on the comparison endpoint with push-top-limit

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactoryDatasets.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactoryDatasets.java
@@ -41,7 +41,7 @@ public class SortingFactoryDatasets extends SortingFactory {
     private static final Set<String> PUSH_TOP_SUPPORTED = Set.of(
             ID, DESCRIPTION, TAGS, CREATED_AT, LAST_UPDATED_AT, CREATED_BY, LAST_UPDATED_BY,
             DURATION, FEEDBACK_SCORES, DATA, OUTPUT_WILDCARD, INPUT_WILDCARD, METADATA_WILDCARD,
-            TOTAL_ESTIMATED_COST, USAGE);
+            TOTAL_ESTIMATED_COST, USAGE, COMMENTS);
 
     // Fields that require JOIN with dataset_items_aggr_resolved in the CTE
     private static final Set<String> PUSH_TOP_NEEDS_DIV_JOIN = Set.of(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -3909,6 +3909,13 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
         if ("total_estimated_cost".equals(field)) {
             return "avg(eia_t.total_estimated_cost)";
         }
+        if ("comments".equals(field)) {
+            // comments_array_agg is a String holding toJSONString(groupUniqArray(Tuple(...))).
+            // Project the array of comment texts and sort lexicographically as Array(String);
+            // ClickHouse compares element-wise. Picked from the highest-id experiment item
+            // in the group to match the outer projection (argMax(ei.comments_array_agg, ei.id)).
+            return "arrayMap(elem -> JSONExtractString(elem, 'text'), JSONExtractArrayRaw(argMax(eia_t.comments_array_agg, eia_t.id)))";
+        }
         if (field.startsWith("data.")) {
             return "any(di_t.data)[:%s]".formatted(sf.bindKey());
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -1204,6 +1204,12 @@ public class FilterQueryBuilder {
                 String key = fieldName.substring(METADATA_FIELD_PREFIX.length());
                 fieldMapping.put(fieldName,
                         JSON_EXTRACT_RAW_TEMPLATE.formatted("metadata", key));
+            } else if ("comments".equals(fieldName)) {
+                // The outer projection exposes `comments` as a JSON-string alias. Map it to the
+                // array of comment texts so ClickHouse can ORDER BY element-wise — matching the
+                // push-top-limit CTE expression in DatasetItemVersionDAO#getTopSortExpression.
+                fieldMapping.put(fieldName,
+                        "arrayMap(elem -> JSONExtractString(elem, 'text'), JSONExtractArrayRaw(comments))");
             }
             // For other fields (including feedback_scores, data, etc.), use default dbField()
         }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -8608,7 +8608,13 @@ class DatasetsResourceTest {
                     Arguments
                             .of(SortingField.builder().field("metadata.task_type").direction(Direction.DESC).build()),
                     Arguments.of(SortingField.builder().field("metadata.model").direction(Direction.ASC).build()),
-                    Arguments.of(SortingField.builder().field("metadata.model").direction(Direction.DESC).build()));
+                    Arguments.of(SortingField.builder().field("metadata.model").direction(Direction.DESC).build()),
+
+                    // Comments field sorting (sorts by first comment's text)
+                    Arguments
+                            .of(SortingField.builder().field(SortableFields.COMMENTS).direction(Direction.ASC).build()),
+                    Arguments.of(
+                            SortingField.builder().field(SortableFields.COMMENTS).direction(Direction.DESC).build()));
         }
 
         @Test


### PR DESCRIPTION
## Details

`comments` was already in `SUPPORTED_FIELDS` for the experiment-comparison endpoint, but the resulting sort ran as outer `ORDER BY comments` against the alias holding `argMax(ei.comments_array_agg, ei.id)` — i.e., a JSON string — so ordering was byte-lex dominated by the first comment's UUID and effectively useless. This PR makes comments-sort do something real, and it does so through the push-top-limit fast path:

- Adds `COMMENTS` to `PUSH_TOP_SUPPORTED` in `SortingFactoryDatasets`. Comments come from `experiment_item_aggregates.comments_array_agg`, fully reachable inside `top_dataset_items`, so the `!push_top_needs_div` placement applies — same shape as `duration` / `total_estimated_cost` / `usage` (the variants already benched at 5–13× speedup).
- `DatasetItemVersionDAO#getTopSortExpression`: emits `arrayMap(elem -> JSONExtractString(elem, 'text'), JSONExtractArrayRaw(argMax(eia_t.comments_array_agg, eia_t.id)))`. The CTE picks the comments array of the highest-id experiment item in the group (matching the outer projection) and exposes `Array(String)` of comment texts for ORDER BY — ClickHouse compares element-wise.
- `FilterQueryBuilder#buildDatasetItemFieldMapping`: maps the outer `comments` ORDER BY to the same expression against the outer alias, so push-top-limit and legacy paths produce equivalent ordering.
- Extends the parameterized sorting test in `DatasetsResourceTest` with ASC/DESC cases for `comments`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6311

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: assisted (sort-expression design, code wiring, test extension)
- Human verification: code review + targeted test run

## Testing

```
mvn test -Dtest='DatasetsResourceTest$FindDatasetItemsWithExperimentItemsSortingTest'
```

32 tests pass (30 prior + 2 new comments cases). `mvn -DskipTests compile` and `mvn spotless:check` both pass.

DB perf check intentionally **not** run on staging: cluster-wide scan of `experiment_item_aggregates` shows 0 of 19.65M rows have `comments_array_agg` populated, so an empirical bench against real data isn't possible until the comments feature sees production usage. Structural similarity to other `!push_top_needs_div` EIA-side sorts (5–13× speedup measured in #6559 / #6567) gives high confidence the same speedup bucket applies; the JSON-parse cost on the hot path is bounded by the 25-row `LIMIT` in `top_dataset_items`.

## Documentation

N/A — internal sort-expression change, no public API or schema change.
