### PR TITLE
[OPIK-6375][BE] LlmProviderAnthropic.validateRequest rejects valid Playground/SDK requests with null maxCompletionTokens

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/ChatCompletionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/ChatCompletionService.java
@@ -34,7 +34,6 @@ import static jakarta.ws.rs.core.Response.Status.Family.familyOf;
 public class ChatCompletionService {
     public static final String UNEXPECTED_ERROR_CALLING_LLM_PROVIDER = "Unexpected error calling LLM provider";
     public static final String ERROR_EMPTY_MESSAGES = "messages cannot be empty";
-    public static final String ERROR_NO_COMPLETION_TOKENS = "maxCompletionTokens cannot be null";
 
     private final LlmProviderClientConfig llmProviderClientConfig;
     private final LlmProviderFactory llmProviderFactory;

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/LlmProviderAnthropic.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/LlmProviderAnthropic.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import static com.comet.opik.domain.llm.ChatCompletionService.ERROR_EMPTY_MESSAGES;
-import static com.comet.opik.domain.llm.ChatCompletionService.ERROR_NO_COMPLETION_TOKENS;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -68,9 +67,9 @@ class LlmProviderAnthropic implements LlmProviderService {
         if (CollectionUtils.isEmpty(request.messages())) {
             throw new BadRequestException(ERROR_EMPTY_MESSAGES);
         }
-        if (request.maxCompletionTokens() == null) {
-            throw new BadRequestException(ERROR_NO_COMPLETION_TOKENS);
-        }
+        // maxCompletionTokens is required by Anthropic but defaulted (with a log line) inside
+        // LlmProviderAnthropicMapper.resolveMaxTokens, so callers without an explicit cap still
+        // succeed — same UX as OpenAI in the same flows.
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/LlmProviderAnthropicMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/LlmProviderAnthropicMapper.java
@@ -28,6 +28,8 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Objects;
@@ -35,6 +37,12 @@ import java.util.Objects;
 @Mapper
 interface LlmProviderAnthropicMapper {
     LlmProviderAnthropicMapper INSTANCE = Mappers.getMapper(LlmProviderAnthropicMapper.class);
+
+    Logger LOG = LoggerFactory.getLogger(LlmProviderAnthropicMapper.class);
+
+    // Anthropic requires max_tokens; default applied when callers don't set it (Playground default
+    // config, SDK without an explicit cap). 4096 mirrors langchain4j's default on the judge path.
+    int DEFAULT_MAX_COMPLETION_TOKENS = 4096;
 
     @Mapping(source = "response", target = "choices", qualifiedByName = "mapToChoices")
     @Mapping(source = "usage", target = "usage", qualifiedByName = "mapToUsage")
@@ -52,10 +60,20 @@ interface LlmProviderAnthropicMapper {
     @Mapping(expression = "java(request.temperature())", target = "temperature")
     @Mapping(expression = "java(request.temperature() != null ? null : request.topP())", target = "topP")
     @Mapping(expression = "java(request.stop())", target = "stopSequences")
-    @Mapping(expression = "java(request.maxCompletionTokens())", target = "maxTokens")
+    @Mapping(source = "request", target = "maxTokens", qualifiedByName = "resolveMaxTokens")
     @Mapping(source = "request", target = "messages", qualifiedByName = "mapToMessages")
     @Mapping(source = "request", target = "system", qualifiedByName = "mapToSystemMessages")
     AnthropicCreateMessageRequest toCreateMessageRequest(@NonNull ChatCompletionRequest request);
+
+    @Named("resolveMaxTokens")
+    default Integer resolveMaxTokens(@NonNull ChatCompletionRequest request) {
+        if (request.maxCompletionTokens() != null) {
+            return request.maxCompletionTokens();
+        }
+        LOG.info("Anthropic request for model '{}' has no maxCompletionTokens; defaulting to {}",
+                request.model(), DEFAULT_MAX_COMPLETION_TOKENS);
+        return DEFAULT_MAX_COMPLETION_TOKENS;
+    }
 
     @Named("mapToChoices")
     default List<ChatCompletionChoice> mapToChoices(@NonNull AnthropicCreateMessageResponse response) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ChatCompletionsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ChatCompletionsResourceTest.java
@@ -61,7 +61,6 @@ import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 import static com.comet.opik.domain.llm.ChatCompletionService.ERROR_EMPTY_MESSAGES;
-import static com.comet.opik.domain.llm.ChatCompletionService.ERROR_NO_COMPLETION_TOKENS;
 import static com.comet.opik.domain.llm.LlmProviderFactory.ERROR_MODEL_NOT_SUPPORTED;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -334,12 +333,7 @@ class ChatCompletionsResourceTest {
                         .stream(false)
                         .model(AnthropicModelName.CLAUDE_SONNET_3_7.toString())
                         .maxCompletionTokens(100).build()),
-                        ERROR_EMPTY_MESSAGES),
-                arguments(named("no max tokens", podamFactory.manufacturePojo(ChatCompletionRequest.Builder.class)
-                        .stream(false)
-                        .model(AnthropicModelName.CLAUDE_SONNET_3_7.toString())
-                        .addUserMessage("Say 'Hello World'").build()),
-                        ERROR_NO_COMPLETION_TOKENS));
+                        ERROR_EMPTY_MESSAGES));
     }
 
     private void createLlmProviderApiKey(String workspaceName) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/antropic/AnthropicMappersTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/antropic/AnthropicMappersTest.java
@@ -3,6 +3,7 @@ package com.comet.opik.infrastructure.llm.antropic;
 import com.comet.opik.podam.PodamFactoryUtils;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageRequest;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageResponse;
+import dev.langchain4j.model.anthropic.internal.client.AnthropicClient;
 import dev.langchain4j.model.openai.internal.chat.AssistantMessage;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionChoice;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionRequest;
@@ -11,11 +12,13 @@ import dev.langchain4j.model.openai.internal.shared.Usage;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mockito;
 import uk.co.jemos.podam.api.PodamFactory;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class AnthropicMappersTest {
     private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
@@ -72,6 +75,51 @@ public class AnthropicMappersTest {
                             .map(LlmProviderAnthropicMapper.INSTANCE::mapToSystemMessage)
                             .toList());
         }
+
+        @Test
+        void toCreateMessage_appliesDefaultMaxTokens_whenNull() {
+            var request = ChatCompletionRequest.builder()
+                    .model("claude-sonnet-4-6")
+                    .stream(false)
+                    .addUserMessage("hi")
+                    .build();
+
+            AnthropicCreateMessageRequest actual = LlmProviderAnthropicMapper.INSTANCE
+                    .toCreateMessageRequest(request);
+
+            assertThat(actual.maxTokens).isEqualTo(LlmProviderAnthropicMapper.DEFAULT_MAX_COMPLETION_TOKENS);
+        }
+
+        @Test
+        void toCreateMessage_preservesExplicitMaxTokens() {
+            var request = ChatCompletionRequest.builder()
+                    .model("claude-sonnet-4-6")
+                    .stream(false)
+                    .addUserMessage("hi")
+                    .maxCompletionTokens(123)
+                    .build();
+
+            AnthropicCreateMessageRequest actual = LlmProviderAnthropicMapper.INSTANCE
+                    .toCreateMessageRequest(request);
+
+            assertThat(actual.maxTokens).isEqualTo(123);
+        }
     }
 
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class ValidateRequest {
+        private final LlmProviderAnthropic provider = new LlmProviderAnthropic(Mockito.mock(AnthropicClient.class));
+
+        @Test
+        void acceptsNullMaxCompletionTokens() {
+            var request = ChatCompletionRequest.builder()
+                    .model("claude-sonnet-4-6")
+                    .stream(false)
+                    .addUserMessage("hi")
+                    .build();
+
+            assertThatCode(() -> provider.validateRequest(request)).doesNotThrowAnyException();
+        }
+    }
 }


### PR DESCRIPTION
## Details
`LlmProviderAnthropic.validateRequest` requires `request.maxCompletionTokens()` to be non-null, throwing `BadRequestException("maxCompletionTokens cannot be null")` when it is. This validation does not have a corresponding default applied upstream, so any caller that goes through `ChatCompletionService.create(...)` (the Opik-native provider path) without explicitly setting max tokens — including the Playground UI when the user picks an Anthropic model with default config — gets a hard-fail before the request even leaves the backend.
The failure then surfaces in particularly bad ways downstream:

1. **Playground / experiment runner.** `ExperimentItemProcessor.process` catches the exception (line 49-54), persists the trace with empty output (`{}`), and quietly continues. The user sees an experiment that "completed" but with `{}` for every output — no error indication in the UI.
2. **Any non-experiment Anthropic call** that goes through `ChatCompletionService.create(...)` (chat completions resource, manual evaluation invoking the Opik-native agent path, etc.) returns 400 to the client with a terse "maxCompletionTokens cannot be null" — confusing if the client thought their request was valid because OpenAI accepts the same shape.

## Summary

Fix Anthropic provider rejecting valid Playground/SDK chat-completion requests when `maxCompletionTokens` is null. Instead of throwing `BadRequestException`, the mapper now substitutes a sane default (4096) and logs the substitution so the implicit cap is visible in backend logs.

## Changes by Component

### Backend

- `LlmProviderAnthropic.validateRequest` no longer throws when `maxCompletionTokens` is null; only the unrecoverable empty-messages check remains. Removed the now-unused `ERROR_NO_COMPLETION_TOKENS` import.
- `LlmProviderAnthropicMapper` introduces a new `@Named("resolveMaxTokens")` default method that returns the request's `maxCompletionTokens` when set, otherwise applies `DEFAULT_MAX_COMPLETION_TOKENS = 4096` and emits an `INFO` log line with the model name. The `maxTokens` mapping now uses this qualifier so the substitution and the log are in lockstep.
- `ChatCompletionService.ERROR_NO_COMPLETION_TOKENS` constant removed (no remaining references).
- `ChatCompletionsResourceTest`: dropped the parameterised "no max tokens" case that asserted the old rejection behavior.
- `AnthropicMappersTest`: added three new tests — `validateRequest` accepts null `maxCompletionTokens`, mapper applies the 4096 default when null, mapper preserves the explicit value when set.

## Files Changed

```
 .../opik/domain/llm/ChatCompletionService.java     |  1 -
 .../llm/antropic/LlmProviderAnthropic.java         |  7 ++--
 .../llm/antropic/LlmProviderAnthropicMapper.java   | 20 ++++++++-
 .../v1/priv/ChatCompletionsResourceTest.java       |  8 +---
 .../llm/antropic/AnthropicMappersTest.java         | 48 ++++++++++++++++++++++
 5 files changed, 71 insertions(+), 13 deletions(-)
```

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6375

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
Added additional tests to cover functionality

## Documentation
NA