### PR TITLE
[OPIK-6404] [BE] chore: update default environment colors

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000067_reseed_default_environment_colors.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000067_reseed_default_environment_colors.sql
@@ -1,0 +1,17 @@
+--liquibase formatted sql
+--changeset boryst:000067_reseed_default_environment_colors
+--comment: Truncate and reseed default environments with updated colors. Pre-release feature, no production data to preserve.
+
+TRUNCATE TABLE environments;
+
+INSERT INTO environments (id, workspace_id, name, color, position)
+SELECT UUID(), p.workspace_id, n.name, n.color, n.position
+FROM (SELECT DISTINCT workspace_id FROM projects) p
+CROSS JOIN (
+    SELECT 'development' AS name, '#945FCF' AS color, 0 AS position
+    UNION ALL SELECT 'staging', '#12A4B4', 1
+    UNION ALL SELECT 'production', '#19A979', 2
+) n;
+
+-- Rollback drops user-visible data and cannot restore prior color values; intentional no-op.
+--rollback empty

--- a/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
+++ b/apps/opik-python-backend/src/opik_backend/demo_data_generator.py
@@ -111,8 +111,8 @@ def create_feedback_scores_definition(base_url, workspace_name, comet_api_key):
 
 def create_default_environments(base_url, workspace_name, comet_api_key):
     defaults = [
-        {"name": "development", "position": 0, "color": "#EF6868"},
-        {"name": "staging", "position": 1, "color": "#F4B400"},
+        {"name": "development", "position": 0, "color": "#945FCF"},
+        {"name": "staging", "position": 1, "color": "#12A4B4"},
         {"name": "production", "position": 2, "color": "#19A979"},
     ]
     for payload in defaults:


### PR DESCRIPTION
## Details
Updates the default colors for the seeded environments (`development`, `staging`, `production`) to align with the new design palette.

- Adds Liquibase migration `000067_reseed_default_environment_colors.sql` that truncates the `environments` table and reseeds it per workspace with the updated colors:
  - `development` → `#945FCF` (was `#EF6868`)
  - `staging` → `#12A4B4` (was `#F4B400`)
  - `production` → `#19A979` (unchanged)
- Updates `demo_data_generator.py` so demo workspaces are created with the same updated defaults.

The migration is safe because environments is a pre-release feature with no production data to preserve; rollback is intentionally a no-op.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves #
- OPIK-6404

## Testing
- Run the backend locally and verify the migration applies cleanly; confirm `environments` rows contain the new color values for each existing workspace.
- Trigger demo data generation and verify the seeded environments use the updated colors.

## Documentation
N/A
