### PR TITLE
[OPIK-6365] [BE] fix: python sandbox packages to match litellm 1.83.7 pin

### DIFF
--- a/apps/opik-sandbox-executor-python/requirements.txt
+++ b/apps/opik-sandbox-executor-python/requirements.txt
@@ -1,5 +1,5 @@
 aiohappyeyeballs==2.6.1
-aiohttp==3.13.5
+aiohttp==3.13.4
 aiosignal==1.4.0
 annotated-types==0.7.0
 anyio==4.13.0
@@ -25,13 +25,13 @@ Jinja2==3.1.6
 jiter==0.13.0
 jsonschema==4.23.0
 jsonschema-specifications==2025.9.1
-litellm==1.83.7
+litellm==1.83.14
 markdown-it-py==4.0.0
 MarkupSafe==3.0.3
 mdurl==0.1.2
 multidict==6.7.1
 mypy-boto3-bedrock-runtime==1.42.42
-openai==2.30.0
+openai==2.24.0
 opik==1.11.10
 packaging==26.0
 pluggy==1.6.0
@@ -41,7 +41,7 @@ pydantic-settings==2.13.1
 pydantic_core==2.41.5
 Pygments==2.20.0
 pytest==9.0.2
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 PyYAML==6.0.3
 RapidFuzz==3.14.3
 referencing==0.37.0

--- a/apps/opik-sandbox-executor-python/requirements.txt
+++ b/apps/opik-sandbox-executor-python/requirements.txt
@@ -1,5 +1,5 @@
 aiohappyeyeballs==2.6.1
-aiohttp==3.13.4
+aiohttp==3.13.5
 aiosignal==1.4.0
 annotated-types==0.7.0
 anyio==4.13.0
@@ -8,7 +8,7 @@ boto3-stubs==1.42.79
 botocore-stubs==1.42.41
 certifi==2026.2.25
 charset-normalizer==3.4.6
-click==8.3.1
+click==8.1.8
 distro==1.9.0
 filelock==3.25.2
 frozenlist==1.8.0
@@ -19,11 +19,11 @@ httpcore==1.0.9
 httpx==0.28.1
 huggingface-hub==1.8.0
 idna==3.11
-importlib_metadata==9.0.0
+importlib_metadata==8.5.0
 iniconfig==2.3.0
 Jinja2==3.1.6
 jiter==0.13.0
-jsonschema==4.26.0
+jsonschema==4.23.0
 jsonschema-specifications==2025.9.1
 litellm==1.83.7
 markdown-it-py==4.0.0
@@ -41,7 +41,7 @@ pydantic-settings==2.13.1
 pydantic_core==2.41.5
 Pygments==2.20.0
 pytest==9.0.2
-python-dotenv==1.2.2
+python-dotenv==1.0.1
 PyYAML==6.0.3
 RapidFuzz==3.14.3
 referencing==0.37.0


### PR DESCRIPTION
## Details

Two issues addressed in one small lock-file change to `apps/opik-sandbox-executor-python/requirements.txt`:

1. **CI sandbox image build is broken on `main`.** [#6602](https://github.com/comet-ml/opik/pull/6602) (CVE-2026-42208 mitigation) bumped `litellm==1.83.0` → `litellm==1.83.7` but left the rest of the frozen lock at versions resolved against `1.83.0`. `litellm 1.83.7` introduced stricter `==` exact pins on several transitives, so `pip install -r requirements.txt` started failing in CI with `ResolutionImpossible`.

2. **`python-dotenv==1.0.1` is affected by [CVE-2026-28684](https://nvd.nist.gov/vuln/detail/CVE-2026-28684) / [GHSA-mf9w-mj56-hr94](https://github.com/advisories/GHSA-mf9w-mj56-hr94)** (CVSS 6.6 medium — symlink-following bug in `set_key()` / `unset_key()`, fixed in `python-dotenv >= 1.2.2`). `litellm==1.83.7` hard-pins the vulnerable `python-dotenv==1.0.1` so we can't bump it while staying on that version.

**Solution**: target `litellm==1.83.14` instead. It's the only patch in the `1.83.x` line that bumps `python-dotenv` to the patched `1.2.2`. Cumulative diff is +4 / −4 lines:

- `litellm` 1.83.7 → 1.83.14 (CVE-fix line in `1.83.x`)
- `python-dotenv` 1.0.1 → 1.2.2 (closes CVE-2026-28684)
- `aiohttp` 3.13.5 → 3.13.4 (reverts to pre-#6602 value — `1.83.14` pins `==3.13.4`)
- `openai` 2.30.0 → 2.24.0 (forced transitive — `1.83.14` pins `==2.24.0`)

No other lock entries touched. Five additional transitive packages (`fastuuid`, `typer`, `shellingham`, `watchfiles`, `annotated-doc`) are still pulled in by litellm + huggingface-hub at install time but intentionally not declared in the lock — matches the prior pattern of this file (the OLD lock didn't declare `typer` either, even though it was being pulled in transitively) and avoids extra surface for the external dependency-upgrade machinery.

The SDK-level constraints on `main` (added in #6602) already allow `1.83.14` — they only exclude the vulnerable range `1.83.0`–`1.83.6`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6365

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation + dependency-resolution analysis + CVE verification
- Human verification: full local Docker build (`docker build --no-cache --pull`) on the final 1.83.14 lock, manual CVE verification at NVD + GitHub Advisories, iterative dry-run analysis to find the minimum-bump set

## Testing

- `docker build --no-cache --pull -t opik-sandbox-executor-python:local apps/opik-sandbox-executor-python` succeeds end-to-end against the new lock — verified locally.
- CVE-2026-28684 verified independently against NVD and GitHub Advisories before action: real CVE, severity is **CVSS 6.6 medium** (Baz reviewer flagged as 🔴 high — actual is 🟡 medium), affects `python-dotenv < 1.2.2`, fixed in `1.2.2`. Vulnerability is in `set_key()` / `unset_key()` write paths; `load_dotenv()` reads are unaffected. Sandbox already sets `LITELLM_MODE=PRODUCTION` to suppress litellm's own `load_dotenv()` call.
- All forced bumps traced to `litellm 1.83.14`'s `Requires-Dist` metadata; no speculative version moves.
- CI: existing sandbox image build workflow will re-validate end-to-end on this branch.

## Documentation

N/A — internal lock-file fix only. The litellm CVE constraints in the SDK setup files (added in #6602) already allow `1.83.14` since they only exclude the vulnerable range `1.83.0`–`1.83.6`.