### PR TITLE
[OPIK-6145] [FE] feat: lazy load attachments in traces and spans tables

### DIFF
--- a/apps/opik-frontend/src/api/traces/useTracesList.ts
+++ b/apps/opik-frontend/src/api/traces/useTracesList.ts
@@ -19,6 +19,7 @@ type UseTracesListParams = {
   page: number;
   size: number;
   truncate?: boolean;
+  stripAttachments?: boolean;
   fromTime?: string;
   toTime?: string;
   exclude?: string[];
@@ -41,6 +42,7 @@ const getTracesList = async (
     size,
     page,
     truncate,
+    stripAttachments,
     fromTime,
     toTime,
     exclude,
@@ -62,6 +64,9 @@ const getTracesList = async (
       size,
       page,
       truncate,
+      ...(stripAttachments !== undefined && {
+        strip_attachments: stripAttachments,
+      }),
       ...(fromTime && { from_time: fromTime }),
       ...(toTime && { to_time: toTime }),
       ...(exclude &&

--- a/apps/opik-frontend/src/hooks/useTracesOrSpansList.ts
+++ b/apps/opik-frontend/src/hooks/useTracesOrSpansList.ts
@@ -25,6 +25,7 @@ type UseTracesOrSpansListParams = {
   page: number;
   size: number;
   truncate?: boolean;
+  stripAttachments?: boolean;
   fromTime?: string;
   toTime?: string;
   exclude?: string[];

--- a/apps/opik-frontend/src/v1/pages-shared/traces/ErrorTypeAutocomplete/ErrorTypeAutocomplete.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/traces/ErrorTypeAutocomplete/ErrorTypeAutocomplete.tsx
@@ -42,6 +42,7 @@ const ErrorTypeAutocomplete: React.FC<ErrorTypeAutocompleteProps> = ({
       page: 1,
       size: 100,
       truncate: true,
+      stripAttachments: true,
       filters: ERROR_FILTER,
     },
     {

--- a/apps/opik-frontend/src/v1/pages-shared/traces/TracesOrSpansPathsAutocomplete/TracesOrSpansPathsAutocomplete.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/traces/TracesOrSpansPathsAutocomplete/TracesOrSpansPathsAutocomplete.tsx
@@ -68,6 +68,7 @@ const TracesOrSpansPathsAutocomplete: React.FC<
       page: 1,
       size: 100,
       truncate: true,
+      stripAttachments: true,
     },
     {
       enabled: isProjectId,
@@ -82,6 +83,7 @@ const TracesOrSpansPathsAutocomplete: React.FC<
         page: 1,
         size: 10,
         truncate: false,
+        stripAttachments: true,
       },
       {
         enabled: isProjectId,

--- a/apps/opik-frontend/src/v1/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/v1/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
@@ -382,6 +382,7 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
       size: size as number,
       search: search as string,
       truncate: truncationEnabled,
+      stripAttachments: true,
     },
     {
       placeholderData: keepPreviousData,

--- a/apps/opik-frontend/src/v1/pages/SMEFlowPage/SMEFlowContext.tsx
+++ b/apps/opik-frontend/src/v1/pages/SMEFlowPage/SMEFlowContext.tsx
@@ -333,6 +333,7 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
       filters: annotationQueueFilter,
       search: "",
       truncate: true,
+      stripAttachments: true,
     },
     {
       enabled:

--- a/apps/opik-frontend/src/v1/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v1/pages/TracesPage/TracesSpansTab/TracesSpansTab.tsx
@@ -574,6 +574,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
         size: size as number,
         search: trimmedSearch,
         truncate: truncationEnabled,
+        stripAttachments: true,
         fromTime: intervalStart,
         toTime: intervalEnd,
         exclude: excludeFields,

--- a/apps/opik-frontend/src/v2/layout/DemoProjectBanner/useAutoCompleteAgentOnboarding.ts
+++ b/apps/opik-frontend/src/v2/layout/DemoProjectBanner/useAutoCompleteAgentOnboarding.ts
@@ -42,6 +42,7 @@ const useAutoCompleteAgentOnboarding = ({
       projectId: projectId ?? "",
       page: 1,
       size: 1,
+      stripAttachments: true,
     },
     {
       enabled: enabled && !!projectId,

--- a/apps/opik-frontend/src/v2/pages-shared/TagsAutocomplete/TagsAutocomplete.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/TagsAutocomplete/TagsAutocomplete.tsx
@@ -56,6 +56,7 @@ const TagsAutocomplete: React.FC<TagsAutocompleteProps> = ({
       page: 1,
       size: SAMPLE_SIZE,
       truncate: true,
+      stripAttachments: true,
       filters: TAGS_NOT_EMPTY_FILTER,
     },
     {

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ErrorTypeAutocomplete/ErrorTypeAutocomplete.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ErrorTypeAutocomplete/ErrorTypeAutocomplete.tsx
@@ -42,6 +42,7 @@ const ErrorTypeAutocomplete: React.FC<ErrorTypeAutocompleteProps> = ({
       page: 1,
       size: 100,
       truncate: true,
+      stripAttachments: true,
       filters: ERROR_FILTER,
     },
     {

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
@@ -578,6 +578,7 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
         size: size as number,
         search: trimmedSearch,
         truncate: truncationEnabled,
+        stripAttachments: true,
         fromTime: intervalStart,
         toTime: intervalEnd,
         exclude: excludeFields,

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TracesOrSpansPathsAutocomplete/TracesOrSpansPathsAutocomplete.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TracesOrSpansPathsAutocomplete/TracesOrSpansPathsAutocomplete.tsx
@@ -53,6 +53,7 @@ const TracesOrSpansPathsAutocomplete: React.FC<
       page: 1,
       size: 100,
       truncate: true,
+      stripAttachments: true,
     },
     {
       enabled: isProjectId,
@@ -67,6 +68,7 @@ const TracesOrSpansPathsAutocomplete: React.FC<
         page: 1,
         size: 10,
         truncate: false,
+        stripAttachments: true,
       },
       {
         enabled: isProjectId,

--- a/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationDetailView.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentConfigurationPage/AgentConfigurationTab/AgentConfigurationDetailView.tsx
@@ -95,6 +95,7 @@ const AgentConfigurationDetailView: React.FC<
     ],
     page: 1,
     size: 1,
+    stripAttachments: true,
   });
 
   const hasTraces = (tracesData?.total ?? 0) > 0;

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
@@ -383,6 +383,7 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
       size: size as number,
       search: search as string,
       truncate: truncationEnabled,
+      stripAttachments: true,
     },
     {
       placeholderData: keepPreviousData,

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
@@ -70,6 +70,7 @@ const ConnectAgentStep: React.FC = () => {
       page: 1,
       size: 1,
       sorting: TRACES_OLDEST_FIRST_SORTING,
+      stripAttachments: true,
     },
     {
       enabled: !!projectId,

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -589,6 +589,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
         size: size as number,
         search: trimmedSearch,
         truncate: truncationEnabled,
+        stripAttachments: true,
         fromTime: intervalStart,
         toTime: intervalEnd,
         exclude: excludeFields,
@@ -669,6 +670,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
       type: type as TRACE_DATA_TYPE,
       page: 1,
       size: 1,
+      stripAttachments: true,
       logsSource: LOGS_SOURCE.sdk,
     },
     {

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/SMEFlowContext.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/SMEFlowContext.tsx
@@ -333,6 +333,7 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
       filters: annotationQueueFilter,
       search: "",
       truncate: true,
+      stripAttachments: true,
     },
     {
       enabled:


### PR DESCRIPTION
## Details

Pass `strip_attachments=true` on FE list calls so the BE skips its per-row reinjection step (downloading attachment bytes from object storage and inlining them into each trace's input/output JSON). The traces/spans table only renders text via `PrettyCell`, so the inlined bytes were fetched, transferred, and discarded — pure overhead. Measured at 100 HDFC-shaped traces (image + PDF, page_size=100, MinIO-backed): list payload drops from ~85 MB to 0.13 MB and wall time from ~3.4 s to ~0.1 s.

- Tables: `TracesSpansTab` v1+v2, `TraceLogsSidebar` v2, `TraceQueueItemsTab` v1+v2, `SMEFlowContext` queue-items v1+v2.
- Filter autocompletes / existence checks (don't read input/output bytes): `ErrorTypeAutocomplete` v1+v2, `TagsAutocomplete` v2, `TracesOrSpansPathsAutocomplete` v1+v2 (paths come from JSON keys, unchanged by stripping), `ConnectAgentStep`, `useAutoCompleteAgentOnboarding`, `AgentConfigurationDetailView` (only read `total`).
- Export refetches and Thread / SME data viewers intentionally untouched — they need full content with attachments.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6145

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation (investigation, repro, FE patch)
- Human verification: code review + manual UI testing on local docker stack with MinIO + lint/typecheck/dep-cruiser passing

## Testing

- Repro script: `~/dev/comet-python-experiments/opik/lazy_load_attachments_opik_6145.py` posts HDFC-shaped traces (raw HTTP, OpenAI multimodal `input.messages[*].content[]` with `data:image/...;base64,...` + `data:application/pdf;base64,...`) directly to the BE — no SDK, so the BE `AttachmentStripperService` is what fires.
- Target: local docker stack via `./opik.sh --build` (MinIO-backed; the only environment where the BE reinjector actually works — see "Side-finding" in description).
- Seed: 100 traces × 1 LLM span each, every trace carries a real 255 KB JPEG (`tests_end_to_end/test_files/attachments/test-image1.jpg`) + a real 400 KB PDF (truncated `Owners_Manual.pdf`). Per-trace diagnostic confirms BE stripper fired, attachment row stored, reinjector adds bytes back when `strip_attachments=false`.
- Timing matrix at HDFC scale (page_size=100):
  | strip | truncate | elapsed | payload  |
  |-------|----------|---------|----------|
  | false | true     | ~3.4 s  | ~85 MB   | ← FE today |
  | false | false    | ~3.3 s  | ~83 MB   |
  | true  | true     | ~0.10 s | 0.13 MB  | ← with this patch |
  | true  | false    | ~0.10 s | 0.13 MB  |
- `truncate` is a no-op here because the BE only image-base64-truncates (`ImageUtils.IMAGE_TRUNCATION_REGEX`) and the reinjector adds bytes back regardless. `strip_attachments` is the actual lever, and it is format-agnostic at the BE (covers PDFs / audio / video too).
- Sidebar verified by hand: thumbnail + PDF tile both render in the trace details panel; attachments lazy-load on demand via the existing `useAttachmentsList` flow.
- `bash scripts/dev-runner.sh --lint-fe` (lint:fix + typecheck + deps:validate) passes.

## Documentation

N/A