### PR TITLE
[OPIK-6411] [BE] feat: expose MIGRATION_EXCLUDED_WORKSPACE_IDS size as a metric

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMigrationService.java
@@ -63,6 +63,7 @@ public class ExperimentProjectMigrationService {
 
     private final LongHistogram cycleEligibleWorkspaces;
     private final LongGauge cycleTrappedWorkspaces;
+    private final LongGauge cycleEnvExcludedWorkspaces;
     private final LongHistogram workspaceDuration;
     private final LongCounter experimentsSkipped;
     private final LongHistogram batchSize;
@@ -100,6 +101,12 @@ public class ExperimentProjectMigrationService {
                         "Number of workspaces locally skipped because all their certain experiments point to deleted projects")
                 .ofLongs()
                 .build();
+        this.cycleEnvExcludedWorkspaces = meter
+                .gaugeBuilder("%s.cycle.env_excluded_workspaces".formatted(METRIC_NAMESPACE))
+                .setDescription(
+                        "Number of workspaces excluded from migration via the MIGRATION_EXCLUDED_WORKSPACE_IDS env var. Mirrors trapped_workspaces so the dashboard can show both exclusion paths side by side.")
+                .ofLongs()
+                .build();
         this.workspaceDuration = meter
                 .histogramBuilder("%s.workspace.duration".formatted(METRIC_NAMESPACE))
                 .setDescription("Duration of a single workspace migration, tagged by result")
@@ -120,12 +127,15 @@ public class ExperimentProjectMigrationService {
     public Mono<Void> runMigrationCycle() {
         return Mono.fromCallable(() -> {
             var skippedWorkspaceIds = workspacesService.findMigrationSkippedWorkspaceIds();
+            var envExcludedWorkspaceIds = migrationConfig.getExcludedWorkspaceIds();
             cycleTrappedWorkspaces.set(skippedWorkspaceIds.size());
+            cycleEnvExcludedWorkspaces.set(envExcludedWorkspaceIds.size());
             log.info(
-                    "Starting experiment project migration cycle, workspacesPerRun='{}', batchSize='{}', trappedWorkspaces='{}'",
-                    config.workspacesPerRun(), config.experimentBatchSize(), skippedWorkspaceIds.size());
+                    "Starting experiment project migration cycle, workspacesPerRun='{}', batchSize='{}', trappedWorkspaces='{}', envExcludedWorkspaces='{}'",
+                    config.workspacesPerRun(), config.experimentBatchSize(), skippedWorkspaceIds.size(),
+                    envExcludedWorkspaceIds.size());
             return Stream.concat(
-                    migrationConfig.getExcludedWorkspaceIds().stream(),
+                    envExcludedWorkspaceIds.stream(),
                     skippedWorkspaceIds.stream())
                     .collect(Collectors.toUnmodifiableSet());
         })


### PR DESCRIPTION
## Details

Add a sibling gauge to the existing `cycle.trapped_workspaces` so the Grafana migration dashboard (OPIK-6411) can show both exclusion paths side by side without operators having to inspect the configmap to learn how many workspaces are env-excluded.

**New metric:**
- `opik.migration.experiment_project.cycle.env_excluded_workspaces` (`LongGauge`) — set once per cycle from `migrationConfig.getExcludedWorkspaceIds().size()`.

**Why now:** while validating the OPIK-6411 dashboard on dev, the only signal available for the env-var exclusion path was *"check the configmap"*. The trapped path already had its gauge (`cycle.trapped_workspaces`); the env-var path didn't. With both gauges, the dashboard can render `env_excluded`, `trapped`, and `eligible (post-filter)` side by side and explain itself without external context.

**Why not also a pre-filter SQL count metric:** considered and rejected — `cycle.eligible_workspaces` already records what the migration actually processes after exclusion, and the dashboard gap here was specifically about the env-var path. A pre-filter unfiltered SQL count would require a duplicate query per cycle for a question that's only meaningfully different when the trapped/env sets are large; not worth the cost today.

The cycle log line is also extended to include the env-excluded count alongside the trapped count for parity in pod logs.

## Change checklist

- [x] User facing: no — internal observability metric for SREs
- [x] Documentation update: dashboard panel description updated in the corresponding `comet-monitoring` PR

## Issues

- OPIK-6411

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Opus 4.7
- Scope: full implementation
- Human verification: code review + `mvn compile -DskipTests` clean

## Testing

- `cd apps/opik-backend && mvn compile -DskipTests` — exit 0.
- Manual review of the diff: 13 insertions / 3 deletions in `ExperimentProjectMigrationService.java`. New gauge follows the exact shape of `cycleTrappedWorkspaces` (declared, built in constructor, set in `runMigrationCycle()`).
- After deploy, validation:
  - `opik_migration_experiment_project_cycle_env_excluded_workspaces{k8s_namespace_name="cometml-development"}` returns `1` (matches the dev configmap, which has one env-excluded workspace).
  - The new dashboard panel `Env-excluded workspaces (now)` (in the `comet-monitoring` PR) shows the value.
  - Cycle log line includes `envExcludedWorkspaces='1'`.

Tests not added: this is a tiny gauge wired identically to the existing trapped gauge, which has no dedicated unit test either; covered by integration paths that exercise `runMigrationCycle()`.

## Documentation

- Dashboard panel + description in `comet-monitoring` (separate PR) on the `comet/opik-experiment-project-migration.json` dashboard.
- No new env vars exposed; the metric is built into the migration job.