### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -10020,6 +10020,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10079,6 +10081,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10103,6 +10107,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10434,6 +10440,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10493,6 +10501,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10517,6 +10527,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10903,6 +10915,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10962,6 +10976,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10986,6 +11002,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -11875,6 +11893,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -14646,6 +14666,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     Trace:
       required:
       - start_time
@@ -14776,6 +14800,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     ErrorInfo_ExperimentItemBulkWriteView:
       required:
       - exception_type
@@ -14961,6 +14989,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     Trace_ExperimentItemBulkWriteView:
       required:
       - start_time
@@ -15010,6 +15042,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
       description: "Please provide either none, only one of evaluate_task_result or\
         \ trace, but never both"
     ValueEntry_ExperimentItemBulkWriteView:
@@ -18845,6 +18881,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     ErrorInfo_Write:
       required:
       - exception_type
@@ -18934,6 +18974,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     SpanBatch:
       required:
       - spans
@@ -19133,6 +19177,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     ValueEntry_Public:
       type: object
       properties:
@@ -19292,6 +19340,7 @@ components:
             - duration
             - ttft
             - source
+            - environment
         from_time:
           type: string
           description: Filter spans created from this time (ISO-8601 format).
@@ -19394,6 +19443,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     TraceThreadBatchUpdate:
       required:
       - ids
@@ -19514,6 +19567,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     TraceBatch:
       required:
       - traces
@@ -19771,6 +19828,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     TraceThread:
       type: object
       properties:
@@ -19833,6 +19894,8 @@ components:
         created_at:
           type: string
           format: date-time
+        environment:
+          type: string
     TraceThreadIdentifier:
       required:
       - thread_id
@@ -20044,6 +20107,7 @@ components:
             - providers
             - experiment
             - source
+            - environment
         from_time:
           type: string
           description: Filter traces created from this time (ISO-8601 format).

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -10020,6 +10020,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10079,6 +10081,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10103,6 +10107,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10434,6 +10440,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10493,6 +10501,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10517,6 +10527,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10903,6 +10915,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10962,6 +10976,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -10986,6 +11002,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -11875,6 +11893,8 @@ components:
           - <=
           - is_empty
           - is_not_empty
+          - in
+          - not_in
         key:
           type: string
         value:
@@ -14646,6 +14666,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     Trace:
       required:
       - start_time
@@ -14776,6 +14800,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     ErrorInfo_ExperimentItemBulkWriteView:
       required:
       - exception_type
@@ -14961,6 +14989,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     Trace_ExperimentItemBulkWriteView:
       required:
       - start_time
@@ -15010,6 +15042,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
       description: "Please provide either none, only one of evaluate_task_result or\
         \ trace, but never both"
     ValueEntry_ExperimentItemBulkWriteView:
@@ -18845,6 +18881,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     ErrorInfo_Write:
       required:
       - exception_type
@@ -18934,6 +18974,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     SpanBatch:
       required:
       - spans
@@ -19133,6 +19177,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     ValueEntry_Public:
       type: object
       properties:
@@ -19292,6 +19340,7 @@ components:
             - duration
             - ttft
             - source
+            - environment
         from_time:
           type: string
           description: Filter spans created from this time (ISO-8601 format).
@@ -19394,6 +19443,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     TraceThreadBatchUpdate:
       required:
       - ids
@@ -19514,6 +19567,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     TraceBatch:
       required:
       - traces
@@ -19771,6 +19828,10 @@ components:
           - experiment
           - playground
           - optimization
+        environment:
+          maxLength: 150
+          minLength: 0
+          type: string
     TraceThread:
       type: object
       properties:
@@ -19833,6 +19894,8 @@ components:
         created_at:
           type: string
           format: date-time
+        environment:
+          type: string
     TraceThreadIdentifier:
       required:
       - thread_id
@@ -20044,6 +20107,7 @@ components:
             - providers
             - experiment
             - source
+            - environment
         from_time:
           type: string
           description: Filter traces created from this time (ISO-8601 format).

--- a/sdks/python/src/opik/rest_api/spans/client.py
+++ b/sdks/python/src/opik/rest_api/spans/client.py
@@ -355,6 +355,7 @@ class SpansClient:
         total_estimated_cost_version: typing.Optional[str] = OMIT,
         ttft: typing.Optional[float] = OMIT,
         source: typing.Optional[SpanWriteSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -406,6 +407,8 @@ class SpansClient:
 
         source : typing.Optional[SpanWriteSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -442,6 +445,7 @@ class SpansClient:
             total_estimated_cost_version=total_estimated_cost_version,
             ttft=ttft,
             source=source,
+            environment=environment,
             request_options=request_options,
         )
         return _response.data
@@ -529,6 +533,7 @@ class SpansClient:
         error_info: typing.Optional[ErrorInfo] = OMIT,
         ttft: typing.Optional[float] = OMIT,
         source: typing.Optional[SpanUpdateSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -583,6 +588,8 @@ class SpansClient:
 
         source : typing.Optional[SpanUpdateSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -618,6 +625,7 @@ class SpansClient:
             error_info=error_info,
             ttft=ttft,
             source=source,
+            environment=environment,
             request_options=request_options,
         )
         return _response.data
@@ -1310,6 +1318,7 @@ class AsyncSpansClient:
         total_estimated_cost_version: typing.Optional[str] = OMIT,
         ttft: typing.Optional[float] = OMIT,
         source: typing.Optional[SpanWriteSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -1361,6 +1370,8 @@ class AsyncSpansClient:
 
         source : typing.Optional[SpanWriteSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -1400,6 +1411,7 @@ class AsyncSpansClient:
             total_estimated_cost_version=total_estimated_cost_version,
             ttft=ttft,
             source=source,
+            environment=environment,
             request_options=request_options,
         )
         return _response.data
@@ -1493,6 +1505,7 @@ class AsyncSpansClient:
         error_info: typing.Optional[ErrorInfo] = OMIT,
         ttft: typing.Optional[float] = OMIT,
         source: typing.Optional[SpanUpdateSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -1547,6 +1560,8 @@ class AsyncSpansClient:
 
         source : typing.Optional[SpanUpdateSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -1585,6 +1600,7 @@ class AsyncSpansClient:
             error_info=error_info,
             ttft=ttft,
             source=source,
+            environment=environment,
             request_options=request_options,
         )
         return _response.data

--- a/sdks/python/src/opik/rest_api/spans/raw_client.py
+++ b/sdks/python/src/opik/rest_api/spans/raw_client.py
@@ -416,6 +416,7 @@ class RawSpansClient:
         total_estimated_cost_version: typing.Optional[str] = OMIT,
         ttft: typing.Optional[float] = OMIT,
         source: typing.Optional[SpanWriteSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[None]:
         """
@@ -467,6 +468,8 @@ class RawSpansClient:
 
         source : typing.Optional[SpanWriteSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -507,6 +510,7 @@ class RawSpansClient:
                 "total_estimated_cost_version": total_estimated_cost_version,
                 "ttft": ttft,
                 "source": source,
+                "environment": environment,
             },
             headers={
                 "content-type": "application/json",
@@ -656,6 +660,7 @@ class RawSpansClient:
         error_info: typing.Optional[ErrorInfo] = OMIT,
         ttft: typing.Optional[float] = OMIT,
         source: typing.Optional[SpanUpdateSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[None]:
         """
@@ -710,6 +715,8 @@ class RawSpansClient:
 
         source : typing.Optional[SpanUpdateSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -749,6 +756,7 @@ class RawSpansClient:
                 ),
                 "ttft": ttft,
                 "source": source,
+                "environment": environment,
             },
             headers={
                 "content-type": "application/json",
@@ -1627,6 +1635,7 @@ class AsyncRawSpansClient:
         total_estimated_cost_version: typing.Optional[str] = OMIT,
         ttft: typing.Optional[float] = OMIT,
         source: typing.Optional[SpanWriteSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[None]:
         """
@@ -1678,6 +1687,8 @@ class AsyncRawSpansClient:
 
         source : typing.Optional[SpanWriteSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -1718,6 +1729,7 @@ class AsyncRawSpansClient:
                 "total_estimated_cost_version": total_estimated_cost_version,
                 "ttft": ttft,
                 "source": source,
+                "environment": environment,
             },
             headers={
                 "content-type": "application/json",
@@ -1867,6 +1879,7 @@ class AsyncRawSpansClient:
         error_info: typing.Optional[ErrorInfo] = OMIT,
         ttft: typing.Optional[float] = OMIT,
         source: typing.Optional[SpanUpdateSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[None]:
         """
@@ -1921,6 +1934,8 @@ class AsyncRawSpansClient:
 
         source : typing.Optional[SpanUpdateSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -1960,6 +1975,7 @@ class AsyncRawSpansClient:
                 ),
                 "ttft": ttft,
                 "source": source,
+                "environment": environment,
             },
             headers={
                 "content-type": "application/json",

--- a/sdks/python/src/opik/rest_api/spans/types/span_search_stream_request_public_exclude_item.py
+++ b/sdks/python/src/opik/rest_api/spans/types/span_search_stream_request_public_exclude_item.py
@@ -26,6 +26,7 @@ SpanSearchStreamRequestPublicExcludeItem = typing.Union[
         "duration",
         "ttft",
         "source",
+        "environment",
     ],
     typing.Any,
 ]

--- a/sdks/python/src/opik/rest_api/traces/client.py
+++ b/sdks/python/src/opik/rest_api/traces/client.py
@@ -479,6 +479,7 @@ class TracesClient:
         ttft: typing.Optional[float] = OMIT,
         thread_id: typing.Optional[str] = OMIT,
         source: typing.Optional[TraceWriteSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -516,6 +517,8 @@ class TracesClient:
 
         source : typing.Optional[TraceWriteSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -545,6 +548,7 @@ class TracesClient:
             ttft=ttft,
             thread_id=thread_id,
             source=source,
+            environment=environment,
             request_options=request_options,
         )
         return _response.data
@@ -626,6 +630,7 @@ class TracesClient:
         thread_id: typing.Optional[str] = OMIT,
         ttft: typing.Optional[float] = OMIT,
         source: typing.Optional[TraceUpdateSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -668,6 +673,8 @@ class TracesClient:
 
         source : typing.Optional[TraceUpdateSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -697,6 +704,7 @@ class TracesClient:
             thread_id=thread_id,
             ttft=ttft,
             source=source,
+            environment=environment,
             request_options=request_options,
         )
         return _response.data
@@ -2108,6 +2116,7 @@ class AsyncTracesClient:
         ttft: typing.Optional[float] = OMIT,
         thread_id: typing.Optional[str] = OMIT,
         source: typing.Optional[TraceWriteSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -2145,6 +2154,8 @@ class AsyncTracesClient:
 
         source : typing.Optional[TraceWriteSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -2177,6 +2188,7 @@ class AsyncTracesClient:
             ttft=ttft,
             thread_id=thread_id,
             source=source,
+            environment=environment,
             request_options=request_options,
         )
         return _response.data
@@ -2264,6 +2276,7 @@ class AsyncTracesClient:
         thread_id: typing.Optional[str] = OMIT,
         ttft: typing.Optional[float] = OMIT,
         source: typing.Optional[TraceUpdateSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -2306,6 +2319,8 @@ class AsyncTracesClient:
 
         source : typing.Optional[TraceUpdateSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -2338,6 +2353,7 @@ class AsyncTracesClient:
             thread_id=thread_id,
             ttft=ttft,
             source=source,
+            environment=environment,
             request_options=request_options,
         )
         return _response.data

--- a/sdks/python/src/opik/rest_api/traces/raw_client.py
+++ b/sdks/python/src/opik/rest_api/traces/raw_client.py
@@ -588,6 +588,7 @@ class RawTracesClient:
         ttft: typing.Optional[float] = OMIT,
         thread_id: typing.Optional[str] = OMIT,
         source: typing.Optional[TraceWriteSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[None]:
         """
@@ -625,6 +626,8 @@ class RawTracesClient:
 
         source : typing.Optional[TraceWriteSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -658,6 +661,7 @@ class RawTracesClient:
                 "ttft": ttft,
                 "thread_id": thread_id,
                 "source": source,
+                "environment": environment,
             },
             headers={
                 "content-type": "application/json",
@@ -768,6 +772,7 @@ class RawTracesClient:
         thread_id: typing.Optional[str] = OMIT,
         ttft: typing.Optional[float] = OMIT,
         source: typing.Optional[TraceUpdateSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[None]:
         """
@@ -810,6 +815,8 @@ class RawTracesClient:
 
         source : typing.Optional[TraceUpdateSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -843,6 +850,7 @@ class RawTracesClient:
                 "thread_id": thread_id,
                 "ttft": ttft,
                 "source": source,
+                "environment": environment,
             },
             headers={
                 "content-type": "application/json",
@@ -2696,6 +2704,7 @@ class AsyncRawTracesClient:
         ttft: typing.Optional[float] = OMIT,
         thread_id: typing.Optional[str] = OMIT,
         source: typing.Optional[TraceWriteSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[None]:
         """
@@ -2733,6 +2742,8 @@ class AsyncRawTracesClient:
 
         source : typing.Optional[TraceWriteSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -2766,6 +2777,7 @@ class AsyncRawTracesClient:
                 "ttft": ttft,
                 "thread_id": thread_id,
                 "source": source,
+                "environment": environment,
             },
             headers={
                 "content-type": "application/json",
@@ -2876,6 +2888,7 @@ class AsyncRawTracesClient:
         thread_id: typing.Optional[str] = OMIT,
         ttft: typing.Optional[float] = OMIT,
         source: typing.Optional[TraceUpdateSource] = OMIT,
+        environment: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[None]:
         """
@@ -2918,6 +2931,8 @@ class AsyncRawTracesClient:
 
         source : typing.Optional[TraceUpdateSource]
 
+        environment : typing.Optional[str]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -2951,6 +2966,7 @@ class AsyncRawTracesClient:
                 "thread_id": thread_id,
                 "ttft": ttft,
                 "source": source,
+                "environment": environment,
             },
             headers={
                 "content-type": "application/json",

--- a/sdks/python/src/opik/rest_api/traces/types/trace_search_stream_request_public_exclude_item.py
+++ b/sdks/python/src/opik/rest_api/traces/types/trace_search_stream_request_public_exclude_item.py
@@ -31,6 +31,7 @@ TraceSearchStreamRequestPublicExcludeItem = typing.Union[
         "providers",
         "experiment",
         "source",
+        "environment",
     ],
     typing.Any,
 ]

--- a/sdks/python/src/opik/rest_api/types/dataset_item_filter_operator.py
+++ b/sdks/python/src/opik/rest_api/types/dataset_item_filter_operator.py
@@ -16,6 +16,8 @@ DatasetItemFilterOperator = typing.Union[
         "<=",
         "is_empty",
         "is_not_empty",
+        "in",
+        "not_in",
     ],
     typing.Any,
 ]

--- a/sdks/python/src/opik/rest_api/types/span.py
+++ b/sdks/python/src/opik/rest_api/types/span.py
@@ -54,6 +54,7 @@ class Span(UniversalBaseModel):
     """
 
     source: typing.Optional[SpanSource] = None
+    environment: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/span_experiment_item_bulk_write_view.py
+++ b/sdks/python/src/opik/rest_api/types/span_experiment_item_bulk_write_view.py
@@ -35,6 +35,7 @@ class SpanExperimentItemBulkWriteView(UniversalBaseModel):
     """
 
     source: typing.Optional[SpanExperimentItemBulkWriteViewSource] = None
+    environment: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/span_filter_operator.py
+++ b/sdks/python/src/opik/rest_api/types/span_filter_operator.py
@@ -16,6 +16,8 @@ SpanFilterOperator = typing.Union[
         "<=",
         "is_empty",
         "is_not_empty",
+        "in",
+        "not_in",
     ],
     typing.Any,
 ]

--- a/sdks/python/src/opik/rest_api/types/span_filter_public_operator.py
+++ b/sdks/python/src/opik/rest_api/types/span_filter_public_operator.py
@@ -16,6 +16,8 @@ SpanFilterPublicOperator = typing.Union[
         "<=",
         "is_empty",
         "is_not_empty",
+        "in",
+        "not_in",
     ],
     typing.Any,
 ]

--- a/sdks/python/src/opik/rest_api/types/span_filter_write_operator.py
+++ b/sdks/python/src/opik/rest_api/types/span_filter_write_operator.py
@@ -16,6 +16,8 @@ SpanFilterWriteOperator = typing.Union[
         "<=",
         "is_empty",
         "is_not_empty",
+        "in",
+        "not_in",
     ],
     typing.Any,
 ]

--- a/sdks/python/src/opik/rest_api/types/span_public.py
+++ b/sdks/python/src/opik/rest_api/types/span_public.py
@@ -54,6 +54,7 @@ class SpanPublic(UniversalBaseModel):
     """
 
     source: typing.Optional[SpanPublicSource] = None
+    environment: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/span_update.py
+++ b/sdks/python/src/opik/rest_api/types/span_update.py
@@ -52,6 +52,7 @@ class SpanUpdate(UniversalBaseModel):
     error_info: typing.Optional[ErrorInfo] = None
     ttft: typing.Optional[float] = None
     source: typing.Optional[SpanUpdateSource] = None
+    environment: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/span_write.py
+++ b/sdks/python/src/opik/rest_api/types/span_write.py
@@ -41,6 +41,7 @@ class SpanWrite(UniversalBaseModel):
     """
 
     source: typing.Optional[SpanWriteSource] = None
+    environment: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/trace.py
+++ b/sdks/python/src/opik/rest_api/types/trace.py
@@ -67,6 +67,7 @@ class Trace(UniversalBaseModel):
 
     experiment: typing.Optional[ExperimentItemReference] = None
     source: typing.Optional[TraceSource] = None
+    environment: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/trace_experiment_item_bulk_write_view.py
+++ b/sdks/python/src/opik/rest_api/types/trace_experiment_item_bulk_write_view.py
@@ -37,6 +37,7 @@ class TraceExperimentItemBulkWriteView(UniversalBaseModel):
 
     thread_id: typing.Optional[str] = None
     source: typing.Optional[TraceExperimentItemBulkWriteViewSource] = None
+    environment: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/trace_filter_operator.py
+++ b/sdks/python/src/opik/rest_api/types/trace_filter_operator.py
@@ -16,6 +16,8 @@ TraceFilterOperator = typing.Union[
         "<=",
         "is_empty",
         "is_not_empty",
+        "in",
+        "not_in",
     ],
     typing.Any,
 ]

--- a/sdks/python/src/opik/rest_api/types/trace_filter_public_operator.py
+++ b/sdks/python/src/opik/rest_api/types/trace_filter_public_operator.py
@@ -16,6 +16,8 @@ TraceFilterPublicOperator = typing.Union[
         "<=",
         "is_empty",
         "is_not_empty",
+        "in",
+        "not_in",
     ],
     typing.Any,
 ]

--- a/sdks/python/src/opik/rest_api/types/trace_filter_write_operator.py
+++ b/sdks/python/src/opik/rest_api/types/trace_filter_write_operator.py
@@ -16,6 +16,8 @@ TraceFilterWriteOperator = typing.Union[
         "<=",
         "is_empty",
         "is_not_empty",
+        "in",
+        "not_in",
     ],
     typing.Any,
 ]

--- a/sdks/python/src/opik/rest_api/types/trace_public.py
+++ b/sdks/python/src/opik/rest_api/types/trace_public.py
@@ -62,6 +62,7 @@ class TracePublic(UniversalBaseModel):
 
     experiment: typing.Optional[ExperimentItemReferencePublic] = None
     source: typing.Optional[TracePublicSource] = None
+    environment: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/trace_thread.py
+++ b/sdks/python/src/opik/rest_api/types/trace_thread.py
@@ -31,6 +31,7 @@ class TraceThread(UniversalBaseModel):
     last_updated_by: typing.Optional[str] = None
     created_by: typing.Optional[str] = None
     created_at: typing.Optional[dt.datetime] = None
+    environment: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/trace_thread_filter_operator.py
+++ b/sdks/python/src/opik/rest_api/types/trace_thread_filter_operator.py
@@ -16,6 +16,8 @@ TraceThreadFilterOperator = typing.Union[
         "<=",
         "is_empty",
         "is_not_empty",
+        "in",
+        "not_in",
     ],
     typing.Any,
 ]

--- a/sdks/python/src/opik/rest_api/types/trace_thread_filter_public_operator.py
+++ b/sdks/python/src/opik/rest_api/types/trace_thread_filter_public_operator.py
@@ -16,6 +16,8 @@ TraceThreadFilterPublicOperator = typing.Union[
         "<=",
         "is_empty",
         "is_not_empty",
+        "in",
+        "not_in",
     ],
     typing.Any,
 ]

--- a/sdks/python/src/opik/rest_api/types/trace_thread_filter_write_operator.py
+++ b/sdks/python/src/opik/rest_api/types/trace_thread_filter_write_operator.py
@@ -16,6 +16,8 @@ TraceThreadFilterWriteOperator = typing.Union[
         "<=",
         "is_empty",
         "is_not_empty",
+        "in",
+        "not_in",
     ],
     typing.Any,
 ]

--- a/sdks/python/src/opik/rest_api/types/trace_update.py
+++ b/sdks/python/src/opik/rest_api/types/trace_update.py
@@ -45,6 +45,7 @@ class TraceUpdate(UniversalBaseModel):
     thread_id: typing.Optional[str] = None
     ttft: typing.Optional[float] = None
     source: typing.Optional[TraceUpdateSource] = None
+    environment: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/trace_write.py
+++ b/sdks/python/src/opik/rest_api/types/trace_write.py
@@ -33,6 +33,7 @@ class TraceWrite(UniversalBaseModel):
 
     thread_id: typing.Optional[str] = None
     source: typing.Optional[TraceWriteSource] = None
+    environment: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/typescript/src/opik/rest_api/api/resources/spans/types/SpanSearchStreamRequestPublicExcludeItem.ts
+++ b/sdks/typescript/src/opik/rest_api/api/resources/spans/types/SpanSearchStreamRequestPublicExcludeItem.ts
@@ -24,6 +24,7 @@ export const SpanSearchStreamRequestPublicExcludeItem = {
     Duration: "duration",
     Ttft: "ttft",
     Source: "source",
+    Environment: "environment",
 } as const;
 export type SpanSearchStreamRequestPublicExcludeItem =
     (typeof SpanSearchStreamRequestPublicExcludeItem)[keyof typeof SpanSearchStreamRequestPublicExcludeItem];

--- a/sdks/typescript/src/opik/rest_api/api/resources/traces/types/TraceSearchStreamRequestPublicExcludeItem.ts
+++ b/sdks/typescript/src/opik/rest_api/api/resources/traces/types/TraceSearchStreamRequestPublicExcludeItem.ts
@@ -29,6 +29,7 @@ export const TraceSearchStreamRequestPublicExcludeItem = {
     Providers: "providers",
     Experiment: "experiment",
     Source: "source",
+    Environment: "environment",
 } as const;
 export type TraceSearchStreamRequestPublicExcludeItem =
     (typeof TraceSearchStreamRequestPublicExcludeItem)[keyof typeof TraceSearchStreamRequestPublicExcludeItem];

--- a/sdks/typescript/src/opik/rest_api/api/types/DatasetItemFilterOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/DatasetItemFilterOperator.ts
@@ -13,5 +13,7 @@ export const DatasetItemFilterOperator = {
     LessThanOrEqualTo: "<=",
     IsEmpty: "is_empty",
     IsNotEmpty: "is_not_empty",
+    In: "in",
+    NotIn: "not_in",
 } as const;
 export type DatasetItemFilterOperator = (typeof DatasetItemFilterOperator)[keyof typeof DatasetItemFilterOperator];

--- a/sdks/typescript/src/opik/rest_api/api/types/Span.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/Span.ts
@@ -34,4 +34,5 @@ export interface Span {
     /** Time to first token in milliseconds */
     ttft?: number;
     source?: OpikApi.SpanSource;
+    environment?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/SpanExperimentItemBulkWriteView.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/SpanExperimentItemBulkWriteView.ts
@@ -23,4 +23,5 @@ export interface SpanExperimentItemBulkWriteView {
     /** Time to first token in milliseconds */
     ttft?: number;
     source?: OpikApi.SpanExperimentItemBulkWriteViewSource;
+    environment?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/SpanFilterOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/SpanFilterOperator.ts
@@ -13,5 +13,7 @@ export const SpanFilterOperator = {
     LessThanOrEqualTo: "<=",
     IsEmpty: "is_empty",
     IsNotEmpty: "is_not_empty",
+    In: "in",
+    NotIn: "not_in",
 } as const;
 export type SpanFilterOperator = (typeof SpanFilterOperator)[keyof typeof SpanFilterOperator];

--- a/sdks/typescript/src/opik/rest_api/api/types/SpanFilterPublicOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/SpanFilterPublicOperator.ts
@@ -13,5 +13,7 @@ export const SpanFilterPublicOperator = {
     LessThanOrEqualTo: "<=",
     IsEmpty: "is_empty",
     IsNotEmpty: "is_not_empty",
+    In: "in",
+    NotIn: "not_in",
 } as const;
 export type SpanFilterPublicOperator = (typeof SpanFilterPublicOperator)[keyof typeof SpanFilterPublicOperator];

--- a/sdks/typescript/src/opik/rest_api/api/types/SpanFilterWriteOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/SpanFilterWriteOperator.ts
@@ -13,5 +13,7 @@ export const SpanFilterWriteOperator = {
     LessThanOrEqualTo: "<=",
     IsEmpty: "is_empty",
     IsNotEmpty: "is_not_empty",
+    In: "in",
+    NotIn: "not_in",
 } as const;
 export type SpanFilterWriteOperator = (typeof SpanFilterWriteOperator)[keyof typeof SpanFilterWriteOperator];

--- a/sdks/typescript/src/opik/rest_api/api/types/SpanPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/SpanPublic.ts
@@ -34,4 +34,5 @@ export interface SpanPublic {
     /** Time to first token in milliseconds */
     ttft?: number;
     source?: OpikApi.SpanPublicSource;
+    environment?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/SpanUpdate.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/SpanUpdate.ts
@@ -28,4 +28,5 @@ export interface SpanUpdate {
     errorInfo?: OpikApi.ErrorInfo;
     ttft?: number;
     source?: OpikApi.SpanUpdateSource;
+    environment?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/SpanWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/SpanWrite.ts
@@ -26,4 +26,5 @@ export interface SpanWrite {
     /** Time to first token in milliseconds */
     ttft?: number;
     source?: OpikApi.SpanWriteSource;
+    environment?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/Trace.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/Trace.ts
@@ -39,4 +39,5 @@ export interface Trace {
     providers?: string[];
     experiment?: OpikApi.ExperimentItemReference;
     source?: OpikApi.TraceSource;
+    environment?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceExperimentItemBulkWriteView.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceExperimentItemBulkWriteView.ts
@@ -22,4 +22,5 @@ export interface TraceExperimentItemBulkWriteView {
     ttft?: number;
     threadId?: string;
     source?: OpikApi.TraceExperimentItemBulkWriteViewSource;
+    environment?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceFilterOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceFilterOperator.ts
@@ -13,5 +13,7 @@ export const TraceFilterOperator = {
     LessThanOrEqualTo: "<=",
     IsEmpty: "is_empty",
     IsNotEmpty: "is_not_empty",
+    In: "in",
+    NotIn: "not_in",
 } as const;
 export type TraceFilterOperator = (typeof TraceFilterOperator)[keyof typeof TraceFilterOperator];

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceFilterPublicOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceFilterPublicOperator.ts
@@ -13,5 +13,7 @@ export const TraceFilterPublicOperator = {
     LessThanOrEqualTo: "<=",
     IsEmpty: "is_empty",
     IsNotEmpty: "is_not_empty",
+    In: "in",
+    NotIn: "not_in",
 } as const;
 export type TraceFilterPublicOperator = (typeof TraceFilterPublicOperator)[keyof typeof TraceFilterPublicOperator];

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceFilterWriteOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceFilterWriteOperator.ts
@@ -13,5 +13,7 @@ export const TraceFilterWriteOperator = {
     LessThanOrEqualTo: "<=",
     IsEmpty: "is_empty",
     IsNotEmpty: "is_not_empty",
+    In: "in",
+    NotIn: "not_in",
 } as const;
 export type TraceFilterWriteOperator = (typeof TraceFilterWriteOperator)[keyof typeof TraceFilterWriteOperator];

--- a/sdks/typescript/src/opik/rest_api/api/types/TracePublic.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TracePublic.ts
@@ -37,4 +37,5 @@ export interface TracePublic {
     providers?: string[];
     experiment?: OpikApi.ExperimentItemReferencePublic;
     source?: OpikApi.TracePublicSource;
+    environment?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceThread.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceThread.ts
@@ -22,4 +22,5 @@ export interface TraceThread {
     lastUpdatedBy?: string;
     createdBy?: string;
     createdAt?: Date;
+    environment?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceThreadFilterOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceThreadFilterOperator.ts
@@ -13,5 +13,7 @@ export const TraceThreadFilterOperator = {
     LessThanOrEqualTo: "<=",
     IsEmpty: "is_empty",
     IsNotEmpty: "is_not_empty",
+    In: "in",
+    NotIn: "not_in",
 } as const;
 export type TraceThreadFilterOperator = (typeof TraceThreadFilterOperator)[keyof typeof TraceThreadFilterOperator];

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceThreadFilterPublicOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceThreadFilterPublicOperator.ts
@@ -13,6 +13,8 @@ export const TraceThreadFilterPublicOperator = {
     LessThanOrEqualTo: "<=",
     IsEmpty: "is_empty",
     IsNotEmpty: "is_not_empty",
+    In: "in",
+    NotIn: "not_in",
 } as const;
 export type TraceThreadFilterPublicOperator =
     (typeof TraceThreadFilterPublicOperator)[keyof typeof TraceThreadFilterPublicOperator];

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceThreadFilterWriteOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceThreadFilterWriteOperator.ts
@@ -13,6 +13,8 @@ export const TraceThreadFilterWriteOperator = {
     LessThanOrEqualTo: "<=",
     IsEmpty: "is_empty",
     IsNotEmpty: "is_not_empty",
+    In: "in",
+    NotIn: "not_in",
 } as const;
 export type TraceThreadFilterWriteOperator =
     (typeof TraceThreadFilterWriteOperator)[keyof typeof TraceThreadFilterWriteOperator];

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceUpdate.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceUpdate.ts
@@ -22,4 +22,5 @@ export interface TraceUpdate {
     threadId?: string;
     ttft?: number;
     source?: OpikApi.TraceUpdateSource;
+    environment?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceWrite.ts
@@ -19,4 +19,5 @@ export interface TraceWrite {
     ttft?: number;
     threadId?: string;
     source?: OpikApi.TraceWriteSource;
+    environment?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/resources/spans/types/SpanSearchStreamRequestPublicExcludeItem.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/resources/spans/types/SpanSearchStreamRequestPublicExcludeItem.ts
@@ -30,6 +30,7 @@ export const SpanSearchStreamRequestPublicExcludeItem: core.serialization.Schema
     "duration",
     "ttft",
     "source",
+    "environment",
 ]);
 
 export declare namespace SpanSearchStreamRequestPublicExcludeItem {
@@ -55,5 +56,6 @@ export declare namespace SpanSearchStreamRequestPublicExcludeItem {
         | "total_estimated_cost_version"
         | "duration"
         | "ttft"
-        | "source";
+        | "source"
+        | "environment";
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/resources/traces/types/TraceSearchStreamRequestPublicExcludeItem.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/resources/traces/types/TraceSearchStreamRequestPublicExcludeItem.ts
@@ -35,6 +35,7 @@ export const TraceSearchStreamRequestPublicExcludeItem: core.serialization.Schem
     "providers",
     "experiment",
     "source",
+    "environment",
 ]);
 
 export declare namespace TraceSearchStreamRequestPublicExcludeItem {
@@ -65,5 +66,6 @@ export declare namespace TraceSearchStreamRequestPublicExcludeItem {
         | "visibility_mode"
         | "providers"
         | "experiment"
-        | "source";
+        | "source"
+        | "environment";
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/DatasetItemFilterOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/DatasetItemFilterOperator.ts
@@ -20,6 +20,8 @@ export const DatasetItemFilterOperator: core.serialization.Schema<
     "<=",
     "is_empty",
     "is_not_empty",
+    "in",
+    "not_in",
 ]);
 
 export declare namespace DatasetItemFilterOperator {
@@ -35,5 +37,7 @@ export declare namespace DatasetItemFilterOperator {
         | "<"
         | "<="
         | "is_empty"
-        | "is_not_empty";
+        | "is_not_empty"
+        | "in"
+        | "not_in";
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/Span.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/Span.ts
@@ -42,6 +42,7 @@ export const Span: core.serialization.ObjectSchema<serializers.Span.Raw, OpikApi
     duration: core.serialization.number().optional(),
     ttft: core.serialization.number().optional(),
     source: SpanSource.optional(),
+    environment: core.serialization.string().optional(),
 });
 
 export declare namespace Span {
@@ -74,5 +75,6 @@ export declare namespace Span {
         duration?: number | null;
         ttft?: number | null;
         source?: SpanSource.Raw | null;
+        environment?: string | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/SpanExperimentItemBulkWriteView.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/SpanExperimentItemBulkWriteView.ts
@@ -34,6 +34,7 @@ export const SpanExperimentItemBulkWriteView: core.serialization.ObjectSchema<
     ),
     ttft: core.serialization.number().optional(),
     source: SpanExperimentItemBulkWriteViewSource.optional(),
+    environment: core.serialization.string().optional(),
 });
 
 export declare namespace SpanExperimentItemBulkWriteView {
@@ -57,5 +58,6 @@ export declare namespace SpanExperimentItemBulkWriteView {
         total_estimated_cost_version?: string | null;
         ttft?: number | null;
         source?: SpanExperimentItemBulkWriteViewSource.Raw | null;
+        environment?: string | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/SpanFilterOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/SpanFilterOperator.ts
@@ -20,6 +20,8 @@ export const SpanFilterOperator: core.serialization.Schema<
     "<=",
     "is_empty",
     "is_not_empty",
+    "in",
+    "not_in",
 ]);
 
 export declare namespace SpanFilterOperator {
@@ -35,5 +37,7 @@ export declare namespace SpanFilterOperator {
         | "<"
         | "<="
         | "is_empty"
-        | "is_not_empty";
+        | "is_not_empty"
+        | "in"
+        | "not_in";
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/SpanFilterPublicOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/SpanFilterPublicOperator.ts
@@ -20,6 +20,8 @@ export const SpanFilterPublicOperator: core.serialization.Schema<
     "<=",
     "is_empty",
     "is_not_empty",
+    "in",
+    "not_in",
 ]);
 
 export declare namespace SpanFilterPublicOperator {
@@ -35,5 +37,7 @@ export declare namespace SpanFilterPublicOperator {
         | "<"
         | "<="
         | "is_empty"
-        | "is_not_empty";
+        | "is_not_empty"
+        | "in"
+        | "not_in";
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/SpanFilterWriteOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/SpanFilterWriteOperator.ts
@@ -20,6 +20,8 @@ export const SpanFilterWriteOperator: core.serialization.Schema<
     "<=",
     "is_empty",
     "is_not_empty",
+    "in",
+    "not_in",
 ]);
 
 export declare namespace SpanFilterWriteOperator {
@@ -35,5 +37,7 @@ export declare namespace SpanFilterWriteOperator {
         | "<"
         | "<="
         | "is_empty"
-        | "is_not_empty";
+        | "is_not_empty"
+        | "in"
+        | "not_in";
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/SpanPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/SpanPublic.ts
@@ -46,6 +46,7 @@ export const SpanPublic: core.serialization.ObjectSchema<serializers.SpanPublic.
         duration: core.serialization.number().optional(),
         ttft: core.serialization.number().optional(),
         source: SpanPublicSource.optional(),
+        environment: core.serialization.string().optional(),
     });
 
 export declare namespace SpanPublic {
@@ -78,5 +79,6 @@ export declare namespace SpanPublic {
         duration?: number | null;
         ttft?: number | null;
         source?: SpanPublicSource.Raw | null;
+        environment?: string | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/SpanUpdate.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/SpanUpdate.ts
@@ -36,6 +36,7 @@ export const SpanUpdate: core.serialization.ObjectSchema<serializers.SpanUpdate.
         errorInfo: core.serialization.property("error_info", ErrorInfo.optional()),
         ttft: core.serialization.number().optional(),
         source: SpanUpdateSource.optional(),
+        environment: core.serialization.string().optional(),
     });
 
 export declare namespace SpanUpdate {
@@ -60,5 +61,6 @@ export declare namespace SpanUpdate {
         error_info?: ErrorInfo.Raw | null;
         ttft?: number | null;
         source?: SpanUpdateSource.Raw | null;
+        environment?: string | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/SpanWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/SpanWrite.ts
@@ -34,6 +34,7 @@ export const SpanWrite: core.serialization.ObjectSchema<serializers.SpanWrite.Ra
         ),
         ttft: core.serialization.number().optional(),
         source: SpanWriteSource.optional(),
+        environment: core.serialization.string().optional(),
     });
 
 export declare namespace SpanWrite {
@@ -59,5 +60,6 @@ export declare namespace SpanWrite {
         total_estimated_cost_version?: string | null;
         ttft?: number | null;
         source?: SpanWriteSource.Raw | null;
+        environment?: string | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/Trace.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/Trace.ts
@@ -50,6 +50,7 @@ export const Trace: core.serialization.ObjectSchema<serializers.Trace.Raw, OpikA
     providers: core.serialization.list(core.serialization.string()).optional(),
     experiment: ExperimentItemReference.optional(),
     source: TraceSource.optional(),
+    environment: core.serialization.string().optional(),
 });
 
 export declare namespace Trace {
@@ -85,5 +86,6 @@ export declare namespace Trace {
         providers?: string[] | null;
         experiment?: ExperimentItemReference.Raw | null;
         source?: TraceSource.Raw | null;
+        environment?: string | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceExperimentItemBulkWriteView.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceExperimentItemBulkWriteView.ts
@@ -25,6 +25,7 @@ export const TraceExperimentItemBulkWriteView: core.serialization.ObjectSchema<
     ttft: core.serialization.number().optional(),
     threadId: core.serialization.property("thread_id", core.serialization.string().optional()),
     source: TraceExperimentItemBulkWriteViewSource.optional(),
+    environment: core.serialization.string().optional(),
 });
 
 export declare namespace TraceExperimentItemBulkWriteView {
@@ -43,5 +44,6 @@ export declare namespace TraceExperimentItemBulkWriteView {
         ttft?: number | null;
         thread_id?: string | null;
         source?: TraceExperimentItemBulkWriteViewSource.Raw | null;
+        environment?: string | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceFilterOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceFilterOperator.ts
@@ -20,6 +20,8 @@ export const TraceFilterOperator: core.serialization.Schema<
     "<=",
     "is_empty",
     "is_not_empty",
+    "in",
+    "not_in",
 ]);
 
 export declare namespace TraceFilterOperator {
@@ -35,5 +37,7 @@ export declare namespace TraceFilterOperator {
         | "<"
         | "<="
         | "is_empty"
-        | "is_not_empty";
+        | "is_not_empty"
+        | "in"
+        | "not_in";
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceFilterPublicOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceFilterPublicOperator.ts
@@ -20,6 +20,8 @@ export const TraceFilterPublicOperator: core.serialization.Schema<
     "<=",
     "is_empty",
     "is_not_empty",
+    "in",
+    "not_in",
 ]);
 
 export declare namespace TraceFilterPublicOperator {
@@ -35,5 +37,7 @@ export declare namespace TraceFilterPublicOperator {
         | "<"
         | "<="
         | "is_empty"
-        | "is_not_empty";
+        | "is_not_empty"
+        | "in"
+        | "not_in";
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceFilterWriteOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceFilterWriteOperator.ts
@@ -20,6 +20,8 @@ export const TraceFilterWriteOperator: core.serialization.Schema<
     "<=",
     "is_empty",
     "is_not_empty",
+    "in",
+    "not_in",
 ]);
 
 export declare namespace TraceFilterWriteOperator {
@@ -35,5 +37,7 @@ export declare namespace TraceFilterWriteOperator {
         | "<"
         | "<="
         | "is_empty"
-        | "is_not_empty";
+        | "is_not_empty"
+        | "in"
+        | "not_in";
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TracePublic.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TracePublic.ts
@@ -53,6 +53,7 @@ export const TracePublic: core.serialization.ObjectSchema<serializers.TracePubli
         providers: core.serialization.list(core.serialization.string()).optional(),
         experiment: ExperimentItemReferencePublic.optional(),
         source: TracePublicSource.optional(),
+        environment: core.serialization.string().optional(),
     });
 
 export declare namespace TracePublic {
@@ -87,5 +88,6 @@ export declare namespace TracePublic {
         providers?: string[] | null;
         experiment?: ExperimentItemReferencePublic.Raw | null;
         source?: TracePublicSource.Raw | null;
+        environment?: string | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceThread.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceThread.ts
@@ -32,6 +32,7 @@ export const TraceThread: core.serialization.ObjectSchema<serializers.TraceThrea
         lastUpdatedBy: core.serialization.property("last_updated_by", core.serialization.string().optional()),
         createdBy: core.serialization.property("created_by", core.serialization.string().optional()),
         createdAt: core.serialization.property("created_at", core.serialization.date().optional()),
+        environment: core.serialization.string().optional(),
     });
 
 export declare namespace TraceThread {
@@ -55,5 +56,6 @@ export declare namespace TraceThread {
         last_updated_by?: string | null;
         created_by?: string | null;
         created_at?: string | null;
+        environment?: string | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceThreadFilterOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceThreadFilterOperator.ts
@@ -20,6 +20,8 @@ export const TraceThreadFilterOperator: core.serialization.Schema<
     "<=",
     "is_empty",
     "is_not_empty",
+    "in",
+    "not_in",
 ]);
 
 export declare namespace TraceThreadFilterOperator {
@@ -35,5 +37,7 @@ export declare namespace TraceThreadFilterOperator {
         | "<"
         | "<="
         | "is_empty"
-        | "is_not_empty";
+        | "is_not_empty"
+        | "in"
+        | "not_in";
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceThreadFilterPublicOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceThreadFilterPublicOperator.ts
@@ -20,6 +20,8 @@ export const TraceThreadFilterPublicOperator: core.serialization.Schema<
     "<=",
     "is_empty",
     "is_not_empty",
+    "in",
+    "not_in",
 ]);
 
 export declare namespace TraceThreadFilterPublicOperator {
@@ -35,5 +37,7 @@ export declare namespace TraceThreadFilterPublicOperator {
         | "<"
         | "<="
         | "is_empty"
-        | "is_not_empty";
+        | "is_not_empty"
+        | "in"
+        | "not_in";
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceThreadFilterWriteOperator.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceThreadFilterWriteOperator.ts
@@ -20,6 +20,8 @@ export const TraceThreadFilterWriteOperator: core.serialization.Schema<
     "<=",
     "is_empty",
     "is_not_empty",
+    "in",
+    "not_in",
 ]);
 
 export declare namespace TraceThreadFilterWriteOperator {
@@ -35,5 +37,7 @@ export declare namespace TraceThreadFilterWriteOperator {
         | "<"
         | "<="
         | "is_empty"
-        | "is_not_empty";
+        | "is_not_empty"
+        | "in"
+        | "not_in";
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceUpdate.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceUpdate.ts
@@ -29,6 +29,7 @@ export const TraceUpdate: core.serialization.ObjectSchema<serializers.TraceUpdat
         threadId: core.serialization.property("thread_id", core.serialization.string().optional()),
         ttft: core.serialization.number().optional(),
         source: TraceUpdateSource.optional(),
+        environment: core.serialization.string().optional(),
     });
 
 export declare namespace TraceUpdate {
@@ -47,5 +48,6 @@ export declare namespace TraceUpdate {
         thread_id?: string | null;
         ttft?: number | null;
         source?: TraceUpdateSource.Raw | null;
+        environment?: string | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceWrite.ts
@@ -23,6 +23,7 @@ export const TraceWrite: core.serialization.ObjectSchema<serializers.TraceWrite.
         ttft: core.serialization.number().optional(),
         threadId: core.serialization.property("thread_id", core.serialization.string().optional()),
         source: TraceWriteSource.optional(),
+        environment: core.serialization.string().optional(),
     });
 
 export declare namespace TraceWrite {
@@ -41,5 +42,6 @@ export declare namespace TraceWrite {
         ttft?: number | null;
         thread_id?: string | null;
         source?: TraceWriteSource.Raw | null;
+        environment?: string | null;
     }
 }


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

**Triggered by BE merge:** https://github.com/comet-ml/opik/pull/6608

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate