### PR TITLE
[NA] [SDK] chore: remove redundant litellm version exclusions

### DIFF
--- a/sdks/opik_optimizer/pyproject.toml
+++ b/sdks/opik_optimizer/pyproject.toml
@@ -14,11 +14,6 @@ dependencies = [
     "gepa>=0.0.7",
     "hf_xet",
     # LiteLLM dependency comments:
-    # - Exclude litellm 1.75.0-1.75.5 (broken callbacks system)
-    # - Exclude versions 1.77.2-1.77.4: introduce C++ compiler dependency (madoka), fixed in 1.77.5
-    #   See: https://github.com/BerriAI/litellm/issues/14762
-    # - Exclude versions 1.77.5-1.79.1: remove trace_id/parent_span_id passthrough, fixed in 1.79.2+
-    #   See: https://github.com/BerriAI/litellm/pull/15529
     # - Exclude 1.81.x: HTTP client closed during concurrent calls
     #   See: https://github.com/BerriAI/litellm/issues/19608
     # - Exclude 1.82.7, 1.82.8: compromised in supply chain attack (TeamPCP)
@@ -26,7 +21,7 @@ dependencies = [
     # - Exclude 1.82.*, 1.83.0-1.83.6: CVE-2026-42208 (SQL injection in proxy auth path,
     #   affects 1.81.16-1.83.6, fixed in 1.83.7).
     #   See: https://docs.litellm.ai/blog/cve-2026-42208-litellm-proxy-sql-injection
-    "litellm>=1.79.2,!=1.75.0,!=1.75.1,!=1.75.2,!=1.75.3,!=1.75.4,!=1.75.5,!=1.77.3,!=1.77.4,!=1.77.5,!=1.77.7,!=1.78.0,!=1.78.2,!=1.78.3,!=1.78.4,!=1.78.5,!=1.78.6,!=1.78.7,!=1.79.0,!=1.79.1,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6",
+    "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6",
     "mcp>=1.0.0",
     "opik>=1.9.7",
     "optuna",

--- a/sdks/opik_optimizer/setup.py
+++ b/sdks/opik_optimizer/setup.py
@@ -20,20 +20,15 @@ setup(
         "deap>=1.4.3",
         "hf_xet",
         # LiteLLM dependency comments:
-        # - Exclude litellm 1.75.0-1.75.5 (broken callbacks system)
-        # - Exclude versions 1.77.2-1.77.4: introduce C++ compiler dependency (madoka), fixed in 1.77.5
-        #   See: https://github.com/BerriAI/litellm/issues/14762
-        # - Exclude versions 1.77.5-1.79.1: remove trace_id/parent_span_id passthrough, fixed in 1.79.2+
-        #   See: https://github.com/BerriAI/litellm/pull/15529
         # - Exclude 1.81.x: HTTP client closed during concurrent calls
         #   See: https://github.com/BerriAI/litellm/issues/19608
         # - Exclude 1.82.7, 1.82.8: compromised in supply chain attack (TeamPCP)
         #   See: https://docs.litellm.ai/blog/security-update-march-2026
-        # - Exclude 1.82.*, 1.83.0-1.83.6: CVE-2026-42208 (SQL injection in proxy auth path,
+        # - Exclude 1.81.*, 1.82.*, 1.83.0-1.83.6: CVE-2026-42208 (SQL injection in proxy auth path,
         #   affects 1.81.16-1.83.6, fixed in 1.83.7).
         #   See: https://docs.litellm.ai/blog/cve-2026-42208-litellm-proxy-sql-injection
         # Please keep this list in sync with the one in sdks/opik_optimizer/pyproject.toml
-        "litellm>=1.79.2,!=1.75.0,!=1.75.1,!=1.75.2,!=1.75.3,!=1.75.4,!=1.75.5,!=1.77.3,!=1.77.4,!=1.77.5,!=1.77.7,!=1.78.0,!=1.78.2,!=1.78.3,!=1.78.4,!=1.78.5,!=1.78.6,!=1.78.7,!=1.79.0,!=1.79.1,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6",
+        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6",
         "opik>=1.7.17",
         "optuna",
         "pandas",

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -42,18 +42,13 @@ setup(
         "httpx",  # some older version of openai/litellm are broken with httpx>=0.28.0
         "rapidfuzz>=3.0.0,<4.0.0",
         # LiteLLM dependency comments:
-        # - Exclude litellm 1.75.0-1.75.5 (broken callbacks system)
-        # - Exclude versions 1.77.2-1.77.4: introduce C++ compiler dependency (madoka), fixed in 1.77.5
-        #   See: https://github.com/BerriAI/litellm/issues/14762
-        # - Exclude versions 1.77.5-1.79.1: remove trace_id/parent_span_id passthrough, fixed in 1.79.2+
-        #   See: https://github.com/BerriAI/litellm/pull/15529
         # Please keep this list in sync with the one in sdks/opik_optimizer/pyproject.toml
         # - Exclude 1.82.7, 1.82.8: compromised in supply chain attack (TeamPCP)
         #   See: https://docs.litellm.ai/blog/security-update-march-2026
         # - Exclude 1.81.*, 1.82.*, 1.83.0-1.83.6: CVE-2026-42208 (SQL injection in proxy auth path,
         #   affects 1.81.16-1.83.6, fixed in 1.83.7).
         #   See: https://docs.litellm.ai/blog/cve-2026-42208-litellm-proxy-sql-injection
-        "litellm>=1.79.2,!=1.75.0,!=1.75.1,!=1.75.2,!=1.75.3,!=1.75.4,!=1.75.5,!=1.77.3,!=1.77.4,!=1.77.5,!=1.77.7,!=1.78.0,!=1.78.2,!=1.78.3,!=1.78.4,!=1.78.5,!=1.78.6,!=1.78.7,!=1.79.0,!=1.79.1,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6",
+        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6",
         "openai",
         "pydantic-settings>=2.0.0,<3.0.0,!=2.9.0",
         "pydantic>=2.0.0,<3.0.0",


### PR DESCRIPTION
## Details

Both `sdks/python/setup.py` and `sdks/opik_optimizer/pyproject.toml` pin `litellm>=1.79.2` as the lower bound. This means all individual `!=` exclusions for versions below `1.79.2` (`1.75.x`, `1.77.x`, `1.78.x`, `1.79.0`, `1.79.1`) are already unreachable by pip and purely decorative. This PR removes them along with their now-stale comment bullets to reduce noise and maintenance burden.

The still-relevant exclusions (`!=1.81.*`, `!=1.82.*`, `!=1.83.0–1.83.6`) for the supply-chain attack and CVE-2026-42208 are preserved.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: full implementation
- Human verification: code review

## Testing

No functional code changed — only dependency metadata. Verified with:
- `make precommit-sdks` (all hooks passed)
- Manual inspection: confirmed all removed `!=` pins are strictly below the `>=1.79.2` lower bound

## Documentation

N/A — internal dependency comment cleanup only.