### PR TITLE
[OPIK-6409] [BE] feat: add V1 workspace allowlist

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1049,11 +1049,19 @@ serviceToggles:
   # Use case: gradual V2 rollout — allowlist specific workspace IDs for V2 while the rest use entity-based determination.
   # Operational impact: empty/missing means no allowlisting. Non-allowlisted workspaces are unaffected.
   v2WorkspaceAllowlist: ${TOGGLE_V2_WORKSPACE_ALLOWLIST:-""}
+  # Default: "" (empty, no allowlisted workspaces)
+  # Description: Comma-separated list of workspace IDs that should always receive V1 navigation.
+  # Valid values: comma-separated workspace IDs (e.g. "ws-id-1,ws-id-2"), or "" (empty, disabled).
+  # Scope: Per-workspace — only listed workspace IDs are affected, all others follow normal determination.
+  # Priority: Second — overridden by v2WorkspaceAllowlist; overrides forceWorkspaceVersion and all subsequent determination logic.
+  # Use case: customer-driven V1 stickiness — pin specific workspaces to legacy navigation without affecting the rest of the deployment.
+  # Operational impact: empty/missing means no allowlisting. Non-allowlisted workspaces are unaffected.
+  v1WorkspaceAllowlist: ${TOGGLE_V1_WORKSPACE_ALLOWLIST:-""}
   # Default: disabled
   # Description: Forces ALL workspaces to a specific navigation version.
   # Valid values: "disabled" (use version 1 entity check), "version_1" (force legacy), "version_2" (force project-first).
   # Scope: Global — applies to all workspaces regardless of their entity state.
-  # Priority: Second highest — overridden by v2WorkspaceAllowlist for listed workspaces.
+  # Priority: Third — overridden by v2WorkspaceAllowlist and v1WorkspaceAllowlist for listed workspaces.
   # Overrides: When not "disabled", overrides the version entity check and auth gate entirely.
   # Operational impact: Default is "disabled" (entity-based determination). Override to "version_1" or "version_2" if global enforcement is needed.
   forceWorkspaceVersion: ${TOGGLE_FORCE_WORKSPACE_VERSION:-"disabled"}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
@@ -27,6 +27,7 @@ import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.comet.opik.infrastructure.ServiceTogglesConfig.FORCE_WORKSPACE_VERSION_DISABLED;
 import static com.comet.opik.infrastructure.auth.RequestContext.SYSTEM_USER;
@@ -128,6 +129,21 @@ abstract class AbstractWorkspaceVersionService implements WorkspaceVersionServic
         this.cacheConfiguration = cacheConfiguration;
         this.workspacesService = workspacesService;
         this.analyticsService = analyticsService;
+        warnIfWorkspaceAllowlistsOverlap();
+    }
+
+    private void warnIfWorkspaceAllowlistsOverlap() {
+        var v1 = serviceTogglesConfig.getV1WorkspaceAllowlistIds();
+        var v2 = serviceTogglesConfig.getV2WorkspaceAllowlistIds();
+        if (v1.isEmpty() || v2.isEmpty()) {
+            return;
+        }
+        var overlap = v1.stream().filter(v2::contains).collect(Collectors.toUnmodifiableSet());
+        if (!overlap.isEmpty()) {
+            log.warn(
+                    "Workspace IDs are configured in both V1 and V2 allowlists; V2 wins per priority order, ids '{}'",
+                    overlap);
+        }
     }
 
     @Override
@@ -136,6 +152,11 @@ abstract class AbstractWorkspaceVersionService implements WorkspaceVersionServic
         if (isWorkspaceInV2Allowlist) {
             log.info("Workspace included in version_2 allowlist, workspaceId '{}'", workspaceId);
             return Mono.just(buildResponse(OpikVersion.VERSION_2));
+        }
+        var isWorkspaceInV1Allowlist = serviceTogglesConfig.getV1WorkspaceAllowlistIds().contains(workspaceId);
+        if (isWorkspaceInV1Allowlist) {
+            log.info("Workspace included in version_1 allowlist, workspaceId '{}'", workspaceId);
+            return Mono.just(buildResponse(OpikVersion.VERSION_1));
         }
         var forcedVersion = getForcedVersion();
         if (forcedVersion.isPresent()) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
@@ -213,7 +213,10 @@ abstract class AbstractWorkspaceVersionService implements WorkspaceVersionServic
 
     private void persistAndEmitBlocking(String workspaceId, WorkspaceVersion response, String userName) {
         var newVersion = response.opikVersion();
-        var previousVersion = workspacesService.upsertVersionAndReturnPrevious(workspaceId, newVersion, userName);
+        var previousVersion = workspacesService.findById(workspaceId)
+                .map(Workspace::lastKnownVersion)
+                .flatMap(OpikVersion::findByValue);
+        workspacesService.upsertVersion(workspaceId, newVersion, userName);
         var versionChanged = previousVersion.map(prev -> prev != newVersion).orElse(true);
         analyticsService.trackEvent("workspace_version_determined", Map.of(
                 "workspace_id", workspaceId,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesDAO.java
@@ -15,14 +15,6 @@ public interface WorkspacesDAO {
     @SqlQuery("SELECT * FROM workspaces WHERE id = :id")
     Optional<Workspace> findById(@Bind("id") String id);
 
-    /**
-     * Read the prior {@code last_known_version} with a row-level lock so that concurrent
-     * version-determination writers serialize per workspace. Pair with {@link #upsertVersion}
-     * inside the same transaction to atomically capture the prior value before overwriting it.
-     */
-    @SqlQuery("SELECT last_known_version FROM workspaces WHERE id = :id FOR UPDATE")
-    Optional<String> findVersionForUpdate(@Bind("id") String id);
-
     @SqlUpdate("""
             INSERT INTO workspaces (id, last_known_version, version_determined_at, created_by, last_updated_by)
             VALUES (:id, :version, :determinedAt, :userName, :userName)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesService.java
@@ -14,8 +14,6 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.function.ToIntFunction;
 
 import static com.comet.opik.infrastructure.auth.RequestContext.SYSTEM_USER;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
@@ -30,16 +28,6 @@ public interface WorkspacesService {
      * context).
      */
     int upsertVersion(String workspaceId, OpikVersion version, String userName);
-
-    /**
-     * Atomically capture the prior {@code last_known_version} (with a row-level lock) and upsert
-     * the new value in a single transaction. Concurrent callers serialize per workspace, so each
-     * one observes the previous writer's commit — preventing duplicate {@code version_changed=true}
-     * emissions when two determinations race for the same workspace.
-     *
-     * @return the prior {@link OpikVersion} (empty when no row existed or the column was null)
-     */
-    Optional<OpikVersion> upsertVersionAndReturnPrevious(String workspaceId, OpikVersion version, String userName);
 
     /** Returns the row, or empty if not found / blank id. */
     Optional<Workspace> findById(@NonNull String workspaceId);
@@ -80,18 +68,6 @@ class WorkspacesServiceImpl implements WorkspacesService {
     }
 
     @Override
-    public Optional<OpikVersion> upsertVersionAndReturnPrevious(@NonNull String workspaceId,
-            @NonNull OpikVersion version, @NonNull String userName) {
-        return transactionTemplate.inTransaction(WRITE, handle -> {
-            var dao = handle.attach(WorkspacesDAO.class);
-            var previous = dao.findVersionForUpdate(workspaceId)
-                    .flatMap(OpikVersion::findByValue);
-            dao.upsertVersion(workspaceId, version.getValue(), Instant.now(), userName);
-            return previous;
-        });
-    }
-
-    @Override
     public Optional<Workspace> findById(@NonNull String workspaceId) {
         if (StringUtils.isBlank(workspaceId)) {
             return Optional.empty();
@@ -100,60 +76,63 @@ class WorkspacesServiceImpl implements WorkspacesService {
                 handle -> handle.attach(WorkspacesDAO.class).findById(workspaceId));
     }
 
-    @Override
-    public boolean markFirstTraceReported(@NonNull String workspaceId, @NonNull String userName) {
-        var now = Instant.now();
-        return transitionFlagAtomically(
-                dao -> dao.updateFirstTraceIfNull(workspaceId, now, userName),
-                dao -> dao.insertFirstTrace(workspaceId, now, userName));
-    }
-
-    @Override
-    public boolean markMigrationSkipped(@NonNull String workspaceId, @NonNull String reason) {
-        var now = Instant.now();
-        return transitionFlagAtomically(
-                dao -> dao.updateMigrationSkippedIfNull(workspaceId, now, reason, SYSTEM_USER),
-                dao -> dao.insertMigrationSkipped(workspaceId, now, reason, SYSTEM_USER));
-    }
-
     /**
      * UPDATE-then-INSERT, single transaction. We can't use a single-statement upsert with a
      * ROW_COUNT check here because Connector/J defaults to {@code useAffectedRows=false}
      * ({@code CLIENT_FOUND_ROWS=on}), which makes a matched-but-unchanged upsert return
-     * {@code 1} — indistinguishable from a fresh insert. Splitting into two primitives keeps
-     * the detection unambiguous: the UPDATE's row count is exact.
+     * {@code 1} — indistinguishable from a fresh insert. Splitting into two primitives keeps the
+     * detection unambiguous.
      *
-     * <p>A duplicate-key on the INSERT does <b>not</b> mean another writer flipped <i>this</i>
-     * flag — it just means the row exists. It might have been inserted by an unrelated writer
-     * (version determination, migration job) that didn't touch the target column. We retry the
-     * UPDATE-if-null to disambiguate: if the column is still NULL we flip it (and return true),
-     * otherwise some prior caller already set it (return false).</p>
-     *
-     * @return {@code true} when this caller flipped the flag; {@code false} when another caller
-     *         already set it
+     * <p>A duplicate-key on the INSERT does <b>not</b> mean another writer flipped
+     * {@code first_trace_reported_at} — it just means the row exists. It might have been inserted
+     * by an unrelated writer (version determination, migration job) that didn't touch the column.
+     * Retrying the UPDATE-if-null disambiguates: if the column is still NULL we flip it.</p>
      */
-    private boolean transitionFlagAtomically(ToIntFunction<WorkspacesDAO> updateIfNull,
-            Consumer<WorkspacesDAO> insert) {
+    @Override
+    public boolean markFirstTraceReported(@NonNull String workspaceId, @NonNull String userName) {
         return transactionTemplate.inTransaction(WRITE, handle -> {
             var dao = handle.attach(WorkspacesDAO.class);
-            if (updateIfNull.applyAsInt(dao) > 0) {
+            var now = Instant.now();
+            if (dao.updateFirstTraceIfNull(workspaceId, now, userName) > 0) {
                 return true;
             }
             try {
-                insert.accept(dao);
+                dao.insertFirstTrace(workspaceId, now, userName);
                 return true;
             } catch (UnableToExecuteStatementException exception) {
-                if (isDuplicateKeyViolation(exception)) {
-                    return updateIfNull.applyAsInt(dao) > 0;
+                if (exception.getCause() instanceof SQLException sql
+                        && SQL_STATE_INTEGRITY_CONSTRAINT_VIOLATION.equals(sql.getSQLState())) {
+                    return dao.updateFirstTraceIfNull(workspaceId, now, userName) > 0;
                 }
                 throw exception;
             }
         });
     }
 
-    private static boolean isDuplicateKeyViolation(UnableToExecuteStatementException exception) {
-        return exception.getCause() instanceof SQLException sql
-                && SQL_STATE_INTEGRITY_CONSTRAINT_VIOLATION.equals(sql.getSQLState());
+    /**
+     * Same UPDATE-then-INSERT-then-retry-UPDATE flow as {@link #markFirstTraceReported}, applied
+     * to the {@code migration_skipped_at} flag. Idempotent: returns {@code false} when this caller
+     * loses the race or the workspace was already trapped.
+     */
+    @Override
+    public boolean markMigrationSkipped(@NonNull String workspaceId, @NonNull String reason) {
+        return transactionTemplate.inTransaction(WRITE, handle -> {
+            var dao = handle.attach(WorkspacesDAO.class);
+            var now = Instant.now();
+            if (dao.updateMigrationSkippedIfNull(workspaceId, now, reason, SYSTEM_USER) > 0) {
+                return true;
+            }
+            try {
+                dao.insertMigrationSkipped(workspaceId, now, reason, SYSTEM_USER);
+                return true;
+            } catch (UnableToExecuteStatementException exception) {
+                if (exception.getCause() instanceof SQLException sql
+                        && SQL_STATE_INTEGRITY_CONSTRAINT_VIOLATION.equals(sql.getSQLState())) {
+                    return dao.updateMigrationSkippedIfNull(workspaceId, now, reason, SYSTEM_USER) > 0;
+                }
+                throw exception;
+            }
+        });
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
@@ -70,9 +70,20 @@ public class ServiceTogglesConfig {
 
     @JsonSetter
     public void setV2WorkspaceAllowlist(String v2WorkspaceAllowlist) {
-        this.v2WorkspaceAllowlistIds = Optional.ofNullable(v2WorkspaceAllowlist)
+        this.v2WorkspaceAllowlistIds = parseAllowlist(v2WorkspaceAllowlist);
+    }
+
+    @NotNull Set<@NotBlank String> v1WorkspaceAllowlistIds = Set.of();
+
+    @JsonSetter
+    public void setV1WorkspaceAllowlist(String v1WorkspaceAllowlist) {
+        this.v1WorkspaceAllowlistIds = parseAllowlist(v1WorkspaceAllowlist);
+    }
+
+    private static Set<String> parseAllowlist(String commaSeparated) {
+        return Optional.ofNullable(commaSeparated)
                 .filter(StringUtils::isNotBlank)
-                .map(commaSeparated -> Arrays.stream(commaSeparated.split(","))
+                .map(value -> Arrays.stream(value.split(","))
                         .map(String::strip)
                         .filter(StringUtils::isNotBlank)
                         .collect(Collectors.toUnmodifiableSet()))

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/WorkspaceVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/WorkspaceVersionResourceTest.java
@@ -177,6 +177,101 @@ class WorkspaceVersionResourceTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     @ExtendWith(DropwizardAppExtensionProvider.class)
+    class V1WorkspaceAllowlistTest {
+
+        private static final String V1_ALLOWLISTED_ID_1 = UUID.randomUUID().toString();
+        private static final String V1_ALLOWLISTED_ID_2 = UUID.randomUUID().toString();
+        // Same ID is in both lists — V2 must win per priority order.
+        private static final String V2_AND_V1_ALLOWLISTED_ID = UUID.randomUUID().toString();
+        private static final String V1_WORKSPACE_ALLOWLIST = "%s, %s, %s".formatted(
+                V1_ALLOWLISTED_ID_1, V1_ALLOWLISTED_ID_2, V2_AND_V1_ALLOWLISTED_ID);
+        private static final String V2_WORKSPACE_ALLOWLIST = V2_AND_V1_ALLOWLISTED_ID;
+
+        private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+        private final Network NETWORK = Network.newNetwork();
+        private final GenericContainer<?> ZOOKEEPER = ClickHouseContainerUtils.newZookeeperContainer(false, NETWORK);
+        private final ClickHouseContainer CLICKHOUSE = ClickHouseContainerUtils.newClickHouseContainer(
+                false, NETWORK, ZOOKEEPER);
+        private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer(false);
+
+        @RegisterApp
+        private final TestDropwizardAppExtension app;
+
+        private final WireMockUtils.WireMockRuntime wireMock;
+
+        {
+            wireMock = WireMockUtils.startWireMock();
+
+            Startables.deepStart(REDIS, MYSQL, CLICKHOUSE).join();
+
+            MigrationUtils.runMysqlDbMigration(MYSQL);
+            MigrationUtils.runClickhouseDbMigration(CLICKHOUSE);
+
+            var databaseAnalyticsFactory = ClickHouseContainerUtils
+                    .newDatabaseAnalyticsFactory(CLICKHOUSE, DATABASE_NAME);
+
+            // forceWorkspaceVersion=version_2 lets the test prove V1-allowlist beats the global force.
+            app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                    AppContextConfig.builder()
+                            .redisUrl(REDIS.getRedisURI())
+                            .jdbcUrl(MYSQL.getJdbcUrl())
+                            .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                            .runtimeInfo(wireMock.runtimeInfo())
+                            .customConfigs(List.of(
+                                    new CustomConfig("serviceToggles.v1WorkspaceAllowlist", V1_WORKSPACE_ALLOWLIST),
+                                    new CustomConfig("serviceToggles.v2WorkspaceAllowlist", V2_WORKSPACE_ALLOWLIST),
+                                    new CustomConfig("serviceToggles.forceWorkspaceVersion", "version_2")))
+                            .build());
+        }
+
+        private WorkspaceResourceClient workspaceClient;
+
+        @BeforeAll
+        void beforeAll(ClientSupport clientSupport) {
+            var baseUrl = TestUtils.getBaseUrl(clientSupport);
+            ClientSupportUtils.config(clientSupport);
+            workspaceClient = new WorkspaceResourceClient(clientSupport, baseUrl, podamFactory);
+        }
+
+        @AfterAll
+        void afterAll() {
+            wireMock.server().stop();
+        }
+
+        static Stream<Arguments> workspaceVersion__whenV1AllowlistAndOverrides__returnsExpectedVersion() {
+            return Stream.of(
+                    // V1 allowlist hit → V1, even though forceWorkspaceVersion=version_2.
+                    arguments(V1_ALLOWLISTED_ID_1, V1_WORKSPACE_VERSION),
+                    arguments(V1_ALLOWLISTED_ID_2, V1_WORKSPACE_VERSION),
+                    // Both V1 and V2 allowlists list this id → V2 wins.
+                    arguments(V2_AND_V1_ALLOWLISTED_ID, V2_WORKSPACE_VERSION),
+                    // Not in either allowlist → forceWorkspaceVersion=version_2 takes over.
+                    arguments(UUID.randomUUID().toString(), V2_WORKSPACE_VERSION));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void workspaceVersion__whenV1AllowlistAndOverrides__returnsExpectedVersion(
+                String workspaceId, WorkspaceVersion expectedVersion) {
+            var workspaceName = mockWorkspace(wireMock, workspaceId, null);
+
+            assertThat(workspaceClient.getWorkspaceVersion(API_KEY, workspaceName)).isEqualTo(expectedVersion);
+        }
+
+        @Test
+        void v1AllowlistHit__doesNotPersistRowToWorkspacesTable(WorkspacesService workspacesService) {
+            // V1 allowlist hits short-circuit before persistAndEmit — no workspaces row should ever appear.
+            var workspaceName = mockWorkspace(wireMock, V1_ALLOWLISTED_ID_1, null);
+
+            assertThat(workspaceClient.getWorkspaceVersion(API_KEY, workspaceName)).isEqualTo(V1_WORKSPACE_VERSION);
+
+            assertThat(workspacesService.findById(V1_ALLOWLISTED_ID_1)).isEmpty();
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @ExtendWith(DropwizardAppExtensionProvider.class)
     class ForceWorkspaceVersion1Test {
 
         private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();


### PR DESCRIPTION
## Details

Symmetric counterpart of the existing V2 workspace allowlist: a comma-separated list of workspace IDs that always resolve to `version_1`, short-circuiting cache, auth gate, entity check, and fallback. Use case is customer-driven V1 stickiness — pinning specific workspaces to legacy navigation without the deployment-wide impact of `TOGGLE_FORCE_WORKSPACE_VERSION`.

- New env var / config key `TOGGLE_V1_WORKSPACE_ALLOWLIST` → `serviceToggles.v1WorkspaceAllowlist`, parsed identically to its V2 sibling (the two setters now share a private `parseAllowlist` helper).
- V1 short-circuit slotted into `AbstractWorkspaceVersionService.getWorkspaceVersion(...)` between the V2 allowlist check and the global `forceWorkspaceVersion` override. New priority order: V2 allowlist → V1 allowlist → forceWorkspaceVersion → cache → auth gate → entity check → fallback.
- Allowlist hits return before reaching `computeVersion`, so no row is written to the `workspaces` table and no `workspace_version_determined` analytics event is emitted (verified by a focused test using `WorkspacesService.findById(...)`).
- Constructor logs a one-time `warn` when any workspace ID appears in both V1 and V2 lists (V2 wins, but operators are notified).

> **Stacked on [#6615 (OPIK-4933)](https://github.com/comet-ml/opik/pull/6615).** The base branch points at `thiagohora/OPIK-4933-add-workspaces-table`; once that PR merges, the base will rebase onto `main` cleanly. The "no table write / no event on allowlist hit" test relies on OPIK-4933's `WorkspacesService` being present.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6409

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: implementation, tests
- Human verification: code review (mirror of V2 allowlist), local test run, priority-order audit against the ticket spec

## Testing

Local, in `apps/opik-backend`:

- `mvn compile -DskipTests` — clean.
- `mvn test-compile -DskipTests` — clean.
- `mvn spotless:apply` — clean.
- `mvn test -Dtest='WorkspaceVersionResourceTest$V1WorkspaceAllowlistTest'` — 5/5 pass in ~44s.
  - Parameterized `workspaceVersion__whenV1AllowlistAndOverrides__returnsExpectedVersion` covers the priority matrix:
    - V1-allowlisted workspaces beat `forceWorkspaceVersion=version_2`.
    - Workspace listed in both V1 and V2 → V2 wins.
    - Non-allowlisted workspace → falls through to `forceWorkspaceVersion`.
  - `v1AllowlistHit__doesNotPersistRowToWorkspacesTable` asserts `WorkspacesService.findById(...)` is empty after a V1 hit, confirming the short-circuit happens before `persistAndEmit`.
- `mvn test -Dtest='WorkspaceVersionResourceTest$V2WorkspaceAllowlistTest'` — 3/3 pass (regression check).

## Documentation

N/A — config flag and operational doc-comments inline in `config.yml`. No API surface change, no SDK / FE change.