### PR TITLE
[OPIK-6368] [BE] feat: auto-create environments from trace ingestion

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -751,7 +751,7 @@ optimizationLogs:
 # Environment CRUD configuration
 environment:
   # Maximum number of environments allowed per workspace.
-  maxPerWorkspace: ${OPIK_ENVIRONMENT_MAX_PER_WORKSPACE:-20}
+  maxPerWorkspace: ${OPIK_ENVIRONMENT_MAX_PER_WORKSPACE:-100}
 
 # Data retention policy enforcement
 # The job splits the workspace UUID space into N=executionsPerDay fractions and processes one fraction per tick.

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/EnvironmentAutoCreateListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/EnvironmentAutoCreateListener.java
@@ -37,8 +37,8 @@ public class EnvironmentAutoCreateListener {
         Mono.fromRunnable(() -> environmentService.bulkCreate(names, event.workspaceId(), event.userName()))
                 .subscribeOn(Schedulers.boundedElastic())
                 .doOnError(error -> log.error(
-                        "Failed to auto-create environments for workspace_id '{}': '{}'",
-                        event.workspaceId(), error.getMessage(), error))
+                        "Failed to auto-create environments for workspace_id '{}'",
+                        event.workspaceId(), error))
                 .onErrorResume(error -> Mono.empty())
                 .subscribe();
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/EnvironmentAutoCreateListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/EnvironmentAutoCreateListener.java
@@ -1,0 +1,45 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.events.TracesCreated;
+import com.comet.opik.domain.EnvironmentService;
+import com.google.common.eventbus.Subscribe;
+import jakarta.inject.Inject;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@EagerSingleton
+@Slf4j
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class EnvironmentAutoCreateListener {
+
+    private final @NonNull EnvironmentService environmentService;
+
+    @Subscribe
+    public void onTracesCreated(@NonNull TracesCreated event) {
+        Set<String> names = event.traces().stream()
+                .map(Trace::environment)
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.toSet());
+
+        if (names.isEmpty()) {
+            return;
+        }
+
+        Mono.fromRunnable(() -> environmentService.bulkCreate(names, event.workspaceId(), event.userName()))
+                .subscribeOn(Schedulers.boundedElastic())
+                .doOnError(error -> log.error(
+                        "Failed to auto-create environments for workspace_id '{}': '{}'",
+                        event.workspaceId(), error.getMessage(), error))
+                .onErrorResume(error -> Mono.empty())
+                .subscribe();
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
@@ -25,7 +25,7 @@ interface EnvironmentDAO {
             "VALUES (:bean.id, :workspaceId, :bean.name, :bean.description, COALESCE(:bean.color, 'default'), COALESCE(:bean.position, 0), :bean.createdBy, :bean.lastUpdatedBy)")
     void save(@Bind("workspaceId") String workspaceId, @BindMethods("bean") Environment environment);
 
-    @SqlBatch("INSERT INTO environments (id, workspace_id, name, color, position, created_by, last_updated_by) "
+    @SqlBatch("INSERT IGNORE INTO environments (id, workspace_id, name, color, position, created_by, last_updated_by) "
             +
             "VALUES (:bean.id, :workspaceId, :bean.name, 'default', 0, :userName, :userName)")
     void saveBatch(@Bind("workspaceId") String workspaceId, @Bind("userName") String userName,
@@ -54,6 +54,9 @@ interface EnvironmentDAO {
 
     @SqlQuery("SELECT * FROM environments WHERE workspace_id = :workspaceId ORDER BY created_at ASC")
     List<Environment> findAll(@Bind("workspaceId") String workspaceId);
+
+    @SqlQuery("SELECT name FROM environments WHERE workspace_id = :workspaceId")
+    List<String> findAllNames(@Bind("workspaceId") String workspaceId);
 
     @SqlQuery("SELECT COUNT(*) FROM environments WHERE workspace_id = :workspaceId")
     long countByWorkspace(@Bind("workspaceId") String workspaceId);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
@@ -7,6 +7,7 @@ import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
+import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
@@ -23,6 +24,12 @@ interface EnvironmentDAO {
             +
             "VALUES (:bean.id, :workspaceId, :bean.name, :bean.description, COALESCE(:bean.color, 'default'), COALESCE(:bean.position, 0), :bean.createdBy, :bean.lastUpdatedBy)")
     void save(@Bind("workspaceId") String workspaceId, @BindMethods("bean") Environment environment);
+
+    @SqlBatch("INSERT INTO environments (id, workspace_id, name, color, position, created_by, last_updated_by) "
+            +
+            "VALUES (:bean.id, :workspaceId, :bean.name, 'default', 0, :userName, :userName)")
+    void saveBatch(@Bind("workspaceId") String workspaceId, @Bind("userName") String userName,
+            @BindMethods("bean") List<Environment> environments);
 
     @SqlUpdate("UPDATE environments SET " +
             "name = COALESCE(:name, name), " +

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
@@ -19,6 +19,7 @@ import jakarta.ws.rs.core.Response;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -32,6 +33,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
@@ -40,6 +42,8 @@ import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
 public interface EnvironmentService {
 
     Environment create(Environment environment);
+
+    void bulkCreate(Set<String> names, String workspaceId, String userName);
 
     Environment update(UUID id, EnvironmentUpdate environmentUpdate);
 
@@ -58,6 +62,9 @@ class EnvironmentServiceImpl implements EnvironmentService {
     private static final String ENVIRONMENT_NAME_CONFLICT_TEMPLATE = "Environment with name '%s' already exists in the workspace";
     private static final String ENVIRONMENT_LIMIT_REACHED_TEMPLATE = "Workspace already has the maximum of %d environments";
     private static final String ENVIRONMENT_CREATE_LOCK = "environment_create";
+    private static final String ENVIRONMENT_CREATED_EVENT = "environment_created";
+    private static final String SOURCE_MANUAL = "manual";
+    private static final String SOURCE_INGESTION = "ingestion";
 
     private final @NonNull TransactionTemplate template;
     private final @NonNull IdGenerator idGenerator;
@@ -104,14 +111,77 @@ class EnvironmentServiceImpl implements EnvironmentService {
                 }).subscribeOn(Schedulers.boundedElastic()))
                 .block();
 
-        analyticsService.trackEvent("environment_created", Map.of(
+        analyticsService.trackEvent(ENVIRONMENT_CREATED_EVENT, Map.of(
                 "environment_id", saved.id().toString(),
                 "environment_name", saved.name(),
                 "workspace_id", workspaceId,
                 "user_name", userName,
+                "source", SOURCE_MANUAL,
                 "date", Instant.now().toString()));
 
         return get(saved.id(), workspaceId);
+    }
+
+    @Override
+    public void bulkCreate(@NonNull Set<String> names, @NonNull String workspaceId, @NonNull String userName) {
+        Set<String> validNames = names.stream()
+                .filter(StringUtils::isNotBlank)
+                .filter(name -> name.length() <= 150)
+                .filter(name -> name.matches(Environment.NAME_PATTERN))
+                .collect(Collectors.toSet());
+
+        if (validNames.isEmpty()) {
+            return;
+        }
+
+        List<Environment> created = lockService.executeWithLock(
+                new LockService.Lock(workspaceId, ENVIRONMENT_CREATE_LOCK),
+                Mono.fromCallable(() -> template.inTransaction(WRITE, handle -> {
+                    var repository = handle.attach(EnvironmentDAO.class);
+
+                    Set<String> existingNames = repository.findAll(workspaceId).stream()
+                            .map(Environment::name)
+                            .collect(Collectors.toSet());
+
+                    long availableSlots = (long) environmentConfig.getMaxPerWorkspace() - existingNames.size();
+                    if (availableSlots <= 0) {
+                        log.info("Skipping environment auto-create for workspace_id '{}': cap '{}' reached",
+                                workspaceId, environmentConfig.getMaxPerWorkspace());
+                        return List.<Environment>of();
+                    }
+
+                    List<Environment> environments = validNames.stream()
+                            .filter(name -> !existingNames.contains(name))
+                            .limit(availableSlots)
+                            .map(name -> Environment.builder()
+                                    .id(idGenerator.generateId())
+                                    .name(name)
+                                    .build())
+                            .toList();
+
+                    if (environments.isEmpty()) {
+                        return List.<Environment>of();
+                    }
+
+                    repository.saveBatch(workspaceId, userName, environments);
+                    return environments;
+                })).subscribeOn(Schedulers.boundedElastic()))
+                .block();
+
+        if (created == null || created.isEmpty()) {
+            return;
+        }
+
+        log.info("Auto-created '{}' environments for workspace_id '{}'", created.size(), workspaceId);
+
+        Instant now = Instant.now();
+        created.forEach(env -> analyticsService.trackEvent(ENVIRONMENT_CREATED_EVENT, Map.of(
+                "environment_id", env.id().toString(),
+                "environment_name", env.name(),
+                "workspace_id", workspaceId,
+                "user_name", userName,
+                "source", SOURCE_INGESTION,
+                "date", now.toString())));
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
@@ -66,6 +67,7 @@ class EnvironmentServiceImpl implements EnvironmentService {
     private static final String ENVIRONMENT_CREATED_EVENT = "environment_created";
     private static final String SOURCE_MANUAL = "manual";
     private static final String SOURCE_INGESTION = "ingestion";
+    private static final Pattern NAME_PATTERN = Pattern.compile(Environment.NAME_PATTERN);
 
     private final @NonNull TransactionTemplate template;
     private final @NonNull IdGenerator idGenerator;
@@ -122,7 +124,7 @@ class EnvironmentServiceImpl implements EnvironmentService {
         List<String> validNames = names.stream()
                 .filter(StringUtils::isNotBlank)
                 .filter(name -> name.length() <= 150)
-                .filter(name -> name.matches(Environment.NAME_PATTERN))
+                .filter(name -> NAME_PATTERN.matcher(name).matches())
                 .toList();
 
         if (validNames.isEmpty()) {
@@ -134,8 +136,8 @@ class EnvironmentServiceImpl implements EnvironmentService {
                 Mono.fromCallable(() -> template.inTransaction(WRITE, handle -> {
                     var repository = handle.attach(EnvironmentDAO.class);
 
-                    Set<String> existingLowercaseNames = repository.findAll(workspaceId).stream()
-                            .map(env -> env.name().toLowerCase(Locale.ROOT))
+                    Set<String> existingLowercaseNames = repository.findAllNames(workspaceId).stream()
+                            .map(name -> name.toLowerCase(Locale.ROOT))
                             .collect(Collectors.toSet());
 
                     long availableSlots = (long) environmentConfig.getMaxPerWorkspace() - existingLowercaseNames.size();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
@@ -29,6 +29,7 @@ import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -111,24 +112,18 @@ class EnvironmentServiceImpl implements EnvironmentService {
                 }).subscribeOn(Schedulers.boundedElastic()))
                 .block();
 
-        analyticsService.trackEvent(ENVIRONMENT_CREATED_EVENT, Map.of(
-                "environment_id", saved.id().toString(),
-                "environment_name", saved.name(),
-                "workspace_id", workspaceId,
-                "user_name", userName,
-                "source", SOURCE_MANUAL,
-                "date", Instant.now().toString()));
+        trackEnvironmentCreatedEvent(saved, workspaceId, userName, SOURCE_MANUAL, Instant.now());
 
         return get(saved.id(), workspaceId);
     }
 
     @Override
     public void bulkCreate(@NonNull Set<String> names, @NonNull String workspaceId, @NonNull String userName) {
-        Set<String> validNames = names.stream()
+        List<String> validNames = names.stream()
                 .filter(StringUtils::isNotBlank)
                 .filter(name -> name.length() <= 150)
                 .filter(name -> name.matches(Environment.NAME_PATTERN))
-                .collect(Collectors.toSet());
+                .toList();
 
         if (validNames.isEmpty()) {
             return;
@@ -139,11 +134,11 @@ class EnvironmentServiceImpl implements EnvironmentService {
                 Mono.fromCallable(() -> template.inTransaction(WRITE, handle -> {
                     var repository = handle.attach(EnvironmentDAO.class);
 
-                    Set<String> existingNames = repository.findAll(workspaceId).stream()
-                            .map(Environment::name)
+                    Set<String> existingLowercaseNames = repository.findAll(workspaceId).stream()
+                            .map(env -> env.name().toLowerCase(Locale.ROOT))
                             .collect(Collectors.toSet());
 
-                    long availableSlots = (long) environmentConfig.getMaxPerWorkspace() - existingNames.size();
+                    long availableSlots = (long) environmentConfig.getMaxPerWorkspace() - existingLowercaseNames.size();
                     if (availableSlots <= 0) {
                         log.info("Skipping environment auto-create for workspace_id '{}': cap '{}' reached",
                                 workspaceId, environmentConfig.getMaxPerWorkspace());
@@ -151,7 +146,7 @@ class EnvironmentServiceImpl implements EnvironmentService {
                     }
 
                     List<Environment> environments = validNames.stream()
-                            .filter(name -> !existingNames.contains(name))
+                            .filter(name -> !existingLowercaseNames.contains(name.toLowerCase(Locale.ROOT)))
                             .limit(availableSlots)
                             .map(name -> Environment.builder()
                                     .id(idGenerator.generateId())
@@ -175,13 +170,18 @@ class EnvironmentServiceImpl implements EnvironmentService {
         log.info("Auto-created '{}' environments for workspace_id '{}'", created.size(), workspaceId);
 
         Instant now = Instant.now();
-        created.forEach(env -> analyticsService.trackEvent(ENVIRONMENT_CREATED_EVENT, Map.of(
-                "environment_id", env.id().toString(),
-                "environment_name", env.name(),
+        created.forEach(env -> trackEnvironmentCreatedEvent(env, workspaceId, userName, SOURCE_INGESTION, now));
+    }
+
+    private void trackEnvironmentCreatedEvent(Environment environment, String workspaceId, String userName,
+            String source, Instant date) {
+        analyticsService.trackEvent(ENVIRONMENT_CREATED_EVENT, Map.of(
+                "environment_id", environment.id().toString(),
+                "environment_name", environment.name(),
                 "workspace_id", workspaceId,
                 "user_name", userName,
-                "source", SOURCE_INGESTION,
-                "date", now.toString())));
+                "source", source,
+                "date", date.toString()));
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/EnvironmentConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/EnvironmentConfig.java
@@ -9,5 +9,5 @@ import lombok.Data;
 public class EnvironmentConfig {
 
     @JsonProperty
-    @Min(1) @Max(1000) private int maxPerWorkspace = 20;
+    @Min(1) @Max(1000) private int maxPerWorkspace = 100;
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/EnvironmentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/EnvironmentsResourceTest.java
@@ -256,8 +256,8 @@ class EnvironmentsResourceTest {
             String capWorkspaceId = UUID.randomUUID().toString();
             mockIsolatedWorkspace(capApiKey, capWorkspaceName, capWorkspaceId);
 
-            // default max is 20 — fill the workspace then attempt one more
-            IntStream.range(0, 20).forEach(i -> environmentsClient.createEnvironment(
+            // default max is 100 — fill the workspace then attempt one more
+            IntStream.range(0, 100).forEach(i -> environmentsClient.createEnvironment(
                     buildEnvironment(), capApiKey, capWorkspaceName));
 
             try (var response = environmentsClient.callCreate(buildEnvironment(), capApiKey, capWorkspaceName)) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/EnvironmentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/EnvironmentsResourceTest.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hc.core5.http.HttpStatus;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -40,6 +41,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -96,6 +98,17 @@ class EnvironmentsResourceTest {
     @AfterAll
     void tearDownAll() {
         wireMock.server().stop();
+    }
+
+    @AfterEach
+    void cleanupSharedWorkspaceEnvironments() {
+        try (var response = environmentsClient.callFind(API_KEY, WORKSPACE_NAME)) {
+            var page = response.readEntity(Environment.EnvironmentPage.class);
+            Set<UUID> ids = page.content().stream().map(Environment::id).collect(Collectors.toSet());
+            if (!ids.isEmpty()) {
+                environmentsClient.callBatchDelete(ids, API_KEY, WORKSPACE_NAME).close();
+            }
+        }
     }
 
     private static String randomEnvName() {
@@ -256,8 +269,8 @@ class EnvironmentsResourceTest {
             String capWorkspaceId = UUID.randomUUID().toString();
             mockIsolatedWorkspace(capApiKey, capWorkspaceName, capWorkspaceId);
 
-            // default max is 100 — fill the workspace then attempt one more
-            IntStream.range(0, 100).forEach(i -> environmentsClient.createEnvironment(
+            // test cap from config-test.yml — fill the workspace then attempt one more
+            IntStream.range(0, 5).forEach(i -> environmentsClient.createEnvironment(
                     buildEnvironment(), capApiKey, capWorkspaceName));
 
             try (var response = environmentsClient.callCreate(buildEnvironment(), capApiKey, capWorkspaceName)) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -2491,7 +2491,7 @@ class TracesResourceTest {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class EnvironmentAutoCreate {
 
-        private static final int ENVIRONMENT_CAP = 100;
+        private static final int ENVIRONMENT_CAP = 5;
 
         @Test
         @DisplayName("when trace is created with a new environment, then it is auto-created")
@@ -2555,6 +2555,73 @@ class TracesResourceTest {
                             var page = response.readEntity(Environment.EnvironmentPage.class);
                             assertThat(page.content().stream().map(Environment::name).collect(Collectors.toSet()))
                                     .containsAll(envNames);
+                        }
+                    });
+        }
+
+        @Test
+        @DisplayName("when batch traces share the same new environment, then it is created only once")
+        void batchCreate__whenDuplicatedEnvironmentInBatch__thenCreatedOnce() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            String envName = "dup-env-" + RandomStringUtils.secure().nextAlphanumeric(8);
+            List<Trace> traces = IntStream.range(0, 3)
+                    .mapToObj(i -> factory.manufacturePojo(Trace.class).toBuilder()
+                            .projectName(DEFAULT_PROJECT)
+                            .environment(envName)
+                            .usage(null)
+                            .feedbackScores(null)
+                            .build())
+                    .toList();
+
+            traceResourceClient.batchCreateTraces(traces, apiKey, workspaceName);
+
+            Awaitility.await()
+                    .pollInterval(200, TimeUnit.MILLISECONDS)
+                    .atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        try (var response = environmentsResourceClient.callFind(apiKey, workspaceName)) {
+                            var page = response.readEntity(Environment.EnvironmentPage.class);
+                            assertThat(page.content().stream().map(Environment::name).filter(envName::equals))
+                                    .hasSize(1);
+                        }
+                    });
+        }
+
+        @Test
+        @DisplayName("when batch traces include environment names with disallowed characters, then only valid ones are auto-created")
+        void batchCreate__whenEnvironmentNamesWithDisallowedChars__thenOnlyValidOnesAutoCreated() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            String validEnvName = "valid-" + RandomStringUtils.secure().nextAlphanumeric(8);
+            String invalidCharsEnvName = "invalid env name!";
+
+            List<Trace> traces = Stream.of(validEnvName, invalidCharsEnvName)
+                    .map(name -> factory.manufacturePojo(Trace.class).toBuilder()
+                            .projectName(DEFAULT_PROJECT)
+                            .environment(name)
+                            .usage(null)
+                            .feedbackScores(null)
+                            .build())
+                    .toList();
+
+            traceResourceClient.batchCreateTraces(traces, apiKey, workspaceName);
+
+            Awaitility.await()
+                    .pollInterval(200, TimeUnit.MILLISECONDS)
+                    .atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        try (var response = environmentsResourceClient.callFind(apiKey, workspaceName)) {
+                            var page = response.readEntity(Environment.EnvironmentPage.class);
+                            assertThat(page.content().stream().map(Environment::name))
+                                    .contains(validEnvName)
+                                    .doesNotContain(invalidCharsEnvName);
                         }
                     });
         }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -5,6 +5,7 @@ import com.comet.opik.api.BatchDeleteByProject;
 import com.comet.opik.api.Comment;
 import com.comet.opik.api.DeleteFeedbackScore;
 import com.comet.opik.api.DeleteTraceThreads;
+import com.comet.opik.api.Environment;
 import com.comet.opik.api.ErrorInfo;
 import com.comet.opik.api.ExperimentItem;
 import com.comet.opik.api.FeedbackScore;
@@ -49,6 +50,7 @@ import com.comet.opik.api.resources.utils.TestUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
 import com.comet.opik.api.resources.utils.resources.AttachmentResourceClient;
 import com.comet.opik.api.resources.utils.resources.DatasetResourceClient;
+import com.comet.opik.api.resources.utils.resources.EnvironmentsResourceClient;
 import com.comet.opik.api.resources.utils.resources.ExperimentResourceClient;
 import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.api.resources.utils.resources.SpanResourceClient;
@@ -234,6 +236,7 @@ class TracesResourceTest {
     private AttachmentResourceClient attachmentResourceClient;
     private DatasetResourceClient datasetResourceClient;
     private ExperimentResourceClient experimentResourceClient;
+    private EnvironmentsResourceClient environmentsResourceClient;
 
     @BeforeAll
     void setUpAll(ClientSupport client) {
@@ -252,6 +255,7 @@ class TracesResourceTest {
         this.attachmentResourceClient = new AttachmentResourceClient(client);
         this.datasetResourceClient = new DatasetResourceClient(this.client, baseURI);
         this.experimentResourceClient = new ExperimentResourceClient(this.client, baseURI, factory);
+        this.environmentsResourceClient = new EnvironmentsResourceClient(this.client, baseURI);
     }
 
     private void mockTargetWorkspace(String apiKey, String workspaceName, String workspaceId) {
@@ -2480,6 +2484,117 @@ class TracesResourceTest {
             assertThat(fullInputString).doesNotContainPattern("\\[input-attachment-\\d+-\\d+\\.gif\\]");
         }
 
+    }
+
+    @Nested
+    @DisplayName("Environment auto-create on trace ingestion:")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class EnvironmentAutoCreate {
+
+        private static final int ENVIRONMENT_CAP = 100;
+
+        @Test
+        @DisplayName("when trace is created with a new environment, then it is auto-created")
+        void create__whenTraceWithNewEnvironment__thenEnvironmentAutoCreated() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            String envName = "auto-env-" + RandomStringUtils.secure().nextAlphanumeric(8);
+            var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                    .projectName(DEFAULT_PROJECT)
+                    .environment(envName)
+                    .usage(null)
+                    .feedbackScores(null)
+                    .build();
+
+            traceResourceClient.createTrace(trace, apiKey, workspaceName);
+
+            Awaitility.await()
+                    .pollInterval(200, TimeUnit.MILLISECONDS)
+                    .atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        try (var response = environmentsResourceClient.callFind(apiKey, workspaceName)) {
+                            var page = response.readEntity(Environment.EnvironmentPage.class);
+                            assertThat(page.content().stream().map(Environment::name))
+                                    .contains(envName);
+                        }
+                    });
+        }
+
+        @Test
+        @DisplayName("when batch traces with multiple new environments, then all are auto-created")
+        void batchCreate__whenMultipleEnvironments__thenAllAutoCreated() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            Set<String> envNames = Set.of(
+                    "env-a-" + RandomStringUtils.secure().nextAlphanumeric(8),
+                    "env-b-" + RandomStringUtils.secure().nextAlphanumeric(8),
+                    "env-c-" + RandomStringUtils.secure().nextAlphanumeric(8));
+
+            List<Trace> traces = envNames.stream()
+                    .map(name -> factory.manufacturePojo(Trace.class).toBuilder()
+                            .projectName(DEFAULT_PROJECT)
+                            .environment(name)
+                            .usage(null)
+                            .feedbackScores(null)
+                            .build())
+                    .toList();
+
+            traceResourceClient.batchCreateTraces(traces, apiKey, workspaceName);
+
+            Awaitility.await()
+                    .pollInterval(200, TimeUnit.MILLISECONDS)
+                    .atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        try (var response = environmentsResourceClient.callFind(apiKey, workspaceName)) {
+                            var page = response.readEntity(Environment.EnvironmentPage.class);
+                            assertThat(page.content().stream().map(Environment::name).collect(Collectors.toSet()))
+                                    .containsAll(envNames);
+                        }
+                    });
+        }
+
+        @Test
+        @DisplayName("when workspace at cap, then trace ingestion succeeds and no new env is created")
+        void create__whenWorkspaceAtCap__thenIngestionSucceedsAndNoEnvCreated() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            IntStream.range(0, ENVIRONMENT_CAP).forEach(i -> environmentsResourceClient.createEnvironment(
+                    Environment.builder()
+                            .name("seed-" + RandomStringUtils.secure().nextAlphanumeric(12))
+                            .build(),
+                    apiKey, workspaceName));
+
+            String overflowEnvName = "overflow-" + RandomStringUtils.secure().nextAlphanumeric(8);
+            var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                    .projectName(DEFAULT_PROJECT)
+                    .environment(overflowEnvName)
+                    .usage(null)
+                    .feedbackScores(null)
+                    .build();
+
+            traceResourceClient.createTrace(trace, apiKey, workspaceName);
+
+            Awaitility.await()
+                    .pollDelay(2, TimeUnit.SECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        try (var response = environmentsResourceClient.callFind(apiKey, workspaceName)) {
+                            var page = response.readEntity(Environment.EnvironmentPage.class);
+                            assertThat(page.content()).hasSize(ENVIRONMENT_CAP);
+                            assertThat(page.content().stream().map(Environment::name))
+                                    .doesNotContain(overflowEnvName);
+                        }
+                    });
+        }
     }
 
     @Nested

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -851,3 +851,8 @@ agentConfig:
   # Default: 5000ms
   # Description: Duration of the distributed lock held during blueprint create/update operations
   blueprintLockDuration: 5000ms
+
+# Environment CRUD configuration
+environment:
+  # Low ceiling for tests so cap-related scenarios don't need to insert many environments.
+  maxPerWorkspace: 5


### PR DESCRIPTION
## Details
Automatically provision environments when traces are ingested with an `environment` field that doesn't yet exist in the workspace, removing the need for users to pre-create environments before logging.

- Added [EnvironmentAutoCreateListener](apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/EnvironmentAutoCreateListener.java) that subscribes to `TracesCreated` events, extracts unique non-blank environment names, and delegates creation off the ingestion thread via `Schedulers.boundedElastic()`. Errors are logged and swallowed so ingestion is never impacted.
- Added [EnvironmentService#bulkCreate](apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java) which validates names against `Environment.NAME_PATTERN` and the 150-char limit, runs under the existing `environment_create` workspace lock, skips names that already exist, and respects the workspace cap (`maxPerWorkspace`). Uses a new JDBI `@SqlBatch` insert in [EnvironmentDAO#saveBatch](apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java).
- Auto-created environments are tracked in analytics with `source=ingestion`; manual creations now carry `source=manual` for parity.
- Bumped the default `environment.maxPerWorkspace` from `20` to `100` in [config.yml](apps/opik-backend/config.yml) and [EnvironmentConfig](apps/opik-backend/src/main/java/com/comet/opik/infrastructure/EnvironmentConfig.java) to accommodate ingestion-driven growth.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-6368

## Testing
Added integration tests in [TracesResourceTest.EnvironmentAutoCreate](apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java) covering:
- Single trace with a new `environment` value triggers environment auto-creation.
- Batch trace ingestion with multiple distinct environments creates all of them.
- When the workspace is already at the environment cap, trace ingestion still succeeds and no overflow environment is created.

Updated [EnvironmentsResourceTest](apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/EnvironmentsResourceTest.java) to reflect the new default cap (100).

## Documentation
N/A — backend behavior change. The `OPIK_ENVIRONMENT_MAX_PER_WORKSPACE` env var continues to override the default cap.
