### PR TITLE
[OPIK-6391] [FE] fix: send thread_model_id when adding thread comments

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadAnnotatePanel.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadAnnotatePanel.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { PermissionsProvider } from "@/contexts/PermissionsContext";
+import { DEFAULT_PERMISSIONS } from "@/types/permissions";
+import { TooltipProvider } from "@/ui/tooltip";
+import ThreadAnnotatePanel from "./ThreadAnnotatePanel";
+import { DetailsActionSection } from "@/v2/pages-shared/traces/DetailsActionSection";
+
+const mockCreateMutate = vi.fn();
+const mockBatchDeleteMutate = vi.fn();
+const mockUpdateMutate = vi.fn();
+const mockSetFeedbackScoreMutate = vi.fn();
+const mockDeleteFeedbackScoreMutate = vi.fn();
+
+vi.mock("@/api/traces/useCreateThreadCommentMutation", () => ({
+  default: () => ({ mutate: mockCreateMutate }),
+}));
+vi.mock("@/api/traces/useThreadCommentsBatchDeleteMutation", () => ({
+  default: () => ({ mutate: mockBatchDeleteMutate }),
+}));
+vi.mock("@/api/traces/useUpdateThreadCommentMutation", () => ({
+  default: () => ({ mutate: mockUpdateMutate }),
+}));
+vi.mock("@/api/traces/useThreadFeedbackScoreSetMutation", () => ({
+  default: () => ({ mutate: mockSetFeedbackScoreMutate }),
+}));
+vi.mock("@/api/traces/useThreadFeedbackScoreDeleteMutation", () => ({
+  default: () => ({ mutate: mockDeleteFeedbackScoreMutate }),
+}));
+
+vi.mock("@/store/AppStore", () => ({
+  default: vi.fn((selector) =>
+    selector({
+      activeWorkspaceName: "test-workspace",
+      activeProjectId: "test-project-id",
+    }),
+  ),
+  useLoggedInUserName: () => "tester",
+}));
+
+vi.mock("@/ui/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock(
+  "@/v2/pages-shared/traces/FeedbackScoresEditor/FeedbackScoresEditor",
+  () => {
+    const Stub = () => <div data-testid="feedback-scores-editor" />;
+    Stub.displayName = "FeedbackScoresEditorStub";
+    const StubHeader = () => null;
+    StubHeader.displayName = "FeedbackScoresEditorHeaderStub";
+    const StubFooter = () => null;
+    StubFooter.displayName = "FeedbackScoresEditorFooterStub";
+    Stub.Header = StubHeader;
+    Stub.Footer = StubFooter;
+    return { default: Stub };
+  },
+);
+
+type StubCommentsSectionProps = {
+  onSubmit: (text: string) => void;
+  onDelete: (commentId: string) => void;
+};
+
+vi.mock("@/shared/UserComment/CommentsSection", () => ({
+  default: ({ onSubmit, onDelete }: StubCommentsSectionProps) => (
+    <div data-testid="comments-section">
+      <button onClick={() => onSubmit("hello world")}>submit</button>
+      <button onClick={() => onDelete("comment-1")}>delete</button>
+    </div>
+  ),
+}));
+
+describe("ThreadAnnotatePanel", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    vi.clearAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <PermissionsProvider value={DEFAULT_PERMISSIONS}>
+          {children}
+        </PermissionsProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+
+  const THREAD_ID = "user-facing-thread-id";
+  const THREAD_MODEL_ID = "00000000-0000-0000-0000-000000000abc";
+
+  const renderPanel = () =>
+    render(
+      <ThreadAnnotatePanel
+        threadId={THREAD_ID}
+        threadModelId={THREAD_MODEL_ID}
+        projectId="project-1"
+        projectName="project-name"
+        activeSection={DetailsActionSection.Annotate}
+        setActiveSection={vi.fn()}
+        feedbackScores={[]}
+        comments={[]}
+      />,
+      { wrapper },
+    );
+
+  it("routes comment creation through thread_model_id, not the user-facing thread_id", () => {
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "submit" }));
+
+    expect(mockCreateMutate).toHaveBeenCalledTimes(1);
+    expect(mockCreateMutate).toHaveBeenCalledWith({
+      text: "hello world",
+      threadId: THREAD_MODEL_ID,
+      projectId: "project-1",
+    });
+    expect(mockCreateMutate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: THREAD_ID }),
+    );
+  });
+
+  it("routes comment batch-delete through thread_model_id, not the user-facing thread_id", () => {
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "delete" }));
+
+    expect(mockBatchDeleteMutate).toHaveBeenCalledTimes(1);
+    expect(mockBatchDeleteMutate).toHaveBeenCalledWith({
+      ids: ["comment-1"],
+      threadId: THREAD_MODEL_ID,
+      projectId: "project-1",
+    });
+    expect(mockBatchDeleteMutate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: THREAD_ID }),
+    );
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadAnnotatePanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadAnnotatePanel.tsx
@@ -18,6 +18,7 @@ import { Separator } from "@/ui/separator";
 
 type ThreadAnnotatePanelProps = {
   threadId: string;
+  threadModelId: string;
   projectId: string;
   projectName: string;
   activeSection: DetailsActionSectionValue | null;
@@ -28,6 +29,7 @@ type ThreadAnnotatePanelProps = {
 
 const ThreadAnnotatePanel: React.FC<ThreadAnnotatePanelProps> = ({
   threadId,
+  threadModelId,
   projectId,
   projectName,
   activeSection,
@@ -74,9 +76,13 @@ const ThreadAnnotatePanel: React.FC<ThreadAnnotatePanelProps> = ({
 
   const onCommentSubmit = useCallback(
     (text: string) => {
-      createThreadCommentMutation.mutate({ text, threadId, projectId });
+      createThreadCommentMutation.mutate({
+        text,
+        threadId: threadModelId,
+        projectId,
+      });
     },
-    [createThreadCommentMutation, threadId, projectId],
+    [createThreadCommentMutation, threadModelId, projectId],
   );
 
   const onCommentEdit = useCallback(
@@ -91,10 +97,10 @@ const ThreadAnnotatePanel: React.FC<ThreadAnnotatePanelProps> = ({
       threadCommentsBatchDeleteMutation.mutate({
         ids: [commentId],
         projectId,
-        threadId,
+        threadId: threadModelId,
       });
     },
-    [threadCommentsBatchDeleteMutation, projectId, threadId],
+    [threadCommentsBatchDeleteMutation, projectId, threadModelId],
   );
 
   return (

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
@@ -547,6 +547,7 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
                 {currentActiveSection === DetailsActionSection.Annotate && (
                   <ThreadAnnotatePanel
                     threadId={threadId}
+                    threadModelId={thread.thread_model_id}
                     projectId={projectId}
                     projectName={projectName}
                     activeSection={activeSection}


### PR DESCRIPTION
## Details

The annotate side panel sent the user-facing `thread_id` string as the URL path parameter when creating or batch-deleting thread comments, while the backend resolves the thread by `trace_threads.id` (the UUID `thread_model_id`). The lookup failed and `POST /v1/private/traces/threads/{id}/comments` returned 404, so comments silently weren't saved.

- Add a `threadModelId` prop to `ThreadAnnotatePanel` and use it for `useCreateThreadCommentMutation` and `useThreadCommentsBatchDeleteMutation` (URL-path-bound).
- Keep the user-facing `threadId` for the feedback-score mutations on the same panel — those send `thread_id` in the request body and the backend expects the string identifier there.
- Pass `thread.thread_model_id` from `ThreadDetailsPanel`. The parent `renderContent` already short-circuits on `isThreadPending`/`isTracesPending` and returns `NoData` when `!thread`, so by the time the annotate panel mounts the thread is guaranteed to be loaded — no extra gating required.
- v1 `ThreadComments` and `SMEFlowContext` already passed `thread_model_id` correctly; this only fixes the v2 unified annotate panel.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6391

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.7 (1M context)
  - Scope: full implementation
  - Human verification: code review + lint/typecheck/depcruise

## Testing

- `bash scripts/dev-runner.sh --lint-fe` (runs `npm run lint:fix`, `tsc --noEmit`, `depcruise`) — all green.
- Verified by reading the call sites that no other v2 surface sends the user-facing `threadId` to a URL-path-bound thread endpoint: only `useCreateThreadCommentMutation` (path) and `useThreadUpdateMutation` (path) take a thread UUID, and every caller now passes `thread_model_id`.
- Manual browser verification of the repro (open thread → annotate → add comment → confirm save, and regression-check feedback scores on the same panel) is still pending and should run before merge.

## Documentation

N/A