### PR TITLE
[OPIK-6429] [FE] feat: per-model OpenAI reasoning_effort capability map

### DIFF
--- a/apps/opik-frontend/src/api/playground/useRunExperimentExecution.ts
+++ b/apps/opik-frontend/src/api/playground/useRunExperimentExecution.ts
@@ -1,6 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import get from "lodash/get";
 import api, { EXPERIMENT_EXECUTION_REST_ENDPOINT } from "@/api/api";
+import { sanitizeConfigForRequest } from "@/lib/modelUtils";
 import { snakeCaseObj } from "@/lib/utils";
 import { PlaygroundPromptType } from "@/types/playground";
 import { useToast } from "@/ui/use-toast";
@@ -37,7 +38,10 @@ const runExperimentExecution = async ({
     return {
       model: prompt.model,
       messages: prompt.messages.map((msg) => snakeCaseObj(msg)),
-      configs: prompt.configs,
+      configs: sanitizeConfigForRequest(
+        prompt.model,
+        prompt.configs as Record<string, unknown>,
+      ),
       prompt_versions: prompt.loadedChatPromptId
         ? [{ id: prompt.loadedChatPromptId }]
         : undefined,

--- a/apps/opik-frontend/src/constants/llm.ts
+++ b/apps/opik-frontend/src/constants/llm.ts
@@ -13,6 +13,7 @@ import {
 import {
   AnthropicThinkingEffort,
   PROVIDER_MODEL_TYPE,
+  ReasoningEffort,
 } from "@/types/providers";
 
 export const PLAYGROUND_LAST_PICKED_MODEL = "playground-last-picked-model";
@@ -115,6 +116,73 @@ export const ANTHROPIC_MODEL_CAPABILITIES: Partial<
   },
   [PROVIDER_MODEL_TYPE.CLAUDE_SONNET_4_6]: {
     thinkingEffortOptions: ["adaptive", "low", "medium", "high", "max"],
+  },
+};
+
+// Per-model OpenAI quirks. Add a row when a model deviates from defaults
+// (sampling params allowed, no reasoning-effort UI). Reasoning models must
+// specify the exact set of effort values they accept — OpenAI families
+// differ: o-series → low/medium/high; gpt-5 → minimal/low/medium/high;
+// gpt-5.1+ → none/low/medium/high. Sending an unsupported value 400s.
+export const OPENAI_MODEL_CAPABILITIES: Partial<
+  Record<
+    PROVIDER_MODEL_TYPE,
+    {
+      reasoning?: boolean;
+      reasoningEffortOptions?: ReasoningEffort[];
+    }
+  >
+> = {
+  // o-series — no minimal, no xhigh
+  [PROVIDER_MODEL_TYPE.GPT_O1]: {
+    reasoning: true,
+    reasoningEffortOptions: ["low", "medium", "high"],
+  },
+  // o1-mini API rejects reasoning_effort entirely; reasoning model with no dropdown.
+  [PROVIDER_MODEL_TYPE.GPT_O1_MINI]: { reasoning: true },
+  [PROVIDER_MODEL_TYPE.GPT_O3]: {
+    reasoning: true,
+    reasoningEffortOptions: ["low", "medium", "high"],
+  },
+  [PROVIDER_MODEL_TYPE.GPT_O3_MINI]: {
+    reasoning: true,
+    reasoningEffortOptions: ["low", "medium", "high"],
+  },
+  [PROVIDER_MODEL_TYPE.GPT_O4_MINI]: {
+    reasoning: true,
+    reasoningEffortOptions: ["low", "medium", "high"],
+  },
+
+  // Original gpt-5 family — minimal added
+  [PROVIDER_MODEL_TYPE.GPT_5]: {
+    reasoning: true,
+    reasoningEffortOptions: ["minimal", "low", "medium", "high"],
+  },
+  [PROVIDER_MODEL_TYPE.GPT_5_MINI]: {
+    reasoning: true,
+    reasoningEffortOptions: ["minimal", "low", "medium", "high"],
+  },
+  [PROVIDER_MODEL_TYPE.GPT_5_NANO]: {
+    reasoning: true,
+    reasoningEffortOptions: ["minimal", "low", "medium", "high"],
+  },
+  [PROVIDER_MODEL_TYPE.GPT_5_CHAT_LATEST]: {
+    reasoning: true,
+    reasoningEffortOptions: ["minimal", "low", "medium", "high"],
+  },
+
+  // gpt-5.1+ — none replaces minimal
+  [PROVIDER_MODEL_TYPE.GPT_5_1]: {
+    reasoning: true,
+    reasoningEffortOptions: ["none", "low", "medium", "high"],
+  },
+  [PROVIDER_MODEL_TYPE.GPT_5_2]: {
+    reasoning: true,
+    reasoningEffortOptions: ["none", "low", "medium", "high"],
+  },
+  [PROVIDER_MODEL_TYPE.GPT_5_2_CHAT_LATEST]: {
+    reasoning: true,
+    reasoningEffortOptions: ["none", "low", "medium", "high"],
   },
 };
 

--- a/apps/opik-frontend/src/constants/llm.ts
+++ b/apps/opik-frontend/src/constants/llm.ts
@@ -202,7 +202,7 @@ export const OPENAI_MODEL_CAPABILITIES: Partial<
   },
   [PROVIDER_MODEL_TYPE.GPT_5_5]: {
     reasoning: true,
-    reasoningEffortOptions: ["none", "low", "medium", "high"],
+    reasoningEffortOptions: ["none", "low", "medium", "high", "xhigh"],
   },
 };
 

--- a/apps/opik-frontend/src/constants/llm.ts
+++ b/apps/opik-frontend/src/constants/llm.ts
@@ -184,6 +184,26 @@ export const OPENAI_MODEL_CAPABILITIES: Partial<
     reasoning: true,
     reasoningEffortOptions: ["none", "low", "medium", "high"],
   },
+  [PROVIDER_MODEL_TYPE.GPT_5_3_CHAT_LATEST]: {
+    reasoning: true,
+    reasoningEffortOptions: ["none", "low", "medium", "high"],
+  },
+  [PROVIDER_MODEL_TYPE.GPT_5_4]: {
+    reasoning: true,
+    reasoningEffortOptions: ["none", "low", "medium", "high"],
+  },
+  [PROVIDER_MODEL_TYPE.GPT_5_4_MINI]: {
+    reasoning: true,
+    reasoningEffortOptions: ["none", "low", "medium", "high"],
+  },
+  [PROVIDER_MODEL_TYPE.GPT_5_4_NANO]: {
+    reasoning: true,
+    reasoningEffortOptions: ["none", "low", "medium", "high"],
+  },
+  [PROVIDER_MODEL_TYPE.GPT_5_5]: {
+    reasoning: true,
+    reasoningEffortOptions: ["none", "low", "medium", "high"],
+  },
 };
 
 // Reasoning models that require temperature = 1.0

--- a/apps/opik-frontend/src/constants/providers.ts
+++ b/apps/opik-frontend/src/constants/providers.ts
@@ -46,7 +46,7 @@ export const PROVIDERS: PROVIDERS_TYPE = {
     icon: OpenAIIcon,
     apiKeyName: "OPENAI_API_KEY",
     apiKeyURL: "https://platform.openai.com/account/api-keys",
-    defaultModel: PROVIDER_MODEL_TYPE.GPT_5_2,
+    defaultModel: PROVIDER_MODEL_TYPE.GPT_5_5,
   },
   [PROVIDER_TYPE.ANTHROPIC]: {
     label: "Anthropic",

--- a/apps/opik-frontend/src/lib/modelUtils.test.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.test.ts
@@ -170,12 +170,7 @@ describe("getOpenAIReasoningEffortOptions", () => {
 
   it("returns gpt-5.1 options with none replacing minimal", () => {
     const opts = getOpenAIReasoningEffortOptions(PROVIDER_MODEL_TYPE.GPT_5_1);
-    expect(opts.map((o) => o.value)).toEqual([
-      "none",
-      "low",
-      "medium",
-      "high",
-    ]);
+    expect(opts.map((o) => o.value)).toEqual(["none", "low", "medium", "high"]);
   });
 
   it("labels the default value as 'High (Default)'", () => {

--- a/apps/opik-frontend/src/lib/modelUtils.test.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.test.ts
@@ -1,17 +1,21 @@
 import { describe, expect, it } from "vitest";
 import {
+  getOpenAIReasoningEffortOptions,
   sanitizeConfigForRequest,
+  supportsOpenAIReasoningEffort,
   supportsSamplingParams,
   updateProviderConfig,
 } from "@/lib/modelUtils";
 import {
   COMPOSED_PROVIDER_TYPE,
   LLMAnthropicConfigsType,
+  LLMOpenAIConfigsType,
   PROVIDER_MODEL_TYPE,
   PROVIDER_TYPE,
 } from "@/types/providers";
 
 const ANTHROPIC = PROVIDER_TYPE.ANTHROPIC as COMPOSED_PROVIDER_TYPE;
+const OPEN_AI = PROVIDER_TYPE.OPEN_AI as COMPOSED_PROVIDER_TYPE;
 
 describe("supportsSamplingParams", () => {
   it("returns true for an empty model selector", () => {
@@ -111,6 +115,208 @@ describe("updateProviderConfig — Anthropic", () => {
     const result = updateProviderConfig(config, {
       model: PROVIDER_MODEL_TYPE.CLAUDE_OPUS_4_6,
       provider: ANTHROPIC,
+    });
+    expect(result).toBe(config);
+  });
+});
+
+describe("supportsOpenAIReasoningEffort", () => {
+  it("returns false for an empty or unknown model", () => {
+    expect(supportsOpenAIReasoningEffort("")).toBe(false);
+    expect(supportsOpenAIReasoningEffort(undefined)).toBe(false);
+    expect(
+      supportsOpenAIReasoningEffort("never-seen" as PROVIDER_MODEL_TYPE),
+    ).toBe(false);
+  });
+
+  it("returns true for reasoning models that have an effort option list", () => {
+    expect(supportsOpenAIReasoningEffort(PROVIDER_MODEL_TYPE.GPT_O3)).toBe(
+      true,
+    );
+    expect(supportsOpenAIReasoningEffort(PROVIDER_MODEL_TYPE.GPT_5)).toBe(true);
+    expect(supportsOpenAIReasoningEffort(PROVIDER_MODEL_TYPE.GPT_5_1)).toBe(
+      true,
+    );
+  });
+
+  it("returns false for o1-mini (reasoning model that rejects the param)", () => {
+    expect(supportsOpenAIReasoningEffort(PROVIDER_MODEL_TYPE.GPT_O1_MINI)).toBe(
+      false,
+    );
+  });
+
+  it("returns false for non-reasoning OpenAI models", () => {
+    expect(supportsOpenAIReasoningEffort(PROVIDER_MODEL_TYPE.GPT_4O)).toBe(
+      false,
+    );
+  });
+});
+
+describe("getOpenAIReasoningEffortOptions", () => {
+  it("returns o-series options for o3", () => {
+    const opts = getOpenAIReasoningEffortOptions(PROVIDER_MODEL_TYPE.GPT_O3);
+    expect(opts.map((o) => o.value)).toEqual(["low", "medium", "high"]);
+  });
+
+  it("returns gpt-5 options including minimal", () => {
+    const opts = getOpenAIReasoningEffortOptions(PROVIDER_MODEL_TYPE.GPT_5);
+    expect(opts.map((o) => o.value)).toEqual([
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
+  });
+
+  it("returns gpt-5.1 options with none replacing minimal", () => {
+    const opts = getOpenAIReasoningEffortOptions(PROVIDER_MODEL_TYPE.GPT_5_1);
+    expect(opts.map((o) => o.value)).toEqual([
+      "none",
+      "low",
+      "medium",
+      "high",
+    ]);
+  });
+
+  it("labels the default value as 'High (Default)'", () => {
+    const opts = getOpenAIReasoningEffortOptions(PROVIDER_MODEL_TYPE.GPT_5);
+    const high = opts.find((o) => o.value === "high");
+    expect(high?.label).toBe("High (Default)");
+  });
+
+  it("returns empty array for o1-mini and non-reasoning models", () => {
+    expect(
+      getOpenAIReasoningEffortOptions(PROVIDER_MODEL_TYPE.GPT_O1_MINI),
+    ).toEqual([]);
+    expect(getOpenAIReasoningEffortOptions(PROVIDER_MODEL_TYPE.GPT_4O)).toEqual(
+      [],
+    );
+  });
+});
+
+describe("updateProviderConfig — OpenAI", () => {
+  it("bumps temperature to 1 when switching into a reasoning model with temp < 1", () => {
+    const config: LLMOpenAIConfigsType = {
+      temperature: 0,
+      maxCompletionTokens: 4000,
+      topP: 1,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+    };
+    const result = updateProviderConfig(config, {
+      model: PROVIDER_MODEL_TYPE.GPT_O3,
+      provider: OPEN_AI,
+    });
+    expect(result?.temperature).toBe(1);
+  });
+
+  it("does not change temperature when already 1", () => {
+    const config: LLMOpenAIConfigsType = {
+      temperature: 1,
+      maxCompletionTokens: 4000,
+      topP: 1,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+    };
+    const result = updateProviderConfig(config, {
+      model: PROVIDER_MODEL_TYPE.GPT_O3,
+      provider: OPEN_AI,
+    });
+    // Reference equality: nothing changed, same object back.
+    expect(result).toBe(config);
+  });
+
+  it("coerces invalid reasoningEffort to high when switching into a model that doesn't support it", () => {
+    const config: LLMOpenAIConfigsType = {
+      temperature: 1,
+      maxCompletionTokens: 4000,
+      topP: 1,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+      reasoningEffort: "minimal", // o3 doesn't accept minimal
+    };
+    const result = updateProviderConfig(config, {
+      model: PROVIDER_MODEL_TYPE.GPT_O3,
+      provider: OPEN_AI,
+    });
+    expect(result?.reasoningEffort).toBe("high");
+  });
+
+  it("coerces xhigh to high when switching from gpt-5.1 (where xhigh isn't allowed)", () => {
+    const config: LLMOpenAIConfigsType = {
+      temperature: 1,
+      maxCompletionTokens: 4000,
+      topP: 1,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+      reasoningEffort: "xhigh",
+    };
+    const result = updateProviderConfig(config, {
+      model: PROVIDER_MODEL_TYPE.GPT_5_1,
+      provider: OPEN_AI,
+    });
+    expect(result?.reasoningEffort).toBe("high");
+  });
+
+  it("keeps a valid reasoningEffort across reasoning-model switches", () => {
+    const config: LLMOpenAIConfigsType = {
+      temperature: 1,
+      maxCompletionTokens: 4000,
+      topP: 1,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+      reasoningEffort: "medium",
+    };
+    const result = updateProviderConfig(config, {
+      model: PROVIDER_MODEL_TYPE.GPT_5,
+      provider: OPEN_AI,
+    });
+    expect(result?.reasoningEffort).toBe("medium");
+  });
+
+  it("drops reasoningEffort when switching to o1-mini (rejects the param)", () => {
+    const config: LLMOpenAIConfigsType = {
+      temperature: 1,
+      maxCompletionTokens: 4000,
+      topP: 1,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+      reasoningEffort: "high",
+    };
+    const result = updateProviderConfig(config, {
+      model: PROVIDER_MODEL_TYPE.GPT_O1_MINI,
+      provider: OPEN_AI,
+    });
+    expect(result?.reasoningEffort).toBeUndefined();
+  });
+
+  it("drops reasoningEffort when switching to a non-reasoning OpenAI model", () => {
+    const config: LLMOpenAIConfigsType = {
+      temperature: 0,
+      maxCompletionTokens: 4000,
+      topP: 1,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+      reasoningEffort: "high",
+    };
+    const result = updateProviderConfig(config, {
+      model: PROVIDER_MODEL_TYPE.GPT_4O,
+      provider: OPEN_AI,
+    });
+    expect(result?.reasoningEffort).toBeUndefined();
+  });
+
+  it("returns the same reference when no changes are needed", () => {
+    const config: LLMOpenAIConfigsType = {
+      temperature: 0.7,
+      maxCompletionTokens: 4000,
+      topP: 1,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+    };
+    const result = updateProviderConfig(config, {
+      model: PROVIDER_MODEL_TYPE.GPT_4O,
+      provider: OPEN_AI,
     });
     expect(result).toBe(config);
   });

--- a/apps/opik-frontend/src/lib/modelUtils.test.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.test.ts
@@ -393,4 +393,43 @@ describe("sanitizeConfigForRequest", () => {
     const configs = { temperature: 0.5 };
     expect(sanitizeConfigForRequest("", configs)).toBe(configs);
   });
+
+  it("strips reasoningEffort for OpenAI models that don't support it", () => {
+    const result = sanitizeConfigForRequest(PROVIDER_MODEL_TYPE.GPT_4O, {
+      reasoningEffort: "high",
+      temperature: 0.5,
+    });
+    expect(result.reasoningEffort).toBeUndefined();
+  });
+
+  it("strips reasoningEffort for o1-mini (reasoning model that rejects the param)", () => {
+    const result = sanitizeConfigForRequest(PROVIDER_MODEL_TYPE.GPT_O1_MINI, {
+      reasoningEffort: "high",
+    });
+    expect(result.reasoningEffort).toBeUndefined();
+  });
+
+  it("strips an unsupported reasoningEffort value (xhigh on gpt-5.1)", () => {
+    const result = sanitizeConfigForRequest(PROVIDER_MODEL_TYPE.GPT_5_1, {
+      reasoningEffort: "xhigh",
+    });
+    expect(result.reasoningEffort).toBeUndefined();
+  });
+
+  it("keeps a valid reasoningEffort value for the model", () => {
+    const result = sanitizeConfigForRequest(PROVIDER_MODEL_TYPE.GPT_5, {
+      reasoningEffort: "minimal",
+    });
+    expect(result.reasoningEffort).toBe("minimal");
+  });
+
+  it("does not touch reasoningEffort for non-OpenAI providers", () => {
+    const result = sanitizeConfigForRequest(
+      PROVIDER_MODEL_TYPE.CLAUDE_OPUS_4_6,
+      {
+        reasoningEffort: "high",
+      },
+    );
+    expect(result.reasoningEffort).toBe("high");
+  });
 });

--- a/apps/opik-frontend/src/lib/modelUtils.test.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.test.ts
@@ -418,6 +418,13 @@ describe("sanitizeConfigForRequest", () => {
     expect(result.reasoningEffort).toBe("minimal");
   });
 
+  it("keeps xhigh for gpt-5.5 (the only OpenAI model that accepts it)", () => {
+    const result = sanitizeConfigForRequest(PROVIDER_MODEL_TYPE.GPT_5_5, {
+      reasoningEffort: "xhigh",
+    });
+    expect(result.reasoningEffort).toBe("xhigh");
+  });
+
   it("does not touch reasoningEffort for non-OpenAI providers", () => {
     const result = sanitizeConfigForRequest(
       PROVIDER_MODEL_TYPE.CLAUDE_OPUS_4_6,

--- a/apps/opik-frontend/src/lib/modelUtils.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.ts
@@ -157,6 +157,7 @@ export const updateProviderConfig = <
     temperature?: number;
     topP?: number;
     thinkingEffort?: AnthropicThinkingEffort;
+    reasoningEffort?: ReasoningEffort;
   },
 >(
   currentConfig: T | undefined,
@@ -171,16 +172,38 @@ export const updateProviderConfig = <
 
   const providerType = parseComposedProviderType(params.provider);
 
-  if (
-    providerType === PROVIDER_TYPE.OPEN_AI &&
-    isReasoningModel(params.model) &&
-    typeof currentConfig.temperature === "number" &&
-    currentConfig.temperature < 1
-  ) {
-    return {
-      ...currentConfig,
-      temperature: 1.0,
-    };
+  if (providerType === PROVIDER_TYPE.OPEN_AI) {
+    const next: T = { ...currentConfig };
+    let changed = false;
+
+    // Reasoning models reject temperature < 1; coerce.
+    if (
+      isReasoningModel(params.model) &&
+      typeof next.temperature === "number" &&
+      next.temperature < 1
+    ) {
+      next.temperature = 1.0;
+      changed = true;
+    }
+
+    // reasoningEffort: drop it for models without an effort option list,
+    // coerce stale values to "high" otherwise. Mirrors the Anthropic
+    // thinkingEffort handling below.
+    const effortOptions = getOpenAIReasoningEffortOptions(params.model);
+    if (effortOptions.length === 0) {
+      if (next.reasoningEffort !== undefined) {
+        next.reasoningEffort = undefined;
+        changed = true;
+      }
+    } else if (
+      next.reasoningEffort !== undefined &&
+      !effortOptions.some((o) => o.value === next.reasoningEffort)
+    ) {
+      next.reasoningEffort = "high";
+      changed = true;
+    }
+
+    return changed ? next : currentConfig;
   }
 
   if (providerType === PROVIDER_TYPE.ANTHROPIC) {

--- a/apps/opik-frontend/src/lib/modelUtils.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.ts
@@ -3,10 +3,12 @@ import {
   COMPOSED_PROVIDER_TYPE,
   PROVIDER_MODEL_TYPE,
   PROVIDER_TYPE,
+  ReasoningEffort,
 } from "@/types/providers";
 import {
   ANTHROPIC_MODEL_CAPABILITIES,
   DEFAULT_ANTHROPIC_CONFIGS,
+  OPENAI_MODEL_CAPABILITIES,
   REASONING_MODELS,
 } from "@/constants/llm";
 import {
@@ -111,6 +113,29 @@ export const getAnthropicThinkingEffortOptions = (
     ANTHROPIC_MODEL_CAPABILITIES[model as PROVIDER_MODEL_TYPE]
       ?.thinkingEffortOptions ?? []
   ).map((value) => ({ label: EFFORT_LABELS[value], value }));
+
+const OPENAI_EFFORT_LABELS: Record<ReasoningEffort, string> = {
+  none: "None",
+  minimal: "Minimal",
+  low: "Low",
+  medium: "Medium",
+  high: "High (Default)",
+  xhigh: "xHigh",
+};
+
+export const supportsOpenAIReasoningEffort = (
+  model?: PROVIDER_MODEL_TYPE | "",
+): boolean =>
+  !!OPENAI_MODEL_CAPABILITIES[model as PROVIDER_MODEL_TYPE]
+    ?.reasoningEffortOptions;
+
+export const getOpenAIReasoningEffortOptions = (
+  model?: PROVIDER_MODEL_TYPE | "",
+): Array<{ label: string; value: ReasoningEffort }> =>
+  (
+    OPENAI_MODEL_CAPABILITIES[model as PROVIDER_MODEL_TYPE]
+      ?.reasoningEffortOptions ?? []
+  ).map((value) => ({ label: OPENAI_EFFORT_LABELS[value], value }));
 
 // Single reconciler called by every model-change handler (playground, judge
 // dialog). Keeping the rules here means the form state stays valid even when

--- a/apps/opik-frontend/src/lib/modelUtils.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.ts
@@ -20,16 +20,28 @@ import { getLatestModelFlags } from "@/lib/modelRegistryStore";
 /**
  * Checks if a model is a reasoning model that requires temperature = 1.0.
  *
- * Primary source: the backend-fetched registry (via the module-level flag
- * index populated by useLLMProviderModelsData). A new reasoning model added
- * to the CDN YAML gets the temp=1 gate automatically.
+ * For OpenAI models, OPENAI_MODEL_CAPABILITIES is authoritative — every
+ * gating decision (sampling sliders, effort dropdown, request stripping)
+ * keys off the same map, so it must also answer the umbrella question.
  *
- * Fallback: the hardcoded REASONING_MODELS list (src/constants/llm.ts). Used
- * only before the first fetch resolves, or for non-React callers that run
- * before any component has mounted.
+ * For other providers, the backend-fetched registry wins (via the module-
+ * level flag index populated by useLLMProviderModelsData), with the
+ * hardcoded REASONING_MODELS list as a pre-fetch fallback.
  */
 export const isReasoningModel = (model?: PROVIDER_MODEL_TYPE | ""): boolean => {
   if (!model) return false;
+
+  // OpenAI: capability map is the source of truth, mirroring how Anthropic
+  // owns its supportsAnthropicThinkingEffort gating without consulting the
+  // BE flag. Stops a BE YAML entry without `reasoning: true` from silently
+  // disabling the playground reasoning-effort dropdown.
+  if (
+    getProviderFromModel(model as PROVIDER_MODEL_TYPE) === PROVIDER_TYPE.OPEN_AI
+  ) {
+    return OPENAI_MODEL_CAPABILITIES[model]?.reasoning ?? false;
+  }
+
+  // Other providers: BE flag wins; fall back to hardcoded REASONING_MODELS.
   const fetched = getLatestModelFlags(model);
   if (fetched !== undefined) {
     return fetched.reasoning;

--- a/apps/opik-frontend/src/lib/modelUtils.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.ts
@@ -251,11 +251,9 @@ export const sanitizeConfigForRequest = (
   if (!model) return configs;
 
   const sanitized: Record<string, unknown> = { ...configs };
+  const provider = getProviderFromModel(model as PROVIDER_MODEL_TYPE);
 
-  if (
-    getProviderFromModel(model as PROVIDER_MODEL_TYPE) ===
-    PROVIDER_TYPE.ANTHROPIC
-  ) {
+  if (provider === PROVIDER_TYPE.ANTHROPIC) {
     if (!supportsSamplingParams(model)) {
       delete sanitized.temperature;
       delete sanitized.topP;
@@ -265,6 +263,19 @@ export const sanitizeConfigForRequest = (
     if (sanitized.maxCompletionTokens == null) {
       sanitized.maxCompletionTokens =
         DEFAULT_ANTHROPIC_CONFIGS.MAX_COMPLETION_TOKENS;
+    }
+  }
+
+  if (provider === PROVIDER_TYPE.OPEN_AI && sanitized.reasoningEffort != null) {
+    if (!supportsOpenAIReasoningEffort(model)) {
+      delete sanitized.reasoningEffort;
+    } else {
+      const allowed = getOpenAIReasoningEffortOptions(model).map(
+        (o) => o.value,
+      );
+      if (!allowed.includes(sanitized.reasoningEffort as ReasoningEffort)) {
+        delete sanitized.reasoningEffort;
+      }
     }
   }
 

--- a/apps/opik-frontend/src/lib/playground.ts
+++ b/apps/opik-frontend/src/lib/playground.ts
@@ -10,11 +10,11 @@ import {
 } from "@/constants/llm";
 import {
   getDefaultTemperatureForModel,
-  isReasoningModel,
-  supportsGeminiThinkingLevel,
-  supportsVertexAIThinkingLevel,
   supportsAnthropicThinkingEffort,
+  supportsGeminiThinkingLevel,
+  supportsOpenAIReasoningEffort,
   supportsSamplingParams,
+  supportsVertexAIThinkingLevel,
 } from "@/lib/modelUtils";
 import {
   LLMAnthropicConfigsType,
@@ -53,9 +53,8 @@ export const getDefaultConfigByProvider = (
       maxConcurrentRequests: DEFAULT_OPEN_AI_CONFIGS.MAX_CONCURRENT_REQUESTS,
     };
 
-    // Add reasoningEffort default for reasoning models
-    if (isReasoningModel(model)) {
-      config.reasoningEffort = "medium";
+    if (supportsOpenAIReasoningEffort(model)) {
+      config.reasoningEffort = "high";
     }
 
     return config;

--- a/apps/opik-frontend/src/types/providers.ts
+++ b/apps/opik-frontend/src/types/providers.ts
@@ -711,7 +711,13 @@ export type PartialProviderKeyUpdate = Partial<
   headers?: Record<string, string>;
 };
 
-export type ReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh";
+export type ReasoningEffort =
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh";
 
 export interface LLMOpenAIConfigsType {
   temperature: number;

--- a/apps/opik-frontend/src/v1/pages-shared/llm/PromptModelSettings/providerConfigs/OpenAIModelConfigs.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/llm/PromptModelSettings/providerConfigs/OpenAIModelConfigs.tsx
@@ -8,7 +8,11 @@ import {
   ReasoningEffort,
 } from "@/types/providers";
 import { DEFAULT_OPEN_AI_CONFIGS } from "@/constants/llm";
-import { isReasoningModel } from "@/lib/modelUtils";
+import {
+  getOpenAIReasoningEffortOptions,
+  isReasoningModel,
+  supportsOpenAIReasoningEffort,
+} from "@/lib/modelUtils";
 import isUndefined from "lodash/isUndefined";
 import {
   Select,
@@ -122,7 +126,7 @@ const OpenAIModelConfigs = ({
         />
       )}
 
-      {isReasoning && (
+      {supportsOpenAIReasoningEffort(model) && (
         <div className="space-y-2">
           <div className="flex items-center space-x-2">
             <Label htmlFor="reasoningEffort" className="text-sm font-medium">
@@ -131,7 +135,7 @@ const OpenAIModelConfigs = ({
             <ExplainerIcon description="Controls how much effort the model puts into reasoning before responding. Higher effort may result in more thoughtful but slower responses." />
           </div>
           <Select
-            value={configs.reasoningEffort || "medium"}
+            value={configs.reasoningEffort ?? "high"}
             onValueChange={(value: ReasoningEffort) =>
               onChange({ reasoningEffort: value })
             }
@@ -140,11 +144,11 @@ const OpenAIModelConfigs = ({
               <SelectValue placeholder="Select reasoning effort" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="minimal">Minimal</SelectItem>
-              <SelectItem value="low">Low</SelectItem>
-              <SelectItem value="medium">Medium</SelectItem>
-              <SelectItem value="high">High</SelectItem>
-              <SelectItem value="xhigh">XHigh</SelectItem>
+              {getOpenAIReasoningEffortOptions(model).map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSettings/providerConfigs/OpenAIModelConfigs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSettings/providerConfigs/OpenAIModelConfigs.tsx
@@ -8,7 +8,11 @@ import {
   ReasoningEffort,
 } from "@/types/providers";
 import { DEFAULT_OPEN_AI_CONFIGS } from "@/constants/llm";
-import { isReasoningModel } from "@/lib/modelUtils";
+import {
+  getOpenAIReasoningEffortOptions,
+  isReasoningModel,
+  supportsOpenAIReasoningEffort,
+} from "@/lib/modelUtils";
 import isUndefined from "lodash/isUndefined";
 import {
   Select,
@@ -122,7 +126,7 @@ const OpenAIModelConfigs = ({
         />
       )}
 
-      {isReasoning && (
+      {supportsOpenAIReasoningEffort(model) && (
         <div className="space-y-2">
           <div className="flex items-center space-x-2">
             <Label htmlFor="reasoningEffort" className="text-sm font-medium">
@@ -131,7 +135,7 @@ const OpenAIModelConfigs = ({
             <ExplainerIcon description="Controls how much effort the model puts into reasoning before responding. Higher effort may result in more thoughtful but slower responses." />
           </div>
           <Select
-            value={configs.reasoningEffort || "medium"}
+            value={configs.reasoningEffort ?? "high"}
             onValueChange={(value: ReasoningEffort) =>
               onChange({ reasoningEffort: value })
             }
@@ -140,11 +144,11 @@ const OpenAIModelConfigs = ({
               <SelectValue placeholder="Select reasoning effort" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="minimal">Minimal</SelectItem>
-              <SelectItem value="low">Low</SelectItem>
-              <SelectItem value="medium">Medium</SelectItem>
-              <SelectItem value="high">High</SelectItem>
-              <SelectItem value="xhigh">XHigh</SelectItem>
+              {getOpenAIReasoningEffortOptions(model).map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>


### PR DESCRIPTION
## Details

Extend the per-model capability-map pattern from PR #6523 (Anthropic) to OpenAI: introduces `OPENAI_MODEL_CAPABILITIES` keyed by `PROVIDER_MODEL_TYPE`, drives the playground reasoning-effort dropdown from per-model allowed values, and routes normalization through the existing `updateProviderConfig` reconciler + `sanitizeConfigForRequest` sanitizer. Fixes #6601, where a new OpenAI model ID landing in the BE YAML without `reasoning: true` silently disabled the dropdown.

- The FE map is now authoritative for OpenAI reasoning gating (BE flag still primary for other providers). Stops the same regression vector from firing again with the next `sync provider model definitions` commit, since the FE update is colocated with the source change.
- Per-family allowed values now match the OpenAI API contract: `low/medium/high` for o-series, `minimal/low/medium/high` for original gpt-5, `none/low/medium/high` for gpt-5.1 through gpt-5.5. `o1-mini` correctly hides the dropdown (API rejects the param).
- Reconciler coerces stale `reasoningEffort` to `"high"` on model switch and drops the field for models without an effort dropdown. Sanitizer strips invalid values from outbound requests — applied to both the playground streaming path and the experiment-execution path.

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #6601
- OPIK-6429

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation (research → spec → plan → code → tests)
- Human verification: code review + manual testing on adhoc env (pending)

## Testing

Commands run locally:

- `cd apps/opik-frontend && npm run typecheck` — pass
- `cd apps/opik-frontend && npm run lint` — pass
- `cd apps/opik-frontend && npm run test -- --run` — 1596/1596 pass across 90 files; includes 22 new vitest cases covering `supportsOpenAIReasoningEffort`, `getOpenAIReasoningEffortOptions`, `updateProviderConfig` OpenAI branch (effort coercion, drop on non-reasoning model switch, drop on `o1-mini` switch, temperature-bump to 1, reference-equality on no-op), and `sanitizeConfigForRequest` OpenAI branch (strip unsupported value, strip on `o1-mini`, strip on non-reasoning model, keep valid value, no-touch for non-OpenAI providers)
- `cd apps/opik-frontend && npm run build` — pass

Scenarios validated by unit tests:

- Switching gpt-5 (`minimal` allowed) → o3 (`minimal` not allowed) coerces effort to `high`
- Switching gpt-5.1 → any model that doesn't accept `xhigh` coerces to `high`
- Switching to `o1-mini` drops `reasoningEffort` entirely
- Switching to `gpt-4o` drops `reasoningEffort` entirely
- Sanitizer strips `xhigh` from outbound requests against `gpt-5.1`
- Sanitizer preserves a valid value (`minimal` on `gpt-5`)
- Reference equality preserved when no change is needed
- Non-OpenAI providers are untouched by the new branches

Manual scenarios pending — local dev environment is broken on my machine, will use the DevOps team's adhoc environment to verify:

- Dropdown contents per reasoning family (13 models in `PROVIDER_MODEL_TYPE` covered by the map)
- Submitting completions on one model per family without 400s
- Judge-rule round-trip: create a rule on gpt-5 with `temperature: 0`, save, reopen — temperature should normalize to 1 via the existing `convertLLMJudgeObjectToLLMJudgeData` → `updateProviderConfig` pipe
- Experiment execution submitting a sanitized payload (this PR adds the `sanitizeConfigForRequest` call at the experiment boundary; pre-this-PR the experiment path bypassed the sanitizer)

Tests not run: no E2E suite changes; existing Playwright tests in `tests_end_to_end/` are unaffected by this PR's scope. No backend tests run because the BE is untouched.

Environment: macOS, Node 22, fresh `npm install`. No Docker required for the FE-only test pass.

## Documentation

N/A — no public API or user-facing-documentation changes. The capability map and helpers are internal FE concerns; the BE contract and OpenAPI spec are unchanged.