### PR TITLE
[NA] [GHA] chore: upsert PR linter comment instead of spamming

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -83,10 +83,15 @@ jobs:
               }
             }
             
-            // 3. Final step: Comment on PR and/or fail the job
+            // 3. Find existing linter comment (if any)
+            const COMMENT_MARKER = "<!-- pr-linter-comment -->";
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: pr.number });
+            const existingComment = comments.find(c => c.body && c.body.includes(COMMENT_MARKER));
+
+            // 4. Final step: upsert/delete comment and/or fail the job
             if (errors.length > 0) {
-              const commentBody = "### 📋 PR Linter Failed\n\n" + errors.join("\n\n---\n\n");
-              
+              const commentBody = COMMENT_MARKER + "\n### 📋 PR Linter Failed\n\n" + errors.join("\n\n---\n\n");
+
               const logMessage = "PR Linter Failed:\n\n" + errors.join("\n\n")
                   .replace(/❌ \*\*/g, '❌ ')
                   .replace(/\*\*`/g, '`')
@@ -94,9 +99,16 @@ jobs:
                   .replace(/###\s/g, '')
                   .replace(/---\n\n/g, '');
 
-              await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body: commentBody });
-              
+              if (existingComment) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existingComment.id, body: commentBody });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body: commentBody });
+              }
+
               core.setFailed(logMessage);
             } else {
-               console.log("✅ PR linting passed!");
+              if (existingComment) {
+                await github.rest.issues.deleteComment({ owner, repo, comment_id: existingComment.id });
+              }
+              console.log("✅ PR linting passed!");
             }

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -83,10 +83,10 @@ jobs:
               }
             }
             
-            // 3. Find existing linter comment (if any)
+            // 3. Find all existing linter comments across all pages
             const COMMENT_MARKER = "<!-- pr-linter-comment -->";
-            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: pr.number });
-            const existingComment = comments.find(c => c.body && c.body.includes(COMMENT_MARKER));
+            const allComments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: pr.number });
+            const markerComments = allComments.filter(c => c.body && c.body.includes(COMMENT_MARKER));
 
             // 4. Final step: upsert/delete comment and/or fail the job
             if (errors.length > 0) {
@@ -99,16 +99,17 @@ jobs:
                   .replace(/###\s/g, '')
                   .replace(/---\n\n/g, '');
 
-              if (existingComment) {
-                await github.rest.issues.updateComment({ owner, repo, comment_id: existingComment.id, body: commentBody });
+              if (markerComments.length > 0) {
+                // Keep the newest, delete any duplicates
+                const [keep, ...duplicates] = [...markerComments].sort((a, b) => b.id - a.id);
+                await github.rest.issues.updateComment({ owner, repo, comment_id: keep.id, body: commentBody });
+                await Promise.all(duplicates.map(c => github.rest.issues.deleteComment({ owner, repo, comment_id: c.id })));
               } else {
                 await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body: commentBody });
               }
 
               core.setFailed(logMessage);
             } else {
-              if (existingComment) {
-                await github.rest.issues.deleteComment({ owner, repo, comment_id: existingComment.id });
-              }
+              await Promise.all(markerComments.map(c => github.rest.issues.deleteComment({ owner, repo, comment_id: c.id })));
               console.log("✅ PR linting passed!");
             }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <div align="center"><b><a href="README.md">English</a> | <a href="readme_CN.md">简体中文</a> | <a href="readme_JP.md">日本語</a> | <a href="readme_PT_BR.md">Português (Brasil)</a> | <a href="readme_KO.md">한국어</a><br><a href="readme_ES.md">Español</a> | <a href="readme_FR.md">Français</a> | <a href="readme_DE.md">Deutsch</a> | <a href="readme_RU.md">Русский</a> | <a href="readme_AR.md">العربية</a> | <a href="readme_HI.md">हिन्दी</a> | <a href="readme_TR.md">Türkçe</a></b></div>
 
 
+
 <h1 align="center" style="border-bottom: none">
     <div>
         <a href="https://www.comet.com/site/products/opik/?from=llm&utm_source=opik&utm_medium=github&utm_content=header_img&utm_campaign=opik"><picture>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <div align="center"><b><a href="README.md">English</a> | <a href="readme_CN.md">简体中文</a> | <a href="readme_JP.md">日本語</a> | <a href="readme_PT_BR.md">Português (Brasil)</a> | <a href="readme_KO.md">한국어</a><br><a href="readme_ES.md">Español</a> | <a href="readme_FR.md">Français</a> | <a href="readme_DE.md">Deutsch</a> | <a href="readme_RU.md">Русский</a> | <a href="readme_AR.md">العربية</a> | <a href="readme_HI.md">हिन्दी</a> | <a href="readme_TR.md">Türkçe</a></b></div>
 
 
-
 <h1 align="center" style="border-bottom: none">
     <div>
         <a href="https://www.comet.com/site/products/opik/?from=llm&utm_source=opik&utm_medium=github&utm_content=header_img&utm_campaign=opik"><picture>


### PR DESCRIPTION
## Details
Updates the PR linter workflow to avoid comment spam. Instead of posting a new comment on every push, the workflow now finds and updates the existing linter comment. When all checks pass, the comment is deleted. Also fixes pagination (uses `github.paginate` to fetch all comment pages) and handles duplicate marker comments by keeping the newest and deleting extras.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: full implementation
- Human verification: code review

## Testing
Validated manually on this PR — the linter comment was created, then updated on re-run, and will be deleted once this description fix triggers a passing run.

## Documentation
N/A