### PR TITLE
[OPIK-6348] [BE] fix: rename BI event key 'environment' to 'config_environment'

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentConfigService.java
@@ -795,7 +795,7 @@ class AgentConfigServiceImpl implements AgentConfigService {
                 "project_id", projectId.toString(),
                 "blueprint_id", blueprintId.toString(),
                 "blueprint_name", blueprintName,
-                "environment", envName,
+                "config_environment", envName,
                 "deployed_to_prod", String.valueOf("prod".equalsIgnoreCase(envName))), userName);
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResourceTest.java
@@ -124,7 +124,9 @@ class AgentConfigsResourceTest {
                         .usageReportEnabled(true)
                         .usageReportUrl("%s/v1/notify/event".formatted(wireMock.runtimeInfo().getHttpBaseUrl()))
                         .customConfigs(List.of(
-                                new TestDropwizardAppExtensionUtils.CustomConfig("analytics.enabled", "true")))
+                                new TestDropwizardAppExtensionUtils.CustomConfig("analytics.enabled", "true"),
+                                new TestDropwizardAppExtensionUtils.CustomConfig("analytics.environment",
+                                        "test")))
                         .build());
     }
 
@@ -220,10 +222,10 @@ class AgentConfigsResourceTest {
                                         equalTo(WORKSPACE_ID)))
                                 .and(matchingJsonPath("$.event_properties.config_environment",
                                         equalTo("prod")))
-                                .and(matchingJsonPath("$.event_properties.environment",
-                                        equalTo("prod")))
                                 .and(matchingJsonPath("$.event_properties.deployed_to_prod",
-                                        equalTo("true")))));
+                                        equalTo("true")))
+                                .and(matchingJsonPath("$.event_properties.environment",
+                                        equalTo("test")))));
             });
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentConfigsResourceTest.java
@@ -218,6 +218,8 @@ class AgentConfigsResourceTest {
                         .withRequestBody(matchingJsonPath("$.event_type", equalTo(deployedEvent))
                                 .and(matchingJsonPath("$.event_properties.workspace_id",
                                         equalTo(WORKSPACE_ID)))
+                                .and(matchingJsonPath("$.event_properties.config_environment",
+                                        equalTo("prod")))
                                 .and(matchingJsonPath("$.event_properties.environment",
                                         equalTo("prod")))
                                 .and(matchingJsonPath("$.event_properties.deployed_to_prod",


### PR DESCRIPTION
## Details
The `environment` key used in agent config BI events was clashing with the server-level environment field (production/staging/development). As a result, the config environment value was being overwritten and lost in Segment analytics. Renamed the key to `config_environment` to avoid the collision.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6348

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-sonnet-4-6
  - Scope: commit message + PR description
  - Human verification: code change authored by human, AI assisted with PR creation

## Testing
- Change is a single string key rename in `AgentConfigService.java`
- `mvn spotless:check` passed locally
- Verified the key rename does not affect other BI event fields

## Documentation
N/A