### PR TITLE
[NA] [BE] perf: replace FINAL with LIMIT 1 BY in ExperimentItemDAO refs queries

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
@@ -593,11 +593,15 @@ class ExperimentItemDAO {
             """;
 
     private static final String FILTER_EXPERIMENT_IDS_BY_STATUS = """
-            SELECT id
-            FROM experiments FINAL
-            WHERE workspace_id = :workspace_id
-            AND id IN :experiment_ids
-            AND status IN :statuses
+            WITH ea_dedup AS (
+                SELECT id, status
+                FROM experiments
+                WHERE workspace_id = :workspace_id
+                AND id IN :experiment_ids
+                ORDER BY last_updated_at DESC
+                LIMIT 1 BY workspace_id, dataset_id, id
+            )
+            SELECT id FROM ea_dedup WHERE status IN :statuses
             SETTINGS log_comment = '<log_comment>'
             ;
             """;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
@@ -487,28 +487,60 @@ class ExperimentItemDAO {
             ;
             """;
 
+    // ReplacingMergeTree dedup is reproduced explicitly via `LIMIT 1 BY <full sort key> ORDER BY last_updated_at DESC`,
+    // matching the version column declared on each table. This avoids `FINAL`, which forces materializing all columns
+    // for the merge before WHERE filters apply; on `experiment_items`/`experiments` for a busy workspace, that drives
+    // ~10x latency, ~7x bytes read, and ~40x peak memory vs. the rewrite. Same pattern is used in TraceDAO.find.
     private static final String GET_EXPERIMENT_REFS_BY_TRACE_IDS = """
+            WITH
+                ei_dedup AS (
+                    SELECT experiment_id, trace_id, workspace_id, dataset_item_id, id
+                    FROM experiment_items
+                    WHERE workspace_id = :workspace_id
+                    AND trace_id IN :trace_ids
+                    ORDER BY last_updated_at DESC
+                    LIMIT 1 BY workspace_id, experiment_id, dataset_item_id, trace_id, id
+                ),
+                ea_dedup AS (
+                    SELECT id, status, workspace_id
+                    FROM experiments
+                    WHERE workspace_id = :workspace_id
+                    ORDER BY last_updated_at DESC
+                    LIMIT 1 BY workspace_id, dataset_id, id
+                )
             SELECT ei.experiment_id, ei.trace_id
-            FROM experiment_items AS ei FINAL
-            INNER JOIN experiments AS ea FINAL
+            FROM ei_dedup AS ei
+            INNER JOIN ea_dedup AS ea
                 ON ea.id = ei.experiment_id
                 AND ea.workspace_id = ei.workspace_id
-            WHERE ei.workspace_id = :workspace_id
-            AND ei.trace_id IN :trace_ids
-            AND ea.status IN :statuses
+            WHERE ea.status IN :statuses
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
 
     private static final String GET_EXPERIMENT_REFS_BY_ITEM_IDS = """
+            WITH
+                ei_dedup AS (
+                    SELECT experiment_id, trace_id, workspace_id, dataset_item_id, id
+                    FROM experiment_items
+                    WHERE workspace_id = :workspace_id
+                    AND id IN :item_ids
+                    ORDER BY last_updated_at DESC
+                    LIMIT 1 BY workspace_id, experiment_id, dataset_item_id, trace_id, id
+                ),
+                ea_dedup AS (
+                    SELECT id, status, workspace_id
+                    FROM experiments
+                    WHERE workspace_id = :workspace_id
+                    ORDER BY last_updated_at DESC
+                    LIMIT 1 BY workspace_id, dataset_id, id
+                )
             SELECT ei.experiment_id, ei.trace_id
-            FROM experiment_items AS ei FINAL
-            INNER JOIN experiments AS ea FINAL
+            FROM ei_dedup AS ei
+            INNER JOIN ea_dedup AS ea
                 ON ea.id = ei.experiment_id
                 AND ea.workspace_id = ei.workspace_id
-            WHERE ei.workspace_id = :workspace_id
-            AND ei.id IN :item_ids
-            AND ea.status IN :statuses
+            WHERE ea.status IN :statuses
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
@@ -523,17 +555,39 @@ class ExperimentItemDAO {
             """;
 
     private static final String GET_EXPERIMENT_REFS_BY_SPAN_IDS = """
+            WITH
+                spans_dedup AS (
+                    SELECT DISTINCT trace_id
+                    FROM (
+                        SELECT trace_id, id, workspace_id, project_id, parent_span_id
+                        FROM spans
+                        WHERE workspace_id = :workspace_id
+                        AND id IN :span_ids
+                        ORDER BY last_updated_at DESC
+                        LIMIT 1 BY workspace_id, project_id, trace_id, parent_span_id, id
+                    )
+                ),
+                ei_dedup AS (
+                    SELECT experiment_id, trace_id, workspace_id, dataset_item_id, id
+                    FROM experiment_items
+                    WHERE workspace_id = :workspace_id
+                    AND trace_id IN (SELECT trace_id FROM spans_dedup)
+                    ORDER BY last_updated_at DESC
+                    LIMIT 1 BY workspace_id, experiment_id, dataset_item_id, trace_id, id
+                ),
+                ea_dedup AS (
+                    SELECT id, status, workspace_id
+                    FROM experiments
+                    WHERE workspace_id = :workspace_id
+                    ORDER BY last_updated_at DESC
+                    LIMIT 1 BY workspace_id, dataset_id, id
+                )
             SELECT ei.experiment_id, ei.trace_id
-            FROM experiment_items AS ei FINAL
-            INNER JOIN experiments AS ea FINAL
+            FROM ei_dedup AS ei
+            INNER JOIN ea_dedup AS ea
                 ON ea.id = ei.experiment_id
                 AND ea.workspace_id = ei.workspace_id
-            WHERE ei.workspace_id = :workspace_id
-            AND ei.trace_id IN (
-                SELECT DISTINCT trace_id FROM spans FINAL
-                WHERE id IN :span_ids AND workspace_id = :workspace_id
-            )
-            AND ea.status IN :statuses
+            WHERE ea.status IN :statuses
             SETTINGS log_comment = '<log_comment>'
             ;
             """;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
@@ -437,10 +437,17 @@ class ExperimentItemDAO {
                               trace_id,
                               sum(total_estimated_cost) AS total_estimated_cost,
                               sumMap(usage) AS usage
-                          FROM spans final
-                          WHERE workspace_id = :workspace_id
-                          <if(has_target_projects)>AND project_id IN :target_project_ids<endif>
-                          AND trace_id IN (SELECT trace_id FROM experiment_items_ids)
+                          FROM (
+                              SELECT
+                                  workspace_id, project_id, trace_id, parent_span_id, id,
+                                  total_estimated_cost, usage
+                              FROM spans
+                              WHERE workspace_id = :workspace_id
+                              <if(has_target_projects)>AND project_id IN :target_project_ids<endif>
+                              AND trace_id IN (SELECT trace_id FROM experiment_items_ids)
+                              ORDER BY last_updated_at DESC
+                              LIMIT 1 BY workspace_id, project_id, trace_id, parent_span_id, id
+                          )
                           GROUP BY workspace_id, project_id, trace_id
                       ) s ON s.trace_id = t.id
                   ) AS tfs ON ei.trace_id = tfs.id


### PR DESCRIPTION
## Details

`ExperimentItemDAO` had five places using `FROM <table> FINAL` against `ReplacingMergeTree` tables: four whole SQL constants (`GET_EXPERIMENT_REFS_BY_TRACE_IDS`, `GET_EXPERIMENT_REFS_BY_ITEM_IDS`, `GET_EXPERIMENT_REFS_BY_SPAN_IDS`, `FILTER_EXPERIMENT_IDS_BY_STATUS`), plus one `FROM spans final` aggregation inside the `STREAM` constant. Production query-log analysis showed this pattern dominates ClickHouse load — the SPAN_IDS variant alone runs ~2.2k calls/hour averaging ~12 s each, scanning ~1.26 TiB/hour and ~7B rows. The `FILTER_*` variant runs another 651 calls/hour from the same `ExperimentAggregateEventListener` hot path. The `STREAM` export path runs at lower frequency but has a large per-call footprint.

This PR rewrites all five sites to dedup explicitly via `ORDER BY last_updated_at DESC` + `LIMIT 1 BY <full sort key>` inside CTEs/subqueries. That is the documented FINAL-equivalent for `ReplacingMergeTree` (the version column is `last_updated_at` for `experiment_items`, `experiments`, and `spans`).

After this PR, **no `FINAL` SQL operators remain in this DAO** — only the explanatory comment about the rewrite pattern.

- `FINAL` materializes whole rows for the per-part merge before WHERE/JOIN predicates can filter; the rewrite reads only the projected columns and streams over already-sorted primary key.
- The `status` filter is correctly kept after `ea_dedup` because `status` is not part of the `experiments` sort key — pushing it before dedup would change semantics.
- Bind-parameter signatures unchanged for all call sites; Java callers (`getExperimentRefsByIds`, `filterExperimentIdsByStatus`, the streaming `find`) are untouched.

### Precedent — same pattern is already standard in this codebase

`LIMIT 1 BY` + `ORDER BY ... last_updated_at DESC` is used **207 times across 16 DAO files**:

| file | occurrences |
|---|---:|
| ExperimentDAO.java | 27 |
| DatasetItemVersionDAO.java | 30 |
| TraceDAO.java | 25 |
| ThreadDAO.java | 22 |
| DatasetItemDAO.java | 16 |
| ExperimentAggregatesDAO.java | 14 |
| **ExperimentItemDAO.java (this file)** | **14** |
| SpanDAO.java | 11 |
| KpiCardDAO.java, OptimizationDAO.java, ProjectMetricsDAO.java | 10 each |
| FeedbackScoreDAO.java | 7 |
| AnnotationQueueDAO.java, TraceThreadDAO.java | 3–4 |
| AttachmentDAO.java, CommentDAO.java | 2 each |

The file we are editing **already uses this pattern 14 times** — the five FINAL sites were the outliers, not the rewrite.

The closest precedent is `DatasetItemVersionDAO.java:421-431`, which dedups the **exact same tables** (`experiments`, `experiment_items`) with the **exact same sort keys** used here:

```sql
-- experiments dedup
ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
LIMIT 1 BY id

-- experiment_items dedup
ORDER BY (ei.workspace_id, ei.experiment_id, ei.dataset_item_id, ei.trace_id, ei.id) DESC, ei.last_updated_at DESC
LIMIT 1 BY ei.id
```

## Change checklist

- [ ] User facing
- [ ] Documentation update

## Issues

NA — no Jira ticket; performance fix derived from production ClickHouse query-log analysis.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation (SQL rewrite + empirical validation across all five sites)
- Human verification: production result-equivalence checks, interleaved timing runs, code review of the diff

## Testing

Result equivalence — validated against `opik_prod` ClickHouse cluster using real sampled IDs from a high-volume workspace, comparing original FINAL vs rewrite at every site:

| site | rows returned (FINAL) | rows returned (rewrite) | identical |
|---|---:|---:|:---:|
| `GET_EXPERIMENT_REFS_BY_TRACE_IDS` | 188 | 188 | yes |
| `GET_EXPERIMENT_REFS_BY_ITEM_IDS`  |  20 |  20 | yes |
| `GET_EXPERIMENT_REFS_BY_SPAN_IDS`  |  85 |  85 | yes |
| `FILTER_EXPERIMENT_IDS_BY_STATUS`  |   1 |   1 | yes |
| `STREAM` spans aggregation         | 200 | 200 | yes |

Bit-for-bit equivalence confirmed via sorted-TSV diff (`diff <(orig) <(rewrite)` empty for all five).

### Timing — `GET_EXPERIMENT_REFS_BY_SPAN_IDS` (the prod-slow variant; 1 warmup + 5 timed runs each, interleaved)

| metric | FINAL | LIMIT 1 BY | improvement |
|---|---:|---:|---:|
| duration (median) | 1,034 ms | 101 ms | 10.2x faster |
| read_bytes (avg)  | 228 MiB | 33.7 MiB | 6.8x less |
| memory_usage (avg)| 103 MiB | 2.5 MiB | 41x less |
| cpu_time (avg)    | 823 ms | 133 ms | 6.2x less |
| marks scanned     | ~9,485 | ~9,479 | same scan width |

### Timing — `FILTER_EXPERIMENT_IDS_BY_STATUS` (small table; 1 warmup + 5 timed runs each)

| metric | FINAL | LIMIT 1 BY | improvement |
|---|---:|---:|---:|
| duration (mean)   | ~7.5 ms | ~7.2 ms | no change (table is small) |
| read_bytes (avg)  | 3.95 MiB | 1.47 MiB | 2.7x less |
| memory_usage (avg)| ~3.9 MiB | ~33 KiB | ~120x less |
| cpu_time (avg)    | ~11.2k µs | ~6.4k µs | 1.7x less |

### Timing — `STREAM` spans aggregation (200 trace_ids; 1 warmup + 5 timed runs each)

| metric | FINAL | LIMIT 1 BY | improvement |
|---|---:|---:|---:|
| duration (avg)    | ~192 ms | ~63 ms | ~3.0x faster |
| read_rows (avg)   | ~410k | ~196k | ~2.1x less (FINAL re-reads dupes) |
| read_bytes (avg)  | ~136 MiB | ~15.7 MiB | ~8.7x less |
| memory_usage (avg)| ~79 MiB | ~38 MiB | ~2.1x less |
| cpu_time (avg)    | ~500k µs | ~93k µs | ~5.4x less |
| marks/parts       | ~1,060 / ~135 | identical | same scan width |

Memory drop is the headline number across all variants — it directly raises how many of these can run concurrently without cluster pressure.

Local commands run:

- `cd apps/opik-backend && mvn -q spotless:check -pl .` — passes

CI to run automatically:

- `backend_formatting_check.yml` (spotless)
- `backend_tests.yml` — `ExperimentItemProcessorTest` and `ExperimentAggregateEventListenerTest` exercise these paths; output is unchanged so existing tests pass without modification

## Documentation

N/A — internal SQL refactor with no public API or behavior change.