### PR TITLE
[OPIK-6309] [FE] feat: unify top bars across side panels

### DIFF
--- a/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanel.tsx
+++ b/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanel.tsx
@@ -26,6 +26,7 @@ type ResizableSidePanelProps = {
   panelId: string;
   children: React.ReactNode;
   entity?: string;
+  header?: React.ReactNode;
   headerContent?: React.ReactNode;
   open?: boolean;
   onClose: () => void;
@@ -33,8 +34,7 @@ type ResizableSidePanelProps = {
   minWidth?: number;
   ignoreHotkeys?: boolean;
   closeOnClickOutside?: boolean;
-  closeButtonPosition?: "left" | "right";
-  hideDefaultControls?: boolean;
+  blockOverlayClose?: boolean;
   horizontalNavigation?: ArrowNavigationConfig;
   verticalNavigation?: ArrowNavigationConfig;
   container?: HTMLElement | null;
@@ -65,6 +65,7 @@ const ResizableSidePanel: React.FunctionComponent<ResizableSidePanelProps> = ({
   panelId,
   children,
   entity = "",
+  header,
   headerContent,
   open = false,
   onClose,
@@ -72,8 +73,7 @@ const ResizableSidePanel: React.FunctionComponent<ResizableSidePanelProps> = ({
   minWidth,
   ignoreHotkeys = false,
   closeOnClickOutside = true,
-  closeButtonPosition = "left",
-  hideDefaultControls = false,
+  blockOverlayClose = false,
   horizontalNavigation,
   verticalNavigation,
   container,
@@ -293,8 +293,11 @@ const ResizableSidePanel: React.FunctionComponent<ResizableSidePanelProps> = ({
         !open && "pointer-events-none overflow-hidden",
       )}
     >
-      {open && closeOnClickOutside && (
-        <div className="absolute inset-0 bg-black/10" onClick={onClose} />
+      {open && (closeOnClickOutside || blockOverlayClose) && (
+        <div
+          className="absolute inset-0 bg-black/10"
+          onClick={blockOverlayClose ? undefined : onClose}
+        />
       )}
       <div
         ref={panelRef}
@@ -315,36 +318,32 @@ const ResizableSidePanel: React.FunctionComponent<ResizableSidePanelProps> = ({
               <div
                 className={cn(
                   "absolute inset-x-0 top-0 flex h-[47px] items-center overflow-hidden pr-4",
-                  hideDefaultControls ? "pl-2" : "pl-6",
+                  header !== undefined ? "pl-2" : "pl-6",
                 )}
               >
-                {!hideDefaultControls && (
-                  <div
-                    className={cn(
-                      "flex items-center gap-2",
-                      closeButtonPosition === "right" && "ml-auto",
-                    )}
-                    style={{
-                      order: closeButtonPosition === "right" ? 2 : 0,
-                    }}
-                  >
-                    <TooltipWrapper
-                      content={`Close ${entity}`}
-                      hotkeys={ESC_HOTKEYS}
-                    >
-                      <Button
-                        data-testid="side-panel-close"
-                        variant="outline"
-                        size="icon-sm"
-                        onClick={onClose}
+                {header !== undefined ? (
+                  header
+                ) : (
+                  <>
+                    <div className="flex items-center gap-2">
+                      <TooltipWrapper
+                        content={`Close ${entity}`}
+                        hotkeys={ESC_HOTKEYS}
                       >
-                        <X />
-                      </Button>
-                    </TooltipWrapper>
-                    {renderNavigation()}
-                  </div>
+                        <Button
+                          data-testid="side-panel-close"
+                          variant="outline"
+                          size="icon-sm"
+                          onClick={onClose}
+                        >
+                          <X />
+                        </Button>
+                      </TooltipWrapper>
+                      {renderNavigation()}
+                    </div>
+                    {headerContent && headerContent}
+                  </>
                 )}
-                {headerContent && headerContent}
               </div>
               <div className="absolute inset-x-0 bottom-0 top-[47px] border-t">
                 {children}

--- a/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanel.tsx
+++ b/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanel.tsx
@@ -33,7 +33,6 @@ type ResizableSidePanelProps = {
   initialWidth?: number;
   minWidth?: number;
   ignoreHotkeys?: boolean;
-  closeOnClickOutside?: boolean;
   blockOverlayClose?: boolean;
   horizontalNavigation?: ArrowNavigationConfig;
   verticalNavigation?: ArrowNavigationConfig;
@@ -72,7 +71,6 @@ const ResizableSidePanel: React.FunctionComponent<ResizableSidePanelProps> = ({
   initialWidth = INITIAL_WIDTH,
   minWidth,
   ignoreHotkeys = false,
-  closeOnClickOutside = true,
   blockOverlayClose = false,
   horizontalNavigation,
   verticalNavigation,
@@ -293,7 +291,7 @@ const ResizableSidePanel: React.FunctionComponent<ResizableSidePanelProps> = ({
         !open && "pointer-events-none overflow-hidden",
       )}
     >
-      {open && (closeOnClickOutside || blockOverlayClose) && (
+      {open && (
         <div
           className="absolute inset-0 bg-black/10"
           onClick={blockOverlayClose ? undefined : onClose}
@@ -341,7 +339,7 @@ const ResizableSidePanel: React.FunctionComponent<ResizableSidePanelProps> = ({
                       </TooltipWrapper>
                       {renderNavigation()}
                     </div>
-                    {headerContent && headerContent}
+                    {headerContent}
                   </>
                 )}
               </div>

--- a/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanelArrowNavigation.test.tsx
+++ b/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanelArrowNavigation.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ResizableSidePanelArrowNavigation from "./ResizableSidePanelArrowNavigation";
+
+const buildNavigation = (overrides = {}) => ({
+  hasPrevious: true,
+  hasNext: true,
+  onChange: vi.fn(),
+  ...overrides,
+});
+
+describe("ResizableSidePanelArrowNavigation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when horizontalNavigation is undefined", () => {
+    const { container } = render(<ResizableSidePanelArrowNavigation />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders Previous and Next buttons when horizontalNavigation is provided", () => {
+    render(
+      <ResizableSidePanelArrowNavigation
+        horizontalNavigation={buildNavigation()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /Previous/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Next/ })).toBeInTheDocument();
+  });
+
+  it("calls onChange(-1) when Previous is clicked", () => {
+    const navigation = buildNavigation();
+    render(
+      <ResizableSidePanelArrowNavigation horizontalNavigation={navigation} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Previous/ }));
+    expect(navigation.onChange).toHaveBeenCalledWith(-1);
+  });
+
+  it("calls onChange(1) when Next is clicked", () => {
+    const navigation = buildNavigation();
+    render(
+      <ResizableSidePanelArrowNavigation horizontalNavigation={navigation} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Next/ }));
+    expect(navigation.onChange).toHaveBeenCalledWith(1);
+  });
+
+  it("disables Previous button when hasPrevious is false", () => {
+    render(
+      <ResizableSidePanelArrowNavigation
+        horizontalNavigation={buildNavigation({ hasPrevious: false })}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /Previous/ })).toBeDisabled();
+  });
+
+  it("disables Next button when hasNext is false", () => {
+    render(
+      <ResizableSidePanelArrowNavigation
+        horizontalNavigation={buildNavigation({ hasNext: false })}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /Next/ })).toBeDisabled();
+  });
+
+  it("triggers nav on the J key", () => {
+    const navigation = buildNavigation();
+    render(
+      <ResizableSidePanelArrowNavigation horizontalNavigation={navigation} />,
+    );
+    fireEvent.keyDown(document, { key: "j" });
+    expect(navigation.onChange).toHaveBeenCalledWith(-1);
+  });
+
+  it("triggers nav on the K key", () => {
+    const navigation = buildNavigation();
+    render(
+      <ResizableSidePanelArrowNavigation horizontalNavigation={navigation} />,
+    );
+    fireEvent.keyDown(document, { key: "k" });
+    expect(navigation.onChange).toHaveBeenCalledWith(1);
+  });
+
+  it("does not trigger nav when ignoreHotkeys is true", () => {
+    const navigation = buildNavigation();
+    render(
+      <ResizableSidePanelArrowNavigation
+        horizontalNavigation={navigation}
+        ignoreHotkeys
+      />,
+    );
+    fireEvent.keyDown(document, { key: "j" });
+    fireEvent.keyDown(document, { key: "k" });
+    expect(navigation.onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not call onChange via J when hasPrevious is false", () => {
+    const navigation = buildNavigation({ hasPrevious: false });
+    render(
+      <ResizableSidePanelArrowNavigation horizontalNavigation={navigation} />,
+    );
+    fireEvent.keyDown(document, { key: "j" });
+    expect(navigation.onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not call onChange via K when hasNext is false", () => {
+    const navigation = buildNavigation({ hasNext: false });
+    render(
+      <ResizableSidePanelArrowNavigation horizontalNavigation={navigation} />,
+    );
+    fireEvent.keyDown(document, { key: "k" });
+    expect(navigation.onChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanelArrowNavigation.tsx
+++ b/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanelArrowNavigation.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+
+import { Button } from "@/ui/button";
+import { HotkeyDisplay } from "@/ui/hotkey-display";
+import { Separator } from "@/ui/separator";
+
+type ArrowNavigationConfig = {
+  hasPrevious: boolean;
+  hasNext: boolean;
+  onChange: (shift: 1 | -1) => void;
+};
+
+type ResizableSidePanelArrowNavigationProps = {
+  horizontalNavigation?: ArrowNavigationConfig;
+  previousHotkey?: string;
+  nextHotkey?: string;
+  previousLabel?: string;
+  nextLabel?: string;
+  showSeparator?: boolean;
+  ignoreHotkeys?: boolean;
+};
+
+const ResizableSidePanelArrowNavigation: React.FunctionComponent<
+  ResizableSidePanelArrowNavigationProps
+> = ({
+  horizontalNavigation,
+  previousHotkey,
+  nextHotkey,
+  previousLabel = "Previous",
+  nextLabel = "Next",
+  showSeparator = true,
+  ignoreHotkeys = false,
+}) => {
+  useHotkeys(
+    "j",
+    () =>
+      horizontalNavigation?.hasPrevious && horizontalNavigation.onChange(-1),
+    {
+      enabled: Boolean(horizontalNavigation),
+      enableOnFormTags: false,
+      ignoreEventWhen: () => ignoreHotkeys,
+    },
+    [horizontalNavigation, ignoreHotkeys],
+  );
+  useHotkeys(
+    "k",
+    () => horizontalNavigation?.hasNext && horizontalNavigation.onChange(1),
+    {
+      enabled: Boolean(horizontalNavigation),
+      enableOnFormTags: false,
+      ignoreEventWhen: () => ignoreHotkeys,
+    },
+    [horizontalNavigation, ignoreHotkeys],
+  );
+
+  if (!horizontalNavigation) return null;
+  const previous = previousHotkey ?? "J";
+  const next = nextHotkey ?? "K";
+  return (
+    <>
+      {showSeparator && (
+        <Separator orientation="vertical" className="mx-1 h-4" />
+      )}
+      <Button
+        variant="outline"
+        size="2xs"
+        disabled={!horizontalNavigation.hasPrevious}
+        onClick={() => horizontalNavigation.onChange(-1)}
+        className="gap-1"
+      >
+        {previousLabel}
+        <HotkeyDisplay hotkey={previous} variant="outline" size="2xs" />
+      </Button>
+      <Button
+        variant="outline"
+        size="2xs"
+        disabled={!horizontalNavigation.hasNext}
+        onClick={() => horizontalNavigation.onChange(1)}
+        className="gap-1"
+      >
+        {nextLabel}
+        <HotkeyDisplay hotkey={next} variant="outline" size="2xs" />
+      </Button>
+    </>
+  );
+};
+
+export default ResizableSidePanelArrowNavigation;

--- a/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanelTopBar.tsx
+++ b/apps/opik-frontend/src/shared/ResizableSidePanel/ResizableSidePanelTopBar.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { ChevronsRight, X } from "lucide-react";
+
+import { Button } from "@/ui/button";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+
+type ResizableSidePanelTopBarVariant = "form" | "info";
+
+type ResizableSidePanelTopBarProps = {
+  variant?: ResizableSidePanelTopBarVariant;
+  title?: React.ReactNode;
+  leftIcon?: React.ReactNode;
+  children?: React.ReactNode;
+  onClose: () => void;
+};
+
+const ResizableSidePanelTopBar: React.FunctionComponent<
+  ResizableSidePanelTopBarProps
+> = ({ variant = "info", title, leftIcon, children, onClose }) => {
+  const CloseIcon = variant === "form" ? X : ChevronsRight;
+  return (
+    <div className="flex flex-auto items-center justify-between">
+      <div className="flex items-center gap-1 overflow-hidden">
+        <TooltipWrapper content="Close panel">
+          <Button variant="ghost" size="icon-2xs" onClick={onClose}>
+            <CloseIcon />
+            <span className="sr-only">Close</span>
+          </Button>
+        </TooltipWrapper>
+        {leftIcon}
+        {title !== undefined && (
+          <span className="comet-body-s-accented truncate">{title}</span>
+        )}
+      </div>
+      {children !== undefined && (
+        <div className="flex shrink-0 items-center gap-2 pl-4">{children}</div>
+      )}
+    </div>
+  );
+};
+
+export default ResizableSidePanelTopBar;

--- a/apps/opik-frontend/src/shared/ShareURLButton/ShareURLButton.tsx
+++ b/apps/opik-frontend/src/shared/ShareURLButton/ShareURLButton.tsx
@@ -6,10 +6,12 @@ import { useToast } from "@/ui/use-toast";
 
 type ShareURLButtonProps = {
   message?: string;
+  size?: "sm" | "2xs";
 };
 
 const ShareURLButton: React.FunctionComponent<ShareURLButtonProps> = ({
   message = "URL successfully copied to clipboard",
+  size = "sm",
 }) => {
   const { toast } = useToast();
 
@@ -21,8 +23,8 @@ const ShareURLButton: React.FunctionComponent<ShareURLButtonProps> = ({
   }, [message, toast]);
 
   return (
-    <Button variant="outline" size="sm" onClick={shareClickHandler}>
-      <Share className="mr-2 size-4" />
+    <Button variant="outline" size={size} onClick={shareClickHandler}>
+      <Share className={size === "2xs" ? "mr-1 size-3.5" : "mr-2 size-4"} />
       Share
     </Button>
   );

--- a/apps/opik-frontend/src/shared/SideDialog/SideDialog.tsx
+++ b/apps/opik-frontend/src/shared/SideDialog/SideDialog.tsx
@@ -5,16 +5,24 @@ type SideDialogProps = {
   open: boolean;
   setOpen: (open: boolean) => void;
   children: React.ReactNode;
+  header?: React.ReactNode;
+  blockOverlayClose?: boolean;
 };
 
 const SideDialog: React.FunctionComponent<SideDialogProps> = ({
   open,
   setOpen,
   children,
+  header,
+  blockOverlayClose,
 }) => {
   return (
     <Sheet open={open} onOpenChange={setOpen}>
-      <SheetContent className="w-[calc(100vw-32px)] sm:max-w-full md:w-[calc(100vw-60px)] xl:w-[calc(100vw-240px)]">
+      <SheetContent
+        className="w-[calc(100vw-32px)] sm:max-w-full md:w-[calc(100vw-60px)] xl:w-[calc(100vw-240px)]"
+        header={header}
+        blockOverlayClose={blockOverlayClose}
+      >
         {children}
       </SheetContent>
     </Sheet>

--- a/apps/opik-frontend/src/ui/sheet.tsx
+++ b/apps/opik-frontend/src/ui/sheet.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { cva, type VariantProps } from "class-variance-authority";
-import { X } from "lucide-react";
+import { ChevronsRight, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Button } from "./button";
@@ -49,46 +49,97 @@ const sheetVariants = cva(
   },
 );
 
+type SheetTopBarVariant = "form" | "info";
+
+type SheetTopBarProps = {
+  title?: React.ReactNode;
+  leftIcon?: React.ReactNode;
+  children?: React.ReactNode;
+  variant?: SheetTopBarVariant;
+};
+
+const SheetTopBar = React.forwardRef<HTMLDivElement, SheetTopBarProps>(
+  ({ title, leftIcon, children, variant = "form" }, ref) => {
+    const CloseIcon = variant === "info" ? ChevronsRight : X;
+    return (
+      <div
+        ref={ref}
+        className="flex h-[var(--header-height)] shrink-0 items-center justify-between gap-2 border-b border-b-border px-4"
+      >
+        <div className="flex items-center gap-1 overflow-hidden">
+          <SheetPrimitive.Close asChild>
+            <Button variant="ghost" size="icon-2xs">
+              <CloseIcon />
+              <span className="sr-only">Close</span>
+            </Button>
+          </SheetPrimitive.Close>
+          {leftIcon}
+          {title !== undefined && (
+            <SheetTitle className="comet-body-s-accented truncate">
+              {title}
+            </SheetTitle>
+          )}
+        </div>
+        {children !== undefined && (
+          <div className="flex shrink-0 items-center gap-2 pl-4">
+            {children}
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+SheetTopBar.displayName = "SheetTopBar";
+
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {
   header?: React.ReactNode;
+  blockOverlayClose?: boolean;
 }
-
-const DefaultSheetHeader = () => (
-  <div className="flex h-[var(--header-height)] items-center border-b border-b-border px-6">
-    <Button asChild size="icon-sm" variant="outline">
-      <SheetPrimitive.Close className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
-    </Button>
-  </div>
-);
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, header, ...props }, ref) => {
-  const container = usePortalContainer();
-  return (
-    <SheetPortal container={container}>
-      <SheetOverlay />
-      <SheetPrimitive.Content
-        ref={ref}
-        className={cn(sheetVariants({ side }), className)}
-        {...props}
-      >
-        {header !== undefined ? header : <DefaultSheetHeader />}
-        {header !== undefined ? (
-          children
-        ) : (
-          <div className="max-h-full overflow-y-auto p-6">{children}</div>
-        )}
-      </SheetPrimitive.Content>
-    </SheetPortal>
-  );
-});
+>(
+  (
+    {
+      side = "right",
+      className,
+      children,
+      header,
+      blockOverlayClose,
+      onPointerDownOutside,
+      ...props
+    },
+    ref,
+  ) => {
+    const container = usePortalContainer();
+    return (
+      <SheetPortal container={container}>
+        <SheetOverlay />
+        <SheetPrimitive.Content
+          ref={ref}
+          className={cn(sheetVariants({ side }), className)}
+          onPointerDownOutside={(event) => {
+            if (blockOverlayClose) {
+              event.preventDefault();
+            }
+            onPointerDownOutside?.(event);
+          }}
+          {...props}
+        >
+          {header !== undefined ? header : <SheetTopBar />}
+          {header !== undefined ? (
+            children
+          ) : (
+            <div className="max-h-full overflow-y-auto p-6">{children}</div>
+          )}
+        </SheetPrimitive.Content>
+      </SheetPortal>
+    );
+  },
+);
 SheetContent.displayName = SheetPrimitive.Content.displayName;
 
 const SheetHeader = ({
@@ -154,4 +205,5 @@ export {
   SheetFooter,
   SheetTitle,
   SheetDescription,
+  SheetTopBar,
 };

--- a/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/agent-configuration/AgentConfigurationEditPanel.tsx
@@ -1,9 +1,9 @@
 import React, { useRef, useState } from "react";
-import { ArrowRight, GitCompare, Pencil, Undo2, X } from "lucide-react";
+import { ArrowRight, GitCompare, Pencil, Undo2 } from "lucide-react";
 
 import { ConfigHistoryItem } from "@/types/agent-configs";
 import { Button } from "@/ui/button";
-import { Sheet, SheetContent, SheetTitle } from "@/ui/sheet";
+import { Sheet, SheetContent, SheetTopBar } from "@/ui/sheet";
 import { Tag } from "@/ui/tag";
 import { Textarea } from "@/ui/textarea";
 import AgentConfigurationEditView, {
@@ -62,29 +62,14 @@ const AgentConfigurationEditPanel: React.FC<
       <SheetContent
         side="right"
         className="flex w-full max-w-none flex-col p-0 sm:max-w-[872px]"
+        blockOverlayClose={state.isDirty}
         header={
-          <div className="flex h-12 items-center justify-between border-b px-6">
-            <div className="flex items-center gap-2">
-              <SheetTitle className="comet-body-accented text-left">
-                {title}
-              </SheetTitle>
-              <Tag
-                variant="gray"
-                className="flex items-center gap-1 px-1.5 py-1"
-              >
-                <Pencil className="size-3" />
-                From {item.name}
-              </Tag>
-            </div>
-            <Button
-              variant="outline"
-              size="icon-sm"
-              onClick={handleClose}
-              aria-label="Close"
-            >
-              <X className="size-3.5" />
-            </Button>
-          </div>
+          <SheetTopBar variant="form" title={title}>
+            <Tag variant="gray" className="flex items-center gap-1 px-1.5 py-1">
+              <Pencil className="size-3" />
+              From {item.name}
+            </Tag>
+          </SheetTopBar>
         }
       >
         <div className="min-h-0 flex-1 overflow-y-auto px-6">

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/CreateDatasetSidebar/CreateDatasetSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/CreateDatasetSidebar/CreateDatasetSidebar.tsx
@@ -21,6 +21,7 @@ import CodeHighlighter, {
 } from "@/shared/CodeHighlighter/CodeHighlighter";
 
 import ResizableSidePanel from "@/shared/ResizableSidePanel/ResizableSidePanel";
+import ResizableSidePanelTopBar from "@/shared/ResizableSidePanel/ResizableSidePanelTopBar";
 import AssertionsField from "@/shared/AssertionField/AssertionsField";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
 import UploadField from "@/shared/UploadField/UploadField";
@@ -163,6 +164,13 @@ const CreateDatasetSidebar: React.FunctionComponent<
   }, [open]);
 
   const handleClose = useCallback(() => setOpen(false), [setOpen]);
+
+  const isDirty =
+    step !== Step.SUCCESS &&
+    (name.length > 0 ||
+      description.length > 0 ||
+      csvFile !== undefined ||
+      assertions.length > 0);
 
   const handleGoToEntity = useCallback(() => {
     navigateToEntity?.();
@@ -445,9 +453,13 @@ const CreateDatasetSidebar: React.FunctionComponent<
         onClose={handleClose}
         initialWidth={0.35}
         minWidth={450}
-        closeButtonPosition="right"
-        headerContent={
-          <span className="comet-title-xs">{`Create ${entityLabel}`}</span>
+        blockOverlayClose={isDirty}
+        header={
+          <ResizableSidePanelTopBar
+            variant="form"
+            title={`Create ${entityLabel}`}
+            onClose={handleClose}
+          />
         }
       >
         <div className="flex size-full flex-col">

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemActionsDropdown/DatasetItemActionsDropdown.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemActionsDropdown/DatasetItemActionsDropdown.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Copy, MoreHorizontal, Share, Trash } from "lucide-react";
+
+import { Button } from "@/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/ui/dropdown-menu";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+
+type DatasetItemActionsDropdownProps = {
+  datasetItemId: string;
+  onShare: () => void;
+  onCopyId: () => void;
+  onDelete: () => void;
+};
+
+const DatasetItemActionsDropdown: React.FC<DatasetItemActionsDropdownProps> = ({
+  datasetItemId,
+  onShare,
+  onCopyId,
+  onDelete,
+}) => {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon-2xs">
+          <span className="sr-only">Actions menu</span>
+          <MoreHorizontal />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuItem onClick={onShare}>
+          <Share className="mr-2 size-4" />
+          Share item
+        </DropdownMenuItem>
+        <TooltipWrapper content={datasetItemId} side="left">
+          <DropdownMenuItem onClick={onCopyId}>
+            <Copy className="mr-2 size-4" />
+            Copy item ID
+          </DropdownMenuItem>
+        </TooltipWrapper>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={onDelete}>
+          <Trash className="mr-2 size-4" />
+          Delete item
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default DatasetItemActionsDropdown;

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemEditor/DatasetItemEditorAutosaveLayout.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemEditor/DatasetItemEditorAutosaveLayout.tsx
@@ -1,17 +1,8 @@
 import React, { useCallback, useMemo } from "react";
-import { Copy, MoreHorizontal, Share, Trash } from "lucide-react";
 import copy from "clipboard-copy";
 import ResizableSidePanel from "@/shared/ResizableSidePanel/ResizableSidePanel";
 import ResizableSidePanelTopBar from "@/shared/ResizableSidePanel/ResizableSidePanelTopBar";
 import ResizableSidePanelArrowNavigation from "@/shared/ResizableSidePanel/ResizableSidePanelArrowNavigation";
-import { Button } from "@/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/ui/dropdown-menu";
 import { useToast } from "@/ui/use-toast";
 import Loader from "@/shared/Loader/Loader";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
@@ -20,6 +11,7 @@ import { processInputData } from "@/lib/images";
 import ImagesListWrapper from "@/shared/attachments/ImagesListWrapper/ImagesListWrapper";
 import { useDatasetItemEditorAutosaveContext } from "./DatasetItemEditorAutosaveContext";
 import DatasetItemEditorForm from "./DatasetItemEditorForm";
+import DatasetItemActionsDropdown from "@/v2/pages-shared/datasets/DatasetItemActionsDropdown/DatasetItemActionsDropdown";
 
 interface DatasetItemEditorAutosaveLayoutProps {
   datasetItemId: string;
@@ -98,31 +90,12 @@ const DatasetItemEditorAutosaveLayout: React.FC<
           }
           onClose={handleClose}
         >
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="icon-2xs">
-                <span className="sr-only">Actions menu</span>
-                <MoreHorizontal />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-52">
-              <DropdownMenuItem onClick={handleShare}>
-                <Share className="mr-2 size-4" />
-                Share item
-              </DropdownMenuItem>
-              <TooltipWrapper content={datasetItemId} side="left">
-                <DropdownMenuItem onClick={handleCopyId}>
-                  <Copy className="mr-2 size-4" />
-                  Copy item ID
-                </DropdownMenuItem>
-              </TooltipWrapper>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={handleDeleteItemConfirm}>
-                <Trash className="mr-2 size-4" />
-                Delete item
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <DatasetItemActionsDropdown
+            datasetItemId={datasetItemId}
+            onShare={handleShare}
+            onCopyId={handleCopyId}
+            onDelete={handleDeleteItemConfirm}
+          />
           <ResizableSidePanelArrowNavigation
             horizontalNavigation={horizontalNavigation}
           />

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemEditor/DatasetItemEditorAutosaveLayout.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemEditor/DatasetItemEditorAutosaveLayout.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useMemo } from "react";
 import { Copy, MoreHorizontal, Share, Trash } from "lucide-react";
 import copy from "clipboard-copy";
 import ResizableSidePanel from "@/shared/ResizableSidePanel/ResizableSidePanel";
+import ResizableSidePanelTopBar from "@/shared/ResizableSidePanel/ResizableSidePanelTopBar";
+import ResizableSidePanelArrowNavigation from "@/shared/ResizableSidePanel/ResizableSidePanelArrowNavigation";
 import { Button } from "@/ui/button";
 import {
   DropdownMenu,
@@ -28,47 +30,6 @@ interface DatasetItemEditorAutosaveLayoutProps {
 const truncateId = (id: string): string => {
   if (id.length <= 12) return id;
   return `${id.slice(0, 4)}...${id.slice(-4)}`;
-};
-
-interface DatasetItemEditorActionsPanelProps {
-  datasetItemId: string;
-  onShare: () => void;
-  onCopyId: () => void;
-  onDelete: () => void;
-}
-
-const DatasetItemEditorActionsPanel: React.FC<
-  DatasetItemEditorActionsPanelProps
-> = ({ datasetItemId, onShare, onCopyId, onDelete }) => {
-  return (
-    <div className="flex flex-auto items-center justify-end pl-6">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="icon-sm">
-            <span className="sr-only">Actions menu</span>
-            <MoreHorizontal />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-52">
-          <DropdownMenuItem onClick={onShare}>
-            <Share className="mr-2 size-4" />
-            Share item
-          </DropdownMenuItem>
-          <TooltipWrapper content={datasetItemId} side="left">
-            <DropdownMenuItem onClick={onCopyId}>
-              <Copy className="mr-2 size-4" />
-              Copy item ID
-            </DropdownMenuItem>
-          </TooltipWrapper>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={onDelete}>
-            <Trash className="mr-2 size-4" />
-            Delete item
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
-  );
 };
 
 const DatasetItemEditorAutosaveLayout: React.FC<
@@ -121,15 +82,51 @@ const DatasetItemEditorAutosaveLayout: React.FC<
   return (
     <ResizableSidePanel
       panelId="dataset-item-editor"
-      entity="item"
       open={isOpen}
-      headerContent={
-        <DatasetItemEditorActionsPanel
-          datasetItemId={datasetItemId}
-          onShare={handleShare}
-          onCopyId={handleCopyId}
-          onDelete={handleDeleteItemConfirm}
-        />
+      header={
+        <ResizableSidePanelTopBar
+          variant="info"
+          title={
+            <TooltipWrapper content={datasetItemId}>
+              <span>
+                Dataset item{" "}
+                <span className="comet-body-s text-muted-slate">
+                  {truncateId(datasetItemId)}
+                </span>
+              </span>
+            </TooltipWrapper>
+          }
+          onClose={handleClose}
+        >
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="icon-2xs">
+                <span className="sr-only">Actions menu</span>
+                <MoreHorizontal />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-52">
+              <DropdownMenuItem onClick={handleShare}>
+                <Share className="mr-2 size-4" />
+                Share item
+              </DropdownMenuItem>
+              <TooltipWrapper content={datasetItemId} side="left">
+                <DropdownMenuItem onClick={handleCopyId}>
+                  <Copy className="mr-2 size-4" />
+                  Copy item ID
+                </DropdownMenuItem>
+              </TooltipWrapper>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={handleDeleteItemConfirm}>
+                <Trash className="mr-2 size-4" />
+                Delete item
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <ResizableSidePanelArrowNavigation
+            horizontalNavigation={horizontalNavigation}
+          />
+        </ResizableSidePanelTopBar>
       }
       onClose={handleClose}
       horizontalNavigation={horizontalNavigation}
@@ -140,15 +137,7 @@ const DatasetItemEditorAutosaveLayout: React.FC<
         </div>
       ) : (
         <div className="relative size-full overflow-y-auto">
-          <div className="sticky top-0 z-10 border-b bg-background p-6 pb-4">
-            <TooltipWrapper content={datasetItemId}>
-              <div className="comet-body-accented">
-                Dataset item{" "}
-                <span className="comet-body-s text-muted-slate">
-                  {truncateId(datasetItemId)}
-                </span>
-              </div>
-            </TooltipWrapper>
+          <div className="sticky top-0 z-10 border-b bg-background px-6 py-4">
             <TagListRenderer
               tags={tags}
               onAddTag={handleAddTag}

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemPanel/AddItemPanelWrapper.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemPanel/AddItemPanelWrapper.tsx
@@ -1,6 +1,7 @@
-import React, { ReactNode, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 
 import ResizableSidePanel from "@/shared/ResizableSidePanel/ResizableSidePanel";
+import ResizableSidePanelTopBar from "@/shared/ResizableSidePanel/ResizableSidePanelTopBar";
 import { Button } from "@/ui/button";
 import TagListRenderer from "@/shared/TagListRenderer/TagListRenderer";
 import { useConfirmAction } from "@/shared/ConfirmDialog/useConfirmAction";
@@ -23,11 +24,16 @@ interface AddItemPanelWrapperProps {
 const AddItemPanelWrapperContent: React.FC<{
   formId: string;
   onClose: () => void;
+  onDirtyChange: (dirty: boolean) => void;
   children: (context: AddItemPanelContext) => ReactNode;
-}> = ({ formId, onClose, children }) => {
+}> = ({ formId, onClose, onDirtyChange, children }) => {
   const [tags, setTags] = useState<string[]>([]);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const isDirty = hasUnsavedChanges || tags.length > 0;
+
+  useEffect(() => {
+    onDirtyChange(isDirty);
+  }, [isDirty, onDirtyChange]);
 
   const {
     isOpen: showConfirmDialog,
@@ -39,8 +45,7 @@ const AddItemPanelWrapperContent: React.FC<{
   return (
     <>
       <div className="flex size-full flex-col">
-        <div className="shrink-0 border-b bg-background p-6 pb-4">
-          <div className="comet-body-accented">Add item</div>
+        <div className="shrink-0 border-b bg-background px-6 py-4">
           <TagListRenderer
             tags={tags}
             onAddTag={(tag) => setTags((prev) => [...prev, tag])}
@@ -99,16 +104,29 @@ const AddItemPanelWrapper: React.FC<AddItemPanelWrapperProps> = ({
   initialWidth,
   children,
 }) => {
+  const [isDirty, setIsDirty] = useState(false);
+
   return (
     <ResizableSidePanel
       panelId={panelId}
-      entity="item"
       open={open}
       onClose={onClose}
       initialWidth={initialWidth}
+      blockOverlayClose={isDirty}
+      header={
+        <ResizableSidePanelTopBar
+          variant="form"
+          title="Add item"
+          onClose={onClose}
+        />
+      }
     >
       {open && (
-        <AddItemPanelWrapperContent formId={formId} onClose={onClose}>
+        <AddItemPanelWrapperContent
+          formId={formId}
+          onClose={onClose}
+          onDirtyChange={setIsDirty}
+        >
           {children}
         </AddItemPanelWrapperContent>
       )}

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/TestSuiteItemPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/TestSuiteItemPanel.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from "react";
-import { Copy, MoreHorizontal, Share, Trash } from "lucide-react";
 import copy from "clipboard-copy";
 import {
   DatasetItemColumn,
@@ -16,17 +15,9 @@ import { prepareFormDataForSave } from "@/v2/pages-shared/datasets/DatasetItemEd
 import ResizableSidePanel from "@/shared/ResizableSidePanel/ResizableSidePanel";
 import ResizableSidePanelTopBar from "@/shared/ResizableSidePanel/ResizableSidePanelTopBar";
 import ResizableSidePanelArrowNavigation from "@/shared/ResizableSidePanel/ResizableSidePanelArrowNavigation";
-import { Button } from "@/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/ui/dropdown-menu";
+import DatasetItemActionsDropdown from "@/v2/pages-shared/datasets/DatasetItemActionsDropdown/DatasetItemActionsDropdown";
 import { useToast } from "@/ui/use-toast";
 import Loader from "@/shared/Loader/Loader";
-import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import TagListRenderer from "@/shared/TagListRenderer/TagListRenderer";
 import TestSuiteItemFormContainer from "./TestSuiteItemFormContainer";
 import {
@@ -148,6 +139,21 @@ const TestSuiteItemPanelLayout: React.FC<TestSuiteItemPanelLayoutProps> = ({
     [datasetItemId, columns, editItem, updateItemAssertions, serverEvaluators],
   );
 
+  const handleShare = useCallback(() => {
+    toast({ description: "URL successfully copied to clipboard" });
+    copy(window.location.href);
+  }, [toast]);
+
+  const handleCopyId = useCallback(() => {
+    toast({ description: "Item ID successfully copied to clipboard" });
+    copy(datasetItemId);
+  }, [datasetItemId, toast]);
+
+  const handleDeleteItemConfirm = useCallback(
+    () => handleDelete(onClose),
+    [handleDelete, onClose],
+  );
+
   return (
     <ResizableSidePanel
       panelId="test-suite-item-panel"
@@ -159,45 +165,12 @@ const TestSuiteItemPanelLayout: React.FC<TestSuiteItemPanelLayoutProps> = ({
           onClose={onClose}
         >
           {!isNewItem && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="outline" size="icon-2xs">
-                  <span className="sr-only">Actions menu</span>
-                  <MoreHorizontal />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-52">
-                <DropdownMenuItem
-                  onClick={() => {
-                    toast({
-                      description: "URL successfully copied to clipboard",
-                    });
-                    copy(window.location.href);
-                  }}
-                >
-                  <Share className="mr-2 size-4" />
-                  Share item
-                </DropdownMenuItem>
-                <TooltipWrapper content={datasetItemId} side="left">
-                  <DropdownMenuItem
-                    onClick={() => {
-                      toast({
-                        description: "Item ID successfully copied to clipboard",
-                      });
-                      copy(datasetItemId);
-                    }}
-                  >
-                    <Copy className="mr-2 size-4" />
-                    Copy item ID
-                  </DropdownMenuItem>
-                </TooltipWrapper>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={() => handleDelete(onClose)}>
-                  <Trash className="mr-2 size-4" />
-                  Delete item
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <DatasetItemActionsDropdown
+              datasetItemId={datasetItemId}
+              onShare={handleShare}
+              onCopyId={handleCopyId}
+              onDelete={handleDeleteItemConfirm}
+            />
           )}
           <ResizableSidePanelArrowNavigation
             horizontalNavigation={horizontalNavigation}

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/TestSuiteItemPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/TestSuiteItemPanel.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/v2/pages-shared/datasets/DatasetItemEditor/DatasetItemEditorAutosaveContext";
 import { prepareFormDataForSave } from "@/v2/pages-shared/datasets/DatasetItemEditor/hooks/useDatasetItemFormHelpers";
 import ResizableSidePanel from "@/shared/ResizableSidePanel/ResizableSidePanel";
+import ResizableSidePanelTopBar from "@/shared/ResizableSidePanel/ResizableSidePanelTopBar";
+import ResizableSidePanelArrowNavigation from "@/shared/ResizableSidePanel/ResizableSidePanelArrowNavigation";
 import { Button } from "@/ui/button";
 import {
   DropdownMenu,
@@ -146,54 +148,62 @@ const TestSuiteItemPanelLayout: React.FC<TestSuiteItemPanelLayoutProps> = ({
     [datasetItemId, columns, editItem, updateItemAssertions, serverEvaluators],
   );
 
-  const headerContent = isNewItem ? null : (
-    <div className="flex flex-auto items-center justify-end pl-6">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="icon-sm">
-            <span className="sr-only">Actions menu</span>
-            <MoreHorizontal />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-52">
-          <DropdownMenuItem
-            onClick={() => {
-              toast({ description: "URL successfully copied to clipboard" });
-              copy(window.location.href);
-            }}
-          >
-            <Share className="mr-2 size-4" />
-            Share item
-          </DropdownMenuItem>
-          <TooltipWrapper content={datasetItemId} side="left">
-            <DropdownMenuItem
-              onClick={() => {
-                toast({
-                  description: "Item ID successfully copied to clipboard",
-                });
-                copy(datasetItemId);
-              }}
-            >
-              <Copy className="mr-2 size-4" />
-              Copy item ID
-            </DropdownMenuItem>
-          </TooltipWrapper>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => handleDelete(onClose)}>
-            <Trash className="mr-2 size-4" />
-            Delete item
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
-  );
-
   return (
     <ResizableSidePanel
       panelId="test-suite-item-panel"
-      entity="item"
       open={isOpen}
-      headerContent={headerContent}
+      header={
+        <ResizableSidePanelTopBar
+          variant="info"
+          title={isNewItem ? "Add item" : "Edit item"}
+          onClose={onClose}
+        >
+          {!isNewItem && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="icon-2xs">
+                  <span className="sr-only">Actions menu</span>
+                  <MoreHorizontal />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-52">
+                <DropdownMenuItem
+                  onClick={() => {
+                    toast({
+                      description: "URL successfully copied to clipboard",
+                    });
+                    copy(window.location.href);
+                  }}
+                >
+                  <Share className="mr-2 size-4" />
+                  Share item
+                </DropdownMenuItem>
+                <TooltipWrapper content={datasetItemId} side="left">
+                  <DropdownMenuItem
+                    onClick={() => {
+                      toast({
+                        description: "Item ID successfully copied to clipboard",
+                      });
+                      copy(datasetItemId);
+                    }}
+                  >
+                    <Copy className="mr-2 size-4" />
+                    Copy item ID
+                  </DropdownMenuItem>
+                </TooltipWrapper>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => handleDelete(onClose)}>
+                  <Trash className="mr-2 size-4" />
+                  Delete item
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+          <ResizableSidePanelArrowNavigation
+            horizontalNavigation={horizontalNavigation}
+          />
+        </ResizableSidePanelTopBar>
+      }
       onClose={onClose}
       horizontalNavigation={horizontalNavigation}
     >
@@ -203,10 +213,7 @@ const TestSuiteItemPanelLayout: React.FC<TestSuiteItemPanelLayoutProps> = ({
         </div>
       ) : (
         <div className="relative size-full overflow-y-auto">
-          <div className="sticky top-0 z-10 border-b bg-background p-6 pb-4">
-            <div className="comet-body-accented">
-              {isNewItem ? "Add item" : "Edit item"}
-            </div>
+          <div className="sticky top-0 z-10 border-b bg-background px-6 py-4">
             <TagListRenderer
               tags={tags}
               onAddTag={handleAddTag}

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog.tsx
@@ -11,7 +11,7 @@ import LoadableSelectBox from "@/shared/LoadableSelectBox/LoadableSelectBox";
 import useProjectDatasetsList from "@/api/datasets/useProjectDatasetsList";
 import { DATASET_TYPE } from "@/types/datasets";
 import SideDialog from "@/shared/SideDialog/SideDialog";
-import { SheetTitle } from "@/ui/sheet";
+import { SheetTopBar } from "@/ui/sheet";
 import ApiKeyCard from "@/v2/pages-shared/onboarding/ApiKeyCard/ApiKeyCard";
 import GoogleColabCard from "@/v2/pages-shared/onboarding/GoogleColabCard/GoogleColabCard";
 import { putConfigInCode } from "@/lib/formatCodeSnippets";
@@ -511,15 +511,12 @@ eval_results = evaluate(
   );
 
   return (
-    <SideDialog open={open && canCreateExperiments} setOpen={openChangeHandler}>
-      <div className="pb-20">
-        <div className="pb-8">
-          <SheetTitle>Create a new experiment</SheetTitle>
-          <div className="comet-body-s mx-auto mt-4 max-w-[468px] text-center text-muted-slate">
-            Select a test suite, assign the relevant evaluators, and follow the
-            instructions to track and compare your training runs
-          </div>
-        </div>
+    <SideDialog
+      open={open && canCreateExperiments}
+      setOpen={openChangeHandler}
+      header={<SheetTopBar variant="info" title="Create new experiment" />}
+    >
+      <div className="max-h-full overflow-y-auto p-6 pb-20 pt-4">
         <div className="mx-auto flex w-full flex-col gap-6 md:max-w-[1250px] md:flex-row md:items-start">
           {!isTestSuite && renderEvaluatorsSection()}
           <div className="flex w-full flex-col gap-6 md:min-w-[450px] md:flex-1 md:rounded-md md:border md:border-border md:p-6">

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/AddExperimentDialog/AddExperimentDialog.tsx
@@ -516,8 +516,8 @@ eval_results = evaluate(
       setOpen={openChangeHandler}
       header={<SheetTopBar variant="info" title="Create new experiment" />}
     >
-      <div className="max-h-full overflow-y-auto p-6 pb-20 pt-4">
-        <div className="mx-auto flex w-full flex-col gap-6 md:max-w-[1250px] md:flex-row md:items-start">
+      <div className="max-h-full overflow-y-auto px-5 pb-20 pt-4">
+        <div className="mx-auto flex w-full flex-col gap-6 md:flex-row md:items-start">
           {!isTestSuite && renderEvaluatorsSection()}
           <div className="flex w-full flex-col gap-6 md:min-w-[450px] md:flex-1 md:rounded-md md:border md:border-border md:p-6">
             <div>

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/TestSuiteExperiment/ExperimentItemSidebar/TestSuiteExperimentPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/TestSuiteExperiment/ExperimentItemSidebar/TestSuiteExperimentPanel.tsx
@@ -6,6 +6,8 @@ import { Copy } from "lucide-react";
 
 import NoData from "@/shared/NoData/NoData";
 import ResizableSidePanel from "@/shared/ResizableSidePanel/ResizableSidePanel";
+import ResizableSidePanelTopBar from "@/shared/ResizableSidePanel/ResizableSidePanelTopBar";
+import ResizableSidePanelArrowNavigation from "@/shared/ResizableSidePanel/ResizableSidePanelArrowNavigation";
 import ShareURLButton from "@/shared/ShareURLButton/ShareURLButton";
 import { Button } from "@/ui/button";
 import { useToast } from "@/ui/use-toast";
@@ -151,22 +153,23 @@ export const TestSuiteExperimentPanel: React.FC<
     );
   };
 
-  const headerContent = (
-    <div className="flex flex-auto justify-end gap-2 pl-6">
-      <ShareURLButton />
-      <Button size="sm" variant="outline" onClick={copyClickHandler}>
-        <Copy className="mr-2 size-4" />
-        Copy ID
-      </Button>
-    </div>
-  );
-
   return (
     <ResizableSidePanel
       panelId="eval-suite-experiment"
-      entity="item"
       open={Boolean(experimentsCompareId)}
-      headerContent={headerContent}
+      header={
+        <ResizableSidePanelTopBar variant="info" onClose={onClose}>
+          <ShareURLButton size="2xs" />
+          <Button size="2xs" variant="outline" onClick={copyClickHandler}>
+            <Copy className="mr-1 size-3.5" />
+            Copy ID
+          </Button>
+          <ResizableSidePanelArrowNavigation
+            horizontalNavigation={horizontalNavigation}
+            ignoreHotkeys={isTraceDetailsOpened}
+          />
+        </ResizableSidePanelTopBar>
+      }
       onClose={onClose}
       initialWidth={0.8}
       ignoreHotkeys={isTraceDetailsOpened}

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/QuickstartDialog/QuickstartDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/QuickstartDialog/QuickstartDialog.tsx
@@ -1,6 +1,6 @@
 import SideDialog from "@/shared/SideDialog/SideDialog";
 import React from "react";
-import { SheetTitle } from "@/ui/sheet";
+import { SheetTopBar } from "@/ui/sheet";
 import { IntegrationExplorer } from "@/v2/pages-shared/onboarding/IntegrationExplorer";
 import { useLayoutDialog } from "@/hooks/useLayoutDialog";
 
@@ -10,11 +10,12 @@ const QuickstartDialog: React.FC = () => {
   const { isOpen, setOpen } = useOpenQuickStartDialog();
 
   return (
-    <SideDialog open={isOpen} setOpen={setOpen}>
-      <div className="flex w-full min-w-fit flex-col px-20 pb-20">
-        <SheetTitle className="comet-title-xl my-3 text-left">
-          Quickstart guide
-        </SheetTitle>
+    <SideDialog
+      open={isOpen}
+      setOpen={setOpen}
+      header={<SheetTopBar variant="info" title="Quickstart guide" />}
+    >
+      <div className="flex max-h-full w-full min-w-fit flex-col overflow-y-auto px-20 pb-20 pt-4">
         <div className="comet-body-s mb-10 text-muted-slate">
           Opik helps you improve your LLM features by tracking what happens
           behind the scenes. Integrate Opik to unlock evaluations, experiments,

--- a/apps/opik-frontend/src/v2/pages-shared/traces/GuardrailConfig/SetGuardrailDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/GuardrailConfig/SetGuardrailDialog.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import SideDialog from "@/shared/SideDialog/SideDialog";
-import { SheetTitle } from "@/ui/sheet";
+import { SheetTopBar } from "@/ui/sheet";
 import ApiKeyCard from "@/v2/pages-shared/onboarding/ApiKeyCard/ApiKeyCard";
 import GuardrailConfig from "./GuardrailConfig";
 import { Separator } from "@/ui/separator";
@@ -52,16 +52,16 @@ const SetGuardrailDialog: React.FC<SetGuardrailDialogProps> = ({
   const PII_GUARDRAIL_STATE = guardrailsState[GuardrailTypes.PII];
 
   return (
-    <SideDialog open={open} setOpen={setOpen}>
-      <div className="pb-20">
-        <div className="pb-8">
-          <SheetTitle>Set a guardrail</SheetTitle>
-          <div className="comet-body-s m-auto mt-4 w-[700px] self-center text-center text-muted-slate">
-            Guardrails help you protect your application from risks inherent in
-            LLMs. Use them to check the inputs and outputs of your LLM calls,
-            and detect issues like off-topic answers or leaking sensitive
-            information.
-          </div>
+    <SideDialog
+      open={open}
+      setOpen={setOpen}
+      header={<SheetTopBar variant="form" title="Set a guardrail" />}
+    >
+      <div className="max-h-full overflow-y-auto p-6 pb-20 pt-4">
+        <div className="comet-body-s m-auto mb-8 w-[700px] self-center text-center text-muted-slate">
+          Guardrails help you protect your application from risks inherent in
+          LLMs. Use them to check the inputs and outputs of your LLM calls, and
+          detect issues like off-topic answers or leaking sensitive information.
         </div>
         <div className="m-auto flex w-full max-w-[1250px] items-start gap-6">
           <div className="flex w-[250px] shrink-0 flex-col">

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import {
   Calendar,
-  ChevronsRight,
   Clock,
   Coins,
   Copy,
@@ -44,8 +43,9 @@ import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import Loader from "@/shared/Loader/Loader";
 import NoData from "@/shared/NoData/NoData";
 import ResizableSidePanel from "@/shared/ResizableSidePanel/ResizableSidePanel";
+import ResizableSidePanelTopBar from "@/shared/ResizableSidePanel/ResizableSidePanelTopBar";
+import ResizableSidePanelArrowNavigation from "@/shared/ResizableSidePanel/ResizableSidePanelArrowNavigation";
 import { Button } from "@/ui/button";
-import { HotkeyDisplay } from "@/ui/hotkey-display";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
 import useThreadById from "@/api/traces/useThreadById";
 import useTracesList from "@/api/traces/useTracesList";
@@ -77,7 +77,6 @@ import { JsonParam, StringParam, useQueryParam } from "use-query-params";
 import ThreadAnnotatePanel from "./ThreadAnnotatePanel";
 import useThreadFeedbackScoreDeleteMutation from "@/api/traces/useThreadFeedbackScoreDeleteMutation";
 import ThreadFeedbackScoresInfo from "./ThreadFeedbackScoresInfo";
-import { Separator } from "@/ui/separator";
 import ThreadDetailsTags from "./ThreadDetailsTags";
 import AddToDropdown from "@/v2/pages-shared/traces/AddToDropdown/AddToDropdown";
 import ConfigurableFeedbackScoreTable from "../TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/ConfigurableFeedbackScoreTable";
@@ -358,19 +357,6 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
     { enableOnFormTags: false, enabled: canAnnotateTraceSpanThread },
     [setActiveSection, canAnnotateTraceSpanThread],
   );
-  useHotkeys(
-    "j",
-    () =>
-      horizontalNavigation?.hasPrevious && horizontalNavigation.onChange(-1),
-    { enabled: Boolean(horizontalNavigation) },
-    [horizontalNavigation],
-  );
-  useHotkeys(
-    "k",
-    () => horizontalNavigation?.hasNext && horizontalNavigation.onChange(1),
-    { enabled: Boolean(horizontalNavigation) },
-    [horizontalNavigation],
-  );
 
   const bodyStyle = {
     ...(height && { height: `${height}px` }),
@@ -579,157 +565,130 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
 
   const renderHeaderContent = () => {
     return (
-      <div className="flex flex-auto items-center justify-between">
-        <div className="flex items-center gap-1 overflow-hidden">
-          <TooltipWrapper content="Close panel">
-            <Button variant="ghost" size="icon-2xs" onClick={onClose}>
-              <ChevronsRight />
-            </Button>
-          </TooltipWrapper>
+      <ResizableSidePanelTopBar
+        variant="info"
+        title="Thread"
+        leftIcon={
           <div className="relative flex size-4 shrink-0 items-center justify-center rounded bg-[var(--thread-icon-background)] text-[var(--thread-icon-text)]">
             <MessagesSquare className="size-2" />
           </div>
-          <span className="comet-body-s-accented truncate">Thread</span>
-        </div>
-
-        <div className="flex shrink-0 items-center gap-2 pl-4">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="icon-2xs">
-                <span className="sr-only">Actions menu</span>
-                <MoreHorizontal />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-52">
+        }
+        onClose={onClose}
+      >
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="icon-2xs">
+              <span className="sr-only">Actions menu</span>
+              <MoreHorizontal />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-52">
+            <DropdownMenuItem
+              onClick={() => {
+                toast({
+                  description: "URL successfully copied to clipboard",
+                });
+                copy(window.location.href);
+              }}
+            >
+              <Share className="mr-2 size-4" />
+              Share
+            </DropdownMenuItem>
+            <TooltipWrapper content={threadId} side="left">
               <DropdownMenuItem
                 onClick={() => {
                   toast({
-                    description: "URL successfully copied to clipboard",
+                    description: `Thread ID successfully copied to clipboard`,
                   });
-                  copy(window.location.href);
+                  copy(threadId);
                 }}
               >
-                <Share className="mr-2 size-4" />
-                Share
+                <Copy className="mr-2 size-4" />
+                Copy thread ID
               </DropdownMenuItem>
-              <TooltipWrapper content={threadId} side="left">
+            </TooltipWrapper>
+            <DropdownMenuSeparator />
+            {(["csv", "json"] as const).map((format) => {
+              const handler =
+                format === "csv" ? handleExportCSV : handleExportJSON;
+              const item = (
                 <DropdownMenuItem
-                  onClick={() => {
-                    toast({
-                      description: `Thread ID successfully copied to clipboard`,
-                    });
-                    copy(threadId);
-                  }}
+                  key={format}
+                  onClick={handler}
+                  disabled={!isExportEnabled}
                 >
-                  <Copy className="mr-2 size-4" />
-                  Copy thread ID
+                  <Download className="mr-2 size-4" />
+                  Export as {format.toUpperCase()}
                 </DropdownMenuItem>
-              </TooltipWrapper>
-              <DropdownMenuSeparator />
-              {(["csv", "json"] as const).map((format) => {
-                const handler =
-                  format === "csv" ? handleExportCSV : handleExportJSON;
-                const item = (
-                  <DropdownMenuItem
-                    key={format}
-                    onClick={handler}
-                    disabled={!isExportEnabled}
-                  >
-                    <Download className="mr-2 size-4" />
-                    Export as {format.toUpperCase()}
-                  </DropdownMenuItem>
-                );
+              );
 
-                return isExportEnabled ? (
-                  item
-                ) : (
-                  <TooltipWrapper
-                    key={format}
-                    content="Export functionality is disabled for this installation"
-                    side="left"
-                  >
-                    <div>{item}</div>
-                  </TooltipWrapper>
-                );
-              })}
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onClick={() => setPopupOpen(true)}
-                variant="destructive"
-              >
-                <Trash className="mr-2 size-4" />
-                Delete
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <ConfirmDialog
-            open={popupOpen}
-            setOpen={setPopupOpen}
-            onConfirm={handleThreadDelete}
-            title="Delete thread"
-            description="Deleting a thread will also remove all traces linked to it and their data. This action can’t be undone. Are you sure you want to continue?"
-            confirmText="Delete thread"
-            confirmButtonVariant="destructive"
-          />
-
-          {horizontalNavigation && (
-            <>
-              <Separator orientation="vertical" className="mx-1 h-4" />
-              <Button
-                variant="outline"
-                size="2xs"
-                disabled={!horizontalNavigation.hasPrevious}
-                onClick={() => horizontalNavigation.onChange(-1)}
-                className="gap-1"
-              >
-                Previous
-                <HotkeyDisplay hotkey="J" variant="outline" size="2xs" />
-              </Button>
-              <Button
-                variant="outline"
-                size="2xs"
-                disabled={!horizontalNavigation.hasNext}
-                onClick={() => horizontalNavigation.onChange(1)}
-                className="gap-1"
-              >
-                Next
-                <HotkeyDisplay hotkey="K" variant="outline" size="2xs" />
-              </Button>
-            </>
-          )}
-
-          <TooltipWrapper content="View all traces for this thread">
-            <Button
-              variant="outline"
-              size="2xs"
-              onClick={() => {
-                navigate({
-                  to: "/$workspaceName/projects/$projectId/logs",
-                  params: {
-                    projectId,
-                    workspaceName,
-                  },
-                  search: {
-                    logsType: LOGS_TYPE.traces,
-                    traces_filters: [
-                      {
-                        id: "thread_id_filter",
-                        field: "thread_id",
-                        type: COLUMN_TYPE.string,
-                        operator: "=",
-                        value: threadId,
-                      },
-                    ],
-                  },
-                });
-              }}
+              return isExportEnabled ? (
+                item
+              ) : (
+                <TooltipWrapper
+                  key={format}
+                  content="Export functionality is disabled for this installation"
+                  side="left"
+                >
+                  <div>{item}</div>
+                </TooltipWrapper>
+              );
+            })}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={() => setPopupOpen(true)}
+              variant="destructive"
             >
-              Traces
-              <ArrowUpRight className="ml-1 size-3.5" />
-            </Button>
-          </TooltipWrapper>
-        </div>
-      </div>
+              <Trash className="mr-2 size-4" />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <ConfirmDialog
+          open={popupOpen}
+          setOpen={setPopupOpen}
+          onConfirm={handleThreadDelete}
+          title="Delete thread"
+          description="Deleting a thread will also remove all traces linked to it and their data. This action can’t be undone. Are you sure you want to continue?"
+          confirmText="Delete thread"
+          confirmButtonVariant="destructive"
+        />
+
+        <ResizableSidePanelArrowNavigation
+          horizontalNavigation={horizontalNavigation}
+        />
+
+        <TooltipWrapper content="View all traces for this thread">
+          <Button
+            variant="outline"
+            size="2xs"
+            onClick={() => {
+              navigate({
+                to: "/$workspaceName/projects/$projectId/logs",
+                params: {
+                  projectId,
+                  workspaceName,
+                },
+                search: {
+                  logsType: LOGS_TYPE.traces,
+                  traces_filters: [
+                    {
+                      id: "thread_id_filter",
+                      field: "thread_id",
+                      type: COLUMN_TYPE.string,
+                      operator: "=",
+                      value: threadId,
+                    },
+                  ],
+                },
+              });
+            }}
+          >
+            Traces
+            <ArrowUpRight className="ml-1 size-3.5" />
+          </Button>
+        </TooltipWrapper>
+      </ResizableSidePanelTopBar>
     );
   };
 
@@ -738,9 +697,8 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
       panelId="thread"
       entity="thread"
       open={open}
-      headerContent={renderHeaderContent()}
+      header={renderHeaderContent()}
       onClose={onClose}
-      hideDefaultControls
       initialWidth={0.5}
       minWidth={700}
       horizontalNavigation={horizontalNavigation}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsActionsPanel.tsx
@@ -5,7 +5,6 @@ import { json2csv } from "json-2-csv";
 import get from "lodash/get";
 import {
   ArrowUpRight,
-  ChevronsRight,
   Copy,
   Download,
   MoreHorizontal,
@@ -24,8 +23,6 @@ import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import useTraceDeleteMutation from "@/api/traces/useTraceDeleteMutation";
 import { useToast } from "@/ui/use-toast";
 import { Button } from "@/ui/button";
-import { HotkeyDisplay } from "@/ui/hotkey-display";
-import { Separator } from "@/ui/separator";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -36,6 +33,8 @@ import {
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
 import BaseTraceDataTypeIcon from "@/shared/BaseTraceDataTypeIcon/BaseTraceDataTypeIcon";
+import ResizableSidePanelTopBar from "@/shared/ResizableSidePanel/ResizableSidePanelTopBar";
+import ResizableSidePanelArrowNavigation from "@/shared/ResizableSidePanel/ResizableSidePanelArrowNavigation";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
 import {
@@ -48,7 +47,6 @@ import {
 } from "@/lib/traces/exportUtils";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 import { usePermissions } from "@/contexts/PermissionsContext";
-import { useHotkeys } from "react-hotkeys-hook";
 
 type ArrowNavigationConfig = {
   hasPrevious: boolean;
@@ -113,20 +111,6 @@ const TraceDetailsActionsPanel: React.FunctionComponent<
   }, [treeData, traceId]);
   const canNavigateToExperiment =
     Boolean(experiment) && canViewExperiments && Boolean(activeProjectId);
-
-  useHotkeys(
-    "j",
-    () =>
-      horizontalNavigation?.hasPrevious && horizontalNavigation.onChange(-1),
-    { enabled: Boolean(horizontalNavigation), enableOnFormTags: false },
-    [horizontalNavigation],
-  );
-  useHotkeys(
-    "k",
-    () => horizontalNavigation?.hasNext && horizontalNavigation.onChange(1),
-    { enabled: Boolean(horizontalNavigation), enableOnFormTags: false },
-    [horizontalNavigation],
-  );
 
   const handleTraceDelete = useCallback(() => {
     onDelete();
@@ -227,194 +211,163 @@ const TraceDetailsActionsPanel: React.FunctionComponent<
   );
 
   return (
-    <div className="flex flex-auto items-center justify-between">
-      <div className="flex items-center gap-1 overflow-hidden">
-        <TooltipWrapper content="Close panel">
-          <Button variant="ghost" size="icon-2xs" onClick={onClose}>
-            <ChevronsRight />
+    <ResizableSidePanelTopBar
+      variant="info"
+      title={traceName}
+      leftIcon={traceType && <BaseTraceDataTypeIcon type={traceType} />}
+      onClose={onClose}
+    >
+      {isAIInspectorEnabled && (
+        <TooltipWrapper content="Debug your trace with AI assistance (OpikAssist)">
+          <Button
+            variant="outline"
+            size="2xs"
+            onClick={() => setActiveSection(DetailsActionSection.AIAssistants)}
+          >
+            <Sparkles className="size-3.5 shrink-0" />
+            <span className="ml-1.5">Improve with Ollie</span>
           </Button>
         </TooltipWrapper>
-        {traceType && <BaseTraceDataTypeIcon type={traceType} />}
-        <span className="comet-body-s-accented truncate">{traceName}</span>
-      </div>
+      )}
 
-      <div className="flex shrink-0 items-center gap-2 pl-4">
-        {isAIInspectorEnabled && (
-          <TooltipWrapper content="Debug your trace with AI assistance (OpikAssist)">
-            <Button
-              variant="outline"
-              size="2xs"
-              onClick={() =>
-                setActiveSection(DetailsActionSection.AIAssistants)
-              }
-            >
-              <Sparkles className="size-3.5 shrink-0" />
-              <span className="ml-1.5">Improve with Ollie</span>
-            </Button>
-          </TooltipWrapper>
-        )}
-
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="icon-2xs">
-              <span className="sr-only">Actions menu</span>
-              <MoreHorizontal />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-52">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="icon-2xs">
+            <span className="sr-only">Actions menu</span>
+            <MoreHorizontal />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-52">
+          <DropdownMenuItem
+            onClick={() => {
+              toast({ description: "URL copied to clipboard" });
+              copy(window.location.href);
+            }}
+          >
+            <Share className="mr-2 size-4" />
+            Share
+          </DropdownMenuItem>
+          <TooltipWrapper content={traceId} side="left">
             <DropdownMenuItem
               onClick={() => {
-                toast({ description: "URL copied to clipboard" });
-                copy(window.location.href);
+                toast({ description: "Trace ID copied to clipboard" });
+                copy(traceId);
               }}
             >
-              <Share className="mr-2 size-4" />
-              Share
+              <Copy className="mr-2 size-4" />
+              Copy trace ID
             </DropdownMenuItem>
-            <TooltipWrapper content={traceId} side="left">
+          </TooltipWrapper>
+          {spanId && (
+            <TooltipWrapper content={spanId} side="left">
               <DropdownMenuItem
                 onClick={() => {
-                  toast({ description: "Trace ID copied to clipboard" });
-                  copy(traceId);
+                  toast({ description: "Span ID copied to clipboard" });
+                  copy(spanId);
                 }}
               >
                 <Copy className="mr-2 size-4" />
-                Copy trace ID
+                Copy span ID
               </DropdownMenuItem>
             </TooltipWrapper>
-            {spanId && (
-              <TooltipWrapper content={spanId} side="left">
-                <DropdownMenuItem
-                  onClick={() => {
-                    toast({ description: "Span ID copied to clipboard" });
-                    copy(spanId);
-                  }}
-                >
-                  <Copy className="mr-2 size-4" />
-                  Copy span ID
-                </DropdownMenuItem>
+          )}
+          <DropdownMenuSeparator />
+          {(["csv", "json"] as const).map((format) => {
+            const item = (
+              <DropdownMenuItem
+                key={format}
+                onClick={() => handleExport(format)}
+                disabled={!isExportEnabled}
+              >
+                <Download className="mr-2 size-4" />
+                Export as {format.toUpperCase()}
+              </DropdownMenuItem>
+            );
+
+            return isExportEnabled ? (
+              item
+            ) : (
+              <TooltipWrapper
+                key={format}
+                content="Export functionality is disabled for this installation"
+                side="left"
+              >
+                <div>{item}</div>
               </TooltipWrapper>
-            )}
-            <DropdownMenuSeparator />
-            {(["csv", "json"] as const).map((format) => {
-              const item = (
-                <DropdownMenuItem
-                  key={format}
-                  onClick={() => handleExport(format)}
-                  disabled={!isExportEnabled}
-                >
-                  <Download className="mr-2 size-4" />
-                  Export as {format.toUpperCase()}
-                </DropdownMenuItem>
-              );
+            );
+          })}
+          {canDeleteTraces && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => setPopupOpen(true)}
+                variant="destructive"
+              >
+                <Trash className="mr-2 size-4" />
+                Delete trace
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
 
-              return isExportEnabled ? (
-                item
-              ) : (
-                <TooltipWrapper
-                  key={format}
-                  content="Export functionality is disabled for this installation"
-                  side="left"
-                >
-                  <div>{item}</div>
-                </TooltipWrapper>
-              );
-            })}
-            {canDeleteTraces && (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={() => setPopupOpen(true)}
-                  variant="destructive"
-                >
-                  <Trash className="mr-2 size-4" />
-                  Delete trace
-                </DropdownMenuItem>
-              </>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+      {canDeleteTraces && (
+        <ConfirmDialog
+          open={popupOpen}
+          setOpen={setPopupOpen}
+          onConfirm={handleTraceDelete}
+          title="Delete trace"
+          description="Deleting a trace will also remove the trace data from related experiment samples. This action can't be undone. Are you sure you want to continue?"
+          confirmText="Delete trace"
+          confirmButtonVariant="destructive"
+        />
+      )}
 
-        {canDeleteTraces && (
-          <ConfirmDialog
-            open={popupOpen}
-            setOpen={setPopupOpen}
-            onConfirm={handleTraceDelete}
-            title="Delete trace"
-            description="Deleting a trace will also remove the trace data from related experiment samples. This action can't be undone. Are you sure you want to continue?"
-            confirmText="Delete trace"
-            confirmButtonVariant="destructive"
-          />
-        )}
+      <ResizableSidePanelArrowNavigation
+        horizontalNavigation={horizontalNavigation}
+      />
 
-        {horizontalNavigation && (
-          <>
-            <Separator orientation="vertical" className="mx-1 h-4" />
-            <Button
-              variant="outline"
-              size="2xs"
-              disabled={!horizontalNavigation.hasPrevious}
-              onClick={() => horizontalNavigation.onChange(-1)}
-              className="gap-1"
-            >
-              Previous
-              <HotkeyDisplay hotkey="J" variant="outline" size="2xs" />
-            </Button>
-            <Button
-              variant="outline"
-              size="2xs"
-              disabled={!horizontalNavigation.hasNext}
-              onClick={() => horizontalNavigation.onChange(1)}
-              className="gap-1"
-            >
-              Next
-              <HotkeyDisplay hotkey="K" variant="outline" size="2xs" />
-            </Button>
-          </>
-        )}
-
-        {canNavigateToExperiment && experiment && (
-          <TooltipWrapper
-            content={`View this item in experiment: ${experiment.name}`}
+      {canNavigateToExperiment && experiment && (
+        <TooltipWrapper
+          content={`View this item in experiment: ${experiment.name}`}
+        >
+          <Button
+            variant="outline"
+            size="2xs"
+            onClick={() =>
+              navigate({
+                to: "/$workspaceName/projects/$projectId/experiments/$datasetId/compare",
+                params: {
+                  workspaceName,
+                  projectId: activeProjectId as string,
+                  datasetId: experiment.dataset_id,
+                },
+                search: {
+                  experiments: [experiment.id],
+                  row: experiment.dataset_item_id,
+                },
+              })
+            }
           >
-            <Button
-              variant="outline"
-              size="2xs"
-              onClick={() =>
-                navigate({
-                  to: "/$workspaceName/projects/$projectId/experiments/$datasetId/compare",
-                  params: {
-                    workspaceName,
-                    projectId: activeProjectId as string,
-                    datasetId: experiment.dataset_id,
-                  },
-                  search: {
-                    experiments: [experiment.id],
-                    row: experiment.dataset_item_id,
-                  },
-                })
-              }
-            >
-              Experiment
-              <ArrowUpRight className="ml-1 size-3.5" />
-            </Button>
-          </TooltipWrapper>
-        )}
+            Experiment
+            <ArrowUpRight className="ml-1 size-3.5" />
+          </Button>
+        </TooltipWrapper>
+      )}
 
-        {hasThread && (
-          <TooltipWrapper content="Go to thread">
-            <Button
-              variant="outline"
-              size="2xs"
-              onClick={() => setThreadId!(threadId)}
-            >
-              Thread
-              <ArrowUpRight className="ml-1 size-3.5" />
-            </Button>
-          </TooltipWrapper>
-        )}
-      </div>
-    </div>
+      {hasThread && (
+        <TooltipWrapper content="Go to thread">
+          <Button
+            variant="outline"
+            size="2xs"
+            onClick={() => setThreadId!(threadId)}
+          >
+            Thread
+            <ArrowUpRight className="ml-1 size-3.5" />
+          </Button>
+        </TooltipWrapper>
+      )}
+    </ResizableSidePanelTopBar>
   );
 };
 

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
@@ -434,7 +434,7 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
       panelId="traces"
       entity="trace"
       open={open}
-      headerContent={
+      header={
         <TraceDetailsActionsPanel
           traceId={traceId}
           spanId={spanId}
@@ -451,7 +451,6 @@ const TraceDetailsPanel: React.FunctionComponent<TraceDetailsPanelProps> = ({
         />
       }
       onClose={onClose}
-      hideDefaultControls
       ignoreHotkeys={isGraphFullscreen}
       horizontalNavigation={horizontalNavigation}
       verticalNavigation={verticalNavigation}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
@@ -11,7 +11,7 @@ import {
   ColumnSort,
   RowSelectionState,
 } from "@tanstack/react-table";
-import { Undo2, X } from "lucide-react";
+import { Undo2 } from "lucide-react";
 import findIndex from "lodash/findIndex";
 import isObject from "lodash/isObject";
 import isNumber from "lodash/isNumber";
@@ -54,7 +54,7 @@ import FiltersButton from "@/shared/FiltersButton/FiltersButton";
 import TracesActionsPanel from "@/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel";
 import { Separator } from "@/ui/separator";
 import { Button } from "@/ui/button";
-import { Sheet, SheetContent, SheetTitle } from "@/ui/sheet";
+import { Sheet, SheetContent, SheetTopBar } from "@/ui/sheet";
 import DataTableRowHeightSelector from "@/shared/DataTableRowHeightSelector/DataTableRowHeightSelector";
 import ColumnsButton from "@/shared/ColumnsButton/ColumnsButton";
 import RefreshButton from "@/shared/RefreshButton/RefreshButton";
@@ -921,18 +921,12 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
   ]);
 
   const sheetHeader = (
-    <>
-      <SheetTitle className="sr-only">{title}</SheetTitle>
-      <div className="flex items-center justify-between border-b px-5 py-3">
-        <Button variant="outline" size="2xs" onClick={onClose}>
-          <Undo2 className="mr-1 size-3" />
-          {backLabel}
-        </Button>
-        <Button variant="ghost" size="icon-sm" onClick={onClose}>
-          <X />
-        </Button>
-      </div>
-    </>
+    <SheetTopBar variant="info" title={title}>
+      <Button variant="outline" size="2xs" onClick={onClose}>
+        <Undo2 className="mr-1 size-3" />
+        {backLabel}
+      </Button>
+    </SheetTopBar>
   );
 
   return (
@@ -948,10 +942,6 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
         }}
       >
         <div className="flex min-h-0 flex-1 flex-col">
-          <div className="px-6 pb-1 pt-4">
-            <h2 className="comet-title-xxs">{title}</h2>
-          </div>
-
           <div className="flex flex-wrap items-center justify-between gap-x-8 gap-y-2 px-6 py-4">
             <div className="flex items-center gap-2">
               <SearchInput

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
@@ -11,7 +11,6 @@ import {
   ColumnSort,
   RowSelectionState,
 } from "@tanstack/react-table";
-import { Undo2 } from "lucide-react";
 import findIndex from "lodash/findIndex";
 import isObject from "lodash/isObject";
 import isNumber from "lodash/isNumber";
@@ -53,7 +52,6 @@ import SearchInput from "@/shared/SearchInput/SearchInput";
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";
 import TracesActionsPanel from "@/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel";
 import { Separator } from "@/ui/separator";
-import { Button } from "@/ui/button";
 import { Sheet, SheetContent, SheetTopBar } from "@/ui/sheet";
 import DataTableRowHeightSelector from "@/shared/DataTableRowHeightSelector/DataTableRowHeightSelector";
 import ColumnsButton from "@/shared/ColumnsButton/ColumnsButton";
@@ -391,7 +389,6 @@ type TraceLogsSidebarProps = {
   projectName?: string;
   logsSource?: LOGS_SOURCE;
   title?: string;
-  backLabel?: string;
 };
 
 const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
@@ -401,7 +398,6 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
   projectName = "",
   logsSource,
   title = "Logs",
-  backLabel = "Back",
 }) => {
   const type = TRACE_DATA_TYPE.traces;
   const truncationEnabled = useTruncationEnabled();
@@ -927,21 +923,12 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
     setMetadataColumnsOrder,
   ]);
 
-  const sheetHeader = (
-    <SheetTopBar variant="info" title={title}>
-      <Button variant="outline" size="2xs" onClick={onClose}>
-        <Undo2 className="mr-1 size-3" />
-        {backLabel}
-      </Button>
-    </SheetTopBar>
-  );
-
   return (
     <Sheet open={open} onOpenChange={handleOpenChange}>
       <SheetContent
         ref={setSheetContentRef}
         className="flex w-screen flex-col shadow-none sm:max-w-full"
-        header={sheetHeader}
+        header={<SheetTopBar variant="info" title={title} />}
         onEscapeKeyDown={(e) => {
           if (traceId) {
             e.preventDefault();

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
@@ -59,7 +59,10 @@ import DataTableRowHeightSelector from "@/shared/DataTableRowHeightSelector/Data
 import ColumnsButton from "@/shared/ColumnsButton/ColumnsButton";
 import RefreshButton from "@/shared/RefreshButton/RefreshButton";
 import DataTable from "@/shared/DataTable/DataTable";
-import DataTableNoData from "@/shared/DataTableNoData/DataTableNoData";
+import DataTableEmptyContent from "@/shared/DataTableNoData/DataTableEmptyContent";
+import DataTableNoMatchingData from "@/shared/DataTableNoData/DataTableNoMatchingData";
+import emptyLogsLightUrl from "/images/empty-logs-light.svg";
+import emptyLogsDarkUrl from "/images/empty-logs-dark.svg";
 import DataTablePagination from "@/shared/DataTablePagination/DataTablePagination";
 import LinkCell from "@/shared/DataTableCells/LinkCell";
 import ResourceCell from "@/shared/DataTableCells/ResourceCell";
@@ -637,7 +640,11 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
   const isTableLoading = isPending || isFeedbackScoresPending;
 
   const noData = !search && filters.length === 0;
-  const noDataText = noData ? "There are no traces yet" : "No search results";
+
+  const handleClearFilters = useCallback(() => {
+    setSearch("");
+    setFilters([]);
+  }, [setSearch, setFilters]);
 
   const rows: Array<Trace> = useMemo(
     () => (data?.content as Trace[]) ?? [],
@@ -1008,7 +1015,14 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
             <DataTableStateHandler
               isLoading={isTableLoading}
               isEmpty={showEmptyState}
-              emptyState={<DataTableNoData title="There are no traces yet" />}
+              emptyState={
+                <DataTableEmptyContent
+                  title="There are no traces yet"
+                  description="Traces will appear here once your agent starts receiving requests."
+                  lightImageUrl={emptyLogsLightUrl}
+                  darkImageUrl={emptyLogsDarkUrl}
+                />
+              }
             >
               <DataTable
                 columns={columns}
@@ -1025,7 +1039,15 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
                 getRowId={getRowId}
                 rowHeight={height as ROW_HEIGHT}
                 columnPinning={DEFAULT_TRACES_COLUMN_PINNING}
-                noData={<DataTableNoData title={noDataText} />}
+                noData={
+                  <DataTableNoMatchingData
+                    onClearFilters={
+                      search || filters.length > 0
+                        ? handleClearFilters
+                        : undefined
+                    }
+                  />
+                }
                 showLoadingOverlay={isPlaceholderData && isFetching}
               />
             </DataTableStateHandler>

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebarButton.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebarButton.tsx
@@ -20,19 +20,11 @@ type TraceLogsSidebarButtonProps = {
   sourceFilters?: Filter[];
   variant?: "tag" | "icon";
   title?: string;
-  backLabel?: string;
 };
 
 const TraceLogsSidebarButton: React.FunctionComponent<
   TraceLogsSidebarButtonProps
-> = ({
-  projectId,
-  logsSource,
-  sourceFilters,
-  variant = "tag",
-  title,
-  backLabel,
-}) => {
+> = ({ projectId, logsSource, sourceFilters, variant = "tag", title }) => {
   const [open = false, setOpen] = useQueryParam(
     `${TLS_QUERY_PREFIX}open`,
     BooleanParam,
@@ -101,7 +93,6 @@ const TraceLogsSidebarButton: React.FunctionComponent<
         projectId={projectId}
         logsSource={logsSource}
         title={title}
-        backLabel={backLabel}
       />
     </>
   );

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
@@ -135,7 +135,6 @@ const CompareExperimentsDetails: React.FunctionComponent<
             logsSource={LOGS_SOURCE.experiment}
             sourceFilters={experimentSourceFilters}
             title="Experiment logs"
-            backLabel={isCompare ? "Back to compare" : "Back to experiment"}
           />
         )}
         {!isCompare &&

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/CompareExperimentsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/CompareExperimentsPanel.tsx
@@ -162,6 +162,7 @@ const CompareExperimentsPanel: React.FunctionComponent<
           </Button>
           <ResizableSidePanelArrowNavigation
             horizontalNavigation={horizontalNavigation}
+            ignoreHotkeys={isTraceDetailsOpened}
           />
         </ResizableSidePanelTopBar>
       }

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/CompareExperimentsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/CompareExperimentsPanel.tsx
@@ -9,6 +9,8 @@ import { Copy } from "lucide-react";
 
 import NoData from "@/shared/NoData/NoData";
 import ResizableSidePanel from "@/shared/ResizableSidePanel/ResizableSidePanel";
+import ResizableSidePanelTopBar from "@/shared/ResizableSidePanel/ResizableSidePanelTopBar";
+import ResizableSidePanelArrowNavigation from "@/shared/ResizableSidePanel/ResizableSidePanelArrowNavigation";
 import ShareURLButton from "@/shared/ShareURLButton/ShareURLButton";
 import { Button } from "@/ui/button";
 import { useToast } from "@/ui/use-toast";
@@ -147,24 +149,22 @@ const CompareExperimentsPanel: React.FunctionComponent<
     );
   };
 
-  const renderHeaderContent = () => {
-    return (
-      <div className="flex flex-auto justify-end gap-2 pl-6">
-        <ShareURLButton />
-        <Button size="sm" variant="outline" onClick={copyClickHandler}>
-          <Copy className="mr-2 size-4" />
-          Copy ID
-        </Button>
-      </div>
-    );
-  };
-
   return (
     <ResizableSidePanel
       panelId="compare-experiments"
-      entity="item"
       open={Boolean(experimentsCompareId)}
-      headerContent={renderHeaderContent()}
+      header={
+        <ResizableSidePanelTopBar variant="info" onClose={onClose}>
+          <ShareURLButton size="2xs" />
+          <Button size="2xs" variant="outline" onClick={copyClickHandler}>
+            <Copy className="mr-1 size-3.5" />
+            Copy ID
+          </Button>
+          <ResizableSidePanelArrowNavigation
+            horizontalNavigation={horizontalNavigation}
+          />
+        </ResizableSidePanelTopBar>
+      }
       onClose={onClose}
       initialWidth={0.8}
       ignoreHotkeys={isTraceDetailsOpened}

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/AddOptimizationDialog/AddOptimizationDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/AddOptimizationDialog/AddOptimizationDialog.tsx
@@ -360,8 +360,8 @@ const AddOptimizationDialog: React.FunctionComponent<
       setOpen={openChangeHandler}
       header={<SheetTopBar variant="info" title="Start optimization run" />}
     >
-      <div className="max-h-full overflow-y-auto p-6 pb-20 pt-4">
-        <div className="m-auto flex w-full max-w-[1250px] items-start gap-6">
+      <div className="max-h-full overflow-y-auto px-5 pb-20 pt-4">
+        <div className="m-auto flex w-full items-start gap-6">
           <div className="flex w-[250px] shrink-0 flex-col gap-2">
             <div className="comet-title-s">Optimization algorithms</div>
             {generateList(OPTIMIZATION_ALGORITHMS_OPTIONS)}

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/AddOptimizationDialog/AddOptimizationDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/AddOptimizationDialog/AddOptimizationDialog.tsx
@@ -6,7 +6,7 @@ import CodeHighlighter from "@/shared/CodeHighlighter/CodeHighlighter";
 import LoadableSelectBox from "@/shared/LoadableSelectBox/LoadableSelectBox";
 import useProjectDatasetsList from "@/api/datasets/useProjectDatasetsList";
 import SideDialog from "@/shared/SideDialog/SideDialog";
-import { SheetTitle } from "@/ui/sheet";
+import { SheetTopBar } from "@/ui/sheet";
 import ApiKeyCard from "@/v2/pages-shared/onboarding/ApiKeyCard/ApiKeyCard";
 import GoogleColabCard from "@/v2/pages-shared/onboarding/GoogleColabCard/GoogleColabCard";
 import ConfiguredCodeHighlighter from "@/v2/pages-shared/onboarding/ConfiguredCodeHighlighter/ConfiguredCodeHighlighter";
@@ -355,15 +355,12 @@ const AddOptimizationDialog: React.FunctionComponent<
   };
 
   return (
-    <SideDialog open={open} setOpen={openChangeHandler}>
-      <div className="pb-20">
-        <div className="pb-8">
-          <SheetTitle>Start an optimization run</SheetTitle>
-          <div className="comet-body-s m-auto mt-4 w-[468px] self-center text-center text-muted-slate">
-            Select a test suite, choose the optimizer you would like to use, and
-            we will improve your prompt for you
-          </div>
-        </div>
+    <SideDialog
+      open={open}
+      setOpen={openChangeHandler}
+      header={<SheetTopBar variant="info" title="Start optimization run" />}
+    >
+      <div className="max-h-full overflow-y-auto p-6 pb-20 pt-4">
         <div className="m-auto flex w-full max-w-[1250px] items-start gap-6">
           <div className="flex w-[250px] shrink-0 flex-col gap-2">
             <div className="comet-title-s">Optimization algorithms</div>

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundHeader.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundHeader.tsx
@@ -461,7 +461,6 @@ const PlaygroundHeader = ({
               logsSource={LOGS_SOURCE.playground}
               variant="icon"
               title="Playground logs"
-              backLabel="Back to playground"
             />
           )}
         </div>

--- a/apps/opik-frontend/src/v2/pages/TrialPage/TrialDetails/TrialDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages/TrialPage/TrialDetails/TrialDetails.tsx
@@ -98,7 +98,6 @@ const TrialDetails: React.FC<TrialDetailsProps> = ({
             logsSource={LOGS_SOURCE.optimization}
             sourceFilters={generateExperimentIdFilter(experiment.id)}
             title="Optimization logs"
-            backLabel="Back to trial"
           />
         )}
       </div>


### PR DESCRIPTION
## Details


https://github.com/user-attachments/assets/ea53df1e-4d8e-419f-bdc1-eb3a0ddb18e3



Unifies the top-bar pattern across every side panel in the v2 UI. Adds two distinct variants — info (chevron close, overlay click closes) for inspection panels, and form (X close, overlay click blocked while dirty) for forms — and migrates 13 v2 panels (Sheet + ResizableSidePanel) to the new shape. The trace-details panel is the visual source-of-truth that all other panels now match.

- New `SheetTopBar` (in `ui/sheet.tsx`) and `ResizableSidePanelTopBar` (in `shared/ResizableSidePanel/`) primitives, plus a self-contained `ResizableSidePanelArrowNavigation` helper that owns J/K hotkeys + visible Previous/Next buttons.
- `Sheet` and `ResizableSidePanel` gain a `blockOverlayClose` prop for form-panel dirty guards. `ResizableSidePanel` also gets a `header` prop that fully replaces the default top-bar contents when supplied; `closeButtonPosition`, `hideDefaultControls`, and `closeOnClickOutside` (all unused by consumers in practice) are removed.
- Playground logs sidebar empty + no-match states reuse the same illustrations and components as the main Logs page.
- v1 mirror panels are intentionally untouched — RSP's default render path is preserved.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6309

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation, with iterative design discussion and user-driven scope adjustments
- Human verification: code review + manual browser verification of each migrated panel (light/dark, dirty/clean states, J/K + ←→ keyboard nav, overlay/ESC close)

## Testing

- \`bash scripts/dev-runner.sh --lint-fe\` — lint + typecheck + dependency validation green after each commit
- Manual browser verification of every migrated panel in v2 (light + dark themes):
  - Sheet panels: AddExperimentDialog, AddOptimizationDialog, QuickstartDialog, SetGuardrailDialog, AgentConfigurationEditPanel, TraceLogsSidebar (Playground logs)
  - ResizableSidePanel panels: TraceDetailsPanel, ThreadDetailsPanel, CompareExperimentsPanel, TestSuiteExperimentPanel, DatasetItemEditorAutosaveLayout, TestSuiteItemPanel, AddItemPanelWrapper, CreateDatasetSidebar
- Verified close affordances: chevron / X click, overlay click (with and without dirty state), ESC, J/K and ←/→ keyboard nav
- v1 spot-check via \`localStorage.setItem("opik-version-override", "v1")\` — auto-fallback close button still renders unchanged
- Playground logs empty + no-match states verified in both themes with the existing \`empty-logs-{light,dark}.svg\` and \`empty-search-{light,dark}.svg\` assets

## Documentation

N/A — no public API surfaces changed; affected primitives and panels are internal to v2.