### PR TITLE
[OPIK-6372] [SDK] fix: merge duplicate Create messages in local emulator

### DIFF
--- a/sdks/python/src/opik/integrations/adk/patchers/patchers.py
+++ b/sdks/python/src/opik/integrations/adk/patchers/patchers.py
@@ -68,6 +68,13 @@ def _patch_adk_opentelemetry_tracers(
     adk_telemetry.tracer.start_as_current_span = no_op_opik_tracer.start_as_current_span
     adk_telemetry.tracer.start_span = no_op_opik_tracer.start_span
 
-    base_agent.tracer.start_as_current_span = no_op_opik_tracer.start_as_current_span
-    base_agent.tracer.start_span = no_op_opik_tracer.start_span
+    # google-adk >= 1.32 dropped the module-level `tracer` symbol from
+    # `google.adk.agents.base_agent` (agent invocation now goes through
+    # `google.adk.telemetry._instrumentation.record_agent_invocation`,
+    # which calls `telemetry.tracing.tracer` — the same singleton
+    # ProxyTracer object we already patched above). On older versions
+    # the attribute is still present and points to the same object.
+    if hasattr(base_agent, "tracer"):
+        base_agent.tracer.start_as_current_span = no_op_opik_tracer.start_as_current_span
+        base_agent.tracer.start_span = no_op_opik_tracer.start_span
     LOGGER.debug("Patched ADK tracers")

--- a/sdks/python/src/opik/integrations/adk/patchers/patchers.py
+++ b/sdks/python/src/opik/integrations/adk/patchers/patchers.py
@@ -75,6 +75,8 @@ def _patch_adk_opentelemetry_tracers(
     # ProxyTracer object we already patched above). On older versions
     # the attribute is still present and points to the same object.
     if hasattr(base_agent, "tracer"):
-        base_agent.tracer.start_as_current_span = no_op_opik_tracer.start_as_current_span
+        base_agent.tracer.start_as_current_span = (
+            no_op_opik_tracer.start_as_current_span
+        )
         base_agent.tracer.start_span = no_op_opik_tracer.start_span
     LOGGER.debug("Patched ADK tracers")

--- a/sdks/python/src/opik/message_processing/emulation/emulator_message_processor.py
+++ b/sdks/python/src/opik/message_processing/emulation/emulator_message_processor.py
@@ -1,9 +1,10 @@
 import abc
 import collections
+import dataclasses
 import datetime
 import logging
 import threading
-from typing import List, Dict, Union, Optional, Any, Type, Callable
+from typing import List, Dict, Tuple, TypeVar, Union, Optional, Any, Type, Callable
 
 from opik import dict_utils
 from opik.rest_api.types import span_write, trace_write
@@ -11,6 +12,13 @@ from opik.types import ErrorInfoDict, SpanType, TraceSource
 from . import models
 from .. import messages
 from ..processors import message_processors
+
+ModelT = TypeVar("ModelT", models.TraceModel, models.SpanModel)
+
+# Fields are populated incrementally from outside the create-message path
+# (tree building, feedback batches, attachment messages). They must not be
+# overwritten when a duplicate Create message merges into an existing model.
+_MERGE_PRESERVED_FIELDS = frozenset({"spans", "feedback_scores", "attachments"})
 
 
 LOGGER = logging.getLogger(__name__)
@@ -86,6 +94,19 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
                 collections.defaultdict(list)
             )
             self._experiment_items: List[models.ExperimentItemModel] = []
+            # Updates that arrived before the matching CreateSpanMessage /
+            # CreateTraceMessage. Applied as soon as the create lands so we
+            # don't drop fields when the queue/batcher delivers messages out
+            # of order (common with batching enabled).
+            self._pending_span_updates: Dict[str, List[Dict[str, Any]]] = (
+                collections.defaultdict(list)
+            )
+            self._pending_trace_updates: Dict[str, List[Dict[str, Any]]] = (
+                collections.defaultdict(list)
+            )
+            # Track parent/span pairs we've already warned about so multiple
+            # `trace_trees` / `span_trees` reads don't spam the log.
+            self._warned_orphan_parents: set = set()
 
     def is_active(self) -> bool:
         with self._rlock:
@@ -105,6 +126,7 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
             # call to connect all spans
             self._build_spans_tree()
             missing_trace_ids: set[str] = set()
+            traces_with_new_children: set = set()
 
             for span_id, trace_id in self._span_to_trace.items():
                 if trace_id is None:
@@ -119,7 +141,12 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
                 ] is None and not _observation_already_stored(span_id, trace.spans):
                     span = self._span_observations[span_id]
                     trace.spans.append(span)
-                    trace.spans.sort(key=lambda x: x.start_time)
+                    traces_with_new_children.add(trace_id)
+
+            for trace_id in traces_with_new_children:
+                self._trace_observations[trace_id].spans.sort(
+                    key=lambda x: x.start_time
+                )
 
             if missing_trace_ids:
                 LOGGER.warning(
@@ -136,42 +163,74 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
             return self._trace_trees
 
     def _save_trace(self, trace: models.TraceModel) -> None:
-        if self.merge_duplicates:
-            # merge traces with the same id to keep only the latest one
-            if trace.id in self._trace_observations:
-                existing_trace: models.TraceModel = self._trace_observations[trace.id]
-                if trace.end_time is not None:
-                    if (
-                        existing_trace.end_time is None
-                        or trace.end_time > existing_trace.end_time
-                    ):
-                        # remove the current trace from the list
-                        self._trace_trees.remove(existing_trace)
+        existing_trace = self._trace_observations.get(trace.id)
 
-        self._trace_trees.append(trace)
-        self._trace_observations[trace.id] = trace
+        if existing_trace is None or not self.merge_duplicates:
+            self._trace_trees.append(trace)
+            self._trace_observations[trace.id] = trace
+            self._apply_pending_trace_updates(trace)
+            return
+
+        merged = _merge_models(existing_trace, trace)
+        if existing_trace in self._trace_trees:
+            index = self._trace_trees.index(existing_trace)
+            self._trace_trees[index] = merged
+        else:
+            self._trace_trees.append(merged)
+        self._trace_observations[trace.id] = merged
+        self._apply_pending_trace_updates(merged)
+
+    def _apply_pending_trace_updates(self, trace: models.TraceModel) -> None:
+        pending = self._pending_trace_updates.pop(trace.id, None)
+        if not pending:
+            return
+        for payload in pending:
+            trace.__dict__.update(payload)
 
     def _save_span(
         self, span: models.SpanModel, trace_id: str, parent_span_id: Optional[str]
     ) -> None:
-        if self.merge_duplicates:
-            # merge spans with the same id to keep only the latest one
-            if span.id in self._span_observations:
-                existing_span = self._span_observations[span.id]
-                if span.end_time is not None:
-                    if (
-                        existing_span.end_time is None
-                        or span.end_time > existing_span.end_time
-                    ):
-                        if existing_span in self._span_trees:
-                            self._span_trees.remove(existing_span)
+        existing_span = self._span_observations.get(span.id)
 
-        self._span_to_parent_span[span.id] = parent_span_id
-        if parent_span_id is None:
-            self._span_trees.append(span)
+        if existing_span is None or not self.merge_duplicates:
+            if parent_span_id is None:
+                self._span_trees.append(span)
+            self._span_to_parent_span[span.id] = parent_span_id
+            self._span_to_trace[span.id] = trace_id
+            self._span_observations[span.id] = span
+            self._apply_pending_span_updates(span)
+            return
 
-        self._span_to_trace[span.id] = trace_id
-        self._span_observations[span.id] = span
+        merged = _merge_models(existing_span, span)
+
+        # Late start messages can arrive with a stale (None) parent_span_id /
+        # trace_id even when the entity already had real values. Prefer the
+        # non-None observation we already had.
+        merged_parent_span_id = parent_span_id
+        if merged_parent_span_id is None:
+            merged_parent_span_id = self._span_to_parent_span.get(span.id)
+        merged_trace_id = trace_id
+        existing_trace_id = self._span_to_trace.get(span.id)
+        if existing_trace_id is not None:
+            merged_trace_id = existing_trace_id
+
+        if existing_span in self._span_trees:
+            index = self._span_trees.index(existing_span)
+            self._span_trees[index] = merged
+        elif merged_parent_span_id is None:
+            self._span_trees.append(merged)
+
+        self._span_to_parent_span[span.id] = merged_parent_span_id
+        self._span_to_trace[span.id] = merged_trace_id
+        self._span_observations[span.id] = merged
+        self._apply_pending_span_updates(merged)
+
+    def _apply_pending_span_updates(self, span: models.SpanModel) -> None:
+        pending = self._pending_span_updates.pop(span.id, None)
+        if not pending:
+            return
+        for payload in pending:
+            span.__dict__.update(payload)
 
     @property
     def span_trees(self) -> List[models.SpanModel]:
@@ -204,13 +263,16 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
                 # warning is the only signal.
                 parent_span = self._span_observations.get(parent_span_id)
                 if parent_span is None:
-                    LOGGER.warning(
-                        "Skipping span %s: parent span %s is not yet observed. "
-                        "Child will remain orphaned until the parent's "
-                        "CreateSpanMessage is processed.",
-                        span_id,
-                        parent_span_id,
-                    )
+                    warning_key = (span_id, parent_span_id)
+                    if warning_key not in self._warned_orphan_parents:
+                        self._warned_orphan_parents.add(warning_key)
+                        LOGGER.warning(
+                            "Skipping span %s: parent span %s is not yet observed. "
+                            "Child will remain orphaned until the parent's "
+                            "CreateSpanMessage is processed.",
+                            span_id,
+                            parent_span_id,
+                        )
                     continue
 
                 # First time we see this parent on this rebuild — drop stale
@@ -222,7 +284,11 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
 
                 if not _observation_already_stored(span_id, parent_span.spans):
                     parent_span.spans.append(self._span_observations[span_id])
-                    parent_span.spans.sort(key=lambda x: x.start_time)
+
+            for parent_id in visited_parents:
+                self._span_observations[parent_id].spans.sort(
+                    key=lambda x: x.start_time
+                )
 
             all_span_ids = self._span_to_trace
             for span_id in all_span_ids:
@@ -464,37 +530,47 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
         )
 
     def _handle_update_span_message(self, message: messages.UpdateSpanMessage) -> None:
-        span = self._span_observations[message.span_id]
-        update_payload = {
-            "output": message.output,
-            "usage": message.usage,
-            "provider": message.provider,
-            "model": message.model,
-            "end_time": message.end_time,
-            "metadata": message.metadata,
-            "error_info": message.error_info,
-            "tags": message.tags,
-            "input": message.input,
-            "total_cost": message.total_cost,
-        }
-        cleaned_update_payload = dict_utils.remove_none_from_dict(update_payload)
-        span.__dict__.update(cleaned_update_payload)
+        update_payload = dict_utils.remove_none_from_dict(
+            {
+                "output": message.output,
+                "usage": message.usage,
+                "provider": message.provider,
+                "model": message.model,
+                "end_time": message.end_time,
+                "metadata": message.metadata,
+                "error_info": message.error_info,
+                "tags": message.tags,
+                "input": message.input,
+                "total_cost": message.total_cost,
+            }
+        )
+        span = self._span_observations.get(message.span_id)
+        if span is None:
+            # Queue the payload until the matching create arrives — batching
+            # can deliver Update before Create.
+            self._pending_span_updates[message.span_id].append(update_payload)
+            return
+        span.__dict__.update(update_payload)
 
     def _handle_update_trace_message(
         self, message: messages.UpdateTraceMessage
     ) -> None:
-        current_trace = self._trace_observations[message.trace_id]
-        update_payload = {
-            "output": message.output,
-            "end_time": message.end_time,
-            "metadata": message.metadata,
-            "error_info": message.error_info,
-            "tags": message.tags,
-            "input": message.input,
-            "thread_id": message.thread_id,
-        }
-        cleaned_update_payload = dict_utils.remove_none_from_dict(update_payload)
-        current_trace.__dict__.update(cleaned_update_payload)
+        update_payload = dict_utils.remove_none_from_dict(
+            {
+                "output": message.output,
+                "end_time": message.end_time,
+                "metadata": message.metadata,
+                "error_info": message.error_info,
+                "tags": message.tags,
+                "input": message.input,
+                "thread_id": message.thread_id,
+            }
+        )
+        current_trace = self._trace_observations.get(message.trace_id)
+        if current_trace is None:
+            self._pending_trace_updates[message.trace_id].append(update_payload)
+            return
+        current_trace.__dict__.update(update_payload)
 
     def _handle_add_span_feedback_scores_batch_message(
         self, message: messages.AddSpanFeedbackScoresBatchMessage
@@ -643,6 +719,76 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
         """Returns the list of experiment items collected."""
         with self._rlock:
             return self._experiment_items
+
+
+def _merge_models(existing: ModelT, new: ModelT) -> ModelT:
+    """Merge two trace/span models that share the same id.
+
+    Duplicate Create messages reach the emulator out of order: a START message
+    (no end_time, defaulted type, no output) can arrive after the matching
+    FULL message (end_time set, output filled). The previous "newer end_time
+    wins" check silently let the late START overwrite the FULL entry. This
+    helper picks the more complete entry as primary and fills any None gaps
+    from the other so neither order produces data loss.
+    """
+    primary, secondary = _pick_primary(existing, new)
+
+    merged_kwargs: Dict[str, Any] = {}
+    for field in dataclasses.fields(type(primary)):
+        if field.name in _MERGE_PRESERVED_FIELDS:
+            # Children/feedback/attachments are accumulated externally; the
+            # in-memory `existing` model already holds whatever was attached.
+            merged_kwargs[field.name] = getattr(existing, field.name)
+            continue
+
+        primary_value = getattr(primary, field.name)
+        secondary_value = getattr(secondary, field.name)
+
+        if _is_missing(primary_value) and not _is_missing(secondary_value):
+            merged_kwargs[field.name] = secondary_value
+        else:
+            merged_kwargs[field.name] = primary_value
+
+    return type(primary)(**merged_kwargs)
+
+
+def _pick_primary(existing: ModelT, new: ModelT) -> Tuple[ModelT, ModelT]:
+    """Return ``(primary, secondary)`` where primary is the more complete entry.
+
+    Completeness order:
+    1. Whichever entry has a non-None ``end_time`` wins (FULL > START).
+    2. If both have end_time, the later one wins.
+    3. If neither has end_time, fall back to ``last_updated_at``; ties go to
+       ``new`` (last write wins).
+    """
+    if existing.end_time is not None and new.end_time is None:
+        return existing, new
+    if existing.end_time is None and new.end_time is not None:
+        return new, existing
+    if existing.end_time is not None and new.end_time is not None:
+        if new.end_time >= existing.end_time:
+            return new, existing
+        return existing, new
+
+    existing_updated = existing.last_updated_at
+    new_updated = new.last_updated_at
+    if existing_updated is not None and new_updated is None:
+        return existing, new
+    if existing_updated is None and new_updated is not None:
+        return new, existing
+    if existing_updated is not None and new_updated is not None:
+        if new_updated >= existing_updated:
+            return new, existing
+        return existing, new
+    return new, existing
+
+
+def _is_missing(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, list) and len(value) == 0:
+        return True
+    return False
 
 
 def _observation_already_stored(

--- a/sdks/python/tests/unit/message_processing/emulation/test_local_emulator_message_processor.py
+++ b/sdks/python/tests/unit/message_processing/emulation/test_local_emulator_message_processor.py
@@ -1660,3 +1660,301 @@ class TestLocalEmulatorMessageProcessorTraceTreesProperty:
             ),
         ]
         assert_helpers.assert_equal(expected=EXPECTED_TRACE_TREE, actual=trace_trees)
+
+
+class TestLocalEmulatorMessageProcessorDuplicateCreateMessages:
+    """Regression tests for OPIK-6372.
+
+    The streamer's batch / replay machinery can deliver the START and FULL
+    Create messages for the same trace/span out of order, including a START
+    arriving after the FULL one. The emulator must converge on a single
+    merged entity per id rather than producing duplicates with stale fields.
+    """
+
+    def setup_method(self):
+        self.processor = local_emulator_message_processor.LocalEmulatorMessageProcessor(
+            active=True, merge_duplicates=True
+        )
+        self.start_time = datetime_helpers.local_timestamp()
+        self.end_time = self.start_time + datetime.timedelta(seconds=1)
+
+    def _full_span_message(self):
+        return messages.CreateSpanMessage(
+            span_id="span_1",
+            trace_id="trace_1",
+            project_name="test_project",
+            parent_span_id=None,
+            name="foo",
+            start_time=self.start_time,
+            end_time=self.end_time,
+            input={"k": 1},
+            output={"is_error": False},
+            metadata=None,
+            tags=None,
+            type="tool",
+            usage=None,
+            model=None,
+            provider=None,
+            error_info=None,
+            total_cost=None,
+            last_updated_at=self.end_time,
+            source="sdk",
+        )
+
+    def _start_span_message(self):
+        return messages.CreateSpanMessage(
+            span_id="span_1",
+            trace_id="trace_1",
+            project_name="test_project",
+            parent_span_id=None,
+            name="foo",
+            start_time=self.start_time,
+            end_time=None,
+            input={"k": 1},
+            output=None,
+            metadata=None,
+            tags=None,
+            type="general",
+            usage=None,
+            model=None,
+            provider=None,
+            error_info=None,
+            total_cost=None,
+            last_updated_at=None,
+            source="sdk",
+        )
+
+    def _full_trace_message(self):
+        return messages.CreateTraceMessage(
+            trace_id="trace_1",
+            project_name="test_project",
+            name="t",
+            start_time=self.start_time,
+            end_time=self.end_time,
+            input=None,
+            output={"final": True},
+            metadata=None,
+            tags=None,
+            error_info=None,
+            thread_id=None,
+            last_updated_at=self.end_time,
+            source="sdk",
+        )
+
+    def _start_trace_message(self):
+        return messages.CreateTraceMessage(
+            trace_id="trace_1",
+            project_name="test_project",
+            name="t",
+            start_time=self.start_time,
+            end_time=None,
+            input=None,
+            output=None,
+            metadata=None,
+            tags=None,
+            error_info=None,
+            thread_id=None,
+            last_updated_at=None,
+            source="sdk",
+        )
+
+    def test_start_span_arriving_after_full_span_keeps_full_fields(self):
+        # OPIK-6372: replay/race could deliver the START span after the FULL
+        # one. The emulator must keep the FULL fields (type=tool, output set).
+        self.processor.process(self._full_trace_message())
+        self.processor.process(self._full_span_message())
+        self.processor.process(self._start_span_message())
+
+        trace_trees = self.processor.trace_trees
+
+        assert len(trace_trees) == 1
+        assert len(trace_trees[0].spans) == 1
+        span = trace_trees[0].spans[0]
+        assert span.id == "span_1"
+        assert span.type == "tool"
+        assert span.output == {"is_error": False}
+        assert span.end_time == self.end_time
+
+    def test_full_span_arriving_after_start_span_keeps_full_fields(self):
+        self.processor.process(self._full_trace_message())
+        self.processor.process(self._start_span_message())
+        self.processor.process(self._full_span_message())
+
+        trace_trees = self.processor.trace_trees
+
+        assert len(trace_trees) == 1
+        assert len(trace_trees[0].spans) == 1
+        span = trace_trees[0].spans[0]
+        assert span.type == "tool"
+        assert span.output == {"is_error": False}
+        assert span.end_time == self.end_time
+
+    def test_start_trace_arriving_after_full_trace_keeps_full_output(self):
+        # OPIK-6372: same race for traces — START must not erase output set
+        # by the already-processed FULL message and must not produce a
+        # duplicate trace_trees entry.
+        self.processor.process(self._full_trace_message())
+        self.processor.process(self._start_trace_message())
+
+        trace_trees = self.processor.trace_trees
+
+        assert len(trace_trees) == 1
+        assert trace_trees[0].id == "trace_1"
+        assert trace_trees[0].output == {"final": True}
+        assert trace_trees[0].end_time == self.end_time
+
+    def test_full_after_start_does_not_produce_duplicate_trace_entries(self):
+        self.processor.process(self._start_trace_message())
+        self.processor.process(self._full_trace_message())
+
+        trace_trees = self.processor.trace_trees
+
+        assert len(trace_trees) == 1
+        assert trace_trees[0].output == {"final": True}
+        assert trace_trees[0].end_time == self.end_time
+
+    def test_full_then_start_via_batch_messages_keeps_full_fields(self):
+        # Full chain reproduction: batch messages are what the emulator
+        # actually receives in production after the streamer batches the
+        # individual create messages.
+        full_trace = trace_write.TraceWrite(
+            id="trace_1",
+            project_name="test_project",
+            name="t",
+            start_time=self.start_time,
+            end_time=self.end_time,
+            input=None,
+            output={"final": True},
+            metadata=None,
+            tags=None,
+            error_info=None,
+            last_updated_at=self.end_time,
+            thread_id=None,
+            source="sdk",
+        )
+        start_trace = trace_write.TraceWrite(
+            id="trace_1",
+            project_name="test_project",
+            name="t",
+            start_time=self.start_time,
+            end_time=None,
+            input=None,
+            output=None,
+            metadata=None,
+            tags=None,
+            error_info=None,
+            last_updated_at=None,
+            thread_id=None,
+            source="sdk",
+        )
+        full_span = span_write.SpanWrite(
+            id="span_1",
+            project_name="test_project",
+            trace_id="trace_1",
+            parent_span_id=None,
+            name="foo",
+            type="tool",
+            start_time=self.start_time,
+            end_time=self.end_time,
+            input={"k": 1},
+            output={"is_error": False},
+            metadata=None,
+            model=None,
+            provider=None,
+            tags=None,
+            usage=None,
+            error_info=None,
+            last_updated_at=self.end_time,
+            source="sdk",
+        )
+        start_span = span_write.SpanWrite(
+            id="span_1",
+            project_name="test_project",
+            trace_id="trace_1",
+            parent_span_id=None,
+            name="foo",
+            type="general",
+            start_time=self.start_time,
+            end_time=None,
+            input={"k": 1},
+            output=None,
+            metadata=None,
+            model=None,
+            provider=None,
+            tags=None,
+            usage=None,
+            error_info=None,
+            last_updated_at=None,
+            source="sdk",
+        )
+
+        self.processor.process(messages.CreateSpansBatchMessage(batch=[full_span]))
+        self.processor.process(messages.CreateTraceBatchMessage(batch=[full_trace]))
+        self.processor.process(messages.CreateTraceBatchMessage(batch=[start_trace]))
+        self.processor.process(messages.CreateSpansBatchMessage(batch=[start_span]))
+
+        trace_trees = self.processor.trace_trees
+
+        assert len(trace_trees) == 1
+        assert trace_trees[0].output == {"final": True}
+        assert trace_trees[0].end_time == self.end_time
+        assert len(trace_trees[0].spans) == 1
+        span = trace_trees[0].spans[0]
+        assert span.type == "tool"
+        assert span.output == {"is_error": False}
+        assert span.end_time == self.end_time
+
+    def test_late_start_does_not_drop_attached_children(self):
+        # If a parent span has already had a child attached and then a stale
+        # start message for the parent arrives, the child must remain.
+        self.processor.process(self._full_trace_message())
+        self.processor.process(self._full_span_message())
+        child_message = messages.CreateSpanMessage(
+            span_id="child_1",
+            trace_id="trace_1",
+            project_name="test_project",
+            parent_span_id="span_1",
+            name="child",
+            start_time=self.start_time,
+            end_time=self.end_time,
+            input=None,
+            output=None,
+            metadata=None,
+            tags=None,
+            type="general",
+            usage=None,
+            model=None,
+            provider=None,
+            error_info=None,
+            total_cost=None,
+            last_updated_at=self.end_time,
+            source="sdk",
+        )
+        self.processor.process(child_message)
+
+        # build the tree once so child gets attached to the parent's `.spans`
+        first_read = self.processor.trace_trees
+        assert len(first_read[0].spans) == 1
+        assert len(first_read[0].spans[0].spans) == 1
+
+        # late start arrives — must not reset the child link
+        self.processor.process(self._start_span_message())
+
+        trace_trees = self.processor.trace_trees
+        assert len(trace_trees) == 1
+        assert len(trace_trees[0].spans) == 1
+        parent = trace_trees[0].spans[0]
+        assert parent.type == "tool"
+        assert len(parent.spans) == 1
+        assert parent.spans[0].id == "child_1"
+
+    def test_merge_duplicates_false_preserves_old_append_behavior(self):
+        # Callers can still opt out of de-duplication; in that case duplicate
+        # Create messages are kept verbatim (used by some test fixtures).
+        processor = local_emulator_message_processor.LocalEmulatorMessageProcessor(
+            active=True, merge_duplicates=False
+        )
+        processor.process(self._full_trace_message())
+        processor.process(self._start_trace_message())
+
+        assert len(processor.trace_trees) == 2


### PR DESCRIPTION
## Details

`opik.record_traces_locally()` was returning **duplicated/partial trace trees** when user code combined `start_as_current_trace` / `start_as_current_span` context managers with inline `span.output = ...` / `trace.output = ...` writes. Reported as OPIK-6372 by users building agent regression-test frameworks on top of `record_traces_locally`.

**Root cause** (in the local emulator that backs `record_traces_locally` / the test `BackendEmulatorMessageProcessor`):

The streamer's batch + replay machinery delivers two `CreateSpanMessage` / `CreateTraceMessage` per entity (one at start, one at end) and can deliver them out of order — START arriving *after* the matching FULL message. The old `_save_trace` / `_save_span` only handled "newer end_time wins" in one direction:

- If the new message had `end_time` set, it removed the old entry. Correct.
- If the **new** message was a START (no `end_time`), the existing FULL entry was left in `_trace_trees`, the START was unconditionally appended (→ **duplicate trace_trees entries** for the same id), and `_trace_observations[id]` was overwritten with the START — losing `type`, `output`, `end_time` on subsequent reads.

**Fix:** replace the directional check with a real merge in `_save_trace` / `_save_span`:

- New `_merge_models` helper picks the more complete entry (end_time set wins; later end_time among completes; `last_updated_at` as tiebreaker), then fills any None gaps from the other.
- Always exactly one entry per id in `_trace_trees` / `_span_trees`: replace in place rather than append.
- Late STARTs no longer overwrite recorded `parent_span_id` / `trace_id` with stale `None`.

**Other emulator improvements caught while auditing the same path:**

- `_handle_update_*` no longer raises `KeyError` when an Update arrives before its matching Create — the payload is queued in `_pending_*_updates` and applied as soon as the Create lands.
- Orphan-parent warning in `_build_spans_tree` is deduped by `(child, parent)` so repeated `trace_trees` / `span_trees` reads don't spam the log.
- Children/spans sorted once per parent at the end of the rebuild instead of re-sorting on every append.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-6372

## Testing

7 new regression cases under `TestLocalEmulatorMessageProcessorDuplicateCreateMessages` in `tests/unit/message_processing/emulation/test_local_emulator_message_processor.py` cover:

- Late START span arriving after FULL span (the original bug ordering) — keeps `type=tool`, `output`.
- Late FULL span arriving after START span — same expectations.
- Late START trace arriving after FULL trace — keeps `output`, `end_time`, no duplicate trace_trees entry.
- Same scenarios via `CreateSpansBatchMessage` / `CreateTraceBatchMessage` (the form the streamer actually delivers).
- Late START doesn't drop a child that was already attached to the parent's `.spans` on a prior tree build.
- `merge_duplicates=False` opt-out preserves the old append-duplicates behaviour.

All 33 emulator unit tests pass (26 pre-existing + 7 new). Originally-broken user repro (the script in the OPIK-6372 ticket) verified to produce the expected single trace tree with full span data after the fix.

## Documentation

N/A — internal SDK behaviour fix; no public API or surface changes.