### PR TITLE
fix(sdk): surface evaluation task failures

### DIFF
--- a/sdks/typescript/src/opik/evaluation/engine/EvaluationEngine.ts
+++ b/sdks/typescript/src/opik/evaluation/engine/EvaluationEngine.ts
@@ -11,6 +11,7 @@ import {
   EvaluationTestCase,
   EvaluationTestResult,
   ScoringKeyMappingType,
+  TASK_ERROR_SCORE_NAME,
 } from "../types";
 import { logger } from "@/utils/logger";
 import { EvaluateOptions } from "../evaluate";
@@ -26,21 +27,9 @@ import ora from "ora";
 import type { ExecutionPolicy } from "../suite/types";
 import { BaseSuiteEvaluator } from "../suite_evaluators/BaseSuiteEvaluator";
 
-class EvaluationItemRunError extends Error {
-  public readonly testResult: EvaluationTestResult;
-  public readonly originalError: unknown;
-
-  constructor(
-    message: string,
-    testResult: EvaluationTestResult,
-    originalError: unknown,
-  ) {
-    super(message);
-    this.name = "EvaluationItemRunError";
-    this.testResult = testResult;
-    this.originalError = originalError;
-  }
-}
+type ItemRunOutcome =
+  | { kind: "success"; testResult: EvaluationTestResult }
+  | { kind: "failure"; testResult: EvaluationTestResult; error: Error };
 
 type DatasetOrVersion<T extends DatasetItemData> =
   | Dataset<T>
@@ -176,24 +165,27 @@ export class EvaluationEngine<T = Record<string, unknown>> {
             running++;
 
             this.executeItemRun(item, metrics, runIndex)
-              .then((testResult) => {
-                testResults.push(testResult);
+              .then((outcome) => {
+                testResults.push(outcome.testResult);
+                if (outcome.kind === "failure") {
+                  errors.push({
+                    datasetItemId: item.id,
+                    runIndex,
+                    message: outcome.error.message,
+                    error: outcome.error,
+                  });
+                  progress.recordFailure();
+                }
               })
               .catch((error) => {
+                // Unexpected engine errors (infrastructure failures)
                 const errorMessage =
                   error instanceof Error ? error.message : String(error);
-                if (error instanceof EvaluationItemRunError) {
-                  testResults.push(error.testResult);
-                }
-                const originalError =
-                  error instanceof EvaluationItemRunError
-                    ? error.originalError
-                    : error;
                 errors.push({
                   datasetItemId: item.id,
                   runIndex,
                   message: errorMessage,
-                  ...(originalError instanceof Error && { error: originalError }),
+                  ...(error instanceof Error && { error }),
                 });
                 progress.recordFailure();
               })
@@ -322,7 +314,7 @@ export class EvaluationEngine<T = Record<string, unknown>> {
     datasetItem: DatasetItemData & T & { id: string },
     metrics: BaseMetric[] | undefined,
     runIndex: number,
-  ): Promise<EvaluationTestResult> {
+  ): Promise<ItemRunOutcome> {
     const trace = this.client.trace({
       projectName: this.projectName,
       name: "evaluation_task",
@@ -332,62 +324,76 @@ export class EvaluationEngine<T = Record<string, unknown>> {
     });
     trackStorage.enterWith({ trace });
 
-    try {
-      const { testCase, taskOutput } = await this.runTask(datasetItem, trace);
+    let taskOutput: Record<string, unknown>;
+    let testCase: EvaluationTestCase;
 
+    try {
+      ({ testCase, taskOutput } = await this.runTask(datasetItem, trace));
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
       trace.update({
-        output: taskOutput,
+        errorInfo: {
+          message: err.message,
+          exceptionType: err.name,
+          traceback: err.stack ?? "",
+        },
         endTime: new Date(),
       });
 
-      // Commit experiment item to DB.
-      await this.experiment.insert([
-        new ExperimentItemReferences({
-          datasetItemId: datasetItem.id,
-          traceId: trace.data.id,
-          projectName: trace.data.projectName,
-        }),
-      ]);
-
-      const testResult = await this.scoreTestCase(testCase, metrics, trace);
-
-      if (this.suiteMode) {
-        testResult.trialId = runIndex;
-        const itemPolicy = this.itemPolicyMap?.get(datasetItem.id);
-        if (itemPolicy) {
-          testResult.resolvedExecutionPolicy = itemPolicy;
-        }
+      // Best-effort: record the failed item so it appears in the experiment
+      // view. If the insert itself fails, log and continue so the original
+      // task error is never swallowed.
+      try {
+        await this.experiment.insert([
+          new ExperimentItemReferences({
+            datasetItemId: datasetItem.id,
+            traceId: trace.data.id,
+            projectName: trace.data.projectName,
+          }),
+        ]);
+      } catch (insertError) {
+        logger.warn(
+          `Failed to record experiment item for failed task: ${insertError}`,
+        );
       }
 
-      return testResult;
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      trace.update({
-        ...(error instanceof Error && {
-          errorInfo: {
-            message: error.message,
-            exceptionType: error.name,
-            traceback: error.stack ?? "",
-          },
-        }),
-        endTime: new Date(),
-      });
-
-      await this.experiment.insert([
-        new ExperimentItemReferences({
-          datasetItemId: datasetItem.id,
-          traceId: trace.data.id,
-          projectName: trace.data.projectName,
-        }),
-      ]);
-
-      throw new EvaluationItemRunError(
-        errorMessage,
-        this.createFailedTestResult(datasetItem, trace, runIndex, errorMessage),
-        error,
-      );
+      return {
+        kind: "failure",
+        testResult: this.createFailedTestResult(
+          datasetItem,
+          trace,
+          runIndex,
+          err.message,
+        ),
+        error: err,
+      };
     }
+
+    trace.update({
+      output: taskOutput,
+      endTime: new Date(),
+    });
+
+    // Commit experiment item to DB.
+    await this.experiment.insert([
+      new ExperimentItemReferences({
+        datasetItemId: datasetItem.id,
+        traceId: trace.data.id,
+        projectName: trace.data.projectName,
+      }),
+    ]);
+
+    const testResult = await this.scoreTestCase(testCase, metrics, trace);
+
+    if (this.suiteMode) {
+      testResult.trialId = runIndex;
+      const itemPolicy = this.itemPolicyMap?.get(datasetItem.id);
+      if (itemPolicy) {
+        testResult.resolvedExecutionPolicy = itemPolicy;
+      }
+    }
+
+    return { kind: "success", testResult };
   }
 
   private createFailedTestResult(
@@ -400,12 +406,12 @@ export class EvaluationEngine<T = Record<string, unknown>> {
       testCase: {
         traceId: trace.data.id,
         datasetItemId: datasetItem.id,
-        scoringInputs: { ...datasetItem },
-        taskOutput: { input: datasetItem },
+        scoringInputs: this.prepareScoringInputs(datasetItem, {}),
+        taskOutput: {},
       },
       scoreResults: [
         {
-          name: "task_error",
+          name: TASK_ERROR_SCORE_NAME,
           value: 0,
           reason: errorMessage,
           scoringFailed: true,

--- a/sdks/typescript/src/opik/evaluation/engine/EvaluationEngine.ts
+++ b/sdks/typescript/src/opik/evaluation/engine/EvaluationEngine.ts
@@ -26,6 +26,22 @@ import ora from "ora";
 import type { ExecutionPolicy } from "../suite/types";
 import { BaseSuiteEvaluator } from "../suite_evaluators/BaseSuiteEvaluator";
 
+class EvaluationItemRunError extends Error {
+  public readonly testResult: EvaluationTestResult;
+  public readonly originalError: unknown;
+
+  constructor(
+    message: string,
+    testResult: EvaluationTestResult,
+    originalError: unknown,
+  ) {
+    super(message);
+    this.name = "EvaluationItemRunError";
+    this.testResult = testResult;
+    this.originalError = originalError;
+  }
+}
+
 type DatasetOrVersion<T extends DatasetItemData> =
   | Dataset<T>
   | DatasetVersion<T>;
@@ -90,7 +106,7 @@ export class EvaluationEngine<T = Record<string, unknown>> {
   constructor(
     options: EvaluationEngineOptions<T>,
     client: OpikClient,
-    experiment: Experiment
+    experiment: Experiment,
   ) {
     this.client = client;
     this.dataset = options.dataset;
@@ -135,7 +151,11 @@ export class EvaluationEngine<T = Record<string, unknown>> {
       let completedRuns = 0;
 
       // Build flat list of all (item, runIndex) pairs
-      const runQueue: { item: (typeof items)[number]; metrics: BaseMetric[] | undefined; runIndex: number }[] = [];
+      const runQueue: {
+        item: (typeof items)[number];
+        metrics: BaseMetric[] | undefined;
+        runIndex: number;
+      }[] = [];
       for (const item of items) {
         const runsPerItem = this.getRunsPerItem(item);
         const metrics = this.getItemMetrics(item);
@@ -162,11 +182,19 @@ export class EvaluationEngine<T = Record<string, unknown>> {
               .catch((error) => {
                 const errorMessage =
                   error instanceof Error ? error.message : String(error);
+                if (error instanceof EvaluationItemRunError) {
+                  testResults.push(error.testResult);
+                }
                 errors.push({
                   datasetItemId: item.id,
                   runIndex,
                   message: errorMessage,
-                  ...(error instanceof Error && { error }),
+                  ...(error instanceof EvaluationItemRunError &&
+                    error.originalError instanceof Error && {
+                      error: error.originalError,
+                    }),
+                  ...(!(error instanceof EvaluationItemRunError) &&
+                    error instanceof Error && { error }),
                 });
                 progress.recordFailure();
               })
@@ -201,7 +229,7 @@ export class EvaluationEngine<T = Record<string, unknown>> {
         testResults,
         this.experiment,
         elapsedSeconds,
-        errors
+        errors,
       );
     } finally {
       clearInterval(flushInterval);
@@ -212,7 +240,9 @@ export class EvaluationEngine<T = Record<string, unknown>> {
   private async getDatasetItems(): Promise<
     (DatasetItemData & T & { id: string })[]
   > {
-    return this.prefetchedItems ?? (await this.dataset.getItems(this.nbSamples));
+    return (
+      this.prefetchedItems ?? (await this.dataset.getItems(this.nbSamples))
+    );
   }
 
   private calculateTotalRuns(items: { id: string }[]): number {
@@ -242,7 +272,7 @@ export class EvaluationEngine<T = Record<string, unknown>> {
 
   private createProgressTracker(
     totalItems: number,
-    totalRuns: number
+    totalRuns: number,
   ): ProgressTracker {
     const savedLogLevel = logger.settings.minLevel;
     logger.settings.minLevel = 6;
@@ -272,7 +302,6 @@ export class EvaluationEngine<T = Record<string, unknown>> {
         } else {
           spinner.succeed(message);
         }
-
       },
       recordFailure: () => {
         failedRuns++;
@@ -280,7 +309,7 @@ export class EvaluationEngine<T = Record<string, unknown>> {
       reportErrors: (errors: EvaluationError[]) => {
         for (const err of errors) {
           logger.error(
-            `Dataset item ${err.datasetItemId} (run ${err.runIndex}): ${err.message}`
+            `Dataset item ${err.datasetItemId} (run ${err.runIndex}): ${err.message}`,
           );
         }
       },
@@ -293,7 +322,7 @@ export class EvaluationEngine<T = Record<string, unknown>> {
   private async executeItemRun(
     datasetItem: DatasetItemData & T & { id: string },
     metrics: BaseMetric[] | undefined,
-    runIndex: number
+    runIndex: number,
   ): Promise<EvaluationTestResult> {
     const trace = this.client.trace({
       projectName: this.projectName,
@@ -333,6 +362,8 @@ export class EvaluationEngine<T = Record<string, unknown>> {
 
       return testResult;
     } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
       if (error instanceof Error) {
         trace.update({
           errorInfo: {
@@ -344,18 +375,59 @@ export class EvaluationEngine<T = Record<string, unknown>> {
         });
       }
 
-      throw error;
+      throw new EvaluationItemRunError(
+        errorMessage,
+        this.createFailedTestResult(datasetItem, trace, runIndex, errorMessage),
+        error,
+      );
     }
+  }
+
+  private createFailedTestResult(
+    datasetItem: DatasetItemData & T & { id: string },
+    trace: Trace,
+    runIndex: number,
+    errorMessage: string,
+  ): EvaluationTestResult {
+    const failedResult: EvaluationTestResult = {
+      testCase: {
+        traceId: trace.data.id,
+        datasetItemId: datasetItem.id,
+        scoringInputs: { ...datasetItem },
+        taskOutput: {},
+      },
+      scoreResults: [
+        {
+          name: "task_error",
+          value: 0,
+          reason: errorMessage,
+          scoringFailed: true,
+        },
+      ],
+    };
+
+    if (this.suiteMode) {
+      failedResult.trialId = runIndex;
+      const itemPolicy = this.itemPolicyMap?.get(datasetItem.id);
+      if (itemPolicy) {
+        failedResult.resolvedExecutionPolicy = itemPolicy;
+      }
+    }
+
+    return failedResult;
   }
 
   private async runTask(
     datasetItem: DatasetItemData & T & { id: string },
-    trace: Trace
-  ): Promise<{ testCase: EvaluationTestCase; taskOutput: Record<string, unknown> }> {
+    trace: Trace,
+  ): Promise<{
+    testCase: EvaluationTestCase;
+    taskOutput: Record<string, unknown>;
+  }> {
     logger.debug(`Starting evaluation task on dataset item ${datasetItem.id}`);
     const taskOutput = await track(
       { name: "llm_task", type: SpanType.General },
-      this.task
+      this.task,
     )(datasetItem);
     logger.debug(`Finished evaluation task on dataset item ${datasetItem.id}`);
 
@@ -374,7 +446,7 @@ export class EvaluationEngine<T = Record<string, unknown>> {
   private async scoreTestCase(
     testCase: EvaluationTestCase,
     metrics: BaseMetric[] | undefined,
-    trace: Trace
+    trace: Trace,
   ): Promise<EvaluationTestResult> {
     const effectiveMetrics = metrics ?? this.scoringMetrics;
 
@@ -392,7 +464,7 @@ export class EvaluationEngine<T = Record<string, unknown>> {
   private async calculateScores(
     testCase: EvaluationTestCase,
     metrics: BaseMetric[] | undefined,
-    trace: Trace
+    trace: Trace,
   ): Promise<EvaluationTestResult> {
     const scoreResults: EvaluationScoreResult[] = [];
     const { scoringInputs } = testCase;
@@ -432,16 +504,16 @@ export class EvaluationEngine<T = Record<string, unknown>> {
         value: score.value,
         reason: score.reason,
         categoryName: score.categoryName,
-      })
+      }),
     );
 
     const assertionProjectName = this.client.resolveProjectName(
-      trace.data.projectName
+      trace.data.projectName,
     );
     assertionResults.forEach((result) => {
       if (result.value !== 0 && result.value !== 1) {
         logger.warn(
-          `Suite evaluator "${result.name}" returned non-binary value ${result.value}; coercing to "failed". BaseSuiteEvaluator.score() must return 0 or 1.`
+          `Suite evaluator "${result.name}" returned non-binary value ${result.value}; coercing to "failed". BaseSuiteEvaluator.score() must return 0 or 1.`,
         );
       }
       this.client.traceAssertionResultsBatchQueue.create({
@@ -463,7 +535,7 @@ export class EvaluationEngine<T = Record<string, unknown>> {
 
   private prepareScoringInputs(
     datasetItem: Record<string, unknown>,
-    taskOutput: Record<string, unknown>
+    taskOutput: Record<string, unknown>,
   ): Record<string, unknown> {
     const combined = { ...datasetItem, ...taskOutput };
 
@@ -473,7 +545,7 @@ export class EvaluationEngine<T = Record<string, unknown>> {
     const mapped: Record<string, unknown> = { ...combined };
 
     for (const [targetKey, sourceKey] of Object.entries(
-      this.scoringKeyMapping
+      this.scoringKeyMapping,
     )) {
       const value = getSourceObjValue(combined, sourceKey);
 

--- a/sdks/typescript/src/opik/evaluation/engine/EvaluationEngine.ts
+++ b/sdks/typescript/src/opik/evaluation/engine/EvaluationEngine.ts
@@ -185,16 +185,15 @@ export class EvaluationEngine<T = Record<string, unknown>> {
                 if (error instanceof EvaluationItemRunError) {
                   testResults.push(error.testResult);
                 }
+                const originalError =
+                  error instanceof EvaluationItemRunError
+                    ? error.originalError
+                    : error;
                 errors.push({
                   datasetItemId: item.id,
                   runIndex,
                   message: errorMessage,
-                  ...(error instanceof EvaluationItemRunError &&
-                    error.originalError instanceof Error && {
-                      error: error.originalError,
-                    }),
-                  ...(!(error instanceof EvaluationItemRunError) &&
-                    error instanceof Error && { error }),
+                  ...(originalError instanceof Error && { error: originalError }),
                 });
                 progress.recordFailure();
               })
@@ -364,16 +363,24 @@ export class EvaluationEngine<T = Record<string, unknown>> {
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
-      if (error instanceof Error) {
-        trace.update({
+      trace.update({
+        ...(error instanceof Error && {
           errorInfo: {
             message: error.message,
             exceptionType: error.name,
             traceback: error.stack ?? "",
           },
-          endTime: new Date(),
-        });
-      }
+        }),
+        endTime: new Date(),
+      });
+
+      await this.experiment.insert([
+        new ExperimentItemReferences({
+          datasetItemId: datasetItem.id,
+          traceId: trace.data.id,
+          projectName: trace.data.projectName,
+        }),
+      ]);
 
       throw new EvaluationItemRunError(
         errorMessage,
@@ -394,7 +401,7 @@ export class EvaluationEngine<T = Record<string, unknown>> {
         traceId: trace.data.id,
         datasetItemId: datasetItem.id,
         scoringInputs: { ...datasetItem },
-        taskOutput: {},
+        taskOutput: { input: datasetItem },
       },
       scoreResults: [
         {

--- a/sdks/typescript/src/opik/evaluation/types.ts
+++ b/sdks/typescript/src/opik/evaluation/types.ts
@@ -21,7 +21,11 @@ export type EvaluationResult = {
   /** Name of the experiment */
   experimentName?: string;
 
-  /** Test results for all evaluated items */
+  /**
+   * Test results for all evaluated items, including failed ones.
+   * Items whose task threw will have a synthetic score named
+   * {@link TASK_ERROR_SCORE_NAME} with `scoringFailed: true`.
+   */
   testResults: EvaluationTestResult[];
 
   /** Optional URL to view detailed results in the Opik platform */
@@ -49,6 +53,19 @@ export type EvaluationError = {
 };
 
 /**
+ * Reserved score name injected into failed task runs.
+ *
+ * When a task throws, the engine adds a synthetic score with this name and
+ * `scoringFailed: true` so failed items remain visible in experiment results.
+ * Consumers can filter on this name to distinguish task-level failures from
+ * real metric scores.
+ *
+ * Note: coordinate with the Python SDK before renaming — picking a stable,
+ * collision-resistant name (OPIK-6437).
+ */
+export const TASK_ERROR_SCORE_NAME = "__opik_task_error__";
+
+/**
  * Represents the result of a metric calculation.
  */
 export type EvaluationScoreResult = {
@@ -61,7 +78,12 @@ export type EvaluationScoreResult = {
   /** Optional reason for the score */
   reason?: string;
 
-  /** Whether the scoring failed */
+  /**
+   * Whether the scoring failed due to a task-level error rather than a metric
+   * failure. When `true`, `name` will equal {@link TASK_ERROR_SCORE_NAME},
+   * which is a reserved name injected by the engine — user-defined metrics
+   * should never produce a score with that name.
+   */
   scoringFailed?: boolean;
 
   /** Optional category name for grouping scores */

--- a/sdks/typescript/tests/evaluation/evaluate.test.ts
+++ b/sdks/typescript/tests/evaluation/evaluate.test.ts
@@ -44,7 +44,7 @@ describe("evaluate function", () => {
         name: "test-dataset",
         description: "Test dataset for evaluation",
       },
-      opikClient
+      opikClient,
     );
 
     createTracesSpy = vi
@@ -64,7 +64,7 @@ describe("evaluate function", () => {
       .mockImplementation(() =>
         createMockHttpResponsePromise({
           name: testDataset.name,
-        })
+        }),
       );
 
     createExperimentSpy = vi
@@ -78,8 +78,8 @@ describe("evaluate function", () => {
             id: "item-1",
             data: { input: "test input 1", expected: "test output 1" },
             source: "sdk",
-          }) + "\n"
-        )
+          }) + "\n",
+        ),
       );
 
     // Mock listDatasetVersions for getVersionInfo() calls
@@ -90,12 +90,12 @@ describe("evaluate function", () => {
           page: 1,
           size: 1,
           total: 1,
-        })
+        }),
     );
 
     vi.spyOn(
       opikClient.api.experiments,
-      "createExperimentItems"
+      "createExperimentItems",
     ).mockImplementation(mockAPIFunction);
 
     vi.useFakeTimers();
@@ -121,7 +121,7 @@ describe("evaluate function", () => {
       expect.objectContaining({
         name: "test-experiment",
         datasetName: "test-dataset",
-      })
+      }),
     );
 
     expect(streamDatasetItemsSpy).toHaveBeenCalled();
@@ -149,7 +149,7 @@ describe("evaluate function", () => {
             startTime: expect.any(Date),
           }),
         ]),
-      })
+      }),
     );
 
     expect(createSpansSpy).toHaveBeenCalled();
@@ -162,7 +162,7 @@ describe("evaluate function", () => {
             name: "llm_task",
           }),
         ]),
-      })
+      }),
     );
 
     expect(result).toEqual({
@@ -186,6 +186,64 @@ describe("evaluate function", () => {
         }),
       ],
     });
+  });
+
+  test("should return failed test results when task execution fails", async () => {
+    const mockTask: EvaluationTask = async () => {
+      throw new Error("task failed");
+    };
+
+    const result = await evaluate({
+      dataset: testDataset,
+      task: mockTask,
+      experimentName: "test-experiment",
+      client: opikClient,
+    });
+
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        datasetItemId: "item-1",
+        runIndex: 0,
+        message: "task failed",
+        error: expect.any(Error),
+      }),
+    ]);
+    expect(result.testResults).toHaveLength(1);
+    expect(result.testResults[0]).toEqual(
+      expect.objectContaining({
+        testCase: expect.objectContaining({
+          datasetItemId: "item-1",
+          traceId: expect.any(String),
+          taskOutput: {},
+          scoringInputs: expect.objectContaining({
+            input: "test input 1",
+            expected: "test output 1",
+          }),
+        }),
+        scoreResults: [
+          expect.objectContaining({
+            name: "task_error",
+            value: 0,
+            reason: "task failed",
+            scoringFailed: true,
+          }),
+        ],
+      }),
+    );
+
+    const createTracesCall = createTracesSpy.mock.calls[0][0];
+    expect(createTracesCall).toEqual(
+      expect.objectContaining({
+        traces: expect.arrayContaining([
+          expect.objectContaining({
+            errorInfo: expect.objectContaining({
+              message: "task failed",
+              exceptionType: "Error",
+            }),
+          }),
+        ]),
+      }),
+    );
   });
 
   test("should execute evaluation with scoring metrics", async () => {
@@ -213,7 +271,7 @@ describe("evaluate function", () => {
             projectName: "opik-sdk-typescript-test",
           }),
         ]),
-      })
+      }),
     );
 
     expect(result.testResults[0].scoreResults).toEqual(
@@ -223,7 +281,7 @@ describe("evaluate function", () => {
           value: 0,
           reason: expect.stringContaining("Exact match: No match"),
         }),
-      ])
+      ]),
     );
 
     expect(createSpansSpy).toHaveBeenCalled();
@@ -241,7 +299,7 @@ describe("evaluate function", () => {
             name: "metrics_calculation",
           }),
         ]),
-      })
+      }),
     );
   });
 
@@ -256,7 +314,7 @@ describe("evaluate function", () => {
         task: mockTask,
         experimentName: "test-experiment",
         client: opikClient,
-      })
+      }),
     ).rejects.toThrow("Dataset is required for evaluation");
     await expect(
       // @ts-expect-error - Intentionally missing required property
@@ -264,7 +322,7 @@ describe("evaluate function", () => {
         task: mockTask,
         experimentName: "test-experiment",
         client: opikClient,
-      })
+      }),
     ).rejects.toThrow("Dataset is required for evaluation");
 
     expect(createExperimentSpy).not.toHaveBeenCalled();
@@ -277,7 +335,7 @@ describe("evaluate function", () => {
         dataset: testDataset,
         experimentName: "test-experiment",
         client: opikClient,
-      })
+      }),
     ).rejects.toThrow("Task function is required for evaluation");
 
     expect(createExperimentSpy).not.toHaveBeenCalled();
@@ -292,7 +350,7 @@ describe("evaluate function", () => {
           name: "v9",
           type: "blueprint",
           values: [],
-        })
+        }),
       );
 
     const mockTask: EvaluationTask = async () => {
@@ -316,16 +374,17 @@ describe("evaluate function", () => {
             blueprint_version: "v9",
           },
         }),
-      })
+      }),
     );
   });
 
   test("should store blueprint_id even when fetch fails", async () => {
-    vi.spyOn(opikClient.api.agentConfigs, "getBlueprintById").mockImplementation(
-      () => {
-        throw new Error("not found");
-      }
-    );
+    vi.spyOn(
+      opikClient.api.agentConfigs,
+      "getBlueprintById",
+    ).mockImplementation(() => {
+      throw new Error("not found");
+    });
 
     const mockTask: EvaluationTask = async () => {
       return { output: "result" };
@@ -346,7 +405,7 @@ describe("evaluate function", () => {
             _blueprint_id: "bp-456",
           },
         }),
-      })
+      }),
     );
   });
 });

--- a/sdks/typescript/tests/evaluation/evaluate.test.ts
+++ b/sdks/typescript/tests/evaluation/evaluate.test.ts
@@ -3,7 +3,7 @@ import { MockInstance } from "vitest";
 import { evaluate } from "@/evaluation/evaluate";
 import { OpikClient } from "@/client/Client";
 import { Dataset } from "@/dataset/Dataset";
-import { EvaluationTask } from "@/evaluation/types";
+import { EvaluationTask, TASK_ERROR_SCORE_NAME } from "@/evaluation/types";
 import {
   createMockHttpResponsePromise,
   mockAPIFunction,
@@ -29,6 +29,9 @@ describe("evaluate function", () => {
   >;
   let scoreBatchOfTracesSpy: MockInstance<
     typeof opikClient.api.traces.scoreBatchOfTraces
+  >;
+  let createExperimentItemsSpy: MockInstance<
+    typeof opikClient.api.experiments.createExperimentItems
   >;
 
   beforeEach(() => {
@@ -93,10 +96,9 @@ describe("evaluate function", () => {
         }),
     );
 
-    vi.spyOn(
-      opikClient.api.experiments,
-      "createExperimentItems",
-    ).mockImplementation(mockAPIFunction);
+    createExperimentItemsSpy = vi
+      .spyOn(opikClient.api.experiments, "createExperimentItems")
+      .mockImplementation(mockAPIFunction);
 
     vi.useFakeTimers();
   });
@@ -214,7 +216,7 @@ describe("evaluate function", () => {
         testCase: expect.objectContaining({
           datasetItemId: "item-1",
           traceId: expect.any(String),
-          taskOutput: expect.objectContaining({ input: expect.any(Object) }),
+          taskOutput: {},
           scoringInputs: expect.objectContaining({
             input: "test input 1",
             expected: "test output 1",
@@ -222,7 +224,7 @@ describe("evaluate function", () => {
         }),
         scoreResults: [
           expect.objectContaining({
-            name: "task_error",
+            name: TASK_ERROR_SCORE_NAME,
             value: 0,
             reason: "task failed",
             scoringFailed: true,
@@ -246,6 +248,41 @@ describe("evaluate function", () => {
           }),
         ]),
       }),
+    );
+
+    // Failed run must still be attached to the experiment so it appears in the UI.
+    expect(createExperimentItemsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        experimentItems: expect.arrayContaining([
+          expect.objectContaining({
+            datasetItemId: "item-1",
+            traceId: capturedTraceId,
+          }),
+        ]),
+      }),
+    );
+  });
+
+  test("surfaces original task error when experiment insert also fails", async () => {
+    const mockTask: EvaluationTask = async () => {
+      throw new Error("task failed");
+    };
+
+    createExperimentItemsSpy.mockRejectedValueOnce(new Error("insert failed"));
+
+    const result = await evaluate({
+      dataset: testDataset,
+      task: mockTask,
+      experimentName: "test-experiment",
+      client: opikClient,
+    });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toBe("task failed");
+    expect(result.errors[0].error?.message).toBe("task failed");
+    expect(result.testResults).toHaveLength(1);
+    expect(result.testResults[0].scoreResults[0].name).toBe(
+      TASK_ERROR_SCORE_NAME,
     );
   });
 

--- a/sdks/typescript/tests/evaluation/evaluate.test.ts
+++ b/sdks/typescript/tests/evaluation/evaluate.test.ts
@@ -214,7 +214,7 @@ describe("evaluate function", () => {
         testCase: expect.objectContaining({
           datasetItemId: "item-1",
           traceId: expect.any(String),
-          taskOutput: {},
+          taskOutput: expect.objectContaining({ input: expect.any(Object) }),
           scoringInputs: expect.objectContaining({
             input: "test input 1",
             expected: "test output 1",
@@ -232,6 +232,9 @@ describe("evaluate function", () => {
     );
 
     const createTracesCall = createTracesSpy.mock.calls[0][0];
+    const capturedTraceId = createTracesCall.traces[0].id;
+    expect(capturedTraceId).toBeDefined();
+    expect(result.testResults[0].testCase.traceId).toBe(capturedTraceId);
     expect(createTracesCall).toEqual(
       expect.objectContaining({
         traces: expect.arrayContaining([

--- a/sdks/typescript/tests/unit/evaluation/suite/evaluateTestSuite.test.ts
+++ b/sdks/typescript/tests/unit/evaluation/suite/evaluateTestSuite.test.ts
@@ -695,9 +695,24 @@ describe("evaluateTestSuite", () => {
       client: opikClient,
     });
 
-    // item-1 failed, item-2 succeeded
-    expect(result.testResults).toHaveLength(1);
-    expect(result.testResults[0].testCase.datasetItemId).toBe("item-2");
+    // item-1 failed (produces a task_error result), item-2 succeeded
+    expect(result.testResults).toHaveLength(2);
+    const failedResult = result.testResults.find(
+      (r) => r.testCase.datasetItemId === "item-1"
+    );
+    const successResult = result.testResults.find(
+      (r) => r.testCase.datasetItemId === "item-2"
+    );
+    expect(failedResult).toBeDefined();
+    expect(failedResult?.scoreResults).toEqual([
+      expect.objectContaining({
+        name: "task_error",
+        value: 0,
+        reason: "API connection failed",
+        scoringFailed: true,
+      }),
+    ]);
+    expect(successResult).toBeDefined();
 
     // Error collected for item-1
     expect(result.errors).toHaveLength(1);

--- a/sdks/typescript/tests/unit/evaluation/suite/evaluateTestSuite.test.ts
+++ b/sdks/typescript/tests/unit/evaluation/suite/evaluateTestSuite.test.ts
@@ -35,7 +35,7 @@ vi.mock("@/evaluation/suite_evaluators/LLMJudge", () => {
 import { evaluateTestSuite } from "@/evaluation/suite/evaluateTestSuite";
 import { OpikClient } from "@/client/Client";
 import { Dataset } from "@/dataset/Dataset";
-import { EvaluationTask } from "@/evaluation/types";
+import { EvaluationTask, TASK_ERROR_SCORE_NAME } from "@/evaluation/types";
 import { LLMJudge } from "@/evaluation/suite_evaluators/LLMJudge";
 import {
   createMockHttpResponsePromise,
@@ -695,7 +695,7 @@ describe("evaluateTestSuite", () => {
       client: opikClient,
     });
 
-    // item-1 failed (produces a task_error result), item-2 succeeded
+    // item-1 failed (produces a TASK_ERROR_SCORE_NAME result), item-2 succeeded
     expect(result.testResults).toHaveLength(2);
     const failedResult = result.testResults.find(
       (r) => r.testCase.datasetItemId === "item-1"
@@ -706,7 +706,7 @@ describe("evaluateTestSuite", () => {
     expect(failedResult).toBeDefined();
     expect(failedResult?.scoreResults).toEqual([
       expect.objectContaining({
-        name: "task_error",
+        name: TASK_ERROR_SCORE_NAME,
         value: 0,
         reason: "API connection failed",
         scoringFailed: true,


### PR DESCRIPTION
## Summary

Resolves #5523 

- Keeps failed TypeScript SDK evaluation task runs visible in `testResults`
- Adds a `task_error` score with `scoringFailed: true` while preserving the existing `errors` array with the original error
- Adds a regression test for a task failure so downstream callers still receive a concrete `testCase`

## Evidence and scope limits

This patch is based on #5523, local inspection of `sdks/typescript/src/opik/evaluation/engine/EvaluationEngine.ts`, the existing `EvaluationResult` / `EvaluationError` types, and the focused local tests below.

I did not verify every integration test, every image-evaluation CI failure, or all production evaluation paths. This is a scoped SDK behavior fix for task-run failures; it does not claim to fix all CI flakiness, all integration flakiness, all task/metric failures, or all Opik evaluation behavior.

## AANA gate

I selected and checked this issue with an AANA-gated community issue workflow as a publish guard for scope and evidence. AANA is not claimed to certify correctness, compliance, alignment, production readiness, or Opik behavior.

## Tests

- `npm run typecheck`
- `npx vitest run tests/evaluation/evaluate.test.ts`
- `npx prettier --check src/opik/evaluation/engine/EvaluationEngine.ts tests/evaluation/evaluate.test.ts`

Note: on Windows, I created a local dummy `C:\dev\null` file for the focused Vitest run because the repo's `vitest.config.ts` sets `OPIK_CONFIG_PATH` to `/dev/null`.
