### PR TITLE
[OPIK-6334] [FE] feat: add skeleton loaders to Prompt and Agent Playgrounds

### DIFF
--- a/apps/opik-frontend/src/hooks/usePairingState.test.ts
+++ b/apps/opik-frontend/src/hooks/usePairingState.test.ts
@@ -10,6 +10,7 @@ let mockRunnerData: { status: string; id: string } | null = null;
 vi.mock("@/api/agent-sandbox/useSandboxConnectionStatus", () => ({
   default: vi.fn(() => ({
     data: mockRunnerData,
+    isFetched: true,
   })),
 }));
 

--- a/apps/opik-frontend/src/hooks/usePairingState.ts
+++ b/apps/opik-frontend/src/hooks/usePairingState.ts
@@ -10,13 +10,14 @@ export interface PairingState {
   status: RunnerConnectionStatus;
   runnerId: string | null;
   runner: LocalRunner | null;
+  isInitialLoading: boolean;
 }
 
 export default function usePairingState(
   projectId: string,
   runnerType?: LocalRunnerType,
 ): PairingState {
-  const { data: runnerData } = useSandboxConnectionStatus({
+  const { data: runnerData, isFetched } = useSandboxConnectionStatus({
     projectId,
     runnerType,
   });
@@ -39,5 +40,6 @@ export default function usePairingState(
     status,
     runnerId: runnerData?.id ?? null,
     runner: runnerData ?? null,
+    isInitialLoading: !isFetched,
   };
 }

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx
@@ -107,6 +107,7 @@ describe("AgentRunnerContent", () => {
       status: RunnerConnectionStatus.IDLE,
       runnerId: null,
       runner: null,
+      isInitialLoading: false,
     };
     mockUseNavigationBlocker.mockReturnValue({
       DialogComponent: <div data-testid="navigation-blocker-dialog" />,

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
@@ -53,7 +53,7 @@ const renderAgentRunnerLoadingSkeleton = () => (
           <Skeleton className="size-3 rounded-sm" />
           <Skeleton className="h-4 w-[40px]" />
         </div>
-        <div className="flex min-h-0 flex-1 flex-col bg-white p-4">
+        <div className="flex min-h-0 flex-1 flex-col bg-background p-4">
           <Skeleton className="h-[213px] w-full" />
         </div>
       </div>

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerContent.tsx
@@ -3,6 +3,7 @@ import { Pause, Play, RotateCcw, Unplug } from "lucide-react";
 
 import { Button } from "@/ui/button";
 import { HotkeyDisplay } from "@/ui/hotkey-display";
+import { Skeleton } from "@/ui/skeleton";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import {
   ResizableHandle,
@@ -26,6 +27,39 @@ import AgentRunnerConnectedState from "./AgentRunnerConnectedState";
 import AgentRunnerResult from "./AgentRunnerResult";
 
 const TRACE_POLL_INTERVAL = 1000;
+
+const renderAgentRunnerLoadingSkeleton = () => (
+  <ResizablePanelGroup
+    direction="vertical"
+    autoSaveId="agent-sandbox-layout"
+    className="min-h-0 flex-1"
+  >
+    <ResizablePanel id="agent-input" defaultSize={50} minSize={20}>
+      <div className="flex h-full flex-col">
+        <div className="flex h-10 shrink-0 items-center gap-2 border-b bg-soft-background px-4">
+          <Skeleton className="h-4 w-[40px]" />
+          <Skeleton className="h-4 w-[80px]" />
+        </div>
+        <div className="flex min-h-0 flex-1 flex-col gap-2 bg-soft-background p-4">
+          <Skeleton className="h-[116px] w-full" />
+          <Skeleton className="h-[62px] w-full" />
+        </div>
+      </div>
+    </ResizablePanel>
+    <ResizableHandle />
+    <ResizablePanel id="agent-result" defaultSize={50} minSize={15}>
+      <div className="flex h-full flex-col">
+        <div className="flex h-10 shrink-0 items-center gap-2 border-b bg-soft-background px-4">
+          <Skeleton className="size-3 rounded-sm" />
+          <Skeleton className="h-4 w-[40px]" />
+        </div>
+        <div className="flex min-h-0 flex-1 flex-col bg-white p-4">
+          <Skeleton className="h-[213px] w-full" />
+        </div>
+      </div>
+    </ResizablePanel>
+  </ResizablePanelGroup>
+);
 
 type AgentRunnerContentProps = {
   projectId: string;
@@ -158,7 +192,7 @@ const AgentRunnerContent: React.FC<AgentRunnerContentProps> = ({
       <div className="flex items-center gap-3 border-b bg-gray-100 px-4 py-3">
         <h1 className="comet-title-xs">Agent playground</h1>
 
-        {isConnected ? (
+        {pairing.isInitialLoading ? null : isConnected ? (
           <TooltipWrapper content="Your agent is connected to Opik">
             <span className="comet-body-xs flex items-center gap-1.5 text-emerald-600">
               <span className="size-1.5 rounded-full bg-emerald-500" />
@@ -232,7 +266,9 @@ const AgentRunnerContent: React.FC<AgentRunnerContentProps> = ({
         </div>
       </div>
 
-      {isConnected && pairing.runner ? (
+      {pairing.isInitialLoading ? (
+        renderAgentRunnerLoadingSkeleton()
+      ) : isConnected && pairing.runner ? (
         <ResizablePanelGroup
           direction="vertical"
           autoSaveId="agent-sandbox-layout"

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -62,7 +62,7 @@ const renderPlaygroundLoadingSkeleton = () => (
         <Skeleton className="h-[62px] w-full" />
         <Skeleton className="h-4 w-[84px]" />
       </div>
-      <div className="flex flex-1 flex-col border-r bg-white p-4">
+      <div className="flex flex-1 flex-col border-r bg-background p-4">
         <Skeleton className="h-[213px] w-full" />
       </div>
     </div>

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -5,10 +5,10 @@ import React, {
   useRef,
   useState,
 } from "react";
-import Loader from "@/shared/Loader/Loader";
 import { keepPreviousData } from "@tanstack/react-query";
 
 import { Separator } from "@/ui/separator";
+import { Skeleton } from "@/ui/skeleton";
 import PlaygroundOutputs from "@/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputs";
 import PlaygroundAddVariant from "@/v2/pages/PlaygroundPage/PlaygroundAddVariant";
 import { usePlaygroundDataset } from "@/hooks/usePlaygroundDataset";
@@ -49,6 +49,29 @@ import { DEFAULT_LOADED_DATASETS } from "@/v2/pages-shared/DatasetVersionSelectB
 
 const EMPTY_ITEMS: DatasetItem[] = [];
 const EMPTY_DATASETS: Dataset[] = [];
+
+const renderPlaygroundLoadingSkeleton = () => (
+  <div className="flex min-h-0 flex-1">
+    <div className="flex flex-1 flex-col">
+      <div className="flex h-10 shrink-0 items-center gap-2 border-b border-r bg-soft-background px-4">
+        <Skeleton className="h-4 w-[85px]" />
+        <Skeleton className="h-4 w-[69px]" />
+      </div>
+      <div className="flex h-[calc(50vh-40px)] shrink-0 flex-col gap-2 border-b border-r bg-soft-background p-4">
+        <Skeleton className="h-[116px] w-full" />
+        <Skeleton className="h-[62px] w-full" />
+        <Skeleton className="h-4 w-[84px]" />
+      </div>
+      <div className="flex flex-1 flex-col border-r bg-white p-4">
+        <Skeleton className="h-[213px] w-full" />
+      </div>
+    </div>
+    <div className="flex w-[var(--add-variant-width)] shrink-0 flex-col items-center gap-2 pt-[170px]">
+      <Skeleton className="size-7 rounded-md" />
+      <Skeleton className="h-4 w-[66px]" />
+    </div>
+  </div>
+);
 
 const PlaygroundPage = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
@@ -216,11 +239,9 @@ const PlaygroundPage = () => {
     return () => stopAll();
   }, [stopAll]);
 
-  if (isPendingProviderKeys) {
-    return <Loader />;
-  }
-
-  const headerMaxWidth = `calc(${promptCount} * var(--max-prompt-width) + var(--add-variant-width))`;
+  const headerMaxWidth = isPendingProviderKeys
+    ? undefined
+    : `calc(${promptCount} * var(--max-prompt-width) + var(--add-variant-width))`;
 
   return (
     <div
@@ -252,7 +273,9 @@ const PlaygroundPage = () => {
 
         <Separator />
 
-        {isExperimentMode ? (
+        {isPendingProviderKeys ? (
+          renderPlaygroundLoadingSkeleton()
+        ) : isExperimentMode ? (
           <>
             <div className="flex h-[50vh] shrink-0 overflow-x-auto">
               <div


### PR DESCRIPTION
## Details


https://github.com/user-attachments/assets/9ab34138-15df-4ed6-83ce-b344bac17d26


Replaces the full-page Loader on the **Prompt Playground** and the brief flash of the disconnected empty state on the **Agent Playground** with custom skeleton placeholders matching the Figma specs (`533:83979`, `533:84053`, `533:84379`). Page chrome (sidebar, breadcrumbs, action bar) renders immediately; only the prompt/output area or the agent input/result area shows shimmer placeholders until data resolves.

- **Prompt Playground** (`PlaygroundPage.tsx`) — drop the early-return Loader, render `<PlaygroundHeader>` + `<Separator>` immediately, replace the body with a 4-section skeleton (top toolbar strip, prompt editor panel, outputs panel, plus a right-side AddVariant column matching `533:84053`). Also fixes a header layout regression: `headerMaxWidth` collapsed to 90px while `promptCount=0` during initial load — skipped while pending so the chrome lays out correctly.
- **Agent Playground** (`AgentRunnerContent.tsx`) — render the skeleton (mirroring the connected `<ResizablePanelGroup>` Input + Result layout) while the connection-status query has not yet resolved; hide the connection status badge during that window. Skeleton uses the same `autoSaveId="agent-sandbox-layout"` so it respects the user's persisted resize ratio — no jump when the connected state mounts.
- **`usePairingState`** — expose `isInitialLoading` (derived from `isFetched`) instead of `isPending`. `isPending` flipped `true` on every poll cycle while the connection-status query stayed in error/no-data state, causing the skeleton to blink every 3 seconds against a permanently-erroring backend; `isFetched` is stable after the first response (success or error) and prevents the blink.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6334

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.7 (1M context)
  - Scope: full implementation under continuous human direction (skeleton structure per page, dimension tweaks against Figma, defensive isFetched fix verified live in Chrome DevTools, all reviewed and approved iteratively)
  - Human verification: code review + manual testing on local dev (Prompt Playground cold-load, Agent Playground with network throttling enabled to confirm no skeleton blink across poll cycles)

## Testing

- `bash scripts/dev-runner.sh --lint-fe` (lint:fix + typecheck + deps:validate) — green
- `npx vitest run src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx src/hooks/usePairingState.test.ts` — 13/13 pass (default `mockPairingState` updated to include `isInitialLoading: false`)
- Live verification in Chrome DevTools:
  - Prompt Playground: 8 skeleton elements, all inside the main content area, dimensions match Figma `533:83979` + `533:84053` (85×16, 69×16, 116×full, 62×full, 16×84, 213×full, 28×28 icon, 66×16 label)
  - Agent Playground with throttling on a 501-returning backend: confirmed `isFetched=true` is stable across poll cycles, skeleton no longer flashes on every refetch
  - Resizable Input/Result panels in skeleton respect persisted layout (same `autoSaveId`)

## Documentation

N/A