### PR TITLE
[OPIK-6370] [BE] fix: tolerate plain-string UUIDs in Redis stream deserialization

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/LenientUUIDDeserializer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/LenientUUIDDeserializer.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.UUIDDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -24,6 +25,14 @@ import java.util.UUID;
  * shim, {@code XAUTOCLAIM} fires {@code MismatchedInputException} every
  * {@code pending-message-duration} window for those stuck messages and never
  * makes progress on them.
+ * <p>
+ * {@link #deserializeWithType(JsonParser, DeserializationContext, TypeDeserializer)}
+ * is the load-bearing override: when the upstream {@link JsonJacksonCodec} enables
+ * default typing, the property deserializer invokes that method (not
+ * {@link #deserialize}) and the {@link com.fasterxml.jackson.databind.jsontype.impl.AsArrayTypeDeserializer}
+ * fails before ever delegating to the value deserializer if the token is a bare
+ * string. Intercepting the {@code VALUE_STRING} branch here is the only way to
+ * make plain-string inputs tolerated.
  */
 public class LenientUUIDDeserializer extends UUIDDeserializer {
 
@@ -42,5 +51,17 @@ public class LenientUUIDDeserializer extends UUIDDeserializer {
             return result;
         }
         return super.deserialize(p, ctxt);
+    }
+
+    @Override
+    public Object deserializeWithType(JsonParser p, DeserializationContext ctxt, TypeDeserializer typeDeserializer)
+            throws IOException {
+        // Default path delegates to typeDeserializer, which under As.WRAPPER_ARRAY expects
+        // START_ARRAY and rejects bare strings. Short-circuit when we see a VALUE_STRING so
+        // legacy plain-string UUIDs in the stream PEL still parse.
+        if (p.currentToken() == JsonToken.VALUE_STRING) {
+            return deserialize(p, ctxt);
+        }
+        return typeDeserializer.deserializeTypedFromAny(p, ctxt);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/LenientUUIDDeserializer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/LenientUUIDDeserializer.java
@@ -1,0 +1,46 @@
+package com.comet.opik.infrastructure.redis;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.UUIDDeserializer;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Tolerant UUID deserializer for Redis stream payloads.
+ * <p>
+ * Accepts both shapes:
+ * <ul>
+ *   <li>Plain string: {@code "6caf374f-6568-4c6f-aad0-257e0c7296a4"}</li>
+ *   <li>Jackson polymorphic {@code As.WRAPPER_ARRAY}:
+ *       {@code ["java.util.UUID", "6caf374f-6568-4c6f-aad0-257e0c7296a4"]}</li>
+ * </ul>
+ * <p>
+ * Older opik-backend versions running on a different Redisson default-typing
+ * configuration left messages of one shape in the {@code XPENDING} list of
+ * Redis streams; the current version produces the other. Without this lenient
+ * shim, {@code XAUTOCLAIM} fires {@code MismatchedInputException} every
+ * {@code pending-message-duration} window for those stuck messages and never
+ * makes progress on them.
+ */
+public class LenientUUIDDeserializer extends UUIDDeserializer {
+
+    public static final LenientUUIDDeserializer INSTANCE = new LenientUUIDDeserializer();
+
+    @Override
+    public UUID deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        if (p.currentToken() == JsonToken.START_ARRAY) {
+            // Wrapper-array form produced when Jackson default-typing wraps the value as
+            // ["java.util.UUID", "<uuid>"]. Skip the type-id token, parse the value, then
+            // advance past the closing END_ARRAY so the parent reader stays positioned.
+            p.nextToken();
+            p.nextToken();
+            UUID result = super.deserialize(p, ctxt);
+            p.nextToken();
+            return result;
+        }
+        return super.deserialize(p, ctxt);
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/LenientUUIDDeserializer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/LenientUUIDDeserializer.java
@@ -43,11 +43,17 @@ public class LenientUUIDDeserializer extends UUIDDeserializer {
         if (p.currentToken() == JsonToken.START_ARRAY) {
             // Wrapper-array form produced when Jackson default-typing wraps the value as
             // ["java.util.UUID", "<uuid>"]. Skip the type-id token, parse the value, then
-            // advance past the closing END_ARRAY so the parent reader stays positioned.
+            // require the closing END_ARRAY so a malformed shape like
+            // ["...", "<uuid>", "extra"] is rejected instead of leaving the parser
+            // misaligned for the next field.
             p.nextToken();
             p.nextToken();
             UUID result = super.deserialize(p, ctxt);
-            p.nextToken();
+            JsonToken next = p.nextToken();
+            if (next != JsonToken.END_ARRAY) {
+                throw ctxt.wrongTokenException(p, UUID.class, JsonToken.END_ARRAY,
+                        "Expected end of UUID wrapper array, found " + next);
+            }
             return result;
         }
         return super.deserialize(p, ctxt);

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedisStreamCodec.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedisStreamCodec.java
@@ -1,6 +1,8 @@
 package com.comet.opik.infrastructure.redis;
 
 import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.base.Suppliers;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,14 +14,29 @@ import org.redisson.codec.JsonJacksonCodec;
 import org.redisson.codec.LZ4CodecV2;
 
 import java.util.Arrays;
+import java.util.UUID;
 import java.util.function.Supplier;
 
 @AllArgsConstructor
 @Getter
 public enum RedisStreamCodec {
     JAVA(Constants.JAVA, Suppliers.memoize(() -> new CompositeCodec(new LZ4CodecV2(),
-            new JsonJacksonCodec(JsonUtils.getMapper())))),
+            new JsonJacksonCodec(buildStreamMapper())))),
     JSON(Constants.JSON, () -> StringCodec.INSTANCE);
+
+    /**
+     * Returns an {@link ObjectMapper} dedicated to the Redis stream codec, registering
+     * {@link LenientUUIDDeserializer} so {@link UUID} fields parse from both plain-string
+     * and Jackson polymorphic {@code As.WRAPPER_ARRAY} shapes. Old stuck messages produced
+     * by previous opik-backend versions used one shape, the current version may produce
+     * the other; tolerating both keeps {@code XAUTOCLAIM} from looping on a decode error
+     * every {@code pending-message-duration} window.
+     */
+    private static ObjectMapper buildStreamMapper() {
+        ObjectMapper mapper = JsonUtils.getMapper().copy();
+        mapper.registerModule(new SimpleModule().addDeserializer(UUID.class, LenientUUIDDeserializer.INSTANCE));
+        return mapper;
+    }
 
     private final String name;
     private final Supplier<Codec> codecSupplier;

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/LenientUUIDDeserializerCodecTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/LenientUUIDDeserializerCodecTest.java
@@ -1,0 +1,90 @@
+package com.comet.opik.infrastructure.redis;
+
+import com.comet.opik.api.events.ExperimentAggregationMessage;
+import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.redisson.codec.JsonJacksonCodec;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Verifies the lenient UUID deserializer survives the production-shape codec
+ * (Redisson {@link JsonJacksonCodec} on top of the configured {@link JsonUtils}
+ * mapper with default typing enabled), not just a vanilla {@link ObjectMapper}.
+ * Wire format observed in this configuration:
+ * <pre>
+ * {"@class":"...","experiment_id":["java.util.UUID","&lt;uuid&gt;"], ...}
+ * </pre>
+ * Field names are snake_case because of {@code JsonUtils.MAPPER}'s naming strategy,
+ * and UUID is wrapped under {@code As.WRAPPER_ARRAY}. Old stuck messages instead
+ * carry the UUID as a bare string {@code "experiment_id":"<uuid>"}; the lenient
+ * deserializer must accept both.
+ */
+@DisplayName("LenientUUIDDeserializer integrated with JsonJacksonCodec (default typing on)")
+class LenientUUIDDeserializerCodecTest {
+
+    private static final UUID UUID_VALUE = UUID.fromString("6caf374f-6568-4c6f-aad0-257e0c7296a4");
+    private static final String CLASS_HEADER = "\"@class\":\"com.comet.opik.api.events.ExperimentAggregationMessage\"";
+
+    private static JsonJacksonCodec buildCodec() {
+        ObjectMapper mapper = JsonUtils.getMapper().copy();
+        mapper.registerModule(new SimpleModule().addDeserializer(UUID.class, LenientUUIDDeserializer.INSTANCE));
+        return new JsonJacksonCodec(mapper);
+    }
+
+    @Test
+    @DisplayName("publish: production-shape codec encodes UUID under As.WRAPPER_ARRAY default typing")
+    void publishProducesWrapperArrayUuid() throws Exception {
+        var codec = buildCodec();
+        var msg = ExperimentAggregationMessage.builder()
+                .experimentId(UUID_VALUE).workspaceId("ws").userName("user").build();
+
+        ByteBuf encoded = codec.getValueEncoder().encode(msg);
+        String wire = encoded.toString(CharsetUtil.UTF_8);
+
+        assertThat(wire)
+                .as("Default typing under JsonJacksonCodec wraps UUID in [\"java.util.UUID\",\"...\"]")
+                .contains("\"experiment_id\":[\"java.util.UUID\",\"" + UUID_VALUE + "\"]");
+    }
+
+    @Test
+    @DisplayName("read: production-shape codec decodes a plain-string UUID payload (legacy stuck format)")
+    void readDecodesPlainStringUuid() throws Exception {
+        var codec = buildCodec();
+        String raw = "{" + CLASS_HEADER + ","
+                + "\"experiment_id\":\"" + UUID_VALUE + "\","
+                + "\"workspace_id\":\"ws\",\"user_name\":\"user\"}";
+
+        Object decoded = codec.getValueDecoder().decode(
+                Unpooled.wrappedBuffer(raw.getBytes(StandardCharsets.UTF_8)), null);
+
+        assertThat(decoded).isInstanceOf(ExperimentAggregationMessage.class);
+        assertThat(((ExperimentAggregationMessage) decoded).experimentId()).isEqualTo(UUID_VALUE);
+    }
+
+    @Test
+    @DisplayName("read: production-shape codec round-trips an As.WRAPPER_ARRAY UUID payload (current format)")
+    void readDecodesWrapperArrayUuid() {
+        var codec = buildCodec();
+        String raw = "{" + CLASS_HEADER + ","
+                + "\"experiment_id\":[\"java.util.UUID\",\"" + UUID_VALUE + "\"],"
+                + "\"workspace_id\":\"ws\",\"user_name\":\"user\"}";
+
+        assertThatNoException().isThrownBy(() -> {
+            Object decoded = codec.getValueDecoder().decode(
+                    Unpooled.wrappedBuffer(raw.getBytes(StandardCharsets.UTF_8)), null);
+            assertThat(decoded).isInstanceOf(ExperimentAggregationMessage.class);
+            assertThat(((ExperimentAggregationMessage) decoded).experimentId()).isEqualTo(UUID_VALUE);
+        });
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/LenientUUIDDeserializerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/LenientUUIDDeserializerTest.java
@@ -1,0 +1,58 @@
+package com.comet.opik.infrastructure.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("LenientUUIDDeserializer accepts both plain-string and WRAPPER_ARRAY forms")
+class LenientUUIDDeserializerTest {
+
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ObjectMapper();
+        mapper.registerModule(new SimpleModule().addDeserializer(UUID.class, LenientUUIDDeserializer.INSTANCE));
+    }
+
+    @Test
+    @DisplayName("plain string form")
+    void plainString() throws Exception {
+        var json = "{\"experimentId\":\"6caf374f-6568-4c6f-aad0-257e0c7296a4\"}";
+        var result = mapper.readValue(json, Holder.class);
+        assertThat(result.experimentId).isEqualTo(UUID.fromString("6caf374f-6568-4c6f-aad0-257e0c7296a4"));
+    }
+
+    @Test
+    @DisplayName("As.WRAPPER_ARRAY form")
+    void wrapperArray() throws Exception {
+        var json = "{\"experimentId\":[\"java.util.UUID\",\"6caf374f-6568-4c6f-aad0-257e0c7296a4\"]}";
+        var result = mapper.readValue(json, Holder.class);
+        assertThat(result.experimentId).isEqualTo(UUID.fromString("6caf374f-6568-4c6f-aad0-257e0c7296a4"));
+    }
+
+    @Test
+    @DisplayName("plain string form survives round-trip")
+    void plainStringRoundTrip() throws Exception {
+        var original = new Holder(UUID.fromString("019d4245-7895-7fb0-b8e4-06eec6f6f3a9"));
+        var json = mapper.writeValueAsString(original);
+        var roundTrip = mapper.readValue(json, Holder.class);
+        assertThat(roundTrip.experimentId).isEqualTo(original.experimentId);
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    static class Holder {
+        private UUID experimentId;
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/LenientUUIDDeserializerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/LenientUUIDDeserializerTest.java
@@ -1,6 +1,7 @@
 package com.comet.opik.infrastructure.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("LenientUUIDDeserializer accepts both plain-string and WRAPPER_ARRAY forms")
 class LenientUUIDDeserializerTest {
@@ -47,6 +49,15 @@ class LenientUUIDDeserializerTest {
         var json = mapper.writeValueAsString(original);
         var roundTrip = mapper.readValue(json, Holder.class);
         assertThat(roundTrip.experimentId).isEqualTo(original.experimentId);
+    }
+
+    @Test
+    @DisplayName("wrapper array with extra trailing elements is rejected, not silently accepted")
+    void wrapperArrayWithExtraElementsIsRejected() {
+        var json = "{\"experimentId\":[\"java.util.UUID\",\"6caf374f-6568-4c6f-aad0-257e0c7296a4\",\"extra\"]}";
+        assertThatThrownBy(() -> mapper.readValue(json, Holder.class))
+                .isInstanceOf(MismatchedInputException.class)
+                .hasMessageContaining("Expected end of UUID wrapper array");
     }
 
     @Data


### PR DESCRIPTION
## Details

The Redis stream codec used by `experiment_denormalization_stream` (and any other Java-codec stream) wraps a Jackson `ObjectMapper` with default typing enabled inside `JsonJacksonCodec`. Older opik-backend versions ran on a different default-typing configuration and left messages with `UUID` fields serialized as plain strings in the consumer-group's pending entry list (PEL); the current version's deserializer expects Jackson's `As.WRAPPER_ARRAY` shape (`["java.util.UUID","<uuid>"]`).

`XAUTOCLAIM` repeatedly tries to reclaim those stuck messages on every tick (interval = `pending-message-duration`, default 10 minutes), the codec fails decoding with `MismatchedInputException`, and the subscriber emits an `ERROR`-level log every 10 minutes — generating alert noise indefinitely. The bad message is never acked or removed.

This PR adds a `LenientUUIDDeserializer` that accepts both shapes:

- Plain string: `"6caf374f-6568-4c6f-aad0-257e0c7296a4"`
- `As.WRAPPER_ARRAY`: `["java.util.UUID","6caf374f-6568-4c6f-aad0-257e0c7296a4"]`

It's registered on a copy of `JsonUtils.getMapper()` (`buildStreamMapper`) which is then handed to `JsonJacksonCodec` inside `RedisStreamCodec`. **Scope is limited to the Redis stream codec** — the global `JsonUtils.MAPPER` is untouched, so HTTP API JSON behavior is unchanged.

After this fix, stuck messages flow through the regular `processMessage` path. If they're still otherwise invalid (e.g., the message references a deleted experiment), the existing retry-and-NACK logic in `BaseRedisSubscriber` will eventually ACK them after `maxRetries` attempts.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-6370

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: assisted (deserializer design, codec wiring, test scaffolding)
- Human verification: code review + targeted test runs (existing `RedisStreamCodecTest` + new `LenientUUIDDeserializerTest`)

## Testing

```
mvn test -Dtest='LenientUUIDDeserializerTest'              # 3/3 pass
mvn test -Dtest='RedisStreamCodecTest'                     # 5/5 pass (no regression)
```

`mvn -DskipTests compile` and `mvn spotless:check` both pass.

The new unit test covers:

- Plain-string UUID deserialization
- `As.WRAPPER_ARRAY` UUID deserialization
- Round-trip (write plain, read back) — verifies the happy path isn't broken

Not run: full backend test suite (no other code paths touched), end-to-end against a real Redis stream with stale PEL entries (would require synthetically populating the stream — out of scope; the unit test pins the deserialization invariant).

## Documentation

N/A — internal infrastructure change, no API or schema impact.
