### PR TITLE
[OPIK-6268] [SDK] feat: add environment support

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/reference/typescript-sdk/opik-query-language.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/reference/typescript-sdk/opik-query-language.mdx
@@ -75,6 +75,24 @@ OQL provides a powerful, SQL-like syntax for filtering data in Opik. It's used w
 'end_time < "2024-12-31T23:59:59Z"';
 ```
 
+### Enum Operators
+
+Used for fields with a fixed set of values, such as `environment`:
+
+```typescript
+// Exact match
+'environment = "production"';
+
+// Not equal
+'environment != "development"';
+
+// Match any of a set of values
+'environment in ("production", "staging")';
+
+// Exclude a set of values
+'environment not_in ("development", "local")';
+```
+
 ### List Operators
 
 ```typescript
@@ -155,6 +173,18 @@ const unratedThreads = await client.searchThreads({
   filterString: 'feedback_scores.quality is_empty'
 });
 
+// Filter by environment
+const prodThreads = await client.searchThreads({
+  projectName: "my-project",
+  filterString: 'environment = "production"'
+});
+
+// Filter by multiple environments
+const stagingOrProdThreads = await client.searchThreads({
+  projectName: "my-project",
+  filterString: 'environment in ("production", "staging")'
+});
+
 // Filter by tags and metadata
 const importantProdThreads = await client.searchThreads({
   projectName: "my-project",
@@ -185,6 +215,18 @@ const traces = await client.searchTraces({
 const goodTraces = await client.searchTraces({
   projectName: "my-project",
   filterString: 'feedback_scores.accuracy > 0.9'
+});
+
+// Filter by environment
+const prodTraces = await client.searchTraces({
+  projectName: "my-project",
+  filterString: 'environment = "production"'
+});
+
+// Combine environment with other filters
+const goodProdTraces = await client.searchTraces({
+  projectName: "my-project",
+  filterString: 'environment = "production" AND feedback_scores.accuracy > 0.9'
 });
 ```
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/log_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/log_traces.mdx
@@ -997,6 +997,169 @@ evaluation = evaluate(
 ```
 </Warning>
 
+### Logging to a specific environment
+
+Environments let you tag traces with a lifecycle stage — for example `development`, `staging`, or `production` — so you can segment and filter your observability data in the Opik UI.
+
+<Tabs>
+    <Tab title="Typescript" value="typescript" language="typescript">
+        #### Setting the environment
+
+        The environment is resolved in this order:
+
+        1. **Explicit argument** — passed directly to `client.trace(environment: ...)`
+        2. **`OPIK_ENVIRONMENT` environment variable**
+
+        Using the low-level SDK:
+
+        ```typescript
+        import { Opik } from "opik";
+
+        const client = new Opik({ projectName: "my-project" });
+
+        const trace = client.trace({
+            name: "my_trace",
+            input: { question: "Hello" },
+            environment: "production",
+        });
+
+        trace.end();
+        await client.flush();
+        ```
+
+    </Tab>
+    <Tab title="Python" value="python" language="python">
+        #### Setting the environment
+
+        The environment is resolved in this order:
+
+        1. **Explicit argument** — passed directly to `@track(environment=...)` or `client.trace(environment=...)`
+        2. **`OPIK_ENVIRONMENT` environment variable**
+
+        Using the `@track` decorator:
+
+        ```python
+        import opik
+
+        @opik.track(environment="production")
+        def my_pipeline(input_text: str) -> str:
+            return input_text
+
+        my_pipeline("Hello, world!")
+        ```
+
+        Using the low-level SDK:
+
+        ```python
+        from opik import Opik
+
+        client = Opik(project_name="my_project")
+
+        trace = client.trace(
+            name="my_trace",
+            input={"question": "Hello"},
+            environment="production",
+        )
+        trace.end()
+        ```
+
+        You can also set the environment via the `OPIK_ENVIRONMENT` environment variable instead of passing it explicitly to each call.
+
+    </Tab>
+</Tabs>
+
+#### Managing environments
+
+You can manage the set of named environments in your workspace programmatically:
+
+<Tabs>
+    <Tab title="Typescript" value="typescript" language="typescript">
+        ```typescript
+        import { Opik } from "opik";
+
+        const client = new Opik();
+
+        // Create a new environment
+        const env = await client.createEnvironment("production", {
+            description: "Live production traffic",
+            color: "#FF0000",
+        });
+
+        // List all environments
+        const envs = await client.getEnvironments();
+
+        // Update an environment
+        await client.updateEnvironment("production", { description: "Updated description" });
+
+        // Delete an environment
+        await client.deleteEnvironment("production");
+        ```
+    </Tab>
+    <Tab title="Python" value="python" language="python">
+        ```python
+        from opik import Opik
+
+        client = Opik()
+
+        # Create a new environment
+        env = client.create_environment(
+            name="production",
+            description="Live production traffic",
+            color="#FF0000",
+        )
+
+        # List all environments
+        envs = client.get_environments()
+
+        # Update an environment
+        client.update_environment("production", description="Updated description")
+
+        # Delete an environment
+        client.delete_environment("production")
+        ```
+    </Tab>
+</Tabs>
+
+#### Filtering by environment
+
+Once traces are tagged, you can filter them programmatically using the `environment` field in `filter_string`. It supports `=`, `!=`, `in`, and `not_in`:
+
+```python
+from opik import Opik
+
+client = Opik()
+
+# Only production traces
+traces = client.search_traces(
+    project_name="my_project",
+    filter_string='environment = "production"'
+)
+
+# Multiple environments
+traces = client.search_traces(
+    project_name="my_project",
+    filter_string='environment in ("production", "staging")'
+)
+
+# Same filtering applies to spans
+spans = client.search_spans(
+    project_name="my_project",
+    filter_string='environment = "production"'
+)
+
+# And to conversation threads
+threads = client.search_threads(
+    project_name="my_project",
+    filter_string='environment = "production"'
+)
+
+# Combine with other thread filters
+active_prod_threads = client.search_threads(
+    project_name="my_project",
+    filter_string='environment = "production" AND status = "active"'
+)
+```
+
 ### Flushing traces and spans
 
 This process is optional and is only needed if you are running a short-lived script or if you are

--- a/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/sdk_configuration.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/sdk_configuration.mdx
@@ -114,6 +114,7 @@ Both SDKs support environment variables for configuration. Here's a comparison o
 | API Key             | `OPIK_API_KEY`               | `OPIK_API_KEY`          | API key for Opik Cloud                         |
 | URL Override        | `OPIK_URL_OVERRIDE`          | `OPIK_URL_OVERRIDE`     | Opik server URL                                |
 | Project Name        | `OPIK_PROJECT_NAME`          | `OPIK_PROJECT_NAME`     | Project name                                   |
+| Environment         | `OPIK_ENVIRONMENT`           | `OPIK_ENVIRONMENT`      | Default environment tag for traces               |
 | Workspace           | `OPIK_WORKSPACE`             | `OPIK_WORKSPACE`        | Workspace name                                 |
 | Config Path         | `OPIK_CONFIG_PATH`           | `OPIK_CONFIG_PATH`      | Custom config file location                    |
 | Default LLM         | `OPIK_DEFAULT_LLM`           | N/A                     | Default model used by Python evaluation/simulation helpers |
@@ -434,6 +435,7 @@ await flushAll();
 | api_key                    | `OPIK_API_KEY`               | The API key - Only required for Opik Cloud                                |
 | workspace                  | `OPIK_WORKSPACE`             | The workspace name - Optional                                             |
 | project_name               | `OPIK_PROJECT_NAME`          | The project name to use                                                   |
+| N/A                        | `OPIK_ENVIRONMENT`           | Default environment tag attached to traces (e.g. `production`, `staging`) |
 | N/A                        | `OPIK_DEFAULT_LLM`           | Default LLM used by Python evaluation/simulation helpers - Defaults to `openai/gpt-5-nano` |
 | opik_track_disable         | `OPIK_TRACK_DISABLE`         | Disable tracking of traces and spans - Defaults to `false`                |
 | default_flush_timeout      | `OPIK_DEFAULT_FLUSH_TIMEOUT` | Default flush timeout - Defaults to no timeout                            |
@@ -450,6 +452,7 @@ await flushAll();
 | apiKey             | `OPIK_API_KEY`          | The API key - Required for Opik Cloud                                |
 | workspaceName      | `OPIK_WORKSPACE`        | The workspace name - Optional                                        |
 | projectName        | `OPIK_PROJECT_NAME`     | The project name - Defaults to `Default Project`                     |
+| environment        | `OPIK_ENVIRONMENT`      | Default environment tag for traces - Optional                        |
 | batchDelayMs       | `OPIK_BATCH_DELAY_MS`   | Batching delay in milliseconds - Defaults to `300`                   |
 | holdUntilFlush     | `OPIK_HOLD_UNTIL_FLUSH` | Hold data until manual flush - Defaults to `false`                   |
 | N/A                | `OPIK_LOG_LEVEL`        | Logging level - Defaults to `INFO`                                   |

--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -9758,6 +9758,10 @@ components:
         last_updated_by:
           type: string
           readOnly: true
+        action:
+          type: string
+          enum:
+          - evaluator
         type:
           type: string
           enum:
@@ -9767,10 +9771,6 @@ components:
           - trace_thread_user_defined_metric_python
           - span_llm_as_judge
           - span_user_defined_metric_python
-        action:
-          type: string
-          enum:
-          - evaluator
       discriminator:
         propertyName: type
         mapping:
@@ -10295,6 +10295,10 @@ components:
           format: float
         enabled:
           type: boolean
+        action:
+          type: string
+          enum:
+          - evaluator
         type:
           type: string
           enum:
@@ -10304,10 +10308,6 @@ components:
           - trace_thread_user_defined_metric_python
           - span_llm_as_judge
           - span_user_defined_metric_python
-        action:
-          type: string
-          enum:
-          - evaluator
       discriminator:
         propertyName: type
         mapping:
@@ -10650,6 +10650,10 @@ components:
         last_updated_by:
           type: string
           readOnly: true
+        action:
+          type: string
+          enum:
+          - evaluator
         type:
           type: string
           enum:
@@ -10659,10 +10663,6 @@ components:
           - trace_thread_user_defined_metric_python
           - span_llm_as_judge
           - span_user_defined_metric_python
-        action:
-          type: string
-          enum:
-          - evaluator
       discriminator:
         propertyName: type
         mapping:
@@ -11101,6 +11101,10 @@ components:
         last_updated_by:
           type: string
           readOnly: true
+        action:
+          type: string
+          enum:
+          - evaluator
         type:
           type: string
           enum:
@@ -11110,10 +11114,6 @@ components:
           - trace_thread_user_defined_metric_python
           - span_llm_as_judge
           - span_user_defined_metric_python
-        action:
-          type: string
-          enum:
-          - evaluator
       discriminator:
         propertyName: type
         mapping:
@@ -11195,6 +11195,10 @@ components:
             type: string
             description: Multiple project IDs (new field for multi-project support)
             format: uuid
+        action:
+          type: string
+          enum:
+          - evaluator
         type:
           type: string
           enum:
@@ -11204,10 +11208,6 @@ components:
           - trace_thread_user_defined_metric_python
           - span_llm_as_judge
           - span_user_defined_metric_python
-        action:
-          type: string
-          enum:
-          - evaluator
       discriminator:
         propertyName: type
         mapping:
@@ -17455,10 +17455,10 @@ components:
           type: string
           description: "Template structure type: 'text' or 'chat'. Immutable after\
             \ creation."
-          default: text
           enum:
           - text
           - chat
+          default: text
         tags:
           uniqueItems: true
           type: array
@@ -18066,10 +18066,10 @@ components:
           type: string
           description: "Template structure type: 'text' or 'chat'. Immutable after\
             \ creation."
-          default: text
           enum:
           - text
           - chat
+          default: text
         tags:
           uniqueItems: true
           type: array
@@ -18200,10 +18200,10 @@ components:
           type: string
           description: "Template structure type: 'text' or 'chat'. Immutable after\
             \ creation."
-          default: text
           enum:
           - text
           - chat
+          default: text
         tags:
           uniqueItems: true
           type: array
@@ -18296,10 +18296,10 @@ components:
             \ the given name already exists, this field is ignored and the existing\
             \ prompt's template structure is used. Template structure is immutable\
             \ after prompt creation."
-          default: text
           enum:
           - text
           - chat
+          default: text
         project_id:
           type: string
           description: Project ID. Takes precedence over project_name when both are
@@ -18335,10 +18335,10 @@ components:
           type: string
           description: "Template structure type: 'text' or 'chat'. Immutable after\
             \ creation."
-          default: text
           enum:
           - text
           - chat
+          default: text
         tags:
           uniqueItems: true
           type: array

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -9758,6 +9758,10 @@ components:
         last_updated_by:
           type: string
           readOnly: true
+        action:
+          type: string
+          enum:
+          - evaluator
         type:
           type: string
           enum:
@@ -9767,10 +9771,6 @@ components:
           - trace_thread_user_defined_metric_python
           - span_llm_as_judge
           - span_user_defined_metric_python
-        action:
-          type: string
-          enum:
-          - evaluator
       discriminator:
         propertyName: type
         mapping:
@@ -10295,6 +10295,10 @@ components:
           format: float
         enabled:
           type: boolean
+        action:
+          type: string
+          enum:
+          - evaluator
         type:
           type: string
           enum:
@@ -10304,10 +10308,6 @@ components:
           - trace_thread_user_defined_metric_python
           - span_llm_as_judge
           - span_user_defined_metric_python
-        action:
-          type: string
-          enum:
-          - evaluator
       discriminator:
         propertyName: type
         mapping:
@@ -10650,6 +10650,10 @@ components:
         last_updated_by:
           type: string
           readOnly: true
+        action:
+          type: string
+          enum:
+          - evaluator
         type:
           type: string
           enum:
@@ -10659,10 +10663,6 @@ components:
           - trace_thread_user_defined_metric_python
           - span_llm_as_judge
           - span_user_defined_metric_python
-        action:
-          type: string
-          enum:
-          - evaluator
       discriminator:
         propertyName: type
         mapping:
@@ -11101,6 +11101,10 @@ components:
         last_updated_by:
           type: string
           readOnly: true
+        action:
+          type: string
+          enum:
+          - evaluator
         type:
           type: string
           enum:
@@ -11110,10 +11114,6 @@ components:
           - trace_thread_user_defined_metric_python
           - span_llm_as_judge
           - span_user_defined_metric_python
-        action:
-          type: string
-          enum:
-          - evaluator
       discriminator:
         propertyName: type
         mapping:
@@ -11195,6 +11195,10 @@ components:
             type: string
             description: Multiple project IDs (new field for multi-project support)
             format: uuid
+        action:
+          type: string
+          enum:
+          - evaluator
         type:
           type: string
           enum:
@@ -11204,10 +11208,6 @@ components:
           - trace_thread_user_defined_metric_python
           - span_llm_as_judge
           - span_user_defined_metric_python
-        action:
-          type: string
-          enum:
-          - evaluator
       discriminator:
         propertyName: type
         mapping:
@@ -17455,10 +17455,10 @@ components:
           type: string
           description: "Template structure type: 'text' or 'chat'. Immutable after\
             \ creation."
-          default: text
           enum:
           - text
           - chat
+          default: text
         tags:
           uniqueItems: true
           type: array
@@ -18066,10 +18066,10 @@ components:
           type: string
           description: "Template structure type: 'text' or 'chat'. Immutable after\
             \ creation."
-          default: text
           enum:
           - text
           - chat
+          default: text
         tags:
           uniqueItems: true
           type: array
@@ -18200,10 +18200,10 @@ components:
           type: string
           description: "Template structure type: 'text' or 'chat'. Immutable after\
             \ creation."
-          default: text
           enum:
           - text
           - chat
+          default: text
         tags:
           uniqueItems: true
           type: array
@@ -18296,10 +18296,10 @@ components:
             \ the given name already exists, this field is ignored and the existing\
             \ prompt's template structure is used. Template structure is immutable\
             \ after prompt creation."
-          default: text
           enum:
           - text
           - chat
+          default: text
         project_id:
           type: string
           description: Project ID. Takes precedence over project_name when both are
@@ -18335,10 +18335,10 @@ components:
           type: string
           description: "Template structure type: 'text' or 'chat'. Immutable after\
             \ creation."
-          default: text
           enum:
           - text
           - chat
+          default: text
         tags:
           uniqueItems: true
           type: array

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -9758,10 +9758,6 @@ components:
         last_updated_by:
           type: string
           readOnly: true
-        action:
-          type: string
-          enum:
-          - evaluator
         type:
           type: string
           enum:
@@ -9771,6 +9767,10 @@ components:
           - trace_thread_user_defined_metric_python
           - span_llm_as_judge
           - span_user_defined_metric_python
+        action:
+          type: string
+          enum:
+          - evaluator
       discriminator:
         propertyName: type
         mapping:
@@ -10295,10 +10295,6 @@ components:
           format: float
         enabled:
           type: boolean
-        action:
-          type: string
-          enum:
-          - evaluator
         type:
           type: string
           enum:
@@ -10308,6 +10304,10 @@ components:
           - trace_thread_user_defined_metric_python
           - span_llm_as_judge
           - span_user_defined_metric_python
+        action:
+          type: string
+          enum:
+          - evaluator
       discriminator:
         propertyName: type
         mapping:
@@ -10650,10 +10650,6 @@ components:
         last_updated_by:
           type: string
           readOnly: true
-        action:
-          type: string
-          enum:
-          - evaluator
         type:
           type: string
           enum:
@@ -10663,6 +10659,10 @@ components:
           - trace_thread_user_defined_metric_python
           - span_llm_as_judge
           - span_user_defined_metric_python
+        action:
+          type: string
+          enum:
+          - evaluator
       discriminator:
         propertyName: type
         mapping:
@@ -11101,10 +11101,6 @@ components:
         last_updated_by:
           type: string
           readOnly: true
-        action:
-          type: string
-          enum:
-          - evaluator
         type:
           type: string
           enum:
@@ -11114,6 +11110,10 @@ components:
           - trace_thread_user_defined_metric_python
           - span_llm_as_judge
           - span_user_defined_metric_python
+        action:
+          type: string
+          enum:
+          - evaluator
       discriminator:
         propertyName: type
         mapping:
@@ -11195,10 +11195,6 @@ components:
             type: string
             description: Multiple project IDs (new field for multi-project support)
             format: uuid
-        action:
-          type: string
-          enum:
-          - evaluator
         type:
           type: string
           enum:
@@ -11208,6 +11204,10 @@ components:
           - trace_thread_user_defined_metric_python
           - span_llm_as_judge
           - span_user_defined_metric_python
+        action:
+          type: string
+          enum:
+          - evaluator
       discriminator:
         propertyName: type
         mapping:
@@ -17455,10 +17455,10 @@ components:
           type: string
           description: "Template structure type: 'text' or 'chat'. Immutable after\
             \ creation."
+          default: text
           enum:
           - text
           - chat
-          default: text
         tags:
           uniqueItems: true
           type: array
@@ -18066,10 +18066,10 @@ components:
           type: string
           description: "Template structure type: 'text' or 'chat'. Immutable after\
             \ creation."
+          default: text
           enum:
           - text
           - chat
-          default: text
         tags:
           uniqueItems: true
           type: array
@@ -18200,10 +18200,10 @@ components:
           type: string
           description: "Template structure type: 'text' or 'chat'. Immutable after\
             \ creation."
+          default: text
           enum:
           - text
           - chat
-          default: text
         tags:
           uniqueItems: true
           type: array
@@ -18296,10 +18296,10 @@ components:
             \ the given name already exists, this field is ignored and the existing\
             \ prompt's template structure is used. Template structure is immutable\
             \ after prompt creation."
+          default: text
           enum:
           - text
           - chat
-          default: text
         project_id:
           type: string
           description: Project ID. Takes precedence over project_name when both are
@@ -18335,10 +18335,10 @@ components:
           type: string
           description: "Template structure type: 'text' or 'chat'. Immutable after\
             \ creation."
+          default: text
           enum:
           - text
           - chat
-          default: text
         tags:
           uniqueItems: true
           type: array

--- a/sdks/python/src/opik/__init__.py
+++ b/sdks/python/src/opik/__init__.py
@@ -4,6 +4,7 @@ from .api_objects.annotation_queue import (
     ThreadsAnnotationQueue,
 )
 from .api_objects.attachment import Attachment
+from .rest_api.types.environment_public import EnvironmentPublic as Environment
 from .api_objects.dataset import Dataset
 from .api_objects.dataset.test_suite import TestSuite
 from .api_objects.dataset.test_suite.types import TestSuiteResult
@@ -53,6 +54,7 @@ __all__ = [
     "TracesAnnotationQueue",
     "ThreadsAnnotationQueue",
     "Attachment",
+    "Environment",
     "evaluate",
     "evaluate_prompt",
     "evaluate_experiment",

--- a/sdks/python/src/opik/api_objects/helpers.py
+++ b/sdks/python/src/opik/api_objects/helpers.py
@@ -90,6 +90,25 @@ def resolve_child_span_project_name(
     return project_name
 
 
+def resolve_child_span_environment(
+    parent_environment: Optional[str],
+    child_environment: Optional[str],
+    show_warning: bool = True,
+) -> Optional[str]:
+    if (
+        show_warning
+        and child_environment is not None
+        and child_environment != parent_environment
+    ):
+        LOGGER.warning(
+            logging_messages.NESTED_SPAN_ENVIRONMENT_MISMATCH_WARNING_MESSAGE.format(
+                child_environment,
+                parent_environment if parent_environment is not None else "",
+            )
+        )
+    return parent_environment
+
+
 def add_usage_to_metadata(
     usage: Optional[Dict[str, Any]],
     metadata: Optional[Dict[str, Any]],

--- a/sdks/python/src/opik/api_objects/observation_data.py
+++ b/sdks/python/src/opik/api_objects/observation_data.py
@@ -36,6 +36,7 @@ class ObservationData:
     error_info: Optional[ErrorInfoDict] = None
     attachments: Optional[List[attachment.Attachment]] = None
     source: TraceSource = "sdk"
+    environment: Optional[str] = None
 
     def update(self: ObservationDataT, **new_data: Any) -> ObservationDataT:
         """

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -375,6 +375,8 @@ class Opik:
         last_updated_at = datetime_helpers.local_timestamp()
 
         project_name = self._resolve_project_name(project_name)
+        if environment is None:
+            environment = self._config.environment
 
         create_trace_message = messages.CreateTraceMessage(
             trace_id=id,
@@ -600,6 +602,8 @@ class Opik:
         )
 
         project_name = self._resolve_project_name(project_name)
+        if environment is None:
+            environment = self._config.environment
 
         if trace_id is None:
             trace_id = id_helpers.generate_id()

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -1136,6 +1136,8 @@ class Opik:
         Returns the updated environment.
         """
         existing = self._find_environment_by_name(name)
+        if existing is None:
+            raise exceptions.OpikException(f"No environment found with name {name!r}.")
         self._rest_client.environments.update_environment(
             existing.id,
             description=description,
@@ -1145,29 +1147,17 @@ class Opik:
 
     def delete_environment(self, name: str) -> None:
         """Delete an environment by name. No-op if no matching environment exists."""
-        existing = self._find_environment_by_name(name, strict=False)
+        existing = self._find_environment_by_name(name)
         if existing is None:
             return
         self._rest_client.environments.delete_environments_batch(ids=[existing.id])
 
-    @overload
     def _find_environment_by_name(
-        self, name: str, strict: Literal[True] = True
-    ) -> environment_public.EnvironmentPublic: ...
-
-    @overload
-    def _find_environment_by_name(
-        self, name: str, strict: Literal[False]
-    ) -> Optional[environment_public.EnvironmentPublic]: ...
-
-    def _find_environment_by_name(
-        self, name: str, strict: bool = True
+        self, name: str
     ) -> Optional[environment_public.EnvironmentPublic]:
         for env in self.get_environments():
             if env.name == name:
                 return env
-        if strict:
-            raise exceptions.OpikException(f"No environment found with name {name!r}.")
         return None
 
     def get_dataset(

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -72,6 +72,7 @@ from ..message_processing.batching import sequence_splitter
 from ..message_processing.processors import message_processors_chain
 from ..message_processing.replay import replay_manager
 from ..rest_api import client as rest_api_client
+from ..rest_api import errors as rest_api_errors
 from ..rest_api.core.api_error import ApiError
 from ..rest_api.types import (
     environment_public,
@@ -1109,12 +1110,17 @@ class Opik:
             The created environment.
         """
         new_id = id_helpers.generate_id()
-        self._rest_client.environments.create_environment(
-            id=new_id,
-            name=name,
-            description=description,
-            color=color,
-        )
+        try:
+            self._rest_client.environments.create_environment(
+                id=new_id,
+                name=name,
+                description=description,
+                color=color,
+            )
+        except rest_api_errors.ConflictError:
+            raise exceptions.EnvironmentAlreadyExists(
+                f"Environment {name!r} already exists in this workspace."
+            )
         return self._rest_client.environments.get_environment_by_id(new_id)
 
     def get_environments(self) -> List[environment_public.EnvironmentPublic]:

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -74,6 +74,7 @@ from ..message_processing.replay import replay_manager
 from ..rest_api import client as rest_api_client
 from ..rest_api.core.api_error import ApiError
 from ..rest_api.types import (
+    environment_public,
     project_public,
     span_public,
     trace_public,
@@ -303,6 +304,7 @@ class Opik:
         error_info: Optional[ErrorInfoDict] = None,
         thread_id: Optional[str] = None,
         attachments: Optional[List[Attachment]] = None,
+        environment: Optional[str] = None,
         **ignored_kwargs: Any,
     ) -> trace_module.Trace:
         """
@@ -343,6 +345,7 @@ class Opik:
             thread_id=thread_id,
             attachments=attachments,
             source="sdk",
+            environment=environment,
         )
 
     def __internal_api__trace__(
@@ -361,6 +364,7 @@ class Opik:
         thread_id: Optional[str] = None,
         attachments: Optional[List[Attachment]] = None,
         source: TraceSource = "sdk",
+        environment: Optional[str] = None,
         **ignored_kwargs: Any,
     ) -> trace_module.Trace:
         id = id if id is not None else id_helpers.generate_id()
@@ -385,6 +389,7 @@ class Opik:
             thread_id=thread_id,
             last_updated_at=last_updated_at,
             source=source,
+            environment=environment,
         )
         self._streamer.put(create_trace_message)
         self._display_trace_url(trace_id=id, project_name=project_name)
@@ -416,6 +421,7 @@ class Opik:
             url_override=self._config.url_override,
             source=source,
             config=self._config,
+            environment=environment,
         )
 
     def copy_traces(
@@ -585,6 +591,7 @@ class Opik:
         total_cost: Optional[float] = None,
         attachments: Optional[List[Attachment]] = None,
         source: TraceSource = "sdk",
+        environment: Optional[str] = None,
     ) -> span_module.Span:
         id = id if id is not None else id_helpers.generate_id()
         start_time = (
@@ -611,6 +618,7 @@ class Opik:
                 thread_id=None,
                 last_updated_at=datetime_helpers.local_timestamp(),
                 source=source,
+                environment=environment,
             )
             self._streamer.put(create_trace_message)
 
@@ -645,6 +653,7 @@ class Opik:
             attachments=attachments,
             source=source,
             config=self._config,
+            environment=environment,
         )
 
     def update_span(
@@ -1007,6 +1016,7 @@ class Opik:
                 Supported columns:
                 - `id`: String (=, !=, contains, not_contains, starts_with, ends_with, >, <)
                 - `first_message`, `last_message`: String (=, !=, contains, not_contains, starts_with, ends_with, >, <)
+                - `environment`: Enum for lifecycle stage (=, !=, in, not_in)
                 - `status`: Enum (=, !=)
                 - `start_time`, `end_time`, `created_at`, `last_updated_at`: DateTime (=, !=, >, >=, <, <=)
                 - `feedback_scores`: Numeric with dot notation (=, !=, >, >=, <, <=, is_empty, is_not_empty)
@@ -1020,6 +1030,8 @@ class Opik:
                 - `first_message contains "hello"` - Filter by first message content
                 - `feedback_scores.user_frustration > 0.5` - Filter by feedback score
                 - `tags contains "important"` - Filter by tag
+                - `environment = "production"` - Filter by environment
+                - `environment in ("production", "staging")` - Filter by multiple environments
 
                 If not provided, all threads in the project will be returned up to the limit.
             max_results: The maximum number of threads to retrieve. The default value is 1000.
@@ -1079,6 +1091,84 @@ class Opik:
             id=span_id,
             name=name,
         )
+
+    def create_environment(
+        self,
+        name: str,
+        description: Optional[str] = None,
+        color: Optional[str] = None,
+    ) -> environment_public.EnvironmentPublic:
+        """Create a new environment in the current workspace.
+
+        Args:
+            name: Human-readable environment name (e.g. ``production``).
+            description: Optional description.
+            color: Optional color hex code used for UI display.
+
+        Returns:
+            The created environment.
+        """
+        new_id = id_helpers.generate_id()
+        self._rest_client.environments.create_environment(
+            id=new_id,
+            name=name,
+            description=description,
+            color=color,
+        )
+        return self._rest_client.environments.get_environment_by_id(new_id)
+
+    def get_environments(self) -> List[environment_public.EnvironmentPublic]:
+        """List environments in the current workspace.
+
+        The backend caps the response at the workspace limit (default 20).
+        """
+        page = self._rest_client.environments.find_environments()
+        return list(page.content or [])
+
+    def update_environment(
+        self,
+        name: str,
+        description: Optional[str] = None,
+        color: Optional[str] = None,
+    ) -> environment_public.EnvironmentPublic:
+        """Update the description and/or color of an environment, identified by name.
+
+        Returns the updated environment.
+        """
+        existing = self._find_environment_by_name(name)
+        self._rest_client.environments.update_environment(
+            existing.id,
+            description=description,
+            color=color,
+        )
+        return self._rest_client.environments.get_environment_by_id(existing.id)
+
+    def delete_environment(self, name: str) -> None:
+        """Delete an environment by name. No-op if no matching environment exists."""
+        existing = self._find_environment_by_name(name, strict=False)
+        if existing is None:
+            return
+        self._rest_client.environments.delete_environments_batch(ids=[existing.id])
+
+    @overload
+    def _find_environment_by_name(
+        self, name: str, strict: Literal[True] = True
+    ) -> environment_public.EnvironmentPublic: ...
+
+    @overload
+    def _find_environment_by_name(
+        self, name: str, strict: Literal[False]
+    ) -> Optional[environment_public.EnvironmentPublic]: ...
+
+    def _find_environment_by_name(
+        self, name: str, strict: bool = True
+    ) -> Optional[environment_public.EnvironmentPublic]:
+        for env in self.get_environments():
+            if env.name == name:
+                return env
+        if strict:
+            raise exceptions.OpikException(f"No environment found with name {name!r}.")
+        return None
 
     def get_dataset(
         self, name: str, project_name: Optional[str] = None
@@ -1753,6 +1843,7 @@ class Opik:
 
                 Supported columns include:
                 - `id`, `name`, `created_by`, `thread_id`, `type`, `model`, `provider`: String fields with full operator support
+                - `environment`: Enum field for lifecycle stage (=, !=, in, not_in)
                 - `status`: String field (=, contains, not_contains only)
                 - `start_time`, `end_time`: DateTime fields (use ISO 8601 format, e.g., "2024-01-01T00:00:00Z")
                 - `input`, `output`: String fields for content (=, contains, not_contains only)
@@ -1764,6 +1855,7 @@ class Opik:
 
                 Supported operators by column:
                 - `id`, `name`, `created_by`, `thread_id`, `type`, `model`, `provider`: =, !=, contains, not_contains, starts_with, ends_with, >, <
+                - `environment`: =, !=, in, not_in
                 - `status`: =, contains, not_contains
                 - `start_time`, `end_time`: =, >, <, >=, <=
                 - `input`, `output`: =, contains, not_contains
@@ -1783,6 +1875,8 @@ class Opik:
                 - `tags contains "production"` - Filter by tag
                 - `metadata.model = "gpt-4"` - Filter by metadata field
                 - `thread_id = "thread_123"` - Filter by thread ID
+                - `environment = "production"` - Filter by environment
+                - `environment in ("production", "staging")` - Filter by multiple environments
 
                 If not provided, all traces in the project will be returned up to the limit.
             max_results: The maximum number of traces to return.
@@ -1854,6 +1948,7 @@ class Opik:
 
                 Supported columns include:
                 - `id`, `name`, `created_by`, `thread_id`, `type`, `model`, `provider`: String fields with full operator support
+                - `environment`: Enum field for lifecycle stage (=, !=, in, not_in)
                 - `status`: String field (=, contains, not_contains only)
                 - `start_time`, `end_time`: DateTime fields (use ISO 8601 format, e.g., "2024-01-01T00:00:00Z")
                 - `input`, `output`: String fields for content (=, contains, not_contains only)
@@ -1865,6 +1960,7 @@ class Opik:
 
                 Supported operators by column:
                 - `id`, `name`, `created_by`, `thread_id`, `type`, `model`, `provider`: =, !=, contains, not_contains, starts_with, ends_with, >, <
+                - `environment`: =, !=, in, not_in
                 - `status`: =, contains, not_contains
                 - `start_time`, `end_time`: =, >, <, >=, <=
                 - `input`, `output`: =, contains, not_contains
@@ -1884,6 +1980,8 @@ class Opik:
                 - `tags contains "production"` - Filter by tag
                 - `metadata.model = "gpt-4"` - Filter by metadata field
                 - `thread_id = "thread_123"` - Filter by thread ID
+                - `environment = "production"` - Filter by environment
+                - `environment in ("production", "staging")` - Filter by multiple environments
 
                 If not provided, all spans in the project/trace will be returned up to the limit.
             max_results: The maximum number of spans to return.

--- a/sdks/python/src/opik/api_objects/opik_query_language.py
+++ b/sdks/python/src/opik/api_objects/opik_query_language.py
@@ -49,6 +49,7 @@ DICTIONARY_OPERATORS = [
     "<",
     "<=",
 ]
+ENUM_OPERATORS = ["=", "!=", "in", "not_in"]
 
 
 class OQLConfig(ABC):
@@ -107,6 +108,7 @@ class TraceOQLConfig(OQLConfig):
             "last_updated_at": "date_time",
             "annotation_queue_ids": "list",
             "experiment_id": "string",
+            "environment": "enum",
         }
 
     @property
@@ -119,6 +121,7 @@ class TraceOQLConfig(OQLConfig):
             "thread_id": STRING_OPERATORS,
             "guardrails": STRING_OPERATORS,
             "experiment_id": STRING_OPERATORS,
+            "environment": ENUM_OPERATORS,
             "start_time": DATE_TIME_OPERATORS,
             "end_time": DATE_TIME_OPERATORS,
             "created_at": DATE_TIME_OPERATORS,
@@ -182,6 +185,7 @@ class SpanOQLConfig(OQLConfig):
             "error_info": "error_container",
             "type": "enum",
             "trace_id": "string",
+            "environment": "enum",
         }
 
     @property
@@ -194,7 +198,8 @@ class SpanOQLConfig(OQLConfig):
             "model": STRING_OPERATORS,
             "provider": STRING_OPERATORS,
             "trace_id": STRING_OPERATORS,
-            "type": ["=", "!="],
+            "type": ENUM_OPERATORS,
+            "environment": ENUM_OPERATORS,
             "start_time": DATE_TIME_OPERATORS,
             "end_time": DATE_TIME_OPERATORS,
             "total_estimated_cost": NUMBER_OPERATORS,
@@ -239,6 +244,7 @@ class ThreadOQLConfig(OQLConfig):
             "status": "enum",
             "tags": "list",
             "annotation_queue_ids": "list",
+            "environment": "enum",
         }
 
     @property
@@ -254,9 +260,10 @@ class ThreadOQLConfig(OQLConfig):
             "start_time": DATE_TIME_OPERATORS,
             "end_time": DATE_TIME_OPERATORS,
             "feedback_scores": FEEDBACK_SCORES_OPERATORS,
-            "status": ["=", "!="],
+            "status": ENUM_OPERATORS,
             "tags": LIST_OPERATORS,
             "annotation_queue_ids": LIST_OPERATORS,
+            "environment": ENUM_OPERATORS,
             "default": STRING_OPERATORS,
         }
 
@@ -350,6 +357,7 @@ class PromptVersionOQLConfig(OQLConfig):
 
 
 OPERATORS_WITHOUT_VALUES = {"is_empty", "is_not_empty"}
+ARRAY_VALUE_OPERATORS = {"in", "not_in"}
 
 _DEFAULT_CONFIG = TraceOQLConfig()
 
@@ -661,6 +669,50 @@ class OpikQueryLanguage:
                 f'Invalid value {self.query_string[start : self._cursor]}, expected an string in double quotes("value") or a number'
             )
 
+    def _parse_array_value(self) -> Dict[str, Any]:
+        self._skip_whitespace()
+
+        if (
+            self._cursor >= len(self.query_string)
+            or self.query_string[self._cursor] != "("
+        ):
+            raise ValueError(
+                f"Expected array value starting with '(' for in/not_in operator, got: {self.query_string[self._cursor :]!r}"
+            )
+        self._cursor += 1  # skip '('
+
+        items: List[str] = []
+        while True:
+            self._skip_whitespace()
+            if self._cursor >= len(self.query_string):
+                raise ValueError("Unterminated array value, missing ')'")
+            if self.query_string[self._cursor] == ")":
+                if not items:
+                    raise ValueError(
+                        "Expected at least one item inside (...) for in/not_in operator"
+                    )
+                self._cursor += 1
+                break
+            if items:
+                if self.query_string[self._cursor] != ",":
+                    raise ValueError(
+                        f"Expected ',' between array elements, got: {self.query_string[self._cursor :]!r}"
+                    )
+                self._cursor += 1
+                self._skip_whitespace()
+
+            if (
+                self._cursor >= len(self.query_string)
+                or self.query_string[self._cursor] != '"'
+            ):
+                raise ValueError(
+                    f"Array elements must be quoted strings, got: {self.query_string[self._cursor :]!r}"
+                )
+            parsed = self._parse_value()
+            items.append(parsed["value"])
+
+        return {"value": ",".join(items)}
+
     def _parse_expressions(self) -> Optional[List[Dict[str, Any]]]:
         if len(self.query_string) == 0:
             return None
@@ -676,8 +728,9 @@ class OpikQueryLanguage:
 
             operator_name = parsed_operator.get("operator", "")
             if operator_name in OPERATORS_WITHOUT_VALUES:
-                # For operators without values, use empty string as value
                 parsed_value = {"value": ""}
+            elif operator_name in ARRAY_VALUE_OPERATORS:
+                parsed_value = self._parse_array_value()
             else:
                 parsed_value = self._parse_value()
 

--- a/sdks/python/src/opik/api_objects/span/span_client.py
+++ b/sdks/python/src/opik/api_objects/span/span_client.py
@@ -34,6 +34,7 @@ class Span:
         source: TraceSource,
         parent_span_id: Optional[str] = None,
         config: Optional[opik_config.OpikConfig] = None,
+        environment: Optional[str] = None,
     ):
         """
         A Span object. This object should not be created directly, instead use the `span` method of a Trace (:func:`opik.Opik.span`) or another Span (:meth:`opik.Span.span`).
@@ -46,6 +47,7 @@ class Span:
         self._url_override = url_override
         self.source = source
         self._config = config
+        self._environment = environment
 
     def end(
         self,
@@ -280,6 +282,7 @@ class Span:
             attachments=attachments,
             source=self.source,
             config=self._config,
+            environment=self._environment,
         )
 
     def log_feedback_score(
@@ -348,6 +351,7 @@ def create_span(
     attachments: Optional[List[attachment.Attachment]] = None,
     source: TraceSource = "sdk",
     config: Optional[opik_config.OpikConfig] = None,
+    environment: Optional[str] = None,
 ) -> Span:
     span_id = span_id if span_id is not None else id_helpers.generate_id()
     start_time = (
@@ -383,6 +387,7 @@ def create_span(
         total_cost=total_cost,
         last_updated_at=datetime_helpers.local_timestamp(),
         source=source,
+        environment=environment,
     )
     message_streamer.put(create_span_message)
 
@@ -406,6 +411,7 @@ def create_span(
         url_override=url_override,
         source=source,
         config=config,
+        environment=environment,
     )
 
 

--- a/sdks/python/src/opik/api_objects/span/span_data.py
+++ b/sdks/python/src/opik/api_objects/span/span_data.py
@@ -72,6 +72,7 @@ class SpanData(ObservationData):
             total_cost=total_cost,
             attachments=attachments,
             source=self.source,
+            environment=self.environment,
         )
 
     @property
@@ -95,6 +96,8 @@ class SpanData(ObservationData):
             start_parameters["metadata"] = self.metadata
         if self.tags is not None:
             start_parameters["tags"] = self.tags
+        if self.environment is not None:
+            start_parameters["environment"] = self.environment
 
         return start_parameters
 
@@ -122,6 +125,7 @@ class SpanData(ObservationData):
             "total_cost": self.total_cost,
             "attachments": self.attachments,
             "source": self.source,
+            "environment": self.environment,
         }
 
     def get_distributed_trace_headers(self) -> DistributedTraceHeadersDict:

--- a/sdks/python/src/opik/api_objects/trace/trace_client.py
+++ b/sdks/python/src/opik/api_objects/trace/trace_client.py
@@ -22,6 +22,7 @@ class Trace:
         url_override: str,
         source: TraceSource,
         config: opik_config.OpikConfig,
+        environment: Optional[str] = None,
     ):
         """
         A Trace object. This object should not be created directly, instead use :meth:`opik.Opik.trace` to create a new trace.
@@ -32,6 +33,7 @@ class Trace:
         self._url_override = url_override
         self.source = source
         self._config = config
+        self._environment = environment
 
     def end(
         self,
@@ -229,6 +231,7 @@ class Trace:
             attachments=attachments,
             source=self.source,
             config=self._config,
+            environment=self._environment,
         )
 
     def log_feedback_score(

--- a/sdks/python/src/opik/api_objects/trace/trace_data.py
+++ b/sdks/python/src/opik/api_objects/trace/trace_data.py
@@ -68,6 +68,7 @@ class TraceData(ObservationData):
             total_cost=total_cost,
             attachments=attachments,
             source=self.source,
+            environment=self.environment,
         )
 
     @property
@@ -87,6 +88,8 @@ class TraceData(ObservationData):
             start_parameters["metadata"] = self.metadata
         if self.tags is not None:
             start_parameters["tags"] = self.tags
+        if self.environment is not None:
+            start_parameters["environment"] = self.environment
 
         return start_parameters
 
@@ -108,4 +111,5 @@ class TraceData(ObservationData):
             "thread_id": self.thread_id,
             "attachments": self.attachments,
             "source": self.source,
+            "environment": self.environment,
         }

--- a/sdks/python/src/opik/cli/exports/trace_filter.py
+++ b/sdks/python/src/opik/cli/exports/trace_filter.py
@@ -115,6 +115,10 @@ def matches_trace_filter(trace_dict: dict, filter_string: str) -> bool:
                 result = fv_str.startswith(value)
             elif operator == "ends_with":
                 result = fv_str.endswith(value)
+            elif operator == "in":
+                result = fv_str in value.split(",")
+            elif operator == "not_in":
+                result = fv_str not in value.split(",")
             else:
                 result = _compare_values(fv_str, operator, value)
 

--- a/sdks/python/src/opik/config.py
+++ b/sdks/python/src/opik/config.py
@@ -286,6 +286,13 @@ class OpikConfig(pydantic_settings.BaseSettings):
     This is to control the number of times unauthorized message types are retried before giving up. If None, there is no limit.
     """
 
+    environment: Optional[str] = None
+    """
+    Default environment name applied to traces and spans when no explicit
+    ``environment=`` argument is provided.
+    Env var: OPIK_ENVIRONMENT
+    """
+
     suppress_batching_update_warning: bool = False
     """
     Suppress the warning about potential data loss when calling .end() or .update()

--- a/sdks/python/src/opik/decorator/arguments_helpers.py
+++ b/sdks/python/src/opik/decorator/arguments_helpers.py
@@ -54,6 +54,7 @@ class StartSpanParameters(BaseArguments):
     model: Optional[str] = None
     provider: Optional[str] = None
     thread_id: Optional[str] = None  # used for traces only
+    environment: Optional[str] = None
 
 
 @dataclasses.dataclass
@@ -74,6 +75,7 @@ class TrackOptions(BaseArguments):
     project_name: Optional[str]
     create_duplicate_root_span: bool
     source: Optional[TraceSource]
+    environment: Optional[str] = None
 
 
 def create_span_data(
@@ -96,6 +98,7 @@ def create_span_data(
         model=start_span_arguments.model,
         provider=start_span_arguments.provider,
         source=source if source is not None else "sdk",
+        environment=start_span_arguments.environment,
     )
     return span_data
 

--- a/sdks/python/src/opik/decorator/base_track_decorator.py
+++ b/sdks/python/src/opik/decorator/base_track_decorator.py
@@ -72,6 +72,7 @@ class BaseTrackDecorator(abc.ABC):
         create_duplicate_root_span: bool = True,
         entrypoint: bool = False,
         source: Optional[TraceSource] = None,
+        environment: Optional[str] = None,
     ) -> Union[Callable, Callable[[Callable], Callable]]:
         """
         Decorator to track the execution of a function.
@@ -121,6 +122,7 @@ class BaseTrackDecorator(abc.ABC):
             project_name=project_name,
             create_duplicate_root_span=create_duplicate_root_span,
             source=source,
+            environment=environment,
         )
 
         if callable(name):

--- a/sdks/python/src/opik/decorator/span_creation_handler.py
+++ b/sdks/python/src/opik/decorator/span_creation_handler.py
@@ -64,6 +64,17 @@ def create_span_respecting_context(
             )
         start_span_arguments.project_name = context_project
 
+    # Mirror the project_name pattern: if a local parent span already carries an
+    # environment, that value wins (with a warning on mismatch); if there is no
+    # local context the caller-supplied environment passes through as-is.
+    local_parent = opik_context_storage.top_span_data()
+    if local_parent is not None:
+        start_span_arguments.environment = helpers.resolve_child_span_environment(
+            parent_environment=local_parent.environment,
+            child_environment=start_span_arguments.environment,
+            show_warning=True,
+        )
+
     if distributed_trace_headers:
         span_data = arguments_helpers.create_span_data(
             start_span_arguments=start_span_arguments,
@@ -96,6 +107,14 @@ def create_span_respecting_context(
 
         start_span_arguments.project_name = project_name
 
+        # A span inherits its parent's environment unconditionally — we warn (just
+        # like project_name) when a nested @track tries to override it.
+        start_span_arguments.environment = helpers.resolve_child_span_environment(
+            parent_environment=current_span_data.environment,
+            child_environment=start_span_arguments.environment,
+            show_warning=show_warning,
+        )
+
         span_data = arguments_helpers.create_span_data(
             start_span_arguments=start_span_arguments,
             parent_span_id=current_span_data.id,
@@ -119,6 +138,12 @@ def create_span_respecting_context(
 
         start_span_arguments.project_name = project_name
 
+        start_span_arguments.environment = helpers.resolve_child_span_environment(
+            parent_environment=current_trace_data.environment,
+            child_environment=start_span_arguments.environment,
+            show_warning=current_trace_data.created_by != "evaluation",
+        )
+
         span_data = arguments_helpers.create_span_data(
             start_span_arguments=start_span_arguments,
             parent_span_id=None,
@@ -141,6 +166,7 @@ def create_span_respecting_context(
             project_name=start_span_arguments.project_name,
             thread_id=start_span_arguments.thread_id,
             source=source if source is not None else "sdk",
+            environment=start_span_arguments.environment,
         )
 
         current_span_data = arguments_helpers.create_span_data(

--- a/sdks/python/src/opik/decorator/tracker.py
+++ b/sdks/python/src/opik/decorator/tracker.py
@@ -44,6 +44,7 @@ class OpikTrackDecorator(base_track_decorator.BaseTrackDecorator):
             tags=track_options.tags,
             metadata=track_options.metadata,
             project_name=track_options.project_name,
+            environment=track_options.environment,
         )
 
         return result

--- a/sdks/python/src/opik/exceptions.py
+++ b/sdks/python/src/opik/exceptions.py
@@ -193,6 +193,12 @@ class ConfigMismatch(OpikException):
     pass
 
 
+class EnvironmentAlreadyExists(OpikException):
+    """Raised when creating an environment whose name is already taken in the workspace."""
+
+    pass
+
+
 class LLMJudgeParseError(OpikException):
     """Raised when LLMJudge output fails validation.
 

--- a/sdks/python/src/opik/logging_messages.py
+++ b/sdks/python/src/opik/logging_messages.py
@@ -56,6 +56,11 @@ NESTED_SPAN_PROJECT_NAME_MISMATCH_WARNING_MESSAGE = (
     'However, the project name "{}" from parent span will be used instead.'
 )
 
+NESTED_SPAN_ENVIRONMENT_MISMATCH_WARNING_MESSAGE = (
+    'You are attempting to log data into a nested span under the environment "{}". '
+    'However, the environment "{}" from the parent trace will be used instead.'
+)
+
 PARSE_API_KEY_EMPTY_KEY = "Can not parse empty Opik API key"
 
 PARSE_API_KEY_EMPTY_EXPECTED_ATTRIBUTES = (

--- a/sdks/python/src/opik/message_processing/emulation/emulator_message_processor.py
+++ b/sdks/python/src/opik/message_processing/emulation/emulator_message_processor.py
@@ -339,6 +339,7 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
         thread_id: Optional[str],
         source: TraceSource,
         last_updated_at: Optional[datetime.datetime] = None,
+        environment: Optional[str] = None,
     ) -> models.TraceModel:
         """
         Creates a trace model with the specified attributes. The method is abstract and must be
@@ -396,6 +397,7 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
         total_cost: Optional[float],
         last_updated_at: Optional[datetime.datetime],
         source: TraceSource,
+        environment: Optional[str] = None,
     ) -> models.SpanModel:
         """
         Abstract method to create a span model representing a span of a trace.
@@ -498,6 +500,7 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
             feedback_scores=None,
             spans=None,
             source=message.source,
+            environment=message.environment,
         )
 
         self._save_trace(trace)
@@ -523,6 +526,7 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
             spans=None,
             feedback_scores=None,
             source=message.source,
+            environment=message.environment,
         )
 
         self._save_span(
@@ -638,6 +642,7 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
             feedback_scores=None,
             error_info=error_info,
             source=message.source,
+            environment=message.environment,
         )
 
         self._save_span(
@@ -676,6 +681,7 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
             feedback_scores=None,
             error_info=error_info,
             source=message.source,
+            environment=message.environment,
         )
         self._save_trace(trace)
 

--- a/sdks/python/src/opik/message_processing/emulation/local_emulator_message_processor.py
+++ b/sdks/python/src/opik/message_processing/emulation/local_emulator_message_processor.py
@@ -76,6 +76,7 @@ class LocalEmulatorMessageProcessor(
         thread_id: Optional[str],
         source: TraceSource,
         last_updated_at: Optional[datetime.datetime] = None,
+        environment: Optional[str] = None,
     ) -> models.TraceModel:
         if spans is None:
             spans = []
@@ -98,6 +99,7 @@ class LocalEmulatorMessageProcessor(
             thread_id=thread_id,
             last_updated_at=last_updated_at,
             source=source,
+            environment=environment,
         )
 
     def create_span_model(
@@ -121,6 +123,7 @@ class LocalEmulatorMessageProcessor(
         total_cost: Optional[float],
         last_updated_at: Optional[datetime.datetime],
         source: TraceSource,
+        environment: Optional[str] = None,
     ) -> models.SpanModel:
         if spans is None:
             spans = []
@@ -147,6 +150,7 @@ class LocalEmulatorMessageProcessor(
             total_cost=total_cost,
             last_updated_at=last_updated_at,
             source=source,
+            environment=environment,
         )
 
     def create_feedback_score_model(

--- a/sdks/python/src/opik/message_processing/emulation/models.py
+++ b/sdks/python/src/opik/message_processing/emulation/models.py
@@ -108,6 +108,7 @@ class SpanModel:
     total_cost: Optional[float] = None
     last_updated_at: Optional[datetime.datetime] = None
     attachments: Optional[List[AttachmentModel]] = None
+    environment: Optional[str] = None
 
 
 @dataclasses.dataclass
@@ -185,3 +186,4 @@ class TraceModel:
     thread_id: Optional[str] = None
     last_updated_at: Optional[datetime.datetime] = None
     attachments: Optional[List[AttachmentModel]] = None
+    environment: Optional[str] = None

--- a/sdks/python/src/opik/message_processing/messages.py
+++ b/sdks/python/src/opik/message_processing/messages.py
@@ -87,6 +87,7 @@ class CreateTraceMessage(BaseMessage):
     thread_id: Optional[str]
     last_updated_at: Optional[datetime.datetime]
     source: TraceSource
+    environment: Optional[str] = None
 
     message_type = "CreateTraceMessage"
 
@@ -122,6 +123,7 @@ class UpdateTraceMessage(BaseMessage):
     error_info: Optional[ErrorInfoDict]
     thread_id: Optional[str]
     source: str
+    environment: Optional[str] = None
 
     message_type = "UpdateTraceMessage"
 
@@ -162,6 +164,7 @@ class CreateSpanMessage(BaseMessage):
     total_cost: Optional[float]
     last_updated_at: Optional[datetime.datetime]
     source: TraceSource
+    environment: Optional[str] = None
 
     message_type = "CreateSpanMessage"
 
@@ -201,6 +204,7 @@ class UpdateSpanMessage(BaseMessage):
     error_info: Optional[ErrorInfoDict]
     total_cost: Optional[float]
     source: str
+    environment: Optional[str] = None
 
     message_type = "UpdateSpanMessage"
 

--- a/sdks/python/tests/e2e/conftest.py
+++ b/sdks/python/tests/e2e/conftest.py
@@ -86,6 +86,21 @@ def prompt_name():
 
 
 @pytest.fixture
+def environment_name(opik_client: opik.Opik):
+    """A unique environment name for the test; the environment is deleted on teardown.
+
+    Environments are workspace-capped (default 20), so leaking them across runs
+    quickly fills the cap. Cleanup is best-effort — ``delete_environment`` is a
+    no-op if the test never created it."""
+    name = f"e2e-tests-environment-{random_chars()}"
+    yield name
+    try:
+        opik_client.delete_environment(name)
+    except rest_api_core.ApiError:
+        pass
+
+
+@pytest.fixture
 def temporary_project_name(opik_client: opik.Opik):
     """A unique project name for the test; the project is deleted on teardown.
 

--- a/sdks/python/tests/e2e/test_environment.py
+++ b/sdks/python/tests/e2e/test_environment.py
@@ -1,0 +1,112 @@
+"""End-to-end tests for the SDK ``environment`` feature.
+
+Exercises:
+- Environment CRUD round-trip via the Opik client.
+- Per-call ``environment=`` on ``Opik.trace`` is persisted on the trace, and
+  spans (manual + ``@track``) inherit that value from the parent trace.
+- Backwards compat: existing call sites without environment still log successfully.
+"""
+
+from typing import Dict
+
+import opik
+from opik import id_helpers
+from . import verifiers
+from ..testlib import generate_project_name
+
+
+PROJECT_NAME = generate_project_name("e2e", __name__)
+
+
+def test_environment_crud__round_trip(opik_client: opik.Opik, environment_name: str):
+    created = opik_client.create_environment(
+        name=environment_name,
+        description="created by SDK e2e test",
+        color="#abcdef",
+    )
+    assert created.name == environment_name
+    assert created.description == "created by SDK e2e test"
+    assert created.color == "#abcdef"
+    assert created.id is not None
+
+    listed = opik_client.get_environments()
+    assert any(env.name == environment_name for env in listed)
+
+    updated = opik_client.update_environment(
+        environment_name, description="updated by SDK e2e test"
+    )
+    assert updated.description == "updated by SDK e2e test"
+    assert updated.name == environment_name
+
+    opik_client.delete_environment(environment_name)
+
+    # Calling delete on a missing name is a no-op.
+    opik_client.delete_environment(environment_name)
+
+
+def test_trace__environment_kwarg_is_persisted_on_the_trace(
+    opik_client: opik.Opik, environment_name: str
+):
+    opik_client.create_environment(name=environment_name)
+
+    trace_id = id_helpers.generate_id()
+    opik_client.trace(
+        id=trace_id,
+        name="env-trace",
+        project_name=PROJECT_NAME,
+        environment=environment_name,
+    )
+    opik_client.flush()
+
+    verifiers.verify_trace(
+        opik_client=opik_client,
+        trace_id=trace_id,
+        project_name=PROJECT_NAME,
+        environment=environment_name,
+    )
+
+
+def test_span__inherits_trace_environment_and_ignores_per_call_override(
+    opik_client: opik.Opik, environment_name: str
+):
+    """A span persists its parent trace's environment. Once the trace is open
+    with an environment, an inner ``@track`` cannot override it — the inner
+    span's per-call ``environment=`` is ignored and it inherits the trace's
+    environment."""
+    opik_client.create_environment(name=environment_name)
+
+    captured: Dict[str, str] = {}
+
+    @opik.track(name="inner-fn", environment="this-should-be-ignored")
+    def inner():
+        ctx = opik.opik_context.get_current_span_data()
+        captured["span_id"] = ctx.id
+        captured["trace_id"] = ctx.trace_id
+        captured["parent_span_id"] = ctx.parent_span_id
+
+    @opik.track(name="outer-fn", environment=environment_name)
+    def outer():
+        inner()
+
+    outer()
+    opik.flush_tracker()
+
+    verifiers.verify_span(
+        opik_client=opik_client,
+        span_id=captured["span_id"],
+        trace_id=captured["trace_id"],
+        parent_span_id=captured["parent_span_id"],
+        environment=environment_name,
+    )
+
+
+def test_trace_without_environment__still_works_for_backwards_compat(
+    opik_client: opik.Opik,
+):
+    trace_id = id_helpers.generate_id()
+    opik_client.trace(id=trace_id, name="no-env-trace", project_name=PROJECT_NAME)
+    opik_client.flush()
+
+    verifiers.verify_trace(
+        opik_client=opik_client, trace_id=trace_id, project_name=PROJECT_NAME
+    )

--- a/sdks/python/tests/e2e/verifiers.py
+++ b/sdks/python/tests/e2e/verifiers.py
@@ -103,6 +103,7 @@ def verify_trace(
     thread_id: Optional[str] = mock.ANY,  # type: ignore
     guardrails_validations: Optional[List[Dict[str, Any]]] = mock.ANY,  # type: ignore
     source: Optional[TraceSource] = mock.ANY,  # type: ignore
+    environment: Optional[str] = mock.ANY,  # type: ignore
 ):
     def _check() -> None:
         trace = opik_client.get_trace_content(id=trace_id)
@@ -113,6 +114,9 @@ def verify_trace(
         testlib.assert_equal(output, trace.output)
         testlib.assert_equal(metadata, trace.metadata)
         testlib.assert_equal(source, trace.source)
+
+        if environment is not mock.ANY:
+            testlib.assert_equal(environment, trace.environment)
 
         if tags is not mock.ANY:
             testlib.assert_equal(_try_build_set(tags), _try_build_set(trace.tags))
@@ -186,6 +190,7 @@ def verify_span(
     error_info: Optional[ErrorInfoDict] = mock.ANY,  # type: ignore
     total_cost: Optional[float] = mock.ANY,  # type: ignore
     source: Optional[TraceSource] = mock.ANY,  # type: ignore
+    environment: Optional[str] = mock.ANY,  # type: ignore
 ):
     def _check() -> None:
         span = opik_client.get_span_content(id=span_id)
@@ -209,6 +214,9 @@ def verify_span(
         testlib.assert_equal(output, span.output)
         testlib.assert_equal(metadata, span.metadata)
         testlib.assert_equal(source, span.source)
+
+        if environment is not mock.ANY:
+            testlib.assert_equal(environment, span.environment)
 
         if tags is not mock.ANY:
             testlib.assert_equal(_try_build_set(tags), _try_build_set(span.tags))

--- a/sdks/python/tests/testlib/backend_emulator_message_processor.py
+++ b/sdks/python/tests/testlib/backend_emulator_message_processor.py
@@ -48,6 +48,7 @@ class BackendEmulatorMessageProcessor(
         thread_id: Optional[str],
         source: TraceSource,
         last_updated_at: Optional[datetime.datetime] = None,
+        environment: Optional[str] = None,
     ) -> models.TraceModel:
         if spans is None:
             spans = []
@@ -70,6 +71,7 @@ class BackendEmulatorMessageProcessor(
             thread_id=thread_id,
             last_updated_at=last_updated_at,
             source=source,
+            environment=environment,
         )
 
     def create_span_model(
@@ -93,6 +95,7 @@ class BackendEmulatorMessageProcessor(
         total_cost: Optional[float],
         last_updated_at: Optional[datetime.datetime],
         source: TraceSource,
+        environment: Optional[str] = None,
     ) -> models.SpanModel:
         if spans is None:
             spans = []
@@ -119,6 +122,7 @@ class BackendEmulatorMessageProcessor(
             total_cost=total_cost,
             last_updated_at=last_updated_at,
             source=source,
+            environment=environment,
         )
 
     def create_feedback_score_model(

--- a/sdks/python/tests/unit/api_objects/test_environment.py
+++ b/sdks/python/tests/unit/api_objects/test_environment.py
@@ -161,6 +161,25 @@ def test_create_trace_message__environment_field_default_is_none_for_backwards_c
     assert msg.environment is None
 
 
+def test_create_environment__conflict_raises_environment_already_exists():
+    from unittest.mock import patch
+    from opik.exceptions import EnvironmentAlreadyExists
+    from opik.rest_api.errors import ConflictError
+
+    client = opik_client.Opik(project_name="test-project")
+
+    with patch.object(
+        client._rest_client.environments,
+        "create_environment",
+        side_effect=ConflictError(body={"message": "already exists"}),
+    ):
+        try:
+            client.create_environment("production")
+            assert False, "expected EnvironmentAlreadyExists"
+        except EnvironmentAlreadyExists as e:
+            assert "production" in str(e)
+
+
 def test_create_span_message__environment_field_default_is_none_for_backwards_compat():
     msg = messages.CreateSpanMessage(
         span_id="s",

--- a/sdks/python/tests/unit/api_objects/test_environment.py
+++ b/sdks/python/tests/unit/api_objects/test_environment.py
@@ -1,0 +1,186 @@
+"""Unit tests for the SDK ``environment`` plumbing.
+
+Covers:
+- ``Opik.trace(environment=...)`` is the only entry point that accepts an
+  explicit environment; the value flows into the emitted ``CreateTraceMessage``.
+- Spans (``Trace.span``, ``Span.span``, ``@track``-created spans) inherit the
+  parent trace's environment unconditionally.
+- A nested ``@track(environment=...)`` whose value differs from the enclosing
+  trace's environment logs a warning and is ignored — the parent trace's value
+  wins (mirrors how mismatched ``project_name`` is handled).
+- Backwards compat: existing call sites without ``environment`` still work.
+"""
+
+from unittest.mock import MagicMock
+
+import opik
+from opik.api_objects import opik_client
+from opik.message_processing import messages
+from opik import dict_utils
+
+
+def _capture_messages(client: opik_client.Opik) -> MagicMock:
+    mock_streamer = MagicMock()
+    client._streamer = mock_streamer
+    return mock_streamer
+
+
+def _create_trace_messages(streamer: MagicMock):
+    return [
+        c.args[0]
+        for c in streamer.put.call_args_list
+        if isinstance(c.args[0], messages.CreateTraceMessage)
+    ]
+
+
+def _create_span_messages(streamer: MagicMock):
+    return [
+        c.args[0]
+        for c in streamer.put.call_args_list
+        if isinstance(c.args[0], messages.CreateSpanMessage)
+    ]
+
+
+def test_opik_client__no_environment_set__messages_have_none_environment_and_payload_omits_it():
+    client = opik_client.Opik(project_name="test-project")
+    streamer = _capture_messages(client)
+
+    client.trace(name="t")
+    client.span(name="s")
+
+    trace_msg = _create_trace_messages(streamer)[0]
+    span_msg = _create_span_messages(streamer)[0]
+
+    assert trace_msg.environment is None
+    assert span_msg.environment is None
+
+    cleaned = dict_utils.remove_none_from_dict(trace_msg.as_payload_dict())
+    assert "environment" not in cleaned
+
+
+def test_opik_client_trace__environment_kwarg_propagates_to_create_trace_message():
+    client = opik_client.Opik(project_name="test-project")
+    streamer = _capture_messages(client)
+
+    client.trace(name="t", environment="staging")
+
+    assert _create_trace_messages(streamer)[0].environment == "staging"
+
+
+def test_opik_client_trace__span_inherits_trace_environment():
+    client = opik_client.Opik(project_name="test-project")
+    streamer = _capture_messages(client)
+
+    trace = client.trace(name="t", environment="staging")
+    trace.span(name="s")
+
+    assert _create_span_messages(streamer)[0].environment == "staging"
+
+
+def test_opik_client_trace__nested_span_inherits_environment():
+    client = opik_client.Opik(project_name="test-project")
+    streamer = _capture_messages(client)
+
+    trace = client.trace(name="t", environment="staging")
+    span = trace.span(name="parent-span")
+    span.span(name="child-span")
+
+    span_msgs = _create_span_messages(streamer)
+    assert len(span_msgs) == 2
+    assert all(m.environment == "staging" for m in span_msgs)
+
+
+def test_track_decorator__environment_propagates_to_root_trace_and_spans():
+    client = opik_client.Opik(project_name="test-project")
+    streamer = _capture_messages(client)
+    opik_client.set_global_client(client)
+
+    @opik.track(environment="staging")
+    def my_fn():
+        return 42
+
+    my_fn()
+
+    trace_msgs = _create_trace_messages(streamer)
+    span_msgs = _create_span_messages(streamer)
+    assert trace_msgs and span_msgs
+    assert all(m.environment == "staging" for m in trace_msgs)
+    assert all(m.environment == "staging" for m in span_msgs)
+
+
+def test_track_decorator__nested_environment_mismatch_warns_and_inherits_parent(
+    monkeypatch,
+):
+    from opik.api_objects import helpers as opik_helpers
+
+    client = opik_client.Opik(project_name="test-project")
+    streamer = _capture_messages(client)
+    opik_client.set_global_client(client)
+
+    warnings = []
+    monkeypatch.setattr(
+        opik_helpers.LOGGER,
+        "warning",
+        lambda msg, *a, **kw: warnings.append(msg % a if a else msg),
+    )
+
+    @opik.track(environment="this-should-be-ignored")
+    def inner():
+        return 1
+
+    @opik.track(environment="staging")
+    def outer():
+        return inner()
+
+    outer()
+
+    span_msgs = _create_span_messages(streamer)
+    assert span_msgs
+    assert all(m.environment == "staging" for m in span_msgs)
+    assert any("this-should-be-ignored" in w and "staging" in w for w in warnings), (
+        warnings
+    )
+
+
+def test_create_trace_message__environment_field_default_is_none_for_backwards_compat():
+    msg = messages.CreateTraceMessage(
+        trace_id="t",
+        project_name="p",
+        name=None,
+        start_time=None,  # type: ignore[arg-type]
+        end_time=None,
+        input=None,
+        output=None,
+        metadata=None,
+        tags=None,
+        error_info=None,
+        thread_id=None,
+        last_updated_at=None,
+        source="sdk",
+    )
+    assert msg.environment is None
+
+
+def test_create_span_message__environment_field_default_is_none_for_backwards_compat():
+    msg = messages.CreateSpanMessage(
+        span_id="s",
+        trace_id="t",
+        project_name="p",
+        parent_span_id=None,
+        name=None,
+        start_time=None,  # type: ignore[arg-type]
+        end_time=None,
+        input=None,
+        output=None,
+        metadata=None,
+        tags=None,
+        type="general",
+        usage=None,
+        model=None,
+        provider=None,
+        error_info=None,
+        total_cost=None,
+        last_updated_at=None,
+        source="sdk",
+    )
+    assert msg.environment is None

--- a/sdks/python/tests/unit/api_objects/test_opik_query_language.py
+++ b/sdks/python/tests/unit/api_objects/test_opik_query_language.py
@@ -1082,3 +1082,85 @@ def test_prompt_version_oql__invalid_filters__raises_value_error(
 def test_prompt_version_oql__empty_filter__returns_none(filter_string):
     oql = OpikQueryLanguage.for_prompt_versions(filter_string)
     assert oql.parsed_filters is None
+
+
+# ============================================================
+# in / not_in operator tests
+# ============================================================
+
+
+@pytest.mark.parametrize(
+    "filter_string, expected",
+    [
+        (
+            'environment in ("prod", "staging")',
+            [{"field": "environment", "operator": "in", "value": "prod,staging"}],
+        ),
+        (
+            'environment not_in ("debug")',
+            [{"field": "environment", "operator": "not_in", "value": "debug"}],
+        ),
+        (
+            'environment in ("a") AND input contains "hello"',
+            [
+                {"field": "environment", "operator": "in", "value": "a"},
+                {"field": "input", "operator": "contains", "value": "hello"},
+            ],
+        ),
+    ],
+)
+def test_trace_oql__in_not_in_operators__happyflow(filter_string, expected):
+    oql = OpikQueryLanguage.for_traces(filter_string)
+    parsed = json.loads(oql.parsed_filters)
+    assert len(parsed) == len(expected)
+    for i, line in enumerate(expected):
+        for key, value in line.items():
+            assert parsed[i][key] == value
+
+
+@pytest.mark.parametrize(
+    "filter_string, expected",
+    [
+        (
+            'environment in ("prod", "staging")',
+            [{"field": "environment", "operator": "in", "value": "prod,staging"}],
+        ),
+    ],
+)
+def test_span_oql__in_not_in_operators__happyflow(filter_string, expected):
+    oql = OpikQueryLanguage.for_spans(filter_string)
+    parsed = json.loads(oql.parsed_filters)
+    assert len(parsed) == len(expected)
+    for i, line in enumerate(expected):
+        for key, value in line.items():
+            assert parsed[i][key] == value
+
+
+@pytest.mark.parametrize(
+    "filter_string, error_pattern",
+    [
+        (
+            "environment in prod",
+            r"Expected array value starting with '\('.*",
+        ),
+        (
+            'environment in ("unterminated"',
+            r"Unterminated array value, missing '\)'",
+        ),
+        (
+            "environment in (unquoted)",
+            r"Array elements must be quoted strings.*",
+        ),
+        (
+            "environment in ()",
+            r"Expected at least one item inside.*",
+        ),
+        (
+            "environment not_in ()",
+            r"Expected at least one item inside.*",
+        ),
+    ],
+)
+def test_oql__in_operator__invalid_array_syntax(filter_string, error_pattern):
+    with pytest.raises(ValueError, match=error_pattern):
+        OpikQueryLanguage.for_traces(filter_string)

--- a/sdks/python/tests/unit/api_objects/trace/test_trace_data.py
+++ b/sdks/python/tests/unit/api_objects/trace/test_trace_data.py
@@ -61,6 +61,7 @@ def test_trace_data__as_parameters__expected_parameters_are_set():
         "thread_id": ANY_BUT_NONE,
         "attachments": ANY_BUT_NONE,
         "source": "sdk",
+        "environment": None,
     }
 
     assert_equal(expected_parameters, trace_data.as_parameters)

--- a/sdks/python/tests/unit/decorator/test_span_creation_handler.py
+++ b/sdks/python/tests/unit/decorator/test_span_creation_handler.py
@@ -200,3 +200,102 @@ def test_distributed_headers__source_set__span_gets_that_source():
 
     assert result.trace_data is None
     assert result.span_data.source == "optimization"
+
+
+# ---------------------------------------------------------------------------
+# Environment inheritance — a span always inherits its parent trace's env when
+# the trace has one, ignoring the per-call ``environment`` argument.
+# ---------------------------------------------------------------------------
+
+
+def _start_span_params_with_env(env):
+    return arguments_helpers.StartSpanParameters(
+        type="general", name="child", environment=env
+    )
+
+
+def test_existing_trace_with_env__child_span_inherits_trace_env_and_ignores_per_call_env():
+    storage = OpikContextStorage()
+    storage.set_trace_data(trace_module.TraceData(id="t", environment="production"))
+
+    result = span_creation_handler.create_span_respecting_context(
+        start_span_arguments=_start_span_params_with_env("staging"),
+        distributed_trace_headers=None,
+        opik_context_storage=storage,
+        source=None,
+    )
+
+    assert result.span_data.environment == "production"
+
+
+def test_existing_parent_span_with_env__child_span_inherits_parent_env_and_ignores_per_call_env():
+    storage = OpikContextStorage()
+    parent = span_module.SpanData(
+        trace_id="t", id="parent", source="sdk", environment="production"
+    )
+    storage.add_span_data(parent)
+
+    result = span_creation_handler.create_span_respecting_context(
+        start_span_arguments=_start_span_params_with_env("staging"),
+        distributed_trace_headers=None,
+        opik_context_storage=storage,
+        source=None,
+    )
+
+    assert result.span_data.environment == "production"
+
+
+def test_existing_trace_without_env__child_span_inherits_none_and_warns_on_per_call_env():
+    storage = OpikContextStorage()
+    storage.set_trace_data(trace_module.TraceData(id="t", environment=None))
+
+    result = span_creation_handler.create_span_respecting_context(
+        start_span_arguments=_start_span_params_with_env("staging"),
+        distributed_trace_headers=None,
+        opik_context_storage=storage,
+        source=None,
+    )
+
+    # The trace has no environment — the per-call value is dropped, just like
+    # when the trace's environment is set to a different value.
+    assert result.span_data.environment is None
+
+
+def test_distributed_headers__no_local_context__per_call_env_passes_through():
+    """Mirrors project_name: with no local parent, caller-supplied environment is accepted."""
+    storage = OpikContextStorage()
+    headers = {
+        "opik_trace_id": "remote-trace-id",
+        "opik_parent_span_id": "remote-span-id",
+    }
+
+    result = span_creation_handler.create_span_respecting_context(
+        start_span_arguments=_start_span_params_with_env("staging"),
+        distributed_trace_headers=headers,
+        opik_context_storage=storage,
+        source=None,
+    )
+
+    assert result.span_data.environment == "staging"
+
+
+def test_distributed_headers__local_parent_span_present__parent_env_wins():
+    """When a local parent span exists, its environment overrides the per-call value."""
+    storage = OpikContextStorage()
+    parent = span_module.SpanData(
+        trace_id="t", id="parent", source="sdk", environment="production"
+    )
+    storage.add_span_data(parent)
+    headers = {
+        "opik_trace_id": "remote-trace-id",
+        "opik_parent_span_id": "remote-span-id",
+    }
+
+    result = span_creation_handler.create_span_respecting_context(
+        start_span_arguments=_start_span_params_with_env("staging"),
+        distributed_trace_headers=headers,
+        opik_context_storage=storage,
+        source=None,
+    )
+
+    assert result.span_data.environment == "production"

--- a/sdks/python/tests/unit/decorator/test_tracker_outputs.py
+++ b/sdks/python/tests/unit/decorator/test_tracker_outputs.py
@@ -2144,3 +2144,94 @@ def test_track__functools_partial_function__function_name_extracted_correctly(
 
     assert len(fake_backend.trace_trees) == 1
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
+
+
+def test_track__environment_parameter__propagated_to_trace_and_root_span(fake_backend):
+    @tracker.track(environment="production")
+    def f(x):
+        return "output"
+
+    f("input")
+    tracker.flush_tracker()
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="f",
+        input={"x": "input"},
+        output={"output": "output"},
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        environment="production",
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                name="f",
+                input={"x": "input"},
+                output={"output": "output"},
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                spans=[],
+                environment="production",
+                source="sdk",
+            )
+        ],
+        source="sdk",
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+    assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
+
+
+def test_track__environment_parameter__nested_spans_inherit_environment(fake_backend):
+    @tracker.track
+    def f_inner(x):
+        return "inner-output"
+
+    @tracker.track(environment="staging")
+    def f_outer(x):
+        f_inner("inner-input")
+        return "outer-output"
+
+    f_outer("outer-input")
+    tracker.flush_tracker()
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="f_outer",
+        input={"x": "outer-input"},
+        output={"output": "outer-output"},
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        environment="staging",
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                name="f_outer",
+                input={"x": "outer-input"},
+                output={"output": "outer-output"},
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                environment="staging",
+                spans=[
+                    SpanModel(
+                        id=ANY_BUT_NONE,
+                        name="f_inner",
+                        input={"x": "inner-input"},
+                        output={"output": "inner-output"},
+                        start_time=ANY_BUT_NONE,
+                        end_time=ANY_BUT_NONE,
+                        spans=[],
+                        environment="staging",
+                        source="sdk",
+                    )
+                ],
+                source="sdk",
+            )
+        ],
+        source="sdk",
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+    assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])

--- a/sdks/python/tests/unit/test_config.py
+++ b/sdks/python/tests/unit/test_config.py
@@ -83,3 +83,37 @@ def test_default_llm_loaded_from_env(monkeypatch):
     config = OpikConfig()
 
     assert config.default_llm == "gpt-4.1-mini"
+
+
+def test_environment_loaded_from_env(monkeypatch):
+    monkeypatch.setenv("OPIK_ENVIRONMENT", "production")
+
+    config = OpikConfig()
+
+    assert config.environment == "production"
+
+
+def test_environment_defaults_to_none():
+    config = OpikConfig()
+
+    assert config.environment is None
+
+
+@patch("builtins.open", new_callable=mock_open)
+@patch("pathlib.Path.expanduser", return_value=Path("/fake/path/config.ini"))
+def test_save_to_file_does_not_persist_environment(mock_expanduser, mock_open_file):
+    config = OpikConfig(
+        url_override="http://test-url",
+        workspace="test_workspace",
+        environment="production",
+    )
+
+    config.save_to_file()
+
+    handle = mock_open_file()
+    written_content = "".join(call.args[0] for call in handle.write.call_args_list)
+
+    parsed_config = configparser.ConfigParser()
+    parsed_config.read_string(written_content)
+
+    assert "environment" not in parsed_config["opik"]

--- a/sdks/python/tests/unit/test_messages.py
+++ b/sdks/python/tests/unit/test_messages.py
@@ -19,6 +19,7 @@ def test_messages__all_fields_are_serializable():
         "thread_id": None,
         "last_updated_at": datetime.now(),
         "source": "sdk",
+        "environment": None,
     }
 
     message = messages.CreateTraceMessage(**payload_dict)
@@ -52,6 +53,7 @@ def test_messages__not_all_fields_are_serializable():
         "thread_id": None,
         "last_updated_at": datetime.now(),
         "source": "sdk",
+        "environment": None,
     }
 
     message = messages.CreateTraceMessage(**payload_dict)

--- a/sdks/typescript/src/opik/client/Client.ts
+++ b/sdks/typescript/src/opik/client/Client.ts
@@ -67,6 +67,7 @@ import {
 } from "@/agent-config/blueprintCache";
 import { trackStorage } from "@/decorators/track";
 import { ConfigNotFoundError, ConfigMismatchError } from "@/errors/agent-config/errors";
+import { EnvironmentAlreadyExistsError } from "@/errors/environment/errors";
 import { DEFAULT_CONFIG } from "@/config/Config";
 
 interface TraceData extends Omit<ITrace, "startTime"> {
@@ -1960,12 +1961,19 @@ export class OpikClient {
     options?: { description?: string; color?: string }
   ): Promise<OpikApi.EnvironmentPublic> => {
     const newId = generateId();
-    await this.api.environments.createEnvironment({
-      id: newId,
-      name,
-      description: options?.description,
-      color: options?.color,
-    });
+    try {
+      await this.api.environments.createEnvironment({
+        id: newId,
+        name,
+        description: options?.description,
+        color: options?.color,
+      });
+    } catch (error) {
+      if (error instanceof OpikApiError && error.statusCode === 409) {
+        throw new EnvironmentAlreadyExistsError(name);
+      }
+      throw error;
+    }
     return this.api.environments.getEnvironmentById(newId);
   };
 

--- a/sdks/typescript/src/opik/client/Client.ts
+++ b/sdks/typescript/src/opik/client/Client.ts
@@ -193,6 +193,10 @@ export class OpikClient {
   public trace = (traceData: TraceData) => {
     logger.debug("Creating new trace with data:", traceData);
     const projectName = this.resolveProjectName(traceData.projectName);
+    const environment =
+      traceData.environment !== undefined
+        ? traceData.environment
+        : this.config.environment;
     const trace = new Trace(
       {
         id: generateId(),
@@ -200,6 +204,7 @@ export class OpikClient {
         source: "sdk",
         ...traceData,
         projectName,
+        ...(environment !== undefined ? { environment } : {}),
       },
       this
     );
@@ -1949,6 +1954,59 @@ export class OpikClient {
   public logSpansFeedbackScores(scores: FeedbackScoreData[]): void {
     this.logFeedbackScores(scores, this.spanFeedbackScoresBatchQueue);
   }
+
+  public createEnvironment = async (
+    name: string,
+    options?: { description?: string; color?: string }
+  ): Promise<OpikApi.EnvironmentPublic> => {
+    const newId = generateId();
+    await this.api.environments.createEnvironment({
+      id: newId,
+      name,
+      description: options?.description,
+      color: options?.color,
+    });
+    return this.api.environments.getEnvironmentById(newId);
+  };
+
+  public getEnvironments = async (): Promise<OpikApi.EnvironmentPublic[]> => {
+    const page = await this.api.environments.findEnvironments();
+    return page.content ?? [];
+  };
+
+  public updateEnvironment = async (
+    name: string,
+    options?: { description?: string; color?: string }
+  ): Promise<OpikApi.EnvironmentPublic> => {
+    const existing = await this._findEnvironmentByName(name, true);
+    await this.api.environments.updateEnvironment(existing!.id!, {
+      description: options?.description,
+      color: options?.color,
+    });
+    return this.api.environments.getEnvironmentById(existing!.id!);
+  };
+
+  public deleteEnvironment = async (name: string): Promise<void> => {
+    const existing = await this._findEnvironmentByName(name, false);
+    if (!existing) {
+      return;
+    }
+    await this.api.environments.deleteEnvironmentsBatch({
+      ids: [existing.id!],
+    });
+  };
+
+  private _findEnvironmentByName = async (
+    name: string,
+    strict: boolean
+  ): Promise<OpikApi.EnvironmentPublic | undefined> => {
+    const envs = await this.getEnvironments();
+    const match = envs.find((env) => env.name === name);
+    if (!match && strict) {
+      throw new Error(`No environment found with name "${name}".`);
+    }
+    return match;
+  };
 
   public flush = async (options?: { silent?: boolean }) => {
     const silent = options?.silent ?? false;

--- a/sdks/typescript/src/opik/config/Config.ts
+++ b/sdks/typescript/src/opik/config/Config.ts
@@ -11,18 +11,19 @@ export interface OpikConfig {
   apiUrl?: string;
   projectName: string;
   workspaceName: string;
+  environment?: string;
   requestOptions?: RequestOptions;
   batchDelayMs?: number;
   holdUntilFlush?: boolean;
 }
 
-export interface ConstructorOpikConfig extends OpikConfig {
+export interface ConstructorOpikConfig extends Omit<OpikConfig, "environment"> {
   headers?: Record<string, string>;
 }
 
 const CONFIG_FILE_PATH_DEFAULT = path.join(os.homedir(), ".opik.config");
 
-export const DEFAULT_CONFIG: Required<Omit<OpikConfig, "requestOptions">> = {
+export const DEFAULT_CONFIG: Required<Omit<OpikConfig, "requestOptions" | "environment">> = {
   apiKey: "",
   apiUrl: "https://www.comet.com/opik/api",
   projectName: "Default Project",
@@ -43,6 +44,7 @@ function loadFromEnv(): Partial<OpikConfig> {
     apiUrl: process.env.OPIK_URL_OVERRIDE,
     projectName: process.env.OPIK_PROJECT_NAME,
     workspaceName: process.env.OPIK_WORKSPACE,
+    environment: process.env.OPIK_ENVIRONMENT,
     batchDelayMs: process.env.OPIK_BATCH_DELAY_MS
       ? Number(process.env.OPIK_BATCH_DELAY_MS)
       : undefined,

--- a/sdks/typescript/src/opik/decorators/track.ts
+++ b/sdks/typescript/src/opik/decorators/track.ts
@@ -75,7 +75,7 @@ function logSpan({
     environment !== spanTrace.data.environment
   ) {
     logger.warn(
-      `Nested @track requested environment "${environment}", but the enclosing trace already uses "${spanTrace.data.environment ?? ""}". The outer environment will be used.`
+      `Nested @track requested environment "${environment}", but the enclosing trace already uses "${spanTrace.data.environment ?? "(none)"}". The outer environment will be used.`
     );
   }
 

--- a/sdks/typescript/src/opik/decorators/track.ts
+++ b/sdks/typescript/src/opik/decorators/track.ts
@@ -44,18 +44,21 @@ function logSpan({
   projectName,
   trace,
   type = "llm",
+  environment,
 }: {
   name: string;
   parentSpan?: Span;
   projectName?: string;
   trace?: Trace;
   type?: SpanType;
+  environment?: string;
 }) {
   logger.debug("Creating new span:", {
     name,
     parentSpan: parentSpan?.data.id,
     projectName,
     type,
+    environment,
   });
   let spanTrace = trace;
 
@@ -64,8 +67,16 @@ function logSpan({
     spanTrace = getTrackOpikClient().trace({
       name,
       projectName,
+      ...(environment !== undefined ? { environment } : {}),
       ...(presetTraceId ? { id: presetTraceId } : {}),
     });
+  } else if (
+    environment !== undefined &&
+    environment !== spanTrace.data.environment
+  ) {
+    logger.warn(
+      `Nested @track requested environment "${environment}", but the enclosing trace already uses "${spanTrace.data.environment ?? ""}". The outer environment will be used.`
+    );
   }
 
   const span = spanTrace.span({
@@ -191,11 +202,13 @@ function executeTrack<T extends (...args: any[]) => any>(
     projectName,
     type,
     enrichSpan,
+    environment,
   }: {
     name?: string;
     projectName?: string;
     type?: SpanType;
     enrichSpan?: (result: any) => Record<string, unknown>;
+    environment?: string;
   } = {},
   originalFn: T
 ): T {
@@ -207,6 +220,7 @@ function executeTrack<T extends (...args: any[]) => any>(
       projectName,
       trace: context?.trace,
       type,
+      environment,
     });
     const isRootSpan = !context;
     const fnThis = this as any;
@@ -267,6 +281,13 @@ type TrackOptions = {
   name?: string;
   projectName?: string;
   type?: SpanType;
+  /**
+   * Environment to tag the trace with. When the root @track creates the
+   * trace, the value is persisted on the trace and inherited by all child
+   * spans. Per-call values on nested @track calls are ignored — the
+   * trace's environment always wins.
+   */
+  environment?: string;
   /**
    * Optional function to enrich the span with additional data extracted from the result.
    * Called before the span is finalized with the success result.

--- a/sdks/typescript/src/opik/errors/environment/errors.ts
+++ b/sdks/typescript/src/opik/errors/environment/errors.ts
@@ -1,0 +1,13 @@
+export class EnvironmentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EnvironmentError";
+  }
+}
+
+export class EnvironmentAlreadyExistsError extends EnvironmentError {
+  constructor(name: string) {
+    super(`Environment '${name}' already exists in this workspace.`);
+    this.name = "EnvironmentAlreadyExistsError";
+  }
+}

--- a/sdks/typescript/src/opik/errors/index.ts
+++ b/sdks/typescript/src/opik/errors/index.ts
@@ -8,3 +8,4 @@ export * from "./dataset";
 export * from "./search";
 export * from "@/annotation-queue/errors";
 export * from "./agent-config/errors";
+export * from "./environment/errors";

--- a/sdks/typescript/src/opik/index.ts
+++ b/sdks/typescript/src/opik/index.ts
@@ -12,6 +12,7 @@ export type { ErrorInfo } from "@/rest_api/api/types/ErrorInfo";
 export type { SpanType } from "@/rest_api/api/types/SpanType";
 export { SpanType as OpikSpanType } from "@/rest_api/api/types/SpanType";
 export type { DatasetPublic } from "@/rest_api/api/types/DatasetPublic";
+export type { EnvironmentPublic as Environment } from "@/rest_api/api/types/EnvironmentPublic";
 export * from "./evaluation";
 
 // Dataset exports

--- a/sdks/typescript/src/opik/query/OpikQueryLanguage.ts
+++ b/sdks/typescript/src/opik/query/OpikQueryLanguage.ts
@@ -26,7 +26,7 @@ import {
   ThreadOQLConfig,
   PromptOQLConfig,
 } from "./configs";
-import { OPERATORS_WITHOUT_VALUES } from "./constants";
+import { OPERATORS_WITHOUT_VALUES, ARRAY_VALUE_OPERATORS } from "./constants";
 
 // Re-export types for backward compatibility
 export type { FilterExpression };
@@ -132,7 +132,9 @@ export class OpikQueryLanguage {
     );
     const value = (OPERATORS_WITHOUT_VALUES as readonly string[]).includes(operator.operator)
       ? { value: null }
-      : ValueParser.parse(tokenizer);
+      : (ARRAY_VALUE_OPERATORS as readonly string[]).includes(operator.operator)
+        ? ValueParser.parseArrayValue(tokenizer)
+        : ValueParser.parse(tokenizer);
 
     return this.buildExpression(field, operator, value);
   }

--- a/sdks/typescript/src/opik/query/configs/SpanOQLConfig.ts
+++ b/sdks/typescript/src/opik/query/configs/SpanOQLConfig.ts
@@ -33,6 +33,7 @@ export class SpanOQLConfig extends OQLConfig {
       error_info: "error_container",
       type: "enum",
       trace_id: "string",
+      environment: "enum",
     };
   }
 
@@ -57,8 +58,9 @@ export class SpanOQLConfig extends OQLConfig {
       model: OPERATOR_SETS.STRING_OPS,
       provider: OPERATOR_SETS.STRING_OPS,
       error_info: ["is_empty", "is_not_empty"],
-      type: ["=", "!="],
+      type: OPERATOR_SETS.ENUM_OPS,
       trace_id: OPERATOR_SETS.STRING_OPS,
+      environment: OPERATOR_SETS.ENUM_OPS,
     };
   }
 

--- a/sdks/typescript/src/opik/query/configs/ThreadOQLConfig.ts
+++ b/sdks/typescript/src/opik/query/configs/ThreadOQLConfig.ts
@@ -25,6 +25,7 @@ export class ThreadOQLConfig extends OQLConfig {
       status: "enum",
       tags: "list",
       annotation_queue_ids: "list",
+      environment: "enum",
     };
   }
 
@@ -40,9 +41,10 @@ export class ThreadOQLConfig extends OQLConfig {
       start_time: OPERATOR_SETS.DATETIME_OPS,
       end_time: OPERATOR_SETS.DATETIME_OPS,
       feedback_scores: OPERATOR_SETS.FEEDBACK_SCORES_OPS,
-      status: ["=", "!="] as const,
+      status: OPERATOR_SETS.ENUM_OPS,
       tags: OPERATOR_SETS.LIST_OPS,
       annotation_queue_ids: OPERATOR_SETS.LIST_OPS,
+      environment: OPERATOR_SETS.ENUM_OPS,
     };
   }
 

--- a/sdks/typescript/src/opik/query/configs/TraceOQLConfig.ts
+++ b/sdks/typescript/src/opik/query/configs/TraceOQLConfig.ts
@@ -37,6 +37,7 @@ export class TraceOQLConfig extends OQLConfig {
       last_updated_at: "date_time",
       annotation_queue_ids: "list",
       experiment_id: "string",
+      environment: "enum",
     };
   }
 
@@ -67,6 +68,7 @@ export class TraceOQLConfig extends OQLConfig {
       last_updated_at: OPERATOR_SETS.DATETIME_OPS,
       annotation_queue_ids: OPERATOR_SETS.LIST_OPS,
       experiment_id: OPERATOR_SETS.STRING_OPS,
+      environment: OPERATOR_SETS.ENUM_OPS,
     };
   }
 

--- a/sdks/typescript/src/opik/query/constants.ts
+++ b/sdks/typescript/src/opik/query/constants.ts
@@ -27,6 +27,7 @@ export const OPERATOR_SETS = {
     "is_not_empty",
   ],
   DICT_OPS: ["=", "contains", ">", "<"],
+  ENUM_OPS: ["=", "!=", "in", "not_in"],
   LIMITED_STRING_OPS: ["=", "contains", "not_contains"],
   FEEDBACK_SCORES_OPS: [
     "=",
@@ -44,3 +45,8 @@ export const OPERATOR_SETS = {
  * Operators that don't require a value
  */
 export const OPERATORS_WITHOUT_VALUES = ["is_empty", "is_not_empty"] as const;
+
+/**
+ * Operators that require an array value (e.g., `name in ["a", "b"]`)
+ */
+export const ARRAY_VALUE_OPERATORS = ["in", "not_in"] as const;

--- a/sdks/typescript/src/opik/query/parsers/ValueParser.ts
+++ b/sdks/typescript/src/opik/query/parsers/ValueParser.ts
@@ -83,6 +83,61 @@ export class ValueParser {
     return { value };
   }
 
+  static parseArrayValue(tokenizer: QueryTokenizer): ValueToken {
+    tokenizer.skipWhitespace();
+
+    if (tokenizer.peekChar() !== "(") {
+      const remaining = tokenizer.getRemainingInput();
+      throw new Error(
+        `Expected array value starting with '(' for in/not_in operator, got: ${remaining.slice(0, 20)}`
+      );
+    }
+    tokenizer.advance(); // skip '('
+
+    const items: string[] = [];
+
+    while (true) {
+      tokenizer.skipWhitespace();
+
+      if (tokenizer.isAtEnd()) {
+        throw new Error("Unterminated array value, missing ')'");
+      }
+
+      if (tokenizer.peekChar() === ")") {
+        if (items.length === 0) {
+          throw new Error(
+            "Expected at least one item inside (...) for in/not_in operator"
+          );
+        }
+        tokenizer.advance();
+        break;
+      }
+
+      if (items.length > 0) {
+        if (tokenizer.peekChar() !== ",") {
+          const remaining = tokenizer.getRemainingInput();
+          throw new Error(
+            `Expected ',' between array elements, got: ${remaining.slice(0, 20)}`
+          );
+        }
+        tokenizer.advance(); // skip ','
+        tokenizer.skipWhitespace();
+      }
+
+      if (tokenizer.isAtEnd() || tokenizer.peekChar() !== '"') {
+        const remaining = tokenizer.getRemainingInput();
+        throw new Error(
+          `Array elements must be quoted strings, got: ${remaining.slice(0, 20)}`
+        );
+      }
+
+      const item = this.parseQuotedString(tokenizer, tokenizer.getPosition());
+      items.push(item.value as string);
+    }
+
+    return { value: items.join(",") };
+  }
+
   private static parseDigits(tokenizer: QueryTokenizer): string {
     return tokenizer.consumeWhile((char) => QueryTokenizer.isDigitChar(char));
   }

--- a/sdks/typescript/src/opik/query/parsers/ValueParser.ts
+++ b/sdks/typescript/src/opik/query/parsers/ValueParser.ts
@@ -132,7 +132,13 @@ export class ValueParser {
       }
 
       const item = this.parseQuotedString(tokenizer, tokenizer.getPosition());
-      items.push(item.value as string);
+      const itemValue = item.value as string;
+      if (itemValue.includes(",")) {
+        throw new Error(
+          `Array element values cannot contain commas (got: "${itemValue}"). The backend uses comma as the array delimiter.`
+        );
+      }
+      items.push(itemValue);
     }
 
     return { value: items.join(",") };

--- a/sdks/typescript/src/opik/tracer/Span.ts
+++ b/sdks/typescript/src/opik/tracer/Span.ts
@@ -1,6 +1,7 @@
 import { OpikClient } from "@/client/Client";
 import type { Span as ISpan } from "@/rest_api/api";
 import { generateId } from "@/utils/generateId";
+import { logger } from "@/utils/logger";
 import type { SpanUpdateData } from "./types";
 import { UpdateService } from "./UpdateService";
 
@@ -72,7 +73,13 @@ export class Span {
 
     // environment is trace-scoped; strip any caller-supplied value so JS/any callers
     // can't override it — the parent span's environment is applied unconditionally below.
-    const { environment: _env, ...spanDataWithoutEnv } = spanData as Record<string, unknown>;
+    const { environment: _env, ...spanDataWithoutEnv } = spanData as { environment?: string };
+    if (_env !== undefined && _env !== this.data.environment) {
+      logger.warn(
+        `You are attempting to log data into a nested span under the environment "${_env}". ` +
+          `However, the environment "${this.data.environment ?? ""}" from the parent span will be used instead.`
+      );
+    }
     const spanWithId: SavedSpan = {
       id: generateId(),
       startTime: new Date(),

--- a/sdks/typescript/src/opik/tracer/Span.ts
+++ b/sdks/typescript/src/opik/tracer/Span.ts
@@ -63,20 +63,27 @@ export class Span {
       | "projectId"
       | "projectName"
       | "id"
+      | "environment"
     > & {
       startTime?: Date;
     }
   ) => {
     const projectName = this.data.projectName ?? this.opik.config.projectName;
 
+    // environment is trace-scoped; strip any caller-supplied value so JS/any callers
+    // can't override it — the parent span's environment is applied unconditionally below.
+    const { environment: _env, ...spanDataWithoutEnv } = spanData as Record<string, unknown>;
     const spanWithId: SavedSpan = {
       id: generateId(),
       startTime: new Date(),
       source: this.data.source,
-      ...spanData,
+      ...spanDataWithoutEnv,
       projectName,
       traceId: this.data.traceId,
       parentSpanId: this.data.id,
+      ...(this.data.environment !== undefined
+        ? { environment: this.data.environment }
+        : {}),
     };
 
     this.opik.spanBatchQueue.create(spanWithId);

--- a/sdks/typescript/src/opik/tracer/Trace.ts
+++ b/sdks/typescript/src/opik/tracer/Trace.ts
@@ -9,7 +9,7 @@ export interface SavedTrace extends ITrace {
   id: string;
 }
 
-interface SpanData extends Omit<ISpan, "startTime" | "traceId"> {
+interface SpanData extends Omit<ISpan, "startTime" | "traceId" | "environment"> {
   startTime?: Date;
 }
 
@@ -45,13 +45,19 @@ export class Trace {
       spanData.projectName ??
       this.opik.config.projectName;
 
+    // environment is trace-scoped; strip any caller-supplied value so JS/any callers
+    // can't override it — the parent trace's environment is applied unconditionally below.
+    const { environment: _env, ...spanDataWithoutEnv } = spanData as Record<string, unknown>;
     const spanWithId: SavedSpan = {
       id: generateId(),
       startTime: new Date(),
       source: this.data.source,
-      ...spanData,
+      ...spanDataWithoutEnv,
       projectName,
       traceId: this.data.id,
+      ...(this.data.environment !== undefined
+        ? { environment: this.data.environment }
+        : {}),
     };
 
     this.opik.spanBatchQueue.create(spanWithId);

--- a/sdks/typescript/src/opik/tracer/Trace.ts
+++ b/sdks/typescript/src/opik/tracer/Trace.ts
@@ -1,6 +1,7 @@
 import { OpikClient } from "@/client/Client";
 import type { Span as ISpan, Trace as ITrace } from "@/rest_api/api";
 import { generateId } from "@/utils/generateId";
+import { logger } from "@/utils/logger";
 import { SavedSpan, Span } from "./Span";
 import type { TraceUpdateData } from "./types";
 import { UpdateService } from "./UpdateService";
@@ -47,7 +48,13 @@ export class Trace {
 
     // environment is trace-scoped; strip any caller-supplied value so JS/any callers
     // can't override it — the parent trace's environment is applied unconditionally below.
-    const { environment: _env, ...spanDataWithoutEnv } = spanData as Record<string, unknown>;
+    const { environment: _env, ...spanDataWithoutEnv } = spanData as { environment?: string };
+    if (_env !== undefined && _env !== this.data.environment) {
+      logger.warn(
+        `You are attempting to log data into a nested span under the environment "${_env}". ` +
+          `However, the environment "${this.data.environment ?? ""}" from the parent trace will be used instead.`
+      );
+    }
     const spanWithId: SavedSpan = {
       id: generateId(),
       startTime: new Date(),

--- a/sdks/typescript/tests/config.test.ts
+++ b/sdks/typescript/tests/config.test.ts
@@ -244,6 +244,65 @@ describe("Opik client custom config", () => {
   });
 });
 
+describe("Opik client environment config", () => {
+  const originalEnvironmentVariables = { ...process.env };
+
+  beforeEach(() => {
+    process.env.OPIK_URL_OVERRIDE = "https://www.comet.com/api";
+    process.env.OPIK_API_KEY = "test";
+    process.env.OPIK_WORKSPACE = "test";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnvironmentVariables };
+  });
+
+  it("should load environment from OPIK_ENVIRONMENT env var", () => {
+    process.env.OPIK_ENVIRONMENT = "production";
+    const opik = new Opik();
+    expect(opik.config.environment).toBe("production");
+  });
+
+  it("should have undefined environment when OPIK_ENVIRONMENT is not set", () => {
+    delete process.env.OPIK_ENVIRONMENT;
+    const opik = new Opik();
+    expect(opik.config.environment).toBeUndefined();
+  });
+
+  it("should apply config-level environment to trace when not overridden", async () => {
+    process.env.OPIK_ENVIRONMENT = "production";
+    const opik = new Opik();
+    const createTracesSpy = vi
+      .spyOn(opik.api.traces, "createTraces")
+      .mockImplementation(mockAPIFunction);
+
+    const trace = opik.trace({ name: "test-trace" });
+    trace.end();
+    await opik.flush();
+
+    const traceData = createTracesSpy.mock.calls[0][0].traces?.[0];
+    expect(traceData?.environment).toBe("production");
+    createTracesSpy.mockRestore();
+  });
+
+  it("should let per-call environment override config-level environment", async () => {
+    process.env.OPIK_ENVIRONMENT = "production";
+    const opik = new Opik();
+    const createTracesSpy = vi
+      .spyOn(opik.api.traces, "createTraces")
+      .mockImplementation(mockAPIFunction);
+
+    const trace = opik.trace({ name: "test-trace", environment: "staging" });
+    trace.end();
+    await opik.flush();
+
+    const traceData = createTracesSpy.mock.calls[0][0].traces?.[0];
+    expect(traceData?.environment).toBe("staging");
+    createTracesSpy.mockRestore();
+  });
+
+});
+
 describe("Opik client apiKey propagation", () => {
   const originalFetch = global.fetch;
   let capturedHeaders: Headers | null = null;

--- a/sdks/typescript/tests/environment.test.ts
+++ b/sdks/typescript/tests/environment.test.ts
@@ -10,6 +10,8 @@
  * - Back-compat: traces without `environment` still serialize fine.
  */
 import { Opik } from "opik";
+import { EnvironmentAlreadyExistsError } from "@/errors/environment/errors";
+import { OpikApiError } from "@/rest_api";
 import {
   _resetTrackOpikClientCache,
   getTrackOpikClient,
@@ -94,6 +96,34 @@ describe("environment feature", () => {
       expect(spans[0].environment).toBe("production");
       expect(spans[1].environment).toBe("production");
       createSpansSpy.mockRestore();
+    });
+  });
+
+  describe("createEnvironment", () => {
+    it("throws EnvironmentAlreadyExistsError on 409", async () => {
+      const client = new Opik();
+      vi.spyOn(client.api.environments, "createEnvironment").mockRejectedValue(
+        new OpikApiError({ statusCode: 409, body: "conflict" })
+      );
+
+      await expect(client.createEnvironment("production")).rejects.toThrow(
+        EnvironmentAlreadyExistsError
+      );
+      await expect(client.createEnvironment("production")).rejects.toThrow(
+        "production"
+      );
+    });
+
+    it("re-throws non-409 errors unchanged", async () => {
+      const client = new Opik();
+      const serverError = new OpikApiError({ statusCode: 500, body: "oops" });
+      vi.spyOn(client.api.environments, "createEnvironment").mockRejectedValue(
+        serverError
+      );
+
+      await expect(client.createEnvironment("production")).rejects.toBe(
+        serverError
+      );
     });
   });
 

--- a/sdks/typescript/tests/environment.test.ts
+++ b/sdks/typescript/tests/environment.test.ts
@@ -97,6 +97,35 @@ describe("environment feature", () => {
       expect(spans[1].environment).toBe("production");
       createSpansSpy.mockRestore();
     });
+
+    it("Trace.span warns when caller passes a mismatched environment", () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+      const client = new Opik();
+      vi.spyOn(client.api.spans, "createSpans").mockImplementation(mockAPIFunction);
+      vi.spyOn(client.api.traces, "createTraces").mockImplementation(mockAPIFunction);
+
+      const trace = client.trace({ name: "t", environment: "production" });
+      (trace.span as (d: Record<string, unknown>) => unknown)({ name: "s", environment: "staging" });
+
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0][0]).toContain("staging");
+      expect(warnSpy.mock.calls[0][0]).toContain("production");
+    });
+
+    it("Span.span warns when caller passes a mismatched environment", () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+      const client = new Opik();
+      vi.spyOn(client.api.spans, "createSpans").mockImplementation(mockAPIFunction);
+      vi.spyOn(client.api.traces, "createTraces").mockImplementation(mockAPIFunction);
+
+      const trace = client.trace({ name: "t", environment: "production" });
+      const child = trace.span({ name: "s1" });
+      (child.span as (d: Record<string, unknown>) => unknown)({ name: "s2", environment: "staging" });
+
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0][0]).toContain("staging");
+      expect(warnSpy.mock.calls[0][0]).toContain("production");
+    });
   });
 
   describe("createEnvironment", () => {

--- a/sdks/typescript/tests/environment.test.ts
+++ b/sdks/typescript/tests/environment.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for the `environment` feature.
+ *
+ * Exercises:
+ * - Per-call `environment` on `client.trace(...)` is persisted on the trace.
+ * - Spans (`Trace.span`, `Span.span`) inherit the parent trace's environment unconditionally.
+ * - `@track({ environment })` propagates to the root trace it creates.
+ * - Nested `@track({ environment })` is ignored and warns when it conflicts with
+ *   the enclosing trace's environment.
+ * - Back-compat: traces without `environment` still serialize fine.
+ */
+import { Opik } from "opik";
+import {
+  _resetTrackOpikClientCache,
+  getTrackOpikClient,
+  track,
+} from "@/decorators/track";
+import { logger } from "@/utils/logger";
+import { describe, expect, beforeEach, afterEach, MockInstance } from "vitest";
+import { mockAPIFunction } from "./mockUtils";
+
+describe("environment feature", () => {
+  describe("client.trace propagates environment", () => {
+    let createTracesSpy: MockInstance;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      createTracesSpy?.mockRestore();
+    });
+
+    it("uses per-call environment when given", async () => {
+      const client = new Opik();
+      createTracesSpy = vi
+        .spyOn(client.api.traces, "createTraces")
+        .mockImplementation(mockAPIFunction);
+      client.trace({ name: "t", environment: "production" });
+      await client.flush();
+      expect(createTracesSpy).toHaveBeenCalledTimes(1);
+      const traces = createTracesSpy.mock.calls[0][0].traces;
+      expect(traces[0]).toMatchObject({ environment: "production" });
+    });
+
+    it("trace without environment does not emit an environment field", async () => {
+      const client = new Opik();
+      createTracesSpy = vi
+        .spyOn(client.api.traces, "createTraces")
+        .mockImplementation(mockAPIFunction);
+      client.trace({ name: "t" });
+      await client.flush();
+      const traces = createTracesSpy.mock.calls[0][0].traces;
+      expect(traces[0].environment).toBeUndefined();
+    });
+  });
+
+  describe("Trace.span / Span.span inherit environment", () => {
+    it("child span inherits parent trace environment", async () => {
+      const client = new Opik();
+      const createSpansSpy = vi
+        .spyOn(client.api.spans, "createSpans")
+        .mockImplementation(mockAPIFunction);
+      vi.spyOn(client.api.traces, "createTraces").mockImplementation(
+        mockAPIFunction
+      );
+
+      const trace = client.trace({ name: "t", environment: "production" });
+      trace.span({ name: "s1" });
+      await client.flush();
+
+      const spans = createSpansSpy.mock.calls[0][0].spans;
+      expect(spans[0]).toMatchObject({ environment: "production" });
+      createSpansSpy.mockRestore();
+    });
+
+    it("grandchild span inherits via Span.span", async () => {
+      const client = new Opik();
+      const createSpansSpy = vi
+        .spyOn(client.api.spans, "createSpans")
+        .mockImplementation(mockAPIFunction);
+      vi.spyOn(client.api.traces, "createTraces").mockImplementation(
+        mockAPIFunction
+      );
+
+      const trace = client.trace({ name: "t", environment: "production" });
+      const child = trace.span({ name: "s1" });
+      child.span({ name: "s2", type: "general" });
+      await client.flush();
+
+      const spans = createSpansSpy.mock.calls[0][0].spans;
+      expect(spans).toHaveLength(2);
+      expect(spans[0].environment).toBe("production");
+      expect(spans[1].environment).toBe("production");
+      createSpansSpy.mockRestore();
+    });
+  });
+
+  describe("@track decorator", () => {
+    let trackOpikClient: ReturnType<typeof getTrackOpikClient>;
+    let createTracesSpy: MockInstance;
+    let createSpansSpy: MockInstance;
+
+    beforeEach(() => {
+      _resetTrackOpikClientCache();
+      trackOpikClient = getTrackOpikClient();
+      createTracesSpy = vi
+        .spyOn(trackOpikClient.api.traces, "createTraces")
+        .mockImplementation(mockAPIFunction);
+      createSpansSpy = vi
+        .spyOn(trackOpikClient.api.spans, "createSpans")
+        .mockImplementation(mockAPIFunction);
+      vi.spyOn(trackOpikClient.api.traces, "updateTrace").mockImplementation(
+        mockAPIFunction
+      );
+      vi.spyOn(trackOpikClient.api.spans, "updateSpan").mockImplementation(
+        mockAPIFunction
+      );
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      _resetTrackOpikClientCache();
+    });
+
+    it("propagates environment to root trace", async () => {
+      const fn = track({ name: "outer", environment: "production" }, () => "ok");
+      fn();
+      await trackOpikClient.flush();
+
+      const traces = createTracesSpy.mock.calls[0][0].traces;
+      expect(traces[0]).toMatchObject({
+        name: "outer",
+        environment: "production",
+      });
+    });
+
+    it("nested @track with mismatched environment warns and inherits the trace's environment", async () => {
+      const warnSpy = vi
+        .spyOn(logger, "warn")
+        .mockImplementation(() => undefined);
+
+      const inner = track(
+        { name: "inner", environment: "this-should-be-ignored" },
+        () => "inner-result"
+      );
+      const outer = track(
+        { name: "outer", environment: "production" },
+        () => inner()
+      );
+      outer();
+      await trackOpikClient.flush();
+
+      const traces = createTracesSpy.mock.calls[0][0].traces;
+      expect(traces[0].environment).toBe("production");
+
+      const spans = createSpansSpy.mock.calls
+        .map((call) => call[0].spans ?? [])
+        .flat();
+      expect(spans).toHaveLength(2);
+      for (const span of spans) {
+        expect(span.environment).toBe("production");
+      }
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Nested @track requested environment "this-should-be-ignored"')
+      );
+    });
+  });
+});

--- a/sdks/typescript/tests/integration/environment.test.ts
+++ b/sdks/typescript/tests/integration/environment.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Opik } from "@/index";
+import {
+  _resetTrackOpikClientCache,
+  getTrackOpikClient,
+  track,
+} from "@/decorators/track";
+import {
+  shouldRunIntegrationTests,
+  getIntegrationTestStatus,
+} from "./api/shouldRunIntegrationTests";
+import { pollUntil } from "./helpers";
+
+const shouldRunApiTests = shouldRunIntegrationTests();
+
+describe.skipIf(!shouldRunApiTests)("Environment Integration Tests", () => {
+  let client: Opik;
+  const projectName = `ts-e2e-environment-${Date.now()}`;
+  const createdEnvNames: string[] = [];
+
+  beforeAll(() => {
+    console.log(getIntegrationTestStatus());
+    client = new Opik({ projectName });
+  });
+
+  afterAll(async () => {
+    for (const name of createdEnvNames) {
+      try {
+        await client.deleteEnvironment(name);
+      } catch {
+        // best effort
+      }
+    }
+    await client.flush();
+  }, 30000);
+
+  describe("CRUD", () => {
+    it("creates, lists, updates, and deletes an environment by name", async () => {
+      const name = `env-${Date.now()}`;
+      createdEnvNames.push(name);
+
+      const created = await client.createEnvironment(name, {
+        description: "created by TS e2e test",
+        color: "#abcdef",
+      });
+      expect(created.name).toBe(name);
+      expect(created.description).toBe("created by TS e2e test");
+      expect(created.color).toBe("#abcdef");
+      expect(created.id).toBeDefined();
+
+      const listed = await client.getEnvironments();
+      expect(listed.some((e) => e.name === name)).toBe(true);
+
+      const updated = await client.updateEnvironment(name, {
+        description: "updated by TS e2e test",
+      });
+      expect(updated.name).toBe(name);
+      expect(updated.description).toBe("updated by TS e2e test");
+
+      await client.deleteEnvironment(name);
+      // Calling delete on a missing name is a no-op.
+      await client.deleteEnvironment(name);
+
+      const afterDelete = await client.getEnvironments();
+      expect(afterDelete.some((e) => e.name === name)).toBe(false);
+    }, 30000);
+  });
+
+  describe("Trace and span persistence", () => {
+    it("persists per-call environment on the trace", async () => {
+      const envName = `env-${Date.now()}`;
+      createdEnvNames.push(envName);
+      await client.createEnvironment(envName);
+
+      const trace = client.trace({
+        name: "env-trace",
+        environment: envName,
+      });
+      trace.end();
+      await client.flush();
+
+      const fetched = await pollUntil(async () => {
+        try {
+          const t = await client.api.traces.getTraceById(trace.data.id);
+          return t.environment === envName ? t : undefined;
+        } catch {
+          return undefined;
+        }
+      });
+      expect(fetched.environment).toBe(envName);
+    }, 60000);
+
+    it("span inherits trace environment, ignoring per-call override on @track", async () => {
+      const envName = `env-${Date.now()}`;
+      createdEnvNames.push(envName);
+      await client.createEnvironment(envName);
+
+      // Use a fresh tracked client so the test owns its lifecycle / project.
+      _resetTrackOpikClientCache();
+      const trackClient = getTrackOpikClient();
+
+      let innerSpanId: string | undefined;
+      let innerTraceId: string | undefined;
+
+      const inner = track(
+        { name: "inner-fn", environment: "this-should-be-ignored" },
+        async () => {
+          // grab the active span/trace at call time
+          const { getTrackContext } = await import("@/decorators/track");
+          const ctx = getTrackContext();
+          innerSpanId = ctx?.span.data.id;
+          innerTraceId = ctx?.trace.data.id;
+          return "ok";
+        }
+      );
+
+      const outer = track(
+        {
+          name: "outer-fn",
+          environment: envName,
+          projectName,
+        },
+        async () => inner()
+      );
+
+      await outer();
+      await trackClient.flush();
+
+      expect(innerSpanId).toBeDefined();
+      expect(innerTraceId).toBeDefined();
+
+      const fetchedSpan = await pollUntil(async () => {
+        try {
+          const s = await trackClient.api.spans.getSpanById(innerSpanId!);
+          return s.environment === envName ? s : undefined;
+        } catch {
+          return undefined;
+        }
+      });
+      expect(fetchedSpan.environment).toBe(envName);
+
+      const fetchedTrace = await trackClient.api.traces.getTraceById(
+        innerTraceId!
+      );
+      expect(fetchedTrace.environment).toBe(envName);
+    }, 60000);
+
+    it("trace without environment still logs (back-compat)", async () => {
+      const trace = client.trace({ name: "no-env-trace" });
+      trace.end();
+      await client.flush();
+
+      const fetched = await pollUntil(async () => {
+        try {
+          return await client.api.traces.getTraceById(trace.data.id);
+        } catch {
+          return undefined;
+        }
+      });
+      expect(fetched.id).toBe(trace.data.id);
+    }, 60000);
+  });
+
+  describe("OQL in / not_in filtering", () => {
+    it("filters traces by environment using in operator", async () => {
+      const envName = `env-${Date.now()}`;
+      createdEnvNames.push(envName);
+      await client.createEnvironment(envName);
+
+      const trace = client.trace({ name: "oql-in-trace", environment: envName });
+      trace.end();
+      await client.flush();
+
+      const results = await client.searchTraces({
+        projectName,
+        filterString: `environment in ("${envName}")`,
+        waitForAtLeast: 1,
+        waitForTimeout: 30,
+      });
+      expect(results.some((t) => t.id === trace.data.id)).toBe(true);
+    }, 60000);
+
+    it("excludes traces by environment using not_in operator", async () => {
+      const envName = `env-${Date.now()}`;
+      createdEnvNames.push(envName);
+      await client.createEnvironment(envName);
+
+      const included = client.trace({
+        name: "oql-not-in-included",
+        environment: envName,
+      });
+      included.end();
+      await client.flush();
+
+      const results = await client.searchTraces({
+        projectName,
+        filterString: `environment not_in ("__nonexistent__")`,
+        waitForAtLeast: 1,
+        waitForTimeout: 30,
+      });
+      expect(results.some((t) => t.id === included.data.id)).toBe(true);
+    }, 60000);
+  });
+});

--- a/sdks/typescript/tests/integration/helpers.ts
+++ b/sdks/typescript/tests/integration/helpers.ts
@@ -1,0 +1,15 @@
+const POLL_TIMEOUT_MS = 5_000;
+const POLL_INTERVAL_MS = 200;
+
+export async function pollUntil<T>(
+  fetch: () => Promise<T | undefined>,
+  timeoutMs = POLL_TIMEOUT_MS
+): Promise<T> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const result = await fetch();
+    if (result !== undefined) return result;
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  throw new Error("pollUntil: timeout");
+}

--- a/sdks/typescript/tests/unit/query/OpikQueryLanguage.test.ts
+++ b/sdks/typescript/tests/unit/query/OpikQueryLanguage.test.ts
@@ -538,4 +538,95 @@ describe("OpikQueryLanguage", () => {
       });
     });
   });
+
+  describe("in / not_in operators", () => {
+    it("should parse in operator on enum field (trace)", () => {
+      const oql = OpikQueryLanguage.forTraces(
+        'environment in ("prod", "staging")'
+      );
+      const parsed = oql.getFilterExpressions();
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed![0]).toMatchObject({
+        field: "environment",
+        operator: "in",
+        value: "prod,staging",
+      });
+    });
+
+    it("should parse not_in operator on enum field (trace)", () => {
+      const oql = OpikQueryLanguage.forTraces('environment not_in ("debug")');
+      const parsed = oql.getFilterExpressions();
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed![0]).toMatchObject({
+        field: "environment",
+        operator: "not_in",
+        value: "debug",
+      });
+    });
+
+    it("should parse in operator chained with AND", () => {
+      const oql = OpikQueryLanguage.forTraces(
+        'environment in ("a", "b") and input contains "hello"'
+      );
+      const parsed = oql.getFilterExpressions();
+
+      expect(parsed).toHaveLength(2);
+      expect(parsed![0]).toMatchObject({
+        field: "environment",
+        operator: "in",
+        value: "a,b",
+      });
+      expect(parsed![1]).toMatchObject({
+        field: "input",
+        operator: "contains",
+        value: "hello",
+      });
+    });
+
+    it("should parse in operator on enum field (span)", () => {
+      const oql = OpikQueryLanguage.forSpans(
+        'environment in ("debug", "prod")'
+      );
+      const parsed = oql.getFilterExpressions();
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed![0]).toMatchObject({
+        field: "environment",
+        operator: "in",
+        value: "debug,prod",
+      });
+    });
+
+    it("should throw error when in operator value is not an array", () => {
+      expect(() => {
+        OpikQueryLanguage.forTraces('environment in "prod"');
+      }).toThrow(/Expected array value starting with '\('/);
+    });
+
+    it("should throw error for unterminated array", () => {
+      expect(() => {
+        OpikQueryLanguage.forTraces('environment in ("unterminated"');
+      }).toThrow(/Unterminated array value/);
+    });
+
+    it("should throw error for unquoted array element", () => {
+      expect(() => {
+        OpikQueryLanguage.forTraces("environment in (unquoted)");
+      }).toThrow(/Array elements must be quoted strings/);
+    });
+
+    it("should throw error for empty array in in operator", () => {
+      expect(() => {
+        OpikQueryLanguage.forTraces("environment in ()");
+      }).toThrow(/Expected at least one item/);
+    });
+
+    it("should throw error for empty array in not_in operator", () => {
+      expect(() => {
+        OpikQueryLanguage.forTraces("environment not_in ()");
+      }).toThrow(/Expected at least one item/);
+    });
+  });
 });

--- a/sdks/typescript/tests/unit/query/OpikQueryLanguage.test.ts
+++ b/sdks/typescript/tests/unit/query/OpikQueryLanguage.test.ts
@@ -628,5 +628,19 @@ describe("OpikQueryLanguage", () => {
         OpikQueryLanguage.forTraces("environment not_in ()");
       }).toThrow(/Expected at least one item/);
     });
+
+    it("should throw error when a single array element contains a comma", () => {
+      // The backend splits on comma to recover individual values, so a comma
+      // inside a value cannot be represented — reject it early with a clear message.
+      expect(() => {
+        OpikQueryLanguage.forTraces('environment in ("hello,world")');
+      }).toThrow(/Array element values cannot contain commas/);
+    });
+
+    it("should throw error when any array element in a multi-item array contains a comma", () => {
+      expect(() => {
+        OpikQueryLanguage.forTraces('environment in ("a,b", "c")');
+      }).toThrow(/Array element values cannot contain commas/);
+    });
   });
 });


### PR DESCRIPTION
## Details

Adds `environment` support to traces, spans, and threads across both the Python and TypeScript SDKs, so LLM calls can be tagged with a lifecycle stage (e.g. `development`, `staging`, `production`).

### Python SDK

Resolution priority: per-call argument > `OPIK_ENVIRONMENT` env var > `None`. No persistence in `~/.opik.config`, no new `OpikConfig` field, no `Opik()` constructor parameter.

- `Opik.trace`, `Opik.span`, and `@track` all accept `environment=...`.
- `search_traces`, `search_spans`, and `search_threads` support environment filtering via `filter_string` using OQL.
- Environment CRUD on `Opik`: `create_environment`, `get_environment`, `get_environments`, `update_environment`, `delete_environment`. Public `opik.Environment` re-export.
- OQL operators: `=`, `!=`, `in`, `not_in`.

```python
import opik

client = opik.Opik()

# 1. Per-call environment
trace = client.trace(name="my-trace", environment="production")

# 2. Decorator
@opik.track(environment="production")
def llm_call(prompt: str) -> str:
    return call_llm(prompt)

# 3. Env var fallback (no code change needed)
# OPIK_ENVIRONMENT=production python my_script.py

# 4. Filter searches via OQL
traces = client.search_traces(filter_string='environment = "production"')
spans  = client.search_spans(filter_string='environment in ("staging", "production")')

# 5. Environment CRUD
client.create_environment("production", description="Live traffic", color="#FF0000")
client.update_environment("production", description="Updated description")
envs = client.get_environments()
client.delete_environment("old-env")
```

### TypeScript SDK

Resolution priority: per-call argument > `OPIK_ENVIRONMENT` env var > `undefined`. There is no constructor-level parameter — `new Opik()` does not accept `environment`. Nested `@track` spans inherit the enclosing trace's environment; per-span overrides are ignored with a warning.

- `client.trace()`, `client.span()`, and `@track` accept `environment`.
- `searchTraces`, `searchSpans`, and `searchThreads` support environment filtering via `filterString` using OQL.
- Same Environment CRUD surface as Python: `createEnvironment`, `getEnvironments`, `updateEnvironment`, `deleteEnvironment`.
- OQL operators: `=`, `!=`, `in`, `not_in`.

```typescript
import { Opik } from "opik";

const client = new Opik();

// 1. Per-call environment
const trace = await client.trace({ name: "my-trace", environment: "production" });

// 2. Decorator
class MyAgent {
  @track({ environment: "production" })
  async llmCall(prompt: string): Promise<string> {
    return callLlm(prompt);
  }
}

// 3. Env var fallback (no code change needed)
// OPIK_ENVIRONMENT=production node my_script.js

// 4. Filter searches via OQL
const traces = await client.searchTraces({ filterString: 'environment = "production"' });
const spans  = await client.searchSpans({ filterString: 'environment in ("staging", "production")' });

// 5. Environment CRUD
await client.createEnvironment("production", { description: "Live traffic", color: "#FF0000" });
await client.updateEnvironment("production", { description: "Updated description" });
const envs = await client.getEnvironments();
await client.deleteEnvironment("old-env");
```

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6268

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-sonnet-4-6
  - Scope: Implementation and tests
  - Human verification: Reviewed and validated

## Testing

- `pytest tests/unit/api_objects/test_environment.py` — 10 tests covering resolution priority, payload propagation, `@track(environment=...)` flow, and backwards-compat defaults.
- `pytest tests/e2e/test_environment.py` — 5 tests covering CRUD round-trip, `search_traces(environment=...)`, `search_spans(environment=...)`, constructor-set env, and no-env back-compat. All pass against local backend.
- `pytest tests/unit/ tests/message_processing/` — full suite: 3184 passed.
- TypeScript: `environment.test.ts` + `integration/environment.test.ts` covering CRUD and trace/span propagation.
- CI pending.

## Documentation