### PR TITLE
[OPIK-6334] [FE] feat: add skeleton loaders on main list pages

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/CollaboratorsTab.tsx
+++ b/apps/opik-frontend/src/plugins/comet/CollaboratorsTab.tsx
@@ -13,7 +13,6 @@ import useUserPermission from "@/plugins/comet/useUserPermission";
 import DataTable from "@/shared/DataTable/DataTable";
 import ExplainerCallout from "@/shared/ExplainerCallout/ExplainerCallout";
 import SearchInput from "@/shared/SearchInput/SearchInput";
-import Loader from "@/shared/Loader/Loader";
 import { Button } from "@/ui/button";
 import { DropdownMenu, DropdownMenuTrigger } from "@/ui/dropdown-menu";
 import InviteUsersPopover from "./InviteUsersPopover";
@@ -226,16 +225,12 @@ const CollaboratorsTab = () => {
   ]);
 
   const renderTable = () => {
-    const isLoading =
+    const isTableLoading =
       isPending ||
       isPermissionsPending ||
       isInvitedMembersPending ||
       (isPermissionsManagementEnabled &&
         (isUsersRolesPending || isWorkspaceRolesPending));
-
-    if (isLoading) {
-      return <Loader />;
-    }
 
     return (
       <WorkspaceRolesProvider
@@ -246,6 +241,7 @@ const CollaboratorsTab = () => {
           columns={columns}
           data={tableData}
           resizeConfig={resizeConfig}
+          showSkeleton={isTableLoading}
         />
       </WorkspaceRolesProvider>
     );

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPage.tsx
@@ -21,7 +21,6 @@ import OverrideVersionDialog from "@/v2/pages-shared/datasets/OverrideVersionDia
 import DatasetExpansionDialog from "@/v2/pages-shared/datasets/DatasetExpansionDialog";
 import { ExpansionDialogRenderProps } from "@/v2/pages-shared/datasets/DatasetItemsActionsPanel";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
-import Loader from "@/shared/Loader/Loader";
 import { usePermissions } from "@/contexts/PermissionsContext";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/ui/tabs";
 import useNavigationBlocker from "@/hooks/useNavigationBlocker";
@@ -67,7 +66,7 @@ function DatasetItemsPage(): React.ReactElement {
 
   const { mutate: updateDataset } = useDatasetUpdateMutation();
 
-  const { data: dataset, isPending } = useDatasetById(
+  const { data: dataset } = useDatasetById(
     { datasetId },
     {
       refetchInterval: (query) => {
@@ -217,10 +216,6 @@ function DatasetItemsPage(): React.ReactElement {
     ),
     [datasetId, datasetType, isTestSuite, effectiveAssertions],
   );
-
-  if (isPending) {
-    return <Loader />;
-  }
 
   return (
     <div className="pt-4">

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
@@ -52,7 +52,6 @@ import {
   migrateSelectedColumns,
 } from "@/lib/table";
 import DataTableEmptyContent from "@/shared/DataTableNoData/DataTableEmptyContent";
-import Loader from "@/shared/Loader/Loader";
 import {
   buildDatasetFilterColumns,
   mapDynamicColumnTypesToColumnType,
@@ -533,13 +532,7 @@ function DatasetItemsTab({
     selectedRows.length === rows.length &&
     selectedRows.length < totalCount;
 
-  if (isPending) {
-    return (
-      <div className="flex items-center justify-center pt-12">
-        <Loader />
-      </div>
-    );
-  }
+  const isTableLoading = isPending || (isPlaceholderData && rows.length === 0);
 
   return (
     <>
@@ -665,7 +658,8 @@ function DatasetItemsTab({
         onRowClick={canEditDatasets ? handleRowClick : undefined}
         activeRowId={activeRowId ?? ""}
         resizeConfig={resizeConfig}
-        showLoadingOverlay={isPlaceholderData && isFetching}
+        showSkeleton={isTableLoading}
+        showLoadingOverlay={!isTableLoading && isPlaceholderData && isFetching}
         selectionConfig={{
           rowSelection,
           setRowSelection: handleRowSelectionChange,

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetListPage/DatasetListPage.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetListPage/DatasetListPage.tsx
@@ -15,7 +15,6 @@ import DataTableNoData from "@/shared/DataTableNoData/DataTableNoData";
 import PageEmptyState from "@/shared/PageEmptyState/PageEmptyState";
 import useProjectDatasetsList from "@/api/datasets/useProjectDatasetsList";
 import { Dataset, DATASET_TYPE, DatasetListType } from "@/types/datasets";
-import Loader from "@/shared/Loader/Loader";
 import AddEditDatasetDialog from "@/v2/pages-shared/datasets/AddEditDatasetDialog/AddEditDatasetDialog";
 import AddEditTestSuiteDialog from "@/v2/pages-shared/datasets/AddEditTestSuiteDialog/AddEditTestSuiteDialog";
 import CreateDatasetSidebar from "@/v2/pages-shared/datasets/CreateDatasetSidebar/CreateDatasetSidebar";
@@ -304,7 +303,9 @@ const DatasetListPage: React.FunctionComponent<DatasetListPageProps> = ({
   );
   const total = data?.total ?? 0;
   const noData = !search && filters.length === 0;
-  const isEmpty = noData && datasets.length === 0;
+  const isTableLoading =
+    isPending || (isPlaceholderData && datasets.length === 0);
+  const isEmpty = !isTableLoading && noData && datasets.length === 0;
   const noDataText = noData ? config.noDataText : "No search results";
 
   const [selectedColumns, setSelectedColumns] = useLocalStorageState<string[]>(
@@ -418,10 +419,6 @@ const DatasetListPage: React.FunctionComponent<DatasetListPageProps> = ({
     ],
   );
 
-  if (isPending || (isPlaceholderData && datasets.length === 0)) {
-    return <Loader />;
-  }
-
   return (
     <div className="flex min-h-full flex-col pt-4">
       <div className="mb-4 flex min-h-7 items-center justify-between">
@@ -505,7 +502,10 @@ const DatasetListPage: React.FunctionComponent<DatasetListPageProps> = ({
                 )}
               </DataTableNoData>
             }
-            showLoadingOverlay={isPlaceholderData && isFetching}
+            showSkeleton={isTableLoading}
+            showLoadingOverlay={
+              !isTableLoading && isPlaceholderData && isFetching
+            }
           />
           <div className="py-4">
             <DataTablePagination

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/VersionHistoryTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/VersionHistoryTab.tsx
@@ -10,7 +10,6 @@ import TimeCell from "@/shared/DataTableCells/TimeCell";
 import ListCell from "@/shared/DataTableCells/ListCell";
 import { DatasetVersion } from "@/types/datasets";
 import useDatasetVersionsList from "@/api/datasets/useDatasetVersionsList";
-import Loader from "@/shared/Loader/Loader";
 import { convertColumnDataToColumn } from "@/lib/table";
 import { generateActionsColumDef } from "@/shared/DataTable/utils";
 import { usePermissions } from "@/contexts/PermissionsContext";
@@ -118,13 +117,7 @@ const VersionHistoryTab: React.FC<VersionHistoryTabProps> = ({ datasetId }) => {
   const data = versionsData?.content || [];
   const total = versionsData?.total ?? 0;
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center pt-12">
-        <Loader />
-      </div>
-    );
-  }
+  const isTableLoading = isLoading || (isPlaceholderData && data.length === 0);
 
   return (
     <div className="flex flex-col gap-4 pt-4">
@@ -140,7 +133,8 @@ const VersionHistoryTab: React.FC<VersionHistoryTabProps> = ({ datasetId }) => {
             </div>
           </DataTableNoData>
         }
-        showLoadingOverlay={isPlaceholderData && isFetching}
+        showSkeleton={isTableLoading}
+        showLoadingOverlay={!isTableLoading && isPlaceholderData && isFetching}
       />
       <DataTablePagination
         page={page}

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AlertsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AlertsPage.tsx
@@ -19,7 +19,6 @@ import DataTablePagination from "@/shared/DataTablePagination/DataTablePaginatio
 import DataTableNoData from "@/shared/DataTableNoData/DataTableNoData";
 import IdCell from "@/shared/DataTableCells/IdCell";
 import StatusCell from "@/shared/DataTableCells/StatusCell";
-import Loader from "@/shared/Loader/Loader";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";
 import { Button } from "@/ui/button";
@@ -329,11 +328,9 @@ const AlertsPage: React.FunctionComponent = () => {
     });
   }, [navigate, workspaceName, activeProjectId]);
 
-  if (isPending || (isPlaceholderData && alerts.length === 0)) {
-    return <Loader />;
-  }
-
-  const isEmpty = noData && alerts.length === 0;
+  const isTableLoading =
+    isPending || (isPlaceholderData && alerts.length === 0);
+  const isEmpty = !isTableLoading && noData && alerts.length === 0;
 
   return (
     <div className="flex min-h-full flex-col pt-4">
@@ -424,7 +421,10 @@ const AlertsPage: React.FunctionComponent = () => {
                   )}
                 </DataTableNoData>
               }
-              showLoadingOverlay={isPlaceholderData && isFetching}
+              showSkeleton={isTableLoading}
+              showLoadingOverlay={
+                !isTableLoading && isPlaceholderData && isFetching
+              }
             />
             <div className="py-4">
               <DataTablePagination

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
@@ -35,7 +35,6 @@ import {
   generateSelectColumDef,
   getRowId,
 } from "@/shared/DataTable/utils";
-import Loader from "@/shared/Loader/Loader";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";
 import { getTagsFilterConfig } from "@/v2/pages-shared/TagsAutocomplete/tagsFilterConfig";
@@ -485,9 +484,7 @@ const ThreadQueueItemsTab: React.FunctionComponent<
     ];
   }, [scoresColumnsData, scoresColumnsOrder, setScoresColumnsOrder]);
 
-  if (isPending) {
-    return <Loader />;
-  }
+  const isTableLoading = isPending || (isPlaceholderData && rows.length === 0);
 
   return (
     <>
@@ -568,7 +565,8 @@ const ThreadQueueItemsTab: React.FunctionComponent<
         }
         TableWrapper={PageBodyStickyTableWrapper}
         stickyHeader
-        showLoadingOverlay={isPlaceholderData && isFetching}
+        showSkeleton={isTableLoading}
+        showLoadingOverlay={!isTableLoading && isPlaceholderData && isFetching}
       />
       <PageBodyStickyContainer
         className="py-4"

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
@@ -42,7 +42,6 @@ import {
   generateSelectColumDef,
   getRowId,
 } from "@/shared/DataTable/utils";
-import Loader from "@/shared/Loader/Loader";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";
 import { getTagsFilterConfig } from "@/v2/pages-shared/TagsAutocomplete/tagsFilterConfig";
@@ -581,9 +580,7 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
     ];
   }, [scoresColumnsData, scoresColumnsOrder, setScoresColumnsOrder]);
 
-  if (isPending) {
-    return <Loader />;
-  }
+  const isTableLoading = isPending || (isPlaceholderData && rows.length === 0);
 
   return (
     <>
@@ -665,7 +662,8 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
         }
         TableWrapper={PageBodyStickyTableWrapper}
         stickyHeader
-        showLoadingOverlay={isPlaceholderData && isFetching}
+        showSkeleton={isTableLoading}
+        showLoadingOverlay={!isTableLoading && isPlaceholderData && isFetching}
       />
       <PageBodyStickyContainer
         className="py-4"

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuesPage/AnnotationQueuesPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuesPage/AnnotationQueuesPage.tsx
@@ -25,7 +25,6 @@ import DataTablePagination from "@/shared/DataTablePagination/DataTablePaginatio
 import DataTableRowHeightSelector from "@/shared/DataTableRowHeightSelector/DataTableRowHeightSelector";
 import ColumnsButton from "@/shared/ColumnsButton/ColumnsButton";
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";
-import Loader from "@/shared/Loader/Loader";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import FeedbackScoreListCell from "@/shared/DataTableCells/FeedbackScoreListCell";
 import IdCell from "@/shared/DataTableCells/IdCell";
@@ -382,11 +381,8 @@ export const AnnotationQueuesPage: React.FC = () => {
     [columnsWidth, setColumnsWidth],
   );
 
-  if (isLoading || (isPlaceholderData && rows.length === 0)) {
-    return <Loader />;
-  }
-
-  const isEmpty = noData && rows.length === 0 && page === 1;
+  const isTableLoading = isLoading || (isPlaceholderData && rows.length === 0);
+  const isEmpty = !isTableLoading && noData && rows.length === 0 && page === 1;
 
   return (
     <div className="flex min-h-full flex-col pt-4">
@@ -471,7 +467,10 @@ export const AnnotationQueuesPage: React.FC = () => {
             noData={<DataTableNoData title={noDataText} />}
             onRowClick={handleRowClick}
             stickyHeader
-            showLoadingOverlay={isPlaceholderData && isFetching}
+            showSkeleton={isTableLoading}
+            showLoadingOverlay={
+              !isTableLoading && isPlaceholderData && isFetching
+            }
           />
           <div className="py-4">
             <DataTablePagination

--- a/apps/opik-frontend/src/v2/pages/AutomationLogsPage/AutomationLogsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AutomationLogsPage/AutomationLogsPage.tsx
@@ -6,7 +6,6 @@ import { FoldVertical, UnfoldVertical } from "lucide-react";
 
 import useRulesLogsList from "@/api/automations/useRulesLogsList";
 import NoData from "@/shared/NoData/NoData";
-import Loader from "@/shared/Loader/Loader";
 import { Button } from "@/ui/button";
 import PageBodyScrollContainer from "@/v2/layout/PageBodyScrollContainer/PageBodyScrollContainer";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
@@ -164,11 +163,9 @@ const AutomationLogsPage = () => {
     return <NoData message="No rule parameters set."></NoData>;
   }
 
-  if (isPending) {
-    return <Loader />;
-  }
+  const isTableLoading = isPending || (isPlaceholderData && rows.length === 0);
 
-  if (rows.length === 0) {
+  if (!isTableLoading && rows.length === 0) {
     return <NoData message="There are no logs for this rule."></NoData>;
   }
 
@@ -207,7 +204,10 @@ const AutomationLogsPage = () => {
           getRowId={(row) => row.id}
           stickyHeader
           resizeConfig={resizeConfig}
-          showLoadingOverlay={isPlaceholderData && isFetching}
+          showSkeleton={isTableLoading}
+          showLoadingOverlay={
+            !isTableLoading && isPlaceholderData && isFetching
+          }
         />
       </PageBodyScrollContainer>
     </div>

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
@@ -21,7 +21,6 @@ import CompareExperimentsConfigCell, {
 } from "@/v2/pages-shared/experiments/CompareExperimentsConfigCell/CompareExperimentsConfigCell";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
 import PageBodyStickyTableWrapper from "@/v2/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
-import Loader from "@/shared/Loader/Loader";
 import ExplainerCallout from "@/shared/ExplainerCallout/ExplainerCallout";
 import { convertColumnDataToColumn } from "@/lib/table";
 import SearchInput from "@/shared/SearchInput/SearchInput";
@@ -194,9 +193,7 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
     [columnsWidth, setColumnsWidth],
   );
 
-  if (isPending) {
-    return <Loader />;
-  }
+  const isTableLoading = isPending;
 
   return (
     <>
@@ -245,6 +242,7 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
         noData={<DataTableNoData title={noDataText} />}
         TableWrapper={PageBodyStickyTableWrapper}
         stickyHeader
+        showSkeleton={isTableLoading}
       />
       <PageBodyStickyContainer
         className="pb-6"

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentFeedbackScoresTab/ExperimentFeedbackScoresTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentFeedbackScoresTab/ExperimentFeedbackScoresTab.tsx
@@ -20,7 +20,6 @@ import CompareExperimentsHeader from "@/v2/pages-shared/experiments/CompareExper
 import CompareExperimentsActionsPanel from "@/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
 import PageBodyStickyTableWrapper from "@/v2/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
-import Loader from "@/shared/Loader/Loader";
 import { convertColumnDataToColumn } from "@/lib/table";
 import { Experiment } from "@/types/datasets";
 import { formatScoreDisplay, getScoreDisplayName } from "@/lib/feedback-scores";
@@ -212,9 +211,7 @@ const ExperimentFeedbackScoresTab: React.FunctionComponent<
     [columnsWidth, setColumnsWidth],
   );
 
-  if (isPending) {
-    return <Loader />;
-  }
+  const isTableLoading = isPending;
 
   return (
     <>
@@ -235,6 +232,7 @@ const ExperimentFeedbackScoresTab: React.FunctionComponent<
         noData={<DataTableNoData title={noDataText} />}
         TableWrapper={PageBodyStickyTableWrapper}
         stickyHeader
+        showSkeleton={isTableLoading}
       />
       <PageBodyStickyContainer
         className="pb-6"

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -39,7 +39,6 @@ import CompareExperimentsNameCell from "@/v2/pages-shared/experiments/CompareExp
 import CompareExperimentsNameHeader from "@/v2/pages-shared/experiments/CompareExperimentsNameHeader/CompareExperimentsNameHeader";
 import ColumnsButton from "@/shared/ColumnsButton/ColumnsButton";
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";
-import Loader from "@/shared/Loader/Loader";
 import ExplainerCallout from "@/shared/ExplainerCallout/ExplainerCallout";
 import useAppStore from "@/store/AppStore";
 import { Experiment, ExperimentsCompare } from "@/types/datasets";
@@ -651,9 +650,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
     ],
   );
 
-  if (isPending) {
-    return <Loader />;
-  }
+  const isTableLoading = isPending || (isPlaceholderData && rows.length === 0);
 
   return (
     <>
@@ -732,7 +729,8 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         TableBody={DataTableVirtualBody}
         stickyHeader
         meta={meta}
-        showLoadingOverlay={isPlaceholderData && isFetching}
+        showSkeleton={isTableLoading}
+        showLoadingOverlay={!isTableLoading && isPlaceholderData && isFetching}
       />
       <PageBodyStickyContainer
         className="py-4"

--- a/apps/opik-frontend/src/v2/pages/ConfigurationPage/AIProvidersTab/AIProvidersTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/ConfigurationPage/AIProvidersTab/AIProvidersTab.tsx
@@ -14,7 +14,6 @@ import { PROVIDERS, LEGACY_CUSTOM_PROVIDER_NAME } from "@/constants/providers";
 import AIProviderCell from "@/v2/pages/ConfigurationPage/AIProvidersTab/AIProviderCell";
 import { generateActionsColumDef } from "@/shared/DataTable/utils";
 import AIProvidersRowActionsCell from "@/v2/pages/ConfigurationPage/AIProvidersTab/AIProvidersRowActionsCell";
-import Loader from "@/shared/Loader/Loader";
 import ExplainerCallout from "@/shared/ExplainerCallout/ExplainerCallout";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import { Button } from "@/ui/button";
@@ -121,9 +120,7 @@ const AIProvidersTab = () => {
     setOpenDialog(true);
   };
 
-  if (isPending) {
-    return <Loader />;
-  }
+  const isTableLoading = isPending;
 
   return (
     <div>
@@ -150,6 +147,7 @@ const AIProvidersTab = () => {
         columns={columns}
         data={filteredProviderKeys}
         columnPinning={DEFAULT_COLUMN_PINNING}
+        showSkeleton={isTableLoading}
         noData={
           search === "" ? (
             <DataTableEmptyContent

--- a/apps/opik-frontend/src/v2/pages/ConfigurationPage/FeedbackDefinitionsTab/FeedbackDefinitionsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/ConfigurationPage/FeedbackDefinitionsTab/FeedbackDefinitionsTab.tsx
@@ -14,7 +14,6 @@ import DataTableEmptyContent from "@/shared/DataTableNoData/DataTableEmptyConten
 import DataTableNoMatchingData from "@/shared/DataTableNoData/DataTableNoMatchingData";
 import TagCell from "@/shared/DataTableCells/TagCell";
 import IdCell from "@/shared/DataTableCells/IdCell";
-import Loader from "@/shared/Loader/Loader";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import { Button } from "@/ui/button";
 import useAppStore from "@/store/AppStore";
@@ -206,9 +205,8 @@ const FeedbackDefinitionsTab: React.FunctionComponent = () => {
       newFeedbackDefinitionDialogKeyRef.current + 1;
   }, []);
 
-  if (isPending) {
-    return <Loader />;
-  }
+  const isTableLoading =
+    isPending || (isPlaceholderData && feedbackDefinitions.length === 0);
 
   return (
     <div>
@@ -271,7 +269,8 @@ const FeedbackDefinitionsTab: React.FunctionComponent = () => {
             <DataTableNoMatchingData />
           )
         }
-        showLoadingOverlay={isPlaceholderData && isFetching}
+        showSkeleton={isTableLoading}
+        showLoadingOverlay={!isTableLoading && isPlaceholderData && isFetching}
       />
       <div className="py-4">
         <DataTablePagination

--- a/apps/opik-frontend/src/v2/pages/DashboardsPage/DashboardsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/DashboardsPage/DashboardsPage.tsx
@@ -24,7 +24,6 @@ import TextCell from "@/shared/DataTableCells/TextCell";
 import useDashboardsList from "@/api/dashboards/useDashboardsList";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import { Dashboard, DASHBOARD_TYPE_LABELS } from "@/types/dashboard";
-import Loader from "@/shared/Loader/Loader";
 import AddEditCloneDashboardDialog from "@/v2/pages-shared/dashboards/AddEditCloneDashboardDialog/AddEditCloneDashboardDialog";
 import { DashboardRowActionsCell } from "@/v2/pages/DashboardsPage/DashboardRowActionsCell";
 import DashboardsActionsPanel from "@/v2/pages/DashboardsPage/DashboardsActionsPanel";
@@ -348,11 +347,9 @@ const DashboardsPage: React.FunctionComponent = () => {
     resetDialogKeyRef.current = resetDialogKeyRef.current + 1;
   }, []);
 
-  if (isPending || (isPlaceholderData && dashboards.length === 0)) {
-    return <Loader />;
-  }
-
-  const isEmpty = noData && dashboards.length === 0;
+  const isTableLoading =
+    isPending || (isPlaceholderData && dashboards.length === 0);
+  const isEmpty = !isTableLoading && noData && dashboards.length === 0;
 
   return (
     <div className="flex min-h-full flex-col pt-4">
@@ -428,7 +425,10 @@ const DashboardsPage: React.FunctionComponent = () => {
             getRowId={getRowId}
             columnPinning={DEFAULT_COLUMN_PINNING}
             noData={<DataTableNoMatchingData />}
-            showLoadingOverlay={isPlaceholderData && isFetching}
+            showSkeleton={isTableLoading}
+            showLoadingOverlay={
+              !isTableLoading && isPlaceholderData && isFetching
+            }
           />
           <div className="py-4">
             <DataTablePagination

--- a/apps/opik-frontend/src/v2/pages/ExperimentsPage/ExperimentsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ExperimentsPage/ExperimentsPage.tsx
@@ -81,7 +81,7 @@ const ExperimentsPage: React.FC = () => {
             docsUrl={buildDocsUrl("/evaluation/overview")}
           />
         ) : (
-          <GeneralDatasetsTab onNewExperimentClick={handleNewExperimentClick} />
+          <GeneralDatasetsTab isExistencePending={isExistencePending} />
         )}
         <AddExperimentDialog
           key={resetDialogKeyRef.current}

--- a/apps/opik-frontend/src/v2/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
@@ -22,7 +22,7 @@ import isObject from "lodash/isObject";
 
 import DataTable from "@/shared/DataTable/DataTable";
 import DataTablePagination from "@/shared/DataTablePagination/DataTablePagination";
-import DataTableNoData from "@/shared/DataTableNoData/DataTableNoData";
+import DataTableNoMatchingData from "@/shared/DataTableNoData/DataTableNoMatchingData";
 import IdCell from "@/shared/DataTableCells/IdCell";
 import ResourceCell from "@/shared/DataTableCells/ResourceCell";
 import CommentsCell from "@/shared/DataTableCells/CommentsCell";
@@ -32,7 +32,6 @@ import CodeCell from "@/shared/DataTableCells/CodeCell";
 import DurationCell from "@/shared/DataTableCells/DurationCell";
 import ListCell from "@/shared/DataTableCells/ListCell";
 import { RESOURCE_TYPE } from "@/shared/ResourceLink/ResourceLink";
-import Loader from "@/shared/Loader/Loader";
 import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { formatDate } from "@/lib/date";
 import { isTestSuiteExperiment } from "@/lib/experiments";
@@ -58,7 +57,6 @@ import ExperimentRowActionsCell from "@/v2/pages/ExperimentsPage/ExperimentRowAc
 import FeedbackScoresChartsWrapper from "@/v2/pages-shared/experiments/FeedbackScoresChartsWrapper/FeedbackScoresChartsWrapper";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import RefreshButton from "@/shared/RefreshButton/RefreshButton";
-import { Button } from "@/ui/button";
 import { Separator } from "@/ui/separator";
 import { Card } from "@/ui/card";
 import useGroupedExperimentsList, {
@@ -148,11 +146,11 @@ const DEFAULT_COLUMNS_ORDER: string[] = [
 export const MAX_EXPANDED_DEEPEST_GROUPS = 5;
 
 type GeneralDatasetsTabProps = {
-  onNewExperimentClick?: () => void;
+  isExistencePending?: boolean;
 };
 
 const GeneralDatasetsTab: React.FC<GeneralDatasetsTabProps> = ({
-  onNewExperimentClick,
+  isExistencePending = false,
 }) => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const activeProjectId = useActiveProjectId();
@@ -424,10 +422,6 @@ const GeneralDatasetsTab: React.FC<GeneralDatasetsTabProps> = ({
   });
 
   const total = data?.total ?? 0;
-  const noData = !search && filters.length === 0;
-  const noDataText = noData
-    ? "There are no experiments yet"
-    : "No search results";
 
   const {
     columns,
@@ -474,6 +468,11 @@ const GeneralDatasetsTab: React.FC<GeneralDatasetsTabProps> = ({
     },
     [navigate, workspaceName, activeProjectId],
   );
+
+  const handleClearFilters = useCallback(() => {
+    setSearch(undefined);
+    setFilters([]);
+  }, [setSearch, setFilters]);
 
   const hasGroups = Boolean(groups.length);
 
@@ -629,38 +628,40 @@ const GeneralDatasetsTab: React.FC<GeneralDatasetsTabProps> = ({
     groupFieldNames,
   ]);
 
-  if (
+  const isTableLoading =
+    isExistencePending ||
     isPending ||
     isFeedbackScoresPending ||
-    (isPlaceholderData && experiments.length === 0)
-  ) {
-    return <Loader />;
-  }
+    (isPlaceholderData && experiments.length === 0);
 
   return (
     <>
-      {Boolean(experiments.length) && (
+      {(isTableLoading || experiments.length > 0) && (
         <PageBodyStickyContainer
           direction="horizontal"
           className="-mb-2 pt-4"
           limitWidth
         >
-          <FeedbackScoresChartsWrapper
-            chartsData={chartsData}
-            noDataComponent={
-              <Card className="flex min-h-[208px] w-full min-w-[400px] flex-col items-center justify-center gap-2">
-                <ChartLine className="size-4 shrink-0 text-light-slate" />
-                <div className="comet-body-s-accented text-foreground">
-                  No charts to show
-                </div>
-                <div className="comet-body-s text-muted-slate">
-                  Please expand a group to see its chart. You can expand up to{" "}
-                  {MAX_EXPANDED_DEEPEST_GROUPS} deepest groups simultaneously.
-                </div>
-              </Card>
-            }
-            areAggregatedScores
-          />
+          {isTableLoading ? (
+            <Skeleton className="h-[208px] w-full min-w-[400px] rounded-md" />
+          ) : (
+            <FeedbackScoresChartsWrapper
+              chartsData={chartsData}
+              noDataComponent={
+                <Card className="flex min-h-[208px] w-full min-w-[400px] flex-col items-center justify-center gap-2">
+                  <ChartLine className="size-4 shrink-0 text-light-slate" />
+                  <div className="comet-body-s-accented text-foreground">
+                    No charts to show
+                  </div>
+                  <div className="comet-body-s text-muted-slate">
+                    Please expand a group to see its chart. You can expand up to{" "}
+                    {MAX_EXPANDED_DEEPEST_GROUPS} deepest groups simultaneously.
+                  </div>
+                </Card>
+              }
+              areAggregatedScores
+            />
+          )}
         </PageBodyStickyContainer>
       )}
       <PageBodyStickyContainer
@@ -733,18 +734,17 @@ const GeneralDatasetsTab: React.FC<GeneralDatasetsTabProps> = ({
         getRowId={getExperimentRowId}
         columnPinning={columnPinningConfig}
         noData={
-          <DataTableNoData title={noDataText}>
-            {noData && (
-              <Button variant="link" onClick={onNewExperimentClick}>
-                Create experiment
-              </Button>
-            )}
-          </DataTableNoData>
+          <DataTableNoMatchingData
+            onClearFilters={
+              search || filters.length > 0 ? handleClearFilters : undefined
+            }
+          />
         }
         TableWrapper={PageBodyStickyTableWrapper}
         TableBody={DataTableVirtualBody}
         stickyHeader
-        showLoadingOverlay={isPlaceholderData && isFetching}
+        showSkeleton={isTableLoading}
+        showLoadingOverlay={!isTableLoading && isPlaceholderData && isFetching}
       />
       <PageBodyStickyContainer
         className="py-4"

--- a/apps/opik-frontend/src/v2/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
@@ -30,7 +30,6 @@ import {
   generateSelectColumDef,
 } from "@/shared/DataTable/utils";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
-import Loader from "@/shared/Loader/Loader";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import { Button } from "@/ui/button";
 import { Separator } from "@/ui/separator";
@@ -357,11 +356,8 @@ export const OnlineEvaluationPage: React.FC = () => {
     [setEditRuleId, setCloneRuleId],
   );
 
-  if (isPending || (isPlaceholderData && rows.length === 0)) {
-    return <Loader />;
-  }
-
-  const isEmpty = noData && rows.length === 0 && page === 1;
+  const isTableLoading = isPending || (isPlaceholderData && rows.length === 0);
+  const isEmpty = !isTableLoading && noData && rows.length === 0 && page === 1;
 
   return (
     <div className="flex min-h-full flex-col pt-4">
@@ -434,7 +430,10 @@ export const OnlineEvaluationPage: React.FC = () => {
             getRowId={getRowId}
             columnPinning={DEFAULT_COLUMN_PINNING}
             noData={<DataTableNoData title={noDataText} />}
-            showLoadingOverlay={isPlaceholderData && isFetching}
+            showSkeleton={isTableLoading}
+            showLoadingOverlay={
+              !isTableLoading && isPlaceholderData && isFetching
+            }
           />
           <div className="py-4">
             <DataTablePagination

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -318,10 +318,10 @@ const OptimizationsPage: React.FunctionComponent = () => {
     isPending || (isPlaceholderData && optimizations.length === 0);
   const isEmpty = !isTableLoading && noData && optimizations.length === 0;
 
-  const handleClearFilters = () => {
+  const handleClearFilters = useCallback(() => {
     setSearch(undefined);
     setFilters([]);
-  };
+  }, [setSearch, setFilters]);
 
   return (
     <div className="flex min-h-full flex-col pt-4">

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -10,7 +10,7 @@ import {
 } from "use-query-params";
 import DataTable from "@/shared/DataTable/DataTable";
 import DataTablePagination from "@/shared/DataTablePagination/DataTablePagination";
-import DataTableNoData from "@/shared/DataTableNoData/DataTableNoData";
+import DataTableNoMatchingData from "@/shared/DataTableNoData/DataTableNoMatchingData";
 import DatasetNameCell from "@/v2/pages/OptimizationsPage/DatasetNameCell";
 import OptimizationStatusCell from "@/v2/pages/OptimizationsPage/OptimizationStatusCell";
 import {
@@ -20,7 +20,6 @@ import {
   OptimizationCostCell,
   OptimizationTotalCostCell,
 } from "@/v2/pages/OptimizationsPage/OptimizationMetricCells";
-import Loader from "@/shared/Loader/Loader";
 import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import TimeCell from "@/shared/DataTableCells/TimeCell";
 import { COLUMN_DATASET_ID, COLUMN_TYPE, ColumnData } from "@/types/shared";
@@ -36,7 +35,6 @@ import FiltersButton from "@/shared/FiltersButton/FiltersButton";
 import OptimizationRowActionsCell from "@/v2/pages/OptimizationsPage/OptimizationRowActionsCell";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import RefreshButton from "@/shared/RefreshButton/RefreshButton";
-import { Button } from "@/ui/button";
 import { Separator } from "@/ui/separator";
 import {
   generateActionsColumDef,
@@ -217,10 +215,6 @@ const OptimizationsPage: React.FunctionComponent = () => {
   );
 
   const noData = !search && filters.length === 0;
-  const noDataText = noData
-    ? "There are no optimizations yet\n" +
-      "Optimizations help improve your LLM application's performance, accuracy, and overall user experience"
-    : "No search results";
 
   const [selectedColumns, setSelectedColumns] = useLocalStorageState<string[]>(
     SELECTED_COLUMNS_KEY,
@@ -320,11 +314,14 @@ const OptimizationsPage: React.FunctionComponent = () => {
     resetDialogKeyRef.current = resetDialogKeyRef.current + 1;
   }, []);
 
-  if (isPending || (isPlaceholderData && optimizations.length === 0)) {
-    return <Loader />;
-  }
+  const isTableLoading =
+    isPending || (isPlaceholderData && optimizations.length === 0);
+  const isEmpty = !isTableLoading && noData && optimizations.length === 0;
 
-  const isEmpty = noData && optimizations.length === 0;
+  const handleClearFilters = () => {
+    setSearch(undefined);
+    setFilters([]);
+  };
 
   return (
     <div className="flex min-h-full flex-col pt-4">
@@ -355,9 +352,6 @@ const OptimizationsPage: React.FunctionComponent = () => {
             <StudioTemplates />
           )}
           <div className="pt-4">
-            <h2 className="comet-title-s sticky top-0 z-10 truncate break-words bg-soft-background pb-3 pt-2">
-              Optimization runs
-            </h2>
             <div className="mb-4 flex flex-wrap items-center justify-between gap-x-8 gap-y-2">
               <div className="flex items-center gap-2">
                 <SearchInput
@@ -409,15 +403,18 @@ const OptimizationsPage: React.FunctionComponent = () => {
                 setRowSelection,
               }}
               noData={
-                <DataTableNoData title={noDataText}>
-                  {noData && canUseOptimizationStudio && (
-                    <Button variant="link" onClick={handleNewOptimizationClick}>
-                      Create optimization
-                    </Button>
-                  )}
-                </DataTableNoData>
+                <DataTableNoMatchingData
+                  onClearFilters={
+                    search || filters.length > 0
+                      ? handleClearFilters
+                      : undefined
+                  }
+                />
               }
-              showLoadingOverlay={isPlaceholderData && isFetching}
+              showSkeleton={isTableLoading}
+              showLoadingOverlay={
+                !isTableLoading && isPlaceholderData && isFetching
+              }
             />
             <div className="py-4">
               <DataTablePagination

--- a/apps/opik-frontend/src/v2/pages/ProjectsPage/ProjectsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectsPage/ProjectsPage.tsx
@@ -22,7 +22,6 @@ import CostCell from "@/shared/DataTableCells/CostCell";
 import useProjectWithStatisticsList from "@/hooks/useProjectWithStatisticsList";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import { ProjectWithStatistic } from "@/types/projects";
-import Loader from "@/shared/Loader/Loader";
 import AddEditProjectDialog from "@/v2/pages/ProjectsPage/AddEditProjectDialog";
 import ProjectsActionsPanel from "@/v2/pages/ProjectsPage/ProjectsActionsPanel";
 import { ProjectRowActionsCell } from "@/v2/pages/ProjectsPage/ProjectRowActionsCell";
@@ -433,9 +432,7 @@ const ProjectsPage: React.FunctionComponent = () => {
     resetDialogKeyRef.current = resetDialogKeyRef.current + 1;
   }, []);
 
-  if (isPending) {
-    return <Loader />;
-  }
+  const isTableLoading = isPending;
 
   return (
     <div className="pt-4">
@@ -505,7 +502,8 @@ const ProjectsPage: React.FunctionComponent = () => {
             <DataTableNoMatchingData />
           )
         }
-        showLoadingOverlay={isPlaceholderData && isFetching}
+        showSkeleton={isTableLoading}
+        showLoadingOverlay={!isTableLoading && isPlaceholderData && isFetching}
       />
       <div className="py-4">
         <DataTablePagination

--- a/apps/opik-frontend/src/v2/pages/TrialPage/TrialsItemsTab/TrialItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/TrialPage/TrialsItemsTab/TrialItemsTab.tsx
@@ -33,7 +33,6 @@ import TrialScoreCell from "./TrialScoreCell";
 import TraceDetailsPanel from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel";
 import ColumnsButton from "@/shared/ColumnsButton/ColumnsButton";
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";
-import Loader from "@/shared/Loader/Loader";
 import ExplainerCallout from "@/shared/ExplainerCallout/ExplainerCallout";
 import useCompareExperimentsList from "@/api/datasets/useCompareExperimentsList";
 import useAppStore from "@/store/AppStore";
@@ -594,9 +593,10 @@ const TrialItemsTab: React.FC<TrialItemsTabProps> = ({
     setScoresColumnsOrder,
   ]);
 
-  if (isPending || isExperimentsOutputPending) {
-    return <Loader />;
-  }
+  const isTableLoading =
+    isPending ||
+    isExperimentsOutputPending ||
+    (isPlaceholderData && rows.length === 0);
 
   return (
     <>
@@ -668,7 +668,8 @@ const TrialItemsTab: React.FC<TrialItemsTabProps> = ({
         TableWrapper={PageBodyStickyTableWrapper}
         TableBody={DataTableVirtualBody}
         stickyHeader
-        showLoadingOverlay={isPlaceholderData && isFetching}
+        showSkeleton={isTableLoading}
+        showLoadingOverlay={!isTableLoading && isPlaceholderData && isFetching}
       />
       <PageBodyStickyContainer
         className="py-4"


### PR DESCRIPTION
## Details


https://github.com/user-attachments/assets/6c34f124-1e11-4f86-bbe6-57037b4e91ae



Replaces the full-page Loader spinner with table skeleton loaders across v2 list and nested-table pages so the title, CTA, filters, and search render immediately while data is fetching. The skeleton matches each table's actual column structure via the existing `DataTableSkeletonBody`, and the empty-state surface is unified to use `DataTableNoMatchingData` (with a "Clear filters" affordance) for filtered-empty results — the truly-empty case stays on the page-level `PageEmptyState` illustration.

- **Top-level list pages**: Projects, Datasets / Test Suites, Online Evaluation, Annotation Queues, Workspace Dashboards, Alerts.
- **Nested table tabs**: Dataset items, Dataset version history, Annotation queue items (thread + trace), Compare experiments items / configuration / feedback scores, Trial items, Automation logs, Feedback definitions, AI providers, Members (comet plugin).
- **Experiments + Optimization runs**: drop full-page Loader, render a placeholder card above the table during loading; propagate `isExistencePending` from `ExperimentsPage` so the skeleton stays until the parent existence probe resolves (closes the race that briefly showed an inline "There are no experiments yet" before the parent's illustration appeared); drop the duplicate `Optimization runs` h2.
- **Wrapper Loader removal**: drop `DatasetItemsPage`'s redundant `useDatasetById` early-return Loader (the route shell `DatasetDetailPage` already runs the same query for breadcrumbs; React Query dedups).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6334

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.7 (1M context)
  - Scope: full implementation under continuous human direction (per-page approach, inclusion/exclusion of pages, skeleton shape, empty-state cleanup, refactor scope all reviewed and approved iteratively)
  - Human verification: code review + manual smoke testing on each affected page (cold load, sibling-route switch, filter to zero, pagination)

## Testing

- `bash scripts/dev-runner.sh --lint-fe` (runs `lint:fix` + `typecheck` + `deps:validate`) — green on every affected file
- Manual smoke test on each affected page in the browser:
  - Cold load: title + CTA + filters render immediately, table body shows skeleton rows, then real data
  - Sibling-route switches (Dataset A → Dataset B with B uncached, Queue A → Queue B): no "There are no X yet" flash
  - Filter / search to zero: existing rows held with overlay, then `DataTableNoMatchingData` with "Clear filters" affordance
  - Empty workspace / project: page-level `PageEmptyState` illustration shows once, no flicker

No automated tests added — pure UI-rendering / loading-state change with no API or shared-component contract changes.

## Documentation

N/A