### PR TITLE
[OPIK-6443] [PY-SDK] fix: prevent silent data loss in client.end() due to drain/attachment re-enqueue race

### DIFF
--- a/sdks/python/src/opik/message_processing/processors/attachments_extraction_processor.py
+++ b/sdks/python/src/opik/message_processing/processors/attachments_extraction_processor.py
@@ -128,7 +128,7 @@ class AttachmentsExtractionProcessor(message_processors.BaseMessageProcessor):
                 url_override=self._url_override,
                 delete_after_upload=True,  # make sure to delete attachments after upload to avoid leaking space and data
             )
-            self.messages_streamer.put(create_attachment_message)
+            self.messages_streamer.put(create_attachment_message, force=True)
 
 
 def entity_type_from_attachment_message(

--- a/sdks/python/src/opik/message_processing/processors/attachments_extraction_processor.py
+++ b/sdks/python/src/opik/message_processing/processors/attachments_extraction_processor.py
@@ -77,7 +77,7 @@ class AttachmentsExtractionProcessor(message_processors.BaseMessageProcessor):
         # put the original message into the streamer for further processing
         original_message = message.original_message
         setattr(original_message, constants.MARKER_ATTRIBUTE_NAME, True)
-        self.messages_streamer.put(original_message)
+        self.messages_streamer.put(original_message, force=True)
 
     def _process_attachments_in_message(self, original: messages.BaseMessage) -> None:
         entity_details = entity_type_from_attachment_message(original)

--- a/sdks/python/src/opik/message_processing/streamer.py
+++ b/sdks/python/src/opik/message_processing/streamer.py
@@ -49,9 +49,9 @@ class Streamer:
     def use_batching(self) -> bool:
         return self._batch_preprocessor._batch_manager is not None
 
-    def put(self, message: messages.BaseMessage) -> None:
+    def put(self, message: messages.BaseMessage, force: bool = False) -> None:
         with self._lock:
-            if self._drain:
+            if self._drain and not force:
                 return
 
             self._idle = False
@@ -161,6 +161,7 @@ class Streamer:
             check_function=lambda: self._all_done(),
             timeout=timeout,
             sleep_time=0.1,
+            progress_callback=self._batch_preprocessor.flush,
         )
 
         elapsed_time = time.time() - start_time


### PR DESCRIPTION
## Details

When data is created rapidly and `client.end()` is called immediately after, traces and spans can be silently dropped — never sent to the backend. In our tests this manifested as ~4-5% data loss, but the exact amount depends on timing and volume.

This is surprising because `end()` calls `close()`, which calls `flush()` with no timeout — meaning it defaults to infinite wait. The expectation is that `flush()` blocks until every accepted message has been delivered. Instead, messages are silently discarded mid-pipeline.

Calling `flush()` explicitly before `end()` masks the problem — flush drains the pipeline while `_drain` is still `False`, so re-enqueued messages go through normally. But relying on `flush()` + `end()` as a workaround shouldn't be necessary, since `end()` already calls `flush()` internally.

It also wasn't immediately clear whether the data loss was happening on the backend (messages sent but not persisted) or in the SDK (messages never sent). We confirmed via instrumentation that the SDK was silently dropping messages — they never left the client.

**Root cause:** `Streamer.close()` sets `_drain=True` early to block new external messages. However, `AttachmentsExtractionProcessor` — a message processor running in the consumer chain — re-enqueues messages via `streamer.put()` as part of a two-pass pipeline. When `_drain` is set, `put()` silently discards these internal re-enqueue calls, so messages that were already accepted into the pipeline get dropped on their second pass.

**Fix:** Rather than restructuring the close sequence or removing the drain guard, we opted for explicit, intentional behavior:

- Add a `force` parameter to `Streamer.put()` (default `False`) — callers that *know* they need to bypass the drain guard can do so deliberately
- `AttachmentsExtractionProcessor` uses `put(force=True)` for its re-enqueue and attachment upload calls, since these messages were already accepted into the pipeline and must complete their processing
- Add `progress_callback` to the flush poll loop in `Streamer.flush()`, so force-put messages that land in the stopped batch preprocessor still get flushed to the queue

**Related:** This is likely the same root cause behind #6386 and #6454, where the demo data generator was silently losing traces and experiment items through the async pipeline. Those PRs worked around it by switching to synchronous REST calls — bypassing `streamer.put()` entirely.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6443

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: paired investigation + implementation
- Human verification: identified root cause pattern, designed fix approach (force flag), validated with instrumented staging tests (200 traces / 1000 spans)

## Testing

- Verified with instrumented monkey-patch counting messages dropped by `_drain` guard
- Ran the test script (200 traces, 1000 spans) multiple times both before and after the fix — the pattern is consistent:
  - **Before fix**: every run shows data loss, messages silently dropped (~4-5%)
  - **After fix**: every run delivers 200/200 traces and 1000/1000 spans, zero drops
- End-to-end verification against staging environment
- All 357 existing unit tests pass (`pytest tests/unit/message_processing/`)

## Documentation

N/A