### PR TITLE
[OPIK-6308] [BE] feat: tune shared Jersey HTTP client with pooling and timeouts

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -938,6 +938,45 @@ pythonEvaluator:
   # Description: Max wait for the TCP/TLS connection to the Python evaluator to be established.
   connectTimeout: ${PYTHON_EVALUATOR_CONNECT_TIMEOUT:-5s}
 
+# JAX-RS Jersey client configuration. This is the singleton HTTP client shared in the service.
+jerseyClient:
+  # Default: 30s
+  # Description: Overall response read timeout. Per-call timeouts can override via Jersey ClientProperties.READ_TIMEOUT.
+  timeout: ${JERSEY_CLIENT_TIMEOUT:-30s}
+  # Default: 2s
+  # Description: The maximum time to wait for a connection to open.
+  connectionTimeout: ${JERSEY_CLIENT_CONNECTION_TIMEOUT:-2s}
+  # Default: 1s
+  # Description: The maximum time to wait for a connection to be returned from the connection pool.
+  connectionRequestTimeout: ${JERSEY_CLIENT_CONNECTION_REQUEST_TIMEOUT:-1s}
+  # Default: 5m
+  # Description: Max connection lifetime; recycles connections to drain stale upstream pods after rollouts.
+  timeToLive: ${JERSEY_CLIENT_TIME_TO_LIVE:-5m}
+  # Default: 256
+  # Description: The maximum number of concurrent open connections.
+  maxConnections: ${JERSEY_CLIENT_MAX_CONNECTIONS:-256}
+  # Default: 64
+  # Description: The maximum number of concurrent open connections per route.
+  maxConnectionsPerRoute: ${JERSEY_CLIENT_MAX_CONNECTIONS_PER_ROUTE:-64}
+  # Default: 5s
+  # Description: The maximum time before a persistent connection is checked to remain active. If set to 0, no inactivity check will be performed.
+  validateAfterInactivityPeriod: ${JERSEY_CLIENT_VALIDATE_AFTER_INACTIVITY:-5s}
+  # Default: 16
+  # Description: Minimum idle Jersey async worker threads.
+  minThreads: ${JERSEY_CLIENT_MIN_THREADS:-16}
+  # Default: 128
+  # Description: Maximum Jersey async worker threads.
+  maxThreads: ${JERSEY_CLIENT_MAX_THREADS:-128}
+  # Default: 64
+  # Description: The size of the work queue of the pool used for asynchronous requests. Additional threads will be spawn only if the queue is reached its maximum size.
+  workQueueSize: ${JERSEY_CLIENT_WORK_QUEUE_SIZE:-64}
+  # Default: false
+  # Description: Whether to send gzipped request bodies. Off because not all upstreams handle Content-Encoding: gzip on requests.
+  gzipEnabledForRequests: ${JERSEY_CLIENT_GZIP_ENABLED_FOR_REQUESTS:-false}
+  # Default: false
+  # Description: Whether to enable Transfer-Encoding: chunked on outbound request bodies. Off because sending Content-Length is universally accepted.
+  chunkedEncodingEnabled: ${JERSEY_CLIENT_CHUNKED_ENCODING_ENABLED:-false}
+
 serviceToggles:
   # Default: true
   # Description: Whether or not Python evaluator is enabled

--- a/apps/opik-backend/pom.xml
+++ b/apps/opik-backend/pom.xml
@@ -135,6 +135,10 @@
             <artifactId>dropwizard-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty.ee10</groupId>
             <artifactId>jetty-ee10-servlets</artifactId>
         </dependency>

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
@@ -1,6 +1,7 @@
 package com.comet.opik.infrastructure;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.jobs.JobConfiguration;
 import jakarta.validation.Valid;
@@ -82,6 +83,9 @@ public class OpikConfiguration extends JobConfiguration {
 
     @Valid @NotNull @JsonProperty
     private PythonEvaluatorConfig pythonEvaluator = new PythonEvaluatorConfig();
+
+    @Valid @NotNull @JsonProperty
+    private JerseyClientConfiguration jerseyClient = new JerseyClientConfiguration();
 
     @Valid @NotNull @JsonProperty
     private ServiceTogglesConfig serviceToggles = new ServiceTogglesConfig();

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
@@ -18,7 +18,6 @@ import com.google.inject.Provides;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -37,7 +36,8 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
     public AuthService authService(
             @Config("authentication") AuthenticationConfig config,
             @NonNull Provider<RequestContext> requestContext,
-            @NonNull RedissonReactiveClient redissonClient) {
+            @NonNull RedissonReactiveClient redissonClient,
+            @NonNull Client client) {
 
         if (!config.isEnabled()) {
             return new AuthServiceImpl(requestContext);
@@ -53,17 +53,14 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
                 ? new AuthCredentialsCacheService(redissonClient, config.getApiKeyResolutionCacheTTLInSec())
                 : new NoopCacheService();
 
-        return new RemoteAuthService(client(), config.getReactService(), requestContext, cacheService);
-    }
-
-    public Client client() {
-        return ClientBuilder.newClient();
+        return new RemoteAuthService(client, config.getReactService(), requestContext, cacheService);
     }
 
     @Provides
     @Singleton
     public WorkspacePermissionsService workspacePermissionsService(
-            @Config("authentication") AuthenticationConfig config) {
+            @Config("authentication") AuthenticationConfig config,
+            @NonNull Client client) {
 
         if (!config.isEnabled()) {
             return new LocalWorkspacePermissionsService();
@@ -75,7 +72,7 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
         Preconditions.checkArgument(StringUtils.isNotBlank(config.getReactService().url()),
                 "The property authentication.reactService.url must not be blank when authentication is enabled");
 
-        return new RemoteWorkspacePermissionsService(client(), config.getReactService());
+        return new RemoteWorkspacePermissionsService(client, config.getReactService());
     }
 
     @Provides

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/HttpModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/HttpModule.java
@@ -1,17 +1,46 @@
 package com.comet.opik.infrastructure.http;
 
 import com.comet.opik.infrastructure.OpikConfiguration;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Provides;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.jackson.Jackson;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
 import ru.vyarus.dropwizard.guice.module.support.DropwizardAwareModule;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
 public class HttpModule extends DropwizardAwareModule<OpikConfiguration> {
+
+    public static final String CLIENT_NAME = "opik-shared-jersey-client";
+
+    /**
+     * Provides the singleton {@link Client} for outbound HTTP calls.
+     * <p>
+     * Inbound REST API and outbound HTTP calls follow different serialization strategies. The environment
+     * ObjectMapper carries customizations targeting the inbound API (e.g. {@code SnakeCaseStrategy}) which
+     * must NOT leak into outbound calls. Overriding with a clean {@link Jackson#newObjectMapper()} keeps
+     * the two concerns isolated.
+     */
     @Provides
     @Singleton
-    public Client client() {
-        return ClientBuilder.newClient();
+    public Client client(@Config("jerseyClient") JerseyClientConfiguration config) {
+        var builder = new JerseyClientBuilder(environment());
+        return buildClient(builder, config);
+    }
+
+    /**
+     * Used by the production {@link #client} provider and by some test code paths that build
+     * an equivalent {@link Client} without a full Dropwizard {@code Environment}. Encapsulates the
+     * dedicated outbound {@link Jackson#newObjectMapper()} etc.so the two paths stay close to identical.
+     */
+    @VisibleForTesting
+    public static Client buildClient(JerseyClientBuilder builder, JerseyClientConfiguration config) {
+        return builder
+                .using(config)
+                .using(Jackson.newObjectMapper())
+                .build(CLIENT_NAME);
     }
 
     @Override

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/ClientSupportUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/ClientSupportUtils.java
@@ -1,19 +1,31 @@
 package com.comet.opik.api.resources.utils;
 
+import lombok.experimental.UtilityClass;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.grizzly.connector.GrizzlyConnectorProvider;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 
+@UtilityClass
 public class ClientSupportUtils {
 
-    private ClientSupportUtils() {
+    /**
+     * Not using GrizzlyConnectorProvider for multipart support as it doesn't properly
+     * handle multipart Content-Type headers. Uses the default HttpUrlConnector instead.
+     */
+    public void configMultiPartFeature(ClientSupport client) {
+        configCore(client);
+        client.getClient().register(MultiPartFeature.class);
     }
 
-    public static void config(ClientSupport client) {
-        client.getClient().register(new ConditionalGZipFilter());
-
-        client.getClient().getConfiguration().property(ClientProperties.READ_TIMEOUT, 35_000);
+    public void config(ClientSupport client) {
+        configCore(client);
         client.getClient().getConfiguration().connectorProvider(new GrizzlyConnectorProvider()); // Required for PATCH:
         // https://github.com/dropwizard/dropwizard/discussions/6431/ Required for PATCH:
+    }
+
+    private void configCore(ClientSupport client) {
+        client.getClient().register(new ConditionalGZipFilter());
+        client.getClient().getConfiguration().property(ClientProperties.READ_TIMEOUT, 35_000);
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/TestDropwizardAppExtensionUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/TestDropwizardAppExtensionUtils.java
@@ -140,8 +140,6 @@ public class TestDropwizardAppExtensionUtils {
         }
 
         GuiceyConfigurationHook hook = injector -> {
-            injector.modulesOverride(TestHttpClientUtils.testAuthModule());
-
             Optional.ofNullable(appContextConfig.disableModules)
                     .orElse(List.of())
                     .forEach(injector::disableModules);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/TestHttpClientUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/TestHttpClientUtils.java
@@ -1,12 +1,26 @@
 package com.comet.opik.api.resources.utils;
 
-import com.comet.opik.infrastructure.auth.AuthModule;
+import com.codahale.metrics.MetricRegistry;
+import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.infrastructure.http.HttpModule;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.configuration.ConfigurationException;
+import io.dropwizard.configuration.FileConfigurationSourceProvider;
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
 import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
+import lombok.Getter;
+import lombok.experimental.Accessors;
 import lombok.experimental.UtilityClass;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
-import org.apache.http.ssl.SSLContextBuilder;
+
+import java.io.IOException;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.comet.opik.api.ReactServiceErrorResponse.MISSING_API_KEY;
 
@@ -21,25 +35,53 @@ public class TestHttpClientUtils {
     public static final io.dropwizard.jersey.errors.ErrorMessage NO_API_KEY_RESPONSE = new io.dropwizard.jersey.errors.ErrorMessage(
             401, MISSING_API_KEY);
 
-    public static Client client() {
+    /**
+     * Returns a static {@link Client} for direct unit tests that construct services manually
+     * and therefore cannot receive the production singleton via dependency injection.
+     * <p>
+     * Does not build the client itself: delegates to {@link HttpModule#buildClient} with the
+     * configuration from {@code config-test.yml} so the resulting client is wired
+     * close to identically to the production singleton client.
+     * <p>
+     * Callers must NOT close the returned client. It is shared across tests and its worker
+     * threads are daemons, so the underlying executor and connection pool are released on
+     * JVM shutdown without an explicit {@code close()}.
+     */
+    @Getter
+    @Accessors(fluent = true)
+    private final Client client = newClient();
+
+    private Client newClient() {
         try {
-            return ClientBuilder.newBuilder()
-                    .sslContext(SSLContextBuilder.create()
-                            .loadTrustMaterial(new TrustSelfSignedStrategy())
-                            .build())
-                    .hostnameVerifier(NoopHostnameVerifier.INSTANCE)
-                    .build();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+            var jerseyConfig = parseTestOpikConfiguration().getJerseyClient();
+            var executor = new ThreadPoolExecutor(
+                    jerseyConfig.getMinThreads(),
+                    jerseyConfig.getMaxThreads(),
+                    60L, TimeUnit.SECONDS,
+                    new ArrayBlockingQueue<>(jerseyConfig.getWorkQueueSize()),
+                    newThreadFactory());
+            var jerseyClientBuilder = new JerseyClientBuilder(new MetricRegistry())
+                    .using(executor);
+            return HttpModule.buildClient(jerseyClientBuilder, jerseyConfig);
+        } catch (Exception exception) {
+            throw new RuntimeException(exception);
         }
     }
 
-    public static AuthModule testAuthModule() {
-        return new AuthModule() {
-            @Override
-            public Client client() {
-                return TestHttpClientUtils.client();
-            }
+    private OpikConfiguration parseTestOpikConfiguration() throws IOException, ConfigurationException {
+        var yamlConfigFactory = new YamlConfigurationFactory<>(
+                OpikConfiguration.class, Validators.newValidator(), Jackson.newObjectMapper(), "dw");
+        return yamlConfigFactory.build(new FileConfigurationSourceProvider(), "src/test/resources/config-test.yml");
+    }
+
+    private ThreadFactory newThreadFactory() {
+        var counter = new AtomicLong();
+        var defaultThreadFactory = Executors.defaultThreadFactory();
+        return runnable -> {
+            var thread = defaultThreadFactory.newThread(runnable);
+            thread.setName("thread-%s-test-%d".formatted(HttpModule.CLIENT_NAME, counter.incrementAndGet()));
+            thread.setDaemon(true);
+            return thread;
         };
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AttachmentResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AttachmentResourceClient.java
@@ -7,9 +7,9 @@ import com.comet.opik.api.attachment.DeleteAttachmentsRequest;
 import com.comet.opik.api.attachment.EntityType;
 import com.comet.opik.api.attachment.StartMultipartUploadRequest;
 import com.comet.opik.api.attachment.StartMultipartUploadResponse;
+import com.comet.opik.api.resources.utils.TestHttpClientUtils;
 import com.comet.opik.api.resources.utils.TestUtils;
 import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
@@ -32,12 +32,8 @@ public class AttachmentResourceClient {
 
     public AttachmentResourceClient(ClientSupport client) {
         this.client = client;
-        this.externatClient = ClientBuilder.newClient();
+        this.externatClient = TestHttpClientUtils.client();
         this.baseURI = TestUtils.getBaseUrl(client);
-    }
-
-    public void close() {
-        externatClient.close();
     }
 
     public StartMultipartUploadResponse startMultiPartUpload(

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/WebhookSubscriberLoggingTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/WebhookSubscriberLoggingTest.java
@@ -23,7 +23,6 @@ import com.redis.testcontainers.RedisContainer;
 import io.dropwizard.util.Duration;
 import io.r2dbc.spi.ConnectionFactory;
 import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.MediaType;
 import org.awaitility.Awaitility;
 import org.eclipse.jetty.http.HttpHeader;
@@ -103,7 +102,8 @@ class WebhookSubscriberLoggingTest {
     private AlertEventLogsDAO alertEventLogsDAO;
 
     @BeforeAll
-    void setUpAll(ConnectionFactory connectionFactory, RedissonReactiveClient redissonReactiveClient) {
+    void setUpAll(
+            ConnectionFactory connectionFactory, RedissonReactiveClient redissonReactiveClient, Client httpClient) {
         // Get real dependencies via parameter injection
         var userLogTableFactory = UserLogTableFactory.getInstance(connectionFactory);
         alertEventLogsDAO = (AlertEventLogsDAO) userLogTableFactory
@@ -113,8 +113,6 @@ class WebhookSubscriberLoggingTest {
         setupWireMock();
 
         webhookConfig = createWebhookConfig();
-
-        Client httpClient = ClientBuilder.newClient();
 
         // Create real WebhookHttpClient
         webhookHttpClient = new WebhookHttpClient(httpClient, webhookConfig);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/WebhookSubscriberTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/WebhookSubscriberTest.java
@@ -3,6 +3,7 @@ package com.comet.opik.api.resources.v1.events;
 import com.comet.opik.api.AlertEventType;
 import com.comet.opik.api.AlertType;
 import com.comet.opik.api.events.webhooks.WebhookEvent;
+import com.comet.opik.api.resources.utils.TestHttpClientUtils;
 import com.comet.opik.api.resources.v1.events.webhooks.WebhookHttpClient;
 import com.comet.opik.infrastructure.WebhookConfig;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
@@ -43,7 +44,6 @@ class WebhookSubscriberTest {
 
     private WireMockServer wireMockServer;
     private WebhookConfig webhookConfig;
-    private WebhookHttpClient webhookHttpClient;
     private WebhookSubscriber webhookSubscriber;
 
     @BeforeEach
@@ -53,6 +53,8 @@ class WebhookSubscriberTest {
 
         webhookConfig = createWebhookConfig();
 
+        WebhookHttpClient webhookHttpClient;
+
         // Mock the static UserFacingLoggingFactory.getLogger method
         try (MockedStatic<UserFacingLoggingFactory> mockedFactory = mockStatic(UserFacingLoggingFactory.class)) {
             mockedFactory.when(() -> UserFacingLoggingFactory.getLogger(any(Class.class)))
@@ -60,9 +62,7 @@ class WebhookSubscriberTest {
 
             // Create WebhookHttpClient with a real JAX-RS client and a mock UserFacingLoggingFactory
             // Note: The factory parameter is not actually used in the constructor, but is required
-            webhookHttpClient = new WebhookHttpClient(
-                    jakarta.ws.rs.client.ClientBuilder.newClient(),
-                    webhookConfig);
+            webhookHttpClient = new WebhookHttpClient(TestHttpClientUtils.client(), webhookConfig);
         }
 
         webhookSubscriber = new WebhookSubscriber(webhookConfig, redisson, webhookHttpClient);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AttachmentResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AttachmentResourceTest.java
@@ -120,7 +120,6 @@ class AttachmentResourceTest {
     @AfterAll
     void tearDownAll() {
         wireMock.server().stop();
-        attachmentResourceClient.close();
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsCsvUploadResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsCsvUploadResourceTest.java
@@ -6,7 +6,7 @@ import com.comet.opik.api.DatasetItemSource;
 import com.comet.opik.api.DatasetStatus;
 import com.comet.opik.api.resources.utils.AuthTestUtils;
 import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
-import com.comet.opik.api.resources.utils.ConditionalGZipFilter;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
 import com.comet.opik.api.resources.utils.MigrationUtils;
 import com.comet.opik.api.resources.utils.MySQLContainerUtils;
 import com.comet.opik.api.resources.utils.RedisContainerUtils;
@@ -19,17 +19,14 @@ import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.redis.testcontainers.RedisContainer;
-import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.hc.core5.http.HttpStatus;
 import org.awaitility.Awaitility;
-import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
-import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -105,21 +102,15 @@ class DatasetsCsvUploadResourceTest {
     private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
 
     private String baseURI;
-    private Client registeredClient;
+    private ClientSupport registeredClient;
     private DatasetResourceClient datasetResourceClient;
 
     @BeforeAll
     void setUpAll(ClientSupport client) {
         this.baseURI = "http://localhost:%d".formatted(client.getPort());
 
-        // Configure client but DON'T use GrizzlyConnectorProvider for multipart support
-        // GrizzlyConnector doesn't properly handle multipart Content-Type headers
-        client.getClient().register(new ConditionalGZipFilter());
-        client.getClient().property(ClientProperties.READ_TIMEOUT, 35_000);
-        // Note: NOT setting connectorProvider - use default HttpUrlConnector for multipart
-
-        // Register MultiPartFeature on the client and capture the registered client
-        this.registeredClient = client.getClient().register(MultiPartFeature.class);
+        this.registeredClient = client;
+        ClientSupportUtils.configMultiPartFeature(client);
 
         mockTargetWorkspace(API_KEY, TEST_WORKSPACE, WORKSPACE_ID, USER);
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OllamaServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OllamaServiceTest.java
@@ -2,10 +2,9 @@ package com.comet.opik.domain;
 
 import com.comet.opik.api.OllamaConnectionTestResponse;
 import com.comet.opik.api.OllamaModel;
+import com.comet.opik.api.resources.utils.TestHttpClientUtils;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.AfterAll;
@@ -30,7 +29,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class OllamaServiceTest {
 
     private static WireMockServer wireMockServer;
-    private static Client httpClient;
     private static OllamaService ollamaService;
     private static String baseUrl;
 
@@ -41,16 +39,13 @@ class OllamaServiceTest {
         WireMock.configureFor("localhost", wireMockServer.port());
 
         baseUrl = "http://localhost:" + wireMockServer.port();
-        httpClient = ClientBuilder.newClient();
+        var httpClient = TestHttpClientUtils.client();
 
         ollamaService = new OllamaService(httpClient);
     }
 
     @AfterAll
     static void afterAll() {
-        if (httpClient != null) {
-            httpClient.close();
-        }
         if (wireMockServer != null) {
             wireMockServer.stop();
         }

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -499,6 +499,58 @@ pythonEvaluator:
   # Description: Max wait for the TCP/TLS connection to the Python evaluator to be established.
   connectTimeout: 5s
 
+# JAX-RS Jersey client configuration. This is the singleton HTTP client shared in the service.
+jerseyClient:
+  # Default: 30s
+  # Description: Overall response read timeout. Per-call timeouts can override via Jersey ClientProperties.READ_TIMEOUT.
+  timeout: 30s
+  # Default: 2s
+  # Description: The maximum time to wait for a connection to open.
+  connectionTimeout: 2s
+  # Default: 1s
+  # Description: The maximum time to wait for a connection to be returned from the connection pool.
+  connectionRequestTimeout: 1s
+  # Default: 5m
+  # Description: Max connection lifetime; recycles connections to drain stale upstream pods after rollouts.
+  timeToLive: 5m
+  # Default: 256
+  # Description: The maximum number of concurrent open connections.
+  maxConnections: 256
+  # Default: 64
+  # Description: The maximum number of concurrent open connections per route.
+  maxConnectionsPerRoute: 64
+  # Default: 5s
+  # Description: The maximum time before a persistent connection is checked to remain active. If set to 0, no inactivity check will be performed.
+  validateAfterInactivityPeriod: 5s
+  # Default: 16
+  # Description: Minimum idle Jersey async worker threads.
+  minThreads: 16
+  # Default: 128
+  # Description: Maximum Jersey async worker threads.
+  maxThreads: 128
+  # Default: 64
+  # Description: The size of the work queue of the pool used for asynchronous requests. Additional threads will be spawn only if the queue is reached its maximum size.
+  workQueueSize: 64
+  # Default: false
+  # Description: Whether to send gzipped request bodies. Off because not all upstreams handle Content-Encoding: gzip on requests.
+  gzipEnabledForRequests: false
+  # Default: false
+  # Description: Whether to enable Transfer-Encoding: chunked on outbound request bodies. Off because sending Content-Length is universally accepted.
+  chunkedEncodingEnabled: false
+  # Default: false (tests only — production keeps default of true).
+  # Description: Adds an Accept-Encoding: gzip header to all requests, and enables automatic gzip decoding of responses.
+  # WireMock returns plain (non-gzipped) bodies and some response paths surface ZipException.
+  # Off in tests; production upstreams follow the HTTP contract correctly (Content-Encoding only when actually gzipped)
+  gzipEnabled: false
+  # TLS relaxation for tests only. WireMock with uses self-signed certs, miss-matching the hostname.
+  tls:
+    # Default: true
+    # Description: Whether to trust self-signed certificates regardless of trustStore settings.
+    trustSelfSignedCertificates: true
+    # Default: false
+    # Description: Whether to verify the hostname of the server against the hostname presented in the server certificate.
+    verifyHostname: false
+
 serviceToggles:
   # Default: false for testing. It should be enabled for test scenarios when it's relevant.
   # Description: Whether or not Python evaluator is enabled


### PR DESCRIPTION
## Details

Replaces the vanilla `ClientBuilder.newClient()` previously used by `HttpModule` with a properly configured Dropwizard `JerseyClientBuilder` (Apache HttpClient 5 connector, bounded pool, explicit timeouts and connection lifecycle) to fix the JVM thread starvation correlated with Online Evaluation request spikes. Every outbound HTTP consumer in the backend (`RemoteAuthService`, `WebhookHttpClient`, `OllamaService`, `RemoteWorkspacePermissionsService`, `LlmModelRegistryService`, `StatsClient`, `WorkspaceNameService`) already injects the `Client` singleton, so the wiring change is centralized in `HttpModule`.

- New `jerseyClient:` block in `config.yml` and `config-test.yml` (env-var overridable): `timeout=30s`, `connectionTimeout=2s`, `connectionRequestTimeout=1s`, `timeToLive=5m`, `maxConnections=256`, `maxConnectionsPerRoute=64`, `validateAfterInactivityPeriod=5s`, async pool `16-128 / queue 64`, `gzipEnabledForRequests=false`, `chunkedEncodingEnabled=false`. Bounded resource use plus fast-fail via `connectionRequestTimeout` is what addresses the thread starvation root cause.
- `HttpModule.client(@Config)` now builds the singleton via `JerseyClientBuilder` and explicitly overrides the outbound `ObjectMapper` with `Jackson.newObjectMapper()` so the inbound `SnakeCaseStrategy` does not leak into outbound calls (would silently break the React auth contract). `@VisibleForTesting buildClient(builder, config)` is shared with the test path so the test client is wired close to identically.
- `AuthModule.client()` removed; `authService` and `workspacePermissionsService` now take `@NonNull Client client` via Guice — no more per-call `ClientBuilder.newClient()` allocations.
- `TestHttpClientUtils` rebuilt to call `HttpModule.buildClient` against `config-test.yml`. Static `Client` singleton built with a daemon-thread `ThreadPoolExecutor` (no explicit `close()` needed; JVM exit reclaims).
- All test usages of `ClientBuilder.newClient()` removed and replaced per the rule of thumb: tests with the Dropwizard env inject `Client` via guicey parameter (`WebhookSubscriberLoggingTest`); SDK-simulating tests use `TestHttpClientUtils.client()` (`OllamaServiceTest`, `WebhookSubscriberTest`, `RemoteAuthServiceTest`, `RemoteWorkspacePermissionsServiceTest`); in-process API consumers use `ClientSupport`. `AttachmentResourceClient.close()` and the `httpClient.close()` calls in tests are removed (singleton must not be closed). `ClientSupportUtils` gains a `configMultiPartFeature(...)` variant so `DatasetsCsvUploadResourceTest` no longer inlines its own client setup.

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues
- OPIK-6308

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: Full implementation, configuration, and test migration; reviewed and iterated with the human author throughout
- Human verification: Code review, manual reasoning on every config value, full test runs after each iteration.

## Testing

- Targeted backend test runs after each iteration (from `apps/opik-backend`):
  - `mvn test -Dtest='RemoteAuthServiceTest,RemoteWorkspacePermissionsServiceTest,AuthModuleCache2E2Test'` — 19/19, 5/5, 1/1
  - `mvn test -Dtest='WebhookSubscriberTest,WebhookSubscriberLoggingTest,OllamaServiceTest'` — 5/5, 2/2, 13/13
  - `mvn test -Dtest='AttachmentResourceTest,AttachmentResourceMinIOTest,DatasetsCsvUploadResourceTest'` — 3/3, 4/4, 7/7
- Scenarios validated:
  - Production-style outbound from the singleton is exercised by `AuthModuleCache2E2Test` (auth flow against WireMock through the test app's HttpModule singleton built from `config-test.yml`).
  - WireMock plain-body responses validated against `gzipEnabled=false` test config (avoids `ZipException`).
  - S3-style pre-signed URL `PUT` validated against `chunkedEncodingEnabled=false` test config (`AttachmentResourceTest#uploadAttachmentWithMultiPartPresignUrl` — would otherwise broken-pipe due to chunked encoding being rejected by MinIO/S3).
  - Multipart upload via `DatasetsCsvUploadResourceTest` continues to work with `ClientSupportUtils.configMultiPartFeature` (no `GrizzlyConnectorProvider`).
- Environment/context: local Maven, Surefire, Testcontainers (MySQL, ClickHouse, Redis, MinIO), WireMock.
- Tests not run: full repository-wide `mvn test` skipped per workflow convention (CI handles it).
- Production validation: JIRA OPIK-6308 status is `DEPLOYED TO PROD` — settings have been validated under real production traffic patterns.

## Documentation

N/A — configuration is documented inline in `config.yml` and `config-test.yml` (every key has Default + Description comments, and the test-only overrides explain the test-vs-prod divergence and the WireMock/S3 motivation).