### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -18696,6 +18696,7 @@ components:
       - spanLlmAsJudgeEnabled
       - spanUserDefinedMetricPythonEnabled
       - traceThreadPythonEvaluatorEnabled
+      - v1WorkspaceAllowlistIds
       - v2WorkspaceAllowlistIds
       - vertexaiProviderEnabled
       - welcomeWizardEnabled
@@ -18751,6 +18752,12 @@ components:
           items:
             minLength: 1
             type: string
+        v1WorkspaceAllowlistIds:
+          uniqueItems: true
+          type: array
+          items:
+            minLength: 1
+            type: string
         forceWorkspaceVersion:
           minLength: 1
           type: string
@@ -18760,6 +18767,9 @@ components:
           type: integer
           format: int32
         v2WorkspaceAllowlist:
+          type: string
+          writeOnly: true
+        v1WorkspaceAllowlist:
           type: string
           writeOnly: true
     SpanBatchUpdate:

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -18696,6 +18696,7 @@ components:
       - spanLlmAsJudgeEnabled
       - spanUserDefinedMetricPythonEnabled
       - traceThreadPythonEvaluatorEnabled
+      - v1WorkspaceAllowlistIds
       - v2WorkspaceAllowlistIds
       - vertexaiProviderEnabled
       - welcomeWizardEnabled
@@ -18751,6 +18752,12 @@ components:
           items:
             minLength: 1
             type: string
+        v1WorkspaceAllowlistIds:
+          uniqueItems: true
+          type: array
+          items:
+            minLength: 1
+            type: string
         forceWorkspaceVersion:
           minLength: 1
           type: string
@@ -18760,6 +18767,9 @@ components:
           type: integer
           format: int32
         v2WorkspaceAllowlist:
+          type: string
+          writeOnly: true
+        v1WorkspaceAllowlist:
           type: string
           writeOnly: true
     SpanBatchUpdate:

--- a/sdks/python/src/opik/rest_api/types/service_toggles_config.py
+++ b/sdks/python/src/opik/rest_api/types/service_toggles_config.py
@@ -38,10 +38,16 @@ class ServiceTogglesConfig(UniversalBaseModel):
     v2workspace_allowlist_ids: typing_extensions.Annotated[
         typing.List[str], FieldMetadata(alias="v2WorkspaceAllowlistIds")
     ]
+    v1workspace_allowlist_ids: typing_extensions.Annotated[
+        typing.List[str], FieldMetadata(alias="v1WorkspaceAllowlistIds")
+    ]
     force_workspace_version: typing_extensions.Annotated[str, FieldMetadata(alias="forceWorkspaceVersion")]
     default_page_size: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="defaultPageSize")] = None
     v2workspace_allowlist: typing_extensions.Annotated[
         typing.Optional[str], FieldMetadata(alias="v2WorkspaceAllowlist")
+    ] = None
+    v1workspace_allowlist: typing_extensions.Annotated[
+        typing.Optional[str], FieldMetadata(alias="v1WorkspaceAllowlist")
     ] = None
 
     if IS_PYDANTIC_V2:

--- a/sdks/typescript/src/opik/rest_api/api/types/ServiceTogglesConfig.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/ServiceTogglesConfig.ts
@@ -24,7 +24,9 @@ export interface ServiceTogglesConfig {
     ollamaProviderEnabled: boolean;
     collaboratorsTabEnabled: boolean;
     v2WorkspaceAllowlistIds: string[];
+    v1WorkspaceAllowlistIds: string[];
     forceWorkspaceVersion: string;
     defaultPageSize?: number;
     v2WorkspaceAllowlist?: string;
+    v1WorkspaceAllowlist?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/ServiceTogglesConfig.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/ServiceTogglesConfig.ts
@@ -31,9 +31,11 @@ export const ServiceTogglesConfig: core.serialization.ObjectSchema<
     ollamaProviderEnabled: core.serialization.boolean(),
     collaboratorsTabEnabled: core.serialization.boolean(),
     v2WorkspaceAllowlistIds: core.serialization.list(core.serialization.string()),
+    v1WorkspaceAllowlistIds: core.serialization.list(core.serialization.string()),
     forceWorkspaceVersion: core.serialization.string(),
     defaultPageSize: core.serialization.number().optional(),
     v2WorkspaceAllowlist: core.serialization.string().optional(),
+    v1WorkspaceAllowlist: core.serialization.string().optional(),
 });
 
 export declare namespace ServiceTogglesConfig {
@@ -61,8 +63,10 @@ export declare namespace ServiceTogglesConfig {
         ollamaProviderEnabled: boolean;
         collaboratorsTabEnabled: boolean;
         v2WorkspaceAllowlistIds: string[];
+        v1WorkspaceAllowlistIds: string[];
         forceWorkspaceVersion: string;
         defaultPageSize?: number | null;
         v2WorkspaceAllowlist?: string | null;
+        v1WorkspaceAllowlist?: string | null;
     }
 }


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

**Triggered by BE merge:** https://github.com/comet-ml/opik/pull/6631

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate