### PR TITLE
[OPIK-6334] [FE] fix: render page-surface assistant loader and error state full-bleed

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/AssistantErrorState.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantErrorState.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { AlertCircle, X } from "lucide-react";
 import { SLACK_LINK } from "@/shared/SupportHub/SupportHubSubMenu";
+import { AssistantSurfaceVariant } from "@/types/assistant-sidebar";
 
 interface AssistantErrorStateProps {
-  collapsed: boolean;
+  variant: AssistantSurfaceVariant;
   onRetry?: () => void;
   onToggle?: () => void;
   retryCount: number;
@@ -95,12 +96,12 @@ const FirstRetryError: React.FC<
 );
 
 const AssistantErrorState: React.FC<AssistantErrorStateProps> = ({
-  collapsed,
+  variant,
   onRetry,
   onToggle,
   retryCount,
 }) => {
-  if (collapsed)
+  if (variant === "collapsed")
     return <CollapsedError onToggle={onToggle} retryCount={retryCount} />;
   if (retryCount > 0)
     return <EscalatedError onRetry={onRetry} onToggle={onToggle} />;

--- a/apps/opik-frontend/src/plugins/comet/AssistantErrorState.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantErrorState.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { AlertCircle, X } from "lucide-react";
 import { SLACK_LINK } from "@/shared/SupportHub/SupportHubSubMenu";
+import { cn } from "@/lib/utils";
 import { AssistantSurfaceVariant } from "@/types/assistant-sidebar";
 
 interface AssistantErrorStateProps {
@@ -43,11 +44,24 @@ const CloseButton: React.FC<{ onClick?: () => void }> = ({ onClick }) => (
   </button>
 );
 
-const EscalatedError: React.FC<
-  Pick<AssistantErrorStateProps, "onRetry" | "onToggle">
-> = ({ onRetry, onToggle }) => (
-  <div className="relative flex size-full flex-col items-center justify-center gap-3 border-l bg-primary-foreground px-6 text-center">
-    <CloseButton onClick={onToggle} />
+type ExpandedErrorProps = Pick<
+  AssistantErrorStateProps,
+  "variant" | "onRetry" | "onToggle"
+>;
+
+const expandedCardClass = (variant: AssistantSurfaceVariant) =>
+  cn(
+    "relative flex size-full flex-col items-center justify-center gap-3 bg-primary-foreground px-6 text-center",
+    variant === "sidebar" && "border-l",
+  );
+
+const EscalatedError: React.FC<ExpandedErrorProps> = ({
+  variant,
+  onRetry,
+  onToggle,
+}) => (
+  <div className={expandedCardClass(variant)}>
+    {variant === "sidebar" && <CloseButton onClick={onToggle} />}
     <AlertCircle className="size-5 text-destructive" />
     <div className="text-sm font-medium text-foreground">
       Assistant is currently unavailable
@@ -73,11 +87,13 @@ const EscalatedError: React.FC<
   </div>
 );
 
-const FirstRetryError: React.FC<
-  Pick<AssistantErrorStateProps, "onRetry" | "onToggle">
-> = ({ onRetry, onToggle }) => (
-  <div className="relative flex size-full flex-col items-center justify-center gap-3 border-l bg-primary-foreground px-6 text-center">
-    <CloseButton onClick={onToggle} />
+const FirstRetryError: React.FC<ExpandedErrorProps> = ({
+  variant,
+  onRetry,
+  onToggle,
+}) => (
+  <div className={expandedCardClass(variant)}>
+    {variant === "sidebar" && <CloseButton onClick={onToggle} />}
     <AlertCircle className="size-5 text-destructive" />
     <div className="text-sm font-medium text-foreground">
       Unable to load assistant
@@ -104,8 +120,12 @@ const AssistantErrorState: React.FC<AssistantErrorStateProps> = ({
   if (variant === "collapsed")
     return <CollapsedError onToggle={onToggle} retryCount={retryCount} />;
   if (retryCount > 0)
-    return <EscalatedError onRetry={onRetry} onToggle={onToggle} />;
-  return <FirstRetryError onRetry={onRetry} onToggle={onToggle} />;
+    return (
+      <EscalatedError variant={variant} onRetry={onRetry} onToggle={onToggle} />
+    );
+  return (
+    <FirstRetryError variant={variant} onRetry={onRetry} onToggle={onToggle} />
+  );
 };
 
 export default AssistantErrorState;

--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -8,6 +8,7 @@ import React, {
 import { useParams, useRouter } from "@tanstack/react-router";
 import {
   AssistantSidebarBridge,
+  AssistantSurfaceVariant,
   BridgeContext,
   BridgeSurface,
   HostEventMap,
@@ -24,7 +25,7 @@ import useProjectOnboardingStats from "@/hooks/useProjectOnboardingStats";
 import useRunnerBridgeSync from "@/hooks/useRunnerBridgeSync";
 import { BASE_API_URL } from "@/api/api";
 import AssistantErrorState from "@/plugins/comet/AssistantErrorState";
-import OllieLoader, { OllieLoaderVariant } from "@/plugins/comet/OllieLoader";
+import OllieLoader from "@/plugins/comet/OllieLoader";
 import { IS_ASSISTANT_DEV } from "@/plugins/comet/constants/assistant";
 import useAssistantManifest from "@/plugins/comet/useAssistantManifest";
 import {
@@ -75,12 +76,19 @@ const AssistantSidebarLoader: React.FC<AssistantSidebarLoaderProps> = ({
     });
   }, [onWidthChange]);
 
-  const collapsed = !isOpen;
+  let variant: AssistantSurfaceVariant;
+  if (surface === "page") {
+    variant = "page";
+  } else if (!isOpen) {
+    variant = "collapsed";
+  } else {
+    variant = "sidebar";
+  }
 
   if (error) {
     return (
       <AssistantErrorState
-        collapsed={collapsed}
+        variant={variant}
         onRetry={onRetry}
         onToggle={handleToggle}
         retryCount={retryCount}
@@ -88,12 +96,6 @@ const AssistantSidebarLoader: React.FC<AssistantSidebarLoaderProps> = ({
     );
   }
 
-  let variant: OllieLoaderVariant = "sidebar";
-  if (collapsed) {
-    variant = "collapsed";
-  } else if (surface === "page") {
-    variant = "page";
-  }
   return <OllieLoader variant={variant} />;
 };
 

--- a/apps/opik-frontend/src/plugins/comet/OllieLoader.tsx
+++ b/apps/opik-frontend/src/plugins/comet/OllieLoader.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 
 import { cn } from "@/lib/utils";
 import OwlArt from "@/shared/OwlArt";
+import { AssistantSurfaceVariant } from "@/types/assistant-sidebar";
 
 const MESSAGES = [
   "Ollie is waking up\u2026",
@@ -12,16 +13,14 @@ const MESSAGES = [
 
 const ROTATION_INTERVAL_MS = 2200;
 
-export type OllieLoaderVariant = "page" | "sidebar" | "collapsed";
-
-const OWL_SIZE: Record<OllieLoaderVariant, string> = {
+const OWL_SIZE: Record<AssistantSurfaceVariant, string> = {
   page: "size-[72px]",
   sidebar: "size-[48px]",
   collapsed: "size-6",
 };
 
 interface OllieLoaderProps {
-  variant?: OllieLoaderVariant;
+  variant?: AssistantSurfaceVariant;
 }
 
 export function OllieLoader({

--- a/apps/opik-frontend/src/types/assistant-sidebar.ts
+++ b/apps/opik-frontend/src/types/assistant-sidebar.ts
@@ -2,6 +2,7 @@ import { RunnerConnectionStatus } from "@/types/agent-sandbox";
 
 export type BridgeTheme = "light" | "dark";
 export type BridgeSurface = "sidebar" | "page";
+export type AssistantSurfaceVariant = "page" | "sidebar" | "collapsed";
 export type NotificationType = "success" | "error" | "info";
 
 export interface ProjectStats {


### PR DESCRIPTION
## Details


https://github.com/user-attachments/assets/ad31b754-fdbe-4899-8581-60b510050b47



The Project Home (Opik Connect) page surface was inheriting the persisted right-rail sidebar-collapsed flag, so the assistant loader fell into the 24px no-text owl variant and the error state rendered as the 33px vertical-text rail. Derive the surface variant once (`page` | `sidebar` | `collapsed`) and pass it to both `OllieLoader` and `AssistantErrorState`; promote the variant type to `types/assistant-sidebar` so both consumers read from a single source of truth. Internals of `AssistantErrorState` are untouched — only its public prop changed from `collapsed: boolean` to `variant: AssistantSurfaceVariant`.

- Bug introduced 2026-04-17 in commit `3e6bc9b7a3` (PR #6353, OPIK-5918) when the page variant was added — the new branch was placed *after* the `collapsed` check, so the persisted sidebar-collapsed pref always won on the page surface.
- The companion ollie-assist change (skeleton for the iframe's pre-`projectStats` state) is on `andriid/OPIK-6334-chat-page-empty-state-skeleton` in `comet-ml/ollie-assist` and will be a separate PR.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6334

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M)
- Scope: assisted (investigation + implementation under direct review)
- Human verification: code review + manual testing of all three loader/error variants in `make dev-full`

## Testing

- `bash scripts/dev-runner.sh --lint-fe` (eslint + tsc + dependency-cruiser) — all green.
- Local stack via `make dev-full` (opik FE 5174, opik BE 8080, ollie BE 9080, console 3333). Verified Project Home with the persisted sidebar-collapsed flag set:
  - **Loader** — full 72px owl + rotating "Ollie is waking up…" copy on the page surface, instead of the 24px no-text owl.
  - **Error state** — kill the ollie container and reload: full-bleed "Unable to load assistant" card with retry, instead of the 33px vertical-text rail.
  - **Sidebar surface** — opening the assistant in the right rail still picks the sidebar/collapsed variant correctly (regression check).

## Documentation

N/A — no public API or user docs change.